### PR TITLE
Feat/more powerful memory

### DIFF
--- a/docs/dev/modules/agent.md
+++ b/docs/dev/modules/agent.md
@@ -12,7 +12,7 @@ The agent runtime turns user input, session state, tools, memory, skills, and pr
 | Tool execution and registry | `tinybot/agent/tool_executor.py`, `tinybot/agent/tools/` |
 | Streaming and session persistence | `tinybot/agent/stream_handler.py`, `tinybot/agent/session_handler.py`, `tinybot/session/` |
 | Skills and prompt sections | `tinybot/agent/skills.py`, `tinybot/templates/agent/` |
-| Experience and memory support | `tinybot/agent/experience*.py`, `tinybot/agent/memory.py` |
+| Experience and Agent Memory support | `tinybot/agent/experience*.py`, `tinybot/agent/memory.py` |
 | Subagents | `tinybot/agent/subagent.py`, `tinybot/agent/tools/spawn.py` |
 
 ## Design Flow
@@ -44,6 +44,16 @@ Context is assembled with a budget. New context sources should answer three ques
 - Does the source contain untrusted content that needs template isolation?
 
 Long-lived memory and experience features should be treated as advisory context. They should not silently override current user instructions or repository state.
+
+## Agent Memory
+
+Agent Memory is owned by `tinybot/agent/memory.py`. Durable memory is stored as structured Memory Notes in `memory/notes.jsonl`; the Markdown files `memory/MEMORY.md`, `USER.md`, and `SOUL.md` are Memory Views for inspection and prompt compatibility.
+
+Memory Notes carry type, status, priority, confidence, source trace-back, timestamps, and lifecycle links. Only active notes participate in default recall and managed Memory View rendering. Rejected and superseded notes remain in JSONL for debugging and traceability.
+
+Dream is the background capture path for durable conversation facts. Explicit memory tools are the foreground path for user or agent corrections. Both paths write Memory Notes before refreshing Memory Views, so direct edits inside managed Markdown sections should be treated as temporary and overwritten by the next refresh.
+
+Memory Recall is a distinct context section selected from active Memory Notes. It stays separate from Experience, which records reusable execution guidance, and from Knowledge, which provides document evidence. Optional vector indexing may accelerate Memory Note search, but JSONL remains the canonical source and indexes must be rebuildable from it.
 
 ## Extension Points
 

--- a/docs/dev/modules/knowledge.md
+++ b/docs/dev/modules/knowledge.md
@@ -36,6 +36,8 @@ The agent runtime should treat retrieved knowledge as contextual evidence, not a
 
 Automatic retrieval should be budget-aware. Large documents and broad queries need compact summaries or top-k limits to avoid crowding out the conversation context.
 
+Knowledge is not Agent Memory. Document facts, uploaded-file context, and retrieval graph evidence remain in the Knowledge stores unless an explicit Memory Note capture path saves a durable agent-side note. This boundary keeps citations and document provenance separate from preferences, project decisions, fixes, and followups stored in `memory/notes.jsonl`.
+
 ## API Contract
 
 `tinybot/api/knowledge.py` owns:

--- a/tests/agent/test_context.py
+++ b/tests/agent/test_context.py
@@ -1,9 +1,101 @@
-"""Tests for ContextBuilder placeholder."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tinybot.agent.context import ContextBuilder
+from tinybot.agent.memory import MemoryNote, MemorySource
 
 
-class TestContextPlaceholder:
-    """Placeholder tests for ContextBuilder module."""
+def test_context_builder_injects_memory_recall_as_distinct_section(tmp_path):
+    builder = ContextBuilder(tmp_path)
+    source = MemorySource.explicit(session_key="cli:test")
+    builder.memory.upsert_note(
+        MemoryNote.create(
+            "Use uv run pytest for Python validation.",
+            "instruction",
+            [source],
+            priority=0.9,
+            confidence=0.8,
+            tags=["python", "tests"],
+        )
+    )
 
-    def test_placeholder(self):
-        """Placeholder test - Context tests will be added later."""
-        assert True
+    messages = builder.build_messages(
+        history=[],
+        current_message="Please add Python validation tests for this memory feature.",
+        channel="cli",
+        chat_id="test",
+    )
+
+    recall_messages = [
+        message for message in messages if message["role"] == "system" and "[MEMORY RECALL]" in message["content"]
+    ]
+    assert len(recall_messages) == 1
+    assert "Use uv run pytest for Python validation." in recall_messages[0]["content"]
+    assert "[RELEVANT WORKFLOWS]" not in recall_messages[0]["content"]
+    assert "[RELEVANT KNOWLEDGE]" not in recall_messages[0]["content"]
+
+
+def test_context_builder_keeps_memory_experience_and_knowledge_paths_separate(tmp_path):
+    experience_store = MagicMock()
+    experience = SimpleNamespace(
+        id="exp-1",
+        experience_type="workflow",
+        context_summary="Python test workflow",
+        tool_name="pytest",
+        action_hint="Run focused tests",
+        applicability="Python validation work",
+        resolution="Use uv run pytest",
+        confidence=0.8,
+        category="testing",
+    )
+    experience_store.search_workflows.return_value = [experience]
+    experience_store.search_semantic.return_value = []
+
+    knowledge_store = MagicMock()
+    knowledge_store.query.return_value = [
+        {
+            "doc_name": "testing-guide.md",
+            "content": "Knowledge Base evidence about validation.",
+            "summary": "",
+            "line_start": 3,
+            "line_end": 5,
+        }
+    ]
+
+    builder = ContextBuilder(
+        tmp_path,
+        experience_store=experience_store,
+        knowledge_store=knowledge_store,
+    )
+    source = MemorySource.explicit(session_key="cli:test")
+    builder.memory.upsert_note(
+        MemoryNote.create(
+            "Memory Notes should stay separate from Knowledge Base snippets.",
+            "decision",
+            [source],
+            priority=0.9,
+            confidence=0.8,
+        )
+    )
+
+    messages = builder.build_messages(
+        history=[],
+        current_message="Use the memory notes and knowledge guide for Python validation.",
+        channel="cli",
+        chat_id="test",
+    )
+    sections = [message["content"] for message in messages if message["role"] == "system"]
+
+    memory_section = next(section for section in sections if "[MEMORY RECALL]" in section)
+    experience_section = next(section for section in sections if "[RELEVANT WORKFLOWS]" in section)
+    knowledge_section = next(section for section in sections if "[RELEVANT KNOWLEDGE]" in section)
+
+    assert "Memory Notes should stay separate" in memory_section
+    assert "Python test workflow" in experience_section
+    assert "Knowledge Base evidence" in knowledge_section
+    assert "[RELEVANT WORKFLOWS]" not in memory_section
+    assert "[RELEVANT KNOWLEDGE]" not in memory_section
+    assert "[MEMORY RECALL]" not in experience_section
+    assert "[MEMORY RECALL]" not in knowledge_section

--- a/tests/agent/test_memory.py
+++ b/tests/agent/test_memory.py
@@ -16,6 +16,44 @@ from tinybot.agent.memory import (
 )
 
 
+class _FakeMemoryNoteCollection:
+    def __init__(self):
+        self.items = {}
+        self.query_ids = []
+
+    def count(self):
+        return len(self.items)
+
+    def get(self):
+        return {"ids": list(self.items)}
+
+    def delete(self, ids):
+        for item_id in ids:
+            self.items.pop(item_id, None)
+
+    def upsert(self, ids, documents, metadatas):
+        for item_id, document, metadata in zip(ids, documents, metadatas, strict=False):
+            self.items[item_id] = {"document": document, "metadata": metadata}
+
+    def query(self, query_texts, n_results, where=None, include=None):
+        del query_texts, where, include
+        ids = self.query_ids or list(self.items)
+        return {"ids": [ids[:n_results]], "distances": [[0.1 for _ in ids[:n_results]]]}
+
+
+class _FakeMemoryNoteVectorStore:
+    def __init__(self):
+        self.collection = _FakeMemoryNoteCollection()
+
+    def _get_or_create_collection(self, collection_name):
+        assert collection_name == "agent_memory_notes"
+        return self.collection
+
+    def _get_collection(self, collection_name):
+        assert collection_name == "agent_memory_notes"
+        return self.collection
+
+
 def test_memory_note_serializes_and_round_trips(tmp_path):
     store = MemoryStore(tmp_path)
     source = MemorySource(
@@ -328,6 +366,94 @@ def test_explicit_memory_note_operations_validate_inputs(tmp_path):
         store.search_memory_notes(status="archived")
     with pytest.raises(KeyError, match="Memory Note not found"):
         store.trace_memory_note("note_missing")
+
+
+def test_memory_note_lexical_search_fallback_ranks_notes_jsonl(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:test")
+    low_priority = store.upsert_note(
+        MemoryNote.create(
+            "Use Python for one-off repository scripts.",
+            MemoryNoteType.INSTRUCTION,
+            [source],
+            priority=0.4,
+        )
+    )
+    high_priority = store.upsert_note(
+        MemoryNote.create(
+            "Use uv run pytest for Python validation.",
+            MemoryNoteType.INSTRUCTION,
+            [source],
+            priority=0.9,
+            tags=["python", "validation"],
+        )
+    )
+    store.upsert_note(
+        MemoryNote.create(
+            "Keep maintainer documentation logic-only.",
+            MemoryNoteType.PROJECT,
+            [source],
+            priority=0.95,
+        )
+    )
+
+    matches = store.search_memory_notes(query="python validation", status="active")
+
+    assert [note.id for note in matches] == [high_priority.id, low_priority.id]
+
+
+def test_memory_note_vector_search_uses_jsonl_as_canonical_source(tmp_path):
+    store = MemoryStore(tmp_path)
+    vector_store = _FakeMemoryNoteVectorStore()
+    source = MemorySource.explicit(session_key="cli:test")
+    active = store.upsert_note(MemoryNote.create("Use uv run pytest for Python validation.", "instruction", [source]))
+    rejected = store.upsert_note(
+        MemoryNote.create("Use pytest directly for Python validation.", "instruction", [source])
+    )
+    store.reject_memory_note(rejected.id)
+    vector_store.collection.items = {
+        "note_missing": {"document": "stale vector", "metadata": {"kind": "memory_note"}},
+        rejected.id: {"document": rejected.content, "metadata": {"kind": "memory_note"}},
+        active.id: {"document": active.content, "metadata": {"kind": "memory_note"}},
+    }
+    vector_store.collection.query_ids = ["note_missing", rejected.id, active.id]
+
+    matches = store.search_memory_notes(
+        query="python validation",
+        status="active",
+        vector_store=vector_store,
+    )
+
+    assert matches == [active]
+
+
+def test_memory_note_index_rebuild_recreates_active_notes_from_jsonl(tmp_path):
+    store = MemoryStore(tmp_path)
+    vector_store = _FakeMemoryNoteVectorStore()
+    source = MemorySource.explicit(session_key="cli:test")
+    active = store.upsert_note(MemoryNote.create("Active indexed note.", "project", [source]))
+    rejected = store.upsert_note(MemoryNote.create("Rejected unindexed note.", "project", [source]))
+    store.reject_memory_note(rejected.id)
+    vector_store.collection.items = {
+        "note_stale": {"document": "old note", "metadata": {"kind": "memory_note"}},
+    }
+
+    stats = store.rebuild_memory_note_index(vector_store)
+
+    assert stats == {"available": True, "active_notes": 1, "indexed": 1, "deleted": 1}
+    assert set(vector_store.collection.items) == {active.id}
+    assert vector_store.collection.items[active.id]["document"] == "Active indexed note. | Type: project"
+    assert vector_store.collection.items[active.id]["metadata"]["kind"] == "memory_note"
+
+
+def test_memory_note_index_rebuild_is_noop_without_vector_store(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:test")
+    store.upsert_note(MemoryNote.create("Active JSONL-only note.", "project", [source]))
+
+    stats = store.rebuild_memory_note_index(None)
+
+    assert stats == {"available": False, "active_notes": 1, "indexed": 0, "deleted": 0}
 
 
 def test_memory_view_refresh_replaces_only_existing_managed_section(tmp_path):

--- a/tests/agent/test_memory.py
+++ b/tests/agent/test_memory.py
@@ -219,6 +219,69 @@ def test_memory_views_exclude_rejected_and_superseded_notes(tmp_path):
     assert superseded.content not in rendered
 
 
+def test_memory_recall_orders_by_relevance_priority_and_budget(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:default")
+    first = store.upsert_note(
+        MemoryNote.create(
+            "Use uv run pytest for Python validation.",
+            MemoryNoteType.INSTRUCTION,
+            [source],
+            priority=0.7,
+            confidence=0.8,
+            tags=["python", "tests"],
+        )
+    )
+    second = store.upsert_note(
+        MemoryNote.create(
+            "Prefer concise implementation progress updates.",
+            MemoryNoteType.PREFERENCE,
+            [source],
+            priority=0.95,
+            confidence=0.7,
+            tags=["communication"],
+        )
+    )
+    store.upsert_note(
+        MemoryNote.create(
+            "Unrelated but important repository decision.",
+            MemoryNoteType.DECISION,
+            [source],
+            priority=0.9,
+            confidence=0.7,
+        )
+    )
+
+    selected = store.select_memory_recall(
+        "Please add Python tests and validation.",
+        max_notes=2,
+        max_chars=1_000,
+    )
+
+    assert [note.id for note in selected] == [first.id, second.id]
+
+
+def test_memory_recall_excludes_inactive_notes_by_default(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:default")
+    active = store.upsert_note(MemoryNote.create("Active Python testing note.", "instruction", [source]))
+    rejected = store.upsert_note(MemoryNote.create("Rejected Python testing note.", "instruction", [source]))
+    superseded = store.upsert_note(MemoryNote.create("Superseded Python testing note.", "instruction", [source]))
+    store.reject_note(rejected.id)
+    store.supersede_note(
+        superseded.id,
+        MemoryNote.create("Replacement Python testing note.", "instruction", [source]),
+    )
+
+    context = store.format_memory_recall_context("Python testing validation")
+
+    assert active.content in context
+    assert "Replacement Python testing note." in context
+    assert rejected.content not in context
+    assert superseded.content not in context
+    assert "[MEMORY RECALL]" in context
+
+
 def test_memory_view_refresh_replaces_only_existing_managed_section(tmp_path):
     store = MemoryStore(tmp_path)
     source = MemorySource.explicit(session_key="cli:default")

--- a/tests/agent/test_memory.py
+++ b/tests/agent/test_memory.py
@@ -1,8 +1,11 @@
 import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from tinybot.agent.memory import (
+    Dream,
     MemoryCaptureOrigin,
     MemoryNote,
     MemoryNoteStatus,
@@ -237,3 +240,97 @@ def test_memory_view_refresh_replaces_only_existing_managed_section(tmp_path):
     assert "Render this active note." in memory_content
     assert "old managed content" not in memory_content
     assert memory_content.count("<!-- tinybot-memory-notes:start -->") == 1
+
+
+@pytest.mark.asyncio
+async def test_dream_creates_notes_refreshes_views_and_advances_cursor(tmp_path):
+    store = MemoryStore(tmp_path)
+    first_cursor = store.append_history("User confirmed the project uses uv for Python commands.")
+    second_cursor = store.append_history("User prefers concise progress updates.")
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(
+        return_value=SimpleNamespace(
+            content=(
+                "[SAVE:MEMORY] Project uses uv for Python commands.\n[SAVE:USER] User prefers concise progress updates."
+            )
+        )
+    )
+    dream = Dream(store=store, provider=provider, model="test-model")
+
+    assert await dream.run() is True
+
+    notes = store.read_notes()
+    assert len(notes) == 2
+    assert {note.type for note in notes} == {MemoryNoteType.PROJECT, MemoryNoteType.PREFERENCE}
+    assert all(note.sources[0].capture_origin == MemoryCaptureOrigin.DREAM for note in notes)
+    assert all(note.sources[0].history_start_cursor == first_cursor for note in notes)
+    assert all(note.sources[0].history_end_cursor == second_cursor for note in notes)
+    assert "Project uses uv for Python commands." in store.read_memory()
+    assert "User prefers concise progress updates." in store.read_user()
+    assert store.get_last_dream_cursor() == second_cursor
+
+
+@pytest.mark.asyncio
+async def test_dream_supersedes_corrected_note(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:test")
+    old_note = store.upsert_note(
+        MemoryNote.create("Use pytest directly for validation.", MemoryNoteType.INSTRUCTION, [source])
+    )
+    cursor = store.append_history("Correction: use uv run pytest for validation.")
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(
+        return_value=SimpleNamespace(content=f"[SUPERSEDE:{old_note.id}:SOUL] Use uv run pytest for validation.")
+    )
+    dream = Dream(store=store, provider=provider, model="test-model")
+
+    assert await dream.run() is True
+
+    notes = {note.id: note for note in store.read_notes()}
+    replacement_id = notes[old_note.id].superseded_by
+    assert notes[old_note.id].status == MemoryNoteStatus.SUPERSEDED
+    assert replacement_id is not None
+    assert notes[replacement_id].status == MemoryNoteStatus.ACTIVE
+    assert old_note.id in notes[replacement_id].supersedes
+    assert "Use uv run pytest for validation." in store.read_soul()
+    assert "Use pytest directly for validation." not in store.render_memory_view("SOUL.md")
+    assert store.get_last_dream_cursor() == cursor
+
+
+@pytest.mark.asyncio
+async def test_dream_skip_advances_cursor_without_creating_notes(tmp_path):
+    store = MemoryStore(tmp_path)
+    cursor = store.append_history("Short exchange with no durable memory.")
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(return_value=SimpleNamespace(content="[SKIP] no new information"))
+    dream = Dream(store=store, provider=provider, model="test-model")
+
+    assert await dream.run() is True
+
+    assert store.read_notes() == []
+    assert store.get_last_dream_cursor() == cursor
+
+
+@pytest.mark.asyncio
+async def test_dream_keeps_experience_processing_separate_from_memory_notes(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.append_history("A tool execution tactic was observed.")
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(return_value=SimpleNamespace(content="[SKIP] no new information"))
+    experience_store = MagicMock()
+    experience_store.merge_similar.return_value = 0
+    experience_store.decay_confidence.return_value = 0
+    experience_store.prune_stale.return_value = 0
+    experience_store.read_experiences.return_value = []
+    dream = Dream(
+        store=store,
+        provider=provider,
+        model="test-model",
+        experience_store=experience_store,
+    )
+
+    assert await dream.run() is True
+
+    assert store.read_notes() == []
+    experience_store.merge_similar.assert_called_once()
+    experience_store.compact.assert_called_once()

--- a/tests/agent/test_memory.py
+++ b/tests/agent/test_memory.py
@@ -282,6 +282,54 @@ def test_memory_recall_excludes_inactive_notes_by_default(tmp_path):
     assert "[MEMORY RECALL]" in context
 
 
+def test_explicit_memory_note_save_search_trace_reject_and_supersede(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:default", message_start=1, message_end=2)
+
+    saved = store.save_memory_note(
+        content="Use uv for Python validation commands.",
+        note_type="instruction",
+        source=source,
+        priority=0.9,
+        confidence=0.8,
+        tags="python, validation, python",
+    )
+    matches = store.search_memory_notes(query="validation", note_type="instruction", status="active")
+    traced = store.trace_memory_note(saved.id)
+    rejected = store.reject_memory_note(saved.id)
+    replacement = store.supersede_memory_note(
+        saved.id,
+        replacement_content="Use uv run pytest for Python test validation.",
+        source=source,
+    )
+    notes = {note.id: note for note in store.read_notes()}
+
+    assert matches == [saved]
+    assert traced.sources[0].capture_origin == MemoryCaptureOrigin.EXPLICIT
+    assert traced.sources[0].session_key == "cli:default"
+    assert traced.tags == ["python", "validation"]
+    assert rejected.status == MemoryNoteStatus.REJECTED
+    assert notes[saved.id].status == MemoryNoteStatus.SUPERSEDED
+    assert notes[saved.id].superseded_by == replacement.id
+    assert saved.id in notes[replacement.id].supersedes
+    assert replacement.content == "Use uv run pytest for Python test validation."
+
+
+def test_explicit_memory_note_operations_validate_inputs(tmp_path):
+    store = MemoryStore(tmp_path)
+
+    with pytest.raises(ValueError, match="content is required"):
+        store.save_memory_note(content="", note_type="instruction")
+    with pytest.raises(ValueError, match="Invalid Memory Note type"):
+        store.save_memory_note(content="Durable note.", note_type="workflow")
+    with pytest.raises(ValueError, match="priority must be between 0 and 1"):
+        store.save_memory_note(content="Durable note.", note_type="instruction", priority=2)
+    with pytest.raises(ValueError, match="Invalid Memory Note status"):
+        store.search_memory_notes(status="archived")
+    with pytest.raises(KeyError, match="Memory Note not found"):
+        store.trace_memory_note("note_missing")
+
+
 def test_memory_view_refresh_replaces_only_existing_managed_section(tmp_path):
     store = MemoryStore(tmp_path)
     source = MemorySource.explicit(session_key="cli:default")

--- a/tests/agent/test_memory.py
+++ b/tests/agent/test_memory.py
@@ -1,9 +1,166 @@
-"""Tests for Memory placeholder."""
+import json
+
+import pytest
+
+from tinybot.agent.memory import (
+    MemoryCaptureOrigin,
+    MemoryNote,
+    MemoryNoteStatus,
+    MemoryNoteType,
+    MemorySource,
+    MemoryStore,
+    generate_memory_note_id,
+)
 
 
-class TestMemoryPlaceholder:
-    """Placeholder tests for Memory module."""
+def test_memory_note_serializes_and_round_trips(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource(
+        capture_origin=MemoryCaptureOrigin.EXPLICIT,
+        session_key="cli:default",
+        message_start=2,
+        message_end=3,
+    )
+    note = MemoryNote.create(
+        "Use uv for Python commands.",
+        MemoryNoteType.INSTRUCTION,
+        [source],
+        priority=0.9,
+        confidence=0.8,
+        tags=["python", "tooling"],
+    )
 
-    def test_placeholder(self):
-        """Placeholder test - Memory tests will be added later."""
-        assert True
+    stored = store.upsert_note(note)
+    loaded = store.read_notes()
+
+    assert len(loaded) == 1
+    assert loaded[0].id == stored.id
+    assert loaded[0].type == MemoryNoteType.INSTRUCTION
+    assert loaded[0].status == MemoryNoteStatus.ACTIVE
+    assert loaded[0].sources[0].capture_origin == MemoryCaptureOrigin.EXPLICIT
+    assert loaded[0].sources[0].session_key == "cli:default"
+    assert loaded[0].priority == pytest.approx(0.9)
+    assert loaded[0].confidence == pytest.approx(0.8)
+    assert loaded[0].tags == ["python", "tooling"]
+
+
+def test_legacy_note_hydration_uses_safe_defaults(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.notes_file.write_text(
+        json.dumps(
+            {
+                "content": "Legacy note without newer fields.",
+                "sources": [{"origin": "migration", "source_file": "MEMORY.md"}],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    note = store.read_notes()[0]
+
+    assert note.type == MemoryNoteType.PROJECT
+    assert note.status == MemoryNoteStatus.ACTIVE
+    assert note.priority == pytest.approx(0.5)
+    assert note.confidence == pytest.approx(0.5)
+    assert note.id == generate_memory_note_id(note.type, note.content, note.sources)
+    assert note.sources[0].capture_origin == MemoryCaptureOrigin.MIGRATION
+
+
+def test_duplicate_detection_uses_equivalent_content_and_sources(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource(
+        capture_origin=MemoryCaptureOrigin.MIGRATION,
+        source_file="memory/MEMORY.md",
+    )
+    original = MemoryNote.create("Remember  the API choice", "decision", [source])
+    duplicate = MemoryNote.create(" remember the api choice ", "decision", [source])
+
+    stored = store.upsert_note(original)
+    duplicate_result = store.find_duplicate_note(duplicate)
+    upserted = store.upsert_note(duplicate)
+
+    assert duplicate_result is not None
+    assert duplicate_result.id == stored.id
+    assert upserted.id == stored.id
+    assert len(store.read_notes()) == 1
+
+
+def test_note_lifecycle_reject_and_supersede(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource(capture_origin=MemoryCaptureOrigin.EXPLICIT, session_key="cli:default")
+    old_note = store.upsert_note(MemoryNote.create("Use pytest directly.", "instruction", [source]))
+
+    rejected = store.reject_note(old_note.id)
+    assert rejected.status == MemoryNoteStatus.REJECTED
+
+    replacement = MemoryNote.create("Use uv run pytest when validating tests.", "instruction", [source])
+    stored_replacement = store.supersede_note(old_note.id, replacement)
+    notes = {note.id: note for note in store.read_notes()}
+
+    assert notes[old_note.id].status == MemoryNoteStatus.SUPERSEDED
+    assert notes[old_note.id].superseded_by == stored_replacement.id
+    assert notes[stored_replacement.id].status == MemoryNoteStatus.ACTIVE
+    assert old_note.id in notes[stored_replacement.id].supersedes
+
+
+def test_memory_source_helpers_capture_trace_fields():
+    dream = MemorySource.dream(history_start_cursor=4, history_end_cursor=9)
+    explicit = MemorySource.explicit(
+        session_key="cli:default",
+        message_start=1,
+        message_end=2,
+    )
+    migrated = MemorySource.migration("memory/MEMORY.md")
+
+    assert dream.capture_origin == MemoryCaptureOrigin.DREAM
+    assert dream.history_start_cursor == 4
+    assert dream.history_end_cursor == 9
+    assert explicit.capture_origin == MemoryCaptureOrigin.EXPLICIT
+    assert explicit.session_key == "cli:default"
+    assert explicit.message_start == 1
+    assert explicit.message_end == 2
+    assert migrated.capture_origin == MemoryCaptureOrigin.MIGRATION
+    assert migrated.source_file == "memory/MEMORY.md"
+
+
+def test_legacy_migration_creates_conservative_notes_and_preserves_files(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.memory_file.write_text(
+        "# Memory\n\n- Project uses source-linked swarm wording.\n\nKeep maintainer docs separate.",
+        encoding="utf-8",
+    )
+    store.user_file.write_text("- User prefers uv commands.", encoding="utf-8")
+    store.soul_file.write_text("## Soul\n\nAvoid vendor API names in tinybot surfaces.", encoding="utf-8")
+    original_memory = store.memory_file.read_text(encoding="utf-8")
+
+    migrated = store.migrate_legacy_memory_notes()
+    notes = store.read_notes()
+
+    assert len(migrated) == 4
+    assert len(notes) == 4
+    assert store.memory_file.read_text(encoding="utf-8") == original_memory
+    assert {note.type for note in notes} == {
+        MemoryNoteType.PROJECT,
+        MemoryNoteType.PREFERENCE,
+        MemoryNoteType.INSTRUCTION,
+    }
+    assert all(note.confidence == pytest.approx(0.45) for note in notes)
+    assert all(note.status == MemoryNoteStatus.ACTIVE for note in notes)
+    assert {note.sources[0].source_file for note in notes} == {
+        "memory/MEMORY.md",
+        "USER.md",
+        "SOUL.md",
+    }
+
+
+def test_legacy_migration_is_idempotent_and_legacy_context_still_loads(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.memory_file.write_text("- Keep legacy context usable.", encoding="utf-8")
+
+    first = store.migrate_legacy_memory_notes()
+    second = store.migrate_legacy_memory_notes()
+
+    assert [note.id for note in first] == [note.id for note in second]
+    assert len(store.read_notes()) == 1
+    assert "Keep legacy context usable." in store.get_memory_context()

--- a/tests/agent/test_memory.py
+++ b/tests/agent/test_memory.py
@@ -164,3 +164,76 @@ def test_legacy_migration_is_idempotent_and_legacy_context_still_loads(tmp_path)
     assert [note.id for note in first] == [note.id for note in second]
     assert len(store.read_notes()) == 1
     assert "Keep legacy context usable." in store.get_memory_context()
+
+
+def test_memory_view_rendering_writes_active_notes_to_managed_sections(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.memory_file.write_text("# Existing Memory\n\nKeep this paragraph.", encoding="utf-8")
+    source = MemorySource.explicit(session_key="cli:default")
+    project_note = store.upsert_note(
+        MemoryNote.create(
+            "Use the Memory Notes store as canonical agent memory.",
+            MemoryNoteType.PROJECT,
+            [source],
+            priority=0.8,
+            confidence=0.9,
+            tags=["agent-memory"],
+        )
+    )
+    store.upsert_note(MemoryNote.create("User prefers concise summaries.", MemoryNoteType.PREFERENCE, [source]))
+    store.upsert_note(MemoryNote.create("Speak directly and avoid vague claims.", MemoryNoteType.INSTRUCTION, [source]))
+
+    rendered = store.refresh_memory_views()
+
+    memory_content = store.read_memory()
+    user_content = store.read_user()
+    soul_content = store.read_soul()
+    assert "# Existing Memory" in memory_content
+    assert "Keep this paragraph." in memory_content
+    assert "Use the Memory Notes store as canonical agent memory." in memory_content
+    assert project_note.id in rendered["memory/MEMORY.md"]
+    assert "User prefers concise summaries." in user_content
+    assert "Speak directly and avoid vague claims." in soul_content
+
+
+def test_memory_views_exclude_rejected_and_superseded_notes(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:default")
+    active = store.upsert_note(MemoryNote.create("Keep active project note.", MemoryNoteType.PROJECT, [source]))
+    rejected = store.upsert_note(MemoryNote.create("Do not show rejected note.", MemoryNoteType.PROJECT, [source]))
+    superseded = store.upsert_note(MemoryNote.create("Do not show superseded note.", MemoryNoteType.PROJECT, [source]))
+    store.reject_note(rejected.id)
+    store.supersede_note(
+        superseded.id,
+        MemoryNote.create("Show replacement note.", MemoryNoteType.PROJECT, [source]),
+    )
+
+    rendered = store.refresh_memory_views()["memory/MEMORY.md"]
+
+    assert active.content in rendered
+    assert "Show replacement note." in rendered
+    assert rejected.content not in rendered
+    assert superseded.content not in rendered
+
+
+def test_memory_view_refresh_replaces_only_existing_managed_section(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:default")
+    store.memory_file.write_text(
+        "# Existing Memory\n\n"
+        "<!-- tinybot-memory-notes:start -->\n"
+        "old managed content\n"
+        "<!-- tinybot-memory-notes:end -->\n\n"
+        "Unmanaged footer.",
+        encoding="utf-8",
+    )
+    store.upsert_note(MemoryNote.create("Render this active note.", "decision", [source]))
+
+    store.refresh_memory_views()
+    memory_content = store.read_memory()
+
+    assert "# Existing Memory" in memory_content
+    assert "Unmanaged footer." in memory_content
+    assert "Render this active note." in memory_content
+    assert "old managed content" not in memory_content
+    assert memory_content.count("<!-- tinybot-memory-notes:start -->") == 1

--- a/tests/agent/test_memory_tools.py
+++ b/tests/agent/test_memory_tools.py
@@ -1,0 +1,97 @@
+import pytest
+
+from tinybot.agent.memory import MemoryNote, MemoryNoteStatus, MemorySource, MemoryStore
+from tinybot.agent.tools.memory import (
+    RejectMemoryNoteTool,
+    SaveMemoryNoteTool,
+    SearchMemoryNotesTool,
+    SupersedeMemoryNoteTool,
+    TraceMemoryNoteTool,
+)
+
+
+@pytest.mark.asyncio
+async def test_save_search_and_trace_memory_note_tools(tmp_path):
+    store = MemoryStore(tmp_path)
+    save_tool = SaveMemoryNoteTool(store, session_key="cli:test")
+    search_tool = SearchMemoryNotesTool(store)
+    trace_tool = TraceMemoryNoteTool(store)
+
+    saved_result = await save_tool.execute(
+        content="User prefers concise implementation handoffs.",
+        note_type="preference",
+        priority=0.8,
+        confidence=0.7,
+        tags="handoff, communication",
+        message_start=3,
+        message_end=4,
+    )
+    note = store.read_notes()[0]
+    search_result = await search_tool.execute(query="handoff", note_type="preference", status="active")
+    trace_result = await trace_tool.execute(note.id)
+
+    assert saved_result == f"Memory Note saved: {note.id} (preference, active)"
+    assert note.sources[0].session_key == "cli:test"
+    assert note.sources[0].message_start == 3
+    assert "User prefers concise implementation handoffs." in store.read_user()
+    assert f"[{note.id}]" in search_result
+    assert "sources: explicit session=cli:test messages=3-4" in search_result
+    assert f"## Memory Note {note.id}" in trace_result
+    assert "Sources:\n- explicit session=cli:test messages=3-4" in trace_result
+
+
+@pytest.mark.asyncio
+async def test_reject_memory_note_tool_refreshes_views(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:test")
+    note = store.upsert_note(MemoryNote.create("Remove this project note from views.", "project", [source]))
+    store.refresh_memory_views()
+    tool = RejectMemoryNoteTool(store)
+
+    result = await tool.execute(note.id, reason="obsolete")
+
+    assert result == f"Memory Note rejected: {note.id}. Reason: obsolete"
+    assert store.trace_memory_note(note.id).status == MemoryNoteStatus.REJECTED
+    assert "Remove this project note from views." not in store.read_memory()
+
+
+@pytest.mark.asyncio
+async def test_supersede_memory_note_tool_links_replacement_and_refreshes_views(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:test")
+    old = store.upsert_note(MemoryNote.create("Use pytest directly.", "instruction", [source]))
+    store.refresh_memory_views()
+    tool = SupersedeMemoryNoteTool(store, session_key="cli:test")
+
+    result = await tool.execute(
+        old.id,
+        replacement_content="Use uv run pytest for test validation.",
+        tags="python, tests",
+    )
+    notes = {note.id: note for note in store.read_notes()}
+    replacement_id = notes[old.id].superseded_by
+
+    assert replacement_id is not None
+    assert result == f"Memory Note superseded: {old.id} -> {replacement_id}"
+    assert notes[old.id].status == MemoryNoteStatus.SUPERSEDED
+    assert old.id in notes[replacement_id].supersedes
+    assert notes[replacement_id].tags == ["python", "tests"]
+    assert "Use uv run pytest for test validation." in store.read_soul()
+    assert "Use pytest directly." not in store.read_soul()
+
+
+@pytest.mark.asyncio
+async def test_memory_note_tools_return_errors_for_invalid_inputs(tmp_path):
+    store = MemoryStore(tmp_path)
+    save_tool = SaveMemoryNoteTool(store)
+    search_tool = SearchMemoryNotesTool(store)
+    trace_tool = TraceMemoryNoteTool(store)
+    reject_tool = RejectMemoryNoteTool(store)
+    supersede_tool = SupersedeMemoryNoteTool(store)
+
+    assert await save_tool.execute(content="", note_type="instruction") == "Error: Memory Note content is required"
+    assert "Invalid Memory Note type" in await save_tool.execute(content="Durable note.", note_type="workflow")
+    assert "Invalid Memory Note status" in await search_tool.execute(status="archived")
+    assert await trace_tool.execute("note_missing") == "Error: Memory Note 'note_missing' not found"
+    assert await reject_tool.execute("note_missing") == "Error: Memory Note 'note_missing' not found"
+    assert await supersede_tool.execute("note_missing", "Replacement") == "Error: Memory Note 'note_missing' not found"

--- a/tests/cowork/test_observability.py
+++ b/tests/cowork/test_observability.py
@@ -162,6 +162,31 @@ def test_legacy_trace_projects_to_bounded_agent_steps(temp_workspace):
     assert len(tool_step["summary"]["input_summary"]) <= 220
 
 
+def test_legacy_trace_compacts_agent_step_summaries_within_limit(temp_workspace):
+    from tinybot.cowork.trace import compact_text
+
+    service = CoworkService(temp_workspace)
+    session = service.create_session("Compact steps", "Steps", [], [])
+    agent_id = next(iter(session.agents))
+    service.add_trace_event(
+        session,
+        kind="tool",
+        name="Tool call",
+        actor_id=agent_id,
+        input_ref="secret " * 200,
+        summary="result " * 200,
+        data={"task_id": "1", "architecture": session.workflow_mode},
+        save=False,
+    )
+
+    steps = build_cowork_agent_steps(session)
+    tool_step = next(step for step in steps if step["source_span_id"])
+
+    assert len(tool_step["summary"]["input_summary"]) <= 220
+    assert len(tool_step["summary"]["outcome_summary"]) <= 240
+    assert len(compact_text("secret " * 200, 220)) <= 220
+
+
 def test_trace_includes_native_agent_steps(temp_workspace):
     from tinybot.cowork.types import CoworkAgentStep
 

--- a/tinybot/agent/context.py
+++ b/tinybot/agent/context.py
@@ -241,6 +241,10 @@ class ContextBuilder:
                         }
                     )
 
+        memory_recall_context = self._build_memory_recall_context(current_message)
+        if memory_recall_context:
+            messages.append({"role": "system", "content": memory_recall_context})
+
         if self.experience_store is not None:
             experience_context = self._build_experience_context(current_message)
             if experience_context:
@@ -265,6 +269,21 @@ class ContextBuilder:
             return messages
         messages.append({"role": current_role, "content": merged})
         return messages
+
+    def _build_memory_recall_context(
+        self,
+        current_message: str,
+        max_notes: int = 6,
+        max_chars: int = 1_600,
+    ) -> str | None:
+        if self._is_simple_conversation(current_message):
+            return None
+        context = self.memory.format_memory_recall_context(
+            current_message,
+            max_notes=max_notes,
+            max_chars=max_chars,
+        )
+        return context or None
 
     def _build_experience_context(
         self,
@@ -400,57 +419,6 @@ class ContextBuilder:
             persistent_results=persistent_results,
             session_results=session_results,
         )
-
-        lines = ["---\n[RELEVANT KNOWLEDGE]\n\n"]
-        for idx, result in enumerate(results, 1):
-            doc_name = result.get("doc_name", "Unknown")
-            content = result.get("content", "")
-            summary = result.get("summary", "")
-            file_path = result.get("file_path", "")
-            category = result.get("category", "")
-            section_path = result.get("section_path", "")
-            line_start = result.get("line_start", 0)
-            line_end = result.get("line_end", 0)
-            page = result.get("page")
-            matched_claims = result.get("matched_claims", [])
-            matched_relations = result.get("matched_relations", [])
-            matched_entities = result.get("matched_entities", [])
-            matched_child_snippets = result.get("matched_child_snippets", [])
-
-            # Build metadata line
-            meta_parts = [f"文档: {doc_name}"]
-            if file_path:
-                meta_parts.append(f"路径: {file_path}")
-            if category:
-                meta_parts.append(f"分类: {category}")
-            if section_path:
-                meta_parts.append(f"Section: {section_path}")
-            # Line info (more useful than char position)
-            if line_start and line_end:
-                meta_parts.append(f"行: {line_start}-{line_end}")
-            if page is not None:
-                meta_parts.append(f"页码: {page}")
-            meta_str = " | ".join(meta_parts)
-            semantic_parts = []
-            if matched_entities:
-                semantic_parts.append("Entities: " + ", ".join(matched_entities[:5]))
-            if matched_relations:
-                semantic_parts.append("Relations: " + "; ".join(matched_relations[:3]))
-            if matched_claims:
-                semantic_parts.append("Claims: " + " | ".join(matched_claims[:3]))
-            if matched_child_snippets:
-                semantic_parts.append("Matched snippets: " + " | ".join(matched_child_snippets[:2]))
-            semantic_text = "\n".join(semantic_parts)
-            semantic_block = f"\n{semantic_text}" if semantic_text else ""
-
-            # Include summary if available
-            if summary:
-                lines.append(f"[{idx}] {meta_str}{semantic_block}\n摘要: {summary}\n内容: {content}\n\n")
-            else:
-                lines.append(f"[{idx}] {meta_str}{semantic_block}\n{content}\n\n")
-
-        lines.append("注意: 如果引用了上述知识内容，请在对应的回答中附上知识的来源（文档名称，第几页，第几行，文档路径在哪）。\n---")
-        return "".join(lines)
 
     @classmethod
     def _format_retrieved_knowledge_context(

--- a/tinybot/agent/loop.py
+++ b/tinybot/agent/loop.py
@@ -69,6 +69,13 @@ from tinybot.agent.tools.knowledge import (
     ListDocumentsTool,
     QueryKnowledgeTool,
 )
+from tinybot.agent.tools.memory import (
+    RejectMemoryNoteTool,
+    SaveMemoryNoteTool,
+    SearchMemoryNotesTool,
+    SupersedeMemoryNoteTool,
+    TraceMemoryNoteTool,
+)
 from tinybot.agent.tools.message import MessageTool
 from tinybot.agent.tools.registry import ToolRegistry
 from tinybot.agent.tools.shell import ExecTool
@@ -502,6 +509,13 @@ class AgentLoop:
 
         # Add experience tools for Agent to query/save experiences
         session_key = f"{channel}:{chat_id}" if channel and chat_id else ""
+        memory_store = self.context.memory
+        registry.register(SearchMemoryNotesTool(memory_store=memory_store))
+        registry.register(TraceMemoryNoteTool(memory_store=memory_store))
+        registry.register(RejectMemoryNoteTool(memory_store=memory_store))
+        registry.register(SaveMemoryNoteTool(memory_store=memory_store, session_key=session_key))
+        registry.register(SupersedeMemoryNoteTool(memory_store=memory_store, session_key=session_key))
+
         if self.experience_store:
             # Query tool - always available
             query_exp_tool = QueryExperienceTool(

--- a/tinybot/agent/loop.py
+++ b/tinybot/agent/loop.py
@@ -510,11 +510,15 @@ class AgentLoop:
         # Add experience tools for Agent to query/save experiences
         session_key = f"{channel}:{chat_id}" if channel and chat_id else ""
         memory_store = self.context.memory
-        registry.register(SearchMemoryNotesTool(memory_store=memory_store))
+        registry.register(SearchMemoryNotesTool(memory_store=memory_store, vector_store=self._vector_store))
         registry.register(TraceMemoryNoteTool(memory_store=memory_store))
-        registry.register(RejectMemoryNoteTool(memory_store=memory_store))
-        registry.register(SaveMemoryNoteTool(memory_store=memory_store, session_key=session_key))
-        registry.register(SupersedeMemoryNoteTool(memory_store=memory_store, session_key=session_key))
+        registry.register(RejectMemoryNoteTool(memory_store=memory_store, vector_store=self._vector_store))
+        registry.register(SaveMemoryNoteTool(memory_store=memory_store, session_key=session_key, vector_store=self._vector_store))
+        registry.register(SupersedeMemoryNoteTool(
+            memory_store=memory_store,
+            session_key=session_key,
+            vector_store=self._vector_store,
+        ))
 
         if self.experience_store:
             # Query tool - always available

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -73,6 +73,49 @@ def _memory_recall_terms(text: str) -> set[str]:
     }
 
 
+def _memory_note_search_text(note: MemoryNote) -> str:
+    source_parts: list[str] = []
+    for source in note.sources:
+        source_parts.extend(
+            str(part)
+            for part in (
+                source.capture_origin.value,
+                source.session_key,
+                source.source_file,
+                source.history_start_cursor,
+                source.history_end_cursor,
+                source.message_start,
+                source.message_end,
+            )
+            if part is not None
+        )
+    return " ".join(
+        [
+            note.id,
+            note.type.value,
+            note.status.value,
+            note.content,
+            " ".join(note.tags),
+            " ".join(source_parts),
+        ]
+    )
+
+
+def _memory_note_lexical_score(query: str, note: MemoryNote) -> float:
+    if not query.strip():
+        return 0.0
+    query_terms = _memory_recall_terms(query)
+    haystack = _memory_note_search_text(note)
+    haystack_terms = _memory_recall_terms(haystack)
+    normalized_query = _normalize_note_text(query)
+    normalized_haystack = _normalize_note_text(haystack)
+    overlap = len(query_terms & haystack_terms)
+    score = float(overlap)
+    if normalized_query and normalized_query in normalized_haystack:
+        score += 2.5
+    return score
+
+
 def _coerce_enum(enum_type: type[StrEnum], value: Any, default: StrEnum) -> StrEnum:
     try:
         return enum_type(str(value))
@@ -355,6 +398,7 @@ class MemoryStore:
     """Pure file I/O for memory files: MEMORY.md, history.jsonl, SOUL.md, USER.md."""
 
     _DEFAULT_MAX_HISTORY = 1000
+    _MEMORY_NOTE_VECTOR_COLLECTION = "agent_memory_notes"
     _VIEW_MARKER_BEGIN = "<!-- tinybot-memory-notes:start -->"
     _VIEW_MARKER_END = "<!-- tinybot-memory-notes:end -->"
     _VIEW_TITLES = {
@@ -488,45 +532,178 @@ class MemoryStore:
         note_type: MemoryNoteType | str | None = None,
         status: MemoryNoteStatus | str | None = None,
         limit: int = 20,
+        vector_store: VectorStore | None = None,
     ) -> list[MemoryNote]:
-        """Search canonical Memory Notes by lexical query and optional filters."""
+        """Search canonical Memory Notes by vector ids with lexical JSONL fallback."""
         if limit <= 0:
             return []
         type_filter = _strict_note_type(note_type) if note_type else None
         status_filter = _strict_note_status(status) if status else None
-        query_terms = _memory_recall_terms(query)
         normalized_query = _normalize_note_text(query)
 
-        matches: list[MemoryNote] = []
-        for note in self.read_notes():
+        def matches_filters(note: MemoryNote) -> bool:
             if type_filter and note.type != type_filter:
-                continue
+                return False
             if status_filter and note.status != status_filter:
-                continue
-            if query_terms or normalized_query:
-                haystack = " ".join(
-                    [
-                        note.id,
-                        note.type.value,
-                        note.status.value,
-                        note.content,
-                        " ".join(note.tags),
-                        " ".join(source.capture_origin.value for source in note.sources),
-                        " ".join(source.session_key or "" for source in note.sources),
-                        " ".join(source.source_file or "" for source in note.sources),
-                    ]
-                )
-                haystack_terms = _memory_recall_terms(haystack)
-                normalized_haystack = _normalize_note_text(haystack)
-                if query_terms and not (query_terms & haystack_terms):
-                    if normalized_query not in normalized_haystack:
-                        continue
-                elif normalized_query and normalized_query not in normalized_haystack and not query_terms:
+                return False
+            return True
+
+        notes = self.read_notes()
+        note_by_id = {note.id: note for note in notes}
+        results: list[MemoryNote] = []
+        seen: set[str] = set()
+
+        if normalized_query and vector_store is not None:
+            for note_id in self._search_memory_note_vector_index(query, vector_store, limit=limit * 2):
+                note = note_by_id.get(note_id)
+                if (
+                    note is None
+                    or note.id in seen
+                    or note.status != MemoryNoteStatus.ACTIVE
+                    or not matches_filters(note)
+                ):
                     continue
-            matches.append(note)
-            if len(matches) >= limit:
+                results.append(note)
+                seen.add(note.id)
+                if len(results) >= limit:
+                    return results
+
+        lexical_matches: list[tuple[tuple[float, float, float, str, str], MemoryNote]] = []
+        for note in notes:
+            if note.id in seen or not matches_filters(note):
+                continue
+            score = _memory_note_lexical_score(query, note) if normalized_query else 0.0
+            if normalized_query and score <= 0:
+                continue
+            lexical_matches.append((
+                (
+                    score,
+                    note.priority,
+                    note.confidence,
+                    note.type.value,
+                    note.content.casefold(),
+                ),
+                note,
+            ))
+
+        if normalized_query:
+            lexical_matches.sort(key=lambda item: item[0], reverse=True)
+
+        for _, note in lexical_matches:
+            results.append(note)
+            if len(results) >= limit:
                 break
-        return matches
+        return results
+
+    def rebuild_memory_note_index(self, vector_store: VectorStore | None = None) -> dict[str, Any]:
+        """Recreate the optional vector index from canonical ``notes.jsonl``."""
+        active_notes = [
+            note
+            for note in self.read_notes()
+            if note.status == MemoryNoteStatus.ACTIVE and note.content
+        ]
+        if vector_store is None:
+            return {
+                "available": False,
+                "active_notes": len(active_notes),
+                "indexed": 0,
+                "deleted": 0,
+            }
+
+        try:
+            collection = vector_store._get_or_create_collection(self._MEMORY_NOTE_VECTOR_COLLECTION)
+        except Exception:
+            logger.warning("MemoryStore: memory note vector index unavailable")
+            return {
+                "available": False,
+                "active_notes": len(active_notes),
+                "indexed": 0,
+                "deleted": 0,
+            }
+
+        deleted = self._clear_memory_note_vector_collection(collection)
+        if active_notes:
+            try:
+                collection.upsert(
+                    ids=[note.id for note in active_notes],
+                    documents=[self._memory_note_index_document(note) for note in active_notes],
+                    metadatas=[self._memory_note_index_metadata(note) for note in active_notes],
+                )
+            except Exception:
+                logger.warning("MemoryStore: memory note vector upsert failed")
+                return {
+                    "available": False,
+                    "active_notes": len(active_notes),
+                    "indexed": 0,
+                    "deleted": deleted,
+                }
+
+        return {
+            "available": True,
+            "active_notes": len(active_notes),
+            "indexed": len(active_notes),
+            "deleted": deleted,
+        }
+
+    def _search_memory_note_vector_index(
+        self,
+        query: str,
+        vector_store: VectorStore,
+        *,
+        limit: int,
+    ) -> list[str]:
+        try:
+            collection = vector_store._get_collection(self._MEMORY_NOTE_VECTOR_COLLECTION)
+            if collection is None or collection.count() == 0:
+                return []
+            results = collection.query(
+                query_texts=[query],
+                n_results=min(max(limit, 1), collection.count()),
+                where={"kind": "memory_note"},
+                include=["metadatas", "distances"],
+            )
+        except Exception:
+            logger.debug("MemoryStore: memory note vector search failed")
+            return []
+        return [
+            str(note_id)
+            for note_id in results.get("ids", [[]])[0]
+            if note_id
+        ]
+
+    @staticmethod
+    def _memory_note_index_document(note: MemoryNote) -> str:
+        parts = [
+            note.content,
+            f"Type: {note.type.value}",
+            f"Tags: {', '.join(note.tags)}" if note.tags else "",
+        ]
+        return " | ".join(part for part in parts if part)
+
+    @staticmethod
+    def _memory_note_index_metadata(note: MemoryNote) -> dict[str, Any]:
+        return {
+            "kind": "memory_note",
+            "note_id": note.id,
+            "note_type": note.type.value,
+            "status": note.status.value,
+            "priority": note.priority,
+            "confidence": note.confidence,
+            "updated_at": note.updated_at,
+            "tags": json.dumps(note.tags, ensure_ascii=False),
+        }
+
+    @staticmethod
+    def _clear_memory_note_vector_collection(collection: Any) -> int:
+        try:
+            existing = collection.get()
+            ids = [str(note_id) for note_id in existing.get("ids", []) if note_id]
+            if ids:
+                collection.delete(ids=ids)
+            return len(ids)
+        except Exception:
+            logger.debug("MemoryStore: could not clear memory note vector collection")
+            return 0
 
     def trace_memory_note(self, note_id: str) -> MemoryNote:
         note = self.get_note(note_id)

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -301,6 +301,21 @@ class MemoryStore:
     """Pure file I/O for memory files: MEMORY.md, history.jsonl, SOUL.md, USER.md."""
 
     _DEFAULT_MAX_HISTORY = 1000
+    _VIEW_MARKER_BEGIN = "<!-- tinybot-memory-notes:start -->"
+    _VIEW_MARKER_END = "<!-- tinybot-memory-notes:end -->"
+    _VIEW_TITLES = {
+        "memory/MEMORY.md": "Project Memory Notes",
+        "USER.md": "User Memory Notes",
+        "SOUL.md": "Assistant Memory Notes",
+    }
+    _TYPE_VIEW_DEFAULTS = {
+        MemoryNoteType.PREFERENCE: "USER.md",
+        MemoryNoteType.INSTRUCTION: "SOUL.md",
+        MemoryNoteType.PROJECT: "memory/MEMORY.md",
+        MemoryNoteType.DECISION: "memory/MEMORY.md",
+        MemoryNoteType.FIX: "memory/MEMORY.md",
+        MemoryNoteType.FOLLOWUP: "memory/MEMORY.md",
+    }
 
     def __init__(self, workspace: Path, max_history_entries: int = _DEFAULT_MAX_HISTORY):
         self.workspace = workspace
@@ -457,6 +472,86 @@ class MemoryStore:
                 )
                 migrated.append(self.upsert_note(note))
         return migrated
+
+    def refresh_memory_views(self) -> dict[str, str]:
+        """Render active Memory Notes into managed Markdown view sections."""
+        notes = self.read_notes()
+        rendered = {
+            "memory/MEMORY.md": self.render_memory_view("memory/MEMORY.md", notes),
+            "USER.md": self.render_memory_view("USER.md", notes),
+            "SOUL.md": self.render_memory_view("SOUL.md", notes),
+        }
+        self.write_memory(self._replace_managed_memory_view(self.read_memory(), rendered["memory/MEMORY.md"]))
+        self.write_user(self._replace_managed_memory_view(self.read_user(), rendered["USER.md"]))
+        self.write_soul(self._replace_managed_memory_view(self.read_soul(), rendered["SOUL.md"]))
+        return rendered
+
+    def render_memory_view(self, view_file: str, notes: list[MemoryNote] | None = None) -> str:
+        """Render one managed Memory View section from active Memory Notes."""
+        active_notes = [
+            note
+            for note in (notes if notes is not None else self.read_notes())
+            if note.status == MemoryNoteStatus.ACTIVE
+            and note.content
+            and self._note_view_file(note) == view_file
+        ]
+        active_notes.sort(
+            key=lambda note: (
+                note.type.value,
+                -note.priority,
+                -note.confidence,
+                note.content.casefold(),
+            )
+        )
+
+        title = self._VIEW_TITLES.get(view_file, "Memory Notes")
+        lines = [
+            self._VIEW_MARKER_BEGIN,
+            f"## {title}",
+            "",
+            "This managed section is rendered from `memory/notes.jsonl`.",
+            "Edit durable memory through Memory Note operations instead of changing this section directly.",
+            "",
+        ]
+        if not active_notes:
+            lines.append("(No active Memory Notes.)")
+        else:
+            current_type: MemoryNoteType | None = None
+            for note in active_notes:
+                if note.type != current_type:
+                    current_type = note.type
+                    lines.extend(("", f"### {note.type.value.title()}"))
+                metadata = [
+                    f"id: {note.id}",
+                    f"priority: {note.priority:g}",
+                    f"confidence: {note.confidence:g}",
+                ]
+                if note.tags:
+                    metadata.append("tags: " + ", ".join(sorted(note.tags)))
+                lines.append(f"- {note.content} ({'; '.join(metadata)})")
+        lines.append(self._VIEW_MARKER_END)
+        return "\n".join(lines).rstrip() + "\n"
+
+    @classmethod
+    def _replace_managed_memory_view(cls, existing: str, rendered_section: str) -> str:
+        existing = existing.rstrip()
+        begin = existing.find(cls._VIEW_MARKER_BEGIN)
+        end = existing.find(cls._VIEW_MARKER_END)
+        if begin != -1 and end != -1 and begin < end:
+            suffix_start = end + len(cls._VIEW_MARKER_END)
+            prefix = existing[:begin].rstrip()
+            suffix = existing[suffix_start:].strip()
+            parts = [part for part in (prefix, rendered_section.rstrip(), suffix) if part]
+            return "\n\n".join(parts).rstrip() + "\n"
+        if not existing:
+            return rendered_section
+        return existing + "\n\n" + rendered_section
+
+    def _note_view_file(self, note: MemoryNote) -> str:
+        for source in note.sources:
+            if source.source_file in self._VIEW_TITLES:
+                return source.source_file
+        return self._TYPE_VIEW_DEFAULTS.get(note.type, "memory/MEMORY.md")
 
     @staticmethod
     def _parse_legacy_memory_markdown(content: str) -> list[str]:

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -94,6 +94,53 @@ def _coerce_int(value: Any) -> int | None:
         return None
 
 
+def _strict_note_type(value: MemoryNoteType | str) -> MemoryNoteType:
+    try:
+        return MemoryNoteType(str(value))
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in MemoryNoteType)
+        raise ValueError(f"Invalid Memory Note type: {value!r}. Allowed: {allowed}") from exc
+
+
+def _strict_note_status(value: MemoryNoteStatus | str) -> MemoryNoteStatus:
+    try:
+        return MemoryNoteStatus(str(value))
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in MemoryNoteStatus)
+        raise ValueError(f"Invalid Memory Note status: {value!r}. Allowed: {allowed}") from exc
+
+
+def _strict_score(name: str, value: float) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a number between 0 and 1") from exc
+    if score < 0 or score > 1:
+        raise ValueError(f"{name} must be between 0 and 1")
+    return score
+
+
+def _clean_note_tags(tags: list[str] | tuple[str, ...] | str | None) -> list[str]:
+    if tags is None:
+        return []
+    if isinstance(tags, str):
+        raw_tags = tags.split(",")
+    else:
+        raw_tags = tags
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for tag in raw_tags:
+        text = str(tag).strip()
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(text)
+    return cleaned
+
+
 @dataclass(slots=True)
 class MemorySource:
     capture_origin: MemoryCaptureOrigin
@@ -410,6 +457,109 @@ class MemoryStore:
             if note.id == note_id:
                 return note
         return None
+
+    def save_memory_note(
+        self,
+        *,
+        content: str,
+        note_type: MemoryNoteType | str,
+        source: MemorySource | None = None,
+        priority: float = 0.5,
+        confidence: float = 0.5,
+        tags: list[str] | tuple[str, ...] | str | None = None,
+    ) -> MemoryNote:
+        """Save explicit durable Agent Memory after validating user-facing inputs."""
+        if not content or not content.strip():
+            raise ValueError("Memory Note content is required")
+        note = MemoryNote.create(
+            content.strip(),
+            _strict_note_type(note_type),
+            [source or MemorySource.explicit()],
+            priority=_strict_score("priority", priority),
+            confidence=_strict_score("confidence", confidence),
+            tags=_clean_note_tags(tags),
+        )
+        return self.upsert_note(note)
+
+    def search_memory_notes(
+        self,
+        *,
+        query: str = "",
+        note_type: MemoryNoteType | str | None = None,
+        status: MemoryNoteStatus | str | None = None,
+        limit: int = 20,
+    ) -> list[MemoryNote]:
+        """Search canonical Memory Notes by lexical query and optional filters."""
+        if limit <= 0:
+            return []
+        type_filter = _strict_note_type(note_type) if note_type else None
+        status_filter = _strict_note_status(status) if status else None
+        query_terms = _memory_recall_terms(query)
+        normalized_query = _normalize_note_text(query)
+
+        matches: list[MemoryNote] = []
+        for note in self.read_notes():
+            if type_filter and note.type != type_filter:
+                continue
+            if status_filter and note.status != status_filter:
+                continue
+            if query_terms or normalized_query:
+                haystack = " ".join(
+                    [
+                        note.id,
+                        note.type.value,
+                        note.status.value,
+                        note.content,
+                        " ".join(note.tags),
+                        " ".join(source.capture_origin.value for source in note.sources),
+                        " ".join(source.session_key or "" for source in note.sources),
+                        " ".join(source.source_file or "" for source in note.sources),
+                    ]
+                )
+                haystack_terms = _memory_recall_terms(haystack)
+                normalized_haystack = _normalize_note_text(haystack)
+                if query_terms and not (query_terms & haystack_terms):
+                    if normalized_query not in normalized_haystack:
+                        continue
+                elif normalized_query and normalized_query not in normalized_haystack and not query_terms:
+                    continue
+            matches.append(note)
+            if len(matches) >= limit:
+                break
+        return matches
+
+    def trace_memory_note(self, note_id: str) -> MemoryNote:
+        note = self.get_note(note_id)
+        if note is None:
+            raise KeyError(f"Memory Note not found: {note_id}")
+        return note
+
+    def reject_memory_note(self, note_id: str) -> MemoryNote:
+        return self.reject_note(note_id)
+
+    def supersede_memory_note(
+        self,
+        note_id: str,
+        *,
+        replacement_content: str,
+        note_type: MemoryNoteType | str | None = None,
+        source: MemorySource | None = None,
+        priority: float | None = None,
+        confidence: float | None = None,
+        tags: list[str] | tuple[str, ...] | str | None = None,
+    ) -> MemoryNote:
+        old_note = self.trace_memory_note(note_id)
+        if not replacement_content or not replacement_content.strip():
+            raise ValueError("Replacement Memory Note content is required")
+        replacement = MemoryNote.create(
+            replacement_content.strip(),
+            _strict_note_type(note_type) if note_type else old_note.type,
+            [source or MemorySource.explicit()],
+            priority=_strict_score("priority", old_note.priority if priority is None else priority),
+            confidence=_strict_score("confidence", old_note.confidence if confidence is None else confidence),
+            tags=_clean_note_tags(old_note.tags if tags is None else tags),
+        )
+        return self.supersede_note(note_id, replacement)
 
     def set_note_status(self, note_id: str, status: MemoryNoteStatus | str) -> MemoryNote:
         notes = self.read_notes()

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -24,8 +24,6 @@ from tinybot.utils.fs import ensure_dir
 from tinybot.utils.helper import strip_think
 from tinybot.utils.legacy_migrate import migrate_legacy_history
 
-from tinybot.agent.runner import AgentRunSpec, AgentRunner
-from tinybot.agent.tools.registry import ToolRegistry
 from tinybot.utils.gitstore import GitStore
 
 if TYPE_CHECKING:
@@ -1032,13 +1030,20 @@ class Consolidator:
 
 
 class Dream:
-    """Two-phase memory processor: analyze history.jsonl, then edit files via AgentRunner.
+    """Memory processor: analyze history.jsonl, write Memory Notes, refresh views.
 
-    Phase 1 produces an analysis summary (plain LLM call).
-    Phase 2 delegates to AgentRunner with read_file / edit_file tools so the
-    LLM can make targeted, incremental edits instead of replacing entire files.
-    Phase 3 processes experiences: merges similar ones and updates strategies in MEMORY.md.
+    Phase 1 produces structured note operations from conversation history.
+    Phase 2 applies those operations to canonical Memory Notes, then refreshes
+    managed Markdown Memory Views.
+    Phase 3 processes Experiences separately as execution guidance.
     """
+
+    _NOTE_TARGETS = {
+        "MEMORY": ("memory/MEMORY.md", MemoryNoteType.PROJECT),
+        "USER": ("USER.md", MemoryNoteType.PREFERENCE),
+        "SOUL": ("SOUL.md", MemoryNoteType.INSTRUCTION),
+    }
+    _NOTE_LINE_RE = re.compile(r"^\[(?P<header>[^\]]+)\]\s*(?P<content>.*)$")
 
     def __init__(
         self,
@@ -1057,20 +1062,6 @@ class Dream:
         self.max_iterations = max_iterations
         self.max_tool_result_chars = max_tool_result_chars
         self.experience_store = experience_store
-        self._runner = AgentRunner(provider)
-        self._tools = self._build_tools()
-
-    # -- tool registry -------------------------------------------------------
-
-    def _build_tools(self) -> ToolRegistry:
-        """Build a minimal tool registry for the Dream agent."""
-        from tinybot.agent.tools.filesystem import EditFileTool, ReadFileTool
-
-        tools = ToolRegistry()
-        workspace = self.store.workspace
-        tools.register(ReadFileTool(workspace=workspace, allowed_dir=workspace))
-        tools.register(EditFileTool(workspace=workspace, allowed_dir=workspace))
-        return tools
 
     # -- main entry ----------------------------------------------------------
 
@@ -1096,7 +1087,9 @@ class Dream:
         current_memory = self.store.read_memory() or "(empty)"
         current_soul = self.store.read_soul() or "(empty)"
         current_user = self.store.read_user() or "(empty)"
+        current_notes = self._format_current_notes() or "(no Memory Notes)"
         file_context = (
+            f"## Current Memory Notes\n{current_notes}\n\n"
             f"## Current MEMORY.md\n{current_memory}\n\n"
             f"## Current SOUL.md\n{current_soul}\n\n"
             f"## Current USER.md\n{current_user}"
@@ -1126,58 +1119,31 @@ class Dream:
             logger.exception("Dream Phase 1 failed")
             return False
 
-        # Phase 2: Delegate to AgentRunner with read_file / edit_file
-        phase2_prompt = f"## Analysis Result\n{analysis}\n\n{file_context}"
-
-        tools = self._tools
-        messages: list[dict[str, Any]] = [
-            {
-                "role": "system",
-                "content": render_template("agent/dream_phase2.md", strip=True),
-            },
-            {"role": "user", "content": phase2_prompt},
-        ]
-
-        try:
-            result = await self._runner.run(AgentRunSpec(
-                initial_messages=messages,
-                tools=tools,
-                model=self.model,
-                max_iterations=self.max_iterations,
-                max_tool_result_chars=self.max_tool_result_chars,
-                fail_on_tool_error=True,
-            ))
-            logger.debug(
-                "Dream Phase 2 complete: stop_reason={}, tool_events={}",
-                result.stop_reason, len(result.tool_events),
-            )
-        except Exception:
-            logger.exception("Dream Phase 2 failed")
-            result = None
-
-        # Build changelog from tool events
-        changelog: list[str] = []
-        if result and result.tool_events:
-            for event in result.tool_events:
-                if event["status"] == "ok":
-                    changelog.append(f"{event['name']}: {event['detail']}")
+        # Phase 2: apply structured Memory Note operations before refreshing views.
+        source = MemorySource.dream(
+            history_start_cursor=batch[0]["cursor"],
+            history_end_cursor=batch[-1]["cursor"],
+        )
+        changelog = self._apply_memory_note_analysis(analysis, source)
+        if changelog:
+            self.store.refresh_memory_views()
+            changelog.append("refresh_memory_views")
+            logger.info("Dream Phase 2: applied {} Memory Note change(s)", len(changelog) - 1)
+        else:
+            logger.debug("Dream Phase 2: no durable Memory Notes created")
 
         # Advance cursor — always, to avoid re-processing Phase 1
         new_cursor = batch[-1]["cursor"]
         self.store.set_last_dream_cursor(new_cursor)
         self.store.compact_history()
 
-        if result and result.stop_reason == "completed":
+        if changelog:
             logger.info(
                 "Dream done: {} change(s), cursor advanced to {}",
                 len(changelog), new_cursor,
             )
         else:
-            reason = result.stop_reason if result else "exception"
-            logger.warning(
-                "Dream incomplete ({}): cursor advanced to {}",
-                reason, new_cursor,
-            )
+            logger.info("Dream done: no durable memory, cursor advanced to {}", new_cursor)
 
         # Git auto-commit (only when there are actual changes)
         if changelog and self.store.git.is_initialized():
@@ -1192,8 +1158,191 @@ class Dream:
 
         return True
 
+    def _format_current_notes(self) -> str:
+        lines: list[str] = []
+        for note in sorted(
+            self.store.read_notes(),
+            key=lambda item: (item.status.value, item.type.value, item.content.casefold()),
+        ):
+            lines.append(
+                f"- id={note.id} status={note.status.value} type={note.type.value} "
+                f"priority={note.priority:g} confidence={note.confidence:g}: {note.content}"
+            )
+        return "\n".join(lines)
+
+    def _apply_memory_note_analysis(
+        self,
+        analysis: str,
+        source: MemorySource,
+    ) -> list[str]:
+        changes: list[str] = []
+        for operation in self._parse_memory_note_operations(analysis, source):
+            action = operation["action"]
+            note_id = operation.get("note_id") or ""
+            content = operation.get("content") or ""
+            if action == "skip":
+                continue
+            if action == "reject":
+                if note_id:
+                    self.store.reject_note(note_id)
+                    changes.append(f"reject_note:{note_id}")
+                continue
+            if not content:
+                continue
+            note = MemoryNote.create(
+                content,
+                operation["type"],
+                [source],
+                priority=operation["priority"],
+                confidence=operation["confidence"],
+                tags=operation["tags"],
+            )
+            source_file = operation.get("source_file")
+            if source_file:
+                note.sources[0].source_file = source_file
+            if action == "supersede" and note_id:
+                replacement = self.store.supersede_note(note_id, note)
+                changes.append(f"supersede_note:{note_id}->{replacement.id}")
+                continue
+            existing = self._find_active_note_by_type_and_content(note.type, note.content)
+            if existing is not None:
+                existing.sources = self._merge_note_sources(existing.sources, note.sources)
+                existing.priority = max(existing.priority, note.priority)
+                existing.confidence = max(existing.confidence, note.confidence)
+                existing.tags = sorted(set(existing.tags + note.tags))
+                stored = self.store.upsert_note(existing)
+                changes.append(f"merge_note:{stored.id}")
+            else:
+                stored = self.store.upsert_note(note)
+                changes.append(f"save_note:{stored.id}")
+        return changes
+
+    def _parse_memory_note_operations(
+        self,
+        analysis: str,
+        source: MemorySource,
+    ) -> list[dict[str, Any]]:
+        operations: list[dict[str, Any]] = []
+        for raw_line in analysis.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            parsed = self._parse_memory_note_operation(line, source)
+            if parsed is not None:
+                operations.append(parsed)
+        return operations
+
+    def _parse_memory_note_operation(
+        self,
+        line: str,
+        source: MemorySource,
+    ) -> dict[str, Any] | None:
+        del source
+        match = self._NOTE_LINE_RE.match(line)
+        if not match:
+            return None
+        header = match.group("header").strip()
+        content = match.group("content").strip()
+        if header.upper().startswith("SKIP"):
+            return {"action": "skip"}
+
+        parts = [part.strip() for part in header.split(":") if part.strip()]
+        if not parts:
+            return None
+        action = parts[0].casefold()
+        if action in {"memory", "user", "soul"}:
+            target = parts[0].upper()
+            source_file, note_type = self._NOTE_TARGETS[target]
+            return self._build_note_operation("save", content, note_type, source_file)
+        if action in {"save", "note"}:
+            target = parts[1].upper() if len(parts) >= 2 else "MEMORY"
+            source_file, note_type = self._resolve_note_target(target)
+            return self._build_note_operation("save", content, note_type, source_file)
+        if action == "supersede":
+            note_id = parts[1] if len(parts) >= 2 else ""
+            target = parts[2].upper() if len(parts) >= 3 else "MEMORY"
+            source_file, note_type = self._resolve_note_target(target)
+            return self._build_note_operation(
+                "supersede", content, note_type, source_file, note_id=note_id
+            )
+        if action == "reject":
+            note_id = parts[1] if len(parts) >= 2 else ""
+            return {
+                "action": "reject",
+                "note_id": note_id,
+                "content": content,
+                "type": MemoryNoteType.PROJECT,
+                "source_file": None,
+                "priority": 0.5,
+                "confidence": 0.5,
+                "tags": ["dream"],
+            }
+        return None
+
+    def _build_note_operation(
+        self,
+        action: str,
+        content: str,
+        note_type: MemoryNoteType,
+        source_file: str,
+        *,
+        note_id: str = "",
+    ) -> dict[str, Any]:
+        tags = ["dream"]
+        if source_file == "memory/MEMORY.md":
+            tags.append("project-memory")
+        elif source_file == "USER.md":
+            tags.append("user-memory")
+        elif source_file == "SOUL.md":
+            tags.append("assistant-memory")
+        return {
+            "action": action,
+            "note_id": note_id,
+            "content": content,
+            "type": note_type,
+            "source_file": source_file,
+            "priority": 0.6,
+            "confidence": 0.65,
+            "tags": tags,
+        }
+
+    def _resolve_note_target(self, target: str) -> tuple[str, MemoryNoteType]:
+        if target in self._NOTE_TARGETS:
+            return self._NOTE_TARGETS[target]
+        return "memory/MEMORY.md", _coerce_enum(MemoryNoteType, target.casefold(), MemoryNoteType.PROJECT)
+
+    def _find_active_note_by_type_and_content(
+        self,
+        note_type: MemoryNoteType,
+        content: str,
+    ) -> MemoryNote | None:
+        normalized = _normalize_note_text(content)
+        for note in self.store.read_notes():
+            if (
+                note.status == MemoryNoteStatus.ACTIVE
+                and note.type == note_type
+                and _normalize_note_text(note.content) == normalized
+            ):
+                return note
+        return None
+
+    @staticmethod
+    def _merge_note_sources(
+        existing: list[MemorySource],
+        new_sources: list[MemorySource],
+    ) -> list[MemorySource]:
+        merged: list[MemorySource] = []
+        seen: set[tuple[Any, ...]] = set()
+        for source in existing + new_sources:
+            identity = source.identity()
+            if identity in seen:
+                continue
+            seen.add(identity)
+            merged.append(source)
+        return merged
+
     async def _process_experiences(self) -> None:
-        """Phase 3: Merge, decay, prune experiences, and update MEMORY.md."""
+        """Phase 3: keep Experience processing separate from Memory Notes."""
         if self.experience_store is None:
             return
 

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -64,6 +64,15 @@ def _normalize_note_text(text: str) -> str:
     return " ".join(text.strip().casefold().split())
 
 
+def _memory_recall_terms(text: str) -> set[str]:
+    normalized = _normalize_note_text(text)
+    return {
+        term
+        for term in re.findall(r"[\w-]+", normalized, flags=re.UNICODE)
+        if len(term) >= 3
+    }
+
+
 def _coerce_enum(enum_type: type[StrEnum], value: Any, default: StrEnum) -> StrEnum:
     try:
         return enum_type(str(value))
@@ -625,6 +634,98 @@ class MemoryStore:
     def get_memory_context(self) -> str:
         long_term = self.read_memory()
         return f"## Long-term Memory\n{long_term}" if long_term else ""
+
+    def select_memory_recall(
+        self,
+        query: str,
+        *,
+        max_notes: int = 6,
+        max_chars: int = 1_600,
+        high_priority_threshold: float = 0.75,
+    ) -> list[MemoryNote]:
+        """Select active Memory Notes for bounded prompt recall.
+
+        Recall is intentionally lexical and file-backed here. JSONL remains the
+        canonical memory source; optional vector indexes can build on this later.
+        """
+        if max_notes <= 0 or max_chars <= 0:
+            return []
+
+        query_terms = _memory_recall_terms(query)
+        candidates: list[tuple[tuple[float, float, float, str, str], MemoryNote]] = []
+        for note in self.read_notes():
+            if note.status != MemoryNoteStatus.ACTIVE or not note.content:
+                continue
+            note_terms = _memory_recall_terms(
+                " ".join([note.content, note.type.value, " ".join(note.tags)])
+            )
+            overlap = len(query_terms & note_terms)
+            relevance = overlap / max(len(query_terms), 1) if query_terms else 0.0
+            if overlap == 0 and note.priority < high_priority_threshold:
+                continue
+            score = (
+                relevance,
+                note.priority,
+                note.confidence,
+                note.type.value,
+                note.content.casefold(),
+            )
+            candidates.append((score, note))
+
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        selected: list[MemoryNote] = []
+        used_chars = 0
+        for _, note in candidates:
+            line = self._format_memory_recall_note(note)
+            line_cost = len(line) + 1
+            if selected and used_chars + line_cost > max_chars:
+                continue
+            if not selected and line_cost > max_chars:
+                continue
+            selected.append(note)
+            used_chars += line_cost
+            if len(selected) >= max_notes:
+                break
+        return selected
+
+    def format_memory_recall_context(
+        self,
+        query: str,
+        *,
+        max_notes: int = 6,
+        max_chars: int = 1_600,
+    ) -> str:
+        notes = self.select_memory_recall(
+            query,
+            max_notes=max_notes,
+            max_chars=max_chars,
+        )
+        if not notes:
+            return ""
+
+        lines = [
+            "---",
+            "[MEMORY RECALL]",
+            "",
+            "Active Memory Notes selected for this request. Keep this separate from Experience and Knowledge Base context.",
+            "",
+        ]
+        for note in notes:
+            lines.append(self._format_memory_recall_note(note))
+        lines.append("---")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_memory_recall_note(note: MemoryNote) -> str:
+        metadata = [
+            f"id: {note.id}",
+            f"type: {note.type.value}",
+            f"priority: {note.priority:g}",
+            f"confidence: {note.confidence:g}",
+        ]
+        if note.tags:
+            metadata.append("tags: " + ", ".join(sorted(note.tags)))
+        return f"- {note.content} ({'; '.join(metadata)})"
 
     # -- history.jsonl — append-only, JSONL format ---------------------------
 

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -8,7 +8,9 @@ import json
 import re
 import weakref
 
+from dataclasses import dataclass, field
 from datetime import datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
@@ -32,6 +34,266 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
+# Memory Notes - canonical structured Agent Memory records
+# ---------------------------------------------------------------------------
+
+class MemoryNoteType(StrEnum):
+    PREFERENCE = "preference"
+    INSTRUCTION = "instruction"
+    PROJECT = "project"
+    DECISION = "decision"
+    FIX = "fix"
+    FOLLOWUP = "followup"
+
+
+class MemoryNoteStatus(StrEnum):
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    REJECTED = "rejected"
+
+
+class MemoryCaptureOrigin(StrEnum):
+    DREAM = "dream"
+    EXPLICIT = "explicit"
+    MIGRATION = "migration"
+
+
+def _utc_timestamp() -> str:
+    return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _normalize_note_text(text: str) -> str:
+    return " ".join(text.strip().casefold().split())
+
+
+def _coerce_enum(enum_type: type[StrEnum], value: Any, default: StrEnum) -> StrEnum:
+    try:
+        return enum_type(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass(slots=True)
+class MemorySource:
+    capture_origin: MemoryCaptureOrigin
+    captured_at: str = field(default_factory=_utc_timestamp)
+    session_key: str | None = None
+    message_start: int | None = None
+    message_end: int | None = None
+    history_start_cursor: int | None = None
+    history_end_cursor: int | None = None
+    source_file: str | None = None
+
+    @classmethod
+    def dream(
+        cls,
+        *,
+        history_start_cursor: int | None = None,
+        history_end_cursor: int | None = None,
+    ) -> MemorySource:
+        return cls(
+            capture_origin=MemoryCaptureOrigin.DREAM,
+            history_start_cursor=history_start_cursor,
+            history_end_cursor=history_end_cursor,
+        )
+
+    @classmethod
+    def explicit(
+        cls,
+        *,
+        session_key: str | None = None,
+        message_start: int | None = None,
+        message_end: int | None = None,
+    ) -> MemorySource:
+        return cls(
+            capture_origin=MemoryCaptureOrigin.EXPLICIT,
+            session_key=session_key,
+            message_start=message_start,
+            message_end=message_end,
+        )
+
+    @classmethod
+    def migration(cls, source_file: str) -> MemorySource:
+        return cls(
+            capture_origin=MemoryCaptureOrigin.MIGRATION,
+            source_file=source_file,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> MemorySource:
+        raw = data or {}
+        return cls(
+            capture_origin=_coerce_enum(
+                MemoryCaptureOrigin,
+                raw.get("capture_origin") or raw.get("origin"),
+                MemoryCaptureOrigin.EXPLICIT,
+            ),
+            captured_at=str(raw.get("captured_at") or raw.get("created_at") or _utc_timestamp()),
+            session_key=str(raw["session_key"]) if raw.get("session_key") else None,
+            message_start=_coerce_int(raw.get("message_start")),
+            message_end=_coerce_int(raw.get("message_end")),
+            history_start_cursor=_coerce_int(raw.get("history_start_cursor")),
+            history_end_cursor=_coerce_int(raw.get("history_end_cursor")),
+            source_file=str(raw["source_file"]) if raw.get("source_file") else None,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "capture_origin": self.capture_origin.value,
+            "captured_at": self.captured_at,
+        }
+        for key in (
+            "session_key",
+            "message_start",
+            "message_end",
+            "history_start_cursor",
+            "history_end_cursor",
+            "source_file",
+        ):
+            value = getattr(self, key)
+            if value is not None:
+                data[key] = value
+        return data
+
+    def identity(self) -> tuple[Any, ...]:
+        return (
+            self.capture_origin.value,
+            self.session_key,
+            self.message_start,
+            self.message_end,
+            self.history_start_cursor,
+            self.history_end_cursor,
+            self.source_file,
+        )
+
+
+@dataclass(slots=True)
+class MemoryNote:
+    content: str
+    type: MemoryNoteType
+    sources: list[MemorySource]
+    id: str = ""
+    status: MemoryNoteStatus = MemoryNoteStatus.ACTIVE
+    priority: float = 0.5
+    confidence: float = 0.5
+    created_at: str = field(default_factory=_utc_timestamp)
+    updated_at: str = field(default_factory=_utc_timestamp)
+    supersedes: list[str] = field(default_factory=list)
+    superseded_by: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.content = self.content.strip()
+        self.sources = [source for source in self.sources if isinstance(source, MemorySource)]
+        if not self.id:
+            self.id = generate_memory_note_id(self.type, self.content, self.sources)
+
+    @classmethod
+    def create(
+        cls,
+        content: str,
+        note_type: MemoryNoteType | str,
+        sources: list[MemorySource] | None = None,
+        *,
+        priority: float = 0.5,
+        confidence: float = 0.5,
+        tags: list[str] | None = None,
+    ) -> MemoryNote:
+        return cls(
+            content=content,
+            type=_coerce_enum(MemoryNoteType, note_type, MemoryNoteType.PROJECT),
+            sources=sources or [],
+            priority=priority,
+            confidence=confidence,
+            tags=list(tags or []),
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryNote:
+        note_type = _coerce_enum(MemoryNoteType, data.get("type"), MemoryNoteType.PROJECT)
+        content = str(data.get("content") or "")
+        raw_sources = data.get("sources")
+        if isinstance(raw_sources, list):
+            sources = [MemorySource.from_dict(item) for item in raw_sources if isinstance(item, dict)]
+        else:
+            sources = []
+        return cls(
+            id=str(data.get("id") or generate_memory_note_id(note_type, content, sources)),
+            type=note_type,
+            status=_coerce_enum(MemoryNoteStatus, data.get("status"), MemoryNoteStatus.ACTIVE),
+            content=content,
+            priority=_coerce_float(data.get("priority"), 0.5),
+            confidence=_coerce_float(data.get("confidence"), 0.5),
+            sources=sources,
+            created_at=str(data.get("created_at") or _utc_timestamp()),
+            updated_at=str(data.get("updated_at") or data.get("created_at") or _utc_timestamp()),
+            supersedes=[str(item) for item in data.get("supersedes") or []],
+            superseded_by=str(data["superseded_by"]) if data.get("superseded_by") else None,
+            tags=[str(item) for item in data.get("tags") or []],
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "id": self.id,
+            "type": self.type.value,
+            "status": self.status.value,
+            "content": self.content,
+            "priority": self.priority,
+            "confidence": self.confidence,
+            "sources": [source.to_dict() for source in self.sources],
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+        if self.supersedes:
+            data["supersedes"] = list(self.supersedes)
+        if self.superseded_by:
+            data["superseded_by"] = self.superseded_by
+        if self.tags:
+            data["tags"] = list(self.tags)
+        return data
+
+    def equivalent_key(self) -> tuple[Any, ...]:
+        return memory_note_equivalent_key(self.type, self.content, self.sources)
+
+
+def memory_note_equivalent_key(
+    note_type: MemoryNoteType | str,
+    content: str,
+    sources: list[MemorySource] | None = None,
+) -> tuple[Any, ...]:
+    coerced_type = _coerce_enum(MemoryNoteType, note_type, MemoryNoteType.PROJECT)
+    source_keys = sorted((source.identity() for source in (sources or [])), key=repr)
+    return (coerced_type.value, _normalize_note_text(content), tuple(source_keys))
+
+
+def generate_memory_note_id(
+    note_type: MemoryNoteType | str,
+    content: str,
+    sources: list[MemorySource] | None = None,
+) -> str:
+    payload = json.dumps(
+        memory_note_equivalent_key(note_type, content, sources),
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return "note_" + hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
 # MemoryStore — pure file I/O layer
 # ---------------------------------------------------------------------------
 
@@ -45,6 +307,7 @@ class MemoryStore:
         self.max_history_entries = max_history_entries
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
+        self.notes_file = self.memory_dir / "notes.jsonl"
         self.history_file = self.memory_dir / "history.jsonl"
         self.legacy_history_file = self.memory_dir / "HISTORY.md"
         self.soul_file = workspace / "SOUL.md"
@@ -52,7 +315,7 @@ class MemoryStore:
         self._cursor_file = self.memory_dir / ".cursor"
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
         self._git = GitStore(workspace, tracked_files=[
-            "SOUL.md", "USER.md", "memory/MEMORY.md",
+            "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/notes.jsonl",
         ])
         # One-time migration from legacy HISTORY.md format
         migrate_legacy_history(self.memory_dir)
@@ -69,6 +332,176 @@ class MemoryStore:
             return path.read_text(encoding="utf-8")
         except FileNotFoundError:
             return ""
+
+    # -- notes.jsonl (canonical Memory Notes) -------------------------------
+
+    def read_notes(self) -> list[MemoryNote]:
+        """Read all Memory Notes, skipping malformed JSONL rows."""
+        notes: list[MemoryNote] = []
+        try:
+            with open(self.notes_file, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        raw = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(raw, dict):
+                        notes.append(MemoryNote.from_dict(raw))
+        except FileNotFoundError:
+            pass
+        return notes
+
+    def write_notes(self, notes: list[MemoryNote]) -> None:
+        with open(self.notes_file, "w", encoding="utf-8") as f:
+            for note in notes:
+                f.write(json.dumps(note.to_dict(), ensure_ascii=False) + "\n")
+
+    def find_duplicate_note(self, candidate: MemoryNote) -> MemoryNote | None:
+        candidate_key = candidate.equivalent_key()
+        for note in self.read_notes():
+            if note.equivalent_key() == candidate_key:
+                return note
+        return None
+
+    def upsert_note(self, note: MemoryNote) -> MemoryNote:
+        """Insert or replace a Memory Note by id or equivalent content/source."""
+        notes = self.read_notes()
+        replacement = note
+        replacement.updated_at = _utc_timestamp()
+        for idx, existing in enumerate(notes):
+            if existing.id == note.id or existing.equivalent_key() == note.equivalent_key():
+                if existing.id != note.id:
+                    replacement.id = existing.id
+                    replacement.created_at = existing.created_at
+                notes[idx] = replacement
+                self.write_notes(notes)
+                return replacement
+        notes.append(replacement)
+        self.write_notes(notes)
+        return replacement
+
+    def get_note(self, note_id: str) -> MemoryNote | None:
+        for note in self.read_notes():
+            if note.id == note_id:
+                return note
+        return None
+
+    def set_note_status(self, note_id: str, status: MemoryNoteStatus | str) -> MemoryNote:
+        notes = self.read_notes()
+        new_status = _coerce_enum(MemoryNoteStatus, status, MemoryNoteStatus.ACTIVE)
+        for note in notes:
+            if note.id == note_id:
+                note.status = new_status
+                note.updated_at = _utc_timestamp()
+                self.write_notes(notes)
+                return note
+        raise KeyError(f"Memory Note not found: {note_id}")
+
+    def reject_note(self, note_id: str) -> MemoryNote:
+        return self.set_note_status(note_id, MemoryNoteStatus.REJECTED)
+
+    def supersede_note(self, note_id: str, replacement: MemoryNote) -> MemoryNote:
+        """Mark an existing note superseded and link it to a replacement note."""
+        notes = self.read_notes()
+        old_note: MemoryNote | None = None
+        for note in notes:
+            if note.id == note_id:
+                old_note = note
+                break
+        if old_note is None:
+            raise KeyError(f"Memory Note not found: {note_id}")
+
+        replacement.status = MemoryNoteStatus.ACTIVE
+        if note_id not in replacement.supersedes:
+            replacement.supersedes.append(note_id)
+        replacement = self.upsert_note(replacement)
+
+        notes = self.read_notes()
+        for note in notes:
+            if note.id == note_id:
+                note.status = MemoryNoteStatus.SUPERSEDED
+                note.superseded_by = replacement.id
+                note.updated_at = _utc_timestamp()
+                self.write_notes(notes)
+                return replacement
+        raise KeyError(f"Memory Note not found after replacement insert: {note_id}")
+
+    def migrate_legacy_memory_notes(self) -> list[MemoryNote]:
+        """Create conservative Memory Notes from existing Markdown memory views.
+
+        The original Markdown files are read-only inputs here. Re-running this
+        method is idempotent because note ids include normalized content and
+        source identity.
+        """
+        migrated: list[MemoryNote] = []
+        for source_file, path, note_type in (
+            ("memory/MEMORY.md", self.memory_file, MemoryNoteType.PROJECT),
+            ("USER.md", self.user_file, MemoryNoteType.PREFERENCE),
+            ("SOUL.md", self.soul_file, MemoryNoteType.INSTRUCTION),
+        ):
+            content = self.read_file(path)
+            if not content.strip():
+                continue
+            source = MemorySource.migration(source_file)
+            for item in self._parse_legacy_memory_markdown(content):
+                note = MemoryNote.create(
+                    item,
+                    note_type,
+                    [source],
+                    priority=0.4,
+                    confidence=0.45,
+                    tags=["legacy-migration"],
+                )
+                migrated.append(self.upsert_note(note))
+        return migrated
+
+    @staticmethod
+    def _parse_legacy_memory_markdown(content: str) -> list[str]:
+        items: list[str] = []
+        in_fence = False
+        paragraph: list[str] = []
+
+        def flush_paragraph() -> None:
+            if paragraph:
+                text = " ".join(paragraph).strip()
+                if text:
+                    items.append(text)
+                paragraph.clear()
+
+        for raw_line in content.splitlines():
+            line = raw_line.strip()
+            if line.startswith("```"):
+                in_fence = not in_fence
+                flush_paragraph()
+                continue
+            if in_fence:
+                continue
+            if not line:
+                flush_paragraph()
+                continue
+            if line.startswith("#"):
+                flush_paragraph()
+                continue
+            bullet = re.match(r"^(?:[-*+]|\d+[.)])\s+(?P<text>.+)$", line)
+            if bullet:
+                flush_paragraph()
+                items.append(bullet.group("text").strip())
+                continue
+            paragraph.append(line)
+
+        flush_paragraph()
+        seen: set[str] = set()
+        unique: list[str] = []
+        for item in items:
+            normalized = _normalize_note_text(item)
+            if len(normalized) < 3 or normalized in seen:
+                continue
+            seen.add(normalized)
+            unique.append(item)
+        return unique
 
     # -- MEMORY.md (long-term facts) -----------------------------------------
 

--- a/tinybot/agent/tools/memory.py
+++ b/tinybot/agent/tools/memory.py
@@ -10,6 +10,7 @@ from tinybot.agent.tools.schema import IntegerSchema, NumberSchema, StringSchema
 
 if TYPE_CHECKING:
     from tinybot.agent.memory import MemoryStore
+    from tinybot.agent.vector_store import VectorStore
 
 
 _NOTE_TYPES = ["preference", "instruction", "project", "decision", "fix", "followup"]
@@ -71,9 +72,15 @@ def _explicit_source(session_key: str, message_start: int | None, message_end: i
 class SaveMemoryNoteTool(Tool):
     """Save a durable Agent Memory Note explicitly."""
 
-    def __init__(self, memory_store: MemoryStore, session_key: str = ""):
+    def __init__(
+        self,
+        memory_store: MemoryStore,
+        session_key: str = "",
+        vector_store: VectorStore | None = None,
+    ):
         self._store = memory_store
         self._session_key = session_key
+        self._vector_store = vector_store
 
     @property
     def name(self) -> str:
@@ -106,6 +113,7 @@ class SaveMemoryNoteTool(Tool):
                 tags=tags,
             )
             self._store.refresh_memory_views()
+            self._store.rebuild_memory_note_index(self._vector_store)
             return f"Memory Note saved: {note.id} ({note.type.value}, {note.status.value})"
         except ValueError as exc:
             return f"Error: {exc}"
@@ -122,8 +130,9 @@ class SaveMemoryNoteTool(Tool):
 class SearchMemoryNotesTool(Tool):
     """Search canonical Agent Memory Notes."""
 
-    def __init__(self, memory_store: MemoryStore):
+    def __init__(self, memory_store: MemoryStore, vector_store: VectorStore | None = None):
         self._store = memory_store
+        self._vector_store = vector_store
 
     @property
     def name(self) -> str:
@@ -150,6 +159,7 @@ class SearchMemoryNotesTool(Tool):
                 note_type=note_type or None,
                 status=status or None,
                 limit=limit,
+                vector_store=self._vector_store,
             )
         except ValueError as exc:
             return f"Error: {exc}"
@@ -219,8 +229,9 @@ class TraceMemoryNoteTool(Tool):
 class RejectMemoryNoteTool(Tool):
     """Reject an outdated or incorrect Memory Note."""
 
-    def __init__(self, memory_store: MemoryStore):
+    def __init__(self, memory_store: MemoryStore, vector_store: VectorStore | None = None):
         self._store = memory_store
+        self._vector_store = vector_store
 
     @property
     def name(self) -> str:
@@ -234,6 +245,7 @@ class RejectMemoryNoteTool(Tool):
         try:
             note = self._store.reject_memory_note(note_id)
             self._store.refresh_memory_views()
+            self._store.rebuild_memory_note_index(self._vector_store)
         except KeyError:
             return f"Error: Memory Note '{note_id}' not found"
         suffix = f" Reason: {reason.strip()}" if reason.strip() else ""
@@ -256,9 +268,15 @@ class RejectMemoryNoteTool(Tool):
 class SupersedeMemoryNoteTool(Tool):
     """Supersede one Memory Note with a replacement note."""
 
-    def __init__(self, memory_store: MemoryStore, session_key: str = ""):
+    def __init__(
+        self,
+        memory_store: MemoryStore,
+        session_key: str = "",
+        vector_store: VectorStore | None = None,
+    ):
         self._store = memory_store
         self._session_key = session_key
+        self._vector_store = vector_store
 
     @property
     def name(self) -> str:
@@ -290,6 +308,7 @@ class SupersedeMemoryNoteTool(Tool):
                 tags=tags if tags else None,
             )
             self._store.refresh_memory_views()
+            self._store.rebuild_memory_note_index(self._vector_store)
         except KeyError:
             return f"Error: Memory Note '{note_id}' not found"
         except ValueError as exc:

--- a/tinybot/agent/tools/memory.py
+++ b/tinybot/agent/tools/memory.py
@@ -1,0 +1,297 @@
+"""Agent Memory Note tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tinybot.agent.memory import MemoryNote, MemorySource
+from tinybot.agent.tools.base import Tool, tool_parameters
+from tinybot.agent.tools.schema import IntegerSchema, NumberSchema, StringSchema, tool_parameters_schema
+
+if TYPE_CHECKING:
+    from tinybot.agent.memory import MemoryStore
+
+
+_NOTE_TYPES = ["preference", "instruction", "project", "decision", "fix", "followup"]
+_NOTE_STATUSES = ["active", "superseded", "rejected"]
+
+
+def _format_source(source: MemorySource) -> str:
+    fields = [source.capture_origin.value]
+    if source.session_key:
+        fields.append(f"session={source.session_key}")
+    if source.source_file:
+        fields.append(f"file={source.source_file}")
+    if source.history_start_cursor is not None or source.history_end_cursor is not None:
+        fields.append(f"history={source.history_start_cursor}-{source.history_end_cursor}")
+    if source.message_start is not None or source.message_end is not None:
+        fields.append(f"messages={source.message_start}-{source.message_end}")
+    return " ".join(fields)
+
+
+def _source_summary(note: MemoryNote) -> str:
+    if not note.sources:
+        return "none"
+    parts: list[str] = []
+    for source in note.sources:
+        parts.append(_format_source(source))
+    return "; ".join(parts)
+
+
+def _format_note_summary(note: MemoryNote) -> str:
+    tags = f" tags={','.join(note.tags)}" if note.tags else ""
+    return (
+        f"- [{note.id}] {note.type.value}/{note.status.value} "
+        f"priority={note.priority:g} confidence={note.confidence:g}{tags}\n"
+        f"  {note.content}\n"
+        f"  sources: {_source_summary(note)}"
+    )
+
+
+def _explicit_source(session_key: str, message_start: int | None, message_end: int | None) -> MemorySource:
+    return MemorySource.explicit(
+        session_key=session_key or None,
+        message_start=message_start,
+        message_end=message_end,
+    )
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        content=StringSchema("Durable Memory Note content to save.", min_length=1),
+        note_type=StringSchema("Memory Note type.", enum=_NOTE_TYPES),
+        priority=NumberSchema(0.5, description="Importance from 0 to 1.", minimum=0, maximum=1),
+        confidence=NumberSchema(0.5, description="Confidence from 0 to 1.", minimum=0, maximum=1),
+        tags=StringSchema("Optional comma-separated tags."),
+        message_start=IntegerSchema(0, description="Optional source message start index.", minimum=0),
+        message_end=IntegerSchema(0, description="Optional source message end index.", minimum=0),
+        required=["content", "note_type"],
+    )
+)
+class SaveMemoryNoteTool(Tool):
+    """Save a durable Agent Memory Note explicitly."""
+
+    def __init__(self, memory_store: MemoryStore, session_key: str = ""):
+        self._store = memory_store
+        self._session_key = session_key
+
+    @property
+    def name(self) -> str:
+        return "save_memory_note"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Save durable agent-side memory as a typed Memory Note. "
+            "Use this only for durable preferences, instructions, project facts, decisions, fixes, or followups."
+        )
+
+    async def execute(
+        self,
+        content: str,
+        note_type: str,
+        priority: float = 0.5,
+        confidence: float = 0.5,
+        tags: str = "",
+        message_start: int | None = None,
+        message_end: int | None = None,
+    ) -> str:
+        try:
+            note = self._store.save_memory_note(
+                content=content,
+                note_type=note_type,
+                source=_explicit_source(self._session_key, message_start, message_end),
+                priority=priority,
+                confidence=confidence,
+                tags=tags,
+            )
+            self._store.refresh_memory_views()
+            return f"Memory Note saved: {note.id} ({note.type.value}, {note.status.value})"
+        except ValueError as exc:
+            return f"Error: {exc}"
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        query=StringSchema("Optional lexical query over content, id, tags, type, status, and source summary."),
+        note_type=StringSchema("Optional Memory Note type filter.", enum=_NOTE_TYPES),
+        status=StringSchema("Optional Memory Note status filter.", enum=_NOTE_STATUSES),
+        limit=IntegerSchema(10, description="Maximum notes to return.", minimum=1, maximum=50),
+    )
+)
+class SearchMemoryNotesTool(Tool):
+    """Search canonical Agent Memory Notes."""
+
+    def __init__(self, memory_store: MemoryStore):
+        self._store = memory_store
+
+    @property
+    def name(self) -> str:
+        return "search_memory_notes"
+
+    @property
+    def description(self) -> str:
+        return "Search Memory Notes by query, type, status, and limit without mixing in Experience or Knowledge Base."
+
+    @property
+    def read_only(self) -> bool:
+        return True
+
+    async def execute(
+        self,
+        query: str = "",
+        note_type: str = "",
+        status: str = "",
+        limit: int = 10,
+    ) -> str:
+        try:
+            notes = self._store.search_memory_notes(
+                query=query or "",
+                note_type=note_type or None,
+                status=status or None,
+                limit=limit,
+            )
+        except ValueError as exc:
+            return f"Error: {exc}"
+        if not notes:
+            return "No Memory Notes found."
+        return "## Memory Notes\n" + "\n".join(_format_note_summary(note) for note in notes)
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        note_id=StringSchema("Memory Note id to trace.", min_length=1),
+        required=["note_id"],
+    )
+)
+class TraceMemoryNoteTool(Tool):
+    """Trace one Memory Note and its sources."""
+
+    def __init__(self, memory_store: MemoryStore):
+        self._store = memory_store
+
+    @property
+    def name(self) -> str:
+        return "trace_memory_note"
+
+    @property
+    def description(self) -> str:
+        return "Return one Memory Note with its source trace-back fields."
+
+    @property
+    def read_only(self) -> bool:
+        return True
+
+    async def execute(self, note_id: str) -> str:
+        try:
+            note = self._store.trace_memory_note(note_id)
+        except KeyError:
+            return f"Error: Memory Note '{note_id}' not found"
+        lines = [
+            f"## Memory Note {note.id}",
+            "",
+            f"Type: {note.type.value}",
+            f"Status: {note.status.value}",
+            f"Priority: {note.priority:g}",
+            f"Confidence: {note.confidence:g}",
+            f"Created: {note.created_at}",
+            f"Updated: {note.updated_at}",
+        ]
+        if note.tags:
+            lines.append("Tags: " + ", ".join(note.tags))
+        if note.supersedes:
+            lines.append("Supersedes: " + ", ".join(note.supersedes))
+        if note.superseded_by:
+            lines.append(f"Superseded by: {note.superseded_by}")
+        lines.extend(["", note.content, "", "Sources:"])
+        for source in note.sources:
+            lines.append(f"- {_format_source(source)}")
+        return "\n".join(lines)
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        note_id=StringSchema("Memory Note id to reject.", min_length=1),
+        reason=StringSchema("Optional reason for rejection."),
+        required=["note_id"],
+    )
+)
+class RejectMemoryNoteTool(Tool):
+    """Reject an outdated or incorrect Memory Note."""
+
+    def __init__(self, memory_store: MemoryStore):
+        self._store = memory_store
+
+    @property
+    def name(self) -> str:
+        return "reject_memory_note"
+
+    @property
+    def description(self) -> str:
+        return "Mark a Memory Note as rejected so default recall and Memory Views exclude it."
+
+    async def execute(self, note_id: str, reason: str = "") -> str:
+        try:
+            note = self._store.reject_memory_note(note_id)
+            self._store.refresh_memory_views()
+        except KeyError:
+            return f"Error: Memory Note '{note_id}' not found"
+        suffix = f" Reason: {reason.strip()}" if reason.strip() else ""
+        return f"Memory Note rejected: {note.id}.{suffix}"
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        note_id=StringSchema("Existing Memory Note id to supersede.", min_length=1),
+        replacement_content=StringSchema("Replacement durable Memory Note content.", min_length=1),
+        note_type=StringSchema("Optional replacement Memory Note type. Defaults to the old note type.", enum=_NOTE_TYPES),
+        priority=NumberSchema(0.5, description="Optional replacement priority from 0 to 1.", minimum=0, maximum=1),
+        confidence=NumberSchema(0.5, description="Optional replacement confidence from 0 to 1.", minimum=0, maximum=1),
+        tags=StringSchema("Optional comma-separated replacement tags. Defaults to the old note tags."),
+        message_start=IntegerSchema(0, description="Optional source message start index.", minimum=0),
+        message_end=IntegerSchema(0, description="Optional source message end index.", minimum=0),
+        required=["note_id", "replacement_content"],
+    )
+)
+class SupersedeMemoryNoteTool(Tool):
+    """Supersede one Memory Note with a replacement note."""
+
+    def __init__(self, memory_store: MemoryStore, session_key: str = ""):
+        self._store = memory_store
+        self._session_key = session_key
+
+    @property
+    def name(self) -> str:
+        return "supersede_memory_note"
+
+    @property
+    def description(self) -> str:
+        return "Create a replacement Memory Note and mark the old note superseded."
+
+    async def execute(
+        self,
+        note_id: str,
+        replacement_content: str,
+        note_type: str = "",
+        priority: float | None = None,
+        confidence: float | None = None,
+        tags: str = "",
+        message_start: int | None = None,
+        message_end: int | None = None,
+    ) -> str:
+        try:
+            note = self._store.supersede_memory_note(
+                note_id,
+                replacement_content=replacement_content,
+                note_type=note_type or None,
+                source=_explicit_source(self._session_key, message_start, message_end),
+                priority=priority,
+                confidence=confidence,
+                tags=tags if tags else None,
+            )
+            self._store.refresh_memory_views()
+        except KeyError:
+            return f"Error: Memory Note '{note_id}' not found"
+        except ValueError as exc:
+            return f"Error: {exc}"
+        return f"Memory Note superseded: {note_id} -> {note.id}"

--- a/tinybot/cowork/snapshot.py
+++ b/tinybot/cowork/snapshot.py
@@ -18,7 +18,9 @@ def _compact(value: Any, limit: int = 180) -> str:
     text = " ".join(str(value or "").split())
     if len(text) <= limit:
         return text
-    return text[: max(0, limit - 1)].rstrip() + "..."
+    if limit <= 3:
+        return text[:limit]
+    return text[: max(0, limit - 3)].rstrip() + "..."
 
 
 def _status_tone(status: str) -> str:
@@ -485,7 +487,7 @@ def _session_artifacts(session: CoworkSession) -> list[dict[str, Any]]:
             seen.add(key)
             artifacts.append(
                 {
-                    "id": f"artifact:{hashlib.sha1(f'{task.id}:{value}'.encode('utf-8')).hexdigest()[:12]}",
+                    "id": f"artifact:{hashlib.sha1(f'{task.id}:{value}'.encode()).hexdigest()[:12]}",
                     "value": value,
                     "kind": _artifact_kind(value),
                     "source_task_id": task.id,
@@ -889,7 +891,7 @@ def build_cowork_task_dag(session: CoworkSession) -> dict[str, Any]:
                 )
             _add_edge(edges, agent_node_id, f"task:{task.id}", "owns")
         for artifact in _task_artifacts(task):
-            artifact_id = f"artifact:{hashlib.sha1(f'{task.id}:{artifact}'.encode('utf-8')).hexdigest()[:12]}"
+            artifact_id = f"artifact:{hashlib.sha1(f'{task.id}:{artifact}'.encode()).hexdigest()[:12]}"
             nodes.append(
                 {
                     "id": artifact_id,

--- a/tinybot/cowork/trace.py
+++ b/tinybot/cowork/trace.py
@@ -12,7 +12,9 @@ def compact_text(value: Any, limit: int = 240) -> str:
     text = " ".join(str(value or "").split())
     if len(text) <= limit:
         return text
-    return text[: max(0, limit - 1)].rstrip() + "..."
+    if limit <= 3:
+        return text[:limit]
+    return text[: max(0, limit - 3)].rstrip() + "..."
 
 
 def duration_ms(started_at: str, ended_at: str) -> int | None:

--- a/tinybot/skills/memory/SKILL.md
+++ b/tinybot/skills/memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory
-description: Two-layer memory system with Dream-managed knowledge files.
+description: Agent Memory system with canonical Memory Notes, derived Memory Views, Dream capture, and explicit note operations.
 always: true
 ---
 
@@ -8,22 +8,30 @@ always: true
 
 ## Structure
 
-- `SOUL.md` — Bot personality and communication style. **Managed by Dream.** Do NOT edit.
-- `USER.md` — User profile and preferences. **Managed by Dream.** Do NOT edit.
-- `memory/MEMORY.md` — Long-term facts (project context, important events). **Managed by Dream.** Do NOT edit.
-- `memory/history.jsonl` — append-only JSONL, not loaded into context. search with `jq`-style tools.
+- `memory/notes.jsonl` is the canonical Agent Memory store. It contains typed Memory Notes with status, priority, confidence, source trace-back, timestamps, and lifecycle links.
+- `memory/MEMORY.md` is the project Memory View rendered from active project, decision, fix, and followup notes.
+- `USER.md` is the user Memory View rendered from active preference notes.
+- `SOUL.md` is the assistant Memory View rendered from active instruction notes.
+- `memory/history.jsonl` is append-only conversation history used by Dream. It is not loaded directly as durable Memory Notes unless Dream or an explicit operation captures a note.
 
-## Search Past Events
+## Explicit Operations
 
-`memory/history.jsonl` is JSONL format — each line is a JSON object with `cursor`, `timestamp`, `content`.
+Use Memory Note operations for durable agent-side memory:
 
-Examples (replace `keyword`):
-- **Python (cross-platform):** `python -c "import json; [print(json.loads(l).get('content','')) for l in open('memory/history.jsonl','r',encoding='utf-8') if l.strip() and 'keyword' in l.lower()][-20:]"`
-- **jq:** `cat memory/history.jsonl | jq -r 'select(.content | test("keyword"; "i")) | .content' | tail -20`
-- **grep:** `grep -i "keyword" memory/history.jsonl`
+- `save_memory_note` for new durable preferences, instructions, project facts, decisions, fixes, or followups.
+- `search_memory_notes` to find notes by query, type, status, and limit.
+- `trace_memory_note` to inspect note content and source trace-back.
+- `reject_memory_note` to remove a wrong or obsolete note from default recall and Memory Views.
+- `supersede_memory_note` to replace an old note while preserving the lifecycle link.
+
+## Boundaries
+
+- Memory Notes are separate from Experience records. Experience captures reusable execution tactics and recovery guidance.
+- Memory Notes are separate from Knowledge Base snippets and uploaded session documents. Knowledge is evidence, not durable agent memory.
+- Optional vector indexes may accelerate Memory Note search, but `memory/notes.jsonl` remains canonical and indexes must be rebuildable from it.
 
 ## Important
 
-- **Do NOT edit SOUL.md, USER.md, or MEMORY.md.** They are automatically managed by Dream.
-- If you notice outdated information, it will be corrected when Dream runs next.
-- Users can view Dream's activity with the `/dream-log` command.
+- Do not edit managed sections in `SOUL.md`, `USER.md`, or `memory/MEMORY.md` directly. They are Memory Views refreshed from active Memory Notes.
+- If a Memory View looks wrong, use reject or supersede operations on the underlying note instead of editing rendered Markdown.
+- Users can view Dream activity with the `/dream-log` command.

--- a/tinybot/templates/SOUL.md
+++ b/tinybot/templates/SOUL.md
@@ -2,6 +2,8 @@
 
 I am tinybot 🤖, a personal AI assistant.
 
+This file is a human-readable Memory View for assistant-side instructions and traits. Durable assistant memory is stored as Memory Notes in `memory/notes.jsonl`.
+
 ## Personality
 
 - Helpful and friendly
@@ -19,3 +21,12 @@ I am tinybot 🤖, a personal AI assistant.
 - Be clear and direct
 - Explain reasoning when helpful
 - Ask clarifying questions when needed
+
+<!-- tinybot-memory-notes:start -->
+## Assistant Memory Notes
+
+This managed section is rendered from `memory/notes.jsonl`.
+Edit durable memory through Memory Note operations instead of changing this section directly.
+
+(No active Memory Notes.)
+<!-- tinybot-memory-notes:end -->

--- a/tinybot/templates/USER.md
+++ b/tinybot/templates/USER.md
@@ -1,6 +1,6 @@
 # User Profile
 
-Information about the user to help personalize interactions.
+Information about the user to help personalize interactions. Durable user memory is stored as Memory Notes and rendered here as a Memory View.
 
 ## Basic Information
 
@@ -44,6 +44,15 @@ Information about the user to help personalize interactions.
 
 (Any specific instructions for how the assistant should behave)
 
+<!-- tinybot-memory-notes:start -->
+## User Memory Notes
+
+This managed section is rendered from `memory/notes.jsonl`.
+Edit durable memory through Memory Note operations instead of changing this section directly.
+
+(No active Memory Notes.)
+<!-- tinybot-memory-notes:end -->
+
 ---
 
-*Edit this file to customize tinybot's behavior for your needs.*
+*Edit unmanaged sections for manual profile details. The managed Memory Notes section is refreshed by tinybot.*

--- a/tinybot/templates/agent/dream_phase1.md
+++ b/tinybot/templates/agent/dream_phase1.md
@@ -1,13 +1,18 @@
-Compare conversation history against current memory files.
-Output one line per finding:
-[FILE] atomic fact or change description
+Compare conversation history against current Memory Notes and Memory Views.
+Output one structured operation per durable Agent Memory finding:
 
-Files: USER (identity, preferences, habits), SOUL (bot behavior, tone), MEMORY (knowledge, project context, tool patterns)
+- `[SAVE:USER] atomic preference, identity, or habit`
+- `[SAVE:SOUL] durable assistant behavior or tone instruction`
+- `[SAVE:MEMORY] durable project, decision, fix, or follow-up fact`
+- `[SUPERSEDE:<note_id>:USER|SOUL|MEMORY] corrected replacement fact`
+- `[REJECT:<note_id>] reason the existing note is wrong or obsolete`
 
 Rules:
-- Only new or conflicting information — skip duplicates and ephemera
-- Prefer atomic facts: "has a cat named Luna" not "discussed pet care"
-- Corrections: [USER] location is Tokyo, not Osaka
-- Also capture confirmed approaches: if the user validated a non-obvious choice, note it
+- Memory Notes are canonical; Markdown Memory Views are rendered after notes are saved.
+- Use `SUPERSEDE` or `REJECT` when an existing note id is clearly contradicted.
+- Only capture durable, reusable memory. Skip duplicates, ephemera, raw execution tactics, and temporary troubleshooting.
+- Prefer atomic facts: "has a cat named Luna" not "discussed pet care".
+- Capture confirmed approaches only when the user validated a non-obvious durable decision.
+- Do not create Experience records here; execution tactics belong to the separate Experience phase.
 
-If nothing needs updating: [SKIP] no new information
+If nothing needs updating: `[SKIP] no new information`

--- a/tinybot/templates/agent/dream_phase2.md
+++ b/tinybot/templates/agent/dream_phase2.md
@@ -1,13 +1,7 @@
-Update memory files based on the analysis below.
+Memory Views are rendered from canonical Memory Notes.
 
-## Quality standards
-- Every line must carry standalone value — no filler
-- Concise bullet points under clear headers
-- Remove outdated or contradicted information
+Do not rewrite `MEMORY.md`, `USER.md`, or `SOUL.md` directly for durable memory.
+When Dream has extracted durable facts, save, supersede, or reject Memory Notes first,
+then refresh managed Memory View sections from `memory/notes.jsonl`.
 
-## Editing
-- File contents provided below — edit directly, no read_file needed
-- Batch changes to the same file into one edit_file call
-- Surgical edits only — never rewrite entire files
-- Do NOT overwrite correct entries — only add, update, or remove
-- If nothing to update, stop without calling tools
+If no durable Memory Note operation is needed, stop without editing files.

--- a/tinybot/templates/memory/MEMORY.md
+++ b/tinybot/templates/memory/MEMORY.md
@@ -1,6 +1,6 @@
 # Long-term Memory
 
-This file stores important information that should persist across sessions.
+This file is a human-readable Memory View. Durable Agent Memory is stored as structured Memory Notes in `memory/notes.jsonl`.
 
 ## User Information
 
@@ -18,6 +18,15 @@ This file stores important information that should persist across sessions.
 
 (Things to remember)
 
+<!-- tinybot-memory-notes:start -->
+## Project Memory Notes
+
+This managed section is rendered from `memory/notes.jsonl`.
+Edit durable memory through Memory Note operations instead of changing this section directly.
+
+(No active Memory Notes.)
+<!-- tinybot-memory-notes:end -->
+
 ---
 
-*This file is automatically updated by tinybot when important information should be remembered.*
+*This file is automatically refreshed by tinybot as a Memory View.*


### PR DESCRIPTION
## Summary

- Add Memory Notes as the canonical Agent Memory store with typed fields, lifecycle status, source trace-back, stable IDs, dedupe, and JSONL persistence.
- Migrate legacy `MEMORY.md`, `USER.md`, and `SOUL.md` content into conservative Memory Notes while preserving existing Markdown files.
- Render managed Memory Views from active notes and exclude rejected or superseded notes from prompt-facing views.
- Route Dream consolidation through Memory Note creation, merge, supersede, or reject behavior before refreshing Markdown views.
- Add bounded Memory Recall as a separate context path from Experience and Knowledge Base retrieval.
- Add explicit memory tools for save, search, trace, reject, and supersede operations.
- Add lexical/vector indexing rebuild support while keeping `notes.jsonl` canonical.
- Update memory docs, skill guidance, templates, and focused test coverage.

## Validation

- `uv run python -m compileall tinybot/agent tests/agent`
- `uv run pytest tests/agent/test_memory.py tests/agent/test_context.py tests/agent/test_memory_tools.py`