### PR TITLE
feat/memory: A more powerful memory system allows users to see what is being referenced

### DIFF
--- a/docs/dev/modules/agent.md
+++ b/docs/dev/modules/agent.md
@@ -51,7 +51,13 @@ Agent Memory is owned by `tinybot/agent/memory.py`. Durable memory is stored as 
 
 Memory Notes carry type, status, priority, confidence, source trace-back, timestamps, and lifecycle links. Only active notes participate in default recall and managed Memory View rendering. Rejected and superseded notes remain in JSONL for debugging and traceability.
 
-Dream is the background capture path for durable conversation facts. Explicit memory tools are the foreground path for user or agent corrections. Both paths write Memory Notes before refreshing Memory Views, so direct edits inside managed Markdown sections should be treated as temporary and overwritten by the next refresh.
+Conversation Evidence is the message-level source layer for Dream. Completed turns append clean user and assistant text to `memory/conversations/*.jsonl` after Session History has been saved; system prompts, runtime context, recalled memories, knowledge injections, tool material, empty assistant messages, and inline media payloads are excluded or sanitized. `memory/.evidence_cursor` tracks extraction progress. If no pending Conversation Evidence exists, Dream keeps the legacy `memory/history.jsonl` and `.dream_cursor` summary-history fallback.
+
+Dream is the background capture path for durable conversation facts. It reads pending Conversation Evidence first and asks for JSON Memory Operations: `save`, `supersede`, `reject`, or `skip`. Explicit memory tools are the foreground path for user or agent corrections. Both paths write Memory Notes before refreshing Memory Views, so direct edits inside managed Markdown sections should be treated as temporary and overwritten by the next refresh.
+
+Memory Notes carry a `scope` (`user`, `assistant`, `project`, or `session`) separate from their type, plus optional structured metadata. Evidence citations live on `MemorySource.evidence_ids`; trace output and managed views show those citations when present. `session.user_profile` remains a runtime cache for prompt hydration. Durable user facts, preferences, identity, and habits belong in user-scoped Memory Notes.
+
+Memory Extraction triggers are independent from token-budget consolidation. The loop captures evidence synchronously, then schedules extraction after warmup turns, every configured number of later turns, and idle flushes while preventing overlapping extraction for the same session. Token-budget consolidation still only runs from context pressure.
 
 Memory Recall is a distinct context section selected from active Memory Notes. It stays separate from Experience, which records reusable execution guidance, and from Knowledge, which provides document evidence. Optional vector indexing may accelerate Memory Note search, but JSONL remains the canonical source and indexes must be rebuildable from it.
 

--- a/docs/dev/modules/agent.md
+++ b/docs/dev/modules/agent.md
@@ -61,6 +61,10 @@ Memory Extraction triggers are independent from token-budget consolidation. The 
 
 Memory Recall is a distinct context section selected from active Memory Notes. It stays separate from Experience, which records reusable execution guidance, and from Knowledge, which provides document evidence. Optional vector indexing may accelerate Memory Note search, but JSONL remains the canonical source and indexes must be rebuildable from it.
 
+Recent Context Retrieval is the short-term layer between Session History and Durable Memory Notes. Session History is the current chat's persisted turn list; Recent Conversation Evidence is raw, bounded `memory/conversations/*.jsonl` material that can be read for ambiguous follow-up prompts; Durable Memory Notes are curated facts in `memory/notes.jsonl` and rendered Memory Views. Recent Context Retrieval is read-only: it must not write `USER.md`, `SOUL.md`, `memory/MEMORY.md`, or Memory Notes.
+
+When Recent Context is used, `ContextBuilder` injects a separate `[RECENT CONTEXT]` system block and records `_recent_context_references`. These references are distinct from `_memory_references` and should be labeled as "recent context" or "recent conversation references" in user-facing clients, not as memory references.
+
 ## Extension Points
 
 - Add a new tool under `tinybot/agent/tools/` and register it through the existing registry path.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -20,6 +20,12 @@ For focused Cowork work, prepare and ask the user to run:
 uv run pytest tests/cowork
 ```
 
+For Recent Context Retrieval work, prepare and ask the user to run:
+
+```bash
+uv run pytest tests/agent/test_memory.py tests/agent/test_context.py tests/agent/test_loop.py tests/channels/test_websocket.py
+```
+
 For frontend-only syntax checks:
 
 ```bash

--- a/tests/agent/test_context.py
+++ b/tests/agent/test_context.py
@@ -35,6 +35,10 @@ def test_context_builder_injects_memory_recall_as_distinct_section(tmp_path):
     assert "Use uv run pytest for Python validation." in recall_messages[0]["content"]
     assert "[RELEVANT WORKFLOWS]" not in recall_messages[0]["content"]
     assert "[RELEVANT KNOWLEDGE]" not in recall_messages[0]["content"]
+    assert builder.last_memory_references
+    assert builder.last_memory_references[0]["content"] == "Use uv run pytest for Python validation."
+    assert builder.last_memory_references[0]["file"] == "memory/notes.jsonl"
+    assert builder.last_memory_references[0]["line"] == 1
 
 
 def test_context_builder_keeps_memory_experience_and_knowledge_paths_separate(tmp_path):

--- a/tests/agent/test_context.py
+++ b/tests/agent/test_context.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from tinybot.agent.context import ContextBuilder
-from tinybot.agent.memory import MemoryNote, MemorySource
+from tinybot.agent.memory import ConversationEvidence, MemoryNote, MemorySource, RecentContextCandidate
 
 
 def test_context_builder_injects_memory_recall_as_distinct_section(tmp_path):
@@ -132,3 +132,90 @@ def test_context_builder_keeps_memory_experience_and_knowledge_paths_separate(tm
     assert "[RELEVANT KNOWLEDGE]" not in memory_section
     assert "[MEMORY RECALL]" not in experience_section
     assert "[MEMORY RECALL]" not in knowledge_section
+
+
+def test_context_builder_injects_recent_context_for_preparation_prompt(tmp_path):
+    builder = ContextBuilder(tmp_path)
+    evidence = builder.memory.append_conversation_evidence(
+        [
+            ConversationEvidence.create(
+                session_key="websocket:old",
+                turn_id="turn_trip",
+                role="user",
+                content="I have a flight to Tokyo tomorrow and need to pack light.",
+                timestamp="2999-05-18T10:00:00Z",
+            )
+        ]
+    )[0]
+
+    messages = builder.build_messages(
+        history=[],
+        current_message="What should I prepare?",
+        channel="websocket",
+        chat_id="new",
+    )
+
+    recent_messages = [
+        message for message in messages if message["role"] == "system" and "[RECENT CONTEXT]" in message["content"]
+    ]
+    assert len(recent_messages) == 1
+    assert "Recent conversation evidence" in recent_messages[0]["content"]
+    assert "Tokyo tomorrow" in recent_messages[0]["content"]
+    assert builder.last_recent_context_references[0]["evidence_id"] == evidence.id
+    assert builder.last_recent_context_references[0]["file"] == "memory/conversations/2999-05-18.jsonl"
+    assert builder.last_memory_references == []
+
+
+def test_context_builder_skips_recent_context_for_simple_greeting(tmp_path):
+    builder = ContextBuilder(tmp_path)
+    builder.memory.append_conversation_evidence(
+        [
+            ConversationEvidence.create(
+                session_key="websocket:old",
+                turn_id="turn_trip",
+                role="user",
+                content="I have a flight to Tokyo tomorrow.",
+                timestamp="2999-05-18T10:00:00Z",
+            )
+        ]
+    )
+
+    messages = builder.build_messages(
+        history=[],
+        current_message="hi",
+        channel="websocket",
+        chat_id="new",
+    )
+
+    assert not any(message["role"] == "system" and "[RECENT CONTEXT]" in message["content"] for message in messages)
+    assert builder.last_recent_context_references == []
+
+
+def test_recent_context_ranking_prefers_recent_user_future_plan():
+    older_assistant = RecentContextCandidate(
+        evidence_id="ev_old",
+        excerpt="You may want to bring a charger.",
+        timestamp="2026-05-11T10:00:00Z",
+        session_key="websocket:old",
+        role="assistant",
+        turn_id="turn_old",
+        cursor=1,
+    )
+    recent_user = RecentContextCandidate(
+        evidence_id="ev_recent",
+        excerpt="I have a flight to Tokyo tomorrow and a hotel reservation.",
+        timestamp="2999-05-18T10:00:00Z",
+        session_key="websocket:recent",
+        role="user",
+        turn_id="turn_recent",
+        cursor=2,
+    )
+
+    ranked = ContextBuilder._rank_recent_context_candidates(
+        "What should I prepare for the trip?",
+        [older_assistant, recent_user],
+        max_records=2,
+    )
+
+    assert ranked[0].evidence_id == "ev_recent"
+    assert ranked[0].score_inputs["future_plan_marker"] is True

--- a/tests/agent/test_context.py
+++ b/tests/agent/test_context.py
@@ -41,6 +41,35 @@ def test_context_builder_injects_memory_recall_as_distinct_section(tmp_path):
     assert builder.last_memory_references[0]["line"] == 1
 
 
+def test_context_builder_shows_memory_references_for_short_preference_questions(tmp_path):
+    builder = ContextBuilder(tmp_path)
+    source = MemorySource.explicit(session_key="websocket:test")
+    builder.memory.upsert_note(
+        MemoryNote.create(
+            "The user likes eating strawberries (草莓).",
+            "preference",
+            [source],
+            scope="user",
+            priority=0.5,
+            confidence=0.8,
+        )
+    )
+
+    messages = builder.build_messages(
+        history=[],
+        current_message="我喜欢吃什么",
+        channel="websocket",
+        chat_id="test",
+    )
+
+    recall_messages = [
+        message for message in messages if message["role"] == "system" and "[MEMORY RECALL]" in message["content"]
+    ]
+    assert len(recall_messages) == 1
+    assert "strawberries" in recall_messages[0]["content"]
+    assert builder.last_memory_references[0]["content"] == "The user likes eating strawberries (草莓)."
+
+
 def test_context_builder_keeps_memory_experience_and_knowledge_paths_separate(tmp_path):
     experience_store = MagicMock()
     experience = SimpleNamespace(

--- a/tests/agent/test_loop.py
+++ b/tests/agent/test_loop.py
@@ -1,8 +1,15 @@
 """Tests for AgentLoop core logic."""
 
-import pytest
+import asyncio
 
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from tinybot.agent.loop import AgentLoop
 from tinybot.agent.stream_handler import StreamHandler
+from tinybot.agent.memory import MemoryStore
+from tinybot.session.manager import Session
 
 
 class TestLoopHookMergeStreamBuffer:
@@ -66,3 +73,50 @@ class TestAgentLoopPlaceholder:
         """Placeholder async test."""
         # Verify async test support works
         assert True
+
+
+@pytest.mark.asyncio
+async def test_memory_extraction_triggers_warmup_and_prevent_overlap(tmp_path):
+    loop = AgentLoop.__new__(AgentLoop)
+    loop.context = SimpleNamespace(memory=MemoryStore(tmp_path))
+    loop.sessions = MagicMock()
+    loop._config_ref = SimpleNamespace(
+        agents=SimpleNamespace(
+            defaults=SimpleNamespace(dream=SimpleNamespace(extraction_every_n_turns=3, extraction_idle_seconds=60))
+        )
+    )
+    loop._memory_extraction_locks = {}
+    loop._memory_extraction_run_lock = asyncio.Lock()
+    loop._memory_extraction_idle_tasks = {}
+    loop._background_tasks = []
+    loop.dream = SimpleNamespace(run=AsyncMock(return_value=True))
+
+    scheduled = []
+
+    def fake_schedule(coro):
+        scheduled.append(coro)
+        coro.close()
+
+    loop._schedule_background = fake_schedule
+    session = Session(key="cli:test")
+    evidence = [SimpleNamespace(role="user")]
+
+    loop._schedule_memory_extraction_triggers(session, evidence)
+    loop._schedule_memory_extraction_triggers(session, evidence)
+    loop._schedule_memory_extraction_triggers(session, evidence)
+
+    assert session.metadata["memory_extraction"]["completed_user_turns"] == 3
+    assert len(scheduled) == 2
+
+    lock = asyncio.Lock()
+    await lock.acquire()
+    loop._memory_extraction_locks[session.key] = lock
+    loop.sessions.get.return_value = session
+    await loop._run_memory_extraction_once(session.key)
+
+    assert session.metadata["memory_extraction"]["pending"] is True
+    loop.dream.run.assert_not_awaited()
+
+    for task in list(loop._background_tasks):
+        task.cancel()
+    await asyncio.gather(*loop._background_tasks, return_exceptions=True)

--- a/tests/agent/test_loop.py
+++ b/tests/agent/test_loop.py
@@ -120,3 +120,16 @@ async def test_memory_extraction_triggers_warmup_and_prevent_overlap(tmp_path):
     for task in list(loop._background_tasks):
         task.cancel()
     await asyncio.gather(*loop._background_tasks, return_exceptions=True)
+
+
+def test_recent_context_references_attach_to_latest_assistant():
+    loop = AgentLoop.__new__(AgentLoop)
+    session = Session(key="websocket:test")
+    session.add_message("user", "What should I prepare?")
+    session.add_message("assistant", "Pack light.")
+    references = [{"evidence_id": "ev_1", "excerpt": "Tokyo flight tomorrow."}]
+
+    loop._attach_recent_context_references_to_latest_assistant(session, 0, references)
+
+    assert session.messages[-1]["_recent_context_references"] == references
+    assert "_memory_references" not in session.messages[-1]

--- a/tests/agent/test_memory.py
+++ b/tests/agent/test_memory.py
@@ -5,13 +5,16 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from tinybot.agent.memory import (
+    ConversationEvidence,
     Dream,
     MemoryCaptureOrigin,
     MemoryNote,
+    MemoryNoteScope,
     MemoryNoteStatus,
     MemoryNoteType,
     MemorySource,
     MemoryStore,
+    capture_conversation_evidence,
     generate_memory_note_id,
 )
 
@@ -163,6 +166,90 @@ def test_memory_source_helpers_capture_trace_fields():
     assert explicit.message_end == 2
     assert migrated.capture_origin == MemoryCaptureOrigin.MIGRATION
     assert migrated.source_file == "memory/MEMORY.md"
+
+
+def test_conversation_evidence_append_read_cursor_and_capture(tmp_path):
+    store = MemoryStore(tmp_path)
+    messages = [
+        {"role": "system", "content": "runtime prompt"},
+        {"role": "user", "content": "Remember that I prefer concise updates.", "timestamp": "2026-05-18T10:00:00"},
+        {"role": "assistant", "tool_calls": [{"id": "call_1"}], "content": ""},
+        {"role": "tool", "content": "tool result"},
+        {"role": "assistant", "content": "Noted. I will keep updates concise.", "timestamp": "2026-05-18T10:00:02"},
+    ]
+
+    written = capture_conversation_evidence(
+        store,
+        session_key="cli:test",
+        messages=messages,
+        start_index=3,
+    )
+
+    assert [record.role for record in written] == ["user", "assistant"]
+    assert all(record.cursor for record in written)
+    assert written[0].message_index == 4
+    assert written[1].message_index == 7
+    assert len(store.read_pending_conversation_evidence()) == 2
+
+    store.set_last_evidence_cursor(written[0].cursor or 0)
+    pending = store.read_pending_conversation_evidence()
+    assert [record.id for record in pending] == [written[1].id]
+
+    duplicate = capture_conversation_evidence(
+        store,
+        session_key="cli:test",
+        messages=messages,
+        start_index=3,
+    )
+    assert duplicate == []
+
+
+def test_memory_source_and_note_preserve_evidence_scope_and_metadata(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.dream(evidence_ids=["ev_1", "ev_2"])
+    note = store.upsert_note(
+        MemoryNote.create(
+            "User prefers concise updates.",
+            "preference",
+            [source],
+            scope="user",
+            metadata={"reason": "explicit preference"},
+            tags=["dream"],
+        )
+    )
+
+    loaded = store.read_notes()[0]
+    assert loaded.scope == MemoryNoteScope.USER
+    assert loaded.metadata == {"reason": "explicit preference"}
+    assert loaded.sources[0].evidence_ids == ["ev_1", "ev_2"]
+    assert loaded.sources[0].identity() == MemorySource.dream(evidence_ids=["ev_other"]).identity()
+    assert note.id == generate_memory_note_id("preference", "User prefers concise updates.", [source], scope="user")
+
+
+def test_legacy_note_loading_infers_scope(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.notes_file.write_text(
+        json.dumps(
+            {
+                "id": "note_legacy",
+                "type": "instruction",
+                "status": "active",
+                "content": "Be direct.",
+                "priority": 0.5,
+                "confidence": 0.5,
+                "sources": [],
+                "created_at": "2026-05-18T00:00:00Z",
+                "updated_at": "2026-05-18T00:00:00Z",
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    loaded = store.read_notes()[0]
+    assert loaded.scope == MemoryNoteScope.ASSISTANT
+    assert loaded.metadata == {}
 
 
 def test_legacy_migration_creates_conservative_notes_and_preserves_files(tmp_path):
@@ -505,6 +592,159 @@ async def test_dream_creates_notes_refreshes_views_and_advances_cursor(tmp_path)
     assert "Project uses uv for Python commands." in store.read_memory()
     assert "User prefers concise progress updates." in store.read_user()
     assert store.get_last_dream_cursor() == second_cursor
+
+
+@pytest.mark.asyncio
+async def test_dream_processes_pending_evidence_before_legacy_history(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.append_history("Legacy history should wait.")
+    evidence = store.append_conversation_evidence(
+        [
+            ConversationEvidence.create(
+                session_key="cli:test",
+                turn_id="turn_1",
+                role="user",
+                content="I prefer concise progress updates.",
+                message_index=0,
+                timestamp="2026-05-18T10:00:00Z",
+            )
+        ]
+    )
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(
+        return_value=SimpleNamespace(
+            content=json.dumps(
+                [
+                    {
+                        "action": "save",
+                        "scope": "user",
+                        "type": "preference",
+                        "content": "User prefers concise progress updates.",
+                        "priority": 0.8,
+                        "confidence": 0.9,
+                        "evidence_ids": [evidence[0].id],
+                        "metadata": {"source": "conversation-evidence"},
+                        "tags": ["dream"],
+                    }
+                ]
+            )
+        )
+    )
+    dream = Dream(store=store, provider=provider, model="test-model")
+
+    assert await dream.run() is True
+
+    note = store.read_notes()[0]
+    assert note.scope == MemoryNoteScope.USER
+    assert note.sources[0].evidence_ids == [evidence[0].id]
+    assert note.metadata == {"source": "conversation-evidence"}
+    assert store.get_last_evidence_cursor() == evidence[0].cursor
+    assert store.get_last_dream_cursor() == 0
+
+
+@pytest.mark.asyncio
+async def test_dream_evidence_json_parse_failure_preserves_cursor_and_notes(tmp_path):
+    store = MemoryStore(tmp_path)
+    evidence = store.append_conversation_evidence(
+        [
+            ConversationEvidence.create(
+                session_key="cli:test",
+                turn_id="turn_1",
+                role="user",
+                content="I prefer concise progress updates.",
+                message_index=0,
+            )
+        ]
+    )
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(return_value=SimpleNamespace(content="{not valid json"))
+    dream = Dream(store=store, provider=provider, model="test-model")
+
+    assert await dream.run() is False
+
+    assert store.read_notes() == []
+    assert store.get_last_evidence_cursor() == 0
+    assert store.read_pending_conversation_evidence()[0].id == evidence[0].id
+
+
+@pytest.mark.asyncio
+async def test_dream_json_supersede_reject_skip_and_duplicate_merge(tmp_path):
+    store = MemoryStore(tmp_path)
+    source = MemorySource.explicit(session_key="cli:test")
+    old = store.upsert_note(MemoryNote.create("Use pytest directly.", "instruction", [source], scope="assistant"))
+    rejected = store.upsert_note(MemoryNote.create("Obsolete project note.", "project", [source], scope="project"))
+    evidence = store.append_conversation_evidence(
+        [
+            ConversationEvidence.create(
+                session_key="cli:test", turn_id="turn_1", role="user", content="Use uv run pytest.", message_index=0
+            ),
+            ConversationEvidence.create(
+                session_key="cli:test",
+                turn_id="turn_1",
+                role="assistant",
+                content="I will use uv run pytest.",
+                message_index=1,
+            ),
+        ]
+    )
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(
+        return_value=SimpleNamespace(
+            content=json.dumps(
+                [
+                    {
+                        "action": "save",
+                        "scope": "project",
+                        "type": "project",
+                        "content": "Project uses uv for Python validation.",
+                        "priority": 0.7,
+                        "confidence": 0.8,
+                        "evidence_ids": [evidence[0].id],
+                        "metadata": {"first": True},
+                        "tags": ["dream"],
+                    },
+                    {
+                        "action": "save",
+                        "scope": "project",
+                        "type": "project",
+                        "content": "Project uses uv for Python validation.",
+                        "priority": 0.9,
+                        "confidence": 0.85,
+                        "evidence_ids": [evidence[1].id],
+                        "metadata": {"second": True},
+                        "tags": ["validated"],
+                    },
+                    {
+                        "action": "supersede",
+                        "target_note_id": old.id,
+                        "scope": "assistant",
+                        "type": "instruction",
+                        "content": "Use uv run pytest for validation.",
+                        "priority": 0.8,
+                        "confidence": 0.9,
+                        "evidence_ids": [evidence[0].id],
+                        "metadata": {},
+                        "tags": ["dream"],
+                    },
+                    {"action": "reject", "target_note_id": rejected.id},
+                    {"action": "skip"},
+                ]
+            )
+        )
+    )
+    dream = Dream(store=store, provider=provider, model="test-model")
+
+    assert await dream.run() is True
+
+    notes = {note.id: note for note in store.read_notes()}
+    merged = [note for note in notes.values() if note.content == "Project uses uv for Python validation."][0]
+    assert merged.priority == pytest.approx(0.9)
+    assert merged.confidence == pytest.approx(0.85)
+    assert merged.sources[0].evidence_ids == [evidence[0].id, evidence[1].id]
+    assert merged.metadata == {"first": True, "second": True}
+    assert sorted(merged.tags) == ["dream", "validated"]
+    assert notes[old.id].status == MemoryNoteStatus.SUPERSEDED
+    assert notes[rejected.id].status == MemoryNoteStatus.REJECTED
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_memory.py
+++ b/tests/agent/test_memory.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -665,6 +666,62 @@ async def test_dream_evidence_json_parse_failure_preserves_cursor_and_notes(tmp_
     assert store.read_notes() == []
     assert store.get_last_evidence_cursor() == 0
     assert store.read_pending_conversation_evidence()[0].id == evidence[0].id
+
+
+def test_read_recent_conversation_evidence_filters_bounds_and_source_location(tmp_path):
+    store = MemoryStore(tmp_path)
+    fresh_user, stale_user, same_session, assistant = store.append_conversation_evidence(
+        [
+            ConversationEvidence.create(
+                session_key="cli:older",
+                turn_id="turn_1",
+                role="user",
+                content="I have a flight to Tokyo tomorrow.",
+                message_index=0,
+                timestamp="2026-05-18T10:00:00Z",
+            ),
+            ConversationEvidence.create(
+                session_key="cli:older",
+                turn_id="turn_2",
+                role="user",
+                content="This old trip is no longer relevant.",
+                message_index=1,
+                timestamp="2026-05-01T10:00:00Z",
+            ),
+            ConversationEvidence.create(
+                session_key="cli:current",
+                turn_id="turn_3",
+                role="user",
+                content="Current session text should be excluded.",
+                message_index=2,
+                timestamp="2026-05-18T11:00:00Z",
+            ),
+            ConversationEvidence.create(
+                session_key="cli:older",
+                turn_id="turn_4",
+                role="assistant",
+                content="Assistant detail.",
+                message_index=3,
+                timestamp="2026-05-18T11:30:00Z",
+            ),
+        ]
+    )
+
+    results = store.read_recent_conversation_evidence(
+        max_age_days=7,
+        max_records=10,
+        roles={"user"},
+        exclude_session_key="cli:current",
+        now=datetime(2026, 5, 18, 12, 0, 0),
+    )
+
+    assert [record.id for record, _ in results] == [fresh_user.id]
+    assert stale_user.id not in [record.id for record, _ in results]
+    assert same_session.id not in [record.id for record, _ in results]
+    assert assistant.id not in [record.id for record, _ in results]
+    _, source = results[0]
+    assert source.file == "memory/conversations/2026-05-18.jsonl"
+    assert source.line == 1
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_websocket.py
+++ b/tests/channels/test_websocket.py
@@ -9,7 +9,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from tinybot.bus.queue import MessageBus
 from tinybot.bus.events import OutboundMessage
-from tinybot.channels.websocket import WebSocketChannel
+from tinybot.channels.websocket import WebSocketChannel, _serialize_message
 from tinybot.config.schema import Config, MCPServerConfig
 from tinybot.cowork.service import CoworkService
 from tinybot.security.approval import ApprovalAction, ApprovalManager
@@ -93,6 +93,26 @@ async def test_session_rest_endpoints(web_channel, web_client):
     response = await web_client.delete("/api/sessions/websocket:chat-1", headers=headers)
     assert response.status == 200
     assert session_manager.get("websocket:chat-1") is None
+
+
+def test_serialize_message_preserves_memory_references():
+    payload = _serialize_message(
+        {
+            "role": "assistant",
+            "content": "Done",
+            "_memory_references": [
+                {
+                    "note_id": "note_1",
+                    "content": "Use uv.",
+                    "file": "memory/notes.jsonl",
+                    "line": 1,
+                }
+            ],
+        }
+    )
+
+    assert payload["_memory_references"][0]["note_id"] == "note_1"
+    assert payload["_memory_references"][0]["line"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_websocket.py
+++ b/tests/channels/test_websocket.py
@@ -115,6 +115,26 @@ def test_serialize_message_preserves_memory_references():
     assert payload["_memory_references"][0]["line"] == 1
 
 
+def test_serialize_message_preserves_recent_context_references():
+    payload = _serialize_message(
+        {
+            "role": "assistant",
+            "content": "Done",
+            "_recent_context_references": [
+                {
+                    "evidence_id": "ev_1",
+                    "excerpt": "Tokyo flight tomorrow.",
+                    "file": "memory/conversations/2026-05-18.jsonl",
+                    "line": 1,
+                }
+            ],
+        }
+    )
+
+    assert payload["_recent_context_references"][0]["evidence_id"] == "ev_1"
+    assert payload["_recent_context_references"][0]["line"] == 1
+
+
 @pytest.mark.asyncio
 async def test_cowork_rest_endpoints(web_channel, web_client, web_workspace):
     channel, _, _ = web_channel
@@ -440,11 +460,20 @@ async def test_websocket_chat_flow(web_channel, web_client):
             "is_reasoning": False,
         }
 
-        await channel.send_delta(chat_id, "", {"_stream_id": "stream-1", "_stream_end": True})
+        await channel.send_delta(
+            chat_id,
+            "",
+            {
+                "_stream_id": "stream-1",
+                "_stream_end": True,
+                "_recent_context_references": [{"evidence_id": "ev_1"}],
+            },
+        )
         end = await ws.receive_json()
         assert end["event"] == "stream_end"
         assert end["chat_id"] == chat_id
         assert end["message_id"] == "stream-1"
+        assert end["_recent_context_references"] == [{"evidence_id": "ev_1"}]
     finally:
         await ws.close()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,9 @@ class TestAgentDefaults:
         assert defaults.max_tokens == 8192
         assert defaults.temperature == 0.1
         assert defaults.timezone == "UTC"
+        assert defaults.recent_context.enabled is True
+        assert defaults.recent_context.recency_days == 7
+        assert defaults.recent_context.max_records == 3
 
     def test_custom_values(self):
         defaults = AgentDefaults(

--- a/tinybot/agent/context.py
+++ b/tinybot/agent/context.py
@@ -52,6 +52,7 @@ class ContextBuilder:
         self.experience_store = experience_store
         self.knowledge_store = knowledge_store
         self.session_knowledge_store = session_knowledge_store
+        self.last_memory_references: list[dict[str, Any]] = []
 
     @property
     def enabled_skills(self) -> list[str] | None:
@@ -186,6 +187,7 @@ class ContextBuilder:
         user_profile: dict[str, Any] | None = None,
         use_persistent_knowledge: bool | None = None,
     ) -> list[dict[str, Any]]:
+        self.last_memory_references = []
         runtime_ctx = self._build_runtime_context(
             channel, chat_id, self.timezone, self.task_manager, user_profile
         )
@@ -278,11 +280,13 @@ class ContextBuilder:
     ) -> str | None:
         if self._is_simple_conversation(current_message):
             return None
-        context = self.memory.format_memory_recall_context(
+        notes = self.memory.select_memory_recall(
             current_message,
             max_notes=max_notes,
             max_chars=max_chars,
         )
+        self.last_memory_references = self.memory.memory_reference_metadata(notes)
+        context = self.memory.format_memory_recall_notes_context(notes)
         return context or None
 
     def _build_experience_context(

--- a/tinybot/agent/context.py
+++ b/tinybot/agent/context.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import base64
 import mimetypes
 import platform
+import re
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from tinybot.agent.memory import MemoryStore
+from tinybot.agent.memory import MemoryStore, RecentContextCandidate, _parse_utc_timestamp
 from tinybot.agent.skills import SkillsLoader
 from tinybot.utils.helper import build_assistant_message, current_time_str
 from tinybot.utils.media import detect_image_mime
@@ -53,6 +55,7 @@ class ContextBuilder:
         self.knowledge_store = knowledge_store
         self.session_knowledge_store = session_knowledge_store
         self.last_memory_references: list[dict[str, Any]] = []
+        self.last_recent_context_references: list[dict[str, Any]] = []
 
     @property
     def enabled_skills(self) -> list[str] | None:
@@ -188,6 +191,7 @@ class ContextBuilder:
         use_persistent_knowledge: bool | None = None,
     ) -> list[dict[str, Any]]:
         self.last_memory_references = []
+        self.last_recent_context_references = []
         runtime_ctx = self._build_runtime_context(
             channel, chat_id, self.timezone, self.task_manager, user_profile
         )
@@ -200,8 +204,9 @@ class ContextBuilder:
 
         messages = [{"role": "system", "content": self.build_system_prompt(skill_names)}]
 
-        if self.vector_store is not None and channel and chat_id:
-            session_key = f"{channel}:{chat_id}"
+        session_key = f"{channel}:{chat_id}" if channel and chat_id else None
+
+        if self.vector_store is not None and session_key:
             search_query = self._build_search_query(history, current_message)
             retrieval_limits = self._plan_vector_retrieval(history, current_message)
 
@@ -247,13 +252,16 @@ class ContextBuilder:
         if memory_recall_context:
             messages.append({"role": "system", "content": memory_recall_context})
 
+        recent_context = self._build_recent_context(current_message, session_key=session_key)
+        if recent_context:
+            messages.append({"role": "system", "content": recent_context})
+
         if self.experience_store is not None:
             experience_context = self._build_experience_context(current_message)
             if experience_context:
                 messages.append({"role": "system", "content": experience_context})
 
         # RAG: Auto-retrieve relevant knowledge from persistent and session uploads.
-        session_key = f"{channel}:{chat_id}" if channel and chat_id else None
         if self.knowledge_store is not None or self.session_knowledge_store is not None:
             knowledge_context = self._build_knowledge_context(
                 current_message,
@@ -271,6 +279,253 @@ class ContextBuilder:
             return messages
         messages.append({"role": current_role, "content": merged})
         return messages
+
+    def _recent_context_settings(self) -> dict[str, Any]:
+        cfg = None
+        if self.config and hasattr(self.config, "agents"):
+            cfg = getattr(getattr(self.config.agents, "defaults", None), "recent_context", None)
+        return {
+            "enabled": bool(getattr(cfg, "enabled", True)),
+            "recency_days": int(getattr(cfg, "recency_days", 7) or 7),
+            "max_records": int(getattr(cfg, "max_records", 3) or 3),
+            "scan_limit": int(getattr(cfg, "scan_limit", 200) or 200),
+        }
+
+    def _build_recent_context(
+        self,
+        current_message: str,
+        *,
+        session_key: str | None = None,
+    ) -> str | None:
+        settings = self._recent_context_settings()
+        if not settings["enabled"] or not self._should_retrieve_recent_context(current_message):
+            return None
+
+        try:
+            raw_records = self.memory.read_recent_conversation_evidence(
+                max_age_days=settings["recency_days"],
+                max_records=settings["scan_limit"],
+                roles={"user", "assistant"},
+                exclude_session_key=session_key,
+            )
+            candidates = [
+                RecentContextCandidate.from_evidence(record, source_location=source)
+                for record, source in raw_records
+            ]
+            ranked = self._rank_recent_context_candidates(
+                current_message,
+                candidates,
+                max_records=settings["max_records"],
+            )
+        except Exception:
+            self.last_recent_context_references = []
+            return None
+
+        if not ranked:
+            self.last_recent_context_references = []
+            return None
+
+        self.last_recent_context_references = [
+            candidate.reference_metadata() for candidate in ranked
+        ]
+        return self._format_recent_context(ranked)
+
+    @classmethod
+    def _rank_recent_context_candidates(
+        cls,
+        current_message: str,
+        candidates: list[RecentContextCandidate],
+        *,
+        max_records: int = 3,
+    ) -> list[RecentContextCandidate]:
+        query_terms = cls._recent_context_terms(current_message)
+        planning_prompt = cls._is_recent_context_planning_prompt(current_message)
+        ranked: list[RecentContextCandidate] = []
+
+        for candidate in candidates:
+            candidate_terms = cls._recent_context_terms(candidate.excerpt)
+            overlap = len(query_terms & candidate_terms)
+            recency_score = cls._recent_context_recency_score(candidate.timestamp)
+            role_score = 1.0 if candidate.role == "user" else 0.25
+            plan_score = 0.0
+            if planning_prompt and cls._has_recent_context_future_marker(candidate.excerpt):
+                plan_score = 3.0
+            score = (overlap * 2.0) + recency_score + role_score + plan_score
+            candidate.score = score
+            candidate.score_inputs = {
+                "overlap": overlap,
+                "recency": round(recency_score, 3),
+                "role": candidate.role,
+                "future_plan_marker": plan_score > 0,
+            }
+            if score >= 2.0:
+                ranked.append(candidate)
+
+        ranked.sort(
+            key=lambda item: (
+                item.score,
+                1 if item.role == "user" else 0,
+                item.cursor or 0,
+                item.timestamp,
+            ),
+            reverse=True,
+        )
+        return ranked[: max(max_records, 0)]
+
+    @staticmethod
+    def _format_recent_context(candidates: list[RecentContextCandidate]) -> str:
+        lines = [
+            "---",
+            "[RECENT CONTEXT]",
+            "Recent conversation evidence from prior sessions. This is short-term context, not Durable Memory.",
+            "",
+        ]
+        for idx, candidate in enumerate(candidates, 1):
+            source = ""
+            if candidate.source_location is not None:
+                source = candidate.source_location.file
+                if candidate.source_location.line is not None:
+                    source += f":{candidate.source_location.line}"
+            meta_parts = [
+                f"evidence_id={candidate.evidence_id}",
+                f"timestamp={candidate.timestamp}",
+                f"session={candidate.session_key}",
+                f"role={candidate.role}",
+                f"turn_id={candidate.turn_id}",
+            ]
+            if candidate.cursor is not None:
+                meta_parts.append(f"cursor={candidate.cursor}")
+            if source:
+                meta_parts.append(f"source={source}")
+            lines.append(f"[{idx}] " + " | ".join(meta_parts))
+            lines.append(f"Excerpt: {candidate.excerpt}")
+            lines.append("")
+        lines.append("---")
+        return "\n".join(lines)
+
+    @classmethod
+    def _should_retrieve_recent_context(cls, text: str) -> bool:
+        normalized = " ".join(text.strip().casefold().split())
+        if not normalized or cls._is_simple_conversation(normalized):
+            return False
+        if cls._is_recent_context_planning_prompt(normalized):
+            return True
+        explicit_markers = (
+            "recent",
+            "recently",
+            "earlier",
+            "previous",
+            "last time",
+            "we talked",
+            "you said",
+            "i mentioned",
+            "that trip",
+            "that plan",
+            "that meeting",
+            "this weekend",
+            "tomorrow",
+            "next week",
+            "the thing",
+        )
+        if any(marker in normalized for marker in explicit_markers):
+            return True
+        pronouns = set(re.findall(r"[a-z0-9][a-z0-9_-]*", normalized))
+        if pronouns & {"that", "those", "it"}:
+            return True
+        ambiguous_questions = (
+            "what should i do",
+            "what do i need",
+            "do i need anything",
+            "what should i bring",
+            "what should i prepare",
+            "how should i arrange",
+        )
+        return any(marker in normalized for marker in ambiguous_questions)
+
+    @staticmethod
+    def _is_recent_context_planning_prompt(text: str) -> bool:
+        normalized = text.strip().casefold()
+        markers = (
+            "prepare",
+            "bring",
+            "pack",
+            "packing",
+            "schedule",
+            "arrange",
+            "reservation",
+            "book",
+            "booking",
+            "trip",
+            "travel",
+            "flight",
+            "hotel",
+            "meeting",
+            "appointment",
+            "plan",
+            "weekend",
+        )
+        return any(marker in normalized for marker in markers)
+
+    @staticmethod
+    def _has_recent_context_future_marker(text: str) -> bool:
+        normalized = text.strip().casefold()
+        markers = (
+            "tomorrow",
+            "tonight",
+            "this weekend",
+            "next week",
+            "next month",
+            "flight",
+            "train",
+            "hotel",
+            "meeting",
+            "appointment",
+            "trip",
+            "travel",
+            "conference",
+            "deadline",
+            "reservation",
+            "plan to",
+            "going to",
+            "will ",
+        )
+        return any(marker in normalized for marker in markers)
+
+    @staticmethod
+    def _recent_context_terms(text: str) -> set[str]:
+        stopwords = {
+            "about",
+            "after",
+            "again",
+            "anything",
+            "before",
+            "could",
+            "should",
+            "that",
+            "this",
+            "what",
+            "when",
+            "where",
+            "which",
+            "with",
+            "would",
+            "you",
+            "your",
+        }
+        return {
+            term
+            for term in re.findall(r"[a-z0-9][a-z0-9_-]{2,}", text.casefold())
+            if term not in stopwords
+        }
+
+    @staticmethod
+    def _recent_context_recency_score(timestamp: str) -> float:
+        parsed = _parse_utc_timestamp(timestamp)
+        if parsed is None:
+            return 0.0
+        age_seconds = max((datetime.utcnow() - parsed).total_seconds(), 0.0)
+        age_days = age_seconds / 86400
+        return max(0.0, 3.0 - min(age_days, 7.0) * (3.0 / 7.0))
 
     def _build_memory_recall_context(
         self,

--- a/tinybot/agent/context.py
+++ b/tinybot/agent/context.py
@@ -278,16 +278,54 @@ class ContextBuilder:
         max_notes: int = 6,
         max_chars: int = 1_600,
     ) -> str | None:
-        if self._is_simple_conversation(current_message):
+        memory_lookup = self._is_memory_lookup_question(current_message)
+        if self._is_simple_conversation(current_message) and not memory_lookup:
             return None
-        notes = self.memory.select_memory_recall(
-            current_message,
-            max_notes=max_notes,
-            max_chars=max_chars,
-        )
+        if memory_lookup:
+            notes = self._select_memory_lookup_notes(current_message, max_notes=max_notes)
+        else:
+            notes = self.memory.select_memory_recall(
+                current_message,
+                max_notes=max_notes,
+                max_chars=max_chars,
+            )
         self.last_memory_references = self.memory.memory_reference_metadata(notes)
         context = self.memory.format_memory_recall_notes_context(notes)
         return context or None
+
+    def _select_memory_lookup_notes(self, current_message: str, *, max_notes: int) -> list[Any]:
+        text = current_message.casefold()
+        notes = [
+            note for note in self.memory.read_notes()
+            if note.status.value == "active" and note.content
+        ]
+        if not notes:
+            return []
+
+        wants_user_memory = any(marker in text for marker in (
+            "我", "我的", "用户", "user", "my ", "remember about me",
+        ))
+        wants_food = any(marker in text for marker in (
+            "吃", "食物", "喜欢吃", "food", "eat", "eating", "like to eat",
+        ))
+
+        candidates = []
+        for note in notes:
+            score = 0
+            note_text = " ".join([note.content, note.type.value, note.scope.value, " ".join(note.tags)]).casefold()
+            if wants_user_memory and (note.scope.value == "user" or note.type.value == "preference"):
+                score += 4
+            if wants_food and any(marker in note_text for marker in ("吃", "食物", "food", "eat", "eating", "strawber", "草莓")):
+                score += 4
+            if any(marker in text for marker in ("喜欢", "prefer", "preference", "like")) and note.type.value == "preference":
+                score += 2
+            if note.scope.value == "user":
+                score += 1
+            if score > 0:
+                candidates.append(((score, note.priority, note.confidence, note.content.casefold()), note))
+
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        return [note for _, note in candidates[:max_notes]]
 
     def _build_experience_context(
         self,
@@ -536,6 +574,29 @@ class ContextBuilder:
                 return True
 
         return False
+
+    @staticmethod
+    def _is_memory_lookup_question(text: str) -> bool:
+        text = text.strip().casefold()
+        if not text:
+            return False
+        markers = [
+            "我喜欢",
+            "我的偏好",
+            "我爱",
+            "我常",
+            "你记得",
+            "还记得",
+            "记得我",
+            "关于我",
+            "what do i like",
+            "what's my",
+            "what is my",
+            "do you remember",
+            "remember about me",
+            "my preference",
+        ]
+        return any(marker in text for marker in markers)
 
     @staticmethod
     def _build_search_query(

--- a/tinybot/agent/loop.py
+++ b/tinybot/agent/loop.py
@@ -1097,6 +1097,11 @@ class AgentLoop:
         references = getattr(context, "last_memory_references", []) or []
         return [dict(item) for item in references if isinstance(item, dict)]
 
+    @staticmethod
+    def _current_recent_context_references_from_context(context: ContextBuilder) -> list[dict[str, Any]]:
+        references = getattr(context, "last_recent_context_references", []) or []
+        return [dict(item) for item in references if isinstance(item, dict)]
+
     def _attach_memory_references_to_latest_assistant(
         self,
         session: Session,
@@ -1109,6 +1114,20 @@ class AgentLoop:
             message = session.messages[idx]
             if message.get("role") == "assistant":
                 message["_memory_references"] = references
+                return
+
+    def _attach_recent_context_references_to_latest_assistant(
+        self,
+        session: Session,
+        turn_start_index: int,
+        references: list[dict[str, Any]],
+    ) -> None:
+        if not references:
+            return
+        for idx in range(len(session.messages) - 1, max(turn_start_index, 0) - 1, -1):
+            message = session.messages[idx]
+            if message.get("role") == "assistant":
+                message["_recent_context_references"] = references
                 return
 
     def _memory_extraction_config(self) -> tuple[int, int]:
@@ -1350,8 +1369,11 @@ class AgentLoop:
                 user_profile=session.user_profile,
             )
             memory_references = self._current_memory_references_from_context(self.context)
+            recent_context_references = self._current_recent_context_references_from_context(self.context)
             if memory_references:
                 msg.metadata["_memory_references"] = memory_references
+            if recent_context_references:
+                msg.metadata["_recent_context_references"] = recent_context_references
             final_content, _, all_msgs, stop_reason = await self._run_agent_loop(
                 messages, session=session, channel=channel, chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
@@ -1381,6 +1403,7 @@ class AgentLoop:
             self.session_handler.save_turn(session, all_msgs, skip_count, ContextBuilder._RUNTIME_CONTEXT_TAG)
             self.session_handler.clear_checkpoint(session)
             self._attach_memory_references_to_latest_assistant(session, turn_start_index, memory_references)
+            self._attach_recent_context_references_to_latest_assistant(session, turn_start_index, recent_context_references)
             self.sessions.save(session)
             self._schedule_background(self.consolidator.maybe_consolidate_by_tokens(session))
             self._schedule_background(self._update_user_profile(
@@ -1392,7 +1415,10 @@ class AgentLoop:
                 channel=channel,
                 chat_id=chat_id,
                 content=final_content or "Background task completed.",
-                metadata={"_memory_references": memory_references} if memory_references else {},
+                metadata={
+                    **({"_memory_references": memory_references} if memory_references else {}),
+                    **({"_recent_context_references": recent_context_references} if recent_context_references else {}),
+                },
             )
 
         preview = msg.content[:80] + "..." if len(msg.content) > 80 else msg.content
@@ -1425,8 +1451,11 @@ class AgentLoop:
             use_persistent_knowledge=msg.metadata.get("_use_persistent_rag"),
         )
         memory_references = self._current_memory_references_from_context(self.context)
+        recent_context_references = self._current_recent_context_references_from_context(self.context)
         if memory_references:
             msg.metadata["_memory_references"] = memory_references
+        if recent_context_references:
+            msg.metadata["_recent_context_references"] = recent_context_references
 
         # Save user message to session before running agent loop
         # This ensures user input is persisted even if checkpoint saves assistant/tool messages
@@ -1509,6 +1538,7 @@ class AgentLoop:
         self.session_handler.save_turn(session, all_msgs, skip_count, ContextBuilder._RUNTIME_CONTEXT_TAG)
         self.session_handler.clear_checkpoint(session)
         self._attach_memory_references_to_latest_assistant(session, turn_start_index, memory_references)
+        self._attach_recent_context_references_to_latest_assistant(session, turn_start_index, recent_context_references)
         self.sessions.save(session)
         evidence = self._capture_conversation_evidence(session, turn_start_index)
         self._schedule_memory_extraction_triggers(session, evidence)
@@ -1526,6 +1556,8 @@ class AgentLoop:
         meta = dict(msg.metadata or {})
         if memory_references:
             meta["_memory_references"] = memory_references
+        if recent_context_references:
+            meta["_recent_context_references"] = recent_context_references
         if on_stream is not None:
             meta["_streamed"] = True
         return OutboundMessage(
@@ -1743,8 +1775,11 @@ class AgentLoop:
             use_persistent_knowledge=checkpoint.get("_use_persistent_knowledge"),
         )
         memory_references = self._current_memory_references_from_context(self.context)
+        recent_context_references = self._current_recent_context_references_from_context(self.context)
         if memory_references:
             msg.metadata["_memory_references"] = memory_references
+        if recent_context_references:
+            msg.metadata["_recent_context_references"] = recent_context_references
         final_content, _, all_msgs, stop_reason = await self._run_agent_loop(
             messages,
             session=session,
@@ -1773,6 +1808,7 @@ class AgentLoop:
         self.session_handler.save_turn(session, all_msgs, skip_count, ContextBuilder._RUNTIME_CONTEXT_TAG)
         self.session_handler.clear_checkpoint(session)
         self._attach_memory_references_to_latest_assistant(session, turn_start_index, memory_references)
+        self._attach_recent_context_references_to_latest_assistant(session, turn_start_index, recent_context_references)
         self.sessions.save(session)
         evidence = self._capture_conversation_evidence(session, turn_start_index)
         self._schedule_memory_extraction_triggers(session, evidence)
@@ -1781,7 +1817,10 @@ class AgentLoop:
             channel=channel,
             chat_id=chat_id,
             content=final_content,
-            metadata={"_memory_references": memory_references} if memory_references else {},
+            metadata={
+                **({"_memory_references": memory_references} if memory_references else {}),
+                **({"_recent_context_references": recent_context_references} if recent_context_references else {}),
+            },
         )
 
     async def process_direct(

--- a/tinybot/agent/loop.py
+++ b/tinybot/agent/loop.py
@@ -48,7 +48,13 @@ from tinybot.agent.experience_analyzer import ErrorAnalyzer
 from tinybot.agent.experience_summarizer import ExperienceSummarizer
 from tinybot.agent.hook import AgentHook
 from tinybot.agent.knowledge import KnowledgeStore
-from tinybot.agent.memory import Consolidator, Dream, EntityExtractor
+from tinybot.agent.memory import (
+    Consolidator,
+    ConversationEvidence,
+    Dream,
+    EntityExtractor,
+    capture_conversation_evidence,
+)
 from tinybot.agent.runner import AgentRunSpec, AgentRunner
 from tinybot.agent.session_knowledge import SessionKnowledgeStore
 from tinybot.agent.skills import BUILTIN_SKILLS_DIR
@@ -348,6 +354,9 @@ class AgentLoop:
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
         self._background_tasks: list[asyncio.Task] = []
         self._session_locks: dict[str, asyncio.Lock] = {}
+        self._memory_extraction_locks: dict[str, asyncio.Lock] = {}
+        self._memory_extraction_run_lock = asyncio.Lock()
+        self._memory_extraction_idle_tasks: dict[str, asyncio.Task] = {}
         # tinybot_MAX_CONCURRENT_REQUESTS: <=0 means unlimited; default 3.
         _max = int(os.environ.get("tinybot_MAX_CONCURRENT_REQUESTS", "3"))
         self._concurrency_gate: asyncio.Semaphore | None = (
@@ -1060,6 +1069,108 @@ class AgentLoop:
         self._background_tasks.append(task)
         task.add_done_callback(self._background_tasks.remove)
 
+    def _last_user_message_index(self, session: Session) -> int:
+        for idx in range(len(session.messages) - 1, -1, -1):
+            if session.messages[idx].get("role") == "user":
+                return idx
+        return len(session.messages)
+
+    def _capture_conversation_evidence(
+        self,
+        session: Session,
+        turn_start_index: int,
+    ) -> list[ConversationEvidence]:
+        try:
+            turn_messages = session.messages[turn_start_index:]
+            return capture_conversation_evidence(
+                self.context.memory,
+                session_key=session.key,
+                messages=turn_messages,
+                start_index=turn_start_index,
+            )
+        except Exception:
+            logger.exception("Conversation Evidence capture failed for {}", session.key)
+            return []
+
+    def _memory_extraction_config(self) -> tuple[int, int]:
+        dream_cfg = None
+        if self._config_ref is not None:
+            dream_cfg = getattr(getattr(self._config_ref.agents, "defaults", None), "dream", None)
+        every_n = int(getattr(dream_cfg, "extraction_every_n_turns", 6) or 6)
+        idle_seconds = int(getattr(dream_cfg, "extraction_idle_seconds", 300) or 300)
+        return max(every_n, 1), max(idle_seconds, 1)
+
+    def _schedule_memory_extraction_triggers(
+        self,
+        session: Session,
+        evidence: list[ConversationEvidence],
+    ) -> None:
+        if not evidence or not any(record.role == "user" for record in evidence):
+            return
+        every_n, idle_seconds = self._memory_extraction_config()
+        state = session.metadata.setdefault("memory_extraction", {})
+        if not isinstance(state, dict):
+            state = {}
+            session.metadata["memory_extraction"] = state
+
+        completed_turns = int(state.get("completed_user_turns") or 0) + 1
+        state["completed_user_turns"] = completed_turns
+        should_run_now = completed_turns in {1, 2, 4}
+        if completed_turns > 4 and (completed_turns - 4) % every_n == 0:
+            should_run_now = True
+        self.sessions.save(session)
+
+        if should_run_now:
+            self._schedule_background(self._run_memory_extraction_once(session.key))
+
+        old_idle = self._memory_extraction_idle_tasks.pop(session.key, None)
+        if old_idle and not old_idle.done():
+            old_idle.cancel()
+        idle_task = asyncio.create_task(self._run_memory_extraction_after_idle(session.key, idle_seconds))
+        self._memory_extraction_idle_tasks[session.key] = idle_task
+        self._background_tasks.append(idle_task)
+        def _forget_idle_task(task: asyncio.Task, key: str = session.key) -> None:
+            if self._memory_extraction_idle_tasks.get(key) is task:
+                self._memory_extraction_idle_tasks.pop(key, None)
+            if task in self._background_tasks:
+                self._background_tasks.remove(task)
+
+        idle_task.add_done_callback(_forget_idle_task)
+
+    async def _run_memory_extraction_after_idle(self, session_key: str, idle_seconds: int) -> None:
+        try:
+            await asyncio.sleep(idle_seconds)
+        except asyncio.CancelledError:
+            return
+        pending = self.context.memory.read_pending_conversation_evidence(session_key=session_key)
+        if pending:
+            await self._run_memory_extraction_once(session_key)
+
+    async def _run_memory_extraction_once(self, session_key: str) -> None:
+        lock = self._memory_extraction_locks.setdefault(session_key, asyncio.Lock())
+        session = self.sessions.get(session_key)
+        if lock.locked():
+            if session is not None:
+                state = session.metadata.setdefault("memory_extraction", {})
+                if isinstance(state, dict):
+                    state["pending"] = True
+                    self.sessions.save(session)
+            return
+        async with lock:
+            async with self._memory_extraction_run_lock:
+                try:
+                    await self.dream.run()
+                except Exception:
+                    logger.exception("Memory Extraction failed for {}", session_key)
+                    return
+            session = self.sessions.get(session_key)
+            if session is not None:
+                state = session.metadata.setdefault("memory_extraction", {})
+                if isinstance(state, dict):
+                    state["pending"] = False
+                    state["last_extracted_at"] = datetime.now().isoformat()
+                    self.sessions.save(session)
+
     def schedule_approval_retry(
         self,
         *,
@@ -1261,6 +1372,7 @@ class AgentLoop:
 
         key = session_key or msg.session_key
         session = self.sessions.get_or_create(key)
+        turn_start_index = len(session.messages)
 
         # Slash commands
         raw = msg.content.strip()
@@ -1366,6 +1478,8 @@ class AgentLoop:
         self.session_handler.save_turn(session, all_msgs, skip_count, ContextBuilder._RUNTIME_CONTEXT_TAG)
         self.session_handler.clear_checkpoint(session)
         self.sessions.save(session)
+        evidence = self._capture_conversation_evidence(session, turn_start_index)
+        self._schedule_memory_extraction_triggers(session, evidence)
         self._schedule_background(self.consolidator.maybe_consolidate_by_tokens(session))
         self._schedule_background(self._update_user_profile(
             session, msg.content, final_content or "",
@@ -1496,6 +1610,7 @@ class AgentLoop:
 
         request = ApprovalRequest.from_dict(raw_request)
         approved = bool(resolution.get("approved"))
+        turn_start_index = self._last_user_message_index(session)
         checkpoint = session.metadata.get(self.session_handler.RUNTIME_CHECKPOINT_KEY)
         if not isinstance(checkpoint, dict):
             return OutboundMessage(
@@ -1621,6 +1736,8 @@ class AgentLoop:
         self.session_handler.save_turn(session, all_msgs, skip_count, ContextBuilder._RUNTIME_CONTEXT_TAG)
         self.session_handler.clear_checkpoint(session)
         self.sessions.save(session)
+        evidence = self._capture_conversation_evidence(session, turn_start_index)
+        self._schedule_memory_extraction_triggers(session, evidence)
         self._schedule_background(self.consolidator.maybe_consolidate_by_tokens(session))
         return OutboundMessage(channel=channel, chat_id=chat_id, content=final_content)
 

--- a/tinybot/agent/loop.py
+++ b/tinybot/agent/loop.py
@@ -1092,6 +1092,25 @@ class AgentLoop:
             logger.exception("Conversation Evidence capture failed for {}", session.key)
             return []
 
+    @staticmethod
+    def _current_memory_references_from_context(context: ContextBuilder) -> list[dict[str, Any]]:
+        references = getattr(context, "last_memory_references", []) or []
+        return [dict(item) for item in references if isinstance(item, dict)]
+
+    def _attach_memory_references_to_latest_assistant(
+        self,
+        session: Session,
+        turn_start_index: int,
+        references: list[dict[str, Any]],
+    ) -> None:
+        if not references:
+            return
+        for idx in range(len(session.messages) - 1, max(turn_start_index, 0) - 1, -1):
+            message = session.messages[idx]
+            if message.get("role") == "assistant":
+                message["_memory_references"] = references
+                return
+
     def _memory_extraction_config(self) -> tuple[int, int]:
         dream_cfg = None
         if self._config_ref is not None:
@@ -1290,6 +1309,7 @@ class AgentLoop:
             key = f"{channel}:{chat_id}"
 
             session = self.sessions.get_or_create(key)
+            turn_start_index = len(session.messages)
             if msg.sender_id == "approval":
                 return await self._process_approval_resolution(
                     msg=msg,
@@ -1329,6 +1349,9 @@ class AgentLoop:
                 current_role="user",  # Use "user" role to avoid merging with previous assistant message
                 user_profile=session.user_profile,
             )
+            memory_references = self._current_memory_references_from_context(self.context)
+            if memory_references:
+                msg.metadata["_memory_references"] = memory_references
             final_content, _, all_msgs, stop_reason = await self._run_agent_loop(
                 messages, session=session, channel=channel, chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
@@ -1357,6 +1380,7 @@ class AgentLoop:
             skip_count = len(session.messages)
             self.session_handler.save_turn(session, all_msgs, skip_count, ContextBuilder._RUNTIME_CONTEXT_TAG)
             self.session_handler.clear_checkpoint(session)
+            self._attach_memory_references_to_latest_assistant(session, turn_start_index, memory_references)
             self.sessions.save(session)
             self._schedule_background(self.consolidator.maybe_consolidate_by_tokens(session))
             self._schedule_background(self._update_user_profile(
@@ -1364,8 +1388,12 @@ class AgentLoop:
             ))
             if (mt := self.tools.get("message")) and isinstance(mt, MessageTool) and mt._sent_in_turn:
                 return None
-            return OutboundMessage(channel=channel, chat_id=chat_id,
-                                  content=final_content or "Background task completed.")
+            return OutboundMessage(
+                channel=channel,
+                chat_id=chat_id,
+                content=final_content or "Background task completed.",
+                metadata={"_memory_references": memory_references} if memory_references else {},
+            )
 
         preview = msg.content[:80] + "..." if len(msg.content) > 80 else msg.content
         logger.info("Processing message from {}:{}: {}", msg.channel, msg.sender_id, preview)
@@ -1396,6 +1424,9 @@ class AgentLoop:
             user_profile=session.user_profile,
             use_persistent_knowledge=msg.metadata.get("_use_persistent_rag"),
         )
+        memory_references = self._current_memory_references_from_context(self.context)
+        if memory_references:
+            msg.metadata["_memory_references"] = memory_references
 
         # Save user message to session before running agent loop
         # This ensures user input is persisted even if checkpoint saves assistant/tool messages
@@ -1477,6 +1508,7 @@ class AgentLoop:
         skip_count = len(session.messages)
         self.session_handler.save_turn(session, all_msgs, skip_count, ContextBuilder._RUNTIME_CONTEXT_TAG)
         self.session_handler.clear_checkpoint(session)
+        self._attach_memory_references_to_latest_assistant(session, turn_start_index, memory_references)
         self.sessions.save(session)
         evidence = self._capture_conversation_evidence(session, turn_start_index)
         self._schedule_memory_extraction_triggers(session, evidence)
@@ -1492,6 +1524,8 @@ class AgentLoop:
         logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)
 
         meta = dict(msg.metadata or {})
+        if memory_references:
+            meta["_memory_references"] = memory_references
         if on_stream is not None:
             meta["_streamed"] = True
         return OutboundMessage(
@@ -1708,6 +1742,9 @@ class AgentLoop:
             user_profile=session.user_profile,
             use_persistent_knowledge=checkpoint.get("_use_persistent_knowledge"),
         )
+        memory_references = self._current_memory_references_from_context(self.context)
+        if memory_references:
+            msg.metadata["_memory_references"] = memory_references
         final_content, _, all_msgs, stop_reason = await self._run_agent_loop(
             messages,
             session=session,
@@ -1735,11 +1772,17 @@ class AgentLoop:
         skip_count = len(session.messages)
         self.session_handler.save_turn(session, all_msgs, skip_count, ContextBuilder._RUNTIME_CONTEXT_TAG)
         self.session_handler.clear_checkpoint(session)
+        self._attach_memory_references_to_latest_assistant(session, turn_start_index, memory_references)
         self.sessions.save(session)
         evidence = self._capture_conversation_evidence(session, turn_start_index)
         self._schedule_memory_extraction_triggers(session, evidence)
         self._schedule_background(self.consolidator.maybe_consolidate_by_tokens(session))
-        return OutboundMessage(channel=channel, chat_id=chat_id, content=final_content)
+        return OutboundMessage(
+            channel=channel,
+            chat_id=chat_id,
+            content=final_content,
+            metadata={"_memory_references": memory_references} if memory_references else {},
+        )
 
     async def process_direct(
         self,

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -50,6 +50,13 @@ class MemoryNoteStatus(StrEnum):
     REJECTED = "rejected"
 
 
+class MemoryNoteScope(StrEnum):
+    USER = "user"
+    ASSISTANT = "assistant"
+    PROJECT = "project"
+    SESSION = "session"
+
+
 class MemoryCaptureOrigin(StrEnum):
     DREAM = "dream"
     EXPLICIT = "explicit"
@@ -86,16 +93,19 @@ def _memory_note_search_text(note: MemoryNote) -> str:
                 source.history_end_cursor,
                 source.message_start,
                 source.message_end,
+                " ".join(source.evidence_ids),
             )
             if part is not None
         )
     return " ".join(
         [
             note.id,
+            note.scope.value,
             note.type.value,
             note.status.value,
             note.content,
             " ".join(note.tags),
+            json.dumps(note.metadata, ensure_ascii=False, sort_keys=True),
             " ".join(source_parts),
         ]
     )
@@ -145,6 +155,14 @@ def _strict_note_type(value: MemoryNoteType | str) -> MemoryNoteType:
         raise ValueError(f"Invalid Memory Note type: {value!r}. Allowed: {allowed}") from exc
 
 
+def _strict_note_scope(value: MemoryNoteScope | str) -> MemoryNoteScope:
+    try:
+        return MemoryNoteScope(str(value))
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in MemoryNoteScope)
+        raise ValueError(f"Invalid Memory Note scope: {value!r}. Allowed: {allowed}") from exc
+
+
 def _strict_note_status(value: MemoryNoteStatus | str) -> MemoryNoteStatus:
     try:
         return MemoryNoteStatus(str(value))
@@ -184,6 +202,67 @@ def _clean_note_tags(tags: list[str] | tuple[str, ...] | str | None) -> list[str
     return cleaned
 
 
+def _clean_evidence_ids(evidence_ids: list[str] | tuple[str, ...] | str | None) -> list[str]:
+    if evidence_ids is None:
+        return []
+    raw_ids = [evidence_ids] if isinstance(evidence_ids, str) else list(evidence_ids)
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for evidence_id in raw_ids:
+        text = str(evidence_id).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+    return cleaned
+
+
+def _clean_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(metadata, dict):
+        return {}
+    cleaned: dict[str, Any] = {}
+    for key, value in metadata.items():
+        text_key = str(key).strip()
+        if not text_key:
+            continue
+        try:
+            json.dumps(value, ensure_ascii=False)
+        except TypeError:
+            cleaned[text_key] = str(value)
+        else:
+            cleaned[text_key] = value
+    return cleaned
+
+
+def _default_scope_for_type(note_type: MemoryNoteType | str) -> MemoryNoteScope:
+    coerced_type = _coerce_enum(MemoryNoteType, note_type, MemoryNoteType.PROJECT)
+    if coerced_type == MemoryNoteType.PREFERENCE:
+        return MemoryNoteScope.USER
+    if coerced_type == MemoryNoteType.INSTRUCTION:
+        return MemoryNoteScope.ASSISTANT
+    return MemoryNoteScope.PROJECT
+
+
+def _merge_metadata(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(existing)
+    for key, value in incoming.items():
+        if key not in merged or merged[key] in (None, "", [], {}):
+            merged[key] = value
+        elif merged[key] == value:
+            continue
+        elif isinstance(merged[key], list):
+            values = list(merged[key])
+            if value not in values:
+                values.append(value)
+            merged[key] = values
+        else:
+            values = [merged[key]]
+            if value not in values:
+                values.append(value)
+            merged[key] = values
+    return merged
+
+
 @dataclass(slots=True)
 class MemorySource:
     capture_origin: MemoryCaptureOrigin
@@ -194,6 +273,7 @@ class MemorySource:
     history_start_cursor: int | None = None
     history_end_cursor: int | None = None
     source_file: str | None = None
+    evidence_ids: list[str] = field(default_factory=list)
 
     @classmethod
     def dream(
@@ -201,11 +281,13 @@ class MemorySource:
         *,
         history_start_cursor: int | None = None,
         history_end_cursor: int | None = None,
+        evidence_ids: list[str] | None = None,
     ) -> MemorySource:
         return cls(
             capture_origin=MemoryCaptureOrigin.DREAM,
             history_start_cursor=history_start_cursor,
             history_end_cursor=history_end_cursor,
+            evidence_ids=_clean_evidence_ids(evidence_ids),
         )
 
     @classmethod
@@ -215,12 +297,14 @@ class MemorySource:
         session_key: str | None = None,
         message_start: int | None = None,
         message_end: int | None = None,
+        evidence_ids: list[str] | None = None,
     ) -> MemorySource:
         return cls(
             capture_origin=MemoryCaptureOrigin.EXPLICIT,
             session_key=session_key,
             message_start=message_start,
             message_end=message_end,
+            evidence_ids=_clean_evidence_ids(evidence_ids),
         )
 
     @classmethod
@@ -246,6 +330,7 @@ class MemorySource:
             history_start_cursor=_coerce_int(raw.get("history_start_cursor")),
             history_end_cursor=_coerce_int(raw.get("history_end_cursor")),
             source_file=str(raw["source_file"]) if raw.get("source_file") else None,
+            evidence_ids=_clean_evidence_ids(raw.get("evidence_ids")),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -264,6 +349,8 @@ class MemorySource:
             value = getattr(self, key)
             if value is not None:
                 data[key] = value
+        if self.evidence_ids:
+            data["evidence_ids"] = list(self.evidence_ids)
         return data
 
     def identity(self) -> tuple[Any, ...]:
@@ -284,6 +371,7 @@ class MemoryNote:
     type: MemoryNoteType
     sources: list[MemorySource]
     id: str = ""
+    scope: MemoryNoteScope = MemoryNoteScope.PROJECT
     status: MemoryNoteStatus = MemoryNoteStatus.ACTIVE
     priority: float = 0.5
     confidence: float = 0.5
@@ -292,12 +380,15 @@ class MemoryNote:
     supersedes: list[str] = field(default_factory=list)
     superseded_by: str | None = None
     tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         self.content = self.content.strip()
+        self.scope = _coerce_enum(MemoryNoteScope, self.scope, _default_scope_for_type(self.type))
         self.sources = [source for source in self.sources if isinstance(source, MemorySource)]
+        self.metadata = _clean_metadata(self.metadata)
         if not self.id:
-            self.id = generate_memory_note_id(self.type, self.content, self.sources)
+            self.id = generate_memory_note_id(self.type, self.content, self.sources, scope=self.scope)
 
     @classmethod
     def create(
@@ -309,14 +400,19 @@ class MemoryNote:
         priority: float = 0.5,
         confidence: float = 0.5,
         tags: list[str] | None = None,
+        scope: MemoryNoteScope | str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryNote:
+        coerced_type = _coerce_enum(MemoryNoteType, note_type, MemoryNoteType.PROJECT)
         return cls(
             content=content,
-            type=_coerce_enum(MemoryNoteType, note_type, MemoryNoteType.PROJECT),
+            type=coerced_type,
+            scope=_coerce_enum(MemoryNoteScope, scope, _default_scope_for_type(coerced_type)) if scope else _default_scope_for_type(coerced_type),
             sources=sources or [],
             priority=priority,
             confidence=confidence,
             tags=list(tags or []),
+            metadata=_clean_metadata(metadata),
         )
 
     @classmethod
@@ -329,8 +425,14 @@ class MemoryNote:
         else:
             sources = []
         return cls(
-            id=str(data.get("id") or generate_memory_note_id(note_type, content, sources)),
+            id=str(data.get("id") or generate_memory_note_id(
+                note_type,
+                content,
+                sources,
+                scope=_coerce_enum(MemoryNoteScope, data.get("scope"), _default_scope_for_type(note_type)),
+            )),
             type=note_type,
+            scope=_coerce_enum(MemoryNoteScope, data.get("scope"), _default_scope_for_type(note_type)),
             status=_coerce_enum(MemoryNoteStatus, data.get("status"), MemoryNoteStatus.ACTIVE),
             content=content,
             priority=_coerce_float(data.get("priority"), 0.5),
@@ -341,11 +443,13 @@ class MemoryNote:
             supersedes=[str(item) for item in data.get("supersedes") or []],
             superseded_by=str(data["superseded_by"]) if data.get("superseded_by") else None,
             tags=[str(item) for item in data.get("tags") or []],
+            metadata=_clean_metadata(data.get("metadata")),
         )
 
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {
             "id": self.id,
+            "scope": self.scope.value,
             "type": self.type.value,
             "status": self.status.value,
             "content": self.content,
@@ -361,33 +465,226 @@ class MemoryNote:
             data["superseded_by"] = self.superseded_by
         if self.tags:
             data["tags"] = list(self.tags)
+        if self.metadata:
+            data["metadata"] = _clean_metadata(self.metadata)
         return data
 
     def equivalent_key(self) -> tuple[Any, ...]:
-        return memory_note_equivalent_key(self.type, self.content, self.sources)
+        return memory_note_equivalent_key(self.type, self.content, self.sources, scope=self.scope)
 
 
 def memory_note_equivalent_key(
     note_type: MemoryNoteType | str,
     content: str,
     sources: list[MemorySource] | None = None,
+    *,
+    scope: MemoryNoteScope | str | None = None,
 ) -> tuple[Any, ...]:
     coerced_type = _coerce_enum(MemoryNoteType, note_type, MemoryNoteType.PROJECT)
+    coerced_scope = _coerce_enum(MemoryNoteScope, scope, _default_scope_for_type(coerced_type)) if scope else _default_scope_for_type(coerced_type)
     source_keys = sorted((source.identity() for source in (sources or [])), key=repr)
-    return (coerced_type.value, _normalize_note_text(content), tuple(source_keys))
+    return (coerced_scope.value, coerced_type.value, _normalize_note_text(content), tuple(source_keys))
 
 
 def generate_memory_note_id(
     note_type: MemoryNoteType | str,
     content: str,
     sources: list[MemorySource] | None = None,
+    *,
+    scope: MemoryNoteScope | str | None = None,
 ) -> str:
     payload = json.dumps(
-        memory_note_equivalent_key(note_type, content, sources),
+        memory_note_equivalent_key(note_type, content, sources, scope=scope),
         ensure_ascii=False,
         sort_keys=True,
     )
     return "note_" + hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+
+@dataclass(slots=True)
+class ConversationEvidence:
+    id: str
+    turn_id: str
+    session_key: str
+    role: str
+    content: str
+    timestamp: str = field(default_factory=_utc_timestamp)
+    message_index: int | None = None
+    cursor: int | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        session_key: str,
+        turn_id: str,
+        role: str,
+        content: str,
+        message_index: int | None = None,
+        timestamp: str | None = None,
+    ) -> ConversationEvidence:
+        cleaned_content = content.strip()
+        return cls(
+            id=generate_conversation_evidence_id(
+                session_key=session_key,
+                turn_id=turn_id,
+                role=role,
+                content=cleaned_content,
+                message_index=message_index,
+            ),
+            turn_id=turn_id,
+            session_key=session_key,
+            role=role,
+            content=cleaned_content,
+            message_index=message_index,
+            timestamp=timestamp or _utc_timestamp(),
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConversationEvidence:
+        role = str(data.get("role") or "")
+        content = str(data.get("content") or "")
+        session_key = str(data.get("session_key") or "")
+        turn_id = str(data.get("turn_id") or "")
+        message_index = _coerce_int(data.get("message_index"))
+        evidence_id = str(data.get("id") or generate_conversation_evidence_id(
+            session_key=session_key,
+            turn_id=turn_id,
+            role=role,
+            content=content,
+            message_index=message_index,
+        ))
+        return cls(
+            id=evidence_id,
+            turn_id=turn_id,
+            session_key=session_key,
+            role=role,
+            content=content,
+            timestamp=str(data.get("timestamp") or _utc_timestamp()),
+            message_index=message_index,
+            cursor=_coerce_int(data.get("cursor")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "id": self.id,
+            "turn_id": self.turn_id,
+            "session_key": self.session_key,
+            "role": self.role,
+            "content": self.content,
+            "timestamp": self.timestamp,
+        }
+        if self.message_index is not None:
+            data["message_index"] = self.message_index
+        if self.cursor is not None:
+            data["cursor"] = self.cursor
+        return data
+
+
+def generate_conversation_turn_id(
+    session_key: str,
+    messages: list[dict[str, Any]],
+) -> str:
+    payload = []
+    for idx, message in enumerate(messages):
+        role = str(message.get("role") or "")
+        if role not in {"user", "assistant"}:
+            continue
+        content = _conversation_evidence_text(message)
+        if content:
+            payload.append([message.get("_evidence_message_index", idx), role, content])
+    raw = json.dumps([session_key, payload], ensure_ascii=False, sort_keys=True)
+    return "turn_" + hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def generate_conversation_evidence_id(
+    *,
+    session_key: str,
+    turn_id: str,
+    role: str,
+    content: str,
+    message_index: int | None = None,
+) -> str:
+    payload = json.dumps(
+        {
+            "session_key": session_key,
+            "turn_id": turn_id,
+            "role": role,
+            "content": content,
+            "message_index": message_index,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return "ev_" + hashlib.sha1(payload.encode("utf-8")).hexdigest()[:20]
+
+
+def _conversation_evidence_text(message: dict[str, Any]) -> str:
+    role = str(message.get("role") or "")
+    if role not in {"user", "assistant"}:
+        return ""
+    if role == "assistant" and message.get("tool_calls"):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return strip_think(content).strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text" and isinstance(block.get("text"), str):
+                text = strip_think(block["text"]).strip()
+                if text:
+                    parts.append(text)
+                continue
+            if block.get("type") == "image_url":
+                parts.append("[media omitted]")
+        return "\n".join(parts).strip()
+    return ""
+
+
+def capture_conversation_evidence(
+    store: MemoryStore,
+    *,
+    session_key: str,
+    messages: list[dict[str, Any]],
+    start_index: int = 0,
+) -> list[ConversationEvidence]:
+    """Persist clean user/assistant text evidence from already-saved turn messages."""
+    evidence_messages: list[tuple[int, dict[str, Any], str]] = []
+    for offset, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "")
+        if role not in {"user", "assistant"}:
+            continue
+        content = _conversation_evidence_text(message)
+        if not content:
+            continue
+        evidence_messages.append((start_index + offset, message, content))
+    if not evidence_messages:
+        return []
+
+    turn_id = generate_conversation_turn_id(
+        session_key,
+        [
+            {**message, "_evidence_message_index": message_index}
+            for message_index, message, _ in evidence_messages
+        ],
+    )
+    records = [
+        ConversationEvidence.create(
+            session_key=session_key,
+            turn_id=turn_id,
+            role=str(message.get("role") or ""),
+            content=content,
+            message_index=message_index,
+            timestamp=str(message.get("timestamp") or _utc_timestamp()),
+        )
+        for message_index, message, content in evidence_messages
+    ]
+    return store.append_conversation_evidence(records)
 
 
 # ---------------------------------------------------------------------------
@@ -414,6 +711,12 @@ class MemoryStore:
         MemoryNoteType.FIX: "memory/MEMORY.md",
         MemoryNoteType.FOLLOWUP: "memory/MEMORY.md",
     }
+    _SCOPE_VIEW_DEFAULTS = {
+        MemoryNoteScope.USER: "USER.md",
+        MemoryNoteScope.ASSISTANT: "SOUL.md",
+        MemoryNoteScope.PROJECT: "memory/MEMORY.md",
+        MemoryNoteScope.SESSION: "memory/MEMORY.md",
+    }
 
     def __init__(self, workspace: Path, max_history_entries: int = _DEFAULT_MAX_HISTORY):
         self.workspace = workspace
@@ -422,13 +725,17 @@ class MemoryStore:
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.notes_file = self.memory_dir / "notes.jsonl"
         self.history_file = self.memory_dir / "history.jsonl"
+        self.conversations_dir = ensure_dir(self.memory_dir / "conversations")
         self.legacy_history_file = self.memory_dir / "HISTORY.md"
         self.soul_file = workspace / "SOUL.md"
         self.user_file = workspace / "USER.md"
         self._cursor_file = self.memory_dir / ".cursor"
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
+        self._evidence_sequence_file = self.memory_dir / ".evidence_sequence"
+        self._evidence_cursor_file = self.memory_dir / ".evidence_cursor"
         self._git = GitStore(workspace, tracked_files=[
             "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/notes.jsonl",
+            "memory/.evidence_cursor",
         ])
         # One-time migration from legacy HISTORY.md format
         migrate_legacy_history(self.memory_dir)
@@ -472,6 +779,97 @@ class MemoryStore:
             for note in notes:
                 f.write(json.dumps(note.to_dict(), ensure_ascii=False) + "\n")
 
+    # -- conversations/*.jsonl (Conversation Evidence) ----------------------
+
+    def append_conversation_evidence(
+        self,
+        records: list[ConversationEvidence],
+    ) -> list[ConversationEvidence]:
+        """Append Conversation Evidence records and return records actually written."""
+        if not records:
+            return []
+        existing_ids = self._read_conversation_evidence_ids()
+        written: list[ConversationEvidence] = []
+        for record in records:
+            if record.id in existing_ids or not record.content.strip():
+                continue
+            record.cursor = self._next_evidence_cursor()
+            path = self._conversation_evidence_path(record.timestamp)
+            ensure_dir(path.parent)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record.to_dict(), ensure_ascii=False) + "\n")
+            self._evidence_sequence_file.write_text(str(record.cursor), encoding="utf-8")
+            existing_ids.add(record.id)
+            written.append(record)
+        return written
+
+    def read_pending_conversation_evidence(
+        self,
+        *,
+        since_cursor: int | None = None,
+        limit: int | None = None,
+        session_key: str | None = None,
+    ) -> list[ConversationEvidence]:
+        cursor = self.get_last_evidence_cursor() if since_cursor is None else since_cursor
+        records = [
+            record for record in self.read_conversation_evidence()
+            if (record.cursor or 0) > cursor
+            and (session_key is None or record.session_key == session_key)
+        ]
+        records.sort(key=lambda item: (item.cursor or 0, item.timestamp, item.id))
+        if limit is not None:
+            return records[: max(limit, 0)]
+        return records
+
+    def read_conversation_evidence(self) -> list[ConversationEvidence]:
+        records: list[ConversationEvidence] = []
+        for path in sorted(self.conversations_dir.glob("*.jsonl")):
+            try:
+                with open(path, encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            raw = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if isinstance(raw, dict):
+                            records.append(ConversationEvidence.from_dict(raw))
+            except FileNotFoundError:
+                continue
+        records.sort(key=lambda item: (item.cursor or 0, item.timestamp, item.id))
+        return records
+
+    def get_last_evidence_cursor(self) -> int:
+        if self._evidence_cursor_file.exists():
+            try:
+                return int(self._evidence_cursor_file.read_text(encoding="utf-8").strip())
+            except (ValueError, OSError):
+                pass
+        return 0
+
+    def set_last_evidence_cursor(self, cursor: int) -> None:
+        self._evidence_cursor_file.write_text(str(cursor), encoding="utf-8")
+
+    def _conversation_evidence_path(self, timestamp: str | None = None) -> Path:
+        date_part = (timestamp or _utc_timestamp())[:10]
+        if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_part):
+            date_part = datetime.utcnow().strftime("%Y-%m-%d")
+        return self.conversations_dir / f"{date_part}.jsonl"
+
+    def _next_evidence_cursor(self) -> int:
+        if self._evidence_sequence_file.exists():
+            try:
+                return int(self._evidence_sequence_file.read_text(encoding="utf-8").strip()) + 1
+            except (ValueError, OSError):
+                pass
+        last = max((record.cursor or 0 for record in self.read_conversation_evidence()), default=0)
+        return last + 1
+
+    def _read_conversation_evidence_ids(self) -> set[str]:
+        return {record.id for record in self.read_conversation_evidence()}
+
     def find_duplicate_note(self, candidate: MemoryNote) -> MemoryNote | None:
         candidate_key = candidate.equivalent_key()
         for note in self.read_notes():
@@ -507,10 +905,12 @@ class MemoryStore:
         *,
         content: str,
         note_type: MemoryNoteType | str,
+        scope: MemoryNoteScope | str | None = None,
         source: MemorySource | None = None,
         priority: float = 0.5,
         confidence: float = 0.5,
         tags: list[str] | tuple[str, ...] | str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryNote:
         """Save explicit durable Agent Memory after validating user-facing inputs."""
         if not content or not content.strip():
@@ -522,6 +922,8 @@ class MemoryStore:
             priority=_strict_score("priority", priority),
             confidence=_strict_score("confidence", confidence),
             tags=_clean_note_tags(tags),
+            scope=_strict_note_scope(scope) if scope else None,
+            metadata=_clean_metadata(metadata),
         )
         return self.upsert_note(note)
 
@@ -530,6 +932,7 @@ class MemoryStore:
         *,
         query: str = "",
         note_type: MemoryNoteType | str | None = None,
+        scope: MemoryNoteScope | str | None = None,
         status: MemoryNoteStatus | str | None = None,
         limit: int = 20,
         vector_store: VectorStore | None = None,
@@ -538,11 +941,14 @@ class MemoryStore:
         if limit <= 0:
             return []
         type_filter = _strict_note_type(note_type) if note_type else None
+        scope_filter = _strict_note_scope(scope) if scope else None
         status_filter = _strict_note_status(status) if status else None
         normalized_query = _normalize_note_text(query)
 
         def matches_filters(note: MemoryNote) -> bool:
             if type_filter and note.type != type_filter:
+                return False
+            if scope_filter and note.scope != scope_filter:
                 return False
             if status_filter and note.status != status_filter:
                 return False
@@ -675,8 +1081,10 @@ class MemoryStore:
     def _memory_note_index_document(note: MemoryNote) -> str:
         parts = [
             note.content,
+            f"Scope: {note.scope.value}",
             f"Type: {note.type.value}",
             f"Tags: {', '.join(note.tags)}" if note.tags else "",
+            f"Metadata: {json.dumps(note.metadata, ensure_ascii=False, sort_keys=True)}" if note.metadata else "",
         ]
         return " | ".join(part for part in parts if part)
 
@@ -685,12 +1093,14 @@ class MemoryStore:
         return {
             "kind": "memory_note",
             "note_id": note.id,
+            "scope": note.scope.value,
             "note_type": note.type.value,
             "status": note.status.value,
             "priority": note.priority,
             "confidence": note.confidence,
             "updated_at": note.updated_at,
             "tags": json.dumps(note.tags, ensure_ascii=False),
+            "metadata": json.dumps(note.metadata, ensure_ascii=False, sort_keys=True),
         }
 
     @staticmethod
@@ -720,10 +1130,12 @@ class MemoryStore:
         *,
         replacement_content: str,
         note_type: MemoryNoteType | str | None = None,
+        scope: MemoryNoteScope | str | None = None,
         source: MemorySource | None = None,
         priority: float | None = None,
         confidence: float | None = None,
         tags: list[str] | tuple[str, ...] | str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryNote:
         old_note = self.trace_memory_note(note_id)
         if not replacement_content or not replacement_content.strip():
@@ -735,6 +1147,8 @@ class MemoryStore:
             priority=_strict_score("priority", old_note.priority if priority is None else priority),
             confidence=_strict_score("confidence", old_note.confidence if confidence is None else confidence),
             tags=_clean_note_tags(old_note.tags if tags is None else tags),
+            scope=_strict_note_scope(scope) if scope else old_note.scope,
+            metadata=_clean_metadata(old_note.metadata if metadata is None else metadata),
         )
         return self.supersede_note(note_id, replacement)
 
@@ -831,6 +1245,7 @@ class MemoryStore:
         ]
         active_notes.sort(
             key=lambda note: (
+                note.scope.value,
                 note.type.value,
                 -note.priority,
                 -note.confidence,
@@ -857,11 +1272,21 @@ class MemoryStore:
                     lines.extend(("", f"### {note.type.value.title()}"))
                 metadata = [
                     f"id: {note.id}",
+                    f"scope: {note.scope.value}",
                     f"priority: {note.priority:g}",
                     f"confidence: {note.confidence:g}",
                 ]
                 if note.tags:
                     metadata.append("tags: " + ", ".join(sorted(note.tags)))
+                evidence_ids = [
+                    evidence_id
+                    for source in note.sources
+                    for evidence_id in source.evidence_ids
+                ]
+                if evidence_ids:
+                    metadata.append("evidence: " + ", ".join(sorted(set(evidence_ids))))
+                if note.metadata:
+                    metadata.append("metadata: " + json.dumps(note.metadata, ensure_ascii=False, sort_keys=True))
                 lines.append(f"- {note.content} ({'; '.join(metadata)})")
         lines.append(self._VIEW_MARKER_END)
         return "\n".join(lines).rstrip() + "\n"
@@ -882,6 +1307,8 @@ class MemoryStore:
         return existing + "\n\n" + rendered_section
 
     def _note_view_file(self, note: MemoryNote) -> str:
+        if note.scope in self._SCOPE_VIEW_DEFAULTS:
+            return self._SCOPE_VIEW_DEFAULTS[note.scope]
         for source in note.sources:
             if source.source_file in self._VIEW_TITLES:
                 return source.source_file
@@ -1046,12 +1473,15 @@ class MemoryStore:
     def _format_memory_recall_note(note: MemoryNote) -> str:
         metadata = [
             f"id: {note.id}",
+            f"scope: {note.scope.value}",
             f"type: {note.type.value}",
             f"priority: {note.priority:g}",
             f"confidence: {note.confidence:g}",
         ]
         if note.tags:
             metadata.append("tags: " + ", ".join(sorted(note.tags)))
+        if note.metadata:
+            metadata.append("metadata: " + json.dumps(note.metadata, ensure_ascii=False, sort_keys=True))
         return f"- {note.content} ({'; '.join(metadata)})"
 
     # -- history.jsonl — append-only, JSONL format ---------------------------
@@ -1473,6 +1903,9 @@ class Dream:
     }
     _NOTE_LINE_RE = re.compile(r"^\[(?P<header>[^\]]+)\]\s*(?P<content>.*)$")
 
+    class MemoryOperationParseError(ValueError):
+        pass
+
     def __init__(
         self,
         store: MemoryStore,
@@ -1494,6 +1927,85 @@ class Dream:
     # -- main entry ----------------------------------------------------------
 
     async def run(self) -> bool:
+        """Process pending evidence first, then legacy history entries."""
+        evidence_cursor = self.store.get_last_evidence_cursor()
+        evidence = self.store.read_pending_conversation_evidence(
+            since_cursor=evidence_cursor,
+            limit=self.max_batch_size,
+        )
+        if evidence:
+            return await self._run_evidence_batch(evidence, evidence_cursor)
+        return await self._run_legacy_history_batch()
+
+    async def _run_evidence_batch(
+        self,
+        batch: list[ConversationEvidence],
+        last_cursor: int,
+    ) -> bool:
+        logger.info(
+            "Dream: processing {} evidence records (cursor {}->{})",
+            len(batch), last_cursor, batch[-1].cursor,
+        )
+
+        phase1_prompt = (
+            f"## Conversation Evidence\n{self._format_evidence_prompt(batch)}\n\n"
+            f"{self._format_memory_file_context()}"
+        )
+
+        try:
+            phase1_response = await self.provider.chat_with_retry(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": render_template("agent/dream_phase1.md", strip=True),
+                    },
+                    {"role": "user", "content": phase1_prompt},
+                ],
+                tools=None,
+                tool_choice=None,
+            )
+            analysis = phase1_response.content or ""
+            logger.debug("Dream Evidence Phase 1 complete ({} chars)", len(analysis))
+        except Exception:
+            logger.exception("Dream Evidence Phase 1 failed")
+            return False
+
+        source = MemorySource.dream(
+            evidence_ids=[record.id for record in batch],
+        )
+        try:
+            changelog = self._apply_memory_note_analysis(
+                analysis,
+                source,
+                require_json=True,
+            )
+        except self.MemoryOperationParseError:
+            logger.warning("Dream Evidence Phase 2: JSON operation parse failed; evidence cursor unchanged")
+            return False
+
+        if changelog:
+            self.store.refresh_memory_views()
+            changelog.append("refresh_memory_views")
+            logger.info("Dream Evidence Phase 2: applied {} Memory Note change(s)", len(changelog) - 1)
+        else:
+            logger.debug("Dream Evidence Phase 2: no durable Memory Notes created")
+
+        new_cursor = batch[-1].cursor or last_cursor
+        self.store.set_last_evidence_cursor(new_cursor)
+        logger.info("Dream evidence done: cursor advanced to {}", new_cursor)
+
+        if changelog and self.store.git.is_initialized():
+            sha = self.store.git.auto_commit(f"dream: evidence cursor {new_cursor}, {len(changelog)} change(s)")
+            if sha:
+                logger.info("Dream commit: {}", sha)
+
+        if self.experience_store is not None:
+            await self._process_experiences()
+
+        return True
+
+    async def _run_legacy_history_batch(self) -> bool:
         """Process unprocessed history entries. Returns True if work was done."""
         last_cursor = self.store.get_last_dream_cursor()
         entries = self.store.read_unprocessed_history(since_cursor=last_cursor)
@@ -1511,21 +2023,9 @@ class Dream:
             f"[{e['timestamp']}] {e['content']}" for e in batch
         )
 
-        # Current file contents
-        current_memory = self.store.read_memory() or "(empty)"
-        current_soul = self.store.read_soul() or "(empty)"
-        current_user = self.store.read_user() or "(empty)"
-        current_notes = self._format_current_notes() or "(no Memory Notes)"
-        file_context = (
-            f"## Current Memory Notes\n{current_notes}\n\n"
-            f"## Current MEMORY.md\n{current_memory}\n\n"
-            f"## Current SOUL.md\n{current_soul}\n\n"
-            f"## Current USER.md\n{current_user}"
-        )
-
         # Phase 1: Analyze
         phase1_prompt = (
-            f"## Conversation History\n{history_text}\n\n{file_context}"
+            f"## Conversation History\n{history_text}\n\n{self._format_memory_file_context()}"
         )
 
         try:
@@ -1586,6 +2086,32 @@ class Dream:
 
         return True
 
+    def _format_memory_file_context(self) -> str:
+        current_memory = self.store.read_memory() or "(empty)"
+        current_soul = self.store.read_soul() or "(empty)"
+        current_user = self.store.read_user() or "(empty)"
+        current_notes = self._format_current_notes() or "(no Memory Notes)"
+        return (
+            f"## Current Memory Notes\n{current_notes}\n\n"
+            f"## Current MEMORY.md\n{current_memory}\n\n"
+            f"## Current SOUL.md\n{current_soul}\n\n"
+            f"## Current USER.md\n{current_user}"
+        )
+
+    @staticmethod
+    def _format_evidence_prompt(records: list[ConversationEvidence]) -> str:
+        lines: list[str] = []
+        current_turn = ""
+        for record in records:
+            if record.turn_id != current_turn:
+                current_turn = record.turn_id
+                lines.append(f"\n### Turn {record.turn_id} session={record.session_key}")
+            lines.append(
+                f"[{record.id}] cursor={record.cursor} index={record.message_index} "
+                f"{record.role.upper()}: {record.content}"
+            )
+        return "\n".join(lines).strip()
+
     def _format_current_notes(self) -> str:
         lines: list[str] = []
         for note in sorted(
@@ -1593,7 +2119,7 @@ class Dream:
             key=lambda item: (item.status.value, item.type.value, item.content.casefold()),
         ):
             lines.append(
-                f"- id={note.id} status={note.status.value} type={note.type.value} "
+                f"- id={note.id} status={note.status.value} scope={note.scope.value} type={note.type.value} "
                 f"priority={note.priority:g} confidence={note.confidence:g}: {note.content}"
             )
         return "\n".join(lines)
@@ -1602,11 +2128,13 @@ class Dream:
         self,
         analysis: str,
         source: MemorySource,
+        *,
+        require_json: bool = False,
     ) -> list[str]:
         changes: list[str] = []
-        for operation in self._parse_memory_note_operations(analysis, source):
+        for operation in self._parse_memory_note_operations(analysis, source, require_json=require_json):
             action = operation["action"]
-            note_id = operation.get("note_id") or ""
+            note_id = operation.get("note_id") or operation.get("target_note_id") or ""
             content = operation.get("content") or ""
             if action == "skip":
                 continue
@@ -1620,10 +2148,12 @@ class Dream:
             note = MemoryNote.create(
                 content,
                 operation["type"],
-                [source],
+                [self._source_for_operation(source, operation)],
                 priority=operation["priority"],
                 confidence=operation["confidence"],
                 tags=operation["tags"],
+                scope=operation.get("scope"),
+                metadata=operation.get("metadata"),
             )
             source_file = operation.get("source_file")
             if source_file:
@@ -1632,12 +2162,13 @@ class Dream:
                 replacement = self.store.supersede_note(note_id, note)
                 changes.append(f"supersede_note:{note_id}->{replacement.id}")
                 continue
-            existing = self._find_active_note_by_type_and_content(note.type, note.content)
+            existing = self._find_active_note_by_scope_type_and_content(note.scope, note.type, note.content)
             if existing is not None:
                 existing.sources = self._merge_note_sources(existing.sources, note.sources)
                 existing.priority = max(existing.priority, note.priority)
                 existing.confidence = max(existing.confidence, note.confidence)
                 existing.tags = sorted(set(existing.tags + note.tags))
+                existing.metadata = _merge_metadata(existing.metadata, note.metadata)
                 stored = self.store.upsert_note(existing)
                 changes.append(f"merge_note:{stored.id}")
             else:
@@ -1649,7 +2180,15 @@ class Dream:
         self,
         analysis: str,
         source: MemorySource,
+        *,
+        require_json: bool = False,
     ) -> list[dict[str, Any]]:
+        json_operations = self._parse_json_memory_note_operations(analysis, source)
+        if json_operations is not None:
+            return json_operations
+        if require_json:
+            raise self.MemoryOperationParseError("Expected JSON Memory Operations")
+
         operations: list[dict[str, Any]] = []
         for raw_line in analysis.splitlines():
             line = raw_line.strip()
@@ -1659,6 +2198,63 @@ class Dream:
             if parsed is not None:
                 operations.append(parsed)
         return operations
+
+    def _parse_json_memory_note_operations(
+        self,
+        analysis: str,
+        source: MemorySource,
+    ) -> list[dict[str, Any]] | None:
+        raw = analysis.strip()
+        if raw.startswith("```"):
+            match = re.search(r"```(?:json)?\s*(?P<body>.*?)```", raw, flags=re.DOTALL | re.IGNORECASE)
+            if match:
+                raw = match.group("body").strip()
+        if not raw or raw[0] not in "[{":
+            return None
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(parsed, dict):
+            parsed = parsed.get("operations", [parsed])
+        if not isinstance(parsed, list):
+            return None
+        operations: list[dict[str, Any]] = []
+        for item in parsed:
+            if not isinstance(item, dict):
+                continue
+            operation = self._normalize_json_memory_operation(item, source)
+            if operation is not None:
+                operations.append(operation)
+        return operations
+
+    def _normalize_json_memory_operation(
+        self,
+        raw: dict[str, Any],
+        source: MemorySource,
+    ) -> dict[str, Any] | None:
+        del source
+        action = str(raw.get("action") or "save").strip().casefold()
+        if action not in {"save", "supersede", "reject", "skip"}:
+            return None
+        note_id = str(raw.get("target_note_id") or raw.get("note_id") or "").strip()
+        content = str(raw.get("content") or "").strip()
+        note_type = _coerce_enum(MemoryNoteType, raw.get("type"), MemoryNoteType.PROJECT)
+        scope = _coerce_enum(MemoryNoteScope, raw.get("scope"), _default_scope_for_type(note_type))
+        evidence_ids = _clean_evidence_ids(raw.get("evidence_ids"))
+        return {
+            "action": action,
+            "note_id": note_id,
+            "content": content,
+            "type": note_type,
+            "scope": scope,
+            "source_file": None,
+            "priority": _strict_score("priority", _coerce_float(raw.get("priority"), 0.6)),
+            "confidence": _strict_score("confidence", _coerce_float(raw.get("confidence"), 0.65)),
+            "tags": _clean_note_tags(raw.get("tags") or ["dream"]),
+            "metadata": _clean_metadata(raw.get("metadata")),
+            "evidence_ids": evidence_ids,
+        }
 
     def _parse_memory_note_operation(
         self,
@@ -1700,10 +2296,13 @@ class Dream:
                 "note_id": note_id,
                 "content": content,
                 "type": MemoryNoteType.PROJECT,
+                "scope": MemoryNoteScope.PROJECT,
                 "source_file": None,
                 "priority": 0.5,
                 "confidence": 0.5,
                 "tags": ["dream"],
+                "metadata": {},
+                "evidence_ids": [],
             }
         return None
 
@@ -1719,19 +2318,27 @@ class Dream:
         tags = ["dream"]
         if source_file == "memory/MEMORY.md":
             tags.append("project-memory")
+            scope = MemoryNoteScope.PROJECT
         elif source_file == "USER.md":
             tags.append("user-memory")
+            scope = MemoryNoteScope.USER
         elif source_file == "SOUL.md":
             tags.append("assistant-memory")
+            scope = MemoryNoteScope.ASSISTANT
+        else:
+            scope = _default_scope_for_type(note_type)
         return {
             "action": action,
             "note_id": note_id,
             "content": content,
             "type": note_type,
+            "scope": scope,
             "source_file": source_file,
             "priority": 0.6,
             "confidence": 0.65,
             "tags": tags,
+            "metadata": {},
+            "evidence_ids": [],
         }
 
     def _resolve_note_target(self, target: str) -> tuple[str, MemoryNoteType]:
@@ -1739,8 +2346,24 @@ class Dream:
             return self._NOTE_TARGETS[target]
         return "memory/MEMORY.md", _coerce_enum(MemoryNoteType, target.casefold(), MemoryNoteType.PROJECT)
 
-    def _find_active_note_by_type_and_content(
+    @staticmethod
+    def _source_for_operation(source: MemorySource, operation: dict[str, Any]) -> MemorySource:
+        evidence_ids = _clean_evidence_ids(operation.get("evidence_ids")) or list(source.evidence_ids)
+        return MemorySource(
+            capture_origin=source.capture_origin,
+            captured_at=source.captured_at,
+            session_key=source.session_key,
+            message_start=source.message_start,
+            message_end=source.message_end,
+            history_start_cursor=source.history_start_cursor,
+            history_end_cursor=source.history_end_cursor,
+            source_file=source.source_file,
+            evidence_ids=evidence_ids,
+        )
+
+    def _find_active_note_by_scope_type_and_content(
         self,
+        scope: MemoryNoteScope,
         note_type: MemoryNoteType,
         content: str,
     ) -> MemoryNote | None:
@@ -1748,6 +2371,7 @@ class Dream:
         for note in self.store.read_notes():
             if (
                 note.status == MemoryNoteStatus.ACTIVE
+                and note.scope == scope
                 and note.type == note_type
                 and _normalize_note_text(note.content) == normalized
             ):
@@ -1760,12 +2384,14 @@ class Dream:
         new_sources: list[MemorySource],
     ) -> list[MemorySource]:
         merged: list[MemorySource] = []
-        seen: set[tuple[Any, ...]] = set()
+        by_identity: dict[tuple[Any, ...], MemorySource] = {}
         for source in existing + new_sources:
             identity = source.identity()
-            if identity in seen:
+            if identity in by_identity:
+                current = by_identity[identity]
+                current.evidence_ids = _clean_evidence_ids(current.evidence_ids + source.evidence_ids)
                 continue
-            seen.add(identity)
+            by_identity[identity] = source
             merged.append(source)
         return merged
 

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -1469,6 +1469,75 @@ class MemoryStore:
         lines.append("---")
         return "\n".join(lines)
 
+    def format_memory_recall_notes_context(self, notes: list[MemoryNote]) -> str:
+        if not notes:
+            return ""
+        lines = [
+            "---",
+            "[MEMORY RECALL]",
+            "",
+            "Active Memory Notes selected for this request. Keep this separate from Experience and Knowledge Base context.",
+            "",
+        ]
+        for note in notes:
+            lines.append(self._format_memory_recall_note(note))
+        lines.append("---")
+        return "\n".join(lines)
+
+    def memory_reference_metadata(self, notes: list[MemoryNote]) -> list[dict[str, Any]]:
+        references: list[dict[str, Any]] = []
+        for note in notes:
+            note_file, note_line = self._locate_note_jsonl_line(note.id)
+            view_file = self._note_view_file(note)
+            view_line = self._locate_text_line(self.workspace / view_file, note.id)
+            evidence_ids = [
+                evidence_id
+                for source in note.sources
+                for evidence_id in source.evidence_ids
+            ]
+            references.append({
+                "note_id": note.id,
+                "scope": note.scope.value,
+                "type": note.type.value,
+                "status": note.status.value,
+                "content": note.content,
+                "priority": note.priority,
+                "confidence": note.confidence,
+                "tags": list(note.tags),
+                "metadata": _clean_metadata(note.metadata),
+                "evidence_ids": sorted(set(evidence_ids)),
+                "file": note_file,
+                "line": note_line,
+                "view_file": view_file,
+                "view_line": view_line,
+            })
+        return references
+
+    def _locate_note_jsonl_line(self, note_id: str) -> tuple[str, int | None]:
+        try:
+            with open(self.notes_file, encoding="utf-8") as f:
+                for line_no, line in enumerate(f, start=1):
+                    try:
+                        raw = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(raw, dict) and raw.get("id") == note_id:
+                        return "memory/notes.jsonl", line_no
+        except FileNotFoundError:
+            pass
+        return "memory/notes.jsonl", None
+
+    @staticmethod
+    def _locate_text_line(path: Path, needle: str) -> int | None:
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line_no, line in enumerate(f, start=1):
+                    if needle and needle in line:
+                        return line_no
+        except FileNotFoundError:
+            return None
+        return None
+
     @staticmethod
     def _format_memory_recall_note(note: MemoryNote) -> str:
         metadata = [

--- a/tinybot/agent/memory.py
+++ b/tinybot/agent/memory.py
@@ -9,7 +9,7 @@ import re
 import weakref
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -65,6 +65,23 @@ class MemoryCaptureOrigin(StrEnum):
 
 def _utc_timestamp() -> str:
     return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _parse_utc_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
 
 
 def _normalize_note_text(text: str) -> str:
@@ -581,6 +598,72 @@ class ConversationEvidence:
         return data
 
 
+@dataclass(slots=True)
+class ConversationEvidenceSourceLocation:
+    file: str
+    line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"file": self.file}
+        if self.line is not None:
+            data["line"] = self.line
+        return data
+
+
+@dataclass(slots=True)
+class RecentContextCandidate:
+    evidence_id: str
+    excerpt: str
+    timestamp: str
+    session_key: str
+    role: str
+    turn_id: str
+    cursor: int | None = None
+    source_location: ConversationEvidenceSourceLocation | None = None
+    score: float = 0.0
+    score_inputs: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_evidence(
+        cls,
+        evidence: ConversationEvidence,
+        *,
+        source_location: ConversationEvidenceSourceLocation | None = None,
+        max_excerpt_chars: int = 500,
+    ) -> RecentContextCandidate:
+        excerpt = " ".join(evidence.content.split())
+        if len(excerpt) > max_excerpt_chars:
+            excerpt = excerpt[: max_excerpt_chars - 1].rstrip() + "..."
+        return cls(
+            evidence_id=evidence.id,
+            excerpt=excerpt,
+            timestamp=evidence.timestamp,
+            session_key=evidence.session_key,
+            role=evidence.role,
+            turn_id=evidence.turn_id,
+            cursor=evidence.cursor,
+            source_location=source_location,
+        )
+
+    def reference_metadata(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "evidence_id": self.evidence_id,
+            "content": self.excerpt,
+            "excerpt": self.excerpt,
+            "timestamp": self.timestamp,
+            "session_key": self.session_key,
+            "role": self.role,
+            "turn_id": self.turn_id,
+        }
+        if self.cursor is not None:
+            data["cursor"] = self.cursor
+        if self.source_location is not None:
+            data.update(self.source_location.to_dict())
+        if self.score_inputs:
+            data["score_inputs"] = dict(self.score_inputs)
+        return data
+
+
 def generate_conversation_turn_id(
     session_key: str,
     messages: list[dict[str, Any]],
@@ -841,6 +924,70 @@ class MemoryStore:
         records.sort(key=lambda item: (item.cursor or 0, item.timestamp, item.id))
         return records
 
+    def read_recent_conversation_evidence(
+        self,
+        *,
+        max_age_days: int = 7,
+        max_records: int = 200,
+        min_cursor: int | None = None,
+        max_cursor: int | None = None,
+        roles: set[str] | list[str] | tuple[str, ...] | None = None,
+        exclude_session_key: str | None = None,
+        now: datetime | None = None,
+    ) -> list[tuple[ConversationEvidence, ConversationEvidenceSourceLocation]]:
+        """Read bounded recent Conversation Evidence with source file locations."""
+        max_age_days = max(int(max_age_days or 0), 0)
+        max_records = max(int(max_records or 0), 0)
+        role_set = {str(role) for role in roles} if roles else None
+        cutoff = (now or datetime.utcnow()) - timedelta(days=max_age_days)
+        records: list[tuple[ConversationEvidence, ConversationEvidenceSourceLocation]] = []
+
+        for path in sorted(self.conversations_dir.glob("*.jsonl")):
+            rel_path = self._workspace_relative_path(path)
+            try:
+                with open(path, encoding="utf-8") as f:
+                    for line_number, line in enumerate(f, 1):
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            raw = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if not isinstance(raw, dict):
+                            continue
+                        record = ConversationEvidence.from_dict(raw)
+                        if role_set is not None and record.role not in role_set:
+                            continue
+                        if exclude_session_key and record.session_key == exclude_session_key:
+                            continue
+                        cursor = record.cursor or 0
+                        if min_cursor is not None and cursor <= min_cursor:
+                            continue
+                        if max_cursor is not None and cursor > max_cursor:
+                            continue
+                        timestamp = _parse_utc_timestamp(record.timestamp)
+                        if timestamp is None or timestamp < cutoff:
+                            continue
+                        records.append((
+                            record,
+                            ConversationEvidenceSourceLocation(rel_path, line_number),
+                        ))
+            except FileNotFoundError:
+                continue
+
+        records.sort(
+            key=lambda item: (
+                item[0].cursor or 0,
+                item[0].timestamp,
+                item[0].id,
+            ),
+            reverse=True,
+        )
+        if max_records:
+            return records[:max_records]
+        return []
+
     def get_last_evidence_cursor(self) -> int:
         if self._evidence_cursor_file.exists():
             try:
@@ -857,6 +1004,12 @@ class MemoryStore:
         if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_part):
             date_part = datetime.utcnow().strftime("%Y-%m-%d")
         return self.conversations_dir / f"{date_part}.jsonl"
+
+    def _workspace_relative_path(self, path: Path) -> str:
+        try:
+            return path.relative_to(self.workspace).as_posix()
+        except ValueError:
+            return path.as_posix()
 
     def _next_evidence_cursor(self) -> int:
         if self._evidence_sequence_file.exists():

--- a/tinybot/agent/tools/memory.py
+++ b/tinybot/agent/tools/memory.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 _NOTE_TYPES = ["preference", "instruction", "project", "decision", "fix", "followup"]
 _NOTE_STATUSES = ["active", "superseded", "rejected"]
+_NOTE_SCOPES = ["user", "assistant", "project", "session"]
 
 
 def _format_source(source: MemorySource) -> str:
@@ -27,6 +28,8 @@ def _format_source(source: MemorySource) -> str:
         fields.append(f"history={source.history_start_cursor}-{source.history_end_cursor}")
     if source.message_start is not None or source.message_end is not None:
         fields.append(f"messages={source.message_start}-{source.message_end}")
+    if source.evidence_ids:
+        fields.append(f"evidence={','.join(source.evidence_ids)}")
     return " ".join(fields)
 
 
@@ -41,9 +44,10 @@ def _source_summary(note: MemoryNote) -> str:
 
 def _format_note_summary(note: MemoryNote) -> str:
     tags = f" tags={','.join(note.tags)}" if note.tags else ""
+    metadata = f" metadata={note.metadata}" if note.metadata else ""
     return (
-        f"- [{note.id}] {note.type.value}/{note.status.value} "
-        f"priority={note.priority:g} confidence={note.confidence:g}{tags}\n"
+        f"- [{note.id}] {note.scope.value}/{note.type.value}/{note.status.value} "
+        f"priority={note.priority:g} confidence={note.confidence:g}{tags}{metadata}\n"
         f"  {note.content}\n"
         f"  sources: {_source_summary(note)}"
     )
@@ -61,9 +65,11 @@ def _explicit_source(session_key: str, message_start: int | None, message_end: i
     tool_parameters_schema(
         content=StringSchema("Durable Memory Note content to save.", min_length=1),
         note_type=StringSchema("Memory Note type.", enum=_NOTE_TYPES),
+        scope=StringSchema("Optional Memory Note scope.", enum=_NOTE_SCOPES),
         priority=NumberSchema(0.5, description="Importance from 0 to 1.", minimum=0, maximum=1),
         confidence=NumberSchema(0.5, description="Confidence from 0 to 1.", minimum=0, maximum=1),
         tags=StringSchema("Optional comma-separated tags."),
+        metadata=StringSchema("Optional JSON object metadata."),
         message_start=IntegerSchema(0, description="Optional source message start index.", minimum=0),
         message_end=IntegerSchema(0, description="Optional source message end index.", minimum=0),
         required=["content", "note_type"],
@@ -97,20 +103,31 @@ class SaveMemoryNoteTool(Tool):
         self,
         content: str,
         note_type: str,
+        scope: str = "",
         priority: float = 0.5,
         confidence: float = 0.5,
         tags: str = "",
+        metadata: str = "",
         message_start: int | None = None,
         message_end: int | None = None,
     ) -> str:
         try:
+            parsed_metadata = {}
+            if metadata.strip():
+                import json
+                parsed = json.loads(metadata)
+                if not isinstance(parsed, dict):
+                    return "Error: metadata must be a JSON object"
+                parsed_metadata = parsed
             note = self._store.save_memory_note(
                 content=content,
                 note_type=note_type,
+                scope=scope or None,
                 source=_explicit_source(self._session_key, message_start, message_end),
                 priority=priority,
                 confidence=confidence,
                 tags=tags,
+                metadata=parsed_metadata,
             )
             self._store.refresh_memory_views()
             self._store.rebuild_memory_note_index(self._vector_store)
@@ -123,6 +140,7 @@ class SaveMemoryNoteTool(Tool):
     tool_parameters_schema(
         query=StringSchema("Optional lexical query over content, id, tags, type, status, and source summary."),
         note_type=StringSchema("Optional Memory Note type filter.", enum=_NOTE_TYPES),
+        scope=StringSchema("Optional Memory Note scope filter.", enum=_NOTE_SCOPES),
         status=StringSchema("Optional Memory Note status filter.", enum=_NOTE_STATUSES),
         limit=IntegerSchema(10, description="Maximum notes to return.", minimum=1, maximum=50),
     )
@@ -150,6 +168,7 @@ class SearchMemoryNotesTool(Tool):
         self,
         query: str = "",
         note_type: str = "",
+        scope: str = "",
         status: str = "",
         limit: int = 10,
     ) -> str:
@@ -157,6 +176,7 @@ class SearchMemoryNotesTool(Tool):
             notes = self._store.search_memory_notes(
                 query=query or "",
                 note_type=note_type or None,
+                scope=scope or None,
                 status=status or None,
                 limit=limit,
                 vector_store=self._vector_store,
@@ -201,6 +221,7 @@ class TraceMemoryNoteTool(Tool):
             f"## Memory Note {note.id}",
             "",
             f"Type: {note.type.value}",
+            f"Scope: {note.scope.value}",
             f"Status: {note.status.value}",
             f"Priority: {note.priority:g}",
             f"Confidence: {note.confidence:g}",
@@ -209,6 +230,8 @@ class TraceMemoryNoteTool(Tool):
         ]
         if note.tags:
             lines.append("Tags: " + ", ".join(note.tags))
+        if note.metadata:
+            lines.append("Metadata: " + str(note.metadata))
         if note.supersedes:
             lines.append("Supersedes: " + ", ".join(note.supersedes))
         if note.superseded_by:
@@ -257,9 +280,11 @@ class RejectMemoryNoteTool(Tool):
         note_id=StringSchema("Existing Memory Note id to supersede.", min_length=1),
         replacement_content=StringSchema("Replacement durable Memory Note content.", min_length=1),
         note_type=StringSchema("Optional replacement Memory Note type. Defaults to the old note type.", enum=_NOTE_TYPES),
+        scope=StringSchema("Optional replacement Memory Note scope. Defaults to the old note scope.", enum=_NOTE_SCOPES),
         priority=NumberSchema(0.5, description="Optional replacement priority from 0 to 1.", minimum=0, maximum=1),
         confidence=NumberSchema(0.5, description="Optional replacement confidence from 0 to 1.", minimum=0, maximum=1),
         tags=StringSchema("Optional comma-separated replacement tags. Defaults to the old note tags."),
+        metadata=StringSchema("Optional replacement JSON object metadata."),
         message_start=IntegerSchema(0, description="Optional source message start index.", minimum=0),
         message_end=IntegerSchema(0, description="Optional source message end index.", minimum=0),
         required=["note_id", "replacement_content"],
@@ -291,21 +316,32 @@ class SupersedeMemoryNoteTool(Tool):
         note_id: str,
         replacement_content: str,
         note_type: str = "",
+        scope: str = "",
         priority: float | None = None,
         confidence: float | None = None,
         tags: str = "",
+        metadata: str = "",
         message_start: int | None = None,
         message_end: int | None = None,
     ) -> str:
         try:
+            parsed_metadata = None
+            if metadata.strip():
+                import json
+                parsed = json.loads(metadata)
+                if not isinstance(parsed, dict):
+                    return "Error: metadata must be a JSON object"
+                parsed_metadata = parsed
             note = self._store.supersede_memory_note(
                 note_id,
                 replacement_content=replacement_content,
                 note_type=note_type or None,
+                scope=scope or None,
                 source=_explicit_source(self._session_key, message_start, message_end),
                 priority=priority,
                 confidence=confidence,
                 tags=tags if tags else None,
+                metadata=parsed_metadata,
             )
             self._store.refresh_memory_views()
             self._store.rebuild_memory_note_index(self._vector_store)

--- a/tinybot/channels/websocket.py
+++ b/tinybot/channels/websocket.py
@@ -58,6 +58,7 @@ def _serialize_message(message: dict[str, Any]) -> dict[str, Any]:
         "_task_progress",
         "_task_plan_id",
         "_memory_references",
+        "_recent_context_references",
     ):
         if key in message:
             payload[key] = message[key]
@@ -341,6 +342,8 @@ class WebSocketChannel(BaseChannel):
             payload["_task_plan_id"] = meta.get("_task_plan_id")
         if meta.get("_memory_references"):
             payload["_memory_references"] = meta.get("_memory_references")
+        if meta.get("_recent_context_references"):
+            payload["_recent_context_references"] = meta.get("_recent_context_references")
         await self._broadcast(msg.chat_id, payload)
 
     async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
@@ -355,6 +358,8 @@ class WebSocketChannel(BaseChannel):
             }
             if metadata.get("_memory_references"):
                 payload["_memory_references"] = metadata.get("_memory_references")
+            if metadata.get("_recent_context_references"):
+                payload["_recent_context_references"] = metadata.get("_recent_context_references")
             await self._broadcast(chat_id, payload)
             return
 

--- a/tinybot/channels/websocket.py
+++ b/tinybot/channels/websocket.py
@@ -57,6 +57,7 @@ def _serialize_message(message: dict[str, Any]) -> dict[str, Any]:
         "_task_event",
         "_task_progress",
         "_task_plan_id",
+        "_memory_references",
     ):
         if key in message:
             payload[key] = message[key]
@@ -338,21 +339,23 @@ class WebSocketChannel(BaseChannel):
             payload["_task_progress"] = meta.get("_task_progress")
         if meta.get("_task_plan_id"):
             payload["_task_plan_id"] = meta.get("_task_plan_id")
+        if meta.get("_memory_references"):
+            payload["_memory_references"] = meta.get("_memory_references")
         await self._broadcast(msg.chat_id, payload)
 
     async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
         metadata = metadata or {}
         if metadata.get("_stream_end"):
-            await self._broadcast(
-                chat_id,
-                {
-                    "event": "stream_end",
-                    "chat_id": chat_id,
-                    "message_id": metadata.get("_stream_id"),
-                    "reason": "stop",
-                    "resuming": metadata.get("_resuming", False),
-                },
-            )
+            payload = {
+                "event": "stream_end",
+                "chat_id": chat_id,
+                "message_id": metadata.get("_stream_id"),
+                "reason": "stop",
+                "resuming": metadata.get("_resuming", False),
+            }
+            if metadata.get("_memory_references"):
+                payload["_memory_references"] = metadata.get("_memory_references")
+            await self._broadcast(chat_id, payload)
             return
 
         await self._broadcast(

--- a/tinybot/config/schema.py
+++ b/tinybot/config/schema.py
@@ -54,6 +54,8 @@ class DreamConfig(Base):
     )  # Optional Dream-specific model override
     max_batch_size: int = Field(default=20, ge=1)  # Max history entries per run
     max_iterations: int = Field(default=10, ge=1)  # Max tool calls per Phase 2
+    extraction_every_n_turns: int = Field(default=6, ge=1)
+    extraction_idle_seconds: int = Field(default=300, ge=1)
 
     def build_schedule(self, timezone: str) -> CronSchedule:
         """Build the runtime schedule, preferring the legacy cron override if present."""

--- a/tinybot/config/schema.py
+++ b/tinybot/config/schema.py
@@ -88,6 +88,15 @@ class EmbeddingConfig(Base):
     api_version: str | None = None  # Azure API version (e.g. "2024-02-01")
 
 
+class RecentContextConfig(Base):
+    """Short-term read-only retrieval over Conversation Evidence."""
+
+    enabled: bool = True
+    recency_days: int = Field(default=7, ge=1)
+    max_records: int = Field(default=3, ge=1, le=10)
+    scan_limit: int = Field(default=200, ge=1)
+
+
 class AgentDefaults(Base):
     """Default agent configuration."""
 
@@ -109,6 +118,7 @@ class AgentDefaults(Base):
     enable_vector_store: bool = False  # Feature flag: ChromaDB embedding storage for session summaries
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)  # Embedding model configuration
     dream: DreamConfig = Field(default_factory=DreamConfig)
+    recent_context: RecentContextConfig = Field(default_factory=RecentContextConfig)
 
     @field_validator("model")
     @classmethod

--- a/tinybot/skills/memory/SKILL.md
+++ b/tinybot/skills/memory/SKILL.md
@@ -12,7 +12,8 @@ always: true
 - `memory/MEMORY.md` is the project Memory View rendered from active project, decision, fix, and followup notes.
 - `USER.md` is the user Memory View rendered from active preference notes.
 - `SOUL.md` is the assistant Memory View rendered from active instruction notes.
-- `memory/history.jsonl` is append-only conversation history used by Dream. It is not loaded directly as durable Memory Notes unless Dream or an explicit operation captures a note.
+- `memory/conversations/*.jsonl` stores clean Conversation Evidence for completed user/assistant messages. Dream processes it before legacy summary history.
+- `memory/.evidence_cursor` tracks processed Conversation Evidence. `memory/history.jsonl` and `.dream_cursor` remain the legacy fallback path.
 
 ## Explicit Operations
 
@@ -35,3 +36,4 @@ Use Memory Note operations for durable agent-side memory:
 - Do not edit managed sections in `SOUL.md`, `USER.md`, or `memory/MEMORY.md` directly. They are Memory Views refreshed from active Memory Notes.
 - If a Memory View looks wrong, use reject or supersede operations on the underlying note instead of editing rendered Markdown.
 - Users can view Dream activity with the `/dream-log` command.
+- `session.user_profile` is only a runtime cache. Durable user facts belong in user-scoped Memory Notes.

--- a/tinybot/skills/memory/SKILL.md
+++ b/tinybot/skills/memory/SKILL.md
@@ -29,6 +29,7 @@ Use Memory Note operations for durable agent-side memory:
 
 - Memory Notes are separate from Experience records. Experience captures reusable execution tactics and recovery guidance.
 - Memory Notes are separate from Knowledge Base snippets and uploaded session documents. Knowledge is evidence, not durable agent memory.
+- Recent Context is separate from Durable Memory Notes. It reads bounded Conversation Evidence for short-term follow-up continuity, exposes recent conversation references, and does not write `USER.md` or other Memory Views.
 - Optional vector indexes may accelerate Memory Note search, but `memory/notes.jsonl` remains canonical and indexes must be rebuildable from it.
 
 ## Important

--- a/tinybot/templates/agent/dream_phase1.md
+++ b/tinybot/templates/agent/dream_phase1.md
@@ -1,18 +1,38 @@
-Compare conversation history against current Memory Notes and Memory Views.
-Output one structured operation per durable Agent Memory finding:
+Compare Conversation Evidence or legacy conversation history against current Memory Notes and Memory Views.
+Output ONLY a JSON array of Memory Operations. No markdown, no prose.
 
-- `[SAVE:USER] atomic preference, identity, or habit`
-- `[SAVE:SOUL] durable assistant behavior or tone instruction`
-- `[SAVE:MEMORY] durable project, decision, fix, or follow-up fact`
-- `[SUPERSEDE:<note_id>:USER|SOUL|MEMORY] corrected replacement fact`
-- `[REJECT:<note_id>] reason the existing note is wrong or obsolete`
+Each operation:
+
+```json
+{
+  "action": "save | supersede | reject | skip",
+  "scope": "user | assistant | project | session",
+  "type": "preference | instruction | project | decision | fix | followup",
+  "content": "atomic durable fact for save/supersede",
+  "priority": 0.0,
+  "confidence": 0.0,
+  "evidence_ids": ["ev_..."],
+  "metadata": {},
+  "tags": ["dream"],
+  "target_note_id": "note_..."
+}
+```
 
 Rules:
 - Memory Notes are canonical; Markdown Memory Views are rendered after notes are saved.
-- Use `SUPERSEDE` or `REJECT` when an existing note id is clearly contradicted.
+- Use `evidence_ids` from the visible Conversation Evidence records that support the operation. Leave it empty only for legacy history input.
+- Use `supersede` with `target_note_id` when an existing note id is clearly corrected by new evidence.
+- Use `reject` with `target_note_id` when an existing note id is wrong or obsolete and no replacement should be saved.
+- Use `skip` when nothing durable should change.
 - Only capture durable, reusable memory. Skip duplicates, ephemera, raw execution tactics, and temporary troubleshooting.
 - Prefer atomic facts: "has a cat named Luna" not "discussed pet care".
-- Capture confirmed approaches only when the user validated a non-obvious durable decision.
+- Durable user preferences, identity, and habits must use `scope: "user"`.
+- Durable assistant behavior or tone instructions must use `scope: "assistant"`.
+- Durable project facts, decisions, fixes, and followups should use `scope: "project"` unless they apply only to the current session.
 - Do not create Experience records here; execution tactics belong to the separate Experience phase.
 
-If nothing needs updating: `[SKIP] no new information`
+If nothing needs updating:
+
+```json
+[{"action":"skip","scope":"project","type":"project","content":"","priority":0.0,"confidence":1.0,"evidence_ids":[],"metadata":{},"tags":["dream"]}]
+```

--- a/webui/assets/src/legacy/app.js
+++ b/webui/assets/src/legacy/app.js
@@ -1477,6 +1477,9 @@ function updateMessageContent(contentEl, message) {
   if (message.role === "assistant" && Array.isArray(message._memory_references) && message._memory_references.length) {
     contentEl.append(createMemoryReferencesNode(message._memory_references));
   }
+  if (message.role === "assistant" && Array.isArray(message._recent_context_references) && message._recent_context_references.length) {
+    contentEl.append(createRecentContextReferencesNode(message._recent_context_references));
+  }
 }
 
 function createMemoryReferencesNode(references) {
@@ -1521,6 +1524,58 @@ function createMemoryReferencesNode(references) {
       reference.type,
       reference.note_id,
       `${file}${line}${view}`,
+    ].filter(Boolean);
+    meta.textContent = labelParts.join(" · ");
+
+    item.append(content, meta);
+    list.append(item);
+  });
+
+  details.append(list);
+  return details;
+}
+
+function createRecentContextReferencesNode(references) {
+  const details = document.createElement("details");
+  details.className = "memory-references recent-context-references";
+
+  const summary = document.createElement("summary");
+  summary.className = "memory-references-summary";
+
+  const count = references.length;
+  const title = document.createElement("span");
+  title.className = "memory-references-title";
+  title.textContent = `${count} recent conversation reference${count === 1 ? "" : "s"}`;
+
+  const hint = document.createElement("span");
+  hint.className = "memory-references-hint";
+  hint.textContent = "View sources";
+
+  summary.append(title, hint);
+  details.append(summary);
+
+  const list = document.createElement("div");
+  list.className = "memory-references-list";
+
+  references.forEach((reference) => {
+    const item = document.createElement("article");
+    item.className = "memory-reference-item";
+
+    const content = document.createElement("div");
+    content.className = "memory-reference-content";
+    content.textContent = reference.excerpt || reference.content || "";
+
+    const meta = document.createElement("div");
+    meta.className = "memory-reference-meta";
+    const file = reference.file || "";
+    const line = reference.line ? `:${reference.line}` : "";
+    const labelParts = [
+      reference.timestamp,
+      reference.session_key,
+      reference.role,
+      reference.turn_id,
+      reference.evidence_id,
+      file ? `${file}${line}` : "",
     ].filter(Boolean);
     meta.textContent = labelParts.join(" · ");
 
@@ -9361,6 +9416,7 @@ async function connectWebSocket() {
             timestamp: new Date().toISOString(),
             message_id: payload.message_id || "",
             _memory_references: payload._memory_references || [],
+            _recent_context_references: payload._recent_context_references || [],
           });
         }
         loadApprovals(sessionKeyForChat(payload.chat_id)).catch(console.error);
@@ -9384,6 +9440,9 @@ async function connectWebSocket() {
             streamState.entry._stream_resuming = payload.resuming === true;
             if (Array.isArray(payload._memory_references)) {
               streamState.entry._memory_references = payload._memory_references;
+            }
+            if (Array.isArray(payload._recent_context_references)) {
+              streamState.entry._recent_context_references = payload._recent_context_references;
             }
           }
           state.streamBuffers.delete(payload.message_id);

--- a/webui/assets/src/legacy/app.js
+++ b/webui/assets/src/legacy/app.js
@@ -1473,6 +1473,63 @@ function updateMessageContent(contentEl, message) {
 
     contentEl.append(textEl);
   }
+
+  if (message.role === "assistant" && Array.isArray(message._memory_references) && message._memory_references.length) {
+    contentEl.append(createMemoryReferencesNode(message._memory_references));
+  }
+}
+
+function createMemoryReferencesNode(references) {
+  const details = document.createElement("details");
+  details.className = "memory-references";
+
+  const summary = document.createElement("summary");
+  summary.className = "memory-references-summary";
+
+  const count = references.length;
+  const title = document.createElement("span");
+  title.className = "memory-references-title";
+  title.textContent = `${count} 个相关记忆`;
+
+  const hint = document.createElement("span");
+  hint.className = "memory-references-hint";
+  hint.textContent = "查看来源";
+
+  summary.append(title, hint);
+  details.append(summary);
+
+  const list = document.createElement("div");
+  list.className = "memory-references-list";
+
+  references.forEach((reference) => {
+    const item = document.createElement("article");
+    item.className = "memory-reference-item";
+
+    const content = document.createElement("div");
+    content.className = "memory-reference-content";
+    content.textContent = reference.content || "";
+
+    const meta = document.createElement("div");
+    meta.className = "memory-reference-meta";
+    const file = reference.file || "memory/notes.jsonl";
+    const line = reference.line ? `:${reference.line}` : "";
+    const view = reference.view_file
+      ? ` · ${reference.view_file}${reference.view_line ? `:${reference.view_line}` : ""}`
+      : "";
+    const labelParts = [
+      reference.scope,
+      reference.type,
+      reference.note_id,
+      `${file}${line}${view}`,
+    ].filter(Boolean);
+    meta.textContent = labelParts.join(" · ");
+
+    item.append(content, meta);
+    list.append(item);
+  });
+
+  details.append(list);
+  return details;
 }
 
 function updateStreamMessageDOM(messageId) {
@@ -9302,6 +9359,8 @@ async function connectWebSocket() {
             role: "assistant",
             content: payload.text || "",
             timestamp: new Date().toISOString(),
+            message_id: payload.message_id || "",
+            _memory_references: payload._memory_references || [],
           });
         }
         loadApprovals(sessionKeyForChat(payload.chat_id)).catch(console.error);
@@ -9323,6 +9382,9 @@ async function connectWebSocket() {
           const streamState = state.streamBuffers.get(payload.message_id);
           if (streamState?.entry) {
             streamState.entry._stream_resuming = payload.resuming === true;
+            if (Array.isArray(payload._memory_references)) {
+              streamState.entry._memory_references = payload._memory_references;
+            }
           }
           state.streamBuffers.delete(payload.message_id);
           if (payload.resuming !== true && streamState?.sessionKey === state.activeSessionKey) {

--- a/webui/assets/styles/components/chat.css
+++ b/webui/assets/styles/components/chat.css
@@ -851,6 +851,72 @@
   white-space: normal;
 }
 
+.memory-references {
+  margin-top: 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-subtle) 62%, transparent);
+  overflow: hidden;
+}
+
+.memory-references summary {
+  list-style: none;
+}
+
+.memory-references summary::-webkit-details-marker {
+  display: none;
+}
+
+.memory-references-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 34px;
+  padding: 7px 10px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.memory-references-title {
+  font-weight: 500;
+  color: var(--text);
+}
+
+.memory-references-hint {
+  color: var(--text-subtle);
+  font-size: 11px;
+}
+
+.memory-references-list {
+  display: grid;
+  gap: 8px;
+  padding: 0 10px 10px;
+}
+
+.memory-reference-item {
+  padding: 8px 9px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  background: var(--panel);
+}
+
+.memory-reference-content {
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.memory-reference-meta {
+  margin-top: 5px;
+  color: var(--text-subtle);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
 /* Markdown样式 */
 .message-text p {
   margin: 0 0 12px;

--- a/webui/assets/styles/components/chat.css
+++ b/webui/assets/styles/components/chat.css
@@ -917,6 +917,10 @@
   overflow-wrap: anywhere;
 }
 
+.recent-context-references {
+  background: color-mix(in srgb, var(--accent-soft) 40%, transparent);
+}
+
 /* Markdown样式 */
 .message-text p {
   margin: 0 0 12px;


### PR DESCRIPTION
## Summary

Add Recent Context Retrieval as a read-only short-term context layer over `memory/conversations/*.jsonl`.
Add a third context layer between Session History and Durable Memory Notes.


## Changes

- Specified short-term cross-session retrieval over `memory/conversations/*.jsonl`.
- Clarified that recent context:
  - does not write to `USER.md`
  - does not create Durable Memory Notes
  - uses "recent context" / "recent conversation reference" terminology
- Added requirements for:
  - 7-day default recency window
  - trigger-gated retrieval for ambiguous follow-ups
  - bounded ranking and prompt injection
  - `[RECENT CONTEXT]` prompt block
  - UI-visible source references
  - evidence clearing/deletion boundaries
- Added implementation task breakdown for retrieval core, ranking, prompt injection, metadata/UI plumbing, docs, and validation.
- Add Recent Context config defaults: enabled, 7-day recency window, max 3 injected records, bounded scan limit.
- Add `MemoryStore` helpers to read recent Conversation Evidence with age, cursor, role, session-exclusion, and source file/line metadata.
- Add Recent Context candidate metadata with excerpt, score inputs, evidence id, timestamp, session key, role, turn id, cursor, and source location.
- Extend `ContextBuilder` to trigger retrieval for ambiguous follow-ups, recent references, preparation/travel/planning prompts, while skipping simple greetings.
- Inject selected items as a distinct `[RECENT CONTEXT]` block separate from durable Memory Recall.
- Persist and emit `_recent_context_references` separately from `_memory_references`.
- Update WebUI to show compact recent conversation reference counts with expandable details.
- Document the Session History / Recent Conversation Evidence / Durable Memory Notes boundary.
