### PR TITLE
Desktop WebUI shell parity entrypoint

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,6 +1,6 @@
 # Tinybot Desktop
 
-Lightweight desktop host for Tinybot. The desktop app uses Tauri and the platform WebView, keeps the existing Python gateway as the first runtime backend, and does not bundle Chromium by default. Browser automation remains an optional external capability backed by installed Chrome, Edge, Chromium, or a bridge service.
+Desktop host for Tinybot's WebUI. The desktop app uses Tauri and the platform WebView, keeps the existing Python gateway as the runtime backend, and presents the same WebUI surface users see in the browser. Desktop-specific code is limited to startup, gateway readiness, the window frame, OS notifications, native file picking, and external link handling.
 
 ## Prerequisites
 
@@ -70,20 +70,30 @@ npm run tauri build
 - Desktop shell: `src-tauri/`
 - Runtime endpoint: `http://127.0.0.1:18790`
 - WebSocket endpoint: `ws://127.0.0.1:18790/ws`
-- Hosted WebUI fallback: `http://127.0.0.1:18790`
+- Primary UI source: repository `webui/index.html` plus `webui/assets`
 - Browser mode: external browser only
 
 ## Launch Flow
 
 1. Open the desktop app.
-2. The local runtime status view appears even when the gateway is offline.
-3. If an external gateway is already running, the app connects to it and labels it `External`.
-4. If no gateway is running, use `Start Gateway` to launch a shell-owned gateway with `uv run tinybot gateway`.
-5. When the gateway is ready, open `Hosted WebUI` to load the existing gateway-served WebUI inside the desktop shell.
-6. Use `Chat` for the first native desktop slice: session selection, message history, send, streaming deltas, stream end state, and interrupt.
+2. A compact startup state waits for the local gateway to become ready.
+3. If an external gateway is already running, the app attaches to it and treats it as externally owned.
+4. If no gateway is running inside Tauri, the app starts a shell-owned gateway with `uv run tinybot gateway`.
+5. When `/webui/bootstrap` is ready, the desktop window installs the WebUI shell and imports the existing WebUI entry module.
+6. Use the desktop app the same way as the browser WebUI: chat, sessions, approvals, temporary files, settings, providers, tools, skills, knowledge, workspace files, browser frames, Cowork, language toggle, and theme toggle all remain WebUI-owned surfaces.
 
 The app stops only shell-owned gateway processes on exit. Externally owned gateway processes are left running.
 
+## Desktop Adapters
+
+The desktop route keeps WebUI behavior as the source of truth and layers native capabilities around it:
+
+- gateway HTTP and WebSocket requests are routed to the local gateway;
+- menu and keyboard commands click existing WebUI controls;
+- native file picking feeds the WebUI's upload inputs;
+- OS notifications observe existing WebUI approval and task progress surfaces;
+- external links open through the operating system.
+
 ## External Browser Policy
 
-The desktop package does not bundle Chromium. The app UI uses the platform WebView. Browser automation, browser snapshots, and browser bridge status are treated as optional gateway-provided capabilities and should not block runtime status, hosted WebUI, or native chat work.
+The desktop package does not bundle Chromium. The app UI uses the platform WebView. Browser automation, browser snapshots, and browser bridge status are treated as optional gateway-provided capabilities and should not block gateway startup or the WebUI shell.

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -79,6 +79,7 @@ import {
 } from "./desktopFileUpload";
 import { installDesktopWebUiCommandBridge } from "./desktopWebUiCommandBridge";
 import { installDesktopWebUiFilePickerBridge } from "./desktopWebUiFilePickerBridge";
+import { installDesktopWebUiNotificationBridge } from "./desktopWebUiNotificationBridge";
 
 const gatewayConfig = resolveGatewayConfig(DEFAULT_GATEWAY_CONFIG);
 const gatewayApi = createGatewayApiClient({ config: gatewayConfig });
@@ -877,6 +878,11 @@ function installRootWebUiDesktopAdapters(): void {
       invoke<DesktopPickedUploadFile | null>("pick_upload_file", {
         options: desktopUploadPickerOptions(kind),
       }),
+  });
+  installDesktopWebUiNotificationBridge({
+    isFocused: () => document.hasFocus(),
+    canNotify: nativeOsNotifications.canNotify,
+    notify: nativeOsNotifications.notify,
   });
 }
 

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -77,6 +77,7 @@ import {
   type DesktopPickedUploadFile,
   type DesktopUploadKind,
 } from "./desktopFileUpload";
+import { installDesktopWebUiCommandBridge } from "./desktopWebUiCommandBridge";
 import { installDesktopWebUiFilePickerBridge } from "./desktopWebUiFilePickerBridge";
 
 const gatewayConfig = resolveGatewayConfig(DEFAULT_GATEWAY_CONFIG);
@@ -865,6 +866,12 @@ function installRootWebUiDesktopAdapters(): void {
   if (!hasTauriRuntime()) {
     return;
   }
+  installDesktopWebUiCommandBridge({
+    listenToMenuCommand: (handler) =>
+      listen<{ id: string }>("desktop-menu-command", (event) => {
+        handler(event.payload.id);
+      }),
+  });
   installDesktopWebUiFilePickerBridge({
     pickFile: (kind: DesktopUploadKind) =>
       invoke<DesktopPickedUploadFile | null>("pick_upload_file", {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -77,6 +77,7 @@ import {
   type DesktopPickedUploadFile,
   type DesktopUploadKind,
 } from "./desktopFileUpload";
+import { installDesktopWebUiFilePickerBridge } from "./desktopWebUiFilePickerBridge";
 
 const gatewayConfig = resolveGatewayConfig(DEFAULT_GATEWAY_CONFIG);
 const gatewayApi = createGatewayApiClient({ config: gatewayConfig });
@@ -191,6 +192,7 @@ async function bootDesktopWebUi(): Promise<void> {
       return;
     }
     installWebUiShell(webUiHtml);
+    installRootWebUiDesktopAdapters();
     installTauriNavigation();
     installTauriWindowFrame(status);
     await import(/* @vite-ignore */ WEBUI_ENTRY);
@@ -856,6 +858,18 @@ function installNativeFileUploadActions(): void {
     onKnowledgeTaskUpdated: updateNativeKnowledgeTask,
     uploadSessionTemporaryFile: (sessionKey, form) => gatewayApi.sessions.uploadTemporaryFile(sessionKey, form),
     uploadWorkspaceFile: (path, body) => gatewayApi.workspace.putFile(path, body),
+  });
+}
+
+function installRootWebUiDesktopAdapters(): void {
+  if (!hasTauriRuntime()) {
+    return;
+  }
+  installDesktopWebUiFilePickerBridge({
+    pickFile: (kind: DesktopUploadKind) =>
+      invoke<DesktopPickedUploadFile | null>("pick_upload_file", {
+        options: desktopUploadPickerOptions(kind),
+      }),
   });
 }
 

--- a/apps/desktop/src/desktopWebUiCommandBridge.test.ts
+++ b/apps/desktop/src/desktopWebUiCommandBridge.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "vitest";
+import { installDesktopWebUiCommandBridge } from "./desktopWebUiCommandBridge";
+
+class FakeButton {
+  public clicks = 0;
+
+  click(): void {
+    this.clicks += 1;
+  }
+}
+
+class FakeStatus {
+  public textContent = "";
+}
+
+class FakeWebUiDocument {
+  public documentElement = { dataset: {} as Record<string, string> };
+  public listeners = new Map<string, Array<(event: Event) => unknown>>();
+  public readonly nodes: Record<string, unknown> = {
+    "#new-chat-button": new FakeButton(),
+    "#settings-button": new FakeButton(),
+    "#theme-toggle": new FakeButton(),
+    "#sidebar-collapse-button": new FakeButton(),
+    "#help-tour-button": new FakeButton(),
+    "[data-desktop-route-status]": new FakeStatus(),
+  };
+
+  addEventListener(type: string, listener: (event: Event) => unknown): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  dispatchEvent(event: Event): boolean {
+    for (const listener of this.listeners.get(event.type) ?? []) {
+      listener(event);
+    }
+    return true;
+  }
+
+  querySelector(selector: string): unknown {
+    return this.nodes[selector] ?? null;
+  }
+}
+
+describe("desktop WebUI command bridge", () => {
+  test("routes desktop menu commands to existing WebUI controls", () => {
+    const document = new FakeWebUiDocument();
+
+    installDesktopWebUiCommandBridge({
+      targetDocument: document as unknown as Document,
+      targetWindow: fakeWindow(),
+      listenToMenuCommand: () => undefined,
+    });
+
+    document.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "new-chat" } }));
+    document.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "open-settings" } }));
+    document.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "toggle-theme" } }));
+    document.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "toggle-sidebar" } }));
+    document.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "open-shortcut-help" } }));
+
+    expect((document.nodes["#new-chat-button"] as FakeButton).clicks).toBe(1);
+    expect((document.nodes["#settings-button"] as FakeButton).clicks).toBe(1);
+    expect((document.nodes["#theme-toggle"] as FakeButton).clicks).toBe(1);
+    expect((document.nodes["#sidebar-collapse-button"] as FakeButton).clicks).toBe(1);
+    expect((document.nodes["#help-tour-button"] as FakeButton).clicks).toBe(1);
+  });
+
+  test("maps desktop keyboard shortcuts to WebUI controls and docs navigation", () => {
+    const document = new FakeWebUiDocument();
+    const assigned: string[] = [];
+
+    installDesktopWebUiCommandBridge({
+      targetDocument: document as unknown as Document,
+      targetWindow: fakeWindow(assigned),
+      listenToMenuCommand: () => undefined,
+    });
+
+    let newChatPrevented = false;
+    document.dispatchEvent({
+      type: "keydown",
+      key: "n",
+      ctrlKey: true,
+      preventDefault: () => {
+        newChatPrevented = true;
+      },
+    } as unknown as Event);
+    document.dispatchEvent({
+      type: "keydown",
+      key: "F1",
+      preventDefault: () => undefined,
+    } as unknown as Event);
+
+    expect(newChatPrevented).toBe(true);
+    expect((document.nodes["#new-chat-button"] as FakeButton).clicks).toBe(1);
+    expect(assigned).toEqual(["http://localhost:1420/docs"]);
+  });
+
+  test("listens to Tauri menu commands and reports commands without WebUI controls", () => {
+    const document = new FakeWebUiDocument();
+    const handlers: Array<(id: string) => void> = [];
+
+    installDesktopWebUiCommandBridge({
+      targetDocument: document as unknown as Document,
+      targetWindow: fakeWindow(),
+      listenToMenuCommand: (nextHandler) => {
+        handlers.push(nextHandler);
+      },
+    });
+    handlers[0]("stop-generation");
+
+    expect(document.documentElement.dataset.desktopCommandFeedback).toBe(
+      "Stop generation is unavailable in the WebUI shell.",
+    );
+    expect((document.nodes["[data-desktop-route-status]"] as FakeStatus).textContent).toBe(
+      "Stop generation is unavailable in the WebUI shell.",
+    );
+  });
+});
+
+function fakeWindow(assigned: string[] = []): Window {
+  return {
+    location: {
+      origin: "http://localhost:1420",
+      assign: (href: string) => {
+        assigned.push(href);
+      },
+    },
+  } as unknown as Window;
+}

--- a/apps/desktop/src/desktopWebUiCommandBridge.ts
+++ b/apps/desktop/src/desktopWebUiCommandBridge.ts
@@ -1,0 +1,104 @@
+import {
+  resolveDesktopShortcutCommand,
+  type DesktopMenuCommandId,
+} from "./desktopCommandNavigation";
+
+export interface DesktopWebUiCommandBridgeOptions {
+  listenToMenuCommand: (handler: (id: string) => void) => void | Promise<unknown>;
+  targetDocument?: Document;
+  targetWindow?: Window;
+}
+
+const WEBUI_COMMAND_BUTTONS: Partial<Record<DesktopMenuCommandId, string>> = {
+  "new-chat": "#new-chat-button",
+  "open-settings": "#settings-button",
+  "toggle-theme": "#theme-toggle",
+  "toggle-sidebar": "#sidebar-collapse-button",
+  "open-shortcut-help": "#help-tour-button",
+  "open-page-help": "#help-tour-button",
+};
+
+export function installDesktopWebUiCommandBridge({
+  listenToMenuCommand,
+  targetDocument = document,
+  targetWindow = window,
+}: DesktopWebUiCommandBridgeOptions): void {
+  targetDocument.addEventListener("keydown", (event) => {
+    const id = resolveDesktopShortcutCommand(event);
+    if (!id) {
+      return;
+    }
+    event.preventDefault();
+    routeDesktopWebUiCommand(id, targetDocument, targetWindow);
+  });
+
+  targetDocument.addEventListener("desktop-menu-command", (event) => {
+    const id = (event as CustomEvent<{ id?: unknown }>).detail?.id;
+    if (typeof id === "string") {
+      routeDesktopWebUiCommand(id, targetDocument, targetWindow);
+    }
+  });
+
+  void listenToMenuCommand((id) => {
+    routeDesktopWebUiCommand(id, targetDocument, targetWindow);
+  });
+}
+
+function routeDesktopWebUiCommand(id: string, targetDocument: Document, targetWindow: Window): void {
+  if (id === "open-docs") {
+    targetWindow.location.assign(new URL("/docs", targetWindow.location.origin).href);
+    return;
+  }
+
+  const selector = WEBUI_COMMAND_BUTTONS[id as DesktopMenuCommandId];
+  const target = selector ? targetDocument.querySelector<HTMLElement>(selector) : null;
+  if (target && typeof target.click === "function") {
+    target.click();
+    setCommandFeedback(targetDocument, commandFeedback(id));
+    return;
+  }
+
+  setCommandFeedback(targetDocument, commandUnavailableFeedback(id));
+}
+
+function commandFeedback(id: string): string {
+  switch (id) {
+    case "new-chat":
+      return "New chat requested";
+    case "open-settings":
+      return "Settings opened";
+    case "toggle-theme":
+      return "Theme toggled";
+    case "toggle-sidebar":
+      return "Sidebar toggled";
+    case "open-shortcut-help":
+    case "open-page-help":
+      return "Help opened";
+    default:
+      return "Desktop command routed";
+  }
+}
+
+function commandUnavailableFeedback(id: string): string {
+  if (id === "stop-generation") {
+    return "Stop generation is unavailable in the WebUI shell.";
+  }
+  if (id === "search-sessions") {
+    return "Session search is not available in the WebUI shell.";
+  }
+  if (id === "open-command-palette") {
+    return "Command palette is not available in the WebUI shell.";
+  }
+  if (id === "refresh-gateway-status") {
+    return "Gateway status refresh is handled by WebUI status polling.";
+  }
+  return `Unknown desktop command: ${id}`;
+}
+
+function setCommandFeedback(targetDocument: Document, message: string): void {
+  const routeStatus = targetDocument.querySelector<HTMLElement>("[data-desktop-route-status]");
+  if (routeStatus) {
+    routeStatus.textContent = message;
+  }
+  targetDocument.documentElement.dataset.desktopCommandFeedback = message;
+}

--- a/apps/desktop/src/desktopWebUiFilePickerBridge.test.ts
+++ b/apps/desktop/src/desktopWebUiFilePickerBridge.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  installDesktopWebUiFilePickerBridge,
+  selectDesktopFileForWebUiInput,
+} from "./desktopWebUiFilePickerBridge";
+
+class FakeDataTransfer {
+  private readonly storedFiles: File[] = [];
+
+  public readonly items = {
+    add: (file: File) => {
+      this.storedFiles.push(file);
+    },
+  };
+
+  get files(): File[] {
+    return this.storedFiles;
+  }
+}
+
+class FakeElement {
+  private readonly listeners = new Map<string, Array<(event: FakeEvent) => unknown>>();
+
+  addEventListener(type: string, handler: (event: FakeEvent) => unknown): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), handler]);
+  }
+
+  async emit(type: string, event = new FakeEvent(type)): Promise<FakeEvent> {
+    for (const handler of this.listeners.get(type) ?? []) {
+      await handler(event);
+    }
+    return event;
+  }
+}
+
+class FakeInput extends FakeElement {
+  public files: File[] = [];
+  public dispatchedEvents: string[] = [];
+
+  dispatchEvent(event: Event): boolean {
+    this.dispatchedEvents.push(event.type);
+    return true;
+  }
+}
+
+class FakeEvent {
+  public defaultPrevented = false;
+  public propagationStopped = false;
+
+  constructor(public readonly type: string) {}
+
+  preventDefault(): void {
+    this.defaultPrevented = true;
+  }
+
+  stopImmediatePropagation(): void {
+    this.propagationStopped = true;
+  }
+}
+
+class FakeDocument {
+  constructor(private readonly nodes: Record<string, unknown>) {}
+
+  querySelector(selector: string): unknown {
+    return this.nodes[selector] ?? null;
+  }
+}
+
+const pickedFile = {
+  name: "notes.md",
+  path: "C:\\Users\\tinybot\\notes.md",
+  mime_type: "text/markdown",
+  size_bytes: 5,
+  bytes: [...new TextEncoder().encode("hello")],
+};
+
+describe("desktop WebUI file picker bridge", () => {
+  test("assigns a native-picked file to an existing WebUI file input and dispatches change", async () => {
+    const input = new FakeInput();
+
+    const selected = await selectDesktopFileForWebUiInput({
+      input: input as unknown as HTMLInputElement,
+      kind: "knowledge-document",
+      pickFile: async () => pickedFile,
+      createDataTransfer: () => new FakeDataTransfer() as unknown as DataTransfer,
+    });
+
+    expect(selected).toBe(true);
+    expect(input.files).toHaveLength(1);
+    expect(input.files[0].name).toBe("notes.md");
+    expect(input.files[0].type).toBe("text/markdown");
+    expect(await input.files[0].text()).toBe("hello");
+    expect(input.dispatchedEvents).toEqual(["change"]);
+  });
+
+  test("intercepts WebUI upload buttons and uses target-specific picker options", async () => {
+    const sessionButton = new FakeElement();
+    const sessionInput = new FakeInput();
+    const document = new FakeDocument({
+      "#temporary-file-button": sessionButton,
+      "#temporary-file-upload": sessionInput,
+    });
+    const pickFile = vi.fn(async () => pickedFile);
+
+    installDesktopWebUiFilePickerBridge({
+      targetDocument: document as unknown as Document,
+      pickFile,
+      createDataTransfer: () => new FakeDataTransfer() as unknown as DataTransfer,
+    });
+    const click = await sessionButton.emit("click");
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(click.propagationStopped).toBe(true);
+    expect(pickFile).toHaveBeenCalledWith(
+      "session-temporary-file",
+      expect.objectContaining({
+        title: "Attach temporary session file",
+      }),
+    );
+    expect(sessionInput.files[0].name).toBe("notes.md");
+    expect(sessionInput.dispatchedEvents).toEqual(["change"]);
+  });
+});

--- a/apps/desktop/src/desktopWebUiFilePickerBridge.ts
+++ b/apps/desktop/src/desktopWebUiFilePickerBridge.ts
@@ -1,0 +1,85 @@
+import {
+  buildDesktopUploadFile,
+  desktopUploadPickerOptions,
+  type DesktopPickedUploadFile,
+  type DesktopUploadKind,
+  type DesktopUploadPickerOptions,
+} from "./desktopFileUpload";
+
+export interface DesktopWebUiFilePickerBridgeOptions {
+  targetDocument?: Document;
+  pickFile: (
+    kind: DesktopUploadKind,
+    options: DesktopUploadPickerOptions,
+  ) => Promise<DesktopPickedUploadFile | null>;
+  createDataTransfer?: () => DataTransfer;
+}
+
+interface DesktopFileInputSelectionOptions extends DesktopWebUiFilePickerBridgeOptions {
+  input: HTMLInputElement;
+  kind: DesktopUploadKind;
+}
+
+const WEBUI_FILE_TARGETS: Array<{
+  buttonSelector: string;
+  inputSelector: string;
+  kind: DesktopUploadKind;
+}> = [
+  {
+    buttonSelector: "#temporary-file-button",
+    inputSelector: "#temporary-file-upload",
+    kind: "session-temporary-file",
+  },
+  {
+    buttonSelector: "#upload-doc-button",
+    inputSelector: "#doc-file-upload",
+    kind: "knowledge-document",
+  },
+];
+
+export function installDesktopWebUiFilePickerBridge({
+  targetDocument = document,
+  pickFile,
+  createDataTransfer,
+}: DesktopWebUiFilePickerBridgeOptions): void {
+  for (const target of WEBUI_FILE_TARGETS) {
+    const button = targetDocument.querySelector<HTMLButtonElement>(target.buttonSelector);
+    const input = targetDocument.querySelector<HTMLInputElement>(target.inputSelector);
+    if (!button || !input) {
+      continue;
+    }
+
+    button.addEventListener(
+      "click",
+      async (event) => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        await selectDesktopFileForWebUiInput({
+          input,
+          kind: target.kind,
+          pickFile,
+          createDataTransfer,
+        });
+      },
+      true,
+    );
+  }
+}
+
+export async function selectDesktopFileForWebUiInput({
+  input,
+  kind,
+  pickFile,
+  createDataTransfer = () => new DataTransfer(),
+}: DesktopFileInputSelectionOptions): Promise<boolean> {
+  const picked = await pickFile(kind, desktopUploadPickerOptions(kind));
+  if (!picked) {
+    return false;
+  }
+
+  const transfer = createDataTransfer();
+  transfer.items.add(buildDesktopUploadFile(picked));
+  input.files = transfer.files;
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+  return true;
+}

--- a/apps/desktop/src/desktopWebUiNotificationBridge.test.ts
+++ b/apps/desktop/src/desktopWebUiNotificationBridge.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "vitest";
+import { installDesktopWebUiNotificationBridge } from "./desktopWebUiNotificationBridge";
+
+class FakeDomNode {
+  public readonly children: FakeDomNode[] = [];
+  public readonly classList = {
+    contains: (className: string) => this.classes.has(className),
+  };
+
+  private readonly classes: Set<string>;
+
+  constructor(
+    className: string,
+    private readonly ownText = "",
+    children: FakeDomNode[] = [],
+  ) {
+    this.classes = new Set(className.split(/\s+/).filter(Boolean));
+    this.children.push(...children);
+  }
+
+  get textContent(): string {
+    return [this.ownText, ...this.children.map((child) => child.textContent)].filter(Boolean).join(" ");
+  }
+
+  append(child: FakeDomNode): void {
+    this.children.push(child);
+  }
+
+  querySelector(selector: string): FakeDomNode | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  querySelectorAll(selector: string): FakeDomNode[] {
+    const matches: FakeDomNode[] = [];
+    for (const child of this.children) {
+      if (child.matches(selector)) {
+        matches.push(child);
+      }
+      matches.push(...child.querySelectorAll(selector));
+    }
+    return matches;
+  }
+
+  private matches(selector: string): boolean {
+    return selector.startsWith(".") && this.classes.has(selector.slice(1));
+  }
+}
+
+class FakeDocument {
+  public readonly body = new FakeDomNode("body");
+
+  querySelectorAll(selector: string): FakeDomNode[] {
+    return this.body.querySelectorAll(selector);
+  }
+}
+
+class FakeObserver {
+  public observed = false;
+
+  constructor(private readonly callback: MutationCallback) {}
+
+  observe(): void {
+    this.observed = true;
+  }
+
+  disconnect(): void {
+    this.observed = false;
+  }
+
+  async flush(): Promise<void> {
+    this.callback([], this as unknown as MutationObserver);
+    await Promise.resolve();
+  }
+}
+
+describe("desktop WebUI notification bridge", () => {
+  test("remembers existing approvals and notifies only when a new approval appears", async () => {
+    const sent: { title: string; body: string }[] = [];
+    const document = new FakeDocument();
+    document.body.append(approvalItem("medium / shell", "Existing approval"));
+    const observers: FakeObserver[] = [];
+
+    installDesktopWebUiNotificationBridge({
+      targetDocument: document as unknown as Document,
+      createObserver: (callback) => {
+        const observer = new FakeObserver(callback);
+        observers.push(observer);
+        return observer as unknown as MutationObserver;
+      },
+      isFocused: () => false,
+      canNotify: () => true,
+      notify: async (notification) => {
+        sent.push(notification);
+        return true;
+      },
+    });
+    document.body.append(approvalItem("high / shell", "Run desktop command"));
+    const observer = observers[0];
+    await observer?.flush();
+
+    expect(observer?.observed).toBe(true);
+    expect(sent).toEqual([
+      {
+        title: "Tinybot approval required",
+        body: "Run desktop command - high / shell",
+      },
+    ]);
+  });
+
+  test("notifies WebUI task progress terminal states while the desktop window is unfocused", async () => {
+    const sent: { title: string; body: string }[] = [];
+    const document = new FakeDocument();
+    const observers: FakeObserver[] = [];
+
+    installDesktopWebUiNotificationBridge({
+      targetDocument: document as unknown as Document,
+      createObserver: (callback) => {
+        const observer = new FakeObserver(callback);
+        observers.push(observer);
+        return observer as unknown as MutationObserver;
+      },
+      isFocused: () => false,
+      canNotify: () => true,
+      notify: async (notification) => {
+        sent.push(notification);
+        return true;
+      },
+    });
+    document.body.append(taskProgressCard("task-progress-failed", "Index notes", "Failed"));
+    document.body.append(taskProgressCard("task-progress-completed", "Sync workspace", "Completed"));
+    const observer = observers[0];
+    await observer?.flush();
+
+    expect(sent).toEqual([
+      {
+        title: "Tinybot task failed",
+        body: "Index notes - Failed",
+      },
+      {
+        title: "Tinybot task completed",
+        body: "Sync workspace - Completed",
+      },
+    ]);
+  });
+});
+
+function approvalItem(meta: string, summary: string): FakeDomNode {
+  return new FakeDomNode("approval-item", "", [
+    new FakeDomNode("approval-meta", meta),
+    new FakeDomNode("approval-summary", summary),
+  ]);
+}
+
+function taskProgressCard(statusClass: string, title: string, badge: string): FakeDomNode {
+  return new FakeDomNode(`task-progress-card ${statusClass}`, "", [
+    new FakeDomNode("task-progress-title", title),
+    new FakeDomNode("task-progress-badge", badge),
+  ]);
+}

--- a/apps/desktop/src/desktopWebUiNotificationBridge.ts
+++ b/apps/desktop/src/desktopWebUiNotificationBridge.ts
@@ -1,0 +1,136 @@
+import type { DesktopTaskNotification } from "./desktopTaskNotifications";
+
+export interface DesktopWebUiNotificationBridgeOptions {
+  targetDocument?: Document;
+  createObserver?: (callback: MutationCallback) => MutationObserver;
+  isFocused?: () => boolean;
+  canNotify?: () => boolean | Promise<boolean>;
+  notify: (notification: DesktopTaskNotification) => boolean | Promise<boolean>;
+}
+
+export interface DesktopWebUiNotificationBridge {
+  disconnect: () => void;
+  refresh: () => Promise<void>;
+}
+
+interface WebUiNotificationCandidate {
+  key: string;
+  notification: DesktopTaskNotification;
+}
+
+const TASK_NOTIFICATION_STATES = [
+  {
+    className: "task-progress-failed",
+    title: "Tinybot task failed",
+  },
+  {
+    className: "task-progress-completed",
+    title: "Tinybot task completed",
+  },
+] as const;
+
+export function installDesktopWebUiNotificationBridge({
+  targetDocument = document,
+  createObserver = (callback) => new MutationObserver(callback),
+  isFocused = () => targetDocument.hasFocus(),
+  canNotify = () => true,
+  notify,
+}: DesktopWebUiNotificationBridgeOptions): DesktopWebUiNotificationBridge {
+  const observedRoot = targetDocument.body ?? targetDocument.documentElement;
+  const seen = new Set<string>();
+
+  const scan = async (rememberOnly = false): Promise<void> => {
+    const candidates = collectWebUiNotificationCandidates(targetDocument);
+    if (!candidates.length) {
+      return;
+    }
+    const shouldNotify = !rememberOnly && !isFocused() && (await canNotify());
+    for (const candidate of candidates) {
+      if (seen.has(candidate.key)) {
+        continue;
+      }
+      seen.add(candidate.key);
+      if (shouldNotify) {
+        await notify(candidate.notification);
+      }
+    }
+  };
+
+  void scan(true);
+
+  if (!observedRoot) {
+    return {
+      disconnect: () => undefined,
+      refresh: () => scan(false),
+    };
+  }
+
+  const observer = createObserver(() => {
+    void scan(false);
+  });
+  observer.observe(observedRoot, {
+    attributes: true,
+    attributeFilter: ["class"],
+    childList: true,
+    subtree: true,
+  });
+
+  return {
+    disconnect: () => {
+      observer.disconnect();
+    },
+    refresh: () => scan(false),
+  };
+}
+
+function collectWebUiNotificationCandidates(targetDocument: Document): WebUiNotificationCandidate[] {
+  return [
+    ...collectApprovalCandidates(targetDocument),
+    ...collectTaskProgressCandidates(targetDocument),
+  ];
+}
+
+function collectApprovalCandidates(targetDocument: Document): WebUiNotificationCandidate[] {
+  const candidates: WebUiNotificationCandidate[] = [];
+  for (const item of Array.from(targetDocument.querySelectorAll(".approval-item"))) {
+    const summary = elementText(item.querySelector(".approval-summary")) || elementText(item);
+    const meta = elementText(item.querySelector(".approval-meta"));
+    if (summary) {
+      candidates.push({
+        key: `approval:${summary}:${meta}`,
+        notification: {
+          title: "Tinybot approval required",
+          body: notificationBody(summary, meta),
+        },
+      });
+    }
+  }
+  return candidates;
+}
+
+function collectTaskProgressCandidates(targetDocument: Document): WebUiNotificationCandidate[] {
+  const candidates: WebUiNotificationCandidate[] = [];
+  for (const card of Array.from(targetDocument.querySelectorAll(".task-progress-card"))) {
+    const state = TASK_NOTIFICATION_STATES.find((candidate) => card.classList.contains(candidate.className));
+    if (state) {
+      const title = elementText(card.querySelector(".task-progress-title")) || "Tinybot task";
+      const status = elementText(card.querySelector(".task-progress-badge"));
+      candidates.push({
+        key: `task:${title}:${state.className}:${status}`,
+        notification: {
+          title: state.title,
+          body: notificationBody(title, status),
+        },
+      });
+    }
+  }
+  return candidates;
+}
+
+function elementText(element: Element | null): string {
+  return (element?.textContent ?? "").replace(/\s+/g, " ").trim();
+}
+
+function notificationBody(primary: string, secondary: string): string {
+  return [primary, secondary].filter(Boolean).join(" - ");
+}

--- a/apps/desktop/src/desktopWorkbenchGate.test.ts
+++ b/apps/desktop/src/desktopWorkbenchGate.test.ts
@@ -79,26 +79,26 @@ describe("desktop workbench gate", () => {
     });
   });
 
-  test("uses native workbench as the desktop startup default while preserving root fallback", () => {
+  test("uses root WebUI as the desktop startup default while preserving an explicit native escape hatch", () => {
     expect(
       resolveDesktopWorkbenchStartupMode({
         location: { search: "" },
         storage: storageWith(null),
       }),
     ).toEqual({
-      mode: "native-workbench",
-      requestedMode: "native-workbench",
+      mode: "root-webui",
+      requestedMode: "root-webui",
       source: "default",
     });
 
     expect(
       resolveDesktopWorkbenchStartupMode({
-        location: { search: "?desktop-workbench=root" },
+        location: { search: "?desktop-workbench=native" },
         storage: storageWith(null),
       }),
     ).toEqual({
-      mode: "root-webui",
-      requestedMode: "root-webui",
+      mode: "native-workbench",
+      requestedMode: "native-workbench",
       source: "query",
     });
   });

--- a/apps/desktop/src/desktopWorkbenchGate.ts
+++ b/apps/desktop/src/desktopWorkbenchGate.ts
@@ -23,7 +23,7 @@ export function resolveDesktopWorkbenchStartupMode(
   return resolveDesktopWorkbenchMode({
     ...options,
     nativeWorkbenchAvailable: true,
-    defaultMode: "native-workbench",
+    defaultMode: "root-webui",
   });
 }
 


### PR DESCRIPTION
## Summary

This PR moves the desktop app back to the same product surface as the browser WebUI.

Changes included:
- Default desktop startup now selects the WebUI shell path instead of the independent native workbench path.
- Desktop native file picking is bridged into the existing WebUI upload controls for session temporary files and knowledge documents.
- Desktop menu/window commands are routed into existing WebUI controls such as new chat, settings, theme toggle, sidebar toggle, help, and docs navigation.
- Desktop OS notifications observe existing WebUI approval and task progress surfaces for pending approvals, failed tasks, and completed tasks.
- Desktop README now documents the WebUI entrypoint launch flow and native adapter boundary.

## Validation

- `npm test` in `apps/desktop` passed: 35 files, 174 tests.
- `npm run build` in `apps/desktop` passed.
- `uv run pytest tests/api/test_webui.py` passed: 34 tests.
- Headless Chrome side-by-side smoke loaded gateway WebUI at `http://127.0.0.1:18790/` and desktop preview at `http://127.0.0.1:1420/`; key WebUI selectors matched with no presence mismatches, and desktop reported `root-webui` mode.
- Vite preview smoke served the Tinybot Desktop index from `http://127.0.0.1:4173/`.

## Tracking

Closes #106
Closes #107
Closes #108
Closes #109