### PR TITLE
Refine desktop app native UI/UX

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -65,6 +65,7 @@ import {
 } from "./desktopWorkbenchShell";
 import { installDesktopWorkspaceFileActions } from "./desktopWorkspaceFiles";
 import { buildDesktopWorkspaceFileRows } from "./desktopWorkspaceFiles";
+import { installDesktopRootWebUiWorkbenchAdapter } from "./desktopRootWebUiWorkbench";
 import { installWebUiShell } from "./desktopWebUiShell";
 import { resolveDesktopWorkbenchStartupMode } from "./desktopWorkbenchGate";
 import { installDesktopWindowFrame, setDesktopWindowRuntimeStatus } from "./desktopWindowFrame";
@@ -194,6 +195,7 @@ async function bootDesktopWebUi(): Promise<void> {
       return;
     }
     installWebUiShell(webUiHtml);
+    installDesktopRootWebUiWorkbenchAdapter();
     installRootWebUiDesktopAdapters();
     installTauriNavigation();
     installTauriWindowFrame(status);

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -196,6 +196,10 @@ async function bootDesktopWebUi(): Promise<void> {
     }
     installWebUiShell(webUiHtml);
     installDesktopRootWebUiWorkbenchAdapter();
+    installDesktopCommandPalette({
+      gatewayOrigin: gatewayConfig.httpBaseUrl,
+      loadData: loadNativeCommandPaletteData,
+    });
     installRootWebUiDesktopAdapters();
     installTauriNavigation();
     installTauriWindowFrame(status);

--- a/apps/desktop/src/desktopCommandNavigation.test.ts
+++ b/apps/desktop/src/desktopCommandNavigation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  DESKTOP_CHROME_COMMANDS,
   DESKTOP_MENU_COMMANDS,
   installDesktopMenuCommandRouting,
   resolveDesktopShortcutCommand,
@@ -114,6 +115,27 @@ describe("desktop command navigation", () => {
       "Ctrl+B",
       "Ctrl+Shift+P",
       "Ctrl+Shift+G",
+    ]);
+    expect(DESKTOP_CHROME_COMMANDS.map((command) => command.id)).toEqual([
+      "new-chat",
+      "stop-generation",
+      "search-sessions",
+      "open-command-palette",
+    ]);
+    expect(DESKTOP_CHROME_COMMANDS.map((command) => command.chromeLabel)).toEqual([
+      "New",
+      "Stop",
+      "Search",
+      "Command",
+    ]);
+    expect(DESKTOP_MENU_COMMANDS.filter((command) => command.chromeGroup === "secondary").map((command) => command.id)).toEqual([
+      "open-settings",
+      "open-docs",
+      "open-shortcut-help",
+      "open-page-help",
+      "toggle-theme",
+      "toggle-sidebar",
+      "refresh-gateway-status",
     ]);
   });
 

--- a/apps/desktop/src/desktopCommandNavigation.ts
+++ b/apps/desktop/src/desktopCommandNavigation.ts
@@ -25,6 +25,8 @@ export type DesktopCommandAction =
 export interface DesktopMenuCommand {
   id: DesktopMenuCommandId;
   label: string;
+  chromeLabel?: string;
+  chromeGroup: "primary" | "secondary";
   shortcut: string;
 }
 
@@ -47,18 +49,22 @@ export interface InstallDesktopMenuCommandRoutingOptions {
 }
 
 export const DESKTOP_MENU_COMMANDS: DesktopMenuCommand[] = [
-  { id: "new-chat", label: "New Chat", shortcut: "Ctrl+N" },
-  { id: "stop-generation", label: "Stop Generation", shortcut: "Ctrl+." },
-  { id: "search-sessions", label: "Search Sessions", shortcut: "Ctrl+F" },
-  { id: "open-settings", label: "Settings", shortcut: "Ctrl+," },
-  { id: "open-docs", label: "Documentation", shortcut: "F1" },
-  { id: "open-shortcut-help", label: "Shortcut Help", shortcut: "Ctrl+/" },
-  { id: "open-page-help", label: "Page Help", shortcut: "Ctrl+Shift+/" },
-  { id: "toggle-theme", label: "Toggle Theme", shortcut: "Ctrl+Shift+T" },
-  { id: "toggle-sidebar", label: "Toggle Sidebar", shortcut: "Ctrl+B" },
-  { id: "open-command-palette", label: "Command Palette", shortcut: "Ctrl+Shift+P" },
-  { id: "refresh-gateway-status", label: "Gateway Status", shortcut: "Ctrl+Shift+G" },
+  { id: "new-chat", label: "New Chat", chromeLabel: "New", chromeGroup: "primary", shortcut: "Ctrl+N" },
+  { id: "stop-generation", label: "Stop Generation", chromeLabel: "Stop", chromeGroup: "primary", shortcut: "Ctrl+." },
+  { id: "search-sessions", label: "Search Sessions", chromeLabel: "Search", chromeGroup: "primary", shortcut: "Ctrl+F" },
+  { id: "open-settings", label: "Settings", chromeGroup: "secondary", shortcut: "Ctrl+," },
+  { id: "open-docs", label: "Documentation", chromeGroup: "secondary", shortcut: "F1" },
+  { id: "open-shortcut-help", label: "Shortcut Help", chromeGroup: "secondary", shortcut: "Ctrl+/" },
+  { id: "open-page-help", label: "Page Help", chromeGroup: "secondary", shortcut: "Ctrl+Shift+/" },
+  { id: "toggle-theme", label: "Toggle Theme", chromeGroup: "secondary", shortcut: "Ctrl+Shift+T" },
+  { id: "toggle-sidebar", label: "Toggle Sidebar", chromeGroup: "secondary", shortcut: "Ctrl+B" },
+  { id: "open-command-palette", label: "Command Palette", chromeLabel: "Command", chromeGroup: "primary", shortcut: "Ctrl+Shift+P" },
+  { id: "refresh-gateway-status", label: "Gateway Status", chromeGroup: "secondary", shortcut: "Ctrl+Shift+G" },
 ];
+
+export const DESKTOP_CHROME_COMMANDS: DesktopMenuCommand[] = DESKTOP_MENU_COMMANDS.filter(
+  (command) => command.chromeGroup === "primary",
+);
 
 interface DesktopShortcutLike {
   key: string;

--- a/apps/desktop/src/desktopCommandPalette.test.ts
+++ b/apps/desktop/src/desktopCommandPalette.test.ts
@@ -3,6 +3,7 @@ import {
   activateDesktopCommandPaletteResult,
   buildDesktopCommandPaletteResults,
   createDesktopCommandPaletteState,
+  openDesktopCommandPalette,
 } from "./desktopCommandPalette";
 
 describe("desktop command palette", () => {
@@ -108,6 +109,20 @@ describe("desktop command palette", () => {
       "Skills",
       "Cowork sessions",
     ]);
+  });
+
+  test("opens with an optional initial query for keyboard-first session search", () => {
+    const events: unknown[] = [];
+    const targetDocument = {
+      dispatchEvent: (event: Event) => {
+        events.push((event as CustomEvent).detail);
+        return true;
+      },
+    };
+
+    openDesktopCommandPalette(targetDocument as unknown as Document, "session");
+
+    expect(events).toEqual([{ query: "session" }]);
   });
 
   test("activates quick-search results by navigating and focusing matching entities", () => {

--- a/apps/desktop/src/desktopCommandPalette.ts
+++ b/apps/desktop/src/desktopCommandPalette.ts
@@ -127,8 +127,8 @@ export function buildDesktopCommandPaletteResults(
     .slice(0, limit);
 }
 
-export function openDesktopCommandPalette(targetDocument: Document = document): void {
-  targetDocument.dispatchEvent(new CustomEvent(OPEN_PALETTE_EVENT));
+export function openDesktopCommandPalette(targetDocument: Document = document, query = ""): void {
+  targetDocument.dispatchEvent(new CustomEvent(OPEN_PALETTE_EVENT, { detail: { query } }));
 }
 
 export function activateDesktopCommandPaletteResult(
@@ -170,32 +170,62 @@ export function installDesktopCommandPalette({
   const paletteInput = input;
 
   let state = createDesktopCommandPaletteState();
+  let previousFocus: HTMLElement | null = null;
   renderPalette(targetDocument, state, "");
 
-  targetDocument.addEventListener(OPEN_PALETTE_EVENT, () => {
+  targetDocument.addEventListener(OPEN_PALETTE_EVENT, (event) => {
+    const activeElement = targetDocument.activeElement;
+    previousFocus = activeElement && "focus" in activeElement ? activeElement as HTMLElement : null;
+    const query = (event as CustomEvent<{ query?: unknown }>).detail?.query;
+    if (typeof query === "string") {
+      paletteInput.value = query;
+      renderPalette(targetDocument, state, query);
+    }
     palette.hidden = false;
     paletteInput.focus();
     void refreshPaletteData();
   });
   paletteInput.addEventListener("input", () => renderPalette(targetDocument, state, paletteInput.value));
   results?.addEventListener("click", (event) => {
-    const target = event.target instanceof Element ? event.target.closest<HTMLElement>("[data-palette-result-id]") : null;
+    const eventTarget = event.target as { closest?: (selector: string) => HTMLElement | null } | null;
+    const target = typeof eventTarget?.closest === "function" ? eventTarget.closest("[data-palette-result-id]") : null;
     const result = state.results.find((item) => item.id === target?.dataset.paletteResultId);
     if (!result) {
       return;
     }
     activateDesktopCommandPaletteResult(result, { gatewayOrigin, targetDocument, targetWindow });
-    palette.hidden = true;
+    closePalette();
   });
   close?.addEventListener("click", () => {
-    palette.hidden = true;
+    closePalette();
   });
   targetDocument.addEventListener("keydown", (event) => {
     if (event.key === "Escape" && !palette.hidden) {
-      palette.hidden = true;
+      closePalette();
+      event.preventDefault();
+      return;
+    }
+    if (event.key === "Enter" && !palette.hidden && targetDocument.activeElement === paletteInput) {
+      const [firstResult] = buildDesktopCommandPaletteResults(state, paletteInput.value, 1);
+      if (firstResult) {
+        activateDesktopCommandPaletteResult(firstResult, { gatewayOrigin, targetDocument, targetWindow });
+        closePalette();
+      }
+      event.preventDefault();
+      return;
+    }
+    if (event.key === "ArrowDown" && !palette.hidden && targetDocument.activeElement === paletteInput) {
+      const firstButton = results?.querySelector<HTMLElement>("[data-palette-result-id]");
+      firstButton?.focus();
       event.preventDefault();
     }
   });
+
+  function closePalette(): void {
+    palette!.hidden = true;
+    previousFocus?.focus();
+    previousFocus = null;
+  }
 
   async function refreshPaletteData(): Promise<void> {
     setPaletteStatus(targetDocument, "Loading command palette data.");
@@ -287,8 +317,8 @@ function renderPalette(targetDocument: Document, state: DesktopCommandPaletteSta
     empty.textContent = "No command palette matches.";
     results.append(empty);
   } else {
-    for (const match of matches) {
-      results.append(createResultButton(targetDocument, match));
+    for (const [index, match] of matches.entries()) {
+      results.append(createResultButton(targetDocument, match, index === 0));
     }
   }
   const loaded = state.groups.filter((group) => group.loaded).map((group) => `${group.label} ${group.count}`).join(" / ");
@@ -296,10 +326,11 @@ function renderPalette(targetDocument: Document, state: DesktopCommandPaletteSta
   setPaletteStatus(targetDocument, query ? `${matches.length} result(s). ${loaded}` : `Type to search. ${loaded}${unloaded ? `. Not loaded: ${unloaded}.` : "."}`);
 }
 
-function createResultButton(targetDocument: Document, result: DesktopCommandPaletteResult): HTMLElement {
+function createResultButton(targetDocument: Document, result: DesktopCommandPaletteResult, selected: boolean): HTMLElement {
   const button = targetDocument.createElement("button");
   button.type = "button";
   button.className = "desktop-command-palette-result";
+  button.setAttribute("aria-selected", String(selected));
   button.setAttribute("data-palette-result-id", result.id);
   button.setAttribute("data-palette-module", result.destination.module);
   if (result.destination.commandId) {

--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { applyRootWebUiWorkbenchLayout, ensureDesktopRootWebUiWorkbenchStyle, upgradeDesktopRootWebUiEmptyState } from "./desktopRootWebUiWorkbench";
+import {
+  applyRootWebUiWorkbenchLayout,
+  ensureDesktopRootWebUiWorkbenchStyle,
+  installRootWebUiCommandPaletteSurface,
+  upgradeDesktopRootWebUiEmptyState,
+} from "./desktopRootWebUiWorkbench";
 
 class FakeClassList {
   constructor(private readonly element: FakeElement) {}
@@ -190,6 +195,18 @@ describe("desktop root WebUI workbench adapter", () => {
     ]);
   });
 
+  test("mounts a command palette surface for the hosted root WebUI shell", () => {
+    const targetDocument = new FakeDocument();
+
+    installRootWebUiCommandPaletteSurface(targetDocument as unknown as Document);
+    installRootWebUiCommandPaletteSurface(targetDocument as unknown as Document);
+
+    expect(targetDocument.body.querySelectorAll("#desktop-command-palette")).toHaveLength(1);
+    expect(targetDocument.getElementById("desktop-command-palette")?.getAttribute("role")).toBe("dialog");
+    expect(targetDocument.getElementById("desktop-command-palette-input")?.getAttribute("aria-label")).toBe("Search commands and workbench data");
+    expect(targetDocument.getElementById("desktop-command-palette-results")?.getAttribute("aria-live")).toBe("polite");
+  });
+
   test("declares root WebUI desktop fallback and narrow-window layout rules", () => {
     const targetDocument = new FakeDocument();
 
@@ -200,5 +217,6 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(styleText).toContain('body.desktop-root-webui-workbench > .shell[data-inspector-visible="false"]');
     expect(styleText).toContain("@media (max-width: 980px)");
     expect(styleText).toContain(".desktop-empty-modules");
+    expect(styleText).toContain(".desktop-command-palette");
   });
 });

--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "vitest";
+import { applyRootWebUiWorkbenchLayout, ensureDesktopRootWebUiWorkbenchStyle, upgradeDesktopRootWebUiEmptyState } from "./desktopRootWebUiWorkbench";
+
+class FakeClassList {
+  constructor(private readonly element: FakeElement) {}
+
+  add(value: string): void {
+    const values = new Set(this.element.className.split(/\s+/).filter(Boolean));
+    values.add(value);
+    this.element.className = [...values].join(" ");
+  }
+
+  remove(value: string): void {
+    const values = new Set(this.element.className.split(/\s+/).filter(Boolean));
+    values.delete(value);
+    this.element.className = [...values].join(" ");
+  }
+
+  contains(value: string): boolean {
+    return this.element.className.split(/\s+/).includes(value);
+  }
+}
+
+class FakeElement {
+  public id = "";
+  public className = "";
+  public children: FakeElement[] = [];
+  public attributes = new Map<string, string>();
+  private ownTextContent = "";
+  public classList = new FakeClassList(this);
+  public style = {
+    values: new Map<string, string>(),
+    setProperty: (name: string, value: string) => {
+      this.style.values.set(name, value);
+    },
+  };
+
+  constructor(public readonly tagName: string) {}
+
+  set textContent(value: string) {
+    this.ownTextContent = value;
+  }
+
+  get textContent(): string {
+    return `${this.ownTextContent}${this.children.map((child) => child.textContent).join("")}`;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+    if (name === "id") {
+      this.id = value;
+    }
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  insertBefore(node: FakeElement, child: FakeElement | null): void {
+    if (!child) {
+      this.children.push(node);
+      return;
+    }
+    const index = this.children.indexOf(child);
+    if (index === -1) {
+      this.children.push(node);
+      return;
+    }
+    this.children.splice(index, 0, node);
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    if (matchesSelector(this, selector)) {
+      return this;
+    }
+    for (const child of this.children) {
+      const match = child.querySelector(selector);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const matches: FakeElement[] = matchesSelector(this, selector) ? [this] : [];
+    for (const child of this.children) {
+      matches.push(...child.querySelectorAll(selector));
+    }
+    return matches;
+  }
+}
+
+class FakeDocument {
+  public body = new FakeElement("body");
+  public head = new FakeElement("head");
+
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  }
+
+  getElementById(id: string): FakeElement | null {
+    return this.body.querySelector(`#${id}`) ?? this.head.querySelector(`#${id}`);
+  }
+}
+
+function matchesSelector(element: FakeElement, selector: string): boolean {
+  if (selector.startsWith("#")) {
+    return element.id === selector.slice(1) || element.getAttribute("id") === selector.slice(1);
+  }
+  if (selector.startsWith(".")) {
+    return element.className.split(/\s+/).includes(selector.slice(1));
+  }
+  return false;
+}
+
+function createRootWebUiDocument(): FakeDocument {
+  const document = new FakeDocument();
+  const shell = document.createElement("div");
+  shell.className = "shell inspection-mode";
+
+  const sidebar = document.createElement("aside");
+  sidebar.className = "sidebar";
+  const chat = document.createElement("section");
+  chat.className = "chat-panel";
+  const messageList = document.createElement("section");
+  messageList.setAttribute("id", "message-list");
+  const composer = document.createElement("form");
+  composer.setAttribute("id", "composer-form");
+  const status = document.createElement("section");
+  status.className = "composer-status-panel";
+  composer.append(status);
+  chat.append(messageList, composer);
+  const inspector = document.createElement("aside");
+  inspector.setAttribute("id", "inspector-panel");
+
+  shell.append(sidebar, chat, inspector);
+  document.body.append(shell);
+  return document;
+}
+
+describe("desktop root WebUI workbench adapter", () => {
+  test("marks the hosted root WebUI as a persistent desktop workbench", () => {
+    const targetDocument = createRootWebUiDocument();
+
+    applyRootWebUiWorkbenchLayout(targetDocument as unknown as Document, {
+      sidebar: { visible: false, size: 280 },
+      inspector: { visible: false, size: 420 },
+      bottom: { visible: true, size: 260 },
+    });
+
+    const shell = targetDocument.body.querySelector(".shell");
+    expect(targetDocument.body.classList.contains("desktop-root-webui-workbench")).toBe(true);
+    expect(shell?.getAttribute("data-desktop-workbench")).toBe("root-webui");
+    expect(shell?.getAttribute("data-sidebar-visible")).toBe("false");
+    expect(shell?.getAttribute("data-inspector-visible")).toBe("false");
+    expect(shell?.style.values.get("--desktop-sidebar-size")).toBe("280px");
+    expect(shell?.style.values.get("--desktop-inspector-size")).toBe("420px");
+    expect(targetDocument.body.querySelector(".sidebar")?.getAttribute("data-workbench-region")).toBe("sidebar");
+    expect(targetDocument.getElementById("message-list")?.getAttribute("data-workbench-region")).toBe("conversation");
+    expect(targetDocument.getElementById("composer-form")?.getAttribute("data-workbench-region")).toBe("composer");
+    expect(targetDocument.body.querySelector(".composer-status-panel")?.getAttribute("data-workbench-region")).toBe("runtime-status");
+    expect(targetDocument.getElementById("inspector-panel")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  test("adds task-oriented desktop modules to the root WebUI empty chat state once", () => {
+    const targetDocument = new FakeDocument();
+    const empty = targetDocument.createElement("div");
+    empty.className = "empty-state empty-chat";
+    const title = targetDocument.createElement("div");
+    title.className = "empty-chat-title";
+    const actions = targetDocument.createElement("div");
+    actions.className = "empty-chat-actions";
+    empty.append(title, actions);
+
+    expect(upgradeDesktopRootWebUiEmptyState(empty as unknown as HTMLElement, targetDocument as unknown as Document)).toBe(true);
+    expect(upgradeDesktopRootWebUiEmptyState(empty as unknown as HTMLElement, targetDocument as unknown as Document)).toBe(false);
+
+    expect(empty.getAttribute("data-desktop-empty-state")).toBe("true");
+    expect(empty.querySelectorAll(".desktop-empty-modules")).toHaveLength(1);
+    expect(empty.querySelectorAll(".desktop-empty-module").map((node) => node.textContent)).toEqual([
+      "Recent sessionsUse Search to resume a conversation.",
+      "Files and resourcesAttach a session file or open Workspace.",
+      "Background tasksCheck streaming, cowork, uploads, and approvals.",
+      "Gateway healthUse the gateway chip for diagnostics.",
+    ]);
+  });
+
+  test("declares root WebUI desktop fallback and narrow-window layout rules", () => {
+    const targetDocument = new FakeDocument();
+
+    ensureDesktopRootWebUiWorkbenchStyle(targetDocument as unknown as Document);
+
+    const styleText = targetDocument.head.querySelector("#desktop-root-webui-workbench-style")?.textContent;
+    expect(styleText).toContain("grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr)");
+    expect(styleText).toContain('body.desktop-root-webui-workbench > .shell[data-inspector-visible="false"]');
+    expect(styleText).toContain("@media (max-width: 980px)");
+    expect(styleText).toContain(".desktop-empty-modules");
+  });
+});

--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   applyRootWebUiWorkbenchLayout,
   ensureDesktopRootWebUiWorkbenchStyle,
+  installRootWebUiComposerRuntime,
   installRootWebUiCommandPaletteSurface,
   upgradeDesktopRootWebUiEmptyState,
 } from "./desktopRootWebUiWorkbench";
@@ -33,6 +34,10 @@ class FakeElement {
   public attributes = new Map<string, string>();
   private ownTextContent = "";
   public classList = new FakeClassList(this);
+  public hidden = false;
+  public value = "";
+  public parent: FakeElement | null = null;
+  private listeners = new Map<string, Array<(event: Record<string, unknown>) => void>>();
   public style = {
     values: new Map<string, string>(),
     setProperty: (name: string, value: string) => {
@@ -62,10 +67,14 @@ class FakeElement {
   }
 
   append(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+    }
     this.children.push(...children);
   }
 
   insertBefore(node: FakeElement, child: FakeElement | null): void {
+    node.parent = this;
     if (!child) {
       this.children.push(node);
       return;
@@ -76,6 +85,26 @@ class FakeElement {
       return;
     }
     this.children.splice(index, 0, node);
+  }
+
+  after(node: FakeElement): void {
+    if (!this.parent) {
+      return;
+    }
+    node.parent = this.parent;
+    const index = this.parent.children.indexOf(this);
+    this.parent.children.splice(index + 1, 0, node);
+  }
+
+  addEventListener(type: string, listener: (event: Record<string, unknown>) => void): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  dispatchEvent(event: Record<string, unknown> & { type: string }): boolean {
+    for (const listener of this.listeners.get(event.type) ?? []) {
+      listener(event);
+    }
+    return true;
   }
 
   querySelector(selector: string): FakeElement | null {
@@ -114,6 +143,24 @@ class FakeDocument {
 }
 
 function matchesSelector(element: FakeElement, selector: string): boolean {
+  if (selector.includes(" ")) {
+    const parts = selector.split(/\s+/);
+    const last = parts[parts.length - 1];
+    if (!last || !matchesSelector(element, last)) {
+      return false;
+    }
+    let parent = element.parent;
+    for (let index = parts.length - 2; index >= 0; index -= 1) {
+      while (parent && !matchesSelector(parent, parts[index])) {
+        parent = parent.parent;
+      }
+      if (!parent) {
+        return false;
+      }
+      parent = parent.parent;
+    }
+    return true;
+  }
   if (selector.startsWith("#")) {
     return element.id === selector.slice(1) || element.getAttribute("id") === selector.slice(1);
   }
@@ -136,9 +183,25 @@ function createRootWebUiDocument(): FakeDocument {
   messageList.setAttribute("id", "message-list");
   const composer = document.createElement("form");
   composer.setAttribute("id", "composer-form");
+  const composerRow = document.createElement("div");
+  composerRow.className = "composer-row";
+  const fileButton = document.createElement("button");
+  fileButton.setAttribute("id", "temporary-file-button");
+  const input = document.createElement("textarea");
+  input.setAttribute("id", "composer-input");
+  const sendButton = document.createElement("button");
+  sendButton.setAttribute("id", "send-button");
   const status = document.createElement("section");
   status.className = "composer-status-panel";
-  composer.append(status);
+  const statusItem = document.createElement("div");
+  statusItem.className = "status-item";
+  const statusLabel = document.createElement("span");
+  statusLabel.className = "status-label";
+  statusLabel.textContent = "Provider";
+  statusItem.append(statusLabel);
+  status.append(statusItem);
+  composerRow.append(fileButton, input, sendButton);
+  composer.append(composerRow, status);
   chat.append(messageList, composer);
   const inspector = document.createElement("aside");
   inspector.setAttribute("id", "inspector-panel");
@@ -207,6 +270,28 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(targetDocument.getElementById("desktop-command-palette-results")?.getAttribute("aria-live")).toBe("polite");
   });
 
+  test("upgrades the hosted WebUI composer with runtime chips and blocked-send feedback", () => {
+    const targetDocument = createRootWebUiDocument();
+
+    installRootWebUiComposerRuntime(targetDocument as unknown as Document);
+
+    const composer = targetDocument.getElementById("composer-form");
+    const feedback = targetDocument.getElementById("desktop-composer-feedback");
+    expect(composer?.getAttribute("data-desktop-composer")).toBe("true");
+    expect(targetDocument.body.querySelector(".composer-row")?.getAttribute("data-workbench-region")).toBe("message-entry");
+    expect(targetDocument.getElementById("temporary-file-button")?.getAttribute("data-desktop-drop-target")).toBe("session-temporary-file");
+    expect(targetDocument.getElementById("send-button")?.getAttribute("data-desktop-composer-action")).toBe("send");
+    expect(targetDocument.body.querySelector(".status-item")?.getAttribute("data-desktop-runtime-chip")).toBe("Provider");
+    expect(targetDocument.body.querySelector(".status-item")?.getAttribute("role")).toBe("button");
+
+    composer?.dispatchEvent({ type: "submit" });
+    expect(feedback?.hidden).toBe(false);
+    expect(feedback?.textContent).toContain("Enter a message");
+
+    composer?.dispatchEvent({ type: "dragover", preventDefault: () => undefined });
+    expect(composer?.classList.contains("is-desktop-drop-hover")).toBe(true);
+  });
+
   test("declares root WebUI desktop fallback and narrow-window layout rules", () => {
     const targetDocument = new FakeDocument();
 
@@ -218,5 +303,6 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(styleText).toContain("@media (max-width: 980px)");
     expect(styleText).toContain(".desktop-empty-modules");
     expect(styleText).toContain(".desktop-command-palette");
+    expect(styleText).toContain(".desktop-composer-feedback");
   });
 });

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -23,8 +23,69 @@ export function installDesktopRootWebUiWorkbenchAdapter({
   installRootWebUiCommandPaletteSurface(targetDocument);
   const layout = loadWorkbenchLayout({ storage, viewportWidth });
   applyRootWebUiWorkbenchLayout(targetDocument, layout);
+  installRootWebUiComposerRuntime(targetDocument);
   installRootWebUiPanelPersistence(targetDocument, storage, viewportWidth);
   installEmptyStateObserver(targetDocument);
+}
+
+export function installRootWebUiComposerRuntime(targetDocument: Document): void {
+  const composer = targetDocument.getElementById("composer-form");
+  if (!composer || composer.getAttribute("data-desktop-composer") === "true") {
+    return;
+  }
+
+  composer.setAttribute("data-desktop-composer", "true");
+  composer.classList.add("desktop-composer-runtime");
+  targetDocument.body.querySelector<HTMLElement>(".composer-row")?.setAttribute("data-workbench-region", "message-entry");
+  targetDocument.getElementById("temporary-file-button")?.setAttribute("data-desktop-drop-target", "session-temporary-file");
+  targetDocument.getElementById("send-button")?.setAttribute("data-desktop-composer-action", "send");
+
+  const feedback = targetDocument.createElement("p");
+  feedback.id = "desktop-composer-feedback";
+  feedback.setAttribute("id", "desktop-composer-feedback");
+  feedback.className = "desktop-composer-feedback";
+  feedback.setAttribute("aria-live", "polite");
+  feedback.hidden = true;
+  targetDocument.body.querySelector<HTMLElement>(".composer-row")?.after(feedback);
+
+  for (const item of targetDocument.body.querySelectorAll<HTMLElement>(".composer-status-panel .status-item")) {
+    item.setAttribute("role", "button");
+    item.setAttribute("tabindex", "0");
+    item.setAttribute("data-desktop-runtime-chip", runtimeChipName(item));
+    item.addEventListener("click", () => {
+      setComposerFeedback(feedback, `${runtimeChipName(item)} status selected.`);
+    });
+    item.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") {
+        return;
+      }
+      event.preventDefault();
+      setComposerFeedback(feedback, `${runtimeChipName(item)} status selected.`);
+    });
+  }
+
+  composer.addEventListener("submit", () => {
+    const input = targetDocument.getElementById("composer-input") as HTMLTextAreaElement | null;
+    if (!input?.value.trim()) {
+      setComposerFeedback(feedback, "Enter a message or attach a file before sending.");
+    } else {
+      feedback.hidden = true;
+      feedback.textContent = "";
+    }
+  });
+
+  for (const eventName of ["dragenter", "dragover"]) {
+    composer.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      composer.classList.add("is-desktop-drop-hover");
+      setComposerFeedback(feedback, "Drop a file to attach it to this session.");
+    });
+  }
+  for (const eventName of ["dragleave", "drop"]) {
+    composer.addEventListener(eventName, () => {
+      composer.classList.remove("is-desktop-drop-hover");
+    });
+  }
 }
 
 export function installRootWebUiCommandPaletteSurface(targetDocument: Document): void {
@@ -192,9 +253,91 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       background: color-mix(in srgb, var(--panel, #faf9f5) 92%, transparent);
     }
 
+    body.desktop-root-webui-workbench .composer.desktop-composer-runtime {
+      display: grid;
+      gap: 8px;
+      padding: 14px 22px 12px;
+    }
+
+    body.desktop-root-webui-workbench .composer-row {
+      display: grid;
+      grid-template-columns: 42px minmax(0, 1fr) 54px;
+      gap: 10px;
+      align-items: stretch;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-file,
+    body.desktop-root-webui-workbench .composer-send {
+      width: auto;
+      min-width: 0;
+      min-height: 42px;
+      border-radius: 6px;
+    }
+
+    body.desktop-root-webui-workbench .composer-input {
+      min-height: 42px;
+      max-height: 156px;
+      border-radius: 6px;
+    }
+
     body.desktop-root-webui-workbench .composer-meta {
       align-items: center;
       min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel {
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .panel-header {
+      display: none;
+    }
+
+    body.desktop-root-webui-workbench .system-status {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 10px;
+      align-items: center;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .status-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      min-width: 0;
+      min-height: 22px;
+      border: 0;
+      border-radius: 4px;
+      padding: 0;
+      background: transparent;
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.2;
+      cursor: default;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .status-item:focus-visible {
+      outline: 2px solid var(--primary, #cc785c);
+      outline-offset: 2px;
+    }
+
+    body.desktop-root-webui-workbench .desktop-composer-feedback {
+      margin: 0;
+      color: var(--danger, #c64545);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+
+    body.desktop-root-webui-workbench .desktop-composer-feedback[hidden] {
+      display: none;
+    }
+
+    body.desktop-root-webui-workbench .composer.is-desktop-drop-hover .composer-row {
+      outline: 2px solid var(--primary, #cc785c);
+      outline-offset: 3px;
+      border-radius: 8px;
     }
 
     body.desktop-root-webui-workbench .desktop-empty-modules {
@@ -422,4 +565,13 @@ function installEmptyStateObserver(targetDocument: Document): void {
 
   const observer = new observerConstructor(upgrade);
   observer.observe(messageList, { childList: true });
+}
+
+function runtimeChipName(item: HTMLElement): string {
+  return item.querySelector(".status-label")?.textContent?.trim() || "Runtime";
+}
+
+function setComposerFeedback(feedback: HTMLElement, message: string): void {
+  feedback.hidden = false;
+  feedback.textContent = message;
 }

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -1,0 +1,267 @@
+import {
+  DESKTOP_WORKBENCH_LAYOUT_STORAGE_KEY,
+  loadWorkbenchLayout,
+  persistWorkbenchLayout,
+  toggleWorkbenchPanel,
+  type WorkbenchLayoutState,
+} from "./desktopWorkbenchLayout";
+
+interface InstallDesktopRootWebUiWorkbenchOptions {
+  targetDocument?: Document;
+  storage?: Pick<Storage, "getItem" | "setItem"> | null;
+  viewportWidth?: number;
+}
+
+const STYLE_ID = "desktop-root-webui-workbench-style";
+
+export function installDesktopRootWebUiWorkbenchAdapter({
+  targetDocument = document,
+  storage = targetDocument.defaultView?.localStorage ?? null,
+  viewportWidth = targetDocument.defaultView?.innerWidth ?? Number.POSITIVE_INFINITY,
+}: InstallDesktopRootWebUiWorkbenchOptions = {}): void {
+  ensureDesktopRootWebUiWorkbenchStyle(targetDocument);
+  const layout = loadWorkbenchLayout({ storage, viewportWidth });
+  applyRootWebUiWorkbenchLayout(targetDocument, layout);
+  installRootWebUiPanelPersistence(targetDocument, storage, viewportWidth);
+  installEmptyStateObserver(targetDocument);
+}
+
+export function applyRootWebUiWorkbenchLayout(targetDocument: Document, layout: WorkbenchLayoutState): void {
+  const shell = targetDocument.body.querySelector<HTMLElement>(".shell");
+  if (!shell) {
+    return;
+  }
+
+  targetDocument.body.classList.add("desktop-root-webui-workbench");
+  shell.setAttribute("data-desktop-workbench", "root-webui");
+  shell.setAttribute("data-desktop-layout-storage-key", DESKTOP_WORKBENCH_LAYOUT_STORAGE_KEY);
+  shell.setAttribute("data-sidebar-visible", String(layout.sidebar.visible));
+  shell.setAttribute("data-inspector-visible", String(layout.inspector.visible));
+  shell.setAttribute("data-bottom-visible", String(layout.bottom.visible));
+  shell.style.setProperty("--desktop-sidebar-size", `${layout.sidebar.size}px`);
+  shell.style.setProperty("--desktop-inspector-size", `${layout.inspector.size}px`);
+  shell.style.setProperty("--desktop-bottom-size", `${layout.bottom.size}px`);
+
+  const sidebar = targetDocument.body.querySelector<HTMLElement>(".sidebar");
+  const chatPanel = targetDocument.body.querySelector<HTMLElement>(".chat-panel");
+  const messageList = targetDocument.getElementById("message-list");
+  const inspector = targetDocument.getElementById("inspector-panel");
+  const composer = targetDocument.getElementById("composer-form");
+  const statusPanel = targetDocument.body.querySelector<HTMLElement>(".composer-status-panel");
+
+  sidebar?.setAttribute("data-workbench-region", "sidebar");
+  chatPanel?.setAttribute("data-workbench-region", "main");
+  messageList?.setAttribute("data-workbench-region", "conversation");
+  inspector?.setAttribute("data-workbench-region", "inspector");
+  composer?.setAttribute("data-workbench-region", "composer");
+  statusPanel?.setAttribute("data-workbench-region", "runtime-status");
+
+  if (!layout.sidebar.visible) {
+    shell.classList.add("sidebar-collapsed");
+    sidebar?.classList.add("collapsed");
+  }
+
+  if (!layout.inspector.visible) {
+    shell.classList.remove("inspection-mode");
+    inspector?.setAttribute("aria-hidden", "true");
+  }
+}
+
+export function upgradeDesktopRootWebUiEmptyState(emptyChat: HTMLElement, targetDocument: Document): boolean {
+  if (emptyChat.getAttribute("data-desktop-empty-state") === "true") {
+    return false;
+  }
+
+  emptyChat.setAttribute("data-desktop-empty-state", "true");
+  const modules = targetDocument.createElement("div");
+  modules.className = "desktop-empty-modules";
+  modules.setAttribute("aria-label", "Desktop workbench starting points");
+
+  for (const [title, detail] of [
+    ["Recent sessions", "Use Search to resume a conversation."],
+    ["Files and resources", "Attach a session file or open Workspace."],
+    ["Background tasks", "Check streaming, cowork, uploads, and approvals."],
+    ["Gateway health", "Use the gateway chip for diagnostics."],
+  ]) {
+    const item = targetDocument.createElement("article");
+    item.className = "desktop-empty-module";
+
+    const heading = targetDocument.createElement("strong");
+    heading.textContent = title;
+    const copy = targetDocument.createElement("span");
+    copy.textContent = detail;
+
+    item.append(heading, copy);
+    modules.append(item);
+  }
+
+  const actions = emptyChat.querySelector<HTMLElement>(".empty-chat-actions");
+  emptyChat.insertBefore(modules, actions ?? null);
+  return true;
+}
+
+export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): void {
+  if (targetDocument.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = targetDocument.createElement("style");
+  style.id = STYLE_ID;
+  style.setAttribute("id", STYLE_ID);
+  style.textContent = `
+    body.desktop-root-webui-workbench > .shell {
+      grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) minmax(0, var(--desktop-inspector-size, 360px));
+      background: var(--panel, #faf9f5);
+      box-shadow: none;
+    }
+
+    body.desktop-root-webui-workbench > .shell[data-inspector-visible="false"]:not(.inspection-mode) {
+      grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) 0;
+    }
+
+    body.desktop-root-webui-workbench > .shell[data-sidebar-visible="false"],
+    body.desktop-root-webui-workbench > .shell.sidebar-collapsed {
+      grid-template-columns: 68px minmax(0, 1fr) 0;
+    }
+
+    body.desktop-root-webui-workbench .sidebar,
+    body.desktop-root-webui-workbench .chat-panel,
+    body.desktop-root-webui-workbench .inspector-panel {
+      border-radius: 0;
+      box-shadow: none;
+    }
+
+    body.desktop-root-webui-workbench .message-list {
+      min-width: 0;
+      scrollbar-gutter: stable;
+    }
+
+    body.desktop-root-webui-workbench .composer {
+      border-top: 1px solid var(--border, #e6dfd8);
+      background: color-mix(in srgb, var(--panel, #faf9f5) 92%, transparent);
+    }
+
+    body.desktop-root-webui-workbench .composer-meta {
+      align-items: center;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-modules {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(180px, 1fr));
+      gap: 8px;
+      width: min(760px, 100%);
+      margin: 12px auto 2px;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-module {
+      display: grid;
+      gap: 5px;
+      min-width: 0;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 10px 12px;
+      background: color-mix(in srgb, var(--panel-strong, #efe9de) 72%, transparent);
+      text-align: left;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-module strong,
+    body.desktop-root-webui-workbench .desktop-empty-module span {
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-module strong {
+      color: var(--text, #141413);
+      font-size: 12px;
+      line-height: 1.25;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-module span {
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+
+    @media (max-width: 980px) {
+      body.desktop-root-webui-workbench > .shell,
+      body.desktop-root-webui-workbench > .shell.inspection-mode {
+        grid-template-columns: 68px minmax(0, 1fr) 0;
+      }
+
+      body.desktop-root-webui-workbench .inspector-panel {
+        display: none;
+      }
+
+      body.desktop-root-webui-workbench .desktop-empty-modules {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+  `;
+  targetDocument.head.append(style);
+}
+
+function installRootWebUiPanelPersistence(
+  targetDocument: Document,
+  storage: Pick<Storage, "getItem" | "setItem"> | null,
+  viewportWidth: number,
+): void {
+  if (!storage) {
+    return;
+  }
+
+  const sidebarButton = targetDocument.getElementById("sidebar-collapse-button");
+  sidebarButton?.addEventListener("click", () => {
+    queuePanelSync(targetDocument, storage, viewportWidth, "sidebar");
+  });
+
+  const inspectorClose = targetDocument.getElementById("inspector-close");
+  inspectorClose?.addEventListener("click", () => {
+    queuePanelSync(targetDocument, storage, viewportWidth, "inspector");
+  });
+}
+
+function queuePanelSync(
+  targetDocument: Document,
+  storage: Pick<Storage, "getItem" | "setItem">,
+  viewportWidth: number,
+  panel: "sidebar" | "inspector",
+): void {
+  const run = () => {
+    const layout = loadWorkbenchLayout({ storage, viewportWidth });
+    const visible = panel === "sidebar" ? isSidebarVisible(targetDocument) : isInspectorVisible(targetDocument);
+    const nextLayout = toggleWorkbenchPanel(layout, panel, visible);
+    persistWorkbenchLayout(nextLayout, storage);
+    applyRootWebUiWorkbenchLayout(targetDocument, nextLayout);
+  };
+  targetDocument.defaultView?.setTimeout(run, 0) ?? setTimeout(run, 0);
+}
+
+function isSidebarVisible(targetDocument: Document): boolean {
+  return !targetDocument.body.querySelector(".sidebar")?.classList.contains("collapsed");
+}
+
+function isInspectorVisible(targetDocument: Document): boolean {
+  const shell = targetDocument.body.querySelector(".shell");
+  const inspector = targetDocument.getElementById("inspector-panel");
+  return shell?.classList.contains("inspection-mode") === true || inspector?.getAttribute("aria-hidden") !== "true";
+}
+
+function installEmptyStateObserver(targetDocument: Document): void {
+  const upgrade = () => {
+    for (const emptyChat of targetDocument.body.querySelectorAll<HTMLElement>(".empty-chat")) {
+      upgradeDesktopRootWebUiEmptyState(emptyChat, targetDocument);
+    }
+  };
+  upgrade();
+
+  const observerConstructor = targetDocument.defaultView?.MutationObserver ?? globalThis.MutationObserver;
+  const messageList = targetDocument.getElementById("message-list");
+  if (!observerConstructor || !messageList) {
+    return;
+  }
+
+  const observer = new observerConstructor(upgrade);
+  observer.observe(messageList, { childList: true });
+}

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -312,6 +312,7 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
     body.desktop-root-webui-workbench .system-status {
       display: flex !important;
       flex-wrap: wrap;
+      grid-template-columns: none !important;
       gap: 6px 10px;
       align-items: center;
       min-width: 0;
@@ -324,7 +325,7 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       gap: 5px;
       min-width: 0;
       min-height: 22px;
-      width: auto;
+      width: auto !important;
       border: 0;
       border-radius: 4px;
       padding: 0;
@@ -333,6 +334,10 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       font-size: 11px;
       line-height: 1.2;
       cursor: default;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .usage-item {
+      grid-column: auto !important;
     }
 
     body.desktop-root-webui-workbench .composer-status-panel .status-label,

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -286,8 +286,23 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       min-width: 0;
     }
 
-    body.desktop-root-webui-workbench .composer-status-panel {
+    body.desktop-root-webui-workbench .composer-meta-left {
+      display: flex;
+      flex: 1 1 auto;
+      flex-wrap: wrap;
+      gap: 6px 14px;
+      align-items: center;
       min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel {
+      flex: 0 1 auto;
+      min-width: 0;
+      margin: 0;
+      border: 0;
+      padding: 0;
+      background: transparent;
+      box-shadow: none;
     }
 
     body.desktop-root-webui-workbench .composer-status-panel .panel-header {
@@ -295,7 +310,7 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
     }
 
     body.desktop-root-webui-workbench .system-status {
-      display: flex;
+      display: flex !important;
       flex-wrap: wrap;
       gap: 6px 10px;
       align-items: center;
@@ -304,10 +319,12 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
 
     body.desktop-root-webui-workbench .composer-status-panel .status-item {
       display: inline-flex;
+      flex: 0 1 auto;
       align-items: center;
       gap: 5px;
       min-width: 0;
       min-height: 22px;
+      width: auto;
       border: 0;
       border-radius: 4px;
       padding: 0;
@@ -316,6 +333,14 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       font-size: 11px;
       line-height: 1.2;
       cursor: default;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .status-label,
+    body.desktop-root-webui-workbench .composer-status-panel .status-value,
+    body.desktop-root-webui-workbench .composer-status-panel .usage-display {
+      width: auto;
+      min-width: 0;
+      white-space: nowrap;
     }
 
     body.desktop-root-webui-workbench .composer-status-panel .status-item:focus-visible {

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -20,10 +20,61 @@ export function installDesktopRootWebUiWorkbenchAdapter({
   viewportWidth = targetDocument.defaultView?.innerWidth ?? Number.POSITIVE_INFINITY,
 }: InstallDesktopRootWebUiWorkbenchOptions = {}): void {
   ensureDesktopRootWebUiWorkbenchStyle(targetDocument);
+  installRootWebUiCommandPaletteSurface(targetDocument);
   const layout = loadWorkbenchLayout({ storage, viewportWidth });
   applyRootWebUiWorkbenchLayout(targetDocument, layout);
   installRootWebUiPanelPersistence(targetDocument, storage, viewportWidth);
   installEmptyStateObserver(targetDocument);
+}
+
+export function installRootWebUiCommandPaletteSurface(targetDocument: Document): void {
+  if (targetDocument.getElementById("desktop-command-palette")) {
+    return;
+  }
+
+  const palette = targetDocument.createElement("div");
+  palette.id = "desktop-command-palette";
+  palette.setAttribute("id", "desktop-command-palette");
+  palette.className = "desktop-command-palette";
+  palette.setAttribute("role", "dialog");
+  palette.setAttribute("aria-modal", "true");
+  palette.setAttribute("aria-label", "Command palette");
+  palette.hidden = true;
+
+  const header = targetDocument.createElement("div");
+  header.className = "desktop-command-palette-header";
+
+  const input = targetDocument.createElement("input");
+  input.id = "desktop-command-palette-input";
+  input.setAttribute("id", "desktop-command-palette-input");
+  input.className = "desktop-command-palette-input";
+  input.type = "search";
+  input.setAttribute("aria-label", "Search commands and workbench data");
+  input.setAttribute("placeholder", "Search commands, sessions, files, tools...");
+
+  const close = targetDocument.createElement("button");
+  close.id = "desktop-command-palette-close";
+  close.setAttribute("id", "desktop-command-palette-close");
+  close.className = "desktop-command-palette-close";
+  close.type = "button";
+  close.textContent = "Close";
+
+  header.append(input, close);
+
+  const status = targetDocument.createElement("p");
+  status.id = "desktop-command-palette-status";
+  status.setAttribute("id", "desktop-command-palette-status");
+  status.className = "desktop-command-palette-status";
+  status.textContent = "Type to search.";
+
+  const results = targetDocument.createElement("div");
+  results.id = "desktop-command-palette-results";
+  results.setAttribute("id", "desktop-command-palette-results");
+  results.className = "desktop-command-palette-results";
+  results.setAttribute("aria-live", "polite");
+
+  palette.append(header, status, results);
+  targetDocument.body.append(palette);
 }
 
 export function applyRootWebUiWorkbenchLayout(targetDocument: Document, layout: WorkbenchLayoutState): void {
@@ -179,6 +230,113 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
     }
 
     body.desktop-root-webui-workbench .desktop-empty-module span {
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette {
+      position: fixed;
+      top: calc(var(--desktop-window-frame-height, 34px) + 18px);
+      left: 50%;
+      z-index: 1500;
+      display: grid;
+      gap: 10px;
+      width: min(680px, calc(100vw - 48px));
+      max-height: min(620px, calc(100vh - var(--desktop-window-frame-height, 34px) - 44px));
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 8px;
+      padding: 12px;
+      background: var(--panel, #faf9f5);
+      box-shadow: 0 18px 48px rgba(20, 20, 19, 0.18);
+      transform: translateX(-50%);
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette[hidden] {
+      display: none;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-input {
+      min-width: 0;
+      min-height: 36px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 0 10px;
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
+      font: 13px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-close {
+      min-height: 36px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 0 10px;
+      background: var(--panel-strong, #efe9de);
+      color: var(--text, #141413);
+      font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-status {
+      margin: 0;
+      overflow: hidden;
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.35;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-results {
+      display: grid;
+      gap: 6px;
+      max-height: min(430px, 58vh);
+      min-width: 0;
+      overflow: auto;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-result {
+      display: grid;
+      gap: 3px;
+      min-width: 0;
+      min-height: 42px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 7px 9px;
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
+      text-align: left;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-result[aria-selected="true"],
+    body.desktop-root-webui-workbench .desktop-command-palette-result:focus-visible,
+    body.desktop-root-webui-workbench .desktop-command-palette-input:focus-visible,
+    body.desktop-root-webui-workbench .desktop-command-palette-close:focus-visible {
+      outline: 2px solid var(--primary, #cc785c);
+      outline-offset: 2px;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-result strong,
+    body.desktop-root-webui-workbench .desktop-command-palette-result span,
+    body.desktop-root-webui-workbench .desktop-command-palette-empty {
+      min-width: 0;
+      margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-result span,
+    body.desktop-root-webui-workbench .desktop-command-palette-empty {
       color: var(--text-muted, #6c6a64);
       font-size: 11px;
       line-height: 1.35;

--- a/apps/desktop/src/desktopWebUiCommandBridge.test.ts
+++ b/apps/desktop/src/desktopWebUiCommandBridge.test.ts
@@ -16,6 +16,7 @@ class FakeStatus {
 class FakeWebUiDocument {
   public documentElement = { dataset: {} as Record<string, string> };
   public listeners = new Map<string, Array<(event: Event) => unknown>>();
+  public dispatched: string[] = [];
   public readonly nodes: Record<string, unknown> = {
     "#new-chat-button": new FakeButton(),
     "#settings-button": new FakeButton(),
@@ -30,6 +31,7 @@ class FakeWebUiDocument {
   }
 
   dispatchEvent(event: Event): boolean {
+    this.dispatched.push(event.type);
     for (const listener of this.listeners.get(event.type) ?? []) {
       listener(event);
     }
@@ -113,6 +115,47 @@ describe("desktop WebUI command bridge", () => {
     expect((document.nodes["[data-desktop-route-status]"] as FakeStatus).textContent).toBe(
       "Stop generation is unavailable in the WebUI shell.",
     );
+  });
+
+  test("opens the desktop command palette and session search inside the WebUI shell", () => {
+    const document = new FakeWebUiDocument();
+    const paletteQueries: unknown[] = [];
+    document.addEventListener("tinybot:open-command-palette", (event) => {
+      paletteQueries.push((event as CustomEvent).detail?.query);
+    });
+
+    installDesktopWebUiCommandBridge({
+      targetDocument: document as unknown as Document,
+      targetWindow: fakeWindow(),
+      listenToMenuCommand: () => undefined,
+    });
+
+    document.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "open-command-palette" } }));
+    document.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "search-sessions" } }));
+
+    expect(paletteQueries).toEqual(["", "session"]);
+    expect(document.documentElement.dataset.desktopCommandFeedback).toBe("Session search opened");
+  });
+
+  test("records context targets for root WebUI context navigation", () => {
+    const document = new FakeWebUiDocument();
+    installDesktopWebUiCommandBridge({
+      targetDocument: document as unknown as Document,
+      targetWindow: fakeWindow(),
+      listenToMenuCommand: () => undefined,
+    });
+
+    document.dispatchEvent({
+      type: "contextmenu",
+      target: {
+        closest: () => ({
+          dataset: { sessionKey: "WebSocket:chat-1" },
+          classList: { contains: () => false },
+        }),
+      },
+    } as unknown as Event);
+
+    expect(document.documentElement.dataset.desktopContextMenuTarget).toBe("session:WebSocket:chat-1");
   });
 });
 

--- a/apps/desktop/src/desktopWebUiCommandBridge.ts
+++ b/apps/desktop/src/desktopWebUiCommandBridge.ts
@@ -2,6 +2,7 @@ import {
   resolveDesktopShortcutCommand,
   type DesktopMenuCommandId,
 } from "./desktopCommandNavigation";
+import { openDesktopCommandPalette } from "./desktopCommandPalette";
 
 export interface DesktopWebUiCommandBridgeOptions {
   listenToMenuCommand: (handler: (id: string) => void) => void | Promise<unknown>;
@@ -38,6 +39,9 @@ export function installDesktopWebUiCommandBridge({
       routeDesktopWebUiCommand(id, targetDocument, targetWindow);
     }
   });
+  targetDocument.addEventListener("contextmenu", (event) => {
+    recordDesktopWebUiContextTarget(event, targetDocument);
+  });
 
   void listenToMenuCommand((id) => {
     routeDesktopWebUiCommand(id, targetDocument, targetWindow);
@@ -47,6 +51,16 @@ export function installDesktopWebUiCommandBridge({
 function routeDesktopWebUiCommand(id: string, targetDocument: Document, targetWindow: Window): void {
   if (id === "open-docs") {
     targetWindow.location.assign(new URL("/docs", targetWindow.location.origin).href);
+    return;
+  }
+  if (id === "open-command-palette") {
+    openDesktopCommandPalette(targetDocument);
+    setCommandFeedback(targetDocument, "Command palette opened");
+    return;
+  }
+  if (id === "search-sessions") {
+    openDesktopCommandPalette(targetDocument, "session");
+    setCommandFeedback(targetDocument, "Session search opened");
     return;
   }
 
@@ -84,15 +98,59 @@ function commandUnavailableFeedback(id: string): string {
     return "Stop generation is unavailable in the WebUI shell.";
   }
   if (id === "search-sessions") {
-    return "Session search is not available in the WebUI shell.";
+    return "Session search opened";
   }
   if (id === "open-command-palette") {
-    return "Command palette is not available in the WebUI shell.";
+    return "Command palette opened";
   }
   if (id === "refresh-gateway-status") {
     return "Gateway status refresh is handled by WebUI status polling.";
   }
   return `Unknown desktop command: ${id}`;
+}
+
+function recordDesktopWebUiContextTarget(event: Event, targetDocument: Document): void {
+  const target = event.target as HTMLElement | null;
+  const closest = typeof target?.closest === "function"
+    ? target.closest<HTMLElement>("[data-session-key], .session-item, .workspace-panel, .knowledge-panel, .tools-panel, .cowork-panel, .message, .composer, .inspector-panel")
+    : null;
+  if (!closest) {
+    return;
+  }
+
+  targetDocument.documentElement.dataset.desktopContextMenuTarget = contextTargetName(closest);
+  targetDocument.documentElement.dataset.desktopContextMenuAt = new Date(0).toISOString();
+}
+
+function contextTargetName(target: HTMLElement): string {
+  if (target.dataset.sessionKey) {
+    return `session:${target.dataset.sessionKey}`;
+  }
+  if (target.classList.contains("session-item")) {
+    return "session";
+  }
+  if (target.classList.contains("workspace-panel")) {
+    return "workspace";
+  }
+  if (target.classList.contains("knowledge-panel")) {
+    return "knowledge";
+  }
+  if (target.classList.contains("tools-panel")) {
+    return "tools";
+  }
+  if (target.classList.contains("cowork-panel")) {
+    return "cowork";
+  }
+  if (target.classList.contains("message")) {
+    return "message";
+  }
+  if (target.classList.contains("composer")) {
+    return "composer";
+  }
+  if (target.classList.contains("inspector-panel")) {
+    return "inspector";
+  }
+  return "root";
 }
 
 function setCommandFeedback(targetDocument: Document, message: string): void {

--- a/apps/desktop/src/desktopWindowFrame.test.ts
+++ b/apps/desktop/src/desktopWindowFrame.test.ts
@@ -224,4 +224,27 @@ describe("desktop window frame", () => {
     expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-command-palette"]')?.textContent).toBe("Command Palette");
     expect(targetDocument.body.querySelector('[data-desktop-menu-command="refresh-gateway-status"]')?.textContent).toBe("Gateway Status");
   });
+
+  test("declares DESIGN.md shell chrome tokens for the custom frame", () => {
+    const targetDocument = new FakeDocument();
+    const currentWindow = {
+      minimize: vi.fn(async () => {}),
+      toggleMaximize: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      startDragging: vi.fn(async () => {}),
+    };
+
+    installDesktopWindowFrame({
+      targetDocument: targetDocument as unknown as Document,
+      currentWindow,
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-window-frame-style")?.textContent;
+    expect(styleText).toContain("--bg: #faf9f5;");
+    expect(styleText).toContain("--panel-strong: #efe9de;");
+    expect(styleText).toContain("--primary: #cc785c;");
+    expect(styleText).toContain("--success: #5db872;");
+    expect(styleText).toContain("--border: #e6dfd8;");
+    expect(styleText).toContain("outline: 2px solid var(--primary, #cc785c);");
+  });
 });

--- a/apps/desktop/src/desktopWindowFrame.test.ts
+++ b/apps/desktop/src/desktopWindowFrame.test.ts
@@ -85,6 +85,8 @@ class FakeHead extends FakeElement {
 class FakeDocument {
   public body = new FakeBody();
   public head = new FakeHead();
+  public documentElement = { dataset: {} as Record<string, string> };
+  public dispatched: string[] = [];
 
   createElement(tagName: string): FakeElement {
     return new FakeElement(tagName);
@@ -92,6 +94,11 @@ class FakeDocument {
 
   getElementById(id: string): FakeElement | null {
     return this.body.querySelector(`#${id}`) ?? this.head.querySelector(`#${id}`);
+  }
+
+  dispatchEvent(event: Event): boolean {
+    this.dispatched.push(event.type);
+    return true;
   }
 }
 
@@ -106,6 +113,10 @@ function matchesSelector(element: FakeElement, selector: string): boolean {
   const menuCommand = selector.match(/^\[data-desktop-menu-command="(.+)"\]$/);
   if (menuCommand) {
     return element.getAttribute("data-desktop-menu-command") === menuCommand[1];
+  }
+  const runtimeCommand = selector.match(/^\[data-desktop-runtime-command="(.+)"\]$/);
+  if (runtimeCommand) {
+    return element.getAttribute("data-desktop-runtime-command") === runtimeCommand[1];
   }
   return false;
 }
@@ -206,7 +217,7 @@ describe("desktop window frame", () => {
     expect(targetDocument.body.querySelector('[data-window-action="close"]')).toBeTruthy();
   });
 
-  test("renders desktop application menu entries inside the custom app chrome", () => {
+  test("renders only primary desktop commands inside the compact app chrome", () => {
     const targetDocument = new FakeDocument();
     const currentWindow = {
       minimize: vi.fn(async () => {}),
@@ -220,9 +231,62 @@ describe("desktop window frame", () => {
       currentWindow,
     });
 
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="new-chat"]')?.textContent).toBe("New Chat");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-command-palette"]')?.textContent).toBe("Command Palette");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="refresh-gateway-status"]')?.textContent).toBe("Gateway Status");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="new-chat"]')?.textContent).toBe("New");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="search-sessions"]')?.textContent).toBe("Search");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="stop-generation"]')?.textContent).toBe("Stop");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-command-palette"]')?.textContent).toBe("Command");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-docs"]')).toBeNull();
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="refresh-gateway-status"]')).toBeNull();
+  });
+
+  test("routes runtime status clicks through the gateway status command", () => {
+    const targetDocument = new FakeDocument();
+    const currentWindow = {
+      minimize: vi.fn(async () => {}),
+      toggleMaximize: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      startDragging: vi.fn(async () => {}),
+    };
+
+    installDesktopWindowFrame({
+      targetDocument: targetDocument as unknown as Document,
+      currentWindow,
+    });
+
+    const runtimeStatus = targetDocument.body.querySelector('[data-desktop-runtime-command="refresh-gateway-status"]');
+    expect(runtimeStatus?.getAttribute("role")).toBe("button");
+    expect(runtimeStatus?.getAttribute("tabindex")).toBe("0");
+
+    runtimeStatus?.click();
+
+    expect(targetDocument.dispatched).toContain("desktop-menu-command");
+    expect(currentWindow.startDragging).not.toHaveBeenCalled();
+  });
+
+  test("shows the current desktop surface context in app chrome", () => {
+    const targetDocument = new FakeDocument();
+    targetDocument.documentElement.dataset.desktopWorkbenchMode = "root-webui";
+    const currentWindow = {
+      minimize: vi.fn(async () => {}),
+      toggleMaximize: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      startDragging: vi.fn(async () => {}),
+    };
+
+    installDesktopWindowFrame({
+      targetDocument: targetDocument as unknown as Document,
+      currentWindow,
+    });
+
+    expect(targetDocument.body.querySelector("#desktop-window-context")?.textContent).toBe("WebUI shell");
+
+    targetDocument.documentElement.dataset.desktopWorkbenchMode = "native-workbench";
+    installDesktopWindowFrame({
+      targetDocument: targetDocument as unknown as Document,
+      currentWindow,
+    });
+
+    expect(targetDocument.body.querySelector("#desktop-window-context")?.textContent).toBe("Native workbench");
   });
 
   test("declares DESIGN.md shell chrome tokens for the custom frame", () => {

--- a/apps/desktop/src/desktopWindowFrame.ts
+++ b/apps/desktop/src/desktopWindowFrame.ts
@@ -1,4 +1,4 @@
-import { DESKTOP_MENU_COMMANDS } from "./desktopCommandNavigation";
+import { DESKTOP_CHROME_COMMANDS } from "./desktopCommandNavigation";
 import type { GatewayRuntimeStatus } from "./desktopGatewayStartup";
 
 export interface DesktopWindowHandle {
@@ -14,6 +14,7 @@ interface InstallDesktopWindowFrameOptions {
 }
 
 const FRAME_ID = "desktop-window-frame";
+const CONTEXT_ID = "desktop-window-context";
 const RUNTIME_STATUS_ID = "desktop-runtime-status";
 const STYLE_ID = "desktop-window-frame-style";
 
@@ -31,6 +32,7 @@ export function installDesktopWindowFrame({
   targetDocument.body.classList.add("desktop-custom-frame");
 
   if (targetDocument.getElementById(FRAME_ID)) {
+    setDesktopWindowContext(targetDocument);
     return;
   }
 
@@ -47,17 +49,44 @@ export function installDesktopWindowFrame({
   title.setAttribute("data-tauri-drag-region", "");
   title.textContent = "Tinybot";
 
+  const context = targetDocument.createElement("div");
+  context.id = CONTEXT_ID;
+  context.setAttribute("id", CONTEXT_ID);
+  context.className = "desktop-window-context";
+  context.setAttribute("data-tauri-drag-region", "");
+  context.textContent = resolveDesktopWindowContextLabel(targetDocument);
+
+  const titleGroup = targetDocument.createElement("div");
+  titleGroup.className = "desktop-window-title-group";
+  titleGroup.setAttribute("data-tauri-drag-region", "");
+  titleGroup.append(title, context);
+
   const appMenu = createApplicationMenu(targetDocument);
 
   const runtimeStatus = targetDocument.createElement("div");
   runtimeStatus.id = RUNTIME_STATUS_ID;
   runtimeStatus.setAttribute("id", RUNTIME_STATUS_ID);
   runtimeStatus.className = "desktop-runtime-status";
-  runtimeStatus.setAttribute("data-tauri-drag-region", "");
+  runtimeStatus.setAttribute("role", "button");
+  runtimeStatus.setAttribute("tabindex", "0");
+  runtimeStatus.setAttribute("data-desktop-runtime-command", "refresh-gateway-status");
   runtimeStatus.setAttribute("aria-live", "polite");
   runtimeStatus.setAttribute("data-runtime-tone", "pending");
   runtimeStatus.textContent = "Gateway: Starting";
   runtimeStatus.setAttribute("title", "Waiting for Tinybot gateway readiness");
+  runtimeStatus.addEventListener("pointerdown", (event) => event.stopPropagation());
+  runtimeStatus.addEventListener("dblclick", (event) => event.stopPropagation());
+  runtimeStatus.addEventListener("click", (event) => {
+    event.stopPropagation();
+    targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "refresh-gateway-status" } }));
+  });
+  runtimeStatus.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+    event.preventDefault();
+    targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: "refresh-gateway-status" } }));
+  });
 
   const controls = targetDocument.createElement("div");
   controls.className = "desktop-window-controls";
@@ -68,7 +97,7 @@ export function installDesktopWindowFrame({
     createWindowButton(targetDocument, "close", "Close", "×", () => currentWindow.close()),
   );
 
-  frame.append(title, appMenu, runtimeStatus, controls);
+  frame.append(titleGroup, appMenu, runtimeStatus, controls);
   frame.addEventListener("pointerdown", () => {
     void currentWindow.startDragging().catch(logWindowFrameError);
   });
@@ -79,17 +108,37 @@ export function installDesktopWindowFrame({
   targetDocument.body.prepend(frame);
 }
 
+function setDesktopWindowContext(targetDocument: Document): void {
+  const context = targetDocument.getElementById(CONTEXT_ID);
+  if (context) {
+    context.textContent = resolveDesktopWindowContextLabel(targetDocument);
+  }
+}
+
+function resolveDesktopWindowContextLabel(targetDocument: Document): string {
+  const mode = targetDocument.documentElement?.dataset?.desktopWorkbenchMode;
+  if (mode === "native-workbench") {
+    return "Native workbench";
+  }
+  if (mode === "root-webui") {
+    return "WebUI shell";
+  }
+  return "Starting";
+}
+
 function createApplicationMenu(targetDocument: Document): HTMLElement {
   const menu = targetDocument.createElement("nav");
   menu.className = "desktop-application-menu";
   menu.setAttribute("aria-label", "Desktop application menu");
 
-  for (const command of DESKTOP_MENU_COMMANDS) {
+  for (const command of DESKTOP_CHROME_COMMANDS) {
     const button = targetDocument.createElement("button");
     button.type = "button";
     button.className = "desktop-application-menu-item";
     button.setAttribute("data-desktop-menu-command", command.id);
-    button.textContent = command.label;
+    button.setAttribute("aria-label", `${command.label} (${command.shortcut})`);
+    button.title = `${command.label} (${command.shortcut})`;
+    button.textContent = command.chromeLabel ?? command.label;
     button.addEventListener("pointerdown", (event) => event.stopPropagation());
     button.addEventListener("dblclick", (event) => event.stopPropagation());
     button.addEventListener("click", (event) => {
@@ -228,15 +277,38 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       -webkit-user-select: none;
     }
 
-    body.desktop-custom-frame .desktop-window-title {
+    body.desktop-custom-frame .desktop-window-title-group {
+      display: grid;
+      grid-template-columns: auto auto;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    body.desktop-custom-frame .desktop-window-title,
+    body.desktop-custom-frame .desktop-window-context {
       min-width: 0;
       overflow: hidden;
-      color: var(--text-muted, #6c6a64);
       font-size: 12px;
-      font-weight: 600;
       line-height: 1;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+
+    body.desktop-custom-frame .desktop-window-title {
+      color: var(--text, #141413);
+      font-weight: 700;
+    }
+
+    body.desktop-custom-frame .desktop-window-context {
+      color: var(--text-muted, #6c6a64);
+      font-weight: 500;
+    }
+
+    body.desktop-custom-frame .desktop-window-context::before {
+      content: "/";
+      padding-right: 8px;
+      color: var(--text-muted, #6c6a64);
     }
 
     body.desktop-custom-frame .desktop-application-menu {
@@ -250,7 +322,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
 
     body.desktop-custom-frame .desktop-application-menu-item {
       flex: 0 1 auto;
-      max-width: 130px;
+      max-width: 82px;
       min-width: 0;
       height: 26px;
       padding: 0 8px;
@@ -286,6 +358,13 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       line-height: 1;
       text-overflow: ellipsis;
       white-space: nowrap;
+      cursor: default;
+    }
+
+    body.desktop-custom-frame .desktop-runtime-status:focus-visible {
+      outline: 2px solid var(--primary, #cc785c);
+      outline-offset: 1px;
+      box-shadow: 0 0 0 4px var(--focus-ring, rgba(204, 120, 92, 0.28));
     }
 
     body.desktop-custom-frame .desktop-runtime-status[data-runtime-tone="ok"] {

--- a/apps/desktop/src/desktopWindowFrame.ts
+++ b/apps/desktop/src/desktopWindowFrame.ts
@@ -191,6 +191,19 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
   style.textContent = `
     :root {
       --desktop-window-frame-height: 34px;
+      --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      --bg: #faf9f5;
+      --bg-subtle: #f5f0e8;
+      --panel: #faf9f5;
+      --panel-strong: #efe9de;
+      --text: #141413;
+      --text-muted: #6c6a64;
+      --border: #e6dfd8;
+      --primary: #cc785c;
+      --success: #5db872;
+      --warning: #d4a017;
+      --danger: #c64545;
+      --focus-ring: rgba(204, 120, 92, 0.28);
     }
 
     body.desktop-custom-frame {
@@ -208,9 +221,9 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       justify-content: space-between;
       height: var(--desktop-window-frame-height);
       padding: 0 6px 0 14px;
-      border-bottom: 1px solid var(--border, #dedbd3);
-      background: color-mix(in srgb, var(--panel-strong, #ffffff) 92%, var(--bg-subtle, #f6f4ef));
-      color: var(--text, #24211d);
+      border-bottom: 1px solid var(--border, #e6dfd8);
+      background: color-mix(in srgb, var(--panel-strong, #efe9de) 92%, var(--bg-subtle, #f5f0e8));
+      color: var(--text, #141413);
       user-select: none;
       -webkit-user-select: none;
     }
@@ -218,7 +231,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
     body.desktop-custom-frame .desktop-window-title {
       min-width: 0;
       overflow: hidden;
-      color: var(--text-muted, #6f685d);
+      color: var(--text-muted, #6c6a64);
       font-size: 12px;
       font-weight: 600;
       line-height: 1;
@@ -245,7 +258,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       border-radius: 4px;
       overflow: hidden;
       background: transparent;
-      color: var(--text, #24211d);
+      color: var(--text, #141413);
       font: 600 11px/1 var(--font-sans, system-ui, sans-serif);
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -254,8 +267,9 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
 
     body.desktop-custom-frame .desktop-application-menu-item:hover,
     body.desktop-custom-frame .desktop-application-menu-item:focus-visible {
-      background: color-mix(in srgb, var(--text, #24211d) 10%, transparent);
-      outline: none;
+      background: color-mix(in srgb, var(--primary, #cc785c) 12%, transparent);
+      outline: 2px solid var(--primary, #cc785c);
+      outline-offset: 1px;
     }
 
     body.desktop-custom-frame .desktop-runtime-status {
@@ -264,9 +278,9 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       overflow: hidden;
       margin-left: 14px;
       padding: 4px 9px;
-      border: 1px solid color-mix(in srgb, var(--border, #dedbd3) 88%, transparent);
+      border: 1px solid color-mix(in srgb, var(--border, #e6dfd8) 88%, transparent);
       border-radius: 999px;
-      color: var(--text-muted, #6f685d);
+      color: var(--text-muted, #6c6a64);
       font-size: 11px;
       font-weight: 600;
       line-height: 1;
@@ -275,18 +289,18 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
     }
 
     body.desktop-custom-frame .desktop-runtime-status[data-runtime-tone="ok"] {
-      border-color: color-mix(in srgb, #1f8f4d 40%, var(--border, #dedbd3));
-      color: #1f6f3f;
+      border-color: color-mix(in srgb, var(--success, #5db872) 44%, var(--border, #e6dfd8));
+      color: #2f7b45;
     }
 
     body.desktop-custom-frame .desktop-runtime-status[data-runtime-tone="pending"] {
-      border-color: color-mix(in srgb, #9a6a00 38%, var(--border, #dedbd3));
-      color: #7a5600;
+      border-color: color-mix(in srgb, var(--warning, #d4a017) 44%, var(--border, #e6dfd8));
+      color: #7c5a09;
     }
 
     body.desktop-custom-frame .desktop-runtime-status[data-runtime-tone="warn"] {
-      border-color: color-mix(in srgb, #b42318 40%, var(--border, #dedbd3));
-      color: #9b1c14;
+      border-color: color-mix(in srgb, var(--danger, #c64545) 44%, var(--border, #e6dfd8));
+      color: #9a3030;
     }
 
     body.desktop-custom-frame .desktop-window-controls {
@@ -305,13 +319,13 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       border: 0;
       border-radius: 4px;
       background: transparent;
-      color: var(--text, #24211d);
+      color: var(--text, #141413);
       font: 16px/1 var(--font-sans, system-ui, sans-serif);
       cursor: default;
     }
 
     body.desktop-custom-frame .desktop-window-button:hover {
-      background: color-mix(in srgb, var(--text, #24211d) 10%, transparent);
+      background: color-mix(in srgb, var(--primary, #cc785c) 12%, transparent);
     }
 
     body.desktop-custom-frame .desktop-window-button-close:hover {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -1521,6 +1521,41 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain(".desktop-workspace-editor:focus-visible");
   });
 
+  test("declares DESIGN.md-aligned desktop surface tokens", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent;
+    expect(styleText).toContain("--bg: #faf9f5;");
+    expect(styleText).toContain("--panel-strong: #efe9de;");
+    expect(styleText).toContain("--primary: #cc785c;");
+    expect(styleText).toContain("--surface-dark: #181715;");
+    expect(styleText).toContain("--border: #e6dfd8;");
+    expect(styleText).toContain('--font-display: "Tiempos Headline"');
+  });
+
+  test("uses dark product surfaces for runtime diagnostics", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent;
+    expect(styleText).toContain(".desktop-gateway-runtime");
+    expect(styleText).toContain("background: var(--surface-dark, #181715);");
+    expect(styleText).toContain(".desktop-task-center-diagnostics:not(:empty)");
+    expect(styleText).toContain(".desktop-run-chain-detail");
+    expect(styleText).toContain("background: var(--surface-dark-soft, #1f1e1b);");
+  });
+
   test("styles the task center as a constrained keyboard-accessible bottom surface", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -2027,12 +2027,44 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
   const style = targetDocument.createElement("style");
   style.id = STYLE_ID;
   style.textContent = `
+    :root {
+      --font-display: "Tiempos Headline", "Cormorant Garamond", "EB Garamond", Garamond, "Times New Roman", serif;
+      --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+      --bg: #faf9f5;
+      --bg-subtle: #f5f0e8;
+      --panel: #faf9f5;
+      --panel-strong: #efe9de;
+      --surface-cream-strong: #e8e0d2;
+      --surface-dark: #181715;
+      --surface-dark-elevated: #252320;
+      --surface-dark-soft: #1f1e1b;
+      --text: #141413;
+      --text-strong: #252523;
+      --text-muted: #6c6a64;
+      --muted: #8e8b82;
+      --border: #e6dfd8;
+      --border-soft: #ebe6df;
+      --primary: #cc785c;
+      --primary-active: #a9583e;
+      --accent: #cc785c;
+      --accent-teal: #5db8a6;
+      --success: #5db872;
+      --warning: #d4a017;
+      --danger: #c64545;
+      --on-dark: #faf9f5;
+      --on-dark-soft: #a09d96;
+      --focus-ring: rgba(204, 120, 92, 0.28);
+      --shadow-soft: 0 1px 3px rgba(20, 20, 19, 0.08);
+    }
+
     body.desktop-native-workbench {
       margin: 0;
       min-height: 100vh;
       overflow: hidden;
-      background: var(--bg, #f7f7f4);
-      color: var(--text, #24211d);
+      background: var(--bg, #faf9f5);
+      color: var(--text, #141413);
+      font-family: var(--font-sans, system-ui, sans-serif);
     }
 
     body.desktop-native-workbench .desktop-workbench-shell,
@@ -2046,8 +2078,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: grid;
       grid-template-columns: 52px minmax(220px, var(--desktop-sidebar-size, 260px)) minmax(420px, 1fr) minmax(280px, var(--desktop-inspector-size, 360px));
       grid-template-rows: minmax(0, 1fr) auto;
-      border-top: 1px solid var(--border, #dedbd3);
-      background: var(--bg, #f7f7f4);
+      border-top: 1px solid var(--border, #e6dfd8);
+      background: var(--bg, #faf9f5);
     }
 
     body.desktop-native-workbench .desktop-workbench-shell[data-inspector-visible="false"] {
@@ -2069,8 +2101,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       flex-direction: column;
       gap: 6px;
       padding: 10px 6px;
-      border-right: 1px solid var(--border, #dedbd3);
-      background: var(--panel-strong, #ffffff);
+      border-right: 1px solid var(--border, #e6dfd8);
+      background: var(--surface-dark, #181715);
     }
 
     body.desktop-native-workbench .desktop-activity-button,
@@ -2079,10 +2111,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-items: center;
       justify-content: center;
       min-height: 36px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
       text-decoration: none;
       cursor: pointer;
@@ -2095,8 +2127,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       min-height: 0;
       overflow: hidden;
-      border-right: 1px solid var(--border, #dedbd3);
-      background: var(--panel, #ffffff);
+      border-right: 1px solid var(--border, #e6dfd8);
+      background: var(--panel, #faf9f5);
     }
 
     body.desktop-native-workbench .desktop-workbench-sidebar {
@@ -2121,7 +2153,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       grid-template-rows: minmax(0, 1fr) auto;
       padding: 14px;
       overflow: auto;
-      background: var(--bg-subtle, #f2f0ea);
+      background: var(--bg-subtle, #f5f0e8);
     }
 
     body.desktop-native-workbench .desktop-empty-session {
@@ -2130,6 +2162,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       gap: 12px;
       max-width: 720px;
       min-width: 0;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 12px;
+      padding: 18px;
+      background: var(--panel-strong, #efe9de);
     }
 
     body.desktop-native-workbench .desktop-empty-session > * {
@@ -2138,14 +2174,18 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-empty-session h1 {
       margin: 0;
-      font-size: 20px;
+      color: var(--text, #141413);
+      font-family: var(--font-display, Georgia, serif);
+      font-size: 24px;
+      font-weight: 500;
       line-height: 1.2;
+      letter-spacing: -0.01em;
     }
 
     body.desktop-native-workbench .desktop-empty-session p,
     body.desktop-native-workbench .desktop-workbench-section p {
       margin: 0;
-      color: var(--text-muted, #6f685d);
+      color: var(--text-muted, #6c6a64);
       font-size: 12px;
       line-height: 1.45;
       overflow-wrap: anywhere;
@@ -2154,7 +2194,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workbench-link {
       min-width: 0;
       overflow: hidden;
-      color: var(--text, #24211d);
+      color: var(--text, #141413);
       font-size: 12px;
       line-height: 1.3;
       text-decoration: none;
@@ -2165,14 +2205,21 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workbench-link:focus-visible,
     body.desktop-native-workbench .desktop-activity-button:focus-visible,
     body.desktop-native-workbench .desktop-quick-action:focus-visible {
-      outline: 2px solid var(--accent, #5c6bc0);
+      outline: 2px solid var(--primary, #cc785c);
       outline-offset: 2px;
+      box-shadow: 0 0 0 4px var(--focus-ring, rgba(204, 120, 92, 0.28));
     }
 
     body.desktop-native-workbench .desktop-quick-actions {
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
+    }
+
+    body.desktop-native-workbench .desktop-quick-actions .desktop-quick-action:first-child {
+      border-color: var(--primary, #cc785c);
+      background: var(--primary, #cc785c);
+      color: #ffffff;
     }
 
     body.desktop-native-workbench .desktop-panel-controls {
@@ -2184,28 +2231,28 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-panel-control {
       min-height: 32px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 10px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
       cursor: pointer;
     }
 
     body.desktop-native-workbench .desktop-panel-control[aria-pressed="true"] {
-      border-color: var(--accent, #5c6bc0);
-      background: var(--panel-strong, #ffffff);
+      border-color: var(--primary, #cc785c);
+      background: var(--panel-strong, #efe9de);
     }
 
     body.desktop-native-workbench .desktop-command-palette {
       display: grid;
       gap: 8px;
       width: min(680px, 100%);
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 10px;
-      background: var(--panel, #ffffff);
+      background: var(--panel, #faf9f5);
       box-shadow: 0 12px 30px rgba(20, 18, 15, 0.16);
     }
 
@@ -2229,10 +2276,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-command-palette-close,
     body.desktop-native-workbench .desktop-command-palette-result {
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 12px/1.2 var(--font-sans, system-ui, sans-serif);
       cursor: pointer;
     }
@@ -2246,10 +2293,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       width: 100%;
       min-width: 0;
       min-height: 34px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 10px;
-      color: var(--text, #24211d);
+      color: var(--text, #141413);
       font: 13px/1.2 var(--font-sans, system-ui, sans-serif);
     }
 
@@ -2285,7 +2332,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-command-palette-result span,
     body.desktop-native-workbench .desktop-command-palette-status,
     body.desktop-native-workbench .desktop-command-palette-empty {
-      color: var(--text-muted, #6f685d);
+      color: var(--text-muted, #6c6a64);
       font-size: 11px;
       line-height: 1.35;
     }
@@ -2293,7 +2340,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-command-palette-close:focus-visible,
     body.desktop-native-workbench .desktop-command-palette-input:focus-visible,
     body.desktop-native-workbench .desktop-command-palette-result:focus-visible {
-      outline: 2px solid var(--accent, #5c6bc0);
+      outline: 2px solid var(--primary, #cc785c);
       outline-offset: 2px;
     }
 
@@ -2308,7 +2355,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-session-upload-key:focus-visible,
     body.desktop-native-workbench .desktop-workspace-file-row:focus-visible,
     body.desktop-native-workbench .desktop-workspace-editor:focus-visible {
-      outline: 2px solid var(--accent, #5c6bc0);
+      outline: 2px solid var(--primary, #cc785c);
       outline-offset: 2px;
     }
 
@@ -2332,10 +2379,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-file-action {
       min-height: 34px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
       cursor: pointer;
     }
@@ -2357,11 +2404,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-items: center;
       justify-content: center;
       min-height: 32px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 10px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
       text-decoration: none;
       cursor: pointer;
@@ -2369,16 +2416,16 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-file-action.is-desktop-drop-hover,
     body.desktop-native-workbench .desktop-file-action[data-desktop-drop-target]:focus-visible {
-      outline: 2px solid var(--accent, #5c6bc0);
+      outline: 2px solid var(--primary, #cc785c);
       outline-offset: 2px;
-      background: var(--panel-strong, #ffffff);
+      background: var(--panel-strong, #efe9de);
     }
 
     body.desktop-native-workbench .desktop-session-upload-key {
       min-width: 0;
       width: min(220px, 100%);
       min-height: 34px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 10px;
       font: 12px/1.2 var(--font-sans, system-ui, sans-serif);
@@ -2410,12 +2457,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workspace-file-row {
       min-width: 0;
       min-height: 28px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 8px;
       overflow: hidden;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 12px/1.2 var(--font-sans, system-ui, sans-serif);
       text-align: left;
       text-overflow: ellipsis;
@@ -2433,7 +2480,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       width: 100%;
       min-height: 138px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 8px;
       resize: vertical;
@@ -2441,7 +2488,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-workspace-error {
-      color: var(--danger, #a33a2f);
+      color: var(--danger, #c64545);
     }
 
     body.desktop-native-workbench .desktop-bottom-content {
@@ -2460,7 +2507,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       min-height: 0;
       padding: 12px;
-      border-right: 1px solid var(--border, #dedbd3);
+      border-right: 1px solid var(--border, #e6dfd8);
     }
 
     body.desktop-native-workbench .desktop-task-center h2,
@@ -2480,7 +2527,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-task-center-empty,
     body.desktop-native-workbench .desktop-task-center-detail,
     body.desktop-native-workbench .desktop-task-center-diagnostics {
-      color: var(--text-muted, #6f685d);
+      color: var(--text-muted, #6c6a64);
       font-size: 11px;
       line-height: 1.35;
       overflow-wrap: anywhere;
@@ -2498,22 +2545,30 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: grid;
       gap: 6px;
       min-width: 0;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 8px;
-      background: var(--panel-strong, #ffffff);
+      background: var(--panel-strong, #efe9de);
     }
 
     body.desktop-native-workbench .desktop-task-center-item[data-desktop-task-state="failed"] {
-      border-color: var(--danger, #a33a2f);
+      border-color: var(--danger, #c64545);
     }
 
     body.desktop-native-workbench .desktop-task-center-item[data-desktop-task-state="blocked"] {
-      border-color: var(--warning, #a76a00);
+      border-color: var(--warning, #d4a017);
     }
 
     body.desktop-native-workbench .desktop-task-center-item[data-desktop-task-state="completed"] {
       opacity: 0.82;
+    }
+
+    body.desktop-native-workbench .desktop-task-center-diagnostics:not(:empty) {
+      border-radius: 6px;
+      padding: 6px 8px;
+      background: var(--surface-dark-soft, #1f1e1b);
+      color: var(--on-dark-soft, #a09d96);
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace);
     }
 
     body.desktop-native-workbench .desktop-task-center-item-heading {
@@ -2533,10 +2588,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-task-state-badge {
       flex: 0 0 auto;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 2px 6px;
-      color: var(--text-muted, #6f685d);
+      color: var(--text-muted, #6c6a64);
       font-size: 10px;
       line-height: 1.2;
       text-transform: uppercase;
@@ -2554,11 +2609,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-items: center;
       justify-content: center;
       min-height: 28px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 8px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 600 11px/1.2 var(--font-sans, system-ui, sans-serif);
       text-decoration: none;
       cursor: pointer;
@@ -2567,9 +2622,16 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-gateway-runtime {
       min-width: 0;
       overflow: auto;
+      background: var(--surface-dark, #181715);
+      color: var(--on-dark, #faf9f5);
+    }
+
+    body.desktop-native-workbench .desktop-gateway-runtime h2 {
+      color: var(--on-dark, #faf9f5);
     }
 
     body.desktop-native-workbench .desktop-gateway-runtime-row {
+      color: var(--on-dark-soft, #a09d96);
       white-space: pre-wrap;
     }
 
@@ -2582,17 +2644,17 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-gateway-action {
       min-height: 28px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--surface-dark-elevated, #252320);
       border-radius: 6px;
       padding: 0 8px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--surface-dark-elevated, #252320);
+      color: var(--on-dark, #faf9f5);
       font: 600 11px/1.2 var(--font-sans, system-ui, sans-serif);
       cursor: pointer;
     }
 
     body.desktop-native-workbench .desktop-gateway-action:focus-visible {
-      outline: 2px solid var(--accent, #5c6bc0);
+      outline: 2px solid var(--primary, #cc785c);
       outline-offset: 2px;
     }
 
@@ -2600,7 +2662,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: grid;
       gap: 8px;
       padding: 12px;
-      border-bottom: 1px solid var(--border, #dedbd3);
+      border-bottom: 1px solid var(--border, #e6dfd8);
     }
 
     body.desktop-native-workbench .desktop-workbench-section h2 {
@@ -2655,12 +2717,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-cowork-graph-node {
       min-width: 0;
       min-height: 30px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 8px;
       overflow: hidden;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 600 11px/1.25 var(--font-sans, system-ui, sans-serif);
       text-align: left;
       text-overflow: ellipsis;
@@ -2682,19 +2744,19 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-cowork-observability-tab[aria-selected="true"] {
-      border-color: var(--accent, #5c6bc0);
-      background: var(--panel-strong, #ffffff);
+      border-color: var(--primary, #cc785c);
+      background: var(--panel-strong, #efe9de);
     }
 
     body.desktop-native-workbench .desktop-cowork-observability-filter {
       min-width: 0;
       width: 100%;
       min-height: 30px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 8px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 12px/1.35 var(--font-sans, system-ui, sans-serif);
       letter-spacing: 0;
     }
@@ -2705,10 +2767,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       max-height: min(320px, 40vh);
       overflow: auto;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 8px;
-      background: var(--panel, #ffffff);
+      background: var(--panel, #faf9f5);
     }
 
     body.desktop-native-workbench .desktop-cowork-observability-panel p {
@@ -2728,11 +2790,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       width: 100%;
       min-height: 58px;
       resize: vertical;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 7px 8px;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 12px/1.35 var(--font-sans, system-ui, sans-serif);
       letter-spacing: 0;
     }
@@ -2764,12 +2826,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-run-chain-item {
       min-width: 0;
       min-height: 32px;
-      border: 1px solid var(--border, #dedbd3);
+      border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 6px 8px;
       overflow: hidden;
-      background: var(--panel, #ffffff);
-      color: var(--text, #24211d);
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
       font: 12px/1.35 var(--font-sans, system-ui, sans-serif);
       text-align: left;
       text-overflow: ellipsis;
@@ -2778,24 +2840,33 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-run-chain-item[aria-selected="true"] {
-      border-color: var(--accent, #5c6bc0);
-      background: var(--panel-strong, #ffffff);
+      border-color: var(--primary, #cc785c);
+      background: var(--panel-strong, #efe9de);
     }
 
     body.desktop-native-workbench .desktop-run-chain-item:focus-visible {
-      outline: 2px solid var(--accent, #5c6bc0);
+      outline: 2px solid var(--primary, #cc785c);
       outline-offset: 2px;
     }
 
     body.desktop-native-workbench .desktop-run-chain-detail {
       min-width: 0;
       overflow: auto;
+      border-radius: 6px;
+      padding: 8px;
+      background: var(--surface-dark-soft, #1f1e1b);
+      color: var(--on-dark, #faf9f5);
+    }
+
+    body.desktop-native-workbench .desktop-run-chain-detail p {
+      color: var(--on-dark-soft, #a09d96);
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace);
     }
 
     body.desktop-native-workbench .desktop-status-strip {
       overflow: hidden;
       padding: 8px 0 0;
-      color: var(--text-muted, #6f685d);
+      color: var(--text-muted, #6c6a64);
       font-size: 11px;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -2805,7 +2876,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       grid-column: 2 / span 3;
       width: auto;
       height: var(--desktop-bottom-size, var(--region-size));
-      border-top: 1px solid var(--border, #dedbd3);
+      border-top: 1px solid var(--border, #e6dfd8);
     }
 
     @media (max-width: 760px) {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,12 +1,33 @@
 :root {
+  --color-canvas: #faf9f5;
+  --color-surface-soft: #f5f0e8;
+  --color-surface-card: #efe9de;
+  --color-surface-strong: #e8e0d2;
+  --color-surface-dark: #181715;
+  --color-surface-dark-elevated: #252320;
+  --color-surface-dark-soft: #1f1e1b;
+  --color-primary: #cc785c;
+  --color-primary-active: #a9583e;
+  --color-accent-teal: #5db8a6;
+  --color-success: #5db872;
+  --color-warning: #d4a017;
+  --color-error: #c64545;
+  --color-hairline: #e6dfd8;
+  --color-hairline-soft: #ebe6df;
+  --color-ink: #141413;
+  --color-body: #3d3d3a;
+  --color-muted: #6c6a64;
+  --color-muted-soft: #8e8b82;
+  --font-display: "Tiempos Headline", "Cormorant Garamond", "EB Garamond", Garamond, "Times New Roman", serif;
+  --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+    var(--font-sans);
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-  color: #1f2933;
-  background: #f4f6f8;
+  color: var(--color-ink);
+  background: var(--color-canvas);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -22,6 +43,7 @@ body {
   margin: 0;
   min-width: 720px;
   min-height: 100vh;
+  background: var(--color-canvas);
 }
 
 button {
@@ -35,8 +57,8 @@ button {
 }
 
 .sidebar {
-  background: #101820;
-  color: #f8fafc;
+  background: var(--color-surface-dark);
+  color: var(--color-canvas);
   padding: 20px 16px;
   display: flex;
   flex-direction: column;
@@ -55,8 +77,8 @@ button {
   display: grid;
   place-items: center;
   border-radius: 8px;
-  background: #f2c94c;
-  color: #101820;
+  background: var(--color-primary);
+  color: #ffffff;
   font-weight: 800;
 }
 
@@ -75,7 +97,7 @@ button {
 }
 
 .brand p {
-  color: #a8b3bd;
+  color: #a09d96;
   font-size: 13px;
 }
 
@@ -89,20 +111,20 @@ button {
   border: 0;
   border-radius: 8px;
   padding: 10px 12px;
-  color: #d6dde4;
+  color: #d8d2c9;
   background: transparent;
   text-align: left;
   cursor: pointer;
 }
 
 .nav-item.active {
-  color: #101820;
-  background: #f8fafc;
+  color: var(--color-ink);
+  background: var(--color-canvas);
   font-weight: 700;
 }
 
 .nav-item:disabled {
-  color: #687684;
+  color: #807a70;
   cursor: default;
 }
 
@@ -126,33 +148,40 @@ button {
 }
 
 .topbar h2 {
+  font-family: var(--font-display);
   font-size: 24px;
   letter-spacing: 0;
+  font-weight: 500;
 }
 
 .topbar p {
-  color: #64748b;
+  color: var(--color-muted);
   margin-top: 2px;
 }
 
 .button {
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
   padding: 9px 14px;
-  background: #fff;
-  color: #1f2933;
+  background: var(--color-canvas);
+  color: var(--color-ink);
   cursor: pointer;
 }
 
 .button.primary {
   color: #fff;
-  background: #2563eb;
-  border-color: #2563eb;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.button.primary:hover {
+  background: var(--color-primary-active);
+  border-color: var(--color-primary-active);
 }
 
 .button:disabled {
-  color: #94a3b8;
-  background: #f8fafc;
+  color: var(--color-muted-soft);
+  background: var(--color-surface-soft);
   cursor: not-allowed;
 }
 
@@ -171,9 +200,9 @@ button {
 
 .status-panel,
 .activity-panel {
-  border: 1px solid #d9e2ec;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-canvas);
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
@@ -203,19 +232,19 @@ button {
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: #94a3b8;
+  background: var(--color-muted-soft);
 }
 
 .status-dot.ok {
-  background: #16a34a;
+  background: var(--color-success);
 }
 
 .status-dot.warn {
-  background: #f97316;
+  background: var(--color-warning);
 }
 
 .status-dot.idle {
-  background: #94a3b8;
+  background: var(--color-muted-soft);
 }
 
 dl {
@@ -231,14 +260,14 @@ dl div {
 }
 
 dt {
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 dd {
   margin: 0;
   min-width: 0;
   overflow-wrap: anywhere;
-  color: #111827;
+  color: var(--color-ink);
 }
 
 .activity-panel {
@@ -256,15 +285,15 @@ dd {
 
 .hosted-summary p {
   margin: 4px 0 0;
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .hosted-shell {
   min-height: 0;
-  border: 1px solid #d9e2ec;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
   overflow: hidden;
-  background: #fff;
+  background: var(--color-canvas);
 }
 
 .hosted-shell iframe {
@@ -272,7 +301,7 @@ dd {
   height: calc(100vh - 132px);
   min-height: 560px;
   border: 0;
-  background: #fff;
+  background: var(--color-canvas);
 }
 
 .hosted-offline {
@@ -291,7 +320,7 @@ dd {
 
 .hosted-offline p {
   max-width: 520px;
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .native-chat-shell {
@@ -304,9 +333,9 @@ dd {
 .native-sessions,
 .native-chat-main {
   min-height: 0;
-  border: 1px solid #d9e2ec;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-canvas);
   overflow: hidden;
 }
 
@@ -318,7 +347,7 @@ dd {
 .native-panel-heading,
 .native-chat-header {
   padding: 16px 18px;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-hairline-soft);
 }
 
 .native-panel-heading h3,
@@ -333,7 +362,7 @@ dd {
 }
 
 .native-chat-header p {
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 13px;
 }
 
@@ -351,13 +380,13 @@ dd {
   display: grid;
   gap: 4px;
   background: transparent;
-  color: #1f2933;
+  color: var(--color-ink);
   text-align: left;
   cursor: pointer;
 }
 
 .session-row.active {
-  background: #eaf1ff;
+  background: var(--color-surface-card);
 }
 
 .session-row strong {
@@ -369,7 +398,7 @@ dd {
 .session-row span,
 .empty-list,
 .empty-chat {
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 13px;
 }
 
@@ -394,11 +423,11 @@ dd {
 }
 
 .native-agent-ui-surfaces {
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--color-hairline-soft);
   padding: 14px 20px;
   display: grid;
   gap: 12px;
-  background: #fbfdff;
+  background: var(--color-surface-soft);
 }
 
 .native-agent-ui-surfaces[hidden] {
@@ -422,12 +451,12 @@ dd {
 .native-message-content {
   border-radius: 8px;
   padding: 11px 13px;
-  background: #f1f5f9;
-  color: #111827;
+  background: var(--color-surface-card);
+  color: var(--color-ink);
 }
 
 .native-message.user .native-message-content {
-  background: #2563eb;
+  background: var(--color-primary);
   color: #fff;
 }
 
@@ -438,17 +467,17 @@ dd {
 
 .native-reasoning {
   margin-bottom: 8px !important;
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 13px;
 }
 
 .native-message-meta {
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 12px;
 }
 
 .chat-composer {
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--color-hairline-soft);
   padding: 14px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -460,17 +489,17 @@ dd {
   resize: vertical;
   min-height: 72px;
   max-height: 180px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
   padding: 10px 12px;
   font: inherit;
 }
 
 .agent-ui-form-card {
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
   padding: 14px;
-  background: #fff;
+  background: var(--color-canvas);
   display: grid;
   gap: 12px;
 }
@@ -493,18 +522,18 @@ dd {
 
 .agent-ui-form-status,
 .status-pill {
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--color-hairline);
   border-radius: 999px;
   padding: 3px 8px;
-  color: #475569;
-  background: #f8fafc;
+  color: var(--color-muted);
+  background: var(--color-surface-soft);
   font-size: 12px;
 }
 
 .agent-ui-form-description,
 .agent-ui-form-help,
 .agent-ui-form-error {
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 13px;
 }
 
@@ -522,7 +551,7 @@ dd {
 .agent-ui-form-field textarea,
 .agent-ui-form-field select {
   width: 100%;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
   padding: 9px 10px;
   font: inherit;
@@ -548,7 +577,7 @@ dd {
 }
 
 .agent-ui-form-error {
-  color: #b42318;
+  color: var(--color-error);
 }
 
 .agent-ui-form-actions {
@@ -559,10 +588,10 @@ dd {
 
 .browser-observation-shell {
   min-height: 0;
-  border: 1px solid #d9e2ec;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
   overflow: hidden;
-  background: #fff;
+  background: var(--color-canvas);
   display: grid;
   place-items: center;
 }
@@ -584,14 +613,14 @@ dd {
 
 .browser-observation-empty p,
 .browser-observation-command {
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .browser-observation-image {
   width: 100%;
   max-height: calc(100vh - 180px);
   object-fit: contain;
-  background: #0f172a;
+  background: var(--color-surface-dark);
 }
 
 .browser-observation-command {
@@ -607,9 +636,9 @@ dd {
 
 .module-panel {
   min-height: 0;
-  border: 1px solid #d9e2ec;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-canvas);
   padding: 16px;
   display: grid;
   align-content: start;
@@ -633,19 +662,19 @@ dd {
 }
 
 .module-row {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-hairline-soft);
   border-radius: 8px;
   padding: 10px;
   display: grid;
   gap: 4px;
-  background: #fbfdff;
+  background: var(--color-surface-soft);
 }
 
 .module-row button {
   border: 0;
   padding: 0;
   background: transparent;
-  color: #1f2933;
+  color: var(--color-ink);
   text-align: left;
   cursor: pointer;
 }
@@ -657,7 +686,7 @@ dd {
 .module-row span,
 .module-actions,
 .module-empty {
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 13px;
 }
 
@@ -671,10 +700,10 @@ dd {
 .workspace-editor {
   width: 100%;
   min-height: 420px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--color-hairline);
   border-radius: 8px;
   padding: 12px;
-  font: 13px/1.5 ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font: 13px/1.5 var(--font-mono);
   resize: vertical;
 }
 
@@ -693,11 +722,11 @@ dd {
 
 .activity-header {
   padding: 16px 18px;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-hairline-soft);
 }
 
 .activity-header span {
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 13px;
 }
 
@@ -706,8 +735,8 @@ pre {
   padding: 18px;
   min-height: 0;
   overflow: auto;
-  color: #dbeafe;
-  background: #111827;
+  color: #faf9f5;
+  background: var(--color-surface-dark);
   font-size: 13px;
   line-height: 1.45;
 }


### PR DESCRIPTION
Closes #111.

Implements OpenSpec change `refine-desktop-app-native-ui-ux` across the actual desktop root-WebUI shell and existing native workbench surfaces.

Scope:
- Aligns desktop theme tokens with `DESIGN.md` warm cream, coral action, dark runtime, focus, border, and typography roles.
- Refines custom Tauri chrome into compact app commands: `New`, `Stop`, `Search`, `Command`, with interactive gateway status and drag-region isolation.
- Adds a root-WebUI desktop adapter that marks existing WebUI regions as desktop workbench regions, persists layout state, adds narrow-window fallback, and upgrades empty chat with task-oriented desktop modules.
- Mounts and installs the desktop command palette in root-WebUI mode with gateway-backed sessions, files, knowledge, tools, skills, and Cowork results.
- Refines root-WebUI composer/runtime status into desktop attachment/input/send proportions, runtime chips, blocked-send feedback, and drag/drop feedback.

Verification:
- `npm test` -> 36 files / 187 tests passed
- `npm run build` -> passed, with existing Vite large chunk warning
- `cargo check` in `apps/desktop/src-tauri` -> passed
- `openspec validate refine-desktop-app-native-ui-ux --strict` -> passed
- `openspec instructions apply --change refine-desktop-app-native-ui-ux --json` -> 27/27 local tasks complete
- Live desktop screenshots captured locally under `.codex/screenshots/` and not committed
- Keyboard-opened command palette verified on the live desktop window via `Ctrl+Shift+P`

Not included by design:
- OpenSpec files
- `.gitignore`
- `DESIGN.md`
- Generated screenshots/build artifacts