### PR TITLE
Fix desktop WebUI hidden inspector layout

### DIFF
--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -235,6 +235,22 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(targetDocument.getElementById("inspector-panel")?.getAttribute("aria-hidden")).toBe("true");
   });
 
+  test("collapses a persisted inspector column when the hosted WebUI has no active inspector", () => {
+    const targetDocument = createRootWebUiDocument();
+    targetDocument.getElementById("inspector-panel")?.setAttribute("aria-hidden", "true");
+
+    applyRootWebUiWorkbenchLayout(targetDocument as unknown as Document, {
+      sidebar: { visible: true, size: 260 },
+      inspector: { visible: true, size: 420 },
+      bottom: { visible: false, size: 220 },
+    });
+
+    const shell = targetDocument.body.querySelector(".shell");
+    expect(shell?.getAttribute("data-inspector-visible")).toBe("false");
+    expect(shell?.classList.contains("inspection-mode")).toBe(false);
+    expect(targetDocument.getElementById("inspector-panel")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
   test("adds task-oriented desktop modules to the root WebUI empty chat state once", () => {
     const targetDocument = new FakeDocument();
     const empty = targetDocument.createElement("div");

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -143,12 +143,13 @@ export function applyRootWebUiWorkbenchLayout(targetDocument: Document, layout: 
   if (!shell) {
     return;
   }
+  const inspectorVisible = layout.inspector.visible && isInspectorVisible(targetDocument);
 
   targetDocument.body.classList.add("desktop-root-webui-workbench");
   shell.setAttribute("data-desktop-workbench", "root-webui");
   shell.setAttribute("data-desktop-layout-storage-key", DESKTOP_WORKBENCH_LAYOUT_STORAGE_KEY);
   shell.setAttribute("data-sidebar-visible", String(layout.sidebar.visible));
-  shell.setAttribute("data-inspector-visible", String(layout.inspector.visible));
+  shell.setAttribute("data-inspector-visible", String(inspectorVisible));
   shell.setAttribute("data-bottom-visible", String(layout.bottom.visible));
   shell.style.setProperty("--desktop-sidebar-size", `${layout.sidebar.size}px`);
   shell.style.setProperty("--desktop-inspector-size", `${layout.inspector.size}px`);
@@ -173,7 +174,7 @@ export function applyRootWebUiWorkbenchLayout(targetDocument: Document, layout: 
     sidebar?.classList.add("collapsed");
   }
 
-  if (!layout.inspector.visible) {
+  if (!inspectorVisible) {
     shell.classList.remove("inspection-mode");
     inspector?.setAttribute("aria-hidden", "true");
   }
@@ -576,7 +577,7 @@ function isSidebarVisible(targetDocument: Document): boolean {
 function isInspectorVisible(targetDocument: Document): boolean {
   const shell = targetDocument.body.querySelector(".shell");
   const inspector = targetDocument.getElementById("inspector-panel");
-  return shell?.classList.contains("inspection-mode") === true || inspector?.getAttribute("aria-hidden") !== "true";
+  return shell?.classList.contains("inspection-mode") === true && inspector?.getAttribute("aria-hidden") !== "true";
 }
 
 function installEmptyStateObserver(targetDocument: Document): void {


### PR DESCRIPTION
## Summary

- Collapse the desktop root WebUI inspector column when the hosted WebUI does not have an active inspector.
- Treat inspector visibility as active only when both `inspection-mode` and `aria-hidden != "true"` agree.
- Add a regression test for persisted inspector visibility causing an empty right column.

## Root cause

The desktop adapter reused the persisted inspector visibility flag even when the WebUI inspector was actually hidden. That left a blank third grid column and squeezed the chat/composer layout.

## Validation

- `npm test -- desktopRootWebUiWorkbench.test.ts`
- `npm test`
- `npm run build`