### PR TITLE
Fix desktop WebUI composer status layout

### DIFF
--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -320,5 +320,8 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(styleText).toContain(".desktop-empty-modules");
     expect(styleText).toContain(".desktop-command-palette");
     expect(styleText).toContain(".desktop-composer-feedback");
+    expect(styleText).toContain("body.desktop-root-webui-workbench .composer-status-panel .system-status");
+    expect(styleText).toContain("grid-auto-flow: column");
+    expect(styleText).toContain("grid-auto-columns: max-content");
   });
 });

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -319,6 +319,15 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       min-width: 0;
     }
 
+    body.desktop-root-webui-workbench .composer-status-panel .system-status {
+      display: grid !important;
+      grid-auto-flow: column;
+      grid-auto-columns: max-content;
+      grid-template-columns: none !important;
+      justify-content: start;
+      overflow: visible;
+    }
+
     body.desktop-root-webui-workbench .composer-status-panel .status-item {
       display: inline-flex;
       flex: 0 1 auto;


### PR DESCRIPTION
## Summary

- Keep the desktop root WebUI composer runtime status strip horizontally arranged.
- Scope the horizontal grid rule to `.composer-status-panel .system-status` so general status panels keep their desktop flex behavior.
- Add a style regression assertion for the desktop composer status layout.

## Root cause

The desktop adapter applied a generic wrapping flex override to `.system-status`. In the composer runtime area this could wrap each Provider / Model / WebSocket / Token usage chip into a vertical stack instead of matching the WebUI's horizontal status strip.

Closes #115.

## Validation

- `npm test -- desktopRootWebUiWorkbench.test.ts`
- `npm test`
- `npm run build`