### PR TITLE
Fix desktop WebUI sidebar placement on narrow windows

### DIFF
--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -323,5 +323,10 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(styleText).toContain("body.desktop-root-webui-workbench .composer-status-panel .system-status");
     expect(styleText).toContain("grid-auto-flow: column");
     expect(styleText).toContain("grid-auto-columns: max-content");
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .sidebar");
+    expect(styleText).toContain("grid-column: 1");
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .chat-panel");
+    expect(styleText).toContain("grid-column: 2");
+    expect(styleText).toContain("order: 0");
   });
 });

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -529,9 +529,29 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       body.desktop-root-webui-workbench > .shell,
       body.desktop-root-webui-workbench > .shell.inspection-mode {
         grid-template-columns: 68px minmax(0, 1fr) 0;
+        grid-template-rows: minmax(0, 1fr);
+        height: calc(100vh - var(--desktop-window-frame-height, 34px));
+        min-height: 0;
+      }
+
+      body.desktop-root-webui-workbench > .shell .sidebar {
+        order: 0;
+        grid-column: 1;
+        grid-row: 1;
+        max-height: none;
+      }
+
+      body.desktop-root-webui-workbench > .shell .chat-panel {
+        order: 0;
+        grid-column: 2;
+        grid-row: 1;
+        min-height: 0;
+        height: auto;
       }
 
       body.desktop-root-webui-workbench .inspector-panel {
+        grid-column: 3;
+        grid-row: 1;
         display: none;
       }
 


### PR DESCRIPTION
## Summary

- Keep the desktop root WebUI sidebar pinned to the left column at narrow widths.
- Override the WebUI responsive `order` / single-column placement for `.sidebar` and `.chat-panel` inside the desktop shell.
- Add style regression assertions for sidebar/chat narrow-window grid placement.

## Root cause

The WebUI responsive stylesheet switches `.shell` to a single-column layout below 1100px and sets `.chat-panel { order: 1 }` and `.sidebar { order: 2 }`. The desktop root WebUI adapter only changed the narrow grid columns, so those order rules could move the sidebar to the right or after the chat panel.

Closes #117.

## Validation

- `npm test -- desktopRootWebUiWorkbench.test.ts`
- `npm test`
- `npm run build`