### PR TITLE
Fix desktop WebUI sidebar placement at intermediate widths

### DIFF
--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -328,5 +328,14 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .chat-panel");
     expect(styleText).toContain("grid-column: 2");
     expect(styleText).toContain("order: 0");
+    const narrowRuleIndex = styleText?.indexOf("@media (max-width: 980px)") ?? -1;
+    const sidebarPlacementIndex =
+      styleText?.indexOf("body.desktop-root-webui-workbench > .shell .sidebar") ?? -1;
+    const chatPlacementIndex =
+      styleText?.indexOf("body.desktop-root-webui-workbench > .shell .chat-panel") ?? -1;
+    expect(sidebarPlacementIndex).toBeGreaterThan(-1);
+    expect(chatPlacementIndex).toBeGreaterThan(-1);
+    expect(sidebarPlacementIndex).toBeLessThan(narrowRuleIndex);
+    expect(chatPlacementIndex).toBeLessThan(narrowRuleIndex);
   });
 });

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -244,6 +244,24 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       box-shadow: none;
     }
 
+    body.desktop-root-webui-workbench > .shell .sidebar {
+      order: 0;
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    body.desktop-root-webui-workbench > .shell .chat-panel {
+      order: 0;
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    body.desktop-root-webui-workbench > .shell .inspector-panel {
+      order: 0;
+      grid-column: 3;
+      grid-row: 1;
+    }
+
     body.desktop-root-webui-workbench .message-list {
       min-width: 0;
       scrollbar-gutter: stable;
@@ -535,23 +553,15 @@ export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): 
       }
 
       body.desktop-root-webui-workbench > .shell .sidebar {
-        order: 0;
-        grid-column: 1;
-        grid-row: 1;
         max-height: none;
       }
 
       body.desktop-root-webui-workbench > .shell .chat-panel {
-        order: 0;
-        grid-column: 2;
-        grid-row: 1;
         min-height: 0;
         height: auto;
       }
 
       body.desktop-root-webui-workbench .inspector-panel {
-        grid-column: 3;
-        grid-row: 1;
         display: none;
       }
 


### PR DESCRIPTION
## Summary

- Pin the desktop root WebUI sidebar, chat panel, and inspector to their grid columns in the base desktop adapter styles.
- Keep the existing compact 68px sidebar behavior only for the very narrow `max-width: 980px` breakpoint.
- Add a regression assertion that placement overrides exist before the 980px media rule, covering the intermediate 981-1100px range.

## Root cause

The WebUI responsive stylesheet starts reordering the shell below 1100px via `.chat-panel { order: 1 }` and `.sidebar { order: 2 }`. The desktop adapter only reset that placement inside its 980px media rule, leaving an intermediate range where auto-placement could put the chat in the sidebar column and the sidebar in the main column.

Closes #119.

## Validation

- `npm test -- desktopRootWebUiWorkbench.test.ts`
- `npm test`
- `npm run build`