### PR TITLE
Add desktop shell shared models

### DIFF
--- a/apps/desktop/src/desktopSharedModels.test.ts
+++ b/apps/desktop/src/desktopSharedModels.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildDesktopCommandEntriesFromSidebar,
+  buildRootWebUiRuntimeChips,
+  buildRootWebUiSidebarModel,
+  buildRootWebUiWorkspaceContext,
+  type DesktopSidebarItem,
+} from "./desktopSharedModels";
+
+describe("desktop shared shell models", () => {
+  test("builds root WebUI workspace context with an optional active session", () => {
+    const context = buildRootWebUiWorkspaceContext({
+      workspaceId: "workspace:tinybot",
+      workspaceLabel: "tinybot",
+      activeSession: {
+        id: "session-1",
+        title: "Desktop shell planning",
+        meta: "2m ago",
+      },
+    });
+
+    expect(context).toEqual({
+      id: "workspace:tinybot",
+      label: "tinybot",
+      mode: "root-webui",
+      activeSession: {
+        id: "session-1",
+        title: "Desktop shell planning",
+        meta: "2m ago",
+      },
+    });
+  });
+
+  test("builds root WebUI sidebar groups for actions, workspace sessions, and footer actions", () => {
+    const sessions: DesktopSidebarItem[] = [
+      {
+        id: "session:chat-1",
+        kind: "session",
+        label: "Plan shell",
+        meta: "4m",
+        active: true,
+      },
+    ];
+    const model = buildRootWebUiSidebarModel({
+      workspace: buildRootWebUiWorkspaceContext({ workspaceLabel: "tinybot" }),
+      sessions,
+    });
+
+    expect(model.mode).toBe("root-webui");
+    expect(model.groups.map((group) => group.id)).toEqual(["actions", "workspace", "footer"]);
+    expect(model.groups[0].items.map((item) => item.commandId ?? item.href)).toEqual([
+      "new-chat",
+      "search-sessions",
+      "open-command-palette",
+      "/tools",
+      "/cowork",
+    ]);
+    expect(model.groups[1]).toMatchObject({
+      id: "workspace",
+      label: "tinybot",
+      items: sessions,
+    });
+    expect(model.groups[2].items.map((item) => item.commandId)).toEqual([
+      "open-settings",
+      "refresh-gateway-status",
+      "open-docs",
+    ]);
+  });
+
+  test("builds compact runtime chips from root WebUI status values", () => {
+    expect(
+      buildRootWebUiRuntimeChips({
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        websocketConnected: true,
+        tokenUsage: "42%",
+      }),
+    ).toEqual([
+      { id: "provider", label: "Provider", value: "deepseek", tone: "ok" },
+      { id: "model", label: "Model", value: "deepseek-v4-flash", tone: "ok" },
+      { id: "websocket", label: "WebSocket", value: "Connected", tone: "ok" },
+      { id: "token-usage", label: "Token usage", value: "42%", tone: "ok" },
+    ]);
+  });
+
+  test("marks missing or disconnected runtime values without dropping chips", () => {
+    expect(buildRootWebUiRuntimeChips({ websocketConnected: false }).map((chip) => [chip.id, chip.value, chip.tone])).toEqual([
+      ["provider", "-", "muted"],
+      ["model", "-", "muted"],
+      ["websocket", "Disconnected", "warn"],
+      ["token-usage", "-", "muted"],
+    ]);
+  });
+
+  test("derives command entries from sidebar models for root WebUI and native reuse", () => {
+    const entries = buildDesktopCommandEntriesFromSidebar(buildRootWebUiSidebarModel());
+
+    expect(entries.map((entry) => entry.id)).toContain("sidebar:command:new-chat");
+    expect(entries.map((entry) => entry.id)).toContain("sidebar:link:tools");
+    expect(entries.find((entry) => entry.commandId === "open-command-palette")).toMatchObject({
+      title: "Command Palette",
+      group: "Actions",
+    });
+    expect(entries.find((entry) => entry.href === "/tools")?.keywords).toEqual(
+      expect.arrayContaining(["tools", "actions", "tinybot"]),
+    );
+  });
+});

--- a/apps/desktop/src/desktopSharedModels.ts
+++ b/apps/desktop/src/desktopSharedModels.ts
@@ -1,0 +1,247 @@
+import { DESKTOP_MENU_COMMANDS, type DesktopMenuCommandId } from "./desktopCommandNavigation";
+
+export type DesktopShellMode = "root-webui" | "native-workbench";
+
+export type DesktopSidebarGroupId = "actions" | "workspace" | "footer";
+
+export type DesktopSidebarItemKind = "command" | "link" | "session" | "status";
+
+export interface DesktopSidebarItem {
+  id: string;
+  kind: DesktopSidebarItemKind;
+  label: string;
+  commandId?: DesktopMenuCommandId;
+  href?: string;
+  icon?: string;
+  shortcut?: string;
+  meta?: string;
+  active?: boolean;
+  disabled?: boolean;
+}
+
+export interface DesktopSidebarGroup {
+  id: DesktopSidebarGroupId;
+  label?: string;
+  items: DesktopSidebarItem[];
+}
+
+export interface DesktopSidebarModel {
+  mode: DesktopShellMode;
+  workspace: DesktopWorkspaceContext;
+  groups: DesktopSidebarGroup[];
+}
+
+export interface DesktopCommandEntry {
+  id: string;
+  title: string;
+  group: string;
+  keywords: string[];
+  commandId?: DesktopMenuCommandId;
+  href?: string;
+}
+
+export type DesktopRuntimeChipTone = "ok" | "pending" | "warn" | "muted";
+
+export interface DesktopRuntimeChip {
+  id: string;
+  label: string;
+  value: string;
+  tone: DesktopRuntimeChipTone;
+}
+
+export interface DesktopWorkspaceContext {
+  id: string;
+  label: string;
+  mode: DesktopShellMode;
+  activeSession?: {
+    id: string;
+    title: string;
+    meta?: string;
+  };
+}
+
+export interface RootWebUiSidebarModelOptions {
+  workspace?: DesktopWorkspaceContext;
+  sessions?: DesktopSidebarItem[];
+}
+
+export interface RootWebUiWorkspaceContextOptions {
+  workspaceId?: string;
+  workspaceLabel?: string;
+  activeSession?: DesktopWorkspaceContext["activeSession"];
+}
+
+export interface RootWebUiRuntimeChipOptions {
+  provider?: string | null;
+  model?: string | null;
+  websocketConnected?: boolean | null;
+  tokenUsage?: string | null;
+}
+
+const ROOT_WEBUI_ACTION_COMMANDS: DesktopMenuCommandId[] = [
+  "new-chat",
+  "search-sessions",
+  "open-command-palette",
+];
+
+const ROOT_WEBUI_FOOTER_COMMANDS: DesktopMenuCommandId[] = [
+  "open-settings",
+  "refresh-gateway-status",
+  "open-docs",
+];
+
+const MENU_COMMANDS_BY_ID = new Map(DESKTOP_MENU_COMMANDS.map((command) => [command.id, command]));
+
+export function buildRootWebUiWorkspaceContext({
+  workspaceId = "root-webui",
+  workspaceLabel = "tinybot",
+  activeSession,
+}: RootWebUiWorkspaceContextOptions = {}): DesktopWorkspaceContext {
+  return {
+    id: workspaceId,
+    label: workspaceLabel,
+    mode: "root-webui",
+    activeSession,
+  };
+}
+
+export function buildRootWebUiSidebarModel({
+  workspace = buildRootWebUiWorkspaceContext(),
+  sessions = [],
+}: RootWebUiSidebarModelOptions = {}): DesktopSidebarModel {
+  return {
+    mode: "root-webui",
+    workspace,
+    groups: [
+      {
+        id: "actions",
+        items: [
+          ...sidebarItemsFromCommands(ROOT_WEBUI_ACTION_COMMANDS),
+          { id: "link:tools", kind: "link", label: "Tools", href: "/tools", icon: "tools" },
+          { id: "link:automations", kind: "link", label: "Automations", href: "/cowork", icon: "automation" },
+        ],
+      },
+      {
+        id: "workspace",
+        label: workspace.label,
+        items: sessions,
+      },
+      {
+        id: "footer",
+        items: sidebarItemsFromCommands(ROOT_WEBUI_FOOTER_COMMANDS),
+      },
+    ],
+  };
+}
+
+export function buildRootWebUiRuntimeChips({
+  provider,
+  model,
+  websocketConnected,
+  tokenUsage,
+}: RootWebUiRuntimeChipOptions = {}): DesktopRuntimeChip[] {
+  return [
+    {
+      id: "provider",
+      label: "Provider",
+      value: normalizeRuntimeValue(provider),
+      tone: provider ? "ok" : "muted",
+    },
+    {
+      id: "model",
+      label: "Model",
+      value: normalizeRuntimeValue(model),
+      tone: model ? "ok" : "muted",
+    },
+    {
+      id: "websocket",
+      label: "WebSocket",
+      value: websocketConnected === true ? "Connected" : websocketConnected === false ? "Disconnected" : "-",
+      tone: websocketConnected === true ? "ok" : websocketConnected === false ? "warn" : "muted",
+    },
+    {
+      id: "token-usage",
+      label: "Token usage",
+      value: normalizeRuntimeValue(tokenUsage),
+      tone: tokenUsage ? "ok" : "muted",
+    },
+  ];
+}
+
+export function buildDesktopCommandEntriesFromSidebar(model: DesktopSidebarModel): DesktopCommandEntry[] {
+  return model.groups.flatMap((group) =>
+    group.items.map((item) => ({
+      id: `sidebar:${item.id}`,
+      title: item.label,
+      group: group.label ?? sidebarGroupLabel(group.id),
+      keywords: commandKeywords(item, group, model.workspace),
+      commandId: item.commandId,
+      href: item.href,
+    })),
+  );
+}
+
+function sidebarItemsFromCommands(commandIds: DesktopMenuCommandId[]): DesktopSidebarItem[] {
+  return commandIds.map((commandId) => {
+    const command = MENU_COMMANDS_BY_ID.get(commandId);
+    return {
+      id: `command:${commandId}`,
+      kind: "command",
+      label: command?.label ?? commandId,
+      commandId,
+      icon: commandIcon(commandId),
+      shortcut: command?.shortcut,
+    };
+  });
+}
+
+function normalizeRuntimeValue(value: string | null | undefined): string {
+  const normalized = value?.trim();
+  return normalized || "-";
+}
+
+function commandIcon(commandId: DesktopMenuCommandId): string {
+  switch (commandId) {
+    case "new-chat":
+      return "new-chat";
+    case "search-sessions":
+      return "search";
+    case "open-command-palette":
+      return "command";
+    case "open-settings":
+      return "settings";
+    case "refresh-gateway-status":
+      return "gateway";
+    case "open-docs":
+      return "docs";
+    default:
+      return "command";
+  }
+}
+
+function sidebarGroupLabel(groupId: DesktopSidebarGroupId): string {
+  switch (groupId) {
+    case "actions":
+      return "Actions";
+    case "workspace":
+      return "Workspace";
+    case "footer":
+      return "System";
+  }
+}
+
+function commandKeywords(
+  item: DesktopSidebarItem,
+  group: DesktopSidebarGroup,
+  workspace: DesktopWorkspaceContext,
+): string[] {
+  return [
+    item.label,
+    item.id,
+    item.commandId ?? "",
+    item.href ?? "",
+    group.id,
+    group.label ?? "",
+    workspace.label,
+  ].filter(Boolean).map((value) => value.toLowerCase());
+}


### PR DESCRIPTION
## Summary

- Add shared desktop shell models for sidebar groups/items, command entries, runtime chips, and workspace context.
- Add root WebUI builders for default sidebar actions, footer actions, workspace context, and runtime chips.
- Add focused tests for the builders and reuse assumptions.

Closes #121.

## Validation

- `npm test -- desktopSharedModels.test.ts`
- `npm test`
- `npm run build`