### PR TITLE
Extract desktop shell layout module

### DIFF
--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -1,10 +1,12 @@
 import {
-  DESKTOP_WORKBENCH_LAYOUT_STORAGE_KEY,
   loadWorkbenchLayout,
   persistWorkbenchLayout,
   toggleWorkbenchPanel,
-  type WorkbenchLayoutState,
 } from "./desktopWorkbenchLayout";
+import {
+  applyRootWebUiShellLayout,
+  ensureDesktopRootWebUiShellLayoutStyle,
+} from "./desktopShellLayout";
 
 interface InstallDesktopRootWebUiWorkbenchOptions {
   targetDocument?: Document;
@@ -12,21 +14,24 @@ interface InstallDesktopRootWebUiWorkbenchOptions {
   viewportWidth?: number;
 }
 
-const STYLE_ID = "desktop-root-webui-workbench-style";
-
 export function installDesktopRootWebUiWorkbenchAdapter({
   targetDocument = document,
   storage = targetDocument.defaultView?.localStorage ?? null,
   viewportWidth = targetDocument.defaultView?.innerWidth ?? Number.POSITIVE_INFINITY,
 }: InstallDesktopRootWebUiWorkbenchOptions = {}): void {
-  ensureDesktopRootWebUiWorkbenchStyle(targetDocument);
+  ensureDesktopRootWebUiShellLayoutStyle(targetDocument);
   installRootWebUiCommandPaletteSurface(targetDocument);
   const layout = loadWorkbenchLayout({ storage, viewportWidth });
-  applyRootWebUiWorkbenchLayout(targetDocument, layout);
+  applyRootWebUiShellLayout(targetDocument, layout);
   installRootWebUiComposerRuntime(targetDocument);
   installRootWebUiPanelPersistence(targetDocument, storage, viewportWidth);
   installEmptyStateObserver(targetDocument);
 }
+
+export {
+  applyRootWebUiShellLayout as applyRootWebUiWorkbenchLayout,
+  ensureDesktopRootWebUiShellLayoutStyle as ensureDesktopRootWebUiWorkbenchStyle,
+} from "./desktopShellLayout";
 
 export function installRootWebUiComposerRuntime(targetDocument: Document): void {
   const composer = targetDocument.getElementById("composer-form");
@@ -138,48 +143,6 @@ export function installRootWebUiCommandPaletteSurface(targetDocument: Document):
   targetDocument.body.append(palette);
 }
 
-export function applyRootWebUiWorkbenchLayout(targetDocument: Document, layout: WorkbenchLayoutState): void {
-  const shell = targetDocument.body.querySelector<HTMLElement>(".shell");
-  if (!shell) {
-    return;
-  }
-  const inspectorVisible = layout.inspector.visible && isInspectorVisible(targetDocument);
-
-  targetDocument.body.classList.add("desktop-root-webui-workbench");
-  shell.setAttribute("data-desktop-workbench", "root-webui");
-  shell.setAttribute("data-desktop-layout-storage-key", DESKTOP_WORKBENCH_LAYOUT_STORAGE_KEY);
-  shell.setAttribute("data-sidebar-visible", String(layout.sidebar.visible));
-  shell.setAttribute("data-inspector-visible", String(inspectorVisible));
-  shell.setAttribute("data-bottom-visible", String(layout.bottom.visible));
-  shell.style.setProperty("--desktop-sidebar-size", `${layout.sidebar.size}px`);
-  shell.style.setProperty("--desktop-inspector-size", `${layout.inspector.size}px`);
-  shell.style.setProperty("--desktop-bottom-size", `${layout.bottom.size}px`);
-
-  const sidebar = targetDocument.body.querySelector<HTMLElement>(".sidebar");
-  const chatPanel = targetDocument.body.querySelector<HTMLElement>(".chat-panel");
-  const messageList = targetDocument.getElementById("message-list");
-  const inspector = targetDocument.getElementById("inspector-panel");
-  const composer = targetDocument.getElementById("composer-form");
-  const statusPanel = targetDocument.body.querySelector<HTMLElement>(".composer-status-panel");
-
-  sidebar?.setAttribute("data-workbench-region", "sidebar");
-  chatPanel?.setAttribute("data-workbench-region", "main");
-  messageList?.setAttribute("data-workbench-region", "conversation");
-  inspector?.setAttribute("data-workbench-region", "inspector");
-  composer?.setAttribute("data-workbench-region", "composer");
-  statusPanel?.setAttribute("data-workbench-region", "runtime-status");
-
-  if (!layout.sidebar.visible) {
-    shell.classList.add("sidebar-collapsed");
-    sidebar?.classList.add("collapsed");
-  }
-
-  if (!inspectorVisible) {
-    shell.classList.remove("inspection-mode");
-    inspector?.setAttribute("aria-hidden", "true");
-  }
-}
-
 export function upgradeDesktopRootWebUiEmptyState(emptyChat: HTMLElement, targetDocument: Document): boolean {
   if (emptyChat.getAttribute("data-desktop-empty-state") === "true") {
     return false;
@@ -213,366 +176,6 @@ export function upgradeDesktopRootWebUiEmptyState(emptyChat: HTMLElement, target
   return true;
 }
 
-export function ensureDesktopRootWebUiWorkbenchStyle(targetDocument: Document): void {
-  if (targetDocument.getElementById(STYLE_ID)) {
-    return;
-  }
-
-  const style = targetDocument.createElement("style");
-  style.id = STYLE_ID;
-  style.setAttribute("id", STYLE_ID);
-  style.textContent = `
-    body.desktop-root-webui-workbench > .shell {
-      grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) minmax(0, var(--desktop-inspector-size, 360px));
-      background: var(--panel, #faf9f5);
-      box-shadow: none;
-    }
-
-    body.desktop-root-webui-workbench > .shell[data-inspector-visible="false"]:not(.inspection-mode) {
-      grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) 0;
-    }
-
-    body.desktop-root-webui-workbench > .shell[data-sidebar-visible="false"],
-    body.desktop-root-webui-workbench > .shell.sidebar-collapsed {
-      grid-template-columns: 68px minmax(0, 1fr) 0;
-    }
-
-    body.desktop-root-webui-workbench .sidebar,
-    body.desktop-root-webui-workbench .chat-panel,
-    body.desktop-root-webui-workbench .inspector-panel {
-      border-radius: 0;
-      box-shadow: none;
-    }
-
-    body.desktop-root-webui-workbench > .shell .sidebar {
-      order: 0;
-      grid-column: 1;
-      grid-row: 1;
-    }
-
-    body.desktop-root-webui-workbench > .shell .chat-panel {
-      order: 0;
-      grid-column: 2;
-      grid-row: 1;
-    }
-
-    body.desktop-root-webui-workbench > .shell .inspector-panel {
-      order: 0;
-      grid-column: 3;
-      grid-row: 1;
-    }
-
-    body.desktop-root-webui-workbench .message-list {
-      min-width: 0;
-      scrollbar-gutter: stable;
-    }
-
-    body.desktop-root-webui-workbench .composer {
-      border-top: 1px solid var(--border, #e6dfd8);
-      background: color-mix(in srgb, var(--panel, #faf9f5) 92%, transparent);
-    }
-
-    body.desktop-root-webui-workbench .composer.desktop-composer-runtime {
-      display: grid;
-      gap: 8px;
-      padding: 14px 22px 12px;
-    }
-
-    body.desktop-root-webui-workbench .composer-row {
-      display: grid;
-      grid-template-columns: 42px minmax(0, 1fr) 54px;
-      gap: 10px;
-      align-items: stretch;
-      min-width: 0;
-    }
-
-    body.desktop-root-webui-workbench .composer-file,
-    body.desktop-root-webui-workbench .composer-send {
-      width: auto;
-      min-width: 0;
-      min-height: 42px;
-      border-radius: 6px;
-    }
-
-    body.desktop-root-webui-workbench .composer-input {
-      min-height: 42px;
-      max-height: 156px;
-      border-radius: 6px;
-    }
-
-    body.desktop-root-webui-workbench .composer-meta {
-      align-items: center;
-      min-width: 0;
-    }
-
-    body.desktop-root-webui-workbench .composer-meta-left {
-      display: flex;
-      flex: 1 1 auto;
-      flex-wrap: wrap;
-      gap: 6px 14px;
-      align-items: center;
-      min-width: 0;
-    }
-
-    body.desktop-root-webui-workbench .composer-status-panel {
-      flex: 0 1 auto;
-      min-width: 0;
-      margin: 0;
-      border: 0;
-      padding: 0;
-      background: transparent;
-      box-shadow: none;
-    }
-
-    body.desktop-root-webui-workbench .composer-status-panel .panel-header {
-      display: none;
-    }
-
-    body.desktop-root-webui-workbench .system-status {
-      display: flex !important;
-      flex-wrap: wrap;
-      grid-template-columns: none !important;
-      gap: 6px 10px;
-      align-items: center;
-      min-width: 0;
-    }
-
-    body.desktop-root-webui-workbench .composer-status-panel .system-status {
-      display: grid !important;
-      grid-auto-flow: column;
-      grid-auto-columns: max-content;
-      grid-template-columns: none !important;
-      justify-content: start;
-      overflow: visible;
-    }
-
-    body.desktop-root-webui-workbench .composer-status-panel .status-item {
-      display: inline-flex;
-      flex: 0 1 auto;
-      align-items: center;
-      gap: 5px;
-      min-width: 0;
-      min-height: 22px;
-      width: auto !important;
-      border: 0;
-      border-radius: 4px;
-      padding: 0;
-      background: transparent;
-      color: var(--text-muted, #6c6a64);
-      font-size: 11px;
-      line-height: 1.2;
-      cursor: default;
-    }
-
-    body.desktop-root-webui-workbench .composer-status-panel .usage-item {
-      grid-column: auto !important;
-    }
-
-    body.desktop-root-webui-workbench .composer-status-panel .status-label,
-    body.desktop-root-webui-workbench .composer-status-panel .status-value,
-    body.desktop-root-webui-workbench .composer-status-panel .usage-display {
-      width: auto;
-      min-width: 0;
-      white-space: nowrap;
-    }
-
-    body.desktop-root-webui-workbench .composer-status-panel .status-item:focus-visible {
-      outline: 2px solid var(--primary, #cc785c);
-      outline-offset: 2px;
-    }
-
-    body.desktop-root-webui-workbench .desktop-composer-feedback {
-      margin: 0;
-      color: var(--danger, #c64545);
-      font-size: 11px;
-      line-height: 1.35;
-    }
-
-    body.desktop-root-webui-workbench .desktop-composer-feedback[hidden] {
-      display: none;
-    }
-
-    body.desktop-root-webui-workbench .composer.is-desktop-drop-hover .composer-row {
-      outline: 2px solid var(--primary, #cc785c);
-      outline-offset: 3px;
-      border-radius: 8px;
-    }
-
-    body.desktop-root-webui-workbench .desktop-empty-modules {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(180px, 1fr));
-      gap: 8px;
-      width: min(760px, 100%);
-      margin: 12px auto 2px;
-      min-width: 0;
-    }
-
-    body.desktop-root-webui-workbench .desktop-empty-module {
-      display: grid;
-      gap: 5px;
-      min-width: 0;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
-      padding: 10px 12px;
-      background: color-mix(in srgb, var(--panel-strong, #efe9de) 72%, transparent);
-      text-align: left;
-    }
-
-    body.desktop-root-webui-workbench .desktop-empty-module strong,
-    body.desktop-root-webui-workbench .desktop-empty-module span {
-      min-width: 0;
-      overflow-wrap: anywhere;
-    }
-
-    body.desktop-root-webui-workbench .desktop-empty-module strong {
-      color: var(--text, #141413);
-      font-size: 12px;
-      line-height: 1.25;
-    }
-
-    body.desktop-root-webui-workbench .desktop-empty-module span {
-      color: var(--text-muted, #6c6a64);
-      font-size: 11px;
-      line-height: 1.35;
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette {
-      position: fixed;
-      top: calc(var(--desktop-window-frame-height, 34px) + 18px);
-      left: 50%;
-      z-index: 1500;
-      display: grid;
-      gap: 10px;
-      width: min(680px, calc(100vw - 48px));
-      max-height: min(620px, calc(100vh - var(--desktop-window-frame-height, 34px) - 44px));
-      min-width: 0;
-      overflow: hidden;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 8px;
-      padding: 12px;
-      background: var(--panel, #faf9f5);
-      box-shadow: 0 18px 48px rgba(20, 20, 19, 0.18);
-      transform: translateX(-50%);
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette[hidden] {
-      display: none;
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-header {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
-      gap: 8px;
-      min-width: 0;
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-input {
-      min-width: 0;
-      min-height: 36px;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
-      padding: 0 10px;
-      background: var(--panel, #faf9f5);
-      color: var(--text, #141413);
-      font: 13px/1.2 var(--font-sans, system-ui, sans-serif);
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-close {
-      min-height: 36px;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
-      padding: 0 10px;
-      background: var(--panel-strong, #efe9de);
-      color: var(--text, #141413);
-      font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-status {
-      margin: 0;
-      overflow: hidden;
-      color: var(--text-muted, #6c6a64);
-      font-size: 11px;
-      line-height: 1.35;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-results {
-      display: grid;
-      gap: 6px;
-      max-height: min(430px, 58vh);
-      min-width: 0;
-      overflow: auto;
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-result {
-      display: grid;
-      gap: 3px;
-      min-width: 0;
-      min-height: 42px;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
-      padding: 7px 9px;
-      background: var(--panel, #faf9f5);
-      color: var(--text, #141413);
-      text-align: left;
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-result[aria-selected="true"],
-    body.desktop-root-webui-workbench .desktop-command-palette-result:focus-visible,
-    body.desktop-root-webui-workbench .desktop-command-palette-input:focus-visible,
-    body.desktop-root-webui-workbench .desktop-command-palette-close:focus-visible {
-      outline: 2px solid var(--primary, #cc785c);
-      outline-offset: 2px;
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-result strong,
-    body.desktop-root-webui-workbench .desktop-command-palette-result span,
-    body.desktop-root-webui-workbench .desktop-command-palette-empty {
-      min-width: 0;
-      margin: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    body.desktop-root-webui-workbench .desktop-command-palette-result span,
-    body.desktop-root-webui-workbench .desktop-command-palette-empty {
-      color: var(--text-muted, #6c6a64);
-      font-size: 11px;
-      line-height: 1.35;
-    }
-
-    @media (max-width: 980px) {
-      body.desktop-root-webui-workbench > .shell,
-      body.desktop-root-webui-workbench > .shell.inspection-mode {
-        grid-template-columns: 68px minmax(0, 1fr) 0;
-        grid-template-rows: minmax(0, 1fr);
-        height: calc(100vh - var(--desktop-window-frame-height, 34px));
-        min-height: 0;
-      }
-
-      body.desktop-root-webui-workbench > .shell .sidebar {
-        max-height: none;
-      }
-
-      body.desktop-root-webui-workbench > .shell .chat-panel {
-        min-height: 0;
-        height: auto;
-      }
-
-      body.desktop-root-webui-workbench .inspector-panel {
-        display: none;
-      }
-
-      body.desktop-root-webui-workbench .desktop-empty-modules {
-        grid-template-columns: minmax(0, 1fr);
-      }
-    }
-  `;
-  targetDocument.head.append(style);
-}
-
 function installRootWebUiPanelPersistence(
   targetDocument: Document,
   storage: Pick<Storage, "getItem" | "setItem"> | null,
@@ -604,7 +207,7 @@ function queuePanelSync(
     const visible = panel === "sidebar" ? isSidebarVisible(targetDocument) : isInspectorVisible(targetDocument);
     const nextLayout = toggleWorkbenchPanel(layout, panel, visible);
     persistWorkbenchLayout(nextLayout, storage);
-    applyRootWebUiWorkbenchLayout(targetDocument, nextLayout);
+    applyRootWebUiShellLayout(targetDocument, nextLayout);
   };
   targetDocument.defaultView?.setTimeout(run, 0) ?? setTimeout(run, 0);
 }

--- a/apps/desktop/src/desktopShellLayout.test.ts
+++ b/apps/desktop/src/desktopShellLayout.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "vitest";
+import { applyRootWebUiShellLayout, ensureDesktopRootWebUiShellLayoutStyle } from "./desktopShellLayout";
+
+class FakeClassList {
+  constructor(private readonly element: FakeElement) {}
+
+  add(value: string): void {
+    const values = new Set(this.element.className.split(/\s+/).filter(Boolean));
+    values.add(value);
+    this.element.className = [...values].join(" ");
+  }
+
+  remove(value: string): void {
+    const values = new Set(this.element.className.split(/\s+/).filter(Boolean));
+    values.delete(value);
+    this.element.className = [...values].join(" ");
+  }
+
+  contains(value: string): boolean {
+    return this.element.className.split(/\s+/).includes(value);
+  }
+}
+
+class FakeElement {
+  public id = "";
+  public className = "";
+  public children: FakeElement[] = [];
+  public attributes = new Map<string, string>();
+  public classList = new FakeClassList(this);
+  public parent: FakeElement | null = null;
+  private ownTextContent = "";
+  public style = {
+    values: new Map<string, string>(),
+    setProperty: (name: string, value: string) => {
+      this.style.values.set(name, value);
+    },
+  };
+
+  constructor(public readonly tagName: string) {}
+
+  set textContent(value: string) {
+    this.ownTextContent = value;
+  }
+
+  get textContent(): string {
+    return `${this.ownTextContent}${this.children.map((child) => child.textContent).join("")}`;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+    if (name === "id") {
+      this.id = value;
+    }
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  append(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+    }
+    this.children.push(...children);
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    if (matchesSelector(this, selector)) {
+      return this;
+    }
+    for (const child of this.children) {
+      const match = child.querySelector(selector);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+}
+
+class FakeDocument {
+  public body = new FakeElement("body");
+  public head = new FakeElement("head");
+
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  }
+
+  getElementById(id: string): FakeElement | null {
+    return this.body.querySelector(`#${id}`) ?? this.head.querySelector(`#${id}`);
+  }
+}
+
+function matchesSelector(element: FakeElement, selector: string): boolean {
+  if (selector.includes(" ")) {
+    const parts = selector.split(/\s+/);
+    const last = parts[parts.length - 1];
+    if (!last || !matchesSelector(element, last)) {
+      return false;
+    }
+    let parent = element.parent;
+    for (let index = parts.length - 2; index >= 0; index -= 1) {
+      while (parent && !matchesSelector(parent, parts[index])) {
+        parent = parent.parent;
+      }
+      if (!parent) {
+        return false;
+      }
+      parent = parent.parent;
+    }
+    return true;
+  }
+  if (selector.startsWith("#")) {
+    return element.id === selector.slice(1) || element.getAttribute("id") === selector.slice(1);
+  }
+  if (selector.startsWith(".")) {
+    return element.className.split(/\s+/).includes(selector.slice(1));
+  }
+  return false;
+}
+
+function createRootWebUiDocument(): FakeDocument {
+  const document = new FakeDocument();
+  const shell = document.createElement("div");
+  shell.className = "shell inspection-mode";
+
+  const sidebar = document.createElement("aside");
+  sidebar.className = "sidebar";
+  const brand = document.createElement("div");
+  brand.className = "brand";
+  brand.textContent = "TinybotMINIMAL WEB UI";
+  sidebar.append(brand);
+
+  const chat = document.createElement("section");
+  chat.className = "chat-panel";
+  const messageList = document.createElement("section");
+  messageList.setAttribute("id", "message-list");
+  const composer = document.createElement("form");
+  composer.setAttribute("id", "composer-form");
+  const status = document.createElement("section");
+  status.className = "composer-status-panel";
+  composer.append(status);
+  chat.append(messageList, composer);
+
+  const inspector = document.createElement("aside");
+  inspector.setAttribute("id", "inspector-panel");
+
+  shell.append(sidebar, chat, inspector);
+  document.body.append(shell);
+  return document;
+}
+
+describe("desktop shell layout", () => {
+  test("adds stable desktop region hooks to the hosted root WebUI shell", () => {
+    const targetDocument = createRootWebUiDocument();
+
+    applyRootWebUiShellLayout(targetDocument as unknown as Document, {
+      sidebar: { visible: true, size: 260 },
+      inspector: { visible: true, size: 360 },
+      bottom: { visible: false, size: 220 },
+    });
+
+    expect(targetDocument.body.classList.contains("desktop-root-webui-workbench")).toBe(true);
+    expect(targetDocument.body.querySelector(".sidebar")?.getAttribute("data-workbench-region")).toBe("sidebar");
+    expect(targetDocument.body.querySelector(".sidebar")?.getAttribute("data-desktop-shell-region")).toBe("sidebar");
+    expect(targetDocument.body.querySelector(".chat-panel")?.getAttribute("data-workbench-region")).toBe("main");
+    expect(targetDocument.body.querySelector(".chat-panel")?.getAttribute("data-desktop-shell-region")).toBe("workspace");
+    expect(targetDocument.getElementById("message-list")?.getAttribute("data-desktop-shell-region")).toBe("message-list");
+    expect(targetDocument.getElementById("inspector-panel")?.getAttribute("data-desktop-shell-region")).toBe("inspector");
+    expect(targetDocument.getElementById("composer-form")?.getAttribute("data-desktop-shell-region")).toBe("composer");
+    expect(targetDocument.body.querySelector(".composer-status-panel")?.getAttribute("data-desktop-shell-region")).toBe("runtime-status");
+  });
+
+  test("scopes shell layout CSS and removes the repeated content brand affordance", () => {
+    const targetDocument = new FakeDocument();
+
+    ensureDesktopRootWebUiShellLayoutStyle(targetDocument as unknown as Document);
+
+    const styleText = targetDocument.head.querySelector("#desktop-root-webui-workbench-style")?.textContent ?? "";
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell");
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .sidebar");
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .chat-panel");
+    expect(styleText).toContain("body.desktop-root-webui-workbench [data-desktop-shell-region=\"workspace\"]");
+    expect(styleText).toContain("order: 0");
+    expect(styleText).toContain("grid-column: 1");
+    expect(styleText).toContain("grid-column: 2");
+    expect(styleText).toContain("body.desktop-root-webui-workbench .sidebar .brand");
+    expect(styleText).toContain("display: none");
+  });
+});

--- a/apps/desktop/src/desktopShellLayout.ts
+++ b/apps/desktop/src/desktopShellLayout.ts
@@ -1,0 +1,431 @@
+import {
+  DESKTOP_WORKBENCH_LAYOUT_STORAGE_KEY,
+  type WorkbenchLayoutState,
+} from "./desktopWorkbenchLayout";
+
+const STYLE_ID = "desktop-root-webui-workbench-style";
+
+export function applyRootWebUiShellLayout(targetDocument: Document, layout: WorkbenchLayoutState): void {
+  const shell = targetDocument.body.querySelector<HTMLElement>(".shell");
+  if (!shell) {
+    return;
+  }
+  const inspectorVisible = layout.inspector.visible && isRootWebUiInspectorVisible(targetDocument);
+
+  targetDocument.body.classList.add("desktop-root-webui-workbench");
+  shell.setAttribute("data-desktop-workbench", "root-webui");
+  shell.setAttribute("data-desktop-layout-storage-key", DESKTOP_WORKBENCH_LAYOUT_STORAGE_KEY);
+  shell.setAttribute("data-sidebar-visible", String(layout.sidebar.visible));
+  shell.setAttribute("data-inspector-visible", String(inspectorVisible));
+  shell.setAttribute("data-bottom-visible", String(layout.bottom.visible));
+  shell.style.setProperty("--desktop-sidebar-size", `${layout.sidebar.size}px`);
+  shell.style.setProperty("--desktop-inspector-size", `${layout.inspector.size}px`);
+  shell.style.setProperty("--desktop-bottom-size", `${layout.bottom.size}px`);
+
+  const sidebar = targetDocument.body.querySelector<HTMLElement>(".sidebar");
+  const chatPanel = targetDocument.body.querySelector<HTMLElement>(".chat-panel");
+  const messageList = targetDocument.getElementById("message-list");
+  const inspector = targetDocument.getElementById("inspector-panel");
+  const composer = targetDocument.getElementById("composer-form");
+  const statusPanel = targetDocument.body.querySelector<HTMLElement>(".composer-status-panel");
+
+  markShellRegion(sidebar, "sidebar", "sidebar");
+  markShellRegion(chatPanel, "main", "workspace");
+  markShellRegion(messageList, "conversation", "message-list");
+  markShellRegion(inspector, "inspector", "inspector");
+  markShellRegion(composer, "composer", "composer");
+  markShellRegion(statusPanel, "runtime-status", "runtime-status");
+
+  if (!layout.sidebar.visible) {
+    shell.classList.add("sidebar-collapsed");
+    sidebar?.classList.add("collapsed");
+  }
+
+  if (!inspectorVisible) {
+    shell.classList.remove("inspection-mode");
+    inspector?.setAttribute("aria-hidden", "true");
+  }
+}
+
+export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document): void {
+  if (targetDocument.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = targetDocument.createElement("style");
+  style.id = STYLE_ID;
+  style.setAttribute("id", STYLE_ID);
+  style.textContent = `
+    body.desktop-root-webui-workbench > .shell {
+      grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) minmax(0, var(--desktop-inspector-size, 360px));
+      background: var(--panel, #faf9f5);
+      box-shadow: none;
+    }
+
+    body.desktop-root-webui-workbench > .shell[data-inspector-visible="false"]:not(.inspection-mode) {
+      grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) 0;
+    }
+
+    body.desktop-root-webui-workbench > .shell[data-sidebar-visible="false"],
+    body.desktop-root-webui-workbench > .shell.sidebar-collapsed {
+      grid-template-columns: 68px minmax(0, 1fr) 0;
+    }
+
+    body.desktop-root-webui-workbench .sidebar,
+    body.desktop-root-webui-workbench .chat-panel,
+    body.desktop-root-webui-workbench .inspector-panel {
+      border-radius: 0;
+      box-shadow: none;
+    }
+
+    body.desktop-root-webui-workbench .sidebar .brand,
+    body.desktop-root-webui-workbench .sidebar .sidebar-brand,
+    body.desktop-root-webui-workbench .sidebar [data-desktop-content-branding] {
+      display: none;
+    }
+
+    body.desktop-root-webui-workbench > .shell .sidebar {
+      order: 0;
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    body.desktop-root-webui-workbench > .shell .chat-panel,
+    body.desktop-root-webui-workbench [data-desktop-shell-region="workspace"] {
+      order: 0;
+      grid-column: 2;
+      grid-row: 1;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench > .shell .inspector-panel {
+      order: 0;
+      grid-column: 3;
+      grid-row: 1;
+    }
+
+    body.desktop-root-webui-workbench .message-list {
+      min-width: 0;
+      scrollbar-gutter: stable;
+    }
+
+    body.desktop-root-webui-workbench .composer {
+      border-top: 1px solid var(--border, #e6dfd8);
+      background: color-mix(in srgb, var(--panel, #faf9f5) 92%, transparent);
+    }
+
+    body.desktop-root-webui-workbench .composer.desktop-composer-runtime {
+      display: grid;
+      gap: 8px;
+      padding: 14px 22px 12px;
+    }
+
+    body.desktop-root-webui-workbench .composer-row {
+      display: grid;
+      grid-template-columns: 42px minmax(0, 1fr) 54px;
+      gap: 10px;
+      align-items: stretch;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-file,
+    body.desktop-root-webui-workbench .composer-send {
+      width: auto;
+      min-width: 0;
+      min-height: 42px;
+      border-radius: 6px;
+    }
+
+    body.desktop-root-webui-workbench .composer-input {
+      min-height: 42px;
+      max-height: 156px;
+      border-radius: 6px;
+    }
+
+    body.desktop-root-webui-workbench .composer-meta {
+      align-items: center;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-meta-left {
+      display: flex;
+      flex: 1 1 auto;
+      flex-wrap: wrap;
+      gap: 6px 14px;
+      align-items: center;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel {
+      flex: 0 1 auto;
+      min-width: 0;
+      margin: 0;
+      border: 0;
+      padding: 0;
+      background: transparent;
+      box-shadow: none;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .panel-header {
+      display: none;
+    }
+
+    body.desktop-root-webui-workbench .system-status {
+      display: flex !important;
+      flex-wrap: wrap;
+      grid-template-columns: none !important;
+      gap: 6px 10px;
+      align-items: center;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .system-status {
+      display: grid !important;
+      grid-auto-flow: column;
+      grid-auto-columns: max-content;
+      grid-template-columns: none !important;
+      justify-content: start;
+      overflow: visible;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .status-item {
+      display: inline-flex;
+      flex: 0 1 auto;
+      align-items: center;
+      gap: 5px;
+      min-width: 0;
+      min-height: 22px;
+      width: auto !important;
+      border: 0;
+      border-radius: 4px;
+      padding: 0;
+      background: transparent;
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.2;
+      cursor: default;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .usage-item {
+      grid-column: auto !important;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .status-label,
+    body.desktop-root-webui-workbench .composer-status-panel .status-value,
+    body.desktop-root-webui-workbench .composer-status-panel .usage-display {
+      width: auto;
+      min-width: 0;
+      white-space: nowrap;
+    }
+
+    body.desktop-root-webui-workbench .composer-status-panel .status-item:focus-visible {
+      outline: 2px solid var(--primary, #cc785c);
+      outline-offset: 2px;
+    }
+
+    body.desktop-root-webui-workbench .desktop-composer-feedback {
+      margin: 0;
+      color: var(--danger, #c64545);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+
+    body.desktop-root-webui-workbench .desktop-composer-feedback[hidden] {
+      display: none;
+    }
+
+    body.desktop-root-webui-workbench .composer.is-desktop-drop-hover .composer-row {
+      outline: 2px solid var(--primary, #cc785c);
+      outline-offset: 3px;
+      border-radius: 8px;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-modules {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(180px, 1fr));
+      gap: 8px;
+      width: min(760px, 100%);
+      margin: 12px auto 2px;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-module {
+      display: grid;
+      gap: 5px;
+      min-width: 0;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 10px 12px;
+      background: color-mix(in srgb, var(--panel-strong, #efe9de) 72%, transparent);
+      text-align: left;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-module strong,
+    body.desktop-root-webui-workbench .desktop-empty-module span {
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-module strong {
+      color: var(--text, #141413);
+      font-size: 12px;
+      line-height: 1.25;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-module span {
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette {
+      position: fixed;
+      top: calc(var(--desktop-window-frame-height, 34px) + 18px);
+      left: 50%;
+      z-index: 1500;
+      display: grid;
+      gap: 10px;
+      width: min(680px, calc(100vw - 48px));
+      max-height: min(620px, calc(100vh - var(--desktop-window-frame-height, 34px) - 44px));
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 8px;
+      padding: 12px;
+      background: var(--panel, #faf9f5);
+      box-shadow: 0 18px 48px rgba(20, 20, 19, 0.18);
+      transform: translateX(-50%);
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette[hidden] {
+      display: none;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-input {
+      min-width: 0;
+      min-height: 36px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 0 10px;
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
+      font: 13px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-close {
+      min-height: 36px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 0 10px;
+      background: var(--panel-strong, #efe9de);
+      color: var(--text, #141413);
+      font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-status {
+      margin: 0;
+      overflow: hidden;
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.35;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-results {
+      display: grid;
+      gap: 6px;
+      max-height: min(430px, 58vh);
+      min-width: 0;
+      overflow: auto;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-result {
+      display: grid;
+      gap: 3px;
+      min-width: 0;
+      min-height: 42px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 7px 9px;
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
+      text-align: left;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-result[aria-selected="true"],
+    body.desktop-root-webui-workbench .desktop-command-palette-result:focus-visible,
+    body.desktop-root-webui-workbench .desktop-command-palette-input:focus-visible,
+    body.desktop-root-webui-workbench .desktop-command-palette-close:focus-visible {
+      outline: 2px solid var(--primary, #cc785c);
+      outline-offset: 2px;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-result strong,
+    body.desktop-root-webui-workbench .desktop-command-palette-result span,
+    body.desktop-root-webui-workbench .desktop-command-palette-empty {
+      min-width: 0;
+      margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-root-webui-workbench .desktop-command-palette-result span,
+    body.desktop-root-webui-workbench .desktop-command-palette-empty {
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+
+    @media (max-width: 980px) {
+      body.desktop-root-webui-workbench > .shell,
+      body.desktop-root-webui-workbench > .shell.inspection-mode {
+        grid-template-columns: 68px minmax(0, 1fr) 0;
+        grid-template-rows: minmax(0, 1fr);
+        height: calc(100vh - var(--desktop-window-frame-height, 34px));
+        min-height: 0;
+      }
+
+      body.desktop-root-webui-workbench > .shell .sidebar {
+        max-height: none;
+      }
+
+      body.desktop-root-webui-workbench > .shell .chat-panel {
+        min-height: 0;
+        height: auto;
+      }
+
+      body.desktop-root-webui-workbench .inspector-panel {
+        display: none;
+      }
+
+      body.desktop-root-webui-workbench .desktop-empty-modules {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+  `;
+  targetDocument.head.append(style);
+}
+
+function markShellRegion(
+  element: HTMLElement | null,
+  workbenchRegion: string,
+  desktopShellRegion: string,
+): void {
+  element?.setAttribute("data-workbench-region", workbenchRegion);
+  element?.setAttribute("data-desktop-shell-region", desktopShellRegion);
+}
+
+function isRootWebUiInspectorVisible(targetDocument: Document): boolean {
+  const shell = targetDocument.body.querySelector(".shell");
+  const inspector = targetDocument.getElementById("inspector-panel");
+  return shell?.classList.contains("inspection-mode") === true && inspector?.getAttribute("aria-hidden") !== "true";
+}


### PR DESCRIPTION
## Summary

- Move root WebUI shell layout application and scoped layout styles into a dedicated desktop layout module.
- Add explicit desktop shell region attributes for sidebar, workspace, message list, inspector, composer, and runtime status while preserving existing workbench region attributes.
- Add focused layout tests for shell hooks, scoped selectors, and hidden repeated content branding.

Closes #123.

## Validation

- `npm test -- desktopShellLayout.test.ts`
- `npm test -- desktopRootWebUiWorkbench.test.ts`
- `npm test -- desktopShellLayout.test.ts desktopRootWebUiWorkbench.test.ts`
- `npm test`
- `npm run build`