### PR TITLE
Add desktop app sidebar renderer

### DIFF
--- a/apps/desktop/src/desktopAppSidebar.test.ts
+++ b/apps/desktop/src/desktopAppSidebar.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "vitest";
+import { renderDesktopAppSidebar } from "./desktopAppSidebar";
+import {
+  buildRootWebUiSidebarModel,
+  buildRootWebUiWorkspaceContext,
+  type DesktopSidebarItem,
+} from "./desktopSharedModels";
+
+class FakeClassList {
+  constructor(private readonly element: FakeElement) {}
+
+  add(value: string): void {
+    const values = new Set(this.element.className.split(/\s+/).filter(Boolean));
+    values.add(value);
+    this.element.className = [...values].join(" ");
+  }
+
+  remove(value: string): void {
+    const values = new Set(this.element.className.split(/\s+/).filter(Boolean));
+    values.delete(value);
+    this.element.className = [...values].join(" ");
+  }
+
+  contains(value: string): boolean {
+    return this.element.className.split(/\s+/).includes(value);
+  }
+}
+
+class FakeElement {
+  public id = "";
+  public className = "";
+  public children: FakeElement[] = [];
+  public attributes = new Map<string, string>();
+  public classList = new FakeClassList(this);
+  public parent: FakeElement | null = null;
+  private ownTextContent = "";
+
+  constructor(public readonly tagName: string) {}
+
+  set textContent(value: string) {
+    this.ownTextContent = value;
+  }
+
+  get textContent(): string {
+    return `${this.ownTextContent}${this.children.map((child) => child.textContent).join("")}`;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+    if (name === "id") {
+      this.id = value;
+    }
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  append(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+    }
+    this.children.push(...children);
+  }
+
+  replaceChildren(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+    }
+    this.children = [...children];
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    if (matchesSelector(this, selector)) {
+      return this;
+    }
+    for (const child of this.children) {
+      const match = child.querySelector(selector);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const matches: FakeElement[] = matchesSelector(this, selector) ? [this] : [];
+    for (const child of this.children) {
+      matches.push(...child.querySelectorAll(selector));
+    }
+    return matches;
+  }
+}
+
+class FakeDocument {
+  public body = new FakeElement("body");
+
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  }
+}
+
+function matchesSelector(element: FakeElement, selector: string): boolean {
+  const attributeMatch = selector.match(/^\[([^=\]]+)="([^"]+)"\]$/);
+  if (attributeMatch) {
+    return element.getAttribute(attributeMatch[1]) === attributeMatch[2];
+  }
+  if (selector.startsWith(".")) {
+    return element.className.split(/\s+/).includes(selector.slice(1));
+  }
+  return false;
+}
+
+function sidebarItems(): DesktopSidebarItem[] {
+  return [
+    {
+      id: "session:active",
+      kind: "session",
+      label: "Desktop shell planning",
+      meta: "2 min",
+      active: true,
+    },
+    {
+      id: "session:older",
+      kind: "session",
+      label: "Gateway follow-up",
+      meta: "1 day",
+    },
+  ];
+}
+
+describe("desktop app sidebar", () => {
+  test("renders action, workspace, and footer groups from the shared sidebar model", () => {
+    const targetDocument = new FakeDocument();
+    const host = targetDocument.createElement("aside");
+    host.className = "sidebar";
+    const model = buildRootWebUiSidebarModel({
+      workspace: buildRootWebUiWorkspaceContext({
+        workspaceLabel: "tinybot",
+        activeSession: { id: "active", title: "Desktop shell planning", meta: "2 min" },
+      }),
+      sessions: sidebarItems(),
+    });
+
+    renderDesktopAppSidebar(host as unknown as HTMLElement, model, targetDocument as unknown as Document);
+
+    expect(host.getAttribute("data-desktop-app-sidebar")).toBe("true");
+    expect(host.classList.contains("desktop-app-sidebar")).toBe(true);
+    expect(host.classList.contains("desktop-app-sidebar-card")).toBe(false);
+    expect(host.querySelectorAll(".desktop-app-sidebar-group").map((node) => node.getAttribute("data-sidebar-group"))).toEqual([
+      "actions",
+      "workspace",
+      "footer",
+    ]);
+    expect(host.querySelector('[data-sidebar-group="workspace"]')?.textContent).toContain("tinybot");
+    expect(host.querySelectorAll(".desktop-app-sidebar-item").map((node) => node.getAttribute("data-sidebar-item-kind"))).toContain("command");
+    expect(host.querySelectorAll(".desktop-app-sidebar-item").map((node) => node.getAttribute("data-sidebar-item-kind"))).toContain("link");
+    expect(host.querySelectorAll(".desktop-app-sidebar-item").map((node) => node.getAttribute("data-sidebar-item-kind"))).toContain("session");
+  });
+
+  test("keeps command, link, and selected session metadata on sidebar items", () => {
+    const targetDocument = new FakeDocument();
+    const host = targetDocument.createElement("aside");
+    const model = buildRootWebUiSidebarModel({ sessions: sidebarItems() });
+
+    renderDesktopAppSidebar(host as unknown as HTMLElement, model, targetDocument as unknown as Document);
+
+    const newChat = host.querySelector('[data-sidebar-command="new-chat"]');
+    const tools = host.querySelector('[data-sidebar-href="/tools"]');
+    const activeSession = host.querySelector('[data-sidebar-item-id="session:active"]');
+
+    expect(newChat?.getAttribute("type")).toBe("button");
+    expect(newChat?.getAttribute("data-sidebar-item-kind")).toBe("command");
+    expect(newChat?.textContent).toContain("New");
+    expect(tools?.getAttribute("href")).toBe("/tools");
+    expect(tools?.getAttribute("data-sidebar-item-kind")).toBe("link");
+    expect(activeSession?.getAttribute("aria-current")).toBe("page");
+    expect(activeSession?.getAttribute("data-active")).toBe("true");
+    expect(activeSession?.textContent).toContain("Desktop shell planning");
+    expect(activeSession?.textContent).toContain("2 min");
+  });
+});

--- a/apps/desktop/src/desktopAppSidebar.ts
+++ b/apps/desktop/src/desktopAppSidebar.ts
@@ -1,0 +1,107 @@
+import type {
+  DesktopSidebarGroup,
+  DesktopSidebarItem,
+  DesktopSidebarModel,
+} from "./desktopSharedModels";
+
+export function renderDesktopAppSidebar(
+  host: HTMLElement,
+  model: DesktopSidebarModel,
+  targetDocument: Document = document,
+): void {
+  host.classList.add("desktop-app-sidebar");
+  host.classList.remove("desktop-app-sidebar-card");
+  host.setAttribute("data-desktop-app-sidebar", "true");
+  host.setAttribute("data-desktop-sidebar-mode", model.mode);
+  host.setAttribute("aria-label", "Desktop navigation");
+
+  const content = targetDocument.createElement("nav");
+  content.className = "desktop-app-sidebar-content";
+  content.setAttribute("aria-label", "Desktop sidebar");
+
+  for (const group of model.groups) {
+    content.append(createGroup(targetDocument, group));
+  }
+
+  host.replaceChildren(content);
+}
+
+function createGroup(targetDocument: Document, group: DesktopSidebarGroup): HTMLElement {
+  const section = targetDocument.createElement("section");
+  section.className = "desktop-app-sidebar-group";
+  section.setAttribute("data-sidebar-group", group.id);
+
+  const label = targetDocument.createElement("p");
+  label.className = "desktop-app-sidebar-group-label";
+  label.textContent = group.label ?? defaultGroupLabel(group.id);
+  section.append(label);
+
+  const list = targetDocument.createElement("div");
+  list.className = "desktop-app-sidebar-list";
+  list.setAttribute("role", "list");
+  for (const item of group.items) {
+    const row = createSidebarItem(targetDocument, item);
+    list.append(row);
+  }
+  section.append(list);
+
+  return section;
+}
+
+function createSidebarItem(targetDocument: Document, item: DesktopSidebarItem): HTMLElement {
+  const element = item.kind === "link" ? targetDocument.createElement("a") : targetDocument.createElement("button");
+  element.className = "desktop-app-sidebar-item";
+  element.setAttribute("data-sidebar-item-id", item.id);
+  element.setAttribute("data-sidebar-item-kind", item.kind);
+  element.setAttribute("role", "listitem");
+
+  if (item.kind === "link" && item.href) {
+    element.setAttribute("href", item.href);
+    element.setAttribute("data-sidebar-href", item.href);
+  } else {
+    element.setAttribute("type", "button");
+  }
+
+  if (item.commandId) {
+    element.setAttribute("data-sidebar-command", item.commandId);
+  }
+  if (item.active) {
+    element.setAttribute("data-active", "true");
+    element.setAttribute("aria-current", "page");
+  }
+  if (item.disabled) {
+    element.setAttribute("aria-disabled", "true");
+  }
+  if (item.icon) {
+    element.setAttribute("data-sidebar-icon", item.icon);
+  }
+  if (item.shortcut) {
+    element.setAttribute("data-sidebar-shortcut", item.shortcut);
+  }
+
+  const label = targetDocument.createElement("span");
+  label.className = "desktop-app-sidebar-item-label";
+  label.textContent = item.label;
+  element.append(label);
+
+  const detail = item.meta ?? item.shortcut;
+  if (detail) {
+    const meta = targetDocument.createElement("span");
+    meta.className = "desktop-app-sidebar-item-meta";
+    meta.textContent = detail;
+    element.append(meta);
+  }
+
+  return element;
+}
+
+function defaultGroupLabel(groupId: DesktopSidebarGroup["id"]): string {
+  switch (groupId) {
+    case "actions":
+      return "Actions";
+    case "workspace":
+      return "Workspace";
+    case "footer":
+      return "System";
+  }
+}

--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  installDesktopRootWebUiWorkbenchAdapter,
   applyRootWebUiWorkbenchLayout,
   ensureDesktopRootWebUiWorkbenchStyle,
   installRootWebUiComposerRuntime,
@@ -73,6 +74,13 @@ class FakeElement {
     this.children.push(...children);
   }
 
+  replaceChildren(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+    }
+    this.children = [...children];
+  }
+
   insertBefore(node: FakeElement, child: FakeElement | null): void {
     node.parent = this;
     if (!child) {
@@ -143,6 +151,13 @@ class FakeDocument {
 }
 
 function matchesSelector(element: FakeElement, selector: string): boolean {
+  if (selector.includes(",")) {
+    return selector.split(",").some((part) => matchesSelector(element, part.trim()));
+  }
+  const attribute = selector.match(/^\[([^=\]]+)=['"]([^'"]+)['"]\]$/);
+  if (attribute) {
+    return element.getAttribute(attribute[1]) === attribute[2];
+  }
   if (selector.includes(" ")) {
     const parts = selector.split(/\s+/);
     const last = parts[parts.length - 1];
@@ -284,6 +299,39 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(targetDocument.getElementById("desktop-command-palette")?.getAttribute("role")).toBe("dialog");
     expect(targetDocument.getElementById("desktop-command-palette-input")?.getAttribute("aria-label")).toBe("Search commands and workbench data");
     expect(targetDocument.getElementById("desktop-command-palette-results")?.getAttribute("aria-live")).toBe("polite");
+  });
+
+  test("installs the desktop app sidebar into the hosted root WebUI sidebar", () => {
+    const targetDocument = createRootWebUiDocument();
+    const session = targetDocument.createElement("button");
+    session.className = "session-item active";
+    session.setAttribute("data-session-id", "chat-1");
+    session.setAttribute("aria-current", "page");
+    const sessionTitle = targetDocument.createElement("span");
+    sessionTitle.className = "session-title";
+    sessionTitle.textContent = "Desktop shell planning";
+    const sessionMeta = targetDocument.createElement("span");
+    sessionMeta.className = "session-meta";
+    sessionMeta.textContent = "2 min";
+    session.append(sessionTitle, sessionMeta);
+    targetDocument.body.querySelector(".sidebar")?.append(session);
+
+    installDesktopRootWebUiWorkbenchAdapter({
+      targetDocument: targetDocument as unknown as Document,
+      storage: null,
+    });
+
+    const sidebar = targetDocument.body.querySelector(".sidebar");
+    expect(sidebar?.getAttribute("data-desktop-app-sidebar")).toBe("true");
+    expect(sidebar?.classList.contains("desktop-app-sidebar")).toBe(true);
+    expect(sidebar?.querySelectorAll(".desktop-app-sidebar-group").map((node) => node.getAttribute("data-sidebar-group"))).toEqual([
+      "actions",
+      "workspace",
+      "footer",
+    ]);
+    expect(sidebar?.querySelector('[data-sidebar-command="new-chat"]')?.textContent).toContain("New");
+    expect(sidebar?.querySelector('[data-sidebar-href="/tools"]')?.getAttribute("href")).toBe("/tools");
+    expect(sidebar?.querySelector('[data-sidebar-item-id="session:chat-1"]')?.getAttribute("aria-current")).toBe("page");
   });
 
   test("upgrades the hosted WebUI composer with runtime chips and blocked-send feedback", () => {

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -3,10 +3,16 @@ import {
   persistWorkbenchLayout,
   toggleWorkbenchPanel,
 } from "./desktopWorkbenchLayout";
+import { renderDesktopAppSidebar } from "./desktopAppSidebar";
 import {
   applyRootWebUiShellLayout,
   ensureDesktopRootWebUiShellLayoutStyle,
 } from "./desktopShellLayout";
+import {
+  buildRootWebUiSidebarModel,
+  buildRootWebUiWorkspaceContext,
+  type DesktopSidebarItem,
+} from "./desktopSharedModels";
 
 interface InstallDesktopRootWebUiWorkbenchOptions {
   targetDocument?: Document;
@@ -23,6 +29,7 @@ export function installDesktopRootWebUiWorkbenchAdapter({
   installRootWebUiCommandPaletteSurface(targetDocument);
   const layout = loadWorkbenchLayout({ storage, viewportWidth });
   applyRootWebUiShellLayout(targetDocument, layout);
+  installRootWebUiDesktopAppSidebar(targetDocument);
   installRootWebUiComposerRuntime(targetDocument);
   installRootWebUiPanelPersistence(targetDocument, storage, viewportWidth);
   installEmptyStateObserver(targetDocument);
@@ -143,6 +150,26 @@ export function installRootWebUiCommandPaletteSurface(targetDocument: Document):
   targetDocument.body.append(palette);
 }
 
+export function installRootWebUiDesktopAppSidebar(targetDocument: Document): void {
+  const sidebar = targetDocument.body.querySelector<HTMLElement>(".sidebar");
+  if (!sidebar) {
+    return;
+  }
+
+  const workspace = buildRootWebUiWorkspaceContext({
+    workspaceLabel: "tinybot",
+    activeSession: rootWebUiActiveSession(targetDocument),
+  });
+  renderDesktopAppSidebar(
+    sidebar,
+    buildRootWebUiSidebarModel({
+      workspace,
+      sessions: rootWebUiSessionItems(targetDocument),
+    }),
+    targetDocument,
+  );
+}
+
 export function upgradeDesktopRootWebUiEmptyState(emptyChat: HTMLElement, targetDocument: Document): boolean {
   if (emptyChat.getAttribute("data-desktop-empty-state") === "true") {
     return false;
@@ -220,6 +247,56 @@ function isInspectorVisible(targetDocument: Document): boolean {
   const shell = targetDocument.body.querySelector(".shell");
   const inspector = targetDocument.getElementById("inspector-panel");
   return shell?.classList.contains("inspection-mode") === true && inspector?.getAttribute("aria-hidden") !== "true";
+}
+
+function rootWebUiActiveSession(targetDocument: Document): { id: string; title: string; meta?: string } | undefined {
+  const active = targetDocument.body.querySelector<HTMLElement>(
+    ".session-item.active, .session-item[aria-current='page'], .session-row.active, .session-row[aria-current='page']",
+  );
+  if (!active) {
+    return undefined;
+  }
+  const item = sessionItemFromElement(active);
+  return {
+    id: item.id,
+    title: item.label,
+    meta: item.meta,
+  };
+}
+
+function rootWebUiSessionItems(targetDocument: Document): DesktopSidebarItem[] {
+  return [
+    ...targetDocument.body.querySelectorAll<HTMLElement>(
+      ".session-item, .session-row, [data-session-id], [data-chat-id]",
+    ),
+  ].map(sessionItemFromElement);
+}
+
+function sessionItemFromElement(element: HTMLElement): DesktopSidebarItem {
+  const sessionId =
+    element.getAttribute("data-session-id") ??
+    element.getAttribute("data-chat-id") ??
+    element.querySelector<HTMLElement>("[data-session-id]")?.getAttribute("data-session-id") ??
+    element.querySelector<HTMLElement>("[data-chat-id]")?.getAttribute("data-chat-id") ??
+    element.textContent?.trim().toLowerCase().replace(/\s+/g, "-") ??
+    "session";
+  const title =
+    element.querySelector<HTMLElement>(".session-title, .session-name, [data-session-title]")?.textContent?.trim() ??
+    element.getAttribute("data-session-title") ??
+    element.textContent?.trim() ??
+    "Untitled session";
+  const meta =
+    element.querySelector<HTMLElement>(".session-meta, .session-time, [data-session-meta]")?.textContent?.trim() ??
+    element.getAttribute("data-session-meta") ??
+    undefined;
+
+  return {
+    id: `session:${sessionId}`,
+    kind: "session",
+    label: title,
+    meta,
+    active: element.classList.contains("active") || element.getAttribute("aria-current") === "page",
+  };
 }
 
 function installEmptyStateObserver(targetDocument: Document): void {

--- a/apps/desktop/src/desktopShellLayout.test.ts
+++ b/apps/desktop/src/desktopShellLayout.test.ts
@@ -186,5 +186,7 @@ describe("desktop shell layout", () => {
     expect(styleText).toContain("grid-column: 2");
     expect(styleText).toContain("body.desktop-root-webui-workbench .sidebar .brand");
     expect(styleText).toContain("display: none");
+    expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-app-sidebar");
+    expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-app-sidebar-group");
   });
 });

--- a/apps/desktop/src/desktopShellLayout.ts
+++ b/apps/desktop/src/desktopShellLayout.ts
@@ -84,6 +84,96 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
       display: none;
     }
 
+    body.desktop-root-webui-workbench .desktop-app-sidebar {
+      display: flex;
+      min-width: 0;
+      min-height: 0;
+      overflow: hidden;
+      border-right: 1px solid var(--border, #e6dfd8);
+      border-radius: 0;
+      background: var(--panel-strong, #efe9de);
+      box-shadow: none;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-content {
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr) auto;
+      gap: 12px;
+      width: 100%;
+      min-width: 0;
+      min-height: 0;
+      padding: 12px 10px;
+      overflow: hidden;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-group {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+      min-height: 0;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-group[data-sidebar-group="workspace"] {
+      overflow: hidden;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-group-label {
+      margin: 0;
+      overflow: hidden;
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.25;
+      text-overflow: ellipsis;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-list {
+      display: grid;
+      gap: 4px;
+      min-width: 0;
+      overflow: auto;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-item {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      min-height: 32px;
+      border: 1px solid transparent;
+      border-radius: 6px;
+      padding: 6px 8px;
+      background: transparent;
+      color: var(--text, #141413);
+      font: 500 12px/1.2 var(--font-sans, system-ui, sans-serif);
+      text-align: left;
+      text-decoration: none;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-item[data-active="true"],
+    body.desktop-root-webui-workbench .desktop-app-sidebar-item:hover,
+    body.desktop-root-webui-workbench .desktop-app-sidebar-item:focus-visible {
+      border-color: var(--border, #e6dfd8);
+      background: var(--panel, #faf9f5);
+      outline: none;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-item-label,
+    body.desktop-root-webui-workbench .desktop-app-sidebar-item-meta {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-root-webui-workbench .desktop-app-sidebar-item-meta {
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      font-weight: 500;
+    }
+
     body.desktop-root-webui-workbench > .shell .sidebar {
       order: 0;
       grid-column: 1;


### PR DESCRIPTION
## Summary

- Add a reusable desktop app sidebar renderer for action, workspace/session, and footer groups.
- Install the renderer in the root WebUI desktop adapter using the existing sidebar host.
- Add scoped sidebar styles and focused tests for structure, selected state, and item metadata.

Closes #125.

## Validation

- `npm test -- desktopAppSidebar.test.ts`
- `npm test -- desktopRootWebUiWorkbench.test.ts`
- `npm test -- desktopShellLayout.test.ts`
- `npm test`
- `npm run build`