### PR TITLE
Clean up desktop window chrome actions

### DIFF
--- a/apps/desktop/src/desktopCommandNavigation.test.ts
+++ b/apps/desktop/src/desktopCommandNavigation.test.ts
@@ -117,16 +117,18 @@ describe("desktop command navigation", () => {
       "Ctrl+Shift+G",
     ]);
     expect(DESKTOP_CHROME_COMMANDS.map((command) => command.id)).toEqual([
-      "new-chat",
-      "stop-generation",
-      "search-sessions",
-      "open-command-palette",
+      "open-settings",
+      "open-docs",
+      "open-shortcut-help",
+      "open-page-help",
+      "toggle-theme",
     ]);
     expect(DESKTOP_CHROME_COMMANDS.map((command) => command.chromeLabel)).toEqual([
-      "New",
-      "Stop",
-      "Search",
-      "Command",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
     ]);
     expect(DESKTOP_MENU_COMMANDS.filter((command) => command.chromeGroup === "secondary").map((command) => command.id)).toEqual([
       "open-settings",

--- a/apps/desktop/src/desktopCommandNavigation.ts
+++ b/apps/desktop/src/desktopCommandNavigation.ts
@@ -62,9 +62,17 @@ export const DESKTOP_MENU_COMMANDS: DesktopMenuCommand[] = [
   { id: "refresh-gateway-status", label: "Gateway Status", chromeGroup: "secondary", shortcut: "Ctrl+Shift+G" },
 ];
 
-export const DESKTOP_CHROME_COMMANDS: DesktopMenuCommand[] = DESKTOP_MENU_COMMANDS.filter(
-  (command) => command.chromeGroup === "primary",
-);
+const DESKTOP_CHROME_COMMAND_IDS: DesktopMenuCommandId[] = [
+  "open-settings",
+  "open-docs",
+  "open-shortcut-help",
+  "open-page-help",
+  "toggle-theme",
+];
+
+export const DESKTOP_CHROME_COMMANDS: DesktopMenuCommand[] = DESKTOP_CHROME_COMMAND_IDS
+  .map((id) => DESKTOP_MENU_COMMANDS.find((command) => command.id === id))
+  .filter((command): command is DesktopMenuCommand => Boolean(command));
 
 interface DesktopShortcutLike {
   key: string;

--- a/apps/desktop/src/desktopWebUiCommandBridge.test.ts
+++ b/apps/desktop/src/desktopWebUiCommandBridge.test.ts
@@ -117,6 +117,25 @@ describe("desktop WebUI command bridge", () => {
     );
   });
 
+  test("routes stop generation only when the WebUI exposes a stop control", () => {
+    const document = new FakeWebUiDocument();
+    document.nodes["#stop-generation-button"] = new FakeButton();
+    const handlers: Array<(id: string) => void> = [];
+
+    installDesktopWebUiCommandBridge({
+      targetDocument: document as unknown as Document,
+      targetWindow: fakeWindow(),
+      listenToMenuCommand: (nextHandler) => {
+        handlers.push(nextHandler);
+      },
+    });
+
+    handlers[0]("stop-generation");
+
+    expect((document.nodes["#stop-generation-button"] as FakeButton).clicks).toBe(1);
+    expect(document.documentElement.dataset.desktopCommandFeedback).toBe("Stop generation requested");
+  });
+
   test("opens the desktop command palette and session search inside the WebUI shell", () => {
     const document = new FakeWebUiDocument();
     const paletteQueries: unknown[] = [];

--- a/apps/desktop/src/desktopWebUiCommandBridge.ts
+++ b/apps/desktop/src/desktopWebUiCommandBridge.ts
@@ -12,6 +12,7 @@ export interface DesktopWebUiCommandBridgeOptions {
 
 const WEBUI_COMMAND_BUTTONS: Partial<Record<DesktopMenuCommandId, string>> = {
   "new-chat": "#new-chat-button",
+  "stop-generation": "#stop-generation-button",
   "open-settings": "#settings-button",
   "toggle-theme": "#theme-toggle",
   "toggle-sidebar": "#sidebar-collapse-button",
@@ -79,6 +80,8 @@ function commandFeedback(id: string): string {
   switch (id) {
     case "new-chat":
       return "New chat requested";
+    case "stop-generation":
+      return "Stop generation requested";
     case "open-settings":
       return "Settings opened";
     case "toggle-theme":

--- a/apps/desktop/src/desktopWindowFrame.test.ts
+++ b/apps/desktop/src/desktopWindowFrame.test.ts
@@ -231,11 +231,15 @@ describe("desktop window frame", () => {
       currentWindow,
     });
 
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="new-chat"]')?.textContent).toBe("New");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="search-sessions"]')?.textContent).toBe("Search");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="stop-generation"]')?.textContent).toBe("Stop");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-command-palette"]')?.textContent).toBe("Command");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-docs"]')).toBeNull();
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="new-chat"]')).toBeNull();
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="search-sessions"]')).toBeNull();
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="stop-generation"]')).toBeNull();
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-command-palette"]')).toBeNull();
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-settings"]')?.textContent).toBe("Settings");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-docs"]')?.textContent).toBe("Documentation");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-shortcut-help"]')?.textContent).toBe("Shortcut Help");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-page-help"]')?.textContent).toBe("Page Help");
+    expect(targetDocument.body.querySelector('[data-desktop-menu-command="toggle-theme"]')?.textContent).toBe("Toggle Theme");
     expect(targetDocument.body.querySelector('[data-desktop-menu-command="refresh-gateway-status"]')).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- Remove permanent task-level controls from the custom window frame menu.
- Keep app-level menu commands in the frame alongside Gateway status and window controls.
- Route Stop from the hosted WebUI path only when a stop control is present.

Closes #127.

## Validation

- `npm test -- desktopCommandNavigation.test.ts`
- `npm test -- desktopWindowFrame.test.ts`
- `npm test -- desktopWebUiCommandBridge.test.ts`
- `npm test`
- `npm run build`