### PR TITLE
Add compact desktop empty state

### DIFF
--- a/apps/desktop/src/desktopEmptyState.test.ts
+++ b/apps/desktop/src/desktopEmptyState.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "vitest";
+import { upgradeDesktopRootWebUiEmptyState } from "./desktopEmptyState";
+
+class FakeClassList {
+  constructor(private readonly element: FakeElement) {}
+
+  add(value: string): void {
+    const values = new Set(this.element.className.split(/\s+/).filter(Boolean));
+    values.add(value);
+    this.element.className = [...values].join(" ");
+  }
+
+  contains(value: string): boolean {
+    return this.element.className.split(/\s+/).includes(value);
+  }
+}
+
+class FakeElement {
+  public id = "";
+  public className = "";
+  public children: FakeElement[] = [];
+  public attributes = new Map<string, string>();
+  public classList = new FakeClassList(this);
+  public parent: FakeElement | null = null;
+  private ownTextContent = "";
+
+  constructor(public readonly tagName: string) {}
+
+  set textContent(value: string) {
+    this.ownTextContent = value;
+  }
+
+  get textContent(): string {
+    return `${this.ownTextContent}${this.children.map((child) => child.textContent).join("")}`;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+    if (name === "id") {
+      this.id = value;
+    }
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  append(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+    }
+    this.children.push(...children);
+  }
+
+  insertBefore(node: FakeElement, child: FakeElement | null): void {
+    node.parent = this;
+    if (!child) {
+      this.children.push(node);
+      return;
+    }
+    const index = this.children.indexOf(child);
+    if (index === -1) {
+      this.children.push(node);
+      return;
+    }
+    this.children.splice(index, 0, node);
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    if (matchesSelector(this, selector)) {
+      return this;
+    }
+    for (const child of this.children) {
+      const match = child.querySelector(selector);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const matches: FakeElement[] = matchesSelector(this, selector) ? [this] : [];
+    for (const child of this.children) {
+      matches.push(...child.querySelectorAll(selector));
+    }
+    return matches;
+  }
+}
+
+class FakeDocument {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  }
+}
+
+function matchesSelector(element: FakeElement, selector: string): boolean {
+  if (selector.startsWith(".")) {
+    return element.className.split(/\s+/).includes(selector.slice(1));
+  }
+  return false;
+}
+
+function createEmptyChat(targetDocument: FakeDocument): FakeElement {
+  const empty = targetDocument.createElement("div");
+  empty.className = "empty-state empty-chat";
+  const title = targetDocument.createElement("div");
+  title.className = "empty-chat-title";
+  title.textContent = "Current session has no messages.";
+  const actions = targetDocument.createElement("div");
+  actions.className = "empty-chat-actions";
+  for (const label of [
+    "Summarize my uploaded files",
+    "Explain a concept",
+    "Answer from the knowledge base",
+    "Create a todo/reminder",
+  ]) {
+    const button = targetDocument.createElement("button");
+    button.textContent = label;
+    actions.append(button);
+  }
+  empty.append(title, actions);
+  return empty;
+}
+
+describe("desktop empty state", () => {
+  test("upgrades the root WebUI empty chat to compact workbench hints once", () => {
+    const targetDocument = new FakeDocument();
+    const empty = createEmptyChat(targetDocument);
+
+    expect(upgradeDesktopRootWebUiEmptyState(empty as unknown as HTMLElement, targetDocument as unknown as Document)).toBe(true);
+    expect(upgradeDesktopRootWebUiEmptyState(empty as unknown as HTMLElement, targetDocument as unknown as Document)).toBe(false);
+
+    expect(empty.getAttribute("data-desktop-empty-state")).toBe("true");
+    expect(empty.classList.contains("desktop-empty-state-compact")).toBe(true);
+    expect(empty.querySelectorAll(".desktop-empty-hints")).toHaveLength(1);
+    expect(empty.querySelectorAll(".desktop-empty-hint").map((node) => node.textContent)).toEqual([
+      "Recent sessionsUse Search to resume a conversation.",
+      "Files and resourcesAttach a session file or open Workspace.",
+      "Background tasksCheck streaming, cowork, uploads, and approvals.",
+      "Gateway healthUse the Gateway status for diagnostics.",
+    ]);
+    expect(empty.querySelectorAll(".desktop-empty-module")).toHaveLength(0);
+  });
+
+  test("keeps suggested prompts as lightweight command hints", () => {
+    const targetDocument = new FakeDocument();
+    const empty = createEmptyChat(targetDocument);
+
+    upgradeDesktopRootWebUiEmptyState(empty as unknown as HTMLElement, targetDocument as unknown as Document);
+
+    const actions = empty.querySelector(".empty-chat-actions");
+    expect(actions?.classList.contains("desktop-empty-command-hints")).toBe(true);
+    expect(actions?.getAttribute("data-desktop-empty-command-hints")).toBe("true");
+    expect(actions?.textContent).toContain("Summarize my uploaded files");
+    expect(actions?.textContent).toContain("Create a todo/reminder");
+  });
+});

--- a/apps/desktop/src/desktopEmptyState.ts
+++ b/apps/desktop/src/desktopEmptyState.ts
@@ -1,0 +1,38 @@
+const EMPTY_HINTS = [
+  ["Recent sessions", "Use Search to resume a conversation."],
+  ["Files and resources", "Attach a session file or open Workspace."],
+  ["Background tasks", "Check streaming, cowork, uploads, and approvals."],
+  ["Gateway health", "Use the Gateway status for diagnostics."],
+] as const;
+
+export function upgradeDesktopRootWebUiEmptyState(emptyChat: HTMLElement, targetDocument: Document): boolean {
+  if (emptyChat.getAttribute("data-desktop-empty-state") === "true") {
+    return false;
+  }
+
+  emptyChat.setAttribute("data-desktop-empty-state", "true");
+  emptyChat.classList.add("desktop-empty-state-compact");
+
+  const hints = targetDocument.createElement("div");
+  hints.className = "desktop-empty-hints";
+  hints.setAttribute("aria-label", "Desktop workbench starting points");
+
+  for (const [title, detail] of EMPTY_HINTS) {
+    const item = targetDocument.createElement("article");
+    item.className = "desktop-empty-hint";
+
+    const heading = targetDocument.createElement("strong");
+    heading.textContent = title;
+    const copy = targetDocument.createElement("span");
+    copy.textContent = detail;
+
+    item.append(heading, copy);
+    hints.append(item);
+  }
+
+  const actions = emptyChat.querySelector<HTMLElement>(".empty-chat-actions");
+  actions?.classList.add("desktop-empty-command-hints");
+  actions?.setAttribute("data-desktop-empty-command-hints", "true");
+  emptyChat.insertBefore(hints, actions ?? null);
+  return true;
+}

--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -266,7 +266,7 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(targetDocument.getElementById("inspector-panel")?.getAttribute("aria-hidden")).toBe("true");
   });
 
-  test("adds task-oriented desktop modules to the root WebUI empty chat state once", () => {
+  test("adds compact desktop hints to the root WebUI empty chat state once", () => {
     const targetDocument = new FakeDocument();
     const empty = targetDocument.createElement("div");
     empty.className = "empty-state empty-chat";
@@ -280,13 +280,15 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(upgradeDesktopRootWebUiEmptyState(empty as unknown as HTMLElement, targetDocument as unknown as Document)).toBe(false);
 
     expect(empty.getAttribute("data-desktop-empty-state")).toBe("true");
-    expect(empty.querySelectorAll(".desktop-empty-modules")).toHaveLength(1);
-    expect(empty.querySelectorAll(".desktop-empty-module").map((node) => node.textContent)).toEqual([
+    expect(empty.classList.contains("desktop-empty-state-compact")).toBe(true);
+    expect(empty.querySelectorAll(".desktop-empty-hints")).toHaveLength(1);
+    expect(empty.querySelectorAll(".desktop-empty-hint").map((node) => node.textContent)).toEqual([
       "Recent sessionsUse Search to resume a conversation.",
       "Files and resourcesAttach a session file or open Workspace.",
       "Background tasksCheck streaming, cowork, uploads, and approvals.",
-      "Gateway healthUse the gateway chip for diagnostics.",
+      "Gateway healthUse the Gateway status for diagnostics.",
     ]);
+    expect(actions.classList.contains("desktop-empty-command-hints")).toBe(true);
   });
 
   test("mounts a command palette surface for the hosted root WebUI shell", () => {
@@ -365,7 +367,8 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(styleText).toContain("grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr)");
     expect(styleText).toContain('body.desktop-root-webui-workbench > .shell[data-inspector-visible="false"]');
     expect(styleText).toContain("@media (max-width: 980px)");
-    expect(styleText).toContain(".desktop-empty-modules");
+    expect(styleText).toContain(".desktop-empty-state-compact");
+    expect(styleText).toContain(".desktop-empty-hints");
     expect(styleText).toContain(".desktop-command-palette");
     expect(styleText).toContain(".desktop-composer-feedback");
     expect(styleText).toContain("body.desktop-root-webui-workbench .composer-status-panel .system-status");

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -8,6 +8,7 @@ import {
   applyRootWebUiShellLayout,
   ensureDesktopRootWebUiShellLayoutStyle,
 } from "./desktopShellLayout";
+import { upgradeDesktopRootWebUiEmptyState } from "./desktopEmptyState";
 import {
   buildRootWebUiSidebarModel,
   buildRootWebUiWorkspaceContext,
@@ -39,6 +40,7 @@ export {
   applyRootWebUiShellLayout as applyRootWebUiWorkbenchLayout,
   ensureDesktopRootWebUiShellLayoutStyle as ensureDesktopRootWebUiWorkbenchStyle,
 } from "./desktopShellLayout";
+export { upgradeDesktopRootWebUiEmptyState } from "./desktopEmptyState";
 
 export function installRootWebUiComposerRuntime(targetDocument: Document): void {
   const composer = targetDocument.getElementById("composer-form");
@@ -168,39 +170,6 @@ export function installRootWebUiDesktopAppSidebar(targetDocument: Document): voi
     }),
     targetDocument,
   );
-}
-
-export function upgradeDesktopRootWebUiEmptyState(emptyChat: HTMLElement, targetDocument: Document): boolean {
-  if (emptyChat.getAttribute("data-desktop-empty-state") === "true") {
-    return false;
-  }
-
-  emptyChat.setAttribute("data-desktop-empty-state", "true");
-  const modules = targetDocument.createElement("div");
-  modules.className = "desktop-empty-modules";
-  modules.setAttribute("aria-label", "Desktop workbench starting points");
-
-  for (const [title, detail] of [
-    ["Recent sessions", "Use Search to resume a conversation."],
-    ["Files and resources", "Attach a session file or open Workspace."],
-    ["Background tasks", "Check streaming, cowork, uploads, and approvals."],
-    ["Gateway health", "Use the gateway chip for diagnostics."],
-  ]) {
-    const item = targetDocument.createElement("article");
-    item.className = "desktop-empty-module";
-
-    const heading = targetDocument.createElement("strong");
-    heading.textContent = title;
-    const copy = targetDocument.createElement("span");
-    copy.textContent = detail;
-
-    item.append(heading, copy);
-    modules.append(item);
-  }
-
-  const actions = emptyChat.querySelector<HTMLElement>(".empty-chat-actions");
-  emptyChat.insertBefore(modules, actions ?? null);
-  return true;
 }
 
 function installRootWebUiPanelPersistence(

--- a/apps/desktop/src/desktopShellLayout.test.ts
+++ b/apps/desktop/src/desktopShellLayout.test.ts
@@ -133,6 +133,8 @@ function createRootWebUiDocument(): FakeDocument {
 
   const chat = document.createElement("section");
   chat.className = "chat-panel";
+  const header = document.createElement("header");
+  header.className = "chat-header";
   const messageList = document.createElement("section");
   messageList.setAttribute("id", "message-list");
   const composer = document.createElement("form");
@@ -140,7 +142,7 @@ function createRootWebUiDocument(): FakeDocument {
   const status = document.createElement("section");
   status.className = "composer-status-panel";
   composer.append(status);
-  chat.append(messageList, composer);
+  chat.append(header, messageList, composer);
 
   const inspector = document.createElement("aside");
   inspector.setAttribute("id", "inspector-panel");
@@ -165,6 +167,8 @@ describe("desktop shell layout", () => {
     expect(targetDocument.body.querySelector(".sidebar")?.getAttribute("data-desktop-shell-region")).toBe("sidebar");
     expect(targetDocument.body.querySelector(".chat-panel")?.getAttribute("data-workbench-region")).toBe("main");
     expect(targetDocument.body.querySelector(".chat-panel")?.getAttribute("data-desktop-shell-region")).toBe("workspace");
+    expect(targetDocument.body.querySelector(".chat-header")?.classList.contains("desktop-workspace-header")).toBe(true);
+    expect(targetDocument.body.querySelector(".chat-header")?.getAttribute("data-desktop-shell-region")).toBe("workspace-header");
     expect(targetDocument.getElementById("message-list")?.getAttribute("data-desktop-shell-region")).toBe("message-list");
     expect(targetDocument.getElementById("inspector-panel")?.getAttribute("data-desktop-shell-region")).toBe("inspector");
     expect(targetDocument.getElementById("composer-form")?.getAttribute("data-desktop-shell-region")).toBe("composer");
@@ -188,5 +192,10 @@ describe("desktop shell layout", () => {
     expect(styleText).toContain("display: none");
     expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-app-sidebar");
     expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-app-sidebar-group");
+    expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-empty-state-compact");
+    expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-empty-hints");
+    expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-empty-command-hints");
+    expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-workspace-header");
+    expect(styleText).not.toContain(".desktop-empty-module");
   });
 });

--- a/apps/desktop/src/desktopShellLayout.ts
+++ b/apps/desktop/src/desktopShellLayout.ts
@@ -28,13 +28,19 @@ export function applyRootWebUiShellLayout(targetDocument: Document, layout: Work
   const inspector = targetDocument.getElementById("inspector-panel");
   const composer = targetDocument.getElementById("composer-form");
   const statusPanel = targetDocument.body.querySelector<HTMLElement>(".composer-status-panel");
+  const workspaceHeader =
+    targetDocument.body.querySelector<HTMLElement>(".chat-header") ??
+    targetDocument.body.querySelector<HTMLElement>(".session-header") ??
+    targetDocument.body.querySelector<HTMLElement>("[data-desktop-workspace-header]");
 
   markShellRegion(sidebar, "sidebar", "sidebar");
   markShellRegion(chatPanel, "main", "workspace");
+  markShellRegion(workspaceHeader, "workspace-header", "workspace-header");
   markShellRegion(messageList, "conversation", "message-list");
   markShellRegion(inspector, "inspector", "inspector");
   markShellRegion(composer, "composer", "composer");
   markShellRegion(statusPanel, "runtime-status", "runtime-status");
+  workspaceHeader?.classList.add("desktop-workspace-header");
 
   if (!layout.sidebar.visible) {
     shell.classList.add("sidebar-collapsed");
@@ -199,6 +205,50 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
       scrollbar-gutter: stable;
     }
 
+    body.desktop-root-webui-workbench .chat-header,
+    body.desktop-root-webui-workbench .session-header,
+    body.desktop-root-webui-workbench [data-desktop-workspace-header] {
+      display: grid;
+      gap: 4px;
+      min-width: 0;
+      border-bottom: 1px solid var(--border, #e6dfd8);
+      padding: 14px 24px 12px;
+      background: var(--panel, #faf9f5);
+    }
+
+    body.desktop-root-webui-workbench .desktop-workspace-header {
+      display: grid;
+      gap: 4px;
+      min-width: 0;
+      border-bottom: 1px solid var(--border, #e6dfd8);
+      padding: 14px 24px 12px;
+      background: var(--panel, #faf9f5);
+    }
+
+    body.desktop-root-webui-workbench .chat-header h1,
+    body.desktop-root-webui-workbench .session-header h1,
+    body.desktop-root-webui-workbench .desktop-workspace-header h1 {
+      margin: 0;
+      color: var(--text, #141413);
+      font-size: 22px;
+      font-weight: 500;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+
+    body.desktop-root-webui-workbench .chat-header p,
+    body.desktop-root-webui-workbench .session-header p,
+    body.desktop-root-webui-workbench .desktop-workspace-header p {
+      margin: 0;
+      overflow: hidden;
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      line-height: 1.35;
+      text-overflow: ellipsis;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
     body.desktop-root-webui-workbench .composer {
       border-top: 1px solid var(--border, #e6dfd8);
       background: color-mix(in srgb, var(--panel, #faf9f5) 92%, transparent);
@@ -330,42 +380,75 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
       border-radius: 8px;
     }
 
-    body.desktop-root-webui-workbench .desktop-empty-modules {
+    body.desktop-root-webui-workbench .desktop-empty-state-compact {
       display: grid;
-      grid-template-columns: repeat(2, minmax(180px, 1fr));
-      gap: 8px;
-      width: min(760px, 100%);
-      margin: 12px auto 2px;
+      gap: 12px;
+      width: min(720px, calc(100% - 48px));
       min-width: 0;
+      margin: 36px auto;
+      border: 0;
+      border-radius: 0;
+      padding: 0;
+      background: transparent;
+      box-shadow: none;
     }
 
-    body.desktop-root-webui-workbench .desktop-empty-module {
+    body.desktop-root-webui-workbench .desktop-empty-hints {
       display: grid;
-      gap: 5px;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px 18px;
       min-width: 0;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
-      padding: 10px 12px;
-      background: color-mix(in srgb, var(--panel-strong, #efe9de) 72%, transparent);
+      margin: 0;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-hint {
+      display: grid;
+      gap: 3px;
+      min-width: 0;
+      border-left: 1px solid var(--border, #e6dfd8);
+      padding: 0 0 0 10px;
+      background: transparent;
       text-align: left;
     }
 
-    body.desktop-root-webui-workbench .desktop-empty-module strong,
-    body.desktop-root-webui-workbench .desktop-empty-module span {
+    body.desktop-root-webui-workbench .desktop-empty-hint strong,
+    body.desktop-root-webui-workbench .desktop-empty-hint span {
       min-width: 0;
       overflow-wrap: anywhere;
     }
 
-    body.desktop-root-webui-workbench .desktop-empty-module strong {
+    body.desktop-root-webui-workbench .desktop-empty-hint strong {
       color: var(--text, #141413);
       font-size: 12px;
       line-height: 1.25;
     }
 
-    body.desktop-root-webui-workbench .desktop-empty-module span {
+    body.desktop-root-webui-workbench .desktop-empty-hint span {
       color: var(--text-muted, #6c6a64);
       font-size: 11px;
       line-height: 1.35;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-command-hints {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: center;
+      min-width: 0;
+      margin: 0;
+    }
+
+    body.desktop-root-webui-workbench .desktop-empty-command-hints button,
+    body.desktop-root-webui-workbench .desktop-empty-command-hints .empty-chat-action {
+      min-width: 0;
+      min-height: 30px;
+      border: 1px solid color-mix(in srgb, var(--border, #e6dfd8) 70%, transparent);
+      border-radius: 6px;
+      padding: 6px 10px;
+      background: transparent;
+      color: var(--text, #141413);
+      font: 500 12px/1.2 var(--font-sans, system-ui, sans-serif);
+      box-shadow: none;
     }
 
     body.desktop-root-webui-workbench .desktop-command-palette {
@@ -497,7 +580,7 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
         display: none;
       }
 
-      body.desktop-root-webui-workbench .desktop-empty-modules {
+      body.desktop-root-webui-workbench .desktop-empty-hints {
         grid-template-columns: minmax(0, 1fr);
       }
     }


### PR DESCRIPTION
## Summary

- Extract root WebUI empty session upgrade logic into a focused desktop empty-state module.
- Replace large nested empty cards with compact workbench hints for recent sessions, files/resources, background tasks, and Gateway health.
- Keep suggested prompt actions available as lightweight command hints and mark compact workspace headers.

## Validation

- `npm test -- desktopEmptyState.test.ts`
- `npm test -- desktopRootWebUiWorkbench.test.ts`
- `npm test -- desktopShellLayout.test.ts`
- `npm test`
- `npm run build`

Closes #129