### PR TITLE
Add desktop responsive shell rules

### DIFF
--- a/apps/desktop/src/desktopComposerSurface.test.ts
+++ b/apps/desktop/src/desktopComposerSurface.test.ts
@@ -286,4 +286,19 @@ describe("desktop composer surface", () => {
     expect(styleText).toContain(".desktop-task-status-surface");
     expect(styleText).toContain('[data-desktop-composer-action="stop"]');
   });
+
+  test("declares narrow composer controls that stay within the workspace", () => {
+    const targetDocument = new FakeDocument();
+
+    ensureDesktopComposerSurfaceStyle(targetDocument as unknown as Document);
+
+    const styleText = targetDocument.head.querySelector("#desktop-composer-surface-style")?.textContent ?? "";
+    expect(styleText).toContain("@media (max-width: 980px) and (min-width: 721px)");
+    expect(styleText).toContain("@media (max-width: 720px)");
+    expect(styleText).toContain("grid-template-columns: 38px minmax(0, 1fr) 48px");
+    expect(styleText).toContain("grid-template-columns: 36px minmax(0, 1fr)");
+    expect(styleText).toContain('[data-desktop-composer-action="stop"]');
+    expect(styleText).toContain("grid-column: 2 / 3");
+    expect(styleText).toContain("width: min(960px, 100%)");
+  });
 });

--- a/apps/desktop/src/desktopComposerSurface.ts
+++ b/apps/desktop/src/desktopComposerSurface.ts
@@ -237,6 +237,57 @@ export function ensureDesktopComposerSurfaceStyle(targetDocument: Document): voi
       font-size: 11px;
       line-height: 1.3;
     }
+
+    @media (max-width: 980px) and (min-width: 721px) {
+      body.desktop-root-webui-workbench .composer.desktop-composer-surface {
+        padding: 12px 16px 10px;
+      }
+
+      body.desktop-root-webui-workbench [data-desktop-composer-region="controls"] {
+        grid-template-columns: 38px minmax(0, 1fr) 48px;
+        gap: 8px;
+      }
+
+      body.desktop-root-webui-workbench [data-desktop-composer-action="stop"] {
+        grid-column: 2 / 3;
+        min-height: 32px;
+      }
+
+      body.desktop-root-webui-workbench [data-desktop-composer-region="runtime-status"],
+      body.desktop-root-webui-workbench .desktop-composer-feedback {
+        width: min(960px, 100%);
+      }
+    }
+
+    @media (max-width: 720px) {
+      body.desktop-root-webui-workbench .composer.desktop-composer-surface {
+        padding: 10px 12px 10px;
+      }
+
+      body.desktop-root-webui-workbench [data-desktop-composer-region="controls"] {
+        grid-template-columns: 36px minmax(0, 1fr);
+        gap: 7px;
+      }
+
+      body.desktop-root-webui-workbench [data-desktop-composer-action="send"] {
+        grid-column: 2 / 3;
+        min-height: 34px;
+      }
+
+      body.desktop-root-webui-workbench [data-desktop-composer-action="stop"] {
+        grid-column: 2 / 3;
+        min-height: 32px;
+      }
+
+      body.desktop-root-webui-workbench [data-desktop-composer-region="runtime-status"] {
+        width: min(960px, 100%);
+        overflow-x: auto;
+      }
+
+      body.desktop-root-webui-workbench .desktop-composer-feedback {
+        width: min(960px, 100%);
+      }
+    }
   `;
   targetDocument.head.append(style);
 }

--- a/apps/desktop/src/desktopShellLayout.test.ts
+++ b/apps/desktop/src/desktopShellLayout.test.ts
@@ -198,4 +198,27 @@ describe("desktop shell layout", () => {
     expect(styleText).toContain("body.desktop-root-webui-workbench .desktop-workspace-header");
     expect(styleText).not.toContain(".desktop-empty-module");
   });
+
+  test("declares desktop-owned responsive placement across shell breakpoints", () => {
+    const targetDocument = new FakeDocument();
+
+    ensureDesktopRootWebUiShellLayoutStyle(targetDocument as unknown as Document);
+
+    const styleText = targetDocument.head.querySelector("#desktop-root-webui-workbench-style")?.textContent ?? "";
+    expect(styleText).toContain("@media (min-width: 1181px)");
+    expect(styleText).toContain("@media (max-width: 1180px) and (min-width: 981px)");
+    expect(styleText).toContain("@media (max-width: 980px) and (min-width: 721px)");
+    expect(styleText).toContain("@media (max-width: 720px)");
+    expect(styleText).toContain("--desktop-sidebar-rail-size");
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .sidebar");
+    expect(styleText).toContain("order: 0 !important");
+    expect(styleText).toContain("grid-column: 1 !important");
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .chat-panel");
+    expect(styleText).toContain("grid-column: 2 !important");
+    expect(styleText).toContain("grid-template-columns: minmax(220px, var(--desktop-sidebar-size, 248px)) minmax(0, 1fr) 0");
+    expect(styleText).toContain("grid-template-columns: var(--desktop-sidebar-rail-size, 68px) minmax(0, 1fr) 0");
+    expect(styleText).toContain("grid-template-columns: 56px minmax(0, 1fr) 0");
+    expect(styleText).toContain(".desktop-app-sidebar-item-label");
+    expect(styleText).toContain(".desktop-app-sidebar-item-meta");
+  });
 });

--- a/apps/desktop/src/desktopShellLayout.ts
+++ b/apps/desktop/src/desktopShellLayout.ts
@@ -63,6 +63,7 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
   style.setAttribute("id", STYLE_ID);
   style.textContent = `
     body.desktop-root-webui-workbench > .shell {
+      --desktop-sidebar-rail-size: 68px;
       grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) minmax(0, var(--desktop-inspector-size, 360px));
       background: var(--panel, #faf9f5);
       box-shadow: none;
@@ -158,6 +159,19 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
       text-decoration: none;
     }
 
+    body.desktop-root-webui-workbench .desktop-app-sidebar-item[data-sidebar-icon]::before {
+      content: attr(data-sidebar-icon);
+      display: none;
+      min-width: 0;
+      overflow: hidden;
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      font-weight: 700;
+      line-height: 1;
+      text-align: center;
+      text-transform: uppercase;
+    }
+
     body.desktop-root-webui-workbench .desktop-app-sidebar-item[data-active="true"],
     body.desktop-root-webui-workbench .desktop-app-sidebar-item:hover,
     body.desktop-root-webui-workbench .desktop-app-sidebar-item:focus-visible {
@@ -181,22 +195,22 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
     }
 
     body.desktop-root-webui-workbench > .shell .sidebar {
-      order: 0;
-      grid-column: 1;
+      order: 0 !important;
+      grid-column: 1 !important;
       grid-row: 1;
     }
 
     body.desktop-root-webui-workbench > .shell .chat-panel,
     body.desktop-root-webui-workbench [data-desktop-shell-region="workspace"] {
-      order: 0;
-      grid-column: 2;
+      order: 0 !important;
+      grid-column: 2 !important;
       grid-row: 1;
       min-width: 0;
     }
 
     body.desktop-root-webui-workbench > .shell .inspector-panel {
-      order: 0;
-      grid-column: 3;
+      order: 0 !important;
+      grid-column: 3 !important;
       grid-row: 1;
     }
 
@@ -427,26 +441,187 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
       line-height: 1.35;
     }
 
-    @media (max-width: 980px) {
+    @media (min-width: 1181px) {
       body.desktop-root-webui-workbench > .shell,
       body.desktop-root-webui-workbench > .shell.inspection-mode {
-        grid-template-columns: 68px minmax(0, 1fr) 0;
+        grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) minmax(0, var(--desktop-inspector-size, 360px));
+        grid-template-rows: minmax(0, 1fr);
+      }
+
+      body.desktop-root-webui-workbench > .shell[data-inspector-visible="false"]:not(.inspection-mode) {
+        grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) 0;
+      }
+    }
+
+    @media (max-width: 1180px) and (min-width: 981px) {
+      body.desktop-root-webui-workbench > .shell,
+      body.desktop-root-webui-workbench > .shell.inspection-mode {
+        grid-template-columns: minmax(220px, var(--desktop-sidebar-size, 248px)) minmax(0, 1fr) 0;
         grid-template-rows: minmax(0, 1fr);
         height: calc(100vh - var(--desktop-window-frame-height, 34px));
         min-height: 0;
       }
 
       body.desktop-root-webui-workbench > .shell .sidebar {
+        order: 0 !important;
+        grid-column: 1 !important;
+        grid-row: 1;
         max-height: none;
       }
 
-      body.desktop-root-webui-workbench > .shell .chat-panel {
+      body.desktop-root-webui-workbench > .shell .chat-panel,
+      body.desktop-root-webui-workbench [data-desktop-shell-region="workspace"] {
+        order: 0 !important;
+        grid-column: 2 !important;
+        grid-row: 1;
+        min-width: 0;
         min-height: 0;
         height: auto;
       }
 
       body.desktop-root-webui-workbench .inspector-panel {
         display: none;
+      }
+    }
+
+    @media (max-width: 980px) and (min-width: 721px) {
+      body.desktop-root-webui-workbench > .shell,
+      body.desktop-root-webui-workbench > .shell.inspection-mode {
+        grid-template-columns: var(--desktop-sidebar-rail-size, 68px) minmax(0, 1fr) 0;
+        grid-template-rows: minmax(0, 1fr);
+        height: calc(100vh - var(--desktop-window-frame-height, 34px));
+        min-height: 0;
+      }
+
+      body.desktop-root-webui-workbench > .shell .sidebar {
+        order: 0 !important;
+        grid-column: 1 !important;
+        grid-row: 1;
+        max-height: none;
+      }
+
+      body.desktop-root-webui-workbench > .shell .chat-panel {
+        order: 0 !important;
+        grid-column: 2 !important;
+        grid-row: 1;
+        min-height: 0;
+        height: auto;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-content {
+        grid-template-rows: auto minmax(0, 1fr) auto;
+        gap: 10px;
+        padding: 10px 8px;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-group-label,
+      body.desktop-root-webui-workbench .desktop-app-sidebar-item-meta {
+        display: none;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-item {
+        grid-template-columns: minmax(0, 1fr);
+        justify-items: center;
+        position: relative;
+        min-height: 36px;
+        padding: 7px 6px;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-item[data-sidebar-icon]::before {
+        display: block;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-item-label {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        white-space: nowrap;
+      }
+
+      body.desktop-root-webui-workbench .inspector-panel {
+        display: none;
+      }
+
+      body.desktop-root-webui-workbench .desktop-empty-hints {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+
+    @media (max-width: 720px) {
+      body.desktop-root-webui-workbench > .shell,
+      body.desktop-root-webui-workbench > .shell.inspection-mode {
+        grid-template-columns: 56px minmax(0, 1fr) 0;
+        grid-template-rows: minmax(0, 1fr);
+        height: calc(100vh - var(--desktop-window-frame-height, 34px));
+        min-width: 0;
+        min-height: 0;
+      }
+
+      body.desktop-root-webui-workbench > .shell .sidebar {
+        order: 0 !important;
+        grid-column: 1 !important;
+        grid-row: 1;
+        max-height: none;
+      }
+
+      body.desktop-root-webui-workbench > .shell .chat-panel,
+      body.desktop-root-webui-workbench [data-desktop-shell-region="workspace"] {
+        order: 0 !important;
+        grid-column: 2 !important;
+        grid-row: 1;
+        min-width: 0;
+        min-height: 0;
+        height: auto;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-content {
+        gap: 8px;
+        padding: 8px 6px;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-group-label,
+      body.desktop-root-webui-workbench .desktop-app-sidebar-item-meta {
+        display: none;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-item {
+        grid-template-columns: minmax(0, 1fr);
+        justify-items: center;
+        position: relative;
+        min-height: 34px;
+        padding: 6px 4px;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-item[data-sidebar-icon]::before {
+        display: block;
+      }
+
+      body.desktop-root-webui-workbench .desktop-app-sidebar-item-label {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        white-space: nowrap;
+      }
+
+      body.desktop-root-webui-workbench .inspector-panel {
+        display: none;
+      }
+
+      body.desktop-root-webui-workbench .chat-header,
+      body.desktop-root-webui-workbench .session-header,
+      body.desktop-root-webui-workbench .desktop-workspace-header {
+        padding: 12px 14px 10px;
+      }
+
+      body.desktop-root-webui-workbench .desktop-empty-state-compact {
+        width: min(100%, calc(100% - 24px));
+        margin: 24px auto;
       }
 
       body.desktop-root-webui-workbench .desktop-empty-hints {


### PR DESCRIPTION
## Summary

- Add explicit wide, mid-width, narrow, and very narrow shell breakpoints.
- Keep sidebar, workspace, and inspector placement independent from hosted WebUI responsive ordering.
- Collapse the sidebar into a compact rail at narrow widths.
- Reflow composer controls at narrow and very narrow widths so the input surface stays inside the workspace.

## Validation

- `npm test -- desktopShellLayout.test.ts`
- `npm test -- desktopComposerSurface.test.ts`
- `npm test -- desktopRootWebUiWorkbench.test.ts`
- `npm test`
- `npm run build`

Closes #133