### PR TITLE
Integrate desktop sidebar commands

### DIFF
--- a/apps/desktop/src/desktopAppSidebar.test.ts
+++ b/apps/desktop/src/desktopAppSidebar.test.ts
@@ -34,6 +34,7 @@ class FakeElement {
   public classList = new FakeClassList(this);
   public parent: FakeElement | null = null;
   private ownTextContent = "";
+  private eventListeners = new Map<string, Array<(event: Event) => void>>();
 
   constructor(public readonly tagName: string) {}
 
@@ -70,6 +71,23 @@ class FakeElement {
     this.children = [...children];
   }
 
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    const listeners = this.eventListeners.get(type) ?? [];
+    listeners.push(listener);
+    this.eventListeners.set(type, listeners);
+  }
+
+  dispatchEvent(event: Event): boolean {
+    for (const listener of this.eventListeners.get(event.type) ?? []) {
+      listener(event);
+    }
+    return true;
+  }
+
+  click(): void {
+    this.dispatchEvent(new Event("click"));
+  }
+
   querySelector(selector: string): FakeElement | null {
     if (matchesSelector(this, selector)) {
       return this;
@@ -94,9 +112,15 @@ class FakeElement {
 
 class FakeDocument {
   public body = new FakeElement("body");
+  public events: Array<{ type: string; detail: unknown }> = [];
 
   createElement(tagName: string): FakeElement {
     return new FakeElement(tagName);
+  }
+
+  dispatchEvent(event: Event): boolean {
+    this.events.push({ type: event.type, detail: (event as CustomEvent).detail });
+    return true;
   }
 }
 
@@ -178,5 +202,22 @@ describe("desktop app sidebar", () => {
     expect(activeSession?.getAttribute("data-active")).toBe("true");
     expect(activeSession?.textContent).toContain("Desktop shell planning");
     expect(activeSession?.textContent).toContain("2 min");
+  });
+
+  test("dispatches sidebar commands through the desktop menu command event path", () => {
+    const targetDocument = new FakeDocument();
+    const host = targetDocument.createElement("aside");
+    const model = buildRootWebUiSidebarModel({ sessions: sidebarItems() });
+
+    renderDesktopAppSidebar(host as unknown as HTMLElement, model, targetDocument as unknown as Document);
+
+    host.querySelector('[data-sidebar-command="new-chat"]')?.click();
+
+    expect(targetDocument.events).toEqual([
+      {
+        type: "desktop-menu-command",
+        detail: { id: "new-chat", source: "desktop-sidebar" },
+      },
+    ]);
   });
 });

--- a/apps/desktop/src/desktopAppSidebar.ts
+++ b/apps/desktop/src/desktopAppSidebar.ts
@@ -64,6 +64,14 @@ function createSidebarItem(targetDocument: Document, item: DesktopSidebarItem): 
 
   if (item.commandId) {
     element.setAttribute("data-sidebar-command", item.commandId);
+    element.addEventListener("click", () => {
+      if (item.disabled) {
+        return;
+      }
+      targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", {
+        detail: { id: item.commandId, source: "desktop-sidebar" },
+      }));
+    });
   }
   if (item.active) {
     element.setAttribute("data-active", "true");

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -81,6 +81,10 @@ import {
 import { installDesktopWebUiCommandBridge } from "./desktopWebUiCommandBridge";
 import { installDesktopWebUiFilePickerBridge } from "./desktopWebUiFilePickerBridge";
 import { installDesktopWebUiNotificationBridge } from "./desktopWebUiNotificationBridge";
+import {
+  buildDesktopCommandEntriesFromSidebar,
+  buildRootWebUiSidebarModel,
+} from "./desktopSharedModels";
 
 const gatewayConfig = resolveGatewayConfig(DEFAULT_GATEWAY_CONFIG);
 const gatewayApi = createGatewayApiClient({ config: gatewayConfig });
@@ -198,7 +202,8 @@ async function bootDesktopWebUi(): Promise<void> {
     installDesktopRootWebUiWorkbenchAdapter();
     installDesktopCommandPalette({
       gatewayOrigin: gatewayConfig.httpBaseUrl,
-      loadData: loadNativeCommandPaletteData,
+      desktopCommands: buildRootWebUiDesktopCommands(),
+      loadData: loadRootWebUiCommandPaletteData,
     });
     installRootWebUiDesktopAdapters();
     installTauriNavigation();
@@ -822,6 +827,17 @@ function installNativeCommandPalette(): void {
     gatewayOrigin: gatewayConfig.httpBaseUrl,
     loadData: loadNativeCommandPaletteData,
   });
+}
+
+function buildRootWebUiDesktopCommands(): ReturnType<typeof buildDesktopCommandEntriesFromSidebar> {
+  return buildDesktopCommandEntriesFromSidebar(buildRootWebUiSidebarModel());
+}
+
+async function loadRootWebUiCommandPaletteData(): Promise<DesktopCommandPaletteInput> {
+  return {
+    ...await loadNativeCommandPaletteData(),
+    desktopCommands: buildRootWebUiDesktopCommands(),
+  };
 }
 
 async function loadNativeCommandPaletteData(): Promise<DesktopCommandPaletteInput> {

--- a/apps/desktop/src/desktopCommandPalette.test.ts
+++ b/apps/desktop/src/desktopCommandPalette.test.ts
@@ -5,8 +5,40 @@ import {
   createDesktopCommandPaletteState,
   openDesktopCommandPalette,
 } from "./desktopCommandPalette";
+import {
+  buildDesktopCommandEntriesFromSidebar,
+  buildRootWebUiSidebarModel,
+} from "./desktopSharedModels";
 
 describe("desktop command palette", () => {
+  test("adapts shared desktop entries into root command search destinations", () => {
+    const desktopCommands = buildDesktopCommandEntriesFromSidebar(buildRootWebUiSidebarModel());
+    const state = createDesktopCommandPaletteState({
+      desktopCommands,
+    });
+
+    expect(buildDesktopCommandPaletteResults(state, "automations")[0]).toMatchObject({
+      group: "Actions",
+      title: "Automations",
+      destination: { module: "cowork", href: "/cowork" },
+    });
+    expect(buildDesktopCommandPaletteResults(state, "tools")[0]).toMatchObject({
+      group: "Actions",
+      title: "Tools",
+      destination: { module: "tools", href: "/tools" },
+    });
+    expect(buildDesktopCommandPaletteResults(state, "settings")[0]).toMatchObject({
+      group: "System",
+      title: "Settings",
+      destination: { module: "command", commandId: "open-settings" },
+    });
+    expect(buildDesktopCommandPaletteResults(state, "runtime diagnostics")[0]).toMatchObject({
+      group: "System",
+      title: "Gateway Status",
+      destination: { module: "command", commandId: "refresh-gateway-status" },
+    });
+  });
+
   test("groups searchable commands and loaded workbench data", () => {
     const state = createDesktopCommandPaletteState({
       sessions: {

--- a/apps/desktop/src/desktopCommandPalette.ts
+++ b/apps/desktop/src/desktopCommandPalette.ts
@@ -1,5 +1,6 @@
 import { DESKTOP_MENU_COMMANDS, type DesktopMenuCommandId } from "./desktopCommandNavigation";
 import { resolveDesktopNavigationTarget } from "./desktopNavigation";
+import type { DesktopCommandEntry } from "./desktopSharedModels";
 import type { NativeChatSession } from "./nativeChat";
 import type { DesktopCoworkSessionRow } from "./desktopCowork";
 import type { DesktopKnowledgeDocumentRow } from "./desktopKnowledgeTraceability";
@@ -54,6 +55,7 @@ export interface DesktopCommandPaletteState {
 }
 
 export interface DesktopCommandPaletteInput {
+  desktopCommands?: DesktopCommandEntry[];
   sessions?: LoadedRows<NativeChatSession>;
   workspaceFiles?: LoadedRows<DesktopWorkspaceFileRow>;
   knowledgeDocuments?: LoadedRows<DesktopKnowledgeDocumentRow>;
@@ -66,6 +68,7 @@ export interface InstallDesktopCommandPaletteOptions {
   gatewayOrigin?: string;
   targetDocument?: Document;
   targetWindow?: Window;
+  desktopCommands?: DesktopCommandEntry[];
   loadData?: () => Promise<DesktopCommandPaletteInput>;
 }
 
@@ -83,15 +86,7 @@ interface LoadedRows<T> {
 const OPEN_PALETTE_EVENT = "tinybot:open-command-palette";
 
 export function createDesktopCommandPaletteState(input: DesktopCommandPaletteInput = {}): DesktopCommandPaletteState {
-  const commandResults = DESKTOP_MENU_COMMANDS.map((command) => ({
-    id: `command:${command.id}`,
-    groupId: "commands" as const,
-    group: "Commands",
-    title: command.label,
-    secondary: command.shortcut,
-    keywords: ["command", command.id, command.shortcut, ...commandKeywords(command.id)],
-    destination: { module: "command" as const, commandId: command.id },
-  }));
+  const commandResults = commandResultsFromInput(input.desktopCommands);
   const resultGroups: Array<[DesktopCommandPaletteGroupId, string, LoadedRows<unknown>, DesktopCommandPaletteResult[]]> = [
     ["commands", "Commands", { loaded: true, rows: DESKTOP_MENU_COMMANDS }, commandResults],
     ["sessions", "Sessions", input.sessions ?? unloaded(), sessionResults(input.sessions?.rows ?? [])],
@@ -158,6 +153,7 @@ export function installDesktopCommandPalette({
   gatewayOrigin = "",
   targetDocument = document,
   targetWindow = window,
+  desktopCommands = [],
   loadData = async () => ({}),
 }: InstallDesktopCommandPaletteOptions = {}): void {
   const palette = targetDocument.querySelector<HTMLElement>("#desktop-command-palette");
@@ -169,7 +165,7 @@ export function installDesktopCommandPalette({
   }
   const paletteInput = input;
 
-  let state = createDesktopCommandPaletteState();
+  let state = createDesktopCommandPaletteState({ desktopCommands });
   let previousFocus: HTMLElement | null = null;
   renderPalette(targetDocument, state, "");
 
@@ -230,14 +226,87 @@ export function installDesktopCommandPalette({
   async function refreshPaletteData(): Promise<void> {
     setPaletteStatus(targetDocument, "Loading command palette data.");
     try {
-      state = createDesktopCommandPaletteState(await loadData());
+      const loadedData = await loadData();
+      state = createDesktopCommandPaletteState({
+        ...loadedData,
+        desktopCommands: loadedData.desktopCommands ?? desktopCommands,
+      });
       renderPalette(targetDocument, state, paletteInput.value);
     } catch (error) {
-      state = createDesktopCommandPaletteState();
+      state = createDesktopCommandPaletteState({ desktopCommands });
       renderPalette(targetDocument, state, paletteInput.value);
       setPaletteStatus(targetDocument, `Command palette data unavailable: ${stringifyError(error)}`);
     }
   }
+}
+
+function commandResultsFromInput(desktopCommands: DesktopCommandEntry[] | undefined): DesktopCommandPaletteResult[] {
+  if (!desktopCommands?.length) {
+    return menuCommandResults(DESKTOP_MENU_COMMANDS);
+  }
+
+  const representedCommands = new Set(desktopCommands.map((entry) => entry.commandId).filter(Boolean));
+  return [
+    ...desktopCommands.map(desktopCommandEntryResult),
+    ...menuCommandResults(DESKTOP_MENU_COMMANDS.filter((command) => !representedCommands.has(command.id))),
+  ];
+}
+
+function menuCommandResults(commands: typeof DESKTOP_MENU_COMMANDS): DesktopCommandPaletteResult[] {
+  return commands.map((command) => ({
+    id: `command:${command.id}`,
+    groupId: "commands",
+    group: "Commands",
+    title: command.label,
+    secondary: command.shortcut,
+    keywords: ["command", command.id, command.shortcut, ...commandKeywords(command.id)],
+    destination: { module: "command", commandId: command.id },
+  }));
+}
+
+function desktopCommandEntryResult(entry: DesktopCommandEntry): DesktopCommandPaletteResult {
+  return {
+    id: entry.id,
+    groupId: "commands",
+    group: entry.group,
+    title: entry.title,
+    secondary: entry.href ?? entry.commandId ?? "",
+    keywords: [...entry.keywords, entry.commandId ? commandKeywords(entry.commandId).join(" ") : ""],
+    destination: desktopCommandEntryDestination(entry),
+  };
+}
+
+function desktopCommandEntryDestination(entry: DesktopCommandEntry): DesktopCommandPaletteDestination {
+  if (entry.commandId) {
+    return { module: "command", commandId: entry.commandId };
+  }
+  if (entry.href) {
+    return { module: moduleForDesktopCommandHref(entry.href), href: entry.href };
+  }
+  if (entry.id.startsWith("sidebar:session:")) {
+    const entityId = entry.id.replace(/^sidebar:session:/, "");
+    return { module: "sessions", entityId, href: `/chat/${entityId}` };
+  }
+  return { module: "command" };
+}
+
+function moduleForDesktopCommandHref(href: string): DesktopCommandPaletteDestinationModule {
+  if (href.startsWith("/tools")) {
+    return "tools";
+  }
+  if (href.startsWith("/cowork")) {
+    return "cowork";
+  }
+  if (href.startsWith("/workspace")) {
+    return "workspace";
+  }
+  if (href.startsWith("/knowledge")) {
+    return "knowledge";
+  }
+  if (href.startsWith("/chat")) {
+    return "sessions";
+  }
+  return "command";
 }
 
 function routePaletteNavigation(
@@ -434,7 +503,7 @@ function commandKeywords(id: DesktopMenuCommandId): string[] {
     case "open-command-palette":
       return ["palette", "quick search"];
     case "refresh-gateway-status":
-      return ["gateway", "runtime", "status"];
+      return ["gateway", "runtime", "diagnostics", "status"];
     case "search-sessions":
       return ["session", "search"];
     case "open-settings":


### PR DESCRIPTION
## Summary

- Dispatch desktop sidebar command buttons through the existing command event path.
- Feed shared desktop navigation entries into command search for root WebUI desktop mode.
- Add command search coverage for tools, automations, settings, and Gateway/runtime actions.

## Validation

- `npm test -- desktopRootWebUiWorkbench.test.ts desktopAppSidebar.test.ts desktopCommandPalette.test.ts`
- `npm test`
- `npm run build`

Closes #135