### PR TITLE
Backfill native workbench command entries

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -83,6 +83,7 @@ import { installDesktopWebUiFilePickerBridge } from "./desktopWebUiFilePickerBri
 import { installDesktopWebUiNotificationBridge } from "./desktopWebUiNotificationBridge";
 import {
   buildDesktopCommandEntriesFromSidebar,
+  buildNativeWorkbenchSidebarModel,
   buildRootWebUiSidebarModel,
 } from "./desktopSharedModels";
 
@@ -825,12 +826,17 @@ function updateNativeSettingsPane(
 function installNativeCommandPalette(): void {
   installDesktopCommandPalette({
     gatewayOrigin: gatewayConfig.httpBaseUrl,
+    desktopCommands: buildNativeWorkbenchDesktopCommands(),
     loadData: loadNativeCommandPaletteData,
   });
 }
 
 function buildRootWebUiDesktopCommands(): ReturnType<typeof buildDesktopCommandEntriesFromSidebar> {
   return buildDesktopCommandEntriesFromSidebar(buildRootWebUiSidebarModel());
+}
+
+function buildNativeWorkbenchDesktopCommands(): ReturnType<typeof buildDesktopCommandEntriesFromSidebar> {
+  return buildDesktopCommandEntriesFromSidebar(buildNativeWorkbenchSidebarModel());
 }
 
 async function loadRootWebUiCommandPaletteData(): Promise<DesktopCommandPaletteInput> {
@@ -852,6 +858,7 @@ async function loadNativeCommandPaletteData(): Promise<DesktopCommandPaletteInpu
   ]);
   replaceNativeCoworkTasks(coworkSessions);
   return {
+    desktopCommands: buildNativeWorkbenchDesktopCommands(),
     sessions: { loaded: true, rows: normalizeSessionsPayload(sessions) },
     workspaceFiles: { loaded: true, rows: buildDesktopWorkspaceFileRows(workspaceFiles) },
     knowledgeDocuments: { loaded: true, rows: buildDesktopKnowledgeDocumentRows(knowledgeDocuments) },

--- a/apps/desktop/src/desktopCommandPalette.test.ts
+++ b/apps/desktop/src/desktopCommandPalette.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./desktopCommandPalette";
 import {
   buildDesktopCommandEntriesFromSidebar,
+  buildNativeWorkbenchSidebarModel,
   buildRootWebUiSidebarModel,
 } from "./desktopSharedModels";
 
@@ -37,6 +38,24 @@ describe("desktop command palette", () => {
       title: "Gateway Status",
       destination: { module: "command", commandId: "refresh-gateway-status" },
     });
+  });
+
+  test("keeps root and native shared entries searchable for the same core destinations", () => {
+    const rootState = createDesktopCommandPaletteState({
+      desktopCommands: buildDesktopCommandEntriesFromSidebar(buildRootWebUiSidebarModel()),
+    });
+    const nativeState = createDesktopCommandPaletteState({
+      desktopCommands: buildDesktopCommandEntriesFromSidebar(buildNativeWorkbenchSidebarModel()),
+    });
+
+    for (const query of ["tools", "automations", "settings", "runtime diagnostics"]) {
+      const rootResult = buildDesktopCommandPaletteResults(rootState, query)[0];
+      const nativeResult = buildDesktopCommandPaletteResults(nativeState, query)[0];
+      expect(nativeResult).toMatchObject({
+        title: rootResult.title,
+        destination: rootResult.destination,
+      });
+    }
   });
 
   test("groups searchable commands and loaded workbench data", () => {

--- a/apps/desktop/src/desktopSharedModels.test.ts
+++ b/apps/desktop/src/desktopSharedModels.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   buildDesktopCommandEntriesFromSidebar,
+  buildNativeWorkbenchSidebarModel,
   buildRootWebUiRuntimeChips,
   buildRootWebUiSidebarModel,
   buildRootWebUiWorkspaceContext,
@@ -104,5 +105,45 @@ describe("desktop shared shell models", () => {
     expect(entries.find((entry) => entry.href === "/tools")?.keywords).toEqual(
       expect.arrayContaining(["tools", "actions", "tinybot"]),
     );
+  });
+
+  test("builds native workbench sidebar groups from the shared desktop model shape", () => {
+    const model = buildNativeWorkbenchSidebarModel();
+
+    expect(model.mode).toBe("native-workbench");
+    expect(model.groups.map((group) => group.id)).toEqual(["actions", "workspace", "footer"]);
+    expect(model.groups[0].items.map((item) => item.commandId)).toEqual([
+      "new-chat",
+      "search-sessions",
+      "open-command-palette",
+    ]);
+    expect(model.groups[1].items.map((item) => [item.label, item.href])).toEqual([
+      ["Workspace", "/workspace"],
+      ["Knowledge", "/knowledge"],
+      ["Tools", "/tools"],
+      ["Automations", "/cowork"],
+      ["Docs", "/docs"],
+      ["Tinybot repo", "https://github.com/SudoJacky/tinybot"],
+    ]);
+    expect(model.groups[2].items.map((item) => item.commandId)).toEqual([
+      "open-settings",
+      "refresh-gateway-status",
+      "open-docs",
+    ]);
+  });
+
+  test("keeps root and native command entries aligned for core desktop destinations", () => {
+    const rootEntries = buildDesktopCommandEntriesFromSidebar(buildRootWebUiSidebarModel());
+    const nativeEntries = buildDesktopCommandEntriesFromSidebar(buildNativeWorkbenchSidebarModel());
+    const rootLookup = new Map(rootEntries.map((entry) => [entry.title, entry]));
+    const nativeLookup = new Map(nativeEntries.map((entry) => [entry.title, entry]));
+
+    for (const title of ["New Chat", "Search Sessions", "Command Palette", "Tools", "Automations", "Settings", "Gateway Status", "Documentation"]) {
+      expect(nativeLookup.get(title)).toMatchObject({
+        title,
+        commandId: rootLookup.get(title)?.commandId,
+        href: rootLookup.get(title)?.href,
+      });
+    }
   });
 });

--- a/apps/desktop/src/desktopSharedModels.ts
+++ b/apps/desktop/src/desktopSharedModels.ts
@@ -78,6 +78,10 @@ export interface RootWebUiRuntimeChipOptions {
   tokenUsage?: string | null;
 }
 
+export interface NativeWorkbenchSidebarModelOptions {
+  workspace?: DesktopWorkspaceContext;
+}
+
 const ROOT_WEBUI_ACTION_COMMANDS: DesktopMenuCommandId[] = [
   "new-chat",
   "search-sessions",
@@ -131,6 +135,45 @@ export function buildRootWebUiSidebarModel({
         items: sidebarItemsFromCommands(ROOT_WEBUI_FOOTER_COMMANDS),
       },
     ],
+  };
+}
+
+export function buildNativeWorkbenchSidebarModel({
+  workspace = buildNativeWorkbenchWorkspaceContext(),
+}: NativeWorkbenchSidebarModelOptions = {}): DesktopSidebarModel {
+  return {
+    mode: "native-workbench",
+    workspace,
+    groups: [
+      {
+        id: "actions",
+        items: sidebarItemsFromCommands(ROOT_WEBUI_ACTION_COMMANDS),
+      },
+      {
+        id: "workspace",
+        label: "Resources",
+        items: [
+          { id: "link:workspace", kind: "link", label: "Workspace", href: "/workspace", icon: "files" },
+          { id: "link:knowledge", kind: "link", label: "Knowledge", href: "/knowledge", icon: "knowledge" },
+          { id: "link:tools", kind: "link", label: "Tools", href: "/tools", icon: "tools" },
+          { id: "link:automations", kind: "link", label: "Automations", href: "/cowork", icon: "automation" },
+          { id: "link:docs", kind: "link", label: "Docs", href: "/docs", icon: "docs" },
+          { id: "link:repo", kind: "link", label: "Tinybot repo", href: "https://github.com/SudoJacky/tinybot", icon: "repo" },
+        ],
+      },
+      {
+        id: "footer",
+        items: sidebarItemsFromCommands(ROOT_WEBUI_FOOTER_COMMANDS),
+      },
+    ],
+  };
+}
+
+function buildNativeWorkbenchWorkspaceContext(): DesktopWorkspaceContext {
+  return {
+    id: "native-workbench",
+    label: "tinybot",
+    mode: "native-workbench",
   };
 }
 

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -249,10 +249,37 @@ describe("desktop workbench shell", () => {
       "/workspace",
       "/knowledge",
       "/tools",
+      "/cowork",
       "/docs",
       "https://github.com/SudoJacky/tinybot",
+      null,
+      null,
+      null,
     ]);
     expect(targetDocument.body.querySelector(".desktop-status-strip")?.getAttribute("data-desktop-route-status")).toBe("");
+  });
+
+  test("renders native sidebar navigation from shared desktop item metadata", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    expect(targetDocument.body.querySelectorAll(".desktop-workbench-link")
+      .filter((node) => node.getAttribute("href") !== null)
+      .map((node) => node.getAttribute("data-sidebar-item-id"))).toEqual([
+      "link:workspace",
+      "link:knowledge",
+      "link:tools",
+      "link:automations",
+      "link:docs",
+      "link:repo",
+    ]);
+    expect(targetDocument.body.querySelector('[data-sidebar-command="open-settings"]')?.textContent).toBe("Settings");
+    expect(targetDocument.body.querySelector('[data-sidebar-command="refresh-gateway-status"]')?.textContent).toBe("Gateway Status");
   });
 
   test("renders a keyboard-accessible command palette surface", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -29,6 +29,11 @@ import {
 import type { DesktopTaskActionId, DesktopTaskCenterAction, DesktopTaskCenterItem } from "./desktopTaskCenter";
 import type { WorkbenchLayoutState, WorkbenchPanelId, WorkbenchPanelState } from "./desktopWorkbenchLayout";
 import { loadWorkbenchLayout } from "./desktopWorkbenchLayout";
+import {
+  buildNativeWorkbenchSidebarModel,
+  type DesktopSidebarGroup,
+  type DesktopSidebarItem,
+} from "./desktopSharedModels";
 
 export interface DesktopTaskCenterActionEvent {
   action: DesktopTaskActionId;
@@ -331,17 +336,15 @@ function createActivityRail(targetDocument: Document): HTMLElement {
 }
 
 function createSidebar(targetDocument: Document): HTMLElement {
+  const model = buildNativeWorkbenchSidebarModel();
+  const workspaceGroup = model.groups.find((group) => group.id === "workspace");
+  const footerGroup = model.groups.find((group) => group.id === "footer");
   const sidebar = targetDocument.createElement("div");
   sidebar.className = "desktop-sidebar-content";
   sidebar.append(
     createSection(targetDocument, "Sessions", ["No active session", "Recent sessions will appear here"]),
-    createLinkSection(targetDocument, "Resources", [
-      ["Workspace", "/workspace"],
-      ["Knowledge", "/knowledge"],
-      ["Tools and skills", "/tools"],
-      ["Docs", "/docs"],
-      ["Tinybot repo", "https://github.com/SudoJacky/tinybot"],
-    ]),
+    createSharedSidebarLinkSection(targetDocument, workspaceGroup),
+    createSharedSidebarCommandSection(targetDocument, footerGroup),
   );
   return sidebar;
 }
@@ -1995,14 +1998,65 @@ function renderInspectorView(targetDocument: Document, view: DesktopInspectorVie
   return section;
 }
 
-function createLinkSection(targetDocument: Document, title: string, rows: [string, string][]): HTMLElement {
+function createSharedSidebarLinkSection(targetDocument: Document, group: DesktopSidebarGroup | undefined): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section";
-  section.append(createText(targetDocument, "h2", title));
-  for (const [label, href] of rows) {
-    section.append(createWorkbenchLink(targetDocument, label, href, "desktop-workbench-link"));
+  section.append(createText(targetDocument, "h2", group?.label ?? "Resources"));
+  for (const item of group?.items ?? []) {
+    if (item.kind === "link" && item.href) {
+      section.append(createSharedWorkbenchLink(targetDocument, item));
+    }
   }
   return section;
+}
+
+function createSharedSidebarCommandSection(targetDocument: Document, group: DesktopSidebarGroup | undefined): HTMLElement {
+  const section = targetDocument.createElement("section");
+  section.className = "desktop-workbench-section";
+  section.append(createText(targetDocument, "h2", group?.label ?? "System"));
+  for (const item of group?.items ?? []) {
+    if (item.kind === "command" && item.commandId) {
+      section.append(createSharedSidebarCommandButton(targetDocument, item));
+    }
+  }
+  return section;
+}
+
+function createSharedWorkbenchLink(targetDocument: Document, item: DesktopSidebarItem): HTMLElement {
+  const link = createWorkbenchLink(targetDocument, item.label, item.href ?? "#", "desktop-workbench-link");
+  applySharedSidebarItemAttributes(link, item);
+  return link;
+}
+
+function createSharedSidebarCommandButton(targetDocument: Document, item: DesktopSidebarItem): HTMLElement {
+  const button = targetDocument.createElement("button");
+  button.className = "desktop-workbench-link";
+  button.setAttribute("type", "button");
+  button.textContent = item.label;
+  applySharedSidebarItemAttributes(button, item);
+  button.addEventListener("click", () => {
+    if (!item.commandId) {
+      return;
+    }
+    targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", {
+      detail: { id: item.commandId, source: "native-sidebar" },
+    }));
+  });
+  return button;
+}
+
+function applySharedSidebarItemAttributes(element: HTMLElement, item: DesktopSidebarItem): void {
+  element.setAttribute("data-sidebar-item-id", item.id);
+  element.setAttribute("data-sidebar-item-kind", item.kind);
+  if (item.href) {
+    element.setAttribute("data-sidebar-href", item.href);
+  }
+  if (item.commandId) {
+    element.setAttribute("data-sidebar-command", item.commandId);
+  }
+  if (item.icon) {
+    element.setAttribute("data-sidebar-icon", item.icon);
+  }
 }
 
 function createWorkbenchLink(targetDocument: Document, label: string, href: string, className: string): HTMLElement {


### PR DESCRIPTION
## Summary

- Add a native workbench sidebar model using the shared desktop navigation shape.
- Feed native shared command entries into command search.
- Render native sidebar links and system buttons with shared metadata and command dispatch.

## Validation

- `npm test -- desktopSharedModels.test.ts desktopCommandPalette.test.ts desktopWorkbenchShell.test.ts`
- `npm test`
- `npm run build`

Closes #137