### PR TITLE
Fix desktop WebUI initialization stall

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -200,6 +200,7 @@ async function bootDesktopWebUi(): Promise<void> {
       return;
     }
     installWebUiShell(webUiHtml);
+    await import(/* @vite-ignore */ WEBUI_ENTRY);
     installDesktopRootWebUiWorkbenchAdapter();
     installDesktopCommandPalette({
       gatewayOrigin: gatewayConfig.httpBaseUrl,
@@ -209,7 +210,6 @@ async function bootDesktopWebUi(): Promise<void> {
     installRootWebUiDesktopAdapters();
     installTauriNavigation();
     installTauriWindowFrame(status);
-    await import(/* @vite-ignore */ WEBUI_ENTRY);
     console.info("Tinybot desktop WebUI initialized", status);
   } catch (error) {
     setStartupState(

--- a/apps/desktop/src/desktopBootstrapOrder.test.ts
+++ b/apps/desktop/src/desktopBootstrapOrder.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const bootstrapSource = readFileSync(resolve(currentDir, "desktopBootstrap.ts"), "utf8");
+
+function callPosition(call: string): number {
+  const position = bootstrapSource.indexOf(call);
+  expect(position).toBeGreaterThanOrEqual(0);
+  return position;
+}
+
+describe("desktop root WebUI bootstrap order", () => {
+  test("lets the WebUI entry bind its original DOM before installing the desktop root adapter", () => {
+    const shellPosition = callPosition("installWebUiShell(webUiHtml);");
+    const webUiEntryPosition = callPosition("await import(/* @vite-ignore */ WEBUI_ENTRY);");
+    const rootAdapterPosition = callPosition("installDesktopRootWebUiWorkbenchAdapter();");
+
+    expect(webUiEntryPosition).toBeGreaterThan(shellPosition);
+    expect(webUiEntryPosition).toBeLessThan(rootAdapterPosition);
+  });
+});


### PR DESCRIPTION
Closes #139.

## Summary
- Load the root WebUI entry before installing the desktop sidebar adapter so legacy WebUI event binding runs against the original DOM.
- Add a regression test that locks the desktop root WebUI bootstrap order.

## Verification
- `npm test -- desktopBootstrapOrder.test.ts desktopRootWebUiWorkbench.test.ts desktopWebUiShell.test.ts`
- `npm test`
- `npm run build`
- Chrome headless DOM check: `#init-skeleton` is absent after boot and no runtime exceptions are reported.