### PR TITLE
Fix desktop root sidebar actions and framing

### DIFF
--- a/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.test.ts
@@ -115,6 +115,10 @@ class FakeElement {
     return true;
   }
 
+  click(): void {
+    this.dispatchEvent({ type: "click" });
+  }
+
   querySelector(selector: string): FakeElement | null {
     if (matchesSelector(this, selector)) {
       return this;
@@ -192,6 +196,17 @@ function createRootWebUiDocument(): FakeDocument {
 
   const sidebar = document.createElement("aside");
   sidebar.className = "sidebar";
+  const newChat = document.createElement("button");
+  newChat.setAttribute("id", "new-chat-button");
+  const settings = document.createElement("button");
+  settings.setAttribute("id", "settings-button");
+  const theme = document.createElement("button");
+  theme.setAttribute("id", "theme-toggle");
+  const collapse = document.createElement("button");
+  collapse.setAttribute("id", "sidebar-collapse-button");
+  const help = document.createElement("button");
+  help.setAttribute("id", "help-tour-button");
+  sidebar.append(newChat, settings, theme, collapse, help);
   const chat = document.createElement("section");
   chat.className = "chat-panel";
   const messageList = document.createElement("section");
@@ -334,6 +349,33 @@ describe("desktop root WebUI workbench adapter", () => {
     expect(sidebar?.querySelector('[data-sidebar-command="new-chat"]')?.textContent).toContain("New");
     expect(sidebar?.querySelector('[data-sidebar-href="/tools"]')?.getAttribute("href")).toBe("/tools");
     expect(sidebar?.querySelector('[data-sidebar-item-id="session:chat-1"]')?.getAttribute("aria-current")).toBe("page");
+  });
+
+  test("keeps original WebUI command controls as hidden proxies after installing the desktop sidebar", () => {
+    const targetDocument = createRootWebUiDocument();
+    let newChatClicks = 0;
+    let settingsClicks = 0;
+    targetDocument.getElementById("new-chat-button")?.addEventListener("click", () => {
+      newChatClicks += 1;
+    });
+    targetDocument.getElementById("settings-button")?.addEventListener("click", () => {
+      settingsClicks += 1;
+    });
+
+    installDesktopRootWebUiWorkbenchAdapter({
+      targetDocument: targetDocument as unknown as Document,
+      storage: null,
+    });
+
+    expect(targetDocument.getElementById("new-chat-button")?.getAttribute("data-desktop-command-proxy")).toBe("true");
+    expect(targetDocument.getElementById("settings-button")?.getAttribute("data-desktop-command-proxy")).toBe("true");
+    expect(targetDocument.body.querySelector(".desktop-webui-command-proxies")?.getAttribute("aria-hidden")).toBe("true");
+
+    targetDocument.getElementById("new-chat-button")?.click();
+    targetDocument.getElementById("settings-button")?.click();
+
+    expect(newChatClicks).toBe(1);
+    expect(settingsClicks).toBe(1);
   });
 
   test("upgrades the hosted WebUI composer with runtime chips and blocked-send feedback", () => {

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -107,6 +107,7 @@ export function installRootWebUiDesktopAppSidebar(targetDocument: Document): voi
     return;
   }
 
+  preserveRootWebUiCommandProxies(targetDocument);
   const workspace = buildRootWebUiWorkspaceContext({
     workspaceLabel: "tinybot",
     activeSession: rootWebUiActiveSession(targetDocument),
@@ -119,6 +120,48 @@ export function installRootWebUiDesktopAppSidebar(targetDocument: Document): voi
     }),
     targetDocument,
   );
+}
+
+const ROOT_WEBUI_COMMAND_PROXY_IDS = [
+  "new-chat-button",
+  "stop-generation-button",
+  "settings-button",
+  "theme-toggle",
+  "sidebar-collapse-button",
+  "help-tour-button",
+];
+
+function preserveRootWebUiCommandProxies(targetDocument: Document): void {
+  const controls = ROOT_WEBUI_COMMAND_PROXY_IDS
+    .map((id) => targetDocument.getElementById(id))
+    .filter((control): control is HTMLElement => Boolean(control));
+  if (controls.length === 0) {
+    return;
+  }
+
+  const proxyHost = ensureCommandProxyHost(targetDocument);
+  for (const control of controls) {
+    control.setAttribute("data-desktop-command-proxy", "true");
+    control.setAttribute("aria-hidden", "true");
+    control.tabIndex = -1;
+    proxyHost.append(control);
+  }
+}
+
+function ensureCommandProxyHost(targetDocument: Document): HTMLElement {
+  const existing = targetDocument.getElementById("desktop-webui-command-proxies");
+  if (existing) {
+    return existing;
+  }
+
+  const proxyHost = targetDocument.createElement("div");
+  proxyHost.id = "desktop-webui-command-proxies";
+  proxyHost.className = "desktop-webui-command-proxies";
+  proxyHost.setAttribute("id", "desktop-webui-command-proxies");
+  proxyHost.setAttribute("aria-hidden", "true");
+  proxyHost.hidden = true;
+  targetDocument.body.append(proxyHost);
+  return proxyHost;
 }
 
 function installRootWebUiPanelPersistence(

--- a/apps/desktop/src/desktopShellLayout.test.ts
+++ b/apps/desktop/src/desktopShellLayout.test.ts
@@ -182,8 +182,14 @@ describe("desktop shell layout", () => {
 
     const styleText = targetDocument.head.querySelector("#desktop-root-webui-workbench-style")?.textContent ?? "";
     expect(styleText).toContain("body.desktop-root-webui-workbench > .shell");
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell {");
+    expect(styleText).toContain("border: 0;");
+    expect(styleText).toContain("border-radius: 0;");
     expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .sidebar");
     expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .chat-panel");
+    expect(styleText).toContain("body.desktop-root-webui-workbench > .shell .chat-panel {");
+    expect(styleText).toContain("border: 1px solid var(--border, #e6dfd8);");
+    expect(styleText).toContain("border-radius: 12px;");
     expect(styleText).toContain("body.desktop-root-webui-workbench [data-desktop-shell-region=\"workspace\"]");
     expect(styleText).toContain("order: 0");
     expect(styleText).toContain("grid-column: 1");

--- a/apps/desktop/src/desktopShellLayout.ts
+++ b/apps/desktop/src/desktopShellLayout.ts
@@ -65,7 +65,9 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
     body.desktop-root-webui-workbench > .shell {
       --desktop-sidebar-rail-size: 68px;
       grid-template-columns: var(--desktop-sidebar-size, 248px) minmax(0, 1fr) minmax(0, var(--desktop-inspector-size, 360px));
-      background: var(--panel, #faf9f5);
+      border: 0;
+      border-radius: 0;
+      background: transparent;
       box-shadow: none;
     }
 
@@ -100,6 +102,10 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
       border-radius: 0;
       background: var(--panel-strong, #efe9de);
       box-shadow: none;
+    }
+
+    body.desktop-root-webui-workbench .desktop-webui-command-proxies {
+      display: none !important;
     }
 
     body.desktop-root-webui-workbench .desktop-app-sidebar-content {
@@ -206,6 +212,13 @@ export function ensureDesktopRootWebUiShellLayoutStyle(targetDocument: Document)
       grid-column: 2 !important;
       grid-row: 1;
       min-width: 0;
+    }
+
+    body.desktop-root-webui-workbench > .shell .chat-panel {
+      overflow: hidden;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 12px;
+      background: var(--panel, #faf9f5);
     }
 
     body.desktop-root-webui-workbench > .shell .inspector-panel {


### PR DESCRIPTION
Closes #141.

## Summary
- Preserve original WebUI command controls as hidden proxies before replacing the sidebar, so desktop sidebar commands can keep routing through existing WebUI behavior.
- Move the desktop root frame styling off the whole shell and onto the right workspace panel.
- Add regression coverage for command proxies and root shell framing.

## Verification
- `npm test -- desktopRootWebUiWorkbench.test.ts desktopShellLayout.test.ts`
- `npm test`
- `npm run build`
- Chrome headless DOM/style check: no init skeleton, hidden command proxies exist, shell has no border/radius, left sidebar has no radius, right workspace has a 12px radius and 1px border.