### PR TITLE
Add desktop Work Lens projection foundation

### DIFF
--- a/apps/desktop/src/desktopWorkLens.test.ts
+++ b/apps/desktop/src/desktopWorkLens.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "vitest";
+import { buildDesktopTaskCenterItems } from "./desktopTaskCenter";
+import {
+  buildDesktopWorkLensProjection,
+  type DesktopWorkLensRelatedResourceInput,
+} from "./desktopWorkLens";
+
+describe("desktop work lens projection", () => {
+  test("projects a chat run from task-center state and run-chain resources", () => {
+    const [task] = buildDesktopTaskCenterItems({
+      chatStreams: [
+        {
+          id: "chat:session-1:run-7",
+          title: "Streaming answer",
+          status: "streaming",
+          detail: "Using workspace files",
+          progress: { percent: 42 },
+          canonical: { module: "chat", entityId: "session-1", href: "/chat/session-1" },
+          cancelable: true,
+        },
+      ],
+    });
+    const resources: DesktopWorkLensRelatedResourceInput[] = [
+      {
+        kind: "tool",
+        id: "tool:web.run",
+        title: "web.run",
+        detail: "Search evidence",
+        route: { module: "chat", entityId: "session-1", href: "/chat/session-1" },
+      },
+      {
+        kind: "file",
+        id: "file:AGENTS.md",
+        title: "AGENTS.md",
+        detail: "Workspace context",
+        route: { module: "workspace", entityId: "AGENTS.md", href: "/workspace" },
+      },
+    ];
+
+    const lens = buildDesktopWorkLensProjection({ task, resources });
+
+    expect(lens).toMatchObject({
+      mode: "ready",
+      kind: "chatRun",
+      id: "chat:session-1:run-7",
+      title: "Streaming answer",
+      state: "active",
+      stateReason: "Using workspace files",
+      canonicalRoute: { module: "chat", entityId: "session-1", href: "/chat/session-1" },
+    });
+    expect(lens.sections.map((section) => section.id)).toEqual(["happening", "used", "changed", "next"]);
+    expect(lens.sections.find((section) => section.id === "happening")?.rows).toContainEqual({
+      label: "Progress",
+      value: "42%",
+    });
+    expect(lens.relatedResources.map((resource) => `${resource.kind}:${resource.title}`)).toEqual([
+      "tool:web.run",
+      "file:AGENTS.md",
+    ]);
+    expect(lens.nextActions.map((action) => action.id)).toEqual(["cancel", "open", "inspect"]);
+  });
+
+  test("projects failed knowledge work with evidence resources and diagnostics actions", () => {
+    const [task] = buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-1:index",
+          title: "Index Desktop UX Notes",
+          status: "failed",
+          detail: "Embedding provider returned 429",
+          canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+          retryable: true,
+          diagnostics: "HTTP 429: rate limit",
+        },
+      ],
+    });
+
+    const lens = buildDesktopWorkLensProjection({
+      task,
+      resources: [
+        {
+          kind: "evidence",
+          id: "evidence:doc-1:claim-2",
+          title: "Claim evidence",
+          detail: "docs/desktop.md line 42",
+          route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+        },
+      ],
+      outputs: [
+        {
+          kind: "diagnostic",
+          id: "diagnostic:knowledge:doc-1:index",
+          title: "Failure diagnostics",
+          detail: "HTTP 429: rate limit",
+          route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+        },
+      ],
+    });
+
+    expect(lens.kind).toBe("knowledgeJob");
+    expect(lens.state).toBe("failed");
+    expect(lens.relatedResources).toHaveLength(1);
+    expect(lens.outputs).toHaveLength(1);
+    expect(lens.nextActions.map((action) => action.id)).toEqual(["retry", "open", "inspect", "copyDiagnostics"]);
+    expect(lens.nextActions.find((action) => action.id === "copyDiagnostics")).toMatchObject({
+      diagnosticText: "HTTP 429: rate limit",
+    });
+  });
+
+  test("projects Cowork blocked work without broad or destructive actions", () => {
+    const [task] = buildDesktopTaskCenterItems({
+      coworkRuns: [
+        {
+          id: "cowork:session-9",
+          title: "Refine operator workflow",
+          status: "intervention-needed",
+          detail: "Branch result needs review",
+          canonical: { module: "cowork", entityId: "session-9", href: "/cowork" },
+          diagnostics: "task-4 blocked by review",
+        },
+      ],
+    });
+
+    const lens = buildDesktopWorkLensProjection({
+      task,
+      resources: [
+        {
+          kind: "coworkEntity",
+          id: "cowork:session-9:task-4",
+          title: "Task 4",
+          detail: "Needs review",
+          route: { module: "cowork", entityId: "session-9", href: "/cowork" },
+        },
+        {
+          kind: "artifact",
+          id: "artifact:final-draft",
+          title: "Final draft",
+          detail: "Produced by branch B",
+          route: { module: "cowork", entityId: "session-9", href: "/cowork" },
+        },
+      ],
+    });
+
+    expect(lens.kind).toBe("coworkRun");
+    expect(lens.state).toBe("blocked");
+    expect(lens.nextActions.map((action) => action.id)).toEqual(["open", "inspect", "copyDiagnostics"]);
+    expect(lens.nextActions.some((action) => action.id === "dismiss")).toBe(false);
+    expect(lens.relatedResources.map((resource) => resource.kind)).toEqual(["coworkEntity", "artifact"]);
+  });
+
+  test("falls back for unsupported task-center sources", () => {
+    const [task] = buildDesktopTaskCenterItems({
+      providerRefreshes: [
+        {
+          id: "provider:openai:models",
+          title: "Refresh OpenAI models",
+          status: "completed",
+          detail: "24 models loaded",
+          canonical: { module: "settings", entityId: "openai", href: "/settings" },
+        },
+      ],
+    });
+
+    const lens = buildDesktopWorkLensProjection({ task });
+
+    expect(lens).toMatchObject({
+      mode: "fallback",
+      fallbackReason: "unsupported-source",
+      title: "Refresh OpenAI models",
+      canonicalRoute: { module: "settings", entityId: "openai", href: "/settings" },
+    });
+    expect(lens.nextActions.map((action) => action.id)).toEqual(["open"]);
+  });
+});

--- a/apps/desktop/src/desktopWorkLens.ts
+++ b/apps/desktop/src/desktopWorkLens.ts
@@ -1,0 +1,257 @@
+import type {
+  DesktopTaskCenterItem,
+  DesktopTaskDestination,
+  DesktopTaskSource,
+  DesktopTaskState,
+} from "./desktopTaskCenter";
+
+export type DesktopWorkLensMode = "ready" | "fallback";
+export type DesktopWorkLensKind = "chatRun" | "knowledgeJob" | "coworkRun" | "unsupported";
+export type DesktopWorkLensSectionId = "happening" | "used" | "changed" | "next";
+export type DesktopWorkLensRelatedResourceKind =
+  | "file"
+  | "evidence"
+  | "tool"
+  | "log"
+  | "artifact"
+  | "provider"
+  | "coworkEntity"
+  | "diagnostic";
+export type DesktopWorkLensActionId =
+  | "retry"
+  | "cancel"
+  | "resume"
+  | "open"
+  | "inspect"
+  | "rebuild"
+  | "copyDiagnostics"
+  | "dismiss";
+export type DesktopWorkLensFallbackReason = "no-selection" | "unsupported-source" | "missing-context" | "projection-failed";
+
+export interface DesktopWorkLensRelatedResourceInput {
+  kind: DesktopWorkLensRelatedResourceKind;
+  id: string;
+  title: string;
+  detail?: string;
+  route: DesktopTaskDestination;
+}
+
+export interface DesktopWorkLensRelatedResource {
+  kind: DesktopWorkLensRelatedResourceKind;
+  id: string;
+  title: string;
+  detail: string;
+  route: DesktopTaskDestination;
+}
+
+export interface DesktopWorkLensNextAction {
+  id: DesktopWorkLensActionId;
+  label: string;
+  route?: DesktopTaskDestination;
+  diagnosticText?: string;
+}
+
+export interface DesktopWorkLensSection {
+  id: DesktopWorkLensSectionId;
+  title: string;
+  rows: Array<{ label: string; value: string }>;
+}
+
+export interface DesktopWorkLensProjectionInput {
+  task?: DesktopTaskCenterItem | null;
+  resources?: DesktopWorkLensRelatedResourceInput[];
+  outputs?: DesktopWorkLensRelatedResourceInput[];
+  fallbackReason?: DesktopWorkLensFallbackReason;
+}
+
+export interface DesktopWorkLensProjection {
+  mode: DesktopWorkLensMode;
+  kind: DesktopWorkLensKind;
+  id: string;
+  title: string;
+  state: DesktopTaskState | "unsupported";
+  stateReason: string;
+  canonicalRoute: DesktopTaskDestination | null;
+  fallbackReason: DesktopWorkLensFallbackReason | "";
+  relatedResources: DesktopWorkLensRelatedResource[];
+  outputs: DesktopWorkLensRelatedResource[];
+  nextActions: DesktopWorkLensNextAction[];
+  sections: DesktopWorkLensSection[];
+}
+
+const SUPPORTED_WORK_SOURCES: Partial<Record<DesktopTaskSource, DesktopWorkLensKind>> = {
+  chat: "chatRun",
+  knowledge: "knowledgeJob",
+  cowork: "coworkRun",
+};
+
+const ACTION_LABELS: Record<DesktopWorkLensActionId, string> = {
+  retry: "Retry",
+  cancel: "Cancel",
+  resume: "Resume",
+  open: "Open",
+  inspect: "Inspect",
+  rebuild: "Rebuild",
+  copyDiagnostics: "Copy diagnostics",
+  dismiss: "Dismiss",
+};
+
+export function buildDesktopWorkLensProjection({
+  task,
+  resources = [],
+  outputs = [],
+  fallbackReason = "no-selection",
+}: DesktopWorkLensProjectionInput): DesktopWorkLensProjection {
+  if (!task) {
+    return fallbackProjection({
+      fallbackReason,
+      title: "No running work selected",
+      canonicalRoute: null,
+      nextActions: [],
+    });
+  }
+
+  const kind = SUPPORTED_WORK_SOURCES[task.source];
+  const relatedResources = normalizeResources(resources);
+  const outputResources = normalizeResources(outputs);
+  if (!kind) {
+    return fallbackProjection({
+      fallbackReason: "unsupported-source",
+      title: task.title,
+      canonicalRoute: task.destination,
+      nextActions: fallbackActions(task),
+    });
+  }
+
+  const nextActions = task.actions
+    .filter((action) => action.id !== "dismiss")
+    .map((action) => ({
+      id: action.id,
+      label: ACTION_LABELS[action.id],
+      route: action.id === "open" || action.id === "inspect" ? task.destination : undefined,
+      diagnosticText: action.id === "copyDiagnostics" ? task.diagnostics : undefined,
+    }));
+
+  return {
+    mode: "ready",
+    kind,
+    id: task.id,
+    title: task.title,
+    state: task.state,
+    stateReason: task.detail,
+    canonicalRoute: task.destination,
+    fallbackReason: "",
+    relatedResources,
+    outputs: outputResources,
+    nextActions,
+    sections: buildSections(task, relatedResources, outputResources, nextActions),
+  };
+}
+
+function fallbackProjection({
+  fallbackReason,
+  title,
+  canonicalRoute,
+  nextActions,
+}: {
+  fallbackReason: DesktopWorkLensFallbackReason;
+  title: string;
+  canonicalRoute: DesktopTaskDestination | null;
+  nextActions: DesktopWorkLensNextAction[];
+}): DesktopWorkLensProjection {
+  return {
+    mode: "fallback",
+    kind: "unsupported",
+    id: "",
+    title,
+    state: "unsupported",
+    stateReason: "",
+    canonicalRoute,
+    fallbackReason,
+    relatedResources: [],
+    outputs: [],
+    nextActions,
+    sections: [],
+  };
+}
+
+function fallbackActions(task: DesktopTaskCenterItem): DesktopWorkLensNextAction[] {
+  return task.actions
+    .filter((action) => action.id === "open")
+    .map((action) => ({
+      id: action.id,
+      label: ACTION_LABELS[action.id],
+      route: task.destination,
+    }));
+}
+
+function normalizeResources(resources: DesktopWorkLensRelatedResourceInput[]): DesktopWorkLensRelatedResource[] {
+  return resources
+    .filter((resource) => resource.id.trim() && resource.title.trim())
+    .map((resource) => ({
+      kind: resource.kind,
+      id: resource.id,
+      title: resource.title,
+      detail: resource.detail ?? "",
+      route: resource.route,
+    }));
+}
+
+function buildSections(
+  task: DesktopTaskCenterItem,
+  relatedResources: DesktopWorkLensRelatedResource[],
+  outputs: DesktopWorkLensRelatedResource[],
+  nextActions: DesktopWorkLensNextAction[],
+): DesktopWorkLensSection[] {
+  return [
+    {
+      id: "happening",
+      title: "What is happening?",
+      rows: compactRows([
+        ["State", task.state],
+        ["Status", task.status],
+        ["Reason", task.detail],
+        ["Progress", task.progressLabel],
+      ]),
+    },
+    {
+      id: "used",
+      title: "What did it use?",
+      rows: relatedResources.map((resource) => ({
+        label: resourceKindLabel(resource.kind),
+        value: [resource.title, resource.detail].filter(Boolean).join(" / "),
+      })),
+    },
+    {
+      id: "changed",
+      title: "What changed?",
+      rows: outputs.map((output) => ({
+        label: resourceKindLabel(output.kind),
+        value: [output.title, output.detail].filter(Boolean).join(" / "),
+      })),
+    },
+    {
+      id: "next",
+      title: "What can I do next?",
+      rows: nextActions.map((action) => ({
+        label: action.label,
+        value: action.route?.href ?? action.diagnosticText ?? "",
+      })),
+    },
+  ];
+}
+
+function compactRows(rows: Array<[string, string]>): Array<{ label: string; value: string }> {
+  return rows
+    .filter(([, value]) => value.trim())
+    .map(([label, value]) => ({ label, value }));
+}
+
+function resourceKindLabel(kind: DesktopWorkLensRelatedResourceKind): string {
+  switch (kind) {
+    case "coworkEntity":
+      return "Cowork entity";
+    default:
+      return kind.charAt(0).toUpperCase() + kind.slice(1);
+  }
+}

--- a/apps/desktop/src/desktopWorkLensFocus.test.ts
+++ b/apps/desktop/src/desktopWorkLensFocus.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "vitest";
+import { buildDesktopTaskCenterItems } from "./desktopTaskCenter";
+import {
+  applyDesktopWorkLensFocusEvent,
+  createDesktopWorkLensFocusState,
+} from "./desktopWorkLensFocus";
+
+function fixtureTasks() {
+  const [chat] = buildDesktopTaskCenterItems({
+    chatStreams: [
+      {
+        id: "chat:session-1:run-1",
+        title: "Streaming answer",
+        status: "streaming",
+        detail: "Using workspace files",
+        canonical: { module: "chat", entityId: "session-1", href: "/chat/session-1" },
+        cancelable: true,
+      },
+    ],
+  });
+  const [knowledge] = buildDesktopTaskCenterItems({
+    knowledgeJobs: [
+      {
+        id: "knowledge:doc-1:index",
+        title: "Index Desktop UX Notes",
+        status: "failed",
+        detail: "Embedding provider returned 429",
+        canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+        retryable: true,
+      },
+    ],
+  });
+  const [cowork] = buildDesktopTaskCenterItems({
+    coworkRuns: [
+      {
+        id: "cowork:session-9",
+        title: "Refine operator workflow",
+        status: "intervention-needed",
+        detail: "Branch result needs review",
+        canonical: { module: "cowork", entityId: "session-9", href: "/cowork" },
+      },
+    ],
+  });
+  return { chat, knowledge, cowork };
+}
+
+describe("desktop work lens focus state", () => {
+  test("follows running work focus from task center and modules", () => {
+    const { chat, knowledge } = fixtureTasks();
+
+    const focusedChat = applyDesktopWorkLensFocusEvent(createDesktopWorkLensFocusState(), {
+      type: "focusWork",
+      source: "taskCenter",
+      task: chat,
+    });
+    const focusedKnowledge = applyDesktopWorkLensFocusEvent(focusedChat, {
+      type: "focusWork",
+      source: "knowledge",
+      task: knowledge,
+    });
+
+    expect(focusedChat.current?.id).toBe("chat:session-1:run-1");
+    expect(focusedChat.source).toBe("taskCenter");
+    expect(focusedKnowledge.current?.id).toBe("knowledge:doc-1:index");
+    expect(focusedKnowledge.source).toBe("knowledge");
+    expect(focusedKnowledge.isPinned).toBe(false);
+  });
+
+  test("preserves pinned work while recording a replace candidate", () => {
+    const { chat, cowork } = fixtureTasks();
+    const focused = applyDesktopWorkLensFocusEvent(createDesktopWorkLensFocusState(), {
+      type: "focusWork",
+      source: "chat",
+      task: chat,
+    });
+    const pinned = applyDesktopWorkLensFocusEvent(focused, { type: "pin" });
+    const browsed = applyDesktopWorkLensFocusEvent(pinned, {
+      type: "focusWork",
+      source: "cowork",
+      task: cowork,
+    });
+
+    expect(browsed.isPinned).toBe(true);
+    expect(browsed.current?.id).toBe("chat:session-1:run-1");
+    expect(browsed.pinned?.id).toBe("chat:session-1:run-1");
+    expect(browsed.replaceCandidate?.id).toBe("cowork:session-9");
+  });
+
+  test("can replace or unpin a pinned work lens without losing candidate context", () => {
+    const { chat, cowork } = fixtureTasks();
+    const pinned = applyDesktopWorkLensFocusEvent(
+      applyDesktopWorkLensFocusEvent(
+        applyDesktopWorkLensFocusEvent(createDesktopWorkLensFocusState(), {
+          type: "focusWork",
+          source: "chat",
+          task: chat,
+        }),
+        { type: "pin" },
+      ),
+      {
+        type: "focusWork",
+        source: "cowork",
+        task: cowork,
+      },
+    );
+
+    const replaced = applyDesktopWorkLensFocusEvent(pinned, { type: "replacePinned" });
+    const unpinned = applyDesktopWorkLensFocusEvent(pinned, { type: "unpin" });
+
+    expect(replaced.current?.id).toBe("cowork:session-9");
+    expect(replaced.pinned?.id).toBe("cowork:session-9");
+    expect(replaced.replaceCandidate).toBeNull();
+    expect(replaced.isPinned).toBe(true);
+    expect(unpinned.current?.id).toBe("cowork:session-9");
+    expect(unpinned.pinned).toBeNull();
+    expect(unpinned.replaceCandidate).toBeNull();
+    expect(unpinned.isPinned).toBe(false);
+  });
+
+  test("opening a related resource preserves pinned work context", () => {
+    const { chat } = fixtureTasks();
+    const pinned = applyDesktopWorkLensFocusEvent(
+      applyDesktopWorkLensFocusEvent(createDesktopWorkLensFocusState(), {
+        type: "focusWork",
+        source: "chat",
+        task: chat,
+      }),
+      { type: "pin" },
+    );
+    const withResource = applyDesktopWorkLensFocusEvent(pinned, {
+      type: "openResource",
+      route: { module: "workspace", entityId: "AGENTS.md", href: "/workspace" },
+    });
+
+    expect(withResource.current?.id).toBe("chat:session-1:run-1");
+    expect(withResource.isPinned).toBe(true);
+    expect(withResource.lastResourceRoute).toEqual({ module: "workspace", entityId: "AGENTS.md", href: "/workspace" });
+  });
+
+  test("clears stale focus without leaving pinned or replacement state behind", () => {
+    const { chat, knowledge } = fixtureTasks();
+    const stale = applyDesktopWorkLensFocusEvent(
+      applyDesktopWorkLensFocusEvent(
+        applyDesktopWorkLensFocusEvent(createDesktopWorkLensFocusState(), {
+          type: "focusWork",
+          source: "chat",
+          task: chat,
+        }),
+        { type: "pin" },
+      ),
+      {
+        type: "focusWork",
+        source: "knowledge",
+        task: knowledge,
+      },
+    );
+
+    const cleared = applyDesktopWorkLensFocusEvent(stale, { type: "clear" });
+
+    expect(cleared.current).toBeNull();
+    expect(cleared.pinned).toBeNull();
+    expect(cleared.replaceCandidate).toBeNull();
+    expect(cleared.isPinned).toBe(false);
+    expect(cleared.lastResourceRoute).toBeNull();
+  });
+});

--- a/apps/desktop/src/desktopWorkLensFocus.ts
+++ b/apps/desktop/src/desktopWorkLensFocus.ts
@@ -1,0 +1,102 @@
+import type { DesktopTaskCenterItem, DesktopTaskDestination } from "./desktopTaskCenter";
+
+export type DesktopWorkLensFocusSource =
+  | "taskCenter"
+  | "chat"
+  | "knowledge"
+  | "cowork"
+  | "commandPalette"
+  | "failureFeedback";
+
+export interface DesktopWorkLensFocusState {
+  current: DesktopTaskCenterItem | null;
+  pinned: DesktopTaskCenterItem | null;
+  replaceCandidate: DesktopTaskCenterItem | null;
+  source: DesktopWorkLensFocusSource | "";
+  isPinned: boolean;
+  lastResourceRoute: DesktopTaskDestination | null;
+}
+
+export type DesktopWorkLensFocusEvent =
+  | {
+      type: "focusWork";
+      source: DesktopWorkLensFocusSource;
+      task: DesktopTaskCenterItem;
+    }
+  | { type: "pin" }
+  | { type: "unpin" }
+  | { type: "replacePinned" }
+  | {
+      type: "openResource";
+      route: DesktopTaskDestination;
+    }
+  | { type: "clear" };
+
+export function createDesktopWorkLensFocusState(): DesktopWorkLensFocusState {
+  return {
+    current: null,
+    pinned: null,
+    replaceCandidate: null,
+    source: "",
+    isPinned: false,
+    lastResourceRoute: null,
+  };
+}
+
+export function applyDesktopWorkLensFocusEvent(
+  state: DesktopWorkLensFocusState,
+  event: DesktopWorkLensFocusEvent,
+): DesktopWorkLensFocusState {
+  switch (event.type) {
+    case "focusWork":
+      if (state.isPinned) {
+        return {
+          ...state,
+          replaceCandidate: event.task,
+          source: event.source,
+        };
+      }
+      return {
+        ...state,
+        current: event.task,
+        replaceCandidate: null,
+        source: event.source,
+      };
+    case "pin": {
+      const current = state.current;
+      return {
+        ...state,
+        pinned: current,
+        isPinned: Boolean(current),
+        replaceCandidate: null,
+      };
+    }
+    case "unpin":
+      return {
+        ...state,
+        current: state.replaceCandidate ?? state.current,
+        pinned: null,
+        replaceCandidate: null,
+        isPinned: false,
+      };
+    case "replacePinned": {
+      const replacement = state.replaceCandidate ?? state.current;
+      return {
+        ...state,
+        current: replacement,
+        pinned: replacement,
+        replaceCandidate: null,
+        isPinned: Boolean(replacement),
+      };
+    }
+    case "openResource":
+      return {
+        ...state,
+        lastResourceRoute: event.route,
+      };
+    case "clear":
+      return createDesktopWorkLensFocusState();
+    default:
+      return state;
+  }
+}

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -5,6 +5,7 @@ import { buildDesktopRunChainItems } from "./desktopRunChainInspector";
 import { buildDesktopSettingsFormState, buildDesktopSettingsPaneModel } from "./desktopSettingsProviders";
 import { buildDesktopTaskCenterItems } from "./desktopTaskCenter";
 import { buildDesktopToolsSkillsPaneModel } from "./desktopToolsSkills";
+import { buildDesktopWorkLensProjection } from "./desktopWorkLens";
 import { createDefaultWorkbenchLayout } from "./desktopWorkbenchLayout";
 import { installDesktopWorkbenchShell, updateDesktopSettingsPane, updateDesktopTaskCenterItems, updateDesktopToolsSkillsPane } from "./desktopWorkbenchShell";
 
@@ -432,6 +433,143 @@ describe("desktop workbench shell", () => {
     expect(pane?.querySelector('[data-desktop-run-chain-item="m-plan:planning"]')?.getAttribute("aria-selected")).toBe("true");
     expect(pane?.querySelector(".desktop-run-chain-detail")?.textContent).toContain("Thinking: Inspect the active context");
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session");
+  });
+
+  test("renders a right-side Work Lens before generic inspector detail for running work", () => {
+    const targetDocument = new FakeDocument();
+    const [task] = buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-1:index",
+          title: "Index Desktop UX Notes",
+          status: "failed",
+          detail: "Embedding provider returned 429",
+          canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+          retryable: true,
+          diagnostics: "HTTP 429",
+        },
+      ],
+    });
+    const workLens = buildDesktopWorkLensProjection({
+      task,
+      resources: [
+        {
+          kind: "evidence",
+          id: "evidence:doc-1",
+          title: "Desktop UX evidence",
+          detail: "Claim evidence",
+          route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+        },
+      ],
+      outputs: [
+        {
+          kind: "diagnostic",
+          id: "diagnostic:doc-1",
+          title: "Failure diagnostics",
+          detail: "HTTP 429",
+          route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+        },
+      ],
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      workLens,
+    });
+
+    const inspector = targetDocument.body.querySelector('[data-workbench-region="inspector"]');
+    const lens = inspector?.querySelector(".desktop-work-lens");
+    expect(lens?.getAttribute("aria-label")).toBe("Work Lens");
+    expect(lens?.getAttribute("data-desktop-work-lens-mode")).toBe("ready");
+    expect(lens?.textContent).toContain("Index Desktop UX Notes");
+    expect(lens?.textContent).toContain("What is happening?");
+    expect(lens?.textContent).toContain("Embedding provider returned 429");
+    expect(lens?.textContent).toContain("What did it use?");
+    expect(lens?.textContent).toContain("Desktop UX evidence");
+    expect(lens?.textContent).toContain("What changed?");
+    expect(lens?.textContent).toContain("Failure diagnostics");
+    expect(lens?.querySelectorAll("[data-desktop-work-lens-action]").map((node) => node.getAttribute("data-desktop-work-lens-action"))).toEqual([
+      "retry",
+      "open",
+      "inspect",
+      "copyDiagnostics",
+    ]);
+    expect(lens?.querySelector('[data-desktop-work-lens-resource="evidence:doc-1"]')?.getAttribute("href")).toBe("/knowledge");
+  });
+
+  test("renders Work Lens fallback without replacing source module access", () => {
+    const targetDocument = new FakeDocument();
+    const [task] = buildDesktopTaskCenterItems({
+      providerRefreshes: [
+        {
+          id: "provider:openai:models",
+          title: "Refresh OpenAI models",
+          status: "completed",
+          detail: "24 models loaded",
+          canonical: { module: "settings", entityId: "openai", href: "/settings" },
+        },
+      ],
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      workLens: buildDesktopWorkLensProjection({ task }),
+    });
+
+    const lens = targetDocument.body.querySelector(".desktop-work-lens");
+    expect(lens?.getAttribute("data-desktop-work-lens-mode")).toBe("fallback");
+    expect(lens?.textContent).toContain("Refresh OpenAI models");
+    expect(lens?.textContent).toContain("unsupported-source");
+    expect(lens?.querySelector('[data-desktop-work-lens-action="open"]')?.getAttribute("href")).toBe("/settings");
+  });
+
+  test("dispatches bounded Work Lens actions without falling back to generic task actions", () => {
+    const targetDocument = new FakeDocument();
+    const events: string[] = [];
+    const copied: string[] = [];
+    const [task] = buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-1:index",
+          title: "Index Desktop UX Notes",
+          status: "failed",
+          detail: "Embedding provider returned 429",
+          canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+          retryable: true,
+          diagnostics: "HTTP 429",
+        },
+      ],
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      workLens: buildDesktopWorkLensProjection({ task }),
+      workLensActions: {
+        onWorkLensAction: ({ action, workLens }) => events.push(`${action}:${workLens.id}`),
+        copyText: (text) => {
+          copied.push(text);
+        },
+      },
+      taskActions: {
+        onTaskAction: ({ action }) => events.push(`task:${action}`),
+      },
+    });
+
+    targetDocument.body.querySelector('[data-desktop-work-lens-action="retry"]')?.click();
+    targetDocument.body.querySelector('[data-desktop-work-lens-action="copyDiagnostics"]')?.click();
+    targetDocument.body.querySelector('[data-desktop-work-lens-action="open"]')?.click();
+
+    expect(events).toEqual([
+      "retry:knowledge:doc-1:index",
+      "copyDiagnostics:knowledge:doc-1:index",
+    ]);
+    expect(copied).toEqual(["HTTP 429"]);
   });
 
   test("renders native file upload actions for knowledge and session files", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -27,6 +27,11 @@ import {
   type DesktopRunChainItem,
 } from "./desktopRunChainInspector";
 import type { DesktopTaskActionId, DesktopTaskCenterAction, DesktopTaskCenterItem } from "./desktopTaskCenter";
+import type {
+  DesktopWorkLensActionId,
+  DesktopWorkLensProjection,
+  DesktopWorkLensRelatedResource,
+} from "./desktopWorkLens";
 import type { WorkbenchLayoutState, WorkbenchPanelId, WorkbenchPanelState } from "./desktopWorkbenchLayout";
 import { loadWorkbenchLayout } from "./desktopWorkbenchLayout";
 import {
@@ -53,6 +58,16 @@ export interface DesktopGatewayRuntimeActionEvent {
 
 interface DesktopGatewayRuntimeActionOptions {
   onGatewayRuntimeAction?: (event: DesktopGatewayRuntimeActionEvent) => void;
+  copyText?: (text: string) => void | Promise<void>;
+}
+
+export interface DesktopWorkLensActionEvent {
+  action: DesktopWorkLensActionId;
+  workLens: DesktopWorkLensProjection;
+}
+
+interface DesktopWorkLensActionOptions {
+  onWorkLensAction?: (event: DesktopWorkLensActionEvent) => void;
   copyText?: (text: string) => void | Promise<void>;
 }
 
@@ -149,6 +164,8 @@ interface InstallDesktopWorkbenchShellOptions {
   coworkActions?: DesktopCoworkActionOptions;
   runChainItems?: DesktopRunChainItem[];
   selectedRunChainItemKey?: string | null;
+  workLens?: DesktopWorkLensProjection | null;
+  workLensActions?: DesktopWorkLensActionOptions;
   taskActions?: DesktopTaskCenterActionOptions;
   gatewayActions?: DesktopGatewayRuntimeActionOptions;
 }
@@ -185,12 +202,14 @@ export function installDesktopWorkbenchShell({
   coworkActions = {},
   runChainItems = [],
   selectedRunChainItemKey = null,
+  workLens = null,
+  workLensActions = {},
   taskActions = {},
   gatewayActions = {},
 }: InstallDesktopWorkbenchShellOptions): void {
   ensureDesktopWorkbenchShellStyle(targetDocument);
   targetDocument.body.classList.add("desktop-native-workbench");
-  targetDocument.body.replaceChildren(createWorkbenchShell(targetDocument, layout, runtimeStatus, gatewayHttp, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, runChainItems, selectedRunChainItemKey, taskActions, gatewayActions));
+  targetDocument.body.replaceChildren(createWorkbenchShell(targetDocument, layout, runtimeStatus, gatewayHttp, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, runChainItems, selectedRunChainItemKey, workLens, workLensActions, taskActions, gatewayActions));
   installDesktopHelpEventRouting(targetDocument);
 }
 
@@ -289,6 +308,8 @@ function createWorkbenchShell(
   coworkActions: DesktopCoworkActionOptions,
   runChainItems: DesktopRunChainItem[],
   selectedRunChainItemKey: string | null,
+  workLens: DesktopWorkLensProjection | null,
+  workLensActions: DesktopWorkLensActionOptions,
   taskActions: DesktopTaskCenterActionOptions,
   gatewayActions: DesktopGatewayRuntimeActionOptions,
 ): HTMLElement {
@@ -306,7 +327,7 @@ function createWorkbenchShell(
     createActivityRail(targetDocument),
     createPanel(targetDocument, "sidebar", layout.sidebar, createSidebar(targetDocument)),
     createMainRegion(targetDocument, gatewayHttp, layout, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions),
-    createPanel(targetDocument, "inspector", layout.inspector, createInspector(targetDocument, runChainItems, selectedRunChainItemKey)),
+    createPanel(targetDocument, "inspector", layout.inspector, createInspector(targetDocument, runChainItems, selectedRunChainItemKey, workLens, workLensActions)),
     createPanel(targetDocument, "bottom", layout.bottom, createBottomRegion(targetDocument, runtimeStatus, gatewayHttp, taskCenterItems, taskActions, gatewayActions)),
   );
 
@@ -1377,15 +1398,107 @@ function createInspector(
   targetDocument: Document,
   runChainItems: DesktopRunChainItem[] = [],
   selectedRunChainItemKey: string | null = null,
+  workLens: DesktopWorkLensProjection | null = null,
+  workLensActions: DesktopWorkLensActionOptions = {},
 ): HTMLElement {
   const inspector = targetDocument.createElement("aside");
   inspector.className = "desktop-inspector-content";
   inspector.append(
-    runChainItems.length
+    workLens
+      ? createWorkLensPane(targetDocument, workLens, workLensActions)
+      : runChainItems.length
       ? createRunChainInspectorPane(targetDocument, runChainItems, selectedRunChainItemKey)
       : renderInspectorView(targetDocument, createDesktopRunChainInspectorView(null)),
   );
   return inspector;
+}
+
+function createWorkLensPane(
+  targetDocument: Document,
+  workLens: DesktopWorkLensProjection,
+  workLensActions: DesktopWorkLensActionOptions,
+): HTMLElement {
+  const section = targetDocument.createElement("section");
+  section.className = "desktop-workbench-section desktop-work-lens";
+  section.setAttribute("aria-label", "Work Lens");
+  section.setAttribute("data-desktop-work-lens-mode", workLens.mode);
+  section.setAttribute("data-desktop-work-lens-kind", workLens.kind);
+  section.append(createText(targetDocument, "h2", "Work Lens"));
+  section.append(createText(targetDocument, "p", workLens.title));
+
+  if (workLens.fallbackReason) {
+    section.append(createText(targetDocument, "p", workLens.fallbackReason));
+  }
+
+  for (const lensSection of workLens.sections) {
+    const group = targetDocument.createElement("section");
+    group.className = "desktop-work-lens-section";
+    group.setAttribute("data-desktop-work-lens-section", lensSection.id);
+    group.append(createText(targetDocument, "h2", lensSection.title));
+    for (const row of lensSection.rows) {
+      group.append(createText(targetDocument, "p", `${row.label}: ${row.value}`));
+    }
+    section.append(group);
+  }
+
+  if (workLens.relatedResources.length) {
+    section.append(createWorkLensResourceList(targetDocument, "Related resources", workLens.relatedResources));
+  }
+  if (workLens.outputs.length) {
+    section.append(createWorkLensResourceList(targetDocument, "Outputs", workLens.outputs));
+  }
+
+  if (workLens.nextActions.length) {
+    const actions = targetDocument.createElement("div");
+    actions.className = "desktop-work-lens-actions";
+    actions.setAttribute("aria-label", `${workLens.title} next actions`);
+    for (const action of workLens.nextActions) {
+      const element = action.route?.href
+        ? createWorkbenchLink(targetDocument, action.label, action.route.href, "desktop-work-lens-action")
+        : targetDocument.createElement("button");
+      element.setAttribute("data-desktop-work-lens-action", action.id);
+      if (!action.route?.href) {
+        element.className = "desktop-work-lens-action";
+        element.setAttribute("type", "button");
+        element.textContent = action.label;
+        element.addEventListener("click", (event) => {
+          event.preventDefault?.();
+          workLensActions.onWorkLensAction?.({ action: action.id, workLens });
+          if (action.id === "copyDiagnostics" && action.diagnosticText) {
+            void copyTaskDiagnostics(action.diagnosticText, workLensActions.copyText);
+          }
+        });
+      }
+      actions.append(element);
+    }
+    section.append(actions);
+  }
+
+  return section;
+}
+
+function createWorkLensResourceList(
+  targetDocument: Document,
+  title: string,
+  resources: DesktopWorkLensRelatedResource[],
+): HTMLElement {
+  const list = targetDocument.createElement("section");
+  list.className = "desktop-work-lens-resources";
+  list.append(createText(targetDocument, "h2", title));
+  for (const resource of resources) {
+    const element = resource.route.href
+      ? createWorkbenchLink(targetDocument, `${resource.title}: ${resource.detail}`.replace(/: $/, ""), resource.route.href, "desktop-work-lens-resource")
+      : targetDocument.createElement("button");
+    element.setAttribute("data-desktop-work-lens-resource", resource.id);
+    element.setAttribute("data-desktop-work-lens-resource-kind", resource.kind);
+    if (!resource.route.href) {
+      element.className = "desktop-work-lens-resource";
+      element.setAttribute("type", "button");
+      element.textContent = `${resource.title}: ${resource.detail}`.replace(/: $/, "");
+    }
+    list.append(element);
+  }
+  return list;
 }
 
 function createRunChainInspectorPane(


### PR DESCRIPTION
## Summary
- Add desktop Work Lens projection and focus-state helpers.
- Render Work Lens content in the desktop right-side region when provided.
- Add tests for projection normalization, pin/focus behavior, right-region rendering, and bounded action dispatch.

## Validation
- `npm test` from `apps/desktop`
- `npm run build` from `apps/desktop`
- `openspec validate improve-desktop-operator-experience --strict`