### PR TITLE
Route Task Center inspect to Work Lens

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -572,6 +572,40 @@ describe("desktop workbench shell", () => {
     expect(copied).toEqual(["HTTP 429"]);
   });
 
+  test("routes Task Center inspect selection into the right-side Work Lens", () => {
+    const targetDocument = new FakeDocument();
+    const items = buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-1:index",
+          title: "Index Desktop UX Notes",
+          status: "failed",
+          detail: "Embedding provider returned 429",
+          canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+          retryable: true,
+          diagnostics: "HTTP 429",
+        },
+      ],
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      taskCenterItems: items,
+    });
+
+    targetDocument.body.querySelector('[data-desktop-task-action="inspect"]')?.click();
+
+    const inspector = targetDocument.body.querySelector('[data-workbench-region="inspector"]');
+    const lens = inspector?.querySelector(".desktop-work-lens");
+    expect(lens?.getAttribute("data-desktop-work-lens-kind")).toBe("knowledgeJob");
+    expect(lens?.textContent).toContain("Index Desktop UX Notes");
+    expect(lens?.textContent).toContain("Embedding provider returned 429");
+    expect(lens?.textContent).toContain("What can I do next?");
+    expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Index Desktop UX Notes in Work Lens");
+  });
+
   test("renders native file upload actions for knowledge and session files", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -27,10 +27,11 @@ import {
   type DesktopRunChainItem,
 } from "./desktopRunChainInspector";
 import type { DesktopTaskActionId, DesktopTaskCenterAction, DesktopTaskCenterItem } from "./desktopTaskCenter";
-import type {
+import {
+  buildDesktopWorkLensProjection,
   DesktopWorkLensActionId,
-  DesktopWorkLensProjection,
-  DesktopWorkLensRelatedResource,
+  type DesktopWorkLensProjection,
+  type DesktopWorkLensRelatedResource,
 } from "./desktopWorkLens";
 import type { WorkbenchLayoutState, WorkbenchPanelId, WorkbenchPanelState } from "./desktopWorkbenchLayout";
 import { loadWorkbenchLayout } from "./desktopWorkbenchLayout";
@@ -1784,8 +1785,8 @@ function handleTaskAction(
   }
   taskActions.onTaskAction?.({ action, item });
   if (action === "inspect") {
-    renderTaskInspector(targetDocument, item);
-    setRouteStatus(targetDocument, `Inspecting ${item.title}`);
+    const renderedWorkLens = renderTaskWorkLens(targetDocument, item);
+    setRouteStatus(targetDocument, renderedWorkLens ? `Inspecting ${item.title} in Work Lens` : `Inspecting ${item.title}`);
   } else if (action === "copyDiagnostics" && item.diagnostics) {
     void copyTaskDiagnostics(item.diagnostics, taskActions.copyText);
     setRouteStatus(targetDocument, `Copied diagnostics for ${item.title}`);
@@ -1815,6 +1816,20 @@ function renderTaskInspector(targetDocument: Document, item: DesktopTaskCenterIt
       ...(item.diagnostics ? [{ type: "text" as const, label: "Diagnostics", text: item.diagnostics }] : []),
     ],
   }));
+}
+
+function renderTaskWorkLens(targetDocument: Document, item: DesktopTaskCenterItem): boolean {
+  const inspector = targetDocument.querySelector<HTMLElement>('[data-workbench-region="inspector"]');
+  if (!inspector) {
+    return false;
+  }
+  const projection = buildDesktopWorkLensProjection({ task: item });
+  if (projection.mode !== "ready") {
+    renderTaskInspector(targetDocument, item);
+    return false;
+  }
+  inspector.replaceChildren(createWorkLensPane(targetDocument, projection, {}));
+  return true;
 }
 
 async function copyTaskDiagnostics(text: string, copyText?: (text: string) => void | Promise<void>): Promise<void> {


### PR DESCRIPTION
## Summary
- Route supported Task Center inspect selections into the right-side Work Lens.
- Preserve generic inspector fallback for unsupported task sources.
- Add coverage for knowledge job inspection through the Task Center.

## Validation
- `npm test` from `apps/desktop`
- `npm run build` from `apps/desktop`
- `openspec validate improve-desktop-operator-experience --strict`