### PR TITLE
Route Cowork session selection to Work Lens

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -606,6 +606,46 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Index Desktop UX Notes in Work Lens");
   });
 
+  test("routes Cowork session selection into the right-side Work Lens", () => {
+    const targetDocument = new FakeDocument();
+    const session = {
+      id: "cowork-1",
+      title: "Review desktop release",
+      goal: "Ship the desktop Work Lens",
+      status: "intervention-needed",
+      architecture: "adaptive_starter",
+      updated_at: "2026-06-01T09:00:00Z",
+      tasks: [
+        { id: "task-1", title: "Review migration notes", status: "blocked" },
+        { id: "task-2", title: "Publish release draft", status: "completed" },
+      ],
+      artifacts: [{ id: "artifact-1", title: "Release draft", path: "docs/release.md" }],
+      completion_decision: { blocked: [{ id: "blocker-1", content: "Operator approval required." }] },
+    };
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      coworkPane: {
+        sessionRows: buildDesktopCoworkSessionRows({ sessions: [session] }),
+        cockpitView: buildDesktopCoworkCockpitView(session),
+      },
+    });
+
+    targetDocument.body.querySelector('[data-desktop-cowork-session="cowork-1"]')?.click();
+
+    const inspector = targetDocument.body.querySelector('[data-workbench-region="inspector"]');
+    const lens = inspector?.querySelector(".desktop-work-lens");
+    expect(lens?.getAttribute("data-desktop-work-lens-kind")).toBe("coworkRun");
+    expect(lens?.textContent).toContain("Review desktop release");
+    expect(lens?.textContent).toContain("Reason: 1 blocker");
+    expect(lens?.textContent).toContain("Progress: 1/2");
+    expect(lens?.textContent).toContain("What did it use?");
+    expect(lens?.textContent).toContain("What changed?");
+    expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Review desktop release in Work Lens");
+  });
+
   test("renders native file upload actions for knowledge and session files", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -11,6 +11,7 @@ import {
   resolveDesktopVisibleHelpTargets,
 } from "./desktopHelp";
 import {
+  buildDesktopCoworkTaskOperation,
   buildDesktopCoworkCockpitView,
   type DesktopCoworkCockpitView,
   type DesktopCoworkActionInput,
@@ -26,7 +27,12 @@ import {
   type DesktopInspectorView,
   type DesktopRunChainItem,
 } from "./desktopRunChainInspector";
-import type { DesktopTaskActionId, DesktopTaskCenterAction, DesktopTaskCenterItem } from "./desktopTaskCenter";
+import {
+  buildDesktopTaskCenterItems,
+  type DesktopTaskActionId,
+  type DesktopTaskCenterAction,
+  type DesktopTaskCenterItem,
+} from "./desktopTaskCenter";
 import {
   buildDesktopWorkLensProjection,
   DesktopWorkLensActionId,
@@ -620,6 +626,14 @@ function createCoworkCockpitPane(
     row.className = "desktop-cowork-session-row";
     row.setAttribute("data-desktop-cowork-session", session.id);
     row.textContent = `${session.title}: ${session.meta}`;
+    row.addEventListener("click", () => {
+      const [item] = buildDesktopTaskCenterItems({ coworkRuns: [buildDesktopCoworkTaskOperation(session.raw)] });
+      if (!item) {
+        return;
+      }
+      const renderedWorkLens = renderTaskWorkLens(targetDocument, item);
+      setRouteStatus(targetDocument, renderedWorkLens ? `Inspecting ${item.title} in Work Lens` : `Inspecting ${item.title}`);
+    });
     sessions.append(row);
   }
   section.append(sessions);


### PR DESCRIPTION
## Summary
- route Cowork cockpit session selection through the existing Work Lens projection path
- add regression coverage for selecting a Cowork session from the desktop cockpit

## Validation
- `npm test` from `apps/desktop`
- `npm run build` from `apps/desktop`
- `openspec validate improve-desktop-operator-experience --strict`