### PR TITLE
Add accessible Work Lens labels

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -499,6 +499,71 @@ describe("desktop workbench shell", () => {
     expect(lens?.querySelector('[data-desktop-work-lens-resource="evidence:doc-1"]')?.getAttribute("href")).toBe("/knowledge");
   });
 
+  test("adds stable accessible names for Work Lens sections, resources, actions, and fallbacks", () => {
+    const targetDocument = new FakeDocument();
+    const [task] = buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-1:index",
+          title: "Index Desktop UX Notes",
+          status: "failed",
+          detail: "Embedding provider returned 429",
+          canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+          retryable: true,
+          diagnostics: "HTTP 429",
+        },
+      ],
+    });
+    const workLens = buildDesktopWorkLensProjection({
+      task,
+      resources: [
+        {
+          kind: "evidence",
+          id: "evidence:doc-1",
+          title: "Desktop UX evidence",
+          detail: "Claim evidence",
+          route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+        },
+      ],
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      workLens,
+    });
+
+    const lens = targetDocument.body.querySelector(".desktop-work-lens");
+    expect(lens?.querySelector('[data-desktop-work-lens-section="happening"]')?.getAttribute("aria-label")).toBe("Work Lens section: happening");
+    expect(lens?.querySelector('[data-desktop-work-lens-section="next"]')?.getAttribute("aria-label")).toBe("Work Lens section: next");
+    expect(lens?.querySelector('[data-desktop-work-lens-resource="evidence:doc-1"]')?.getAttribute("aria-label")).toBe("Work Lens resource: evidence Desktop UX evidence");
+    expect(lens?.querySelector('[data-desktop-work-lens-action="retry"]')?.getAttribute("aria-label")).toBe("Work Lens action: retry Index Desktop UX Notes");
+    expect(lens?.querySelector('[data-desktop-work-lens-action="open"]')?.getAttribute("aria-label")).toBe("Work Lens action: open Index Desktop UX Notes");
+
+    const [unsupported] = buildDesktopTaskCenterItems({
+      providerRefreshes: [
+        {
+          id: "provider:openai:models",
+          title: "Refresh OpenAI models",
+          status: "completed",
+          detail: "24 models loaded",
+          canonical: { module: "settings", entityId: "openai", href: "/settings" },
+        },
+      ],
+    });
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      workLens: buildDesktopWorkLensProjection({ task: unsupported }),
+    });
+
+    const fallback = targetDocument.body.querySelector(".desktop-work-lens");
+    expect(fallback?.getAttribute("data-desktop-work-lens-fallback-reason")).toBe("unsupported-source");
+    expect(fallback?.querySelector('[data-desktop-work-lens-fallback="unsupported-source"]')?.getAttribute("aria-label")).toBe("Work Lens fallback: unsupported-source");
+  });
+
   test("renders Work Lens fallback without replacing source module access", () => {
     const targetDocument = new FakeDocument();
     const [task] = buildDesktopTaskCenterItems({

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -1459,17 +1459,24 @@ function createWorkLensPane(
   section.setAttribute("data-desktop-work-lens-mode", workLens.mode);
   section.setAttribute("data-desktop-work-lens-kind", workLens.kind);
   section.setAttribute("data-desktop-work-lens-placement", placement);
+  if (workLens.fallbackReason) {
+    section.setAttribute("data-desktop-work-lens-fallback-reason", workLens.fallbackReason);
+  }
   section.append(createText(targetDocument, "h2", "Work Lens"));
   section.append(createText(targetDocument, "p", workLens.title));
 
   if (workLens.fallbackReason) {
-    section.append(createText(targetDocument, "p", workLens.fallbackReason));
+    const fallback = createText(targetDocument, "p", workLens.fallbackReason);
+    fallback.setAttribute("data-desktop-work-lens-fallback", workLens.fallbackReason);
+    fallback.setAttribute("aria-label", `Work Lens fallback: ${workLens.fallbackReason}`);
+    section.append(fallback);
   }
 
   for (const lensSection of workLens.sections) {
     const group = targetDocument.createElement("section");
     group.className = "desktop-work-lens-section";
     group.setAttribute("data-desktop-work-lens-section", lensSection.id);
+    group.setAttribute("aria-label", `Work Lens section: ${lensSection.id}`);
     group.append(createText(targetDocument, "h2", lensSection.title));
     for (const row of lensSection.rows) {
       group.append(createText(targetDocument, "p", `${row.label}: ${row.value}`));
@@ -1493,6 +1500,7 @@ function createWorkLensPane(
         ? createWorkbenchLink(targetDocument, action.label, action.route.href, "desktop-work-lens-action")
         : targetDocument.createElement("button");
       element.setAttribute("data-desktop-work-lens-action", action.id);
+      element.setAttribute("aria-label", `Work Lens action: ${action.id} ${workLens.title}`);
       if (!action.route?.href) {
         element.className = "desktop-work-lens-action";
         element.setAttribute("type", "button");
@@ -1527,6 +1535,7 @@ function createWorkLensResourceList(
       : targetDocument.createElement("button");
     element.setAttribute("data-desktop-work-lens-resource", resource.id);
     element.setAttribute("data-desktop-work-lens-resource-kind", resource.kind);
+    element.setAttribute("aria-label", `Work Lens resource: ${resource.kind} ${resource.title}`);
     if (!resource.route.href) {
       element.className = "desktop-work-lens-resource";
       element.setAttribute("type", "button");


### PR DESCRIPTION
## Summary
- add stable accessible names for Work Lens sections, resources, actions, and fallback states
- expose fallback reason metadata on Work Lens fallback panes
- add regression coverage for Work Lens accessibility labels

## Validation
- npm test from apps/desktop
- npm run build from apps/desktop
- openspec validate improve-desktop-operator-experience --strict