### PR TITLE
Refresh visible Work Lens from task updates

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -747,6 +747,57 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.querySelector(".desktop-work-lens")).toBeNull();
   });
 
+  test("refreshes or invalidates a visible Work Lens when task center state changes", () => {
+    const targetDocument = new FakeDocument();
+    const items = buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-1:index",
+          title: "Index Desktop UX Notes",
+          status: "failed",
+          detail: "Embedding provider returned 429",
+          canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+          retryable: true,
+          diagnostics: "HTTP 429",
+        },
+      ],
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      taskCenterItems: items,
+    });
+
+    targetDocument.body.querySelector('[data-desktop-task-action="inspect"]')?.click();
+    expect(targetDocument.body.querySelector(".desktop-work-lens")?.textContent).toContain("Embedding provider returned 429");
+
+    updateDesktopTaskCenterItems(targetDocument as unknown as Document, buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-1:index",
+          title: "Index Desktop UX Notes",
+          status: "completed",
+          detail: "Indexed 4 chunks",
+          canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+        },
+      ],
+    }));
+
+    const refreshed = targetDocument.body.querySelector(".desktop-work-lens");
+    expect(refreshed?.getAttribute("data-desktop-work-lens-id")).toBe("knowledge:doc-1:index");
+    expect(refreshed?.textContent).toContain("Status: completed");
+    expect(refreshed?.textContent).toContain("Indexed 4 chunks");
+    expect(refreshed?.textContent).not.toContain("Embedding provider returned 429");
+
+    updateDesktopTaskCenterItems(targetDocument as unknown as Document, []);
+
+    const invalidated = targetDocument.body.querySelector(".desktop-work-lens");
+    expect(invalidated?.getAttribute("data-desktop-work-lens-mode")).toBe("fallback");
+    expect(invalidated?.getAttribute("data-desktop-work-lens-fallback-reason")).toBe("missing-context");
+  });
+
   test("renders native file upload actions for knowledge and session files", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -232,6 +232,7 @@ export function updateDesktopTaskCenterItems(
   }
   const next = createTaskCenterSurface(targetDocument, items, taskActions);
   taskCenter.replaceChildren(...Array.from(next.children));
+  refreshVisibleWorkLensFromTaskCenter(targetDocument, items);
 }
 
 export function updateDesktopGatewayRuntimeStatus(
@@ -1458,6 +1459,7 @@ function createWorkLensPane(
   section.setAttribute("aria-label", "Work Lens");
   section.setAttribute("data-desktop-work-lens-mode", workLens.mode);
   section.setAttribute("data-desktop-work-lens-kind", workLens.kind);
+  section.setAttribute("data-desktop-work-lens-id", workLens.id);
   section.setAttribute("data-desktop-work-lens-placement", placement);
   if (workLens.fallbackReason) {
     section.setAttribute("data-desktop-work-lens-fallback-reason", workLens.fallbackReason);
@@ -1863,19 +1865,54 @@ function renderTaskInspector(targetDocument: Document, item: DesktopTaskCenterIt
 }
 
 function renderTaskWorkLens(targetDocument: Document, item: DesktopTaskCenterItem): boolean {
+  return renderWorkLensProjection(targetDocument, buildDesktopWorkLensProjection({ task: item }), item);
+}
+
+function refreshVisibleWorkLensFromTaskCenter(targetDocument: Document, items: DesktopTaskCenterItem[]): void {
+  const current = targetDocument.querySelector<HTMLElement>(".desktop-work-lens");
+  const currentId = current?.getAttribute("data-desktop-work-lens-id") ?? "";
+  if (!current || !currentId) {
+    return;
+  }
+  const nextItem = items.find((item) => item.id === currentId);
+  if (nextItem) {
+    renderTaskWorkLens(targetDocument, nextItem);
+    return;
+  }
+  renderWorkLensProjection(targetDocument, buildDesktopWorkLensProjection({ fallbackReason: "missing-context" }));
+}
+
+function renderWorkLensProjection(
+  targetDocument: Document,
+  projection: DesktopWorkLensProjection,
+  fallbackItem?: DesktopTaskCenterItem,
+): boolean {
   const inspector = targetDocument.querySelector<HTMLElement>('[data-workbench-region="inspector"]');
   const inlineHost = targetDocument.getElementById(WORK_LENS_INLINE_ID);
   if (!inspector && !inlineHost) {
     return false;
   }
   const inspectorVisible = inspector?.getAttribute("data-visible") !== "false";
-  const projection = buildDesktopWorkLensProjection({ task: item });
   if (projection.mode !== "ready") {
-    if (inspector && inspectorVisible) {
-      renderTaskInspector(targetDocument, item);
+    if (projection.fallbackReason === "missing-context") {
+      renderProjectionInVisibleWorkLensTarget(targetDocument, projection, inspector, inlineHost);
+      return false;
+    }
+    if (inspector && inspectorVisible && fallbackItem) {
+      renderTaskInspector(targetDocument, fallbackItem);
     }
     return false;
   }
+  return renderProjectionInVisibleWorkLensTarget(targetDocument, projection, inspector, inlineHost);
+}
+
+function renderProjectionInVisibleWorkLensTarget(
+  targetDocument: Document,
+  projection: DesktopWorkLensProjection,
+  inspector: HTMLElement | null,
+  inlineHost: HTMLElement | null,
+): boolean {
+  const inspectorVisible = inspector?.getAttribute("data-visible") !== "false";
   if (inspector && inspectorVisible) {
     inlineHost?.replaceChildren();
     inspector.replaceChildren(createWorkLensPane(targetDocument, projection, {}, "inspector"));


### PR DESCRIPTION
## Summary
- refresh the visible Work Lens when Task Center updates the selected running work item
- invalidate the visible Work Lens with a missing-context fallback when the selected task disappears
- add regression coverage for Work Lens refresh and invalidation

## Validation
- npm test from apps/desktop
- npm run build from apps/desktop
- openspec validate improve-desktop-operator-experience --strict