### PR TITLE
Route module work selections to Work Lens

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -711,6 +711,76 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Review desktop release in Work Lens");
   });
 
+  test("routes Chat module run selection into the right-side Work Lens", () => {
+    const targetDocument = new FakeDocument();
+    const items = buildDesktopTaskCenterItems({
+      chatStreams: [
+        {
+          id: "chat:stream:chat-1",
+          title: "Streaming response",
+          status: "streaming",
+          detail: "Generating answer",
+          progress: { percent: 42 },
+          canonical: { module: "chat", entityId: "chat-1", href: "/chat/chat-1" },
+          cancelable: true,
+        },
+      ],
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      taskCenterItems: items,
+    });
+
+    targetDocument.body.querySelector('[data-desktop-module-work="chat:stream:chat-1"]')?.click();
+
+    const inspector = targetDocument.body.querySelector('[data-workbench-region="inspector"]');
+    const lens = inspector?.querySelector(".desktop-work-lens");
+    expect(lens?.getAttribute("data-desktop-work-lens-kind")).toBe("chatRun");
+    expect(lens?.textContent).toContain("Streaming response");
+    expect(lens?.textContent).toContain("Progress: 42%");
+    expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Streaming response in Work Lens");
+  });
+
+  test("routes Knowledge module job selection into the right-side Work Lens", () => {
+    const targetDocument = new FakeDocument();
+    const items = buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-1:index",
+          title: "Index Desktop UX Notes",
+          status: "failed",
+          detail: "Embedding provider returned 429",
+          canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+          retryable: true,
+          diagnostics: "HTTP 429",
+        },
+      ],
+    });
+    const knowledgePane = buildDesktopKnowledgePaneModel({
+      documentsPayload: { documents: [{ id: "doc-1", title: "Desktop UX Notes", path: "docs/desktop.md", chunk_count: 4, status: "stale" }] },
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      taskCenterItems: items,
+      knowledgePane,
+    });
+
+    targetDocument.body.querySelector('[data-desktop-module-work="knowledge:doc-1:index"]')?.click();
+
+    const inspector = targetDocument.body.querySelector('[data-workbench-region="inspector"]');
+    const lens = inspector?.querySelector(".desktop-work-lens");
+    expect(lens?.getAttribute("data-desktop-work-lens-kind")).toBe("knowledgeJob");
+    expect(lens?.textContent).toContain("Index Desktop UX Notes");
+    expect(lens?.textContent).toContain("Embedding provider returned 429");
+    expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Index Desktop UX Notes in Work Lens");
+  });
+
   test("keeps Work Lens available in the main region when the inspector is hidden", () => {
     const targetDocument = new FakeDocument();
     const items = buildDesktopTaskCenterItems({
@@ -1892,6 +1962,21 @@ describe("desktop workbench shell", () => {
     const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent;
     expect(styleText).toContain("overflow-wrap: anywhere;");
     expect(styleText).toContain("min-width: 0;");
+  });
+
+  test("styles module running-work rows as compact selectable desktop controls", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent;
+    expect(styleText).toContain(".desktop-module-work-row");
+    expect(styleText).toContain("min-height: 34px;");
+    expect(styleText).toContain("overflow-wrap: anywhere;");
   });
 
   test("declares visible focus states for workbench controls", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -32,6 +32,7 @@ import {
   type DesktopTaskActionId,
   type DesktopTaskCenterAction,
   type DesktopTaskCenterItem,
+  type DesktopTaskSource,
 } from "./desktopTaskCenter";
 import {
   buildDesktopWorkLensProjection,
@@ -335,7 +336,7 @@ function createWorkbenchShell(
   shell.append(
     createActivityRail(targetDocument),
     createPanel(targetDocument, "sidebar", layout.sidebar, createSidebar(targetDocument)),
-    createMainRegion(targetDocument, gatewayHttp, layout, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, workLens, workLensActions),
+    createMainRegion(targetDocument, gatewayHttp, layout, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, workLens, workLensActions),
     createPanel(targetDocument, "inspector", layout.inspector, createInspector(targetDocument, runChainItems, selectedRunChainItemKey, workLens, workLensActions)),
     createPanel(targetDocument, "bottom", layout.bottom, createBottomRegion(targetDocument, runtimeStatus, gatewayHttp, taskCenterItems, taskActions, gatewayActions)),
   );
@@ -383,6 +384,7 @@ function createMainRegion(
   targetDocument: Document,
   gatewayHttp: string,
   layout: WorkbenchLayoutState,
+  taskCenterItems: DesktopTaskCenterItem[],
   settingsPane: DesktopSettingsPaneModel | null,
   settingsActions: DesktopSettingsActionOptions,
   knowledgePane: DesktopKnowledgePaneModel | null,
@@ -398,6 +400,7 @@ function createMainRegion(
   main.className = "desktop-workbench-main";
   main.setAttribute("data-workbench-region", "main");
   main.setAttribute("aria-label", "Primary desktop work area");
+  const chatWorkItems = moduleWorkItems(taskCenterItems, "chat");
 
   const empty = targetDocument.createElement("div");
   empty.className = "desktop-empty-session";
@@ -407,12 +410,13 @@ function createMainRegion(
     createQuickActions(targetDocument),
     createPanelControls(targetDocument, layout),
     createWorkLensInlineHost(targetDocument, layout.inspector.visible ? null : workLens, workLensActions),
+    ...(chatWorkItems.length ? [createModuleWorkSection(targetDocument, "Chat runs", chatWorkItems)] : []),
     createCommandPalette(targetDocument),
     createFileActions(targetDocument),
     createDesktopHelpSurface(targetDocument),
     createWorkspaceFilesSurface(targetDocument),
     ...(settingsPane ? [createSettingsProvidersPane(targetDocument, settingsPane, settingsActions)] : []),
-    ...(knowledgePane ? [createKnowledgePane(targetDocument, knowledgePane, knowledgeActions)] : []),
+    ...(knowledgePane ? [createKnowledgePane(targetDocument, knowledgePane, knowledgeActions, moduleWorkItems(taskCenterItems, "knowledge"))] : []),
     ...(toolsSkillsPane ? [createToolsSkillsPane(targetDocument, toolsSkillsPane, toolsSkillsActions)] : []),
     ...(coworkPane ? [createCoworkCockpitPane(targetDocument, coworkPane, coworkActions)] : []),
   );
@@ -439,6 +443,34 @@ function createWorkLensInlineHost(
     host.append(createWorkLensPane(targetDocument, workLens, workLensActions, "inline"));
   }
   return host;
+}
+
+function moduleWorkItems(items: DesktopTaskCenterItem[], source: DesktopTaskSource): DesktopTaskCenterItem[] {
+  return items.filter((item) => item.source === source && item.actions.some((action) => action.id === "inspect"));
+}
+
+function createModuleWorkSection(targetDocument: Document, title: string, items: DesktopTaskCenterItem[]): HTMLElement {
+  const section = targetDocument.createElement("section");
+  section.className = "desktop-module-work";
+  section.setAttribute("aria-label", title);
+  section.append(createText(targetDocument, "h2", title));
+
+  for (const item of items) {
+    const row = targetDocument.createElement("button");
+    row.type = "button";
+    row.className = "desktop-module-work-row";
+    row.setAttribute("data-desktop-module-work", item.id);
+    row.setAttribute("data-desktop-module-work-source", item.source);
+    row.setAttribute("aria-label", `Inspect ${item.title} in Work Lens`);
+    row.textContent = `${item.title}: ${[item.status, item.detail, item.progressLabel].filter(Boolean).join(" / ")}`;
+    row.addEventListener("click", () => {
+      const renderedWorkLens = renderTaskWorkLens(targetDocument, item);
+      setRouteStatus(targetDocument, renderedWorkLens ? `Inspecting ${item.title} in Work Lens` : `Inspecting ${item.title}`);
+    });
+    section.append(row);
+  }
+
+  return section;
 }
 
 function createToolsSkillsPane(
@@ -536,6 +568,7 @@ function createKnowledgePane(
   targetDocument: Document,
   pane: DesktopKnowledgePaneModel,
   knowledgeActions: DesktopKnowledgeActionOptions = {},
+  workItems: DesktopTaskCenterItem[] = [],
 ): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-knowledge-pane";
@@ -565,6 +598,9 @@ function createKnowledgePane(
     actionRow.append(button);
   }
   section.append(actionRow);
+  if (workItems.length) {
+    section.append(createModuleWorkSection(targetDocument, "Knowledge jobs", workItems));
+  }
 
   const readiness = targetDocument.createElement("section");
   readiness.className = "desktop-knowledge-readiness";
@@ -2461,6 +2497,26 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       background: var(--panel, #faf9f5);
     }
 
+    body.desktop-native-workbench .desktop-module-work {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-module-work-row {
+      min-width: 0;
+      min-height: 34px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 6px 8px;
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
+      font: 600 12px/1.3 var(--font-sans, system-ui, sans-serif);
+      text-align: left;
+      overflow-wrap: anywhere;
+      cursor: pointer;
+    }
+
     body.desktop-native-workbench .desktop-empty-session h1 {
       margin: 0;
       color: var(--text, #141413);
@@ -2640,6 +2696,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-cowork-action:focus-visible,
     body.desktop-native-workbench .desktop-cowork-observability-tab:focus-visible,
     body.desktop-native-workbench .desktop-cowork-graph-node:focus-visible,
+    body.desktop-native-workbench .desktop-module-work-row:focus-visible,
     body.desktop-native-workbench .desktop-task-action:focus-visible,
     body.desktop-native-workbench .desktop-session-upload-key:focus-visible,
     body.desktop-native-workbench .desktop-workspace-file-row:focus-visible,


### PR DESCRIPTION
## Summary
- add selectable running-work rows for Chat and Knowledge module surfaces using existing task-center projections
- route module work selection through the existing Work Lens rendering path
- add regression coverage for Chat and Knowledge module Work Lens selection and compact row styling

## Validation
- npm test from apps/desktop
- npm run build from apps/desktop
- openspec validate improve-desktop-operator-experience --strict