### PR TITLE
Carry Work Lens context resources

### DIFF
--- a/apps/desktop/src/desktopCowork.test.ts
+++ b/apps/desktop/src/desktopCowork.test.ts
@@ -251,7 +251,7 @@ describe("desktop Cowork helpers", () => {
       ],
     });
 
-    expect(operations).toEqual([
+    expect(operations).toMatchObject([
       {
         id: "cowork:running",
         title: "Running session",
@@ -322,6 +322,21 @@ describe("desktop Cowork helpers", () => {
       },
     ]);
 
+    expect(operations.find((operation) => operation.id === "cowork:running")?.relatedResources?.map((resource) => resource.title)).toEqual([
+      "Task 1",
+      "Task 2",
+    ]);
+    expect(operations.find((operation) => operation.id === "cowork:failed")?.outputs).toEqual([]);
+    expect(operations.find((operation) => operation.id === "cowork:done")?.outputs).toEqual([
+      {
+        kind: "artifact",
+        id: "cowork:done:final-output",
+        title: "Final output",
+        detail: "Ship it",
+        route: { module: "cowork", entityId: "done", href: "/cowork" },
+      },
+    ]);
+
     expect(buildDesktopTaskCenterItems({ coworkRuns: operations }).map((item) => [item.id, item.state, item.tone, item.actions.map((action) => action.id).join(",")])).toEqual([
       ["cowork:blocked", "blocked", "attention", "open,inspect"],
       ["cowork:paused", "blocked", "attention", "open,inspect"],
@@ -329,6 +344,40 @@ describe("desktop Cowork helpers", () => {
       ["cowork:failed", "failed", "danger", "retry,open,inspect,copyDiagnostics,dismiss"],
       ["cowork:running", "active", "normal", "cancel,open,inspect"],
       ["cowork:done", "completed", "complete", "open,dismiss"],
+    ]);
+  });
+
+  test("projects Cowork task, work-unit, branch, and artifact context for Work Lens", () => {
+    const [operation] = buildDesktopCoworkTaskOperations({
+      sessions: [
+        {
+          id: "rich",
+          title: "Review desktop release",
+          status: "blocked",
+          tasks: [{ id: "task-1", title: "Review migration notes", status: "blocked", assigned_agent_id: "agent-1" }],
+          swarm_plan: {
+            work_units: [{ id: "wu-1", title: "Extract projections", status: "failed", assigned_agent_id: "agent-1" }],
+          },
+          branches: [{ id: "branch-1", title: "release-notes", status: "ready" }],
+          artifacts: [{ id: "artifact-1", title: "Release draft", kind: "markdown", path: "outputs/release.md" }],
+          completion_decision: { blocked: [{ id: "blocker-1", content: "Operator approval required." }] },
+        },
+      ],
+    });
+
+    expect(operation?.relatedResources?.map((resource) => [resource.kind, resource.id, resource.title, resource.detail])).toEqual([
+      ["coworkEntity", "cowork:rich:task:task-1", "Review migration notes", "blocked / agent-1"],
+      ["coworkEntity", "cowork:rich:work-unit:wu-1", "Extract projections", "failed / agent-1"],
+      ["coworkEntity", "cowork:rich:branch:branch-1", "release-notes", "ready"],
+    ]);
+    expect(operation?.outputs).toEqual([
+      {
+        kind: "artifact",
+        id: "cowork:rich:artifact:artifact-1",
+        title: "Release draft",
+        detail: "markdown / outputs/release.md",
+        route: { module: "cowork", entityId: "rich", href: "/cowork" },
+      },
     ]);
   });
 

--- a/apps/desktop/src/desktopCowork.ts
+++ b/apps/desktop/src/desktopCowork.ts
@@ -360,10 +360,60 @@ export function buildDesktopCoworkTaskOperation(value: unknown): DesktopTaskSour
     ...(progress ? { progress } : {}),
     canonical: { module: "cowork", entityId: row.id, href: "/cowork" },
     diagnostics: stringValue(session.error) || stringValue(session.last_error),
+    relatedResources: coworkWorkLensResources(session, row.id),
+    outputs: coworkWorkLensOutputs(session, row.id),
     retryable: COWORK_RETRYABLE_STATUSES.has(status.toLowerCase()),
     cancelable: COWORK_CANCELABLE_STATUSES.has(status.toLowerCase()),
     updatedAt: row.updatedAt,
   };
+}
+
+function coworkWorkLensResources(session: UnknownRecord, sessionId: string) {
+  const route = { module: "cowork" as const, entityId: sessionId, href: "/cowork" };
+  const taskResources = arrayValue(session.tasks).filter(isRecord).slice(0, 4).map((task, index) => ({
+    kind: "coworkEntity" as const,
+    id: `cowork:${sessionId}:task:${stringValue(task.id) || index + 1}`,
+    title: stringValue(task.title) || stringValue(task.name) || `Task ${index + 1}`,
+    detail: [stringValue(task.status), stringValue(task.assigned_agent_id) || stringValue(task.owner)].filter(Boolean).join(" / "),
+    route,
+  }));
+  const workUnitResources = arrayValue(asRecord(session.swarm_plan).work_units).filter(isRecord).slice(0, 4).map((unit, index) => ({
+    kind: "coworkEntity" as const,
+    id: `cowork:${sessionId}:work-unit:${stringValue(unit.id) || index + 1}`,
+    title: stringValue(unit.title) || stringValue(unit.name) || `Work unit ${index + 1}`,
+    detail: [stringValue(unit.status), stringValue(unit.assigned_agent_id) || stringValue(unit.owner)].filter(Boolean).join(" / "),
+    route,
+  }));
+  const branchResources = arrayValue(session.branches).filter(isRecord).slice(0, 4).map((branch, index) => ({
+    kind: "coworkEntity" as const,
+    id: `cowork:${sessionId}:branch:${stringValue(branch.id) || index + 1}`,
+    title: stringValue(branch.title) || stringValue(branch.name) || `Branch ${index + 1}`,
+    detail: [stringValue(branch.status), stringValue(branch.result_status)].filter(Boolean).join(" / "),
+    route,
+  }));
+  return [...taskResources, ...workUnitResources, ...branchResources];
+}
+
+function coworkWorkLensOutputs(session: UnknownRecord, sessionId: string) {
+  const route = { module: "cowork" as const, entityId: sessionId, href: "/cowork" };
+  const artifactOutputs = arrayValue(session.artifacts).filter(isRecord).slice(0, 4).map((artifact, index) => ({
+    kind: "artifact" as const,
+    id: `cowork:${sessionId}:artifact:${stringValue(artifact.id) || index + 1}`,
+    title: stringValue(artifact.title) || stringValue(artifact.name) || stringValue(artifact.path) || `Artifact ${index + 1}`,
+    detail: [stringValue(artifact.kind) || stringValue(artifact.type), stringValue(artifact.status), stringValue(artifact.path)].filter(Boolean).join(" / "),
+    route,
+  }));
+  const finalOutput = coworkFinalOutput(session);
+  return finalOutput ? [
+    ...artifactOutputs,
+    {
+      kind: "artifact" as const,
+      id: `cowork:${sessionId}:final-output`,
+      title: "Final output",
+      detail: finalOutput,
+      route,
+    },
+  ] : artifactOutputs;
 }
 
 export function buildDesktopCoworkGraphView(value: unknown): DesktopCoworkGraphView {

--- a/apps/desktop/src/desktopFileUpload.test.ts
+++ b/apps/desktop/src/desktopFileUpload.test.ts
@@ -208,6 +208,16 @@ describe("desktop file upload adapters", () => {
         progress: { completed: 0, total: 1 },
         canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
         diagnostics: "",
+        relatedResources: [
+          {
+            kind: "evidence",
+            id: "knowledge-source:doc-1",
+            title: "notes.md",
+            detail: "queued",
+            route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+          },
+        ],
+        outputs: [],
         retryable: false,
         updatedAt: "",
       },

--- a/apps/desktop/src/desktopKnowledgeTraceability.test.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.test.ts
@@ -70,50 +70,50 @@ describe("desktop knowledge and traceability helpers", () => {
   });
 
   test("projects backend knowledge indexing and rebuild jobs into task center operations", () => {
-    expect(
-      buildDesktopKnowledgeTaskOperations([
-        {
-          job: {
-            id: "kjob_index",
-            doc_id: "doc-1",
-            name: "desktop-notes.md",
-            status: "running",
-            stage: "dense_indexing",
-            message: "Indexing retrieval vectors",
-            processed: 2,
-            total: 5,
-            error: "",
-            updated_at: "2026-05-31T10:00:00Z",
-          },
+    const operations = buildDesktopKnowledgeTaskOperations([
+      {
+        job: {
+          id: "kjob_index",
+          doc_id: "doc-1",
+          name: "desktop-notes.md",
+          status: "running",
+          stage: "dense_indexing",
+          message: "Indexing retrieval vectors",
+          processed: 2,
+          total: 5,
+          error: "",
+          updated_at: "2026-05-31T10:00:00Z",
         },
-        {
-          message: "Knowledge index rebuild started",
-          type: "all",
-          job: {
-            id: "kjob_rebuild",
-            name: "rebuild:all",
-            status: "queued",
-            stage: "queued",
-            message: "Queued for knowledge index rebuild",
-            processed: 0,
-            total: 3,
-          },
+      },
+      {
+        message: "Knowledge index rebuild started",
+        type: "all",
+        job: {
+          id: "kjob_rebuild",
+          name: "rebuild:all",
+          status: "queued",
+          stage: "queued",
+          message: "Queued for knowledge index rebuild",
+          processed: 0,
+          total: 3,
         },
-        {
-          data: {
-            id: "kjob_failed",
-            doc_id: "doc-2",
-            name: "broken.md",
-            status: "failed",
-            stage: "failed",
-            message: "Knowledge indexing failed",
-            error: "embedding timeout",
-            processed: 1,
-            total: 4,
-          },
+      },
+      {
+        data: {
+          id: "kjob_failed",
+          doc_id: "doc-2",
+          name: "broken.md",
+          status: "failed",
+          stage: "failed",
+          message: "Knowledge indexing failed",
+          error: "embedding timeout",
+          processed: 1,
+          total: 4,
         },
-      ]),
-    ).toEqual([
+      },
+    ]);
+
+    expect(operations).toMatchObject([
       {
         id: "knowledge:kjob_index",
         title: "Index desktop-notes.md",
@@ -146,6 +146,24 @@ describe("desktop knowledge and traceability helpers", () => {
         diagnostics: "embedding timeout",
         retryable: false,
         updatedAt: "",
+      },
+    ]);
+    expect(operations[0].relatedResources).toEqual([
+      {
+        kind: "evidence",
+        id: "knowledge-source:doc-1",
+        title: "desktop-notes.md",
+        detail: "dense_indexing",
+        route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+      },
+    ]);
+    expect(operations[2].outputs).toEqual([
+      {
+        kind: "diagnostic",
+        id: "knowledge-diagnostic:kjob_failed",
+        title: "Knowledge diagnostics",
+        detail: "embedding timeout",
+        route: { module: "knowledge", entityId: "doc-2", href: "/knowledge" },
       },
     ]);
   });

--- a/apps/desktop/src/desktopKnowledgeTraceability.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.ts
@@ -508,6 +508,9 @@ export function buildDesktopKnowledgeTaskOperation(payload: unknown): DesktopTas
   const message = firstNonEmpty(job.message, root.message);
   const processed = numberValue(job.processed ?? job.completed);
   const total = numberValue(job.total);
+  const sourceTitle = firstNonEmpty(job.source_title, job.doc_name, job.document_name, root.source_title, root.doc_name, root.document_name, name, docId);
+  const sourceDetail = firstNonEmpty(job.source_path, job.path, job.file_path, root.source_path, root.path, root.file_path, stage);
+  const diagnostics = firstNonEmpty(job.error, root.error);
   return {
     id: `knowledge:${id}`,
     title: knowledgeTaskTitle(name),
@@ -515,7 +518,25 @@ export function buildDesktopKnowledgeTaskOperation(payload: unknown): DesktopTas
     detail: [message, stage].filter(Boolean).join(" / "),
     progress: total ? { completed: processed, total } : undefined,
     canonical: { module: "knowledge", entityId: docId || id, href: "/knowledge" },
-    diagnostics: firstNonEmpty(job.error, root.error),
+    diagnostics,
+    relatedResources: sourceTitle ? [
+      {
+        kind: "evidence",
+        id: `knowledge-source:${docId || id}`,
+        title: sourceTitle,
+        detail: sourceDetail,
+        route: { module: "knowledge", entityId: docId || id, href: "/knowledge" },
+      },
+    ] : [],
+    outputs: diagnostics ? [
+      {
+        kind: "diagnostic",
+        id: `knowledge-diagnostic:${id}`,
+        title: "Knowledge diagnostics",
+        detail: diagnostics,
+        route: { module: "knowledge", entityId: docId || id, href: "/knowledge" },
+      },
+    ] : [],
     retryable: false,
     updatedAt: firstNonEmpty(job.updated_at, job.updatedAt, root.updated_at, root.updatedAt),
   };

--- a/apps/desktop/src/desktopTaskCenter.ts
+++ b/apps/desktop/src/desktopTaskCenter.ts
@@ -26,6 +26,24 @@ export interface DesktopTaskDestination {
   href?: string;
 }
 
+export type DesktopTaskRelatedResourceKind =
+  | "file"
+  | "evidence"
+  | "tool"
+  | "log"
+  | "artifact"
+  | "provider"
+  | "coworkEntity"
+  | "diagnostic";
+
+export interface DesktopTaskRelatedResourceInput {
+  kind: DesktopTaskRelatedResourceKind;
+  id: string;
+  title: string;
+  detail?: string;
+  route: DesktopTaskDestination;
+}
+
 export interface DesktopTaskProgress {
   completed?: number;
   total?: number;
@@ -42,6 +60,8 @@ export interface DesktopTaskSourceOperation {
   retryable?: boolean;
   cancelable?: boolean;
   diagnostics?: string;
+  relatedResources?: DesktopTaskRelatedResourceInput[];
+  outputs?: DesktopTaskRelatedResourceInput[];
   updatedAt?: string;
 }
 
@@ -73,6 +93,8 @@ export interface DesktopTaskCenterItem {
   progressLabel: string;
   destination: DesktopTaskDestination;
   diagnostics: string;
+  relatedResources: DesktopTaskRelatedResourceInput[];
+  outputs: DesktopTaskRelatedResourceInput[];
   actions: DesktopTaskCenterAction[];
   updatedAt: string;
 }
@@ -121,6 +143,8 @@ function projectOperations(source: DesktopTaskSource, operations: DesktopTaskSou
       progressLabel: progressLabel(operation.progress),
       destination: operation.canonical,
       diagnostics: operation.diagnostics ?? "",
+      relatedResources: operation.relatedResources ?? [],
+      outputs: operation.outputs ?? [],
       actions: taskActions(state, operation),
       updatedAt: operation.updatedAt ?? "",
     };

--- a/apps/desktop/src/desktopWorkLens.test.ts
+++ b/apps/desktop/src/desktopWorkLens.test.ts
@@ -107,6 +107,52 @@ describe("desktop work lens projection", () => {
     });
   });
 
+  test("uses task-center related resources and outputs when no explicit lens resources are passed", () => {
+    const [task] = buildDesktopTaskCenterItems({
+      knowledgeJobs: [
+        {
+          id: "knowledge:doc-2:index",
+          title: "Rebuild source evidence",
+          status: "failed",
+          detail: "Source citation mismatch",
+          canonical: { module: "knowledge", entityId: "doc-2", href: "/knowledge" },
+          retryable: true,
+          relatedResources: [
+            {
+              kind: "evidence",
+              id: "evidence:doc-2:claim-1",
+              title: "Claim 1 evidence",
+              detail: "docs/operators.md line 12",
+              route: { module: "knowledge", entityId: "doc-2", href: "/knowledge" },
+            },
+          ],
+          outputs: [
+            {
+              kind: "diagnostic",
+              id: "diagnostic:doc-2",
+              title: "Citation mismatch",
+              detail: "Missing source span",
+              route: { module: "knowledge", entityId: "doc-2", href: "/knowledge" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const lens = buildDesktopWorkLensProjection({ task });
+
+    expect(lens.relatedResources.map((resource) => resource.id)).toEqual(["evidence:doc-2:claim-1"]);
+    expect(lens.outputs.map((resource) => resource.id)).toEqual(["diagnostic:doc-2"]);
+    expect(lens.sections.find((section) => section.id === "used")?.rows).toContainEqual({
+      label: "Evidence",
+      value: "Claim 1 evidence / docs/operators.md line 12",
+    });
+    expect(lens.sections.find((section) => section.id === "changed")?.rows).toContainEqual({
+      label: "Diagnostic",
+      value: "Citation mismatch / Missing source span",
+    });
+  });
+
   test("projects Cowork blocked work without broad or destructive actions", () => {
     const [task] = buildDesktopTaskCenterItems({
       coworkRuns: [

--- a/apps/desktop/src/desktopWorkLens.ts
+++ b/apps/desktop/src/desktopWorkLens.ts
@@ -98,8 +98,8 @@ const ACTION_LABELS: Record<DesktopWorkLensActionId, string> = {
 
 export function buildDesktopWorkLensProjection({
   task,
-  resources = [],
-  outputs = [],
+  resources,
+  outputs,
   fallbackReason = "no-selection",
 }: DesktopWorkLensProjectionInput): DesktopWorkLensProjection {
   if (!task) {
@@ -112,8 +112,8 @@ export function buildDesktopWorkLensProjection({
   }
 
   const kind = SUPPORTED_WORK_SOURCES[task.source];
-  const relatedResources = normalizeResources(resources);
-  const outputResources = normalizeResources(outputs);
+  const relatedResources = normalizeResources(resources ?? task.relatedResources);
+  const outputResources = normalizeResources(outputs ?? task.outputs);
   if (!kind) {
     return fallbackProjection({
       fallbackReason: "unsupported-source",

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -649,6 +649,24 @@ describe("desktop workbench shell", () => {
           canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
           retryable: true,
           diagnostics: "HTTP 429",
+          relatedResources: [
+            {
+              kind: "evidence",
+              id: "evidence:doc-1",
+              title: "Desktop UX evidence",
+              detail: "Claim evidence",
+              route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+            },
+          ],
+          outputs: [
+            {
+              kind: "diagnostic",
+              id: "diagnostic:doc-1",
+              title: "Failure diagnostics",
+              detail: "HTTP 429",
+              route: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
+            },
+          ],
         },
       ],
     });
@@ -667,7 +685,10 @@ describe("desktop workbench shell", () => {
     expect(lens?.getAttribute("data-desktop-work-lens-kind")).toBe("knowledgeJob");
     expect(lens?.textContent).toContain("Index Desktop UX Notes");
     expect(lens?.textContent).toContain("Embedding provider returned 429");
+    expect(lens?.textContent).toContain("Desktop UX evidence");
+    expect(lens?.textContent).toContain("Failure diagnostics");
     expect(lens?.textContent).toContain("What can I do next?");
+    expect(lens?.querySelector('[data-desktop-work-lens-resource="evidence:doc-1"]')?.getAttribute("href")).toBe("/knowledge");
     expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Index Desktop UX Notes in Work Lens");
   });
 


### PR DESCRIPTION
## Summary
- Carry related resources and outputs from desktop task-center operations into Work Lens projections.
- Add knowledge source/diagnostic and Cowork task/work-unit/branch/artifact context for Work Lens inspection.
- Extend desktop tests for Task Center inspect, Work Lens inherited resources, knowledge upload/index jobs, and Cowork context.

## Verification
- `npm test` from `apps/desktop`
- `npm run build` from `apps/desktop`
- Tauri WebView CDP smoke for Work Lens selection, pinning model, resource routing, bounded actions, fallback, and inline responsive placement
- `openspec validate improve-desktop-operator-experience --strict`