### PR TITLE
fix: route desktop WebUI sidebar drawers

### DIFF
--- a/apps/desktop/src/desktopWebUiCommandBridge.test.ts
+++ b/apps/desktop/src/desktopWebUiCommandBridge.test.ts
@@ -23,6 +23,8 @@ class FakeWebUiDocument {
     "#theme-toggle": new FakeButton(),
     "#sidebar-collapse-button": new FakeButton(),
     "#help-tour-button": new FakeButton(),
+    "#tools-toggle": new FakeButton(),
+    "#cowork-toggle": new FakeButton(),
     "[data-desktop-route-status]": new FakeStatus(),
   };
 
@@ -156,6 +158,29 @@ describe("desktop WebUI command bridge", () => {
     expect(document.documentElement.dataset.desktopCommandFeedback).toBe("Session search opened");
   });
 
+  test("routes desktop workbench links to root WebUI drawers", () => {
+    const document = new FakeWebUiDocument();
+    const window = fakeWindow();
+
+    installDesktopWebUiCommandBridge({
+      targetDocument: document as unknown as Document,
+      targetWindow: window,
+      listenToMenuCommand: () => undefined,
+    });
+
+    window.dispatchEvent(new CustomEvent("tinybot:desktop-route", {
+      detail: { kind: "workbench-route", href: "http://localhost:1420/tools" },
+    }));
+    window.dispatchEvent(new CustomEvent("tinybot:desktop-route", {
+      detail: { kind: "workbench-route", href: "http://localhost:1420/cowork" },
+    }));
+
+    expect((document.nodes["#tools-toggle"] as FakeButton).clicks).toBe(1);
+    expect((document.nodes["#cowork-toggle"] as FakeButton).clicks).toBe(1);
+    expect(document.documentElement.dataset.desktopCommandFeedback).toBe("Automations opened");
+    expect((document.nodes["[data-desktop-route-status]"] as FakeStatus).textContent).toBe("Automations opened");
+  });
+
   test("records context targets for root WebUI context navigation", () => {
     const document = new FakeWebUiDocument();
     installDesktopWebUiCommandBridge({
@@ -179,7 +204,17 @@ describe("desktop WebUI command bridge", () => {
 });
 
 function fakeWindow(assigned: string[] = []): Window {
+  const listeners = new Map<string, Array<(event: Event) => void>>();
   return {
+    addEventListener: (type: string, listener: (event: Event) => void) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+    },
+    dispatchEvent: (event: Event) => {
+      for (const listener of listeners.get(event.type) ?? []) {
+        listener(event);
+      }
+      return true;
+    },
     location: {
       origin: "http://localhost:1420",
       assign: (href: string) => {

--- a/apps/desktop/src/desktopWebUiCommandBridge.ts
+++ b/apps/desktop/src/desktopWebUiCommandBridge.ts
@@ -20,6 +20,11 @@ const WEBUI_COMMAND_BUTTONS: Partial<Record<DesktopMenuCommandId, string>> = {
   "open-page-help": "#help-tour-button",
 };
 
+const WEBUI_ROUTE_BUTTONS: Record<string, { selector: string; feedback: string }> = {
+  "/tools": { selector: "#tools-toggle", feedback: "Tools opened" },
+  "/cowork": { selector: "#cowork-toggle", feedback: "Automations opened" },
+};
+
 export function installDesktopWebUiCommandBridge({
   listenToMenuCommand,
   targetDocument = document,
@@ -42,6 +47,9 @@ export function installDesktopWebUiCommandBridge({
   });
   targetDocument.addEventListener("contextmenu", (event) => {
     recordDesktopWebUiContextTarget(event, targetDocument);
+  });
+  targetWindow.addEventListener("tinybot:desktop-route", (event) => {
+    routeDesktopWebUiWorkbenchRoute(event, targetDocument);
   });
 
   void listenToMenuCommand((id) => {
@@ -74,6 +82,31 @@ function routeDesktopWebUiCommand(id: string, targetDocument: Document, targetWi
   }
 
   setCommandFeedback(targetDocument, commandUnavailableFeedback(id));
+}
+
+function routeDesktopWebUiWorkbenchRoute(event: Event, targetDocument: Document): void {
+  const href = (event as CustomEvent<{ href?: unknown }>).detail?.href;
+  if (typeof href !== "string") {
+    return;
+  }
+  const pathname = routePathname(href);
+  const route = pathname ? WEBUI_ROUTE_BUTTONS[pathname] : undefined;
+  if (!route) {
+    return;
+  }
+  const target = targetDocument.querySelector<HTMLElement>(route.selector);
+  if (target && typeof target.click === "function") {
+    target.click();
+    setCommandFeedback(targetDocument, route.feedback);
+  }
+}
+
+function routePathname(href: string): string {
+  try {
+    return new URL(href, "http://localhost").pathname;
+  } catch {
+    return "";
+  }
 }
 
 function commandFeedback(id: string): string {


### PR DESCRIPTION
Closes #151

## Summary
- Route desktop workbench sidebar `/tools` and `/cowork` navigation events to the root WebUI drawer buttons.
- Add regression coverage for desktop route events opening Tools and Automations drawers.

## Verification
- `npm test -- desktopWebUiCommandBridge.test.ts`
- `git diff --check -- apps/desktop/src/desktopWebUiCommandBridge.ts apps/desktop/src/desktopWebUiCommandBridge.test.ts`

Note: full desktop WebView smoke was not completed because local WebView2 remote debugging launch was blocked by Windows access-denied errors in this environment.