### PR TITLE
Add translated English docs under docs/en

### DIFF
--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -1,0 +1,123 @@
+﻿# Command-line Interface
+
+The CLI is suitable for terminal users and is also good for quick one-line questions or when you need Tinybot to work with files in the current workspace.
+
+## Start chat
+
+```bash
+uv run tinybot agent
+```
+
+After starting, you enter a full-screen chat interface. Type your request and press Enter.
+
+```text
+Please read the current directory and tell me the main modules of this project.
+```
+
+Exit chat by entering `/exit` or pressing `Ctrl+C`.
+
+## One-shot prompts
+
+If you do not want to open interactive chat, use `-m` to send one message:
+
+```bash
+uv run tinybot agent -m "Introduce this project in three sentences"
+```
+
+This is good for scripts, quick queries, or ad-hoc summaries.
+
+## What you can see in terminal
+
+| Area | Meaning |
+|------|------|
+| Top status | Current model, context, workspace, etc. |
+| Message history | You and Tinybot chat history |
+| Task progress | Step and status shown during complex tasks |
+| Bottom input | Enter messages or commands like `/config`, `/help` |
+
+When Tinybot reads files, runs commands, or decomposes tasks, the interface shows progress, helping you track what it is doing.
+
+## Shortcuts and built-in commands
+
+| Action | Usage |
+|------|------|
+| Send message | Enter |
+| Open config editor | `Ctrl+O` or type `/config` |
+| Show help | `/help` |
+| Clear current conversation | `/clear` |
+| Exit | `/exit`, `:q`, or `Ctrl+C` |
+| Show deeper reasoning text | `Ctrl+R`, useful only when the model returns reasoning content |
+
+Note: Enter in the input line sends immediately; it is not a multi-line editor. For long prompts, write to a file first, then let Tinybot read that file.
+
+## Config editor
+
+In chat, enter:
+
+```text
+/config
+```
+
+Or press `Ctrl+O` to open the config editor. Commonly changed items include:
+
+| Setting | When to change |
+|------|----------------|
+| Provider/API Key | Switch AI service or key |
+| Model | Choose faster or stronger model |
+| Workspace | Restrict where Tinybot can operate |
+| Tools | Toggle web search, command execution, MCP, etc. |
+| Gateway | Change web port and heartbeat settings |
+
+Edit and follow UI prompts to save and return to chat.
+
+## How to instruct an agent
+
+Because Tinybot can call tools, make instructions clear about goal, scope, and output format.
+
+Recommended:
+
+```text
+Please read only the docs directory and identify unclear parts in beginner docs, then suggest fixes.
+```
+
+Not recommended:
+
+```text
+Look at this.
+```
+
+If you want file changes, say it explicitly:
+
+```text
+Please update docs/quickstart.md to make installation steps easier for first-time users.
+```
+
+If you only want recommendations and no edits, say that explicitly:
+
+```text
+Do not edit files yet, only list recommendations.
+```
+
+## Common issues
+
+### Garbled Chinese output
+
+Windows users should use PowerShell or Windows Terminal and ensure UTF-8 output is enabled. Tinybot tries to set encoding automatically, but older terminals may still display incorrectly.
+
+### Slow AI responses
+
+Common causes are slow model responses, network latency, large file reads, or active tool execution. Try:
+
+1. Switching to a faster model such as `deepseek-chat`
+2. Narrowing task scope, e.g. “docs directory only”
+3. Splitting into smaller tasks
+
+### Command execution fails or lacks permission
+
+Check workspace, command execution tool, and system permissions. If `restrict_to_workspace` is on, Tinybot can only modify files inside workspace.
+
+## Next steps
+
+- [Web UI](webui.md): manage conversations, knowledge, and skills more visually
+- [Configuration](config.md): learn model, keys, and security settings
+- [Tools](tools.md): know what file reads and knowledge retrieval can do

--- a/docs/en/config.md
+++ b/docs/en/config.md
@@ -1,0 +1,333 @@
+﻿# Configuration Guide
+
+Configuration determines which model Tinybot uses, which tools it can access, where it can read/write files, and how web services are started. Beginners do not need to understand all settings at once; focus first on model, keys, workspace, and safety limits.
+
+## Configuration location
+
+Default configuration file:
+
+```text
+~/.tinybot/config.json
+```
+
+Check current state:
+
+```bash
+uv run tinybot status
+```
+
+Reopen the onboarding wizard:
+
+```bash
+uv run tinybot onboard
+```
+
+You can also open the configuration editor in CLI chat by entering `/config` or pressing `Ctrl+O`.
+
+## Minimum workable configuration
+
+A minimum working setup needs three kinds of information:
+
+| Setting | Purpose |
+|------|------|
+| Provider API Key | Allows Tinybot to call the AI service |
+| Model | Specifies which model Tinybot uses |
+| Workspace | Defines where Tinybot can operate |
+
+Example:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "deepseek-chat",
+      "workspace": "~/.tinybot/workspace",
+      "timezone": "Asia/Shanghai"
+    }
+  },
+  "providers": {
+    "deepseek": {
+      "apiKey": "your DeepSeek key"
+    }
+  }
+}
+```
+
+The configuration supports both camelCase and snake_case. `apiKey` above can also be written as `api_key`.
+
+## Model selection
+
+Tinybot automatically maps model names to providers. For beginners, choose:
+
+| Scenario | Recommended model |
+|------|----------|
+| Daily chat, writing docs, summarization | `deepseek-chat` |
+| Complex analysis, code reasoning, multi-step planning | `deepseek-reasoner` |
+| Existing OpenAI account | `gpt-4o` or another OpenAI model |
+| Qwen users | `qwen-max` or an available Qwen model in your account |
+
+Config location:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "deepseek-chat"
+    }
+  }
+}
+```
+
+If model and key do not match, for example using `gpt-4o` while only DeepSeek key is configured, calls will fail.
+
+## Configure API keys
+
+Use the onboarding wizard or web settings to fill keys. You can also edit the config manually:
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "apiKey": "your key"
+    },
+    "openai": {
+      "apiKey": "your key"
+    },
+    "dashscope": {
+      "apiKey": "your key"
+    }
+  }
+}
+```
+
+If you share the project with others, make sure no real keys are committed to Git.
+
+## Workspace and safety limits
+
+Workspace is the default directory for file reads and writes:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "workspace": "~/.tinybot/workspace"
+    }
+  }
+}
+```
+
+Beginners should also enable workspace restrictions:
+
+```json
+{
+  "tools": {
+    "restrictToWorkspace": true
+  }
+}
+```
+
+This keeps Tinybot’s file operations mostly within the workspace and reduces the chance of modifying system or unrelated project files.
+
+## Common agent parameters
+
+| Setting | Default tendency | Description |
+|------|----------|------|
+| `temperature` | `0.1` | Lower is more stable; suitable for coding and strict tasks |
+| `maxTokens` | `8192` | Maximum length of one response |
+| `contextWindowTokens` | `65536` | Maximum retained context length |
+| `maxToolIterations` | `200` | Maximum tool calls in one task cycle |
+| `reasoningEffort` | empty or model-supported values | For reasoning models use `low`, `medium`, or `high` |
+| `timezone` | `UTC` | For users in China, use `Asia/Shanghai` |
+
+Example:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "temperature": 0.1,
+      "maxToolIterations": 100,
+      "timezone": "Asia/Shanghai"
+    }
+  }
+}
+```
+
+## Tool settings
+
+Tool capabilities are controlled by `tools`:
+
+```json
+{
+  "tools": {
+    "web": {
+      "enable": true,
+      "proxy": null,
+      "search": {
+        "provider": "duckduckgo",
+        "maxResults": 5
+      }
+    },
+    "exec": {
+      "enable": true,
+      "timeout": 60
+    },
+    "restrictToWorkspace": true
+  }
+}
+```
+
+| Setting | Recommendation |
+|------|------|
+| `tools.web.enable` | Enable when web search is needed |
+| `tools.exec.enable` | Enable for command execution; disable if unsure |
+| `tools.exec.timeout` | Maximum command runtime, default 60 seconds |
+| `tools.restrictToWorkspace` | Recommended for beginners |
+
+## Web UI settings
+
+The web UI is served by the WebSocket channel:
+
+```json
+{
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 18790
+    }
+  }
+}
+```
+
+`gateway.port` config is for gateway service settings; WebSocket channel also has its own `port`. Usually keep them aligned or use the WebSocket default.
+
+Start:
+
+```bash
+uv run tinybot gateway
+```
+
+Visit:
+
+```text
+http://127.0.0.1:18790
+```
+
+## Knowledge settings
+
+Knowledge base is off by default. Turn it on only if you want Tinybot to reference your documents:
+
+```json
+{
+  "knowledge": {
+    "enabled": true,
+    "autoRetrieve": true,
+    "maxChunks": 5,
+    "retrievalMode": "hybrid"
+  }
+}
+```
+
+| Setting | Meaning |
+|------|------|
+| `enabled` | Whether knowledge base is on |
+| `autoRetrieve` | Whether to auto-retrieve relevant docs for each question |
+| `maxChunks` | Max number of chunks returned each turn |
+| `retrievalMode` | `hybrid` works best for most cases |
+
+Default low-cost mode keeps `retrievalMode: "hybrid"` and `semanticExtractionMode: "rule"`, using keyword, vector, and rule-based semantic signals. It does not call LLM for extraction or evidence expansion by default.
+
+For higher-quality traceable provenance, explicitly enable the more expensive stages:
+
+```json
+{
+  "knowledge": {
+    "semanticExtractionMode": "llm",
+    "llmExtractionStrategy": "entity_guided",
+    "evidenceExpansionEnabled": true,
+    "evidenceExpansionScope": "document",
+    "evidenceExpansionMaxQueries": 5,
+    "evidenceExpansionMaxLlmCalls": 0,
+    "evidenceExpansionMaxTokens": 0,
+    "evidenceExpansionTimeoutSeconds": 30,
+    "evidenceExpansionConcurrency": 2
+  }
+}
+```
+
+| Setting | Meaning |
+|------|------|
+| `semanticExtractionMode` | `rule` for free rule extraction; `llm` for model-based extraction; `hybrid` combines both |
+| `llmExtractionStrategy` | `single_pass` one-pass extraction; `entity_guided` uses known entities for a second-pass extraction |
+| `evidenceExpansionEnabled` | Whether evidence expansion is enabled; off by default |
+| `evidenceExpansionScope` | `document`, `collection`, or `global`; default is current document |
+| `evidenceExpansionMaxQueries` | Max expansion queries per entity or record |
+| `evidenceExpansionMaxLlmCalls` / `evidenceExpansionMaxTokens` | Budget for LLM calls and tokens in expansion stage (default 0) |
+| `evidenceExpansionTimeoutSeconds` / `evidenceExpansionConcurrency` | Timeout and concurrency limits for expansion stage |
+
+Prefer the default low-cost mode first. Enable LLM extraction or evidence expansion only when you need traceable claims, relations, conflicts, GraphRAG community reports, and original evidence.
+
+## Common issues
+
+### What to do if configuration is broken
+
+Back up the old config first, then run onboarding again:
+
+```bash
+uv run tinybot onboard
+```
+
+To fully reset, delete `~/.tinybot/config.json` and run onboarding again. Ensure nothing important is missing before deletion.
+
+### Environment variables set but Tinybot does not read them
+
+Current schema mainly reads provider keys from `config.json`. The most reliable method is to write keys through `uv run tinybot onboard` or web settings.
+
+### Errors after model switch
+
+Check if model and provider match:
+
+| Model | Required key |
+|------|------------|
+| `deepseek-chat` | DeepSeek |
+| `gpt-4o` | OpenAI |
+| `qwen-max` | DashScope/Qwen |
+
+## Next steps
+
+- [AI provider setup](providers.md): choose and configure providers
+- [Tool features](tools.md): understand tool permissions and security boundaries
+- [Web UI](webui.md): edit settings in browser
+## Catalog-backed providers
+
+Tinybot now accepts provider ids from the backend provider catalog in
+`agents.defaults.provider`, not only the legacy `openai`, `deepseek`, and
+`dashscope` values. Existing configs remain valid.
+
+```toml
+[agents.defaults]
+provider = "openrouter"
+model = "openai/gpt-4o-mini"
+
+[providers.openrouter]
+api_key = "..."
+api_base = "https://openrouter.ai/api/v1"
+```
+
+Named profiles continue to work and can carry model lists, manual model ids,
+model discovery settings, and provider request defaults:
+
+```toml
+[agents.defaults]
+active_profile = "dashscope-coding"
+model = "qwen3-coder-plus"
+
+[providers.profiles.dashscope-coding]
+provider = "dashscope"
+api_key = "..."
+api_base = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+models = ["qwen3-coder-plus"]
+manual_models = ["custom-qwen-id"]
+supports_model_discovery = true
+```

--- a/docs/en/cowork.md
+++ b/docs/en/cowork.md
@@ -1,0 +1,419 @@
+# Cowork
+
+Cowork is a persistent multi-agent workspace for goals that benefit from several specialized perspectives. It is not limited to software roles: Tinybot can create a team for research, travel planning, writing, analysis, operations, or other broad tasks.
+
+## What It Adds
+
+- Dynamic team planning from the user goal
+- One persistent context per agent
+- Agent inboxes and discussion threads
+- A shared task list with optional ownership, lead assignment, and teammate self-claim
+- Session events for status and UI updates
+- Agent-to-agent messages through the internal cowork tool
+- Readiness scoring for smarter scheduling
+- Structured task results, shared memory, blocker snapshots, and final drafts
+- Architecture runtime policies for Adaptive Starter, Agent Team, Generator-Verifier, Message Bus, Shared State, and Swarm
+- Cowork branches for architecture derivation, branch-local continuation, branch results, and explicit session final-result selection or merge
+- Agent Steps with default summaries, tool observations, browser observations, full-detail expansion, and sensitivity/redaction states
+- Versioned graph and trace projections for agents, tasks, mailbox envelopes, artifacts, memory, decisions, budgets, and scheduler causality
+- Architecture-specific organization projections inside one shared Cowork UI shell
+- Reusable Cowork blueprints for graph-oriented team setup, validation, preview, launch, and export
+- Session budgets for rounds, parallel width, agent calls, spawned agents, tool calls, tokens, cost hints, and explicit stop reasons
+
+## Runtime Model
+
+Cowork follows a shared-session runtime model:
+
+1. Cowork Session: one persistent collaboration container shared by every architecture.
+2. Architecture Runtime Policy: the architecture-specific owner of topology, scheduling, routing, delegation, completion, and projection semantics.
+3. Cowork Branch: an independent continuation inside the same session, optionally derived from a source branch with an organized Stage Record.
+4. Control plane: the API, CLI, and WebUI consume the same session snapshot, branches, graph, trace, budget, blueprint, Agent Steps, and blocker contracts.
+
+## Basic Use
+
+Start a session:
+
+```text
+Use cowork to plan a seven-day family trip to Japan, balancing budget, food, logistics, and kid-friendly activities.
+```
+
+Tinybot can call:
+
+```text
+cowork action=start goal="..." auto_run=true
+```
+
+Check status:
+
+```text
+cowork action=status session_id="cw_xxxxxxxx" verbose=true
+```
+
+Run more rounds:
+
+```text
+cowork action=run session_id="cw_xxxxxxxx" max_rounds=3 max_agents=4
+```
+
+## Standalone CLI
+
+Cowork also has its own command group, so it can be used without entering the normal chat loop:
+
+```bash
+uv run tinybot cowork start "Plan a seven-day family trip to Japan" --run --rounds 2
+uv run tinybot cowork start "Compare release plans" --architecture generator_verifier --run
+uv run tinybot cowork list
+uv run tinybot cowork status cw_xxxxxxxx --verbose
+uv run tinybot cowork run cw_xxxxxxxx --rounds 3
+uv run tinybot cowork message cw_xxxxxxxx "Prioritize train travel" --to researcher
+uv run tinybot cowork task cw_xxxxxxxx "Check rainy-day options" --agent analyst
+uv run tinybot cowork task cw_xxxxxxxx "Find backup restaurant options"
+uv run tinybot cowork summary cw_xxxxxxxx
+```
+
+This path constructs a standalone Cowork runtime instead of a full chat `AgentLoop`.
+
+Use `--architecture` for new CLI commands. The older `--mode` option is accepted as a compatibility alias, and legacy `hybrid` input normalizes to `adaptive_starter`.
+
+Blueprint commands:
+
+```bash
+uv run tinybot cowork validate-blueprint cowork-plan.json
+uv run tinybot cowork preview-blueprint cowork-plan.json
+uv run tinybot cowork launch-blueprint cowork-plan.json --run --until-idle --agents 8 --agent-calls 80
+uv run tinybot cowork export-blueprint cw_xxxxxxxx
+```
+
+Existing commands keep their behavior. New budget flags are optional:
+
+```bash
+uv run tinybot cowork run cw_xxxxxxxx --rounds 10 --agents 6 --agent-calls 60 --until-idle
+```
+
+## Blueprint Example
+
+```json
+{
+  "goal": "Prepare a release readiness review",
+  "workflow_mode": "swarm",
+  "agents": [
+    {
+      "id": "lead",
+      "name": "Lead",
+      "role": "Coordinator",
+      "goal": "Keep the review moving",
+      "tools": ["cowork_internal"],
+      "subscriptions": ["coordination", "summary"]
+    },
+    {
+      "id": "qa",
+      "name": "QA",
+      "role": "Verifier",
+      "goal": "Check risks and test gaps",
+      "tools": ["read_file", "list_dir", "cowork_internal"],
+      "subscriptions": ["review", "risk"]
+    }
+  ],
+  "tasks": [
+    {
+      "id": "collect",
+      "title": "Collect release facts",
+      "description": "Summarize scope, changes, and open risks.",
+      "assigned_agent_id": "lead"
+    },
+    {
+      "id": "verify",
+      "title": "Verify readiness",
+      "description": "Review the collected facts.",
+      "assigned_agent_id": "qa",
+      "dependencies": ["collect"],
+      "review_required": true,
+      "reviewer_agent_ids": ["qa"]
+    }
+  ],
+  "routes": [
+    {"id": "lead_to_qa", "from": "lead", "to": "qa", "kind": "handoff", "topic": "review"}
+  ],
+  "budgets": {
+    "parallel_width": 4,
+    "max_rounds_per_run": 20,
+    "max_agent_calls_per_run": 60,
+    "max_spawned_agents": 2
+  },
+  "layout": {
+    "nodes": {
+      "lead": {"x": 220, "y": 180},
+      "qa": {"x": 520, "y": 180}
+    }
+  }
+}
+```
+
+Validation returns diagnostics with `severity`, `code`, `message`, and `path`. Duplicate ids, missing references, dependency cycles, invalid routes, unknown reviewers, disallowed tools, and out-of-policy budgets are reported before any session is created. Preview returns the normalized blueprint, graph preview, budget plan, and initial ready work without writing to the Cowork store.
+
+## WebUI and Gateway
+
+When Tinybot is started with `tinybot gateway`, the hosted WebUI includes an independent Cowork entry in the right panel. The same workspace can also be opened directly at:
+
+```text
+http://127.0.0.1:<gateway-port>/cowork
+```
+
+The frontend calls the gateway Cowork API under `/api/cowork`, while normal chat, skills, knowledge, and workspace editing continue to use their existing routes.
+
+Blueprint and control endpoints:
+
+```text
+POST /api/cowork/blueprints/validate
+POST /api/cowork/blueprints/preview
+POST /api/cowork/sessions              # accepts either goal or blueprint
+GET  /api/cowork/sessions/{id}
+GET  /api/cowork/sessions/{id}/graph
+GET  /api/cowork/sessions/{id}/trace
+GET  /api/cowork/sessions/{id}/blueprint
+POST /api/cowork/sessions/{id}/run     # accepts max_rounds, max_agents, max_agent_calls, run_until_idle, stop_on_blocker
+GET  /api/cowork/sessions/{id}/branches
+POST /api/cowork/sessions/{id}/branches/{branch_id}/select
+POST /api/cowork/sessions/{id}/branches/{branch_id}/derive
+POST /api/cowork/sessions/{id}/branches/{branch_id}/result/select-final
+POST /api/cowork/sessions/{id}/branch-results/merge
+GET  /api/cowork/sessions/{id}/observations/{detail_id}
+```
+
+Chat-originated Cowork sessions also emit additive websocket frames for live WebUI updates. `cowork_state` announces authoritative session changes, `cowork_stream` carries public agent output, and `cowork_mailbox_stream` carries transient mailbox draft text while a `cowork_internal send_message` tool call is still being generated.
+
+`cowork_mailbox_stream` payloads include:
+
+- `chat_id`, `session_id`, `sender_agent_id`
+- `draft_id`, `tool_call_id`
+- `phase`, `status`, `sequence`, `timestamp`, `completed`
+- bounded safe `text` deltas
+- optional routing metadata: `recipient_ids`, `requires_reply`, `wake_recipients`, `topic`, `event_type`, `request_type`, `thread_id`
+
+Mailbox draft frames are transient UI state. The stream policy extracts only allowlisted message text and routing metadata; it does not forward raw tool arguments, private notes, hidden reasoning, or unrelated tool fields. Durable mailbox records and agent activity remain authoritative after delivery. When available, delivered records include `draft_id` and `tool_call_id` so clients can replace draft bubbles without duplicates. Legacy records may be reconciled only by tightly scoped sender, recipient, and exact content matching.
+
+Providers that do not expose native tool-call argument deltas skip `cowork_mailbox_stream`; final tool execution and snapshot-only mailbox behavior continue unchanged. Rollback can disable the Cowork mailbox stream hook while leaving durable mailbox delivery, `cowork_state`, and activity projections intact.
+
+Send a message to agents:
+
+```text
+cowork action=send_message session_id="cw_xxxxxxxx" recipient_ids=["researcher"] content="Prioritize train travel."
+```
+
+`requires_reply` means the recipient owes a concrete answer. `wake_recipients`
+controls whether the message should put recipients back into the scheduler for
+another round. Routine acknowledgements and courtesy messages should not wake
+recipients; use `private_note` or status instead of sending “thanks” /
+“you are welcome” loops.
+
+Add an unassigned task to the shared pool:
+
+```text
+cowork action=add_task session_id="cw_xxxxxxxx" title="Compare museum passes"
+```
+
+Assign an existing task explicitly:
+
+```text
+cowork action=assign_task session_id="cw_xxxxxxxx" task_id="task_xxxxxxxx" assigned_agent_id="analyst"
+```
+
+## How Context Works
+
+Each agent keeps its own private summary and inbox. Shared information moves through tasks, discussion threads, and completed task results. This keeps token use bounded because agents do not receive every other agent's full history on every round.
+
+## Agent Team Workflow
+
+Cowork follows the same basic shape as an agent team:
+
+- A lead or user creates the session, agents, and initial task list.
+- Starting a session sends the user goal only to the lead and creates only a lead-owned delegation task.
+- Tasks can be assigned to a specific agent or left unassigned in the shared task pool.
+- Non-lead agents start idle and should be activated by lead messages or lead-assigned tasks.
+- When an agent has no assigned ready task, it can claim the lowest-id unassigned task whose dependencies are complete.
+- Agents coordinate through mailbox records, direct messages, and discussion threads instead of sharing full private context.
+- The scheduler wakes agents with inbox work, assigned ready tasks, claimable shared tasks, or unanswered mailbox requests.
+- The scheduler ranks candidates by readiness, including reply pressure, ready tasks, shared tasks, blocked status, repeated activation, and whether the lead needs to synthesize.
+- The user talks only to the lead. User broadcasts and direct messages to non-lead agents are routed to the lead.
+- Non-lead agents cannot talk directly to the user. Their user-facing notes are routed to the lead for review and synthesis.
+- The user can still monitor all mailbox messages, events, tasks, and agent status through the Cowork UI/API.
+- When an agent answers another agent's reply-required request, the answer is routed back to the requester and marks the mailbox record as replied.
+
+## Architectures
+
+Cowork uses one persistent session model with architecture runtime policies instead of separate systems. New sessions, blueprints, API responses, CLI output, and WebUI labels use canonical architecture names.
+
+- `adaptive_starter`: clarifies vague goals, recommends a concrete architecture, or starts the smallest useful collaboration structure.
+- `team`: long-running specialist agents keep private summaries, own worker domains, coordinate through tasks/messages, and synthesize through a coordinator.
+- `generator_verifier`: producers create candidate answers or artifacts, then verifiers check them against an explicit rubric and produce pass, revision, or blocker verdicts.
+- `message_bus`: mailbox records act as routed envelopes with topics, event types, lineage, subscribers, direct routes, and reply correlation.
+- `shared_state`: agents directly accumulate findings, evidence, competing claims, risks, open questions, decisions, and artifacts in shared memory.
+- `swarm`: dynamic sub-agent creation, parallel work units, queue-aware fanout, synthesis, review gates, and budget-aware horizontal scaling.
+
+Legacy stored `hybrid` values and legacy CLI/API inputs still load and normalize to `adaptive_starter`. `supervisor`, `orchestrator`, and `peer_handoff` are compatibility-era names, not current creation choices.
+
+The scheduler also tracks convergence. If consecutive rounds produce no new tracked messages, tasks, completed results, artifacts, or shared-memory entries, the session reports `review_convergence` instead of spending more rounds.
+
+## Budget Semantics
+
+Every session exposes:
+
+- `budget_state.limits`: configured caps such as `parallel_width`, `max_rounds_per_run`, `max_agent_calls_per_run`, `max_agent_calls_total`, `max_spawned_agents`, `max_tool_calls`, `max_tokens`, and `max_cost`
+- `budget_state.usage`: observed counters for rounds, agent calls, spawned agents, tool calls, token/cost counters when available, and `stop_reason`
+- `budget_state.remaining`: remaining capacity when a limit is numeric
+
+Plain-goal sessions use conservative defaults compatible with the old behavior. Blueprint sessions can lower or raise caps within policy. The scheduler records machine-readable stop reasons such as `idle`, `completed`, `paused`, `blocker`, `convergence`, `max_rounds`, `ready_to_finish`, `agent_call_budget_exhausted`, and other budget exhaustion reasons.
+
+## Swarm Orchestration and Metrics
+
+Swarm sessions include an `orchestration` assessment inside `swarm_plan` and expose the same payload as `orchestration_assessment` in API snapshots. It records the recommended mode (`single`, `team`, `small_swarm`, `large_swarm`, or `blocked`), fanout score, workstream hints, spawn strategy, recommended parallel width, risk level, review need, user-input need, and budget recommendation. The lead uses this assessment to decide whether to keep work local, reuse the existing team, or request bounded temporary specialists.
+
+Swarm snapshots also expose `swarm_metrics` so users can tell whether parallelism is useful rather than just noisy:
+
+- `critical_path_depth`: longest dependency path through work units plus reducer/reviewer gates.
+- `critical_rounds`: current round count or estimated critical-path rounds.
+- `fanout_width_observed`: largest observed width from running or started work units.
+- `parallel_efficiency`: completed required work units divided by critical path depth.
+- `fanout_utilization`: observed fanout width divided by configured parallel width.
+- `duplicate_rejection_count`: scheduler duplicate activations skipped.
+- `blocked_slot_count`: parallel slots effectively blocked by failed, blocked, revision-needed, or dependency-blocked units.
+- `reducer_coverage`: fraction of completed required work units cited by reducer output.
+
+Low fanout utilization or parallel efficiency usually means the goal should stay smaller, dependencies are too serial, or the reducer/reviewer gates need clearer source coverage before adding more agents.
+
+### Source-Linked Swarm Organization
+
+Cowork's swarm mode follows a local, auditable agent-organization pattern: a lead assesses the task shape, fans out only when workstreams are meaningfully separable, gives each worker a narrow brief, and requires reducer/reviewer gates to preserve source links. It is not a free-form pool of unlimited agents. The policy and budget caps still control parallel width, spawned agents, tool use, work-unit count, and user-approval boundaries.
+
+Use swarm mode when the goal has independent products, files, research targets, expert perspectives, or review dimensions. Prefer `team` or `adaptive_starter` for simple summarization, vague goals, or work where fanout would mostly duplicate effort.
+
+Large swarms expose `swarm_organization` with grouped workstreams, status counts, gates, metrics, and blockers. The WebUI defaults to grouped workstream cards when a session has many units, while search/filter can drill into a workstream, work-unit id, agent, artifact, trace status, blocker, or source field.
+
+Reducer output should include:
+
+```json
+{
+  "answer": "Final synthesis",
+  "findings": [
+    {
+      "summary": "Important sourced finding",
+      "source_work_unit_ids": ["market_review"],
+      "source_artifact_refs": ["market.md"]
+    }
+  ],
+  "source_work_unit_ids": ["market_review", "risk_review"],
+  "source_artifact_refs": ["market.md", "risk.md"],
+  "coverage_by_workstream": {"market": 1.0, "risk": 1.0},
+  "confidence_by_section": {"market": 0.82, "risk": 0.76},
+  "confidence": 0.8
+}
+```
+
+Reviewer output may report `coverage_issues`, `uncited_claims`, `artifact_issues`, and `required_follow_up_units`. Required follow-up units become bounded revision work units linked back to the reviewer result and the affected source work units/artifacts.
+
+### CLI and API Examples
+
+Start a small swarm from the CLI:
+
+```bash
+uv run tinybot cowork start --architecture swarm "Compare market, security, customer, finance, and engineering risks"
+```
+
+Inspect organization metrics through the API:
+
+```bash
+curl http://127.0.0.1:8000/api/cowork/sessions/{session_id}/organization
+```
+
+Steer a swarm, retry a failed work unit, skip a blocked unit, and request review:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/cowork/sessions/{session_id}/messages \
+  -H "content-type: application/json" \
+  -d "{\"content\":\"Prioritize security and finance streams; keep parallel width at 4.\"}"
+
+curl -X POST http://127.0.0.1:8000/api/cowork/sessions/{session_id}/work-units/{work_unit_id}/retry \
+  -H "content-type: application/json" \
+  -d "{\"reason\":\"retry after source update\"}"
+
+curl -X POST http://127.0.0.1:8000/api/cowork/sessions/{session_id}/work-units/{work_unit_id}/skip \
+  -H "content-type: application/json" \
+  -d "{\"reason\":\"out of scope for this run\"}"
+
+curl -X POST http://127.0.0.1:8000/api/cowork/sessions/{session_id}/tasks/{task_id}/review \
+  -H "content-type: application/json" \
+  -d "{\"reviewer_agent_id\":\"reviewer\"}"
+```
+
+Safe usage guidelines:
+
+- Keep `parallel_width` and `max_work_units` close to the amount of genuinely independent work.
+- Require review for code, file writes, command execution, web access, credentials, final artifact delivery, or low-confidence synthesis.
+- Treat `parallel_efficiency`, `fanout_utilization`, and `reducer_coverage` as signals for whether the next run should broaden, narrow, or add reducer citations.
+- Prefer source-linked reducer outputs over prose-only summaries. Missing `source_work_unit_ids`, missing workstream coverage, uncited claims, and missing artifact refs surface as evaluation warnings or blockers according to policy.
+
+## Graph and Trace Contract
+
+Verbose session snapshots and `/api/cowork/sessions/{id}/graph` return a `cowork.graph.v2` projection with:
+
+- `schema_version`, `generated_at`, `nodes`, `edges`, `stats`, and `truncated`
+- node kinds including `session`, `agent`, `task`, `thread`, `mailbox`, `message`, `artifact`, `memory`, `decision`, and `budget`
+- edge kinds including `member`, `assigned_to`, `depends_on`, `sent`, `delivered_to`, `replied_to`, `caused_by`, `blocks`, `produced`, `uses_memory`, `synthesizes`, `spawned`, and `parent_of`
+- both `from`/`to` and `source`/`target` fields on every edge for old and new graph consumers
+- aggregate hidden counts when a focused graph omits nodes or edges
+
+Trace records merge user/agent messages, session events, scheduler decisions, trace spans, and derived stop reasons. Unknown event types are kept as generic trace records instead of being dropped.
+
+## Branches and Results
+
+Every session has a `default` Cowork Branch. A derived branch starts from a source branch and records a Stage Record with the derivation reason, inherited context summary, references, and decisions. The source branch remains available, and users may continue from either branch.
+
+Branch completion creates a Branch Result with summary, artifacts, decision metadata, confidence, source architecture, and source branch id. A Branch Result does not automatically overwrite the session output. The session gets a Session Final Result only when the user explicitly selects a branch result or merges multiple branch results.
+
+## Agent Steps and Observations
+
+Agent Step is the smallest observable execution unit. Native steps include branch, architecture, agent, task or work-unit reference, scheduler reason, action kind, status, timing, linked messages/artifacts/tasks/envelopes, and a compact Step Summary. Legacy trace spans and events are projected into Agent Step-like payloads for UI compatibility.
+
+Tool Observations record tool name, sanitized parameter summary, status, timing, and result summary. Browser Observations record purpose, resource reference, title, timing, result summary, artifacts, and sensitivity markers. Full Observation Detail is requested separately and can be `available`, `redacted`, `unavailable`, or denied by policy.
+
+## Runtime Policy Developer Notes
+
+Architecture-specific behavior belongs in `tinybot/cowork/policies/`. A policy should implement the capabilities that matter for its architecture: topology, branch initialization, step selection, envelope routing, delegation handling, completion evaluation, and organization projection.
+
+Keep shared lifecycle, persistence, API snapshots, branch result selection, budget accounting, and generic observability in `CoworkService`. Add a new architecture by registering a policy in the registry, defining canonical projection sections, adding public service/API tests, and avoiding architecture-specific session subclasses.
+
+## Structured Results and Intelligence
+
+Agents can return structured task results as well as prose:
+
+```json
+{
+  "task_id": "task_xxxxxxxx",
+  "answer": "Recommended answer or completed work",
+  "findings": ["Confirmed fact or useful observation"],
+  "risks": ["Known caveat or failure mode"],
+  "open_questions": ["Question still needing input"],
+  "artifacts": ["Path, URL, or generated output"],
+  "confidence": 0.82
+}
+```
+
+Cowork stores this on the task, rolls recent completed work into shared session memory, and keeps a current final draft. The API and WebUI expose the session's `completion_decision`, `shared_summary`, and `final_draft` so users can see whether the team should run another round, resolve blockers, review failures, or summarize.
+
+Mailbox records can also carry collaboration protocol hints:
+
+- `topic`, `event_type`, `lineage_id`, and `caused_by_envelope_id`: event routing and lineage metadata for message-bus style workflows
+- `request_type`: `clarify`, `verify`, `produce`, `review`, or `unblock`
+- `expected_output_schema`: a lightweight shape for the expected reply
+- `blocking_task_id`: the task currently waiting on the reply
+- `escalate_after_rounds`: when the lead should intervene
+
+## Current Scope
+
+The implementation provides the core backend, tool interface, standalone CLI, API, and WebUI control plane. It supports persistent state, dynamic roles, discussion messages, architecture runtime policies, branch derivation, branch result selection/merge, Agent Step observability, repeated scheduling rounds, readiness scoring, structured results, blocker tracking, blueprint import/export, graph/trace observability, budget stop reasons, stale blocker escalation, and direct gateway access. Older stores remain JSON-compatible: missing blueprint, budget, graph, trace, lineage, memory, branches, Agent Steps, and decision fields default to empty or derived values during load.
+
+## Migration Notes
+
+Plain-goal Cowork still works through the existing planner and fallback team. Those generated sessions now include an exportable blueprint, so users can start with a simple goal, inspect the generated structure, export it, and then edit the JSON for repeatable future launches. Runtime-only messages, completed results, branch results, private summaries, and event history are not included in exported blueprints unless a future import format explicitly asks for them.
+
+Stored `hybrid` workflow values are migration aliases. Loading a legacy session maps `hybrid` to `adaptive_starter` and creates a default Cowork Branch if branch metadata is absent. Compatibility aliases are accepted at input boundaries, but new UI, CLI, API, and blueprint output should use canonical architecture names.

--- a/docs/en/gateway.md
+++ b/docs/en/gateway.md
@@ -1,0 +1,152 @@
+﻿# Gateway Service
+
+The gateway service enables Tinybot to run continuously and provides entry points for web UI, chat platforms, scheduled tasks, and heartbeat services. In short: if you want browser access to Tinybot, you usually need to run the gateway.
+
+## When you need the gateway
+
+| Scenario | Requires gateway |
+|------|----------|
+| Temporary CLI chat | No, use `uv run tinybot agent` |
+| Web UI | Yes |
+| Feishu, DingTalk, WeChat channels | Yes |
+| Scheduled tasks and heartbeat long-run service | Yes |
+| OpenAI-compatible API | No, use `uv run tinybot api` |
+
+## Start the gateway
+
+```bash
+uv run tinybot gateway
+```
+
+If WebSocket channel is enabled, open in browser:
+
+```text
+http://127.0.0.1:18790
+```
+
+## Enable web channel
+
+Your configuration must include:
+```json
+{
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 18790
+    }
+  }
+}
+```
+
+`127.0.0.1` means local-only access, which is suitable for personal use. Do not expose the service to the public internet unless you understand the security impact.
+
+## Change port
+
+If `18790` is occupied, temporarily specify another port:
+
+```bash
+uv run tinybot gateway --port 18800
+```
+
+You can also change the WebSocket channel settings:
+
+```json
+{
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 18800
+    }
+  }
+}
+```
+
+Then open:
+
+```text
+http://127.0.0.1:18800
+```
+
+## Connect chat platforms
+
+Tinybot has built-in channels for Feishu, DingTalk, WeChat, etc. After configuring those channels, gateway receives platform messages and forwards them to agents.
+
+Typical flow:
+
+1. Create an app in the corresponding platform
+2. Obtain required IDs, secrets, tokens
+3. Enable the corresponding channel under `channels`
+4. Start `uv run tinybot gateway`
+5. Finish callback URL / login configuration on platform side
+
+Example structure:
+Fields differ by platform; follow each channel’s configuration.
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "enabled": true,
+      "appId": "your App ID",
+      "appSecret": "your App Secret"
+    }
+  }
+}
+```
+
+Fields differ by platform; follow each channel’s configuration.
+
+## Heartbeat service
+
+Gateway includes heartbeat service for periodic maintenance, such as memory cleanup and background task checks.
+
+Related config:
+
+```json
+{
+  "gateway": {
+    "heartbeat": {
+      "enabled": true,
+      "intervalS": 1800,
+      "keepRecentMessages": 8
+    }
+  }
+}
+```
+
+Beginner default is fine.
+## Scheduled tasks
+
+After gateway starts, Tinybot can process scheduled tasks. For example in conversation you can say:
+```text
+Remind me every day at 9:00 AM to check my to-do list.
+```
+
+Scheduled tasks require gateway to keep running; stopping terminal stops these tasks.
+
+## Troubleshooting
+
+### Web UI cannot open
+
+Check:
+
+1. Whether `uv run tinybot gateway` is still running
+2. Whether WebSocket channel is enabled
+3. Whether the port is correct
+4. Whether firewall is blocking access
+
+### Gateway starts but no UI
+
+Usually `channels.websocket.enabled` is not enabled, or `staticDir` points to missing web files.
+
+### Other devices in LAN cannot access
+
+Set `host` to `0.0.0.0` and ensure firewall allows access to the port. Do this only on trusted networks.
+
+## Next steps
+
+- [Web UI](webui.md): chat with Tinybot in browser
+- [Configuration](config.md): learn gateway and channel settings
+- [Task system](tasks.md): use scheduled tasks and complex workflows

--- a/docs/en/knowledge.md
+++ b/docs/en/knowledge.md
@@ -1,0 +1,152 @@
+﻿# Knowledge Base
+
+The knowledge base lets Tinybot answer questions using your curated materials. It is ideal for situations with many references that you may ask repeatedly, such as product manuals, project docs, policy workflows, meeting minutes, and FAQs.
+
+## Difference from normal chat
+
+Normal chat relies only on the current conversation and the model’s pre-trained knowledge. The knowledge base splits and indexes your documents, retrieves relevant chunks when you ask a question, and passes them to the model for answer generation.
+
+| Scenario | Suggested to use knowledge base |
+|------|------------------|
+| One-off temporary question | Not necessary |
+| Summarizing a short newly pasted text | Not necessary; paste directly |
+| Frequent questions on the same document set | Suggested |
+| Internal policies or product manuals | Suggested |
+| Long-lived technical docs | Suggested |
+
+## Enable the knowledge base
+
+Enable it in configuration:
+
+```json
+{
+  "knowledge": {
+    "enabled": true,
+    "autoRetrieve": true,
+    "maxChunks": 5,
+    "retrievalMode": "hybrid"
+  }
+}
+```
+
+It can also be enabled in the web UI settings panel.
+
+## Add materials
+
+Recommended to add through the web UI:
+
+1. Start `uv run tinybot gateway`
+2. Open `http://127.0.0.1:18790`
+3. Open the knowledge panel on the right
+4. Add text, Markdown, or supported uploaded files
+5. Wait for indexing to complete
+
+The current web session also supports temporary uploads of `txt`, `md`, and `pdf` files for session-local QA.
+
+## Ask questions
+
+When asking, make clear you want retrieval from the knowledge base:
+
+```text
+Based on the product docs in the knowledge base, explain the onboarding flow for a new user account.
+```
+
+```text
+Only use the PDF I uploaded and summarize its risk points.
+```
+
+If you find a response that did not reference materials, ask directly:
+
+```text
+Please re-retrieve the knowledge base and show which document content the answer came from.
+```
+
+## Retrieval settings
+
+| Setting | Beginner recommendation | Meaning |
+|------|----------|------|
+| `autoRetrieve` | On | Automatically search the knowledge base for each question |
+| `maxChunks` | 5 | Number of returned document chunks |
+| `retrievalMode` | `hybrid` | Use semantic and keyword retrieval together |
+| `rerankEnabled` | Off first | Requires additional service; turn on only if search quality is poor |
+
+If your documents have many exact terms, IDs, and interface names, keyword retrieval is important. If user queries are phrased differently from the source docs, semantic retrieval becomes more important. `hybrid` combines both and is suitable for most cases.
+
+## Source evidence and knowledge graph
+
+New indexing keeps interpretable information: documents, chunks, raw evidence, page/line references, extraction method, confidence, and graph signals such as `claim`, `relation`, `conflict`, and `projection`. The answer view and graph panel prefer original source snippets; graph, community report, and summaries are derived views and should not replace original evidence.
+
+In default low-cost mode, Tinybot prefers hybrid retrieval and rule-based semantic extraction. LLM extraction, entity-guided second-pass extraction, evidence expansion, and LLM community reports must be explicitly enabled in configuration.
+
+## High-quality mode
+
+If you need a more complete, inspectable graph, enable in stages:
+
+1. Set `semanticExtractionMode` to `llm` or `hybrid` so the model generates candidate entities, claims, and relations.
+2. Set `llmExtractionStrategy` to `entity_guided` so the model uses known entities to add claims and relations.
+3. Enable `evidenceExpansionEnabled`, starting with `document` scope.
+4. Tune `evidenceExpansionMaxQueries`, `evidenceExpansionMaxLlmCalls`, `evidenceExpansionMaxTokens`, timeout, and concurrency for cost control.
+
+LLM output does not become authoritative facts directly. Candidate items must map back to source snippets and pass validation before entering claim/relation/conflict records.
+
+## Partial indexing and conflicts
+
+Indexing status includes retrieval-ready, claim-ready, relation-ready, partially expanded evidence, graph-ready, failed, and expired states. Even when graph building is incomplete, completed retrieval chunks can still be used for answers. After document updates, graph or community reports may become expired and require rebuilding.
+
+When materials conflict, Tinybot keeps both sides and their sources rather than hiding one side automatically. For important conclusions, ask it to list raw evidence and conflict explanations.
+
+## Material preparation tips
+
+For better retrieval:
+
+- Keep one topic per document.
+- Use clear headings such as “Refund process”, “Deployment steps”, “API authentication”.
+- Avoid putting large unrelated content in one document.
+- Reindex after document updates.
+- Use the knowledge base for long-lived reference materials; use session uploads for temporary files.
+
+## The knowledge base is not omniscient
+
+The knowledge base increases accuracy for “use my materials,” but it does not guarantee every answer is perfectly correct. For critical conclusions, ask Tinybot to list evidence sources or quote source snippets.
+
+Recommended prompt:
+
+```text
+Please answer based on the knowledge base and list key source excerpts used.
+```
+
+## Common issues
+
+### Tinybot did not use my documents
+
+Check:
+
+1. `knowledge.enabled` is `true`
+2. `autoRetrieve` is enabled
+3. Documents are fully indexed
+4. The question matches document content
+5. Whether reindexing is required
+
+### Search results are inaccurate
+
+Try:
+
+1. Ask a more specific question
+2. Increase `maxChunks`
+3. Use `hybrid` retrieval
+4. Split long documents
+5. Enable reranking
+
+### When to skip knowledge base
+
+If you only need Tinybot to read a few current files, directly provide file paths:
+
+```text
+Please read docs/quickstart.md and point out issues.
+```
+
+## Next steps
+
+- [Web UI](webui.md): manage the knowledge base in the browser
+- [Tool features](tools.md): distinguish file reading from web search
+- [Skills](skills.md): turn recurring Q&A flows into skills

--- a/docs/en/providers.md
+++ b/docs/en/providers.md
@@ -1,0 +1,193 @@
+﻿# AI Provider Configuration
+
+Providers are the backend model service sources Tinybot can call, such as DeepSeek, OpenAI, Qwen, local compatible services, and more.
+
+## Suggested providers
+
+| Provider | Default choice |
+|--------|------|
+| Budget-friendly general use | DeepSeek + `deepseek-chat` |
+| More careful reasoning | DeepSeek + `deepseek-reasoner` or OpenAI-compatible alternatives |
+| OpenAI account users | OpenAI + your preferred model |
+| Users with local compatible endpoints | DashScope / compatible provider |
+| Private/Open source/local models | Ollama or local endpoint |
+
+Select one that fits your usage and budget.
+
+## Get API URLs
+
+| Provider | URL |
+|------|------|
+| DeepSeek | https://platform.deepseek.com |
+| OpenAI | https://platform.openai.com |
+| DashScope / OpenAI-compatible | https://dashscope.aliyuncs.com |
+
+After obtaining an API key, add it to Tinybot config.
+
+## Configure through wizard
+
+```bash
+uv run tinybot onboard
+```
+
+Choose `[P] LLM Provider`, select provider and fill in `apiKey`, then go to `[A] Agent Settings` to set the default model.
+
+Check status after setup:
+
+```bash
+uv run tinybot status
+```
+
+## Manual configuration examples
+
+### DeepSeek
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "deepseek-chat"
+    }
+  },
+  "providers": {
+    "deepseek": {
+      "apiKey": "your DeepSeek key"
+    }
+  }
+}
+```
+
+### OpenAI
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "gpt-4o"
+    }
+  },
+  "providers": {
+    "openai": {
+      "apiKey": "your OpenAI key"
+    }
+  }
+}
+```
+
+### DashScope / Qwen
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "qwen-max"
+    }
+  },
+  "providers": {
+    "dashscope": {
+      "apiKey": "your DashScope key"
+    }
+  }
+}
+```
+
+## Provider to model mapping
+
+Tinybot uses provider and model names to route calls.
+
+| Model name | Auto-associated provider |
+|--------------|----------|
+| `deepseek-chat` / `deepseek-reasoner` | DeepSeek |
+| `gpt-4o` / `gpt-4o-mini` | OpenAI |
+| `qwen-max` / `qwen-turbo` | DashScope |
+
+If automatic matching fails, set both model and provider in config:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "provider": "deepseek",
+      "model": "deepseek-chat"
+    }
+  }
+}
+```
+
+## Customizing OpenAI-compatible endpoint
+
+If you use a custom OpenAI-compatible service, set `apiBase`:
+
+```json
+{
+  "providers": {
+    "openai": {
+      "apiKey": "your key",
+      "apiBase": "https://example.com/v1"
+    }
+  }
+}
+```
+
+For provider name placeholders in config, treat them as labels, not service IDs.
+
+## Model selection recommendations
+
+| Requirement | Suggestion |
+|------|------|
+| Cost-sensitive casual use | DeepSeek |
+| Rich analysis and coding workflows | OpenAI |
+| Large-scale inference / heavy usage | DeepSeek |
+| Strong Chinese support | Qwen or DashScope |
+
+Pick based on cost, speed, availability, and your own model availability. You can switch later as needed.
+
+## Troubleshooting
+
+### API call failures
+
+Check:
+
+1. Whether API key is valid
+2. Whether client can reach provider backend
+3. Whether model name exists
+4. Whether model matches provider
+5. Whether gateway/network is healthy
+
+### Low-quality answers from specific providers
+
+Tinybot first follows `agents.defaults.model` and `agents.defaults.provider`. For quality-sensitive work, verify:
+
+```bash
+uv run tinybot status
+```
+
+### Key format issues
+
+Use `uv run tinybot onboard` for consistent onboarding.
+If a key is malformed, Tinybot can fail silently or return confusing errors.
+
+## Next steps
+
+- [Quick start](quickstart.md): set up and run first request
+- [Configuration](config.md): manage global config details
+## Provider catalog and cards
+
+Provider setup is catalog-backed. The WebUI Providers section requests
+`/api/providers` and renders cards for built-in, local, aggregator, and custom
+providers. Each card shows readiness, credential state, API base, model count,
+default model state, and available actions.
+
+Status meanings:
+
+- `ready`: credentials or local access are available and at least one model is known.
+- `needs_key`: the provider requires an API key and neither config nor env provides it.
+- `no_models`: the provider is configured but has no curated, discovered, profile, or manual models.
+- `unavailable`: a custom/local provider is missing required endpoint details.
+- `unsupported`: the catalog entry uses an API mode Tinybot cannot run yet.
+
+Model lists merge curated catalog models, profile models, live `/models`
+discovery, and manual model ids without duplicates. Discovery failures are
+warnings; curated and manual models stay selectable. Custom, local, and
+aggregator providers can use manual model ids when strict validation cannot
+prove them invalid.

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -1,0 +1,206 @@
+﻿# Quick Start
+
+This document is for users new to AI agents. You do not need to understand every concept first. If you complete installation, configure keys, and send your first command, you can start using Tinybot.
+
+## What is Tinybot
+
+Tinybot is an AI assistant that can use tools. It does more than answer questions: with your permissions, it can read files, organize materials, run commands, search the web, manage a knowledge base, decompose complex tasks, and interact with you through web or CLI.
+
+You can think of it as:
+
+| What you want to do | What Tinybot does |
+|------------|----------------|
+| Ask a question | Reply like a normal chatbot |
+| Organize a document set | Read it, extract key points, and generate results |
+| Analyze a project | Scan files, understand structure, and produce a report |
+| Perform multi-step work | Break into small steps and show progress |
+| Keep using consistent habits | Persist through config, skills, and knowledge base |
+
+## Before you begin
+
+Prepare three things:
+
+| Item | Description |
+|------|------|
+| Python | Requires Python 3.13 or newer |
+| uv | This project uses uv for dependency management and Python command execution |
+| AI service key | Start with one of DeepSeek, OpenAI, or Qwen |
+
+If you do not have uv yet, install it first. Run all commands in the project directory.
+
+## Step 1: Install dependencies
+
+```bash
+uv sync
+```
+
+This installs Tinybot dependencies according to project configuration. First run can take some time.
+
+## Step 2: Initialize configuration
+
+```bash
+uv run tinybot onboard
+```
+
+The onboarding wizard asks for AI service, model, keys, workspace, and gateway options. Beginners can keep the minimum setup:
+
+| Option | Recommendation |
+|--------|------|
+| Provider | Choose one you already have a key for, e.g. DeepSeek |
+| API Key | Enter the key from that platform |
+| Model | Start with `deepseek-chat` for DeepSeek, switch to `deepseek-reasoner` for complex reasoning |
+| Workspace | Keep default or set to your desired file directory for Tinybot operations |
+
+Check status after setup:
+
+```bash
+uv run tinybot status
+```
+
+If config file, workspace, and model info are shown, the basic setup is working.
+
+## Step 3: Start a conversation
+
+### Method 1: CLI chat
+
+```bash
+uv run tinybot agent
+```
+
+After entering chat, type your request directly, for example:
+
+```text
+Please summarize what this project is about.
+```
+
+For a single-line question and immediate exit:
+
+```bash
+uv run tinybot agent -m "Hi, introduce Tinybot in one sentence"
+```
+
+### Method 2: Web UI
+
+Web UI requires WebSocket enabled. If onboarding did not enable it, add this to config:
+
+```json
+{
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 18790
+    }
+  }
+}
+```
+
+Then start gateway:
+
+```bash
+uv run tinybot gateway
+```
+
+Open in browser:
+
+```text
+http://127.0.0.1:18790
+```
+
+Beginners usually start with web UI because it shows conversations, tools, skills, knowledge base, and settings.
+
+## How to ask first
+
+AI agents work best on requests with clear goals and defined scope. Example prompts:
+
+```text
+Please read the README and docs directory in the current workspace and tell me who this project is for and how to start it.
+```
+
+```text
+Please check whether docs/quickstart.md is beginner-friendly and point out likely sticking points.
+```
+
+```text
+Please turn this meeting note into a to-do list and group by owner.
+```
+
+A better prompt usually includes three parts:
+
+| Item | Example |
+|------|------|
+| Goal | I need installation instructions |
+| Scope | Look only at docs directory and README |
+| Output format | Step-by-step list, concise |
+
+## Common commands
+
+| Command | Purpose | Who should use |
+|------|------|--------|
+| `uv run tinybot onboard` | Initialize or reconfigure | Everyone |
+| `uv run tinybot status` | Check configuration status | Troubleshooting |
+| `uv run tinybot agent` | CLI chat | Terminal users |
+| `uv run tinybot agent -m "question"` | One-shot prompt | Quick Q&A |
+| `uv run tinybot gateway` | Start web UI and multi-channel services | Web users, long-running sessions |
+| `uv run tinybot api` | Start OpenAI-compatible API | Developers |
+
+## Common issues
+
+### AI does not reply or API errors
+
+Check:
+
+1. Whether `uv run tinybot onboard` has been run
+2. Whether API key is correct
+3. Whether model name belongs to the correct provider
+4. Whether account balance is sufficient
+5. Whether network access to the AI service works
+
+Run:
+
+```bash
+uv run tinybot status
+```
+
+### Web UI cannot open
+
+Check:
+
+1. Whether `channels.websocket.enabled` is enabled
+2. Whether `uv run tinybot gateway` is running
+3. Whether URL is `http://127.0.0.1:18790`
+
+If port is in use, change port:
+
+```bash
+uv run tinybot gateway --port 18800
+```
+
+Then open `http://127.0.0.1:18800`.
+
+### Concerned about file safety
+
+Set workspace to a dedicated directory and enable workspace restriction:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "workspace": "~/.tinybot/workspace"
+    }
+  },
+  "tools": {
+    "restrict_to_workspace": true
+  }
+}
+```
+
+This limits file operations to workspace scope.
+
+## Next steps
+
+- [Web UI](webui.md): learn conversations, settings, knowledge base, and skills in browser
+- [CLI](cli.md): learn terminal chatting, shortcuts, and one-shot prompts
+- [Configuration](config.md): learn model, keys, workspace, and safety limits
+- [Tools](tools.md): learn which tools Tinybot can call
+- [Knowledge base](knowledge.md): use your own documents for answers

--- a/docs/en/skills.md
+++ b/docs/en/skills.md
@@ -1,0 +1,143 @@
+﻿# Skills System
+
+Skills are work instructions for Tinybot. They tell the AI: when this type of task appears, what steps to follow, what to watch for, and what output format to produce.
+
+## What problems skills are good for
+
+If you find yourself repeatedly reminding Tinybot of the same behavior, consider making a skill.
+
+| Repeated reminder | Candidate skill |
+|----------|--------------|
+| “When summarizing meetings, output by owner and due date” | Meeting summary skill |
+| “Reviewing code: list risks first, don’t praise code immediately” | Code review skill |
+| “Weekly report format: progress, risks, plan” | Weekly report skill |
+| “For support tickets, classify first, then provide response script” | Support handling skill |
+
+Skills do not replace model capability; they stabilize your preferences and workflow.
+
+## Built-in skills
+
+Tinybot includes built-in skills, including summarization, scheduling, memory management, browser workflows, and OpenCLI-related routines. You can view and toggle available skills in the web UI skill panel.
+
+## How skills are triggered
+
+Tinybot uses the skill description to decide whether to use it. You do not need to memorize names, but keep descriptions clear.
+
+Example description:
+
+```text
+Use this when the user asks to summarize meeting notes, extract action items, and identify owners and due dates.
+```
+
+When users phrase requests like this, activation is easier:
+
+```text
+Please turn this meeting note into a list of action items.
+```
+
+## Create a custom skill
+
+A skill is usually an `SKILL.md` file inside a directory. Basic format:
+
+```markdown
+---
+name: meeting-summary
+description: Use when the user asks to summarize meeting notes, action items, and risks.
+---
+
+# Meeting summary
+
+## Steps
+1. Identify meeting theme and context first.
+2. Extract explicit action items.
+3. If owner and due date are clear, list them separately.
+4. Mark items without an explicit owner.
+
+## Output format
+Use Markdown table:
+
+| Action item | Owner | Due date | Risk |
+```
+
+When writing a skill, prioritize three points:
+
+| Content | Description |
+|------|------|
+| When to use | Write in `description` |
+| How to work | Write steps |
+| What to output | Provide format or example |
+
+## Good vs weak skills
+
+Good skill:
+
+```text
+When the user requests Python code review, first list concrete bugs, risks, and missing tests, then give a concise summary. Each issue should include file path, root cause, and suggestion.
+```
+
+Weak skill:
+
+```text
+Make the code good.
+```
+
+More specific skills produce more stable execution.
+
+## Manage skills
+
+### Web UI
+
+In skill panel you can:
+
+- View skill list
+- Enable or disable skills
+- View skill details
+- Create or edit workspace skills
+
+### Configuration file
+
+You can control scope via `skills.enabled`:
+
+```json
+{
+  "skills": {
+    "enabled": ["*"]
+  }
+}
+```
+
+`["*"]` enables all available skills. You can also list specific skill names only.
+
+## Skills vs knowledge base
+
+| Capability | Purpose |
+|------|------|
+| Skills | Define how Tinybot should work |
+| Knowledge base | Provide retrievable reference materials |
+
+For example, “support response flow” is a good skill, while “product price list and policy text” belongs in the knowledge base.
+
+## Common issues
+
+### Skill not triggering
+
+Check:
+
+1. Whether the skill is enabled
+2. Whether `description` clearly defines triggering scenarios
+3. Whether the user request truly matches those scenarios
+4. Whether another similar skill is overshadowing it
+
+### Is a longer skill better?
+
+Not necessarily. Keep skills short and explicit. Put stable rules in skills, temporary reference data in knowledge base, and context-specific details in chat.
+
+### Need to restart after skill change?
+
+Usually no. Restart conversation or refresh the web page. If skills list does not update, restart gateway.
+
+## Next steps
+
+- [Knowledge base](knowledge.md): manage long-term reference materials
+- [Task system](tasks.md): understand multi-step execution
+- [Web UI](webui.md): manage skills in browser

--- a/docs/en/tasks.md
+++ b/docs/en/tasks.md
@@ -1,0 +1,123 @@
+﻿# Task System
+
+The task system is for organizing multi-step goals that cannot be solved by one-shot responses. When an AI request requires planning and repeated actions, Tinybot can break it into tasks and execute them with traceable progress.
+
+## What a task system does
+
+You can think of it this way:
+
+```text
+Read README → inspect project files → identify issues → propose fixes → summarize outputs
+```
+
+Tinybot can usually perform this sequence:
+
+1. Read README and docs
+2. Inspect project config and execution steps
+3. Verify code quality and structure
+4. Check and enable required modules and settings
+5. Return a concrete task report
+
+If outputs look unreliable, ask for a clearer task breakdown and scope.
+
+## Basic task types
+
+| Type | Suggested use |
+|------|------|
+| `README + docs` triage | New projects, unfamiliar repositories |
+| Code task list generation | New feature planning or maintenance prep |
+| Long-running workflows | Scheduled or repeated processing |
+| Risk and blocker review | Identify dependencies, risks, and unresolved issues |
+| Evidence reporting | Include files, logs, and commands in the final output |
+
+## How to send requests to task system
+
+| Request type | Example |
+|------|------|
+| Quick scan | `Please read README and docs` |
+| Result output | `Please output a risk checklist` |
+| Runtime execution | `Please run checks and summarize` |
+| Deployment readiness | `Please produce an action checklist for launch` |
+| Regression check | `Please identify commands to run again for validation` |
+
+## Task-oriented context controls
+
+| Control | Meaning |
+|----------|--------------|
+| `scope` | Directory or repository scope, e.g., workspace |
+| `workspace` | Path Tinybot should operate in |
+| `persona` | Planning-focused or execution-focused behavior |
+| `output` | Desired output format, e.g., Markdown table |
+
+Example:
+
+```text
+Please read docs and README, inspect project setup, and output a deployment checklist.
+```
+
+After a long run:
+
+```text
+I asked for a project check and the task is complete. Please also list: changed files, verification steps, risks, and residual actions.
+```
+
+## Task progress view
+
+### Runtime progress
+
+Task progress shows status and completion per step so you can see what is currently running, completed, or blocked.
+
+### Web UI
+
+The web UI shows progress in task cards and each completed step, and it can also display agent-level execution traces.
+
+## Manual and scheduled runs
+
+Tinybot can execute task plans now or in the future if scheduled. You can continue a task even if workspace state changes.
+
+Tips for stable tasks:
+
+- Keep instructions deterministic and bounded.
+- Ask for periodic checkpoints.
+- For high-risk tasks, request a summary before each major change.
+
+## Cancel and stop
+
+| Area | Action |
+|------|------|
+| Runtime execution | Use `Ctrl+C` |
+| Web UI | Click the stop button |
+
+If a task is hard to stop, request a higher-level break and reissue with a tighter scope.
+
+## Troubleshooting
+
+### Task output is incomplete
+
+Most likely causes:
+
+```text
+Workspace path ignored or incorrect; `.venv`, `.git`, and virtual env files should usually be excluded.
+```
+
+### Output format mismatch
+
+Try this:
+
+```text
+Please output as Markdown. For each finding, include file path, command, and status.
+```
+
+### Too much content, not enough useful results
+
+If useful, request:
+
+```text
+Summarize only key findings; do not execute tests or Python code.
+```
+
+## Next steps
+
+- [Tool features](tools.md): better understand execution controls
+- [Skills system](skills.md): lock stable task workflows into reusable behavior
+- [Knowledge base](knowledge.md): improve consistency for repeated checks

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -1,0 +1,198 @@
+﻿# Tool Features
+
+The main difference between an AI agent and a normal chat bot is that an agent can use tools. Tinybot’s tools let the AI read files, search the web, execute commands, work with the knowledge base, and call external MCP services.
+
+## Cowork
+
+The `cowork` tool is used to start and drive multi-agent collaboration sessions. It dynamically generates a set of roles based on the goal, where each role has its own context, mailbox, tasks, and discussion thread. It works well for research, travel planning, writing, analysis, operations, and other tasks that benefit from multiple perspectives.
+
+Cowork can also be used as a standalone workflow without entering regular chat: `uv run tinybot cowork start "..."`.
+
+Cowork supports multiple canonical architectures on one shared session, task, mailbox, and shared-memory model: `adaptive_starter`, `team`, `generator_verifier`, `message_bus`, `shared_state`, and `swarm`.
+
+Common actions:
+
+- `start`: create a cowork session; optional `auto_run=true` immediately runs one round
+- `status`: view agents, tasks, discussion threads, and events
+- `run`: continue running scheduling rounds
+- `send_message`: user sends extra constraints or requirements to specific agents
+- `add_task`: add a task to a specific agent
+- `summary`: summarize current results
+
+## What it means for a tool-backed assistant
+
+A normal chatbot only generates text from your input. Tinybot can perform actions during a task, for example:
+
+| User request | Tool Tinybot can use |
+|----------|------------------------|
+| “Summarize this project” | Read README, search docs, organize output |
+| “Check whether config is correct” | Read config files, analyze fields |
+| “Generate docs for me” | Read references, write Markdown files |
+| “Search for latest information” | Search the web, open pages, summarize sources |
+| “Run tests” | Execute commands, read test output |
+
+The more tools are enabled, the more clearly you should define scope and safety boundaries.
+
+## File operations
+
+Tinybot can read, search, create, and modify files. It is useful for:
+
+- Summarizing project structure
+- Editing documentation
+- Finding configuration entries
+- Generating reports
+- Organizing text materials
+
+Recommended prompts:
+
+```text
+Please read only the docs directory and identify places where the instructions are not beginner-friendly.
+```
+
+```text
+Please update docs/quickstart.md to make it more suitable for first-time Tinybot users.
+```
+
+If you do not want file changes, state it clearly:
+
+```text
+Do not edit files yet. Just give me suggestions.
+```
+
+## Command execution
+
+Tinybot can execute terminal commands, such as installing dependencies, running tests, and checking status.
+
+Example:
+
+```text
+Please run project tests and summarize the failure reasons.
+```
+
+Related settings:
+
+```json
+{
+  "tools": {
+    "exec": {
+      "enable": true,
+      "timeout": 60
+    }
+  }
+}
+```
+
+If you do not want AI to execute commands, disable this:
+
+```json
+{
+  "tools": {
+    "exec": {
+      "enable": false
+    }
+  }
+}
+```
+
+## Web search
+
+Tinybot can search the internet, useful for information that changes over time, such as news, prices, versions, policies, and third-party docs.
+
+```text
+Please search the latest docs for this library and tell me upgrade notes.
+```
+
+Related settings:
+
+```json
+{
+  "tools": {
+    "web": {
+      "enable": true,
+      "search": {
+        "provider": "duckduckgo",
+        "maxResults": 5
+      }
+    }
+  }
+}
+```
+
+If web access is restricted, you can configure a proxy:
+
+```json
+{
+  "tools": {
+    "web": {
+      "proxy": "http://127.0.0.1:7890"
+    }
+  }
+}
+```
+
+## Browser automation
+
+Browser automation lets AI open web pages, click buttons, enter content, and extract page data. It usually requires extra browser bridge tooling and extensions.
+
+Good for:
+
+- Checking web interfaces
+- Extracting structured data from pages
+- Assisting local WebUI testing
+
+If you are not familiar, you can skip this at first; basic chat, file operations, and knowledge base still work.
+
+## MCP tools
+
+MCP connects external tool services into Tinybot. After integration, these tools can be called by the agent like built-in ones.
+
+Useful for developer/team scenarios, such as connecting internal systems, databases, design tools, or code platforms. New users do not need to configure MCP right away.
+
+## Security recommendations
+
+| Setting | Recommendation |
+|------|------|
+| Workspace | Set it to a clear directory, not your entire system root |
+| `restrictToWorkspace` | Recommended for beginners |
+| Command execution | Turn off when not needed |
+| API Key | Do not commit real keys to public repos |
+| File edits | Let Tinybot announce scope before making changes |
+
+Recommended safe config:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "workspace": "~/.tinybot/workspace"
+    }
+  },
+  "tools": {
+    "restrictToWorkspace": true,
+    "exec": {
+      "enable": true,
+      "timeout": 60
+    }
+  }
+}
+```
+
+## Common issues
+
+### Tinybot says "permission denied"
+
+This is often caused by workspace restrictions. Confirm the target file is inside `agents.defaults.workspace`.
+
+### Command execution timeout
+
+Default timeout is 60 seconds. Increase `tools.exec.timeout`, or ask Tinybot to split large tasks.
+
+### Search results are inaccurate
+
+Use clearer questions, or increase `maxResults`. For static/official references, prefer the knowledge base over live web searches.
+
+## Next steps
+
+- [Configuration](config.md): enable or disable tools
+- [Knowledge base](knowledge.md): manage long-lived materials
+- [Task system](tasks.md): understand how complex tasks are decomposed and executed

--- a/docs/en/webui.md
+++ b/docs/en/webui.md
@@ -1,0 +1,158 @@
+﻿# Web UI
+
+The web UI is suitable for most beginners. It is more intuitive than a terminal and lets you see chat history, settings, knowledge base, skills, tools, and task status at the same time.
+
+## Start the web UI
+
+The web UI is provided by the WebSocket channel. Make sure your configuration includes:
+
+```json
+{
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 18790
+    }
+  }
+}
+```
+
+Then start the gateway:
+
+```bash
+uv run tinybot gateway
+```
+
+Open in your browser:
+
+```text
+http://127.0.0.1:18790
+```
+
+If you are using it locally, keep `host` as `127.0.0.1` and avoid changing it to a public address.
+
+## UI regions
+
+| Region | Purpose |
+|------|------|
+| Left conversation list | Start new sessions, switch history, continue previous conversations |
+| Middle chat area | Enter requests and view Tinybot responses and execution progress |
+| Right panel | Manage tools, knowledge base, skills, settings, and workspace files |
+| Top or status area | View current model, connection status, and task status |
+
+## First-time workflow
+
+1. Open the web UI and enter the settings panel first.
+2. Confirm Provider, API Key, and Model are configured.
+3. Return to chat and send a simple test message.
+4. Then try letting Tinybot read your workspace or organize documentation.
+
+Example test message:
+
+```text
+Hi, tell me which model you are currently using, and explain what you can help me with.
+```
+
+If it replies normally, try this:
+
+```text
+Please read the README in the current workspace and summarize the project purpose and startup method.
+```
+
+## Conversation management
+
+The web UI saves conversation history. You can:
+
+| Action | Meaning |
+|------|------|
+| New conversation | Start a new topic |
+| Switch conversation | Continue asking from previous context |
+| Clear conversation | Delete history context of the current conversation |
+| Delete conversation | Remove no-longer-needed history |
+
+Use separate conversations for different tasks, e.g. "project analysis", "writing docs", "daily Q&A". This keeps context cleaner.
+
+## Right-side function panel
+
+### Settings
+
+Used to change model, API keys, workspace, and tool toggles. The most common settings for beginners are:
+
+| Setting | Purpose |
+|------|------|
+| `providers.*.apiKey` | Configure the key for the corresponding AI service |
+| `agents.defaults.model` | Select the model |
+| `agents.defaults.workspace` | Set file operation scope |
+| `tools.restrictToWorkspace` | Limit Tinybot to workspace-only file operations |
+
+### Tools
+
+Displays tools Tinybot can currently use. Tools include file operations, command execution, web search, and MCP extensions. More tools increase capability but also require clearer authorization boundaries.
+
+### Knowledge base
+
+Used to let Tinybot answer questions based on your provided materials. Suitable for storing product manuals, project documentation, workflow rules, meeting materials, etc.
+
+### Skills
+
+Skills are behavioral instructions. You can enable, disable, or create skills so Tinybot follows fixed workflows in specific scenarios.
+
+### Workspace files
+
+Use this to inspect the file scope Tinybot can access. Before editing files, verify the workspace points to the correct directory.
+
+## When to use the web UI
+
+| Scenario | Recommended |
+|------|----------|
+| First-time Tinybot setup | Recommended |
+| Long AI collaboration sessions | Recommended |
+| Managing knowledge base and skills | Recommended |
+| One-sentence quick questions | `agent -m` in CLI is faster |
+| API backend integration | Use `tinybot api` |
+
+## FAQ
+
+### Browser cannot open
+
+Check:
+
+1. Whether `uv run tinybot gateway` is running
+2. Whether WebSocket channel is enabled
+3. Whether the port is in use
+4. Whether URL is exactly `http://127.0.0.1:18790`
+
+### Page opens but AI does not reply
+
+Check:
+
+1. Whether API Key is correct
+2. Whether model name matches the provider
+3. Whether account balance is sufficient
+4. Whether backend terminal logs show errors
+
+### Settings do not take effect immediately
+
+Model and keys usually update dynamically. A few gateway, channel, or tool settings may require restart:
+
+```bash
+uv run tinybot gateway
+```
+
+## Next steps
+
+- [Knowledge Base](knowledge.md): Give Tinybot your own documents to use
+- [Skills](skills.md): Make Tinybot follow a fixed workflow
+- [Configuration](config.md): Understand each commonly used setting
+## Providers page
+
+The settings modal includes a provider card grid loaded from `/api/providers`.
+Use search and filters to find providers by name, alias, status, or category.
+The Models action refreshes provider models through `/api/provider-models`,
+shows source labels, lets a model become the default, and supports manual model
+entry. The Settings action selects the provider and exposes API key, base URL,
+profile, discovery, and advanced request fields without overloading the card.
+
+Provider cards do not write masked secret placeholders back as new secrets.
+When a masked value is unchanged, the backend preserves the existing key.


### PR DESCRIPTION
This PR adds an English documentation copy under `docs/en` translated from existing markdown files outside `docs/dev` and `docs/superpowers`, without changing existing source docs.

Scope:
- Add translated docs: `docs/en/cli.md`, `config.md`, `cowork.md`, `gateway.md`, `knowledge.md`, `providers.md`, `quickstart.md`, `skills.md`, `tasks.md`, `tools.md`, `webui.md`

Notes:
- Existing repo files outside `docs/en` are intentionally left untouched.
- Files under `docs/dev` and `docs/superpowers` were excluded per request.