### PR TITLE
Align native desktop workbench styling with root WebUI

### DIFF
--- a/apps/desktop/src/desktopDesignTokens.test.ts
+++ b/apps/desktop/src/desktopDesignTokens.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { DESKTOP_DESIGN_TOKENS_STYLE_ID, installDesktopDesignTokens } from "./desktopDesignTokens";
+
+class FakeElement {
+  public id = "";
+  public textContent = "";
+  public children: FakeElement[] = [];
+  public attributes = new Map<string, string>();
+
+  constructor(public readonly tagName: string) {}
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+    if (name === "id") {
+      this.id = value;
+    }
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    if (selector.startsWith("#") && this.id === selector.slice(1)) {
+      return this;
+    }
+    for (const child of this.children) {
+      const match = child.querySelector(selector);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+}
+
+class FakeDocument {
+  public head = new FakeElement("head");
+
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  }
+
+  getElementById(id: string): FakeElement | null {
+    return this.head.querySelector(`#${id}`);
+  }
+}
+
+describe("desktop design tokens", () => {
+  test("installs root WebUI design tokens with native compatibility aliases once", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopDesignTokens(targetDocument as unknown as Document);
+    installDesktopDesignTokens(targetDocument as unknown as Document);
+
+    expect(targetDocument.head.children).toHaveLength(1);
+    const style = targetDocument.getElementById(DESKTOP_DESIGN_TOKENS_STYLE_ID);
+    expect(style?.textContent).toContain("--bg: #faf9f5;");
+    expect(style?.textContent).toContain("--panel-strong: #faf9f5;");
+    expect(style?.textContent).toContain("--accent-hover: #a9583e;");
+    expect(style?.textContent).toContain("--primary: var(--accent);");
+    expect(style?.textContent).toContain("--muted: var(--text-muted);");
+    expect(style?.textContent).toContain("--focus-ring: var(--accent-glow);");
+    expect(style?.textContent).toContain('[data-theme="dark"]');
+  });
+});

--- a/apps/desktop/src/desktopDesignTokens.ts
+++ b/apps/desktop/src/desktopDesignTokens.ts
@@ -1,0 +1,108 @@
+export const DESKTOP_DESIGN_TOKENS_STYLE_ID = "desktop-design-tokens";
+
+export function installDesktopDesignTokens(targetDocument: Document = document): void {
+  if (targetDocument.getElementById(DESKTOP_DESIGN_TOKENS_STYLE_ID)) {
+    return;
+  }
+
+  const style = targetDocument.createElement("style");
+  style.id = DESKTOP_DESIGN_TOKENS_STYLE_ID;
+  style.setAttribute("id", DESKTOP_DESIGN_TOKENS_STYLE_ID);
+  style.textContent = `
+    :root {
+      --bg: #faf9f5;
+      --bg-subtle: #f5f0e8;
+      --panel: #faf9f5;
+      --panel-strong: #faf9f5;
+      --panel-gradient: #faf9f5;
+      --border: #e6dfd8;
+      --border-subtle: #ebe6df;
+      --text: #141413;
+      --text-strong: #252523;
+      --text-muted: #6c6a64;
+      --text-subtle: #8e8b82;
+      --accent: #cc785c;
+      --accent-hover: #a9583e;
+      --accent-soft: rgba(204, 120, 92, 0.12);
+      --accent-glow: rgba(204, 120, 92, 0.15);
+      --accent-glow-strong: rgba(204, 120, 92, 0.24);
+      --danger: #c64545;
+      --danger-soft: rgba(198, 69, 69, 0.12);
+      --success: #5db872;
+      --success-soft: rgba(93, 184, 114, 0.14);
+      --warning: #d4a017;
+      --warning-soft: rgba(212, 160, 23, 0.14);
+      --surface-card: #efe9de;
+      --surface-soft: #f5f0e8;
+      --surface-cream-strong: #e8e0d2;
+      --surface-dark: #181715;
+      --surface-dark-elevated: #252320;
+      --surface-dark-soft: #1f1e1b;
+      --on-primary: #ffffff;
+      --on-dark: #faf9f5;
+      --on-dark-soft: #a09d96;
+      --accent-teal: #5db8a6;
+      --accent-amber: #e8a55a;
+      --shadow-xs: 0 1px 2px rgba(20, 20, 19, 0.04);
+      --shadow-sm: 0 1px 3px rgba(20, 20, 19, 0.08);
+      --shadow-md: 0 8px 22px rgba(20, 20, 19, 0.08);
+      --shadow-lg: 0 14px 36px rgba(20, 20, 19, 0.10);
+      --shadow-xl: 0 22px 54px rgba(20, 20, 19, 0.12);
+      --radius-xs: 4px;
+      --radius-sm: 6px;
+      --radius-md: 8px;
+      --radius-lg: 12px;
+      --radius-xl: 16px;
+      --radius-full: 9999px;
+      --transition-fast: 120ms ease;
+      --transition-base: 200ms ease;
+      --transition-slow: 300ms ease;
+      --font-display: "Cormorant Garamond", "Tiempos Headline", Garamond, "Times New Roman", serif;
+      --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-mono: "JetBrains Mono", "Cascadia Mono", "SF Mono", Consolas, "Liberation Mono", monospace;
+      --primary: var(--accent);
+      --primary-hover: var(--accent-hover);
+      --primary-active: var(--accent-hover);
+      --muted: var(--text-muted);
+      --border-soft: var(--border-subtle);
+      --focus-ring: var(--accent-glow);
+    }
+
+    [data-theme="dark"] {
+      --bg: #181715;
+      --bg-subtle: #1f1e1b;
+      --panel: #1f1e1b;
+      --panel-strong: #252320;
+      --panel-gradient: #1f1e1b;
+      --border: rgba(250, 249, 245, 0.12);
+      --border-subtle: rgba(250, 249, 245, 0.08);
+      --text: #faf9f5;
+      --text-strong: #faf9f5;
+      --text-muted: #a09d96;
+      --text-subtle: #8e8b82;
+      --accent: #cc785c;
+      --accent-hover: #e08b6f;
+      --accent-soft: rgba(204, 120, 92, 0.16);
+      --accent-glow: rgba(204, 120, 92, 0.20);
+      --accent-glow-strong: rgba(204, 120, 92, 0.30);
+      --danger: #e05b5b;
+      --danger-soft: rgba(224, 91, 91, 0.16);
+      --success: #5db872;
+      --success-soft: rgba(93, 184, 114, 0.16);
+      --warning: #e8a55a;
+      --warning-soft: rgba(232, 165, 90, 0.16);
+      --surface-card: #252320;
+      --surface-soft: #1f1e1b;
+      --surface-cream-strong: #252320;
+      --surface-dark: #141413;
+      --surface-dark-elevated: #252320;
+      --surface-dark-soft: #1f1e1b;
+      --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.26);
+      --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.28);
+      --shadow-md: 0 8px 22px rgba(0, 0, 0, 0.30);
+      --shadow-lg: 0 14px 36px rgba(0, 0, 0, 0.34);
+      --shadow-xl: 0 22px 54px rgba(0, 0, 0, 0.38);
+    }
+  `;
+  targetDocument.head.append(style);
+}

--- a/apps/desktop/src/desktopRootWebUiWorkbench.ts
+++ b/apps/desktop/src/desktopRootWebUiWorkbench.ts
@@ -18,6 +18,7 @@ import {
   buildRootWebUiWorkspaceContext,
   type DesktopSidebarItem,
 } from "./desktopSharedModels";
+import { installDesktopDesignTokens } from "./desktopDesignTokens";
 
 interface InstallDesktopRootWebUiWorkbenchOptions {
   targetDocument?: Document;
@@ -30,6 +31,7 @@ export function installDesktopRootWebUiWorkbenchAdapter({
   storage = targetDocument.defaultView?.localStorage ?? null,
   viewportWidth = targetDocument.defaultView?.innerWidth ?? Number.POSITIVE_INFINITY,
 }: InstallDesktopRootWebUiWorkbenchOptions = {}): void {
+  installDesktopDesignTokens(targetDocument);
   ensureDesktopRootWebUiShellLayoutStyle(targetDocument);
   ensureDesktopComposerSurfaceStyle(targetDocument);
   installRootWebUiCommandPaletteSurface(targetDocument);

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -205,6 +205,7 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector('[data-workbench-region="main"]')).toBeTruthy();
     expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.style.values.get("--region-size")).toBe("360px");
     expect(targetDocument.body.querySelector('[data-workbench-region="bottom"]')?.getAttribute("data-visible")).toBe("false");
+    expect(targetDocument.head.querySelector("#desktop-design-tokens")).toBeTruthy();
     expect(targetDocument.head.querySelector("#desktop-workbench-shell-style")).toBeTruthy();
   });
 
@@ -2027,16 +2028,36 @@ describe("desktop workbench shell", () => {
       gatewayHttp: "http://127.0.0.1:18790",
     });
 
+    const tokenText = targetDocument.head.querySelector("#desktop-design-tokens")?.textContent;
     const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent;
-    expect(styleText).toContain("--bg: #faf9f5;");
-    expect(styleText).toContain("--panel-strong: #efe9de;");
-    expect(styleText).toContain("--primary: #cc785c;");
-    expect(styleText).toContain("--surface-dark: #181715;");
-    expect(styleText).toContain("--border: #e6dfd8;");
-    expect(styleText).toContain('--font-display: "Tiempos Headline"');
+    expect(tokenText).toContain("--bg: #faf9f5;");
+    expect(tokenText).toContain("--panel-strong: #faf9f5;");
+    expect(tokenText).toContain("--primary: var(--accent);");
+    expect(tokenText).toContain("--surface-dark: #181715;");
+    expect(tokenText).toContain("--border: #e6dfd8;");
+    expect(tokenText).toContain('--font-display: "Cormorant Garamond"');
+    expect(styleText).not.toContain(":root {");
   });
 
-  test("uses dark product surfaces for runtime diagnostics", () => {
+  test("renders a bottom composer-like surface for native visual parity", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const composer = targetDocument.getElementById("desktop-native-composer");
+    expect(composer?.getAttribute("aria-label")).toBe("Native desktop composer");
+    expect(targetDocument.getElementById("desktop-native-composer-input")?.getAttribute("aria-label")).toBe("Native composer input");
+    expect(targetDocument.getElementById("desktop-native-composer-input")?.getAttribute("placeholder")).toBe("Ask Tinybot");
+    expect(targetDocument.getElementById("desktop-native-composer-attach")?.getAttribute("data-desktop-composer-action")).toBe("attach");
+    expect(targetDocument.getElementById("desktop-native-composer-send")?.getAttribute("data-desktop-composer-action")).toBe("send");
+    expect(targetDocument.getElementById("desktop-native-composer-runtime")?.textContent).toContain("Gateway ready");
+  });
+
+  test("reserves dark product surfaces for diagnostics instead of the runtime panel", () => {
     const targetDocument = new FakeDocument();
 
     installDesktopWorkbenchShell({
@@ -2047,7 +2068,7 @@ describe("desktop workbench shell", () => {
 
     const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent;
     expect(styleText).toContain(".desktop-gateway-runtime");
-    expect(styleText).toContain("background: var(--surface-dark, #181715);");
+    expect(styleText).toContain("background: var(--panel);");
     expect(styleText).toContain(".desktop-task-center-diagnostics:not(:empty)");
     expect(styleText).toContain(".desktop-run-chain-detail");
     expect(styleText).toContain("background: var(--surface-dark-soft, #1f1e1b);");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -47,6 +47,7 @@ import {
   type DesktopSidebarGroup,
   type DesktopSidebarItem,
 } from "./desktopSharedModels";
+import { installDesktopDesignTokens } from "./desktopDesignTokens";
 
 export interface DesktopTaskCenterActionEvent {
   action: DesktopTaskActionId;
@@ -216,6 +217,7 @@ export function installDesktopWorkbenchShell({
   taskActions = {},
   gatewayActions = {},
 }: InstallDesktopWorkbenchShellOptions): void {
+  installDesktopDesignTokens(targetDocument);
   ensureDesktopWorkbenchShellStyle(targetDocument);
   targetDocument.body.classList.add("desktop-native-workbench");
   targetDocument.body.replaceChildren(createWorkbenchShell(targetDocument, layout, runtimeStatus, gatewayHttp, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, runChainItems, selectedRunChainItemKey, workLens, workLensActions, taskActions, gatewayActions));
@@ -426,8 +428,55 @@ function createMainRegion(
   status.setAttribute("data-desktop-route-status", "");
   status.textContent = `Gateway ${gatewayHttp}`;
 
-  main.append(empty, status);
+  main.append(empty, createNativeComposerSurface(targetDocument, gatewayHttp), status);
   return main;
+}
+
+function createNativeComposerSurface(targetDocument: Document, gatewayHttp: string): HTMLElement {
+  const composer = targetDocument.createElement("form");
+  composer.id = "desktop-native-composer";
+  composer.className = "desktop-native-composer";
+  composer.setAttribute("aria-label", "Native desktop composer");
+
+  const attach = targetDocument.createElement("button");
+  attach.id = "desktop-native-composer-attach";
+  attach.type = "button";
+  attach.className = "desktop-native-composer-action";
+  attach.setAttribute("data-desktop-composer-action", "attach");
+  attach.setAttribute("aria-label", "Attach file");
+  attach.textContent = "+";
+
+  const input = targetDocument.createElement("textarea");
+  input.id = "desktop-native-composer-input";
+  input.className = "desktop-native-composer-input";
+  input.setAttribute("aria-label", "Native composer input");
+  input.setAttribute("placeholder", "Ask Tinybot");
+
+  const send = targetDocument.createElement("button");
+  send.id = "desktop-native-composer-send";
+  send.type = "button";
+  send.className = "desktop-native-composer-send";
+  send.setAttribute("data-desktop-composer-action", "send");
+  send.setAttribute("aria-label", "Send message");
+  send.textContent = "Send";
+
+  const runtime = targetDocument.createElement("div");
+  runtime.id = "desktop-native-composer-runtime";
+  runtime.className = "desktop-native-composer-runtime";
+  runtime.append(
+    createComposerChip(targetDocument, "Gateway ready", gatewayHttp),
+    createComposerChip(targetDocument, "Native visual mode", "Composer shell"),
+  );
+
+  composer.append(attach, input, send, runtime);
+  return composer;
+}
+
+function createComposerChip(targetDocument: Document, label: string, value: string): HTMLElement {
+  const chip = targetDocument.createElement("span");
+  chip.className = "desktop-native-composer-chip";
+  chip.textContent = `${label}: ${value}`;
+  return chip;
 }
 
 function createWorkLensInlineHost(
@@ -2338,44 +2387,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
   const style = targetDocument.createElement("style");
   style.id = STYLE_ID;
   style.textContent = `
-    :root {
-      --font-display: "Tiempos Headline", "Cormorant Garamond", "EB Garamond", Garamond, "Times New Roman", serif;
-      --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
-      --bg: #faf9f5;
-      --bg-subtle: #f5f0e8;
-      --panel: #faf9f5;
-      --panel-strong: #efe9de;
-      --surface-cream-strong: #e8e0d2;
-      --surface-dark: #181715;
-      --surface-dark-elevated: #252320;
-      --surface-dark-soft: #1f1e1b;
-      --text: #141413;
-      --text-strong: #252523;
-      --text-muted: #6c6a64;
-      --muted: #8e8b82;
-      --border: #e6dfd8;
-      --border-soft: #ebe6df;
-      --primary: #cc785c;
-      --primary-active: #a9583e;
-      --accent: #cc785c;
-      --accent-teal: #5db8a6;
-      --success: #5db872;
-      --warning: #d4a017;
-      --danger: #c64545;
-      --on-dark: #faf9f5;
-      --on-dark-soft: #a09d96;
-      --focus-ring: rgba(204, 120, 92, 0.28);
-      --shadow-soft: 0 1px 3px rgba(20, 20, 19, 0.08);
-    }
-
     body.desktop-native-workbench {
       margin: 0;
       min-height: 100vh;
       overflow: hidden;
-      background: var(--bg, #faf9f5);
-      color: var(--text, #141413);
-      font-family: var(--font-sans, system-ui, sans-serif);
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--font-sans);
     }
 
     body.desktop-native-workbench .desktop-workbench-shell,
@@ -2387,22 +2405,22 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       height: calc(100vh - var(--desktop-window-frame-height, 0px));
       padding-top: var(--desktop-window-frame-height, 0px);
       display: grid;
-      grid-template-columns: 52px minmax(220px, var(--desktop-sidebar-size, 260px)) minmax(420px, 1fr) minmax(280px, var(--desktop-inspector-size, 360px));
+      grid-template-columns: 56px minmax(220px, var(--desktop-sidebar-size, 260px)) minmax(420px, 1fr) minmax(280px, var(--desktop-inspector-size, 360px));
       grid-template-rows: minmax(0, 1fr) auto;
-      border-top: 1px solid var(--border, #e6dfd8);
-      background: var(--bg, #faf9f5);
+      border-top: 1px solid var(--border);
+      background: var(--bg);
     }
 
     body.desktop-native-workbench .desktop-workbench-shell[data-inspector-visible="false"] {
-      grid-template-columns: 52px minmax(220px, var(--desktop-sidebar-size, 260px)) minmax(0, 1fr) 0;
+      grid-template-columns: 56px minmax(220px, var(--desktop-sidebar-size, 260px)) minmax(0, 1fr) 0;
     }
 
     body.desktop-native-workbench .desktop-workbench-shell[data-sidebar-visible="false"] {
-      grid-template-columns: 52px 0 minmax(420px, 1fr) minmax(280px, var(--desktop-inspector-size, 360px));
+      grid-template-columns: 56px 0 minmax(420px, 1fr) minmax(280px, var(--desktop-inspector-size, 360px));
     }
 
     body.desktop-native-workbench .desktop-workbench-shell[data-sidebar-visible="false"][data-inspector-visible="false"] {
-      grid-template-columns: 52px 0 minmax(0, 1fr) 0;
+      grid-template-columns: 56px 0 minmax(0, 1fr) 0;
     }
 
     body.desktop-native-workbench .desktop-activity-rail {
@@ -2411,9 +2429,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: flex;
       flex-direction: column;
       gap: 6px;
-      padding: 10px 6px;
-      border-right: 1px solid var(--border, #e6dfd8);
-      background: var(--surface-dark, #181715);
+      padding: 10px 7px;
+      border-right: 1px solid var(--border);
+      background: var(--bg);
     }
 
     body.desktop-native-workbench .desktop-activity-button,
@@ -2422,13 +2440,20 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-items: center;
       justify-content: center;
       min-height: 36px;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
-      background: var(--panel, #faf9f5);
-      color: var(--text, #141413);
-      font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
+      border: 1px solid transparent;
+      border-radius: var(--radius-md);
+      background: transparent;
+      color: var(--text-muted);
+      font: 600 12px/1.2 var(--font-sans);
       text-decoration: none;
       cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-activity-button:hover,
+    body.desktop-native-workbench .desktop-activity-button:focus-visible {
+      border-color: var(--border);
+      background: var(--surface-soft);
+      color: var(--text);
     }
 
     body.desktop-native-workbench .desktop-workbench-sidebar,
@@ -2438,8 +2463,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       min-height: 0;
       overflow: hidden;
-      border-right: 1px solid var(--border, #e6dfd8);
-      background: var(--panel, #faf9f5);
+      border-right: 1px solid var(--border);
+      background: var(--panel);
     }
 
     body.desktop-native-workbench .desktop-workbench-sidebar {
@@ -2461,22 +2486,24 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workbench-main {
       grid-column: 3;
       display: grid;
-      grid-template-rows: minmax(0, 1fr) auto;
-      padding: 14px;
+      grid-template-rows: minmax(0, 1fr) auto auto;
+      padding: 18px 24px 12px;
       overflow: auto;
-      background: var(--bg-subtle, #f5f0e8);
+      background: var(--bg);
     }
 
     body.desktop-native-workbench .desktop-empty-session {
       align-self: start;
       display: grid;
       gap: 12px;
-      max-width: 720px;
+      width: min(820px, 100%);
+      max-width: 820px;
       min-width: 0;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 12px;
-      padding: 18px;
-      background: var(--panel-strong, #efe9de);
+      margin: 0 auto;
+      border: 0;
+      border-radius: 0;
+      padding: 14px 0 18px;
+      background: transparent;
     }
 
     body.desktop-native-workbench .desktop-empty-session > * {
@@ -2550,9 +2577,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workbench-link:focus-visible,
     body.desktop-native-workbench .desktop-activity-button:focus-visible,
     body.desktop-native-workbench .desktop-quick-action:focus-visible {
-      outline: 2px solid var(--primary, #cc785c);
+      outline: 2px solid var(--primary);
       outline-offset: 2px;
-      box-shadow: 0 0 0 4px var(--focus-ring, rgba(204, 120, 92, 0.28));
+      box-shadow: 0 0 0 4px var(--focus-ring);
     }
 
     body.desktop-native-workbench .desktop-quick-actions {
@@ -2562,8 +2589,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-quick-actions .desktop-quick-action:first-child {
-      border-color: var(--primary, #cc785c);
-      background: var(--primary, #cc785c);
+      border-color: var(--primary);
+      background: var(--primary);
       color: #ffffff;
     }
 
@@ -2576,29 +2603,29 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-panel-control {
       min-height: 32px;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
       padding: 0 10px;
-      background: var(--panel, #faf9f5);
-      color: var(--text, #141413);
-      font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
+      background: var(--panel);
+      color: var(--text);
+      font: 600 12px/1.2 var(--font-sans);
       cursor: pointer;
     }
 
     body.desktop-native-workbench .desktop-panel-control[aria-pressed="true"] {
-      border-color: var(--primary, #cc785c);
-      background: var(--panel-strong, #efe9de);
+      border-color: var(--primary);
+      background: var(--surface-card);
     }
 
     body.desktop-native-workbench .desktop-command-palette {
       display: grid;
       gap: 8px;
       width: min(680px, 100%);
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
       padding: 10px;
-      background: var(--panel, #faf9f5);
-      box-shadow: 0 12px 30px rgba(20, 18, 15, 0.16);
+      background: var(--panel);
+      box-shadow: var(--shadow-lg);
     }
 
     body.desktop-native-workbench .desktop-command-palette[hidden] {
@@ -2621,11 +2648,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-command-palette-close,
     body.desktop-native-workbench .desktop-command-palette-result {
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
-      background: var(--panel, #faf9f5);
-      color: var(--text, #141413);
-      font: 12px/1.2 var(--font-sans, system-ui, sans-serif);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: var(--panel);
+      color: var(--text);
+      font: 12px/1.2 var(--font-sans);
       cursor: pointer;
     }
 
@@ -2638,11 +2665,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       width: 100%;
       min-width: 0;
       min-height: 34px;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
       padding: 0 10px;
-      color: var(--text, #141413);
-      font: 13px/1.2 var(--font-sans, system-ui, sans-serif);
+      background: var(--bg);
+      color: var(--text);
+      font: 13px/1.2 var(--font-sans);
     }
 
     body.desktop-native-workbench .desktop-command-palette-results {
@@ -2837,6 +2865,87 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       color: var(--danger, #c64545);
     }
 
+    body.desktop-native-workbench .desktop-native-composer {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      grid-template-rows: auto auto;
+      gap: 8px;
+      width: min(820px, 100%);
+      min-width: 0;
+      margin: 0 auto 10px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: 10px;
+      background: var(--panel);
+      box-shadow: var(--shadow-sm);
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-action,
+    body.desktop-native-workbench .desktop-native-composer-send {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 36px;
+      min-height: 36px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 0 12px;
+      background: var(--bg);
+      color: var(--text);
+      font: 600 12px/1.2 var(--font-sans);
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-send {
+      border-color: var(--primary);
+      background: var(--primary);
+      color: var(--on-primary);
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-input {
+      min-width: 0;
+      width: 100%;
+      min-height: 36px;
+      max-height: 108px;
+      border: 0;
+      border-radius: var(--radius-md);
+      padding: 8px 10px;
+      resize: vertical;
+      background: transparent;
+      color: var(--text);
+      font: 13px/1.45 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-input:focus-visible,
+    body.desktop-native-workbench .desktop-native-composer-action:focus-visible,
+    body.desktop-native-workbench .desktop-native-composer-send:focus-visible {
+      outline: 2px solid var(--primary);
+      outline-offset: 2px;
+      box-shadow: 0 0 0 4px var(--focus-ring);
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-runtime {
+      grid-column: 1 / -1;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-chip {
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-full);
+      padding: 3px 8px;
+      background: var(--surface-soft);
+      color: var(--text-muted);
+      font: 500 11px/1.25 var(--font-sans);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     body.desktop-native-workbench .desktop-bottom-content {
       display: grid;
       grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
@@ -2968,16 +3077,16 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-gateway-runtime {
       min-width: 0;
       overflow: auto;
-      background: var(--surface-dark, #181715);
-      color: var(--on-dark, #faf9f5);
+      background: var(--panel);
+      color: var(--text);
     }
 
     body.desktop-native-workbench .desktop-gateway-runtime h2 {
-      color: var(--on-dark, #faf9f5);
+      color: var(--text);
     }
 
     body.desktop-native-workbench .desktop-gateway-runtime-row {
-      color: var(--on-dark-soft, #a09d96);
+      color: var(--text-muted);
       white-space: pre-wrap;
     }
 
@@ -2990,12 +3099,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-gateway-action {
       min-height: 28px;
-      border: 1px solid var(--surface-dark-elevated, #252320);
-      border-radius: 6px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
       padding: 0 8px;
-      background: var(--surface-dark-elevated, #252320);
-      color: var(--on-dark, #faf9f5);
-      font: 600 11px/1.2 var(--font-sans, system-ui, sans-serif);
+      background: var(--bg);
+      color: var(--text);
+      font: 600 11px/1.2 var(--font-sans);
       cursor: pointer;
     }
 


### PR DESCRIPTION
Closes #154

## Summary
- Add shared desktop design tokens for native and root WebUI desktop shells.
- Restyle the native workbench toward the root WebUI visual language while preserving native workbench density.
- Add a bottom composer-like native surface for visual parity.

## Verification
- `npm test -- desktopDesignTokens.test.ts desktopWorkbenchShell.test.ts desktopRootWebUiWorkbench.test.ts`
- `npm test`
- `npm run build`
- Browser DOM/overflow QA on `http://localhost:1420/?desktop-workbench=native` and `?desktop-workbench=root`

Note: local migration spec remains untracked by request.