### PR TITLE
Default desktop startup to native workbench

### DIFF
--- a/apps/desktop/src/desktopWorkbenchGate.test.ts
+++ b/apps/desktop/src/desktopWorkbenchGate.test.ts
@@ -79,26 +79,26 @@ describe("desktop workbench gate", () => {
     });
   });
 
-  test("uses root WebUI as the desktop startup default while preserving an explicit native escape hatch", () => {
+  test("uses native workbench as the desktop startup default while preserving an explicit root fallback", () => {
     expect(
       resolveDesktopWorkbenchStartupMode({
         location: { search: "" },
         storage: storageWith(null),
       }),
     ).toEqual({
-      mode: "root-webui",
-      requestedMode: "root-webui",
+      mode: "native-workbench",
+      requestedMode: "native-workbench",
       source: "default",
     });
 
     expect(
       resolveDesktopWorkbenchStartupMode({
-        location: { search: "?desktop-workbench=native" },
+        location: { search: "?desktop-workbench=root" },
         storage: storageWith(null),
       }),
     ).toEqual({
-      mode: "native-workbench",
-      requestedMode: "native-workbench",
+      mode: "root-webui",
+      requestedMode: "root-webui",
       source: "query",
     });
   });

--- a/apps/desktop/src/desktopWorkbenchGate.ts
+++ b/apps/desktop/src/desktopWorkbenchGate.ts
@@ -23,7 +23,7 @@ export function resolveDesktopWorkbenchStartupMode(
   return resolveDesktopWorkbenchMode({
     ...options,
     nativeWorkbenchAvailable: true,
-    defaultMode: "root-webui",
+    defaultMode: "native-workbench",
   });
 }
 


### PR DESCRIPTION
Closes #156

## Summary
- Change desktop startup default mode to `native-workbench`.
- Keep explicit `?desktop-workbench=root` fallback behavior covered by tests.

## Verification
- `npm test -- desktopWorkbenchGate.test.ts`
- `npm test -- desktopWorkbenchGate.test.ts desktopRootWebUiWorkbench.test.ts desktopWorkbenchShell.test.ts`
- `npm test -- desktopBootstrapOrder.test.ts desktopWorkbenchGate.test.ts`
- `uv run pre-commit run --files apps/desktop/src/desktopWorkbenchGate.ts apps/desktop/src/desktopWorkbenchGate.test.ts`