### PR TITLE
Fix native desktop workbench UI regressions

### DIFF
--- a/apps/desktop/src/desktopChatSessionController.test.ts
+++ b/apps/desktop/src/desktopChatSessionController.test.ts
@@ -24,6 +24,34 @@ describe("desktop chat session controller", () => {
     expect(sent).toEqual([{ type: "attach", chat_id: "chat-1" }]);
   });
 
+  test("preserves gateway session keys when selecting recent chats with non-WebSocket keys", async () => {
+    const sent: unknown[] = [];
+    const controller = createDesktopChatSessionController({
+      api: {
+        listSessions: vi.fn(async () => ({
+          items: [
+            { key: "7e9e439b4487", chat_id: "chat-7e9e", title: "你好", updated_at: "2026-06-03T08:11:21Z" },
+            { key: "WebSocket:chat-1", chat_id: "chat-1", title: "New session" },
+          ],
+        })),
+        loadMessages: vi.fn(async (key: string) => ({
+          messages: [{ role: "assistant", content: `loaded ${key}`, message_id: `m-${key}` }],
+        })),
+      },
+      sendSocketMessage: (message) => sent.push(message),
+    });
+
+    await controller.loadSessions();
+    await controller.selectSession("7e9e439b4487", "chat-7e9e");
+
+    expect(controller.state.activeSessionKey).toBe("7e9e439b4487");
+    expect(controller.state.activeChatId).toBe("chat-7e9e");
+    expect(controller.state.sessions.map((session) => session.title)).toEqual(["你好", "New session"]);
+    expect(controller.state.sessions.filter((session) => session.title === "New session")).toHaveLength(1);
+    expect(controller.state.messages.get("7e9e439b4487")).toMatchObject([{ content: "loaded 7e9e439b4487" }]);
+    expect(sent).toContainEqual({ type: "attach", chat_id: "chat-7e9e" });
+  });
+
   test("queues a new chat before sending pending content without changing WebSocket payload semantics", async () => {
     const sent: unknown[] = [];
     const controller = createDesktopChatSessionController({

--- a/apps/desktop/src/desktopChatSessionController.ts
+++ b/apps/desktop/src/desktopChatSessionController.ts
@@ -1,8 +1,8 @@
 import {
-  activateChat,
   appendUserMessage,
   applyChatEvent,
   createNativeChatState,
+  activateSession,
   normalizeMessagesPayload,
   normalizeSessionsPayload,
   setMessages,
@@ -63,7 +63,7 @@ export function createDesktopChatSessionController({
   }
 
   async function selectSession(sessionKey: string, chatId: string): Promise<void> {
-    activateChat(state, chatId);
+    activateSession(state, sessionKey, chatId);
     const payload = await api.loadMessages(sessionKey);
     setMessages(state, sessionKey, normalizeMessagesPayload(payload));
     sendSocketMessage(createGatewaySocketMessage.attach(chatId));

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -617,12 +617,44 @@ describe("desktop workbench shell", () => {
     const activityButtons = targetDocument.body.querySelectorAll(".desktop-activity-button");
     expect(activityButtons.map((node) => node.getAttribute("href"))).toEqual(["/chat", "/workspace", "/knowledge", "/cowork"]);
     expect(activityButtons.map((node) => node.getAttribute("aria-label"))).toEqual(["Chat", "Files", "Knowledge", "Cowork"]);
+    expect(activityButtons.map((node) => node.textContent)).toEqual(["Chat", "Files", "Knowledge", "Cowork"]);
+    expect(activityButtons.map((node) => node.getAttribute("data-desktop-module-target"))).toEqual(["chat", "workspace", "knowledge", "cowork"]);
     expect(activityButtons.map((node) => node.getAttribute("data-focus-order"))).toEqual([
       "activity-1",
       "activity-2",
       "activity-3",
       "activity-4",
     ]);
+  });
+
+  test("routes recent chat rows by stable session key and keeps selected title visible", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [
+          {
+            key: "7e9e439b4487",
+            chatId: "chat-7e9e",
+            title: "你好",
+            createdAt: "",
+            updatedAt: "2026-06-03T08:11:21Z",
+          },
+        ],
+        activeSessionKey: "7e9e439b4487",
+        activeChatId: "chat-7e9e",
+        messages: [],
+        status: "Session loaded from gateway.",
+      },
+    });
+
+    const row = targetDocument.body.querySelector('[data-desktop-entity-id="7e9e439b4487"]');
+    expect(row?.getAttribute("href")).toBe("/chat/7e9e439b4487");
+    expect(targetDocument.body.querySelector(".desktop-chat-header")?.textContent).toContain("你好");
+    expect(targetDocument.body.querySelector(".desktop-chat-header")?.textContent).not.toContain("New session");
   });
 
   test("renders keyboard-operable panel controls with accessible labels", () => {
@@ -2391,6 +2423,28 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.getElementById("desktop-native-composer-attach")?.getAttribute("data-desktop-composer-action")).toBe("attach");
     expect(targetDocument.getElementById("desktop-native-composer-send")?.getAttribute("data-desktop-composer-action")).toBe("send");
     expect(targetDocument.getElementById("desktop-native-composer-runtime")?.textContent).toContain("Gateway: http://127.0.0.1:18790");
+  });
+
+  test("declares non-overlapping native workbench layout rules for composer, scroll, modules, and inspector", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
+    expect(styleText).toContain("grid-template-columns: 92px minmax(220px, 280px) minmax(0, 1fr) minmax(280px, 340px);");
+    expect(styleText).toContain('grid-template-areas: "attach input input input" "runtime runtime runtime runtime" "stop spacer microphone send";');
+    expect(styleText).toContain(".desktop-native-composer-runtime {\n      grid-area: runtime;");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-thread {\n      display: grid;");
+    expect(styleText).toContain("min-height: 0;");
+    expect(styleText).toContain("overflow-y: auto;");
+    expect(styleText).toContain('html[data-desktop-active-workbench-module="workspace"] body.desktop-native-workbench .desktop-utility-surfaces');
+    expect(styleText).toContain("[data-desktop-module-surface]");
+    expect(styleText).toContain(".desktop-inspector-content {\n      display: grid;");
+    expect(styleText).toContain("overflow-x: hidden;");
   });
 
   test("reserves dark product surfaces for diagnostics instead of the runtime panel", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -485,36 +485,38 @@ function createActivityRail(targetDocument: Document): HTMLElement {
 
   const primary = targetDocument.createElement("div");
   primary.className = "desktop-activity-primary";
-  for (const [index, [label, href, icon]] of [
-    ["Chat", "/chat", "C"],
-    ["Files", "/workspace", "F"],
-    ["Knowledge", "/knowledge", "K"],
-    ["Cowork", "/cowork", "Y"],
+  for (const [index, [label, href, module]] of [
+    ["Chat", "/chat", "chat"],
+    ["Files", "/workspace", "workspace"],
+    ["Knowledge", "/knowledge", "knowledge"],
+    ["Cowork", "/cowork", "cowork"],
   ].entries()) {
     const item = targetDocument.createElement("a");
     item.className = "desktop-activity-button";
     item.setAttribute("href", href);
-    item.textContent = icon;
+    item.textContent = label;
     item.setAttribute("aria-label", label);
     item.setAttribute("title", label);
+    item.setAttribute("data-desktop-module-target", module);
     item.setAttribute("data-focus-order", `activity-${index + 1}`);
     primary.append(item);
   }
 
   const secondary = targetDocument.createElement("div");
   secondary.className = "desktop-activity-secondary";
-  for (const [label, href, icon] of [
-    ["Workspace files", "/workspace", "D"],
-    ["Documents", "/docs", "M"],
-    ["Source control", "https://github.com/SudoJacky/tinybot", "G"],
-    ["Settings", "/settings", "S"],
+  for (const [label, href, module] of [
+    ["Files", "/workspace", "workspace"],
+    ["Docs", "/docs", "docs"],
+    ["GitHub", "https://github.com/SudoJacky/tinybot", "gateway"],
+    ["Settings", "/settings", "settings"],
   ]) {
     const item = targetDocument.createElement("a");
     item.className = "desktop-activity-secondary-button";
     item.setAttribute("href", href);
-    item.textContent = icon;
+    item.textContent = label;
     item.setAttribute("aria-label", label);
     item.setAttribute("title", label);
+    item.setAttribute("data-desktop-module-target", module);
     secondary.append(item);
   }
 
@@ -596,6 +598,7 @@ function createSidebarRecentChats(targetDocument: Document, chat: DesktopNativeC
   if (chat) {
     const sessions = chat.sessions.length ? chat.sessions : [];
     for (const session of sessions) {
+      const routeId = desktopChatRouteId(session);
       list.append(createSidebarRow(
         targetDocument,
         session.title || "New session",
@@ -603,7 +606,7 @@ function createSidebarRecentChats(targetDocument: Document, chat: DesktopNativeC
         session.key === chat.activeSessionKey,
         "chat",
         "chat",
-        session.chatId || session.key,
+        routeId,
       ));
     }
     if (!sessions.length) {
@@ -625,6 +628,13 @@ function createSidebarRecentChats(targetDocument: Document, chat: DesktopNativeC
 
   section.append(list);
   return section;
+}
+
+function desktopChatRouteId(session: NativeChatSession): string {
+  if (session.key && !session.key.startsWith("WebSocket:")) {
+    return session.key;
+  }
+  return session.chatId || session.key;
 }
 
 function createSidebarSectionHeading(targetDocument: Document, title: string, action?: string): HTMLElement {
@@ -1064,6 +1074,7 @@ function createAgentUiFormsSurface(
 ): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-agent-ui-forms";
+  section.setAttribute("data-desktop-module-surface", "chat");
   section.setAttribute("aria-label", "Agent UI forms");
   section.append(createText(targetDocument, "h2", "Agent UI forms"));
 
@@ -1230,6 +1241,7 @@ function createToolsSkillsPane(
 ): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-tools-skills-pane";
+  section.setAttribute("data-desktop-module-surface", "tools skills");
   section.setAttribute("aria-label", "Tools and skills");
   section.append(createText(targetDocument, "h2", "Tools and skills"), createText(targetDocument, "p", pane.status));
 
@@ -1326,6 +1338,7 @@ function createKnowledgePane(
 ): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-knowledge-pane";
+  section.setAttribute("data-desktop-module-surface", "knowledge");
   section.setAttribute("aria-label", "Knowledge workbench");
   section.append(createText(targetDocument, "h2", "Knowledge"), createText(targetDocument, "p", pane.status));
 
@@ -1423,6 +1436,7 @@ function createCoworkCockpitPane(
 ): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-cowork-cockpit";
+  section.setAttribute("data-desktop-module-surface", "cowork");
   section.setAttribute("aria-label", "Cowork cockpit");
   section.append(createText(targetDocument, "h2", "Cowork"));
 
@@ -2038,6 +2052,7 @@ function createSettingsProvidersPane(
 ): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-settings-pane";
+  section.setAttribute("data-desktop-module-surface", "settings");
   section.setAttribute("aria-label", "Settings and providers");
   section.append(
     createText(targetDocument, "h2", "Settings"),
@@ -2272,7 +2287,15 @@ function createRunChainOverviewPanel(targetDocument: Document): HTMLElement {
     tab.className = "desktop-run-chain-tab";
     tab.setAttribute("role", "tab");
     tab.setAttribute("aria-selected", String(index === 0));
+    tab.setAttribute("data-desktop-run-chain-tab", label.toLowerCase());
     tab.textContent = label;
+    tab.addEventListener("click", () => {
+      for (const sibling of Array.from(tabs.children)) {
+        sibling.setAttribute("aria-selected", "false");
+      }
+      tab.setAttribute("aria-selected", "true");
+      setRouteStatus(targetDocument, `Run Chain ${label}`);
+    });
     tabs.append(tab);
   }
 
@@ -2283,19 +2306,22 @@ function createRunChainOverviewPanel(targetDocument: Document): HTMLElement {
       ["Endpoint", "http://127.0.0.1:18790"],
       ["Mode", "External"],
       ["Version", "v0.1.0"],
-    ], "Open Gateway Status"),
+    ], "Open Gateway Status", "/api/status"),
     createRunChainCard(targetDocument, "Workspace", "", [
       ["tinybot", "D:\\code\\tinybot\\tinybot"],
-    ], "Open Workspace"),
+    ], "Open Workspace", "/workspace"),
     createRunChainCard(targetDocument, "Current Run", "Idle", [
       ["No run in progress", "Select an item below to run."],
     ]),
   );
 
   const add = targetDocument.createElement("button");
-  add.type = "button";
   add.className = "desktop-run-chain-new-item";
   add.textContent = "+  New Run Chain Item";
+  add.setAttribute("type", "button");
+  add.addEventListener("click", () => {
+    setRouteStatus(targetDocument, "Open Cowork to create a run chain item.");
+  });
 
   section.append(header, tabs, cards, add);
   return section;
@@ -2307,6 +2333,7 @@ function createRunChainCard(
   badge: string,
   rows: [string, string][],
   action?: string,
+  actionHref?: string,
 ): HTMLElement {
   const card = targetDocument.createElement("article");
   card.className = "desktop-run-chain-card";
@@ -2327,11 +2354,16 @@ function createRunChainCard(
     card.append(row);
   }
   if (action) {
-    const button = targetDocument.createElement("button");
-    button.type = "button";
-    button.className = "desktop-run-chain-card-action";
-    button.textContent = action;
-    card.append(button);
+    const element = actionHref
+      ? createWorkbenchLink(targetDocument, action, actionHref, "desktop-run-chain-card-action")
+      : targetDocument.createElement("button");
+    if (!actionHref) {
+      element.setAttribute("type", "button");
+      element.textContent = action;
+      element.className = "desktop-run-chain-card-action";
+    }
+    element.setAttribute("data-desktop-run-chain-action", action);
+    card.append(element);
   }
   return card;
 }
@@ -2876,6 +2908,7 @@ function createQuickActions(targetDocument: Document): HTMLElement {
 function createFileActions(targetDocument: Document, chat: DesktopNativeChatModel | null = null): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-file-actions";
+  section.setAttribute("data-desktop-module-surface", "workspace knowledge");
   section.append(createText(targetDocument, "h2", "File imports"));
 
   const knowledge = targetDocument.createElement("button");
@@ -2938,6 +2971,7 @@ function syncSessionFileUploadKey(targetDocument: Document, activeSessionKey: st
 function createDesktopHelpSurface(targetDocument: Document): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-help-pane";
+  section.setAttribute("data-desktop-module-surface", "docs settings");
   section.setAttribute("aria-label", "Desktop help");
   section.append(createText(targetDocument, "h2", "Help"));
 
@@ -3021,6 +3055,7 @@ function renderDesktopPageHelp(targetDocument: Document, title: string): void {
 function createWorkspaceFilesSurface(targetDocument: Document): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workspace-files";
+  section.setAttribute("data-desktop-module-surface", "workspace");
   section.append(createText(targetDocument, "h2", "Workspace files"));
 
   const status = targetDocument.createElement("p");
@@ -3768,18 +3803,18 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-workbench-shell {
-      grid-template-columns: 76px minmax(280px, 328px) minmax(520px, 1fr) minmax(360px, var(--desktop-inspector-size, 420px));
+      grid-template-columns: 92px minmax(220px, 280px) minmax(0, 1fr) minmax(280px, 340px);
       grid-template-rows: minmax(0, 1fr) auto;
       border-top: 0;
       background: #fbfaf7;
     }
 
     body.desktop-native-workbench .desktop-workbench-shell[data-inspector-visible="false"] {
-      grid-template-columns: 76px minmax(280px, 328px) minmax(0, 1fr) 0;
+      grid-template-columns: 92px minmax(220px, 280px) minmax(0, 1fr) 0;
     }
 
     body.desktop-native-workbench .desktop-workbench-shell[data-sidebar-visible="false"] {
-      grid-template-columns: 76px 0 minmax(520px, 1fr) minmax(360px, var(--desktop-inspector-size, 420px));
+      grid-template-columns: 92px 0 minmax(0, 1fr) minmax(280px, 340px);
     }
 
     body.desktop-native-workbench .desktop-activity-rail {
@@ -3798,12 +3833,15 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-activity-button,
     body.desktop-native-workbench .desktop-activity-secondary-button {
-      width: 48px;
+      width: 72px;
       min-height: 48px;
       border-radius: 8px;
       color: #2f302e;
-      font-size: 13px;
+      font-size: 11px;
       font-weight: 700;
+      line-height: 1.15;
+      text-align: center;
+      white-space: normal;
       box-shadow: none;
     }
 
@@ -3962,7 +4000,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-workbench-main {
-      grid-template-rows: auto auto minmax(0, auto) auto;
+      grid-template-rows: minmax(0, 1fr) auto auto;
+      height: 100%;
+      min-height: 0;
       padding: 0;
       overflow: hidden;
       background: #ffffff;
@@ -4030,9 +4070,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: grid;
       align-content: start;
       gap: 22px;
-      min-height: 390px;
+      min-height: 0;
       padding: 32px min(8vw, 72px) 22px;
-      overflow: auto;
+      overflow-y: auto;
+      overflow-x: hidden;
     }
 
     body.desktop-native-workbench .desktop-conversation-message {
@@ -4111,8 +4152,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-native-composer {
-      grid-template-columns: 48px minmax(0, 1fr) auto auto;
-      grid-template-rows: minmax(72px, auto) auto;
+      grid-template-columns: 48px minmax(0, 1fr) 48px 56px;
+      grid-template-rows: minmax(72px, auto) auto auto;
+      grid-template-areas: "attach input input input" "runtime runtime runtime runtime" "stop spacer microphone send";
       gap: 10px 12px;
       width: min(820px, calc(100% - 56px));
       margin: 0 auto 20px;
@@ -4133,14 +4175,24 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       font-size: 18px;
     }
 
+    body.desktop-native-workbench #desktop-native-composer-attach {
+      grid-area: attach;
+    }
+
+    body.desktop-native-workbench #desktop-native-composer-stop {
+      grid-area: stop;
+      font-size: 12px;
+    }
+
     body.desktop-native-workbench .desktop-native-composer-input {
+      grid-area: input;
       min-height: 54px;
       padding: 10px 4px;
       font-size: 15px;
     }
 
     body.desktop-native-workbench .desktop-native-composer-runtime {
-      grid-column: 2;
+      grid-area: runtime;
       align-self: end;
       align-items: center;
     }
@@ -4157,8 +4209,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-native-composer-microphone {
-      grid-column: 3;
-      grid-row: 2;
+      grid-area: microphone;
       width: 38px;
       min-height: 38px;
       border: 0;
@@ -4169,8 +4220,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-native-composer-send {
-      grid-column: 4;
-      grid-row: 2;
+      grid-area: send;
       width: 46px;
       min-width: 46px;
       min-height: 46px;
@@ -4184,6 +4234,46 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       max-height: 0;
       min-width: 0;
       overflow: hidden;
+    }
+
+    body.desktop-native-workbench .desktop-utility-surfaces [data-desktop-module-surface] {
+      display: none;
+    }
+
+    html[data-desktop-active-workbench-module="workspace"] body.desktop-native-workbench .desktop-chat-workbench,
+    html[data-desktop-active-workbench-module="knowledge"] body.desktop-native-workbench .desktop-chat-workbench,
+    html[data-desktop-active-workbench-module="cowork"] body.desktop-native-workbench .desktop-chat-workbench,
+    html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-chat-workbench,
+    html[data-desktop-active-workbench-module="docs"] body.desktop-native-workbench .desktop-chat-workbench {
+      display: none;
+    }
+
+    html[data-desktop-active-workbench-module="workspace"] body.desktop-native-workbench .desktop-native-composer,
+    html[data-desktop-active-workbench-module="knowledge"] body.desktop-native-workbench .desktop-native-composer,
+    html[data-desktop-active-workbench-module="cowork"] body.desktop-native-workbench .desktop-native-composer,
+    html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-native-composer,
+    html[data-desktop-active-workbench-module="docs"] body.desktop-native-workbench .desktop-native-composer {
+      display: none;
+    }
+
+    html[data-desktop-active-workbench-module="workspace"] body.desktop-native-workbench .desktop-utility-surfaces,
+    html[data-desktop-active-workbench-module="knowledge"] body.desktop-native-workbench .desktop-utility-surfaces,
+    html[data-desktop-active-workbench-module="cowork"] body.desktop-native-workbench .desktop-utility-surfaces,
+    html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-utility-surfaces,
+    html[data-desktop-active-workbench-module="docs"] body.desktop-native-workbench .desktop-utility-surfaces {
+      max-height: none;
+      height: 100%;
+      min-height: 0;
+      padding: 18px 28px;
+      overflow: auto;
+    }
+
+    html[data-desktop-active-workbench-module="workspace"] body.desktop-native-workbench [data-desktop-module-surface~="workspace"],
+    html[data-desktop-active-workbench-module="knowledge"] body.desktop-native-workbench [data-desktop-module-surface~="knowledge"],
+    html[data-desktop-active-workbench-module="cowork"] body.desktop-native-workbench [data-desktop-module-surface~="cowork"],
+    html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench [data-desktop-module-surface~="settings"],
+    html[data-desktop-active-workbench-module="docs"] body.desktop-native-workbench [data-desktop-module-surface~="docs"] {
+      display: grid;
     }
 
     body.desktop-native-workbench .desktop-status-strip {
@@ -4201,7 +4291,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       height: 100%;
       min-height: 0;
       padding: 18px 20px;
-      overflow: auto;
+      overflow-y: auto;
+      overflow-x: hidden;
       background: #fbfaf7;
     }
 
@@ -4745,25 +4836,21 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
       body.desktop-native-workbench .desktop-native-composer {
         width: calc(100% - 28px);
-        grid-template-columns: 48px minmax(0, 1fr) auto;
+        grid-template-columns: 48px minmax(0, 1fr) 56px;
         grid-template-rows: auto auto auto;
+        grid-template-areas: "attach input input" "runtime runtime runtime" "stop microphone send";
       }
 
       body.desktop-native-workbench .desktop-native-composer-runtime {
-        grid-column: 2;
         display: grid;
         grid-template-columns: minmax(0, max-content);
       }
 
       body.desktop-native-workbench .desktop-native-composer-microphone {
-        grid-column: 2;
-        grid-row: 3;
         justify-self: end;
       }
 
       body.desktop-native-workbench .desktop-native-composer-send {
-        grid-column: 3;
-        grid-row: 3;
       }
 
       body.desktop-native-workbench .desktop-empty-session {

--- a/apps/desktop/src/nativeChat.ts
+++ b/apps/desktop/src/nativeChat.ts
@@ -97,8 +97,13 @@ export function setMessages(state: NativeChatState, sessionKey: string, messages
 }
 
 export function activateChat(state: NativeChatState, chatId: string) {
+  const existing = state.sessions.find((session) => session.chatId === chatId);
+  activateSession(state, existing?.key || sessionKeyForChat(chatId), chatId);
+}
+
+export function activateSession(state: NativeChatState, sessionKey: string, chatId: string) {
   state.activeChatId = chatId;
-  state.activeSessionKey = sessionKeyForChat(chatId);
+  state.activeSessionKey = sessionKey || sessionKeyForChat(chatId);
   ensureMessageBucket(state, state.activeSessionKey);
   if (!state.sessions.some((session) => session.key === state.activeSessionKey)) {
     state.sessions = [


### PR DESCRIPTION
## Summary
- Clarify native workbench activity navigation labels and make module surfaces reachable.
- Preserve gateway session keys when selecting recent chats so selecting an existing chat does not create a stale New session header.
- Rework chat composer, scroll, and right inspector layout to avoid overlap and clipping.
- Add basic actions for Run Chain tabs/cards and regression coverage for the reported interactions.

Fixes #160

## Verification
- `npm test` in `apps/desktop`
- `npm run build` in `apps/desktop`