### PR TITLE
Fix desktop native navigation active state

### DIFF
--- a/apps/desktop/src/desktopEntityFocus.test.ts
+++ b/apps/desktop/src/desktopEntityFocus.test.ts
@@ -48,4 +48,63 @@ describe("desktop entity focus", () => {
     })).toBe(true);
     expect(focused).toEqual(["docs/desktop.md", "form-1"]);
   });
+
+  test("syncs active route state into mounted workbench navigation controls", () => {
+    const activityKnowledge = fakeElement({
+      "data-desktop-module-target": "knowledge",
+      href: "/knowledge",
+    });
+    const activityCowork = fakeElement({
+      "data-desktop-module-target": "cowork",
+      href: "/cowork",
+      "data-active": "true",
+      "aria-current": "page",
+    });
+    const sidebarKnowledge = fakeElement({
+      "data-sidebar-href": "/knowledge",
+    });
+    const sidebarSettings = fakeElement({
+      "data-sidebar-command": "open-settings",
+    });
+    const targetDocument = {
+      documentElement: { dataset: {} as Record<string, string> },
+      querySelectorAll: (selector: string) => {
+        if (selector === "[data-desktop-module-target]") {
+          return [activityKnowledge, activityCowork];
+        }
+        if (selector === "[data-sidebar-href], [data-sidebar-command]") {
+          return [sidebarKnowledge, sidebarSettings];
+        }
+        return [];
+      },
+    };
+
+    expect(applyDesktopWorkbenchRouteState(targetDocument as unknown as Document, "/knowledge")).toBe("knowledge");
+
+    expect(targetDocument.documentElement.dataset.desktopActiveWorkbenchModule).toBe("knowledge");
+    expect(activityKnowledge.getAttribute("data-active")).toBe("true");
+    expect(activityKnowledge.getAttribute("aria-current")).toBe("page");
+    expect(activityCowork.getAttribute("data-active")).toBeNull();
+    expect(activityCowork.getAttribute("aria-current")).toBeNull();
+    expect(sidebarKnowledge.getAttribute("data-active")).toBe("true");
+    expect(sidebarKnowledge.getAttribute("aria-current")).toBe("page");
+    expect(sidebarSettings.getAttribute("data-active")).toBeNull();
+
+    expect(applyDesktopWorkbenchRouteState(targetDocument as unknown as Document, "/settings")).toBe("settings");
+
+    expect(sidebarKnowledge.getAttribute("data-active")).toBeNull();
+    expect(sidebarSettings.getAttribute("data-active")).toBe("true");
+    expect(sidebarSettings.getAttribute("aria-current")).toBe("page");
+  });
 });
+
+function fakeElement(initialAttributes: Record<string, string>) {
+  const attributes = new Map(Object.entries(initialAttributes));
+  return {
+    setAttribute: (name: string, value: string) => attributes.set(name, value),
+    getAttribute: (name: string) => attributes.get(name) ?? null,
+    removeAttribute: (name: string) => {
+      attributes.delete(name);
+    },
+  };
+}

--- a/apps/desktop/src/desktopEntityFocus.ts
+++ b/apps/desktop/src/desktopEntityFocus.ts
@@ -47,6 +47,7 @@ export function applyDesktopWorkbenchRouteState(targetDocument: Document, pathna
   const module = moduleForDesktopWorkbenchPath(pathname);
   if (module) {
     targetDocument.documentElement.dataset.desktopActiveWorkbenchModule = module;
+    syncDesktopWorkbenchNavigationState(targetDocument, module);
   }
   return module;
 }
@@ -83,6 +84,55 @@ function focusSelectorsFor(destination: DesktopEntityDestination): string[] {
     default:
       return [generic];
   }
+}
+
+function syncDesktopWorkbenchNavigationState(targetDocument: Document, activeModule: DesktopWorkbenchEntityModule): void {
+  if (typeof targetDocument.querySelectorAll !== "function") {
+    return;
+  }
+  for (const element of Array.from(targetDocument.querySelectorAll<HTMLElement>("[data-desktop-module-target]"))) {
+    setRouteElementActive(element, element.getAttribute("data-desktop-module-target") === activeModule);
+  }
+  for (const element of Array.from(targetDocument.querySelectorAll<HTMLElement>("[data-sidebar-href], [data-sidebar-command]"))) {
+    setRouteElementActive(element, moduleForSidebarElement(element) === activeModule);
+  }
+}
+
+function moduleForSidebarElement(element: HTMLElement): DesktopWorkbenchEntityModule | "" {
+  const commandModule = moduleForDesktopMenuCommand(element.getAttribute("data-sidebar-command") ?? "");
+  if (commandModule) {
+    return commandModule;
+  }
+  const href = element.getAttribute("data-sidebar-href") ?? "";
+  if (!href || !href.startsWith("/")) {
+    return "";
+  }
+  return moduleForDesktopWorkbenchPath(new URL(href, "http://desktop.local").pathname);
+}
+
+function moduleForDesktopMenuCommand(commandId: string): DesktopWorkbenchEntityModule | "" {
+  switch (commandId) {
+    case "new-chat":
+      return "chat";
+    case "open-settings":
+      return "settings";
+    case "open-docs":
+      return "docs";
+    case "refresh-gateway-status":
+      return "gateway";
+    default:
+      return "";
+  }
+}
+
+function setRouteElementActive(element: HTMLElement, active: boolean): void {
+  if (active) {
+    element.setAttribute("data-active", "true");
+    element.setAttribute("aria-current", "page");
+    return;
+  }
+  element.removeAttribute("data-active");
+  element.removeAttribute("aria-current");
 }
 
 function selectorValue(value: string): string {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2443,6 +2443,8 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain("overflow-y: auto;");
     expect(styleText).toContain('html[data-desktop-active-workbench-module="workspace"] body.desktop-native-workbench .desktop-utility-surfaces');
     expect(styleText).toContain("[data-desktop-module-surface]");
+    expect(styleText).toContain(".desktop-activity-button[data-active=\"true\"]");
+    expect(styleText).toContain(".desktop-workbench-link[data-active=\"true\"]");
     expect(styleText).toContain(".desktop-inspector-content {\n      display: grid;");
     expect(styleText).toContain("overflow-x: hidden;");
   });

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -498,6 +498,10 @@ function createActivityRail(targetDocument: Document): HTMLElement {
     item.setAttribute("aria-label", label);
     item.setAttribute("title", label);
     item.setAttribute("data-desktop-module-target", module);
+    if (module === "chat") {
+      item.setAttribute("data-active", "true");
+      item.setAttribute("aria-current", "page");
+    }
     item.setAttribute("data-focus-order", `activity-${index + 1}`);
     primary.append(item);
   }
@@ -3845,7 +3849,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       box-shadow: none;
     }
 
-    body.desktop-native-workbench .desktop-activity-button:first-child {
+    body.desktop-native-workbench .desktop-activity-button[data-active="true"],
+    body.desktop-native-workbench .desktop-activity-secondary-button[data-active="true"] {
       border-color: #eaded8;
       background: #ffffff;
       color: var(--primary);
@@ -3860,6 +3865,14 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       background: transparent;
       text-decoration: none;
       cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-workbench-link[data-active="true"] {
+      border-radius: 6px;
+      padding: 4px 8px;
+      background: #ffffff;
+      color: var(--primary);
+      box-shadow: inset 3px 0 0 var(--primary);
     }
 
     body.desktop-native-workbench .desktop-workbench-sidebar,


### PR DESCRIPTION
## Summary
- Sync native workbench route changes into activity rail and sidebar active states.
- Replace the fixed Chat rail highlight with data-driven active styling.
- Add regression coverage for route-to-navigation state and active styling.

## Root cause
The native workbench route state updated the active module on the document element, but mounted navigation controls were not updated, and the rail visually highlighted Chat through a static first-child selector.

## Validation
- `npm test` in `apps/desktop`
- `npm run build` in `apps/desktop`
- Browser smoke opened the Vite page; the local gateway was not running, so the native workbench could not fully mount in-browser.

Closes #162