### PR TITLE
Fix desktop native bottom spacing

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2441,6 +2441,8 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-thread {\n      display: grid;");
     expect(styleText).toContain("min-height: 0;");
     expect(styleText).toContain("overflow-y: auto;");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-chat-workbench {\n      align-self: stretch;");
+    expect(styleText).toContain("height: 100%;");
     expect(styleText).toContain('html[data-desktop-active-workbench-module="workspace"] body.desktop-native-workbench .desktop-utility-surfaces');
     expect(styleText).toContain("[data-desktop-module-surface]");
     expect(styleText).toContain(".desktop-activity-button[data-active=\"true\"]");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -4022,11 +4022,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-chat-workbench {
+      align-self: stretch;
       display: grid;
       grid-template-rows: auto minmax(0, 1fr);
       gap: 0;
       width: 100%;
       max-width: none;
+      height: 100%;
       min-height: 0;
       margin: 0;
       padding: 0;


### PR DESCRIPTION
## Summary
- Stretch the native chat workbench to fill the available main work area.
- Preserve the conversation thread as the scrolling region instead of leaving unused vertical space below the chat content.
- Add regression coverage for the vertical stretch rule.

## Root cause
The chat workbench also carries the `desktop-empty-session` class, whose earlier `align-self: start` rule prevented the workbench from stretching inside the main grid row. That left unused vertical space in the main work area.

## Validation
- `npm test` in `apps/desktop`
- `npm run build` in `apps/desktop`
- Browser smoke opened the Vite page; the local gateway was not running, so the native workbench could not fully mount in-browser.

Closes #163