### PR TITLE
Fix desktop composer runtime status spacing

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -435,6 +435,8 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.getElementById("desktop-native-composer-runtime")?.textContent).toContain("Token: Ready");
     expect(targetDocument.getElementById("desktop-native-composer-runtime")?.textContent).toContain("Token usage: 42%");
     expect(targetDocument.getElementById("desktop-native-composer-runtime")?.textContent).toContain("Gateway: http://127.0.0.1:18790");
+    expect(targetDocument.getElementById("desktop-native-composer-runtime")?.getAttribute("data-desktop-composer-region")).toBe("runtime-status");
+    expect(targetDocument.getElementById("desktop-native-composer-runtime")?.getAttribute("aria-label")).toBe("Runtime status");
   });
 
   test("renders the native workbench in the latest Codex-style three-column layout", () => {
@@ -2436,8 +2438,9 @@ describe("desktop workbench shell", () => {
 
     const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
     expect(styleText).toContain("grid-template-columns: 92px minmax(220px, 280px) minmax(0, 1fr) minmax(280px, 340px);");
-    expect(styleText).toContain('grid-template-areas: "attach input input input" "runtime runtime runtime runtime" "stop spacer microphone send";');
-    expect(styleText).toContain(".desktop-native-composer-runtime {\n      grid-area: runtime;");
+    expect(styleText).toContain('grid-template-areas: "attach input input input" "stop spacer microphone send";');
+    expect(styleText).toContain(".desktop-native-composer-runtime {\n      position: absolute;");
+    expect(styleText).toContain("max-height: 30px;");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-thread {\n      display: grid;");
     expect(styleText).toContain("min-height: 0;");
     expect(styleText).toContain("overflow-y: auto;");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -946,6 +946,8 @@ function createNativeComposerSurface(
   const runtime = targetDocument.createElement("div");
   runtime.id = "desktop-native-composer-runtime";
   runtime.className = "desktop-native-composer-runtime";
+  runtime.setAttribute("data-desktop-composer-region", "runtime-status");
+  runtime.setAttribute("aria-label", "Runtime status");
   runtime.append(
     createComposerModelControl(targetDocument, chat),
     createComposerChip(targetDocument, "Provider", chat?.runtime?.provider || "-"),
@@ -4167,12 +4169,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-native-composer {
+      position: relative;
       grid-template-columns: 48px minmax(0, 1fr) 48px 56px;
-      grid-template-rows: minmax(72px, auto) auto auto;
-      grid-template-areas: "attach input input input" "runtime runtime runtime runtime" "stop spacer microphone send";
+      grid-template-rows: minmax(72px, auto) auto;
+      grid-template-areas: "attach input input input" "stop spacer microphone send";
       gap: 10px 12px;
       width: min(820px, calc(100% - 56px));
-      margin: 0 auto 20px;
+      margin: 0 auto 46px;
       border-color: #ddd5cd;
       border-radius: 16px;
       padding: 12px;
@@ -4207,9 +4210,15 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-native-composer-runtime {
-      grid-area: runtime;
-      align-self: end;
+      position: absolute;
+      top: calc(100% + 8px);
+      left: 0;
+      right: 0;
       align-items: center;
+      max-height: 30px;
+      overflow-x: auto;
+      overflow-y: hidden;
+      flex-wrap: nowrap;
     }
 
     body.desktop-native-workbench .desktop-native-composer-model {
@@ -4852,13 +4861,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       body.desktop-native-workbench .desktop-native-composer {
         width: calc(100% - 28px);
         grid-template-columns: 48px minmax(0, 1fr) 56px;
-        grid-template-rows: auto auto auto;
-        grid-template-areas: "attach input input" "runtime runtime runtime" "stop microphone send";
+        grid-template-rows: auto auto;
+        grid-template-areas: "attach input input" "stop microphone send";
       }
 
       body.desktop-native-workbench .desktop-native-composer-runtime {
-        display: grid;
-        grid-template-columns: minmax(0, max-content);
+        display: flex;
       }
 
       body.desktop-native-workbench .desktop-native-composer-microphone {


### PR DESCRIPTION
## Summary
- Move native composer runtime status chips out of the primary composer grid rows.
- Render the runtime chips as a separate single-line status band below the composer panel.
- Add regression coverage for runtime status semantics and the compact composer grid.

## Root cause
The native composer placed provider/session/RAG/generation/WebSocket/token/gateway chips inside a dedicated grid row in the same compact composer panel, so runtime metadata competed with the text input and primary actions for vertical space.

## Validation
- `npm test` in `apps/desktop`
- `npm run build` in `apps/desktop`
- Browser smoke opened the Vite page; the local gateway was not running, so the native workbench could not fully mount in-browser.

Closes #164