### PR TITLE
Fix desktop Run Chain panel controls

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -672,9 +672,10 @@ describe("desktop workbench shell", () => {
     expect(controls.map((node) => node.getAttribute("data-desktop-panel-control"))).toEqual(["sidebar", "inspector", "bottom"]);
     expect(controls.map((node) => node.getAttribute("aria-label"))).toEqual([
       "Toggle sidebar panel",
-      "Toggle inspector panel",
+      "Toggle Run Chain panel",
       "Toggle task and runtime panel",
     ]);
+    expect(controls.map((node) => node.textContent)).toEqual(["Sidebar", "Run Chain", "Tasks"]);
     expect(controls.map((node) => node.getAttribute("aria-pressed"))).toEqual(["true", "true", "false"]);
     expect(controls[0].getAttribute("aria-keyshortcuts")).toBe("Ctrl+B");
 
@@ -691,6 +692,7 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
     expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("false");
     expect(controls[1].getAttribute("aria-pressed")).toBe("false");
+    expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Run Chain panel hidden");
   });
 
   test("renders a persistent run-chain inspector pane with selectable details", () => {
@@ -738,6 +740,11 @@ describe("desktop workbench shell", () => {
     expect(pane?.querySelector('[data-desktop-run-chain-item="m-plan:planning"]')?.getAttribute("aria-selected")).toBe("true");
     expect(pane?.querySelector(".desktop-run-chain-detail")?.textContent).toContain("Thinking: Inspect the active context");
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session");
+
+    targetDocument.body.querySelector('[data-desktop-run-chain-control="close"]')?.click();
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
+    expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("false");
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-pressed")).toBe("false");
   });
 
   test("renders a right-side Work Lens before generic inspector detail for running work", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -2137,8 +2137,8 @@ function createPanelControls(targetDocument: Document, layout: WorkbenchLayoutSt
     },
     {
       panel: "inspector",
-      label: "Inspector",
-      ariaLabel: "Toggle inspector panel",
+      label: "Run Chain",
+      ariaLabel: "Toggle Run Chain panel",
       visible: layout.inspector.visible,
     },
     {
@@ -2195,6 +2195,9 @@ function toggleDesktopPanel(targetDocument: Document, panel: DesktopPanelControl
 }
 
 function formatPanelName(panel: DesktopPanelControlId): string {
+  if (panel === "inspector") {
+    return "Run Chain";
+  }
   if (panel === "bottom") {
     return "Task and runtime";
   }
@@ -2271,15 +2274,23 @@ function createRunChainOverviewPanel(targetDocument: Document): HTMLElement {
   header.append(createText(targetDocument, "h2", "Run Chain"));
   const controls = targetDocument.createElement("div");
   controls.className = "desktop-run-chain-header-controls";
-  for (const [label, value] of [
-    ["Pin Run Chain", "Pin"],
-    ["Close Run Chain", "Close"],
+  for (const [label, value, action] of [
+    ["Pin Run Chain", "Pin", "pin"],
+    ["Close Run Chain", "Close", "close"],
   ]) {
     const button = targetDocument.createElement("button");
     button.type = "button";
     button.className = "desktop-run-chain-icon-button";
     button.setAttribute("aria-label", label);
+    button.setAttribute("data-desktop-run-chain-control", action);
     button.textContent = value;
+    button.addEventListener("click", () => {
+      if (action === "close") {
+        toggleDesktopPanel(targetDocument, "inspector");
+        return;
+      }
+      setRouteStatus(targetDocument, "Run Chain pinned");
+    });
     controls.append(button);
   }
   header.append(controls);


### PR DESCRIPTION
## Summary
- Rename the right-side panel toggle from Inspector to Run Chain so the control matches the visible panel.
- Make the Run Chain header Close button collapse the right-side panel through the same panel state path.
- Cover the visible toggle label, status text, and close-button collapse behavior in desktop shell tests.

Fixes #166

## Verification
- npm test -- desktopWorkbenchShell
- npm test
- npm run build

Note: browser smoke could not run because Playwright is not available in the local Node REPL environment; DOM interaction coverage is included in the desktop shell tests.