### PR TITLE
Fix desktop settings editable pane

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -34,6 +34,7 @@ import {
 } from "./desktopNativeWorkbenchRuntime";
 import { createDesktopOsNotificationBridge } from "./desktopOsNotifications";
 import {
+  applyDesktopSettingsFieldEdit,
   applyDesktopProviderModels,
   buildDesktopProviderCatalogItems,
   buildDesktopProviderModelRequest,
@@ -988,6 +989,11 @@ async function loadNativeSettingsPane(): Promise<DesktopSettingsPaneModel> {
 
 async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Promise<void> {
   if (!nativeSettingsState) {
+    return;
+  }
+  if (event.action === "edit") {
+    nativeSettingsState = applyDesktopSettingsFieldEdit(nativeSettingsState, event.fieldId, event.value);
+    updateNativeSettingsPane("idle");
     return;
   }
   if (event.action === "save") {

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   applyDesktopProviderModels,
+  applyDesktopSettingsFieldEdit,
   buildDesktopProviderCatalogItems,
   buildDesktopSettingsPaneModel,
   buildDesktopProviderModelRequest,
@@ -286,8 +287,8 @@ describe("desktop settings and provider helpers", () => {
     expect(pane.validationErrors.map((error) => error.field)).toEqual(["model", "timezone"]);
     expect(pane.groups.map((group) => group.id)).toEqual(["agent", "provider", "knowledge", "tools", "gateway", "channels"]);
     expect(pane.groups.find((group) => group.id === "agent")?.fields).toEqual(expect.arrayContaining([
-      { id: "model", label: "Model", value: "", state: "invalid" },
-      { id: "timezone", label: "Timezone", value: "Shanghai", state: "invalid" },
+      expect.objectContaining({ id: "model", label: "Model", value: "", state: "invalid", control: "text" }),
+      expect.objectContaining({ id: "timezone", label: "Timezone", value: "Shanghai", state: "invalid", control: "text" }),
     ]));
     expect(pane.providerCatalog).toEqual([{ id: "openai", label: "OpenAI", status: "ready" }]);
     expect(pane.providerEditor).toMatchObject({
@@ -297,5 +298,23 @@ describe("desktop settings and provider helpers", () => {
       models: ["gpt-4.1", "gpt-4.1-mini"],
       canDiscoverModels: true,
     });
+  });
+
+  test("applies desktop settings field edits to the saved config patch shape", () => {
+    const state = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work" } },
+      providers: { profiles: { work: { provider: "openai", api_key: "sk-live", models: ["gpt-4.1-mini"] } } },
+      knowledge: { enabled: true },
+      gateway: { port: 18790 },
+    }, [{ id: "openai", displayName: "OpenAI", status: "ready" }]);
+
+    const withModel = applyDesktopSettingsFieldEdit(state, "model", "gpt-4.1");
+    const withoutKnowledge = applyDesktopSettingsFieldEdit(withModel, "enabled", false);
+    const withPort = applyDesktopSettingsFieldEdit(withoutKnowledge, "port", "18888");
+    const patch = createDesktopSettingsPatch(withPort, {}, [{ id: "openai", displayName: "OpenAI", status: "ready" }]);
+
+    expect(patch.agents).toMatchObject({ defaults: { model: "gpt-4.1" } });
+    expect(patch.knowledge).toMatchObject({ enabled: false });
+    expect(patch.gateway).toMatchObject({ port: 18888 });
   });
 });

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -117,12 +117,23 @@ export interface DesktopSecretField {
 }
 
 export type DesktopSettingsSaveStatus = "idle" | "saving" | "saved" | "failed";
+export type DesktopSettingsPaneFieldControl = "text" | "number" | "checkbox" | "textarea" | "select";
+export type DesktopSettingsEditableValue = string | boolean;
+
+export interface DesktopSettingsPaneFieldOption {
+  value: string;
+  label: string;
+}
 
 export interface DesktopSettingsPaneField {
   id: string;
   label: string;
   value: string;
   state: "normal" | "invalid";
+  control: DesktopSettingsPaneFieldControl;
+  inputValue: string;
+  checked?: boolean;
+  options?: DesktopSettingsPaneFieldOption[];
 }
 
 export interface DesktopSettingsPaneGroup {
@@ -426,7 +437,7 @@ export function buildDesktopSettingsPaneModel(
       message: saveStatus === "failed" ? options.saveError || "Save failed" : formatDesktopSettingsSaveMessage(saveStatus, dirty),
       canSave: dirty && validationErrors.length === 0 && saveStatus !== "saving",
     },
-    groups: buildDesktopSettingsPaneGroups(state, validationErrors),
+    groups: buildDesktopSettingsPaneGroups(state, validationErrors, options.providerCatalog ?? []),
     providerCatalog: (options.providerCatalog ?? []).map((provider) => ({
       id: stringValue(provider.id),
       label: stringValue(provider.displayName) || stringValue(provider.id),
@@ -483,6 +494,83 @@ export function applyDesktopProviderModels(
     status: "loaded",
     message: stringValue(payload.warning) || `Loaded models ${models.length}`,
   };
+}
+
+export function applyDesktopSettingsFieldEdit(
+  state: DesktopSettingsFormState,
+  fieldId: string,
+  value: DesktopSettingsEditableValue,
+): DesktopSettingsFormState {
+  const nextState = cloneSettingsState(state);
+  const text = String(value);
+  switch (fieldId) {
+    case "model":
+      nextState.agent.model = stringOrNullInput(text);
+      break;
+    case "provider":
+      nextState.agent.provider = stringOrNullInput(text);
+      break;
+    case "activeProfile":
+      nextState.agent.activeProfile = stringOrNullInput(text);
+      break;
+    case "timezone":
+      nextState.agent.timezone = stringOrNullInput(text);
+      break;
+    case "selectedProvider":
+      nextState.providerEditor.selectedProvider = stringOrNullInput(text) || "deepseek";
+      nextState.agent.provider = nextState.providerEditor.selectedProvider;
+      break;
+    case "profileId":
+      nextState.providerEditor.profileId = text.trim();
+      nextState.agent.activeProfile = stringOrNullInput(text);
+      break;
+    case "apiBase":
+      nextState.providerEditor.apiBase = stringOrNullInput(text);
+      break;
+    case "models":
+      nextState.providerEditor.modelsText = text;
+      break;
+    case "enabled":
+      nextState.knowledge.enabled = Boolean(value);
+      break;
+    case "retrievalMode":
+      nextState.knowledge.retrievalMode = stringOrNullInput(text);
+      break;
+    case "maxChunks":
+      nextState.knowledge.maxChunks = numberOrNullInput(text);
+      break;
+    case "rerankApiBase":
+      nextState.knowledge.rerankApiBase = stringOrNullInput(text);
+      break;
+    case "webEnable":
+      nextState.tools.webEnable = Boolean(value);
+      break;
+    case "execEnable":
+      nextState.tools.execEnable = Boolean(value);
+      break;
+    case "mcpServers":
+      nextState.tools.mcpServersText = text;
+      break;
+    case "host":
+      nextState.gateway.host = stringOrNullInput(text);
+      break;
+    case "port":
+      nextState.gateway.port = numberOrNullInput(text);
+      break;
+    case "heartbeat":
+      nextState.gateway.heartbeatEnabled = Boolean(value);
+      break;
+    case "sendProgress":
+      nextState.channels.sendProgress = Boolean(value);
+      break;
+    case "sendToolHints":
+      nextState.channels.sendToolHints = Boolean(value);
+      break;
+    case "sendMaxRetries":
+      nextState.channels.sendMaxRetries = numberOrNullInput(text);
+      break;
+  }
+  return nextState;
 }
 
 export function buildDesktopSecretField(value: unknown, mask = MASKED_SECRET): DesktopSecretField {
@@ -610,13 +698,39 @@ function cloneSettingsState(state: DesktopSettingsFormState): DesktopSettingsFor
 function buildDesktopSettingsPaneGroups(
   state: DesktopSettingsFormState,
   validationErrors: DesktopSettingsValidationError[],
+  providerCatalog: DesktopProviderCatalogItem[] = [],
 ): DesktopSettingsPaneGroup[] {
   const invalidFields = new Set(validationErrors.map((error) => error.field));
-  const field = (id: string, label: string, value: unknown, validationField?: DesktopSettingsValidationField): DesktopSettingsPaneField => ({
+  const editorProviderOptions = providerCatalog.map((provider) => ({
+      value: stringValue(provider.id),
+      label: stringValue(provider.displayName) || stringValue(provider.id),
+    })).filter((provider) => provider.value);
+  for (const value of [state.providerEditor.selectedProvider, "deepseek"].filter(Boolean)) {
+    if (!editorProviderOptions.some((option) => option.value === value)) {
+      editorProviderOptions.push({ value, label: value });
+    }
+  }
+  const agentProviderOptions = [
+    { value: "auto", label: "Auto" },
+    ...editorProviderOptions,
+  ];
+  const field = (
+    id: string,
+    label: string,
+    value: unknown,
+    validationField?: DesktopSettingsValidationField,
+    control: DesktopSettingsPaneFieldControl = "text",
+    options?: DesktopSettingsPaneFieldOption[],
+    inputValue = stringValue(value),
+  ): DesktopSettingsPaneField => ({
     id,
     label,
     value: formatDesktopSettingsFieldValue(value),
     state: validationField && invalidFields.has(validationField) ? "invalid" : "normal",
+    control,
+    inputValue,
+    checked: control === "checkbox" ? value === true : undefined,
+    options,
   });
   return [
     {
@@ -624,7 +738,7 @@ function buildDesktopSettingsPaneGroups(
       label: "Agent",
       fields: [
         field("model", "Model", state.agent.model, "model"),
-        field("provider", "Provider", state.agent.provider),
+        field("provider", "Provider", state.agent.provider, undefined, "select", agentProviderOptions),
         field("activeProfile", "Profile", state.agent.activeProfile),
         field("timezone", "Timezone", state.agent.timezone, "timezone"),
       ],
@@ -633,19 +747,19 @@ function buildDesktopSettingsPaneGroups(
       id: "provider",
       label: "Provider",
       fields: [
-        field("selectedProvider", "Selected provider", state.providerEditor.selectedProvider),
+        field("selectedProvider", "Selected provider", state.providerEditor.selectedProvider, undefined, "select", editorProviderOptions),
         field("profileId", "Profile ID", state.providerEditor.profileId),
         field("apiBase", "API base", state.providerEditor.apiBase, "providerApiBase"),
-        field("models", "Models", parseDesktopProviderModelList(state.providerEditor.modelsText).join(", ")),
+        field("models", "Models", parseDesktopProviderModelList(state.providerEditor.modelsText).join(", "), undefined, "textarea", undefined, state.providerEditor.modelsText),
       ],
     },
     {
       id: "knowledge",
       label: "Knowledge",
       fields: [
-        field("enabled", "Enabled", state.knowledge.enabled),
+        field("enabled", "Enabled", state.knowledge.enabled, undefined, "checkbox"),
         field("retrievalMode", "Retrieval mode", state.knowledge.retrievalMode),
-        field("maxChunks", "Max chunks", state.knowledge.maxChunks),
+        field("maxChunks", "Max chunks", state.knowledge.maxChunks, undefined, "number"),
         field("rerankApiBase", "Rerank API base", state.knowledge.rerankApiBase, "rerankApiBase"),
       ],
     },
@@ -653,9 +767,9 @@ function buildDesktopSettingsPaneGroups(
       id: "tools",
       label: "Tools",
       fields: [
-        field("webEnable", "Web tools", state.tools.webEnable),
-        field("execEnable", "Exec tools", state.tools.execEnable),
-        field("mcpServers", "MCP servers", state.tools.mcpServersText ? "Configured" : "None", "mcpServers"),
+        field("webEnable", "Web tools", state.tools.webEnable, undefined, "checkbox"),
+        field("execEnable", "Exec tools", state.tools.execEnable, undefined, "checkbox"),
+        field("mcpServers", "MCP servers", state.tools.mcpServersText ? "Configured" : "None", "mcpServers", "textarea", undefined, state.tools.mcpServersText),
       ],
     },
     {
@@ -663,17 +777,17 @@ function buildDesktopSettingsPaneGroups(
       label: "Gateway",
       fields: [
         field("host", "Host", state.gateway.host),
-        field("port", "Port", state.gateway.port, "gatewayPort"),
-        field("heartbeat", "Heartbeat", state.gateway.heartbeatEnabled),
+        field("port", "Port", state.gateway.port, "gatewayPort", "number"),
+        field("heartbeat", "Heartbeat", state.gateway.heartbeatEnabled, undefined, "checkbox"),
       ],
     },
     {
       id: "channels",
       label: "Channels",
       fields: [
-        field("sendProgress", "Progress events", state.channels.sendProgress),
-        field("sendToolHints", "Tool hints", state.channels.sendToolHints),
-        field("sendMaxRetries", "Max retries", state.channels.sendMaxRetries),
+        field("sendProgress", "Progress events", state.channels.sendProgress, undefined, "checkbox"),
+        field("sendToolHints", "Tool hints", state.channels.sendToolHints, undefined, "checkbox"),
+        field("sendMaxRetries", "Max retries", state.channels.sendMaxRetries, undefined, "number"),
       ],
     },
   ];
@@ -723,6 +837,20 @@ function stringOrNull(value: unknown): string | null {
 
 function stringOrDefault(value: unknown, fallback: string): string {
   return stringOrNull(value) ?? fallback;
+}
+
+function stringOrNullInput(value: string): string | null {
+  const text = value.trim();
+  return text ? text : null;
+}
+
+function numberOrNullInput(value: string): number | null {
+  const text = value.trim();
+  if (!text) {
+    return null;
+  }
+  const numeric = Number.parseFloat(text);
+  return Number.isFinite(numeric) ? numeric : null;
 }
 
 function numberOrDefault(value: unknown, fallback: number): number {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -1511,7 +1511,13 @@ describe("desktop workbench shell", () => {
       gatewayHttp: "http://127.0.0.1:18790",
       settingsPane,
       settingsActions: {
-        onSettingsAction: ({ action }) => settingsActions.push(action),
+        onSettingsAction: (event) => {
+          if (event.action === "edit") {
+            settingsActions.push(`${event.action}:${event.fieldId}:${String(event.value)}`);
+            return;
+          }
+          settingsActions.push(event.action);
+        },
       },
     });
 
@@ -1526,11 +1532,24 @@ describe("desktop workbench shell", () => {
     expect(pane?.textContent).toContain("API key: ********");
     expect(pane?.textContent).toContain("Catalog: OpenAI (ready)");
     expect(pane?.textContent).toContain("Models: gpt-4.1, gpt-4.1-mini");
+    expect(pane?.querySelector('[data-desktop-settings-control="model"]')?.getAttribute("aria-invalid")).toBe("true");
+    expect(pane?.querySelector('[data-desktop-settings-control="timezone"]')?.getAttribute("aria-invalid")).toBe("true");
+    expect(pane?.querySelector('[data-desktop-settings-control="enabled"]')?.checked).toBe(true);
+    expect(pane?.querySelector('[data-desktop-settings-control="mcpServers"]')?.tagName).toBe("textarea");
     expect(pane?.querySelector('[data-desktop-settings-action="save"]')?.getAttribute("disabled")).toBe("true");
     expect(pane?.querySelector('[data-desktop-settings-action="discoverModels"]')?.textContent).toBe("Refresh models");
+
+    const modelInput = pane?.querySelector('[data-desktop-settings-control="model"]');
+    modelInput!.value = "gpt-4.1";
+    modelInput?.dispatchEvent({ type: "input", target: modelInput });
+
+    const knowledgeToggle = pane?.querySelector('[data-desktop-settings-control="enabled"]');
+    knowledgeToggle!.checked = false;
+    knowledgeToggle?.dispatchEvent({ type: "change", target: knowledgeToggle });
+
     pane?.querySelector('[data-desktop-settings-action="save"]')?.click();
     pane?.querySelector('[data-desktop-settings-action="discoverModels"]')?.click();
-    expect(settingsActions).toEqual(["save", "discoverModels"]);
+    expect(settingsActions).toEqual(["edit:model:gpt-4.1", "edit:enabled:false", "save", "discoverModels"]);
   });
 
   test("updates the installed settings pane without rebuilding the workbench", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -104,12 +104,19 @@ interface DesktopAgentUiFormActionOptions {
   onAgentUiFormAction?: (event: DesktopAgentUiFormActionEvent) => void;
 }
 
-export type DesktopSettingsActionId = "save" | "discoverModels";
+export type DesktopSettingsActionId = "save" | "discoverModels" | "edit";
 
-export interface DesktopSettingsActionEvent {
-  action: DesktopSettingsActionId;
-  pane: DesktopSettingsPaneModel;
-}
+export type DesktopSettingsActionEvent =
+  | {
+      action: "save" | "discoverModels";
+      pane: DesktopSettingsPaneModel;
+    }
+  | {
+      action: "edit";
+      pane: DesktopSettingsPaneModel;
+      fieldId: string;
+      value: string | boolean;
+    };
 
 interface DesktopSettingsActionOptions {
   onSettingsAction?: (event: DesktopSettingsActionEvent) => void;
@@ -2060,10 +2067,12 @@ function createSettingsProvidersPane(
   section.className = "desktop-workbench-section desktop-settings-pane";
   section.setAttribute("data-desktop-module-surface", "settings");
   section.setAttribute("aria-label", "Settings and providers");
-  section.append(
+  const header = targetDocument.createElement("header");
+  header.className = "desktop-settings-header";
+  const title = targetDocument.createElement("div");
+  title.append(
     createText(targetDocument, "h2", "Settings"),
-    createText(targetDocument, "p", `Save: ${pane.save.message}`),
-    createText(targetDocument, "p", pane.validationErrors.length ? `Validation: ${pane.validationErrors.map((error) => error.field).join(", ")}` : "Validation: ready"),
+    createText(targetDocument, "p", pane.dirty ? "Unsaved desktop configuration changes" : "Desktop configuration is up to date"),
   );
 
   const actions = targetDocument.createElement("div");
@@ -2089,7 +2098,23 @@ function createSettingsProvidersPane(
     settingsActions.onSettingsAction?.({ action: "discoverModels", pane });
   });
   actions.append(save, discover);
-  section.append(actions);
+  header.append(title, actions);
+  section.append(header);
+
+  const summary = targetDocument.createElement("div");
+  summary.className = "desktop-settings-summary";
+  summary.append(
+    createText(targetDocument, "p", `Save: ${pane.save.message}`),
+    createText(targetDocument, "p", pane.validationErrors.length ? `Validation: ${pane.validationErrors.map((error) => error.field).join(", ")}` : "Validation: ready"),
+    createText(targetDocument, "p", `Provider profile: ${pane.providerEditor.profileId || "default"}`),
+    createText(targetDocument, "p", `API key: ${pane.providerEditor.apiKey.displayValue || "Not configured"}`),
+    createText(targetDocument, "p", `Catalog: ${pane.providerCatalog.map((provider) => `${provider.label} (${provider.status})`).join(", ") || "No providers loaded"}`),
+    createText(targetDocument, "p", `Models: ${pane.providerEditor.models.join(", ") || "No models loaded"}`),
+  );
+  section.append(summary);
+
+  const grid = targetDocument.createElement("div");
+  grid.className = "desktop-settings-grid";
 
   for (const group of pane.groups) {
     const groupSection = targetDocument.createElement("section");
@@ -2101,19 +2126,80 @@ function createSettingsProvidersPane(
       row.className = "desktop-settings-field";
       row.setAttribute("data-desktop-settings-field", field.id);
       row.setAttribute("data-state", field.state);
-      row.textContent = `${field.label}: ${field.value}`;
+      const label = targetDocument.createElement("label");
+      label.textContent = `${field.label}: `;
+      label.setAttribute("for", `desktop-settings-${field.id}`);
+      const control = createDesktopSettingsControl(targetDocument, pane, field, settingsActions);
+      row.append(label, control);
       groupSection.append(row);
     }
-    section.append(groupSection);
+    grid.append(groupSection);
   }
 
-  section.append(
-    createText(targetDocument, "p", `Provider profile: ${pane.providerEditor.profileId || "default"}`),
-    createText(targetDocument, "p", `API key: ${pane.providerEditor.apiKey.displayValue || "Not configured"}`),
-    createText(targetDocument, "p", `Catalog: ${pane.providerCatalog.map((provider) => `${provider.label} (${provider.status})`).join(", ") || "No providers loaded"}`),
-    createText(targetDocument, "p", `Models: ${pane.providerEditor.models.join(", ") || "No models loaded"}`),
-  );
+  section.append(grid);
   return section;
+}
+
+function createDesktopSettingsControl(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  field: DesktopSettingsPaneModel["groups"][number]["fields"][number],
+  settingsActions: DesktopSettingsActionOptions,
+): HTMLElement {
+  const tagName = field.control === "textarea" ? "textarea" : field.control === "select" ? "select" : "input";
+  const control = targetDocument.createElement(tagName);
+  control.setAttribute("id", `desktop-settings-${field.id}`);
+  control.setAttribute("data-desktop-settings-control", field.id);
+  control.setAttribute("data-state", field.state);
+  if (field.state === "invalid") {
+    control.setAttribute("aria-invalid", "true");
+  }
+
+  if (field.control === "checkbox") {
+    (control as HTMLInputElement).type = "checkbox";
+    (control as HTMLInputElement).checked = Boolean(field.checked);
+    control.addEventListener("change", (event) => {
+      settingsActions.onSettingsAction?.({
+        action: "edit",
+        pane,
+        fieldId: field.id,
+        value: Boolean((event.target as HTMLInputElement | null)?.checked),
+      });
+    });
+    return control;
+  }
+
+  if (field.control === "number") {
+    (control as HTMLInputElement).type = "number";
+  } else if (field.control === "text") {
+    (control as HTMLInputElement).type = "text";
+  }
+
+  if (field.control === "select") {
+    for (const option of field.options ?? []) {
+      const element = targetDocument.createElement("option");
+      element.setAttribute("value", option.value);
+      element.textContent = option.label;
+      if (option.value === field.inputValue) {
+        element.setAttribute("selected", "true");
+      }
+      control.append(element);
+    }
+    (control as HTMLSelectElement).value = field.inputValue;
+  } else {
+    (control as HTMLInputElement | HTMLTextAreaElement).value = field.inputValue;
+  }
+
+  const eventName = field.control === "select" ? "change" : "input";
+  control.addEventListener(eventName, (event) => {
+    settingsActions.onSettingsAction?.({
+      action: "edit",
+      pane,
+      fieldId: field.id,
+      value: String((event.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null)?.value ?? ""),
+    });
+  });
+  return control;
 }
 
 function createPanelControls(targetDocument: Document, layout: WorkbenchLayoutState): HTMLElement {
@@ -4309,6 +4395,147 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench [data-desktop-module-surface~="settings"],
     html[data-desktop-active-workbench-module="docs"] body.desktop-native-workbench [data-desktop-module-surface~="docs"] {
       display: grid;
+    }
+
+    body.desktop-native-workbench .desktop-settings-pane {
+      align-content: start;
+      gap: 18px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-settings-header {
+      display: flex;
+      align-items: start;
+      justify-content: space-between;
+      gap: 16px;
+      min-width: 0;
+      border-bottom: 1px solid #e9e4df;
+      padding-bottom: 14px;
+    }
+
+    body.desktop-native-workbench .desktop-settings-header h2 {
+      margin: 0;
+      color: #1f1d1a;
+      font: 700 20px/1.2 var(--font-sans);
+      letter-spacing: 0;
+    }
+
+    body.desktop-native-workbench .desktop-settings-header p,
+    body.desktop-native-workbench .desktop-settings-summary p {
+      margin: 4px 0 0;
+      color: #67605a;
+      font: 500 12px/1.45 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-settings-actions {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: end;
+      gap: 8px;
+    }
+
+    body.desktop-native-workbench .desktop-settings-actions button,
+    body.desktop-native-workbench .desktop-settings-field input,
+    body.desktop-native-workbench .desktop-settings-field select,
+    body.desktop-native-workbench .desktop-settings-field textarea {
+      border: 1px solid #d8d0c8;
+      border-radius: 6px;
+      background: #fffdfa;
+      color: #25211d;
+      font: 500 13px/1.35 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-settings-actions button {
+      min-height: 34px;
+      padding: 0 12px;
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-settings-actions button:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    body.desktop-native-workbench .desktop-settings-summary {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px 14px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-settings-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(280px, 1fr));
+      gap: 16px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-settings-group {
+      display: grid;
+      align-content: start;
+      gap: 12px;
+      min-width: 0;
+      border: 1px solid #ebe4dd;
+      border-radius: 8px;
+      padding: 14px;
+      background: #fffdfa;
+    }
+
+    body.desktop-native-workbench .desktop-settings-group h2 {
+      margin: 0;
+      color: #2d2924;
+      font: 650 14px/1.2 var(--font-sans);
+      letter-spacing: 0;
+    }
+
+    body.desktop-native-workbench .desktop-settings-field {
+      display: grid;
+      grid-template-columns: minmax(100px, 0.38fr) minmax(0, 1fr);
+      align-items: center;
+      gap: 10px;
+      margin: 0;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-settings-field label {
+      color: #625b54;
+      font: 600 12px/1.35 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-settings-field input,
+    body.desktop-native-workbench .desktop-settings-field select,
+    body.desktop-native-workbench .desktop-settings-field textarea {
+      width: 100%;
+      min-width: 0;
+      min-height: 34px;
+      padding: 7px 9px;
+    }
+
+    body.desktop-native-workbench .desktop-settings-field input[type="checkbox"] {
+      width: 18px;
+      min-height: 18px;
+      padding: 0;
+      justify-self: start;
+    }
+
+    body.desktop-native-workbench .desktop-settings-field textarea {
+      min-height: 76px;
+      resize: vertical;
+    }
+
+    body.desktop-native-workbench .desktop-settings-field input[aria-invalid="true"],
+    body.desktop-native-workbench .desktop-settings-field select[aria-invalid="true"],
+    body.desktop-native-workbench .desktop-settings-field textarea[aria-invalid="true"] {
+      border-color: #bd3d2a;
+      box-shadow: 0 0 0 1px rgba(189, 61, 42, 0.12);
+    }
+
+    body.desktop-native-workbench .desktop-settings-actions button:focus-visible,
+    body.desktop-native-workbench .desktop-settings-field input:focus-visible,
+    body.desktop-native-workbench .desktop-settings-field select:focus-visible,
+    body.desktop-native-workbench .desktop-settings-field textarea:focus-visible {
+      outline: 2px solid rgba(31, 111, 235, 0.45);
+      outline-offset: 2px;
     }
 
     body.desktop-native-workbench .desktop-status-strip {


### PR DESCRIPTION
## Summary
- Rebuild the desktop native Settings pane into a structured editable form with grouped sections, clear save/validation summary, and consistent spacing.
- Add typed field metadata and draft edit application so Settings changes update the gateway config PATCH shape before save.
- Wire edit events through the desktop bootstrap settings handler, keeping save/discover actions on the existing path.
- Cover editable controls, validation state, edit events, and config patch updates in desktop tests.

Fixes #167

## Verification
- npm test -- desktopWorkbenchShell -t "renders grouped settings"
- npm test -- desktopSettingsProviders desktopWorkbenchShell -t "settings"
- npm test
- npm run build

Note: browser smoke could not run because Playwright/Browser automation is unavailable in this local environment; DOM interaction coverage is included in the desktop shell tests.