### PR TITLE
Fix duplicate desktop Files navigation entry

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -514,6 +514,10 @@ describe("desktop workbench shell", () => {
       "/knowledge",
       "/cowork",
     ]);
+    expect([
+      ...targetDocument.body.querySelectorAll(".desktop-activity-button"),
+      ...targetDocument.body.querySelectorAll(".desktop-activity-secondary-button"),
+    ].filter((node) => node.getAttribute("href") === "/workspace")).toHaveLength(1);
     expect(targetDocument.body.querySelectorAll(".desktop-quick-action").map((node) => node.getAttribute("href"))).toEqual([
       "/chat/new",
       "/workspace",

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -516,7 +516,6 @@ function createActivityRail(targetDocument: Document): HTMLElement {
   const secondary = targetDocument.createElement("div");
   secondary.className = "desktop-activity-secondary";
   for (const [label, href, module] of [
-    ["Files", "/workspace", "workspace"],
     ["Docs", "/docs", "docs"],
     ["GitHub", "https://github.com/SudoJacky/tinybot", "gateway"],
     ["Settings", "/settings", "settings"],


### PR DESCRIPTION
## Summary

- Remove the duplicate secondary `Files` activity-rail entry that pointed to the same `/workspace` route as the primary Files button.
- Add a regression assertion that the desktop activity rail exposes only one `/workspace` entry across primary and secondary activity controls.

## Root cause

`createActivityRail()` rendered `Files -> /workspace` in both the primary activity group and the secondary activity group, so the left desktop navigation showed two file/workspace buttons with the same target.

## Validation

- `npm test -- desktopWorkbenchShell.test.ts`
- `npm test`
- `npm run build`
- Browser check attempted against `http://127.0.0.1:5173`; the dev page stayed behind the gateway/Tauri readiness gate even though `/webui/bootstrap` on `127.0.0.1:18790` returned 200 with a token, so this was not counted as completed manual UI verification.

Closes #175