### PR TITLE
Add desktop native chat session delete action

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -258,6 +258,7 @@ async function loadNativeChatRuntime(): Promise<DesktopNativeWorkbenchRuntime> {
     api: {
       listSessions: () => gatewayApi.sessions.list(),
       loadMessages: (sessionKey) => gatewayApi.sessions.messages(sessionKey),
+      deleteSession: (sessionKey) => gatewayApi.sessions.delete(sessionKey),
     },
     sendSocketMessage: (message) => sendNativeChatSocketMessage(message),
   });
@@ -357,6 +358,21 @@ function nativeChatActions() {
       }
       nativeWorkbenchRuntime.startNewChat();
       updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
+    },
+    onDeleteSession: (event: { sessionKey: string; title: string }) => {
+      if (!nativeWorkbenchRuntime) {
+        return;
+      }
+      if (!window.confirm(`Delete chat "${event.title}"? This cannot be undone.`)) {
+        return;
+      }
+      void nativeWorkbenchRuntime.deleteChatSession(event.sessionKey).then(() => {
+        if (nativeWorkbenchRuntime) {
+          updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
+        }
+      }).catch((error) => {
+        console.warn("Tinybot desktop session delete failed", error);
+      });
     },
     onPersistentRagChange: (enabled: boolean) => {
       if (!nativeWorkbenchRuntime) {

--- a/apps/desktop/src/desktopChatSessionController.test.ts
+++ b/apps/desktop/src/desktopChatSessionController.test.ts
@@ -52,6 +52,48 @@ describe("desktop chat session controller", () => {
     expect(sent).toContainEqual({ type: "attach", chat_id: "chat-7e9e" });
   });
 
+  test("deletes the active session, refreshes gateway sessions, and selects the next chat", async () => {
+    const sent: unknown[] = [];
+    const deleted: string[] = [];
+    let sessions = [
+      { key: "WebSocket:chat-1", chat_id: "chat-1", title: "First chat" },
+      { key: "WebSocket:chat-2", chat_id: "chat-2", title: "Second chat" },
+    ];
+    const controller = createDesktopChatSessionController({
+      api: {
+        listSessions: vi.fn(async () => ({ items: sessions })),
+        loadMessages: vi.fn(async (key: string) => ({
+          messages: [{ role: "assistant", content: `loaded ${key}`, message_id: `m-${key}` }],
+        })),
+        deleteSession: vi.fn(async (key: string) => {
+          deleted.push(key);
+          sessions = sessions.filter((session) => session.key !== key);
+          return { deleted: true };
+        }),
+      },
+      sendSocketMessage: (message) => sent.push(message),
+    });
+
+    await controller.loadSessions();
+
+    await expect(controller.deleteSession("WebSocket:chat-1")).resolves.toEqual({
+      status: "deleted",
+      deletedSessionKey: "WebSocket:chat-1",
+      nextSessionKey: "WebSocket:chat-2",
+    });
+
+    expect(deleted).toEqual(["WebSocket:chat-1"]);
+    expect(controller.state.sessions.map((session) => session.key)).toEqual(["WebSocket:chat-2"]);
+    expect(controller.state.activeSessionKey).toBe("WebSocket:chat-2");
+    expect(controller.state.activeChatId).toBe("chat-2");
+    expect(controller.state.messages.has("WebSocket:chat-1")).toBe(false);
+    expect(controller.state.messages.get("WebSocket:chat-2")).toMatchObject([{ content: "loaded WebSocket:chat-2" }]);
+    expect(sent).toEqual([
+      { type: "attach", chat_id: "chat-1" },
+      { type: "attach", chat_id: "chat-2" },
+    ]);
+  });
+
   test("queues a new chat before sending pending content without changing WebSocket payload semantics", async () => {
     const sent: unknown[] = [];
     const controller = createDesktopChatSessionController({

--- a/apps/desktop/src/desktopChatSessionController.ts
+++ b/apps/desktop/src/desktopChatSessionController.ts
@@ -15,6 +15,7 @@ import { createGatewaySocketMessage, type NormalizedGatewayEvent } from "./gatew
 export interface DesktopChatSessionControllerApi {
   listSessions(): Promise<unknown>;
   loadMessages(sessionKey: string): Promise<unknown>;
+  deleteSession?: (sessionKey: string) => Promise<unknown>;
 }
 
 export interface DesktopChatSessionControllerOptions {
@@ -34,11 +35,17 @@ export type ChatGatewayEventResult = {
   reloadedSessions: boolean;
 };
 
+export type ChatDeleteSessionResult =
+  | { status: "missing"; deletedSessionKey: string; nextSessionKey: "" }
+  | { status: "unavailable"; deletedSessionKey: string; nextSessionKey: "" }
+  | { status: "deleted"; deletedSessionKey: string; nextSessionKey: string };
+
 export interface DesktopChatSessionController {
   readonly state: NativeChatState;
   loadSessions(): Promise<number>;
   selectSession(sessionKey: string, chatId: string): Promise<void>;
   startNewChat(): void;
+  deleteSession(sessionKey: string): Promise<ChatDeleteSessionResult>;
   submitMessage(content: string, usePersistentRag?: boolean): ChatSubmitResult;
   interruptActiveChat(): boolean;
   handleGatewayEvent(event: NormalizedGatewayEvent): Promise<ChatGatewayEventResult>;
@@ -71,6 +78,43 @@ export function createDesktopChatSessionController({
 
   function startNewChat(): void {
     sendSocketMessage(createGatewaySocketMessage.newChat());
+  }
+
+  async function deleteSession(sessionKey: string): Promise<ChatDeleteSessionResult> {
+    const deletedSessionKey = sessionKey;
+    const target = state.sessions.find((session) => session.key === sessionKey);
+    if (!target) {
+      return { status: "missing", deletedSessionKey, nextSessionKey: "" };
+    }
+    if (!api.deleteSession) {
+      return { status: "unavailable", deletedSessionKey, nextSessionKey: "" };
+    }
+
+    await api.deleteSession(sessionKey);
+    state.messages.delete(sessionKey);
+    state.respondingSessionKeys.delete(sessionKey);
+    for (const [messageId, messageSessionKey] of state.streamMessageKeys) {
+      if (messageSessionKey === sessionKey) {
+        state.streamMessageKeys.delete(messageId);
+      }
+    }
+
+    const sessions = normalizeSessionsPayload(await api.listSessions());
+    setSessions(state, sessions);
+    if (state.activeSessionKey === sessionKey) {
+      const next = sessions[0];
+      if (next) {
+        await selectSession(next.key, next.chatId);
+      } else {
+        state.activeSessionKey = "";
+        state.activeChatId = "";
+      }
+    }
+    return {
+      status: "deleted",
+      deletedSessionKey,
+      nextSessionKey: state.activeSessionKey,
+    };
   }
 
   function submitMessage(content: string, usePersistentRag = true): ChatSubmitResult {
@@ -145,6 +189,7 @@ export function createDesktopChatSessionController({
     loadSessions,
     selectSession,
     startNewChat,
+    deleteSession,
     submitMessage,
     interruptActiveChat,
     handleGatewayEvent,

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
@@ -30,6 +30,7 @@ export interface DesktopNativeWorkbenchRuntime {
   setRuntimeMetadata(metadata: NonNullable<DesktopNativeChatModel["runtime"]>): void;
   selectChatSession(sessionKey: string, chatId: string): Promise<void>;
   startNewChat(): void;
+  deleteChatSession(sessionKey: string): Promise<void>;
   setPersistentRag(enabled: boolean): void;
   submitComposerMessage(content: string, usePersistentRag?: boolean): ChatSubmitResult;
   interruptActiveChat(): boolean;
@@ -65,6 +66,16 @@ export function createDesktopNativeWorkbenchRuntime({
   function startNewChat(): void {
     chatController.startNewChat();
     chatStatus = "Creating chat session.";
+  }
+
+  async function deleteChatSession(sessionKey: string): Promise<void> {
+    const result = await chatController.deleteSession(sessionKey);
+    if (result.status === "deleted") {
+      chatStatus = result.nextSessionKey ? "Session deleted. Next chat loaded." : "Session deleted.";
+      composerState = "idle";
+      return;
+    }
+    chatStatus = result.status === "unavailable" ? "Session deletion is unavailable." : "Session not found.";
   }
 
   function setPersistentRag(enabled: boolean): void {
@@ -165,6 +176,7 @@ export function createDesktopNativeWorkbenchRuntime({
     setRuntimeMetadata,
     selectChatSession,
     startNewChat,
+    deleteChatSession,
     setPersistentRag,
     submitComposerMessage,
     interruptActiveChat,

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -248,6 +248,7 @@ describe("desktop workbench shell", () => {
 
   test("renders live native chat and sidebar state instead of static shell examples", () => {
     const targetDocument = new FakeDocument();
+    const deletedSessions: string[] = [];
     const sessions: NativeChatSession[] = [
       {
         key: "WebSocket:chat-live",
@@ -279,6 +280,9 @@ describe("desktop workbench shell", () => {
       targetDocument: targetDocument as unknown as Document,
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
+      chatActions: {
+        onDeleteSession: (event) => deletedSessions.push(event.sessionKey),
+      },
       chat: {
         sessions,
         activeSessionKey: "WebSocket:chat-live",
@@ -304,6 +308,10 @@ describe("desktop workbench shell", () => {
     const recentChat = targetDocument.body.querySelector('[data-desktop-entity-id="chat-live"]');
     expect(recentChat?.getAttribute("data-desktop-entity-module")).toBe("chat");
     expect(recentChat?.getAttribute("href")).toBe("/chat/chat-live");
+    const deleteButton = targetDocument.body.querySelector('[data-desktop-chat-delete="WebSocket:chat-live"]');
+    expect(deleteButton?.getAttribute("aria-label")).toBe("Delete chat Live gateway session");
+    deleteButton?.click();
+    expect(deletedSessions).toEqual(["WebSocket:chat-live"]);
   });
 
   test("updates native chat regions without reinstalling the whole workbench", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -87,10 +87,17 @@ export interface DesktopNativeChatComposerSubmitEvent {
   usePersistentRag: boolean;
 }
 
+export interface DesktopNativeChatDeleteSessionEvent {
+  sessionKey: string;
+  chatId: string;
+  title: string;
+}
+
 interface DesktopNativeChatActionOptions {
   onComposerSubmit?: (event: DesktopNativeChatComposerSubmitEvent) => void;
   onInterrupt?: () => void;
   onNewChat?: () => void;
+  onDeleteSession?: (event: DesktopNativeChatDeleteSessionEvent) => void;
   onPersistentRagChange?: (enabled: boolean) => void;
 }
 
@@ -405,7 +412,7 @@ export function updateDesktopNativeChat(
 
   const recentChats = targetDocument.querySelector<HTMLElement>(".desktop-recent-chat-list");
   if (recentChats) {
-    const next = createSidebarRecentChats(targetDocument, chat).querySelector<HTMLElement>(".desktop-recent-chat-list");
+    const next = createSidebarRecentChats(targetDocument, chat, chatActions).querySelector<HTMLElement>(".desktop-recent-chat-list");
     recentChats.replaceChildren(...Array.from(next?.children ?? []));
   }
 
@@ -475,7 +482,7 @@ function createWorkbenchShell(
 
   shell.append(
     createActivityRail(targetDocument),
-    createPanel(targetDocument, "sidebar", layout.sidebar, createSidebar(targetDocument, chat)),
+    createPanel(targetDocument, "sidebar", layout.sidebar, createSidebar(targetDocument, chat, chatActions)),
     createMainRegion(targetDocument, gatewayHttp, layout, chat, chatActions, agentUiForms, agentUiActions, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, workLens, workLensActions),
     createPanel(targetDocument, "inspector", layout.inspector, createInspector(targetDocument, runChainItems, selectedRunChainItemKey, workLens, workLensActions)),
     createPanel(targetDocument, "bottom", layout.bottom, createBottomRegion(targetDocument, runtimeStatus, gatewayHttp, taskCenterItems, taskActions, gatewayActions)),
@@ -534,7 +541,11 @@ function createActivityRail(targetDocument: Document): HTMLElement {
   return rail;
 }
 
-function createSidebar(targetDocument: Document, chat: DesktopNativeChatModel | null): HTMLElement {
+function createSidebar(
+  targetDocument: Document,
+  chat: DesktopNativeChatModel | null,
+  chatActions: DesktopNativeChatActionOptions,
+): HTMLElement {
   const model = buildNativeWorkbenchSidebarModel();
   const workspaceGroup = model.groups.find((group) => group.id === "workspace");
   const footerGroup = model.groups.find((group) => group.id === "footer");
@@ -543,7 +554,7 @@ function createSidebar(targetDocument: Document, chat: DesktopNativeChatModel | 
   sidebar.append(
     createSidebarActions(targetDocument),
     createSidebarWorkspaceList(targetDocument, chat),
-    createSidebarRecentChats(targetDocument, chat),
+    createSidebarRecentChats(targetDocument, chat, chatActions),
     createSharedSidebarLinkSection(targetDocument, workspaceGroup),
     createSharedSidebarCommandSection(targetDocument, footerGroup),
   );
@@ -597,7 +608,11 @@ function createSidebarWorkspaceList(targetDocument: Document, chat: DesktopNativ
   return section;
 }
 
-function createSidebarRecentChats(targetDocument: Document, chat: DesktopNativeChatModel | null): HTMLElement {
+function createSidebarRecentChats(
+  targetDocument: Document,
+  chat: DesktopNativeChatModel | null,
+  chatActions: DesktopNativeChatActionOptions = {},
+): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-sidebar-list-section";
   section.append(createSidebarSectionHeading(targetDocument, "Recent chats"));
@@ -609,15 +624,7 @@ function createSidebarRecentChats(targetDocument: Document, chat: DesktopNativeC
     const sessions = chat.sessions.length ? chat.sessions : [];
     for (const session of sessions) {
       const routeId = desktopChatRouteId(session);
-      list.append(createSidebarRow(
-        targetDocument,
-        session.title || "New session",
-        session.updatedAt ? `Updated ${formatCompactTime(session.updatedAt)}` : session.chatId,
-        session.key === chat.activeSessionKey,
-        "chat",
-        "chat",
-        routeId,
-      ));
+      list.append(createRecentChatRow(targetDocument, session, session.key === chat.activeSessionKey, chatActions, routeId));
     }
     if (!sessions.length) {
       list.append(createText(targetDocument, "p", "No recent chats."));
@@ -645,6 +652,56 @@ function desktopChatRouteId(session: NativeChatSession): string {
     return session.key;
   }
   return session.chatId || session.key;
+}
+
+function createRecentChatRow(
+  targetDocument: Document,
+  session: NativeChatSession,
+  active: boolean,
+  chatActions: DesktopNativeChatActionOptions,
+  routeId = desktopChatRouteId(session),
+): HTMLElement {
+  const row = targetDocument.createElement("div");
+  row.className = "desktop-sidebar-chat-row";
+  row.setAttribute("role", "listitem");
+  row.setAttribute("data-active", String(active));
+  row.setAttribute("data-sidebar-row-kind", "chat");
+
+  const link = targetDocument.createElement("a");
+  link.className = "desktop-sidebar-row desktop-sidebar-row-main";
+  link.setAttribute("href", `/chat/${encodeURIComponent(routeId)}`);
+  link.setAttribute("data-active", String(active));
+  link.setAttribute("data-sidebar-row-kind", "chat");
+  link.setAttribute("data-desktop-entity-module", "chat");
+  link.setAttribute("data-desktop-entity-id", routeId);
+
+  const title = session.title || "New session";
+  const label = targetDocument.createElement("span");
+  label.className = "desktop-sidebar-row-label";
+  label.textContent = title;
+  const time = targetDocument.createElement("span");
+  time.className = "desktop-sidebar-row-meta";
+  time.textContent = session.updatedAt ? `Updated ${formatCompactTime(session.updatedAt)}` : session.chatId;
+  link.append(label, time);
+
+  const deleteButton = targetDocument.createElement("button");
+  deleteButton.type = "button";
+  deleteButton.className = "desktop-sidebar-delete-session";
+  deleteButton.setAttribute("data-desktop-chat-delete", session.key);
+  deleteButton.setAttribute("aria-label", `Delete chat ${title}`);
+  deleteButton.textContent = "Delete";
+  deleteButton.addEventListener("click", (event) => {
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    chatActions.onDeleteSession?.({
+      sessionKey: session.key,
+      chatId: session.chatId,
+      title,
+    });
+  });
+
+  row.append(link, deleteButton);
+  return row;
 }
 
 function createSidebarSectionHeading(targetDocument: Document, title: string, action?: string): HTMLElement {
@@ -3678,6 +3735,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-panel-control:focus-visible,
     body.desktop-native-workbench .desktop-file-action:focus-visible,
     body.desktop-native-workbench .desktop-help-action:focus-visible,
+    body.desktop-native-workbench .desktop-sidebar-delete-session:focus-visible,
     body.desktop-native-workbench .desktop-cowork-session-row:focus-visible,
     body.desktop-native-workbench .desktop-cowork-action:focus-visible,
     body.desktop-native-workbench .desktop-cowork-observability-tab:focus-visible,
@@ -4088,6 +4146,36 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       color: #262522;
       font: 500 13px/1.2 var(--font-sans);
       text-decoration: none;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-chat-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 4px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-chat-row .desktop-sidebar-row {
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-delete-session {
+      width: 52px;
+      min-height: 30px;
+      border: 1px solid transparent;
+      border-radius: 6px;
+      background: transparent;
+      color: #8d4a3a;
+      font: 600 11px/1 var(--font-sans);
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-delete-session:hover,
+    body.desktop-native-workbench .desktop-sidebar-delete-session:focus-visible {
+      border-color: #f0d8cf;
+      background: #fff4ef;
+      color: #b4533c;
     }
 
     body.desktop-native-workbench .desktop-sidebar-row[data-active="true"] {


### PR DESCRIPTION
## Summary

- Add a desktop native recent-chat Delete action that emits a dedicated session delete event instead of overloading row navigation.
- Wire the action through bootstrap with a confirmation prompt before calling the gateway session delete endpoint.
- Add controller/runtime handling so deleting the active session refreshes gateway sessions, removes stale message state, and selects the next available chat.

## Root cause

The desktop native shell rendered recent chat rows as navigation-only links. The gateway client already exposed `sessions.delete(...)`, but the native chat controller/runtime and sidebar UI did not provide a safe way to invoke it.

## Validation

- `npm test -- desktopChatSessionController.test.ts desktopNativeWorkbenchRuntime.test.ts desktopWorkbenchShell.test.ts`
- `npm test`
- `npm run build`
- Browser check attempted against `http://127.0.0.1:5173`; the dev page stayed behind the gateway/Tauri readiness gate with `Failed to fetch`, so this was not counted as completed manual UI verification.

Closes #174