### PR TITLE
Fix desktop native dark theme coverage

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2447,6 +2447,25 @@ describe("desktop workbench shell", () => {
     expect(styleText).not.toContain(":root {");
   });
 
+  test("declares dark theme overrides for native workbench surfaces", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent;
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-rail');
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-sidebar');
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-workbench');
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer');
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-inspector-content');
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-pane');
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-files');
+  });
+
   test("renders a bottom composer-like surface for native visual parity", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -5154,6 +5154,110 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       border-top: 1px solid var(--border, #e6dfd8);
     }
 
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-shell,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-rail,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-main,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-workbench {
+      background: var(--bg);
+      color: var(--text);
+      border-color: var(--border);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-sidebar,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-inspector,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-bottom,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-content,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-conversation-thread,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-utility-surfaces,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-inspector-content,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-pane,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-files,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-status-strip {
+      background: var(--panel);
+      color: var(--text);
+      border-color: var(--border);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-button,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-secondary-button,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-row,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-delete-session,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-link,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-panel-control,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-file-action,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-help-action,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-action,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-input,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-actions button,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field input,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field select,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field textarea,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-file-row,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-editor,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-task-action,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-session-row,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-action,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-observability-tab,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-observability-filter,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-observability-panel,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-action-input,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-item,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-card,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-card-action,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-new-item,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-gateway-action {
+      background: var(--panel-strong);
+      color: var(--text);
+      border-color: var(--border);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-button:hover,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-button:focus-visible,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-button[data-active="true"],
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-row[data-active="true"],
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-delete-session:hover,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-panel-control[aria-pressed="true"],
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-item[aria-selected="true"],
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-observability-tab[aria-selected="true"] {
+      background: var(--accent-soft);
+      color: var(--text-strong);
+      border-color: var(--accent);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-row-meta,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-empty-session p,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-section p,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-chip,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-command-palette-status,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-task-center-summary,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-task-center-detail,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-action-status,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-action-summary,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-card-row,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-gateway-runtime-row {
+      color: var(--text-muted);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-send,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-quick-actions .desktop-quick-action:first-child {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: var(--on-primary);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-task-center-diagnostics:not(:empty),
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-detail {
+      background: var(--surface-dark);
+      color: var(--on-dark);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-task-center-diagnostics:not(:empty) p,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-detail p {
+      color: var(--on-dark-soft);
+    }
+
     @media (max-width: 760px) {
       body.desktop-native-workbench .desktop-workbench-shell,
       body.desktop-native-workbench .desktop-workbench-shell[data-inspector-visible="false"] {


### PR DESCRIPTION
## Summary
- Add dark theme overrides for the major desktop native workbench surfaces, panels, controls, and status areas.
- Cover the theme CSS regression so the native workbench declares dark overrides for the rail, sidebar, chat, composer, inspector, settings, and Files surfaces.

## Root cause
The Toggle Theme command updates the document theme state, but many native workbench selectors still used hardcoded light colors. Token-based elements changed while those hardcoded surfaces stayed visually light.

## Validation
- `npm test -- desktopWorkbenchShell.test.ts`
- `npm test`
- `npm run build`
- Browser/manual native UI verification was attempted, but the local page remained at the gateway/Tauri readiness gate and was not counted as completed.

Closes #168