### PR TITLE
Fix desktop recent chat row affordance

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -322,7 +322,11 @@ describe("desktop workbench shell", () => {
     const recentChat = targetDocument.body.querySelector('[data-desktop-entity-id="chat-live"]');
     expect(recentChat?.getAttribute("data-desktop-entity-module")).toBe("chat");
     expect(recentChat?.getAttribute("href")).toBe("/chat/chat-live");
+    const recentChatRow = targetDocument.body.querySelector(".desktop-sidebar-chat-row");
+    expect(recentChatRow?.getAttribute("role")).toBe("listitem");
+    expect(recentChatRow?.getAttribute("data-active")).toBe("true");
     const deleteButton = targetDocument.body.querySelector('[data-desktop-chat-delete="WebSocket:chat-live"]');
+    expect(recentChatRow?.querySelector('[data-desktop-chat-delete="WebSocket:chat-live"]')).toBe(deleteButton);
     expect(deleteButton?.getAttribute("aria-label")).toBe("Delete chat Live gateway session");
     expect(deleteButton?.textContent).toBe("x");
     deleteButton?.click();

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -4309,7 +4309,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workspace-list,
     body.desktop-native-workbench .desktop-recent-chat-list {
       display: grid;
-      gap: 2px;
+      align-content: start;
+      grid-auto-rows: min-content;
+      gap: 6px;
       min-width: 0;
       overflow: auto;
     }
@@ -4332,21 +4334,30 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
       align-items: center;
-      gap: 4px;
+      gap: 6px;
       min-width: 0;
+      min-height: 36px;
+      border: 1px solid transparent;
+      border-radius: 7px;
+      padding: 0 5px 0 0;
+      transition: background-color 120ms ease, border-color 120ms ease;
     }
 
     body.desktop-native-workbench .desktop-sidebar-chat-row .desktop-sidebar-row {
       min-width: 0;
+      min-height: 34px;
+      border: 0;
+      padding: 0 4px 0 10px;
+      background: transparent;
     }
 
     body.desktop-native-workbench .desktop-sidebar-delete-session {
-      width: 30px;
-      min-height: 30px;
+      width: 24px;
+      min-height: 24px;
       border: 1px solid transparent;
-      border-radius: 6px;
+      border-radius: 5px;
       background: transparent;
-      color: #8d4a3a;
+      color: #8b5b4e;
       font: 600 11px/1 var(--font-sans);
       cursor: pointer;
     }
@@ -4355,16 +4366,26 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       width: 64px;
     }
 
-    body.desktop-native-workbench .desktop-sidebar-delete-session:hover,
-    body.desktop-native-workbench .desktop-sidebar-delete-session:focus-visible {
-      border-color: #f0d8cf;
-      background: #fff4ef;
-      color: #b4533c;
+    body.desktop-native-workbench .desktop-sidebar-chat-row:hover {
+      border-color: #eee4dd;
+      background: #fffdfb;
     }
 
+    body.desktop-native-workbench .desktop-sidebar-delete-session:hover,
+    body.desktop-native-workbench .desktop-sidebar-delete-session:focus-visible {
+      border-color: #eaded8;
+      background: #f8eee9;
+      color: #8d4a3a;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-chat-row[data-active="true"],
     body.desktop-native-workbench .desktop-sidebar-row[data-active="true"] {
       border-color: #f0d8cf;
       background: #f8e7e1;
+      color: #b4533c;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-chat-row[data-active="true"] .desktop-sidebar-row {
       color: #b4533c;
     }
 


### PR DESCRIPTION
## Summary
- Keep desktop recent chat rows top-aligned with fixed row spacing.
- Move subtle active and hover affordances to the whole recent chat row so the delete control is visually contained in the same session row.
- Add regression coverage for the row/listitem structure around the delete control.

## Verification
- `npm test -- desktopWorkbenchShell.test.ts`
- `npm run build`

Closes #182