### PR TITLE
Restrict CI to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
 on:
-  push:
-    branches: [master, main]
   pull_request:
-    branches: [master, main]
+    types: [opened, synchronize, reopened]
+
+env:
+  UV_DEFAULT_INDEX: https://pypi.org/simple
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Run CI only for pull request opened, synchronize, and reopened events.
- Set `UV_DEFAULT_INDEX` to `https://pypi.org/simple` at the workflow level so uv does not use the unavailable mirror during CI dependency installation.

## Verification
- `git diff --check -- .github/workflows/ci.yml`
- pre-commit `check yaml`

Closes #184