### PR TITLE
Fix dark theme recent chat row styling

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2557,6 +2557,8 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-inspector-content');
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-pane');
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-files');
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-chat-row[data-active="true"]');
+    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-chat-row:hover');
   });
 
   test("renders a bottom composer-like surface for native visual parity", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -5432,6 +5432,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-button:hover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-button:focus-visible,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-button[data-active="true"],
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-chat-row[data-active="true"],
     html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-row[data-active="true"],
     html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-delete-session:hover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-panel-control[aria-pressed="true"],
@@ -5440,6 +5441,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       background: var(--accent-soft);
       color: var(--text-strong);
       border-color: var(--accent);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-chat-row:hover {
+      background: var(--panel-strong);
+      border-color: var(--border);
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-row-meta,


### PR DESCRIPTION
## Summary
- Add dark-theme coverage for the active recent chat row parent introduced in PR #183.
- Keep recent chat row hover subtle in dark theme instead of inheriting the light hover background.
- Add regression coverage for the dark-theme selectors.

## Verification
- `npm test -- desktopWorkbenchShell.test.ts`
- `npm run build`

Follow-up to #183. Closes #186