### PR TITLE
Improve native middle conversation rendering

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -466,6 +466,108 @@ describe("desktop workbench shell", () => {
     expect(assistantBody?.innerHTML).toContain('rel="noreferrer"');
   });
 
+  test("renders native reasoning and tool activities as interactive middle conversation blocks", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{
+          key: "WebSocket:chat-live",
+          chatId: "chat-live",
+          title: "Tool chat",
+          createdAt: "",
+          updatedAt: "",
+        }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [
+          {
+            role: "assistant",
+            content: "The command finished.",
+            reasoningContent: "I should inspect the workspace first.",
+            toolActivities: [
+              {
+                id: "call-shell",
+                name: "shell",
+                argsText: "{\"command\":\"pwd\"}",
+                responseText: "D:/code/tinybot/tinybot",
+                kind: "result",
+              },
+            ],
+            timestamp: "2026-06-03T08:20:00.000Z",
+            messageId: "assistant-1",
+          },
+        ],
+        status: "Connected",
+      },
+    });
+
+    const message = targetDocument.body.querySelector(".desktop-conversation-message");
+    const reasoning = message?.querySelector(".desktop-message-reasoning");
+    const toolActivity = message?.querySelector(".desktop-tool-activity");
+    const body = message?.querySelector(".desktop-conversation-body");
+
+    expect(reasoning?.tagName).toBe("details");
+    expect(reasoning?.querySelector(".desktop-message-reasoning-title")?.textContent).toBe("Thinking");
+    expect(reasoning?.textContent).toContain("I should inspect the workspace first.");
+    expect(toolActivity?.tagName).toBe("details");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-title")?.textContent).toBe("shell");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-badge")?.textContent).toBe("Result");
+    expect(toolActivity?.textContent).toContain("Arguments");
+    expect(toolActivity?.textContent).toContain("{\"command\":\"pwd\"}");
+    expect(toolActivity?.textContent).toContain("Response");
+    expect(toolActivity?.textContent).toContain("D:/code/tinybot/tinybot");
+    expect(body?.textContent).not.toContain("I should inspect the workspace first.");
+    expect(body?.textContent).toContain("The command finished.");
+  });
+
+  test("renders standalone native tool results without duplicating response text as message body", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{
+          key: "WebSocket:chat-live",
+          chatId: "chat-live",
+          title: "Tool result chat",
+          createdAt: "",
+          updatedAt: "",
+        }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [
+          {
+            role: "tool",
+            content: "stdout: done",
+            reasoningContent: "",
+            toolActivities: [
+              {
+                id: "call-shell",
+                name: "shell",
+                argsText: "",
+                responseText: "stdout: done",
+                kind: "result",
+              },
+            ],
+            timestamp: "2026-06-03T08:20:00.000Z",
+            messageId: "tool-1",
+          },
+        ],
+        status: "Connected",
+      },
+    });
+
+    const message = targetDocument.body.querySelector(".desktop-conversation-message");
+    expect(message?.querySelector(".desktop-tool-activity")?.textContent).toContain("stdout: done");
+    expect(message?.querySelector(".desktop-conversation-body")?.textContent).not.toContain("stdout: done");
+  });
+
   test("routes native composer send and temporary file attach actions", () => {
     const targetDocument = new FakeDocument();
     const composerActions: string[] = [];

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -865,7 +865,9 @@ function createConversationThread(targetDocument: Document, chat: DesktopNativeC
       author: message.role === "user" ? "You" : "Tinybot",
       time: formatCompactTime(message.timestamp),
       tone: message.role === "user" ? "user" : "assistant",
-      body: [message.reasoningContent, message.content].filter(Boolean),
+      reasoningContent: message.reasoningContent,
+      body: shouldRenderConversationBody(message) ? [message.content].filter(Boolean) : [],
+      toolActivities: message.toolActivities,
       references: message.references,
     })));
     return thread;
@@ -894,13 +896,19 @@ function createConversationThread(targetDocument: Document, chat: DesktopNativeC
   return thread;
 }
 
+function shouldRenderConversationBody(message: NativeChatMessage): boolean {
+  return !((message.role === "tool" || message.role === "progress") && Boolean(message.toolActivities?.length));
+}
+
 function createConversationMessage(
   targetDocument: Document,
   options: {
     author: string;
     time: string;
     tone: "user" | "assistant";
+    reasoningContent?: string;
     body: string[];
+    toolActivities?: NativeChatMessage["toolActivities"];
     references?: NativeChatMessage["references"];
     attachment?: string;
   },
@@ -915,6 +923,12 @@ function createConversationMessage(
   meta.className = "desktop-conversation-meta";
   meta.append(createText(targetDocument, "strong", options.author), createText(targetDocument, "span", options.time));
   content.append(meta);
+  if (options.reasoningContent?.trim()) {
+    content.append(createConversationReasoning(targetDocument, options.reasoningContent));
+  }
+  if (options.toolActivities?.length) {
+    content.append(createToolActivities(targetDocument, options.toolActivities));
+  }
   content.append(createConversationBody(targetDocument, options.body, options.tone));
   for (const reference of options.references ?? []) {
     const node = createText(targetDocument, "p", `${reference.kind}: ${reference.title}${reference.detail ? ` - ${reference.detail}` : ""}`);
@@ -929,6 +943,111 @@ function createConversationMessage(
   }
   article.append(content);
   return article;
+}
+
+function createConversationReasoning(targetDocument: Document, reasoningContent: string): HTMLElement {
+  const details = targetDocument.createElement("details");
+  details.className = "desktop-message-reasoning";
+  const summary = targetDocument.createElement("summary");
+  summary.className = "desktop-message-reasoning-summary";
+  const title = createText(targetDocument, "span", "Thinking");
+  title.className = "desktop-message-reasoning-title";
+  const meta = createText(targetDocument, "span", "Show details");
+  meta.className = "desktop-message-reasoning-meta";
+  summary.append(title, meta);
+  const body = createText(targetDocument, "div", reasoningContent);
+  body.className = "desktop-message-reasoning-body";
+  details.append(summary, body);
+  return details;
+}
+
+function createToolActivities(
+  targetDocument: Document,
+  activities: NonNullable<NativeChatMessage["toolActivities"]>,
+): HTMLElement {
+  const wrapper = targetDocument.createElement("div");
+  wrapper.className = "desktop-tool-activities";
+  for (const activity of activities) {
+    wrapper.append(createToolActivity(targetDocument, activity));
+  }
+  return wrapper;
+}
+
+function createToolActivity(
+  targetDocument: Document,
+  activity: NonNullable<NativeChatMessage["toolActivities"]>[number],
+): HTMLElement {
+  const details = targetDocument.createElement("details");
+  details.className = "desktop-tool-activity";
+  details.setAttribute("data-desktop-tool-activity-kind", activity.kind);
+  if (activity.id) {
+    details.setAttribute("data-desktop-tool-activity-id", activity.id);
+  }
+
+  const summary = targetDocument.createElement("summary");
+  summary.className = "desktop-tool-activity-summary";
+  const icon = createText(targetDocument, "span", ">");
+  icon.className = "desktop-tool-activity-icon";
+  icon.setAttribute("aria-hidden", "true");
+  const main = targetDocument.createElement("span");
+  main.className = "desktop-tool-activity-main";
+  const title = createText(targetDocument, "span", activity.name || "unknown");
+  title.className = "desktop-tool-activity-title";
+  const preview = createText(targetDocument, "span", summarizeToolText(activity.argsText || activity.responseText));
+  preview.className = "desktop-tool-activity-preview";
+  main.append(title, preview);
+  const badges = targetDocument.createElement("span");
+  badges.className = "desktop-tool-activity-badges";
+  if (activity.approvalStatus === "approved") {
+    const approval = createText(targetDocument, "span", "Approved");
+    approval.className = "desktop-tool-activity-badge desktop-tool-activity-approval-badge";
+    badges.append(approval);
+  }
+  const badge = createText(targetDocument, "span", activity.kind === "result" ? "Result" : "Call");
+  badge.className = "desktop-tool-activity-badge";
+  badges.append(badge);
+  summary.append(icon, main, badges);
+  details.append(summary);
+
+  const body = targetDocument.createElement("div");
+  body.className = "desktop-tool-activity-body";
+  if (activity.argsText) {
+    body.append(createToolActivitySection(targetDocument, "Arguments", activity.argsText, "call"));
+  }
+  if (activity.responseText) {
+    body.append(createToolActivitySection(targetDocument, "Response", activity.responseText, "response"));
+  }
+  if (!activity.argsText && !activity.responseText) {
+    const empty = createText(targetDocument, "div", "No arguments or response.");
+    empty.className = "desktop-tool-activity-empty";
+    body.append(empty);
+  }
+  details.append(body);
+  return details;
+}
+
+function createToolActivitySection(
+  targetDocument: Document,
+  label: string,
+  text: string,
+  kind: "call" | "response",
+): HTMLElement {
+  const section = targetDocument.createElement("div");
+  section.className = `desktop-tool-activity-section desktop-tool-activity-section-${kind}`;
+  const labelNode = createText(targetDocument, "div", label);
+  labelNode.className = "desktop-tool-activity-label";
+  const pre = createText(targetDocument, "pre", text);
+  pre.className = "desktop-tool-activity-pre";
+  section.append(labelNode, pre);
+  return section;
+}
+
+function summarizeToolText(value: string): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "No details";
+  }
+  return normalized.length > 96 ? `${normalized.slice(0, 93)}...` : normalized;
 }
 
 function createConversationBody(
@@ -4540,6 +4659,195 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-conversation-content p {
       margin: 0;
       overflow-wrap: anywhere;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning {
+      overflow: hidden;
+      border: 1px solid #e2d9d2;
+      border-radius: 8px;
+      background: #fbfaf7;
+      color: #625d57;
+      font-size: 13px;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning summary {
+      list-style: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning summary::-webkit-details-marker {
+      display: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-summary {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 36px;
+      padding: 8px 11px;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-summary::before {
+      content: ">";
+      display: grid;
+      place-items: center;
+      width: 16px;
+      height: 16px;
+      border-radius: 4px;
+      color: #a9583e;
+      font: 700 11px/1 var(--font-mono);
+      transition: transform 150ms ease;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning[open] .desktop-message-reasoning-summary::before {
+      transform: rotate(90deg);
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-title {
+      color: #3f3a35;
+      font-weight: 700;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-meta {
+      margin-left: auto;
+      color: #7a746d;
+      font-size: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-body {
+      max-height: 320px;
+      overflow: auto;
+      padding: 0 14px 12px 37px;
+      white-space: pre-wrap;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activities {
+      display: grid;
+      gap: 6px;
+      margin: 2px 0;
+      font-size: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity {
+      overflow: hidden;
+      border: 1px solid #e2d9d2;
+      border-radius: 8px;
+      background: #fbfaf7;
+      color: #625d57;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity summary {
+      list-style: none;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity summary::-webkit-details-marker {
+      display: none;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-summary {
+      display: grid;
+      grid-template-columns: 18px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 8px;
+      min-height: 34px;
+      padding: 6px 9px;
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-icon {
+      display: grid;
+      place-items: center;
+      width: 16px;
+      height: 16px;
+      border-radius: 4px;
+      background: rgba(109, 105, 100, 0.1);
+      color: #7a746d;
+      font: 700 11px/1 var(--font-mono);
+      transition: transform 150ms ease;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity[open] .desktop-tool-activity-icon {
+      transform: rotate(90deg);
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-main {
+      display: grid;
+      min-width: 0;
+      gap: 1px;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-title {
+      overflow: hidden;
+      color: #3f3a35;
+      font: 650 12px/1.35 var(--font-mono);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-preview {
+      overflow: hidden;
+      color: #7a746d;
+      font-size: 11px;
+      line-height: 1.35;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-badges {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-badge {
+      border: 1px solid #e2d9d2;
+      border-radius: 999px;
+      padding: 1px 6px;
+      background: #ffffff;
+      color: #6d6964;
+      font-size: 10px;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-approval-badge {
+      border-color: rgba(93, 184, 114, 0.4);
+      background: rgba(93, 184, 114, 0.12);
+      color: #3b8a4d;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-body {
+      display: grid;
+      gap: 0;
+      border-top: 1px solid #e8dfd7;
+      padding: 7px 11px 11px 35px;
+      background: #fffdf9;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-section {
+      display: grid;
+      gap: 5px;
+      padding: 5px 0 7px;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-label {
+      color: #7a746d;
+      font-size: 10px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-pre,
+    body.desktop-native-workbench .desktop-tool-activity-empty {
+      margin: 0;
+      min-height: auto;
+      overflow-x: auto;
+      padding: 0;
+      background: transparent;
+      color: #625d57;
+      font: 11px/1.5 var(--font-mono);
+      white-space: pre-wrap;
     }
 
     body.desktop-native-workbench .desktop-conversation-bullet {

--- a/apps/desktop/src/nativeChat.test.ts
+++ b/apps/desktop/src/nativeChat.test.ts
@@ -45,7 +45,11 @@ describe("native chat state", () => {
             role: "assistant",
             content: "hi",
             reasoning_content: "thinking",
-            tool_calls: [{ name: "read_file", path: "docs/desktop.md" }],
+            tool_calls: [{
+              id: "call-read",
+              function: { name: "read_file", arguments: "{\"path\":\"docs/desktop.md\"}" },
+            }],
+            tool_results: [{ tool_call_id: "call-read", content: "file contents" }],
             browser_references: [{ title: "Browser snapshot", url: "https://example.com" }],
             memory_references: [{ id: "mem-1", summary: "Remembered setting" }],
             timestamp: "2026-05-29T08:00:01Z",
@@ -65,8 +69,18 @@ describe("native chat state", () => {
         role: "assistant",
         content: "hi",
         reasoningContent: "thinking",
+        toolActivities: [
+          {
+            id: "call-read",
+            name: "read_file",
+            argsText: "{\"path\":\"docs/desktop.md\"}",
+            responseText: "file contents",
+            kind: "result",
+          },
+        ],
         references: [
-          { kind: "tool", title: "read_file", detail: "docs/desktop.md" },
+          { kind: "tool", title: "read_file", detail: "{\"path\":\"docs/desktop.md\"}" },
+          { kind: "tool", title: "call-read", detail: "file contents" },
           { kind: "browser", title: "Browser snapshot", detail: "https://example.com" },
           { kind: "memory", title: "mem-1", detail: "Remembered setting" },
         ],
@@ -142,5 +156,39 @@ describe("native chat state", () => {
 
     expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(false);
     expect(state.error).toBe("chat is not attached");
+  });
+
+  test("normalizes standalone tool result messages into native tool activities", () => {
+    expect(
+      normalizeMessagesPayload({
+        messages: [
+          {
+            role: "tool",
+            name: "shell",
+            tool_call_id: "call-shell",
+            content: "stdout: done",
+            timestamp: "2026-05-29T08:00:02Z",
+            message_id: "tool-1",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        role: "tool",
+        content: "stdout: done",
+        reasoningContent: "",
+        toolActivities: [
+          {
+            id: "call-shell",
+            name: "shell",
+            argsText: "",
+            responseText: "stdout: done",
+            kind: "result",
+          },
+        ],
+        timestamp: "2026-05-29T08:00:02Z",
+        messageId: "tool-1",
+      },
+    ]);
   });
 });

--- a/apps/desktop/src/nativeChat.ts
+++ b/apps/desktop/src/nativeChat.ts
@@ -12,9 +12,19 @@ export type NativeChatMessage = {
   role: string;
   content: string;
   reasoningContent: string;
+  toolActivities?: NativeChatToolActivity[];
   references?: NativeChatReference[];
   timestamp: string;
   messageId: string;
+};
+
+export type NativeChatToolActivity = {
+  id: string;
+  name: string;
+  argsText: string;
+  responseText: string;
+  kind: "call" | "result";
+  approvalStatus?: string;
 };
 
 export type NativeChatReference = {
@@ -72,10 +82,12 @@ export function normalizeMessagesPayload(payload: unknown): NativeChatMessage[] 
   }
   return payload.messages.filter(isRecord).map((message) => {
     const references = normalizeMessageReferences(message);
+    const toolActivities = normalizeToolActivities(message);
     return {
       role: stringValue(message.role) || "assistant",
       content: stringValue(message.content ?? message.text),
       reasoningContent: stringValue(message.reasoning_content),
+      ...(toolActivities.length ? { toolActivities } : {}),
       ...(references.length ? { references } : {}),
       timestamp: stringValue(message.timestamp),
       messageId: stringValue(message.message_id),
@@ -240,8 +252,8 @@ function ensureMessageBucket(state: NativeChatState, sessionKey: string): Native
 
 function normalizeMessageReferences(message: Record<string, unknown>): NativeChatReference[] {
   return [
-    ...referenceRows(message.tool_calls, "tool"),
-    ...referenceRows(message.tool_results, "tool"),
+    ...toolCallReferenceRows(message.tool_calls),
+    ...toolResultReferenceRows(message.tool_results),
     ...referenceRows(message.browser_references, "browser"),
     ...referenceRows(message.browser_snapshots, "browser"),
     ...referenceRows(message.memory_references, "memory"),
@@ -251,15 +263,113 @@ function normalizeMessageReferences(message: Record<string, unknown>): NativeCha
   ];
 }
 
-function referenceRows(value: unknown, kind: NativeChatReference["kind"]): NativeChatReference[] {
-  if (!Array.isArray(value)) {
-    return [];
+function normalizeToolActivities(message: Record<string, unknown>): NativeChatToolActivity[] {
+  const calls = toolCallRows(message.tool_calls);
+  const results = toolResultRows(message.tool_results);
+  const usedResultIndexes = new Set<number>();
+  const activities = calls.map((call, index) => {
+    const resultIndex = results.findIndex((result, candidateIndex) => (
+      !usedResultIndexes.has(candidateIndex)
+      && Boolean(result.id)
+      && result.id === call.id
+    ));
+    const fallbackIndex = resultIndex === -1 && results[index] && !usedResultIndexes.has(index) ? index : -1;
+    const pairedIndex = resultIndex === -1 ? fallbackIndex : resultIndex;
+    const result = pairedIndex === -1 ? null : results[pairedIndex];
+    if (pairedIndex !== -1) {
+      usedResultIndexes.add(pairedIndex);
+    }
+    return {
+      id: call.id || result?.id || `tool-call-${index + 1}`,
+      name: call.name || result?.name || "unknown",
+      argsText: call.argsText,
+      responseText: result?.responseText || "",
+      kind: result?.responseText ? "result" as const : "call" as const,
+      ...(call.approvalStatus || result?.approvalStatus ? { approvalStatus: call.approvalStatus || result?.approvalStatus } : {}),
+    };
+  });
+
+  results.forEach((result, index) => {
+    if (usedResultIndexes.has(index)) {
+      return;
+    }
+    activities.push({
+      id: result.id || `tool-result-${index + 1}`,
+      name: result.name || "tool",
+      argsText: "",
+      responseText: result.responseText,
+      kind: "result",
+      ...(result.approvalStatus ? { approvalStatus: result.approvalStatus } : {}),
+    });
+  });
+
+  if (!activities.length && (message.role === "tool" || message.role === "progress")) {
+    const responseText = textValue(message.content ?? message.text);
+    if (responseText) {
+      activities.push({
+        id: stringValue(message.tool_call_id ?? message._tool_call_id) || stringValue(message.message_id) || "tool-result",
+        name: stringValue(message._tool_name ?? message.name) || "tool",
+        argsText: "",
+        responseText,
+        kind: "result",
+        ...(stringValue(message._approval_status) ? { approvalStatus: stringValue(message._approval_status) } : {}),
+      });
+    }
   }
-  return value.filter(isRecord).map((row) => ({
+
+  return activities;
+}
+
+function toolCallRows(value: unknown): Array<Pick<NativeChatToolActivity, "id" | "name" | "argsText"> & { approvalStatus?: string }> {
+  return arrayRows(value).map((row, index) => {
+    const functionPayload = isRecord(row.function) ? row.function : {};
+    return {
+      id: stringValue(row.id ?? row.tool_call_id) || `tool-call-${index + 1}`,
+      name: stringValue(functionPayload.name ?? row.name) || "unknown",
+      argsText: textValue(functionPayload.arguments ?? row.arguments ?? row.detail ?? row.path),
+      ...(stringValue(row._approval_status ?? row.approval_status) ? { approvalStatus: stringValue(row._approval_status ?? row.approval_status) } : {}),
+    };
+  });
+}
+
+function toolResultRows(value: unknown): Array<Pick<NativeChatToolActivity, "id" | "name" | "responseText"> & { approvalStatus?: string }> {
+  return arrayRows(value).map((row, index) => ({
+    id: stringValue(row.tool_call_id ?? row.id) || `tool-result-${index + 1}`,
+    name: stringValue(row.name ?? row.title ?? row.tool_name) || "",
+    responseText: textValue(row.content ?? row.response ?? row.result ?? row.output ?? row.detail ?? row.summary),
+    ...(stringValue(row._approval_status ?? row.approval_status) ? { approvalStatus: stringValue(row._approval_status ?? row.approval_status) } : {}),
+  }));
+}
+
+function toolCallReferenceRows(value: unknown): NativeChatReference[] {
+  return toolCallRows(value).map((row) => ({
+    kind: "tool",
+    title: row.name || row.id || "tool",
+    detail: row.argsText,
+  }));
+}
+
+function toolResultReferenceRows(value: unknown): NativeChatReference[] {
+  return toolResultRows(value).map((row) => ({
+    kind: "tool",
+    title: row.id || row.name || "tool",
+    detail: row.responseText,
+  }));
+}
+
+function referenceRows(value: unknown, kind: NativeChatReference["kind"]): NativeChatReference[] {
+  return arrayRows(value).map((row) => ({
     kind,
     title: stringValue(row.title ?? row.name ?? row.id ?? row.url) || kind,
     detail: stringValue(row.detail ?? row.summary ?? row.path ?? row.url ?? row.content),
   }));
+}
+
+function arrayRows(value: unknown): Record<string, unknown>[] {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord);
+  }
+  return isRecord(value) ? [value] : [];
 }
 
 function chatIdFromKey(key: string): string {
@@ -272,4 +382,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stringValue(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function textValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }


### PR DESCRIPTION
## Summary
- Add native structured tool activity normalization for tool calls, paired results, and standalone tool/progress result messages.
- Render reasoning and tool activity blocks in the desktop native conversation as collapsible middle-message UI instead of flattening them into normal chat text.
- Add regression coverage for reasoning, tool call/result display, and standalone tool result de-duplication.

## Verification
- `npm test -- nativeChat.test.ts desktopWorkbenchShell.test.ts`
- `npm test`
- `npm run build`
- `git diff --check -- apps/desktop/src/nativeChat.ts apps/desktop/src/nativeChat.test.ts apps/desktop/src/desktopWorkbenchShell.ts apps/desktop/src/desktopWorkbenchShell.test.ts`

Fixes #190