### PR TITLE
Tighten native sidebar workspace and recent chat spacing

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -709,6 +709,10 @@ describe("desktop workbench shell", () => {
     expect(sidebarSearch?.getAttribute("placeholder")).toBe("Search");
     expect(workspaceList?.textContent).toContain("tinybot");
     expect(recentChats?.textContent).toContain("Design native workbench");
+    const sidebarStyle = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
+    expect(sidebarStyle).toContain("grid-template-rows: auto auto auto");
+    expect(sidebarStyle).toContain(".desktop-sidebar-list-section-recent");
+    expect(sidebarStyle).toContain("max-height: min(42vh, 360px)");
 
     const chatHeader = targetDocument.body.querySelector(".desktop-chat-header");
     const conversationThread = targetDocument.body.querySelector(".desktop-conversation-thread");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -580,7 +580,7 @@ function createSidebarActions(targetDocument: Document): HTMLElement {
 
 function createSidebarWorkspaceList(targetDocument: Document, chat: DesktopNativeChatModel | null): HTMLElement {
   const section = targetDocument.createElement("section");
-  section.className = "desktop-sidebar-list-section";
+  section.className = "desktop-sidebar-list-section desktop-sidebar-list-section-workspaces";
   section.append(createSidebarSectionHeading(targetDocument, "Workspaces", "+"));
 
   const list = targetDocument.createElement("div");
@@ -610,7 +610,7 @@ function createSidebarRecentChats(
   chatActions: DesktopNativeChatActionOptions = {},
 ): HTMLElement {
   const section = targetDocument.createElement("section");
-  section.className = "desktop-sidebar-list-section";
+  section.className = "desktop-sidebar-list-section desktop-sidebar-list-section-recent";
   section.append(createSidebarSectionHeading(targetDocument, "Recent chats"));
 
   const list = targetDocument.createElement("div");
@@ -4365,8 +4365,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-sidebar-content {
       display: grid;
-      grid-template-rows: auto auto minmax(0, 1fr);
-      gap: 14px;
+      grid-template-rows: auto auto auto;
+      align-content: start;
+      gap: 10px;
       height: 100%;
       min-height: 0;
       padding: 18px 14px;
@@ -4425,6 +4426,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       overflow: hidden;
     }
 
+    body.desktop-native-workbench .desktop-sidebar-list-section-recent {
+      margin-top: 6px;
+    }
+
     body.desktop-native-workbench .desktop-sidebar-section-heading {
       display: flex;
       align-items: center;
@@ -4459,6 +4464,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       gap: 6px;
       min-width: 0;
       overflow: auto;
+    }
+
+    body.desktop-native-workbench .desktop-recent-chat-list {
+      max-height: min(42vh, 360px);
     }
 
     body.desktop-native-workbench .desktop-sidebar-row {


### PR DESCRIPTION
## Summary
- Stack native sidebar sections compactly instead of allowing Recent Chats to stretch into the remaining sidebar height.
- Add semantic sidebar section classes for Workspaces and Recent Chats.
- Cap the Recent Chats list height so the heading stays close to session rows while the list can still scroll.

## Verification
- `npm test -- desktopWorkbenchShell.test.ts`
- `npm test`
- `npm run build`
- `git diff --check -- apps/desktop/src/desktopWorkbenchShell.ts apps/desktop/src/desktopWorkbenchShell.test.ts`

Fixes #192