### PR TITLE
Sync Run Chain summary clicks with tab state

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -968,6 +968,16 @@ describe("desktop workbench shell", () => {
     expect(panel?.textContent).toContain("Current Run");
     expect(panel?.textContent).toContain("New Run Chain Item");
 
+    overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.click();
+    expect(overview?.querySelector('[data-desktop-run-chain-tab="context"]')?.getAttribute("aria-selected")).toBe("true");
+    expect(overview?.querySelector('[data-desktop-run-chain-tab="tasks"]')?.getAttribute("aria-selected")).toBe("false");
+    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("context");
+
+    overview?.querySelector('[data-desktop-run-chain-summary="items"]')?.click();
+    expect(overview?.querySelector('[data-desktop-run-chain-tab="context"]')?.getAttribute("aria-selected")).toBe("false");
+    expect(overview?.querySelector('[data-desktop-run-chain-tab="tasks"]')?.getAttribute("aria-selected")).toBe("true");
+    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("tasks");
+
     const pin = overview?.querySelector('[data-desktop-run-chain-control="pin"]');
     expect(pin?.getAttribute("aria-pressed")).toBe("false");
     pin?.click();

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -2680,7 +2680,7 @@ function createRunChainOverviewPanel(
 function createRunChainSummaryStrip(
   targetDocument: Document,
   runChainItems: DesktopRunChainItem[],
-  renderPanel: (tabId: RunChainOverviewTab) => void,
+  selectTab: (tabId: RunChainOverviewTab) => void,
 ): HTMLElement {
   const summary = targetDocument.createElement("div");
   summary.className = "desktop-run-chain-summary-strip";
@@ -2696,7 +2696,7 @@ function createRunChainSummaryStrip(
     button.setAttribute("data-desktop-run-chain-summary", item.label.toLowerCase());
     button.textContent = `${item.label} ${item.value}`;
     button.addEventListener("click", () => {
-      renderPanel(item.tab);
+      selectTab(item.tab);
       setRouteStatus(targetDocument, `Run Chain ${item.label}`);
     });
     summary.append(button);


### PR DESCRIPTION
## Summary
- Address PR #195 review feedback for Run Chain summary click behavior.
- Route summary-strip clicks through an explicitly named `selectTab` callback instead of the ambiguous `renderPanel` parameter.
- Add regression assertions that Gateway and Items summary clicks update both the visible panel and tab `aria-selected` state.

## Verification
- `npm test -- desktopWorkbenchShell.test.ts`
- `npm test`
- `npm run build`
- `git diff --check -- apps/desktop/src/desktopWorkbenchShell.ts apps/desktop/src/desktopWorkbenchShell.test.ts`

Follow-up to #195.
Fixes #196