### PR TITLE
Improve native Files page UI

### DIFF
--- a/apps/desktop/src/desktopFileUpload.test.ts
+++ b/apps/desktop/src/desktopFileUpload.test.ts
@@ -36,6 +36,15 @@ describe("desktop file upload adapters", () => {
       title: "Attach temporary session file",
       filters: [{ name: "Session files", extensions: ["md", "txt", "pdf", "docx", "csv", "json", "png", "jpg", "jpeg"] }],
     });
+    expect(desktopUploadPickerOptions("workspace-file")).toEqual({
+      title: "Import workspace file",
+      filters: [
+        {
+          name: "Workspace files",
+          extensions: ["md", "markdown", "txt", "json", "csv", "py", "js", "ts", "tsx", "jsx", "html", "css", "yaml", "yml", "toml"],
+        },
+      ],
+    });
   });
 
   test("converts an explicitly selected native file into a browser File", async () => {
@@ -195,6 +204,43 @@ describe("desktop file upload adapters", () => {
     expect(targetDocument.querySelector("#desktop-file-upload-status")?.textContent).toContain("Attached notes.md to WebSocket:chat-1.");
   });
 
+  test("imports a picked workspace file when the workspace import target is clicked", async () => {
+    const targetDocument = createUploadTestDocument();
+    const workspace = targetDocument.createElement("a");
+    workspace.setAttribute("id", "desktop-workspace-file-drop");
+    const status = targetDocument.createElement("p");
+    status.setAttribute("id", "desktop-file-upload-status");
+    targetDocument.body.append(workspace, status);
+    const pickedKinds: string[] = [];
+    const workspaceWrites: { path: string; body: unknown }[] = [];
+    const importedPaths: string[] = [];
+
+    installDesktopFileUploadActions({
+      targetDocument: targetDocument as unknown as Document,
+      pickFile: async (kind) => {
+        pickedKinds.push(kind);
+        return pickedFile;
+      },
+      uploadKnowledgeDocument: async () => ({}),
+      uploadSessionTemporaryFile: async () => undefined,
+      uploadWorkspaceFile: async (path, body) => {
+        workspaceWrites.push({ path, body });
+      },
+      onWorkspaceFileImported: async (path) => {
+        importedPaths.push(path);
+      },
+    });
+
+    targetDocument.querySelector("#desktop-workspace-file-drop")?.click();
+    await flushPromises();
+    await flushPromises();
+
+    expect(pickedKinds).toEqual(["workspace-file"]);
+    expect(workspaceWrites).toEqual([{ path: "notes.md", body: { content: "hello world", expected_updated_at: null } }]);
+    expect(importedPaths).toEqual(["notes.md"]);
+    expect(targetDocument.querySelector("#desktop-file-upload-status")?.textContent).toContain("Imported notes.md into workspace.");
+  });
+
   test("routes dropped files through the matching gateway contracts with accepted and rejected feedback", async () => {
     const knowledgeFormBodies: FormData[] = [];
     const sessionFormBodies: FormData[] = [];
@@ -325,7 +371,7 @@ class UploadTestElement {
   public dataset: Record<string, string> = {};
   public children: UploadTestElement[] = [];
   private ownTextContent = "";
-  private listeners = new Map<string, ((event: { type: string; detail?: unknown }) => void)[]>();
+  private listeners = new Map<string, ((event: { type: string; detail?: unknown; preventDefault?: () => void }) => void)[]>();
   private attributes = new Map<string, string>();
 
   constructor(public readonly tagName: string) {}
@@ -357,11 +403,11 @@ class UploadTestElement {
     this.ownTextContent = "";
   }
 
-  addEventListener(type: string, listener: (event: { type: string; detail?: unknown }) => void): void {
+  addEventListener(type: string, listener: (event: { type: string; detail?: unknown; preventDefault?: () => void }) => void): void {
     this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
   }
 
-  dispatchEvent(event: { type: string; detail?: unknown }): boolean {
+  dispatchEvent(event: { type: string; detail?: unknown; preventDefault?: () => void }): boolean {
     for (const listener of this.listeners.get(event.type) ?? []) {
       listener(event);
     }
@@ -369,7 +415,7 @@ class UploadTestElement {
   }
 
   click(): void {
-    this.dispatchEvent({ type: "click" });
+    this.dispatchEvent({ type: "click", preventDefault: () => undefined });
   }
 
   querySelector(selector: string): UploadTestElement | null {
@@ -384,6 +430,20 @@ class UploadTestElement {
     }
     return null;
   }
+
+  querySelectorAll(selector: string): UploadTestElement[] {
+    const matches: UploadTestElement[] = [];
+    if (selector === "[data-desktop-drop-target]" && this.attributes.has("data-desktop-drop-target")) {
+      matches.push(this);
+    }
+    if (selector.startsWith("#") && this.id === selector.slice(1)) {
+      matches.push(this);
+    }
+    for (const child of this.children) {
+      matches.push(...child.querySelectorAll(selector));
+    }
+    return matches;
+  }
 }
 
 class UploadTestDocument {
@@ -396,6 +456,10 @@ class UploadTestDocument {
 
   querySelector(selector: string): UploadTestElement | null {
     return this.body.querySelector(selector);
+  }
+
+  querySelectorAll(selector: string): UploadTestElement[] {
+    return this.body.querySelectorAll(selector);
   }
 
   addEventListener(type: string, listener: (event: { type: string; detail?: unknown }) => void): void {

--- a/apps/desktop/src/desktopFileUpload.ts
+++ b/apps/desktop/src/desktopFileUpload.ts
@@ -4,8 +4,8 @@ import {
 } from "./desktopKnowledgeTraceability";
 import type { DesktopTaskSourceOperation } from "./desktopTaskCenter";
 
-export type DesktopUploadKind = "knowledge-document" | "session-temporary-file";
-export type DesktopDropTargetKind = DesktopUploadKind | "workspace-file";
+export type DesktopUploadKind = "knowledge-document" | "session-temporary-file" | "workspace-file";
+export type DesktopDropTargetKind = DesktopUploadKind;
 
 export interface DesktopUploadPickerFilter {
   name: string;
@@ -101,6 +101,17 @@ export function desktopUploadPickerOptions(kind: DesktopUploadKind): DesktopUplo
         {
           name: "Knowledge documents",
           extensions: ["md", "markdown", "txt", "pdf", "docx", "csv", "json"],
+        },
+      ],
+    };
+  }
+  if (kind === "workspace-file") {
+    return {
+      title: "Import workspace file",
+      filters: [
+        {
+          name: "Workspace files",
+          extensions: ["md", "markdown", "txt", "json", "csv", "py", "js", "ts", "tsx", "jsx", "html", "css", "yaml", "yml", "toml"],
         },
       ],
     };
@@ -212,6 +223,10 @@ export function renderDesktopSessionTemporaryFiles(
   container.replaceChildren();
   container.dataset.sessionKey = sessionKey;
   container.dataset.fileCount = String(rows.length);
+  const count = ownerDocument.querySelector<HTMLElement>("#desktop-session-file-count");
+  if (count) {
+    count.textContent = String(rows.length);
+  }
   if (!sessionKey) {
     container.textContent = "Select a chat session to view temporary files.";
     return rows;
@@ -339,6 +354,31 @@ export function installDesktopFileUploadActions({
     });
   });
 
+  targetDocument.querySelector<HTMLButtonElement>("#desktop-session-files-refresh")?.addEventListener("click", () => {
+    const sessionKey = (
+      getSessionKey?.() ||
+      targetDocument.querySelector<HTMLInputElement>("#desktop-session-upload-key")?.value ||
+      targetDocument.querySelector<HTMLElement>("#desktop-workbench-shell")?.dataset.activeSessionKey ||
+      ""
+    ).trim();
+    void refreshSessionTemporaryFiles(sessionKey).catch((error) => {
+      setUploadStatus(targetDocument, `Temporary file refresh failed: ${stringifyError(error)}`);
+    });
+  });
+
+  targetDocument.querySelector<HTMLElement>("#desktop-workspace-file-drop")?.addEventListener("click", (event) => {
+    if (!uploadWorkspaceFile) {
+      return;
+    }
+    event.preventDefault();
+    void runWorkspaceFileImport({
+      targetDocument,
+      pickFile,
+      uploadWorkspaceFile,
+      onWorkspaceFileImported,
+    });
+  });
+
   targetDocument.addEventListener("tinybot:desktop-session-key-changed", (event) => {
     const sessionKey = ((event as CustomEvent<{ sessionKey?: string }>).detail?.sessionKey ?? "").trim();
     void refreshSessionTemporaryFiles(sessionKey).catch((error) => {
@@ -366,6 +406,27 @@ export function installDesktopFileUploadActions({
       onWorkspaceFileImported,
     });
   }
+}
+
+async function runWorkspaceFileImport({
+  targetDocument,
+  pickFile,
+  uploadWorkspaceFile,
+  onWorkspaceFileImported,
+}: Pick<DesktopFileUploadActions, "targetDocument" | "pickFile" | "uploadWorkspaceFile" | "onWorkspaceFileImported"> & {
+  uploadWorkspaceFile: NonNullable<DesktopFileUploadActions["uploadWorkspaceFile"]>;
+}): Promise<void> {
+  setUploadStatus(targetDocument, "Opening workspace file picker.");
+  const picked = await pickFile("workspace-file", desktopUploadPickerOptions("workspace-file"));
+  if (!picked) {
+    setUploadStatus(targetDocument, "Workspace import canceled.");
+    return;
+  }
+  const payload = await buildDesktopWorkspaceImport(buildDesktopUploadFile(picked));
+  setUploadStatus(targetDocument, `Importing ${payload.path} into workspace.`);
+  await uploadWorkspaceFile(payload.path, payload.body);
+  await onWorkspaceFileImported?.(payload.path);
+  setUploadStatus(targetDocument, `Imported ${payload.path} into workspace.`);
 }
 
 function installDesktopFileDropActions({

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -1524,6 +1524,12 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.getElementById("desktop-session-upload-key")?.getAttribute("data-active-session-key")).toBe("WebSocket:chat-live");
     expect(targetDocument.getElementById("desktop-session-upload-key")?.value).toBe("WebSocket:chat-live");
     expect(targetDocument.getElementById("desktop-file-upload-status")?.textContent).toContain("No file operation running");
+    expect(targetDocument.body.querySelector(".desktop-file-import-grid")?.textContent).toContain("Drop files here or click to select");
+    expect(targetDocument.getElementById("desktop-file-knowledge-formats")?.textContent).toContain("pdf");
+    expect(targetDocument.getElementById("desktop-file-session-formats")?.textContent).toContain("png");
+    expect(targetDocument.getElementById("desktop-file-workspace-formats")?.textContent).toContain("toml");
+    expect(targetDocument.getElementById("desktop-session-file-count")?.textContent).toContain("0");
+    expect(targetDocument.getElementById("desktop-session-files-refresh")?.getAttribute("data-desktop-session-files-refresh")).toBe("true");
   });
 
   test("renders native Agent UI form cards and routes submit and cancel actions", () => {
@@ -2609,10 +2615,13 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.getElementById("desktop-workspace-active-path")?.textContent).toContain("No workspace file selected");
     expect(targetDocument.getElementById("desktop-workspace-updated-at")?.textContent).toContain("No timestamp");
     expect(targetDocument.getElementById("desktop-workspace-detail")?.textContent).toContain("No workspace file selected");
+    expect(targetDocument.getElementById("desktop-workspace-search")?.getAttribute("placeholder")).toBe("Search workspace files...");
+    expect(targetDocument.getElementById("desktop-workspace-size")?.textContent).toContain("No size");
     expect(targetDocument.getElementById("desktop-workspace-editor")?.getAttribute("aria-label")).toBe("Workspace file editor");
     expect(targetDocument.getElementById("desktop-workspace-save")?.getAttribute("disabled")).toBe("");
     expect(targetDocument.getElementById("desktop-workspace-reveal")?.getAttribute("disabled")).toBe("");
     expect(targetDocument.getElementById("desktop-workspace-export")?.getAttribute("disabled")).toBe("");
+    expect(targetDocument.getElementById("desktop-workspace-reload")?.getAttribute("disabled")).toBe("");
     expect(targetDocument.getElementById("desktop-workspace-save-state")?.textContent).toContain("Select a workspace file");
     expect(targetDocument.getElementById("desktop-workspace-error")?.textContent).toBe("");
   });
@@ -2633,6 +2642,7 @@ describe("desktop workbench shell", () => {
     expect(filesSurface?.querySelector(".desktop-workspace-editor-panel")?.querySelector("#desktop-workspace-editor")).toBeTruthy();
     expect(filesSurface?.querySelector(".desktop-workspace-action-rail")?.getAttribute("aria-label")).toBe("Workspace file actions");
     expect(filesSurface?.querySelector(".desktop-workspace-action-rail")?.querySelector("#desktop-workspace-save")).toBeTruthy();
+    expect(filesSurface?.querySelector(".desktop-workspace-action-rail")?.querySelector("#desktop-workspace-reload")).toBeTruthy();
   });
 
   test("keeps the desktop Files workspace grid shrinkable inside the main work area", () => {
@@ -2646,7 +2656,7 @@ describe("desktop workbench shell", () => {
 
     const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
     expect(styleText).not.toContain("grid-template-columns: minmax(190px, 260px) minmax(280px, 1fr) minmax(120px, 160px);");
-    expect(styleText).toContain("grid-template-columns: minmax(150px, 0.8fr) minmax(0, 1.2fr) minmax(92px, 0.5fr);");
+    expect(styleText).toContain("grid-template-columns: minmax(220px, 0.78fr) minmax(0, 1.55fr) minmax(150px, 0.48fr);");
   });
 
   test("allows the main work area to shrink when the inspector is collapsed", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -3358,14 +3358,6 @@ function createFileActions(targetDocument: Document, chat: DesktopNativeChatMode
   section.setAttribute("data-desktop-module-surface", "workspace knowledge");
   section.append(createText(targetDocument, "h2", "File imports"));
 
-  const knowledge = targetDocument.createElement("button");
-  knowledge.setAttribute("id", "desktop-knowledge-upload");
-  knowledge.setAttribute("type", "button");
-  knowledge.setAttribute("class", "desktop-file-action");
-  knowledge.setAttribute("data-desktop-file-upload", "knowledge-document");
-  knowledge.setAttribute("data-desktop-drop-target", "knowledge-document");
-  knowledge.textContent = "Import knowledge";
-
   const sessionKey = targetDocument.createElement("input");
   sessionKey.setAttribute("id", "desktop-session-upload-key");
   sessionKey.setAttribute("class", "desktop-session-upload-key");
@@ -3377,17 +3369,52 @@ function createFileActions(targetDocument: Document, chat: DesktopNativeChatMode
     sessionKey.setAttribute("data-active-session-key", chat.activeSessionKey);
   }
 
-  const session = targetDocument.createElement("button");
-  session.setAttribute("id", "desktop-session-file-upload");
-  session.setAttribute("type", "button");
-  session.setAttribute("class", "desktop-file-action");
-  session.setAttribute("data-desktop-file-upload", "session-temporary-file");
-  session.setAttribute("data-desktop-drop-target", "session-temporary-file");
-  session.textContent = "Attach to session";
+  const knowledge = createFileImportCard(targetDocument, {
+    id: "desktop-knowledge-upload",
+    label: "Import knowledge",
+    uploadKind: "knowledge-document",
+    dropTarget: "knowledge-document",
+    formatsId: "desktop-file-knowledge-formats",
+    formats: ["md", "pdf", "docx", "csv", "json"],
+  });
 
-  const workspace = createWorkbenchLink(targetDocument, "Workspace import", "/workspace", "desktop-file-action");
-  workspace.setAttribute("id", "desktop-workspace-file-drop");
-  workspace.setAttribute("data-desktop-drop-target", "workspace-file");
+  const session = createFileImportCard(targetDocument, {
+    id: "desktop-session-file-upload",
+    label: "Attach to session",
+    uploadKind: "session-temporary-file",
+    dropTarget: "session-temporary-file",
+    formatsId: "desktop-file-session-formats",
+    formats: ["md", "txt", "pdf", "docx", "csv", "json", "png", "jpg"],
+  });
+
+  const sessionCard = targetDocument.createElement("div");
+  sessionCard.className = "desktop-file-session-card";
+  const sessionLabel = targetDocument.createElement("label");
+  sessionLabel.setAttribute("for", "desktop-session-upload-key");
+  sessionLabel.textContent = "Session key";
+  const sessionMeta = targetDocument.createElement("div");
+  sessionMeta.className = "desktop-file-session-meta";
+  const sessionCount = targetDocument.createElement("span");
+  sessionCount.setAttribute("id", "desktop-session-file-count");
+  sessionCount.className = "desktop-file-count-pill";
+  sessionCount.textContent = "0";
+  const sessionRefresh = targetDocument.createElement("button");
+  sessionRefresh.setAttribute("id", "desktop-session-files-refresh");
+  sessionRefresh.setAttribute("type", "button");
+  sessionRefresh.setAttribute("class", "desktop-file-refresh");
+  sessionRefresh.setAttribute("data-desktop-session-files-refresh", "true");
+  sessionRefresh.textContent = "Refresh";
+  sessionMeta.append(createText(targetDocument, "span", "Temporary files"), sessionCount, sessionRefresh);
+  sessionCard.append(sessionLabel, sessionKey, sessionMeta);
+
+  const workspace = createFileImportCard(targetDocument, {
+    id: "desktop-workspace-file-drop",
+    label: "Workspace import",
+    href: "/workspace",
+    dropTarget: "workspace-file",
+    formatsId: "desktop-file-workspace-formats",
+    formats: ["md", "txt", "json", "csv", "py", "js", "ts", "html", "css", "yaml", "toml"],
+  });
 
   const status = targetDocument.createElement("p");
   status.setAttribute("id", "desktop-file-upload-status");
@@ -3400,8 +3427,77 @@ function createFileActions(targetDocument: Document, chat: DesktopNativeChatMode
   sessionFiles.setAttribute("aria-label", "Session temporary files");
   sessionFiles.textContent = chat?.activeSessionKey ? "Temporary files not loaded yet." : "Select a chat session to view temporary files.";
 
-  section.append(knowledge, sessionKey, session, workspace, status, sessionFiles);
+  const grid = targetDocument.createElement("div");
+  grid.className = "desktop-file-import-grid";
+  grid.append(knowledge, session, sessionCard, workspace);
+
+  const operationStrip = targetDocument.createElement("div");
+  operationStrip.className = "desktop-file-operation-strip";
+  operationStrip.append(
+    createFileOperationStatus(targetDocument, "Knowledge upload", "Waiting"),
+    createFileOperationStatus(targetDocument, "Session upload", "Waiting"),
+    createFileOperationStatus(targetDocument, "Workspace import", "Waiting"),
+    status,
+  );
+
+  section.append(grid, operationStrip, sessionFiles);
   return section;
+}
+
+function createFileImportCard(
+  targetDocument: Document,
+  options: {
+    id: string;
+    label: string;
+    uploadKind?: string;
+    dropTarget: string;
+    formatsId: string;
+    formats: string[];
+    href?: string;
+  },
+): HTMLElement {
+  const control = options.href
+    ? createWorkbenchLink(targetDocument, options.label, options.href, "desktop-file-action desktop-file-import-button")
+    : targetDocument.createElement("button");
+  control.setAttribute("id", options.id);
+  control.setAttribute("class", "desktop-file-action desktop-file-import-button");
+  control.setAttribute("data-desktop-drop-target", options.dropTarget);
+  if (!options.href) {
+    control.setAttribute("type", "button");
+  }
+  if (options.uploadKind) {
+    control.setAttribute("data-desktop-file-upload", options.uploadKind);
+  }
+  control.append(
+    createText(targetDocument, "span", options.label),
+    createText(targetDocument, "small", "Drop files here or click to select"),
+  );
+
+  const card = targetDocument.createElement("div");
+  card.className = "desktop-file-import-card";
+  card.append(control, createFormatChipList(targetDocument, options.formatsId, options.formats));
+  return card;
+}
+
+function createFormatChipList(targetDocument: Document, id: string, formats: string[]): HTMLElement {
+  const row = targetDocument.createElement("p");
+  row.className = "desktop-file-format-row";
+  row.setAttribute("id", id);
+  row.append(createText(targetDocument, "span", "Formats:"));
+  for (const format of formats) {
+    const chip = targetDocument.createElement("span");
+    chip.className = "desktop-file-format-chip";
+    chip.textContent = format;
+    row.append(chip);
+  }
+  return row;
+}
+
+function createFileOperationStatus(targetDocument: Document, label: string, status: string): HTMLElement {
+  const item = targetDocument.createElement("div");
+  item.className = "desktop-file-operation-status";
+  item.append(createText(targetDocument, "span", label), createText(targetDocument, "strong", status));
+  return item;
 }
 
 function syncSessionFileUploadKey(targetDocument: Document, activeSessionKey: string): void {
@@ -3525,6 +3621,13 @@ function createWorkspaceFilesSurface(targetDocument: Document): HTMLElement {
   recent.setAttribute("class", "desktop-workspace-recent-files");
   recent.setAttribute("aria-label", "Recent workspace files");
 
+  const search = targetDocument.createElement("input");
+  search.setAttribute("id", "desktop-workspace-search");
+  search.setAttribute("class", "desktop-workspace-search");
+  search.setAttribute("type", "search");
+  search.setAttribute("placeholder", "Search workspace files...");
+  search.setAttribute("aria-label", "Search workspace files");
+
   const activePath = targetDocument.createElement("p");
   activePath.setAttribute("id", "desktop-workspace-active-path");
   activePath.setAttribute("class", "desktop-workspace-active-path");
@@ -3535,6 +3638,11 @@ function createWorkspaceFilesSurface(targetDocument: Document): HTMLElement {
   updatedAt.setAttribute("class", "desktop-workspace-updated-at");
   updatedAt.textContent = "No timestamp";
 
+  const size = targetDocument.createElement("p");
+  size.setAttribute("id", "desktop-workspace-size");
+  size.setAttribute("class", "desktop-workspace-size");
+  size.textContent = "No size";
+
   const detail = targetDocument.createElement("p");
   detail.setAttribute("id", "desktop-workspace-detail");
   detail.setAttribute("class", "desktop-workspace-detail");
@@ -3544,6 +3652,7 @@ function createWorkspaceFilesSurface(targetDocument: Document): HTMLElement {
   browser.className = "desktop-workspace-browser";
   browser.append(
     createText(targetDocument, "h3", "Files"),
+    search,
     recent,
   );
 
@@ -3553,6 +3662,7 @@ function createWorkspaceFilesSurface(targetDocument: Document): HTMLElement {
     createText(targetDocument, "h3", "Selection"),
     activePath,
     updatedAt,
+    size,
     detail,
   );
 
@@ -3592,6 +3702,13 @@ function createWorkspaceFilesSurface(targetDocument: Document): HTMLElement {
   reveal.setAttribute("disabled", "");
   reveal.textContent = "Reveal";
 
+  const reload = targetDocument.createElement("button");
+  reload.setAttribute("id", "desktop-workspace-reload");
+  reload.setAttribute("type", "button");
+  reload.setAttribute("class", "desktop-file-action desktop-workspace-reload");
+  reload.setAttribute("disabled", "");
+  reload.textContent = "Reload";
+
   const exportButton = targetDocument.createElement("button");
   exportButton.setAttribute("id", "desktop-workspace-export");
   exportButton.setAttribute("type", "button");
@@ -3601,7 +3718,7 @@ function createWorkspaceFilesSurface(targetDocument: Document): HTMLElement {
 
   const actions = targetDocument.createElement("div");
   actions.setAttribute("class", "desktop-workspace-actions");
-  actions.append(save, reveal, exportButton);
+  actions.append(save, reveal, exportButton, reload);
 
   const actionRail = targetDocument.createElement("aside");
   actionRail.className = "desktop-workspace-action-rail";
@@ -4092,7 +4209,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-cowork-graph-node:focus-visible,
     body.desktop-native-workbench .desktop-module-work-row:focus-visible,
     body.desktop-native-workbench .desktop-task-action:focus-visible,
+    body.desktop-native-workbench .desktop-file-refresh:focus-visible,
     body.desktop-native-workbench .desktop-session-upload-key:focus-visible,
+    body.desktop-native-workbench .desktop-workspace-search:focus-visible,
     body.desktop-native-workbench .desktop-workspace-file-row:focus-visible,
     body.desktop-native-workbench .desktop-workspace-editor:focus-visible,
     body.desktop-native-workbench .desktop-inspector-restore:focus-visible,
@@ -4112,15 +4231,148 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-file-actions {
       display: grid;
-      grid-template-columns: repeat(2, minmax(130px, max-content));
-      gap: 8px;
-      align-items: center;
+      gap: 10px;
       min-width: 0;
     }
 
-    body.desktop-native-workbench .desktop-file-actions h2,
-    body.desktop-native-workbench .desktop-file-upload-status {
-      grid-column: 1 / -1;
+    body.desktop-native-workbench .desktop-file-actions h2 {
+      margin: 0;
+      color: var(--text-strong, #141413);
+      font: 700 20px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-file-import-grid {
+      display: grid;
+      grid-template-columns: minmax(160px, 1fr) minmax(160px, 1fr) minmax(170px, 0.82fr) minmax(180px, 1.18fr);
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 8px;
+      background: var(--panel, #faf9f5);
+    }
+
+    body.desktop-native-workbench .desktop-file-import-card,
+    body.desktop-native-workbench .desktop-file-session-card {
+      display: grid;
+      align-content: start;
+      gap: 10px;
+      min-width: 0;
+      min-height: 128px;
+      border-right: 1px solid var(--border, #e6dfd8);
+      padding: 14px;
+    }
+
+    body.desktop-native-workbench .desktop-file-import-card:last-child {
+      border-right: 0;
+    }
+
+    body.desktop-native-workbench .desktop-file-import-button {
+      display: grid;
+      grid-template-columns: 28px minmax(0, 1fr);
+      grid-template-areas: "icon label" "icon hint";
+      justify-content: start;
+      min-height: 42px;
+      border: 0;
+      padding: 0;
+      background: transparent;
+      color: var(--text, #141413);
+      text-align: left;
+      text-decoration: none;
+    }
+
+    body.desktop-native-workbench .desktop-file-import-button::before {
+      content: "↑";
+      grid-area: icon;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+      background: var(--accent-soft, #fff0ea);
+      color: var(--primary, #d85f45);
+      font: 700 16px/1 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-file-import-button span {
+      grid-area: label;
+      min-width: 0;
+      font: 700 12px/1.25 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-file-import-button small {
+      grid-area: hint;
+      min-width: 0;
+      color: var(--text-muted, #6f685f);
+      font: 12px/1.35 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-file-format-row,
+    body.desktop-native-workbench .desktop-file-session-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      align-items: center;
+      min-width: 0;
+      margin: 0;
+      color: var(--text-muted, #6f685f);
+      font: 11px/1.3 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-file-format-chip,
+    body.desktop-native-workbench .desktop-file-count-pill,
+    body.desktop-native-workbench .desktop-file-operation-status strong {
+      display: inline-flex;
+      align-items: center;
+      min-height: 20px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 999px;
+      padding: 0 7px;
+      background: var(--bg, #fffdfa);
+      color: var(--text, #141413);
+      font: 600 11px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-file-session-card label {
+      color: var(--text-strong, #141413);
+      font: 700 12px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-file-refresh {
+      min-height: 24px;
+      border: 0;
+      border-radius: 6px;
+      padding: 0 6px;
+      background: transparent;
+      color: var(--primary, #d85f45);
+      font: 700 11px/1.2 var(--font-sans, system-ui, sans-serif);
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-file-operation-strip {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(120px, 1fr)) minmax(180px, 1.2fr);
+      gap: 12px;
+      align-items: center;
+      min-width: 0;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: var(--panel, #faf9f5);
+    }
+
+    body.desktop-native-workbench .desktop-file-operation-status {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      min-width: 0;
+      font: 700 12px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-file-operation-status strong {
+      border-color: #bfe4c4;
+      background: #effaf0;
+      color: #2f7d3e;
     }
 
     body.desktop-native-workbench .desktop-file-action {
@@ -4169,17 +4421,19 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-session-upload-key {
       min-width: 0;
-      width: min(220px, 100%);
+      width: 100%;
       min-height: 34px;
       border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 0 10px;
+      background: var(--bg, #fffdfa);
+      color: var(--text, #141413);
       font: 12px/1.2 var(--font-sans, system-ui, sans-serif);
     }
 
     body.desktop-native-workbench .desktop-workspace-files {
       display: grid;
-      grid-template-columns: minmax(150px, 0.8fr) minmax(0, 1.2fr) minmax(92px, 0.5fr);
+      grid-template-columns: minmax(220px, 0.78fr) minmax(0, 1.55fr) minmax(150px, 0.48fr);
       grid-template-areas:
         "header header header"
         "browser detail actions"
@@ -4238,6 +4492,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-workspace-title-group p,
     body.desktop-native-workbench .desktop-workspace-updated-at,
+    body.desktop-native-workbench .desktop-workspace-size,
     body.desktop-native-workbench .desktop-workspace-detail,
     body.desktop-native-workbench .desktop-workspace-save-state,
     body.desktop-native-workbench .desktop-workspace-status {
@@ -4271,6 +4526,18 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       padding: 10px;
     }
 
+    body.desktop-native-workbench .desktop-workspace-search {
+      width: 100%;
+      min-width: 0;
+      min-height: 34px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 0 10px;
+      background: var(--bg, #fffdfa);
+      color: var(--text, #141413);
+      font: 12px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
     body.desktop-native-workbench .desktop-workspace-browser h3,
     body.desktop-native-workbench .desktop-workspace-detail-panel h3,
     body.desktop-native-workbench .desktop-workspace-editor-panel h3,
@@ -4297,10 +4564,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-workspace-file-row {
       min-width: 0;
-      min-height: 34px;
+      min-height: 46px;
       border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
-      padding: 0 10px;
+      padding: 7px 10px;
       overflow: hidden;
       background: var(--panel, #faf9f5);
       color: var(--text, #141413);
@@ -4309,6 +4576,30 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       text-overflow: ellipsis;
       white-space: nowrap;
       cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-file-import-button {
+      min-height: 42px;
+      border: 0;
+      padding: 0;
+      background: transparent;
+      text-decoration: none;
+    }
+
+    body.desktop-native-workbench .desktop-file-upload-status {
+      min-width: 0;
+      margin: 0;
+      overflow: hidden;
+      color: var(--text-muted, #6f685f);
+      font: 12px/1.35 var(--font-sans, system-ui, sans-serif);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-native-workbench .desktop-workspace-file-row[aria-selected="true"] {
+      border-color: var(--primary, #cc785c);
+      background: var(--accent-soft, #fff0ea);
+      color: var(--text-strong, #141413);
     }
 
     body.desktop-native-workbench .desktop-workspace-actions {
@@ -6002,6 +6293,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-detail-panel,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-editor-panel,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-action-rail,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-file-import-grid,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-file-import-card,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-file-session-card,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-file-operation-strip,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-status-strip {
       background: var(--panel);
       color: var(--text);
@@ -6023,6 +6318,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field select,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field textarea,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-file-row,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-search,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-editor,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-task-action,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-session-row,
@@ -6041,6 +6337,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       background: var(--panel-strong);
       color: var(--text);
       border-color: var(--border);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-file-import-button {
+      background: transparent;
+      border-color: transparent;
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-button:hover,
@@ -6110,7 +6411,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       }
 
       body.desktop-native-workbench .desktop-workspace-actions {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+
+      body.desktop-native-workbench .desktop-file-import-grid,
+      body.desktop-native-workbench .desktop-file-operation-strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
     }
 
@@ -6174,6 +6480,17 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       body.desktop-native-workbench .desktop-workspace-header {
         align-items: flex-start;
         flex-direction: column;
+      }
+
+      body.desktop-native-workbench .desktop-file-import-grid,
+      body.desktop-native-workbench .desktop-file-operation-strip {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      body.desktop-native-workbench .desktop-file-import-card,
+      body.desktop-native-workbench .desktop-file-session-card {
+        border-right: 0;
+        border-bottom: 1px solid var(--border, #e6dfd8);
       }
     }
   `;

--- a/apps/desktop/src/desktopWorkspaceFiles.test.ts
+++ b/apps/desktop/src/desktopWorkspaceFiles.test.ts
@@ -136,11 +136,15 @@ function matchesSelector(element: FakeElement, selector: string): boolean {
 
 function createWorkspaceShell(targetDocument: FakeDocument): void {
   const root = targetDocument.createElement("section");
+  const search = targetDocument.createElement("input");
+  search.setAttribute("id", "desktop-workspace-search");
+  root.append(search);
   for (const id of [
     "desktop-workspace-status",
     "desktop-workspace-recent-files",
     "desktop-workspace-active-path",
     "desktop-workspace-updated-at",
+    "desktop-workspace-size",
     "desktop-workspace-detail",
     "desktop-workspace-save-state",
     "desktop-workspace-error",
@@ -158,6 +162,9 @@ function createWorkspaceShell(targetDocument: FakeDocument): void {
   const reveal = targetDocument.createElement("button");
   reveal.setAttribute("id", "desktop-workspace-reveal");
   root.append(reveal);
+  const reload = targetDocument.createElement("button");
+  reload.setAttribute("id", "desktop-workspace-reload");
+  root.append(reload);
   const exportButton = targetDocument.createElement("button");
   exportButton.setAttribute("id", "desktop-workspace-export");
   root.append(exportButton);
@@ -337,6 +344,66 @@ describe("desktop workspace file adapter", () => {
       ["file:workspace:AGENTS.md:save", "saving", "Save AGENTS.md", ""],
       ["file:workspace:AGENTS.md:save", "failed", "Save AGENTS.md", "Gateway request failed: HTTP 404 file is not editable"],
     ]);
+  });
+
+  test("filters workspace files, marks the active row, shows size, and reloads after a save conflict", async () => {
+    const targetDocument = new FakeDocument();
+    createWorkspaceShell(targetDocument);
+    let loadCount = 0;
+
+    installDesktopWorkspaceFileActions({
+      targetDocument: targetDocument as unknown as Document,
+      listWorkspaceFiles: async () => ({
+        items: [
+          { path: "AGENTS.md", exists: true, updated_at: "2026-05-31T10:00:00+00:00" },
+          { path: "docs/notes.md", exists: true, updated_at: "2026-05-30T10:00:00+00:00" },
+        ],
+      }),
+      loadWorkspaceFile: async (path) => {
+        loadCount += 1;
+        return {
+          path,
+          content: loadCount > 1 ? "# Rules\n\nReloaded.\n" : "# Rules\n",
+          updated_at: loadCount > 1 ? "2026-05-31T10:30:00+00:00" : "2026-05-31T10:00:00+00:00",
+          exists: true,
+        };
+      },
+      saveWorkspaceFile: async () => {
+        throw new Error("Gateway request failed: HTTP 409");
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const search = targetDocument.getElementById("desktop-workspace-search");
+    search!.value = "notes";
+    search!.dispatchEvent("input", { target: search });
+
+    expect(targetDocument.getElementById("desktop-workspace-recent-files")?.textContent).not.toContain("AGENTS.md");
+    expect(targetDocument.getElementById("desktop-workspace-recent-files")?.textContent).toContain("docs/notes.md");
+
+    search!.value = "";
+    search!.dispatchEvent("input", { target: search });
+    targetDocument.body.querySelector("[data-desktop-workspace-file]")?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const activeRow = targetDocument.body.querySelector("[data-desktop-workspace-file]");
+    expect(activeRow?.getAttribute("aria-selected")).toBe("true");
+    expect(targetDocument.getElementById("desktop-workspace-size")?.textContent).toContain("8 B");
+
+    const editor = targetDocument.getElementById("desktop-workspace-editor");
+    editor!.value = "# Rules\n\nUse uv.\n";
+    editor!.dispatchEvent("input", { target: editor });
+    targetDocument.getElementById("desktop-workspace-save")?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(targetDocument.getElementById("desktop-workspace-error")?.textContent).toContain("Reload before saving");
+    expect(targetDocument.getElementById("desktop-workspace-reload")?.disabled).toBe(false);
+
+    targetDocument.getElementById("desktop-workspace-reload")?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect((targetDocument.getElementById("desktop-workspace-editor") as FakeElement).value).toBe("# Rules\n\nReloaded.\n");
+    expect(targetDocument.getElementById("desktop-workspace-updated-at")?.textContent).toContain("2026-05-31T10:30:00+00:00");
   });
 
   test("shows export failures without discarding unsaved workspace drafts", async () => {

--- a/apps/desktop/src/desktopWorkspaceFiles.ts
+++ b/apps/desktop/src/desktopWorkspaceFiles.ts
@@ -20,12 +20,14 @@ export interface DesktopWorkspaceFileState {
   recentPaths: string[];
   activePath: string | null;
   activeUpdatedAt: string | null;
+  activeSizeBytes: number | null;
   draft: string;
   savedDraft: string;
   dirty: boolean;
   saveState: DesktopWorkspaceSaveState;
   error: string | null;
   exportedPath: string | null;
+  searchQuery: string;
 }
 
 export interface DesktopWorkspaceFilePayload {
@@ -99,12 +101,14 @@ export function createDesktopWorkspaceFileState(
       recentPaths: previous?.recentPaths ?? [],
       activePath: previous?.activePath ?? null,
       activeUpdatedAt: previous?.activeUpdatedAt ?? null,
+      activeSizeBytes: previous?.activeSizeBytes ?? null,
       draft: previous?.draft ?? "",
       savedDraft: previous?.savedDraft ?? "",
       dirty: previous?.dirty ?? false,
       saveState: previous?.saveState ?? "idle",
       error: previous?.error ?? null,
       exportedPath: previous?.exportedPath ?? null,
+      searchQuery: previous?.searchQuery ?? "",
     };
   }
 
@@ -116,12 +120,14 @@ export function createDesktopWorkspaceFileState(
     recentPaths: updateDesktopWorkspaceRecentFiles(previous?.recentPaths ?? [], path),
     activePath: path,
     activeUpdatedAt: updatedAt,
+    activeSizeBytes: byteSize(content),
     draft: content,
     savedDraft: content,
     dirty: false,
     saveState: previous?.dirty ? "saved" : "idle",
     error: null,
     exportedPath: null,
+    searchQuery: previous?.searchQuery ?? "",
   };
 }
 
@@ -133,6 +139,7 @@ export function applyDesktopWorkspaceDraft(
   return {
     ...state,
     draft,
+    activeSizeBytes: byteSize(draft),
     dirty,
     saveState: dirty ? "dirty" : "idle",
     error: dirty ? null : state.error,
@@ -226,13 +233,28 @@ export function installDesktopWorkspaceFileActions({
 }: DesktopWorkspaceFileActions): void {
   let state = createDesktopWorkspaceFileState();
   const editor = targetDocument.querySelector<HTMLTextAreaElement>("#desktop-workspace-editor");
+  const search = targetDocument.querySelector<HTMLInputElement>("#desktop-workspace-search");
   const saveButton = targetDocument.querySelector<HTMLButtonElement>("#desktop-workspace-save");
   const revealButton = targetDocument.querySelector<HTMLButtonElement>("#desktop-workspace-reveal");
+  const reloadButton = targetDocument.querySelector<HTMLButtonElement>("#desktop-workspace-reload");
   const exportButton = targetDocument.querySelector<HTMLButtonElement>("#desktop-workspace-export");
 
   editor?.addEventListener("input", () => {
     state = applyDesktopWorkspaceDraft(state, editor.value);
     renderWorkspaceState(targetDocument, state, undefined, Boolean(revealWorkspaceFile), Boolean(exportWorkspaceFile));
+  });
+
+  search?.addEventListener("input", () => {
+    state = { ...state, searchQuery: search.value };
+    renderWorkspaceState(
+      targetDocument,
+      state,
+      (path) => {
+        void loadWorkspaceFileByPath(path);
+      },
+      Boolean(revealWorkspaceFile),
+      Boolean(exportWorkspaceFile),
+    );
   });
 
   saveButton?.addEventListener("click", () => {
@@ -241,6 +263,12 @@ export function installDesktopWorkspaceFileActions({
 
   revealButton?.addEventListener("click", () => {
     void revealActiveWorkspaceFile();
+  });
+
+  reloadButton?.addEventListener("click", () => {
+    if (state.activePath) {
+      void loadWorkspaceFileByPath(state.activePath);
+    }
   });
 
   exportButton?.addEventListener("click", () => {
@@ -445,17 +473,20 @@ function renderWorkspaceState(
 ): void {
   const recent = targetDocument.querySelector<HTMLElement>("#desktop-workspace-recent-files");
   if (recent) {
+    const query = state.searchQuery.trim().toLowerCase();
     const rows = state.recentPaths.length
       ? state.recentPaths
       : state.files.map((file) => file.path).slice(0, 6);
+    const visibleRows = rows.filter((path) => !query || path.toLowerCase().includes(query));
     recent.replaceChildren(
-      ...rows.map((path) => {
+      ...visibleRows.map((path) => {
         const button = targetDocument.createElement("button");
         button.type = "button";
         button.className = "desktop-workspace-file-row";
         button.setAttribute("data-desktop-workspace-file", path);
         button.setAttribute("data-desktop-entity-module", "workspace");
         button.setAttribute("data-desktop-entity-id", path);
+        button.setAttribute("aria-selected", state.activePath === path ? "true" : "false");
         const meta = state.files.find((file) => file.path === path)?.meta ?? "Recent";
         button.textContent = `${path} ${meta}`;
         button.addEventListener("click", () => onSelect?.(path));
@@ -468,6 +499,7 @@ function renderWorkspaceState(
   setText(targetDocument, "#desktop-workspace-status", `${state.files.length} ${fileLabel}`);
   setText(targetDocument, "#desktop-workspace-active-path", state.activePath ? `Active path: ${state.activePath}` : "No workspace file selected.");
   setText(targetDocument, "#desktop-workspace-updated-at", state.activeUpdatedAt ? `Updated: ${state.activeUpdatedAt}` : "No timestamp");
+  setText(targetDocument, "#desktop-workspace-size", typeof state.activeSizeBytes === "number" ? `Size: ${formatFileSize(state.activeSizeBytes)}` : "No size");
   setText(
     targetDocument,
     "#desktop-workspace-detail",
@@ -489,6 +521,10 @@ function renderWorkspaceState(
   const reveal = targetDocument.querySelector<HTMLButtonElement>("#desktop-workspace-reveal");
   if (reveal) {
     reveal.disabled = !state.activePath || !canReveal || state.saveState === "saving";
+  }
+  const reload = targetDocument.querySelector<HTMLButtonElement>("#desktop-workspace-reload");
+  if (reload) {
+    reload.disabled = !state.activePath || state.saveState !== "conflict-error";
   }
   const exportButton = targetDocument.querySelector<HTMLButtonElement>("#desktop-workspace-export");
   if (exportButton) {
@@ -538,6 +574,25 @@ function stringValue(value: unknown): string {
 
 function fileNameFromPath(path = ""): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? "";
+}
+
+function byteSize(value: string): number {
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(value).length;
+  }
+  return value.length;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const kib = bytes / 1024;
+  if (kib < 1024) {
+    return `${kib.toFixed(kib >= 10 ? 0 : 1)} KB`;
+  }
+  const mib = kib / 1024;
+  return `${mib.toFixed(mib >= 10 ? 0 : 1)} MB`;
 }
 
 function stringifyError(error: unknown): string {


### PR DESCRIPTION
## Summary
- Redesign the native Files page around the generated mockup with compact import cards, format chips, status strip, search, metadata, and clearer action rail
- Add click-to-select workspace import alongside drag-and-drop import
- Add session temporary file refresh/count, workspace active row state, file size display, and conflict reload behavior

## Verification
- npm test -- desktopFileUpload.test.ts desktopWorkbenchShell.test.ts desktopWorkspaceFiles.test.ts
- npm test
- npm run build

Closes #198