### PR TITLE
Fix native desktop workbench layout

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { defaultWindowIcon } from "@tauri-apps/api/app";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import webUiHtml from "../../../webui/index.html?raw";
@@ -1377,7 +1378,7 @@ function installTauriWindowFrame(runtimeStatus?: GatewayRuntimeStatus | null): v
   if (!hasTauriRuntime()) {
     return;
   }
-  installDesktopWindowFrame({ currentWindow: getCurrentWindow() });
+  installDesktopWindowFrame({ currentWindow: getCurrentWindow(), defaultWindowIcon });
   if (runtimeStatus !== undefined) {
     setDesktopWindowRuntimeStatus(runtimeStatus);
   }

--- a/apps/desktop/src/desktopTauriIconConfig.test.ts
+++ b/apps/desktop/src/desktopTauriIconConfig.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+describe("desktop Tauri icon config", () => {
+  test("uses the Tinybot icon for the native window and Windows taskbar", () => {
+    const config = JSON.parse(readFileSync(resolve(__dirname, "../src-tauri/tauri.conf.json"), "utf8"));
+
+    expect(config.app.windows[0].icon).toBeUndefined();
+    expect(config.bundle.icon).toContain("icons/icon.ico");
+    expect(readFileSync(resolve(__dirname, "../src-tauri/icons/icon.ico")).byteLength).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/desktopWindowFrame.test.ts
+++ b/apps/desktop/src/desktopWindowFrame.test.ts
@@ -186,6 +186,27 @@ describe("desktop window frame", () => {
     });
   });
 
+  test("applies the bundled Tinybot icon to the current native window", async () => {
+    const targetDocument = new FakeDocument();
+    const currentWindow = {
+      minimize: vi.fn(async () => {}),
+      toggleMaximize: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      startDragging: vi.fn(async () => {}),
+      setIcon: vi.fn(async () => {}),
+    };
+
+    installDesktopWindowFrame({
+      targetDocument: targetDocument as unknown as Document,
+      currentWindow,
+      defaultWindowIcon: async () => "tinybot-window-icon",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(currentWindow.setIcon).toHaveBeenCalledWith("tinybot-window-icon");
+  });
+
   test("updates the installed frame runtime status without replacing window controls", () => {
     const targetDocument = new FakeDocument();
     const currentWindow = {
@@ -313,6 +334,9 @@ describe("desktop window frame", () => {
     });
 
     const styleText = targetDocument.head.querySelector("#desktop-window-frame-style")?.textContent;
+    expect(styleText).toContain("--desktop-window-frame-height: 48px;");
+    expect(styleText).toContain("height: 30px;");
+    expect(styleText).toContain("width: 30px;");
     expect(styleText).toContain("--bg: #faf9f5;");
     expect(styleText).toContain("--panel-strong: #efe9de;");
     expect(styleText).toContain("--primary: #cc785c;");

--- a/apps/desktop/src/desktopWindowFrame.ts
+++ b/apps/desktop/src/desktopWindowFrame.ts
@@ -6,11 +6,13 @@ export interface DesktopWindowHandle {
   toggleMaximize(): Promise<void>;
   close(): Promise<void>;
   startDragging(): Promise<void>;
+  setIcon?(icon: unknown): Promise<void>;
 }
 
 interface InstallDesktopWindowFrameOptions {
   targetDocument?: Document;
   currentWindow: DesktopWindowHandle;
+  defaultWindowIcon?: () => Promise<unknown | null>;
 }
 
 const FRAME_ID = "desktop-window-frame";
@@ -27,9 +29,11 @@ export interface DesktopRuntimeStatusView {
 export function installDesktopWindowFrame({
   targetDocument = document,
   currentWindow,
+  defaultWindowIcon,
 }: InstallDesktopWindowFrameOptions): void {
   ensureDesktopWindowFrameStyle(targetDocument);
   targetDocument.body.classList.add("desktop-custom-frame");
+  syncDesktopWindowIcon(currentWindow, defaultWindowIcon);
 
   if (targetDocument.getElementById(FRAME_ID)) {
     setDesktopWindowContext(targetDocument);
@@ -106,6 +110,23 @@ export function installDesktopWindowFrame({
   });
 
   targetDocument.body.prepend(frame);
+}
+
+function syncDesktopWindowIcon(
+  currentWindow: DesktopWindowHandle,
+  defaultWindowIcon: (() => Promise<unknown | null>) | undefined,
+): void {
+  if (!currentWindow.setIcon || !defaultWindowIcon) {
+    return;
+  }
+  void defaultWindowIcon()
+    .then((icon) => {
+      if (!icon) {
+        return;
+      }
+      return currentWindow.setIcon?.(icon);
+    })
+    .catch(logWindowFrameError);
 }
 
 function setDesktopWindowContext(targetDocument: Document): void {
@@ -239,7 +260,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
   style.setAttribute("id", STYLE_ID);
   style.textContent = `
     :root {
-      --desktop-window-frame-height: 58px;
+      --desktop-window-frame-height: 48px;
       --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       --bg: #faf9f5;
       --bg-subtle: #f5f0e8;
@@ -269,7 +290,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       align-items: center;
       justify-content: space-between;
       height: var(--desktop-window-frame-height);
-      padding: 0 16px 0 22px;
+      padding: 0 12px 0 16px;
       border-bottom: 1px solid var(--border, #e6dfd8);
       background: #fbfaf7;
       color: var(--text, #141413);
@@ -317,7 +338,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       align-items: center;
       gap: 2px;
       min-width: 0;
-      margin-left: 24px;
+      margin-left: 18px;
       overflow: hidden;
     }
 
@@ -325,14 +346,14 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       flex: 0 1 auto;
       max-width: 136px;
       min-width: 0;
-      height: 34px;
-      padding: 0 12px;
+      height: 30px;
+      padding: 0 10px;
       border: 0;
       border-radius: 4px;
       overflow: hidden;
       background: transparent;
       color: var(--text, #141413);
-      font: 500 14px/1 var(--font-sans, system-ui, sans-serif);
+      font: 500 13px/1 var(--font-sans, system-ui, sans-serif);
       text-overflow: ellipsis;
       white-space: nowrap;
       cursor: default;
@@ -350,11 +371,11 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       max-width: min(38vw, 340px);
       overflow: hidden;
       margin-left: auto;
-      padding: 8px 14px;
+      padding: 6px 12px;
       border: 1px solid color-mix(in srgb, var(--border, #e6dfd8) 88%, transparent);
       border-radius: 999px;
       color: var(--text-muted, #6c6a64);
-      font-size: 13px;
+      font-size: 12px;
       font-weight: 600;
       line-height: 1;
       text-overflow: ellipsis;
@@ -398,13 +419,13 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       display: flex;
       align-items: center;
       align-self: stretch;
-      gap: 8px;
-      margin-left: 16px;
+      gap: 4px;
+      margin-left: 12px;
     }
 
     body.desktop-custom-frame .desktop-window-button {
-      width: 34px;
-      height: 34px;
+      width: 30px;
+      height: 30px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -427,12 +448,12 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
 
     body.desktop-custom-frame > .desktop-startup-shell {
       min-height: calc(100vh - var(--desktop-window-frame-height));
-      padding-top: calc(var(--desktop-window-frame-height) + 24px);
+      padding-top: calc(var(--desktop-window-frame-height) + 16px);
     }
 
     body.desktop-custom-frame > .shell {
-      height: calc(100vh - var(--desktop-window-frame-height) - 32px);
-      margin: calc(var(--desktop-window-frame-height) + 16px) 16px 16px;
+      height: calc(100vh - var(--desktop-window-frame-height) - 18px);
+      margin: calc(var(--desktop-window-frame-height) + 8px) 10px 10px;
     }
 
     @media (max-width: 760px) {
@@ -449,13 +470,13 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       body.desktop-custom-frame .desktop-runtime-status {
         max-width: 92px;
         margin-left: auto;
-        padding: 7px 10px;
+        padding: 6px 9px;
       }
     }
 
     @media (max-width: 1100px) {
       body.desktop-custom-frame > .shell {
-        min-height: calc(100vh - var(--desktop-window-frame-height) - 32px);
+        min-height: calc(100vh - var(--desktop-window-frame-height) - 18px);
       }
     }
   `;

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -315,7 +315,7 @@ describe("desktop workbench shell", () => {
     expect(shellText).toContain("Checked active session metadata.");
     expect(shellText).toContain("tool: read_file");
     expect(shellText).toContain("docs/desktop.md");
-    expect(shellText).toContain("Loaded from gateway");
+    expect(shellText).not.toContain("Loaded from gateway");
     expect(shellText).not.toContain("Design native workbench");
     expect(shellText).not.toContain("tinybot_native_workbench_design.png");
     expect(shellText).not.toContain("ai-rvc");
@@ -390,7 +390,7 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.getElementById("desktop-workbench-shell")).toBe(shell);
     expect(targetDocument.body.textContent).toContain("Updated live session");
     expect(targetDocument.body.textContent).toContain("Updated without full shell reinstall.");
-    expect(targetDocument.body.textContent).toContain("Updated status");
+    expect(targetDocument.body.textContent).not.toContain("Updated status");
     expect(targetDocument.getElementById("desktop-native-composer")?.getAttribute("data-desktop-composer-responding")).toBe("true");
     expect(targetDocument.getElementById("desktop-native-composer")?.getAttribute("data-desktop-composer-rag")).toBe("false");
     expect(targetDocument.getElementById("desktop-native-composer")?.getAttribute("data-desktop-composer-state")).toBe("queued");
@@ -904,6 +904,40 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector(".desktop-chat-header")?.textContent).not.toContain("New session");
   });
 
+  test("keeps chat header actions compact and owns sidebar and run-chain toggles there", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-1", chatId: "chat-1", title: "Session one", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-1",
+        activeChatId: "chat-1",
+        messages: [],
+        status: "Session loaded from gateway.",
+      },
+    });
+
+    const header = targetDocument.body.querySelector(".desktop-chat-header");
+    expect(header?.textContent).toContain("Session one");
+    expect(header?.textContent).toContain("...");
+    expect(header?.textContent).not.toContain("Session loaded from gateway.");
+    expect(targetDocument.body.querySelector(".desktop-chat-runtime-status")).toBeNull();
+    expect(header?.querySelector(".desktop-chat-menu")?.getAttribute("data-desktop-chat-menu")).toBe("more");
+    expect(header?.querySelector(".desktop-chat-menu")?.textContent).toBe("...");
+    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Collapse session list");
+    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-label")).toBe("Close Run Chain panel");
+    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.textContent).toBe("▌");
+    expect(targetDocument.body.querySelector("[data-desktop-inspector-restore]")).toBeNull();
+
+    header?.querySelector('[data-desktop-panel-control="sidebar"]')?.click();
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("false");
+    expect(targetDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("false");
+    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Expand session list");
+  });
+
   test("renders keyboard-operable panel controls with accessible labels", () => {
     const targetDocument = new FakeDocument();
 
@@ -986,11 +1020,11 @@ describe("desktop workbench shell", () => {
     overview?.querySelector('[data-desktop-run-chain-control="close"]')?.click();
     const restore = targetDocument.body.querySelector("[data-desktop-inspector-restore]");
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
-    expect(restore?.textContent).toContain("Open Run Chain");
-    restore?.click();
+    expect(restore).toBeNull();
+    targetDocument.body.querySelector(".desktop-chat-header")?.querySelector('[data-desktop-panel-control="inspector"]')?.click();
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("true");
     expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("true");
-    expect(targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-pressed")).toBe("true");
+    expect(targetDocument.body.querySelectorAll('[data-desktop-panel-control="inspector"]').map((node) => node.getAttribute("aria-pressed"))).toContain("true");
   });
 
   test("renders a persistent run-chain inspector pane with selectable details", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -397,7 +397,7 @@ export function updateDesktopNativeChat(
   syncNativeChatDocumentState(targetDocument, chat);
   const header = targetDocument.querySelector<HTMLElement>(".desktop-chat-header");
   if (header) {
-    const next = createChatHeader(targetDocument, chat);
+    const next = createChatHeader(targetDocument, chat, readCurrentWorkbenchLayout(targetDocument));
     header.replaceChildren(...Array.from(next.children));
   }
 
@@ -795,13 +795,12 @@ function createMainRegion(
   const workbench = targetDocument.createElement("div");
   workbench.className = "desktop-empty-session desktop-chat-workbench";
   workbench.append(
-    createChatHeader(targetDocument, chat),
+    createChatHeader(targetDocument, chat, layout),
     createConversationThread(targetDocument, chat),
     createText(targetDocument, "span", "Ready for a new session"),
     createText(targetDocument, "span", "Start from chat, inspect workspace, or check gateway status."),
     createQuickActions(targetDocument),
     createPanelControls(targetDocument, layout),
-    createInspectorRestoreButton(targetDocument, layout),
     createWorkLensInlineHost(targetDocument, layout.inspector.visible ? null : workLens, workLensActions),
     ...(chatWorkItems.length ? [createModuleWorkSection(targetDocument, "Chat runs", chatWorkItems)] : []),
   );
@@ -829,24 +828,106 @@ function createMainRegion(
   return main;
 }
 
-function createChatHeader(targetDocument: Document, chat: DesktopNativeChatModel | null): HTMLElement {
+function createChatHeader(
+  targetDocument: Document,
+  chat: DesktopNativeChatModel | null,
+  layout: WorkbenchLayoutState,
+): HTMLElement {
   const header = targetDocument.createElement("header");
   header.className = "desktop-chat-header";
+
+  const titleRow = targetDocument.createElement("div");
+  titleRow.className = "desktop-chat-title-row";
+
   const title = targetDocument.createElement("h1");
   title.textContent = activeChatTitle(chat);
+
   const menu = targetDocument.createElement("button");
   menu.type = "button";
   menu.className = "desktop-chat-menu";
+  menu.setAttribute("data-desktop-chat-menu", "more");
   menu.setAttribute("aria-label", "More chat actions");
   menu.textContent = "...";
-  header.append(title);
-  if (chat?.status) {
-    const status = createText(targetDocument, "span", chat.status);
-    status.className = "desktop-chat-runtime-status";
-    header.append(status);
-  }
-  header.append(menu);
+
+  titleRow.append(title, menu);
+
+  const actions = targetDocument.createElement("div");
+  actions.className = "desktop-chat-header-actions";
+  actions.append(
+    createHeaderPanelControl(targetDocument, {
+      panel: "sidebar",
+      visible: layout.sidebar.visible,
+      label: "▏",
+      pressedLabel: "Collapse session list",
+      unpressedLabel: "Expand session list",
+    }),
+    createHeaderPanelControl(targetDocument, {
+      panel: "inspector",
+      visible: layout.inspector.visible,
+      label: "▌",
+      pressedLabel: "Close Run Chain panel",
+      unpressedLabel: "Open Run Chain panel",
+    }),
+  );
+
+  header.append(titleRow, actions);
   return header;
+}
+
+function readCurrentWorkbenchLayout(targetDocument: Document): WorkbenchLayoutState {
+  const shell = targetDocument.getElementById(SHELL_ID);
+  return {
+    sidebar: {
+      visible: shell?.getAttribute("data-sidebar-visible") !== "false",
+      size: 260,
+    },
+    inspector: {
+      visible: shell?.getAttribute("data-inspector-visible") !== "false",
+      size: 360,
+    },
+    bottom: {
+      visible: shell?.getAttribute("data-bottom-visible") === "true",
+      size: 220,
+    },
+  };
+}
+
+function createHeaderPanelControl(
+  targetDocument: Document,
+  {
+    panel,
+    visible,
+    label,
+    pressedLabel,
+    unpressedLabel,
+  }: {
+    panel: DesktopPanelControlId;
+    visible: boolean;
+    label: string;
+    pressedLabel: string;
+    unpressedLabel: string;
+  },
+): HTMLElement {
+  const button = targetDocument.createElement("button");
+  button.type = "button";
+  button.className = "desktop-chat-header-panel-button";
+  button.setAttribute("data-desktop-panel-control", panel);
+  button.setAttribute("data-desktop-panel-label-pressed", pressedLabel);
+  button.setAttribute("data-desktop-panel-label-unpressed", unpressedLabel);
+  button.setAttribute("aria-label", visible ? pressedLabel : unpressedLabel);
+  button.setAttribute("aria-pressed", String(visible));
+  button.textContent = label;
+  button.addEventListener("click", () => {
+    toggleDesktopPanel(targetDocument, panel);
+  });
+  button.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+    event.preventDefault();
+    toggleDesktopPanel(targetDocument, panel);
+  });
+  return button;
 }
 
 function createConversationThread(targetDocument: Document, chat: DesktopNativeChatModel | null): HTMLElement {
@@ -2471,24 +2552,6 @@ function createPanelControls(targetDocument: Document, layout: WorkbenchLayoutSt
   return controls;
 }
 
-function createInspectorRestoreButton(targetDocument: Document, layout: WorkbenchLayoutState): HTMLElement {
-  const button = targetDocument.createElement("button");
-  button.type = "button";
-  button.className = "desktop-inspector-restore";
-  button.setAttribute("data-desktop-inspector-restore", "");
-  button.setAttribute("aria-label", "Open Run Chain panel");
-  button.setAttribute("aria-hidden", String(layout.inspector.visible));
-  button.textContent = "Open Run Chain";
-  button.addEventListener("click", () => {
-    const shell = targetDocument.getElementById(SHELL_ID);
-    if (shell?.getAttribute("data-inspector-visible") !== "false") {
-      return;
-    }
-    toggleDesktopPanel(targetDocument, "inspector");
-  });
-  return button;
-}
-
 function toggleDesktopPanel(targetDocument: Document, panel: DesktopPanelControlId): void {
   const shell = targetDocument.getElementById(SHELL_ID);
   const panelElement = targetDocument.querySelector<HTMLElement>(`[data-workbench-region="${panel}"]`);
@@ -2497,13 +2560,12 @@ function toggleDesktopPanel(targetDocument: Document, panel: DesktopPanelControl
   const nextVisible = currentValue === "false";
   shell?.setAttribute(stateAttribute, String(nextVisible));
   panelElement?.setAttribute("data-visible", String(nextVisible));
-  targetDocument
-    .querySelector<HTMLElement>(`[data-desktop-panel-control="${panel}"]`)
-    ?.setAttribute("aria-pressed", String(nextVisible));
-  if (panel === "inspector") {
-    targetDocument
-      .querySelector<HTMLElement>("[data-desktop-inspector-restore]")
-      ?.setAttribute("aria-hidden", String(nextVisible));
+  for (const control of targetDocument.querySelectorAll<HTMLElement>(`[data-desktop-panel-control="${panel}"]`)) {
+    control.setAttribute("aria-pressed", String(nextVisible));
+    const label = control.getAttribute(nextVisible ? "data-desktop-panel-label-pressed" : "data-desktop-panel-label-unpressed");
+    if (label) {
+      control.setAttribute("aria-label", label);
+    }
   }
 
   const status = targetDocument.querySelector<HTMLElement>("[data-desktop-route-status]");
@@ -4215,6 +4277,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workspace-file-row:focus-visible,
     body.desktop-native-workbench .desktop-workspace-editor:focus-visible,
     body.desktop-native-workbench .desktop-inspector-restore:focus-visible,
+    body.desktop-native-workbench .desktop-chat-header-panel-button:focus-visible,
     body.desktop-native-workbench .desktop-run-chain-icon-button:focus-visible,
     body.desktop-native-workbench .desktop-run-chain-summary-item:focus-visible,
     body.desktop-native-workbench .desktop-run-chain-tab:focus-visible,
@@ -5049,12 +5112,19 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 16px;
+      gap: 12px;
       min-width: 0;
-      min-height: 72px;
+      min-height: 54px;
       border-bottom: 1px solid #e9e4df;
-      padding: 0 28px;
+      padding: 0 18px;
       background: #ffffff;
+    }
+
+    body.desktop-native-workbench .desktop-chat-title-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
     }
 
     body.desktop-native-workbench .desktop-chat-header h1 {
@@ -5067,15 +5137,42 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       letter-spacing: 0;
     }
 
+    body.desktop-native-workbench .desktop-chat-header-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex: 0 0 auto;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-chat-header-panel-button,
     body.desktop-native-workbench .desktop-chat-menu {
-      width: 40px;
-      height: 40px;
-      border: 1px solid #e6dfd8;
-      border-radius: 8px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 30px;
+      height: 30px;
+      min-width: 30px;
+      min-height: 30px;
+      border: 0;
+      border-radius: 6px;
       background: #ffffff;
       color: #262522;
       font: 700 16px/1 var(--font-sans);
       cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-chat-header-panel-button {
+      border: 1px solid #e4ddd6;
+      color: #59544f;
+      font-size: 15px;
+    }
+
+    body.desktop-native-workbench .desktop-chat-menu:hover,
+    body.desktop-native-workbench .desktop-chat-menu:focus-visible,
+    body.desktop-native-workbench .desktop-chat-header-panel-button:hover,
+    body.desktop-native-workbench .desktop-chat-header-panel-button:focus-visible {
+      background: #f7f2ed;
     }
 
     body.desktop-native-workbench .desktop-conversation-thread {
@@ -6437,7 +6534,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       }
 
       body.desktop-native-workbench .desktop-chat-header {
-        min-height: 84px;
+        min-height: 54px;
         padding: 0 16px;
       }
 


### PR DESCRIPTION
## Summary

Fixes #204.

- Reduces native desktop top chrome height and tightens window controls, menu items, and runtime pill spacing.
- Moves native chat header controls into a compact session-title row: unboxed overflow menu plus icon-only sidebar and Run Chain panel toggles.
- Hides transient chat status text such as `Session loaded from gateway.` from the message/header content.
- Removes the floating `Open Run Chain` restore button and restores the right panel through the header icon instead.
- Applies the bundled Tinybot default window icon to the current native Tauri window at runtime, so the app/taskbar icon does not fall back to the Tauri default.

## Validation

- `npm test` in `apps/desktop` — 48 files, 285 tests passed.
- `npm run build` in `apps/desktop` — passed; existing Vite chunk-size warning remains.
- `npm run tauri -- info` in `apps/desktop` — passed and validates Tauri config loading.

## Notes

- In-app browser verification could only reach the non-Tauri browser fallback (`Tinybot gateway is not ready`) because native workbench mounting requires the Tauri runtime. The native behavior is covered by the desktop unit tests above.