### PR TITLE
Improve native chat header actions

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -995,6 +995,39 @@ describe("desktop workbench shell", () => {
     expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.textContent).toContain("Run Chain");
   });
 
+  test("preserves pinned sessions when native chat refreshes", () => {
+    const targetDocument = new FakeDocument();
+    const chat = {
+      sessions: [
+        { key: "WebSocket:chat-2", chatId: "chat-2", title: "Session two", createdAt: "", updatedAt: "" },
+        { key: "WebSocket:chat-1", chatId: "chat-1", title: "Session one", createdAt: "", updatedAt: "" },
+      ],
+      activeSessionKey: "WebSocket:chat-1",
+      activeChatId: "chat-1",
+      messages: [],
+    };
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat,
+    });
+
+    const header = targetDocument.body.querySelector(".desktop-chat-header");
+    header?.querySelector(".desktop-chat-menu")?.click();
+    header?.querySelector('[data-desktop-chat-menu-action="pin"]')?.click();
+
+    updateDesktopNativeChat(targetDocument as unknown as Document, chat, "http://127.0.0.1:18790");
+
+    const firstRow = targetDocument.body.querySelector('[data-desktop-session-key]');
+    expect(firstRow?.getAttribute("data-desktop-session-key")).toBe("WebSocket:chat-1");
+    expect(firstRow?.getAttribute("data-pinned")).toBe("true");
+    const refreshedHeader = targetDocument.body.querySelector(".desktop-chat-header");
+    refreshedHeader?.querySelector(".desktop-chat-menu")?.click();
+    expect(refreshedHeader?.querySelector('[data-desktop-chat-menu-action="pin"]')?.textContent).toBe("Unpin session");
+  });
+
   test("renders keyboard-operable panel controls with accessible labels", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -929,13 +929,70 @@ describe("desktop workbench shell", () => {
     expect(header?.querySelector(".desktop-chat-menu")?.textContent).toBe("...");
     expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Collapse session list");
     expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-label")).toBe("Close Run Chain panel");
-    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.textContent).toBe("▌");
+    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.textContent).toContain("Sessions");
+    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.textContent).toContain("Run Chain");
     expect(targetDocument.body.querySelector("[data-desktop-inspector-restore]")).toBeNull();
 
     header?.querySelector('[data-desktop-panel-control="sidebar"]')?.click();
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("false");
     expect(targetDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("false");
     expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Expand session list");
+  });
+
+  test("opens chat header menu actions and updates the active session affordances", () => {
+    const targetDocument = new FakeDocument();
+    (targetDocument as unknown as { defaultView: { prompt: () => string } }).defaultView = {
+      prompt: () => "Renamed session",
+    };
+    const pinEvents: unknown[] = [];
+    const renameEvents: unknown[] = [];
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [
+          { key: "WebSocket:chat-2", chatId: "chat-2", title: "Session two", createdAt: "", updatedAt: "" },
+          { key: "WebSocket:chat-1", chatId: "chat-1", title: "Session one", createdAt: "", updatedAt: "" },
+        ],
+        activeSessionKey: "WebSocket:chat-1",
+        activeChatId: "chat-1",
+        messages: [],
+      },
+      chatActions: {
+        onPinSession: (event) => pinEvents.push(event),
+        onRenameSession: (event) => renameEvents.push(event),
+      },
+    });
+
+    const header = targetDocument.body.querySelector(".desktop-chat-header");
+    const menu = header?.querySelector(".desktop-chat-menu");
+    const popover = header?.querySelector(".desktop-chat-menu-popover") as unknown as { hidden: boolean } | null;
+    expect(menu?.getAttribute("aria-expanded")).toBe("false");
+    expect(popover?.hidden).toBe(true);
+
+    menu?.click();
+    expect(menu?.getAttribute("aria-expanded")).toBe("true");
+    expect(popover?.hidden).toBe(false);
+    header?.querySelector('[data-desktop-chat-menu-action="pin"]')?.click();
+    expect(pinEvents).toEqual([{ sessionKey: "WebSocket:chat-1", chatId: "chat-1", title: "Session one", pinned: true }]);
+    expect(targetDocument.body.querySelector('[data-desktop-session-key]')?.getAttribute("data-desktop-session-key")).toBe(
+      "WebSocket:chat-1",
+    );
+    expect(targetDocument.body.querySelector('[data-desktop-session-key]')?.getAttribute("data-pinned")).toBe("true");
+    expect(header?.querySelector('[data-desktop-chat-menu-action="pin"]')?.textContent).toBe("Unpin session");
+    expect(menu?.getAttribute("aria-expanded")).toBe("false");
+
+    menu?.click();
+    header?.querySelector('[data-desktop-chat-menu-action="rename"]')?.click();
+    expect(renameEvents).toEqual([{ sessionKey: "WebSocket:chat-1", chatId: "chat-1", title: "Renamed session" }]);
+    expect(header?.querySelector(".desktop-chat-title")?.textContent).toBe("Renamed session");
+    expect(targetDocument.body.querySelector('[data-desktop-session-key]')?.querySelector(".desktop-sidebar-row-label")?.textContent).toBe(
+      "Renamed session",
+    );
+    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.textContent).toContain("Sessions");
+    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.textContent).toContain("Run Chain");
   });
 
   test("renders keyboard-operable panel controls with accessible labels", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -95,12 +95,27 @@ export interface DesktopNativeChatDeleteSessionEvent {
   title: string;
 }
 
+export interface DesktopNativeChatPinSessionEvent {
+  sessionKey: string;
+  chatId: string;
+  title: string;
+  pinned: boolean;
+}
+
+export interface DesktopNativeChatRenameSessionEvent {
+  sessionKey: string;
+  chatId: string;
+  title: string;
+}
+
 interface DesktopNativeChatActionOptions {
   onComposerSubmit?: (event: DesktopNativeChatComposerSubmitEvent) => void;
   onInterrupt?: () => void;
   onAttachSessionFile?: () => void;
   onNewChat?: () => void;
   onDeleteSession?: (event: DesktopNativeChatDeleteSessionEvent) => void;
+  onPinSession?: (event: DesktopNativeChatPinSessionEvent) => void;
+  onRenameSession?: (event: DesktopNativeChatRenameSessionEvent) => void;
   onPersistentRagChange?: (enabled: boolean) => void;
 }
 
@@ -397,7 +412,7 @@ export function updateDesktopNativeChat(
   syncNativeChatDocumentState(targetDocument, chat);
   const header = targetDocument.querySelector<HTMLElement>(".desktop-chat-header");
   if (header) {
-    const next = createChatHeader(targetDocument, chat, readCurrentWorkbenchLayout(targetDocument));
+    const next = createChatHeader(targetDocument, chat, readCurrentWorkbenchLayout(targetDocument), chatActions);
     header.replaceChildren(...Array.from(next.children));
   }
 
@@ -662,6 +677,10 @@ function createRecentChatRow(
   row.setAttribute("role", "listitem");
   row.setAttribute("data-active", String(active));
   row.setAttribute("data-sidebar-row-kind", "chat");
+  row.setAttribute("data-desktop-session-key", session.key);
+  row.setAttribute("data-desktop-chat-id", session.chatId);
+  row.setAttribute("data-desktop-route-id", routeId);
+  row.setAttribute("data-pinned", "false");
 
   const link = targetDocument.createElement("a");
   link.className = "desktop-sidebar-row desktop-sidebar-row-main";
@@ -795,7 +814,7 @@ function createMainRegion(
   const workbench = targetDocument.createElement("div");
   workbench.className = "desktop-empty-session desktop-chat-workbench";
   workbench.append(
-    createChatHeader(targetDocument, chat, layout),
+    createChatHeader(targetDocument, chat, layout, chatActions),
     createConversationThread(targetDocument, chat),
     createText(targetDocument, "span", "Ready for a new session"),
     createText(targetDocument, "span", "Start from chat, inspect workspace, or check gateway status."),
@@ -832,6 +851,7 @@ function createChatHeader(
   targetDocument: Document,
   chat: DesktopNativeChatModel | null,
   layout: WorkbenchLayoutState,
+  chatActions: DesktopNativeChatActionOptions = {},
 ): HTMLElement {
   const header = targetDocument.createElement("header");
   header.className = "desktop-chat-header";
@@ -839,17 +859,28 @@ function createChatHeader(
   const titleRow = targetDocument.createElement("div");
   titleRow.className = "desktop-chat-title-row";
 
+  const activeSession = activeChatSession(chat);
   const title = targetDocument.createElement("h1");
+  title.className = "desktop-chat-title";
   title.textContent = activeChatTitle(chat);
 
   const menu = targetDocument.createElement("button");
   menu.type = "button";
   menu.className = "desktop-chat-menu";
   menu.setAttribute("data-desktop-chat-menu", "more");
+  menu.setAttribute("aria-haspopup", "menu");
+  menu.setAttribute("aria-expanded", "false");
   menu.setAttribute("aria-label", "More chat actions");
   menu.textContent = "...";
 
-  titleRow.append(title, menu);
+  const popover = createChatMenuPopover(targetDocument, chat, activeSession, title, menu, chatActions);
+  menu.addEventListener("click", () => {
+    const expanded = menu.getAttribute("aria-expanded") === "true";
+    menu.setAttribute("aria-expanded", String(!expanded));
+    popover.hidden = expanded;
+  });
+
+  titleRow.append(title, menu, popover);
 
   const actions = targetDocument.createElement("div");
   actions.className = "desktop-chat-header-actions";
@@ -872,6 +903,144 @@ function createChatHeader(
 
   header.append(titleRow, actions);
   return header;
+}
+
+function activeChatSession(chat: DesktopNativeChatModel | null): NativeChatSession | null {
+  if (!chat?.activeSessionKey) {
+    return null;
+  }
+  return chat.sessions.find((session) => session.key === chat.activeSessionKey) ?? null;
+}
+
+function createChatMenuPopover(
+  targetDocument: Document,
+  chat: DesktopNativeChatModel | null,
+  session: NativeChatSession | null,
+  titleElement: HTMLElement,
+  trigger: HTMLElement,
+  chatActions: DesktopNativeChatActionOptions,
+): HTMLElement {
+  const popover = targetDocument.createElement("div");
+  popover.className = "desktop-chat-menu-popover";
+  popover.setAttribute("role", "menu");
+  popover.setAttribute("aria-label", "Chat session actions");
+  popover.hidden = true;
+
+  const close = () => {
+    popover.hidden = true;
+    trigger.setAttribute("aria-expanded", "false");
+  };
+
+  const appendAction = (action: string, label: string, handler: (button: HTMLElement) => void, disabled = false) => {
+    const button = targetDocument.createElement("button");
+    button.type = "button";
+    button.className = "desktop-chat-menu-action";
+    button.setAttribute("role", "menuitem");
+    button.setAttribute("data-desktop-chat-menu-action", action);
+    button.textContent = label;
+    if (disabled) {
+      button.setAttribute("disabled", "");
+    }
+    button.addEventListener("click", (event) => {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      if (disabled) {
+        return;
+      }
+      handler(button);
+      close();
+    });
+    popover.append(button);
+    return button;
+  };
+
+  appendAction(
+    "pin",
+    "Pin session",
+    (button) => {
+      if (!session) {
+        return;
+      }
+      const pinned = toggleActiveSessionPinned(targetDocument, session);
+      button.textContent = pinned ? "Unpin session" : "Pin session";
+      chatActions.onPinSession?.({
+        sessionKey: session.key,
+        chatId: session.chatId,
+        title: session.title || "New session",
+        pinned,
+      });
+    },
+    !session,
+  );
+  appendAction(
+    "rename",
+    "Rename session",
+    () => {
+      if (!session) {
+        return;
+      }
+      const renamedTitle = promptForSessionTitle(targetDocument, session.title || "New session");
+      if (!renamedTitle) {
+        return;
+      }
+      session.title = renamedTitle;
+      titleElement.textContent = renamedTitle;
+      updateSessionRowTitle(targetDocument, session.key, renamedTitle);
+      chatActions.onRenameSession?.({
+        sessionKey: session.key,
+        chatId: session.chatId,
+        title: renamedTitle,
+      });
+    },
+    !session,
+  );
+  appendAction("new-chat", "New chat", () => chatActions.onNewChat?.(), !chatActions.onNewChat);
+
+  if (!chat?.sessions.length) {
+    const empty = createText(targetDocument, "span", "No active session");
+    empty.className = "desktop-chat-menu-empty";
+    popover.append(empty);
+  }
+
+  return popover;
+}
+
+function promptForSessionTitle(targetDocument: Document, currentTitle: string): string | null {
+  const prompt = (targetDocument as Document & {
+    defaultView?: { prompt?: (message?: string, defaultValue?: string) => string | null };
+  }).defaultView?.prompt;
+  const nextTitle = prompt?.("Rename session", currentTitle)?.trim();
+  if (!nextTitle || nextTitle === currentTitle) {
+    return null;
+  }
+  return nextTitle;
+}
+
+function toggleActiveSessionPinned(targetDocument: Document, session: NativeChatSession): boolean {
+  const row = findSessionRow(targetDocument, session.key);
+  const pinned = row?.getAttribute("data-pinned") !== "true";
+  row?.setAttribute("data-pinned", String(pinned));
+  if (pinned) {
+    const list = targetDocument.querySelector<HTMLElement>(".desktop-recent-chat-list");
+    if (list && row) {
+      const rows = Array.from(list.children).filter((child) => child !== row);
+      list.replaceChildren(row, ...rows);
+    }
+  }
+  return pinned;
+}
+
+function updateSessionRowTitle(targetDocument: Document, sessionKey: string, title: string): void {
+  const row = findSessionRow(targetDocument, sessionKey);
+  const label = row?.querySelector<HTMLElement>(".desktop-sidebar-row-label");
+  if (label) {
+    label.textContent = title;
+  }
+}
+
+function findSessionRow(targetDocument: Document, sessionKey: string): HTMLElement | null {
+  return Array.from(targetDocument.querySelectorAll<HTMLElement>("[data-desktop-session-key]"))
+    .find((row) => row.getAttribute("data-desktop-session-key") === sessionKey) ?? null;
 }
 
 function readCurrentWorkbenchLayout(targetDocument: Document): WorkbenchLayoutState {
@@ -916,7 +1085,18 @@ function createHeaderPanelControl(
   button.setAttribute("data-desktop-panel-label-unpressed", unpressedLabel);
   button.setAttribute("aria-label", visible ? pressedLabel : unpressedLabel);
   button.setAttribute("aria-pressed", String(visible));
-  button.textContent = label;
+  const displayLabel = panel === "sidebar" ? "Sessions" : panel === "inspector" ? "Run Chain" : label;
+  const displayIcon = panel === "sidebar" ? "||" : panel === "inspector" ? "[]" : "";
+  if (displayIcon) {
+    const icon = createText(targetDocument, "span", displayIcon);
+    icon.className = "desktop-chat-header-panel-icon";
+    icon.setAttribute("aria-hidden", "true");
+    const text = createText(targetDocument, "span", displayLabel);
+    text.className = "desktop-chat-header-panel-label";
+    button.append(icon, text);
+  } else {
+    button.textContent = displayLabel;
+  }
   button.addEventListener("click", () => {
     toggleDesktopPanel(targetDocument, panel);
   });
@@ -5058,6 +5238,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       color: #b4533c;
     }
 
+    body.desktop-native-workbench .desktop-sidebar-chat-row[data-pinned="true"] {
+      border-color: #e9cabe;
+      background: #fbf2ee;
+    }
+
     body.desktop-native-workbench .desktop-sidebar-row-label,
     body.desktop-native-workbench .desktop-sidebar-row-meta {
       min-width: 0;
@@ -5121,6 +5306,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-chat-title-row {
+      position: relative;
       display: flex;
       align-items: center;
       gap: 8px;
@@ -5150,7 +5336,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 30px;
       height: 30px;
       min-width: 30px;
       min-height: 30px;
@@ -5163,9 +5348,23 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-chat-header-panel-button {
+      gap: 7px;
+      min-width: 0;
+      padding: 0 10px;
       border: 1px solid #e4ddd6;
       color: #59544f;
-      font-size: 15px;
+      font: 650 12px/1 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-chat-header-panel-icon {
+      color: #8b8580;
+      font: 700 11px/1 var(--font-mono);
+    }
+
+    body.desktop-native-workbench .desktop-chat-menu {
+      width: 30px;
+      padding: 0;
+      font-size: 16px;
     }
 
     body.desktop-native-workbench .desktop-chat-menu:hover,
@@ -5173,6 +5372,48 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-chat-header-panel-button:hover,
     body.desktop-native-workbench .desktop-chat-header-panel-button:focus-visible {
       background: #f7f2ed;
+    }
+
+    body.desktop-native-workbench .desktop-chat-menu-popover {
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      z-index: 8;
+      display: grid;
+      gap: 4px;
+      min-width: 176px;
+      border: 1px solid #e5ddd7;
+      border-radius: 8px;
+      padding: 6px;
+      background: #ffffff;
+      box-shadow: 0 12px 26px rgba(42, 34, 27, 0.14);
+    }
+
+    body.desktop-native-workbench .desktop-chat-menu-popover[hidden] {
+      display: none;
+    }
+
+    body.desktop-native-workbench .desktop-chat-menu-action {
+      min-height: 30px;
+      border: 0;
+      border-radius: 6px;
+      padding: 0 10px;
+      background: transparent;
+      color: #262522;
+      font: 600 13px/1.2 var(--font-sans);
+      text-align: left;
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-chat-menu-action:hover,
+    body.desktop-native-workbench .desktop-chat-menu-action:focus-visible {
+      background: #f7f2ed;
+    }
+
+    body.desktop-native-workbench .desktop-chat-menu-empty {
+      padding: 7px 10px;
+      color: #77736f;
+      font: 500 12px/1.2 var(--font-sans);
     }
 
     body.desktop-native-workbench .desktop-conversation-thread {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -53,6 +53,8 @@ import {
 import { installDesktopDesignTokens } from "./desktopDesignTokens";
 import type { NativeChatMessage, NativeChatSession } from "./nativeChat";
 
+const desktopPinnedChatSessions = new WeakMap<Document, Set<string>>();
+
 export interface DesktopTaskCenterActionEvent {
   action: DesktopTaskActionId;
   item: DesktopTaskCenterItem;
@@ -632,10 +634,20 @@ function createSidebarRecentChats(
   list.className = "desktop-recent-chat-list";
   list.setAttribute("role", "list");
   if (chat) {
-    const sessions = chat.sessions.length ? chat.sessions : [];
+    const pinnedSessionKeys = pinnedSessionKeysForDocument(targetDocument);
+    const sessions = chat.sessions.length
+      ? sortPinnedSessionsFirst(chat.sessions, pinnedSessionKeys)
+      : [];
     for (const session of sessions) {
       const routeId = desktopChatRouteId(session);
-      list.append(createRecentChatRow(targetDocument, session, session.key === chat.activeSessionKey, chatActions, routeId));
+      list.append(createRecentChatRow(
+        targetDocument,
+        session,
+        session.key === chat.activeSessionKey,
+        chatActions,
+        routeId,
+        pinnedSessionKeys.has(session.key),
+      ));
     }
     if (!sessions.length) {
       list.append(createText(targetDocument, "p", "No recent chats."));
@@ -665,12 +677,19 @@ function desktopChatRouteId(session: NativeChatSession): string {
   return session.chatId || session.key;
 }
 
+function sortPinnedSessionsFirst(sessions: NativeChatSession[], pinnedSessionKeys: Set<string>): NativeChatSession[] {
+  return [...sessions].sort(
+    (left, right) => Number(pinnedSessionKeys.has(right.key)) - Number(pinnedSessionKeys.has(left.key)),
+  );
+}
+
 function createRecentChatRow(
   targetDocument: Document,
   session: NativeChatSession,
   active: boolean,
   chatActions: DesktopNativeChatActionOptions,
   routeId = desktopChatRouteId(session),
+  pinned = false,
 ): HTMLElement {
   const row = targetDocument.createElement("div");
   row.className = "desktop-sidebar-chat-row";
@@ -680,7 +699,7 @@ function createRecentChatRow(
   row.setAttribute("data-desktop-session-key", session.key);
   row.setAttribute("data-desktop-chat-id", session.chatId);
   row.setAttribute("data-desktop-route-id", routeId);
-  row.setAttribute("data-pinned", "false");
+  row.setAttribute("data-pinned", String(pinned));
 
   const link = targetDocument.createElement("a");
   link.className = "desktop-sidebar-row desktop-sidebar-row-main";
@@ -954,9 +973,10 @@ function createChatMenuPopover(
     return button;
   };
 
+  const initialPinned = session ? isSessionPinned(targetDocument, session.key) : false;
   appendAction(
     "pin",
-    "Pin session",
+    initialPinned ? "Unpin session" : "Pin session",
     (button) => {
       if (!session) {
         return;
@@ -1016,9 +1036,32 @@ function promptForSessionTitle(targetDocument: Document, currentTitle: string): 
   return nextTitle;
 }
 
+function pinnedSessionKeysForDocument(targetDocument: Document): Set<string> {
+  let keys = desktopPinnedChatSessions.get(targetDocument);
+  if (!keys) {
+    keys = new Set<string>();
+    desktopPinnedChatSessions.set(targetDocument, keys);
+  }
+  return keys;
+}
+
+function isSessionPinned(targetDocument: Document, sessionKey: string): boolean {
+  return pinnedSessionKeysForDocument(targetDocument).has(sessionKey);
+}
+
+function setSessionPinned(targetDocument: Document, sessionKey: string, pinned: boolean): void {
+  const keys = pinnedSessionKeysForDocument(targetDocument);
+  if (pinned) {
+    keys.add(sessionKey);
+    return;
+  }
+  keys.delete(sessionKey);
+}
+
 function toggleActiveSessionPinned(targetDocument: Document, session: NativeChatSession): boolean {
   const row = findSessionRow(targetDocument, session.key);
-  const pinned = row?.getAttribute("data-pinned") !== "true";
+  const pinned = !isSessionPinned(targetDocument, session.key);
+  setSessionPinned(targetDocument, session.key, pinned);
   row?.setAttribute("data-pinned", String(pinned));
   if (pinned) {
     const list = targetDocument.querySelector<HTMLElement>(".desktop-recent-chat-list");


### PR DESCRIPTION
## Summary
- Add a working native chat header overflow menu with pin, rename, and new chat actions.
- Redesign the header panel controls so Session list and Run Chain are readable without clicking.
- Add regression coverage for menu open state, pin ordering, rename updates, and clear panel labels.

## Verification
- `npm test` in `apps/desktop` (48 files, 286 tests)
- `npm run build` in `apps/desktop`

Fixes #206