### PR TITLE
Fix native left rail clipping

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2801,6 +2801,27 @@ describe("desktop workbench shell", () => {
     );
   });
 
+  test("keeps the activity rail at its native width when both side panels are collapsed", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: {
+        ...createDefaultWorkbenchLayout(),
+        sidebar: { visible: false, size: 260 },
+        inspector: { visible: false, size: 360 },
+      },
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("false");
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
+    expect(styleText).toContain(
+      'body.desktop-native-workbench .desktop-workbench-shell[data-sidebar-visible="false"][data-inspector-visible="false"] {\n      grid-template-columns: 92px 0 minmax(0, 1fr) 0;',
+    );
+  });
+
   test("collapses secondary panes at the minimum desktop width", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -5040,6 +5040,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       grid-template-columns: 92px 0 minmax(0, 1fr) minmax(280px, 340px);
     }
 
+    body.desktop-native-workbench .desktop-workbench-shell[data-sidebar-visible="false"][data-inspector-visible="false"] {
+      grid-template-columns: 92px 0 minmax(0, 1fr) 0;
+    }
+
     body.desktop-native-workbench .desktop-activity-rail {
       justify-content: space-between;
       gap: 14px;


### PR DESCRIPTION
## Summary
- keep the native activity rail at its 92px layout width when both side panels are collapsed
- add a regression test for the double-collapsed workbench shell state

## Verification
- npm test -- desktopWorkbenchShell.test.ts -t "keeps the activity rail at its native width"
- npm test
- npm run build

Closes #208
