### PR TITLE
Fix native chat menu popover clipping

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -995,6 +995,28 @@ describe("desktop workbench shell", () => {
     expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.textContent).toContain("Run Chain");
   });
 
+  test("anchors the chat header menu popover inside the main work area", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-1", chatId: "chat-1", title: "你好", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-1",
+        activeChatId: "chat-1",
+        messages: [],
+      },
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-chat-menu-popover");
+    expect(styleText).toContain("left: 0;");
+    expect(styleText).toContain("right: auto;");
+    expect(styleText).not.toContain("right: 0;\n      z-index: 8;");
+  });
+
   test("preserves pinned sessions when native chat refreshes", () => {
     const targetDocument = new FakeDocument();
     const chat = {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -5424,7 +5424,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-chat-menu-popover {
       position: absolute;
       top: calc(100% + 8px);
-      right: 0;
+      left: 0;
+      right: auto;
       z-index: 8;
       display: grid;
       gap: 4px;


### PR DESCRIPTION
## Summary
- anchor the native chat header popover to the title row's left edge so it opens inside the main work area
- add a regression test for the three-dot chat menu placement

## Verification
- Browser CUA click on the three-dot menu at http://127.0.0.1:1420/chat/new, then measured popover x=390 against main work area x=372
- npm test -- desktopWorkbenchShell.test.ts -t "anchors the chat header menu popover"
- npm test
- npm run build
