### PR TITLE
Wire native settings provider controls

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -18,6 +18,7 @@ class FakeElement {
   public value = "";
   public checked = false;
   public disabled = false;
+  public hidden = false;
   public innerHTML = "";
   private listeners = new Map<string, ((event: unknown) => void)[]>();
   private ownTextContent = "";
@@ -1990,7 +1991,11 @@ describe("desktop workbench shell", () => {
         lastSavedState: null,
         saveStatus: "failed",
         saveError: "HTTP 400",
-        providerCatalog: [{ id: "openai", displayName: "OpenAI", status: "ready" }],
+        providerCatalog: [
+          { id: "openai", displayName: "OpenAI", status: "ready" },
+          { id: "deepseek", displayName: "DeepSeek", status: "ready" },
+          { id: "ollama", displayName: "Ollama", status: "not_configured" },
+        ],
       },
     );
 
@@ -2035,6 +2040,11 @@ describe("desktop workbench shell", () => {
     expect(pane?.querySelector(".desktop-settings-provider-card")?.textContent).toContain("Base URL: https://api.openai.com/v1");
     expect(pane?.querySelector(".desktop-settings-provider-card")?.textContent).toContain("API Key: ********");
     expect(pane?.querySelector(".desktop-settings-provider-card")?.textContent).toContain("Model: gpt-4.1, gpt-4.1-mini");
+    expect(pane?.querySelectorAll(".desktop-settings-provider-card").map((card) => card.getAttribute("data-desktop-settings-provider-card"))).toEqual([
+      "openai",
+      "deepseek",
+      "ollama",
+    ]);
     expect(pane?.querySelector('[data-desktop-settings-group="agent"]')?.getAttribute("id")).toBe("desktop-settings-group-agent");
     expect(pane?.textContent).toContain("设置 / 模型");
     expect(pane?.textContent).toContain("Save: HTTP 400");
@@ -2070,6 +2080,33 @@ describe("desktop workbench shell", () => {
     providerSelect!.value = "deepseek";
     providerSelect?.dispatchEvent({ type: "change", target: providerSelect });
     expect(settingsActions[settingsActions.length - 1]).toBe("edit:selectedProvider:deepseek");
+
+    const providerSearch = pane?.querySelector(".desktop-settings-provider-search");
+    providerSearch!.value = "deep";
+    providerSearch?.dispatchEvent({ type: "input", target: providerSearch });
+    const filteredCards = pane?.querySelectorAll(".desktop-settings-provider-card") ?? [];
+    expect(filteredCards.map((card) => card.hidden)).toEqual([true, false, true]);
+
+    settingsActions.length = 0;
+    pane?.querySelector('[data-desktop-settings-action="addProvider"]')?.click();
+    expect(settingsActions).toEqual(["edit:selectedProvider:deepseek"]);
+
+    settingsActions.length = 0;
+    pane?.querySelector('[data-desktop-settings-provider-card="deepseek"]')
+      ?.querySelector('[data-desktop-settings-provider-action="settings"]')
+      ?.click();
+    expect(settingsActions).toEqual(["edit:selectedProvider:deepseek"]);
+
+    pane?.querySelector('[data-desktop-settings-provider-card="openai"]')
+      ?.querySelector('[data-desktop-settings-provider-action="models"]')
+      ?.click();
+    expect(targetDocument.activeElement).toBe(modelInput);
+
+    const apiBaseInput = pane?.querySelector('[data-desktop-settings-control="apiBase"]');
+    pane?.querySelector('[data-desktop-settings-provider-card="openai"]')
+      ?.querySelector('[data-desktop-settings-provider-action="settings"]')
+      ?.click();
+    expect(targetDocument.activeElement).toBe(apiBaseInput);
   });
 
   test("allows custom model entry when no provider model catalog is loaded", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -1915,6 +1915,9 @@ describe("desktop workbench shell", () => {
   test("renders grouped settings and providers pane state in the desktop workbench", () => {
     const targetDocument = new FakeDocument();
     const settingsActions: string[] = [];
+    (targetDocument as unknown as { defaultView: { prompt: () => string } }).defaultView = {
+      prompt: () => "custom-openai",
+    };
     const settingsPane = buildDesktopSettingsPaneModel(
       {
         agent: {
@@ -2089,7 +2092,7 @@ describe("desktop workbench shell", () => {
 
     settingsActions.length = 0;
     pane?.querySelector('[data-desktop-settings-action="addProvider"]')?.click();
-    expect(settingsActions).toEqual(["edit:selectedProvider:deepseek"]);
+    expect(settingsActions).toEqual(["edit:selectedProvider:custom-openai"]);
 
     settingsActions.length = 0;
     pane?.querySelector('[data-desktop-settings-provider-card="deepseek"]')

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -2813,13 +2813,10 @@ function createProviderManagementSection(
   add.className = "desktop-settings-provider-add";
   add.setAttribute("type", "button");
   add.setAttribute("data-desktop-settings-action", "addProvider");
-  const addTarget = getProviderCards(pane).find((provider) => provider.id !== pane.providerEditor.selectedProvider);
-  if (!addTarget) {
-    add.setAttribute("disabled", "true");
-  }
   add.addEventListener("click", () => {
-    if (addTarget) {
-      selectSettingsProvider(pane, settingsActions, addTarget.id);
+    const providerId = promptForSettingsProviderId(targetDocument);
+    if (providerId) {
+      selectSettingsProvider(pane, settingsActions, providerId);
       focusDesktopSettingsControl(targetDocument, "selectedProvider");
     }
   });
@@ -2959,6 +2956,11 @@ function filterSettingsProviderCards(cards: HTMLElement, query: string): void {
     const haystack = `${card.getAttribute("data-desktop-settings-provider-card") ?? ""} ${card.textContent ?? ""}`.toLowerCase();
     card.hidden = Boolean(normalizedQuery) && !haystack.includes(normalizedQuery);
   }
+}
+
+function promptForSettingsProviderId(targetDocument: Document): string | null {
+  const providerId = targetDocument.defaultView?.prompt("Provider ID", "")?.trim() ?? "";
+  return providerId || null;
 }
 
 function handleSettingsProviderCardAction(

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -2813,6 +2813,16 @@ function createProviderManagementSection(
   add.className = "desktop-settings-provider-add";
   add.setAttribute("type", "button");
   add.setAttribute("data-desktop-settings-action", "addProvider");
+  const addTarget = getProviderCards(pane).find((provider) => provider.id !== pane.providerEditor.selectedProvider);
+  if (!addTarget) {
+    add.setAttribute("disabled", "true");
+  }
+  add.addEventListener("click", () => {
+    if (addTarget) {
+      selectSettingsProvider(pane, settingsActions, addTarget.id);
+      focusDesktopSettingsControl(targetDocument, "selectedProvider");
+    }
+  });
   add.textContent = "+ 添加提供商";
   tools.append(search, refresh, add);
   header.append(tools);
@@ -2820,8 +2830,11 @@ function createProviderManagementSection(
   const cards = targetDocument.createElement("div");
   cards.className = "desktop-settings-provider-grid";
   for (const provider of getProviderCards(pane)) {
-    cards.append(createProviderManagementCard(targetDocument, provider));
+    cards.append(createProviderManagementCard(targetDocument, pane, provider, settingsActions));
   }
+  search.addEventListener("input", () => {
+    filterSettingsProviderCards(cards, search.value);
+  });
 
   section.append(header, cards);
   return section;
@@ -2881,7 +2894,12 @@ function createDesktopSettingsModelSelect(
   return select;
 }
 
-function createProviderManagementCard(targetDocument: Document, provider: DesktopProviderCardModel): HTMLElement {
+function createProviderManagementCard(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  provider: DesktopProviderCardModel,
+  settingsActions: DesktopSettingsActionOptions,
+): HTMLElement {
   const card = targetDocument.createElement("article");
   card.className = "desktop-settings-provider-card";
   card.setAttribute("data-desktop-settings-provider-card", provider.id);
@@ -2910,10 +2928,19 @@ function createProviderManagementCard(targetDocument: Document, provider: Deskto
 
   const actions = targetDocument.createElement("div");
   actions.className = "desktop-settings-provider-card-actions";
-  actions.append(createText(targetDocument, "button", "模型"), createText(targetDocument, "button", "设置"));
-  for (const button of actions.querySelectorAll("button")) {
-    button.setAttribute("type", "button");
-  }
+  const modelAction = createText(targetDocument, "button", "\u6a21\u578b");
+  modelAction.setAttribute("type", "button");
+  modelAction.setAttribute("data-desktop-settings-provider-action", "models");
+  modelAction.addEventListener("click", () => {
+    handleSettingsProviderCardAction(targetDocument, pane, settingsActions, provider.id, "model");
+  });
+  const settingsAction = createText(targetDocument, "button", "\u8bbe\u7f6e");
+  settingsAction.setAttribute("type", "button");
+  settingsAction.setAttribute("data-desktop-settings-provider-action", "settings");
+  settingsAction.addEventListener("click", () => {
+    handleSettingsProviderCardAction(targetDocument, pane, settingsActions, provider.id, "settings");
+  });
+  actions.replaceChildren(modelAction, settingsAction);
 
   card.append(header, details, actions);
   return card;
@@ -2924,6 +2951,46 @@ function createSettingsProviderDetail(targetDocument: Document, label: string, v
   row.className = "desktop-settings-provider-detail";
   row.append(createText(targetDocument, "span", `${label}: `), createText(targetDocument, "strong", value));
   return row;
+}
+
+function filterSettingsProviderCards(cards: HTMLElement, query: string): void {
+  const normalizedQuery = query.trim().toLowerCase();
+  for (const card of cards.querySelectorAll<HTMLElement>(".desktop-settings-provider-card")) {
+    const haystack = `${card.getAttribute("data-desktop-settings-provider-card") ?? ""} ${card.textContent ?? ""}`.toLowerCase();
+    card.hidden = Boolean(normalizedQuery) && !haystack.includes(normalizedQuery);
+  }
+}
+
+function handleSettingsProviderCardAction(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions,
+  providerId: string,
+  target: "model" | "settings",
+): void {
+  if (providerId !== pane.providerEditor.selectedProvider) {
+    selectSettingsProvider(pane, settingsActions, providerId);
+    focusDesktopSettingsControl(targetDocument, "selectedProvider");
+    return;
+  }
+  focusDesktopSettingsControl(targetDocument, target === "model" ? "model" : "apiBase");
+}
+
+function selectSettingsProvider(
+  pane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions,
+  providerId: string,
+): void {
+  settingsActions.onSettingsAction?.({
+    action: "edit",
+    pane,
+    fieldId: "selectedProvider",
+    value: providerId,
+  });
+}
+
+function focusDesktopSettingsControl(targetDocument: Document, fieldId: string): void {
+  targetDocument.querySelector<HTMLElement>(`[data-desktop-settings-control="${fieldId}"]`)?.focus();
 }
 
 type DesktopSettingsPaneGroup = DesktopSettingsPaneModel["groups"][number];


### PR DESCRIPTION
## Summary
- Wire the native settings provider search to filter provider cards.
- Connect Add Provider and provider card actions to the existing settings edit flow.
- Focus model/API controls for the active provider actions.

## Verification
- `npm run test -- src/desktopSettingsProviders.test.ts src/desktopWorkbenchShell.test.ts`
- `npm run build`

Closes #214