### PR TITLE
Polish native desktop status copy

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -265,7 +265,11 @@ describe("desktop workbench shell", () => {
       },
     });
 
-    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session.");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session. Start");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Start from chat, inspect the workspace, or check gateway status.");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("sessionStart");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("session.Start");
     expect(targetDocument.body.querySelectorAll(".desktop-quick-action").map((node) => node.textContent)).toEqual([
       "New chat",
       "Open workspace",
@@ -1154,8 +1158,9 @@ describe("desktop workbench shell", () => {
 
     const overview = targetDocument.body.querySelector(".desktop-run-chain-overview");
     const panel = overview?.querySelector(".desktop-run-chain-panel");
-    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Gateway");
-    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Idle");
+    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Gateway: Connected");
+    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Run: Idle");
+    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("0 items");
     expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("context");
     expect(panel?.textContent).toContain("Endpoint");
 
@@ -1240,7 +1245,8 @@ describe("desktop workbench shell", () => {
     pane?.querySelector('[data-desktop-run-chain-item="m-plan:planning"]')?.click();
     expect(pane?.querySelector('[data-desktop-run-chain-item="m-plan:planning"]')?.getAttribute("aria-selected")).toBe("true");
     expect(pane?.querySelector(".desktop-run-chain-detail")?.textContent).toContain("Thinking: Inspect the active context");
-    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session.");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("session.Start");
 
     targetDocument.body.querySelector('[data-desktop-run-chain-control="close"]')?.click();
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
@@ -3239,7 +3245,9 @@ describe("desktop workbench shell", () => {
 
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("without leaving");
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain(
-      "Start from chat, inspect workspace, or check gateway status.",
+      "Start from chat, inspect the workspace, or check gateway status.",
     );
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("sessionStart");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("session.Start");
   });
 });

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -1154,8 +1154,8 @@ function createMainRegion(
   const workbenchChrome = targetDocument.createElement("div");
   workbenchChrome.className = "desktop-chat-workbench-chrome";
   workbenchChrome.append(
-    createText(targetDocument, "span", "Ready for a new session"),
-    createText(targetDocument, "span", "Start from chat, inspect workspace, or check gateway status."),
+    createText(targetDocument, "span", "Ready for a new session. "),
+    createText(targetDocument, "span", "Start from chat, inspect the workspace, or check gateway status."),
     createQuickActions(targetDocument),
     createPanelControls(targetDocument, layout),
     ...(chatWorkItems.length ? [createModuleWorkSection(targetDocument, "Chat runs", chatWorkItems)] : []),
@@ -1950,7 +1950,10 @@ function createConversationMessage(
   content.className = "desktop-conversation-content";
   const meta = targetDocument.createElement("div");
   meta.className = "desktop-conversation-meta";
-  meta.append(createText(targetDocument, "strong", options.author), createText(targetDocument, "span", options.time));
+  const separator = createText(targetDocument, "span", " · ");
+  separator.className = "desktop-conversation-meta-separator";
+  separator.setAttribute("aria-hidden", "true");
+  meta.append(createText(targetDocument, "strong", options.author), separator, createText(targetDocument, "span", options.time));
   mountConversationMetaVueIsland(meta, { author: options.author, time: options.time });
   content.append(meta);
   if (options.reasoningContent?.trim()) {
@@ -5145,15 +5148,15 @@ function createRunChainSummaryStrip(
   summary.className = "desktop-run-chain-summary-strip";
   const status = runChainOverviewStatus(runChainItems);
   for (const item of [
-    { label: "Gateway", value: "Connected", tab: "context" as const },
-    { label: "Run", value: status, tab: "tasks" as const },
-    { label: "Items", value: String(runChainItems.length), tab: "tasks" as const },
+    { label: "Gateway", text: "Gateway: Connected", tab: "context" as const },
+    { label: "Run", text: `Run: ${status}`, tab: "tasks" as const },
+    { label: "Items", text: `${runChainItems.length} ${runChainItems.length === 1 ? "item" : "items"}`, tab: "tasks" as const },
   ]) {
     const button = targetDocument.createElement("button");
     button.type = "button";
     button.className = "desktop-run-chain-summary-item";
     button.setAttribute("data-desktop-run-chain-summary", item.label.toLowerCase());
-    button.textContent = `${item.label} ${item.value}`;
+    button.textContent = item.text;
     button.addEventListener("click", () => {
       selectTab(item.tab);
       setRouteStatus(targetDocument, `Run Chain ${item.label}`);

--- a/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
@@ -204,8 +204,11 @@ describe("desktop workbench shell Vue integration", () => {
 
     const workbench = document.querySelector<HTMLElement>(".desktop-chat-workbench-chrome");
     expect(workbench?.getAttribute("data-desktop-vue-island")).toBe("chat-workbench");
-    expect(workbench?.textContent).toContain("Ready for a new session");
-    expect(workbench?.textContent).toContain("Start from chat, inspect workspace, or check gateway status.");
+    expect(workbench?.textContent).toContain("Ready for a new session.");
+    expect(workbench?.textContent).toContain("Ready for a new session. Start");
+    expect(workbench?.textContent).toContain("Start from chat, inspect the workspace, or check gateway status.");
+    expect(workbench?.textContent).not.toContain("sessionStart");
+    expect(workbench?.textContent).not.toContain("session.Start");
     expect(workbench?.querySelector(".desktop-quick-actions")?.getAttribute("data-desktop-vue-island")).toBe("quick-actions");
     expect(workbench?.querySelector(".desktop-panel-controls")?.getAttribute("data-desktop-vue-island")).toBe("panel-controls");
     expect(workbench?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-pressed")).toBe("true");

--- a/apps/desktop/src/native-vue/chatWorkbenchIsland.test.ts
+++ b/apps/desktop/src/native-vue/chatWorkbenchIsland.test.ts
@@ -40,8 +40,11 @@ describe("chat workbench Vue island", () => {
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("chat-workbench");
     expect(host.className).toBe("desktop-chat-workbench-chrome");
-    expect(host.textContent).toContain("Ready for a new session");
-    expect(host.textContent).toContain("Start from chat, inspect workspace, or check gateway status.");
+    expect(host.textContent).toContain("Ready for a new session.");
+    expect(host.textContent).toContain("Ready for a new session. Start");
+    expect(host.textContent).toContain("Start from chat, inspect the workspace, or check gateway status.");
+    expect(host.textContent).not.toContain("sessionStart");
+    expect(host.textContent).not.toContain("session.Start");
     expect(host.querySelector(".desktop-quick-actions")?.getAttribute("data-desktop-vue-island")).toBe("quick-actions");
     expect(host.querySelector(".desktop-quick-actions")?.textContent).toContain("Open workspace");
     expect(host.querySelector(".desktop-panel-controls")?.getAttribute("data-desktop-vue-island")).toBe("panel-controls");

--- a/apps/desktop/src/native-vue/chatWorkbenchIsland.ts
+++ b/apps/desktop/src/native-vue/chatWorkbenchIsland.ts
@@ -65,8 +65,8 @@ function createChatWorkbenchApp(options: ChatWorkbenchIslandOptions): App {
 
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => [
-          h(NText, { tag: "span" }, { default: () => "Ready for a new session" }),
-          h(NText, { depth: 3, tag: "span" }, { default: () => "Start from chat, inspect workspace, or check gateway status." }),
+          h(NText, { tag: "span" }, { default: () => "Ready for a new session. " }),
+          h(NText, { depth: 3, tag: "span" }, { default: () => "Start from chat, inspect the workspace, or check gateway status." }),
           h("div", { ref: quickActions }),
           h("div", { ref: panelControls }),
           options.moduleWorkItems?.length ? h("section", { ref: moduleWork }) : null,

--- a/apps/desktop/src/native-vue/conversationMessageIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationMessageIsland.test.ts
@@ -27,7 +27,8 @@ describe("conversation message Vue island", () => {
     expect(host.querySelector(".desktop-conversation-reference")?.getAttribute("data-desktop-vue-island")).toBe("conversation-reference");
     expect(host.querySelector(".desktop-conversation-attachment")?.getAttribute("data-desktop-vue-island")).toBe("conversation-attachment");
     expect(host.querySelector(".desktop-conversation-meta strong")?.textContent).toBe("Tinybot");
-    expect(host.querySelector(".desktop-conversation-meta span")?.textContent).toBe("10:28 AM");
+    expect(host.querySelector(".desktop-conversation-meta-separator")?.textContent).toBe(" · ");
+    expect(Array.from(host.querySelectorAll(".desktop-conversation-meta span")).at(-1)?.textContent).toBe("10:28 AM");
     expect(host.querySelector(".desktop-conversation-body a")?.getAttribute("target")).toBe("_blank");
     expect(host.querySelector(".desktop-conversation-reference")?.textContent).toBe("File: README.md - lines 1-4");
     expect(host.querySelector(".desktop-conversation-attachment")?.textContent).toBe("design.png  1.2 MB");

--- a/apps/desktop/src/native-vue/conversationMetaIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationMetaIsland.test.ts
@@ -15,8 +15,10 @@ describe("conversation meta Vue island", () => {
     expect(host.getAttribute("data-desktop-vue-island")).toBe("conversation-meta");
     expect(host.className).toBe("desktop-conversation-meta");
     expect(host.querySelector("strong")?.textContent).toBe("Tinybot");
-    expect(host.querySelector("span")?.textContent).toBe("10:28 AM");
-    expect(host.textContent).toBe("Tinybot10:28 AM");
+    expect(host.querySelector(".desktop-conversation-meta-separator")?.textContent).toBe(" · ");
+    expect(host.querySelector(".desktop-conversation-meta-separator")?.getAttribute("aria-hidden")).toBe("true");
+    expect(Array.from(host.querySelectorAll("span")).at(-1)?.textContent).toBe("10:28 AM");
+    expect(host.textContent).toBe("Tinybot · 10:28 AM");
 
     mounted.unmount();
     expect(host.textContent).toBe("");

--- a/apps/desktop/src/native-vue/conversationMetaIsland.ts
+++ b/apps/desktop/src/native-vue/conversationMetaIsland.ts
@@ -45,6 +45,7 @@ export function renderConversationMetaNode(options: ConversationMetaIslandOption
 export function renderConversationMetaChildren(options: ConversationMetaIslandOptions) {
   return [
     h(NText, { strong: true, tag: "strong" }, { default: () => options.author }),
+    h("span", { class: "desktop-conversation-meta-separator", "aria-hidden": "true" }, " · "),
     h(NText, { depth: 3, tag: "span" }, { default: () => options.time }),
   ];
 }

--- a/apps/desktop/src/native-vue/runChainOverviewIsland.test.ts
+++ b/apps/desktop/src/native-vue/runChainOverviewIsland.test.ts
@@ -44,8 +44,9 @@ describe("run chain overview Vue island", () => {
     expect(host.className).toContain("desktop-run-chain-overview");
     expect(host.getAttribute("aria-label")).toBe("Run Chain");
     expect(host.querySelector("h2")?.textContent).toBe("Run Chain");
-    expect(host.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Run Running");
-    expect(host.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Items 2");
+    expect(host.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Gateway: Connected");
+    expect(host.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Run: Running");
+    expect(host.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("2 items");
     expect(host.querySelector(".desktop-run-chain-panel")?.getAttribute("data-desktop-run-chain-panel")).toBe("context");
 
     host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-tab="files"]')?.click();

--- a/apps/desktop/src/native-vue/runChainOverviewIsland.ts
+++ b/apps/desktop/src/native-vue/runChainOverviewIsland.ts
@@ -129,9 +129,9 @@ function renderSummaryStrip(
 ) {
   const status = runChainOverviewStatus(items);
   const summaries = [
-    { value: "gateway", label: "Gateway", text: "Gateway Connected", tab: "context" },
-    { value: "run", label: "Run", text: `Run ${status}`, tab: "tasks" },
-    { value: "items", label: "Items", text: `Items ${items.length}`, tab: "tasks" },
+    { value: "gateway", label: "Gateway", text: "Gateway: Connected", tab: "context" },
+    { value: "run", label: "Run", text: `Run: ${status}`, tab: "tasks" },
+    { value: "items", label: "Items", text: `${items.length} ${items.length === 1 ? "item" : "items"}`, tab: "tasks" },
   ] as const;
   return h(NSpace, {
     class: "desktop-run-chain-summary-strip",


### PR DESCRIPTION
## Summary
- Add clearer spacing to native chat empty-state copy.
- Separate conversation author and timestamp metadata.
- Clarify Run Chain summary labels for gateway, run state, and item count.

Closes #219

## Verification
- npm test -- desktopWorkbenchShell.test.ts desktopWorkbenchShell.vue.test.ts native-vue/chatWorkbenchIsland.test.ts native-vue/conversationMetaIsland.test.ts native-vue/conversationMessageIsland.test.ts native-vue/runChainOverviewIsland.test.ts