### PR TITLE
fix(desktop): refine native visual hierarchy

### DIFF
--- a/apps/desktop/src/desktopAppSidebar.test.ts
+++ b/apps/desktop/src/desktopAppSidebar.test.ts
@@ -75,14 +75,14 @@ class FakeElement {
     this.children.push(...children);
   }
 
-  replaceChildren(...children: FakeElement[]): void {
+  replaceChildren(...children: this[]): void {
     this.children = [...children];
   }
 
   addEventListener(): void {}
 
   querySelectorAll(selector: string): FakeElement[] {
-    const matches = matchesFakeSelector(this, selector) ? [this] : [];
+    const matches: FakeElement[] = matchesFakeSelector(this, selector) ? [this] : [];
     for (const child of this.children) {
       matches.push(...child.querySelectorAll(selector));
     }

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -1361,6 +1361,7 @@ function installTauriMenuCommandRouting(): void {
       listen<{ id: string }>("desktop-menu-command", (event) => {
         handler(event.payload.id);
       }),
+    openExternal: (href) => openUrl(href),
   });
 }
 

--- a/apps/desktop/src/desktopCommandNavigation.test.ts
+++ b/apps/desktop/src/desktopCommandNavigation.test.ts
@@ -3,6 +3,8 @@ import {
   DESKTOP_CHROME_COMMANDS,
   DESKTOP_HELP_COMMANDS,
   DESKTOP_MENU_COMMANDS,
+  DESKTOP_RESOURCE_COMMANDS,
+  DESKTOP_SYSTEM_COMMANDS,
   installDesktopMenuCommandRouting,
   resolveDesktopShortcutCommand,
   routeDesktopMenuCommand,
@@ -82,6 +84,11 @@ describe("desktop command navigation", () => {
       "new-chat",
       "stop-generation",
       "search-sessions",
+      "open-workspace",
+      "open-knowledge",
+      "open-tools",
+      "open-automations",
+      "open-tinybot-repo",
       "open-settings",
       "open-docs",
       "open-shortcut-help",
@@ -95,6 +102,11 @@ describe("desktop command navigation", () => {
       "New Chat",
       "Stop Generation",
       "Search Sessions",
+      "Workspace",
+      "Knowledge",
+      "Tools",
+      "Automations",
+      "Tinybot repo",
       "Settings",
       "Documentation",
       "Shortcut Help",
@@ -108,6 +120,11 @@ describe("desktop command navigation", () => {
       "Ctrl+N",
       "Ctrl+.",
       "Ctrl+F",
+      "",
+      "",
+      "",
+      "",
+      "",
       "Ctrl+,",
       "F1",
       "Ctrl+/",
@@ -118,14 +135,23 @@ describe("desktop command navigation", () => {
       "Ctrl+Shift+G",
     ]);
     expect(DESKTOP_CHROME_COMMANDS.map((command) => command.id)).toEqual([
-      "open-settings",
-      "open-docs",
       "toggle-theme",
     ]);
     expect(DESKTOP_CHROME_COMMANDS.map((command) => command.chromeLabel)).toEqual([
       undefined,
-      undefined,
-      undefined,
+    ]);
+    expect(DESKTOP_RESOURCE_COMMANDS.map((command) => command.id)).toEqual([
+      "open-workspace",
+      "open-knowledge",
+      "open-tools",
+      "open-automations",
+      "open-docs",
+      "open-tinybot-repo",
+    ]);
+    expect(DESKTOP_SYSTEM_COMMANDS.map((command) => command.id)).toEqual([
+      "open-settings",
+      "refresh-gateway-status",
+      "open-docs",
     ]);
     expect(DESKTOP_HELP_COMMANDS.map((command) => command.id)).toEqual([
       "open-shortcut-help",
@@ -136,6 +162,11 @@ describe("desktop command navigation", () => {
       "Page Help",
     ]);
     expect(DESKTOP_MENU_COMMANDS.filter((command) => command.chromeGroup === "secondary").map((command) => command.id)).toEqual([
+      "open-workspace",
+      "open-knowledge",
+      "open-tools",
+      "open-automations",
+      "open-tinybot-repo",
       "open-settings",
       "open-docs",
       "open-shortcut-help",
@@ -155,6 +186,14 @@ describe("desktop command navigation", () => {
 
     expect(routeDesktopMenuCommand("new-chat", context)).toMatchObject({ kind: "navigate", href: "/chat/new" });
     expect(routeDesktopMenuCommand("search-sessions", context)).toMatchObject({ kind: "action", action: "open-session-search" });
+    expect(routeDesktopMenuCommand("open-workspace", context)).toMatchObject({ kind: "navigate", href: "/workspace" });
+    expect(routeDesktopMenuCommand("open-knowledge", context)).toMatchObject({ kind: "navigate", href: "/knowledge" });
+    expect(routeDesktopMenuCommand("open-tools", context)).toMatchObject({ kind: "navigate", href: "/tools" });
+    expect(routeDesktopMenuCommand("open-automations", context)).toMatchObject({ kind: "navigate", href: "/cowork" });
+    expect(routeDesktopMenuCommand("open-tinybot-repo", context)).toMatchObject({
+      kind: "navigate",
+      href: "https://github.com/SudoJacky/tinybot",
+    });
     expect(routeDesktopMenuCommand("open-settings", context)).toMatchObject({ kind: "navigate", href: "/settings" });
     expect(routeDesktopMenuCommand("open-docs", context)).toMatchObject({ kind: "navigate", href: "/docs" });
     expect(routeDesktopMenuCommand("open-shortcut-help", context)).toMatchObject({ kind: "action", action: "open-shortcut-help" });

--- a/apps/desktop/src/desktopCommandNavigation.ts
+++ b/apps/desktop/src/desktopCommandNavigation.ts
@@ -4,6 +4,11 @@ export type DesktopMenuCommandId =
   | "new-chat"
   | "stop-generation"
   | "search-sessions"
+  | "open-workspace"
+  | "open-knowledge"
+  | "open-tools"
+  | "open-automations"
+  | "open-tinybot-repo"
   | "open-settings"
   | "open-docs"
   | "open-shortcut-help"
@@ -44,6 +49,7 @@ export type DesktopMenuCommandResult =
 export interface InstallDesktopMenuCommandRoutingOptions {
   gatewayOrigin: string;
   listenToMenuCommand: (handler: (id: string) => void) => void | Promise<unknown>;
+  openExternal?: (href: string) => Promise<void> | void;
   targetDocument?: Document;
   targetWindow?: Window;
 }
@@ -52,6 +58,11 @@ export const DESKTOP_MENU_COMMANDS: DesktopMenuCommand[] = [
   { id: "new-chat", label: "New Chat", chromeLabel: "New", chromeGroup: "primary", shortcut: "Ctrl+N" },
   { id: "stop-generation", label: "Stop Generation", chromeLabel: "Stop", chromeGroup: "primary", shortcut: "Ctrl+." },
   { id: "search-sessions", label: "Search Sessions", chromeLabel: "Search", chromeGroup: "primary", shortcut: "Ctrl+F" },
+  { id: "open-workspace", label: "Workspace", chromeGroup: "secondary", shortcut: "" },
+  { id: "open-knowledge", label: "Knowledge", chromeGroup: "secondary", shortcut: "" },
+  { id: "open-tools", label: "Tools", chromeGroup: "secondary", shortcut: "" },
+  { id: "open-automations", label: "Automations", chromeGroup: "secondary", shortcut: "" },
+  { id: "open-tinybot-repo", label: "Tinybot repo", chromeGroup: "secondary", shortcut: "" },
   { id: "open-settings", label: "Settings", chromeGroup: "secondary", shortcut: "Ctrl+," },
   { id: "open-docs", label: "Documentation", chromeGroup: "secondary", shortcut: "F1" },
   { id: "open-shortcut-help", label: "Shortcut Help", chromeGroup: "secondary", shortcut: "Ctrl+/" },
@@ -63,12 +74,33 @@ export const DESKTOP_MENU_COMMANDS: DesktopMenuCommand[] = [
 ];
 
 const DESKTOP_CHROME_COMMAND_IDS: DesktopMenuCommandId[] = [
-  "open-settings",
-  "open-docs",
   "toggle-theme",
 ];
 
+const DESKTOP_RESOURCE_COMMAND_IDS: DesktopMenuCommandId[] = [
+  "open-workspace",
+  "open-knowledge",
+  "open-tools",
+  "open-automations",
+  "open-docs",
+  "open-tinybot-repo",
+];
+
+const DESKTOP_SYSTEM_COMMAND_IDS: DesktopMenuCommandId[] = [
+  "open-settings",
+  "refresh-gateway-status",
+  "open-docs",
+];
+
 export const DESKTOP_CHROME_COMMANDS: DesktopMenuCommand[] = DESKTOP_CHROME_COMMAND_IDS
+  .map((id) => DESKTOP_MENU_COMMANDS.find((command) => command.id === id))
+  .filter((command): command is DesktopMenuCommand => Boolean(command));
+
+export const DESKTOP_RESOURCE_COMMANDS: DesktopMenuCommand[] = DESKTOP_RESOURCE_COMMAND_IDS
+  .map((id) => DESKTOP_MENU_COMMANDS.find((command) => command.id === id))
+  .filter((command): command is DesktopMenuCommand => Boolean(command));
+
+export const DESKTOP_SYSTEM_COMMANDS: DesktopMenuCommand[] = DESKTOP_SYSTEM_COMMAND_IDS
   .map((id) => DESKTOP_MENU_COMMANDS.find((command) => command.id === id))
   .filter((command): command is DesktopMenuCommand => Boolean(command));
 
@@ -99,6 +131,16 @@ export function routeDesktopMenuCommand(id: string, context: DesktopMenuCommandC
         : { kind: "unavailable", feedback: "Stop generation is unavailable without an active response." };
     case "search-sessions":
       return { kind: "action", action: "open-session-search" };
+    case "open-workspace":
+      return { kind: "navigate", href: "/workspace" };
+    case "open-knowledge":
+      return { kind: "navigate", href: "/knowledge" };
+    case "open-tools":
+      return { kind: "navigate", href: "/tools" };
+    case "open-automations":
+      return { kind: "navigate", href: "/cowork" };
+    case "open-tinybot-repo":
+      return { kind: "navigate", href: "https://github.com/SudoJacky/tinybot" };
     case "open-settings":
       return { kind: "navigate", href: "/settings" };
     case "open-docs":
@@ -208,6 +250,7 @@ function readCommandContext(targetDocument: Document): DesktopMenuCommandContext
 function applyDesktopMenuCommandResult(
   result: DesktopMenuCommandResult,
   options: Pick<InstallDesktopMenuCommandRoutingOptions, "gatewayOrigin" | "targetDocument" | "targetWindow"> & {
+    openExternal?: (href: string) => Promise<void> | void;
     targetDocument: Document;
     targetWindow: Window;
   },
@@ -227,7 +270,7 @@ function applyDesktopMenuCommandResult(
 
 function routeMenuNavigation(
   href: string,
-  { gatewayOrigin, targetDocument, targetWindow }: Pick<InstallDesktopMenuCommandRoutingOptions, "gatewayOrigin"> & {
+  { gatewayOrigin, openExternal, targetDocument, targetWindow }: Pick<InstallDesktopMenuCommandRoutingOptions, "gatewayOrigin" | "openExternal"> & {
     targetDocument: Document;
     targetWindow: Window;
   },
@@ -251,6 +294,14 @@ function routeMenuNavigation(
   }
   if (target.kind === "gateway-action") {
     targetWindow.dispatchEvent(new CustomEvent("tinybot:desktop-gateway-action", { detail: target }));
+    return;
+  }
+  if (target.kind === "external-url") {
+    if (openExternal) {
+      void openExternal(target.href);
+      return;
+    }
+    targetWindow.open(target.href, "_blank", "noopener");
   }
 }
 

--- a/apps/desktop/src/desktopCommandPalette.ts
+++ b/apps/desktop/src/desktopCommandPalette.ts
@@ -430,6 +430,16 @@ function coworkResults(rows: DesktopCoworkSessionRow[]): DesktopCommandPaletteRe
 
 function commandKeywords(id: DesktopMenuCommandId): string[] {
   switch (id) {
+    case "open-workspace":
+      return ["workspace", "files", "project"];
+    case "open-knowledge":
+      return ["knowledge", "documents", "rag"];
+    case "open-tools":
+      return ["tools", "skills"];
+    case "open-automations":
+      return ["automations", "cowork", "agents"];
+    case "open-tinybot-repo":
+      return ["github", "repo", "repository"];
     case "open-docs":
       return ["desktop", "docs", "help", "documentation"];
     case "open-shortcut-help":

--- a/apps/desktop/src/desktopWindowFrame.test.ts
+++ b/apps/desktop/src/desktopWindowFrame.test.ts
@@ -90,6 +90,7 @@ class FakeDocument {
   public head = new FakeHead();
   public documentElement = { dataset: {} as Record<string, string> };
   public dispatched: string[] = [];
+  private listeners = new Map<string, Array<(event: Event) => void>>();
 
   createElement(tagName: string): FakeElement {
     return new FakeElement(tagName);
@@ -99,8 +100,15 @@ class FakeDocument {
     return this.body.querySelector(`#${id}`) ?? this.head.querySelector(`#${id}`);
   }
 
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
   dispatchEvent(event: Event): boolean {
     this.dispatched.push(event.type);
+    for (const listener of this.listeners.get(event.type) ?? []) {
+      listener(event);
+    }
     return true;
   }
 }
@@ -123,6 +131,10 @@ function matchesSelector(element: FakeElement, selector: string): boolean {
   const runtimeCommand = selector.match(/^\[data-desktop-runtime-command="(.+)"\]$/);
   if (runtimeCommand) {
     return element.getAttribute("data-desktop-runtime-command") === runtimeCommand[1];
+  }
+  const attribute = selector.match(/^\[([^=\]]+)="([^"]*)"\]$/);
+  if (attribute) {
+    return element.getAttribute(attribute[1]) === attribute[2];
   }
   return false;
 }
@@ -266,13 +278,45 @@ describe("desktop window frame", () => {
     expect(targetDocument.body.querySelector('[data-desktop-menu-command="search-sessions"]')).toBeNull();
     expect(targetDocument.body.querySelector('[data-desktop-menu-command="stop-generation"]')).toBeNull();
     expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-command-palette"]')).toBeNull();
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-settings"]')?.textContent).toBe("Settings");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="open-docs"]')?.textContent).toBe("Documentation");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="toggle-theme"]')?.textContent).toBe("Toggle Theme");
-    expect(targetDocument.body.querySelector('[data-desktop-menu-command="refresh-gateway-status"]')).toBeNull();
+    const appContainer = targetDocument.body.querySelector('[data-desktop-menu-label="App"]');
+    const appTrigger = appContainer?.querySelector(".desktop-help-menu-trigger");
+    const appMenu = appContainer?.querySelector(".desktop-help-menu-popover");
+    expect(appTrigger?.textContent).toBe("App");
+    expect(appTrigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(appMenu?.hidden).toBe(true);
+    appTrigger?.click();
+    expect(appTrigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(appMenu?.querySelector('[data-desktop-menu-command="toggle-theme"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Toggle Theme");
+    expect(appMenu?.querySelector('[data-desktop-menu-command="open-settings"]')).toBeNull();
 
-    const helpTrigger = targetDocument.body.querySelector(".desktop-help-menu-trigger");
-    const helpMenu = targetDocument.body.querySelector(".desktop-help-menu-popover");
+    const resourcesContainer = targetDocument.body.querySelector('[data-desktop-menu-label="Resources"]');
+    const resourcesTrigger = resourcesContainer?.querySelector(".desktop-help-menu-trigger");
+    const resourcesMenu = resourcesContainer?.querySelector(".desktop-help-menu-popover");
+    expect(resourcesTrigger?.textContent).toBe("Resources");
+    resourcesTrigger?.click();
+    expect(appTrigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(resourcesTrigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(resourcesMenu?.querySelector('[data-desktop-menu-command="open-workspace"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Workspace");
+    expect(resourcesMenu?.querySelector('[data-desktop-menu-command="open-knowledge"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Knowledge");
+    expect(resourcesMenu?.querySelector('[data-desktop-menu-command="open-tools"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Tools");
+    expect(resourcesMenu?.querySelector('[data-desktop-menu-command="open-automations"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Automations");
+    expect(resourcesMenu?.querySelector('[data-desktop-menu-command="open-docs"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Documentation");
+    expect(resourcesMenu?.querySelector('[data-desktop-menu-command="open-tinybot-repo"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Tinybot repo");
+
+    targetDocument.dispatchEvent(new Event("click"));
+    expect(resourcesTrigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(resourcesMenu?.hidden).toBe(true);
+
+    const systemContainer = targetDocument.body.querySelector('[data-desktop-menu-label="System"]');
+    const systemMenu = systemContainer?.querySelector(".desktop-help-menu-popover");
+    expect(systemContainer?.querySelector(".desktop-help-menu-trigger")?.textContent).toBe("System");
+    expect(systemMenu?.querySelector('[data-desktop-menu-command="open-settings"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Settings");
+    expect(systemMenu?.querySelector('[data-desktop-menu-command="refresh-gateway-status"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Gateway Status");
+    expect(systemMenu?.querySelector('[data-desktop-menu-command="open-docs"]')?.querySelector(".desktop-help-menu-label")?.textContent).toBe("Documentation");
+
+    const helpContainer = targetDocument.body.querySelector('[data-desktop-menu-label="Help"]');
+    const helpTrigger = helpContainer?.querySelector(".desktop-help-menu-trigger");
+    const helpMenu = helpContainer?.querySelector(".desktop-help-menu-popover");
     expect(helpTrigger?.textContent).toBe("Help");
     expect(helpTrigger?.getAttribute("aria-haspopup")).toBe("menu");
     expect(helpTrigger?.getAttribute("aria-expanded")).toBe("false");
@@ -390,7 +434,7 @@ describe("desktop window frame", () => {
       currentWindow,
     });
 
-    const helpMenu = document.body.querySelector<HTMLElement>(".desktop-help-menu");
+    const helpMenu = document.body.querySelector<HTMLElement>('[data-desktop-menu-label="Help"]');
     const helpTrigger = helpMenu?.querySelector<HTMLButtonElement>(".desktop-help-menu-trigger");
     const shortcutHelp = helpMenu?.querySelector<HTMLButtonElement>('[data-desktop-menu-command="open-shortcut-help"]');
     expect(helpMenu?.getAttribute("data-desktop-vue-island")).toBe("desktop-help-menu");
@@ -406,7 +450,7 @@ describe("desktop window frame", () => {
     expect(helpTrigger?.getAttribute("aria-expanded")).toBe("false");
   });
 
-  test("uses Vue island hosts for real app menu commands", () => {
+  test("routes real app menu commands through the compact app menu", () => {
     document.body.replaceChildren();
     document.head.replaceChildren();
     const currentWindow = {
@@ -425,12 +469,18 @@ describe("desktop window frame", () => {
       currentWindow,
     });
 
-    const settings = document.body.querySelector<HTMLElement>('[data-desktop-menu-command="open-settings"]');
-    const docs = document.body.querySelector<HTMLElement>('[data-desktop-menu-command="open-docs"]');
-    const theme = document.body.querySelector<HTMLElement>('[data-desktop-menu-command="toggle-theme"]');
-    expect(settings?.closest("[data-desktop-vue-island]")?.getAttribute("data-desktop-vue-island")).toBe("desktop-app-menu-command");
-    expect(docs?.closest("[data-desktop-vue-island]")?.getAttribute("data-desktop-vue-island")).toBe("desktop-app-menu-command");
-    expect(theme?.closest("[data-desktop-vue-island]")?.getAttribute("data-desktop-vue-island")).toBe("desktop-app-menu-command");
+    const appMenu = document.body.querySelector<HTMLElement>('[data-desktop-menu-label="App"]');
+    const resourcesMenu = document.body.querySelector<HTMLElement>('[data-desktop-menu-label="Resources"]');
+    const systemMenu = document.body.querySelector<HTMLElement>('[data-desktop-menu-label="System"]');
+    const theme = appMenu?.querySelector<HTMLElement>('[data-desktop-menu-command="toggle-theme"]');
+    const workspace = resourcesMenu?.querySelector<HTMLElement>('[data-desktop-menu-command="open-workspace"]');
+    const settings = systemMenu?.querySelector<HTMLElement>('[data-desktop-menu-command="open-settings"]');
+    expect(document.body.querySelector(".desktop-app-menu .desktop-help-menu-trigger")?.textContent).toBe("App");
+    expect(document.body.querySelector(".desktop-resources-menu .desktop-help-menu-trigger")?.textContent).toBe("Resources");
+    expect(document.body.querySelector(".desktop-system-menu .desktop-help-menu-trigger")?.textContent).toBe("System");
+    expect(theme?.closest(".desktop-app-menu")).not.toBeNull();
+    expect(workspace?.closest(".desktop-resources-menu")).not.toBeNull();
+    expect(settings?.closest(".desktop-system-menu")).not.toBeNull();
     expect(settings?.textContent).toContain("Settings");
 
     settings?.click();

--- a/apps/desktop/src/desktopWindowFrame.ts
+++ b/apps/desktop/src/desktopWindowFrame.ts
@@ -1,6 +1,11 @@
-import { DESKTOP_CHROME_COMMANDS, DESKTOP_HELP_COMMANDS, type DesktopMenuCommand } from "./desktopCommandNavigation";
+import {
+  DESKTOP_CHROME_COMMANDS,
+  DESKTOP_HELP_COMMANDS,
+  DESKTOP_RESOURCE_COMMANDS,
+  DESKTOP_SYSTEM_COMMANDS,
+  type DesktopMenuCommand,
+} from "./desktopCommandNavigation";
 import type { GatewayRuntimeStatus } from "./desktopGatewayStartup";
-import { mountDesktopAppMenuCommandIsland } from "./native-vue/desktopAppMenuCommandIsland";
 import { mountDesktopHelpMenuIsland } from "./native-vue/desktopHelpMenuIsland";
 import { mountOrUpdateDesktopRuntimeStatusIsland } from "./native-vue/desktopRuntimeStatusIsland";
 import { mountDesktopWindowControlsIsland } from "./native-vue/desktopWindowControlsIsland";
@@ -123,49 +128,30 @@ function createApplicationMenu(targetDocument: Document): HTMLElement {
   menu.className = "desktop-application-menu";
   menu.setAttribute("aria-label", "Desktop application menu");
 
-  for (const command of DESKTOP_CHROME_COMMANDS) {
-    menu.append(createApplicationMenuCommand(targetDocument, command));
-    if (command.id === "open-docs") {
-      menu.append(createHelpMenu(targetDocument));
-    }
-  }
+  menu.append(
+    createDesktopTopMenu(targetDocument, "App", "Application menu", DESKTOP_CHROME_COMMANDS),
+    createDesktopTopMenu(targetDocument, "Resources", "Resources menu", DESKTOP_RESOURCE_COMMANDS),
+    createDesktopTopMenu(targetDocument, "System", "System menu", DESKTOP_SYSTEM_COMMANDS),
+    createDesktopTopMenu(targetDocument, "Help", "Help menu", DESKTOP_HELP_COMMANDS),
+  );
 
   return menu;
 }
 
-function createApplicationMenuCommand(targetDocument: Document, command: DesktopMenuCommand): HTMLElement {
-  const host = targetDocument.createElement("span");
-  if (canMountDesktopAppMenuCommandIsland(host)) {
-    mountDesktopAppMenuCommandIsland(host, {
-      command,
-      onCommand: (id) => {
-        targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id } }));
-      },
-    });
-    return host;
-  }
-
-  const button = targetDocument.createElement("button");
-  button.type = "button";
-  button.className = "desktop-application-menu-item";
-  button.setAttribute("data-desktop-menu-command", command.id);
-  button.setAttribute("aria-label", `${command.label} (${command.shortcut})`);
-  button.title = `${command.label} (${command.shortcut})`;
-  button.textContent = command.chromeLabel ?? command.label;
-  button.addEventListener("pointerdown", (event) => event.stopPropagation());
-  button.addEventListener("dblclick", (event) => event.stopPropagation());
-  button.addEventListener("click", (event) => {
-    event.stopPropagation();
-    targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: command.id } }));
-  });
-  return button;
-}
-
-function createHelpMenu(targetDocument: Document): HTMLElement {
+function createDesktopTopMenu(
+  targetDocument: Document,
+  label: string,
+  menuLabel: string,
+  commands: DesktopMenuCommand[],
+): HTMLElement {
   const menu = targetDocument.createElement("div");
+  menu.className = `desktop-help-menu desktop-${label.toLowerCase()}-menu`;
+  menu.setAttribute("data-desktop-menu-label", label);
   if (canMountDesktopHelpMenuIsland(menu)) {
     mountDesktopHelpMenuIsland(menu, {
-      commands: DESKTOP_HELP_COMMANDS,
+      commands,
+      label,
+      menuLabel,
       onCommand: (id) => {
         targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id } }));
       },
@@ -173,19 +159,17 @@ function createHelpMenu(targetDocument: Document): HTMLElement {
     return menu;
   }
 
-  menu.className = "desktop-help-menu";
-
   const trigger = targetDocument.createElement("button");
   trigger.type = "button";
   trigger.className = "desktop-application-menu-item desktop-help-menu-trigger";
   trigger.setAttribute("aria-haspopup", "menu");
   trigger.setAttribute("aria-expanded", "false");
-  trigger.textContent = "Help";
+  trigger.textContent = label;
 
   const popover = targetDocument.createElement("div");
   popover.className = "desktop-help-menu-popover";
   popover.setAttribute("role", "menu");
-  popover.setAttribute("aria-label", "Help menu");
+  popover.setAttribute("aria-label", menuLabel);
   popover.hidden = true;
 
   const close = () => {
@@ -194,9 +178,14 @@ function createHelpMenu(targetDocument: Document): HTMLElement {
   };
   const toggle = () => {
     const expanded = trigger.getAttribute("aria-expanded") === "true";
+    targetDocument.dispatchEvent(new CustomEvent("desktop-menu-close-all"));
     popover.hidden = expanded;
     trigger.setAttribute("aria-expanded", String(!expanded));
   };
+  const handleOutsideClick = () => close();
+  const handleCloseAll = () => close();
+  targetDocument.addEventListener("click", handleOutsideClick);
+  targetDocument.addEventListener("desktop-menu-close-all", handleCloseAll);
 
   trigger.addEventListener("pointerdown", (event) => event.stopPropagation());
   trigger.addEventListener("dblclick", (event) => event.stopPropagation());
@@ -212,30 +201,42 @@ function createHelpMenu(targetDocument: Document): HTMLElement {
     close();
   });
 
-  for (const command of DESKTOP_HELP_COMMANDS) {
-    const item = targetDocument.createElement("button");
-    item.type = "button";
-    item.className = "desktop-help-menu-item";
-    item.setAttribute("role", "menuitem");
-    item.setAttribute("data-desktop-menu-command", command.id);
-    item.setAttribute("aria-label", `${command.label} (${command.shortcut})`);
-    item.title = `${command.label} (${command.shortcut})`;
-    item.append(
-      createHelpMenuText(targetDocument, "desktop-help-menu-label", command.label),
-      createHelpMenuText(targetDocument, "desktop-help-menu-shortcut", command.shortcut),
-    );
-    item.addEventListener("pointerdown", (event) => event.stopPropagation());
-    item.addEventListener("dblclick", (event) => event.stopPropagation());
-    item.addEventListener("click", (event) => {
-      event.stopPropagation();
-      close();
-      targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: command.id } }));
-    });
-    popover.append(item);
+  for (const command of commands) {
+    popover.append(createMenuPopoverCommand(targetDocument, command, close));
   }
 
   menu.append(trigger, popover);
   return menu;
+}
+
+function createMenuPopoverCommand(
+  targetDocument: Document,
+  command: DesktopMenuCommand,
+  close: () => void,
+): HTMLElement {
+  const item = targetDocument.createElement("button");
+  item.type = "button";
+  item.className = "desktop-help-menu-item";
+  item.setAttribute("role", "menuitem");
+  item.setAttribute("data-desktop-menu-command", command.id);
+  item.setAttribute("aria-label", menuCommandAccessibleLabel(command));
+  item.title = menuCommandAccessibleLabel(command);
+  item.append(
+    createHelpMenuText(targetDocument, "desktop-help-menu-label", command.label),
+    ...(command.shortcut ? [createHelpMenuText(targetDocument, "desktop-help-menu-shortcut", command.shortcut)] : []),
+  );
+  item.addEventListener("pointerdown", (event) => event.stopPropagation());
+  item.addEventListener("dblclick", (event) => event.stopPropagation());
+  item.addEventListener("click", (event) => {
+    event.stopPropagation();
+    close();
+    targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", { detail: { id: command.id } }));
+  });
+  return item;
+}
+
+function menuCommandAccessibleLabel(command: DesktopMenuCommand): string {
+  return command.shortcut ? `${command.label} (${command.shortcut})` : command.label;
 }
 
 function canMountDesktopHelpMenuIsland(menu: HTMLElement): boolean {
@@ -323,10 +324,6 @@ function createWindowButton(
     void handler().catch(logWindowFrameError);
   });
   return button;
-}
-
-function canMountDesktopAppMenuCommandIsland(host: HTMLElement): boolean {
-  return typeof window !== "undefined" && host instanceof window.HTMLElement;
 }
 
 function canMountDesktopWindowControlsIsland(controls: HTMLElement): boolean {
@@ -446,7 +443,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       z-index: 1410;
       display: grid;
       gap: 2px;
-      width: 260px;
+      width: 236px;
       border: 1px solid color-mix(in srgb, var(--border, #e6dfd8) 72%, transparent);
       border-radius: 8px;
       padding: 8px 0;

--- a/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
@@ -52,10 +52,10 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("./native-vue/taskCenterIsland")');
   });
 
-  test("statically imports the panel controls island", () => {
+  test("does not lazy load the retired panel controls island", () => {
     const source = readFileSync(resolve(__dirname, "desktopWorkbenchShell.ts"), "utf8");
 
-    expect(source).toContain('import { mountPanelControlsIsland } from "./native-vue/panelControlsIsland";');
+    expect(source).not.toContain('import { mountPanelControlsIsland } from "./native-vue/panelControlsIsland";');
     expect(source).not.toContain('void import("./native-vue/panelControlsIsland")');
   });
 
@@ -100,7 +100,6 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("./native-vue/conversationAttachmentIsland")');
     expect(source).toContain('import { mountConversationBodyIsland } from "./native-vue/conversationBodyIsland";');
     expect(source).not.toContain('void import("./native-vue/conversationBodyIsland")');
-    expect(source).toContain('import { mountConversationEmptyStateIsland } from "./native-vue/conversationEmptyStateIsland";');
     expect(source).not.toContain('void import("./native-vue/conversationEmptyStateIsland")');
     expect(source).toContain('import { mountConversationMetaIsland } from "./native-vue/conversationMetaIsland";');
     expect(source).not.toContain('void import("./native-vue/conversationMetaIsland")');
@@ -160,7 +159,7 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("./native-vue/toolDetailIsland")');
     expect(source).toContain('import { mountToolsListIsland } from "./native-vue/toolsListIsland";');
     expect(source).not.toContain('void import("./native-vue/toolsListIsland")');
-    expect(source).toContain('import { mountToolsSkillsActionsIsland } from "./native-vue/toolsSkillsActionsIsland";');
+    expect(source).toContain('import { mountToolsSkillsActionsIsland, type ToolsSkillsActionId } from "./native-vue/toolsSkillsActionsIsland";');
     expect(source).not.toContain('void import("./native-vue/toolsSkillsActionsIsland")');
   });
 
@@ -259,16 +258,16 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("./native-vue/sessionUploadCardIsland")');
   });
 
-  test("statically imports the shared sidebar islands", () => {
+  test("does not import shared resource/system sidebar islands into the workbench shell", () => {
     const source = readFileSync(resolve(__dirname, "desktopWorkbenchShell.ts"), "utf8");
 
-    expect(source).toContain('import { mountSharedSidebarCommandButtonIsland } from "./native-vue/sharedSidebarCommandButtonIsland";');
+    expect(source).not.toContain('import { mountSharedSidebarCommandButtonIsland } from "./native-vue/sharedSidebarCommandButtonIsland";');
     expect(source).not.toContain('void import("./native-vue/sharedSidebarCommandButtonIsland")');
-    expect(source).toContain('import { mountSharedSidebarCommandsIsland } from "./native-vue/sharedSidebarCommandsIsland";');
+    expect(source).not.toContain('import { mountSharedSidebarCommandsIsland } from "./native-vue/sharedSidebarCommandsIsland";');
     expect(source).not.toContain('void import("./native-vue/sharedSidebarCommandsIsland")');
-    expect(source).toContain('import { mountSharedSidebarLinkIsland } from "./native-vue/sharedSidebarLinkIsland";');
+    expect(source).not.toContain('import { mountSharedSidebarLinkIsland } from "./native-vue/sharedSidebarLinkIsland";');
     expect(source).not.toContain('void import("./native-vue/sharedSidebarLinkIsland")');
-    expect(source).toContain('import { mountSharedSidebarLinksIsland } from "./native-vue/sharedSidebarLinksIsland";');
+    expect(source).not.toContain('import { mountSharedSidebarLinksIsland } from "./native-vue/sharedSidebarLinksIsland";');
     expect(source).not.toContain('void import("./native-vue/sharedSidebarLinksIsland")');
   });
 

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -265,16 +265,16 @@ describe("desktop workbench shell", () => {
       },
     });
 
-    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session.");
-    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session. Start");
-    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Start from chat, inspect the workspace, or check gateway status.");
+    expect(targetDocument.body.querySelector(".desktop-chat-workbench-chrome")?.textContent).toContain("Start a new session");
+    expect(targetDocument.body.querySelector(".desktop-chat-workbench-chrome")?.textContent).toContain("Ask Tinybot about the workspace, inspect files, or create a task.");
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("sessionStart");
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("session.Start");
     expect(targetDocument.body.querySelectorAll(".desktop-quick-action").map((node) => node.textContent)).toEqual([
-      "New chat",
+      "Ask about this project",
       "Open workspace",
-      "Gateway status",
+      "Check gateway",
     ]);
+    expect(targetDocument.body.querySelector(".desktop-panel-controls")).toBeNull();
     expect(targetDocument.body.querySelector(".desktop-status-strip")?.textContent).toContain("http://127.0.0.1:18790");
   });
 
@@ -407,6 +407,8 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.getElementById("desktop-workbench-shell")).toBe(shell);
     expect(targetDocument.body.textContent).toContain("Updated live session");
     expect(targetDocument.body.textContent).toContain("Updated without full shell reinstall.");
+    expect(targetDocument.body.textContent).not.toContain("Ready for a new session");
+    expect(targetDocument.body.querySelector(".desktop-chat-workbench-chrome")).toBeNull();
     expect(targetDocument.body.textContent).not.toContain("Updated status");
     expect(targetDocument.getElementById("desktop-native-composer")?.getAttribute("data-desktop-composer-responding")).toBe("true");
     expect(targetDocument.getElementById("desktop-native-composer")?.getAttribute("data-desktop-composer-rag")).toBe("false");
@@ -470,6 +472,8 @@ describe("desktop workbench shell", () => {
     const messages = thread?.querySelectorAll(".desktop-conversation-message") ?? [];
     expect(thread?.querySelector(".desktop-conversation-avatar")).toBeNull();
     expect(messages).toHaveLength(2);
+    expect(targetDocument.body.textContent).not.toContain("Ready for a new session");
+    expect(targetDocument.body.querySelector(".desktop-chat-workbench-chrome")).toBeNull();
 
     const userBody = messages[0].querySelector(".desktop-conversation-body");
     expect(userBody?.textContent).toContain("<img src=x onerror=alert(1)>");
@@ -527,8 +531,11 @@ describe("desktop workbench shell", () => {
     const toolActivity = message?.querySelector(".desktop-tool-activity");
     const body = message?.querySelector(".desktop-conversation-body");
 
+    expect(message?.querySelector(".desktop-conversation-header")?.querySelector(".desktop-conversation-meta")?.textContent).toContain("Tinybot");
+    expect(reasoning?.querySelector(".desktop-message-reasoning-summary")?.textContent).toBe("Details");
+    expect(message?.querySelector(".desktop-conversation-content")?.children[1]).toBe(reasoning);
     expect(reasoning?.tagName).toBe("details");
-    expect(reasoning?.querySelector(".desktop-message-reasoning-title")?.textContent).toBe("Thinking");
+    expect(reasoning?.querySelector(".desktop-message-reasoning-title")).toBeNull();
     expect(reasoning?.textContent).toContain("I should inspect the workspace first.");
     expect(toolActivity?.tagName).toBe("details");
     expect(toolActivity?.querySelector(".desktop-tool-activity-title")?.textContent).toBe("shell");
@@ -643,6 +650,12 @@ describe("desktop workbench shell", () => {
       targetDocument: targetDocument as unknown as Document,
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+      },
     });
 
     const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
@@ -662,9 +675,14 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain("border-radius: 999px;");
     expect(styleText).toContain("border: 0;");
     expect(styleText).toContain("box-shadow: none;");
-    expect(styleText).toContain("box-shadow: 0 8px 20px rgba(216, 112, 72, 0.18);");
+    expect(styleText).toContain("background: transparent;");
+    expect(styleText).toContain("background: #fff7ef;");
+    expect(styleText).toContain(".desktop-native-composer-model:hover");
     expect(styleText).toContain(".desktop-native-composer-model:focus-visible");
+    expect(styleText).toContain(".desktop-native-composer-rag-toggle:hover");
     expect(styleText).toContain('.desktop-native-composer-rag-toggle[aria-pressed="true"]');
+    expect(styleText).toContain('.desktop-native-composer-rag-toggle[aria-pressed="false"]:not(:hover):not(:focus-visible)');
+    expect(styleText).not.toContain("box-shadow: 0 8px 20px rgba(216, 112, 72, 0.18);");
     expect(styleText).toContain("padding: 14px 8px 8px 14px;");
     expect(styleText).toContain("grid-template-rows: auto auto;");
     expect(styleText).toContain("min-height: 0;");
@@ -744,7 +762,8 @@ describe("desktop workbench shell", () => {
     expect(workspaceList?.textContent).toContain("tinybot");
     expect(recentChats?.textContent).toContain("Design native workbench");
     const sidebarStyle = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
-    expect(sidebarStyle).toContain("grid-template-rows: auto auto auto");
+    expect(sidebarStyle).toContain("flex-direction: column;");
+    expect(sidebarStyle).toContain("overflow-y: auto;");
     expect(sidebarStyle).toContain(".desktop-sidebar-list-section-recent");
     expect(sidebarStyle).toContain("max-height: min(42vh, 360px)");
 
@@ -754,6 +773,7 @@ describe("desktop workbench shell", () => {
     expect(chatHeader).toBeTruthy();
     expect(conversationThread).toBeTruthy();
     expect(composerModel).toBeTruthy();
+    expect(chatHeader?.querySelector(".desktop-chat-context")?.textContent).toBe("tinybot");
     expect(chatHeader?.textContent).toContain("Design native workbench");
     expect(conversationThread?.textContent).toContain("这是目前的 native 界面");
     expect(composerModel?.textContent).toContain("Tinybot Pro");
@@ -761,26 +781,35 @@ describe("desktop workbench shell", () => {
     const inspector = targetDocument.body.querySelector(".desktop-inspector-content");
     const runTabs = targetDocument.body.querySelector(".desktop-run-chain-tabs");
     const runCards = targetDocument.body.querySelector(".desktop-run-chain-cards");
-    const runNewItem = targetDocument.body.querySelector(".desktop-run-chain-new-item");
     expect(inspector).toBeTruthy();
     expect(runTabs).toBeTruthy();
     expect(runCards).toBeTruthy();
-    expect(runNewItem).toBeTruthy();
     expect(inspector?.textContent).toContain("Run Chain");
     expect(runTabs?.textContent).toContain("Context");
     expect(runCards?.textContent).toContain("Gateway");
     targetDocument.body.querySelector('[data-desktop-run-chain-tab="files"]')?.click();
     expect(runCards?.textContent).toContain("Workspace");
+    expect(targetDocument.body.querySelectorAll(".desktop-run-chain-new-item")).toHaveLength(0);
+    targetDocument.body.querySelector('[data-desktop-run-chain-tab="tasks"]')?.click();
+    const runNewItem = targetDocument.body.querySelector(".desktop-run-chain-new-item");
     expect(runNewItem?.textContent).toContain("New Run Chain Item");
+    expect(runCards?.textContent).toContain("No chain items yet.");
   });
 
   test("renders explicit desktop navigation links for workbench, docs, gateway, and external routes", () => {
     const targetDocument = new FakeDocument();
+    const chat = {
+      sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+      activeSessionKey: "WebSocket:chat-live",
+      activeChatId: "chat-live",
+      messages: [],
+    };
 
     installDesktopWorkbenchShell({
       targetDocument: targetDocument as unknown as Document,
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
+      chat,
     });
 
     expect(targetDocument.body.querySelectorAll(".desktop-activity-button").map((node) => node.getAttribute("href"))).toEqual([
@@ -788,6 +817,8 @@ describe("desktop workbench shell", () => {
       "/workspace",
       "/knowledge",
       "/cowork",
+      "/docs",
+      "https://github.com/SudoJacky/tinybot",
     ]);
     expect([
       ...targetDocument.body.querySelectorAll(".desktop-activity-button"),
@@ -798,41 +829,37 @@ describe("desktop workbench shell", () => {
       "/workspace",
       "/api/status",
     ]);
-    expect(targetDocument.body.querySelectorAll(".desktop-workbench-link").map((node) => node.getAttribute("href"))).toEqual([
-      "/workspace",
-      "/knowledge",
-      "/tools",
-      "/cowork",
-      "/docs",
-      "https://github.com/SudoJacky/tinybot",
-      null,
-      null,
-      null,
+    expect(targetDocument.body.querySelectorAll(".desktop-quick-action").map((node) => node.textContent)).toEqual([
+      "Ask about this project",
+      "Open workspace",
+      "Check gateway",
     ]);
+    expect(targetDocument.body.querySelectorAll(".desktop-workbench-link")).toHaveLength(0);
+    expect(targetDocument.body.querySelectorAll("[data-sidebar-command]")).toHaveLength(0);
     expect(targetDocument.body.querySelector(".desktop-status-strip")?.getAttribute("data-desktop-route-status")).toBe("");
   });
 
-  test("renders native sidebar navigation from shared desktop item metadata", () => {
+  test("keeps resource and system navigation out of the native sidebar", () => {
     const targetDocument = new FakeDocument();
 
     installDesktopWorkbenchShell({
       targetDocument: targetDocument as unknown as Document,
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+      },
     });
 
-    expect(targetDocument.body.querySelectorAll(".desktop-workbench-link")
-      .filter((node) => node.getAttribute("href") !== null)
-      .map((node) => node.getAttribute("data-sidebar-item-id"))).toEqual([
-      "link:workspace",
-      "link:knowledge",
-      "link:tools",
-      "link:automations",
-      "link:docs",
-      "link:repo",
-    ]);
-    expect(targetDocument.body.querySelector('[data-sidebar-command="open-settings"]')?.textContent).toBe("Settings");
-    expect(targetDocument.body.querySelector('[data-sidebar-command="refresh-gateway-status"]')?.textContent).toBe("Gateway Status");
+    expect(targetDocument.body.querySelector(".desktop-sidebar-list-section-workspaces")?.textContent).toContain("tinybot");
+    expect(targetDocument.body.querySelector(".desktop-sidebar-list-section-recent")?.textContent).toContain("Live session");
+    expect(targetDocument.body.querySelectorAll(".desktop-workbench-link")).toHaveLength(0);
+    expect(targetDocument.body.querySelectorAll("[data-sidebar-command]")).toHaveLength(0);
+    expect(targetDocument.body.textContent).not.toContain("RESOURCES");
+    expect(targetDocument.body.textContent).not.toContain("SYSTEM");
   });
 
   test("renders a keyboard-accessible command palette surface", () => {
@@ -905,15 +932,24 @@ describe("desktop workbench shell", () => {
     });
 
     const activityButtons = targetDocument.body.querySelectorAll(".desktop-activity-button");
-    expect(activityButtons.map((node) => node.getAttribute("href"))).toEqual(["/chat", "/workspace", "/knowledge", "/cowork"]);
-    expect(activityButtons.map((node) => node.getAttribute("aria-label"))).toEqual(["Chat", "Files", "Knowledge", "Cowork"]);
-    expect(activityButtons.map((node) => node.textContent)).toEqual(["Chat", "Files", "Knowledge", "Cowork"]);
-    expect(activityButtons.map((node) => node.getAttribute("data-desktop-module-target"))).toEqual(["chat", "workspace", "knowledge", "cowork"]);
+    expect(activityButtons.map((node) => node.getAttribute("href"))).toEqual([
+      "/chat",
+      "/workspace",
+      "/knowledge",
+      "/cowork",
+      "/docs",
+      "https://github.com/SudoJacky/tinybot",
+    ]);
+    expect(activityButtons.map((node) => node.getAttribute("aria-label"))).toEqual(["Chat", "Files", "Knowledge", "Cowork", "Docs", "GitHub"]);
+    expect(activityButtons.map((node) => node.textContent)).toEqual(["Chat", "Files", "Knowledge", "Cowork", "Docs", "GitHub"]);
+    expect(activityButtons.map((node) => node.getAttribute("data-desktop-module-target"))).toEqual(["chat", "workspace", "knowledge", "cowork", "docs", "gateway"]);
     expect(activityButtons.map((node) => node.getAttribute("data-focus-order"))).toEqual([
       "activity-1",
       "activity-2",
       "activity-3",
       "activity-4",
+      "activity-5",
+      "activity-6",
     ]);
   });
 
@@ -1120,16 +1156,14 @@ describe("desktop workbench shell", () => {
       gatewayHttp: "http://127.0.0.1:18790",
     });
 
-    const controls = targetDocument.body.querySelectorAll(".desktop-panel-control");
-    expect(controls.map((node) => node.getAttribute("data-desktop-panel-control"))).toEqual(["sidebar", "inspector", "bottom"]);
+    const controls = targetDocument.body.querySelectorAll(".desktop-chat-header-panel-button");
+    expect(controls.map((node) => node.getAttribute("data-desktop-panel-control"))).toEqual(["sidebar", "inspector"]);
     expect(controls.map((node) => node.getAttribute("aria-label"))).toEqual([
-      "Toggle sidebar panel",
-      "Toggle Run Chain panel",
-      "Toggle task and runtime panel",
+      "Collapse session list",
+      "Close Run Chain panel",
     ]);
-    expect(controls.map((node) => node.textContent)).toEqual(["Sidebar", "Run Chain", "Tasks"]);
-    expect(controls.map((node) => node.getAttribute("aria-pressed"))).toEqual(["true", "true", "false"]);
-    expect(controls[0].getAttribute("aria-keyshortcuts")).toBe("Ctrl+B");
+    expect(controls.map((node) => node.getAttribute("aria-pressed"))).toEqual(["true", "true"]);
+    expect(controls[0].querySelector(".desktop-chat-header-panel-icon")?.getAttribute("data-panel-icon")).toBe("collapse-left");
 
     let prevented = false;
     controls[1].dispatchEvent({
@@ -1161,6 +1195,10 @@ describe("desktop workbench shell", () => {
     expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Gateway: Connected");
     expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Run: Idle");
     expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("0 items");
+    expect(overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.className).toContain("desktop-run-chain-status-pill");
+    expect(overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.getAttribute("data-status-tone")).toBe("connected");
+    expect(overview?.querySelector('[data-desktop-run-chain-summary="run"]')?.getAttribute("data-status-tone")).toBe("muted");
+    expect(overview?.querySelector(".desktop-run-chain-status-dot")).not.toBeNull();
     expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("context");
     expect(panel?.textContent).toContain("Endpoint");
 
@@ -1173,8 +1211,11 @@ describe("desktop workbench shell", () => {
     overview?.querySelector('[data-desktop-run-chain-tab="tasks"]')?.click();
     expect(overview?.querySelector('[data-desktop-run-chain-tab="tasks"]')?.getAttribute("aria-selected")).toBe("true");
     expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("tasks");
-    expect(panel?.textContent).toContain("Current Run");
+    expect(panel?.textContent).toContain("Tasks");
+    expect(panel?.textContent).toContain("Task center: Available");
+    expect(panel?.textContent).toContain("No chain items yet.");
     expect(panel?.textContent).toContain("New Run Chain Item");
+    expect(panel?.querySelector(".desktop-run-chain-new-item")?.getAttribute("data-button-variant")).toBe("secondary");
 
     overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.click();
     expect(overview?.querySelector('[data-desktop-run-chain-tab="context"]')?.getAttribute("aria-selected")).toBe("true");
@@ -1187,6 +1228,11 @@ describe("desktop workbench shell", () => {
     expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("tasks");
 
     const pin = overview?.querySelector('[data-desktop-run-chain-control="pin"]');
+    expect(pin?.getAttribute("data-button-variant")).toBe("ghost");
+    expect(pin?.getAttribute("aria-label")).toBe("Pin panel");
+    expect(overview?.querySelector('[data-desktop-run-chain-control="close"]')?.getAttribute("title")).toBe("Close panel");
+    expect(overview?.querySelector('[data-desktop-run-chain-action="Open Task Center"]')?.getAttribute("data-button-variant")).toBe("primary");
+    expect(overview?.querySelector('[data-desktop-run-chain-action="New Run Chain Item"]')?.getAttribute("data-button-variant")).toBe("secondary");
     expect(pin?.getAttribute("aria-pressed")).toBe("false");
     pin?.click();
     expect(pin?.getAttribute("aria-pressed")).toBe("true");
@@ -1245,13 +1291,87 @@ describe("desktop workbench shell", () => {
     pane?.querySelector('[data-desktop-run-chain-item="m-plan:planning"]')?.click();
     expect(pane?.querySelector('[data-desktop-run-chain-item="m-plan:planning"]')?.getAttribute("aria-selected")).toBe("true");
     expect(pane?.querySelector(".desktop-run-chain-detail")?.textContent).toContain("Thinking: Inspect the active context");
-    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Ready for a new session.");
-    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("session.Start");
+    expect(targetDocument.body.querySelector(".desktop-chat-workbench-chrome")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("Ready for a new session.");
 
     targetDocument.body.querySelector('[data-desktop-run-chain-control="close"]')?.click();
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
     expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("false");
     expect(targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("opens the run-chain inspector detail when a conversation tool activity is selected", () => {
+    const targetDocument = new FakeDocument();
+    const layout = createDefaultWorkbenchLayout();
+    layout.inspector.visible = false;
+    const runChainItems = buildDesktopRunChainItems([
+      {
+        role: "assistant",
+        message_id: "assistant-1",
+        content: "The command finished.",
+        tool_calls: [
+          {
+            id: "call-shell",
+            type: "function",
+            function: {
+              name: "shell",
+              arguments: "{\"command\":\"pwd\"}",
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        message_id: "tool-result-1",
+        tool_call_id: "call-shell",
+        name: "shell",
+        content: "D:/code/tinybot",
+      },
+    ]);
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout,
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Tool chat", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [
+          {
+            role: "assistant",
+            content: "The command finished.",
+            reasoningContent: "",
+            toolActivities: [
+              {
+                id: "call-shell",
+                name: "shell",
+                argsText: "{\"command\":\"pwd\"}",
+                responseText: "D:/code/tinybot",
+                kind: "result",
+              },
+            ],
+            timestamp: "2026-06-03T08:20:00.000Z",
+            messageId: "assistant-1",
+          },
+        ],
+        status: "Connected",
+      },
+      runChainItems,
+    });
+
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
+    const toolActivity = targetDocument.body.querySelector(".desktop-tool-activity");
+    expect(toolActivity?.getAttribute("data-desktop-run-chain-item-key")).toBe("assistant-1:call-shell");
+
+    toolActivity?.querySelector(".desktop-tool-activity-summary")?.click();
+
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("true");
+    expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("true");
+    const selectedRow = targetDocument.body.querySelector('[data-desktop-run-chain-item="assistant-1:call-shell"]');
+    expect(selectedRow?.getAttribute("aria-selected")).toBe("true");
+    expect(targetDocument.body.querySelector(".desktop-run-chain-detail")?.textContent).toContain("shell");
+    expect(targetDocument.body.querySelector(".desktop-run-chain-detail")?.textContent).toContain("\"command\": \"pwd\"");
   });
 
   test("renders a right-side Work Lens before generic inspector detail for running work", () => {
@@ -1495,6 +1615,12 @@ describe("desktop workbench shell", () => {
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
       taskCenterItems: items,
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+      },
     });
 
     targetDocument.body.querySelector('[data-desktop-task-action="inspect"]')?.click();
@@ -1572,6 +1698,12 @@ describe("desktop workbench shell", () => {
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
       taskCenterItems: items,
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+      },
     });
 
     targetDocument.body.querySelector('[data-desktop-module-work="chat:stream:chat-1"]')?.click();
@@ -2922,6 +3054,12 @@ describe("desktop workbench shell", () => {
       targetDocument: targetDocument as unknown as Document,
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+      },
     });
 
     expect(targetDocument.getElementById("desktop-workspace-recent-files")?.getAttribute("aria-label")).toBe("Recent workspace files");
@@ -3184,10 +3322,16 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain(".desktop-native-composer-runtime {\n      grid-area: runtime;");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-thread {\n      display: grid;");
     expect(styleText).toContain("overflow-y: auto;");
-    expect(styleText).toContain("body.desktop-native-workbench .desktop-chat-workbench {\n      align-self: stretch;");
+    expect(styleText).toContain("--desktop-chat-column-width: 840px;");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-chat-workbench {");
+    expect(styleText).toContain("align-self: stretch;");
     expect(styleText).toContain("height: 100%;");
     expect(styleText).toContain("padding: 0 clamp(20px, 3vw, 46px);");
-    expect(styleText).toContain("width: min(1120px, 100%);");
+    expect(styleText).toContain("width: min(var(--desktop-chat-column-width), 100%);");
+    expect(styleText).toContain("width: min(var(--desktop-chat-column-width), calc(100% - 112px));");
+    expect(styleText).toContain("--desktop-composer-reserve: 152px;");
+    expect(styleText).toContain("padding: 18px 0 var(--desktop-composer-reserve);");
+    expect(styleText).toContain("gap: 10px;");
     expect(styleText).toContain("grid-template-rows: minmax(0, 1fr) auto 0;");
     expect(styleText).toContain("margin: 0 auto 8px;");
     expect(styleText).toContain("margin: 16px 16px 16px 0;");
@@ -3236,16 +3380,24 @@ describe("desktop workbench shell", () => {
 
   test("keeps empty-session support copy concise for minimum windows", () => {
     const targetDocument = new FakeDocument();
+    const chat = {
+      sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+      activeSessionKey: "WebSocket:chat-live",
+      activeChatId: "chat-live",
+      messages: [],
+    };
 
     installDesktopWorkbenchShell({
       targetDocument: targetDocument as unknown as Document,
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
+      chat,
     });
 
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("without leaving");
+    expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain("Start a new session");
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).toContain(
-      "Start from chat, inspect the workspace, or check gateway status.",
+      "Ask Tinybot about the workspace, inspect files, or create a task.",
     );
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("sessionStart");
     expect(targetDocument.body.querySelector(".desktop-empty-session")?.textContent).not.toContain("session.Start");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -45,11 +45,6 @@ import {
 } from "./desktopWorkLens";
 import type { WorkbenchLayoutState, WorkbenchPanelId, WorkbenchPanelState } from "./desktopWorkbenchLayout";
 import { loadWorkbenchLayout } from "./desktopWorkbenchLayout";
-import {
-  buildNativeWorkbenchSidebarModel,
-  type DesktopSidebarGroup,
-  type DesktopSidebarItem,
-} from "./desktopSharedModels";
 import { installDesktopDesignTokens } from "./desktopDesignTokens";
 import type { NativeChatMessage, NativeChatSession } from "./nativeChat";
 import { mountAgentUiFormActionsIsland } from "./native-vue/agentUiFormActionsIsland";
@@ -73,7 +68,6 @@ import { mountComposerSendButtonIsland } from "./native-vue/composerSendButtonIs
 import { mountComposerSurfaceIsland } from "./native-vue/composerSurfaceIsland";
 import { mountConversationAttachmentIsland } from "./native-vue/conversationAttachmentIsland";
 import { mountConversationBodyIsland } from "./native-vue/conversationBodyIsland";
-import { mountConversationEmptyStateIsland } from "./native-vue/conversationEmptyStateIsland";
 import { mountConversationMessageIsland } from "./native-vue/conversationMessageIsland";
 import { mountConversationMetaIsland } from "./native-vue/conversationMetaIsland";
 import { mountConversationReasoningIsland } from "./native-vue/conversationReasoningIsland";
@@ -109,7 +103,6 @@ import { mountKnowledgeReadinessIsland } from "./native-vue/knowledgeReadinessIs
 import { mountKnowledgeReferenceRowIsland } from "./native-vue/knowledgeReferenceRowIsland";
 import { mountMainUtilitiesRegionIsland } from "./native-vue/mainUtilitiesRegionIsland";
 import { mountModuleWorkSectionIsland } from "./native-vue/moduleWorkSectionIsland";
-import { mountPanelControlsIsland } from "./native-vue/panelControlsIsland";
 import { mountPanelIconPartIsland } from "./native-vue/panelIconPartIsland";
 import { mountPersistentRagToggleIsland } from "./native-vue/persistentRagToggleIsland";
 import { mountQuickActionsIsland } from "./native-vue/quickActionsIsland";
@@ -132,10 +125,6 @@ import { mountSettingsStatusIsland } from "./native-vue/settingsStatusIsland";
 import { mountSettingsStatusItemIsland } from "./native-vue/settingsStatusItemIsland";
 import { mountOrUpdateSessionFileListIsland } from "./native-vue/sessionFileListIsland";
 import { mountSessionUploadCardIsland } from "./native-vue/sessionUploadCardIsland";
-import { mountSharedSidebarCommandButtonIsland } from "./native-vue/sharedSidebarCommandButtonIsland";
-import { mountSharedSidebarCommandsIsland } from "./native-vue/sharedSidebarCommandsIsland";
-import { mountSharedSidebarLinkIsland } from "./native-vue/sharedSidebarLinkIsland";
-import { mountSharedSidebarLinksIsland } from "./native-vue/sharedSidebarLinksIsland";
 import { mountShortcutHelpDialogIsland } from "./native-vue/shortcutHelpDialogIsland";
 import { mountSkillEditorIsland } from "./native-vue/skillEditorIsland";
 import { mountSkillDetailSummaryIsland } from "./native-vue/skillDetailSummaryIsland";
@@ -147,9 +136,10 @@ import { mountTaskStateBadgeIsland } from "./native-vue/taskStateBadgeIsland";
 import { mountToolDetailIsland } from "./native-vue/toolDetailIsland";
 import { mountToolActivitiesIsland } from "./native-vue/toolActivitiesIsland";
 import { mountToolActivityIsland } from "./native-vue/toolActivityIsland";
+import type { ToolActivityIslandOptions } from "./native-vue/toolActivityIsland";
 import { mountToolActivitySectionIsland } from "./native-vue/toolActivitySectionIsland";
 import { mountToolsListIsland } from "./native-vue/toolsListIsland";
-import { mountToolsSkillsActionsIsland } from "./native-vue/toolsSkillsActionsIsland";
+import { mountToolsSkillsActionsIsland, type ToolsSkillsActionId } from "./native-vue/toolsSkillsActionsIsland";
 import { mountToolsSkillsPaneIsland } from "./native-vue/toolsSkillsPaneIsland";
 import { mountTokenUsageOrbIsland } from "./native-vue/tokenUsageOrbIsland";
 import { mountWorkLensIsland } from "./native-vue/workLensIsland";
@@ -157,6 +147,8 @@ import { mountWorkbenchPanelIsland } from "./native-vue/workbenchPanelIsland";
 import { mountWorkspaceBrowserIsland } from "./native-vue/workspaceBrowserIsland";
 
 const desktopPinnedChatSessions = new WeakMap<Document, Set<string>>();
+
+type ConversationToolActivityRenderOptions = ToolActivityIslandOptions;
 
 export interface DesktopTaskCenterActionEvent {
   action: DesktopTaskActionId;
@@ -380,14 +372,6 @@ const COWORK_OBSERVABILITY_ROW_LIMIT = 24;
 const COWORK_TASK_FEED_LIMIT = 20;
 type DesktopPanelControlId = "sidebar" | "inspector" | "bottom";
 
-interface DesktopPanelControlItem {
-  panel: DesktopPanelControlId;
-  label: string;
-  ariaLabel: string;
-  visible: boolean;
-  shortcut?: string;
-}
-
 export function installDesktopWorkbenchShell({
   targetDocument = document,
   layout = loadWorkbenchLayout(),
@@ -535,6 +519,8 @@ export function updateDesktopNativeChat(
     thread.replaceChildren(...Array.from(next.children));
   }
 
+  syncChatWorkbenchChrome(targetDocument, chat);
+
   const workspaceList = targetDocument.querySelector<HTMLElement>(".desktop-workspace-list");
   if (workspaceList) {
     const next = createSidebarWorkspaceList(targetDocument, chat).querySelector<HTMLElement>(".desktop-workspace-list");
@@ -557,6 +543,24 @@ export function updateDesktopNativeChat(
     composer.replaceChildren(...Array.from(next.children));
   }
   syncSessionFileUploadKey(targetDocument, chat.activeSessionKey);
+}
+
+function syncChatWorkbenchChrome(targetDocument: Document, chat: DesktopNativeChatModel): void {
+  const workbench = targetDocument.querySelector<HTMLElement>(".desktop-chat-workbench");
+  if (!workbench) {
+    return;
+  }
+  const header = workbench.querySelector<HTMLElement>(".desktop-chat-header");
+  const thread = workbench.querySelector<HTMLElement>(".desktop-conversation-thread");
+  const workLens = workbench.querySelector<HTMLElement>(".desktop-work-lens-inline");
+  const children = [header, thread].filter((child): child is HTMLElement => Boolean(child));
+  if (!hasVisibleConversationMessages(chat)) {
+    children.push(createChatWorkbenchEmptyState(targetDocument, []));
+  }
+  if (workLens) {
+    children.push(workLens);
+  }
+  workbench.replaceChildren(...children);
 }
 
 function syncNativeChatDocumentState(targetDocument: Document, chat: DesktopNativeChatModel): void {
@@ -633,6 +637,8 @@ function createActivityRail(targetDocument: Document): HTMLElement {
     ["Files", "/workspace", "workspace"],
     ["Knowledge", "/knowledge", "knowledge"],
     ["Cowork", "/cowork", "cowork"],
+    ["Docs", "/docs", "docs"],
+    ["GitHub", "https://github.com/SudoJacky/tinybot", "gateway"],
   ].entries()) {
     const item = targetDocument.createElement("a");
     item.className = "desktop-activity-button";
@@ -652,8 +658,6 @@ function createActivityRail(targetDocument: Document): HTMLElement {
   const secondary = targetDocument.createElement("div");
   secondary.className = "desktop-activity-secondary";
   for (const [label, href, module] of [
-    ["Docs", "/docs", "docs"],
-    ["GitHub", "https://github.com/SudoJacky/tinybot", "gateway"],
     ["Settings", "/settings", "settings"],
   ]) {
     const item = targetDocument.createElement("a");
@@ -675,20 +679,15 @@ function createSidebar(
   chat: DesktopNativeChatModel | null,
   chatActions: DesktopNativeChatActionOptions,
 ): HTMLElement {
-  const model = buildNativeWorkbenchSidebarModel();
-  const workspaceGroup = model.groups.find((group) => group.id === "workspace");
-  const footerGroup = model.groups.find((group) => group.id === "footer");
   const sidebar = targetDocument.createElement("div");
   sidebar.className = "desktop-sidebar-content";
   sidebar.append(
     createSidebarActions(targetDocument),
     createSidebarWorkspaceList(targetDocument, chat),
     createSidebarRecentChats(targetDocument, chat, chatActions),
-    createSharedSidebarLinkSection(targetDocument, workspaceGroup),
-    createSharedSidebarCommandSection(targetDocument, footerGroup),
   );
   if (chat) {
-    mountSidebarContentVueIsland(sidebar, targetDocument, chat, chatActions, workspaceGroup, footerGroup);
+    mountSidebarContentVueIsland(sidebar, targetDocument, chat);
   }
   return sidebar;
 }
@@ -697,9 +696,6 @@ function mountSidebarContentVueIsland(
   sidebar: HTMLElement,
   targetDocument: Document,
   chat: DesktopNativeChatModel,
-  chatActions: DesktopNativeChatActionOptions,
-  workspaceGroup: DesktopSidebarGroup | undefined,
-  footerGroup: DesktopSidebarGroup | undefined,
 ): void {
   if (!canMountVueIsland(sidebar)) {
     return;
@@ -711,11 +707,9 @@ function mountSidebarContentVueIsland(
     pinnedSessionKeys.has(session.key),
   ));
   mountSidebarContentIsland(sidebar, {
-    commandItems: sidebarCommandItems(footerGroup),
-    commandLabel: footerGroup?.label,
+    commandItems: [],
     recentChats,
-    resourceItems: sidebarLinkItems(workspaceGroup),
-    resourceLabel: workspaceGroup?.label,
+    resourceItems: [],
     targetDocument,
     workspaceRows: [{
       active: true,
@@ -724,18 +718,6 @@ function mountSidebarContentVueIsland(
       title: "tinybot",
     }],
   });
-}
-
-function sidebarLinkItems(group: DesktopSidebarGroup | undefined): Array<DesktopSidebarItem & { href: string; kind: "link" }> {
-  return (group?.items ?? []).flatMap((item) => item.kind === "link" && item.href
-    ? [{ ...item, href: item.href, kind: "link" as const }]
-    : []);
-}
-
-function sidebarCommandItems(group: DesktopSidebarGroup | undefined): Array<DesktopSidebarItem & { commandId: string; kind: "command" }> {
-  return (group?.items ?? []).flatMap((item) => item.kind === "command" && item.commandId
-    ? [{ ...item, commandId: item.commandId, kind: "command" as const }]
-    : []);
 }
 
 function createSidebarActions(targetDocument: Document): HTMLElement {
@@ -1148,25 +1130,19 @@ function createMainRegion(
   main.setAttribute("data-workbench-region", "main");
   main.setAttribute("aria-label", "Primary desktop work area");
   const chatWorkItems = moduleWorkItems(taskCenterItems, "chat");
+  const showEmptySession = chat ? !hasVisibleConversationMessages(chat) : false;
 
   const workbench = targetDocument.createElement("div");
   workbench.className = "desktop-empty-session desktop-chat-workbench";
-  const workbenchChrome = targetDocument.createElement("div");
-  workbenchChrome.className = "desktop-chat-workbench-chrome";
-  workbenchChrome.append(
-    createText(targetDocument, "span", "Ready for a new session. "),
-    createText(targetDocument, "span", "Start from chat, inspect the workspace, or check gateway status."),
-    createQuickActions(targetDocument),
-    createPanelControls(targetDocument, layout),
-    ...(chatWorkItems.length ? [createModuleWorkSection(targetDocument, "Chat runs", chatWorkItems)] : []),
-  );
-  mountChatWorkbenchVueIsland(workbenchChrome, targetDocument, layout, chatWorkItems);
-  workbench.append(
+  const workbenchChildren = [
     createChatHeader(targetDocument, chat, layout, chatActions),
     createConversationThread(targetDocument, chat),
-    workbenchChrome,
-    createWorkLensInlineHost(targetDocument, layout.inspector.visible ? null : workLens, workLensActions),
-  );
+  ];
+  if (showEmptySession) {
+    workbenchChildren.push(createChatWorkbenchEmptyState(targetDocument, chatWorkItems));
+  }
+  workbenchChildren.push(createWorkLensInlineHost(targetDocument, layout.inspector.visible ? null : workLens, workLensActions));
+  workbench.append(...workbenchChildren);
 
   const utilities = targetDocument.createElement("div");
   utilities.className = "desktop-utility-surfaces";
@@ -1210,10 +1186,34 @@ function createMainRegion(
   return main;
 }
 
+function hasVisibleConversationMessages(chat: DesktopNativeChatModel): boolean {
+  if (!chat.activeSessionKey) {
+    return false;
+  }
+  return chat.messages.some((message) => Boolean(
+    message.content?.trim()
+      || message.reasoningContent?.trim()
+      || message.toolActivities?.length
+      || message.references?.length,
+  ));
+}
+
+function createChatWorkbenchEmptyState(targetDocument: Document, chatWorkItems: DesktopTaskCenterItem[]): HTMLElement {
+  const workbenchChrome = targetDocument.createElement("div");
+  workbenchChrome.className = "desktop-chat-workbench-chrome";
+  workbenchChrome.append(
+    createText(targetDocument, "h2", "Start a new session"),
+    createText(targetDocument, "p", "Ask Tinybot about the workspace, inspect files, or create a task."),
+    createQuickActions(targetDocument),
+    ...(chatWorkItems.length ? [createModuleWorkSection(targetDocument, "Chat runs", chatWorkItems)] : []),
+  );
+  mountChatWorkbenchVueIsland(workbenchChrome, targetDocument, chatWorkItems);
+  return workbenchChrome;
+}
+
 function mountChatWorkbenchVueIsland(
   workbenchChrome: HTMLElement,
   targetDocument: Document,
-  layout: WorkbenchLayoutState,
   chatWorkItems: DesktopTaskCenterItem[],
 ): void {
   if (!canMountVueIsland(workbenchChrome)) {
@@ -1221,9 +1221,7 @@ function mountChatWorkbenchVueIsland(
   }
   mountChatWorkbenchIsland(workbenchChrome, {
     moduleWorkItems: chatWorkItems,
-    panelControls: buildDesktopPanelControls(layout),
     onInspectWorkItem: (item) => inspectModuleWorkItem(targetDocument, item),
-    onPanelToggle: (panel) => toggleDesktopPanel(targetDocument, panel),
   });
 }
 
@@ -1312,12 +1310,18 @@ function createChatHeader(
   titleRow.className = "desktop-chat-title-row";
 
   const activeSession = activeChatSession(chat);
+  const titleGroup = targetDocument.createElement("div");
+  titleGroup.className = "desktop-chat-title-group";
+  const context = targetDocument.createElement("span");
+  context.className = "desktop-chat-context";
+  context.textContent = "tinybot";
   const title = targetDocument.createElement("h1");
   title.className = "desktop-chat-title";
   title.textContent = activeChatTitle(chat);
   if (canMountVueIsland(title)) {
     mountChatTitleIsland(title, { title: activeChatTitle(chat) });
   }
+  titleGroup.append(context, title);
 
   const menu = targetDocument.createElement("button");
   menu.type = "button";
@@ -1331,7 +1335,7 @@ function createChatHeader(
   const popover = createChatMenuPopover(targetDocument, chat, activeSession, title, menu, chatActions);
   mountChatMenuButtonVueIsland(menu, popover);
 
-  titleRow.append(title, menu, popover);
+  titleRow.append(titleGroup, menu, popover);
 
   const actions = targetDocument.createElement("div");
   actions.className = "desktop-chat-header-actions";
@@ -1831,19 +1835,17 @@ function createConversationThread(targetDocument: Document, chat: DesktopNativeC
   thread.setAttribute("aria-label", "Conversation");
   if (chat) {
     if (!chat.activeSessionKey) {
-      renderConversationEmptyState(targetDocument, thread, "No live session selected.");
-      mountConversationThreadVueIsland(thread, { emptyMessage: "No live session selected.", messages: [] });
+      mountConversationThreadVueIsland(thread, { emptyMessage: "", messages: [] });
       return thread;
     }
-    if (!chat.messages.length) {
-      renderConversationEmptyState(targetDocument, thread, "No messages in this session.");
-      mountConversationThreadVueIsland(thread, { emptyMessage: "No messages in this session.", messages: [] });
+    if (!hasVisibleConversationMessages(chat)) {
+      mountConversationThreadVueIsland(thread, { emptyMessage: "", messages: [] });
       return thread;
     }
     const messages = chat.messages.map((message) => ({
       author: message.role === "user" ? "You" : "Tinybot",
       time: formatCompactTime(message.timestamp),
-      tone: message.role === "user" ? "user" : "assistant",
+      tone: message.role === "user" ? "user" as const : "assistant" as const,
       reasoningContent: message.reasoningContent,
       body: shouldRenderConversationBody(message) ? [message.content].filter(Boolean) : [],
       toolActivities: (message.toolActivities ?? []).map((activity) => ({
@@ -1853,6 +1855,7 @@ function createConversationThread(targetDocument: Document, chat: DesktopNativeC
         kind: activity.kind,
         name: activity.name || "",
         responseText: activity.responseText || "",
+        runChainItemKey: conversationToolActivityRunChainKey(message, activity),
       })),
       references: (message.references ?? []).map((reference) => ({
         detail: reference.detail ?? "",
@@ -1907,6 +1910,7 @@ function mountConversationThreadVueIsland(
         kind: "call" | "result";
         name: string;
         responseText: string;
+        runChainItemKey?: string;
       }>;
     }>;
   },
@@ -1917,16 +1921,24 @@ function mountConversationThreadVueIsland(
   mountConversationThreadIsland(thread, options);
 }
 
-function renderConversationEmptyState(targetDocument: Document, thread: HTMLElement, message: string): void {
-  thread.append(createText(targetDocument, "p", message));
-  if (!canMountVueIsland(thread)) {
-    return;
-  }
-  mountConversationEmptyStateIsland(thread, { message });
-}
-
 function shouldRenderConversationBody(message: NativeChatMessage): boolean {
   return !((message.role === "tool" || message.role === "progress") && Boolean(message.toolActivities?.length));
+}
+
+function conversationToolActivityRunChainKey(
+  message: NativeChatMessage,
+  activity: NonNullable<NativeChatMessage["toolActivities"]>[number],
+): string | undefined {
+  if (!message.messageId) {
+    return undefined;
+  }
+  if (activity.id) {
+    return `${message.messageId}:${activity.id}`;
+  }
+  if (message.role === "tool" || activity.kind === "result") {
+    return `${message.messageId}:result`;
+  }
+  return `${message.messageId}:detail`;
 }
 
 function createConversationMessage(
@@ -1937,7 +1949,7 @@ function createConversationMessage(
     tone: "user" | "assistant";
     reasoningContent?: string;
     body: string[];
-    toolActivities?: NativeChatMessage["toolActivities"];
+    toolActivities?: ConversationToolActivityRenderOptions[];
     references?: NativeChatMessage["references"];
     attachment?: string;
   },
@@ -1948,14 +1960,18 @@ function createConversationMessage(
 
   const content = targetDocument.createElement("div");
   content.className = "desktop-conversation-content";
+  const header = targetDocument.createElement("div");
+  header.className = "desktop-conversation-header";
   const meta = targetDocument.createElement("div");
   meta.className = "desktop-conversation-meta";
   const separator = createText(targetDocument, "span", " · ");
   separator.className = "desktop-conversation-meta-separator";
+  separator.textContent = " · ";
   separator.setAttribute("aria-hidden", "true");
   meta.append(createText(targetDocument, "strong", options.author), separator, createText(targetDocument, "span", options.time));
   mountConversationMetaVueIsland(meta, { author: options.author, time: options.time });
-  content.append(meta);
+  header.append(meta);
+  content.append(header);
   if (options.reasoningContent?.trim()) {
     content.append(createConversationReasoning(targetDocument, options.reasoningContent));
   }
@@ -1963,15 +1979,9 @@ function createConversationMessage(
     content.append(createToolActivities(targetDocument, options.toolActivities));
   }
   content.append(createConversationBody(targetDocument, options.body, options.tone));
-  for (const reference of options.references ?? []) {
-    const node = createText(targetDocument, "p", conversationReferenceText(reference));
-    node.className = "desktop-conversation-reference";
-    mountConversationReferenceVueIsland(node, {
-      detail: reference.detail ?? "",
-      kind: reference.kind,
-      title: reference.title,
-    });
-    content.append(node);
+  const referenceGroups = createConversationReferenceGroups(targetDocument, options.references ?? []);
+  if (referenceGroups) {
+    content.append(referenceGroups);
   }
   if (options.attachment) {
     const attachment = targetDocument.createElement("div");
@@ -1982,6 +1992,12 @@ function createConversationMessage(
       sizeLabel: "1.2 MB",
     });
     content.append(attachment);
+  }
+  if (options.tone === "assistant") {
+    const actions = targetDocument.createElement("div");
+    actions.className = "desktop-message-actions";
+    actions.append(createConversationCopyButton(targetDocument, options.body));
+    content.append(actions);
   }
   article.append(content);
   mountConversationMessageVueIsland(article, {
@@ -2003,6 +2019,7 @@ function createConversationMessage(
       kind: activity.kind,
       name: activity.name || "",
       responseText: activity.responseText || "",
+      runChainItemKey: activity.runChainItemKey,
     })),
   });
   return article;
@@ -2025,6 +2042,7 @@ function mountConversationMessageVueIsland(
       kind: "call" | "result";
       name: string;
       responseText: string;
+      runChainItemKey?: string;
     }>;
   },
 ): void {
@@ -2041,8 +2059,122 @@ function mountConversationMetaVueIsland(meta: HTMLElement, options: { author: st
   mountConversationMetaIsland(meta, options);
 }
 
-function conversationReferenceText(reference: { detail?: string; kind: string; title: string }): string {
-  return `${reference.kind}: ${reference.title}${reference.detail ? ` - ${reference.detail}` : ""}`;
+function createConversationCopyButton(targetDocument: Document, body: string[]): HTMLElement {
+  const button = targetDocument.createElement("button");
+  button.type = "button";
+  button.className = "desktop-message-copy-button";
+  button.setAttribute("aria-label", "Copy message");
+  button.setAttribute("title", "Copy message");
+  const icon = targetDocument.createElement("span");
+  icon.className = "desktop-message-copy-icon";
+  icon.setAttribute("aria-hidden", "true");
+  button.append(icon);
+  button.addEventListener("click", () => {
+    const copyAttempt = copyDesktopText(body.filter((line) => line.trim()).join("\n\n"), targetDocument);
+    button.setAttribute("aria-label", "Copied");
+    button.setAttribute("title", "Copied");
+    void copyAttempt
+      .catch(() => {
+        button.setAttribute("aria-label", "Failed");
+        button.setAttribute("title", "Failed");
+      });
+  });
+  return button;
+}
+
+function createConversationReferenceGroups(
+  targetDocument: Document,
+  references: Array<{ detail?: string; kind: string; title: string }>,
+): HTMLElement | null {
+  const groups = groupConversationReferences(references);
+  if (!groups.length) {
+    return null;
+  }
+  const wrapper = targetDocument.createElement("div");
+  wrapper.className = "desktop-message-references";
+  for (const group of groups) {
+    const details = targetDocument.createElement("details");
+    details.className = `desktop-message-reference-group desktop-message-reference-group-${group.id}`;
+    const summary = targetDocument.createElement("summary");
+    summary.className = "desktop-message-references-summary";
+    const title = createText(targetDocument, "span", group.label);
+    title.className = "desktop-message-references-title";
+    const count = createText(targetDocument, "span", `${group.references.length} ${group.references.length === 1 ? "source" : "sources"}`);
+    count.className = "desktop-message-references-count";
+    summary.append(title, count);
+    const list = targetDocument.createElement("div");
+    list.className = "desktop-message-reference-list";
+    for (const reference of group.references) {
+      const item = targetDocument.createElement("article");
+      item.className = "desktop-message-reference-item desktop-conversation-reference";
+      item.setAttribute("data-desktop-vue-island", "conversation-reference");
+      item.setAttribute("data-desktop-reference-island", mountConversationReferenceIsland.name);
+      item.setAttribute("data-desktop-reference-kind", reference.kind);
+      const kind = createText(targetDocument, "span", `${reference.kind}: `);
+      kind.className = "desktop-message-reference-kind";
+      const referenceTitle = createText(targetDocument, "strong", reference.title);
+      referenceTitle.className = "desktop-message-reference-title";
+      item.append(kind, referenceTitle);
+      if (reference.detail) {
+        const detail = createText(targetDocument, "span", reference.detail);
+        detail.className = "desktop-message-reference-detail";
+        item.append(detail);
+      }
+      list.append(item);
+    }
+    details.append(summary, list);
+    wrapper.append(details);
+  }
+  return wrapper;
+}
+
+function groupConversationReferences(
+  references: Array<{ detail?: string; kind: string; title: string }>,
+): Array<{ id: string; label: string; references: Array<{ detail?: string; kind: string; title: string }> }> {
+  const groups: Array<{ id: string; label: string; references: Array<{ detail?: string; kind: string; title: string }> }> = [];
+  for (const reference of references) {
+    const id = normalizeConversationReferenceKind(reference.kind);
+    const group = groups.find((candidate) => candidate.id === id);
+    if (group) {
+      group.references.push(reference);
+    } else {
+      groups.push({ id, label: conversationReferenceGroupLabel(id), references: [reference] });
+    }
+  }
+  return groups;
+}
+
+function normalizeConversationReferenceKind(kind: string): string {
+  const normalized = kind.toLowerCase();
+  if (normalized.includes("memory")) {
+    return "memory";
+  }
+  if (normalized.includes("recent")) {
+    return "recent";
+  }
+  if (normalized.includes("browser")) {
+    return "browser";
+  }
+  if (normalized.includes("file") || normalized.includes("reference")) {
+    return "file";
+  }
+  return "reference";
+}
+
+function conversationReferenceGroupLabel(kind: string): string {
+  if (kind === "memory") {
+    return "Memory references";
+  }
+  if (kind === "recent") {
+    return "Recent context";
+  }
+  if (kind === "browser") {
+    return "Browser references";
+  }
+  if (kind === "file") {
+    return "File references";
+  }
+  return "References";
 }
 
 function conversationAttachmentText(name: string, sizeLabel: string): string {
@@ -2059,26 +2191,12 @@ function mountConversationAttachmentVueIsland(
   mountConversationAttachmentIsland(attachment, options);
 }
 
-function mountConversationReferenceVueIsland(
-  reference: HTMLElement,
-  options: { detail: string; kind: string; title: string },
-): void {
-  if (!canMountVueIsland(reference)) {
-    return;
-  }
-  mountConversationReferenceIsland(reference, options);
-}
-
 function createConversationReasoning(targetDocument: Document, reasoningContent: string): HTMLElement {
   const details = targetDocument.createElement("details");
   details.className = "desktop-message-reasoning";
   const summary = targetDocument.createElement("summary");
   summary.className = "desktop-message-reasoning-summary";
-  const title = createText(targetDocument, "span", "Thinking");
-  title.className = "desktop-message-reasoning-title";
-  const meta = createText(targetDocument, "span", "Show details");
-  meta.className = "desktop-message-reasoning-meta";
-  summary.append(title, meta);
+  summary.append(createText(targetDocument, "span", "Details"));
   const body = createText(targetDocument, "div", reasoningContent);
   body.className = "desktop-message-reasoning-body";
   details.append(summary, body);
@@ -2095,7 +2213,7 @@ function mountConversationReasoningVueIsland(reasoning: HTMLElement, content: st
 
 function createToolActivities(
   targetDocument: Document,
-  activities: NonNullable<NativeChatMessage["toolActivities"]>,
+  activities: ConversationToolActivityRenderOptions[],
 ): HTMLElement {
   const wrapper = targetDocument.createElement("div");
   wrapper.className = "desktop-tool-activities";
@@ -2109,6 +2227,7 @@ function createToolActivities(
     kind: activity.kind,
     name: activity.name || "",
     responseText: activity.responseText || "",
+    runChainItemKey: activity.runChainItemKey,
   })));
   return wrapper;
 }
@@ -2122,6 +2241,7 @@ function mountToolActivitiesVueIsland(
     kind: "call" | "result";
     name: string;
     responseText: string;
+    runChainItemKey?: string;
   }>,
 ): void {
   if (!canMountVueIsland(wrapper)) {
@@ -2132,7 +2252,7 @@ function mountToolActivitiesVueIsland(
 
 function createToolActivity(
   targetDocument: Document,
-  activity: NonNullable<NativeChatMessage["toolActivities"]>[number],
+  activity: ConversationToolActivityRenderOptions,
 ): HTMLElement {
   const details = targetDocument.createElement("details");
   details.className = "desktop-tool-activity";
@@ -2140,9 +2260,18 @@ function createToolActivity(
   if (activity.id) {
     details.setAttribute("data-desktop-tool-activity-id", activity.id);
   }
+  if (activity.runChainItemKey) {
+    details.setAttribute("data-desktop-run-chain-item-key", activity.runChainItemKey);
+  }
 
   const summary = targetDocument.createElement("summary");
   summary.className = "desktop-tool-activity-summary";
+  summary.addEventListener("click", () => {
+    if (activity.runChainItemKey) {
+      inspectRunChainItemFromConversation(targetDocument, activity.runChainItemKey);
+      dispatchDesktopCustomEvent(targetDocument, "desktop-run-chain-inspect", { itemKey: activity.runChainItemKey });
+    }
+  });
   const icon = createText(targetDocument, "span", ">");
   icon.className = "desktop-tool-activity-icon";
   icon.setAttribute("aria-hidden", "true");
@@ -2187,6 +2316,7 @@ function createToolActivity(
     kind: activity.kind,
     name: activity.name || "",
     responseText: activity.responseText || "",
+    runChainItemKey: activity.runChainItemKey,
   });
   return details;
 }
@@ -2200,6 +2330,7 @@ function mountToolActivityVueIsland(
     kind: "call" | "result";
     name: string;
     responseText: string;
+    runChainItemKey?: string;
   },
 ): void {
   if (!canMountVueIsland(activity)) {
@@ -2216,6 +2347,22 @@ function createToolActivitySection(
 ): HTMLElement {
   const section = targetDocument.createElement("div");
   section.className = `desktop-tool-activity-section desktop-tool-activity-section-${kind}`;
+  if (shouldCollapseToolContent(text)) {
+    const details = targetDocument.createElement("details");
+    details.className = "desktop-tool-activity-content-details";
+    const summary = targetDocument.createElement("summary");
+    summary.className = "desktop-tool-activity-content-summary";
+    const labelNode = createText(targetDocument, "span", label);
+    labelNode.className = "desktop-tool-activity-label";
+    const preview = createText(targetDocument, "span", summarizeToolText(text));
+    preview.className = "desktop-tool-activity-content-preview";
+    const pre = createText(targetDocument, "pre", text);
+    pre.className = "desktop-tool-activity-pre";
+    summary.append(labelNode, preview);
+    details.append(summary, pre);
+    section.append(details);
+    return section;
+  }
   const labelNode = createText(targetDocument, "div", label);
   labelNode.className = "desktop-tool-activity-label";
   const pre = createText(targetDocument, "pre", text);
@@ -2241,6 +2388,10 @@ function summarizeToolText(value: string): string {
     return "No details";
   }
   return normalized.length > 96 ? `${normalized.slice(0, 93)}...` : normalized;
+}
+
+function shouldCollapseToolContent(value: string): boolean {
+  return value.length > 140 || value.split(/\r?\n/).length > 6;
 }
 
 function createConversationBody(
@@ -2284,6 +2435,7 @@ function renderConversationMarkdown(target: HTMLElement, content: string): void 
     target.querySelectorAll("pre code").forEach((block) => {
       hljs.highlightElement(block as HTMLElement);
     });
+    addConversationCodeCopyButtons(target);
   } catch {
     target.textContent = content;
   }
@@ -2291,6 +2443,26 @@ function renderConversationMarkdown(target: HTMLElement, content: string): void 
 
 function addMarkdownLinkAttributes(html: string): string {
   return html.replace(/<a\s+(?![^>]*\btarget=)([^>]*href=)/gi, '<a target="_blank" rel="noreferrer" $1');
+}
+
+function addConversationCodeCopyButtons(target: HTMLElement): void {
+  target.querySelectorAll("pre").forEach((pre) => {
+    const button = target.ownerDocument.createElement("button");
+    button.type = "button";
+    button.className = "desktop-code-copy-button";
+    button.setAttribute("aria-label", "Copy code");
+    button.textContent = "Copy";
+    button.addEventListener("click", () => {
+      const code = pre.querySelector("code");
+      const copyAttempt = copyDesktopText((code?.textContent ?? pre.textContent ?? "").trimEnd(), target.ownerDocument);
+      button.textContent = "Copied";
+      void copyAttempt
+        .catch(() => {
+          button.textContent = "Failed";
+        });
+    });
+    pre.append(button);
+  });
 }
 
 function createNativeComposerSurface(
@@ -3006,7 +3178,7 @@ function createToolsSkillsPane(
     );
     mountSkillDetailSummaryVueIsland(summary, pane.selectedSkill);
     detail.append(summary, createDesktopSkillEditor(targetDocument, pane, toolsSkillsActions));
-    const actions: Array<[DesktopToolsSkillsActionId, string, boolean]> = [
+    const actions: Array<[ToolsSkillsActionId, string, boolean]> = [
       ["createSkill", "Create skill", pane.selectedSkill.actions.create],
       ["saveSkill", "Save skill", pane.selectedSkill.actions.save],
       ["validateSkill", "Validate skill", pane.selectedSkill.actions.validate],
@@ -3054,7 +3226,7 @@ function mountToolsSkillsPaneVueIsland(
 
 function mountToolsSkillsActionsVueIsland(
   actionRow: HTMLElement,
-  actions: Array<[DesktopToolsSkillsActionId, string, boolean]>,
+  actions: Array<[ToolsSkillsActionId, string, boolean]>,
   pane: DesktopToolsSkillsPaneModel,
   toolsSkillsActions: DesktopToolsSkillsActionOptions,
 ): void {
@@ -3228,7 +3400,7 @@ function mountKnowledgePaneVueIsland(
   mountKnowledgePaneIsland(section, {
     pane,
     workItems,
-    onInspectWorkItem: (item) => renderWorkLensFromTask(targetDocument, item),
+    onInspectWorkItem: (item) => renderTaskWorkLens(targetDocument, item),
     onKnowledgeAction: (event) => {
       knowledgeActions.onKnowledgeAction?.(event);
     },
@@ -4829,79 +5001,6 @@ function createDesktopSettingsControl(
   return control;
 }
 
-function createPanelControls(targetDocument: Document, layout: WorkbenchLayoutState): HTMLElement {
-  const controls = targetDocument.createElement("div");
-  controls.className = "desktop-panel-controls";
-  controls.setAttribute("aria-label", "Workbench panel controls");
-
-  const panelControls = buildDesktopPanelControls(layout);
-
-  for (const control of panelControls) {
-    const button = targetDocument.createElement("button");
-    button.className = "desktop-panel-control";
-    button.setAttribute("type", "button");
-    button.setAttribute("data-desktop-panel-control", control.panel);
-    button.setAttribute("aria-label", control.ariaLabel);
-    button.setAttribute("aria-pressed", String(control.visible));
-    if (control.shortcut) {
-      button.setAttribute("aria-keyshortcuts", control.shortcut);
-    }
-    button.textContent = control.label;
-    button.addEventListener("click", () => {
-      toggleDesktopPanel(targetDocument, control.panel);
-    });
-    button.addEventListener("keydown", (event) => {
-      if (event.key !== "Enter" && event.key !== " ") {
-        return;
-      }
-      event.preventDefault();
-      toggleDesktopPanel(targetDocument, control.panel);
-    });
-    controls.append(button);
-  }
-
-  mountPanelControlsVueIsland(controls, targetDocument, panelControls);
-  return controls;
-}
-
-function buildDesktopPanelControls(layout: WorkbenchLayoutState): DesktopPanelControlItem[] {
-  return [
-    {
-      panel: "sidebar",
-      label: "Sidebar",
-      ariaLabel: "Toggle sidebar panel",
-      visible: layout.sidebar.visible,
-      shortcut: "Ctrl+B",
-    },
-    {
-      panel: "inspector",
-      label: "Run Chain",
-      ariaLabel: "Toggle Run Chain panel",
-      visible: layout.inspector.visible,
-    },
-    {
-      panel: "bottom",
-      label: "Tasks",
-      ariaLabel: "Toggle task and runtime panel",
-      visible: layout.bottom.visible,
-    },
-  ];
-}
-
-function mountPanelControlsVueIsland(
-  controls: HTMLElement,
-  targetDocument: Document,
-  panelControls: DesktopPanelControlItem[],
-): void {
-  if (!canMountVueIsland(controls)) {
-    return;
-  }
-  mountPanelControlsIsland(controls, {
-    controls: panelControls,
-    onToggle: (panel) => toggleDesktopPanel(targetDocument, panel),
-  });
-}
-
 function toggleDesktopPanel(targetDocument: Document, panel: DesktopPanelControlId): void {
   const shell = targetDocument.getElementById(SHELL_ID);
   const panelElement = targetDocument.querySelector<HTMLElement>(`[data-workbench-region="${panel}"]`);
@@ -5059,14 +5158,16 @@ function createRunChainOverviewPanel(
   const controls = targetDocument.createElement("div");
   controls.className = "desktop-run-chain-header-controls";
   for (const [label, value, action] of [
-    ["Pin Run Chain", "Pin", "pin"],
-    ["Close Run Chain", "Close", "close"],
+    ["Pin panel", "Pin", "pin"],
+    ["Close panel", "Close", "close"],
   ]) {
     const button = targetDocument.createElement("button");
     button.type = "button";
     button.className = "desktop-run-chain-icon-button";
     button.setAttribute("aria-label", label);
+    button.setAttribute("title", label);
     button.setAttribute("data-desktop-run-chain-control", action);
+    button.setAttribute("data-button-variant", "ghost");
     if (action === "pin") {
       button.setAttribute("aria-pressed", "false");
     }
@@ -5128,10 +5229,7 @@ function createRunChainOverviewPanel(
   const actions = targetDocument.createElement("div");
   actions.className = "desktop-run-chain-actions";
   actions.append(
-    createRunChainActionButton(targetDocument, "Open Task Center", () => toggleDesktopPanel(targetDocument, "bottom")),
-    createRunChainActionButton(targetDocument, "New Run Chain Item", () => {
-      setRouteStatus(targetDocument, "Open Cowork to create a run chain item.");
-    }, "desktop-run-chain-new-item"),
+    createRunChainActionButton(targetDocument, "Open Task Center", () => toggleDesktopPanel(targetDocument, "bottom"), "desktop-run-chain-panel-action", "primary"),
   );
 
   section.append(header, summary, tabs, panel, actions);
@@ -5148,15 +5246,22 @@ function createRunChainSummaryStrip(
   summary.className = "desktop-run-chain-summary-strip";
   const status = runChainOverviewStatus(runChainItems);
   for (const item of [
-    { label: "Gateway", text: "Gateway: Connected", tab: "context" as const },
-    { label: "Run", text: `Run: ${status}`, tab: "tasks" as const },
-    { label: "Items", text: `${runChainItems.length} ${runChainItems.length === 1 ? "item" : "items"}`, tab: "tasks" as const },
+    { label: "Gateway", text: "Gateway: Connected", tab: "context" as const, tone: "connected" },
+    { label: "Run", text: `Run: ${status}`, tab: "tasks" as const, tone: "muted" },
+    { label: "Items", text: `${runChainItems.length} ${runChainItems.length === 1 ? "item" : "items"}`, tab: "tasks" as const, tone: "muted" },
   ]) {
     const button = targetDocument.createElement("button");
     button.type = "button";
-    button.className = "desktop-run-chain-summary-item";
+    button.className = "desktop-run-chain-summary-item desktop-run-chain-status-pill";
     button.setAttribute("data-desktop-run-chain-summary", item.label.toLowerCase());
-    button.textContent = item.text;
+    button.setAttribute("data-status-tone", item.tone);
+    if (item.tone === "connected") {
+      const dot = targetDocument.createElement("span");
+      dot.className = "desktop-run-chain-status-dot";
+      dot.setAttribute("aria-hidden", "true");
+      button.append(dot);
+    }
+    button.append(createText(targetDocument, "span", item.text));
     button.addEventListener("click", () => {
       selectTab(item.tab);
       setRouteStatus(targetDocument, `Run Chain ${item.label}`);
@@ -5183,12 +5288,13 @@ function createRunChainOverviewPanelContent(
   if (tabId === "tasks") {
     const feed = createRunChainActivityFeed(targetDocument, runChainItems);
     return [
-      createRunChainPanelSection(targetDocument, "Current Run", [
-        ["Status", runChainOverviewStatus(runChainItems)],
+      createRunChainPanelSection(targetDocument, "Tasks", [
+        ["Task center", "Available"],
+        ["Run", runChainOverviewStatus(runChainItems)],
         ["Chain items", String(runChainItems.length)],
       ], createRunChainActionButton(targetDocument, "New Run Chain Item", () => {
         setRouteStatus(targetDocument, "Open Cowork to create a run chain item.");
-      }, "desktop-run-chain-panel-action desktop-run-chain-new-item")),
+      }, "desktop-run-chain-panel-action desktop-run-chain-new-item", "secondary"), runChainItems.length ? undefined : "No chain items yet."),
       ...(feed ? [feed] : []),
     ];
   }
@@ -5212,6 +5318,7 @@ function createRunChainPanelSection(
   title: string,
   rows: [string, string][],
   action?: HTMLElement,
+  emptyState?: string,
 ): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-run-chain-panel-section";
@@ -5221,6 +5328,12 @@ function createRunChainPanelSection(
     row.className = "desktop-run-chain-card-row";
     row.textContent = `${label}: ${value}`;
     section.append(row);
+  }
+  if (emptyState) {
+    const empty = targetDocument.createElement("p");
+    empty.className = "desktop-run-chain-empty-state";
+    empty.textContent = emptyState;
+    section.append(empty);
   }
   if (action) {
     section.append(action);
@@ -5257,11 +5370,13 @@ function createRunChainActionButton(
   label: string,
   onClick: () => void,
   className = "desktop-run-chain-panel-action",
+  variant: "primary" | "secondary" | "ghost" = "secondary",
 ): HTMLElement {
   const button = targetDocument.createElement("button");
   button.type = "button";
   button.className = className;
   button.setAttribute("data-desktop-run-chain-action", label);
+  button.setAttribute("data-button-variant", variant);
   button.textContent = label;
   button.addEventListener("click", onClick);
   return button;
@@ -5487,6 +5602,7 @@ function mountRunChainInspectorVueIsland(
     return;
   }
   mountRunChainInspectorIsland(section, {
+    eventTarget: targetDocument,
     items,
     selectedItemKey,
     onSelect: (item) => setRouteStatus(targetDocument, `Inspecting ${item.title}`),
@@ -5626,6 +5742,34 @@ function handleGatewayRuntimeActionId(
 
 function canMountVueIsland(element: HTMLElement): boolean {
   return typeof HTMLElement !== "undefined" && element instanceof HTMLElement;
+}
+
+function inspectRunChainItemFromConversation(targetDocument: Document, itemKey: string): void {
+  const shell = targetDocument.getElementById(SHELL_ID);
+  if (shell?.getAttribute("data-inspector-visible") === "false") {
+    toggleDesktopPanel(targetDocument, "inspector");
+  }
+  const row = targetDocument.querySelector<HTMLElement>(`[data-desktop-run-chain-item="${itemKey}"]`);
+  row?.click();
+}
+
+function dispatchDesktopCustomEvent(targetDocument: Document, type: string, detail: Record<string, unknown>): void {
+  const CustomEventConstructor = targetDocument.defaultView?.CustomEvent
+    ?? (typeof CustomEvent !== "undefined" ? CustomEvent : null);
+  if (CustomEventConstructor) {
+    targetDocument.dispatchEvent(new CustomEventConstructor(type, { detail }));
+    return;
+  }
+  targetDocument.dispatchEvent({ type, detail } as unknown as Event);
+}
+
+async function copyDesktopText(text: string, targetDocument: Document): Promise<void> {
+  const clipboard = targetDocument.defaultView?.navigator?.clipboard
+    ?? (typeof navigator !== "undefined" ? navigator.clipboard : undefined);
+  if (!clipboard?.writeText) {
+    throw new Error("Clipboard is unavailable.");
+  }
+  return clipboard.writeText(text);
 }
 
 async function copyGatewayRuntimeDiagnostics(text: string, copyText?: (text: string) => void | Promise<void>): Promise<void> {
@@ -6007,9 +6151,9 @@ function createQuickActions(targetDocument: Document): HTMLElement {
   const actions = targetDocument.createElement("div");
   actions.className = "desktop-quick-actions";
   for (const [label, href] of [
-    ["New chat", "/chat/new"],
+    ["Ask about this project", "/chat/new"],
     ["Open workspace", "/workspace"],
-    ["Gateway status", "/api/status"],
+    ["Check gateway", "/api/status"],
   ]) {
     actions.append(createWorkbenchLink(targetDocument, label, href, "desktop-quick-action"));
   }
@@ -6667,124 +6811,6 @@ function mountInspectorViewVueIsland(
   mountInspectorViewIsland(section, options);
 }
 
-function createSharedSidebarLinkSection(targetDocument: Document, group: DesktopSidebarGroup | undefined): HTMLElement {
-  const section = targetDocument.createElement("section");
-  section.className = "desktop-workbench-section";
-  section.append(createText(targetDocument, "h2", group?.label ?? "Resources"));
-  const linkItems: Array<DesktopSidebarItem & { href: string; kind: "link" }> = [];
-  for (const item of group?.items ?? []) {
-    if (item.kind === "link" && item.href) {
-      linkItems.push({ ...item, href: item.href, kind: "link" });
-      section.append(createSharedWorkbenchLink(targetDocument, item));
-    }
-  }
-  mountSharedSidebarLinksVueIsland(section, group?.label, linkItems);
-  return section;
-}
-
-function mountSharedSidebarLinksVueIsland(
-  section: HTMLElement,
-  label: string | undefined,
-  items: Array<DesktopSidebarItem & { href: string; kind: "link" }>,
-): void {
-  if (!canMountVueIsland(section)) {
-    return;
-  }
-  mountSharedSidebarLinksIsland(section, { label, items });
-}
-
-function createSharedSidebarCommandSection(targetDocument: Document, group: DesktopSidebarGroup | undefined): HTMLElement {
-  const section = targetDocument.createElement("section");
-  section.className = "desktop-workbench-section";
-  section.append(createText(targetDocument, "h2", group?.label ?? "System"));
-  const commandItems: Array<DesktopSidebarItem & { commandId: string; kind: "command" }> = [];
-  for (const item of group?.items ?? []) {
-    if (item.kind === "command" && item.commandId) {
-      commandItems.push({ ...item, commandId: item.commandId, kind: "command" });
-      section.append(createSharedSidebarCommandButton(targetDocument, item));
-    }
-  }
-  mountSharedSidebarCommandsVueIsland(section, targetDocument, group?.label, commandItems);
-  return section;
-}
-
-function mountSharedSidebarCommandsVueIsland(
-  section: HTMLElement,
-  targetDocument: Document,
-  label: string | undefined,
-  items: Array<DesktopSidebarItem & { commandId: string; kind: "command" }>,
-): void {
-  if (!canMountVueIsland(section)) {
-    return;
-  }
-  mountSharedSidebarCommandsIsland(section, { label, items, targetDocument });
-}
-
-function createSharedWorkbenchLink(targetDocument: Document, item: DesktopSidebarItem): HTMLElement {
-  const link = createWorkbenchLink(targetDocument, item.label, item.href ?? "#", "desktop-workbench-link");
-  applySharedSidebarItemAttributes(link, item);
-  mountSharedSidebarLinkVueIsland(link, item);
-  return link;
-}
-
-function mountSharedSidebarLinkVueIsland(link: HTMLElement, item: DesktopSidebarItem): void {
-  if (!canMountVueIsland(link) || item.kind !== "link" || !item.href) {
-    return;
-  }
-  mountSharedSidebarLinkIsland(link, {
-    href: item.href ?? "#",
-    icon: item.icon,
-    id: item.id,
-    kind: "link",
-    label: item.label,
-  });
-}
-
-function createSharedSidebarCommandButton(targetDocument: Document, item: DesktopSidebarItem): HTMLElement {
-  const button = targetDocument.createElement("button");
-  button.className = "desktop-workbench-link";
-  button.setAttribute("type", "button");
-  button.textContent = item.label;
-  applySharedSidebarItemAttributes(button, item);
-  button.addEventListener("click", () => {
-    if (!item.commandId) {
-      return;
-    }
-    targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", {
-      detail: { id: item.commandId, source: "native-sidebar" },
-    }));
-  });
-  mountSharedSidebarCommandButtonVueIsland(button, item);
-  return button;
-}
-
-function mountSharedSidebarCommandButtonVueIsland(button: HTMLElement, item: DesktopSidebarItem): void {
-  if (!canMountVueIsland(button) || item.kind !== "command" || !item.commandId) {
-    return;
-  }
-  mountSharedSidebarCommandButtonIsland(button, {
-    commandId: item.commandId ?? "",
-    icon: item.icon,
-    id: item.id,
-    kind: "command",
-    label: item.label,
-  });
-}
-
-function applySharedSidebarItemAttributes(element: HTMLElement, item: DesktopSidebarItem): void {
-  element.setAttribute("data-sidebar-item-id", item.id);
-  element.setAttribute("data-sidebar-item-kind", item.kind);
-  if (item.href) {
-    element.setAttribute("data-sidebar-href", item.href);
-  }
-  if (item.commandId) {
-    element.setAttribute("data-sidebar-command", item.commandId);
-  }
-  if (item.icon) {
-    element.setAttribute("data-sidebar-icon", item.icon);
-  }
-}
-
 function createWorkbenchLink(targetDocument: Document, label: string, href: string, className: string): HTMLElement {
   const link = targetDocument.createElement("a");
   link.className = className;
@@ -6814,6 +6840,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
   style.id = STYLE_ID;
   style.textContent = `
     body.desktop-native-workbench {
+      --desktop-chat-column-width: 840px;
       margin: 0;
       min-height: 100vh;
       overflow: hidden;
@@ -6922,8 +6949,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-self: start;
       display: grid;
       gap: 12px;
-      width: min(820px, 100%);
-      max-width: 820px;
+      width: min(var(--desktop-chat-column-width), 100%);
+      max-width: var(--desktop-chat-column-width);
       min-width: 0;
       margin: 0 auto;
       border: 0;
@@ -7014,10 +7041,18 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       gap: 8px;
     }
 
-    body.desktop-native-workbench .desktop-quick-actions .desktop-quick-action:first-child {
-      border-color: var(--primary);
-      background: var(--primary);
-      color: #ffffff;
+    body.desktop-native-workbench .desktop-quick-action {
+      border-color: var(--border);
+      background: var(--panel);
+      color: var(--text-muted);
+      padding: 0 12px;
+    }
+
+    body.desktop-native-workbench .desktop-quick-action:hover,
+    body.desktop-native-workbench .desktop-quick-action:focus-visible {
+      border-color: #dfd4cc;
+      background: #fffaf5;
+      color: var(--text);
     }
 
     body.desktop-native-workbench .desktop-panel-controls {
@@ -7713,7 +7748,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-native-composer {
       display: block;
-      width: min(1100px, 100%);
+      width: min(var(--desktop-chat-column-width), calc(100% - 112px));
       min-width: 0;
       margin: 0 auto 10px;
       border: 1px solid var(--border);
@@ -7801,7 +7836,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       grid-area: runtime;
       display: flex;
       flex-wrap: nowrap;
-      gap: 16px;
+      gap: 10px;
       align-items: center;
       justify-content: flex-end;
       min-width: 0;
@@ -7851,9 +7886,25 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-activity-rail {
       justify-content: space-between;
-      gap: 14px;
-      padding: 16px 10px 18px;
+      gap: 12px;
+      padding: 14px 10px 16px;
       background: #fbfaf7;
+    }
+
+    body.desktop-native-workbench .desktop-activity-rail > .n-config-provider {
+      display: flex;
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+
+    body.desktop-native-workbench .desktop-activity-rail-stack {
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      gap: 12px;
+      width: 100%;
+      height: 100%;
+      min-height: 0;
     }
 
     body.desktop-native-workbench .desktop-activity-primary,
@@ -7863,12 +7914,16 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
     }
 
+    body.desktop-native-workbench .desktop-activity-secondary {
+      margin-top: auto;
+    }
+
     body.desktop-native-workbench .desktop-activity-button,
     body.desktop-native-workbench .desktop-activity-secondary-button {
       width: 72px;
-      min-height: 48px;
+      min-height: 42px;
       border-radius: 8px;
-      color: #2f302e;
+      color: #5f5b56;
       font-size: 11px;
       font-weight: 700;
       line-height: 1.15;
@@ -7880,9 +7935,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-activity-button[data-active="true"],
     body.desktop-native-workbench .desktop-activity-secondary-button[data-active="true"] {
       border-color: #eaded8;
-      background: #ffffff;
+      background: #fff7ef;
       color: var(--primary);
-      box-shadow: 0 8px 20px rgba(20, 20, 19, 0.08);
+      box-shadow: none;
     }
 
     body.desktop-native-workbench .desktop-activity-secondary-button {
@@ -7893,6 +7948,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       background: transparent;
       text-decoration: none;
       cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-activity-secondary-button:hover,
+    body.desktop-native-workbench .desktop-activity-secondary-button:focus-visible {
+      border-color: #eaded8;
+      background: #fff7ef;
+      color: #262522;
     }
 
     body.desktop-native-workbench .desktop-workbench-link[data-active="true"] {
@@ -7919,19 +7981,30 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-sidebar-content {
-      display: grid;
-      grid-template-rows: auto auto auto;
-      align-content: start;
+      display: flex;
+      flex-direction: column;
       gap: 10px;
       height: 100%;
       min-height: 0;
       padding: 18px 14px;
-      overflow: hidden;
+      overflow-y: auto;
+      overflow-x: hidden;
       background: #fbfaf7;
     }
 
     body.desktop-native-workbench .desktop-sidebar-content > .desktop-workbench-section {
-      display: none;
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+      border: 0;
+      padding: 4px 0 0;
+      background: transparent;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-content > .desktop-workbench-section:last-child {
+      margin-top: auto;
+      padding-top: 12px;
+      border-top: 1px solid #ebe3dc;
     }
 
     body.desktop-native-workbench .desktop-sidebar-actions {
@@ -8039,6 +8112,31 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       text-decoration: none;
     }
 
+    body.desktop-native-workbench .desktop-workbench-link {
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      width: 100%;
+      min-height: 30px;
+      border: 1px solid transparent;
+      border-radius: 7px;
+      padding: 0 9px;
+      background: transparent;
+      color: #4d4944;
+      font: 500 12px/1.2 var(--font-sans);
+      text-align: left;
+      text-decoration: none;
+      cursor: pointer;
+      appearance: none;
+    }
+
+    body.desktop-native-workbench .desktop-workbench-link:hover,
+    body.desktop-native-workbench .desktop-workbench-link:focus-visible {
+      border-color: #eee4dd;
+      background: #fff7ef;
+      color: #262522;
+    }
+
     body.desktop-native-workbench .desktop-sidebar-chat-row {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
@@ -8103,7 +8201,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-sidebar-chat-row[data-active="true"],
     body.desktop-native-workbench .desktop-sidebar-row[data-active="true"] {
       border-color: #f0d8cf;
-      background: #f8e7e1;
+      background: #fff7ef;
       color: #b4533c;
     }
 
@@ -8140,6 +8238,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-chat-workbench {
+      --desktop-composer-reserve: 152px;
       align-self: stretch;
       display: grid;
       grid-template-rows: auto minmax(0, 1fr);
@@ -8167,17 +8266,44 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       white-space: nowrap;
     }
 
+    body.desktop-native-workbench .desktop-chat-workbench-chrome {
+      display: grid;
+      gap: 12px;
+      width: min(var(--desktop-chat-column-width), 100%);
+      margin: 14px auto 0;
+      padding: 24px 0;
+      background: transparent;
+    }
+
+    body.desktop-native-workbench .desktop-chat-workbench-chrome h2 {
+      margin: 0;
+      color: #1f1d1a;
+      font: 700 18px/1.25 var(--font-sans);
+      letter-spacing: 0;
+    }
+
+    body.desktop-native-workbench .desktop-chat-workbench-chrome p {
+      max-width: 520px;
+      color: #69635d;
+      font: 500 13px/1.55 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-chat-workbench-chrome .desktop-quick-actions {
+      gap: 8px;
+    }
+
     body.desktop-native-workbench .desktop-chat-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 12px;
-      width: min(1120px, 100%);
+      width: min(var(--desktop-chat-column-width), 100%);
       min-width: 0;
       min-height: 54px;
-      border-bottom: 1px solid #e9e4df;
-      padding: 0 18px;
-      background: #ffffff;
+      margin: 0 auto;
+      border-bottom: 0;
+      padding: 0;
+      background: transparent;
     }
 
     body.desktop-native-workbench .desktop-chat-title-row {
@@ -8186,6 +8312,21 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-items: center;
       gap: 8px;
       min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-chat-title-group {
+      display: grid;
+      gap: 2px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-chat-context {
+      overflow: hidden;
+      color: #8a8179;
+      font: 650 11px/1.1 var(--font-sans);
+      letter-spacing: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     body.desktop-native-workbench .desktop-chat-header h1 {
@@ -8339,32 +8480,67 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-conversation-thread {
       display: grid;
       align-content: start;
-      gap: 22px;
-      width: min(1120px, 100%);
+      justify-items: stretch;
+      gap: 10px;
+      width: min(var(--desktop-chat-column-width), 100%);
       min-height: 0;
-      padding: 32px min(8vw, 72px) 22px;
+      margin: 0 auto;
+      padding: 18px 0 var(--desktop-composer-reserve);
       overflow-y: auto;
       overflow-x: hidden;
     }
 
     body.desktop-native-workbench .desktop-conversation-message {
       display: grid;
-      max-width: 760px;
+      justify-self: stretch;
+      width: 100%;
+      max-width: 100%;
       min-width: 0;
     }
 
+    body.desktop-native-workbench .desktop-conversation-content-card,
     body.desktop-native-workbench .desktop-conversation-content {
       display: grid;
-      gap: 10px;
+      gap: 8px;
+      width: 100%;
       min-width: 0;
+      border: 0;
+      border-radius: 0;
+      padding: 4px 0 8px;
+      background: transparent;
       color: #1f1d1a;
-      font: 14px/1.75 var(--font-sans);
+      font: 14px/1.58 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-conversation-message[data-message-tone="assistant"] .desktop-conversation-content {
+      padding: 4px 0 8px;
+      line-height: 1.62;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-content-card .n-card__content {
+      padding: 0;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-content-card {
+      border: 0;
+      padding: 0;
+      background: transparent;
+      box-shadow: none;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      min-width: 0;
+      min-height: 20px;
     }
 
     body.desktop-native-workbench .desktop-conversation-meta {
       display: flex;
       align-items: baseline;
-      gap: 10px;
+      gap: 6px;
       min-width: 0;
       color: #6d6964;
       font-size: 12px;
@@ -8374,6 +8550,59 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-conversation-meta strong {
       color: #1f1d1a;
       font-size: 14px;
+      font-weight: 700;
+    }
+
+    body.desktop-native-workbench .desktop-message-copy-button {
+      position: relative;
+      display: inline-grid;
+      place-items: center;
+      width: 24px;
+      height: 24px;
+      border: 0;
+      border-radius: 6px;
+      padding: 0;
+      background: transparent;
+      color: #77716a;
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-message-copy-button:hover,
+    body.desktop-native-workbench .desktop-message-copy-button:focus-visible {
+      background: #f7f2ed;
+      color: #3f3a35;
+      outline: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-actions {
+      display: flex;
+      justify-content: flex-start;
+      min-height: 24px;
+      margin-top: 2px;
+    }
+
+    body.desktop-native-workbench .desktop-message-copy-icon,
+    body.desktop-native-workbench .desktop-message-copy-icon::before,
+    body.desktop-native-workbench .desktop-message-copy-icon::after {
+      box-sizing: border-box;
+      display: block;
+      width: 12px;
+      height: 12px;
+      border: 1.5px solid currentColor;
+      border-radius: 3px;
+    }
+
+    body.desktop-native-workbench .desktop-message-copy-icon {
+      position: relative;
+      transform: translate(2px, -2px);
+    }
+
+    body.desktop-native-workbench .desktop-message-copy-icon::before {
+      content: "";
+      position: absolute;
+      right: 4px;
+      top: 4px;
+      background: transparent;
     }
 
     body.desktop-native-workbench .desktop-conversation-content p {
@@ -8382,15 +8611,26 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-message-reasoning {
-      overflow: hidden;
-      border: 1px solid #e2d9d2;
-      border-radius: 8px;
-      background: #fbfaf7;
-      color: #625d57;
-      font-size: 13px;
+      display: grid;
+      justify-items: end;
+      justify-self: stretch;
+      width: 100%;
+      max-width: 100%;
+      margin-top: 0;
+      overflow: visible;
+      border: 0;
+      background: transparent;
+      color: #77716a;
+      font-size: 11px;
+      opacity: 0.86;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning[open] {
+      justify-items: stretch;
     }
 
     body.desktop-native-workbench .desktop-message-reasoning summary {
+      justify-self: end;
       list-style: none;
     }
 
@@ -8401,23 +8641,92 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-message-reasoning-summary {
       display: flex;
       align-items: center;
-      gap: 10px;
-      min-height: 36px;
-      padding: 8px 11px;
+      gap: 5px;
+      width: fit-content;
+      margin-left: auto;
+      min-height: 22px;
+      border-radius: 999px;
+      padding: 0 7px;
+      background: transparent;
+      color: #77716a;
+      font: 650 11px/1.2 var(--font-sans);
       cursor: pointer;
       user-select: none;
     }
 
+    body.desktop-native-workbench .desktop-message-reasoning-summary:hover,
+    body.desktop-native-workbench .desktop-message-reasoning-summary:focus-visible {
+      background: #f7f2ed;
+      color: #3f3a35;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-summary::before {
+      content: "";
+      display: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-summary::after {
+      content: "⌄";
+      color: #8c847c;
+      font: 700 11px/1 var(--font-sans);
+      transition: transform 150ms ease;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning[open] .desktop-message-reasoning-summary::after {
+      transform: rotate(90deg);
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-toggle {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      width: fit-content;
+      margin-left: auto;
+      min-height: 22px;
+      border: 0;
+      border-radius: 999px;
+      padding: 0 7px;
+      background: transparent;
+      color: #77716a;
+      font: 650 11px/1.2 var(--font-sans);
+      cursor: pointer;
+      user-select: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-toggle:hover,
+    body.desktop-native-workbench .desktop-message-reasoning-toggle:focus-visible {
+      background: #f7f2ed;
+      color: #3f3a35;
+      outline: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-toggle::before {
+      content: ">";
+      display: inline-block;
+      color: #8c847c;
+      font: 700 11px/1 var(--font-sans);
+      transition: transform 150ms ease;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-toggle[aria-expanded="true"]::before {
+      transform: rotate(90deg);
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning[data-expanded="true"] {
+      justify-items: stretch;
+    }
+
     body.desktop-native-workbench .desktop-message-reasoning-summary::before {
       content: ">";
-      display: grid;
-      place-items: center;
-      width: 16px;
-      height: 16px;
-      border-radius: 4px;
-      color: #a9583e;
-      font: 700 11px/1 var(--font-mono);
+      display: inline-block;
+      color: #8c847c;
+      font: 700 11px/1 var(--font-sans);
       transition: transform 150ms ease;
+    }
+
+    body.desktop-native-workbench .desktop-message-reasoning-summary::after {
+      content: none;
+      display: none;
     }
 
     body.desktop-native-workbench .desktop-message-reasoning[open] .desktop-message-reasoning-summary::before {
@@ -8436,9 +8745,16 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-message-reasoning-body {
-      max-height: 320px;
+      box-sizing: border-box;
+      width: 100%;
+      max-height: 240px;
+      margin-top: 8px;
       overflow: auto;
-      padding: 0 14px 12px 37px;
+      border: 1px solid #eee6de;
+      border-radius: 8px;
+      padding: 8px 10px;
+      background: #fffaf6;
+      color: #625d57;
       white-space: pre-wrap;
     }
 
@@ -8551,6 +8867,34 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       padding: 5px 0 7px;
     }
 
+    body.desktop-native-workbench .desktop-tool-activity-content-details {
+      display: grid;
+      gap: 6px;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-content-summary {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      color: #7a746d;
+      cursor: pointer;
+      list-style: none;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-content-summary::-webkit-details-marker {
+      display: none;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-content-preview {
+      min-width: 0;
+      overflow: hidden;
+      color: #8a847e;
+      font: 11px/1.4 var(--font-mono);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     body.desktop-native-workbench .desktop-tool-activity-label {
       color: #7a746d;
       font-size: 10px;
@@ -8608,6 +8952,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-conversation-body pre {
+      position: relative;
       margin: 12px 0;
       min-height: auto;
       max-width: 100%;
@@ -8618,6 +8963,26 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       background: #fbfaf7;
       color: #1f1d1a;
       font: 12px/1.55 var(--font-mono);
+    }
+
+    body.desktop-native-workbench .desktop-code-copy-button {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      border: 1px solid #e6ded6;
+      border-radius: 999px;
+      padding: 3px 8px;
+      background: rgba(255, 253, 249, 0.92);
+      color: #6d6964;
+      font: 650 11px/1.2 var(--font-sans);
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-code-copy-button:hover,
+    body.desktop-native-workbench .desktop-code-copy-button:focus-visible {
+      background: #f7f2ed;
+      color: #3f3a35;
+      outline: none;
     }
 
     body.desktop-native-workbench .desktop-conversation-body code {
@@ -8653,6 +9018,83 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       border-bottom-color: #a9583e;
     }
 
+    body.desktop-native-workbench .desktop-message-references {
+      display: grid;
+      gap: 6px;
+      margin-top: 2px;
+    }
+
+    body.desktop-native-workbench .desktop-message-reference-group {
+      border: 0;
+      border-radius: 8px;
+      background: transparent;
+      color: #6d6964;
+      font-size: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-message-references-summary {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      width: fit-content;
+      border-radius: 999px;
+      padding: 3px 8px;
+      color: #77716a;
+      cursor: pointer;
+      list-style: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-references-summary::-webkit-details-marker {
+      display: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-references-summary:hover,
+    body.desktop-native-workbench .desktop-message-references-summary:focus-visible {
+      background: #f7f2ed;
+      color: #3f3a35;
+      outline: none;
+    }
+
+    body.desktop-native-workbench .desktop-message-references-title {
+      font-weight: 700;
+    }
+
+    body.desktop-native-workbench .desktop-message-references-count {
+      color: #8a847e;
+      font-size: 11px;
+    }
+
+    body.desktop-native-workbench .desktop-message-reference-list {
+      display: grid;
+      gap: 5px;
+      padding: 5px 0 0 8px;
+    }
+
+    body.desktop-native-workbench .desktop-message-reference-item {
+      display: grid;
+      gap: 2px;
+      border-left: 2px solid #eee2d7;
+      padding-left: 8px;
+      color: #625d57;
+    }
+
+    body.desktop-native-workbench .desktop-message-reference-title {
+      color: #3f3a35;
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    body.desktop-native-workbench .desktop-message-reference-kind {
+      color: #8a847e;
+      font-size: 11px;
+      font-weight: 700;
+    }
+
+    body.desktop-native-workbench .desktop-message-reference-detail {
+      color: #7a746d;
+      font-size: 11px;
+    }
+
     body.desktop-native-workbench .desktop-conversation-body table {
       width: 100%;
       margin: 12px 0;
@@ -8679,7 +9121,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-native-composer {
       position: relative;
-      width: min(1120px, calc(100% - 40px));
+      width: min(var(--desktop-chat-column-width), calc(100% - 112px));
       min-height: 0;
       margin: 0 auto 8px;
       border-color: #ddd5cd;
@@ -8693,7 +9135,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       grid-template-columns: 40px minmax(0, 1fr) 44px;
       grid-template-rows: auto auto;
       grid-template-areas: "input input input" "attach runtime send";
-      gap: 10px 18px;
+      gap: 10px 14px;
       align-items: end;
     }
 
@@ -8732,7 +9174,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       max-height: none;
       overflow-x: auto;
       overflow-y: visible;
-      gap: 16px;
+      gap: 10px;
       flex-wrap: nowrap;
       min-width: 0;
     }
@@ -8742,20 +9184,28 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       border: 0;
       border-radius: 999px;
       padding: 0 14px;
-      background: #fffaf6;
+      background: transparent;
       color: #262522;
       font: 600 12px/1.2 var(--font-sans);
       box-shadow: none;
       cursor: pointer;
     }
 
-    body.desktop-native-workbench .desktop-native-composer-model:focus-visible,
-    body.desktop-native-workbench .desktop-native-composer-rag-toggle[aria-pressed="true"] {
+    body.desktop-native-workbench .desktop-native-composer-model:hover,
+    body.desktop-native-workbench .desktop-native-composer-model:focus-visible {
       outline: 0;
-      box-shadow: 0 8px 20px rgba(216, 112, 72, 0.18);
+      background: #fff7ef;
+      box-shadow: none;
     }
 
-    body.desktop-native-workbench .desktop-native-composer-rag-toggle[aria-pressed="false"] {
+    body.desktop-native-workbench .desktop-native-composer-rag-toggle:hover,
+    body.desktop-native-workbench .desktop-native-composer-rag-toggle[aria-pressed="true"] {
+      background: #fff7ef;
+      box-shadow: none;
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-rag-toggle[aria-pressed="false"]:not(:hover):not(:focus-visible) {
+      background: transparent;
       box-shadow: none;
     }
 
@@ -9414,6 +9864,18 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       cursor: pointer;
     }
 
+    body.desktop-native-workbench .desktop-run-chain-icon-button[data-button-variant="ghost"] {
+      border-color: transparent;
+      background: transparent;
+      color: #77716a;
+    }
+
+    body.desktop-native-workbench .desktop-run-chain-icon-button[data-button-variant="ghost"]:hover,
+    body.desktop-native-workbench .desktop-run-chain-icon-button[data-button-variant="ghost"]:focus-visible {
+      background: #f2eee8;
+      color: #262522;
+    }
+
     body.desktop-native-workbench .desktop-run-chain-icon-button[aria-pressed="true"] {
       border-color: rgba(217, 104, 76, 0.35);
       background: rgba(217, 104, 76, 0.1);
@@ -9421,36 +9883,63 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-run-chain-summary-strip {
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 6px;
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 7px;
       min-width: 0;
     }
 
     body.desktop-native-workbench .desktop-run-chain-summary-item {
-      display: grid;
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-start;
+      gap: 6px;
+      flex: 1 1 0;
       min-width: 0;
-      min-height: 34px;
-      border: 1px solid #e6dfd8;
-      border-radius: 6px;
-      padding: 5px 7px;
+      min-height: 26px;
+      border: 0;
+      border-radius: 999px;
+      padding: 0 8px;
       overflow: hidden;
-      background: #fffdf9;
-      color: #3f3a35;
-      font: 700 11px/1.25 var(--font-sans);
+      background: #f4eee8;
+      color: #625d57;
+      font: 650 11px/1.2 var(--font-sans);
       text-align: left;
       text-overflow: ellipsis;
       white-space: nowrap;
       cursor: pointer;
     }
 
+    body.desktop-native-workbench .desktop-run-chain-summary-item span:last-child {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    body.desktop-native-workbench .desktop-run-chain-status-pill[data-status-tone="connected"] {
+      background: #eff8f2;
+      color: #28694b;
+    }
+
+    body.desktop-native-workbench .desktop-run-chain-status-pill[data-status-tone="muted"] {
+      background: #f5f1ec;
+      color: #77716a;
+    }
+
+    body.desktop-native-workbench .desktop-run-chain-status-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 999px;
+      background: #2f9b62;
+      box-shadow: 0 0 0 2px rgba(47, 155, 98, 0.13);
+    }
+
     body.desktop-native-workbench .desktop-run-chain-tabs {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 4px;
+      gap: 2px;
       min-width: 0;
-      border: 1px solid #e3dbd4;
-      border-radius: 7px;
+      border: 0;
+      border-radius: 8px;
       padding: 3px;
       background: #f2eee8;
     }
@@ -9459,18 +9948,18 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       min-height: 30px;
       border: 0;
-      border-radius: 5px;
+      border-radius: 6px;
       padding: 0 8px;
       background: transparent;
-      color: #262522;
-      font: 700 12px/1.2 var(--font-sans);
+      color: #625d57;
+      font: 650 12px/1.2 var(--font-sans);
       cursor: pointer;
     }
 
     body.desktop-native-workbench .desktop-run-chain-tab[aria-selected="true"] {
       background: #ffffff;
       color: #1f1d1a;
-      box-shadow: 0 1px 2px rgba(20, 20, 19, 0.06);
+      box-shadow: 0 1px 1px rgba(20, 20, 19, 0.04);
     }
 
     body.desktop-native-workbench .desktop-run-chain-panel {
@@ -9485,22 +9974,37 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: grid;
       gap: 7px;
       min-width: 0;
-      border-top: 1px solid #e7dfd8;
-      padding: 10px 0 2px;
+      border: 1px solid #ebe3dc;
+      border-radius: 8px;
+      padding: 12px;
+      background: #fffdf9;
     }
 
     body.desktop-native-workbench .desktop-run-chain-card-row {
       margin: 0;
-      color: #4e4943;
-      font: 12px/1.4 var(--font-sans);
+      color: #77716a;
+      font: 500 11px/1.45 var(--font-sans);
       overflow-wrap: anywhere;
     }
 
+    body.desktop-native-workbench .desktop-run-chain-empty-state {
+      margin: 2px 0 0;
+      border-radius: 7px;
+      padding: 8px 9px;
+      background: #f7f2ed;
+      color: #77716a;
+      font: 500 12px/1.35 var(--font-sans);
+    }
+
     body.desktop-native-workbench .desktop-run-chain-actions {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      display: flex;
+      justify-content: stretch;
       gap: 8px;
       min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-run-chain-actions .desktop-run-chain-panel-action {
+      flex: 1 1 auto;
     }
 
     body.desktop-native-workbench .desktop-run-chain-panel-action,
@@ -9518,16 +10022,30 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       cursor: pointer;
     }
 
+    body.desktop-native-workbench .desktop-run-chain-panel-action[data-button-variant="primary"] {
+      border-color: var(--primary);
+      background: var(--primary);
+      color: #ffffff;
+    }
+
+    body.desktop-native-workbench .desktop-run-chain-panel-action[data-button-variant="secondary"],
+    body.desktop-native-workbench .desktop-run-chain-new-item[data-button-variant="secondary"] {
+      border-color: #e2d9d2;
+      background: #ffffff;
+      color: #3f3a35;
+    }
+
+    body.desktop-native-workbench .desktop-run-chain-panel-action[data-button-variant="ghost"] {
+      border-color: transparent;
+      background: transparent;
+      color: #77716a;
+    }
+
     body.desktop-native-workbench .desktop-run-chain-feed-item {
       overflow: hidden;
       text-align: left;
       text-overflow: ellipsis;
       white-space: nowrap;
-    }
-
-    body.desktop-native-workbench .desktop-run-chain-new-item {
-      border-color: var(--primary);
-      color: var(--primary);
     }
 
     body.desktop-native-workbench .desktop-bottom-content {
@@ -10073,6 +10591,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-row-meta,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-context,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-empty-session p,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-section p,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-title-group p,
@@ -10084,16 +10603,31 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-task-center-detail,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-action-status,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-cowork-action-summary,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-empty-state,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-card-row,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-gateway-runtime-row {
       color: var(--text-muted);
     }
 
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-empty-state {
+      background: var(--panel-strong);
+    }
+
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-send:not(:disabled),
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-quick-actions .desktop-quick-action:first-child {
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-panel-action[data-button-variant="primary"] {
       background: var(--accent);
       border-color: var(--accent);
       color: var(--on-primary);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-status-pill[data-status-tone="connected"] {
+      background: rgba(47, 155, 98, 0.16);
+      color: #8ed3a8;
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-run-chain-status-pill[data-status-tone="muted"] {
+      background: var(--panel-strong);
+      color: var(--text-muted);
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-task-center-diagnostics:not(:empty),
@@ -10145,19 +10679,21 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
       body.desktop-native-workbench .desktop-chat-header {
         min-height: 54px;
-        padding: 0 16px;
+        width: min(var(--desktop-chat-column-width), 100%);
+        padding: 0;
       }
 
       body.desktop-native-workbench .desktop-conversation-thread {
-        padding: 28px 18px 18px;
+        width: min(var(--desktop-chat-column-width), 100%);
+        padding: 18px 0 var(--desktop-composer-reserve);
       }
 
       body.desktop-native-workbench .desktop-conversation-message {
-        grid-template-columns: 48px minmax(0, 1fr);
+        width: 100%;
       }
 
       body.desktop-native-workbench .desktop-native-composer {
-        width: calc(100% - 28px);
+        width: min(var(--desktop-chat-column-width), calc(100% - 28px));
       }
 
       body.desktop-native-workbench .desktop-native-composer-layout {

--- a/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
@@ -13,6 +13,12 @@ describe("desktop workbench shell Vue integration", () => {
     installDesktopWorkbenchShell({
       targetDocument: document,
       layout: createDefaultWorkbenchLayout(),
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+      },
       gatewayHttp: "http://127.0.0.1:18790",
     });
 
@@ -195,23 +201,28 @@ describe("desktop workbench shell Vue integration", () => {
   test("renders the chat workbench chrome through the Vue shell island", () => {
     document.body.replaceChildren();
     document.head.replaceChildren();
+    const chat = {
+      sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+      activeSessionKey: "WebSocket:chat-live",
+      activeChatId: "chat-live",
+      messages: [],
+    };
 
     installDesktopWorkbenchShell({
       targetDocument: document,
       layout: createDefaultWorkbenchLayout(),
+      chat,
       gatewayHttp: "http://127.0.0.1:18790",
     });
 
     const workbench = document.querySelector<HTMLElement>(".desktop-chat-workbench-chrome");
     expect(workbench?.getAttribute("data-desktop-vue-island")).toBe("chat-workbench");
-    expect(workbench?.textContent).toContain("Ready for a new session.");
-    expect(workbench?.textContent).toContain("Ready for a new session. Start");
-    expect(workbench?.textContent).toContain("Start from chat, inspect the workspace, or check gateway status.");
+    expect(workbench?.textContent).toContain("Start a new session");
+    expect(workbench?.textContent).toContain("Ask Tinybot about the workspace, inspect files, or create a task.");
     expect(workbench?.textContent).not.toContain("sessionStart");
     expect(workbench?.textContent).not.toContain("session.Start");
     expect(workbench?.querySelector(".desktop-quick-actions")?.getAttribute("data-desktop-vue-island")).toBe("quick-actions");
-    expect(workbench?.querySelector(".desktop-panel-controls")?.getAttribute("data-desktop-vue-island")).toBe("panel-controls");
-    expect(workbench?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-pressed")).toBe("true");
+    expect(workbench?.querySelector(".desktop-panel-controls")).toBeNull();
   });
 
   test("renders the main utility surfaces through the Vue shell island", () => {
@@ -379,7 +390,8 @@ describe("desktop workbench shell Vue integration", () => {
     const thread = document.querySelector<HTMLElement>(".desktop-conversation-thread");
     expect(thread?.getAttribute("data-desktop-vue-island")).toBe("conversation-thread");
     expect(thread?.getAttribute("aria-label")).toBe("Conversation");
-    expect(thread?.textContent).toContain("No messages in this session.");
+    expect(thread?.textContent).not.toContain("No messages in this session.");
+    expect(document.querySelector(".desktop-chat-workbench-chrome")?.textContent).toContain("Start a new session");
   });
 
   test("renders fallback conversation messages through the Vue shell island without an active chat", () => {

--- a/apps/desktop/src/native-vue/activityRailIsland.test.ts
+++ b/apps/desktop/src/native-vue/activityRailIsland.test.ts
@@ -15,19 +15,30 @@ describe("activity rail Vue island", () => {
     expect(host.getAttribute("aria-label")).toBe("Desktop workbench modules");
 
     const primary = Array.from(host.querySelectorAll<HTMLAnchorElement>(".desktop-activity-button"));
-    expect(primary.map((item) => item.textContent)).toEqual(["Chat", "Files", "Knowledge", "Cowork"]);
-    expect(primary.map((item) => item.getAttribute("href"))).toEqual(["/chat", "/workspace", "/knowledge", "/cowork"]);
+    expect(primary.map((item) => item.textContent)).toEqual(["Chat", "Files", "Knowledge", "Cowork", "Docs", "GitHub"]);
+    expect(primary.map((item) => item.getAttribute("href"))).toEqual([
+      "/chat",
+      "/workspace",
+      "/knowledge",
+      "/cowork",
+      "/docs",
+      "https://github.com/SudoJacky/tinybot",
+    ]);
     expect(primary.map((item) => item.getAttribute("data-desktop-module-target"))).toEqual([
       "chat",
       "workspace",
       "knowledge",
       "cowork",
+      "docs",
+      "gateway",
     ]);
     expect(primary.map((item) => item.getAttribute("data-focus-order"))).toEqual([
       "activity-1",
       "activity-2",
       "activity-3",
       "activity-4",
+      "activity-5",
+      "activity-6",
     ]);
     expect(primary[0]?.getAttribute("data-active")).toBe("true");
     expect(primary[0]?.getAttribute("aria-current")).toBe("page");
@@ -42,17 +53,9 @@ describe("activity rail Vue island", () => {
     mountActivityRailIsland(host);
 
     const secondary = Array.from(host.querySelectorAll<HTMLAnchorElement>(".desktop-activity-secondary-button"));
-    expect(secondary.map((item) => item.textContent)).toEqual(["Docs", "GitHub", "Settings"]);
-    expect(secondary.map((item) => item.getAttribute("href"))).toEqual([
-      "/docs",
-      "https://github.com/SudoJacky/tinybot",
-      "/settings",
-    ]);
-    expect(secondary.map((item) => item.getAttribute("data-desktop-module-target"))).toEqual([
-      "docs",
-      "gateway",
-      "settings",
-    ]);
+    expect(secondary.map((item) => item.textContent)).toEqual(["Settings"]);
+    expect(secondary.map((item) => item.getAttribute("href"))).toEqual(["/settings"]);
+    expect(secondary.map((item) => item.getAttribute("data-desktop-module-target"))).toEqual(["settings"]);
     expect(secondary.every((item) => item.getAttribute("aria-label") === item.textContent)).toBe(true);
     expect(secondary.every((item) => item.getAttribute("title") === item.textContent)).toBe(true);
   });

--- a/apps/desktop/src/native-vue/activityRailIsland.ts
+++ b/apps/desktop/src/native-vue/activityRailIsland.ts
@@ -13,11 +13,11 @@ const PRIMARY_ACTIVITY_ITEMS: ActivityRailItem[] = [
   { href: "/workspace", label: "Files", module: "workspace" },
   { href: "/knowledge", label: "Knowledge", module: "knowledge" },
   { href: "/cowork", label: "Cowork", module: "cowork" },
+  { href: "/docs", label: "Docs", module: "docs" },
+  { href: "https://github.com/SudoJacky/tinybot", label: "GitHub", module: "gateway" },
 ];
 
 const SECONDARY_ACTIVITY_ITEMS: ActivityRailItem[] = [
-  { href: "/docs", label: "Docs", module: "docs" },
-  { href: "https://github.com/SudoJacky/tinybot", label: "GitHub", module: "gateway" },
   { href: "/settings", label: "Settings", module: "settings" },
 ];
 
@@ -45,7 +45,7 @@ function createActivityRailApp(): App {
     name: "ActivityRailIsland",
     setup() {
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => [
+        default: () => h("div", { class: "desktop-activity-rail-stack" }, [
           h(NSpace, {
             class: "desktop-activity-primary",
             vertical: true,
@@ -67,7 +67,7 @@ function createActivityRailApp(): App {
               className: "desktop-activity-secondary-button",
             })),
           }),
-        ],
+        ]),
       });
     },
   }));

--- a/apps/desktop/src/native-vue/agentUiFormCardIsland.ts
+++ b/apps/desktop/src/native-vue/agentUiFormCardIsland.ts
@@ -77,7 +77,7 @@ function createAgentUiFormCardApp(options: AgentUiFormCardIslandOptions): App {
             class: "desktop-agent-ui-form",
             "data-agent-ui-form-id": options.form.form_id,
           }, [
-            ...options.form.fields.map((field, index) => h("label", {
+            ...options.form.fields.map((_field, index) => h("label", {
               ref: (element) => {
                 fieldHosts.value[index] = element as HTMLElement | null;
               },

--- a/apps/desktop/src/native-vue/chatWorkbenchIsland.test.ts
+++ b/apps/desktop/src/native-vue/chatWorkbenchIsland.test.ts
@@ -25,37 +25,27 @@ const chatRun: DesktopTaskCenterItem = {
 describe("chat workbench Vue island", () => {
   test("renders workbench chrome, panel controls, quick actions, and module work", () => {
     const host = document.createElement("div");
-    const panels: string[] = [];
     const inspected: string[] = [];
 
     const mounted = mountChatWorkbenchIsland(host, {
       moduleWorkItems: [chatRun],
-      panelControls: [
-        { panel: "sidebar", label: "Sidebar", ariaLabel: "Toggle Sidebar panel", visible: true },
-        { panel: "bottom", label: "Tasks", ariaLabel: "Toggle Tasks panel", visible: false },
-      ],
       onInspectWorkItem: (item) => inspected.push(item.id),
-      onPanelToggle: (panel) => panels.push(panel),
     });
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("chat-workbench");
     expect(host.className).toBe("desktop-chat-workbench-chrome");
-    expect(host.textContent).toContain("Ready for a new session.");
-    expect(host.textContent).toContain("Ready for a new session. Start");
-    expect(host.textContent).toContain("Start from chat, inspect the workspace, or check gateway status.");
+    expect(host.textContent).toContain("Start a new session");
+    expect(host.textContent).toContain("Ask Tinybot about the workspace, inspect files, or create a task.");
     expect(host.textContent).not.toContain("sessionStart");
     expect(host.textContent).not.toContain("session.Start");
     expect(host.querySelector(".desktop-quick-actions")?.getAttribute("data-desktop-vue-island")).toBe("quick-actions");
     expect(host.querySelector(".desktop-quick-actions")?.textContent).toContain("Open workspace");
-    expect(host.querySelector(".desktop-panel-controls")?.getAttribute("data-desktop-vue-island")).toBe("panel-controls");
-    expect(host.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-pressed")).toBe("true");
+    expect(host.querySelector(".desktop-panel-controls")).toBeNull();
     expect(host.querySelector(".desktop-module-work")?.getAttribute("data-desktop-vue-island")).toBe("module-work");
     expect(host.querySelector('[data-desktop-module-work="chat:stream:chat-1"]')?.textContent).toContain("Streaming response");
 
-    host.querySelector<HTMLButtonElement>('[data-desktop-panel-control="bottom"]')?.click();
     host.querySelector<HTMLButtonElement>('[data-desktop-module-work="chat:stream:chat-1"]')?.click();
 
-    expect(panels).toEqual(["bottom"]);
     expect(inspected).toEqual(["chat:stream:chat-1"]);
 
     mounted.unmount();

--- a/apps/desktop/src/native-vue/chatWorkbenchIsland.ts
+++ b/apps/desktop/src/native-vue/chatWorkbenchIsland.ts
@@ -2,15 +2,12 @@ import { createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, type Ap
 import { NConfigProvider, NText } from "naive-ui";
 import type { DesktopTaskCenterItem } from "../desktopTaskCenter";
 import { mountModuleWorkSectionIsland } from "./moduleWorkSectionIsland";
-import { mountPanelControlsIsland, type PanelControlId, type PanelControlItem } from "./panelControlsIsland";
 import { mountQuickActionsIsland } from "./quickActionsIsland";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 export interface ChatWorkbenchIslandOptions {
   moduleWorkItems?: DesktopTaskCenterItem[];
   onInspectWorkItem?: (item: DesktopTaskCenterItem) => void;
-  onPanelToggle?: (panel: PanelControlId) => void;
-  panelControls: PanelControlItem[];
 }
 
 export interface MountedChatWorkbenchIsland {
@@ -39,15 +36,10 @@ function createChatWorkbenchApp(options: ChatWorkbenchIslandOptions): App {
     setup() {
       const mountedChildren: Array<{ unmount: () => void }> = [];
       const quickActions = ref<HTMLElement | null>(null);
-      const panelControls = ref<HTMLElement | null>(null);
       const moduleWork = ref<HTMLElement | null>(null);
 
       onMounted(() => {
         mountChild(mountedChildren, quickActions.value, (host) => mountQuickActionsIsland(host));
-        mountChild(mountedChildren, panelControls.value, (host) => mountPanelControlsIsland(host, {
-          controls: options.panelControls,
-          onToggle: options.onPanelToggle,
-        }));
         if (options.moduleWorkItems?.length) {
           mountChild(mountedChildren, moduleWork.value, (host) => mountModuleWorkSectionIsland(host, {
             title: "Chat runs",
@@ -65,10 +57,9 @@ function createChatWorkbenchApp(options: ChatWorkbenchIslandOptions): App {
 
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => [
-          h(NText, { tag: "span" }, { default: () => "Ready for a new session. " }),
-          h(NText, { depth: 3, tag: "span" }, { default: () => "Start from chat, inspect the workspace, or check gateway status." }),
+          h(NText, { tag: "h2" }, { default: () => "Start a new session" }),
+          h(NText, { depth: 3, tag: "p" }, { default: () => "Ask Tinybot about the workspace, inspect files, or create a task." }),
           h("div", { ref: quickActions }),
-          h("div", { ref: panelControls }),
           options.moduleWorkItems?.length ? h("section", { ref: moduleWork }) : null,
         ],
       });

--- a/apps/desktop/src/native-vue/commandPaletteResultsIsland.ts
+++ b/apps/desktop/src/native-vue/commandPaletteResultsIsland.ts
@@ -52,8 +52,8 @@ function renderResultButton(result: DesktopCommandPaletteResult, selected: boole
     "data-palette-module": result.destination.module,
     "data-palette-result-id": result.id,
     class: "desktop-command-palette-result",
+    attrType: "button",
     tag: "button",
-    type: "button",
   }, {
     default: () => [
       h(NText, { strong: true, tag: "strong" }, { default: () => result.title }),

--- a/apps/desktop/src/native-vue/conversationBodyIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationBodyIsland.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { mountConversationBodyIsland } from "./conversationBodyIsland";
 
 describe("conversation body Vue island", () => {
@@ -36,5 +36,28 @@ describe("conversation body Vue island", () => {
     expect(link?.getAttribute("href")).toBe("https://example.com");
     expect(link?.getAttribute("target")).toBe("_blank");
     expect(link?.getAttribute("rel")).toBe("noreferrer");
+  });
+
+  test("adds WebUI-style copy buttons to assistant code blocks", async () => {
+    const host = document.createElement("div");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    mountConversationBodyIsland(host, {
+      body: ["```ts\nconst answer = 42;\n```"],
+      tone: "assistant",
+    });
+
+    const copy = host.querySelector<HTMLButtonElement>(".desktop-code-copy-button");
+    expect(copy?.textContent).toBe("Copy");
+
+    copy?.click();
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith("const answer = 42;");
+    expect(copy?.textContent).toBe("Copied");
   });
 });

--- a/apps/desktop/src/native-vue/conversationBodyIsland.ts
+++ b/apps/desktop/src/native-vue/conversationBodyIsland.ts
@@ -85,6 +85,7 @@ function renderConversationMarkdown(target: HTMLElement, content: string): void 
     target.querySelectorAll("pre code").forEach((block) => {
       hljs.highlightElement(block as HTMLElement);
     });
+    addCodeCopyButtons(target);
   } catch {
     target.textContent = content;
   }
@@ -92,4 +93,36 @@ function renderConversationMarkdown(target: HTMLElement, content: string): void 
 
 function addMarkdownLinkAttributes(html: string): string {
   return html.replace(/<a\s+(?![^>]*\btarget=)([^>]*href=)/gi, '<a target="_blank" rel="noreferrer" $1');
+}
+
+function addCodeCopyButtons(target: HTMLElement): void {
+  target.querySelectorAll("pre").forEach((pre) => {
+    if (pre.querySelector(".desktop-code-copy-button")) {
+      return;
+    }
+    const button = target.ownerDocument.createElement("button");
+    button.type = "button";
+    button.className = "desktop-code-copy-button";
+    button.setAttribute("aria-label", "Copy code");
+    button.textContent = "Copy";
+    button.addEventListener("click", () => {
+      const code = pre.querySelector("code");
+      const copyAttempt = writeClipboard((code?.textContent ?? pre.textContent ?? "").trimEnd(), target.ownerDocument);
+      button.textContent = "Copied";
+      void copyAttempt
+        .catch(() => {
+          button.textContent = "Failed";
+        });
+    });
+    pre.append(button);
+  });
+}
+
+async function writeClipboard(text: string, ownerDocument: Document): Promise<void> {
+  const clipboard = ownerDocument.defaultView?.navigator?.clipboard
+    ?? (typeof navigator !== "undefined" ? navigator.clipboard : undefined);
+  if (!clipboard?.writeText) {
+    throw new Error("Clipboard is unavailable.");
+  }
+  return clipboard.writeText(text);
 }

--- a/apps/desktop/src/native-vue/conversationMessageIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationMessageIsland.test.ts
@@ -1,18 +1,26 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { nextTick } from "vue";
 import { mountConversationMessageIsland } from "./conversationMessageIsland";
 
 describe("conversation message Vue island", () => {
   test("renders composed assistant message content", async () => {
     const host = document.createElement("article");
+    const staleReasoning = document.createElement("details");
+    staleReasoning.className = "desktop-message-reasoning";
+    staleReasoning.append(document.createElement("summary"));
+    host.append(staleReasoning);
 
     const mounted = mountConversationMessageIsland(host, {
       attachment: "design.png",
       author: "Tinybot",
       body: ["See [docs](https://example.com)."],
-      references: [{ detail: "lines 1-4", kind: "File", title: "README.md" }],
+      references: [
+        { detail: "lines 1-4", kind: "File", title: "README.md" },
+        { detail: "Saved preference", kind: "memory", title: "Memory note" },
+      ],
+      reasoningContent: "Inspected project context.",
       time: "10:28 AM",
       tone: "assistant",
     });
@@ -28,9 +36,25 @@ describe("conversation message Vue island", () => {
     expect(host.querySelector(".desktop-conversation-attachment")?.getAttribute("data-desktop-vue-island")).toBe("conversation-attachment");
     expect(host.querySelector(".desktop-conversation-meta strong")?.textContent).toBe("Tinybot");
     expect(host.querySelector(".desktop-conversation-meta-separator")?.textContent).toBe(" · ");
-    expect(Array.from(host.querySelectorAll(".desktop-conversation-meta span")).at(-1)?.textContent).toBe("10:28 AM");
+    const metaSpans = Array.from(host.querySelectorAll(".desktop-conversation-meta span"));
+    expect(metaSpans[metaSpans.length - 1]?.textContent).toBe("10:28 AM");
+    expect(host.querySelectorAll(".desktop-message-reasoning-summary")).toHaveLength(0);
+    const reasoningToggle = host.querySelector<HTMLButtonElement>(".desktop-message-reasoning-toggle");
+    expect(reasoningToggle?.textContent).toBe("Details");
+    expect(reasoningToggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(host.querySelector(".desktop-message-reasoning-body")).toBeNull();
+    reasoningToggle?.click();
+    await nextTick();
+    expect(reasoningToggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(host.querySelector(".desktop-message-reasoning-title")).toBeNull();
+    expect(host.querySelector(".desktop-message-reasoning-body")?.textContent).toContain("Inspected project context.");
     expect(host.querySelector(".desktop-conversation-body a")?.getAttribute("target")).toBe("_blank");
-    expect(host.querySelector(".desktop-conversation-reference")?.textContent).toBe("File: README.md - lines 1-4");
+    expect(host.querySelector(".desktop-message-references")).not.toBeNull();
+    expect(Array.from(host.querySelectorAll(".desktop-message-references-summary")).map((summary) => summary.textContent)).toEqual([
+      "File references1 source",
+      "Memory references1 source",
+    ]);
+    expect(host.querySelector(".desktop-message-reference-item")?.textContent).toContain("README.md");
     expect(host.querySelector(".desktop-conversation-attachment")?.textContent).toBe("design.png  1.2 MB");
 
     mounted.unmount();
@@ -52,5 +76,32 @@ describe("conversation message Vue island", () => {
       "First",
       "Second",
     ]);
+  });
+
+  test("renders a message-level copy action for assistant responses", async () => {
+    const host = document.createElement("article");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    mountConversationMessageIsland(host, {
+      author: "Tinybot",
+      body: ["First paragraph", "Second paragraph"],
+      references: [],
+      time: "10:30 AM",
+      tone: "assistant",
+    });
+
+    const copy = host.querySelector<HTMLButtonElement>(".desktop-message-copy-button");
+    expect(copy?.getAttribute("aria-label")).toBe("Copy message");
+
+    copy?.click();
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith("First paragraph\n\nSecond paragraph");
+    expect(copy?.getAttribute("aria-label")).toBe("Copied");
+    expect(copy?.querySelector(".desktop-message-copy-icon")).not.toBeNull();
   });
 });

--- a/apps/desktop/src/native-vue/conversationMessageIsland.ts
+++ b/apps/desktop/src/native-vue/conversationMessageIsland.ts
@@ -4,8 +4,7 @@ import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 import { mountConversationAttachmentIsland, renderConversationAttachmentNode } from "./conversationAttachmentIsland";
 import { mountConversationBodyIsland, renderConversationBodyNode } from "./conversationBodyIsland";
 import { mountConversationMetaIsland, renderConversationMetaNode } from "./conversationMetaIsland";
-import { mountConversationReasoningIsland, renderConversationReasoningNode } from "./conversationReasoningIsland";
-import { mountConversationReferenceIsland, renderConversationReferenceNode, type ConversationReferenceIslandOptions } from "./conversationReferenceIsland";
+import type { ConversationReferenceIslandOptions } from "./conversationReferenceIsland";
 import { mountToolActivitiesIsland, renderToolActivitiesNode } from "./toolActivitiesIsland";
 import type { ToolActivityIslandOptions } from "./toolActivityIsland";
 
@@ -31,6 +30,7 @@ export function mountConversationMessageIsland(
   host.setAttribute("data-desktop-vue-island", "conversation-message");
   host.className = "desktop-conversation-message";
   host.setAttribute("data-message-tone", options.tone);
+  host.replaceChildren();
   const app = createConversationMessageApp(options);
   app.mount(host);
   return {
@@ -48,21 +48,34 @@ function createConversationMessageApp(options: ConversationMessageIslandOptions)
       const attachmentHost = ref<HTMLElement | null>(null);
       const bodyHost = ref<HTMLElement | null>(null);
       const metaHost = ref<HTMLElement | null>(null);
-      const reasoningHost = ref<HTMLElement | null>(null);
-      const referenceHosts = ref<Array<HTMLElement | null>>([]);
       const toolActivitiesHost = ref<HTMLElement | null>(null);
       const mountedChildren: Array<{ unmount: () => void }> = [];
+      const copyLabel = ref("Copy");
+      const reasoningExpanded = ref(false);
+      const hasReasoning = Boolean(options.reasoningContent?.trim());
+      const copyMessage = (event: MouseEvent): void => {
+        const button = event.currentTarget instanceof HTMLButtonElement ? event.currentTarget : null;
+        const copyAttempt = writeClipboard(conversationCopyText(options), document);
+        copyLabel.value = "Copied";
+        if (button) {
+          button.setAttribute("aria-label", "Copied");
+          button.setAttribute("title", "Copied");
+        }
+        void copyAttempt
+          .catch(() => {
+            copyLabel.value = "Failed";
+            if (button) {
+              button.setAttribute("aria-label", "Failed");
+              button.setAttribute("title", "Failed");
+            }
+          });
+      };
 
       onMounted(() => {
         mountChild(mountedChildren, metaHost.value, (host) => mountConversationMetaIsland(host, {
           author: options.author,
           time: options.time,
         }));
-        if (options.reasoningContent?.trim()) {
-          mountChild(mountedChildren, reasoningHost.value, (host) => mountConversationReasoningIsland(host, {
-            content: options.reasoningContent!,
-          }));
-        }
         if (options.toolActivities?.length) {
           mountChild(mountedChildren, toolActivitiesHost.value, (host) => mountToolActivitiesIsland(host, {
             activities: options.toolActivities!,
@@ -72,9 +85,6 @@ function createConversationMessageApp(options: ConversationMessageIslandOptions)
           body: options.body,
           tone: options.tone,
         }));
-        options.references.forEach((reference, index) => {
-          mountChild(mountedChildren, referenceHosts.value[index] ?? null, (host) => mountConversationReferenceIsland(host, reference));
-        });
         if (options.attachment) {
           mountChild(mountedChildren, attachmentHost.value, (host) => mountConversationAttachmentIsland(host, {
             name: options.attachment!,
@@ -96,22 +106,29 @@ function createConversationMessageApp(options: ConversationMessageIslandOptions)
           bordered: false,
         }, {
           default: () => h("div", { class: "desktop-conversation-content" }, [
-            h("div", { ref: metaHost, class: "desktop-conversation-meta" }),
-            options.reasoningContent?.trim()
-              ? h("details", { ref: reasoningHost, class: "desktop-message-reasoning" })
+            h("div", { class: "desktop-conversation-header" }, [
+              h("div", { ref: metaHost, class: "desktop-conversation-meta" }),
+              hasReasoning
+                ? renderReasoningToggle(reasoningExpanded.value, () => {
+                  reasoningExpanded.value = !reasoningExpanded.value;
+                })
+                : null,
+            ]),
+            hasReasoning && reasoningExpanded.value
+              ? renderReasoningPanel(options.reasoningContent!)
               : null,
             options.toolActivities?.length
               ? h("div", { ref: toolActivitiesHost, class: "desktop-tool-activities" })
               : null,
             h("div", { ref: bodyHost, class: "desktop-conversation-body" }),
-            ...options.references.map((reference, index) => h("p", {
-              ref: (element) => {
-                referenceHosts.value[index] = element as HTMLElement | null;
-              },
-              class: "desktop-conversation-reference",
-            })),
+            ...renderReferenceGroups(options.references),
             options.attachment
               ? h("div", { ref: attachmentHost, class: "desktop-conversation-attachment" })
+              : null,
+            options.tone === "assistant"
+              ? h("div", { class: "desktop-message-actions" }, [
+                renderCopyButton(copyLabel.value === "Copy" ? "Copy message" : copyLabel.value, copyMessage),
+              ])
               : null,
           ]),
         }),
@@ -129,12 +146,41 @@ export function renderConversationMessageNode(options: ConversationMessageIsland
 
 export function renderConversationMessageChildren(options: ConversationMessageIslandOptions) {
   return h("div", { class: "desktop-conversation-content" }, [
-    renderConversationMetaNode({ author: options.author, time: options.time }),
-    options.reasoningContent?.trim() ? renderConversationReasoningNode({ content: options.reasoningContent }) : null,
+    h("div", { class: "desktop-conversation-header" }, [
+      renderConversationMetaNode({ author: options.author, time: options.time }),
+      options.reasoningContent?.trim() ? renderReasoningToggle(false, () => {}) : null,
+    ]),
     options.toolActivities?.length ? renderToolActivitiesNode({ activities: options.toolActivities }) : null,
     renderConversationBodyNode({ body: options.body, tone: options.tone }),
-    ...options.references.map((reference) => renderConversationReferenceNode(reference)),
+    ...renderReferenceGroups(options.references),
     options.attachment ? renderConversationAttachmentNode({ name: options.attachment, sizeLabel: "1.2 MB" }) : null,
+    options.tone === "assistant"
+      ? h("div", { class: "desktop-message-actions" }, [
+        renderCopyButton("Copy message", () => {
+          void writeClipboard(conversationCopyText(options), document);
+        }),
+      ])
+      : null,
+  ]);
+}
+
+function renderReasoningToggle(expanded: boolean, onClick: (event: MouseEvent) => void) {
+  return h("button", {
+    "aria-expanded": String(expanded),
+    "aria-label": expanded ? "Hide details" : "Show details",
+    class: "desktop-message-reasoning-toggle",
+    onClick,
+    title: expanded ? "Hide details" : "Show details",
+    type: "button",
+  }, "Details");
+}
+
+function renderReasoningPanel(content: string) {
+  return h("div", {
+    class: "desktop-message-reasoning",
+    "data-expanded": "true",
+  }, [
+    h("div", { class: "desktop-message-reasoning-body" }, content),
   ]);
 }
 
@@ -147,4 +193,103 @@ function mountChild<T extends { unmount: () => void }>(
     return;
   }
   mountedChildren.push(mount(host));
+}
+
+function renderReferenceGroups(references: ConversationReferenceIslandOptions[]) {
+  if (!references.length) {
+    return [];
+  }
+  return [h("div", { class: "desktop-message-references" }, groupReferences(references).map((group) => h("details", {
+    class: `desktop-message-reference-group desktop-message-reference-group-${group.id}`,
+  }, [
+    h("summary", { class: "desktop-message-references-summary" }, [
+      h("span", { class: "desktop-message-references-title" }, group.label),
+      h("span", { class: "desktop-message-references-count" }, `${group.references.length} ${group.references.length === 1 ? "source" : "sources"}`),
+    ]),
+      h("div", { class: "desktop-message-reference-list" }, group.references.map((reference) => h("article", {
+      class: "desktop-message-reference-item desktop-conversation-reference",
+      "data-desktop-vue-island": "conversation-reference",
+      "data-desktop-reference-kind": reference.kind,
+    }, [
+      h("span", { class: "desktop-message-reference-kind" }, `${reference.kind}: `),
+      h("strong", { class: "desktop-message-reference-title" }, reference.title),
+      reference.detail ? h("span", { class: "desktop-message-reference-detail" }, reference.detail) : null,
+    ]))),
+  ])))];
+}
+
+function renderCopyButton(label: string, onClick: (event: MouseEvent) => void) {
+  return h("button", {
+    "aria-label": label,
+    class: "desktop-message-copy-button",
+    onClick,
+    title: label,
+    type: "button",
+  }, [
+    h("span", { "aria-hidden": "true", class: "desktop-message-copy-icon" }),
+  ]);
+}
+
+function groupReferences(references: ConversationReferenceIslandOptions[]): Array<{
+  id: string;
+  label: string;
+  references: ConversationReferenceIslandOptions[];
+}> {
+  const groups: Array<{ id: string; label: string; references: ConversationReferenceIslandOptions[] }> = [];
+  for (const reference of references) {
+    const id = normalizeReferenceKind(reference.kind);
+    const existing = groups.find((group) => group.id === id);
+    if (existing) {
+      existing.references.push(reference);
+    } else {
+      groups.push({ id, label: referenceGroupLabel(id), references: [reference] });
+    }
+  }
+  return groups;
+}
+
+function normalizeReferenceKind(kind: string): string {
+  const normalized = kind.toLowerCase();
+  if (normalized.includes("memory")) {
+    return "memory";
+  }
+  if (normalized.includes("recent")) {
+    return "recent";
+  }
+  if (normalized.includes("browser")) {
+    return "browser";
+  }
+  if (normalized.includes("file") || normalized.includes("reference")) {
+    return "file";
+  }
+  return "reference";
+}
+
+function referenceGroupLabel(kind: string): string {
+  if (kind === "memory") {
+    return "Memory references";
+  }
+  if (kind === "recent") {
+    return "Recent context";
+  }
+  if (kind === "browser") {
+    return "Browser references";
+  }
+  if (kind === "file") {
+    return "File references";
+  }
+  return "References";
+}
+
+function conversationCopyText(options: ConversationMessageIslandOptions): string {
+  return options.body.filter((line) => line.trim()).join("\n\n");
+}
+
+async function writeClipboard(text: string, ownerDocument: Document): Promise<void> {
+  const clipboard = ownerDocument.defaultView?.navigator?.clipboard
+    ?? (typeof navigator !== "undefined" ? navigator.clipboard : undefined);
+  if (!clipboard?.writeText) {
+    throw new Error("Clipboard is unavailable.");
+  }
+  return clipboard.writeText(text);
 }

--- a/apps/desktop/src/native-vue/conversationMetaIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationMetaIsland.test.ts
@@ -17,7 +17,8 @@ describe("conversation meta Vue island", () => {
     expect(host.querySelector("strong")?.textContent).toBe("Tinybot");
     expect(host.querySelector(".desktop-conversation-meta-separator")?.textContent).toBe(" · ");
     expect(host.querySelector(".desktop-conversation-meta-separator")?.getAttribute("aria-hidden")).toBe("true");
-    expect(Array.from(host.querySelectorAll("span")).at(-1)?.textContent).toBe("10:28 AM");
+    const spans = Array.from(host.querySelectorAll("span"));
+    expect(spans[spans.length - 1]?.textContent).toBe("10:28 AM");
     expect(host.textContent).toBe("Tinybot · 10:28 AM");
 
     mounted.unmount();

--- a/apps/desktop/src/native-vue/conversationReasoningIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationReasoningIsland.test.ts
@@ -13,8 +13,8 @@ describe("conversation reasoning Vue island", () => {
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("conversation-reasoning");
     expect(host.className).toBe("desktop-message-reasoning");
-    expect(host.querySelector(".desktop-message-reasoning-title")?.textContent).toBe("Thinking");
-    expect(host.querySelector(".desktop-message-reasoning-meta")?.textContent).toBe("Show details");
+    expect(host.querySelector(".desktop-message-reasoning-title")).toBeNull();
+    expect(host.querySelector(".desktop-message-reasoning-summary")?.textContent).toBe("Details");
     expect(host.querySelector(".desktop-message-reasoning-body")?.textContent).toBe("Inspected the workspace and selected the next Vue island.");
 
     mounted.unmount();

--- a/apps/desktop/src/native-vue/conversationReasoningIsland.ts
+++ b/apps/desktop/src/native-vue/conversationReasoningIsland.ts
@@ -16,6 +16,7 @@ export function mountConversationReasoningIsland(
 ): MountedConversationReasoningIsland {
   host.setAttribute("data-desktop-vue-island", "conversation-reasoning");
   host.className = "desktop-message-reasoning";
+  host.replaceChildren();
   const app = createConversationReasoningApp(options);
   app.mount(host);
   return {
@@ -44,8 +45,7 @@ export function renderConversationReasoningNode(options: ConversationReasoningIs
 export function renderConversationReasoningChildren(options: ConversationReasoningIslandOptions) {
   return [
     h("summary", { class: "desktop-message-reasoning-summary" }, [
-      h(NText, { class: "desktop-message-reasoning-title", tag: "span" }, { default: () => "Thinking" }),
-      h(NText, { class: "desktop-message-reasoning-meta", depth: 3, tag: "span" }, { default: () => "Show details" }),
+      h(NText, { depth: 3, tag: "span" }, { default: () => "Details" }),
     ]),
     h(NText, { class: "desktop-message-reasoning-body", tag: "div" }, { default: () => options.content }),
   ];

--- a/apps/desktop/src/native-vue/conversationThreadIsland.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.ts
@@ -57,7 +57,7 @@ function createConversationThreadApp(options: ConversationThreadIslandOptions): 
             class: "desktop-conversation-message",
             "data-message-tone": message.tone,
           }))
-          : h(NEmpty, { description: options.emptyMessage }),
+          : (options.emptyMessage ? h(NEmpty, { description: options.emptyMessage }) : null),
       });
     },
   }));

--- a/apps/desktop/src/native-vue/coworkInspectorIsland.ts
+++ b/apps/desktop/src/native-vue/coworkInspectorIsland.ts
@@ -98,7 +98,9 @@ function selectedActionControls(
   if (type === "task") {
     return [
       h("input", {
-        ref: assignedAgentInput,
+        ref: (element) => {
+          assignedAgentInput.value = element as HTMLInputElement | null;
+        },
         class: "desktop-cowork-action-input",
         "aria-label": "Assign task to agent",
         "data-desktop-cowork-input": "assignedAgentId",

--- a/apps/desktop/src/native-vue/desktopAppMenuCommandIsland.ts
+++ b/apps/desktop/src/native-vue/desktopAppMenuCommandIsland.ts
@@ -42,7 +42,7 @@ function createDesktopAppMenuCommandApp(options: DesktopAppMenuCommandIslandOpti
         default: () => h(NButton, {
           quaternary: true,
           size: "small",
-          type: "button",
+          attrType: "button",
           class: "desktop-application-menu-item",
           "data-desktop-menu-command": command.id,
           "aria-label": `${command.label} (${command.shortcut})`,

--- a/apps/desktop/src/native-vue/desktopAppSidebarIsland.ts
+++ b/apps/desktop/src/native-vue/desktopAppSidebarIsland.ts
@@ -88,10 +88,10 @@ function renderSidebarItem(options: DesktopAppSidebarIslandOptions, item: Deskto
   }
   return h(NButton, {
     ...shared,
-    disabled: item.disabled,
+    attrType: "button",
+    disabled: item.disabled ?? false,
     quaternary: true,
     tag: "button",
-    type: "button",
     onClick: () => dispatchSidebarCommand(options.targetDocument ?? document, item),
   }, { default: children });
 }

--- a/apps/desktop/src/native-vue/desktopHelpMenuIsland.ts
+++ b/apps/desktop/src/native-vue/desktopHelpMenuIsland.ts
@@ -1,9 +1,11 @@
-import { createApp, defineComponent, h, ref, type App } from "vue";
+import { createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, type App } from "vue";
 import { NButton, NConfigProvider, NText } from "naive-ui";
 import type { DesktopMenuCommand, DesktopMenuCommandId } from "../desktopCommandNavigation";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 interface DesktopHelpMenuIslandOptions {
+  label?: string;
+  menuLabel?: string;
   commands: DesktopMenuCommand[];
   onCommand?: (id: DesktopMenuCommandId) => void;
 }
@@ -16,7 +18,7 @@ export function mountDesktopHelpMenuIsland(
   host: HTMLElement,
   options: DesktopHelpMenuIslandOptions,
 ): MountedDesktopHelpMenuIsland {
-  applyDesktopHelpMenuHost(host);
+  applyDesktopHelpMenuHost(host, options.label ?? "Help");
   const app = createDesktopHelpMenuApp(options);
   app.mount(host);
   return {
@@ -27,9 +29,10 @@ export function mountDesktopHelpMenuIsland(
   };
 }
 
-function applyDesktopHelpMenuHost(host: HTMLElement): void {
-  host.className = "desktop-help-menu";
+function applyDesktopHelpMenuHost(host: HTMLElement, label: string): void {
+  host.className = `desktop-help-menu desktop-${label.toLowerCase()}-menu`;
   host.setAttribute("data-desktop-vue-island", "desktop-help-menu");
+  host.setAttribute("data-desktop-menu-label", label);
 }
 
 function createDesktopHelpMenuApp(options: DesktopHelpMenuIslandOptions): App {
@@ -37,19 +40,29 @@ function createDesktopHelpMenuApp(options: DesktopHelpMenuIslandOptions): App {
     name: "DesktopHelpMenuIsland",
     setup() {
       const expanded = ref(false);
+      const label = options.label ?? "Help";
       const close = () => {
         expanded.value = false;
       };
-      const toggle = () => {
-        expanded.value = !expanded.value;
-      };
+      const handleDocumentClick = () => close();
+      const handleCloseAll = () => close();
+
+      onMounted(() => {
+        document.addEventListener("click", handleDocumentClick);
+        document.addEventListener("desktop-menu-close-all", handleCloseAll);
+      });
+
+      onBeforeUnmount(() => {
+        document.removeEventListener("click", handleDocumentClick);
+        document.removeEventListener("desktop-menu-close-all", handleCloseAll);
+      });
 
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => [
           h(NButton, {
             quaternary: true,
             size: "small",
-            type: "button",
+            attrType: "button",
             class: "desktop-application-menu-item desktop-help-menu-trigger",
             "aria-haspopup": "menu",
             "aria-expanded": String(expanded.value),
@@ -57,7 +70,12 @@ function createDesktopHelpMenuApp(options: DesktopHelpMenuIslandOptions): App {
             onDblclick: (event: MouseEvent) => event.stopPropagation(),
             onClick: (event: MouseEvent) => {
               event.stopPropagation();
-              toggle();
+              if (expanded.value) {
+                close();
+              } else {
+                document.dispatchEvent(new CustomEvent("desktop-menu-close-all"));
+                expanded.value = true;
+              }
             },
             onKeydown: (event: KeyboardEvent) => {
               if (event.key !== "Escape") {
@@ -66,22 +84,22 @@ function createDesktopHelpMenuApp(options: DesktopHelpMenuIslandOptions): App {
               event.preventDefault();
               close();
             },
-          }, { default: () => "Help" }),
+          }, { default: () => label }),
           h("div", {
             class: "desktop-help-menu-popover",
             role: "menu",
-            "aria-label": "Help menu",
+            "aria-label": options.menuLabel ?? `${label} menu`,
             hidden: !expanded.value,
           }, options.commands.map((command) => h(NButton, {
             key: command.id,
             quaternary: true,
             size: "small",
-            type: "button",
+            attrType: "button",
             class: "desktop-help-menu-item",
             role: "menuitem",
             "data-desktop-menu-command": command.id,
-            "aria-label": `${command.label} (${command.shortcut})`,
-            title: `${command.label} (${command.shortcut})`,
+            "aria-label": menuCommandAccessibleLabel(command),
+            title: menuCommandAccessibleLabel(command),
             onPointerdown: (event: PointerEvent) => event.stopPropagation(),
             onDblclick: (event: MouseEvent) => event.stopPropagation(),
             onClick: (event: MouseEvent) => {
@@ -92,11 +110,17 @@ function createDesktopHelpMenuApp(options: DesktopHelpMenuIslandOptions): App {
           }, {
             default: () => [
               h(NText, { class: "desktop-help-menu-label", tag: "span" }, { default: () => command.label }),
-              h(NText, { class: "desktop-help-menu-shortcut", depth: 3, tag: "span" }, { default: () => command.shortcut }),
+              command.shortcut
+                ? h(NText, { class: "desktop-help-menu-shortcut", depth: 3, tag: "span" }, { default: () => command.shortcut })
+                : null,
             ],
           }))),
         ],
       });
     },
   }));
+}
+
+function menuCommandAccessibleLabel(command: DesktopMenuCommand): string {
+  return command.shortcut ? `${command.label} (${command.shortcut})` : command.label;
 }

--- a/apps/desktop/src/native-vue/inspectorRegionIsland.test.ts
+++ b/apps/desktop/src/native-vue/inspectorRegionIsland.test.ts
@@ -63,9 +63,11 @@ describe("inspector region Vue island", () => {
     const mounted = mountInspectorRegionIsland(host, {
       runChainItems,
       workLens,
-      onRunChainAction: (action) => runActions.push(`${action.type}:${action.value ?? ""}`),
+      onRunChainAction: (action) => runActions.push(`${action.type}:${"value" in action ? action.value : ""}`),
       onWorkLensAction: (event) => lensActions.push(event.action),
-      copyText: (text) => copied.push(text),
+      copyText: (text) => {
+        copied.push(text);
+      },
     });
 
     expect(host.className).toBe("desktop-inspector-content");

--- a/apps/desktop/src/native-vue/inspectorRegionIsland.ts
+++ b/apps/desktop/src/native-vue/inspectorRegionIsland.ts
@@ -66,6 +66,7 @@ function createInspectorRegionApp(options: InspectorRegionIslandOptions): App {
           }));
         } else if (options.runChainItems.length) {
           mountChild(mountedChildren, inspector.value, (host) => mountRunChainInspectorIsland(host, {
+            eventTarget: host.ownerDocument,
             items: options.runChainItems,
             selectedItemKey: options.selectedRunChainItemKey,
             onSelect: options.onRunChainItemSelected,

--- a/apps/desktop/src/native-vue/moduleWorkSectionIsland.test.ts
+++ b/apps/desktop/src/native-vue/moduleWorkSectionIsland.test.ts
@@ -12,10 +12,18 @@ describe("module work section Vue island", () => {
       id: "chat:stream:chat-1",
       source: "chat",
       title: "Streaming response",
+      state: "active",
       status: "running",
+      tone: "normal",
       detail: "Rendering tokens",
+      progress: { percent: 12 },
       progressLabel: "12 tokens",
+      destination: { module: "chat", entityId: "chat-1", href: "/chat/chat-1" },
+      diagnostics: "",
+      relatedResources: [],
+      outputs: [],
       actions: [{ id: "inspect", label: "Inspect" }],
+      updatedAt: "",
     };
 
     const mounted = mountModuleWorkSectionIsland(host, {

--- a/apps/desktop/src/native-vue/persistentRagToggleIsland.ts
+++ b/apps/desktop/src/native-vue/persistentRagToggleIsland.ts
@@ -34,7 +34,7 @@ export function mountPersistentRagToggleIsland(
   };
 }
 
-function createPersistentRagToggleApp(options: PersistentRagToggleIslandOptions): App {
+function createPersistentRagToggleApp(_options: PersistentRagToggleIslandOptions): App {
   return createApp(defineComponent({
     name: "PersistentRagToggleIsland",
     setup() {

--- a/apps/desktop/src/native-vue/quickActionsIsland.test.ts
+++ b/apps/desktop/src/native-vue/quickActionsIsland.test.ts
@@ -13,9 +13,9 @@ describe("quick actions Vue island", () => {
     expect(host.className).toContain("desktop-quick-actions");
     expect(host.querySelectorAll(".n-button.desktop-quick-action")).toHaveLength(3);
     expect([...host.querySelectorAll<HTMLAnchorElement>(".desktop-quick-action")].map((node) => node.textContent)).toEqual([
-      "New chat",
+      "Ask about this project",
       "Open workspace",
-      "Gateway status",
+      "Check gateway",
     ]);
     expect([...host.querySelectorAll<HTMLAnchorElement>(".desktop-quick-action")].map((node) => node.getAttribute("href"))).toEqual([
       "/chat/new",

--- a/apps/desktop/src/native-vue/quickActionsIsland.ts
+++ b/apps/desktop/src/native-vue/quickActionsIsland.ts
@@ -12,9 +12,9 @@ export interface MountedQuickActionsIsland {
 }
 
 const QUICK_ACTION_LINKS: QuickActionLink[] = [
-  { label: "New chat", href: "/chat/new" },
+  { label: "Ask about this project", href: "/chat/new" },
   { label: "Open workspace", href: "/workspace" },
-  { label: "Gateway status", href: "/api/status" },
+  { label: "Check gateway", href: "/api/status" },
 ];
 
 export function mountQuickActionsIsland(host: HTMLElement): MountedQuickActionsIsland {
@@ -54,8 +54,8 @@ export function renderQuickActionsContent() {
       class: "desktop-quick-action",
       href: link.href,
       tag: "a",
-      text: true,
-      type: link.label === "New chat" ? "primary" : "default",
+      secondary: true,
+      type: "default",
     }, { default: () => link.label })),
   });
 }

--- a/apps/desktop/src/native-vue/runChainInspectorIsland.ts
+++ b/apps/desktop/src/native-vue/runChainInspectorIsland.ts
@@ -1,4 +1,4 @@
-import { createApp, defineComponent, h, ref, type App } from "vue";
+import { createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, type App } from "vue";
 import { NButton, NConfigProvider, NText } from "naive-ui";
 import {
   createDesktopRunChainInspectorView,
@@ -8,6 +8,7 @@ import {
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 export interface RunChainInspectorIslandOptions {
+  eventTarget?: Pick<Document, "addEventListener" | "removeEventListener"> | null;
   items: DesktopRunChainItem[];
   selectedItemKey?: string | null;
   onSelect?: (item: DesktopRunChainItem) => void;
@@ -60,6 +61,21 @@ function createRunChainInspectorComponent(options: RunChainInspectorIslandOption
         selectedKey.value = item.key;
         options.onSelect?.(item);
       };
+      const inspectItem = (event: Event): void => {
+        const itemKey = (event as CustomEvent<{ itemKey?: string }>).detail?.itemKey;
+        const item = options.items.find((candidate) => candidate.key === itemKey);
+        if (item) {
+          selectItem(item);
+        }
+      };
+      onMounted(() => {
+        const target = options.eventTarget ?? (typeof document !== "undefined" ? document : null);
+        target?.addEventListener("desktop-run-chain-inspect", inspectItem as EventListener);
+      });
+      onBeforeUnmount(() => {
+        const target = options.eventTarget ?? (typeof document !== "undefined" ? document : null);
+        target?.removeEventListener("desktop-run-chain-inspect", inspectItem as EventListener);
+      });
 
       return () => {
         const selectedItem = options.items.find((item) => item.key === selectedKey.value) ?? resolveSelectedItem(options);

--- a/apps/desktop/src/native-vue/runChainOverviewIsland.test.ts
+++ b/apps/desktop/src/native-vue/runChainOverviewIsland.test.ts
@@ -37,7 +37,7 @@ describe("run chain overview Vue island", () => {
 
     const mounted = mountRunChainOverviewIsland(host, {
       items: runChainItems,
-      onAction: (action) => actions.push(`${action.type}:${action.value ?? ""}`),
+      onAction: (action) => actions.push(`${action.type}:${"value" in action ? action.value : ""}`),
     });
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("run-chain-overview");
@@ -47,6 +47,10 @@ describe("run chain overview Vue island", () => {
     expect(host.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Gateway: Connected");
     expect(host.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Run: Running");
     expect(host.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("2 items");
+    expect(host.querySelector('[data-desktop-run-chain-summary="gateway"]')?.className).toContain("desktop-run-chain-status-pill");
+    expect(host.querySelector('[data-desktop-run-chain-summary="gateway"]')?.getAttribute("data-status-tone")).toBe("connected");
+    expect(host.querySelector('[data-desktop-run-chain-summary="run"]')?.getAttribute("data-status-tone")).toBe("muted");
+    expect(host.querySelector(".desktop-run-chain-status-dot")).not.toBeNull();
     expect(host.querySelector(".desktop-run-chain-panel")?.getAttribute("data-desktop-run-chain-panel")).toBe("context");
 
     host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-tab="files"]')?.click();
@@ -59,8 +63,10 @@ describe("run chain overview Vue island", () => {
     await Promise.resolve();
     expect(host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-tab="tasks"]')?.getAttribute("aria-selected")).toBe("true");
     expect(host.querySelector(".desktop-run-chain-panel")?.getAttribute("data-desktop-run-chain-panel")).toBe("tasks");
-    expect(host.querySelector(".desktop-run-chain-panel")?.textContent).toContain("Current Run");
+    expect(host.querySelector(".desktop-run-chain-panel")?.textContent).toContain("Tasks");
+    expect(host.querySelector(".desktop-run-chain-panel")?.textContent).toContain("Task center: Available");
     expect(host.querySelector(".desktop-run-chain-panel")?.textContent).toContain("Tool: Loaded project files");
+    expect(host.querySelector(".desktop-run-chain-new-item")?.getAttribute("data-button-variant")).toBe("secondary");
 
     host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-control="pin"]')?.click();
     host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-control="close"]')?.click();
@@ -70,6 +76,12 @@ describe("run chain overview Vue island", () => {
     await nextTick();
 
     expect(host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-control="pin"]')?.getAttribute("aria-pressed")).toBe("true");
+    expect(host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-control="pin"]')?.getAttribute("aria-label")).toBe("Pin panel");
+    expect(host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-control="close"]')?.getAttribute("title")).toBe("Close panel");
+    expect(host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-control="pin"]')?.getAttribute("data-button-variant")).toBe("ghost");
+    expect(host.querySelector('[data-desktop-run-chain-action="Open Task Center"]')?.getAttribute("data-button-variant")).toBe("primary");
+    expect(host.querySelectorAll('[data-desktop-run-chain-action="New Run Chain Item"]')).toHaveLength(1);
+    expect(host.querySelector('[data-desktop-run-chain-action="New Run Chain Item"]')?.getAttribute("data-button-variant")).toBe("secondary");
     expect(actions).toEqual([
       "tab:files",
       "summary:items",
@@ -82,5 +94,22 @@ describe("run chain overview Vue island", () => {
 
     mounted.unmount();
     expect(host.textContent).toBe("");
+  });
+
+  test("shows a light empty state when the Tasks tab has no chain items", async () => {
+    const host = document.createElement("section");
+
+    const mounted = mountRunChainOverviewIsland(host, {
+      items: [],
+    });
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-run-chain-tab="tasks"]')?.click();
+    await nextTick();
+
+    expect(host.querySelector(".desktop-run-chain-panel")?.textContent).toContain("No chain items yet.");
+    expect(host.querySelector(".desktop-run-chain-empty-state")).not.toBeNull();
+    expect(host.querySelectorAll('[data-desktop-run-chain-action="New Run Chain Item"]')).toHaveLength(1);
+
+    mounted.unmount();
   });
 });

--- a/apps/desktop/src/native-vue/runChainOverviewIsland.ts
+++ b/apps/desktop/src/native-vue/runChainOverviewIsland.ts
@@ -99,19 +99,23 @@ function renderHeader(
       default: () => [
         h(NButton, {
           class: "desktop-run-chain-icon-button",
-          "aria-label": "Pin Run Chain",
+          "aria-label": "Pin panel",
           "aria-pressed": String(pinned),
           "data-desktop-run-chain-control": "pin",
+          "data-button-variant": "ghost",
           size: "tiny",
           secondary: true,
+          title: "Pin panel",
           onClick: () => onPin(!pinned),
         }, { default: () => (pinned ? "Pinned" : "Pin") }),
         h(NButton, {
           class: "desktop-run-chain-icon-button",
-          "aria-label": "Close Run Chain",
+          "aria-label": "Close panel",
           "data-desktop-run-chain-control": "close",
+          "data-button-variant": "ghost",
           size: "tiny",
           secondary: true,
+          title: "Close panel",
           onClick: () => options.onAction?.({ type: "close" }),
         }, { default: () => "Close" }),
       ],
@@ -129,21 +133,29 @@ function renderSummaryStrip(
 ) {
   const status = runChainOverviewStatus(items);
   const summaries = [
-    { value: "gateway", label: "Gateway", text: "Gateway: Connected", tab: "context" },
-    { value: "run", label: "Run", text: `Run: ${status}`, tab: "tasks" },
-    { value: "items", label: "Items", text: `${items.length} ${items.length === 1 ? "item" : "items"}`, tab: "tasks" },
+    { value: "gateway", label: "Gateway", text: "Gateway: Connected", tab: "context", tone: "connected" },
+    { value: "run", label: "Run", text: `Run: ${status}`, tab: "tasks", tone: "muted" },
+    { value: "items", label: "Items", text: `${items.length} ${items.length === 1 ? "item" : "items"}`, tab: "tasks", tone: "muted" },
   ] as const;
   return h(NSpace, {
     class: "desktop-run-chain-summary-strip",
     size: 8,
   }, {
     default: () => summaries.map((summary) => h(NButton, {
-      class: "desktop-run-chain-summary-item",
+      class: "desktop-run-chain-summary-item desktop-run-chain-status-pill",
       "data-desktop-run-chain-summary": summary.value,
+      "data-status-tone": summary.tone,
       size: "tiny",
       secondary: true,
       onClick: () => onSelect(summary),
-    }, { default: () => summary.text })),
+    }, {
+      default: () => [
+        summary.tone === "connected"
+          ? h("span", { class: "desktop-run-chain-status-dot", "aria-hidden": "true" })
+          : null,
+        h("span", summary.text),
+      ],
+    })),
   });
 }
 
@@ -196,10 +208,11 @@ function renderPanelContent(tab: RunChainOverviewIslandTab, options: RunChainOve
 
   if (tab === "tasks") {
     return [
-      renderPanelSection("Current Run", [
-        ["Status", runChainOverviewStatus(options.items)],
+      renderPanelSection("Tasks", [
+        ["Task center", "Available"],
+        ["Run", runChainOverviewStatus(options.items)],
         ["Chain items", String(options.items.length)],
-      ], renderNewItemButton(options, "desktop-run-chain-panel-action desktop-run-chain-new-item")),
+      ], renderNewItemButton(options, "desktop-run-chain-panel-action desktop-run-chain-new-item", "secondary"), options.items.length ? undefined : "No chain items yet."),
       options.items.length ? renderActivityFeed(options.items, options) : null,
     ];
   }
@@ -225,6 +238,7 @@ function renderPanelSection(
   title: string,
   rows: [string, string][],
   action?: ReturnType<typeof h>,
+  emptyState?: string,
 ) {
   return h(NCard, {
     class: "desktop-run-chain-panel-section",
@@ -237,6 +251,7 @@ function renderPanelSection(
       ...rows.map(([label, value]) => h("p", {
         class: "desktop-run-chain-card-row",
       }, `${label}: ${value}`)),
+      emptyState ? h("p", { class: "desktop-run-chain-empty-state" }, emptyState) : null,
       action ?? null,
     ],
   });
@@ -271,19 +286,24 @@ function renderActions(options: RunChainOverviewIslandOptions) {
       h(NButton, {
         class: "desktop-run-chain-panel-action",
         "data-desktop-run-chain-action": "Open Task Center",
+        "data-button-variant": "primary",
         size: "small",
-        secondary: true,
+        type: "primary",
         onClick: () => options.onAction?.({ type: "open-task-center" }),
       }, { default: () => "Open Task Center" }),
-      renderNewItemButton(options, "desktop-run-chain-panel-action desktop-run-chain-new-item"),
     ],
   });
 }
 
-function renderNewItemButton(options: RunChainOverviewIslandOptions, className: string) {
+function renderNewItemButton(
+  options: RunChainOverviewIslandOptions,
+  className: string,
+  variant = "secondary",
+) {
   return h(NButton, {
     class: className,
     "data-desktop-run-chain-action": "New Run Chain Item",
+    "data-button-variant": variant,
     size: "small",
     secondary: true,
     onClick: () => options.onAction?.({ type: "new-item" }),

--- a/apps/desktop/src/native-vue/sharedSidebarCommandsIsland.ts
+++ b/apps/desktop/src/native-vue/sharedSidebarCommandsIsland.ts
@@ -16,6 +16,8 @@ export interface SharedSidebarCommandsIslandOptions {
   targetDocument?: Document;
 }
 
+type MountedSharedSidebarCommandsOptions = SharedSidebarCommandsIslandOptions & { targetDocument: Document };
+
 export interface MountedSharedSidebarCommandsIsland {
   unmount: () => void;
 }
@@ -39,7 +41,7 @@ export function mountSharedSidebarCommandsIsland(
   };
 }
 
-function createSharedSidebarCommandsApp(options: Required<SharedSidebarCommandsIslandOptions>): App {
+function createSharedSidebarCommandsApp(options: MountedSharedSidebarCommandsOptions): App {
   return createApp(defineComponent({
     name: "SharedSidebarCommandsIsland",
     setup() {
@@ -50,11 +52,11 @@ function createSharedSidebarCommandsApp(options: Required<SharedSidebarCommandsI
   }));
 }
 
-export function renderSharedSidebarCommandsSection(options: Required<SharedSidebarCommandsIslandOptions>) {
+export function renderSharedSidebarCommandsSection(options: MountedSharedSidebarCommandsOptions) {
   return h("section", { class: "desktop-workbench-section" }, renderSharedSidebarCommandsContent(options));
 }
 
-export function renderSharedSidebarCommandsContent(options: Required<SharedSidebarCommandsIslandOptions>) {
+export function renderSharedSidebarCommandsContent(options: MountedSharedSidebarCommandsOptions) {
   const dispatchCommand = (commandId: string) => {
     options.targetDocument.dispatchEvent(new CustomEvent("desktop-menu-command", {
       detail: { id: commandId, source: "native-sidebar" },

--- a/apps/desktop/src/native-vue/sidebarContentIsland.ts
+++ b/apps/desktop/src/native-vue/sidebarContentIsland.ts
@@ -17,6 +17,8 @@ export interface SidebarContentIslandOptions {
   workspaceRows: SidebarWorkspaceListRow[];
 }
 
+type MountedSidebarContentOptions = SidebarContentIslandOptions & { targetDocument: Document };
+
 export interface MountedSidebarContentIsland {
   unmount: () => void;
 }
@@ -40,7 +42,7 @@ export function mountSidebarContentIsland(
   };
 }
 
-function createSidebarContentApp(options: Required<SidebarContentIslandOptions>): App {
+function createSidebarContentApp(options: MountedSidebarContentOptions): App {
   return createApp(defineComponent({
     name: "SidebarContentIsland",
     setup() {
@@ -59,15 +61,19 @@ function createSidebarContentApp(options: Required<SidebarContentIslandOptions>)
         mountChild(mountedChildren, recent.value, (host) => mountSidebarRecentChatsIsland(host, {
           rows: options.recentChats,
         }));
-        mountChild(mountedChildren, links.value, (host) => mountSharedSidebarLinksIsland(host, {
-          items: options.resourceItems,
-          label: options.resourceLabel,
-        }));
-        mountChild(mountedChildren, commands.value, (host) => mountSharedSidebarCommandsIsland(host, {
-          items: options.commandItems,
-          label: options.commandLabel,
-          targetDocument: options.targetDocument,
-        }));
+        if (options.resourceItems.length) {
+          mountChild(mountedChildren, links.value, (host) => mountSharedSidebarLinksIsland(host, {
+            items: options.resourceItems,
+            label: options.resourceLabel,
+          }));
+        }
+        if (options.commandItems.length) {
+          mountChild(mountedChildren, commands.value, (host) => mountSharedSidebarCommandsIsland(host, {
+            items: options.commandItems,
+            label: options.commandLabel,
+            targetDocument: options.targetDocument,
+          }));
+        }
       });
 
       onBeforeUnmount(() => {
@@ -86,8 +92,8 @@ function createSidebarContentApp(options: Required<SidebarContentIslandOptions>)
             h("section", { ref: actions }),
             h("section", { ref: workspaces }),
             h("section", { ref: recent }),
-            h("section", { ref: links }),
-            h("section", { ref: commands }),
+            options.resourceItems.length ? h("section", { ref: links }) : null,
+            options.commandItems.length ? h("section", { ref: commands }) : null,
           ],
         }),
       });

--- a/apps/desktop/src/native-vue/toolActivitiesIsland.ts
+++ b/apps/desktop/src/native-vue/toolActivitiesIsland.ts
@@ -59,6 +59,7 @@ function createToolActivitiesApp(options: ToolActivitiesIslandOptions): App {
             class: "desktop-tool-activity",
             "data-desktop-tool-activity-id": activity.id || undefined,
             "data-desktop-tool-activity-kind": activity.kind,
+            "data-desktop-run-chain-item-key": activity.runChainItemKey || undefined,
           })),
         }),
       });

--- a/apps/desktop/src/native-vue/toolActivityIsland.test.ts
+++ b/apps/desktop/src/native-vue/toolActivityIsland.test.ts
@@ -30,6 +30,33 @@ describe("tool activity Vue island", () => {
     expect(host.textContent).toBe("");
   });
 
+  test("collapses long tool content and dispatches run-chain inspection", () => {
+    const host = document.createElement("details");
+    const inspected: string[] = [];
+    host.addEventListener("desktop-run-chain-inspect", (event) => {
+      inspected.push((event as CustomEvent).detail.itemKey);
+    });
+    const longArgs = JSON.stringify({ query: "tinybot", context: "x".repeat(180) });
+
+    mountToolActivityIsland(host, {
+      argsText: longArgs,
+      approvalStatus: "",
+      id: "tool-1",
+      kind: "call",
+      name: "web_search",
+      responseText: "",
+      runChainItemKey: "assistant-1:tool-call:tool-1",
+    });
+
+    const nestedDetails = host.querySelector(".desktop-tool-activity-content-details");
+    expect(host.getAttribute("data-desktop-run-chain-item-key")).toBe("assistant-1:tool-call:tool-1");
+    expect(nestedDetails?.querySelector(".desktop-tool-activity-content-preview")?.textContent).toContain("tinybot");
+    expect(nestedDetails?.querySelector(".desktop-tool-activity-pre")?.textContent).toBe(longArgs);
+
+    host.querySelector<HTMLElement>(".desktop-tool-activity-summary")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(inspected).toEqual(["assistant-1:tool-call:tool-1"]);
+  });
+
   test("renders empty body for activity without details", () => {
     const host = document.createElement("details");
 

--- a/apps/desktop/src/native-vue/toolActivityIsland.ts
+++ b/apps/desktop/src/native-vue/toolActivityIsland.ts
@@ -9,6 +9,7 @@ export interface ToolActivityIslandOptions {
   kind: "call" | "result";
   name: string;
   responseText: string;
+  runChainItemKey?: string;
 }
 
 export interface MountedToolActivityIsland {
@@ -26,6 +27,11 @@ export function mountToolActivityIsland(
     host.setAttribute("data-desktop-tool-activity-id", options.id);
   } else {
     host.removeAttribute("data-desktop-tool-activity-id");
+  }
+  if (options.runChainItemKey) {
+    host.setAttribute("data-desktop-run-chain-item-key", options.runChainItemKey);
+  } else {
+    host.removeAttribute("data-desktop-run-chain-item-key");
   }
   const app = createToolActivityApp(options);
   app.mount(host);
@@ -56,6 +62,9 @@ export function renderToolActivityNode(options: ToolActivityIslandOptions) {
   if (options.id) {
     attributes["data-desktop-tool-activity-id"] = options.id;
   }
+  if (options.runChainItemKey) {
+    attributes["data-desktop-run-chain-item-key"] = options.runChainItemKey;
+  }
   return h("details", attributes, renderToolActivityChildren(options));
 }
 
@@ -67,7 +76,10 @@ export function renderToolActivityChildren(options: ToolActivityIslandOptions) {
 }
 
 function renderSummary(options: ToolActivityIslandOptions) {
-  return h("summary", { class: "desktop-tool-activity-summary" }, [
+  return h("summary", {
+    class: "desktop-tool-activity-summary",
+    onClick: (event: MouseEvent) => dispatchRunChainInspect(event, options.runChainItemKey),
+  }, [
     h("span", { "aria-hidden": "true", class: "desktop-tool-activity-icon" }, ">"),
     h("span", { class: "desktop-tool-activity-main" }, [
       h(NText, { class: "desktop-tool-activity-title", tag: "span" }, { default: () => options.name || "unknown" }),
@@ -114,6 +126,17 @@ function renderBody(options: ToolActivityIslandOptions) {
 }
 
 function renderSection(label: string, text: string, kind: "call" | "response") {
+  if (shouldCollapseToolContent(text)) {
+    return h("div", { class: `desktop-tool-activity-section desktop-tool-activity-section-${kind}` }, [
+      h("details", { class: "desktop-tool-activity-content-details" }, [
+        h("summary", { class: "desktop-tool-activity-content-summary" }, [
+          h(NText, { class: "desktop-tool-activity-label", tag: "span" }, { default: () => label }),
+          h("span", { class: "desktop-tool-activity-content-preview" }, summarizeToolActivityText(text)),
+        ]),
+        h("pre", { class: "desktop-tool-activity-pre" }, text),
+      ]),
+    ]);
+  }
   return h("div", { class: `desktop-tool-activity-section desktop-tool-activity-section-${kind}` }, [
     h(NText, { class: "desktop-tool-activity-label", tag: "div" }, { default: () => label }),
     h("pre", { class: "desktop-tool-activity-pre" }, text),
@@ -126,4 +149,22 @@ function summarizeToolActivityText(value: string): string {
     return "No details";
   }
   return normalized.length > 96 ? `${normalized.slice(0, 93)}...` : normalized;
+}
+
+function shouldCollapseToolContent(value: string): boolean {
+  return value.length > 140 || value.split(/\r?\n/).length > 6;
+}
+
+function dispatchRunChainInspect(event: MouseEvent, itemKey?: string): void {
+  if (!itemKey) {
+    return;
+  }
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  target.dispatchEvent(new CustomEvent("desktop-run-chain-inspect", {
+    bubbles: true,
+    detail: { itemKey },
+  }));
 }

--- a/apps/desktop/src/native-vue/workLensIsland.test.ts
+++ b/apps/desktop/src/native-vue/workLensIsland.test.ts
@@ -70,7 +70,9 @@ describe("work lens Vue island", () => {
       workLens: readyLens,
       placement: "inspector",
       onAction: (event) => actions.push(event.action),
-      copyText: (text) => copied.push(text),
+      copyText: (text) => {
+        copied.push(text);
+      },
     });
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("work-lens");

--- a/apps/desktop/src/native-vue/workbenchPanelIsland.ts
+++ b/apps/desktop/src/native-vue/workbenchPanelIsland.ts
@@ -35,7 +35,7 @@ export function mountWorkbenchPanelIsland(
   };
 }
 
-function createWorkbenchPanelApp(host: HTMLElement, content: HTMLElement): App {
+function createWorkbenchPanelApp(_host: HTMLElement, content: HTMLElement): App {
   return createApp(defineComponent({
     name: "WorkbenchPanelIsland",
     setup() {


### PR DESCRIPTION
﻿## Summary
- Refine the native desktop workbench visual hierarchy across the activity rail, sidebar, chat workbench, inspector, run-chain, and tool activity surfaces.
- Keep the empty-session and active-conversation chrome synchronized as chat state changes.
- Update desktop regression coverage for the adjusted native Vue islands and shell layout.

Closes #221

## Validation
- `npm test` in `apps/desktop`
- `npm run build` in `apps/desktop`
