### PR TITLE
Polish native desktop chat workbench

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -27,7 +27,7 @@ import {
   type DesktopKnowledgePaneModel,
 } from "./desktopKnowledgeTraceability";
 import { installWebUiRenderGlobals } from "./desktopMarkdownGlobals";
-import { logDesktopNativeChatDebug, summarizeDebugText } from "./desktopNativeChatDebug";
+import { logDesktopNativeChatDebug, logDesktopNativeDebug, summarizeDebugText } from "./desktopNativeChatDebug";
 import { installDesktopNavigation } from "./desktopNavigation";
 import { applyDesktopWorkbenchRouteState } from "./desktopEntityFocus";
 import {
@@ -164,6 +164,10 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 async function bootDesktopWebUi(): Promise<void> {
+  logDesktopNativeDebug("bootstrap.start", {
+    gatewayHttp: gatewayConfig.httpBaseUrl,
+    hasTauriRuntime,
+  });
   setStartupState(document, "Starting local gateway...", null, false);
   try {
     const status = await ensureGatewayReady(gatewayConfig, { invoke, hasTauriRuntime });
@@ -173,6 +177,11 @@ async function bootDesktopWebUi(): Promise<void> {
     document.documentElement.dataset.desktopWorkbenchMode = workbenchMode.mode;
     document.documentElement.dataset.desktopWorkbenchRequestedMode = workbenchMode.requestedMode;
     if (workbenchMode.fallbackReason) {
+      logDesktopNativeDebug("bootstrap.fallback", {
+        fallbackReason: workbenchMode.fallbackReason,
+        mode: workbenchMode.mode,
+        requestedMode: workbenchMode.requestedMode,
+      });
       console.info("Tinybot desktop loading root WebUI fallback", workbenchMode);
     }
     installDesktopGatewayBridge({ config: gatewayConfig });
@@ -232,6 +241,11 @@ async function bootDesktopWebUi(): Promise<void> {
       installTauriWindowFrame(status);
       void refreshNativeCoworkTasks();
       void refreshNativeApprovalTasks();
+      logDesktopNativeDebug("bootstrap.native.initialized", {
+        gatewayHttp: gatewayConfig.httpBaseUrl,
+        mode: workbenchMode.mode,
+        runtimeState: status?.state ?? "",
+      });
       console.info("Tinybot desktop native workbench initialized", status);
       return;
     }
@@ -246,8 +260,17 @@ async function bootDesktopWebUi(): Promise<void> {
     installRootWebUiDesktopAdapters();
     installTauriNavigation();
     installTauriWindowFrame(status);
+    logDesktopNativeDebug("bootstrap.webui.initialized", {
+      gatewayHttp: gatewayConfig.httpBaseUrl,
+      mode: workbenchMode.mode,
+      runtimeState: status?.state ?? "",
+    });
     console.info("Tinybot desktop WebUI initialized", status);
   } catch (error) {
+    logDesktopNativeDebug("bootstrap.failed", {
+      error: stringifyError(error),
+      gatewayHttp: gatewayConfig.httpBaseUrl,
+    });
     setStartupState(
       document,
       "Tinybot gateway is not ready.",
@@ -258,6 +281,9 @@ async function bootDesktopWebUi(): Promise<void> {
 }
 
 async function loadNativeChatRuntime(): Promise<DesktopNativeWorkbenchRuntime> {
+  logDesktopNativeDebug("bootstrap.nativeChat.load.start", {
+    gatewayHttp: gatewayConfig.httpBaseUrl,
+  });
   const runtime = createDesktopNativeWorkbenchRuntime({
     api: {
       listSessions: () => gatewayApi.sessions.list(),
@@ -278,8 +304,15 @@ async function loadNativeChatRuntime(): Promise<DesktopNativeWorkbenchRuntime> {
   try {
     await runtime.loadInitialChatState();
   } catch (error) {
+    logDesktopNativeDebug("bootstrap.nativeChat.load.failed", {
+      error: stringifyError(error),
+    });
     console.warn("Tinybot desktop failed to load native chat state", error);
   }
+  logDesktopNativeDebug("bootstrap.nativeChat.load.complete", {
+    activeSessionKey: runtime.chat.activeSessionKey,
+    sessionCount: runtime.chat.sessions.length,
+  });
   return runtime;
 }
 
@@ -287,6 +320,9 @@ function ensureNativeChatSocket(runtime = nativeWorkbenchRuntime): void {
   if (!runtime || (nativeChatSocket && nativeChatSocket.readyState <= WebSocket.OPEN)) {
     return;
   }
+  logDesktopNativeDebug("socket.ensure", {
+    wsUrl: nativeChatWsUrl,
+  });
   nativeChatSocket = openGatewaySocket(resolveGatewayConfig({ ...gatewayConfig, wsUrl: nativeChatWsUrl }), {
     onOpen: () => {
       logDesktopNativeChatDebug("socket.open", {
@@ -383,14 +419,15 @@ function nativeChatActions() {
     },
     onDeleteSession: (event: { sessionKey: string; title: string }) => {
       if (!nativeWorkbenchRuntime) {
-        return;
+        return Promise.resolve();
       }
-      void nativeWorkbenchRuntime.deleteChatSession(event.sessionKey).then(() => {
+      return nativeWorkbenchRuntime.deleteChatSession(event.sessionKey).then(() => {
         if (nativeWorkbenchRuntime) {
           updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
         }
       }).catch((error) => {
         console.warn("Tinybot desktop session delete failed", error);
+        throw error;
       });
     },
     onPersistentRagChange: (enabled: boolean) => {
@@ -442,10 +479,16 @@ function nativeTaskActions() {
 
 async function handleNativeTaskAction(event: DesktopTaskCenterActionEvent): Promise<void> {
   if (!["approveOnce", "approveSession", "deny"].includes(event.action)) {
+    logDesktopNativeDebug("task.action.ignored", summarizeTaskCenterAction(event));
     return;
   }
   const approvalId = event.item.approval?.approvalId || event.item.destination.entityId || "";
   const sessionKey = event.item.approval?.sessionKey || nativeWorkbenchRuntime?.chat.activeSessionKey || "";
+  logDesktopNativeDebug("task.action.start", {
+    ...summarizeTaskCenterAction(event),
+    approvalId,
+    hasSessionKey: Boolean(sessionKey),
+  });
   if (!approvalId || !sessionKey) {
     nativeApprovalTaskOperations.set(event.item.id, {
       id: event.item.id,
@@ -459,6 +502,7 @@ async function handleNativeTaskAction(event: DesktopTaskCenterActionEvent): Prom
       ...(event.item.approval ? { approval: event.item.approval } : {}),
     });
     publishNativeTaskCenterItems();
+    logDesktopNativeDebug("task.action.missingApprovalContext", summarizeTaskCenterAction(event));
     return;
   }
   try {
@@ -477,6 +521,7 @@ async function handleNativeTaskAction(event: DesktopTaskCenterActionEvent): Prom
     nativeApprovalTaskOperations.delete(event.item.id);
     publishNativeTaskCenterItems();
     await refreshNativeApprovalTasks();
+    logDesktopNativeDebug("task.action.complete", summarizeTaskCenterAction(event));
   } catch (error) {
     nativeApprovalTaskOperations.set(event.item.id, {
       id: event.item.id,
@@ -490,6 +535,10 @@ async function handleNativeTaskAction(event: DesktopTaskCenterActionEvent): Prom
       ...(event.item.approval ? { approval: event.item.approval } : {}),
     });
     publishNativeTaskCenterItems();
+    logDesktopNativeDebug("task.action.failed", {
+      ...summarizeTaskCenterAction(event),
+      error: stringifyError(error),
+    });
   }
 }
 
@@ -502,6 +551,7 @@ function refreshNativeAgentUiForms(): void {
 
 async function handleNativeAgentUiFormAction(event: DesktopAgentUiFormActionEvent): Promise<void> {
   const form = event.form;
+  logDesktopNativeDebug("agentUi.form.action.start", summarizeAgentUiFormAction(event));
   if (event.action === "submit") {
     const values = event.values ?? {};
     try {
@@ -518,12 +568,17 @@ async function handleNativeAgentUiFormAction(event: DesktopAgentUiFormActionEven
       form.submitting = false;
       refreshNativeAgentUiForms();
       publishNativeTaskCenterItems();
+      logDesktopNativeDebug("agentUi.form.submit.complete", summarizeAgentUiFormAction(event));
     } catch (error) {
       form.values = values;
       form.submitting = false;
       form.errors = { ...(form.errors ?? {}), form: stringifyError(error) };
       refreshNativeAgentUiForms();
       publishNativeTaskCenterItems();
+      logDesktopNativeDebug("agentUi.form.submit.failed", {
+        ...summarizeAgentUiFormAction(event),
+        error: stringifyError(error),
+      });
     }
     return;
   }
@@ -539,11 +594,16 @@ async function handleNativeAgentUiFormAction(event: DesktopAgentUiFormActionEven
     form.submitting = false;
     refreshNativeAgentUiForms();
     publishNativeTaskCenterItems();
+    logDesktopNativeDebug("agentUi.form.cancel.complete", summarizeAgentUiFormAction(event));
   } catch (error) {
     form.submitting = false;
     form.errors = { ...(form.errors ?? {}), form: stringifyError(error) };
     refreshNativeAgentUiForms();
     publishNativeTaskCenterItems();
+    logDesktopNativeDebug("agentUi.form.cancel.failed", {
+      ...summarizeAgentUiFormAction(event),
+      error: stringifyError(error),
+    });
   }
 }
 
@@ -552,7 +612,9 @@ function installNativeChatRuntimeActions(): void {
     return;
   }
   nativeChatRuntimeActionsInstalled = true;
+  logDesktopNativeDebug("runtime.actions.install");
   document.addEventListener("tinybot:desktop-stop-generation", () => {
+    logDesktopNativeDebug("runtime.actions.stopGeneration");
     nativeChatActions().onInterrupt();
   });
   document.addEventListener("desktop-tool-approval-action", (event) => {
@@ -565,6 +627,9 @@ function installNativeChatRuntimeActions(): void {
       return;
     }
     const path = new URL(href, window.location.origin).pathname;
+    logDesktopNativeDebug("route.request", {
+      path,
+    });
     applyDesktopWorkbenchRouteState(document, path);
     if (path === "/chat/new") {
       nativeChatActions().onNewChat();
@@ -579,10 +644,12 @@ function installNativeChatRuntimeActions(): void {
 async function handleNativeInlineApprovalAction(detail: unknown): Promise<void> {
   const record = asRecord(detail);
   if (!Object.keys(record).length) {
+    logDesktopNativeDebug("inlineApproval.empty");
     return;
   }
   const action = typeof record.action === "string" ? record.action : "";
   if (!["approveOnce", "approveSession", "deny"].includes(action)) {
+    logDesktopNativeDebug("inlineApproval.ignored", { action });
     return;
   }
   const approvalId = typeof record.approvalId === "string" ? record.approvalId : "";
@@ -591,6 +658,12 @@ async function handleNativeInlineApprovalAction(detail: unknown): Promise<void> 
     : nativeWorkbenchRuntime?.chat.activeSessionKey || "";
   const toolName = typeof record.toolName === "string" && record.toolName ? record.toolName : "tool";
   const taskId = `approval:${approvalId || toolName}`;
+  logDesktopNativeDebug("inlineApproval.start", {
+    action,
+    approvalId,
+    hasSessionKey: Boolean(sessionKey),
+    toolName,
+  });
   if (!approvalId || !sessionKey) {
     nativeApprovalTaskOperations.set(taskId, {
       id: taskId,
@@ -604,6 +677,7 @@ async function handleNativeInlineApprovalAction(detail: unknown): Promise<void> 
       approval: { approvalId, sessionKey },
     });
     publishNativeTaskCenterItems();
+    logDesktopNativeDebug("inlineApproval.missingContext", { action, approvalId, toolName });
     return;
   }
   try {
@@ -622,6 +696,7 @@ async function handleNativeInlineApprovalAction(detail: unknown): Promise<void> 
     nativeApprovalTaskOperations.delete(taskId);
     publishNativeTaskCenterItems();
     await refreshNativeApprovalTasks();
+    logDesktopNativeDebug("inlineApproval.complete", { action, approvalId, toolName });
   } catch (error) {
     nativeApprovalTaskOperations.set(taskId, {
       id: taskId,
@@ -635,25 +710,39 @@ async function handleNativeInlineApprovalAction(detail: unknown): Promise<void> 
       approval: { approvalId, sessionKey },
     });
     publishNativeTaskCenterItems();
+    logDesktopNativeDebug("inlineApproval.failed", {
+      action,
+      approvalId,
+      error: stringifyError(error),
+      toolName,
+    });
   }
 }
 
 async function selectNativeChatFromRoute(path: string): Promise<void> {
   if (!nativeWorkbenchRuntime) {
+    logDesktopNativeDebug("route.chatSelect.skipped", { path, reason: "runtime unavailable" });
     return;
   }
   const chatId = decodeURIComponent(path.replace(/^\/chat\//, ""));
   const session = nativeWorkbenchRuntime.chat.sessions.find((item) => item.chatId === chatId || item.key === chatId);
   if (!session) {
+    logDesktopNativeDebug("route.chatSelect.missing", { chatId, path });
     return;
   }
+  logDesktopNativeDebug("route.chatSelect.start", { chatId, path, sessionKey: session.key });
   await nativeWorkbenchRuntime.selectChatSession(session.key, session.chatId);
   updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
+  logDesktopNativeDebug("route.chatSelect.complete", { chatId, path, sessionKey: session.key });
 }
 
 async function loadNativeKnowledgePane(
   options: { queryResultPayload?: unknown; selectedDocumentId?: string | null } = {},
 ): Promise<DesktopKnowledgePaneModel> {
+  logDesktopNativeDebug("knowledge.load.start", {
+    hasQueryResult: options.queryResultPayload !== undefined,
+    selectedDocumentId: options.selectedDocumentId ?? "",
+  });
   const [stats, documents, config, graph, graphrag] = await Promise.all([
     gatewayApi.knowledge.stats().catch(() => ({})),
     gatewayApi.knowledge.documents().catch(() => ({ documents: [] })),
@@ -671,12 +760,20 @@ async function loadNativeKnowledgePane(
     queryResultPayload: nativeKnowledgeQueryResult,
     graphPayload: mergeNativeKnowledgeGraphPayload(graph, graphrag),
   });
+  logDesktopNativeDebug("knowledge.load.complete", {
+    documentCount: nativeKnowledgePane.documentRows.length,
+    hasQueryResult: nativeKnowledgePane.query.results.rows.length > 0,
+    selectedDocumentId: nativeKnowledgePane.selectedDocument?.id ?? "",
+  });
   return nativeKnowledgePane;
 }
 
 async function loadNativeCoworkPane(
   options: { selectedSessionId?: string | null; actionStatus?: string; summaryText?: string } = {},
 ): Promise<DesktopCoworkPaneModel> {
+  logDesktopNativeDebug("cowork.load.start", {
+    selectedSessionId: options.selectedSessionId ?? nativeCoworkSelectedSessionId,
+  });
   const sessionsPayload = await gatewayApi.cowork.sessions({ includeCompleted: true }).catch(() => ({ sessions: [] }));
   replaceNativeCoworkTasks(sessionsPayload);
   const sessionRows = buildDesktopCoworkSessionRows(sessionsPayload);
@@ -690,6 +787,11 @@ async function loadNativeCoworkPane(
       actionStatus: options.actionStatus,
       summaryText: options.summaryText,
     };
+    logDesktopNativeDebug("cowork.load.complete", {
+      hasCockpit: false,
+      selectedSessionId,
+      sessionCount: sessionRows.length,
+    });
     return nativeCoworkPane;
   }
   const session = await gatewayApi.cowork.session(selectedSessionId).catch(() => null);
@@ -699,11 +801,19 @@ async function loadNativeCoworkPane(
     actionStatus: options.actionStatus,
     summaryText: options.summaryText,
   };
+  logDesktopNativeDebug("cowork.load.complete", {
+    hasCockpit: Boolean(nativeCoworkPane.cockpitView),
+    selectedSessionId,
+    sessionCount: sessionRows.length,
+  });
   return nativeCoworkPane;
 }
 
 async function handleNativeCoworkAction(event: DesktopCoworkActionEvent): Promise<void> {
   const sessionId = event.sessionId || nativeCoworkSelectedSessionId;
+  let outcome: "complete" | "blocked" | "failed" = "complete";
+  let errorMessage = "";
+  logDesktopNativeDebug("cowork.action.start", summarizeCoworkAction(event, sessionId));
   try {
     if (event.action === "validateBlueprint") {
       const blueprint = parseNativeCoworkBlueprint(event.blueprintText ?? "");
@@ -743,6 +853,7 @@ async function handleNativeCoworkAction(event: DesktopCoworkActionEvent): Promis
       return;
     }
     if (!sessionId) {
+      outcome = "blocked";
       setNativeCoworkPane({
         ...event.pane,
         actionStatus: "Select a Cowork session before running this action.",
@@ -845,6 +956,7 @@ async function handleNativeCoworkAction(event: DesktopCoworkActionEvent): Promis
     if (event.action === "mergeBranchResults") {
       const branchIds = event.branchIds ?? [];
       if (branchIds.length < 2) {
+        outcome = "blocked";
         setNativeCoworkPane({
           ...event.pane,
           actionStatus: "Select at least two Cowork branch results before merging.",
@@ -860,9 +972,16 @@ async function handleNativeCoworkAction(event: DesktopCoworkActionEvent): Promis
       setNativeCoworkPane(await loadNativeCoworkPane({ selectedSessionId: sessionId, actionStatus: "Cowork branch results merged." }));
     }
   } catch (error) {
+    outcome = "failed";
+    errorMessage = stringifyError(error);
     setNativeCoworkPane({
       ...event.pane,
-      actionStatus: `Cowork ${event.action} failed: ${stringifyError(error)}`,
+      actionStatus: `Cowork ${event.action} failed: ${errorMessage}`,
+    });
+  } finally {
+    logDesktopNativeDebug(`cowork.action.${outcome}`, {
+      ...summarizeCoworkAction(event, sessionId),
+      ...(errorMessage ? { error: errorMessage } : {}),
     });
   }
 }
@@ -921,6 +1040,9 @@ function extractCoworkSummary(payload: unknown): string {
 }
 
 async function handleNativeKnowledgeAction(event: DesktopKnowledgeActionEvent): Promise<void> {
+  let outcome: "complete" | "failed" | "ignored" = "complete";
+  let errorMessage = "";
+  logDesktopNativeDebug("knowledge.action.start", summarizeKnowledgeAction(event));
   try {
     if (event.action === "uploadDocument") {
       document.getElementById("desktop-knowledge-upload")?.click();
@@ -960,17 +1082,26 @@ async function handleNativeKnowledgeAction(event: DesktopKnowledgeActionEvent): 
       await gatewayApi.knowledge.deleteDocument(event.pane.selectedDocument.id);
       const pane = await loadNativeKnowledgePane({ queryResultPayload: nativeKnowledgeQueryResult });
       setNativeKnowledgePane(pane);
+      return;
     }
+    outcome = "ignored";
   } catch (error) {
+    outcome = "failed";
+    errorMessage = stringifyError(error);
     updateNativeKnowledgeTask({
       id: `knowledge:action:${event.action}`,
       title: `Knowledge ${event.action}`,
       status: "failed",
       detail: "Knowledge action failed",
       canonical: { module: "knowledge", entityId: event.pane.selectedDocument?.id, href: "/knowledge" },
-      diagnostics: stringifyError(error),
+      diagnostics: errorMessage,
       retryable: true,
       updatedAt: new Date().toISOString(),
+    });
+  } finally {
+    logDesktopNativeDebug(`knowledge.action.${outcome}`, {
+      ...summarizeKnowledgeAction(event),
+      ...(errorMessage ? { error: errorMessage } : {}),
     });
   }
 }
@@ -1003,6 +1134,9 @@ async function loadNativeToolsSkillsPane(
   selectedSkillName?: string,
   selectedSkillDetail?: unknown,
 ): Promise<DesktopToolsSkillsPaneModel> {
+  logDesktopNativeDebug("toolsSkills.load.start", {
+    selectedSkillName: selectedSkillName ?? "",
+  });
   const [tools, skills, config] = await Promise.all([
     gatewayApi.tools.list(),
     gatewayApi.skills.list(),
@@ -1020,11 +1154,20 @@ async function loadNativeToolsSkillsPane(
     selectedSkillName: firstSkill,
     selectedSkillDetail: detail,
   });
+  logDesktopNativeDebug("toolsSkills.load.complete", {
+    selectedSkillName: nativeToolsSkillsPane.selectedSkill?.name ?? "",
+    skillCount: nativeToolsSkillsPane.skillRows.length,
+    toolCount: nativeToolsSkillsPane.toolRows.length,
+  });
   return nativeToolsSkillsPane;
 }
 
 async function handleNativeToolsSkillsAction(event: DesktopToolsSkillsActionEvent): Promise<void> {
   const skill = event.pane.selectedSkill;
+  let outcome: "complete" | "failed" | "ignored" = "complete";
+  let errorMessage = "";
+  logDesktopNativeDebug("toolsSkills.action.start", summarizeToolsSkillsAction(event));
+  try {
   if (event.action === "createSkill") {
     setNativeToolsSkillsPane(buildDesktopToolsSkillsPaneModel({
       toolsPayload: nativeToolsPayload,
@@ -1039,10 +1182,10 @@ async function handleNativeToolsSkillsAction(event: DesktopToolsSkillsActionEven
     return;
   }
   if (!skill) {
+    outcome = "ignored";
     return;
   }
   const draft = skill.editor.draft;
-  try {
     if (event.action === "validateSkill") {
       const result = await gatewayApi.skills.validate(skill.name);
       setNativeToolsSkillsPane(buildNativeToolsSkillsPaneFromEditor(skill, {
@@ -1081,11 +1224,21 @@ async function handleNativeToolsSkillsAction(event: DesktopToolsSkillsActionEven
       await refreshNativeToolsSkillsPane(skill.name);
       return;
     }
+    outcome = "ignored";
   } catch (error) {
-    setNativeToolsSkillsPane(buildNativeToolsSkillsPaneFromEditor(skill, {
-      saveStatus: "failed",
-      saveError: `Skill action failed: ${stringifyError(error)}`,
-    }));
+    outcome = "failed";
+    errorMessage = stringifyError(error);
+    if (skill) {
+      setNativeToolsSkillsPane(buildNativeToolsSkillsPaneFromEditor(skill, {
+        saveStatus: "failed",
+        saveError: `Skill action failed: ${errorMessage}`,
+      }));
+    }
+  } finally {
+    logDesktopNativeDebug(`toolsSkills.action.${outcome}`, {
+      ...summarizeToolsSkillsAction(event),
+      ...(errorMessage ? { error: errorMessage } : {}),
+    });
   }
 }
 
@@ -1171,11 +1324,17 @@ async function loadNativeSettingsPane(): Promise<DesktopSettingsPaneModel> {
 
 async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Promise<void> {
   if (!nativeSettingsState) {
+    logDesktopNativeDebug("settings.action.skipped", { action: event.action, reason: "state unavailable" });
     return;
   }
+  logDesktopNativeDebug("settings.action.start", {
+    action: event.action,
+    fieldId: "fieldId" in event ? event.fieldId : undefined,
+  });
   if (event.action === "edit") {
     nativeSettingsState = applyDesktopSettingsFieldEdit(nativeSettingsState, event.fieldId, event.value);
     updateNativeSettingsPane("idle");
+    logDesktopNativeDebug("settings.action.complete", { action: event.action, fieldId: event.fieldId });
     return;
   }
   if (event.action === "save") {
@@ -1187,8 +1346,10 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
 
 async function saveNativeSettingsPane(): Promise<void> {
   if (!nativeSettingsState) {
+    logDesktopNativeDebug("settings.save.skipped", { reason: "state unavailable" });
     return;
   }
+  logDesktopNativeDebug("settings.save.start");
   updateNativeSettingsPane("saving");
   try {
     const patch = createDesktopSettingsPatch(
@@ -1200,16 +1361,24 @@ async function saveNativeSettingsPane(): Promise<void> {
     nativeSettingsState = buildDesktopSettingsFormState(nativeSettingsConfig, nativeSettingsProviderCatalog);
     nativeSettingsLastSavedState = nativeSettingsState;
     updateNativeSettingsPane("saved");
+    logDesktopNativeDebug("settings.save.complete");
   } catch (error) {
-    updateNativeSettingsPane("failed", `Failed to save settings: ${stringifyError(error)}`);
+    const message = stringifyError(error);
+    updateNativeSettingsPane("failed", `Failed to save settings: ${message}`);
+    logDesktopNativeDebug("settings.save.failed", { error: message });
   }
 }
 
 async function refreshNativeProviderModels(): Promise<void> {
   if (!nativeSettingsState) {
+    logDesktopNativeDebug("settings.providerModels.skipped", { reason: "state unavailable" });
     return;
   }
   const request = buildDesktopProviderModelRequest(nativeSettingsState);
+  logDesktopNativeDebug("settings.providerModels.start", {
+    profile: request.profile,
+    provider: request.provider,
+  });
   updateNativeProviderTask(buildDesktopProviderModelDiscoveryTaskOperation({
     provider: request.provider,
     profile: request.profile,
@@ -1227,6 +1396,12 @@ async function refreshNativeProviderModels(): Promise<void> {
       models: applied.models,
       error: applied.status === "failed" ? applied.message : "",
     }));
+    logDesktopNativeDebug("settings.providerModels.complete", {
+      modelCount: applied.models.length,
+      profile: request.profile,
+      provider: request.provider,
+      status: applied.status,
+    });
   } catch (error) {
     const message = stringifyError(error);
     updateNativeSettingsPane("failed", `Failed to refresh provider models: ${message}`);
@@ -1236,6 +1411,11 @@ async function refreshNativeProviderModels(): Promise<void> {
       status: "failed",
       error: message,
     }));
+    logDesktopNativeDebug("settings.providerModels.failed", {
+      error: message,
+      profile: request.profile,
+      provider: request.provider,
+    });
   }
 }
 
@@ -1355,25 +1535,33 @@ function installRootWebUiDesktopAdapters(): void {
 
 function updateNativeKnowledgeTask(operation: DesktopTaskSourceOperation): void {
   nativeKnowledgeTaskOperations.set(operation.id, operation);
+  logDesktopNativeDebug("task.operation.update", summarizeTaskOperation("knowledge", operation));
   publishNativeTaskCenterItems();
 }
 
 function updateNativeFileTask(operation: DesktopTaskSourceOperation): void {
   nativeFileTaskOperations.set(operation.id, operation);
+  logDesktopNativeDebug("task.operation.update", summarizeTaskOperation("files", operation));
   publishNativeTaskCenterItems();
 }
 
 function updateNativeProviderTask(operation: DesktopTaskSourceOperation): void {
   nativeProviderTaskOperations.set(operation.id, operation);
+  logDesktopNativeDebug("task.operation.update", summarizeTaskOperation("providers", operation));
   publishNativeTaskCenterItems();
 }
 
 function updateNativeGatewayTask(operation: DesktopTaskSourceOperation): void {
   nativeGatewayTaskOperations.set(operation.id, operation);
+  logDesktopNativeDebug("task.operation.update", summarizeTaskOperation("gateway", operation));
   publishNativeTaskCenterItems();
 }
 
 async function handleNativeGatewayRuntimeAction(event: DesktopGatewayRuntimeActionEvent): Promise<void> {
+  logDesktopNativeDebug("gatewayRuntime.action.start", {
+    action: event.action,
+    currentState: event.status?.state ?? nativeRuntimeStatus?.state ?? "",
+  });
   try {
     const nextStatus = await runDesktopGatewayRuntimeCommand(event.action, event.status, {
       runCommand: (command, payload) => invokeGatewayRuntimeCommand(command, payload),
@@ -1389,8 +1577,13 @@ async function handleNativeGatewayRuntimeAction(event: DesktopGatewayRuntimeActi
     });
     setDesktopWindowRuntimeStatus(nextStatus);
     updateNativeGatewayTask(buildDesktopGatewayTaskOperation(gatewayTaskActionForRuntimeAction(event.action), nextStatus));
+    logDesktopNativeDebug("gatewayRuntime.action.complete", {
+      action: event.action,
+      nextState: nextStatus.state,
+    });
   } catch (error) {
-    const failedStatus = failedGatewayRuntimeStatus(event.status ?? nativeRuntimeStatus, stringifyError(error));
+    const message = stringifyError(error);
+    const failedStatus = failedGatewayRuntimeStatus(event.status ?? nativeRuntimeStatus, message);
     nativeRuntimeStatus = failedStatus;
     updateDesktopGatewayRuntimeStatus(document, failedStatus, gatewayConfig.httpBaseUrl, {
       onGatewayRuntimeAction: (nextEvent) => {
@@ -1399,6 +1592,10 @@ async function handleNativeGatewayRuntimeAction(event: DesktopGatewayRuntimeActi
     });
     setDesktopWindowRuntimeStatus(failedStatus);
     updateNativeGatewayTask(buildDesktopGatewayTaskOperation(gatewayTaskActionForRuntimeAction(event.action), failedStatus));
+    logDesktopNativeDebug("gatewayRuntime.action.failed", {
+      action: event.action,
+      error: message,
+    });
   }
 }
 
@@ -1439,6 +1636,7 @@ function failedGatewayRuntimeStatus(
 }
 
 async function refreshNativeApprovalTasks(): Promise<void> {
+  logDesktopNativeDebug("approvals.refresh.start");
   try {
     const payload = await gatewayApi.tools.approvals();
     nativeApprovalTaskOperations.clear();
@@ -1446,6 +1644,9 @@ async function refreshNativeApprovalTasks(): Promise<void> {
       nativeApprovalTaskOperations.set(operation.id, operation);
     }
     publishNativeTaskCenterItems();
+    logDesktopNativeDebug("approvals.refresh.complete", {
+      count: nativeApprovalTaskOperations.size,
+    });
   } catch (error) {
     nativeApprovalTaskOperations.set("approval:load", {
       id: "approval:load",
@@ -1458,13 +1659,20 @@ async function refreshNativeApprovalTasks(): Promise<void> {
       updatedAt: new Date().toISOString(),
     });
     publishNativeTaskCenterItems();
+    logDesktopNativeDebug("approvals.refresh.failed", {
+      error: stringifyError(error),
+    });
   }
 }
 
 async function refreshNativeCoworkTasks(): Promise<void> {
+  logDesktopNativeDebug("cowork.tasks.refresh.start");
   try {
     const payload = await gatewayApi.cowork.sessions({ includeCompleted: true });
     replaceNativeCoworkTasks(payload);
+    logDesktopNativeDebug("cowork.tasks.refresh.complete", {
+      count: nativeCoworkTaskOperations.size,
+    });
   } catch (error) {
     updateNativeCoworkTask({
       id: "cowork:load",
@@ -1476,6 +1684,9 @@ async function refreshNativeCoworkTasks(): Promise<void> {
       retryable: true,
       updatedAt: new Date().toISOString(),
     });
+    logDesktopNativeDebug("cowork.tasks.refresh.failed", {
+      error: stringifyError(error),
+    });
   }
 }
 
@@ -1484,11 +1695,16 @@ function replaceNativeCoworkTasks(payload: unknown): void {
   for (const operation of buildDesktopCoworkTaskOperations(payload)) {
     nativeCoworkTaskOperations.set(operation.id, operation);
   }
+  logDesktopNativeDebug("task.operations.replace", {
+    count: nativeCoworkTaskOperations.size,
+    source: "cowork",
+  });
   publishNativeTaskCenterItems();
 }
 
 function updateNativeCoworkTask(operation: DesktopTaskSourceOperation): void {
   nativeCoworkTaskOperations.set(operation.id, operation);
+  logDesktopNativeDebug("task.operation.update", summarizeTaskOperation("cowork", operation));
   publishNativeTaskCenterItems();
 }
 
@@ -1548,6 +1764,83 @@ function installTauriWindowFrame(runtimeStatus?: GatewayRuntimeStatus | null): v
   if (runtimeStatus !== undefined) {
     setDesktopWindowRuntimeStatus(runtimeStatus);
   }
+}
+
+function summarizeTaskCenterAction(event: DesktopTaskCenterActionEvent): Record<string, unknown> {
+  return {
+    action: event.action,
+    destinationEntityId: event.item.destination.entityId ?? "",
+    destinationModule: event.item.destination.module,
+    itemId: event.item.id,
+    source: event.item.source,
+    state: event.item.state,
+    status: event.item.status,
+  };
+}
+
+function summarizeAgentUiFormAction(event: DesktopAgentUiFormActionEvent): Record<string, unknown> {
+  return {
+    action: event.action,
+    fieldCount: Object.keys(event.values ?? {}).length,
+    formId: event.form.form_id,
+    title: event.form.title ?? "",
+  };
+}
+
+function summarizeCoworkAction(
+  event: DesktopCoworkActionEvent,
+  sessionId: string,
+): Record<string, unknown> {
+  return {
+    action: event.action,
+    assignedAgentId: event.assignedAgentId ?? "",
+    blueprintLength: event.blueprintText?.length ?? 0,
+    branchCount: event.branchIds?.length ?? 0,
+    branchId: event.branchId ?? "",
+    goalLength: event.goal?.length ?? 0,
+    messageLength: event.message?.length ?? 0,
+    preview: event.preview === true,
+    resultId: event.resultId ?? "",
+    sessionId,
+    taskAction: event.taskAction ?? "",
+    taskId: event.taskId ?? "",
+    taskTitleLength: event.taskTitle?.length ?? 0,
+    workUnitAction: event.workUnitAction ?? "",
+    workUnitId: event.workUnitId ?? "",
+  };
+}
+
+function summarizeKnowledgeAction(event: DesktopKnowledgeActionEvent): Record<string, unknown> {
+  return {
+    action: event.action,
+    queryLength: event.pane.query.draft.query.length,
+    resultCount: event.pane.query.results.rows.length,
+    selectedDocumentId: event.pane.selectedDocument?.id ?? "",
+  };
+}
+
+function summarizeToolsSkillsAction(event: DesktopToolsSkillsActionEvent): Record<string, unknown> {
+  return {
+    action: event.action,
+    field: event.field ?? "",
+    selectedSkillName: event.pane.selectedSkill?.name ?? "",
+    selectedToolName: event.pane.selectedTool?.name ?? "",
+    valueKind: typeof event.value,
+    valueLength: typeof event.value === "string" ? event.value.length : 0,
+  };
+}
+
+function summarizeTaskOperation(source: string, operation: DesktopTaskSourceOperation): Record<string, unknown> {
+  return {
+    destinationEntityId: operation.canonical.entityId ?? "",
+    destinationModule: operation.canonical.module,
+    id: operation.id,
+    progressPercent: operation.progress?.percent,
+    retryable: operation.retryable === true,
+    source,
+    status: operation.status,
+    title: operation.title,
+  };
 }
 
 function stringifyError(error: unknown): string {

--- a/apps/desktop/src/desktopChatSessionController.ts
+++ b/apps/desktop/src/desktopChatSessionController.ts
@@ -11,6 +11,7 @@ import {
   type NativeChatState,
 } from "./nativeChat";
 import { createGatewaySocketMessage, type NormalizedGatewayEvent } from "./gatewayWebSocketClient";
+import { logDesktopNativeDebug, summarizeDebugText } from "./desktopNativeChatDebug";
 
 export interface DesktopChatSessionControllerApi {
   listSessions(): Promise<unknown>;
@@ -61,32 +62,57 @@ export function createDesktopChatSessionController({
   let pendingMessage: { content: string; usePersistentRag: boolean } | null = null;
 
   async function loadSessions(): Promise<number> {
+    logDesktopNativeDebug("session.load.start", summarizeSessionState());
     const sessions = normalizeSessionsPayload(await api.listSessions());
     setSessions(state, sessions);
     if (!state.activeSessionKey && sessions[0]) {
       await selectSession(sessions[0].key, sessions[0].chatId);
     }
+    logDesktopNativeDebug("session.load.complete", {
+      ...summarizeSessionState(),
+      loadedCount: sessions.length,
+    });
     return sessions.length;
   }
 
   async function selectSession(sessionKey: string, chatId: string): Promise<void> {
+    logDesktopNativeDebug("session.select.start", {
+      ...summarizeSessionState(),
+      chatId,
+      sessionKey,
+    });
     activateSession(state, sessionKey, chatId);
     const payload = await api.loadMessages(sessionKey);
-    setMessages(state, sessionKey, normalizeMessagesPayload(payload));
+    const messages = normalizeMessagesPayload(payload);
+    setMessages(state, sessionKey, messages);
     sendSocketMessage(createGatewaySocketMessage.attach(chatId));
+    logDesktopNativeDebug("session.select.complete", {
+      ...summarizeSessionState(),
+      chatId,
+      messageCount: messages.length,
+      sessionKey,
+    });
   }
 
   function startNewChat(): void {
+    logDesktopNativeDebug("session.new.request", summarizeSessionState());
     sendSocketMessage(createGatewaySocketMessage.newChat());
   }
 
   async function deleteSession(sessionKey: string): Promise<ChatDeleteSessionResult> {
     const deletedSessionKey = sessionKey;
     const target = state.sessions.find((session) => session.key === sessionKey);
+    logDesktopNativeDebug("session.delete.start", {
+      ...summarizeSessionState(),
+      found: Boolean(target),
+      sessionKey,
+    });
     if (!target) {
+      logDesktopNativeDebug("session.delete.missing", { sessionKey });
       return { status: "missing", deletedSessionKey, nextSessionKey: "" };
     }
     if (!api.deleteSession) {
+      logDesktopNativeDebug("session.delete.unavailable", { sessionKey });
       return { status: "unavailable", deletedSessionKey, nextSessionKey: "" };
     }
 
@@ -110,6 +136,11 @@ export function createDesktopChatSessionController({
         state.activeChatId = "";
       }
     }
+    logDesktopNativeDebug("session.delete.complete", {
+      ...summarizeSessionState(),
+      deletedSessionKey,
+      nextSessionKey: state.activeSessionKey,
+    });
     return {
       status: "deleted",
       deletedSessionKey,
@@ -123,37 +154,66 @@ export function createDesktopChatSessionController({
     }
     try {
       await api.deleteSession(target.key);
+      logDesktopNativeDebug("session.delete.gateway", {
+        key: target.key,
+        mode: "primary",
+      });
       return;
     } catch (error) {
       const fallbackKey = sessionKeyForChat(target.chatId);
       if (!fallbackKey || fallbackKey === target.key) {
+        logDesktopNativeDebug("session.delete.failed", {
+          error: error instanceof Error ? error.message : String(error),
+          key: target.key,
+        });
         throw error;
       }
+      logDesktopNativeDebug("session.delete.retry", {
+        fallbackKey,
+        key: target.key,
+      });
       await api.deleteSession(fallbackKey);
+      logDesktopNativeDebug("session.delete.gateway", {
+        key: fallbackKey,
+        mode: "fallback",
+      });
     }
   }
 
   function submitMessage(content: string, usePersistentRag = true): ChatSubmitResult {
     const trimmed = content.trim();
     if (!trimmed) {
+      logDesktopNativeDebug("session.message.empty", summarizeSessionState());
       return { status: "empty" };
     }
 
     if (!state.activeChatId) {
       pendingMessage = { content: trimmed, usePersistentRag };
       startNewChat();
+      logDesktopNativeDebug("session.message.queued", {
+        ...summarizeSessionState(),
+        content: summarizeDebugText(trimmed),
+        usePersistentRag,
+      });
       return { status: "creating", pendingContent: trimmed };
     }
 
     sendActiveChatMessage(trimmed, usePersistentRag);
+    logDesktopNativeDebug("session.message.sent", {
+      ...summarizeSessionState(),
+      content: summarizeDebugText(trimmed),
+      usePersistentRag,
+    });
     return { status: "sent", chatId: state.activeChatId, content: trimmed };
   }
 
   function interruptActiveChat(): boolean {
     if (!state.activeChatId) {
+      logDesktopNativeDebug("session.interrupt.skipped", summarizeSessionState());
       return false;
     }
     sendSocketMessage(createGatewaySocketMessage.interrupt(state.activeChatId));
+    logDesktopNativeDebug("session.interrupt.request", summarizeSessionState());
     return true;
   }
 
@@ -173,6 +233,11 @@ export function createDesktopChatSessionController({
         const { content, usePersistentRag } = pendingMessage;
         pendingMessage = null;
         sendActiveChatMessage(content, usePersistentRag);
+        logDesktopNativeDebug("session.message.queued.sent", {
+          ...summarizeSessionState(),
+          content: summarizeDebugText(content),
+          usePersistentRag,
+        });
         result.pendingMessageSent = true;
       }
     }
@@ -191,7 +256,13 @@ export function createDesktopChatSessionController({
       return false;
     }
     const payload = await api.loadMessages(sessionKey);
-    setMessages(state, sessionKey, normalizeMessagesPayload(payload));
+    const messages = normalizeMessagesPayload(payload);
+    setMessages(state, sessionKey, messages);
+    logDesktopNativeDebug("session.messages.loaded", {
+      chatId,
+      messageCount: messages.length,
+      sessionKey,
+    });
     return true;
   }
 
@@ -211,4 +282,13 @@ export function createDesktopChatSessionController({
     handleGatewayEvent,
     loadMessagesForChat,
   };
+
+  function summarizeSessionState(): Record<string, unknown> {
+    return {
+      activeChatId: state.activeChatId,
+      activeSessionKey: state.activeSessionKey,
+      pendingMessage: Boolean(pendingMessage),
+      sessionCount: state.sessions.length,
+    };
+  }
 }

--- a/apps/desktop/src/desktopNativeChatDebug.ts
+++ b/apps/desktop/src/desktopNativeChatDebug.ts
@@ -1,55 +1,55 @@
-export type DesktopNativeChatDebugStage =
-  | "socket.open"
-  | "socket.close"
-  | "socket.error"
-  | "socket.send"
-  | "socket.frame"
-  | "gateway.event"
-  | "runtime.before"
-  | "runtime.after"
-  | "state.event.before"
-  | "state.event.after"
-  | "shell.update"
-  | "vue.thread.update"
-  | "vue.composer.update";
+export type DesktopNativeDebugStage = string;
+export type DesktopNativeChatDebugStage = DesktopNativeDebugStage;
 
-export interface DesktopNativeChatDebugEntry {
+export interface DesktopNativeDebugEntry {
   at: string;
   details: Record<string, unknown>;
-  stage: DesktopNativeChatDebugStage;
+  stage: DesktopNativeDebugStage;
 }
+
+export type DesktopNativeChatDebugEntry = DesktopNativeDebugEntry;
 
 declare global {
   interface Window {
-    __tinybotNativeChatDebug?: DesktopNativeChatDebugEntry[];
+    __tinybotNativeChatDebug?: DesktopNativeDebugEntry[];
+    __tinybotNativeDebug?: DesktopNativeDebugEntry[];
   }
 }
 
 const MAX_DEBUG_ENTRIES = 300;
-const DEBUG_STORAGE_KEY = "tinybot.desktop.nativeChatDebug";
+const DEBUG_STORAGE_KEY = "tinybot.desktop.nativeDebug";
+const LEGACY_DEBUG_STORAGE_KEY = "tinybot.desktop.nativeChatDebug";
 
-export function logDesktopNativeChatDebug(
-  stage: DesktopNativeChatDebugStage,
+export function logDesktopNativeDebug(
+  stage: DesktopNativeDebugStage,
   details: Record<string, unknown> = {},
 ): void {
-  if (!isDesktopNativeChatDebugEnabled()) {
+  if (!isDesktopNativeDebugEnabled()) {
     return;
   }
-  const entry: DesktopNativeChatDebugEntry = {
+  const entry: DesktopNativeDebugEntry = {
     at: new Date().toISOString(),
     stage,
     details: sanitizeDebugDetails(details),
   };
   const targetWindow = typeof window === "undefined" ? null : window;
   if (targetWindow) {
-    const entries = targetWindow.__tinybotNativeChatDebug ?? [];
+    const entries = targetWindow.__tinybotNativeDebug ?? targetWindow.__tinybotNativeChatDebug ?? [];
     entries.push(entry);
     if (entries.length > MAX_DEBUG_ENTRIES) {
       entries.splice(0, entries.length - MAX_DEBUG_ENTRIES);
     }
+    targetWindow.__tinybotNativeDebug = entries;
     targetWindow.__tinybotNativeChatDebug = entries;
   }
-  console.info("[Tinybot native chat]", stage, entry.details);
+  console.info("[Tinybot native]", stage, entry.details);
+}
+
+export function logDesktopNativeChatDebug(
+  stage: DesktopNativeChatDebugStage,
+  details: Record<string, unknown> = {},
+): void {
+  logDesktopNativeDebug(stage, details);
 }
 
 export function summarizeDebugText(value: string | undefined): { length: number; preview: string } {
@@ -60,7 +60,7 @@ export function summarizeDebugText(value: string | undefined): { length: number;
   };
 }
 
-function isDesktopNativeChatDebugEnabled(): boolean {
+function isDesktopNativeDebugEnabled(): boolean {
   const storageValue = readDebugStorageValue();
   if (/^(0|false|off)$/i.test(storageValue)) {
     return false;
@@ -73,7 +73,12 @@ function isDesktopNativeChatDebugEnabled(): boolean {
 
 function readDebugStorageValue(): string {
   try {
-    return typeof window === "undefined" ? "" : window.localStorage?.getItem(DEBUG_STORAGE_KEY) ?? "";
+    if (typeof window === "undefined") {
+      return "";
+    }
+    return window.localStorage?.getItem(DEBUG_STORAGE_KEY)
+      ?? window.localStorage?.getItem(LEGACY_DEBUG_STORAGE_KEY)
+      ?? "";
   } catch {
     return "";
   }

--- a/apps/desktop/src/desktopNativeDebug.test.ts
+++ b/apps/desktop/src/desktopNativeDebug.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createDesktopNativeWorkbenchRuntime } from "./desktopNativeWorkbenchRuntime";
+import { logDesktopNativeDebug } from "./desktopNativeChatDebug";
+import { DEFAULT_GATEWAY_CONFIG } from "./gatewayConfig";
+import { createGatewayApiClient } from "./gatewayHttpClient";
+
+describe("desktop native debug logger", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    window.__tinybotNativeDebug = [];
+    window.__tinybotNativeChatDebug = [];
+    vi.restoreAllMocks();
+  });
+
+  test("stores sanitized native debug entries behind the localStorage switch", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    window.localStorage.setItem("tinybot.desktop.nativeDebug", "on");
+
+    logDesktopNativeDebug("session.delete.start", {
+      longText: "x".repeat(540),
+      manyItems: Array.from({ length: 20 }, (_, index) => index),
+      nested: { value: "ready" },
+    });
+
+    expect(window.__tinybotNativeDebug).toHaveLength(1);
+    expect(window.__tinybotNativeChatDebug).toBe(window.__tinybotNativeDebug);
+    expect(window.__tinybotNativeDebug?.[0]).toMatchObject({
+      stage: "session.delete.start",
+      details: {
+        longText: `${"x".repeat(500)}...`,
+        manyItems: Array.from({ length: 12 }, (_, index) => index),
+        nested: { value: "ready" },
+      },
+    });
+    expect(info).toHaveBeenCalledWith("[Tinybot native]", "session.delete.start", window.__tinybotNativeDebug?.[0]?.details);
+  });
+
+  test("logs meaningful runtime and session stages for native chat operations", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    window.localStorage.setItem("tinybot.desktop.nativeDebug", "on");
+    const deleted: string[] = [];
+    let sessions = [
+      { key: "WebSocket:chat-1", chat_id: "chat-1", title: "First chat" },
+      { key: "WebSocket:chat-2", chat_id: "chat-2", title: "Second chat" },
+    ];
+    const runtime = createDesktopNativeWorkbenchRuntime({
+      api: {
+        listSessions: async () => ({ items: sessions }),
+        loadMessages: async (key: string) => ({
+          messages: [{ role: "assistant", content: `loaded ${key}`, message_id: `m-${key}` }],
+        }),
+        deleteSession: async (key: string) => {
+          deleted.push(key);
+          sessions = sessions.filter((session) => session.key !== key);
+          return { deleted: true };
+        },
+      },
+      sendSocketMessage: () => undefined,
+    });
+
+    await runtime.loadInitialChatState();
+    runtime.submitComposerMessage("Inspect logs");
+    await runtime.deleteChatSession("WebSocket:chat-1");
+
+    const stages = window.__tinybotNativeDebug?.map((entry) => entry.stage) ?? [];
+    expect(stages).toEqual(expect.arrayContaining([
+      "runtime.load.start",
+      "runtime.load.complete",
+      "runtime.submit",
+      "session.load.start",
+      "session.load.complete",
+      "session.select.start",
+      "session.delete.start",
+      "session.delete.complete",
+    ]));
+    expect(deleted).toEqual(["WebSocket:chat-1"]);
+    expect(info).toHaveBeenCalled();
+  });
+
+  test("logs gateway HTTP request lifecycle without storing request bodies", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    window.localStorage.setItem("tinybot.desktop.nativeDebug", "on");
+    const fetchFn = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).endsWith("/webui/bootstrap")) {
+        return new Response(JSON.stringify({ token: "token-1" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    const client = createGatewayApiClient({
+      config: DEFAULT_GATEWAY_CONFIG,
+      fetchFn,
+    });
+
+    await client.knowledge.query({ query: "sensitive long query", top_k: 5 });
+
+    const entries = window.__tinybotNativeDebug ?? [];
+    expect(entries.map((entry) => entry.stage)).toEqual(expect.arrayContaining([
+      "gateway.bootstrap.start",
+      "gateway.bootstrap.complete",
+      "gateway.http.request",
+      "gateway.http.response",
+    ]));
+    expect(entries.find((entry) => entry.stage === "gateway.http.request")?.details).toMatchObject({
+      method: "POST",
+      path: "/v1/knowledge/query",
+    });
+    expect(JSON.stringify(entries)).not.toContain("sensitive long query");
+  });
+});

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
@@ -13,6 +13,7 @@ import {
 import type { DesktopTaskSourceOperation } from "./desktopTaskCenter";
 import { buildDesktopAgentUiApprovalTaskOperations } from "./desktopTaskCenterSources";
 import type { DesktopNativeChatModel } from "./desktopWorkbenchShell";
+import { logDesktopNativeDebug, summarizeDebugText } from "./desktopNativeChatDebug";
 import type { NormalizedGatewayEvent } from "./gatewayWebSocketClient";
 
 export interface DesktopNativeWorkbenchRuntimeOptions {
@@ -54,37 +55,70 @@ export function createDesktopNativeWorkbenchRuntime({
   const agentUiState = createAgentUiEventState();
 
   async function loadInitialChatState(): Promise<void> {
+    logDesktopNativeDebug("runtime.load.start", summarizeRuntimeState());
     const count = await chatController.loadSessions();
     chatStatus = count ? `Loaded ${count} ${count === 1 ? "session" : "sessions"} from gateway.` : "No sessions yet.";
+    logDesktopNativeDebug("runtime.load.complete", {
+      ...summarizeRuntimeState(),
+      loadedCount: count,
+    });
   }
 
   async function selectChatSession(sessionKey: string, chatId: string): Promise<void> {
+    logDesktopNativeDebug("runtime.select.start", {
+      ...summarizeRuntimeState(),
+      chatId,
+      sessionKey,
+    });
     await chatController.selectSession(sessionKey, chatId);
     chatStatus = "Session loaded from gateway.";
+    logDesktopNativeDebug("runtime.select.complete", summarizeRuntimeState());
   }
 
   function startNewChat(): void {
     chatController.startNewChat();
     chatStatus = "Creating chat session.";
+    logDesktopNativeDebug("runtime.newChat", summarizeRuntimeState());
   }
 
   async function deleteChatSession(sessionKey: string): Promise<void> {
+    logDesktopNativeDebug("runtime.delete.start", {
+      ...summarizeRuntimeState(),
+      sessionKey,
+    });
     const result = await chatController.deleteSession(sessionKey);
     if (result.status === "deleted") {
       chatStatus = result.nextSessionKey ? "Session deleted. Next chat loaded." : "Session deleted.";
       composerState = "idle";
+      logDesktopNativeDebug("runtime.delete.complete", {
+        ...summarizeRuntimeState(),
+        deletedSessionKey: result.deletedSessionKey,
+        nextSessionKey: result.nextSessionKey,
+      });
       return;
     }
     chatStatus = result.status === "unavailable" ? "Session deletion is unavailable." : "Session not found.";
+    logDesktopNativeDebug("runtime.delete.skipped", {
+      ...summarizeRuntimeState(),
+      status: result.status,
+    });
   }
 
   function setPersistentRag(enabled: boolean): void {
     usePersistentRag = enabled;
     chatStatus = `Persistent RAG ${enabled ? "enabled" : "disabled"}.`;
+    logDesktopNativeDebug("runtime.rag.change", {
+      ...summarizeRuntimeState(),
+      enabled,
+    });
   }
 
   function setRuntimeMetadata(metadata: NonNullable<DesktopNativeChatModel["runtime"]>): void {
     runtimeMetadata = { ...runtimeMetadata, ...metadata };
+    logDesktopNativeDebug("runtime.metadata.update", {
+      keys: Object.keys(metadata),
+      runtime: runtimeMetadata,
+    });
   }
 
   function submitComposerMessage(content: string, nextUsePersistentRag = usePersistentRag): ChatSubmitResult {
@@ -100,18 +134,33 @@ export function createDesktopNativeWorkbenchRuntime({
       chatStatus = "Message sent.";
       composerState = "sending";
     }
+    logDesktopNativeDebug("runtime.submit", {
+      ...summarizeRuntimeState(),
+      content: summarizeDebugText(content.trim()),
+      resultStatus: result.status,
+      usePersistentRag,
+    });
     return result;
   }
 
   function interruptActiveChat(): boolean {
     const interrupted = chatController.interruptActiveChat();
     chatStatus = interrupted ? "Interrupt requested." : "No active chat to interrupt.";
+    logDesktopNativeDebug("runtime.interrupt", {
+      ...summarizeRuntimeState(),
+      interrupted,
+    });
     return interrupted;
   }
 
   async function handleGatewayEvent(event: NormalizedGatewayEvent): Promise<void> {
+    logDesktopNativeDebug("runtime.gatewayEvent.start", summarizeGatewayEvent(event));
     if (event.kind === "usage") {
       setRuntimeMetadata({ tokenUsage: event.tokenUsage });
+      logDesktopNativeDebug("runtime.gatewayEvent.complete", {
+        ...summarizeRuntimeState(),
+        kind: event.kind,
+      });
       return;
     }
 
@@ -120,6 +169,11 @@ export function createDesktopNativeWorkbenchRuntime({
         reduceAgentUiEventState(agentUiState, agentUiEvent);
       }
       chatStatus = agentUiState.forms.size ? "Agent UI form requested." : "Agent UI event received.";
+      logDesktopNativeDebug("runtime.gatewayEvent.complete", {
+        ...summarizeRuntimeState(),
+        formCount: agentUiState.forms.size,
+        kind: event.kind,
+      });
       return;
     }
 
@@ -127,6 +181,10 @@ export function createDesktopNativeWorkbenchRuntime({
     if (event.kind === "error") {
       chatStatus = event.message;
       composerState = "idle";
+      logDesktopNativeDebug("runtime.gatewayEvent.error", {
+        ...summarizeRuntimeState(),
+        message: event.message,
+      });
       return;
     }
     if (result.pendingMessageSent) {
@@ -153,6 +211,13 @@ export function createDesktopNativeWorkbenchRuntime({
     if (result.reloadedSessions) {
       chatStatus = "Sessions refreshed.";
     }
+    logDesktopNativeDebug("runtime.gatewayEvent.complete", {
+      ...summarizeRuntimeState(),
+      kind: event.kind,
+      loadedMessagesForChatId: result.loadedMessagesForChatId,
+      pendingMessageSent: result.pendingMessageSent,
+      reloadedSessions: result.reloadedSessions,
+    });
   }
 
   return {
@@ -187,4 +252,25 @@ export function createDesktopNativeWorkbenchRuntime({
     interruptActiveChat,
     handleGatewayEvent,
   };
+
+  function summarizeRuntimeState(): Record<string, unknown> {
+    const state = chatController.state;
+    return {
+      activeChatId: state.activeChatId,
+      activeSessionKey: state.activeSessionKey,
+      composerState,
+      responding: state.activeSessionKey ? state.respondingSessionKeys.has(state.activeSessionKey) : false,
+      sessionCount: state.sessions.length,
+      status: chatStatus,
+    };
+  }
+
+  function summarizeGatewayEvent(event: NormalizedGatewayEvent): Record<string, unknown> {
+    return {
+      chatId: "chatId" in event ? event.chatId : "",
+      kind: event.kind,
+      messageId: "messageId" in event ? event.messageId : "",
+      text: "text" in event ? summarizeDebugText(event.text) : undefined,
+    };
+  }
 }

--- a/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
@@ -116,8 +116,7 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("./native-vue/toolActivitiesIsland")');
     expect(source).toContain('import { mountToolActivityIsland } from "./native-vue/toolActivityIsland";');
     expect(source).not.toContain('void import("./native-vue/toolActivityIsland")');
-    expect(source).toContain('import { mountToolActivitySectionIsland } from "./native-vue/toolActivitySectionIsland";');
-    expect(source).not.toContain('void import("./native-vue/toolActivitySectionIsland")');
+    expect(source).toContain('} from "./native-vue/toolActivityStatus";');
   });
 
   test("statically imports the composer control islands", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -299,7 +299,7 @@ describe("desktop workbench shell", () => {
         role: "assistant",
         content: "The native workbench is rendering gateway data.",
         reasoningContent: "Checked active session metadata.",
-        references: [{ kind: "tool", title: "read_file", detail: "docs/desktop.md" }],
+        references: [{ kind: "reference", title: "docs/desktop.md", detail: "read_file" }],
         toolActivities: [{
           argsText: "shell command",
           approvalStatus: "approval_required",
@@ -336,7 +336,7 @@ describe("desktop workbench shell", () => {
     expect(shellText).toContain("Please summarize the live runtime state.");
     expect(shellText).toContain("The native workbench is rendering gateway data.");
     expect(shellText).toContain("Checked active session metadata.");
-    expect(shellText).toContain("tool: read_file");
+    expect(shellText).toContain("reference: docs/desktop.md");
     expect(shellText).toContain("docs/desktop.md");
     expect(shellText).not.toContain("Loaded from gateway");
     expect(shellText).not.toContain("Design native workbench");
@@ -349,16 +349,10 @@ describe("desktop workbench shell", () => {
     const recentChatRow = targetDocument.body.querySelector(".desktop-sidebar-chat-row");
     expect(recentChatRow?.getAttribute("role")).toBe("listitem");
     expect(recentChatRow?.getAttribute("data-active")).toBe("true");
-    expect(recentChatRow?.querySelector(".desktop-sidebar-row-status")?.getAttribute("data-desktop-chat-status")).toBe("WebSocket:chat-live");
-    expect(recentChatRow?.querySelectorAll(".desktop-sidebar-status-chip").map((chip) => ({
-      kind: chip.getAttribute("data-status-kind"),
-      text: chip.textContent,
-    }))).toEqual([
-      { kind: "running", text: "Running" },
-      { kind: "approval", text: "Approval" },
-      { kind: "files", text: "1 ref" },
-      { kind: "knowledge", text: "Knowledge Off" },
-    ]);
+    expect(recentChatRow?.querySelector(".desktop-sidebar-row-status")).toBeNull();
+    expect(recentChatRow?.textContent).not.toContain("Running");
+    expect(recentChatRow?.textContent).not.toContain("Approval");
+    expect(recentChatRow?.textContent).not.toContain("Knowledge Off");
     const deleteButton = targetDocument.body.querySelector('[data-desktop-chat-delete="WebSocket:chat-live"]');
     expect(recentChatRow?.querySelector('[data-desktop-chat-delete="WebSocket:chat-live"]')).toBe(deleteButton);
     expect(deleteButton?.getAttribute("aria-label")).toBe("Delete chat Live gateway session");
@@ -553,20 +547,20 @@ describe("desktop workbench shell", () => {
     expect(thread?.getAttribute("role")).toBe("log");
     expect(thread?.getAttribute("aria-live")).toBe("polite");
     expect(message?.querySelector(".desktop-conversation-header")?.querySelector(".desktop-conversation-meta")?.textContent).toContain("Tinybot");
-    expect(reasoning?.querySelector(".desktop-message-reasoning-summary")?.textContent).toBe("Details");
+    expect(reasoning?.querySelector(".desktop-message-reasoning-summary")?.textContent).toBe("Thinking complete");
     expect(message?.querySelector(".desktop-conversation-content")?.children[1]).toBe(reasoning);
     expect(reasoning?.tagName).toBe("details");
     expect(reasoning?.querySelector(".desktop-message-reasoning-title")).toBeNull();
     expect(reasoning?.textContent).toContain("I should inspect the workspace first.");
     expect(message?.querySelector(".desktop-tool-activities")?.getAttribute("data-desktop-chat-region")).toBe("tool-timeline");
     expect(message?.querySelector(".desktop-tool-activities")?.getAttribute("aria-label")).toBe("Tool Timeline");
-    expect(toolActivity?.tagName).toBe("details");
+    expect(toolActivity?.tagName).toBe("div");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-row")?.getAttribute("aria-label")).toBe("Open shell tool details, Pending");
     expect(toolActivity?.querySelector(".desktop-tool-activity-title")?.textContent).toBe("shell");
-    expect(toolActivity?.querySelector(".desktop-tool-activity-badge")?.textContent).toBe("Result");
-    expect(toolActivity?.textContent).toContain("Arguments");
-    expect(toolActivity?.textContent).toContain("{\"command\":\"pwd\"}");
-    expect(toolActivity?.textContent).toContain("Response");
-    expect(toolActivity?.textContent).toContain("D:/code/tinybot/tinybot");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-kind")?.textContent).toBe("Tool");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-status-label")?.textContent).toBe("Pending");
+    expect(toolActivity?.textContent).not.toContain("{\"command\":\"pwd\"}");
+    expect(toolActivity?.textContent).not.toContain("D:/code/tinybot/tinybot");
     expect(body?.textContent).not.toContain("I should inspect the workspace first.");
     expect(body?.textContent).toContain("The command finished.");
   });
@@ -611,7 +605,8 @@ describe("desktop workbench shell", () => {
     });
 
     const message = targetDocument.body.querySelector(".desktop-conversation-message");
-    expect(message?.querySelector(".desktop-tool-activity")?.textContent).toContain("stdout: done");
+    expect(message?.querySelector(".desktop-tool-activity")?.textContent).not.toContain("stdout: done");
+    expect(message?.querySelector(".desktop-tool-activity-title")?.textContent).toBe("shell");
     expect(message?.querySelector(".desktop-conversation-body")?.textContent).not.toContain("stdout: done");
   });
 
@@ -1042,6 +1037,12 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector(".desktop-chat-runtime-status")).toBeNull();
     expect(header?.querySelector(".desktop-chat-menu")?.getAttribute("data-desktop-chat-menu")).toBe("more");
     expect(header?.querySelector(".desktop-chat-menu")?.textContent).toBe("...");
+    const titleRow = header?.querySelector(".desktop-chat-title-row");
+    const headerActions = header?.querySelector(".desktop-chat-header-actions");
+    expect(titleRow?.children[0]?.getAttribute("data-desktop-panel-control")).toBe("sidebar");
+    expect(titleRow?.children[1]?.className).toBe("desktop-chat-title-group");
+    expect(headerActions?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
+    expect(headerActions?.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-label")).toBe("Open Activity inspector");
     expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Collapse session list");
     expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-label")).toBe("Open Activity inspector");
     expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.textContent).toBe("");
@@ -1079,7 +1080,7 @@ describe("desktop workbench shell", () => {
           role: "assistant",
           content: "Used a workspace reference.",
           reasoningContent: "",
-          references: [{ kind: "tool", title: "read_file", detail: "README.md" }],
+          references: [{ kind: "reference", title: "README.md", detail: "workspace file" }],
           timestamp: "2026-06-03T08:20:00.000Z",
           messageId: "assistant-1",
         }],
@@ -1538,7 +1539,7 @@ describe("desktop workbench shell", () => {
     const toolActivity = targetDocument.body.querySelector(".desktop-tool-activity");
     expect(toolActivity?.getAttribute("data-desktop-run-chain-item-key")).toBe("assistant-1:call-shell");
 
-    toolActivity?.querySelector(".desktop-tool-activity-summary")?.click();
+    toolActivity?.querySelector(".desktop-tool-activity-row")?.click();
 
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("true");
     expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("true");
@@ -1621,7 +1622,9 @@ describe("desktop workbench shell", () => {
     expect(approvalCard?.textContent).toContain("Approval required");
     expect(approvalCard?.textContent).toContain("shell");
     expect(approvalCard?.textContent).toContain("python scripts/build_index.py");
-    expect(toolActivity?.querySelector(".desktop-tool-activity-pending-approval-badge")?.textContent).toBe("Approval");
+    expect(toolActivity?.getAttribute("data-desktop-tool-status")).toBe("blocked");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-status-label")?.textContent).toBe("Pending approval");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-status-dot")?.getAttribute("data-tool-status-tone")).toBe("pending");
 
     approvalCard?.querySelector('[data-desktop-approval-action="approveOnce"]')?.click();
     approvalCard?.querySelector('[data-desktop-approval-action="approveSession"]')?.click();
@@ -1675,9 +1678,9 @@ describe("desktop workbench shell", () => {
 
     const toolActivity = targetDocument.body.querySelector(".desktop-tool-activity");
     expect(toolActivity?.getAttribute("data-desktop-tool-activity-status")).toBe("running");
-    expect(toolActivity?.querySelector(".desktop-tool-activity-summary")?.getAttribute("aria-label")).toBe("shell tool running");
-    expect(toolActivity?.querySelector(".desktop-tool-activity-status-badge")?.textContent).toBe("Running");
-    expect(Array.from(toolActivity?.querySelectorAll(".desktop-tool-activity-badge") ?? []).map((badge) => badge.textContent)).toEqual(["Running", "Call"]);
+    expect(toolActivity?.querySelector(".desktop-tool-activity-row")?.getAttribute("aria-label")).toBe("Open shell tool details, Running");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-status-label")?.textContent).toBe("Running");
+    expect(toolActivity?.querySelector(".desktop-tool-activity-status-dot")?.getAttribute("data-tool-status-tone")).toBe("running");
   });
 
   test("renders a right-side Work Lens before generic inspector detail for running work", () => {
@@ -3795,13 +3798,25 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain(".desktop-native-composer-runtime {\n      grid-area: runtime;");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-thread {\n      display: grid;");
     expect(styleText).toContain("overflow-y: auto;");
-    expect(styleText).toContain("--desktop-chat-column-width: 840px;");
+    expect(styleText).toContain("--desktop-chat-column-width: clamp(720px, calc(100vw - 240px), 1760px);");
+    expect(styleText).toContain("--desktop-chat-gutter: clamp(16px, 2vw, 36px);");
+    expect(styleText).toContain("--desktop-chat-composer-gutter: clamp(32px, 4vw, 72px);");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-chat-workbench {");
     expect(styleText).toContain("align-self: stretch;");
     expect(styleText).toContain("height: 100%;");
-    expect(styleText).toContain("padding: 0 clamp(20px, 3vw, 46px);");
+    expect(styleText).toContain("padding: 0 var(--desktop-chat-gutter);");
     expect(styleText).toContain("width: min(var(--desktop-chat-column-width), 100%);");
-    expect(styleText).toContain("width: min(var(--desktop-chat-column-width), calc(100% - 112px));");
+    expect(styleText).toContain("width: min(var(--desktop-chat-column-width), calc(100% - var(--desktop-chat-composer-gutter)));");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-layout {\n      display: grid;\n      grid-template-columns: minmax(0, 1fr);");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-layout[data-tool-detail-visible=\"true\"] {\n      grid-template-columns: minmax(0, 1fr) minmax(300px, var(--desktop-tool-detail-width, 50%));");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-timeline {\n      display: grid;\n      gap: 6px;\n      min-width: 0;\n      width: 100%;");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-message[data-message-tone=\"user\"] .desktop-user-message-bubble {\n      box-sizing: border-box;\n      width: fit-content;\n      max-width: min(100%, var(--desktop-chat-column-width));");
+    expect(styleText).not.toContain("max-width: min(75%, 640px);");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-header {\n      display: flex;\n      align-items: baseline;\n      justify-content: flex-start;");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-message-reasoning-toggle {\n      display: flex;\n      align-items: center;\n      gap: 5px;\n      width: fit-content;\n      margin-left: 0;");
+    expect(styleText).not.toContain("body.desktop-native-workbench .desktop-message-reasoning-toggle {\n      display: flex;\n      align-items: center;\n      gap: 5px;\n      width: fit-content;\n      margin-left: auto;");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-content-card .n-card-content {\n      padding: 0;");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-assistant-step-list {\n      display: grid;\n      gap: 6px;");
     expect(styleText).toContain("--desktop-composer-reserve: 36px;");
     expect(styleText).toContain("padding: 18px 0 var(--desktop-composer-reserve);");
     expect(styleText).toContain("gap: 10px;");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -46,7 +46,7 @@ import {
 import type { WorkbenchLayoutState, WorkbenchPanelId, WorkbenchPanelState } from "./desktopWorkbenchLayout";
 import { loadWorkbenchLayout } from "./desktopWorkbenchLayout";
 import { installDesktopDesignTokens } from "./desktopDesignTokens";
-import { logDesktopNativeChatDebug, summarizeDebugText } from "./desktopNativeChatDebug";
+import { logDesktopNativeChatDebug, logDesktopNativeDebug, summarizeDebugText } from "./desktopNativeChatDebug";
 import type { NativeChatMessage, NativeChatReference, NativeChatSession } from "./nativeChat";
 import { mountAgentUiFormActionsIsland } from "./native-vue/agentUiFormActionsIsland";
 import { mountAgentUiFormCardIsland } from "./native-vue/agentUiFormCardIsland";
@@ -107,12 +107,11 @@ import { mountModuleWorkSectionIsland } from "./native-vue/moduleWorkSectionIsla
 import { mountPanelIconPartIsland } from "./native-vue/panelIconPartIsland";
 import { mountPersistentRagToggleIsland } from "./native-vue/persistentRagToggleIsland";
 import { mountRecentChatRowIsland } from "./native-vue/recentChatRowIsland";
-import type { RecentChatStatusChip } from "./native-vue/recentChatRowIsland";
 import { mountRunChainInspectorIsland } from "./native-vue/runChainInspectorIsland";
 import { mountRunChainOverviewIsland } from "./native-vue/runChainOverviewIsland";
 import { mountSidebarActionsIsland } from "./native-vue/sidebarActionsIsland";
 import { mountSidebarContentIsland } from "./native-vue/sidebarContentIsland";
-import { mountSidebarRecentChatsIsland } from "./native-vue/sidebarRecentChatsIsland";
+import { mountSidebarRecentChatsIsland, type SidebarRecentChatRow } from "./native-vue/sidebarRecentChatsIsland";
 import { mountSidebarRowIsland } from "./native-vue/sidebarRowIsland";
 import { mountSidebarSectionHeadingIsland } from "./native-vue/sidebarSectionHeadingIsland";
 import { mountSidebarWorkspaceListIsland } from "./native-vue/sidebarWorkspaceListIsland";
@@ -138,7 +137,12 @@ import { mountToolDetailIsland } from "./native-vue/toolDetailIsland";
 import { mountToolActivitiesIsland } from "./native-vue/toolActivitiesIsland";
 import { mountToolActivityIsland } from "./native-vue/toolActivityIsland";
 import type { ToolActivityIslandOptions } from "./native-vue/toolActivityIsland";
-import { mountToolActivitySectionIsland } from "./native-vue/toolActivitySectionIsland";
+import {
+  getToolStatusLabel,
+  getToolStatusTone,
+  isPendingToolApproval as isPendingToolApprovalState,
+  normalizeToolStatus as normalizeToolStatusModel,
+} from "./native-vue/toolActivityStatus";
 import { mountToolsListIsland } from "./native-vue/toolsListIsland";
 import { mountToolsSkillsActionsIsland, type ToolsSkillsActionId } from "./native-vue/toolsSkillsActionsIsland";
 import { mountToolsSkillsPaneIsland } from "./native-vue/toolsSkillsPaneIsland";
@@ -211,7 +215,7 @@ interface DesktopNativeChatActionOptions {
   onInterrupt?: () => void;
   onAttachSessionFile?: () => void;
   onNewChat?: () => void;
-  onDeleteSession?: (event: DesktopNativeChatDeleteSessionEvent) => void;
+  onDeleteSession?: (event: DesktopNativeChatDeleteSessionEvent) => unknown | Promise<unknown>;
   onPinSession?: (event: DesktopNativeChatPinSessionEvent) => void;
   onRenameSession?: (event: DesktopNativeChatRenameSessionEvent) => void;
   onPersistentRagChange?: (enabled: boolean) => void;
@@ -575,7 +579,10 @@ export function updateDesktopNativeChat(
   }
 
   const recentChats = targetDocument.querySelector<HTMLElement>(".desktop-recent-chat-list");
-  if (recentChats) {
+  const recentChatsSection = targetDocument.querySelector<HTMLElement>(".desktop-sidebar-list-section-recent");
+  if (recentChatsSection && canMountVueIsland(recentChatsSection)) {
+    mountSidebarRecentChatsVueIsland(recentChatsSection, recentChatRowsForChat(targetDocument, chat), chatActions);
+  } else if (recentChats) {
     const next = createSidebarRecentChats(targetDocument, chat, chatActions).querySelector<HTMLElement>(".desktop-recent-chat-list");
     recentChats.replaceChildren(...Array.from(next?.children ?? []));
   }
@@ -951,19 +958,13 @@ function createSidebarRecentChats(
         chatActions,
         routeId,
         pinnedSessionKeys.has(session.key),
-        recentChatStatusChips(session, chat),
       ));
     }
     if (!sessions.length) {
       list.append(createText(targetDocument, "p", "No recent chats."));
     }
     section.append(list);
-    mountSidebarRecentChatsVueIsland(section, sessions.map((session) => recentChatRowModel(
-      session,
-      session.key === chat.activeSessionKey,
-      pinnedSessionKeys.has(session.key),
-      recentChatStatusChips(session, chat),
-    )), chatActions);
+    mountSidebarRecentChatsVueIsland(section, recentChatRowsForChat(targetDocument, chat), chatActions);
     return section;
   }
 
@@ -996,18 +997,7 @@ function recentChatRowModel(
   session: NativeChatSession,
   active: boolean,
   pinned: boolean,
-  statusChips: RecentChatStatusChip[] = [],
-): {
-  active: boolean;
-  chatId: string;
-  href: string;
-  pinned: boolean;
-  routeId: string;
-  sessionKey: string;
-  statusChips: RecentChatStatusChip[];
-  title: string;
-  updatedLabel: string;
-} {
+): SidebarRecentChatRow {
   const routeId = desktopChatRouteId(session);
   const title = session.title || "New session";
   return {
@@ -1017,61 +1007,18 @@ function recentChatRowModel(
     pinned,
     routeId,
     sessionKey: session.key,
-    statusChips,
     title,
     updatedLabel: session.updatedAt ? `Updated ${formatCompactTime(session.updatedAt)}` : session.chatId,
   };
 }
 
-function recentChatStatusChips(session: NativeChatSession, chat: DesktopNativeChatModel): RecentChatStatusChip[] {
-  if (session.key !== chat.activeSessionKey) {
-    return [];
-  }
-  const chips: RecentChatStatusChip[] = [];
-  if (chat.responding === true || chat.composerState === "sending" || chat.composerState === "queued") {
-    chips.push({ kind: "running", label: "Running" });
-  }
-  if (chat.messages.some(messageHasPendingApproval)) {
-    chips.push({ kind: "approval", label: "Approval" });
-  }
-  const referenceCount = chat.messages.reduce((count, message) => count + (message.references?.length ?? 0), 0);
-  if (referenceCount > 0) {
-    chips.push({ kind: "files", label: `${referenceCount} ref${referenceCount === 1 ? "" : "s"}` });
-  }
-  chips.push({
-    kind: "knowledge",
-    label: chat.usePersistentRag === false ? "Knowledge Off" : "Knowledge On",
-  });
-  return chips;
-}
-
-function messageHasPendingApproval(message: NativeChatMessage): boolean {
-  return (message.toolActivities ?? []).some((activity) => {
-    const status = activity.approvalStatus?.toLowerCase() ?? "";
-    return status.includes("approval") && !status.includes("approved");
-  });
-}
-
-function createRecentChatStatus(
-  targetDocument: Document,
-  sessionKey: string,
-  chips: RecentChatStatusChip[],
-): HTMLElement | null {
-  if (!chips.length) {
-    return null;
-  }
-  const status = targetDocument.createElement("span");
-  status.className = "desktop-sidebar-row-status";
-  status.setAttribute("aria-label", "Chat status");
-  status.setAttribute("data-desktop-chat-status", sessionKey);
-  for (const chip of chips) {
-    const pill = targetDocument.createElement("span");
-    pill.className = "desktop-sidebar-status-chip";
-    pill.setAttribute("data-status-kind", chip.kind);
-    pill.textContent = chip.label;
-    status.append(pill);
-  }
-  return status;
+function recentChatRowsForChat(targetDocument: Document, chat: DesktopNativeChatModel): SidebarRecentChatRow[] {
+  const pinnedSessionKeys = pinnedSessionKeysForDocument(targetDocument);
+  return sortPinnedSessionsFirst(chat.sessions, pinnedSessionKeys).map((session) => recentChatRowModel(
+    session,
+    session.key === chat.activeSessionKey,
+    pinnedSessionKeys.has(session.key),
+  ));
 }
 
 function mountSidebarRecentChatsVueIsland(
@@ -1083,7 +1030,6 @@ function mountSidebarRecentChatsVueIsland(
     pinned: boolean;
     routeId: string;
     sessionKey: string;
-    statusChips?: RecentChatStatusChip[];
     title: string;
     updatedLabel: string;
   }>,
@@ -1118,7 +1064,6 @@ function createRecentChatRow(
   chatActions: DesktopNativeChatActionOptions,
   routeId = desktopChatRouteId(session),
   pinned = false,
-  statusChips: RecentChatStatusChip[] = [],
 ): HTMLElement {
   const row = targetDocument.createElement("div");
   row.className = "desktop-sidebar-chat-row";
@@ -1153,10 +1098,6 @@ function createRecentChatRow(
   time.className = "desktop-sidebar-row-meta";
   time.textContent = updatedLabel;
   link.append(titleWrap, time);
-  const status = createRecentChatStatus(targetDocument, session.key, statusChips);
-  if (status) {
-    link.append(status);
-  }
 
   const deleteButton = targetDocument.createElement("button");
   deleteButton.type = "button";
@@ -1194,7 +1135,6 @@ function createRecentChatRow(
     pinned,
     routeId,
     sessionKey: session.key,
-    statusChips,
     title,
     updatedLabel,
   });
@@ -1207,11 +1147,10 @@ function mountRecentChatRowVueIsland(
     active: boolean;
     chatId: string;
     href: string;
-    onDeleteSession?: (event: { chatId: string; sessionKey: string; title: string }) => void;
+    onDeleteSession?: (event: { chatId: string; sessionKey: string; title: string }) => unknown | Promise<unknown>;
     pinned: boolean;
     routeId: string;
     sessionKey: string;
-    statusChips?: RecentChatStatusChip[];
     title: string;
     updatedLabel: string;
   },
@@ -1534,6 +1473,13 @@ function createChatHeader(
   if (headerStatus) {
     titleGroup.append(headerStatus);
   }
+  const sidebarControl = createHeaderPanelControl(targetDocument, {
+    panel: "sidebar",
+    visible: layout.sidebar.visible,
+    label: "Sidebar",
+    pressedLabel: "Collapse session list",
+    unpressedLabel: "Expand session list",
+  });
 
   const menu = targetDocument.createElement("button");
   menu.type = "button";
@@ -1557,7 +1503,7 @@ function createChatHeader(
     closeChatMenuPopover(menu, popover);
   });
 
-  titleRow.append(titleGroup, menu, popover);
+  titleRow.append(sidebarControl, titleGroup, menu, popover);
 
   const actions = targetDocument.createElement("div");
   actions.className = "desktop-chat-header-actions";
@@ -1577,15 +1523,12 @@ function createChatHeader(
       unpressedLabel: "Open Activity inspector",
     }),
   );
+  const inspectorControl = actions.querySelector<HTMLElement>('[data-desktop-panel-control="inspector"]');
+  if (inspectorControl) {
+    actions.replaceChildren(inspectorControl);
+  }
 
   mountChatHeaderActionsVueIsland(actions, targetDocument, [
-    {
-      panel: "sidebar",
-      visible: layout.sidebar.visible,
-      label: "Sidebar",
-      pressedLabel: "Collapse session list",
-      unpressedLabel: "Expand session list",
-    },
     {
       panel: "inspector",
       visible: layout.inspector.visible,
@@ -2293,19 +2236,23 @@ function createConversationMessage(
   article.setAttribute("data-message-tone", options.tone);
 
   const content = targetDocument.createElement("div");
-  content.className = "desktop-conversation-content";
-  const header = targetDocument.createElement("div");
-  header.className = "desktop-conversation-header";
-  const meta = targetDocument.createElement("div");
-  meta.className = "desktop-conversation-meta";
-  const separator = createText(targetDocument, "span", " · ");
-  separator.className = "desktop-conversation-meta-separator";
-  separator.textContent = " · ";
-  separator.setAttribute("aria-hidden", "true");
-  meta.append(createText(targetDocument, "strong", options.author), separator, createText(targetDocument, "span", options.time));
-  mountConversationMetaVueIsland(meta, { author: options.author, time: options.time });
-  header.append(meta);
-  content.append(header);
+  content.className = options.tone === "user"
+    ? "desktop-conversation-content desktop-user-message-bubble"
+    : "desktop-conversation-content";
+  if (options.tone === "assistant") {
+    const header = targetDocument.createElement("div");
+    header.className = "desktop-conversation-header";
+    const meta = targetDocument.createElement("div");
+    meta.className = "desktop-conversation-meta";
+    const separator = createText(targetDocument, "span", " · ");
+    separator.className = "desktop-conversation-meta-separator";
+    separator.textContent = " · ";
+    separator.setAttribute("aria-hidden", "true");
+    meta.append(createText(targetDocument, "strong", options.author), separator, createText(targetDocument, "span", options.time));
+    mountConversationMetaVueIsland(meta, { author: options.author, time: options.time });
+    header.append(meta);
+    content.append(header);
+  }
   if (options.reasoningContent?.trim()) {
     content.append(createConversationReasoning(targetDocument, options.reasoningContent));
   }
@@ -2536,7 +2483,7 @@ function createConversationReasoning(targetDocument: Document, reasoningContent:
   details.className = "desktop-message-reasoning";
   const summary = targetDocument.createElement("summary");
   summary.className = "desktop-message-reasoning-summary";
-  summary.append(createText(targetDocument, "span", "Details"));
+  summary.append(createText(targetDocument, "span", "Thinking complete"));
   const body = createText(targetDocument, "div", reasoningContent);
   body.className = "desktop-message-reasoning-body";
   details.append(summary, body);
@@ -2602,85 +2549,64 @@ function createToolActivity(
   targetDocument: Document,
   activity: ConversationToolActivityRenderOptions,
 ): HTMLElement {
-  const details = targetDocument.createElement("details");
-  details.className = "desktop-tool-activity";
-  details.setAttribute("data-desktop-tool-activity-kind", activity.kind);
-  const activityStatus = normalizeToolActivityStatus(activity.status);
-  if (activityStatus) {
-    details.setAttribute("data-desktop-tool-activity-status", activityStatus);
-  }
-  if (isPendingToolApproval(activity.approvalStatus || "")) {
-    details.setAttribute("data-desktop-approval-status", activity.approvalStatus || "");
+  const wrapper = targetDocument.createElement("div");
+  wrapper.className = "desktop-tool-activity";
+  wrapper.setAttribute("data-desktop-tool-activity-kind", activity.kind);
+  const activityStatus = normalizeToolStatusModel(activity);
+  wrapper.setAttribute("data-desktop-tool-activity-status", activityStatus.status);
+  wrapper.setAttribute("data-desktop-tool-status", activityStatus.status);
+  wrapper.setAttribute("data-desktop-tool-status-tone", getToolStatusTone(activityStatus));
+  if (isPendingToolApprovalState(activity)) {
+    wrapper.setAttribute("data-desktop-approval-status", activity.approvalStatus || "");
   }
   if (activity.id) {
-    details.setAttribute("data-desktop-tool-activity-id", activity.id);
+    wrapper.setAttribute("data-desktop-tool-activity-id", activity.id);
   }
   if (activity.runChainItemKey) {
-    details.setAttribute("data-desktop-run-chain-item-key", activity.runChainItemKey);
+    wrapper.setAttribute("data-desktop-run-chain-item-key", activity.runChainItemKey);
   }
 
-  const summary = targetDocument.createElement("summary");
-  summary.className = "desktop-tool-activity-summary";
-  if (activityStatus) {
-    summary.setAttribute("aria-label", `${activity.name || "unknown"} tool ${toolActivityStatusLabel(activityStatus).toLowerCase()}`);
-  }
-  summary.addEventListener("click", () => {
+  const row = targetDocument.createElement("button");
+  row.className = "desktop-tool-activity-row";
+  row.type = "button";
+  row.setAttribute("aria-label", `Open ${activity.name || "unknown"} tool details, ${getToolStatusLabel(activityStatus)}`);
+  row.setAttribute("aria-selected", "false");
+  row.addEventListener("click", () => {
     if (activity.runChainItemKey) {
       inspectRunChainItemFromConversation(targetDocument, activity.runChainItemKey);
       dispatchDesktopCustomEvent(targetDocument, "desktop-run-chain-inspect", { itemKey: activity.runChainItemKey });
     }
+    dispatchDesktopCustomEvent(targetDocument, "desktop-tool-detail-open", {
+      activity,
+      normalizedStatus: activityStatus,
+    });
   });
-  const icon = createText(targetDocument, "span", ">");
-  icon.className = "desktop-tool-activity-icon";
-  icon.setAttribute("aria-hidden", "true");
+  const dot = targetDocument.createElement("span");
+  dot.className = "desktop-tool-activity-status-dot";
+  dot.setAttribute("aria-hidden", "true");
+  dot.setAttribute("data-tool-status-tone", getToolStatusTone(activityStatus));
+  const kind = createText(targetDocument, "span", "Tool");
+  kind.className = "desktop-tool-activity-kind";
+  const separatorOne = createText(targetDocument, "span", "·");
+  separatorOne.className = "desktop-tool-activity-separator";
+  separatorOne.setAttribute("aria-hidden", "true");
   const main = targetDocument.createElement("span");
   main.className = "desktop-tool-activity-main";
   const title = createText(targetDocument, "span", activity.name || "unknown");
   title.className = "desktop-tool-activity-title";
-  const preview = createText(targetDocument, "span", summarizeToolText(activity.argsText || activity.responseText));
-  preview.className = "desktop-tool-activity-preview";
-  main.append(title, preview);
-  const badges = targetDocument.createElement("span");
-  badges.className = "desktop-tool-activity-badges";
-  if (activityStatus) {
-    const status = createText(targetDocument, "span", toolActivityStatusLabel(activityStatus));
-    status.className = `desktop-tool-activity-badge desktop-tool-activity-status-badge desktop-tool-activity-status-${activityStatus}`;
-    badges.append(status);
+  main.append(title);
+  const separatorTwo = createText(targetDocument, "span", "·");
+  separatorTwo.className = "desktop-tool-activity-separator";
+  separatorTwo.setAttribute("aria-hidden", "true");
+  const status = createText(targetDocument, "span", getToolStatusLabel(activityStatus));
+  status.className = "desktop-tool-activity-status-label";
+  status.setAttribute("data-tool-status-tone", getToolStatusTone(activityStatus));
+  row.append(dot, kind, separatorOne, main, separatorTwo, status);
+  wrapper.append(row);
+  if (isPendingToolApprovalState(activity)) {
+    wrapper.append(createToolApprovalCard(targetDocument, activity));
   }
-  if (isPendingToolApproval(activity.approvalStatus || "")) {
-    const approval = createText(targetDocument, "span", "Approval");
-    approval.className = "desktop-tool-activity-badge desktop-tool-activity-pending-approval-badge";
-    badges.append(approval);
-  }
-  if (activity.approvalStatus === "approved") {
-    const approval = createText(targetDocument, "span", "Approved");
-    approval.className = "desktop-tool-activity-badge desktop-tool-activity-approval-badge";
-    badges.append(approval);
-  }
-  const badge = createText(targetDocument, "span", activity.kind === "result" ? "Result" : "Call");
-  badge.className = "desktop-tool-activity-badge";
-  badges.append(badge);
-  summary.append(icon, main, badges);
-  details.append(summary);
-  if (isPendingToolApproval(activity.approvalStatus || "")) {
-    details.append(createToolApprovalCard(targetDocument, activity));
-  }
-
-  const body = targetDocument.createElement("div");
-  body.className = "desktop-tool-activity-body";
-  if (activity.argsText) {
-    body.append(createToolActivitySection(targetDocument, "Arguments", activity.argsText, "call"));
-  }
-  if (activity.responseText) {
-    body.append(createToolActivitySection(targetDocument, "Response", activity.responseText, "response"));
-  }
-  if (!activity.argsText && !activity.responseText) {
-    const empty = createText(targetDocument, "div", "No arguments or response.");
-    empty.className = "desktop-tool-activity-empty";
-    body.append(empty);
-  }
-  details.append(body);
-  mountToolActivityVueIsland(details, {
+  mountToolActivityVueIsland(wrapper, {
     approvalId: activity.approvalId,
     argsText: activity.argsText || "",
     approvalStatus: activity.approvalStatus || "",
@@ -2692,7 +2618,7 @@ function createToolActivity(
     sessionKey: activity.sessionKey,
     status: activity.status,
   });
-  return details;
+  return wrapper;
 }
 
 function createToolApprovalCard(
@@ -2788,102 +2714,12 @@ function mountToolActivityVueIsland(
   mountToolActivityIsland(activity, options);
 }
 
-function isPendingToolApproval(status: string): boolean {
-  const normalized = status.toLowerCase();
-  return normalized.includes("approval") && !normalized.includes("approved");
-}
-
-function normalizeToolActivityStatus(status: string | undefined): string {
-  const normalized = (status || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
-  if (!normalized) {
-    return "";
-  }
-  if (["running", "in_progress", "started", "streaming"].includes(normalized)) {
-    return "running";
-  }
-  if (["pending", "queued", "created", "waiting"].includes(normalized)) {
-    return "pending";
-  }
-  if (["completed", "complete", "success", "succeeded", "done"].includes(normalized)) {
-    return "completed";
-  }
-  if (["failed", "failure", "error", "errored"].includes(normalized)) {
-    return "failed";
-  }
-  if (["blocked", "approval_required", "waiting_approval"].includes(normalized)) {
-    return "blocked";
-  }
-  if (["cancelled", "canceled", "interrupted", "stopped"].includes(normalized)) {
-    return "cancelled";
-  }
-  return normalized;
-}
-
-function toolActivityStatusLabel(status: string): string {
-  const labels: Record<string, string> = {
-    blocked: "Blocked",
-    cancelled: "Cancelled",
-    completed: "Completed",
-    failed: "Failed",
-    pending: "Pending",
-    running: "Running",
-  };
-  return labels[status] || status.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
-}
-
-function createToolActivitySection(
-  targetDocument: Document,
-  label: string,
-  text: string,
-  kind: "call" | "response",
-): HTMLElement {
-  const section = targetDocument.createElement("div");
-  section.className = `desktop-tool-activity-section desktop-tool-activity-section-${kind}`;
-  if (shouldCollapseToolContent(text)) {
-    const details = targetDocument.createElement("details");
-    details.className = "desktop-tool-activity-content-details";
-    const summary = targetDocument.createElement("summary");
-    summary.className = "desktop-tool-activity-content-summary";
-    const labelNode = createText(targetDocument, "span", label);
-    labelNode.className = "desktop-tool-activity-label";
-    const preview = createText(targetDocument, "span", summarizeToolText(text));
-    preview.className = "desktop-tool-activity-content-preview";
-    const pre = createText(targetDocument, "pre", text);
-    pre.className = "desktop-tool-activity-pre";
-    summary.append(labelNode, preview);
-    details.append(summary, pre);
-    section.append(details);
-    return section;
-  }
-  const labelNode = createText(targetDocument, "div", label);
-  labelNode.className = "desktop-tool-activity-label";
-  const pre = createText(targetDocument, "pre", text);
-  pre.className = "desktop-tool-activity-pre";
-  section.append(labelNode, pre);
-  mountToolActivitySectionVueIsland(section, { kind, label, text });
-  return section;
-}
-
-function mountToolActivitySectionVueIsland(
-  section: HTMLElement,
-  options: { kind: "call" | "response"; label: string; text: string },
-): void {
-  if (!canMountVueIsland(section)) {
-    return;
-  }
-  mountToolActivitySectionIsland(section, options);
-}
-
 function summarizeToolText(value: string): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (!normalized) {
     return "No details";
   }
   return normalized.length > 96 ? `${normalized.slice(0, 93)}...` : normalized;
-}
-
-function shouldCollapseToolContent(value: string): boolean {
-  return value.length > 140 || value.split(/\r?\n/).length > 6;
 }
 
 function createConversationBody(
@@ -5630,6 +5466,11 @@ function toggleDesktopPanel(targetDocument: Document, panel: DesktopPanelControl
   const panelElement = targetDocument.querySelector<HTMLElement>(`[data-workbench-region="${panel}"]`);
   const stateAttribute = `data-${panel}-visible`;
   const currentValue = shell?.getAttribute(stateAttribute) ?? panelElement?.getAttribute("data-visible") ?? "true";
+  logDesktopNativeDebug("shell.panel.toggle", {
+    currentVisible: currentValue !== "false",
+    nextVisible: currentValue === "false",
+    panel,
+  });
   setDesktopPanelVisible(targetDocument, panel, currentValue === "false");
 }
 
@@ -5652,6 +5493,10 @@ function setDesktopPanelVisible(targetDocument: Document, panel: DesktopPanelCon
   if (status) {
     status.textContent = `${formatPanelName(panel)} panel ${nextVisible ? "shown" : "hidden"}`;
   }
+  logDesktopNativeDebug("shell.panel.visible", {
+    nextVisible,
+    panel,
+  });
 }
 
 function formatPanelName(panel: DesktopPanelControlId): string {
@@ -7620,7 +7465,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
   style.id = STYLE_ID;
   style.textContent = `
     body.desktop-native-workbench {
-      --desktop-chat-column-width: 840px;
+      --desktop-chat-column-width: clamp(720px, calc(100vw - 240px), 1760px);
+      --desktop-chat-gutter: clamp(16px, 2vw, 36px);
+      --desktop-chat-composer-gutter: clamp(32px, 4vw, 72px);
       margin: 0;
       min-height: 100vh;
       overflow: hidden;
@@ -8745,7 +8592,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-native-composer {
       display: block;
-      width: min(var(--desktop-chat-column-width), calc(100% - 112px));
+      width: min(var(--desktop-chat-column-width), calc(100% - var(--desktop-chat-composer-gutter)));
       min-width: 0;
       margin: 0 auto 10px;
       border: 1px solid var(--border);
@@ -9225,49 +9072,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       font-weight: 400;
     }
 
-    body.desktop-native-workbench .desktop-sidebar-row-status {
-      grid-column: 1 / -1;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 4px;
-      min-width: 0;
-      margin-top: 1px;
-    }
-
-    body.desktop-native-workbench .desktop-sidebar-status-chip {
-      display: inline-flex;
-      align-items: center;
-      min-height: 18px;
-      max-width: 100%;
-      border: 1px solid #eaded8;
-      border-radius: 999px;
-      padding: 0 6px;
-      background: #fffaf5;
-      color: #6f685f;
-      font: 600 10px/1.2 var(--font-sans);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    body.desktop-native-workbench .desktop-sidebar-status-chip[data-status-kind="running"] {
-      border-color: #bfe4c4;
-      background: #effaf0;
-      color: #2f7d3e;
-    }
-
-    body.desktop-native-workbench .desktop-sidebar-status-chip[data-status-kind="approval"] {
-      border-color: #f2c8b8;
-      background: #fff2ec;
-      color: #b4533c;
-    }
-
-    body.desktop-native-workbench .desktop-sidebar-status-chip[data-status-kind="knowledge"] {
-      border-color: #d8dce8;
-      background: #f4f6fb;
-      color: #4e5d7a;
-    }
-
     body.desktop-native-workbench .desktop-workbench-main {
       grid-template-rows: minmax(0, 1fr) auto 0;
       height: 100%;
@@ -9289,7 +9093,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       height: 100%;
       min-height: 0;
       margin: 0;
-      padding: 0 clamp(20px, 3vw, 46px);
+      padding: 0 var(--desktop-chat-gutter);
       overflow: hidden;
       background: #f7f7f5;
     }
@@ -9570,23 +9374,27 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-conversation-content-card,
     body.desktop-native-workbench .desktop-conversation-content {
       display: grid;
-      gap: 8px;
+      gap: 5px;
       width: 100%;
       min-width: 0;
       border: 0;
       border-radius: 0;
-      padding: 4px 0 8px;
+      padding: 2px 0 5px;
       background: transparent;
       color: #1f1d1a;
       font: 14px/1.58 var(--font-sans);
     }
 
     body.desktop-native-workbench .desktop-conversation-message[data-message-tone="assistant"] .desktop-conversation-content {
-      padding: 4px 0 8px;
+      padding: 2px 0 5px;
       line-height: 1.62;
     }
 
     body.desktop-native-workbench .desktop-conversation-content-card .n-card__content {
+      padding: 0;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-content-card .n-card-content {
       padding: 0;
     }
 
@@ -9600,8 +9408,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-conversation-header {
       display: flex;
       align-items: baseline;
-      justify-content: space-between;
-      gap: 12px;
+      justify-content: flex-start;
+      gap: 8px;
       min-width: 0;
       min-height: 20px;
     }
@@ -9681,7 +9489,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-message-reasoning {
       display: grid;
-      justify-items: end;
+      justify-items: start;
       justify-self: stretch;
       width: 100%;
       max-width: 100%;
@@ -9699,7 +9507,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-message-reasoning summary {
-      justify-self: end;
+      justify-self: start;
       list-style: none;
     }
 
@@ -9712,7 +9520,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-items: center;
       gap: 5px;
       width: fit-content;
-      margin-left: auto;
+      margin-left: 0;
       min-height: 22px;
       border-radius: 999px;
       padding: 0 7px;
@@ -9750,7 +9558,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-items: center;
       gap: 5px;
       width: fit-content;
-      margin-left: auto;
+      margin-left: 0;
       min-height: 22px;
       border: 0;
       border-radius: 999px;
@@ -9840,6 +9648,295 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       border-radius: 8px;
       background: #fbfaf7;
       color: #625d57;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      align-items: start;
+      gap: 18px;
+      min-width: 0;
+      width: 100%;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-layout[data-tool-detail-visible="true"] {
+      grid-template-columns: minmax(0, 1fr) minmax(300px, var(--desktop-tool-detail-width, 50%));
+    }
+
+    body.desktop-native-workbench .desktop-conversation-timeline {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+      width: 100%;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-message {
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-message[data-message-tone="user"] {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    body.desktop-native-workbench .desktop-conversation-message[data-message-tone="user"] .desktop-user-message-bubble {
+      box-sizing: border-box;
+      width: fit-content;
+      max-width: min(100%, var(--desktop-chat-column-width));
+      border: 0;
+      border-radius: 16px;
+      padding: 10px 13px;
+      background: var(--desktop-user-message-bg, #fff1bd);
+      color: var(--text-strong, #262522);
+    }
+
+    body.desktop-native-workbench .desktop-conversation-message[data-message-tone="assistant"] {
+      display: block;
+    }
+
+    body.desktop-native-workbench .desktop-assistant-step-group {
+      min-width: 0;
+      color: #77716a;
+    }
+
+    body.desktop-native-workbench .desktop-assistant-step-group summary::-webkit-details-marker {
+      display: none;
+    }
+
+    body.desktop-native-workbench .desktop-assistant-step-summary {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 28px;
+      border-radius: 7px;
+      padding: 2px 0;
+      color: #77716a;
+      cursor: pointer;
+      font: 500 14px/1.45 var(--font-sans);
+      list-style: none;
+    }
+
+    body.desktop-native-workbench .desktop-assistant-step-summary::after {
+      content: "";
+      width: 7px;
+      height: 7px;
+      border-right: 1.5px solid currentColor;
+      border-bottom: 1.5px solid currentColor;
+      transform: rotate(-45deg);
+      transition: transform 160ms ease;
+    }
+
+    body.desktop-native-workbench .desktop-assistant-step-group[open] .desktop-assistant-step-summary::after {
+      transform: rotate(45deg);
+    }
+
+    body.desktop-native-workbench .desktop-assistant-step-summary-count,
+    body.desktop-native-workbench .desktop-assistant-step-summary-time {
+      color: #918b84;
+    }
+
+    body.desktop-native-workbench .desktop-assistant-step-list {
+      display: grid;
+      gap: 6px;
+      margin: 5px 0 2px;
+      padding-left: 16px;
+      border-left: 1px solid #e3ded7;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity {
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-row {
+      display: inline-grid;
+      grid-template-columns: 10px auto auto minmax(0, auto) auto auto;
+      align-items: center;
+      gap: 6px;
+      max-width: 100%;
+      min-height: 28px;
+      border: 1px solid transparent;
+      border-radius: 7px;
+      padding: 3px 8px;
+      background: transparent;
+      color: #625d57;
+      font: 650 12px/1.35 var(--font-sans);
+      cursor: pointer;
+      text-align: left;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-row:hover,
+    body.desktop-native-workbench .desktop-tool-activity-row:focus-visible,
+    body.desktop-native-workbench .desktop-tool-activity-row[aria-selected="true"] {
+      border-color: var(--border, #e6dfd8);
+      background: var(--panel-strong, #faf9f5);
+      outline: none;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: #9c9891;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-status-dot[data-tool-status-tone="running"] {
+      background: #2f77b4;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-status-dot[data-tool-status-tone="success"] {
+      background: #3b8a4d;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-status-dot[data-tool-status-tone="error"] {
+      background: #b94735;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-status-dot[data-tool-status-tone="denied"] {
+      background: #c88022;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-kind,
+    body.desktop-native-workbench .desktop-tool-activity-separator,
+    body.desktop-native-workbench .desktop-tool-activity-status-label {
+      color: #7a746d;
+      white-space: nowrap;
+    }
+
+    body.desktop-native-workbench .desktop-tool-activity-title {
+      color: #3f3a35;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-panel {
+      position: sticky;
+      top: 0;
+      display: grid;
+      grid-template-rows: auto auto auto minmax(0, 1fr);
+      min-width: 300px;
+      max-height: calc(100vh - 190px);
+      overflow: hidden;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 10px;
+      background: var(--panel, #fffdf9);
+      box-shadow: 0 18px 44px rgba(31, 29, 26, 0.12);
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-resizer {
+      position: absolute;
+      inset: 0 auto 0 -6px;
+      width: 10px;
+      cursor: col-resize;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-header,
+    body.desktop-native-workbench .desktop-tool-detail-status,
+    body.desktop-native-workbench .desktop-tool-detail-approval-actions {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--border, #e6dfd8);
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-header {
+      justify-content: space-between;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-eyebrow {
+      color: #7a746d;
+      font: 700 10px/1.2 var(--font-sans);
+      text-transform: uppercase;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-title {
+      margin: 0;
+      color: #262522;
+      font: 700 15px/1.25 var(--font-mono);
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-close {
+      display: grid;
+      place-items: center;
+      width: 28px;
+      height: 28px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      background: transparent;
+      color: #625d57;
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-body {
+      display: grid;
+      gap: 12px;
+      min-height: 0;
+      overflow: auto;
+      padding: 14px;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-meta {
+      display: grid;
+      grid-template-columns: max-content minmax(0, 1fr);
+      gap: 5px 10px;
+      margin: 0;
+      font-size: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-meta dt {
+      color: #7a746d;
+      font-weight: 700;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-meta dd {
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      color: #3f3a35;
+      font-family: var(--font-mono);
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-section {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-section h4 {
+      margin: 0;
+      color: #625d57;
+      font: 800 11px/1.2 var(--font-sans);
+      text-transform: uppercase;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-pre {
+      max-height: 280px;
+      margin: 0;
+      overflow: auto;
+      border-radius: 8px;
+      padding: 10px;
+      background: var(--surface-dark-soft, #1f1e1b);
+      color: var(--on-dark, #faf9f5);
+      font: 12px/1.5 var(--font-mono);
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-panel[data-tool-detail-mode="overlay"] {
+      position: fixed;
+      z-index: 40;
+      top: 72px;
+      right: 18px;
+      bottom: 92px;
+      width: min(520px, calc(100vw - 36px));
+      max-height: none;
+    }
+
+    body.desktop-native-workbench .desktop-tool-detail-panel[data-tool-detail-mode="overlay"] .desktop-tool-detail-resizer {
+      display: none;
     }
 
     body.desktop-native-workbench .desktop-tool-activity summary {
@@ -10326,7 +10423,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-native-composer {
       position: relative;
-      width: min(var(--desktop-chat-column-width), calc(100% - 112px));
+      width: min(var(--desktop-chat-column-width), calc(100% - var(--desktop-chat-composer-gutter)));
       min-height: 0;
       margin: 0 auto 8px;
       border-color: #ddd5cd;

--- a/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
@@ -192,11 +192,14 @@ describe("desktop workbench shell Vue integration", () => {
     });
 
     const shell = document.getElementById("desktop-workbench-shell");
+    const titleRow = document.querySelector<HTMLElement>(".desktop-chat-title-row");
     const actions = document.querySelector<HTMLElement>(".desktop-chat-header-actions");
-    const sidebar = actions?.querySelector<HTMLButtonElement>('[data-desktop-panel-control="sidebar"]');
+    const sidebar = titleRow?.querySelector<HTMLButtonElement>('[data-desktop-panel-control="sidebar"]');
     const inspector = actions?.querySelector<HTMLButtonElement>('[data-desktop-panel-control="inspector"]');
 
     expect(actions?.getAttribute("data-desktop-vue-island")).toBe("chat-header-actions");
+    expect(actions?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
+    expect(titleRow?.children[0]?.getAttribute("data-desktop-panel-control")).toBe("sidebar");
     expect(sidebar?.getAttribute("aria-label")).toBe("Collapse session list");
     expect(sidebar?.getAttribute("aria-pressed")).toBe("true");
     expect(inspector?.getAttribute("aria-label")).toBe("Open Activity inspector");
@@ -372,6 +375,48 @@ describe("desktop workbench shell Vue integration", () => {
     expect(recent?.querySelector(".desktop-sidebar-section-heading h2")?.textContent).toBe("Recent chats");
     expect(recent?.querySelector(".desktop-recent-chat-list")?.getAttribute("role")).toBe("list");
     expect(recent?.querySelector('[data-desktop-chat-id="Design native workbench"]')?.textContent).toContain("Design native workbench");
+  });
+
+  test("updates mounted sidebar recent chats when native chat sessions refresh", async () => {
+    document.body.replaceChildren();
+    document.head.replaceChildren();
+
+    installDesktopWorkbenchShell({
+      targetDocument: document,
+      layout: createDefaultWorkbenchLayout(),
+      chat: {
+        activeChatId: "chat-1",
+        activeSessionKey: "WebSocket:chat-1",
+        messages: [],
+        sessions: [
+          { chatId: "chat-1", createdAt: "", key: "WebSocket:chat-1", title: "Session one", updatedAt: "2026-06-07T08:11:00.000Z" },
+          { chatId: "chat-2", createdAt: "", key: "WebSocket:chat-2", title: "Session two", updatedAt: "2026-06-07T08:12:00.000Z" },
+        ],
+      },
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+    await nextTick();
+
+    expect(Array.from(document.querySelectorAll(".desktop-sidebar-chat-row")).map((row) => row.getAttribute("data-desktop-session-key"))).toEqual([
+      "WebSocket:chat-1",
+      "WebSocket:chat-2",
+    ]);
+
+    updateDesktopNativeChat(document, {
+      activeChatId: "chat-1",
+      activeSessionKey: "WebSocket:chat-1",
+      messages: [],
+      sessions: [
+        { chatId: "chat-1", createdAt: "", key: "WebSocket:chat-1", title: "Session one updated", updatedAt: "2026-06-07T08:13:00.000Z" },
+      ],
+    });
+    await nextTick();
+
+    expect(Array.from(document.querySelectorAll(".desktop-sidebar-chat-row")).map((row) => row.getAttribute("data-desktop-session-key"))).toEqual([
+      "WebSocket:chat-1",
+    ]);
+    expect(document.body.textContent).toContain("Session one updated");
+    expect(document.body.textContent).not.toContain("Session two");
   });
 
   test("renders an empty conversation thread through the Vue shell island", () => {

--- a/apps/desktop/src/gatewayHttpClient.ts
+++ b/apps/desktop/src/gatewayHttpClient.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_GATEWAY_CONFIG, type GatewayConfig } from "./gatewayConfig";
+import { logDesktopNativeDebug } from "./desktopNativeChatDebug";
 
 type FetchFn = typeof fetch;
 
@@ -259,18 +260,34 @@ async function bootstrapGateway(
 > {
   const controller = new AbortController();
   const timeout = globalThis.setTimeout(() => controller.abort(), config.requestTimeoutMs);
+  logDesktopNativeDebug("gateway.bootstrap.start", {
+    httpBaseUrl: config.httpBaseUrl,
+    timeoutMs: config.requestTimeoutMs,
+  });
   try {
     const response = await fetchFn(`${config.httpBaseUrl}/webui/bootstrap`, {
       signal: controller.signal,
     });
     if (!response.ok) {
+      logDesktopNativeDebug("gateway.bootstrap.error", {
+        status: response.status,
+      });
       return { ok: false, error: `HTTP ${response.status}` };
     }
     const payload = await response.json();
     const token = typeof payload.token === "string" ? payload.token : "";
     if (!token) {
+      logDesktopNativeDebug("gateway.bootstrap.error", {
+        error: "missing token",
+      });
       return { ok: false, error: "bootstrap response missing token" };
     }
+    logDesktopNativeDebug("gateway.bootstrap.complete", {
+      refreshTokenPath: typeof payload.refresh_token_path === "string" ? payload.refresh_token_path : "/webui/refresh-token",
+      tokenReady: true,
+      tokenTtlS: typeof payload.token_ttl_s === "number" ? payload.token_ttl_s : 300,
+      wsPath: typeof payload.ws_path === "string" ? payload.ws_path : "/ws",
+    });
     return {
       ok: true,
       session: {
@@ -282,6 +299,9 @@ async function bootstrapGateway(
       },
     };
   } catch (error) {
+    logDesktopNativeDebug("gateway.bootstrap.error", {
+      error: stringifyError(error),
+    });
     return { ok: false, error: stringifyError(error) };
   } finally {
     globalThis.clearTimeout(timeout);
@@ -289,6 +309,11 @@ async function bootstrapGateway(
 }
 
 async function requestJson(config: GatewayConfig, fetchFn: FetchFn, path: string, init?: RequestInit): Promise<unknown> {
+  const method = init?.method ?? "GET";
+  logDesktopNativeDebug("gateway.http.request", {
+    method,
+    path,
+  });
   const response = await fetchFn(`${config.httpBaseUrl}${path}`, {
     headers: {
       Accept: "application/json",
@@ -297,9 +322,20 @@ async function requestJson(config: GatewayConfig, fetchFn: FetchFn, path: string
     ...init,
   });
   if (!response.ok) {
+    logDesktopNativeDebug("gateway.http.error", {
+      method,
+      path,
+      status: response.status,
+    });
     throw new Error(`Gateway request failed: HTTP ${response.status}`);
   }
-  return response.json();
+  const payload = await response.json();
+  logDesktopNativeDebug("gateway.http.response", {
+    method,
+    path,
+    status: response.status,
+  });
+  return payload;
 }
 
 function authenticatedWsUrl(config: GatewayConfig, session: BootstrapSession): string {

--- a/apps/desktop/src/native-vue/conversationAttachmentIsland.ts
+++ b/apps/desktop/src/native-vue/conversationAttachmentIsland.ts
@@ -39,7 +39,10 @@ function createConversationAttachmentApp(options: ConversationAttachmentIslandOp
 }
 
 export function renderConversationAttachmentNode(options: ConversationAttachmentIslandOptions) {
-  return h("div", { class: "desktop-conversation-attachment" }, renderConversationAttachmentChildren(options));
+  return h("div", {
+    class: "desktop-conversation-attachment",
+    "data-desktop-vue-island": "conversation-attachment",
+  }, renderConversationAttachmentChildren(options));
 }
 
 export function renderConversationAttachmentChildren(options: ConversationAttachmentIslandOptions) {

--- a/apps/desktop/src/native-vue/conversationMessageIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationMessageIsland.test.ts
@@ -38,20 +38,17 @@ describe("conversation message Vue island", () => {
     expect(host.className).toBe("desktop-conversation-message");
     expect(host.getAttribute("data-message-tone")).toBe("assistant");
     expect(host.querySelector(".n-card.desktop-conversation-content-card")).not.toBeNull();
-    expect(host.querySelector(".desktop-conversation-meta")?.getAttribute("data-desktop-vue-island")).toBe("conversation-meta");
+    expect(host.querySelector(".desktop-conversation-meta")).toBeNull();
     expect(host.querySelector(".desktop-conversation-body")?.getAttribute("data-desktop-vue-island")).toBe("conversation-body");
     expect(host.querySelector(".desktop-conversation-reference")?.getAttribute("data-desktop-vue-island")).toBe("conversation-reference");
     expect(host.querySelector(".desktop-conversation-attachment")?.getAttribute("data-desktop-vue-island")).toBe("conversation-attachment");
     expect(host.querySelector(".desktop-tool-activities")?.getAttribute("data-desktop-chat-region")).toBe("tool-timeline");
     expect(host.querySelector(".desktop-tool-activities")?.getAttribute("aria-label")).toBe("Tool Timeline");
     expect(host.querySelector(".desktop-tool-activity")?.textContent).toContain("read_file");
-    expect(host.querySelector(".desktop-conversation-meta strong")?.textContent).toBe("Tinybot");
-    expect(host.querySelector(".desktop-conversation-meta-separator")?.textContent).toBe(" · ");
-    const metaSpans = Array.from(host.querySelectorAll(".desktop-conversation-meta span"));
-    expect(metaSpans[metaSpans.length - 1]?.textContent).toBe("10:28 AM");
+    expect(host.textContent).not.toContain("Tinybot");
     expect(host.querySelectorAll(".desktop-message-reasoning-summary")).toHaveLength(0);
     const reasoningToggle = host.querySelector<HTMLButtonElement>(".desktop-message-reasoning-toggle");
-    expect(reasoningToggle?.textContent).toBe("Details");
+    expect(reasoningToggle?.textContent).toBe("Thinking complete");
     expect(reasoningToggle?.getAttribute("aria-expanded")).toBe("false");
     expect(host.querySelector(".desktop-message-reasoning-body")).toBeNull();
     reasoningToggle?.click();
@@ -84,10 +81,52 @@ describe("conversation message Vue island", () => {
     });
     await nextTick();
 
+    expect(host.getAttribute("data-message-tone")).toBe("user");
+    expect(host.querySelector(".desktop-conversation-meta")).toBeNull();
+    expect(host.querySelector(".desktop-user-message-bubble")).not.toBeNull();
     expect(Array.from(host.querySelectorAll(".desktop-conversation-body p")).map((paragraph) => paragraph.textContent)).toEqual([
       "First",
       "Second",
     ]);
+  });
+
+  test("shows streaming thinking until assistant body begins, then preserves manual expansion", async () => {
+    const host = document.createElement("article");
+    const mounted = mountConversationMessageIsland(host, {
+      author: "Tinybot",
+      body: [],
+      references: [],
+      reasoningContent: "Thinking out loud",
+      time: "10:31 AM",
+      tone: "assistant",
+    });
+    await nextTick();
+
+    const streamingToggle = host.querySelector<HTMLButtonElement>(".desktop-message-reasoning-toggle");
+    expect(streamingToggle?.textContent).toBe("Thinking");
+    expect(streamingToggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(host.querySelector(".desktop-message-reasoning-body")?.textContent).toContain("Thinking out loud");
+
+    mounted.unmount();
+    mountConversationMessageIsland(host, {
+      author: "Tinybot",
+      body: ["Now answering"],
+      references: [],
+      reasoningContent: "Thinking out loud",
+      time: "10:31 AM",
+      tone: "assistant",
+    });
+    await nextTick();
+
+    const collapsedToggle = host.querySelector<HTMLButtonElement>(".desktop-message-reasoning-toggle");
+    expect(collapsedToggle?.textContent).toBe("Thinking complete");
+    expect(collapsedToggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(host.querySelector(".desktop-message-reasoning-body")).toBeNull();
+
+    collapsedToggle?.click();
+    await nextTick();
+    expect(collapsedToggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(host.querySelector(".desktop-message-reasoning-body")?.textContent).toContain("Thinking out loud");
   });
 
   test("renders a message-level copy action for assistant responses", async () => {
@@ -115,5 +154,50 @@ describe("conversation message Vue island", () => {
     expect(writeText).toHaveBeenCalledWith("First paragraph\n\nSecond paragraph");
     expect(copy?.getAttribute("aria-label")).toBe("Copied");
     expect(copy?.querySelector(".desktop-message-copy-icon")).not.toBeNull();
+  });
+
+  test("omits copy chrome for assistant intermediate steps without answer text", async () => {
+    const host = document.createElement("article");
+
+    mountConversationMessageIsland(host, {
+      author: "Tinybot",
+      body: [],
+      references: [],
+      time: "10:31 AM",
+      tone: "assistant",
+      toolActivities: [{
+        argsText: "{\"path\":\".\"}",
+        approvalStatus: "",
+        id: "tool-list",
+        kind: "call",
+        name: "list_dir",
+        responseText: "",
+        status: "pending",
+      }],
+    });
+    await nextTick();
+
+    expect(host.querySelector(".desktop-tool-activity-title")?.textContent).toBe("list_dir");
+    expect(host.querySelector(".desktop-message-actions")).toBeNull();
+    expect(host.querySelector(".desktop-message-copy-button")).toBeNull();
+  });
+
+  test("omits copy chrome when an assistant message is not copyable", async () => {
+    const host = document.createElement("article");
+
+    mountConversationMessageIsland(host, {
+      author: "Tinybot",
+      body: ["Intermediate update with text."],
+      copyable: false,
+      references: [{ detail: "workspace", kind: "File", title: "." }],
+      time: "10:31 AM",
+      tone: "assistant",
+    });
+    await nextTick();
+
+    expect(host.textContent).toContain("Intermediate update with text.");
+    expect(host.querySelector(".desktop-conversation-reference")?.textContent).toContain("File: .");
+    expect(host.querySelector(".desktop-message-actions")).toBeNull();
+    expect(host.querySelector(".desktop-message-copy-button")).toBeNull();
   });
 });

--- a/apps/desktop/src/native-vue/conversationMessageIsland.ts
+++ b/apps/desktop/src/native-vue/conversationMessageIsland.ts
@@ -1,17 +1,17 @@
-import { createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, type App } from "vue";
+import { computed, createApp, defineComponent, h, ref, type App, type PropType } from "vue";
 import { NCard, NConfigProvider } from "naive-ui";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
-import { mountConversationAttachmentIsland, renderConversationAttachmentNode } from "./conversationAttachmentIsland";
-import { mountConversationBodyIsland, renderConversationBodyNode } from "./conversationBodyIsland";
-import { mountConversationMetaIsland, renderConversationMetaNode } from "./conversationMetaIsland";
+import { renderConversationAttachmentNode } from "./conversationAttachmentIsland";
+import { renderConversationBodyNode } from "./conversationBodyIsland";
 import type { ConversationReferenceIslandOptions } from "./conversationReferenceIsland";
-import { mountToolActivitiesIsland, renderToolActivitiesNode } from "./toolActivitiesIsland";
+import { renderToolActivitiesNode } from "./toolActivitiesIsland";
 import type { ToolActivityIslandOptions } from "./toolActivityIsland";
 
 export interface ConversationMessageIslandOptions {
   attachment?: string;
   author: string;
   body: string[];
+  copyable?: boolean;
   references: ConversationReferenceIslandOptions[];
   reasoningContent?: string;
   time: string;
@@ -45,102 +45,85 @@ function createConversationMessageApp(options: ConversationMessageIslandOptions)
   return createApp(defineComponent({
     name: "ConversationMessageIsland",
     setup() {
-      const attachmentHost = ref<HTMLElement | null>(null);
-      const bodyHost = ref<HTMLElement | null>(null);
-      const metaHost = ref<HTMLElement | null>(null);
-      const toolActivitiesHost = ref<HTMLElement | null>(null);
-      const mountedChildren: Array<{ unmount: () => void }> = [];
-      const copyLabel = ref("Copy");
-      const reasoningExpanded = ref(false);
-      const hasReasoning = Boolean(options.reasoningContent?.trim());
-      const copyMessage = (event: MouseEvent): void => {
-        const button = event.currentTarget instanceof HTMLButtonElement ? event.currentTarget : null;
-        const copyAttempt = writeClipboard(conversationCopyText(options), document);
-        copyLabel.value = "Copied";
-        if (button) {
-          button.setAttribute("aria-label", "Copied");
-          button.setAttribute("title", "Copied");
-        }
-        void copyAttempt
-          .catch(() => {
-            copyLabel.value = "Failed";
-            if (button) {
-              button.setAttribute("aria-label", "Failed");
-              button.setAttribute("title", "Failed");
-            }
-          });
-      };
-
-      onMounted(() => {
-        mountChild(mountedChildren, metaHost.value, (host) => mountConversationMetaIsland(host, {
-          author: options.author,
-          time: options.time,
-        }));
-        if (options.toolActivities?.length) {
-          mountChild(mountedChildren, toolActivitiesHost.value, (host) => mountToolActivitiesIsland(host, {
-            activities: options.toolActivities!,
-          }));
-        }
-        mountChild(mountedChildren, bodyHost.value, (host) => mountConversationBodyIsland(host, {
-          body: options.body,
-          tone: options.tone,
-        }));
-        if (options.attachment) {
-          mountChild(mountedChildren, attachmentHost.value, (host) => mountConversationAttachmentIsland(host, {
-            name: options.attachment!,
-            sizeLabel: "1.2 MB",
-          }));
-        }
-      });
-
-      onBeforeUnmount(() => {
-        while (mountedChildren.length) {
-          mountedChildren.pop()?.unmount();
-        }
-      });
-
-      return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => h(NCard, {
-          class: "desktop-conversation-content-card",
-          size: "small",
-          bordered: false,
-        }, {
-          default: () => h("div", { class: "desktop-conversation-content" }, [
-            h("div", { class: "desktop-conversation-header" }, [
-              h("div", { ref: metaHost, class: "desktop-conversation-meta" }),
-              hasReasoning
-                ? renderReasoningToggle(reasoningExpanded.value, () => {
-                  reasoningExpanded.value = !reasoningExpanded.value;
-                })
-                : null,
-            ]),
-            hasReasoning && reasoningExpanded.value
-              ? renderReasoningPanel(options.reasoningContent!)
-              : null,
-            options.toolActivities?.length
-              ? h("div", {
-                ref: toolActivitiesHost,
-                "aria-label": "Tool Timeline",
-                class: "desktop-tool-activities",
-                "data-desktop-chat-region": "tool-timeline",
-              })
-              : null,
-            h("div", { ref: bodyHost, class: "desktop-conversation-body" }),
-            ...renderReferenceGroups(options.references),
-            options.attachment
-              ? h("div", { ref: attachmentHost, class: "desktop-conversation-attachment" })
-              : null,
-            options.tone === "assistant"
-              ? h("div", { class: "desktop-message-actions" }, [
-                renderCopyButton(copyLabel.value === "Copy" ? "Copy message" : copyLabel.value, copyMessage),
-              ])
-              : null,
-          ]),
-        }),
-      });
+      return () => h(ConversationMessageContent, { options });
     },
   }));
 }
+
+const ConversationMessageContent = defineComponent({
+  name: "ConversationMessageContent",
+  props: {
+    options: {
+      required: true,
+      type: Object as PropType<ConversationMessageIslandOptions>,
+    },
+  },
+  setup(props) {
+    const copyLabel = ref("Copy");
+    const manualReasoningExpanded = ref<boolean | null>(null);
+    const hasReasoning = computed(() => Boolean(props.options.reasoningContent?.trim()));
+    const hasBody = computed(() => props.options.body.some((line) => line.trim()));
+    const canCopy = computed(() => props.options.copyable !== false && hasBody.value);
+    const reasoningExpanded = computed(() => {
+      if (!hasReasoning.value) {
+        return false;
+      }
+      return manualReasoningExpanded.value ?? !hasBody.value;
+    });
+    const copyMessage = (event: MouseEvent): void => {
+      const button = event.currentTarget instanceof HTMLButtonElement ? event.currentTarget : null;
+      const copyAttempt = writeClipboard(conversationCopyText(props.options), document);
+      copyLabel.value = "Copied";
+      if (button) {
+        button.setAttribute("aria-label", "Copied");
+        button.setAttribute("title", "Copied");
+      }
+      void copyAttempt
+        .catch(() => {
+          copyLabel.value = "Failed";
+          if (button) {
+            button.setAttribute("aria-label", "Failed");
+            button.setAttribute("title", "Failed");
+          }
+        });
+    };
+    const toggleReasoning = () => {
+      manualReasoningExpanded.value = !reasoningExpanded.value;
+    };
+
+    return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
+      default: () => props.options.tone === "user"
+        ? renderUserMessage(props.options)
+        : h(NCard, {
+          bordered: false,
+          class: "desktop-conversation-content-card",
+          size: "small",
+        }, {
+          default: () => h("div", { class: "desktop-conversation-content" }, [
+            hasReasoning.value
+              ? h("div", { class: "desktop-conversation-header" }, [
+                renderReasoningToggle(
+                  reasoningExpanded.value,
+                  hasBody.value ? "Thinking complete" : "Thinking",
+                  toggleReasoning,
+                ),
+              ])
+              : null,
+            hasReasoning.value && reasoningExpanded.value
+              ? renderReasoningPanel(props.options.reasoningContent!)
+              : null,
+            props.options.toolActivities?.length ? renderToolActivitiesNode({ activities: props.options.toolActivities }) : null,
+            renderConversationBodyNode({ body: props.options.body, tone: props.options.tone }),
+            ...renderReferenceGroups(props.options.references),
+            props.options.attachment ? renderConversationAttachmentNode({ name: props.options.attachment, sizeLabel: "1.2 MB" }) : null,
+            canCopy.value ? h("div", { class: "desktop-message-actions" }, [
+              renderCopyButton(copyLabel.value === "Copy" ? "Copy message" : copyLabel.value, copyMessage),
+            ]) : null,
+          ]),
+        }),
+    });
+  },
+});
 
 export function renderConversationMessageNode(options: ConversationMessageIslandOptions) {
   return h("article", {
@@ -151,34 +134,26 @@ export function renderConversationMessageNode(options: ConversationMessageIsland
 }
 
 export function renderConversationMessageChildren(options: ConversationMessageIslandOptions) {
-  return h("div", { class: "desktop-conversation-content" }, [
-    h("div", { class: "desktop-conversation-header" }, [
-      renderConversationMetaNode({ author: options.author, time: options.time }),
-      options.reasoningContent?.trim() ? renderReasoningToggle(false, () => {}) : null,
-    ]),
-    options.toolActivities?.length ? renderToolActivitiesNode({ activities: options.toolActivities }) : null,
+  return h(ConversationMessageContent, { options });
+}
+
+function renderUserMessage(options: ConversationMessageIslandOptions) {
+  return h("div", { class: "desktop-conversation-content desktop-user-message-bubble" }, [
     renderConversationBodyNode({ body: options.body, tone: options.tone }),
     ...renderReferenceGroups(options.references),
     options.attachment ? renderConversationAttachmentNode({ name: options.attachment, sizeLabel: "1.2 MB" }) : null,
-    options.tone === "assistant"
-      ? h("div", { class: "desktop-message-actions" }, [
-        renderCopyButton("Copy message", () => {
-          void writeClipboard(conversationCopyText(options), document);
-        }),
-      ])
-      : null,
   ]);
 }
 
-function renderReasoningToggle(expanded: boolean, onClick: (event: MouseEvent) => void) {
+function renderReasoningToggle(expanded: boolean, label: string, onClick: (event: MouseEvent) => void) {
   return h("button", {
     "aria-expanded": String(expanded),
-    "aria-label": expanded ? "Hide details" : "Show details",
+    "aria-label": expanded ? "Hide thinking" : "Show thinking",
     class: "desktop-message-reasoning-toggle",
     onClick,
-    title: expanded ? "Hide details" : "Show details",
+    title: expanded ? "Hide thinking" : "Show thinking",
     type: "button",
-  }, "Details");
+  }, label);
 }
 
 function renderReasoningPanel(content: string) {
@@ -188,17 +163,6 @@ function renderReasoningPanel(content: string) {
   }, [
     h("div", { class: "desktop-message-reasoning-body" }, content),
   ]);
-}
-
-function mountChild<T extends { unmount: () => void }>(
-  mountedChildren: Array<{ unmount: () => void }>,
-  host: HTMLElement | null,
-  mount: (host: HTMLElement) => T,
-): void {
-  if (!host) {
-    return;
-  }
-  mountedChildren.push(mount(host));
 }
 
 function renderReferenceGroups(references: ConversationReferenceIslandOptions[]) {

--- a/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
@@ -42,10 +42,7 @@ describe("conversation thread Vue island", () => {
       "conversation-message",
       "conversation-message",
     ]);
-    expect(Array.from(host.querySelectorAll(".desktop-conversation-meta strong")).map((author) => author.textContent)).toEqual([
-      "You",
-      "Tinybot",
-    ]);
+    expect(host.querySelector(".desktop-conversation-meta strong")).toBeNull();
     expect(host.querySelector(".desktop-conversation-reference")?.textContent).toBe("File: README.md");
 
     mounted.unmount();
@@ -171,5 +168,213 @@ describe("conversation thread Vue island", () => {
 
     expect(host.textContent).toContain("first chunk second chunk");
     expect(host.querySelectorAll(".desktop-conversation-message")[1]).toBe(firstAssistant);
+  });
+
+  test("collapses completed assistant intermediate steps behind the final answer", async () => {
+    const host = document.createElement("section");
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [
+        {
+          author: "You",
+          body: ["List the workspace"],
+          references: [],
+          time: "10:30 AM",
+          tone: "user",
+          toolActivities: [],
+        },
+        {
+          author: "Tinybot",
+          body: [],
+          reasoningContent: "I should inspect the workspace.",
+          references: [],
+          time: "10:30 AM",
+          tone: "assistant",
+          toolActivities: [],
+        },
+        {
+          author: "Tinybot",
+          body: ["I found a few top-level entries and will inspect them."],
+          references: [],
+          time: "10:31 AM",
+          tone: "assistant",
+          toolActivities: [{
+            approvalStatus: "",
+            argsText: "{\"path\":\".\"}",
+            id: "tool-list",
+            kind: "call",
+            name: "list_dir",
+            responseText: "workspace files",
+            status: "completed",
+          }],
+        },
+        {
+          author: "Tinybot",
+          body: ["The workspace contains `apps`, `tinybot`, and `tests`."],
+          references: [{ detail: "workspace", kind: "File", title: "." }],
+          time: "10:32 AM",
+          tone: "assistant",
+          toolActivities: [],
+        },
+      ],
+    });
+    await nextTick();
+    await nextTick();
+
+    const summaries = host.querySelectorAll(".desktop-assistant-step-summary");
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.textContent).toContain("Processed");
+    expect(summaries[0]?.textContent).toContain("2 steps");
+    expect(host.textContent).toContain("The workspace contains");
+    expect(host.querySelector(".desktop-conversation-reference")?.textContent).toContain("File: .");
+    expect(host.querySelectorAll(".desktop-conversation-meta strong")).toHaveLength(0);
+
+    const details = host.querySelector<HTMLDetailsElement>(".desktop-assistant-step-group");
+    expect(details?.open).toBe(false);
+    expect(details?.textContent).toContain("I should inspect the workspace.");
+    expect(details?.textContent).toContain("I found a few top-level entries");
+    expect(details?.textContent).toContain("list_dir");
+    details!.open = true;
+    details?.dispatchEvent(new Event("toggle"));
+    await nextTick();
+
+    expect(host.textContent).toContain("I should inspect the workspace.");
+    expect(host.textContent).toContain("list_dir");
+    expect(host.querySelectorAll(".desktop-message-copy-button")).toHaveLength(1);
+    expect(host.querySelector(".desktop-assistant-step-group .desktop-message-copy-button")).toBeNull();
+  });
+
+  test("keeps active assistant work visible until a final answer exists", async () => {
+    const host = document.createElement("section");
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [
+        {
+          author: "You",
+          body: ["List the workspace"],
+          references: [],
+          time: "10:30 AM",
+          tone: "user",
+          toolActivities: [],
+        },
+        {
+          author: "Tinybot",
+          body: [],
+          reasoningContent: "I am checking files.",
+          references: [],
+          time: "10:31 AM",
+          tone: "assistant",
+          toolActivities: [{
+            approvalStatus: "",
+            argsText: "{\"path\":\".\"}",
+            id: "tool-active",
+            kind: "call",
+            name: "list_dir",
+            responseText: "",
+            status: "pending",
+          }],
+        },
+      ],
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(host.querySelector(".desktop-assistant-step-summary")).toBeNull();
+    expect(host.textContent).toContain("I am checking files.");
+    expect(host.textContent).toContain("list_dir");
+  });
+
+  test("opens one resizable tool detail panel and switches selected tool rows", async () => {
+    const host = document.createElement("section");
+    const approvals: unknown[] = [];
+    host.addEventListener("desktop-tool-approval-action", (event) => {
+      approvals.push((event as CustomEvent).detail);
+    });
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [
+        {
+          author: "Tinybot",
+          body: ["I used tools."],
+          references: [],
+          time: "10:31 AM",
+          tone: "assistant",
+          toolActivities: [
+            {
+              approvalId: "approval-1",
+              approvalStatus: "approval_required",
+              argsText: "{\"path\":\"README.md\"}",
+              id: "tool-read",
+              kind: "call",
+              name: "read_file",
+              responseText: "{\"ok\":true}",
+              runChainItemKey: "assistant-1:tool-read",
+              sessionKey: "WebSocket:chat-1",
+              status: "blocked",
+            },
+            {
+              approvalStatus: "",
+              argsText: "{\"command\":\"npm test\"}",
+              id: "tool-shell",
+              kind: "result",
+              name: "shell_exec",
+              responseText: "failed",
+              status: "failed",
+            },
+          ],
+        },
+      ],
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(host.querySelector(".desktop-tool-detail-panel")).toBeNull();
+    expect(host.querySelector(".desktop-conversation-layout")?.getAttribute("data-tool-detail-visible")).toBe("false");
+    expect(host.querySelector<HTMLElement>(".desktop-conversation-layout")?.style.getPropertyValue("--desktop-tool-detail-width")).toBe("");
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-tool-activity-id="tool-read"] .desktop-tool-activity-row')?.click();
+    await nextTick();
+
+    const panel = host.querySelector<HTMLElement>(".desktop-tool-detail-panel");
+    expect(host.querySelector(".desktop-conversation-layout")?.getAttribute("data-tool-detail-visible")).toBe("true");
+    expect(host.querySelector<HTMLElement>(".desktop-conversation-layout")?.style.getPropertyValue("--desktop-tool-detail-width")).toBe("50%");
+    expect(panel?.getAttribute("aria-label")).toBe("Tool call details");
+    expect(panel?.getAttribute("data-tool-detail-mode")).toBe("push");
+    expect(panel?.textContent).toContain("read_file");
+    expect(panel?.textContent).toContain("Pending approval");
+    expect(panel?.textContent).toContain("\"path\": \"README.md\"");
+    expect(panel?.textContent).toContain("\"ok\": true");
+    expect(panel?.textContent).toContain("approval-1");
+    expect(panel?.textContent).toContain("WebSocket:chat-1");
+    expect(panel?.textContent).toContain("No stderr available");
+    expect(panel?.textContent).toContain("Duration unavailable");
+    expect(host.querySelector('[data-desktop-tool-activity-id="tool-read"] .desktop-tool-activity-row')?.getAttribute("aria-selected")).toBe("true");
+    expect(host.querySelectorAll(".desktop-tool-detail-panel")).toHaveLength(1);
+
+    panel?.querySelector<HTMLButtonElement>('[data-desktop-approval-action="approveOnce"]')?.click();
+    panel?.querySelector<HTMLButtonElement>('[data-desktop-approval-action="approveSession"]')?.click();
+    panel?.querySelector<HTMLButtonElement>('[data-desktop-approval-action="deny"]')?.click();
+    expect(approvals).toEqual([
+      { action: "approveOnce", approvalId: "approval-1", runChainItemKey: "assistant-1:tool-read", sessionKey: "WebSocket:chat-1", toolActivityId: "tool-read", toolName: "read_file" },
+      { action: "approveSession", approvalId: "approval-1", runChainItemKey: "assistant-1:tool-read", sessionKey: "WebSocket:chat-1", toolActivityId: "tool-read", toolName: "read_file" },
+      { action: "deny", approvalId: "approval-1", runChainItemKey: "assistant-1:tool-read", sessionKey: "WebSocket:chat-1", toolActivityId: "tool-read", toolName: "read_file" },
+    ]);
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-tool-activity-id="tool-shell"] .desktop-tool-activity-row')?.click();
+    await nextTick();
+    expect(host.querySelector(".desktop-tool-detail-panel")?.textContent).toContain("shell_exec");
+    expect(host.querySelector(".desktop-tool-detail-panel")?.textContent).not.toContain("approval-1");
+    expect(host.querySelector('[data-desktop-tool-activity-id="tool-read"] .desktop-tool-activity-row')?.getAttribute("aria-selected")).toBe("false");
+    expect(host.querySelector('[data-desktop-tool-activity-id="tool-shell"] .desktop-tool-activity-row')?.getAttribute("aria-selected")).toBe("true");
+    expect(host.querySelectorAll(".desktop-tool-detail-panel")).toHaveLength(1);
+
+    host.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+    await nextTick();
+    expect(host.querySelector(".desktop-tool-detail-panel")).toBeNull();
+    expect(host.querySelector(".desktop-conversation-layout")?.getAttribute("data-tool-detail-visible")).toBe("false");
+    expect(host.querySelector<HTMLElement>(".desktop-conversation-layout")?.style.getPropertyValue("--desktop-tool-detail-width")).toBe("");
   });
 });

--- a/apps/desktop/src/native-vue/conversationThreadIsland.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.ts
@@ -1,10 +1,18 @@
-import { createApp, defineComponent, h, ref, type App, type Ref } from "vue";
+import { computed, createApp, defineComponent, h, onBeforeUnmount, ref, type App, type Ref, type VNode } from "vue";
 import { NConfigProvider, NEmpty } from "naive-ui";
 import type { AgentUiForm } from "../agentUiEvents";
-import { logDesktopNativeChatDebug, summarizeDebugText } from "../desktopNativeChatDebug";
+import { logDesktopNativeChatDebug, logDesktopNativeDebug, summarizeDebugText } from "../desktopNativeChatDebug";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 import { renderAgentUiFormCardChildren } from "./agentUiFormCardIsland";
 import { renderConversationMessageChildren, type ConversationMessageIslandOptions } from "./conversationMessageIsland";
+import {
+  formatMaybeJson,
+  getToolStatusLabel,
+  getToolStatusTone,
+  isPendingToolApproval,
+  normalizeToolStatus,
+} from "./toolActivityStatus";
+import type { ToolActivityIslandOptions } from "./toolActivityIsland";
 
 export interface ConversationThreadIslandOptions {
   emptyMessage: string;
@@ -55,7 +63,7 @@ export function mountConversationThreadIsland(
 ): MountedConversationThreadIsland {
   applyHostContract(host);
   const state = ref(options);
-  const app = createConversationThreadApp(state);
+  const app = createConversationThreadApp(state, host);
   app.mount(host);
   return {
     update: (nextOptions) => {
@@ -70,28 +78,184 @@ export function mountConversationThreadIsland(
   };
 }
 
-function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>): App {
+function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>, host: HTMLElement): App {
   return createApp(defineComponent({
     name: "ConversationThreadIsland",
     setup() {
+      const selectedToolKey = ref("");
+      const panelWidth = ref(50);
+      const overlayMode = ref(isToolDetailOverlayMode());
+      const selectedTool = computed(() => selectedToolKey.value ? findToolActivity(state.value.messages, selectedToolKey.value) : null);
+      const closePanel = () => {
+        if (selectedTool.value) {
+          logDesktopNativeDebug("toolDetail.close", summarizeToolActivity(selectedTool.value));
+        }
+        selectedToolKey.value = "";
+      };
+      const openToolDetail = (event: Event) => {
+        const detail = (event as CustomEvent<{ activity?: ToolActivityIslandOptions }>).detail;
+        const activity = detail?.activity;
+        if (!activity) {
+          return;
+        }
+        selectedToolKey.value = toolActivitySelectionKey(activity);
+        logDesktopNativeDebug("toolDetail.open", summarizeToolActivity(activity));
+      };
+      const handleKeydown = (event: KeyboardEvent) => {
+        if (event.key === "Escape" && selectedToolKey.value) {
+          closePanel();
+        }
+      };
+      const updateOverlayMode = () => {
+        overlayMode.value = isToolDetailOverlayMode();
+      };
+      if (typeof window !== "undefined") {
+        window.addEventListener("resize", updateOverlayMode);
+      }
+      host.addEventListener("keydown", handleKeydown);
+      onBeforeUnmount(() => {
+        if (typeof window !== "undefined") {
+          window.removeEventListener("resize", updateOverlayMode);
+        }
+        host.removeEventListener("keydown", handleKeydown);
+      });
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => {
           const nodes = [
-            ...state.value.messages.map((message, index) => h("article", {
-            key: `${message.tone}:${index}`,
-            class: "desktop-conversation-message",
-            "data-desktop-vue-island": "conversation-message",
-            "data-message-tone": message.tone,
-          }, renderConversationMessageChildren(message))),
+            ...renderThreadMessages(state.value.messages, selectedToolKey.value),
             ...(state.value.inlineForms ?? []).map((form) => renderInlineAgentUiForm(state.value, form)),
           ];
           return nodes.length
-            ? nodes
+            ? h("div", {
+              class: "desktop-conversation-layout",
+              "data-tool-detail-visible": String(Boolean(selectedTool.value)),
+              onDesktopToolDetailOpen: openToolDetail,
+              onKeydown: handleKeydown,
+              style: selectedTool.value
+                ? { "--desktop-tool-detail-width": `${panelWidth.value}%` }
+                : undefined,
+              tabindex: "-1",
+            }, [
+              h("div", { class: "desktop-conversation-timeline" }, nodes),
+              selectedTool.value
+                ? renderToolDetailPanel({
+                  activity: selectedTool.value,
+                  mode: overlayMode.value ? "overlay" : "push",
+                  onClose: closePanel,
+                  onResize: (nextWidth) => {
+                    panelWidth.value = clampToolPanelWidth(nextWidth);
+                    logDesktopNativeDebug("toolDetail.resize", {
+                      ...summarizeToolActivity(selectedTool.value),
+                      widthPercent: panelWidth.value,
+                    });
+                  },
+                })
+                : null,
+            ])
             : (state.value.emptyMessage ? h(NEmpty, { description: state.value.emptyMessage }) : null);
         },
       });
     },
   }));
+}
+
+interface AssistantMessageRunItem {
+  index: number;
+  message: ConversationMessageIslandOptions;
+}
+
+function renderThreadMessages(messages: ConversationMessageIslandOptions[], selectedToolKey: string): VNode[] {
+  const nodes: VNode[] = [];
+  let assistantRun: AssistantMessageRunItem[] = [];
+  const flushAssistantRun = () => {
+    nodes.push(...renderAssistantRun(assistantRun, selectedToolKey));
+    assistantRun = [];
+  };
+  messages.forEach((message, index) => {
+    if (message.tone === "assistant") {
+      assistantRun.push({ index, message });
+      return;
+    }
+    flushAssistantRun();
+    nodes.push(renderThreadMessage(message, index, selectedToolKey));
+  });
+  flushAssistantRun();
+  return nodes;
+}
+
+function renderAssistantRun(run: AssistantMessageRunItem[], selectedToolKey: string): VNode[] {
+  if (!run.length) {
+    return [];
+  }
+  const final = run[run.length - 1];
+  const shouldFold = run.length > 1 && hasAssistantFinalAnswer(final.message);
+  if (!shouldFold) {
+    const copyable = run.length === 1 && hasAssistantFinalAnswer(final.message);
+    return run.map((item) => renderThreadMessage(item.message, item.index, selectedToolKey, copyable));
+  }
+  const intermediate = run.slice(0, -1);
+  return [
+    renderAssistantStepGroup(intermediate, selectedToolKey),
+    renderThreadMessage(final.message, final.index, selectedToolKey, true),
+  ];
+}
+
+function renderAssistantStepGroup(items: AssistantMessageRunItem[], selectedToolKey: string) {
+  return h("details", {
+    key: `assistant-steps:${items[0]?.index ?? 0}`,
+    class: "desktop-assistant-step-group",
+    "data-desktop-chat-region": "assistant-intermediate-steps",
+  }, [
+    h("summary", { class: "desktop-assistant-step-summary" }, [
+      h("span", { class: "desktop-assistant-step-summary-label" }, "Processed"),
+      h("span", { class: "desktop-assistant-step-summary-count" }, `${items.length} ${items.length === 1 ? "step" : "steps"}`),
+      h("span", { class: "desktop-assistant-step-summary-time" }, assistantStepTimeRange(items)),
+    ]),
+    h("div", { class: "desktop-assistant-step-list" }, items.map((item) => renderThreadMessage(
+      item.message,
+      item.index,
+      selectedToolKey,
+      false,
+    ))),
+  ]);
+}
+
+function renderThreadMessage(
+  message: ConversationMessageIslandOptions,
+  index: number,
+  selectedToolKey: string,
+  copyable = true,
+) {
+  const toolActivities = (message.toolActivities ?? []).map((activity) => ({
+    ...activity,
+    selected: selectedToolKey === toolActivitySelectionKey(activity),
+  }));
+  return h("article", {
+    key: `${message.tone}:${index}`,
+    class: "desktop-conversation-message",
+    "data-desktop-vue-island": "conversation-message",
+    "data-message-tone": message.tone,
+  }, renderConversationMessageChildren({
+    ...message,
+    copyable,
+    toolActivities,
+  }));
+}
+
+function hasAssistantFinalAnswer(message: ConversationMessageIslandOptions): boolean {
+  return message.tone === "assistant" && message.body.some((line) => line.trim());
+}
+
+function assistantStepTimeRange(items: AssistantMessageRunItem[]): string {
+  const first = items[0]?.message.time ?? "";
+  const last = items[items.length - 1]?.message.time ?? "";
+  if (!first && !last) {
+    return "";
+  }
+  if (!first || first === last) {
+    return first || last;
+  }
+  return `${first} - ${last}`;
 }
 
 function renderInlineAgentUiForm(options: ConversationThreadIslandOptions, form: AgentUiForm) {
@@ -107,6 +271,178 @@ function renderInlineAgentUiForm(options: ConversationThreadIslandOptions, form:
     onCancel: options.onInlineFormCancel,
     onSubmit: options.onInlineFormSubmit,
   }));
+}
+
+function renderToolDetailPanel(options: {
+  activity: ToolActivityIslandOptions;
+  mode: "overlay" | "push";
+  onClose: () => void;
+  onResize: (nextWidth: number) => void;
+}) {
+  const { activity } = options;
+  const status = normalizeToolStatus(activity);
+  const label = getToolStatusLabel(status);
+  const tone = getToolStatusTone(status);
+  return h("aside", {
+    "aria-label": "Tool call details",
+    class: "desktop-tool-detail-panel",
+    "data-tool-detail-mode": options.mode,
+  }, [
+    options.mode === "push"
+      ? h("div", {
+        "aria-label": "Resize tool details",
+        class: "desktop-tool-detail-resizer",
+        onPointerdown: (event: PointerEvent) => startToolDetailResize(event, options.onResize),
+        role: "separator",
+        tabindex: "0",
+      })
+      : null,
+    h("header", { class: "desktop-tool-detail-header" }, [
+      h("div", { class: "desktop-tool-detail-title-group" }, [
+        h("span", { class: "desktop-tool-detail-eyebrow" }, "Tool"),
+        h("h3", { class: "desktop-tool-detail-title" }, activity.name || "unknown"),
+      ]),
+      h("button", {
+        "aria-label": "Close tool details",
+        class: "desktop-tool-detail-close",
+        onClick: options.onClose,
+        type: "button",
+      }, "x"),
+    ]),
+    h("div", { class: "desktop-tool-detail-status" }, [
+      h("span", { class: "desktop-tool-activity-status-dot", "data-tool-status-tone": tone }),
+      h("span", label),
+    ]),
+    isPendingToolApproval(activity)
+      ? h("section", { class: "desktop-tool-detail-approval-actions", "aria-label": "Tool approval actions" }, [
+        renderDetailApprovalButton(activity, "approveOnce", "Approve once"),
+        renderDetailApprovalButton(activity, "approveSession", "Allow session"),
+        renderDetailApprovalButton(activity, "deny", "Deny"),
+      ])
+      : null,
+    h("div", { class: "desktop-tool-detail-body" }, [
+      renderToolDetailMeta(activity),
+      renderToolDetailText("Arguments", activity.argsText, "No arguments available"),
+      renderToolDetailText("Response", activity.responseText, "No response available"),
+      renderToolDetailText("stderr", "", "No stderr available"),
+      renderToolDetailText("Duration", "", "Duration unavailable"),
+    ]),
+  ]);
+}
+
+function renderDetailApprovalButton(
+  activity: ToolActivityIslandOptions,
+  action: "approveOnce" | "approveSession" | "deny",
+  label: string,
+) {
+  return h("button", {
+    class: `desktop-tool-approval-action desktop-tool-approval-action-${action}`,
+    "data-desktop-approval-action": action,
+    onClick: (event: MouseEvent) => dispatchDetailApproval(event, activity, action),
+    type: "button",
+  }, label);
+}
+
+function renderToolDetailMeta(activity: ToolActivityIslandOptions) {
+  const items = [
+    ["approvalId", activity.approvalId || ""],
+    ["approvalStatus", activity.approvalStatus || ""],
+    ["sessionKey", activity.sessionKey || ""],
+    ["kind", activity.kind],
+  ].filter(([, value]) => value);
+  return h("dl", { class: "desktop-tool-detail-meta" }, items.flatMap(([label, value]) => [
+    h("dt", label),
+    h("dd", value),
+  ]));
+}
+
+function renderToolDetailText(label: string, value: string, emptyLabel: string) {
+  const formatted = formatMaybeJson(value);
+  return h("section", { class: "desktop-tool-detail-section" }, [
+    h("h4", label),
+    h("pre", { class: "desktop-tool-detail-pre" }, formatted || emptyLabel),
+  ]);
+}
+
+function dispatchDetailApproval(
+  event: MouseEvent,
+  activity: ToolActivityIslandOptions,
+  action: "approveOnce" | "approveSession" | "deny",
+): void {
+  if (!activity.approvalId) {
+    return;
+  }
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  target.dispatchEvent(new CustomEvent("desktop-tool-approval-action", {
+    bubbles: true,
+    detail: {
+      action,
+      approvalId: activity.approvalId,
+      runChainItemKey: activity.runChainItemKey,
+      sessionKey: activity.sessionKey,
+      toolActivityId: activity.id,
+      toolName: activity.name || "unknown",
+    },
+  }));
+}
+
+function findToolActivity(messages: ConversationMessageIslandOptions[], key: string): ToolActivityIslandOptions | null {
+  for (const message of messages) {
+    const match = (message.toolActivities ?? []).find((activity) => toolActivitySelectionKey(activity) === key);
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+}
+
+function toolActivitySelectionKey(activity: ToolActivityIslandOptions): string {
+  return activity.runChainItemKey || activity.id || `${activity.name}:${activity.kind}`;
+}
+
+function summarizeToolActivity(activity: ToolActivityIslandOptions | null): Record<string, unknown> {
+  return {
+    id: activity?.id ?? "",
+    kind: activity?.kind ?? "",
+    name: activity?.name ?? "",
+    runChainItemKey: activity?.runChainItemKey ?? "",
+    sessionKey: activity?.sessionKey ?? "",
+    status: activity?.status ?? "",
+  };
+}
+
+function isToolDetailOverlayMode(): boolean {
+  return typeof window !== "undefined" ? window.innerWidth < 900 : false;
+}
+
+function clampToolPanelWidth(value: number): number {
+  return Math.min(65, Math.max(34, value));
+}
+
+function startToolDetailResize(event: PointerEvent, onResize: (nextWidth: number) => void): void {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const panel = target.closest(".desktop-tool-detail-panel");
+  const layout = target.closest(".desktop-conversation-layout");
+  if (!(panel instanceof HTMLElement) || !(layout instanceof HTMLElement)) {
+    return;
+  }
+  const layoutRect = layout.getBoundingClientRect();
+  const handlePointerMove = (moveEvent: PointerEvent) => {
+    const widthPx = Math.max(0, layoutRect.right - moveEvent.clientX);
+    onResize((widthPx / Math.max(layoutRect.width, 1)) * 100);
+  };
+  const handlePointerUp = () => {
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", handlePointerUp);
+  };
+  window.addEventListener("pointermove", handlePointerMove);
+  window.addEventListener("pointerup", handlePointerUp, { once: true });
 }
 
 function applyHostContract(host: HTMLElement): void {

--- a/apps/desktop/src/native-vue/recentChatRowIsland.test.ts
+++ b/apps/desktop/src/native-vue/recentChatRowIsland.test.ts
@@ -46,7 +46,7 @@ describe("recent chat row Vue island", () => {
     expect(host.textContent).toBe("");
   });
 
-  test("renders compact work status chips for files, knowledge, approvals, and running state", () => {
+  test("does not render compact work status chips in the session row", () => {
     const host = document.createElement("div");
 
     mountRecentChatRowIsland(host, {
@@ -66,18 +66,11 @@ describe("recent chat row Vue island", () => {
       updatedLabel: "Updated 2m ago",
     });
 
-    const status = host.querySelector(".desktop-sidebar-row-status");
-    expect(status?.getAttribute("aria-label")).toBe("Chat status");
-    expect(status?.getAttribute("data-desktop-chat-status")).toBe("WebSocket:chat-1");
-    expect(Array.from(status?.querySelectorAll(".desktop-sidebar-status-chip") ?? []).map((chip) => ({
-      kind: chip.getAttribute("data-status-kind"),
-      text: chip.textContent,
-    }))).toEqual([
-      { kind: "running", text: "Running" },
-      { kind: "approval", text: "Approval" },
-      { kind: "files", text: "2 files" },
-      { kind: "knowledge", text: "Knowledge On" },
-    ]);
+    expect(host.querySelector(".desktop-sidebar-row-status")).toBeNull();
+    expect(host.querySelector(".desktop-sidebar-status-chip")).toBeNull();
+    expect(host.textContent).not.toContain("Running");
+    expect(host.textContent).not.toContain("Approval");
+    expect(host.textContent).not.toContain("Knowledge On");
   });
 
   test("confirms before invoking delete callback", async () => {

--- a/apps/desktop/src/native-vue/recentChatRowIsland.ts
+++ b/apps/desktop/src/native-vue/recentChatRowIsland.ts
@@ -97,7 +97,6 @@ function createRecentChatRowApp(options: RecentChatRowIslandOptions): App {
             h(NText, { class: "desktop-sidebar-row-meta", depth: 3, tag: "span" }, {
               default: () => options.updatedLabel,
             }),
-            renderStatusChips(options.sessionKey, options.statusChips),
           ]),
           h("button", {
             "aria-label": confirming.value ? `Confirm delete chat ${options.title}` : `Delete chat ${options.title}`,
@@ -113,18 +112,4 @@ function createRecentChatRowApp(options: RecentChatRowIslandOptions): App {
       });
     },
   }));
-}
-
-function renderStatusChips(sessionKey: string, chips: RecentChatStatusChip[] = []) {
-  if (!chips.length) {
-    return null;
-  }
-  return h("span", {
-    "aria-label": "Chat status",
-    class: "desktop-sidebar-row-status",
-    "data-desktop-chat-status": sessionKey,
-  }, chips.map((chip) => h("span", {
-    class: "desktop-sidebar-status-chip",
-    "data-status-kind": chip.kind,
-  }, chip.label)));
 }

--- a/apps/desktop/src/native-vue/sidebarRecentChatsIsland.test.ts
+++ b/apps/desktop/src/native-vue/sidebarRecentChatsIsland.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { nextTick } from "vue";
 import { mountSidebarRecentChatsIsland } from "./sidebarRecentChatsIsland";
 
@@ -50,8 +50,10 @@ describe("sidebar recent chats Vue island", () => {
     expect(rows.map((row) => row.getAttribute("data-pinned"))).toEqual(["true", "false"]);
     expect(rows[0]?.querySelector(".desktop-sidebar-row-label")?.textContent).toBe("Session one");
     expect(rows[0]?.querySelector("[data-desktop-session-pin-icon]")?.textContent).toBe("馃搶");
-    expect(rows[0]?.querySelector(".desktop-sidebar-row-status")?.getAttribute("data-desktop-chat-status")).toBe("WebSocket:chat-1");
-    expect(Array.from(rows[0]?.querySelectorAll(".desktop-sidebar-status-chip") ?? []).map((chip) => chip.textContent)).toEqual(["Running", "Knowledge On"]);
+    expect(rows[0]?.querySelector(".desktop-sidebar-row-status")).toBeNull();
+    expect(rows[0]?.querySelector(".desktop-sidebar-status-chip")).toBeNull();
+    expect(rows[0]?.textContent).not.toContain("Running");
+    expect(rows[0]?.textContent).not.toContain("Knowledge On");
     expect(rows[1]?.querySelector(".desktop-sidebar-row-main")?.getAttribute("href")).toBe("/chat/custom-route");
 
     const deleteButton = rows[1]?.querySelector<HTMLButtonElement>("[data-desktop-chat-delete]");
@@ -64,6 +66,94 @@ describe("sidebar recent chats Vue island", () => {
 
     mounted.unmount();
     expect(host.textContent).toBe("");
+  });
+
+  test("updates mounted recent chat rows after the shell refreshes sessions", async () => {
+    const host = document.createElement("section");
+
+    const mounted = mountSidebarRecentChatsIsland(host, {
+      rows: [
+        {
+          active: true,
+          chatId: "chat-1",
+          href: "/chat/chat-1",
+          pinned: false,
+          routeId: "chat-1",
+          sessionKey: "WebSocket:chat-1",
+          title: "Session one",
+          updatedLabel: "Updated 8:11:21 AM",
+        },
+        {
+          active: false,
+          chatId: "chat-2",
+          href: "/chat/chat-2",
+          pinned: false,
+          routeId: "chat-2",
+          sessionKey: "WebSocket:chat-2",
+          title: "Session two",
+          updatedLabel: "Updated 8:12:00 AM",
+        },
+      ],
+    });
+
+    mounted.update({
+      rows: [
+        {
+          active: true,
+          chatId: "chat-1",
+          href: "/chat/chat-1",
+          pinned: false,
+          routeId: "chat-1",
+          sessionKey: "WebSocket:chat-1",
+          title: "Session one",
+          updatedLabel: "Updated 8:13:00 AM",
+        },
+      ],
+    });
+    await nextTick();
+
+    expect(Array.from(host.querySelectorAll(".desktop-sidebar-chat-row")).map((row) => row.getAttribute("data-desktop-session-key"))).toEqual([
+      "WebSocket:chat-1",
+    ]);
+    expect(host.textContent).not.toContain("Session two");
+    expect(host.textContent).toContain("Updated 8:13:00 AM");
+  });
+
+  test("restores delete affordance when deleting a recent chat fails", async () => {
+    const host = document.createElement("section");
+    const failedDelete = vi.fn(async () => {
+      throw new Error("delete failed");
+    });
+
+    mountSidebarRecentChatsIsland(host, {
+      rows: [
+        {
+          active: false,
+          chatId: "chat-2",
+          href: "/chat/chat-2",
+          pinned: false,
+          routeId: "chat-2",
+          sessionKey: "WebSocket:chat-2",
+          title: "Session two",
+          updatedLabel: "Updated 8:12:00 AM",
+        },
+      ],
+      onDeleteSession: failedDelete,
+    });
+
+    const deleteButton = host.querySelector<HTMLButtonElement>("[data-desktop-chat-delete]");
+    deleteButton?.click();
+    await nextTick();
+    deleteButton?.click();
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+
+    expect(failedDelete).toHaveBeenCalledWith({ chatId: "chat-2", sessionKey: "WebSocket:chat-2", title: "Session two" });
+    expect(deleteButton?.hasAttribute("disabled")).toBe(false);
+    expect(deleteButton?.getAttribute("data-deleting")).toBeNull();
+    expect(deleteButton?.getAttribute("data-confirming")).toBeNull();
+    expect(deleteButton?.textContent).toBe("x");
   });
 
   test("renders empty recent chat state", () => {

--- a/apps/desktop/src/native-vue/sidebarRecentChatsIsland.ts
+++ b/apps/desktop/src/native-vue/sidebarRecentChatsIsland.ts
@@ -1,18 +1,22 @@
-import { createApp, defineComponent, h, ref, type App } from "vue";
+import { createApp, defineComponent, h, ref, type App, type Ref } from "vue";
 import { NConfigProvider, NText } from "naive-ui";
 import type { RecentChatDeleteEvent, RecentChatRowIslandOptions } from "./recentChatRowIsland";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
+import { logDesktopNativeDebug } from "../desktopNativeChatDebug";
 
 export type SidebarRecentChatRow = Omit<RecentChatRowIslandOptions, "onDeleteSession">;
 
 export interface SidebarRecentChatsIslandOptions {
   rows: SidebarRecentChatRow[];
-  onDeleteSession?: (event: RecentChatDeleteEvent) => void;
+  onDeleteSession?: (event: RecentChatDeleteEvent) => unknown | Promise<unknown>;
 }
 
 export interface MountedSidebarRecentChatsIsland {
+  update: (options: SidebarRecentChatsIslandOptions) => void;
   unmount: () => void;
 }
+
+const mountedSidebarRecentChats = new WeakMap<HTMLElement, MountedSidebarRecentChatsIsland>();
 
 export function mountSidebarRecentChatsIsland(
   host: HTMLElement,
@@ -20,22 +24,34 @@ export function mountSidebarRecentChatsIsland(
 ): MountedSidebarRecentChatsIsland {
   host.setAttribute("data-desktop-vue-island", "sidebar-recent-chats");
   host.className = "desktop-sidebar-list-section desktop-sidebar-list-section-recent";
-  const app = createSidebarRecentChatsApp(options);
+  const mounted = mountedSidebarRecentChats.get(host);
+  if (mounted) {
+    mounted.update(options);
+    return mounted;
+  }
+  const state = ref(options);
+  const app = createSidebarRecentChatsApp(state);
   app.mount(host);
-  return {
+  const nextMounted = {
+    update: (nextOptions: SidebarRecentChatsIslandOptions) => {
+      state.value = nextOptions;
+    },
     unmount: () => {
+      mountedSidebarRecentChats.delete(host);
       app.unmount();
       host.replaceChildren();
     },
   };
+  mountedSidebarRecentChats.set(host, nextMounted);
+  return nextMounted;
 }
 
-function createSidebarRecentChatsApp(options: SidebarRecentChatsIslandOptions): App {
+function createSidebarRecentChatsApp(state: Ref<SidebarRecentChatsIslandOptions>): App {
   return createApp(defineComponent({
     name: "SidebarRecentChatsIsland",
     setup() {
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => renderSidebarRecentChatsContent(options),
+        default: () => renderSidebarRecentChatsContent(state.value),
       });
     },
   }));
@@ -74,26 +90,37 @@ function renderRecentChatRow(row: SidebarRecentChatRow, options: SidebarRecentCh
 
 const RecentChatRowComponent = defineComponent<{
   row: SidebarRecentChatRow;
-  onDeleteSession?: (event: RecentChatDeleteEvent) => void;
+  onDeleteSession?: (event: RecentChatDeleteEvent) => unknown | Promise<unknown>;
 }>({
   name: "SidebarRecentChatRow",
   props: ["row", "onDeleteSession"],
   setup(props) {
     const confirming = ref(false);
     const deleting = ref(false);
-    const onDeleteClick = (event: MouseEvent) => {
+    const onDeleteClick = async (event: MouseEvent) => {
       event.preventDefault();
       event.stopPropagation();
       if (!confirming.value) {
         confirming.value = true;
+        logDesktopNativeDebug("recentChat.delete.confirm", summarizeRecentChatRow(props.row));
         return;
       }
       deleting.value = true;
-      props.onDeleteSession?.({
-        chatId: props.row.chatId,
-        sessionKey: props.row.sessionKey,
-        title: props.row.title,
-      });
+      logDesktopNativeDebug("recentChat.delete.request", summarizeRecentChatRow(props.row));
+      try {
+        await Promise.resolve(props.onDeleteSession?.({
+          chatId: props.row.chatId,
+          sessionKey: props.row.sessionKey,
+          title: props.row.title,
+        }));
+        logDesktopNativeDebug("recentChat.delete.complete", summarizeRecentChatRow(props.row));
+      } catch {
+        logDesktopNativeDebug("recentChat.delete.failed", summarizeRecentChatRow(props.row));
+        // The shell reports deletion failures separately; the row only needs to leave its transient state.
+      } finally {
+        deleting.value = false;
+        confirming.value = false;
+      }
     };
 
     return () => h("div", {
@@ -127,7 +154,6 @@ const RecentChatRowComponent = defineComponent<{
             h(NText, { class: "desktop-sidebar-row-meta", depth: 3, tag: "span" }, {
               default: () => props.row.updatedLabel,
             }),
-            renderStatusChips(props.row.sessionKey, props.row.statusChips),
           ]),
       h("button", {
         "aria-label": confirming.value ? `Confirm delete chat ${props.row.title}` : `Delete chat ${props.row.title}`,
@@ -143,16 +169,12 @@ const RecentChatRowComponent = defineComponent<{
   },
 });
 
-function renderStatusChips(sessionKey: string, chips: SidebarRecentChatRow["statusChips"] = []) {
-  if (!chips?.length) {
-    return null;
-  }
-  return h("span", {
-    "aria-label": "Chat status",
-    class: "desktop-sidebar-row-status",
-    "data-desktop-chat-status": sessionKey,
-  }, chips.map((chip) => h("span", {
-    class: "desktop-sidebar-status-chip",
-    "data-status-kind": chip.kind,
-  }, chip.label)));
+function summarizeRecentChatRow(row: SidebarRecentChatRow): Record<string, unknown> {
+  return {
+    active: row.active,
+    chatId: row.chatId,
+    pinned: row.pinned,
+    routeId: row.routeId,
+    sessionKey: row.sessionKey,
+  };
 }

--- a/apps/desktop/src/native-vue/toolActivitiesIsland.test.ts
+++ b/apps/desktop/src/native-vue/toolActivitiesIsland.test.ts
@@ -39,13 +39,16 @@ describe("tool activities Vue island", () => {
       "web_search",
       "web_search",
     ]);
-    expect(Array.from(host.querySelectorAll(".desktop-tool-activity-badge")).map((badge) => badge.textContent)).toEqual([
-      "Approved",
-      "Call",
-      "Result",
+    expect(Array.from(host.querySelectorAll(".desktop-tool-activity-kind")).map((kind) => kind.textContent)).toEqual([
+      "Tool",
+      "Tool",
     ]);
-    expect(host.querySelector('[data-desktop-tool-activity-id="tool-1"] .desktop-tool-activity-section-call .desktop-tool-activity-pre')?.textContent).toBe("{\"query\":\"tinybot\"}");
-    expect(host.querySelector('[data-desktop-tool-activity-id="tool-2"] .desktop-tool-activity-section-response .desktop-tool-activity-pre')?.textContent).toBe("Found docs");
+    expect(Array.from(host.querySelectorAll(".desktop-tool-activity-status-label")).map((status) => status.textContent)).toEqual([
+      "Completed",
+      "Pending",
+    ]);
+    expect(host.textContent).not.toContain("{\"query\":\"tinybot\"}");
+    expect(host.textContent).not.toContain("Found docs");
 
     mounted.unmount();
     expect(host.textContent).toBe("");

--- a/apps/desktop/src/native-vue/toolActivitiesIsland.ts
+++ b/apps/desktop/src/native-vue/toolActivitiesIsland.ts
@@ -54,7 +54,7 @@ function createToolActivitiesApp(options: ToolActivitiesIslandOptions): App {
           size: 8,
           vertical: true,
         }, {
-          default: () => options.activities.map((activity, index) => h("details", {
+          default: () => options.activities.map((activity, index) => h("div", {
             ref: (element) => {
               activityHosts.value[index] = element as HTMLElement | null;
             },

--- a/apps/desktop/src/native-vue/toolActivityIsland.test.ts
+++ b/apps/desktop/src/native-vue/toolActivityIsland.test.ts
@@ -4,8 +4,12 @@ import { describe, expect, test } from "vitest";
 import { mountToolActivityIsland } from "./toolActivityIsland";
 
 describe("tool activity Vue island", () => {
-  test("renders summary badges and call/response sections", () => {
-    const host = document.createElement("details");
+  test("renders a compact clickable status row without inline call and response bodies", () => {
+    const host = document.createElement("div");
+    const opened: unknown[] = [];
+    host.addEventListener("desktop-tool-detail-open", (event) => {
+      opened.push((event as CustomEvent).detail);
+    });
 
     const mounted = mountToolActivityIsland(host, {
       argsText: "{\"query\":\"tinybot\"}",
@@ -14,24 +18,41 @@ describe("tool activity Vue island", () => {
       kind: "call",
       name: "web_search",
       responseText: "Found docs",
+      status: "success",
     });
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("tool-activity");
     expect(host.className).toBe("desktop-tool-activity");
     expect(host.getAttribute("data-desktop-tool-activity-kind")).toBe("call");
     expect(host.getAttribute("data-desktop-tool-activity-id")).toBe("tool-1");
+    expect(host.getAttribute("data-desktop-tool-status")).toBe("completed");
+    expect(host.querySelector(".desktop-tool-activity-row")?.getAttribute("type")).toBe("button");
+    expect(host.querySelector(".desktop-tool-activity-row")?.getAttribute("aria-label")).toBe("Open web_search tool details, Completed");
     expect(host.querySelector(".desktop-tool-activity-title")?.textContent).toBe("web_search");
-    expect(host.querySelector(".desktop-tool-activity-preview")?.textContent).toBe("{\"query\":\"tinybot\"}");
-    expect(Array.from(host.querySelectorAll(".desktop-tool-activity-badge")).map((badge) => badge.textContent)).toEqual(["Approved", "Call"]);
-    expect(host.querySelector(".desktop-tool-activity-section-call .desktop-tool-activity-pre")?.textContent).toBe("{\"query\":\"tinybot\"}");
-    expect(host.querySelector(".desktop-tool-activity-section-response .desktop-tool-activity-pre")?.textContent).toBe("Found docs");
+    expect(host.querySelector(".desktop-tool-activity-kind")?.textContent).toBe("Tool");
+    expect(host.querySelector(".desktop-tool-activity-status-label")?.textContent).toBe("Completed");
+    expect(host.querySelector(".desktop-tool-activity-status-dot")?.getAttribute("data-tool-status-tone")).toBe("success");
+    expect(host.querySelector(".desktop-tool-activity-body")).toBeNull();
+    expect(host.textContent).not.toContain("{\"query\":\"tinybot\"}");
+    expect(host.textContent).not.toContain("Found docs");
+    host.querySelector<HTMLButtonElement>(".desktop-tool-activity-row")?.click();
+    expect(opened).toHaveLength(1);
+    expect(opened[0]).toMatchObject({
+      activity: {
+        argsText: "{\"query\":\"tinybot\"}",
+        id: "tool-1",
+        name: "web_search",
+        responseText: "Found docs",
+        status: "success",
+      },
+    });
 
     mounted.unmount();
     expect(host.textContent).toBe("");
   });
 
-  test("collapses long tool content and dispatches run-chain inspection", () => {
-    const host = document.createElement("details");
+  test("dispatches run-chain inspection when opening a tool row", () => {
+    const host = document.createElement("div");
     const inspected: string[] = [];
     host.addEventListener("desktop-run-chain-inspect", (event) => {
       inspected.push((event as CustomEvent).detail.itemKey);
@@ -48,17 +69,15 @@ describe("tool activity Vue island", () => {
       runChainItemKey: "assistant-1:tool-call:tool-1",
     });
 
-    const nestedDetails = host.querySelector(".desktop-tool-activity-content-details");
     expect(host.getAttribute("data-desktop-run-chain-item-key")).toBe("assistant-1:tool-call:tool-1");
-    expect(nestedDetails?.querySelector(".desktop-tool-activity-content-preview")?.textContent).toContain("tinybot");
-    expect(nestedDetails?.querySelector(".desktop-tool-activity-pre")?.textContent).toBe(longArgs);
+    expect(host.textContent).not.toContain(longArgs);
 
-    host.querySelector<HTMLElement>(".desktop-tool-activity-summary")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    host.querySelector<HTMLButtonElement>(".desktop-tool-activity-row")?.click();
     expect(inspected).toEqual(["assistant-1:tool-call:tool-1"]);
   });
 
   test("renders pending approvals as an inline approval card", () => {
-    const host = document.createElement("details");
+    const host = document.createElement("div");
     const inspected: string[] = [];
     const approvals: unknown[] = [];
     host.addEventListener("desktop-run-chain-inspect", (event) => {
@@ -82,6 +101,9 @@ describe("tool activity Vue island", () => {
 
     const card = host.querySelector(".desktop-tool-approval-card");
     expect(host.getAttribute("data-desktop-approval-status")).toBe("approval_required");
+    expect(host.getAttribute("data-desktop-tool-status")).toBe("blocked");
+    expect(host.querySelector(".desktop-tool-activity-status-label")?.textContent).toBe("Pending approval");
+    expect(host.querySelector(".desktop-tool-activity-status-dot")?.getAttribute("data-tool-status-tone")).toBe("pending");
     expect(card?.getAttribute("role")).toBe("group");
     expect(card?.getAttribute("aria-label")).toBe("Approval required for shell");
     expect(card?.getAttribute("data-desktop-chat-region")).toBe("approval-card");
@@ -109,7 +131,7 @@ describe("tool activity Vue island", () => {
   });
 
   test("renders execution status as a distinct timeline state", () => {
-    const host = document.createElement("details");
+    const host = document.createElement("div");
 
     mountToolActivityIsland(host, {
       argsText: "{\"command\":\"npm test\"}",
@@ -122,13 +144,13 @@ describe("tool activity Vue island", () => {
     });
 
     expect(host.getAttribute("data-desktop-tool-activity-status")).toBe("running");
-    expect(host.querySelector(".desktop-tool-activity-summary")?.getAttribute("aria-label")).toBe("shell tool running");
-    expect(host.querySelector(".desktop-tool-activity-status-badge")?.textContent).toBe("Running");
-    expect(Array.from(host.querySelectorAll(".desktop-tool-activity-badge")).map((badge) => badge.textContent)).toEqual(["Running", "Call"]);
+    expect(host.querySelector(".desktop-tool-activity-row")?.getAttribute("aria-label")).toBe("Open shell tool details, Running");
+    expect(host.querySelector(".desktop-tool-activity-status-label")?.textContent).toBe("Running");
+    expect(host.querySelector(".desktop-tool-activity-status-dot")?.getAttribute("data-tool-status-tone")).toBe("running");
   });
 
   test("renders empty body for activity without details", () => {
-    const host = document.createElement("details");
+    const host = document.createElement("div");
 
     mountToolActivityIsland(host, {
       argsText: "",
@@ -141,8 +163,8 @@ describe("tool activity Vue island", () => {
 
     expect(host.getAttribute("data-desktop-tool-activity-id")).toBeNull();
     expect(host.querySelector(".desktop-tool-activity-title")?.textContent).toBe("unknown");
-    expect(host.querySelector(".desktop-tool-activity-preview")?.textContent).toBe("No details");
-    expect(host.querySelector(".desktop-tool-activity-badge")?.textContent).toBe("Result");
-    expect(host.querySelector(".desktop-tool-activity-empty")?.textContent).toBe("No arguments or response.");
+    expect(host.querySelector(".desktop-tool-activity-kind")?.textContent).toBe("Tool");
+    expect(host.querySelector(".desktop-tool-activity-status-label")?.textContent).toBe("Pending");
+    expect(host.querySelector(".desktop-tool-activity-body")).toBeNull();
   });
 });

--- a/apps/desktop/src/native-vue/toolActivityIsland.ts
+++ b/apps/desktop/src/native-vue/toolActivityIsland.ts
@@ -1,6 +1,13 @@
 import { createApp, defineComponent, h, type App } from "vue";
-import { NConfigProvider, NTag, NText } from "naive-ui";
+import { NConfigProvider, NText } from "naive-ui";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
+import {
+  getToolStatusLabel,
+  getToolStatusTone,
+  isPendingToolApproval,
+  normalizeToolStatus,
+  type NormalizedToolStatus,
+} from "./toolActivityStatus";
 
 export interface ToolActivityIslandOptions {
   approvalId?: string;
@@ -11,6 +18,7 @@ export interface ToolActivityIslandOptions {
   name: string;
   responseText: string;
   runChainItemKey?: string;
+  selected?: boolean;
   sessionKey?: string;
   status?: string;
 }
@@ -36,17 +44,15 @@ export function mountToolActivityIsland(
   } else {
     host.removeAttribute("data-desktop-run-chain-item-key");
   }
-  if (isPendingApproval(options.approvalStatus)) {
+  if (isPendingToolApproval(options)) {
     host.setAttribute("data-desktop-approval-status", options.approvalStatus);
   } else {
     host.removeAttribute("data-desktop-approval-status");
   }
-  const status = normalizeToolActivityStatus(options.status);
-  if (status) {
-    host.setAttribute("data-desktop-tool-activity-status", status);
-  } else {
-    host.removeAttribute("data-desktop-tool-activity-status");
-  }
+  const status = normalizeToolStatus(options);
+  host.setAttribute("data-desktop-tool-activity-status", status.status);
+  host.setAttribute("data-desktop-tool-status", status.status);
+  host.setAttribute("data-desktop-tool-status-tone", getToolStatusTone(status));
   const app = createToolActivityApp(options);
   app.mount(host);
   return {
@@ -79,79 +85,47 @@ export function renderToolActivityNode(options: ToolActivityIslandOptions) {
   if (options.runChainItemKey) {
     attributes["data-desktop-run-chain-item-key"] = options.runChainItemKey;
   }
-  if (isPendingApproval(options.approvalStatus)) {
+  if (isPendingToolApproval(options)) {
     attributes["data-desktop-approval-status"] = options.approvalStatus;
   }
-  const status = normalizeToolActivityStatus(options.status);
-  if (status) {
-    attributes["data-desktop-tool-activity-status"] = status;
-  }
-  return h("details", attributes, renderToolActivityChildren(options));
+  const status = normalizeToolStatus(options);
+  attributes["data-desktop-tool-activity-status"] = status.status;
+  attributes["data-desktop-tool-status"] = status.status;
+  attributes["data-desktop-tool-status-tone"] = getToolStatusTone(status);
+  return h("div", attributes, renderToolActivityChildren(options));
 }
 
 export function renderToolActivityChildren(options: ToolActivityIslandOptions) {
   return [
     renderSummary(options),
-    isPendingApproval(options.approvalStatus) ? renderApprovalCard(options) : null,
-    renderBody(options),
+    isPendingToolApproval(options) ? renderApprovalCard(options) : null,
   ];
 }
 
 function renderSummary(options: ToolActivityIslandOptions) {
-  const status = normalizeToolActivityStatus(options.status);
-  return h("summary", {
-    "aria-label": status ? `${options.name || "unknown"} tool ${statusLabel(status).toLowerCase()}` : undefined,
-    class: "desktop-tool-activity-summary",
-    onClick: (event: MouseEvent) => dispatchRunChainInspect(event, options.runChainItemKey),
+  const status = normalizeToolStatus(options);
+  const label = getToolStatusLabel(status);
+  const tone = getToolStatusTone(status);
+  return h("button", {
+    "aria-label": `Open ${options.name || "unknown"} tool details, ${label}`,
+    "aria-selected": String(Boolean(options.selected)),
+    class: "desktop-tool-activity-row",
+    onClick: (event: MouseEvent) => openToolDetails(event, options, status),
+    type: "button",
   }, [
-    h("span", { "aria-hidden": "true", class: "desktop-tool-activity-icon" }, ">"),
+    h("span", {
+      "aria-hidden": "true",
+      class: "desktop-tool-activity-status-dot",
+      "data-tool-status-tone": tone,
+    }),
+    h("span", { class: "desktop-tool-activity-kind" }, "Tool"),
+    h("span", { class: "desktop-tool-activity-separator", "aria-hidden": "true" }, "·"),
     h("span", { class: "desktop-tool-activity-main" }, [
       h(NText, { class: "desktop-tool-activity-title", tag: "span" }, { default: () => options.name || "unknown" }),
-      h(NText, { class: "desktop-tool-activity-preview", depth: 3, tag: "span" }, {
-        default: () => summarizeToolActivityText(options.argsText || options.responseText),
-      }),
     ]),
-    h("span", { class: "desktop-tool-activity-badges" }, renderBadges(options)),
+    h("span", { class: "desktop-tool-activity-separator", "aria-hidden": "true" }, "·"),
+    h("span", { class: "desktop-tool-activity-status-label", "data-tool-status-tone": tone }, label),
   ]);
-}
-
-function renderBadges(options: ToolActivityIslandOptions) {
-  const status = normalizeToolActivityStatus(options.status);
-  return [
-    status
-      ? h(NTag, {
-        bordered: false,
-        class: `desktop-tool-activity-badge desktop-tool-activity-status-badge desktop-tool-activity-status-${status}`,
-        round: true,
-        size: "small",
-        type: statusTagType(status),
-      }, { default: () => statusLabel(status) })
-      : null,
-    isPendingApproval(options.approvalStatus)
-      ? h(NTag, {
-        bordered: false,
-        class: "desktop-tool-activity-badge desktop-tool-activity-pending-approval-badge",
-        round: true,
-        size: "small",
-        type: "warning",
-      }, { default: () => "Approval" })
-      : null,
-    options.approvalStatus === "approved"
-      ? h(NTag, {
-        bordered: false,
-        class: "desktop-tool-activity-badge desktop-tool-activity-approval-badge",
-        round: true,
-        size: "small",
-        type: "success",
-      }, { default: () => "Approved" })
-      : null,
-    h(NTag, {
-      bordered: false,
-      class: "desktop-tool-activity-badge",
-      round: true,
-      size: "small",
-    }, { default: () => options.kind === "result" ? "Result" : "Call" }),
-  ];
 }
 
 function renderApprovalCard(options: ToolActivityIslandOptions) {
@@ -174,7 +148,7 @@ function renderApprovalActions(options: ToolActivityIslandOptions) {
   const review = h("button", {
     class: "desktop-tool-approval-action desktop-tool-approval-action-review",
     "data-desktop-approval-action": "review",
-    onClick: (event: MouseEvent) => dispatchRunChainInspect(event, options.runChainItemKey),
+    onClick: (event: MouseEvent) => openToolDetails(event, options, normalizeToolStatus(options)),
     type: "button",
   }, options.approvalId ? "Review details" : "Review approval");
   if (!options.approvalId) {
@@ -201,38 +175,6 @@ function renderApprovalActionButton(
   }, label);
 }
 
-function renderBody(options: ToolActivityIslandOptions) {
-  const children = [];
-  if (options.argsText) {
-    children.push(renderSection("Arguments", options.argsText, "call"));
-  }
-  if (options.responseText) {
-    children.push(renderSection("Response", options.responseText, "response"));
-  }
-  if (!children.length) {
-    children.push(h("div", { class: "desktop-tool-activity-empty" }, "No arguments or response."));
-  }
-  return h("div", { class: "desktop-tool-activity-body" }, children);
-}
-
-function renderSection(label: string, text: string, kind: "call" | "response") {
-  if (shouldCollapseToolContent(text)) {
-    return h("div", { class: `desktop-tool-activity-section desktop-tool-activity-section-${kind}` }, [
-      h("details", { class: "desktop-tool-activity-content-details" }, [
-        h("summary", { class: "desktop-tool-activity-content-summary" }, [
-          h(NText, { class: "desktop-tool-activity-label", tag: "span" }, { default: () => label }),
-          h("span", { class: "desktop-tool-activity-content-preview" }, summarizeToolActivityText(text)),
-        ]),
-        h("pre", { class: "desktop-tool-activity-pre" }, text),
-      ]),
-    ]);
-  }
-  return h("div", { class: `desktop-tool-activity-section desktop-tool-activity-section-${kind}` }, [
-    h(NText, { class: "desktop-tool-activity-label", tag: "div" }, { default: () => label }),
-    h("pre", { class: "desktop-tool-activity-pre" }, text),
-  ]);
-}
-
 function summarizeToolActivityText(value: string): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (!normalized) {
@@ -241,67 +183,34 @@ function summarizeToolActivityText(value: string): string {
   return normalized.length > 96 ? `${normalized.slice(0, 93)}...` : normalized;
 }
 
-function shouldCollapseToolContent(value: string): boolean {
-  return value.length > 140 || value.split(/\r?\n/).length > 6;
-}
-
-function isPendingApproval(status: string): boolean {
-  const normalized = status.toLowerCase();
-  return normalized.includes("approval") && !normalized.includes("approved");
-}
-
-function normalizeToolActivityStatus(status: string | undefined): string {
-  const normalized = (status || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
-  if (!normalized) {
-    return "";
+function openToolDetails(
+  event: MouseEvent,
+  options: ToolActivityIslandOptions,
+  status: NormalizedToolStatus,
+): void {
+  dispatchRunChainInspect(event, options.runChainItemKey);
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) {
+    return;
   }
-  if (["running", "in_progress", "started", "streaming"].includes(normalized)) {
-    return "running";
-  }
-  if (["pending", "queued", "created", "waiting"].includes(normalized)) {
-    return "pending";
-  }
-  if (["completed", "complete", "success", "succeeded", "done"].includes(normalized)) {
-    return "completed";
-  }
-  if (["failed", "failure", "error", "errored"].includes(normalized)) {
-    return "failed";
-  }
-  if (["blocked", "approval_required", "waiting_approval"].includes(normalized)) {
-    return "blocked";
-  }
-  if (["cancelled", "canceled", "interrupted", "stopped"].includes(normalized)) {
-    return "cancelled";
-  }
-  return normalized;
-}
-
-function statusLabel(status: string): string {
-  const labels: Record<string, string> = {
-    blocked: "Blocked",
-    cancelled: "Cancelled",
-    completed: "Completed",
-    failed: "Failed",
-    pending: "Pending",
-    running: "Running",
-  };
-  return labels[status] || status.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
-}
-
-function statusTagType(status: string): "default" | "error" | "info" | "success" | "warning" {
-  if (status === "completed") {
-    return "success";
-  }
-  if (status === "failed") {
-    return "error";
-  }
-  if (status === "blocked" || status === "pending") {
-    return "warning";
-  }
-  if (status === "running") {
-    return "info";
-  }
-  return "default";
+  target.dispatchEvent(new CustomEvent("desktop-tool-detail-open", {
+    bubbles: true,
+    detail: {
+      activity: {
+        approvalId: options.approvalId,
+        approvalStatus: options.approvalStatus,
+        argsText: options.argsText,
+        id: options.id,
+        kind: options.kind,
+        name: options.name,
+        responseText: options.responseText,
+        runChainItemKey: options.runChainItemKey,
+        sessionKey: options.sessionKey,
+        status: options.status,
+      },
+      normalizedStatus: status,
+    },
+  }));
 }
 
 function dispatchRunChainInspect(event: MouseEvent, itemKey?: string): void {

--- a/apps/desktop/src/native-vue/toolActivityStatus.test.ts
+++ b/apps/desktop/src/native-vue/toolActivityStatus.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, test } from "vitest";
+import {
+  formatMaybeJson,
+  getToolStatusLabel,
+  getToolStatusTone,
+  isPendingToolApproval,
+  normalizeToolStatus,
+} from "./toolActivityStatus";
+
+describe("tool activity status helpers", () => {
+  test.each([
+    ["approval_required", undefined, "blocked", "Pending approval", "pending"],
+    ["waiting_approval", "running", "blocked", "Pending approval", "pending"],
+    ["approved", "success", "completed", "Completed", "success"],
+    ["denied", "failed", "denied", "Denied", "denied"],
+    [undefined, "cancelled", "cancelled", "Cancelled", "denied"],
+    [undefined, "error", "failed", "Failed", "error"],
+    [undefined, "running", "running", "Running", "running"],
+  ])("normalizes approval=%s status=%s", (approvalStatus, status, normalized, label, tone) => {
+    const result = normalizeToolStatus({ approvalStatus, status });
+
+    expect(result.status).toBe(normalized);
+    expect(getToolStatusLabel(result)).toBe(label);
+    expect(getToolStatusTone(result)).toBe(tone);
+  });
+
+  test("detects pending approvals from either status field", () => {
+    expect(isPendingToolApproval({ approvalStatus: "approval_required" })).toBe(true);
+    expect(isPendingToolApproval({ status: "blocked" })).toBe(true);
+    expect(isPendingToolApproval({ approvalStatus: "approved", status: "completed" })).toBe(false);
+  });
+
+  test("pretty prints JSON while leaving plain text untouched", () => {
+    expect(formatMaybeJson("{\"query\":\"tinybot\",\"limit\":2}")).toBe("{\n  \"query\": \"tinybot\",\n  \"limit\": 2\n}");
+    expect(formatMaybeJson("plain result")).toBe("plain result");
+    expect(formatMaybeJson("")).toBe("");
+  });
+});

--- a/apps/desktop/src/native-vue/toolActivityStatus.ts
+++ b/apps/desktop/src/native-vue/toolActivityStatus.ts
@@ -1,0 +1,113 @@
+export type NormalizedToolStatus = {
+  approvalStatus?: string;
+  pendingApproval: boolean;
+  status: string;
+};
+
+export type ToolStatusTone = "pending" | "running" | "success" | "error" | "denied";
+
+export function normalizeToolStatus(input: { approvalStatus?: string; status?: string }): NormalizedToolStatus {
+  const approvalStatus = normalizeRawStatus(input.approvalStatus);
+  const status = normalizeRawStatus(input.status);
+  if (["denied", "rejected"].includes(approvalStatus)) {
+    return { approvalStatus, pendingApproval: false, status: "denied" };
+  }
+  if (["cancelled", "canceled"].includes(approvalStatus)) {
+    return { approvalStatus, pendingApproval: false, status: "cancelled" };
+  }
+  if (isPendingApprovalValue(approvalStatus) || status === "blocked") {
+    return { approvalStatus, pendingApproval: true, status: "blocked" };
+  }
+  if (status) {
+    return { approvalStatus, pendingApproval: false, status: normalizeExecutionStatus(status) };
+  }
+  if (approvalStatus === "approved") {
+    return { approvalStatus, pendingApproval: false, status: "completed" };
+  }
+  return { approvalStatus, pendingApproval: false, status: "pending" };
+}
+
+export function isPendingToolApproval(input: { approvalStatus?: string; status?: string }): boolean {
+  return normalizeToolStatus(input).pendingApproval;
+}
+
+export function getToolStatusLabel(status: NormalizedToolStatus): string {
+  if (status.pendingApproval) {
+    return "Pending approval";
+  }
+  const labels: Record<string, string> = {
+    blocked: "Pending approval",
+    cancelled: "Cancelled",
+    completed: "Completed",
+    denied: "Denied",
+    failed: "Failed",
+    pending: "Pending",
+    running: "Running",
+  };
+  return labels[status.status] || titleCase(status.status);
+}
+
+export function getToolStatusTone(status: NormalizedToolStatus): ToolStatusTone {
+  if (status.status === "completed") {
+    return "success";
+  }
+  if (status.status === "failed") {
+    return "error";
+  }
+  if (status.status === "running") {
+    return "running";
+  }
+  if (status.status === "denied" || status.status === "cancelled") {
+    return "denied";
+  }
+  return "pending";
+}
+
+export function formatMaybeJson(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeRawStatus(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase().replace(/[\s-]+/g, "_") : "";
+}
+
+function normalizeExecutionStatus(status: string): string {
+  if (["running", "in_progress", "started", "streaming"].includes(status)) {
+    return "running";
+  }
+  if (["completed", "complete", "success", "succeeded", "ok", "done", "approved"].includes(status)) {
+    return "completed";
+  }
+  if (["failed", "failure", "error", "errored"].includes(status)) {
+    return "failed";
+  }
+  if (["denied", "rejected"].includes(status)) {
+    return "denied";
+  }
+  if (["cancelled", "canceled", "interrupted", "stopped"].includes(status)) {
+    return "cancelled";
+  }
+  if (["blocked", "approval_required", "waiting_approval", "pending_approval"].includes(status)) {
+    return "blocked";
+  }
+  if (["pending", "queued", "created", "waiting"].includes(status)) {
+    return "pending";
+  }
+  return status;
+}
+
+function isPendingApprovalValue(status: string): boolean {
+  return ["approval_required", "waiting_approval", "pending_approval"].includes(status);
+}
+
+function titleCase(value: string): string {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/apps/desktop/src/nativeChat.test.ts
+++ b/apps/desktop/src/nativeChat.test.ts
@@ -79,8 +79,6 @@ describe("native chat state", () => {
           },
         ],
         references: [
-          { kind: "tool", title: "read_file", detail: "{\"path\":\"docs/desktop.md\"}" },
-          { kind: "tool", title: "call-read", detail: "file contents" },
           { kind: "browser", title: "Browser snapshot", detail: "https://example.com" },
           { kind: "memory", title: "mem-1", detail: "Remembered setting" },
         ],
@@ -190,6 +188,175 @@ describe("native chat state", () => {
         messageId: "tool-1",
       },
     ]);
+  });
+
+  test("normalizes assistant tool detail metadata without rendering it as assistant text", () => {
+    expect(
+      normalizeMessagesPayload({
+        messages: [
+          {
+            role: "assistant",
+            content: "list_dir(path=\"C:\\\\Users\\\\12921\\\\tinybot\\\\workspace\\\\web-articles\")",
+            _tool_hint: true,
+            _tool_detail: true,
+            _tool_name: "list_dir",
+            timestamp: "2026-05-29T08:00:02Z",
+            message_id: "tool-detail-1",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        role: "assistant",
+        content: "",
+        reasoningContent: "",
+        toolActivities: [
+          {
+            id: "tool-detail-1",
+            name: "list_dir",
+            argsText: "list_dir(path=\"C:\\\\Users\\\\12921\\\\tinybot\\\\workspace\\\\web-articles\")",
+            responseText: "",
+            kind: "call",
+            status: "running",
+          },
+        ],
+        timestamp: "2026-05-29T08:00:02Z",
+        messageId: "tool-detail-1",
+      },
+    ]);
+  });
+
+  test("coalesces persisted tool status messages with the same tool call id", () => {
+    expect(
+      normalizeMessagesPayload({
+        messages: [
+          {
+            role: "assistant",
+            content: "search_memory_notes(query=\"financial banking\")",
+            _tool_hint: true,
+            _tool_detail: true,
+            _tool_call_id: "call-search-memory",
+            _tool_name: "search_memory_notes",
+            status: "running",
+            timestamp: "2026-05-29T08:00:02Z",
+            message_id: "tool-running-1",
+          },
+          {
+            role: "assistant",
+            content: "[{\"summary\":\"User follows AI impact on financial banking.\"}]",
+            _tool_result: true,
+            tool_call_id: "call-search-memory",
+            _tool_name: "search_memory_notes",
+            status: "completed",
+            timestamp: "2026-05-29T08:00:03Z",
+            message_id: "tool-completed-1",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        role: "assistant",
+        content: "",
+        reasoningContent: "",
+        toolActivities: [
+          {
+            id: "call-search-memory",
+            name: "search_memory_notes",
+            argsText: "search_memory_notes(query=\"financial banking\")",
+            responseText: "[{\"summary\":\"User follows AI impact on financial banking.\"}]",
+            kind: "result",
+            status: "completed",
+          },
+        ],
+        timestamp: "2026-05-29T08:00:02Z",
+        messageId: "tool-running-1",
+      },
+    ]);
+  });
+
+  test("routes live tool hint messages into tool activities instead of assistant body text", () => {
+    const state = createNativeChatState();
+    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
+
+    applyChatEvent(state, {
+      kind: "message.completed",
+      chatId: "chat-1",
+      messageId: "tool-detail-1",
+      text: "list_dir(path=\"C:\\\\Users\\\\12921\\\\tinybot\\\\workspace\\\\web-articles\")",
+      raw: {
+        _tool_hint: true,
+        _tool_detail: true,
+        _tool_name: "list_dir",
+      },
+    });
+
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
+      {
+        role: "assistant",
+        content: "",
+        messageId: "tool-detail-1",
+        toolActivities: [
+          {
+            id: "tool-detail-1",
+            name: "list_dir",
+            argsText: "list_dir(path=\"C:\\\\Users\\\\12921\\\\tinybot\\\\workspace\\\\web-articles\")",
+            responseText: "",
+            kind: "call",
+            status: "running",
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("updates live tool activity status instead of appending duplicate tool messages", () => {
+    const state = createNativeChatState();
+    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
+
+    applyChatEvent(state, {
+      kind: "message.completed",
+      chatId: "chat-1",
+      messageId: "tool-running-1",
+      text: "search_memory_notes(query=\"financial banking\")",
+      raw: {
+        _tool_hint: true,
+        _tool_detail: true,
+        _tool_call_id: "call-search-memory",
+        _tool_name: "search_memory_notes",
+        status: "running",
+      },
+    });
+    applyChatEvent(state, {
+      kind: "message.completed",
+      chatId: "chat-1",
+      messageId: "tool-completed-1",
+      text: "[{\"summary\":\"User follows AI impact on financial banking.\"}]",
+      raw: {
+        _tool_result: true,
+        tool_call_id: "call-search-memory",
+        _tool_name: "search_memory_notes",
+        status: "completed",
+      },
+    });
+
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
+      {
+        role: "assistant",
+        content: "",
+        messageId: "tool-running-1",
+        toolActivities: [
+          {
+            id: "call-search-memory",
+            name: "search_memory_notes",
+            argsText: "search_memory_notes(query=\"financial banking\")",
+            responseText: "[{\"summary\":\"User follows AI impact on financial banking.\"}]",
+            kind: "result",
+            status: "completed",
+          },
+        ],
+      },
+    ]);
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toHaveLength(1);
   });
 
   test("normalizes tool activity execution status for timeline rendering", () => {

--- a/apps/desktop/src/nativeChat.ts
+++ b/apps/desktop/src/nativeChat.ts
@@ -32,7 +32,7 @@ export type NativeChatToolActivity = {
 };
 
 export type NativeChatReference = {
-  kind: "tool" | "browser" | "memory" | "reference";
+  kind: "browser" | "memory" | "reference";
   title: string;
   detail: string;
 };
@@ -91,12 +91,13 @@ export function normalizeMessagesPayload(payload: unknown): NativeChatMessage[] 
   if (!isRecord(payload) || !Array.isArray(payload.messages)) {
     return [];
   }
-  return payload.messages.filter(isRecord).map((message) => {
+  const messages = payload.messages.filter(isRecord).map((message) => {
     const references = normalizeMessageReferences(message);
     const toolActivities = normalizeToolActivities(message);
+    const content = stringValue(message.content ?? message.text);
     return {
       role: stringValue(message.role) || "assistant",
-      content: stringValue(message.content ?? message.text),
+      content: shouldSuppressToolActivityContent(message, toolActivities) ? "" : content,
       reasoningContent: stringValue(message.reasoning_content),
       ...(toolActivities.length ? { toolActivities } : {}),
       ...(references.length ? { references } : {}),
@@ -104,6 +105,7 @@ export function normalizeMessagesPayload(payload: unknown): NativeChatMessage[] 
       messageId: stringValue(message.message_id),
     };
   });
+  return coalesceToolActivityMessages(messages);
 }
 
 export function setSessions(state: NativeChatState, sessions: NativeChatSession[]) {
@@ -208,10 +210,23 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
       });
       return;
     }
-    ensureMessageBucket(state, sessionKey).push({
+    const toolMessage = nativeToolMessageFromEvent(event);
+    const bucket = ensureMessageBucket(state, sessionKey);
+    if (toolMessage && upsertToolActivityMessage(bucket, toolMessage)) {
+      state.respondingSessionKeys.delete(sessionKey);
+      state.error = "";
+      logDesktopNativeChatDebug("state.event.after", {
+        event: summarizeChatEvent(event),
+        state: summarizeNativeChatState(state),
+        targetSessionKey: sessionKey,
+      });
+      return;
+    }
+    bucket.push({
       role: "assistant",
-      content: event.text,
+      content: toolMessage ? "" : event.text,
       reasoningContent: "",
+      ...(toolMessage ? { toolActivities: [toolMessage] } : {}),
       timestamp: new Date().toISOString(),
       messageId: event.messageId || "",
     });
@@ -296,6 +311,54 @@ function upsertStreamMessage(
   }
 }
 
+function upsertToolActivityMessage(bucket: NativeChatMessage[], nextActivity: NativeChatToolActivity): boolean {
+  const existingMessage = bucket.find((message) => (
+    Boolean(message.toolActivities?.some((activity) => activity.id === nextActivity.id))
+  ));
+  if (!existingMessage?.toolActivities) {
+    return false;
+  }
+  existingMessage.toolActivities = existingMessage.toolActivities.map((activity) => (
+    activity.id === nextActivity.id ? mergeToolActivity(activity, nextActivity) : activity
+  ));
+  return true;
+}
+
+function coalesceToolActivityMessages(messages: NativeChatMessage[]): NativeChatMessage[] {
+  const coalesced: NativeChatMessage[] = [];
+  for (const message of messages) {
+    const activities = message.toolActivities ?? [];
+    const canCoalesce = message.role === "assistant"
+      && activities.length > 0
+      && !message.content.trim()
+      && !message.reasoningContent.trim()
+      && !message.references?.length;
+    if (canCoalesce) {
+      let merged = false;
+      for (const activity of activities) {
+        merged = upsertToolActivityMessage(coalesced, activity) || merged;
+      }
+      if (merged) {
+        continue;
+      }
+    }
+    coalesced.push(message);
+  }
+  return coalesced;
+}
+
+function mergeToolActivity(
+  current: NativeChatToolActivity,
+  next: NativeChatToolActivity,
+): NativeChatToolActivity {
+  return {
+    ...current,
+    ...next,
+    argsText: next.argsText || current.argsText,
+    responseText: next.responseText || current.responseText,
+  };
+}
+
 function ensureMessageBucket(state: NativeChatState, sessionKey: string): NativeChatMessage[] {
   if (!state.messages.has(sessionKey)) {
     state.messages.set(sessionKey, []);
@@ -325,8 +388,6 @@ function summarizeChatEvent(event: NormalizedGatewayEvent): Record<string, unkno
 
 function normalizeMessageReferences(message: Record<string, unknown>): NativeChatReference[] {
   return [
-    ...toolCallReferenceRows(message.tool_calls),
-    ...toolResultReferenceRows(message.tool_results),
     ...referenceRows(message.browser_references, "browser"),
     ...referenceRows(message.browser_snapshots, "browser"),
     ...referenceRows(message.memory_references, "memory"),
@@ -401,7 +462,54 @@ function normalizeToolActivities(message: Record<string, unknown>): NativeChatTo
     }
   }
 
+  const toolMessage = activities.length ? null : toolActivityFromMessage(message);
+  if (toolMessage) {
+    activities.push(toolMessage);
+  }
+
   return activities;
+}
+
+function nativeToolMessageFromEvent(event: Extract<NormalizedGatewayEvent, { kind: "message.completed" }>): NativeChatToolActivity | null {
+  return toolActivityFromMessage({
+    ...event.raw,
+    content: event.text,
+    message_id: event.messageId,
+  });
+}
+
+function toolActivityFromMessage(message: Record<string, unknown>): NativeChatToolActivity | null {
+  const hasToolMetadata = booleanValue(message._tool_hint)
+    || booleanValue(message._tool_detail)
+    || booleanValue(message._tool_result);
+  const isToolRole = message.role === "tool" || message.role === "progress";
+  if (!hasToolMetadata && !isToolRole) {
+    return null;
+  }
+  const text = textValue(message.content ?? message.text);
+  if (!text) {
+    return null;
+  }
+  const isResult = booleanValue(message._tool_result) || message.role === "tool";
+  const status = normalizeToolActivityStatus(message.status ?? message.state ?? message.phase);
+  return {
+    id: stringValue(message.tool_call_id ?? message._tool_call_id) || stringValue(message.message_id) || (isResult ? "tool-result" : "tool-detail"),
+    name: stringValue(message._tool_name ?? message.name) || inferToolNameFromText(text) || "tool",
+    argsText: isResult ? "" : text,
+    responseText: isResult ? text : "",
+    kind: isResult ? "result" : "call",
+    ...(stringValue(message._approval_id ?? message.approval_id) ? { approvalId: stringValue(message._approval_id ?? message.approval_id) } : {}),
+    ...(stringValue(message._approval_status ?? message.approval_status) ? { approvalStatus: stringValue(message._approval_status ?? message.approval_status) } : {}),
+    ...(status ? { status } : { status: isResult ? "completed" : "running" }),
+  };
+}
+
+function shouldSuppressToolActivityContent(message: Record<string, unknown>, activities: NativeChatToolActivity[]): boolean {
+  return activities.length > 0 && Boolean(
+    booleanValue(message._tool_hint)
+      || booleanValue(message._tool_detail)
+      || booleanValue(message._tool_result),
+  );
 }
 
 function toolCallRows(value: unknown): Array<Pick<NativeChatToolActivity, "id" | "name" | "argsText"> & { approvalId?: string; approvalStatus?: string; status?: string }> {
@@ -459,20 +567,9 @@ function normalizeToolActivityStatus(value: unknown): string {
   return normalized;
 }
 
-function toolCallReferenceRows(value: unknown): NativeChatReference[] {
-  return toolCallRows(value).map((row) => ({
-    kind: "tool",
-    title: row.name || row.id || "tool",
-    detail: row.argsText,
-  }));
-}
-
-function toolResultReferenceRows(value: unknown): NativeChatReference[] {
-  return toolResultRows(value).map((row) => ({
-    kind: "tool",
-    title: row.id || row.name || "tool",
-    detail: row.responseText,
-  }));
+function inferToolNameFromText(value: string): string {
+  const match = value.trim().match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*\(/);
+  return match?.[1] ?? "";
 }
 
 function referenceRows(value: unknown, kind: NativeChatReference["kind"]): NativeChatReference[] {
@@ -517,4 +614,8 @@ function textValue(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function booleanValue(value: unknown): boolean {
+  return value === true || value === "true" || value === 1 || value === "1";
 }


### PR DESCRIPTION
Closes #223

## Summary
- Add structured native desktop logging across bootstrap, gateway, session runtime, workbench actions, tool detail, and recent chat deletion paths.
- Polish the native chat workbench layout: wider dynamic chat column, wider user message bubbles, left-aligned thinking controls, tighter assistant step spacing, and sidebar collapse control next to the chat title.
- Simplify conversation rendering: fold intermediate assistant steps, remove repeated assistant labels, restrict copy to final assistant replies, remove tool calls from References, and coalesce running/completed tool activity updates.
- Clean up recent chat rows by removing session status chips.

## Validation
- `npm test` from `apps/desktop`: 170 files / 602 tests passed.
- `npm run build` from `apps/desktop`: passed with existing Vite chunk/import warnings.
- `git diff --cached --check`: passed.

## Notes
- Native app manual visual verification was not run in this publish pass.