### PR TITLE
Add desktop worker runtime foundation

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,11 @@ use tauri::{
     Emitter, Manager, Runtime, State, WindowEvent,
 };
 
+pub mod worker_protocol;
+pub mod worker_runtime;
+
+use crate::worker_runtime::WorkerRuntimeStatus;
+
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
 
@@ -71,6 +76,7 @@ struct GatewayRuntimeStatus {
     bootstrap_status: String,
     response_class: Option<String>,
     recovery_hint: Option<String>,
+    worker_runtime: WorkerRuntimeStatus,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -280,6 +286,20 @@ const DESKTOP_MENU_ITEM_DESCRIPTORS: &[DesktopMenuItemDescriptor] = &[
 #[tauri::command]
 fn gateway_status(state: State<'_, SharedGateway>) -> GatewayRuntimeStatus {
     current_status(state.inner())
+}
+
+#[tauri::command]
+fn worker_probe_status() -> WorkerRuntimeStatus {
+    WorkerRuntimeStatus::running(
+        crate::worker_protocol::WorkerTransportMode::Stdio,
+        vec![crate::worker_protocol::WorkerDiagnosticLine::new(
+            "stdout",
+            format!(
+                "worker protocol {}",
+                crate::worker_protocol::WORKER_PROTOCOL_VERSION
+            ),
+        )],
+    )
 }
 
 #[tauri::command]
@@ -713,6 +733,7 @@ fn current_status(shared: &SharedGateway) -> GatewayRuntimeStatus {
         bootstrap_status: probe.bootstrap_status(),
         response_class: probe.response_class(),
         recovery_hint: probe.recovery_hint(),
+        worker_runtime: WorkerRuntimeStatus::compatibility_fallback(http_ok),
     }
 }
 
@@ -891,6 +912,7 @@ pub fn run() {
             start_gateway,
             stop_gateway,
             set_gateway_keep_running,
+            worker_probe_status,
             pick_upload_file,
             reveal_workspace_file,
             save_export_file
@@ -994,6 +1016,45 @@ mod tests {
 
         assert_eq!(probe.bootstrap_status(), "bootstrap_error");
         assert_eq!(probe.response_class(), Some("HTTP 403".to_string()));
+    }
+
+    #[test]
+    fn gateway_runtime_status_serializes_worker_runtime_status() {
+        let status = GatewayRuntimeStatus {
+            state: "running".to_string(),
+            owner: "external".to_string(),
+            http_ok: true,
+            gateway_http: "http://127.0.0.1:18790",
+            gateway_ws: "ws://127.0.0.1:18790/ws",
+            command: "uv run tinybot gateway",
+            port: 18790,
+            repo_root: "/repo".to_string(),
+            logs: vec![],
+            last_error: None,
+            exit_policy: "stop_on_exit",
+            bootstrap_status: "ready".to_string(),
+            response_class: Some("tinybot-bootstrap".to_string()),
+            recovery_hint: None,
+            worker_runtime: crate::worker_runtime::WorkerRuntimeStatus::compatibility_fallback(true),
+        };
+
+        let value = serde_json::to_value(status).expect("status should serialize");
+
+        assert_eq!(value["worker_runtime"]["state"], "stopped");
+        assert_eq!(value["worker_runtime"]["gateway_compatibility_available"], true);
+    }
+
+    #[test]
+    fn worker_probe_status_reports_protocol_metadata() {
+        let status = worker_probe_status();
+        let value = serde_json::to_value(status).expect("worker probe status should serialize");
+
+        assert_eq!(value["state"], "running");
+        assert_eq!(value["transport_mode"], "stdio");
+        assert_eq!(
+            value["diagnostics"][0]["line"],
+            format!("worker protocol {}", crate::worker_protocol::WORKER_PROTOCOL_VERSION)
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_protocol.rs
+++ b/apps/desktop/src-tauri/src/worker_protocol.rs
@@ -1,0 +1,200 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::VecDeque;
+
+pub const WORKER_PROTOCOL_VERSION: &str = "2026-06-09";
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerTransportMode {
+    Stdio,
+    LocalPipe,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct WorkerRequest {
+    pub jsonrpc: String,
+    pub id: String,
+    pub method: String,
+    #[serde(default = "empty_json_object")]
+    pub params: Value,
+}
+
+impl WorkerRequest {
+    pub fn new(id: impl Into<String>, method: impl Into<String>, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id: id.into(),
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct WorkerResponse {
+    pub jsonrpc: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<WorkerProtocolError>,
+}
+
+impl WorkerResponse {
+    pub fn success(id: impl Into<String>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id: id.into(),
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn matches_request(&self, request: &WorkerRequest) -> bool {
+        self.id == request.id
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct WorkerNotification {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default = "empty_json_object")]
+    pub params: Value,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerProtocolErrorCode {
+    InvalidProtocol,
+    IncompatibleProtocolVersion,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct WorkerProtocolError {
+    pub code: WorkerProtocolErrorCode,
+    pub message: String,
+}
+
+pub fn validate_protocol_version(version: &str) -> Result<(), WorkerProtocolError> {
+    if version == WORKER_PROTOCOL_VERSION {
+        return Ok(());
+    }
+    Err(WorkerProtocolError {
+        code: WorkerProtocolErrorCode::IncompatibleProtocolVersion,
+        message: format!(
+            "Unsupported worker protocol version '{version}'. Expected '{WORKER_PROTOCOL_VERSION}'."
+        ),
+    })
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WorkerDiagnosticLine {
+    pub stream: String,
+    pub line: String,
+}
+
+impl WorkerDiagnosticLine {
+    pub fn new(stream: impl Into<String>, line: impl Into<String>) -> Self {
+        Self {
+            stream: stream.into(),
+            line: line.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WorkerDiagnostics {
+    capacity: usize,
+    lines: VecDeque<WorkerDiagnosticLine>,
+}
+
+impl WorkerDiagnostics {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            lines: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    pub fn push(&mut self, stream: impl Into<String>, line: impl Into<String>) {
+        if self.capacity == 0 {
+            return;
+        }
+        while self.lines.len() >= self.capacity {
+            self.lines.pop_front();
+        }
+        self.lines
+            .push_back(WorkerDiagnosticLine::new(stream, line));
+    }
+
+    pub fn lines(&self) -> Vec<WorkerDiagnosticLine> {
+        self.lines.iter().cloned().collect()
+    }
+}
+
+fn empty_json_object() -> Value {
+    Value::Object(Default::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn worker_request_response_ids_are_correlated() {
+        let request = WorkerRequest::new(
+            "req-123",
+            "worker.health",
+            json!({ "protocolVersion": WORKER_PROTOCOL_VERSION }),
+        );
+        let response = WorkerResponse::success(&request.id, json!({ "ok": true }));
+
+        assert!(response.matches_request(&request));
+        assert_eq!(response.id, "req-123");
+        assert_eq!(response.result, Some(json!({ "ok": true })));
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn worker_notification_without_id_is_event() {
+        let notification: WorkerNotification = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "worker.progress",
+            "params": { "percent": 42 }
+        }))
+        .expect("notification should parse");
+
+        assert_eq!(notification.method, "worker.progress");
+        assert_eq!(notification.params, json!({ "percent": 42 }));
+    }
+
+    #[test]
+    fn incompatible_protocol_version_returns_protocol_error() {
+        let error = validate_protocol_version("0.9").expect_err("old worker should be rejected");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::IncompatibleProtocolVersion);
+        assert!(error.message.contains(WORKER_PROTOCOL_VERSION));
+    }
+
+    #[test]
+    fn diagnostic_buffer_keeps_recent_lines_only() {
+        let mut diagnostics = WorkerDiagnostics::new(3);
+
+        diagnostics.push("stdout", "one");
+        diagnostics.push("stderr", "two");
+        diagnostics.push("stdout", "three");
+        diagnostics.push("stderr", "four");
+
+        assert_eq!(
+            diagnostics.lines(),
+            vec![
+                WorkerDiagnosticLine::new("stderr", "two"),
+                WorkerDiagnosticLine::new("stdout", "three"),
+                WorkerDiagnosticLine::new("stderr", "four"),
+            ]
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_runtime.rs
+++ b/apps/desktop/src-tauri/src/worker_runtime.rs
@@ -1,0 +1,123 @@
+use crate::worker_protocol::{WorkerDiagnosticLine, WorkerTransportMode};
+use serde::Serialize;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerRuntimeState {
+    Stopped,
+    Starting,
+    Running,
+    Failed,
+    Incompatible,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct WorkerRuntimeStatus {
+    pub state: WorkerRuntimeState,
+    pub transport_mode: Option<WorkerTransportMode>,
+    pub diagnostics: Vec<WorkerDiagnosticLine>,
+    pub last_error: Option<String>,
+    pub recovery_hint: Option<String>,
+    pub gateway_compatibility_available: bool,
+}
+
+impl WorkerRuntimeStatus {
+    pub fn stopped() -> Self {
+        Self {
+            state: WorkerRuntimeState::Stopped,
+            transport_mode: None,
+            diagnostics: Vec::new(),
+            last_error: None,
+            recovery_hint: None,
+            gateway_compatibility_available: false,
+        }
+    }
+
+    pub fn startup_failed(error: impl Into<String>) -> Self {
+        Self {
+            state: WorkerRuntimeState::Failed,
+            transport_mode: None,
+            diagnostics: Vec::new(),
+            last_error: Some(error.into()),
+            recovery_hint: Some(
+                "Managed worker startup failed; keep using the existing gateway compatibility path or retry worker startup."
+                    .to_string(),
+            ),
+            gateway_compatibility_available: false,
+        }
+    }
+
+    pub fn running(
+        transport_mode: WorkerTransportMode,
+        diagnostics: Vec<WorkerDiagnosticLine>,
+    ) -> Self {
+        Self {
+            state: WorkerRuntimeState::Running,
+            transport_mode: Some(transport_mode),
+            diagnostics,
+            last_error: None,
+            recovery_hint: None,
+            gateway_compatibility_available: false,
+        }
+    }
+
+    pub fn compatibility_fallback(gateway_available: bool) -> Self {
+        Self {
+            gateway_compatibility_available: gateway_available,
+            ..Self::stopped()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker_protocol::{WorkerDiagnosticLine, WorkerTransportMode};
+
+    #[test]
+    fn stopped_worker_status_reports_no_transport_or_diagnostics() {
+        let status = WorkerRuntimeStatus::stopped();
+
+        assert_eq!(status.state, WorkerRuntimeState::Stopped);
+        assert_eq!(status.transport_mode, None);
+        assert!(status.diagnostics.is_empty());
+        assert!(status.last_error.is_none());
+    }
+
+    #[test]
+    fn startup_failure_status_includes_error_and_recovery_hint() {
+        let status = WorkerRuntimeStatus::startup_failed("worker executable missing");
+
+        assert_eq!(status.state, WorkerRuntimeState::Failed);
+        assert_eq!(status.last_error.as_deref(), Some("worker executable missing"));
+        assert!(status
+            .recovery_hint
+            .as_deref()
+            .expect("failed worker should expose recovery hint")
+            .contains("existing gateway"));
+    }
+
+    #[test]
+    fn running_worker_status_includes_transport_and_diagnostics() {
+        let status = WorkerRuntimeStatus::running(
+            WorkerTransportMode::Stdio,
+            vec![WorkerDiagnosticLine::new("stdout", "worker ready")],
+        );
+
+        assert_eq!(status.state, WorkerRuntimeState::Running);
+        assert_eq!(status.transport_mode, Some(WorkerTransportMode::Stdio));
+        assert_eq!(
+            status.diagnostics,
+            vec![WorkerDiagnosticLine::new("stdout", "worker ready")]
+        );
+    }
+
+    #[test]
+    fn compatibility_fallback_status_keeps_gateway_available() {
+        let status = WorkerRuntimeStatus::compatibility_fallback(true);
+
+        assert_eq!(status.state, WorkerRuntimeState::Stopped);
+        assert!(status.gateway_compatibility_available);
+        assert!(status.recovery_hint.is_none());
+    }
+}

--- a/apps/desktop/src/desktopGatewayRuntimeControls.test.ts
+++ b/apps/desktop/src/desktopGatewayRuntimeControls.test.ts
@@ -167,4 +167,41 @@ describe("desktop gateway runtime controls", () => {
     ]));
     expect(buildDesktopGatewayRuntimeActions(status).map((action) => action.id)).toContain("retry");
   });
+
+  test("projects worker runtime state and diagnostics without changing gateway actions", () => {
+    const status: GatewayRuntimeStatus = {
+      state: "running",
+      owner: "external",
+      http_ok: true,
+      gateway_http: "http://127.0.0.1:18790",
+      gateway_ws: "ws://127.0.0.1:18790/ws",
+      command: "uv run tinybot gateway",
+      port: 18790,
+      repo_root: "D:/Code/py/tinybot",
+      logs: [],
+      last_error: null,
+      exit_policy: "stop_on_exit",
+      worker_runtime: {
+        state: "running",
+        transport_mode: "stdio",
+        diagnostics: [
+          { stream: "stdout", line: "worker ready" },
+          { stream: "stderr", line: "worker warning" },
+        ],
+        last_error: null,
+        recovery_hint: null,
+        gateway_compatibility_available: true,
+      },
+    };
+
+    expect(buildDesktopGatewayRuntimeRows(status, "http://127.0.0.1:18790")).toEqual(expect.arrayContaining([
+      { label: "Worker", value: "Running via stdio" },
+      { label: "Worker diagnostics", value: "stdout: worker ready\nstderr: worker warning" },
+      { label: "Gateway compatibility", value: "Available" },
+    ]));
+    expect(buildDesktopGatewayRuntimeActions(status).map((action) => action.id)).toEqual([
+      "copyDiagnostics",
+      "openLogs",
+    ]);
+  });
 });

--- a/apps/desktop/src/desktopGatewayRuntimeControls.ts
+++ b/apps/desktop/src/desktopGatewayRuntimeControls.ts
@@ -57,6 +57,7 @@ export function buildDesktopGatewayRuntimeRows(
     { label: "Recent logs", value: logs.length ? logs.join("\n") : "No recent logs" },
     { label: "Last error", value: status?.last_error || "No recent error" },
     ...bootstrapRows(status),
+    ...workerRows(status),
     { label: "Exit policy", value: formatExitPolicy(status?.exit_policy, status?.owner ?? "external") },
   ];
 }
@@ -147,8 +148,36 @@ function bootstrapRows(status: GatewayRuntimeStatus | null): DesktopGatewayRunti
   ];
 }
 
+function workerRows(status: GatewayRuntimeStatus | null): DesktopGatewayRuntimeRow[] {
+  const worker = status?.worker_runtime;
+  if (!worker) {
+    return [];
+  }
+  const diagnostics = (worker.diagnostics ?? []).slice(-4);
+  return [
+    { label: "Worker", value: formatWorkerState(worker.state, worker.transport_mode) },
+    {
+      label: "Worker diagnostics",
+      value: diagnostics.length
+        ? diagnostics.map((line) => `${line.stream}: ${line.line}`).join("\n")
+        : "No worker diagnostics",
+    },
+    { label: "Gateway compatibility", value: worker.gateway_compatibility_available ? "Available" : "Unavailable" },
+    ...(worker.last_error ? [{ label: "Worker error", value: worker.last_error }] : []),
+    ...(worker.recovery_hint ? [{ label: "Worker recovery", value: worker.recovery_hint }] : []),
+  ];
+}
+
 function formatBootstrapStatus(status: string): string {
   return status.replace(/[_-]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatWorkerState(state: string, transportMode?: string | null): string {
+  const stateLabel = state.replace(/[_-]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+  if (!transportMode) {
+    return stateLabel;
+  }
+  return `${stateLabel} via ${transportMode.replace(/[_-]+/g, " ")}`;
 }
 
 function formatExitPolicy(policy: GatewayRuntimeStatus["exit_policy"], owner: GatewayRuntimeStatus["owner"]): string {

--- a/apps/desktop/src/desktopGatewayStartup.ts
+++ b/apps/desktop/src/desktopGatewayStartup.ts
@@ -15,6 +15,16 @@ export type GatewayRuntimeStatus = {
   bootstrap_status?: "ready" | "offline" | "incompatible" | "bootstrap_error" | string | null;
   response_class?: string | null;
   recovery_hint?: string | null;
+  worker_runtime?: DesktopWorkerRuntimeStatus | null;
+};
+
+export type DesktopWorkerRuntimeStatus = {
+  state: "stopped" | "starting" | "running" | "failed" | "incompatible" | string;
+  transport_mode?: "stdio" | "local_pipe" | string | null;
+  diagnostics?: Array<{ stream: string; line: string }>;
+  last_error?: string | null;
+  recovery_hint?: string | null;
+  gateway_compatibility_available?: boolean;
 };
 
 type BootstrapResult = { ok: true } | { ok: false; error: string };


### PR DESCRIPTION
## Summary
- Add Rust worker protocol types for JSON-RPC-style requests, responses, notifications, protocol errors, transport mode, and bounded diagnostics.
- Add a Rust worker runtime status model and expose it through the existing Tauri gateway runtime status payload.
- Add a diagnostic-only `worker_probe_status` command for local protocol metadata verification.
- Extend desktop runtime status rows to show worker state, transport mode, diagnostics, and gateway compatibility while preserving current gateway controls.

## Scope
This is the first migration slice for #230. It does not replace the Python gateway, does not migrate OpenAI/agent logic, and does not add a second worker-owned HTTP/WebSocket service.

## Validation
- `cargo test` from `apps/desktop/src-tauri` passed: 20 tests.
- `npm test -- desktopGatewayRuntimeControls.test.ts gatewayRuntimeIsland.test.ts` from `apps/desktop` passed: 7 tests.
- `npm run build` from `apps/desktop` passed with existing Vite chunk warnings.
- `openspec validate rust-native-core-worker-migration --strict` passed locally.

## Notes
- OpenSpec proposal/design/tasks/spec files remain local-only and are intentionally not included in this PR.
- Existing local `.gitignore`, `DESIGN.md`, and local spec files were not included.

Refs #230