### PR TITLE
Add Rust native worker lifecycle and RPC substrate

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,9 +4,8 @@ use std::{
     io::{BufRead, BufReader, Read, Write},
     net::{SocketAddr, TcpStream},
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    process::Command,
     sync::{Arc, Mutex},
-    thread,
     time::Duration,
 };
 use tauri::{
@@ -14,11 +13,14 @@ use tauri::{
     Emitter, Manager, Runtime, State, WindowEvent,
 };
 
-pub mod worker_protocol;
-pub mod worker_runtime;
 pub mod worker_capability;
 pub mod worker_manager;
+pub mod worker_protocol;
+pub mod worker_runtime;
 
+use crate::worker_manager::{
+    WorkerCommandSpec, WorkerManager, WorkerManagerError, WorkerManagerState,
+};
 use crate::worker_runtime::WorkerRuntimeStatus;
 
 #[cfg(target_os = "windows")]
@@ -45,7 +47,7 @@ fn desktop_status() -> DesktopStatus {
 type SharedGateway = Arc<Mutex<GatewayRuntime>>;
 
 struct GatewayRuntime {
-    child: Option<Child>,
+    worker: WorkerManager,
     logs: VecDeque<String>,
     last_error: Option<String>,
     keep_background: bool,
@@ -54,7 +56,7 @@ struct GatewayRuntime {
 impl Default for GatewayRuntime {
     fn default() -> Self {
         Self {
-            child: None,
+            worker: WorkerManager::new(200),
             logs: VecDeque::with_capacity(200),
             last_error: None,
             keep_background: false,
@@ -326,34 +328,35 @@ fn start_gateway(state: State<'_, SharedGateway>) -> Result<GatewayRuntimeStatus
     }
 
     let repo_root = repo_root();
-    let mut command = Command::new("uv");
-    command
-        .args(["run", "tinybot", "gateway"])
-        .current_dir(&repo_root)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    #[cfg(target_os = "windows")]
-    command.creation_flags(0x08000000);
-
-    let mut child = command
-        .spawn()
-        .map_err(|error| format!("failed to start gateway: {error}"))?;
-
-    if let Some(stdout) = child.stdout.take() {
-        spawn_log_reader(stdout, "stdout", state.inner().clone());
-    }
-    if let Some(stderr) = child.stderr.take() {
-        spawn_log_reader(stderr, "stderr", state.inner().clone());
+    let worker = {
+        let runtime = lock_runtime(state.inner());
+        runtime.worker.clone()
+    };
+    match worker.start(gateway_worker_command_spec()) {
+        Ok(()) => {
+            let mut runtime = lock_runtime(state.inner());
+            runtime.last_error = None;
+            append_log(
+                &mut runtime,
+                "started shell-owned gateway with `uv run tinybot gateway`",
+            );
+        }
+        Err(WorkerManagerError::AlreadyRunning) => {
+            push_log(state.inner(), "shell-owned gateway worker is already running");
+        }
+        Err(error) => {
+            let message = format!("failed to start gateway: {error:?}");
+            let mut runtime = lock_runtime(state.inner());
+            runtime.last_error = Some(message.clone());
+            return Err(message);
+        }
     }
 
     {
         let mut runtime = lock_runtime(state.inner());
-        runtime.child = Some(child);
-        runtime.last_error = None;
         append_log(
             &mut runtime,
-            "started shell-owned gateway with `uv run tinybot gateway`",
+            &format!("gateway worker cwd: {}", repo_root.display()),
         );
     }
 
@@ -681,24 +684,11 @@ fn safe_export_file_name(default_path: &str) -> String {
 fn current_status(shared: &SharedGateway) -> GatewayRuntimeStatus {
     let probe = gateway_bootstrap_probe();
     let http_ok = probe.is_ready();
-    let mut runtime = lock_runtime(shared);
-    let child_running = match runtime.child.as_mut() {
-        Some(child) => match child.try_wait() {
-            Ok(Some(status)) => {
-                runtime.last_error = Some(format!("gateway exited with {status}"));
-                runtime.child = None;
-                false
-            }
-            Ok(None) => true,
-            Err(error) => {
-                runtime.last_error = Some(format!("failed to inspect gateway process: {error}"));
-                false
-            }
-        },
-        None => false,
-    };
+    let runtime = lock_runtime(shared);
+    let worker_status = runtime.worker.status();
+    let worker_running = worker_status.state == WorkerManagerState::Running;
 
-    let owner = if child_running {
+    let owner = if worker_running {
         "shell"
     } else if http_ok {
         "external"
@@ -709,7 +699,7 @@ fn current_status(shared: &SharedGateway) -> GatewayRuntimeStatus {
         "running"
     } else if probe.is_conflict_or_error() {
         "failed"
-    } else if child_running {
+    } else if worker_running {
         "starting"
     } else {
         "offline"
@@ -729,8 +719,12 @@ fn current_status(shared: &SharedGateway) -> GatewayRuntimeStatus {
         command: "uv run tinybot gateway",
         port: 18790,
         repo_root: repo_root().display().to_string(),
-        logs: runtime.logs.iter().cloned().collect(),
-        last_error: runtime.last_error.clone().or_else(|| probe.last_error()),
+        logs: gateway_runtime_logs(&runtime.logs, &worker_status.diagnostics),
+        last_error: runtime
+            .last_error
+            .clone()
+            .or(worker_status.last_error)
+            .or_else(|| probe.last_error()),
         exit_policy,
         bootstrap_status: probe.bootstrap_status(),
         response_class: probe.response_class(),
@@ -813,58 +807,31 @@ fn http_response_body(response: &str) -> &str {
         .unwrap_or(response)
 }
 
+fn gateway_worker_command_spec() -> WorkerCommandSpec {
+    WorkerCommandSpec::new("uv", ["run", "tinybot", "gateway"], repo_root())
+        .with_label("tinybot-gateway")
+}
+
 fn stop_owned_gateway(shared: &SharedGateway, explicit: bool) -> Result<(), String> {
-    let child = {
-        let mut runtime = lock_runtime(shared);
+    let worker = {
+        let runtime = lock_runtime(shared);
         if !explicit && runtime.keep_background {
-            append_log(
-                &mut runtime,
-                "leaving shell-owned gateway running in background",
-            );
+            drop(runtime);
+            push_log(shared, "leaving shell-owned gateway running in background");
             return Ok(());
         }
-        runtime.child.take()
+        runtime.worker.clone()
     };
 
-    if let Some(mut child) = child {
-        terminate_child_process_tree(&mut child)
-            .map_err(|error| format!("failed to stop gateway: {error}"))?;
-        let _ = child.wait();
+    let was_running = worker.status().state == WorkerManagerState::Running;
+    worker
+        .stop()
+        .map_err(|error| format!("failed to stop gateway: {error:?}"))?;
+    if was_running {
         let mut runtime = lock_runtime(shared);
         append_log(&mut runtime, "stopped shell-owned gateway");
     }
     Ok(())
-}
-
-#[cfg(target_os = "windows")]
-fn terminate_child_process_tree(child: &mut Child) -> std::io::Result<()> {
-    let status = Command::new("taskkill")
-        .args(["/PID", &child.id().to_string(), "/T", "/F"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .creation_flags(0x08000000)
-        .status();
-    match status {
-        Ok(status) if status.success() => Ok(()),
-        _ => child.kill(),
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
-fn terminate_child_process_tree(child: &mut Child) -> std::io::Result<()> {
-    child.kill()
-}
-
-fn spawn_log_reader<R>(reader: R, label: &'static str, shared: SharedGateway)
-where
-    R: Read + Send + 'static,
-{
-    thread::spawn(move || {
-        let buffered = BufReader::new(reader);
-        for line in buffered.lines().map_while(Result::ok) {
-            push_log(&shared, &format!("{label}: {line}"));
-        }
-    });
 }
 
 fn push_log(shared: &SharedGateway, line: &str) {
@@ -877,6 +844,21 @@ fn append_log(runtime: &mut GatewayRuntime, line: &str) {
         runtime.logs.pop_front();
     }
     runtime.logs.push_back(line.to_string());
+}
+
+fn gateway_runtime_logs(
+    runtime_logs: &VecDeque<String>,
+    diagnostics: &[crate::worker_protocol::WorkerDiagnosticLine],
+) -> Vec<String> {
+    runtime_logs
+        .iter()
+        .cloned()
+        .chain(
+            diagnostics
+                .iter()
+                .map(|line| format!("{}: {}", line.stream, line.line)),
+        )
+        .collect()
 }
 
 fn lock_runtime(shared: &SharedGateway) -> std::sync::MutexGuard<'_, GatewayRuntime> {
@@ -944,18 +926,22 @@ mod tests {
 
     #[test]
     fn close_shutdown_stops_shell_owned_gateway_child() {
-        let child = spawn_long_running_child();
-        let shared = Arc::new(Mutex::new(GatewayRuntime {
-            child: Some(child),
-            logs: VecDeque::with_capacity(200),
-            last_error: None,
-            keep_background: false,
-        }));
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        {
+            let runtime = lock_runtime(&shared);
+            runtime
+                .worker
+                .start(test_gateway_worker_spec("gateway-close-worker"))
+                .expect("test worker should start");
+        }
 
         stop_owned_gateway(&shared, false).expect("shell-owned gateway child should stop");
 
         let runtime = lock_runtime(&shared);
-        assert!(runtime.child.is_none());
+        assert_eq!(
+            runtime.worker.status().state,
+            crate::worker_manager::WorkerManagerState::Stopped
+        );
         assert!(runtime
             .logs
             .iter()
@@ -963,9 +949,39 @@ mod tests {
     }
 
     #[test]
+    fn gateway_worker_command_spec_uses_uv_gateway_in_repo_root() {
+        let spec = gateway_worker_command_spec();
+
+        assert_eq!(spec.label, "tinybot-gateway");
+        assert_eq!(spec.program, "uv");
+        assert_eq!(spec.args, vec!["run", "tinybot", "gateway"]);
+        assert_eq!(spec.cwd, repo_root());
+    }
+
+    #[test]
+    fn gateway_status_uses_worker_manager_for_shell_owned_process() {
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let worker = {
+            let runtime = lock_runtime(&shared);
+            runtime.worker.clone()
+        };
+        worker
+            .start(test_gateway_short_worker_spec("gateway-status-worker"))
+            .expect("test worker should start");
+
+        let status = current_status(&shared);
+
+        assert_eq!(status.owner, "shell");
+        assert_eq!(
+            status.state,
+            if status.http_ok { "running" } else { "starting" }
+        );
+    }
+
+    #[test]
     fn gateway_status_exposes_port_and_exit_policy() {
         let shared = Arc::new(Mutex::new(GatewayRuntime {
-            child: None,
+            worker: WorkerManager::new(200),
             logs: VecDeque::with_capacity(200),
             last_error: None,
             keep_background: true,
@@ -1168,20 +1184,47 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "windows")]
-    fn spawn_long_running_child() -> Child {
-        Command::new("cmd")
-            .args(["/C", "ping", "-n", "30", "127.0.0.1", ">", "NUL"])
-            .creation_flags(0x08000000)
-            .spawn()
-            .expect("test child process should start")
+    fn test_gateway_worker_spec(label: &str) -> crate::worker_manager::WorkerCommandSpec {
+        #[cfg(target_os = "windows")]
+        {
+            crate::worker_manager::WorkerCommandSpec::new(
+                "cmd",
+                ["/C", "ping", "-n", "30", "127.0.0.1", ">", "NUL"],
+                PathBuf::from("."),
+            )
+            .with_label(label)
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            crate::worker_manager::WorkerCommandSpec::new(
+                "sh",
+                ["-c", "sleep 30"],
+                PathBuf::from("."),
+            )
+            .with_label(label)
+        }
     }
 
-    #[cfg(not(target_os = "windows"))]
-    fn spawn_long_running_child() -> Child {
-        Command::new("sh")
-            .args(["-c", "sleep 30"])
-            .spawn()
-            .expect("test child process should start")
+    fn test_gateway_short_worker_spec(label: &str) -> crate::worker_manager::WorkerCommandSpec {
+        #[cfg(target_os = "windows")]
+        {
+            crate::worker_manager::WorkerCommandSpec::new(
+                "cmd",
+                ["/C", "ping", "-n", "3", "127.0.0.1", ">", "NUL"],
+                PathBuf::from("."),
+            )
+            .with_label(label)
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            crate::worker_manager::WorkerCommandSpec::new(
+                "sh",
+                ["-c", "sleep 2"],
+                PathBuf::from("."),
+            )
+            .with_label(label)
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ use tauri::{
 };
 
 pub mod worker_capability;
+pub mod worker_config;
 pub mod worker_manager;
 pub mod worker_protocol;
 pub mod worker_stdio;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ pub mod worker_protocol;
 pub mod worker_runtime;
 
 use crate::worker_manager::{
-    WorkerCommandSpec, WorkerManager, WorkerManagerError, WorkerManagerState,
+    WorkerCommandSpec, WorkerManager, WorkerManagerError, WorkerManagerState, WorkerManagerStatus,
 };
 use crate::worker_runtime::WorkerRuntimeStatus;
 
@@ -723,13 +723,32 @@ fn current_status(shared: &SharedGateway) -> GatewayRuntimeStatus {
         last_error: runtime
             .last_error
             .clone()
-            .or(worker_status.last_error)
+            .or_else(|| worker_status.last_error.clone())
             .or_else(|| probe.last_error()),
         exit_policy,
         bootstrap_status: probe.bootstrap_status(),
         response_class: probe.response_class(),
         recovery_hint: probe.recovery_hint(),
-        worker_runtime: WorkerRuntimeStatus::compatibility_fallback(http_ok),
+        worker_runtime: gateway_worker_runtime_status(http_ok, &worker_status),
+    }
+}
+
+fn gateway_worker_runtime_status(
+    gateway_available: bool,
+    worker_status: &WorkerManagerStatus,
+) -> WorkerRuntimeStatus {
+    match worker_status.state {
+        WorkerManagerState::Running => WorkerRuntimeStatus::running(
+            crate::worker_protocol::WorkerTransportMode::Stdio,
+            worker_status.diagnostics.clone(),
+        ),
+        WorkerManagerState::Failed => WorkerRuntimeStatus::startup_failed(
+            worker_status
+                .last_error
+                .clone()
+                .unwrap_or_else(|| "worker manager failed".to_string()),
+        ),
+        WorkerManagerState::Stopped => WorkerRuntimeStatus::compatibility_fallback(gateway_available),
     }
 }
 
@@ -976,6 +995,30 @@ mod tests {
             status.state,
             if status.http_ok { "running" } else { "starting" }
         );
+    }
+
+    #[test]
+    fn gateway_status_reflects_running_worker_runtime() {
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let worker = {
+            let runtime = lock_runtime(&shared);
+            runtime.worker.clone()
+        };
+        worker
+            .start(test_gateway_short_worker_spec("gateway-runtime-worker"))
+            .expect("test worker should start");
+
+        let status = current_status(&shared);
+
+        assert_eq!(
+            status.worker_runtime.state,
+            crate::worker_runtime::WorkerRuntimeState::Running
+        );
+        assert_eq!(
+            status.worker_runtime.transport_mode,
+            Some(crate::worker_protocol::WorkerTransportMode::Stdio)
+        );
+        assert!(!status.worker_runtime.gateway_compatibility_available);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub mod worker_config;
 pub mod worker_diagnostics;
 pub mod worker_manager;
 pub mod worker_protocol;
+pub mod worker_rpc;
 pub mod worker_session;
 pub mod worker_stdio;
 pub mod worker_workspace;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ use tauri::{
 pub mod worker_capability;
 pub mod worker_manager;
 pub mod worker_protocol;
+pub mod worker_stdio;
 pub mod worker_runtime;
 
 use crate::worker_manager::{

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ use tauri::{
 
 pub mod worker_capability;
 pub mod worker_config;
+pub mod worker_diagnostics;
 pub mod worker_manager;
 pub mod worker_protocol;
 pub mod worker_session;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -20,7 +20,8 @@ pub mod worker_stdio;
 pub mod worker_runtime;
 
 use crate::worker_manager::{
-    WorkerCommandSpec, WorkerManager, WorkerManagerError, WorkerManagerState, WorkerManagerStatus,
+    WorkerCommandSpec, WorkerManager, WorkerManagerError, WorkerManagerEvent, WorkerManagerState,
+    WorkerManagerStatus,
 };
 use crate::worker_runtime::WorkerRuntimeStatus;
 
@@ -881,6 +882,27 @@ fn gateway_runtime_logs(
         .collect()
 }
 
+fn worker_manager_frontend_event(event: WorkerManagerEvent) -> (&'static str, serde_json::Value) {
+    match event {
+        WorkerManagerEvent::Status(status) => (
+            "worker.status",
+            serde_json::to_value(status).unwrap_or_else(|_| serde_json::json!({})),
+        ),
+        WorkerManagerEvent::Diagnostics(line) => (
+            "diagnostics.log",
+            serde_json::to_value(line).unwrap_or_else(|_| serde_json::json!({})),
+        ),
+    }
+}
+
+fn emit_worker_manager_frontend_event<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    event: WorkerManagerEvent,
+) {
+    let (event_name, payload) = worker_manager_frontend_event(event);
+    let _ = app.emit(event_name, payload);
+}
+
 fn lock_runtime(shared: &SharedGateway) -> std::sync::MutexGuard<'_, GatewayRuntime> {
     shared
         .lock()
@@ -903,13 +925,19 @@ pub fn run() {
         ..GatewayRuntime::default()
     }));
     let close_state = gateway_state.clone();
+    let setup_state = gateway_state.clone();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
         .manage(gateway_state)
-        .setup(|app| {
+        .setup(move |app| {
             install_desktop_application_menu(app)?;
+            let app_handle = app.handle().clone();
+            let runtime = lock_runtime(&setup_state);
+            runtime.worker.set_event_sink(move |event| {
+                emit_worker_manager_frontend_event(&app_handle, event);
+            });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -1106,6 +1134,38 @@ mod tests {
 
         assert_eq!(value["worker_runtime"]["state"], "stopped");
         assert_eq!(value["worker_runtime"]["gateway_compatibility_available"], true);
+    }
+
+    #[test]
+    fn worker_manager_status_event_maps_to_frontend_worker_status_event() {
+        let (event_name, payload) =
+            worker_manager_frontend_event(WorkerManagerEvent::Status(WorkerManagerStatus {
+                state: WorkerManagerState::Running,
+                label: Some("tinybot-gateway".to_string()),
+                pid: Some(1234),
+                started_at_unix_ms: Some(42),
+                diagnostics: vec![],
+                last_error: None,
+            }));
+
+        assert_eq!(event_name, "worker.status");
+        assert_eq!(payload["state"], "running");
+        assert_eq!(payload["label"], "tinybot-gateway");
+        assert_eq!(payload["pid"], 1234);
+    }
+
+    #[test]
+    fn worker_manager_diagnostics_event_maps_to_frontend_diagnostics_log_event() {
+        let (event_name, payload) = worker_manager_frontend_event(
+            WorkerManagerEvent::Diagnostics(crate::worker_protocol::WorkerDiagnosticLine::new(
+                "stderr",
+                "worker ready",
+            )),
+        );
+
+        assert_eq!(event_name, "diagnostics.log");
+        assert_eq!(payload["stream"], "stderr");
+        assert_eq!(payload["line"], "worker ready");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod worker_capability;
 pub mod worker_config;
 pub mod worker_manager;
 pub mod worker_protocol;
+pub mod worker_session;
 pub mod worker_stdio;
 pub mod worker_workspace;
 pub mod worker_runtime;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,8 @@ use tauri::{
 
 pub mod worker_protocol;
 pub mod worker_runtime;
+pub mod worker_capability;
+pub mod worker_manager;
 
 use crate::worker_runtime::WorkerRuntimeStatus;
 
@@ -838,6 +840,8 @@ fn stop_owned_gateway(shared: &SharedGateway, explicit: bool) -> Result<(), Stri
 fn terminate_child_process_tree(child: &mut Child) -> std::io::Result<()> {
     let status = Command::new("taskkill")
         .args(["/PID", &child.id().to_string(), "/T", "/F"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .creation_flags(0x08000000)
         .status();
     match status {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod worker_capability;
 pub mod worker_manager;
 pub mod worker_protocol;
 pub mod worker_stdio;
+pub mod worker_workspace;
 pub mod worker_runtime;
 
 use crate::worker_manager::{

--- a/apps/desktop/src-tauri/src/worker_capability.rs
+++ b/apps/desktop/src-tauri/src/worker_capability.rs
@@ -13,6 +13,8 @@ pub enum WorkerCapability {
     ConfigRead,
     #[serde(rename = "config.write")]
     ConfigWrite,
+    #[serde(rename = "session.metadata.read")]
+    SessionMetadataRead,
     #[serde(rename = "diagnostics.write")]
     DiagnosticsWrite,
     #[serde(rename = "shell.execute")]
@@ -53,6 +55,7 @@ mod tests {
 
         assert!(!policy.allows(&WorkerCapability::NetworkOpenAi));
         assert!(!policy.allows(&WorkerCapability::FsWorkspaceRead));
+        assert!(!policy.allows(&WorkerCapability::SessionMetadataRead));
         assert!(!policy.allows(&WorkerCapability::ShellExecute));
     }
 

--- a/apps/desktop/src-tauri/src/worker_capability.rs
+++ b/apps/desktop/src-tauri/src/worker_capability.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub enum WorkerCapability {
+    #[serde(rename = "network.openai")]
+    NetworkOpenAi,
+    #[serde(rename = "fs.workspace.read")]
+    FsWorkspaceRead,
+    #[serde(rename = "fs.workspace.write")]
+    FsWorkspaceWrite,
+    #[serde(rename = "config.read")]
+    ConfigRead,
+    #[serde(rename = "config.write")]
+    ConfigWrite,
+    #[serde(rename = "diagnostics.write")]
+    DiagnosticsWrite,
+    #[serde(rename = "shell.execute")]
+    ShellExecute,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct CapabilityGrant {
+    pub capability: WorkerCapability,
+    pub scope: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Default, Deserialize, Serialize)]
+pub struct CapabilityPolicy {
+    grants: BTreeSet<WorkerCapability>,
+}
+
+impl CapabilityPolicy {
+    pub fn new(capabilities: impl IntoIterator<Item = WorkerCapability>) -> Self {
+        Self {
+            grants: capabilities.into_iter().collect(),
+        }
+    }
+
+    pub fn allows(&self, capability: &WorkerCapability) -> bool {
+        self.grants.contains(capability)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_worker_policy_denies_sensitive_capabilities() {
+        let policy = CapabilityPolicy::default();
+
+        assert!(!policy.allows(&WorkerCapability::NetworkOpenAi));
+        assert!(!policy.allows(&WorkerCapability::FsWorkspaceRead));
+        assert!(!policy.allows(&WorkerCapability::ShellExecute));
+    }
+
+    #[test]
+    fn explicit_policy_grants_only_named_capabilities() {
+        let policy = CapabilityPolicy::new([
+            WorkerCapability::NetworkOpenAi,
+            WorkerCapability::DiagnosticsWrite,
+        ]);
+
+        assert!(policy.allows(&WorkerCapability::NetworkOpenAi));
+        assert!(policy.allows(&WorkerCapability::DiagnosticsWrite));
+        assert!(!policy.allows(&WorkerCapability::FsWorkspaceWrite));
+        assert!(!policy.allows(&WorkerCapability::ShellExecute));
+    }
+
+    #[test]
+    fn capability_names_serialize_as_protocol_strings() {
+        let grant = CapabilityGrant {
+            capability: WorkerCapability::FsWorkspaceRead,
+            scope: "workspace://current".to_string(),
+        };
+
+        let value = serde_json::to_value(grant).expect("grant should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "capability": "fs.workspace.read",
+                "scope": "workspace://current"
+            })
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_config.rs
+++ b/apps/desktop/src-tauri/src/worker_config.rs
@@ -1,0 +1,220 @@
+use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+use crate::worker_protocol::{
+    WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug)]
+pub struct WorkerConfigRpc {
+    snapshot: Value,
+    policy: CapabilityPolicy,
+}
+
+impl WorkerConfigRpc {
+    pub fn new(snapshot: Value, policy: CapabilityPolicy) -> Self {
+        Self { snapshot, policy }
+    }
+
+    pub fn get(&self, path: &str) -> Result<ConfigGetResult, WorkerProtocolError> {
+        self.require(WorkerCapability::ConfigRead)?;
+        let segments = normalize_config_path(path)?;
+        if segments.iter().any(|segment| is_sensitive_key(segment)) {
+            return Err(sensitive_config_error(path));
+        }
+        let value = get_config_value(&self.snapshot, &segments)
+            .map(redact_sensitive_value)
+            .unwrap_or(Value::Null);
+        Ok(ConfigGetResult {
+            path: segments.join("."),
+            value,
+        })
+    }
+
+    fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
+        if self.policy.allows(&capability) {
+            return Ok(());
+        }
+        Err(WorkerProtocolError::new(
+            WorkerProtocolErrorCode::CapabilityDenied,
+            "worker capability denied",
+            serde_json::json!({ "capability": capability }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ConfigGetResult {
+    pub path: String,
+    pub value: Value,
+}
+
+fn normalize_config_path(path: &str) -> Result<Vec<String>, WorkerProtocolError> {
+    if path.is_empty() || path.contains('\0') {
+        return Err(invalid_config_path(path));
+    }
+    let segments: Vec<String> = path.split('.').map(str::to_string).collect();
+    if segments.iter().any(|segment| segment.is_empty()) {
+        return Err(invalid_config_path(path));
+    }
+    Ok(segments)
+}
+
+fn get_config_value<'a>(snapshot: &'a Value, segments: &[String]) -> Option<&'a Value> {
+    let mut current = snapshot;
+    for segment in segments {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+fn redact_sensitive_value(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, value)| {
+                    if is_sensitive_key(key) {
+                        (key.clone(), Value::Null)
+                    } else {
+                        (key.clone(), redact_sensitive_value(value))
+                    }
+                })
+                .collect(),
+        ),
+        Value::Array(values) => {
+            Value::Array(values.iter().map(redact_sensitive_value).collect())
+        }
+        other => other.clone(),
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    matches!(
+        key.as_str(),
+        "api_key" | "token" | "secret" | "password" | "credentials"
+    )
+}
+
+fn invalid_config_path(path: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "invalid config path",
+        serde_json::json!({ "path": path }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn sensitive_config_error(path: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::CapabilityDenied,
+        "worker config path is sensitive",
+        serde_json::json!({ "path": path }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+    use crate::worker_protocol::{WorkerProtocolErrorCode, WorkerProtocolErrorSource};
+    use serde_json::json;
+
+    #[test]
+    fn default_policy_denies_config_get() {
+        let rpc = WorkerConfigRpc::new(config_fixture(), CapabilityPolicy::default());
+
+        let error = rpc
+            .get("agents.defaults.model")
+            .expect_err("config.get should require capability");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.source, WorkerProtocolErrorSource::RustCore);
+        assert_eq!(error.details["capability"], "config.read");
+    }
+
+    #[test]
+    fn config_get_returns_nested_value_with_read_capability() {
+        let rpc = WorkerConfigRpc::new(config_fixture(), read_policy());
+
+        let result = rpc
+            .get("agents.defaults.model")
+            .expect("config.get should read public value");
+
+        assert_eq!(result.path, "agents.defaults.model");
+        assert_eq!(result.value, json!("gpt-5"));
+    }
+
+    #[test]
+    fn config_get_returns_null_for_missing_public_path() {
+        let rpc = WorkerConfigRpc::new(config_fixture(), read_policy());
+
+        let result = rpc
+            .get("agents.defaults.missing")
+            .expect("missing public path should return null");
+
+        assert_eq!(result.value, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn config_get_rejects_sensitive_path_segments() {
+        let rpc = WorkerConfigRpc::new(config_fixture(), read_policy());
+
+        let error = rpc
+            .get("providers.openai.api_key")
+            .expect_err("api_key should be protected");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.details["path"], "providers.openai.api_key");
+    }
+
+    #[test]
+    fn config_get_redacts_sensitive_descendants_from_objects() {
+        let rpc = WorkerConfigRpc::new(config_fixture(), read_policy());
+
+        let result = rpc
+            .get("providers.openai")
+            .expect("public parent object should read with redaction");
+
+        assert_eq!(result.value["provider"], "openai");
+        assert_eq!(result.value["api_key"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn config_get_rejects_invalid_paths() {
+        let rpc = WorkerConfigRpc::new(config_fixture(), read_policy());
+
+        assert!(rpc.get("").is_err());
+        assert!(rpc.get(".agents").is_err());
+        assert!(rpc.get("agents..defaults").is_err());
+        assert!(rpc.get("agents.defaults.\0model").is_err());
+    }
+
+    fn read_policy() -> CapabilityPolicy {
+        CapabilityPolicy::new([WorkerCapability::ConfigRead])
+    }
+
+    fn config_fixture() -> serde_json::Value {
+        json!({
+            "agents": {
+                "defaults": {
+                    "model": "gpt-5",
+                    "provider": "openai",
+                    "workspace": "~/.tinybot/workspace"
+                }
+            },
+            "providers": {
+                "openai": {
+                    "provider": "openai",
+                    "api_key": "sk-secret",
+                    "api_base": "https://api.openai.com/v1"
+                }
+            }
+        })
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_diagnostics.rs
+++ b/apps/desktop/src-tauri/src/worker_diagnostics.rs
@@ -1,0 +1,131 @@
+use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+use crate::worker_protocol::{
+    WorkerDiagnosticLine, WorkerDiagnostics, WorkerProtocolError, WorkerProtocolErrorCode,
+    WorkerProtocolErrorSource,
+};
+
+#[derive(Clone, Debug)]
+pub struct WorkerDiagnosticsRpc {
+    diagnostics: WorkerDiagnostics,
+    policy: CapabilityPolicy,
+}
+
+impl WorkerDiagnosticsRpc {
+    pub fn new(capacity: usize, policy: CapabilityPolicy) -> Self {
+        Self {
+            diagnostics: WorkerDiagnostics::new(capacity),
+            policy,
+        }
+    }
+
+    pub fn append(
+        &mut self,
+        stream: &str,
+        line: &str,
+    ) -> Result<WorkerDiagnosticLine, WorkerProtocolError> {
+        self.require(WorkerCapability::DiagnosticsWrite)?;
+        validate_diagnostic_stream(stream)?;
+        let diagnostic = WorkerDiagnosticLine::new(stream, line);
+        self.diagnostics
+            .push(diagnostic.stream.clone(), diagnostic.line.clone());
+        Ok(diagnostic)
+    }
+
+    pub fn lines(&self) -> Vec<WorkerDiagnosticLine> {
+        self.diagnostics.lines()
+    }
+
+    fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
+        if self.policy.allows(&capability) {
+            return Ok(());
+        }
+        Err(WorkerProtocolError::new(
+            WorkerProtocolErrorCode::CapabilityDenied,
+            "worker capability denied",
+            serde_json::json!({ "capability": capability }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ))
+    }
+}
+
+fn validate_diagnostic_stream(stream: &str) -> Result<(), WorkerProtocolError> {
+    if matches!(stream, "stdout" | "stderr") {
+        return Ok(());
+    }
+    Err(WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "invalid diagnostics stream",
+        serde_json::json!({ "stream": stream }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+    use crate::worker_protocol::{WorkerProtocolErrorCode, WorkerProtocolErrorSource};
+
+    #[test]
+    fn default_policy_denies_diagnostics_append() {
+        let mut rpc = WorkerDiagnosticsRpc::new(20, CapabilityPolicy::default());
+
+        let error = rpc
+            .append("stdout", "worker ready")
+            .expect_err("diagnostics append should require capability");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.source, WorkerProtocolErrorSource::RustCore);
+        assert_eq!(error.details["capability"], "diagnostics.write");
+    }
+
+    #[test]
+    fn append_records_diagnostic_with_write_capability() {
+        let mut rpc = WorkerDiagnosticsRpc::new(20, write_policy());
+
+        let appended = rpc
+            .append("stderr", "worker warning")
+            .expect("diagnostic should append");
+
+        assert_eq!(appended, WorkerDiagnosticLine::new("stderr", "worker warning"));
+        assert_eq!(
+            rpc.lines(),
+            vec![WorkerDiagnosticLine::new("stderr", "worker warning")]
+        );
+    }
+
+    #[test]
+    fn diagnostics_append_keeps_recent_lines_only() {
+        let mut rpc = WorkerDiagnosticsRpc::new(2, write_policy());
+
+        rpc.append("stdout", "one").expect("first append");
+        rpc.append("stderr", "two").expect("second append");
+        rpc.append("stdout", "three").expect("third append");
+
+        assert_eq!(
+            rpc.lines(),
+            vec![
+                WorkerDiagnosticLine::new("stderr", "two"),
+                WorkerDiagnosticLine::new("stdout", "three"),
+            ]
+        );
+    }
+
+    #[test]
+    fn diagnostics_append_rejects_unknown_stream() {
+        let mut rpc = WorkerDiagnosticsRpc::new(20, write_policy());
+
+        let error = rpc
+            .append("console", "unknown stream")
+            .expect_err("unknown stream should be rejected");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
+        assert_eq!(error.details["stream"], "console");
+    }
+
+    fn write_policy() -> CapabilityPolicy {
+        CapabilityPolicy::new([WorkerCapability::DiagnosticsWrite])
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_manager.rs
+++ b/apps/desktop/src-tauri/src/worker_manager.rs
@@ -1,0 +1,411 @@
+use crate::worker_protocol::{WorkerDiagnosticLine, WorkerDiagnostics};
+use serde::Serialize;
+use std::{
+    io::{BufRead, BufReader, Read},
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex},
+    thread,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkerCommandSpec {
+    pub label: String,
+    pub program: String,
+    pub args: Vec<String>,
+    pub cwd: PathBuf,
+}
+
+impl WorkerCommandSpec {
+    pub fn new(
+        program: impl Into<String>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+        cwd: PathBuf,
+    ) -> Self {
+        let program = program.into();
+        Self {
+            label: program.clone(),
+            program,
+            args: args.into_iter().map(Into::into).collect(),
+            cwd,
+        }
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = label.into();
+        self
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerManagerState {
+    Stopped,
+    Running,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WorkerHealth {
+    Stopped,
+    Running,
+    Exited,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WorkerManagerError {
+    AlreadyRunning,
+    SpawnFailed(String),
+    StopFailed(String),
+    InspectFailed(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct WorkerManagerStatus {
+    pub state: WorkerManagerState,
+    pub label: Option<String>,
+    pub pid: Option<u32>,
+    pub started_at_unix_ms: Option<u128>,
+    pub diagnostics: Vec<WorkerDiagnosticLine>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WorkerManager {
+    inner: Arc<Mutex<WorkerManagerInner>>,
+}
+
+#[derive(Debug)]
+struct WorkerManagerInner {
+    child: Option<Child>,
+    label: Option<String>,
+    pid: Option<u32>,
+    started_at_unix_ms: Option<u128>,
+    diagnostics: WorkerDiagnostics,
+    last_error: Option<String>,
+}
+
+impl WorkerManager {
+    pub fn new(diagnostic_capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(WorkerManagerInner {
+                child: None,
+                label: None,
+                pid: None,
+                started_at_unix_ms: None,
+                diagnostics: WorkerDiagnostics::new(diagnostic_capacity),
+                last_error: None,
+            })),
+        }
+    }
+
+    pub fn start(&self, spec: WorkerCommandSpec) -> Result<(), WorkerManagerError> {
+        {
+            let mut inner = lock_inner(&self.inner);
+            if refresh_child_status(&mut inner)? == WorkerHealth::Running {
+                return Err(WorkerManagerError::AlreadyRunning);
+            }
+        }
+
+        let mut command = Command::new(&spec.program);
+        command
+            .args(&spec.args)
+            .current_dir(&spec.cwd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        #[cfg(target_os = "windows")]
+        command.creation_flags(0x08000000);
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| WorkerManagerError::SpawnFailed(error.to_string()))?;
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        let pid = child.id();
+
+        {
+            let mut inner = lock_inner(&self.inner);
+            inner.child = Some(child);
+            inner.label = Some(spec.label);
+            inner.pid = Some(pid);
+            inner.started_at_unix_ms = Some(now_unix_ms());
+            inner.last_error = None;
+        }
+
+        if let Some(stdout) = stdout {
+            spawn_diagnostic_reader(stdout, "stdout", self.inner.clone());
+        }
+        if let Some(stderr) = stderr {
+            spawn_diagnostic_reader(stderr, "stderr", self.inner.clone());
+        }
+
+        Ok(())
+    }
+
+    pub fn stop(&self) -> Result<(), WorkerManagerError> {
+        let child = {
+            let mut inner = lock_inner(&self.inner);
+            inner.child.take()
+        };
+
+        if let Some(mut child) = child {
+            terminate_child_process_tree(&mut child)
+                .map_err(|error| WorkerManagerError::StopFailed(error.to_string()))?;
+            let _ = child.wait();
+        }
+
+        let mut inner = lock_inner(&self.inner);
+        inner.pid = None;
+        inner.label = None;
+        inner.started_at_unix_ms = None;
+        inner.last_error = None;
+        Ok(())
+    }
+
+    pub fn restart(&self, spec: WorkerCommandSpec) -> Result<(), WorkerManagerError> {
+        self.stop()?;
+        self.start(spec)
+    }
+
+    pub fn health_check(&self) -> WorkerHealth {
+        let mut inner = lock_inner(&self.inner);
+        refresh_child_status(&mut inner).unwrap_or(WorkerHealth::Failed)
+    }
+
+    pub fn status(&self) -> WorkerManagerStatus {
+        let mut inner = lock_inner(&self.inner);
+        let health = refresh_child_status(&mut inner).unwrap_or(WorkerHealth::Failed);
+        WorkerManagerStatus {
+            state: match health {
+                WorkerHealth::Running => WorkerManagerState::Running,
+                WorkerHealth::Failed => WorkerManagerState::Failed,
+                WorkerHealth::Stopped | WorkerHealth::Exited => WorkerManagerState::Stopped,
+            },
+            label: inner.label.clone(),
+            pid: inner.pid,
+            started_at_unix_ms: inner.started_at_unix_ms,
+            diagnostics: inner.diagnostics.lines(),
+            last_error: inner.last_error.clone(),
+        }
+    }
+}
+
+fn refresh_child_status(
+    inner: &mut WorkerManagerInner,
+) -> Result<WorkerHealth, WorkerManagerError> {
+    let Some(child) = inner.child.as_mut() else {
+        return Ok(WorkerHealth::Stopped);
+    };
+
+    match child.try_wait() {
+        Ok(None) => Ok(WorkerHealth::Running),
+        Ok(Some(status)) => {
+            inner.last_error = Some(format!("worker exited with {status}"));
+            inner.child = None;
+            inner.pid = None;
+            inner.started_at_unix_ms = None;
+            Ok(WorkerHealth::Exited)
+        }
+        Err(error) => {
+            let message = format!("failed to inspect worker process: {error}");
+            inner.last_error = Some(message.clone());
+            inner.child = None;
+            inner.pid = None;
+            inner.started_at_unix_ms = None;
+            Err(WorkerManagerError::InspectFailed(message))
+        }
+    }
+}
+
+fn spawn_diagnostic_reader<R>(
+    reader: R,
+    stream: &'static str,
+    inner: Arc<Mutex<WorkerManagerInner>>,
+) where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let buffered = BufReader::new(reader);
+        for line in buffered.lines().map_while(Result::ok) {
+            let mut inner = lock_inner(&inner);
+            inner.diagnostics.push(stream, line);
+        }
+    });
+}
+
+#[cfg(target_os = "windows")]
+fn terminate_child_process_tree(child: &mut Child) -> std::io::Result<()> {
+    let status = Command::new("taskkill")
+        .args(["/PID", &child.id().to_string(), "/T", "/F"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .creation_flags(0x08000000)
+        .status();
+    match status {
+        Ok(status) if status.success() => Ok(()),
+        _ => child.kill(),
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn terminate_child_process_tree(child: &mut Child) -> std::io::Result<()> {
+    child.kill()
+}
+
+fn now_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+fn lock_inner(
+    inner: &Arc<Mutex<WorkerManagerInner>>,
+) -> std::sync::MutexGuard<'_, WorkerManagerInner> {
+    inner
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn manager_starts_worker_once_and_reports_pid() {
+        let manager = WorkerManager::new(20);
+        let spec = test_worker_spec("manager-starts-once");
+
+        manager.start(spec.clone()).expect("worker should start");
+        let duplicate = manager
+            .start(spec)
+            .expect_err("running worker should not start twice");
+        let status = manager.status();
+
+        assert_eq!(duplicate, WorkerManagerError::AlreadyRunning);
+        assert_eq!(status.state, WorkerManagerState::Running);
+        assert!(status.pid.is_some());
+
+        manager.stop().expect("worker should stop");
+    }
+
+    #[test]
+    fn manager_restart_replaces_running_worker() {
+        let manager = WorkerManager::new(20);
+
+        manager
+            .start(test_worker_spec("manager-restart-before"))
+            .expect("worker should start");
+        let before = manager
+            .status()
+            .pid
+            .expect("running worker should expose pid");
+
+        manager
+            .restart(test_worker_spec("manager-restart-after"))
+            .expect("worker should restart");
+        let after = manager
+            .status()
+            .pid
+            .expect("restarted worker should expose pid");
+
+        assert_ne!(before, after);
+        assert_eq!(manager.health_check(), WorkerHealth::Running);
+
+        manager.stop().expect("worker should stop");
+    }
+
+    #[test]
+    fn manager_captures_stdout_and_stderr_diagnostics() {
+        let manager = WorkerManager::new(20);
+
+        manager
+            .start(test_logging_worker_spec())
+            .expect("logging worker should start");
+        std::thread::sleep(std::time::Duration::from_millis(900));
+
+        let diagnostics = manager.status().diagnostics;
+
+        assert!(diagnostics
+            .iter()
+            .any(|line| line.stream == "stdout" && line.line.contains("worker stdout")));
+        assert!(diagnostics
+            .iter()
+            .any(|line| line.stream == "stderr" && line.line.contains("worker stderr")));
+    }
+
+    #[test]
+    fn manager_status_records_last_error_after_exited_worker_health_check() {
+        let manager = WorkerManager::new(20);
+
+        manager
+            .start(test_logging_worker_spec())
+            .expect("short worker should start");
+
+        assert_eq!(wait_for_health(&manager, WorkerHealth::Exited), WorkerHealth::Exited);
+        let status = manager.status();
+
+        assert_eq!(status.state, WorkerManagerState::Stopped);
+        assert!(status.pid.is_none());
+        assert!(status
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("worker exited")));
+    }
+
+    fn test_worker_spec(label: &str) -> WorkerCommandSpec {
+        #[cfg(target_os = "windows")]
+        {
+            WorkerCommandSpec::new(
+                "cmd",
+                ["/C", "ping", "-n", "30", "127.0.0.1", ">", "NUL"],
+                PathBuf::from("."),
+            )
+            .with_label(label)
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            WorkerCommandSpec::new("sh", ["-c", "sleep 30"], PathBuf::from("."))
+                .with_label(label)
+        }
+    }
+
+    fn test_logging_worker_spec() -> WorkerCommandSpec {
+        #[cfg(target_os = "windows")]
+        {
+            WorkerCommandSpec::new(
+                "cmd",
+                ["/C", "echo worker stdout && echo worker stderr 1>&2"],
+                PathBuf::from("."),
+            )
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            WorkerCommandSpec::new(
+                "sh",
+                ["-c", "echo worker stdout && echo worker stderr >&2"],
+                PathBuf::from("."),
+            )
+        }
+    }
+
+    fn wait_for_health(manager: &WorkerManager, expected: WorkerHealth) -> WorkerHealth {
+        for _ in 0..30 {
+            let health = manager.health_check();
+            if health == expected {
+                return health;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        manager.health_check()
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_manager.rs
+++ b/apps/desktop/src-tauri/src/worker_manager.rs
@@ -1,6 +1,7 @@
 use crate::worker_protocol::{WorkerDiagnosticLine, WorkerDiagnostics};
 use serde::Serialize;
 use std::{
+    fmt,
     io::{BufRead, BufReader, Read},
     path::PathBuf,
     process::{Child, Command, Stdio},
@@ -75,9 +76,25 @@ pub struct WorkerManagerStatus {
     pub last_error: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
+pub enum WorkerManagerEvent {
+    Status(WorkerManagerStatus),
+    Diagnostics(WorkerDiagnosticLine),
+}
+
+type WorkerEventSink = Arc<dyn Fn(WorkerManagerEvent) + Send + Sync + 'static>;
+
+#[derive(Clone)]
 pub struct WorkerManager {
     inner: Arc<Mutex<WorkerManagerInner>>,
+    event_sink: Arc<Mutex<Option<WorkerEventSink>>>,
+}
+
+impl fmt::Debug for WorkerManager {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("WorkerManager").finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug)]
@@ -101,7 +118,24 @@ impl WorkerManager {
                 diagnostics: WorkerDiagnostics::new(diagnostic_capacity),
                 last_error: None,
             })),
+            event_sink: Arc::new(Mutex::new(None)),
         }
+    }
+
+    pub fn with_event_sink(
+        self,
+        event_sink: impl Fn(WorkerManagerEvent) + Send + Sync + 'static,
+    ) -> Self {
+        self.set_event_sink(event_sink);
+        self
+    }
+
+    pub fn set_event_sink(
+        &self,
+        event_sink: impl Fn(WorkerManagerEvent) + Send + Sync + 'static,
+    ) {
+        let mut sink = lock_event_sink(&self.event_sink);
+        *sink = Some(Arc::new(event_sink));
     }
 
     pub fn start(&self, spec: WorkerCommandSpec) -> Result<(), WorkerManagerError> {
@@ -137,12 +171,23 @@ impl WorkerManager {
             inner.started_at_unix_ms = Some(now_unix_ms());
             inner.last_error = None;
         }
+        self.emit_status();
 
         if let Some(stdout) = stdout {
-            spawn_diagnostic_reader(stdout, "stdout", self.inner.clone());
+            spawn_diagnostic_reader(
+                stdout,
+                "stdout",
+                self.inner.clone(),
+                self.event_sink.clone(),
+            );
         }
         if let Some(stderr) = stderr {
-            spawn_diagnostic_reader(stderr, "stderr", self.inner.clone());
+            spawn_diagnostic_reader(
+                stderr,
+                "stderr",
+                self.inner.clone(),
+                self.event_sink.clone(),
+            );
         }
 
         Ok(())
@@ -165,6 +210,8 @@ impl WorkerManager {
         inner.label = None;
         inner.started_at_unix_ms = None;
         inner.last_error = None;
+        drop(inner);
+        self.emit_status();
         Ok(())
     }
 
@@ -193,6 +240,10 @@ impl WorkerManager {
             diagnostics: inner.diagnostics.lines(),
             last_error: inner.last_error.clone(),
         }
+    }
+
+    fn emit_status(&self) {
+        emit_worker_event(&self.event_sink, WorkerManagerEvent::Status(self.status()));
     }
 }
 
@@ -227,14 +278,20 @@ fn spawn_diagnostic_reader<R>(
     reader: R,
     stream: &'static str,
     inner: Arc<Mutex<WorkerManagerInner>>,
+    event_sink: Arc<Mutex<Option<WorkerEventSink>>>,
 ) where
     R: Read + Send + 'static,
 {
     thread::spawn(move || {
         let buffered = BufReader::new(reader);
         for line in buffered.lines().map_while(Result::ok) {
+            let diagnostic = WorkerDiagnosticLine::new(stream, line);
             let mut inner = lock_inner(&inner);
-            inner.diagnostics.push(stream, line);
+            inner
+                .diagnostics
+                .push(diagnostic.stream.clone(), diagnostic.line.clone());
+            drop(inner);
+            emit_worker_event(&event_sink, WorkerManagerEvent::Diagnostics(diagnostic));
         }
     });
 }
@@ -273,10 +330,88 @@ fn lock_inner(
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+fn lock_event_sink(
+    sink: &Arc<Mutex<Option<WorkerEventSink>>>,
+) -> std::sync::MutexGuard<'_, Option<WorkerEventSink>> {
+    sink.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn emit_worker_event(
+    event_sink: &Arc<Mutex<Option<WorkerEventSink>>>,
+    event: WorkerManagerEvent,
+) {
+    let sink = lock_event_sink(event_sink).clone();
+    if let Some(sink) = sink {
+        sink(event);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn manager_emits_status_events_on_start_and_stop() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let event_log = events.clone();
+        let manager = WorkerManager::new(20).with_event_sink(move |event| {
+            event_log
+                .lock()
+                .expect("event log should lock")
+                .push(event);
+        });
+
+        manager
+            .start(test_worker_spec("manager-status-events"))
+            .expect("worker should start");
+        manager.stop().expect("worker should stop");
+
+        let events = events.lock().expect("event log should lock");
+
+        assert!(events.iter().any(|event| matches!(
+            event,
+            WorkerManagerEvent::Status(status)
+                if status.state == WorkerManagerState::Running
+                    && status.label.as_deref() == Some("manager-status-events")
+                    && status.pid.is_some()
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            WorkerManagerEvent::Status(status)
+                if status.state == WorkerManagerState::Stopped && status.pid.is_none()
+        )));
+    }
+
+    #[test]
+    fn manager_emits_diagnostics_events_for_stdout_and_stderr() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let event_log = events.clone();
+        let manager = WorkerManager::new(20).with_event_sink(move |event| {
+            event_log
+                .lock()
+                .expect("event log should lock")
+                .push(event);
+        });
+
+        manager
+            .start(test_logging_worker_spec())
+            .expect("logging worker should start");
+        std::thread::sleep(std::time::Duration::from_millis(900));
+
+        let events = events.lock().expect("event log should lock");
+
+        assert!(events.iter().any(|event| matches!(
+            event,
+            WorkerManagerEvent::Diagnostics(line)
+                if line.stream == "stdout" && line.line.contains("worker stdout")
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            WorkerManagerEvent::Diagnostics(line)
+                if line.stream == "stderr" && line.line.contains("worker stderr")
+        )));
+    }
 
     #[test]
     fn manager_starts_worker_once_and_reports_pid() {

--- a/apps/desktop/src-tauri/src/worker_manager.rs
+++ b/apps/desktop/src-tauri/src/worker_manager.rs
@@ -1,8 +1,10 @@
 use crate::worker_protocol::{WorkerDiagnosticLine, WorkerDiagnostics};
+use crate::worker_rpc::WorkerRpcRouter;
+use crate::worker_stdio::WorkerStdioTransport;
 use serde::Serialize;
 use std::{
     fmt,
-    io::{BufRead, BufReader, Read},
+    io::{BufRead, BufReader, Read, Write},
     path::PathBuf,
     process::{Child, Command, Stdio},
     sync::{Arc, Mutex},
@@ -193,6 +195,84 @@ impl WorkerManager {
         Ok(())
     }
 
+    pub fn start_stdio_rpc(
+        &self,
+        spec: WorkerCommandSpec,
+        router: WorkerRpcRouter,
+    ) -> Result<(), WorkerManagerError> {
+        {
+            let mut inner = lock_inner(&self.inner);
+            if refresh_child_status(&mut inner)? == WorkerHealth::Running {
+                return Err(WorkerManagerError::AlreadyRunning);
+            }
+        }
+
+        let mut command = Command::new(&spec.program);
+        command
+            .args(&spec.args)
+            .current_dir(&spec.cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        #[cfg(target_os = "windows")]
+        command.creation_flags(0x08000000);
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| WorkerManagerError::SpawnFailed(error.to_string()))?;
+        let stdin = child.stdin.take();
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        let pid = child.id();
+
+        {
+            let mut inner = lock_inner(&self.inner);
+            inner.child = Some(child);
+            inner.label = Some(spec.label);
+            inner.pid = Some(pid);
+            inner.started_at_unix_ms = Some(now_unix_ms());
+            inner.last_error = None;
+        }
+        self.emit_status();
+
+        match (stdout, stdin) {
+            (Some(stdout), Some(stdin)) => {
+                spawn_stdio_rpc_reader(
+                    stdout,
+                    stdin,
+                    router,
+                    self.inner.clone(),
+                    self.event_sink.clone(),
+                );
+            }
+            _ => {
+                let message = "worker stdio pipes are unavailable".to_string();
+                let mut inner = lock_inner(&self.inner);
+                inner.last_error = Some(message.clone());
+                inner.diagnostics.push("stderr", message.clone());
+                drop(inner);
+                emit_worker_event(
+                    &self.event_sink,
+                    WorkerManagerEvent::Diagnostics(WorkerDiagnosticLine::new(
+                        "stderr", message,
+                    )),
+                );
+            }
+        }
+
+        if let Some(stderr) = stderr {
+            spawn_diagnostic_reader(
+                stderr,
+                "stderr",
+                self.inner.clone(),
+                self.event_sink.clone(),
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn stop(&self) -> Result<(), WorkerManagerError> {
         let child = {
             let mut inner = lock_inner(&self.inner);
@@ -296,6 +376,33 @@ fn spawn_diagnostic_reader<R>(
     });
 }
 
+fn spawn_stdio_rpc_reader<R, W>(
+    reader: R,
+    writer: W,
+    mut router: WorkerRpcRouter,
+    inner: Arc<Mutex<WorkerManagerInner>>,
+    event_sink: Arc<Mutex<Option<WorkerEventSink>>>,
+) where
+    R: Read + Send + 'static,
+    W: Write + Send + 'static,
+{
+    thread::spawn(move || {
+        let buffered = BufReader::new(reader);
+        let mut transport = WorkerStdioTransport::new(buffered, writer);
+        if let Err(error) = transport.serve_rust_rpc_requests(&mut router, |_| {}) {
+            let line = format!("worker protocol error: {}", error.message);
+            let diagnostic = WorkerDiagnosticLine::new("stderr", line.clone());
+            let mut inner = lock_inner(&inner);
+            inner.last_error = Some(line);
+            inner
+                .diagnostics
+                .push(diagnostic.stream.clone(), diagnostic.line.clone());
+            drop(inner);
+            emit_worker_event(&event_sink, WorkerManagerEvent::Diagnostics(diagnostic));
+        }
+    });
+}
+
 #[cfg(target_os = "windows")]
 fn terminate_child_process_tree(child: &mut Child) -> std::io::Result<()> {
     let status = Command::new("taskkill")
@@ -349,6 +456,9 @@ fn emit_worker_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+    use crate::worker_rpc::WorkerRpcRouter;
+    use serde_json::json;
     use std::path::PathBuf;
 
     #[test]
@@ -487,6 +597,39 @@ mod tests {
             .is_some_and(|error| error.contains("worker exited")));
     }
 
+    #[test]
+    fn manager_serves_stdio_worker_rpc_requests() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("notes/today.md", "hello manager rpc");
+        let manager = WorkerManager::new(20);
+        let router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead]),
+        );
+
+        manager
+            .start_stdio_rpc(test_stdio_rpc_worker_spec(), router)
+            .expect("stdio RPC worker should start");
+
+        let diagnostics = wait_for_diagnostics(&manager, |diagnostics| {
+            has_diagnostic_line(diagnostics, "stderr", "hello manager rpc")
+        });
+
+        assert!(has_diagnostic_line(
+            &diagnostics,
+            "stderr",
+            "notes/today.md"
+        ));
+        assert!(has_diagnostic_line(
+            &diagnostics,
+            "stderr",
+            "hello manager rpc"
+        ));
+    }
+
     fn test_worker_spec(label: &str) -> WorkerCommandSpec {
         #[cfg(target_os = "windows")]
         {
@@ -522,6 +665,35 @@ mod tests {
                 ["-c", "echo worker stdout && echo worker stderr >&2"],
                 PathBuf::from("."),
             )
+        }
+    }
+
+    fn test_stdio_rpc_worker_spec() -> WorkerCommandSpec {
+        #[cfg(target_os = "windows")]
+        {
+            WorkerCommandSpec::new(
+                "powershell",
+                [
+                    "-NoProfile",
+                    "-Command",
+                    r#"$json = '{"protocol_version":"1","id":"req-123","trace_id":"trace-abc","method":"workspace.read_file","params":{"path":"notes/today.md"}}'; [Console]::Out.WriteLine($json); $line = [Console]::In.ReadLine(); [Console]::Error.WriteLine($line)"#,
+                ],
+                PathBuf::from("."),
+            )
+            .with_label("stdio-rpc-worker")
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            WorkerCommandSpec::new(
+                "sh",
+                [
+                    "-c",
+                    r#"json='{"protocol_version":"1","id":"req-123","trace_id":"trace-abc","method":"workspace.read_file","params":{"path":"notes/today.md"}}'; printf '%s\n' "$json"; IFS= read -r line; printf '%s\n' "$line" >&2"#,
+                ],
+                PathBuf::from("."),
+            )
+            .with_label("stdio-rpc-worker")
         }
     }
 
@@ -586,5 +758,38 @@ mod tests {
                     if line.stream == stream && line.line.contains(expected)
             )
         })
+    }
+
+    struct WorkspaceFixture {
+        root: PathBuf,
+    }
+
+    impl WorkspaceFixture {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "tinybot-worker-manager-rpc-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("clock should be after unix epoch")
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&root).expect("workspace fixture should create");
+            Self { root }
+        }
+
+        fn write(&self, relative_path: &str, contents: &str) {
+            let path = self.root.join(relative_path.replace('/', std::path::MAIN_SEPARATOR_STR));
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("fixture parent should create");
+            }
+            std::fs::write(path, contents).expect("fixture file should write");
+        }
+    }
+
+    impl Drop for WorkspaceFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/worker_manager.rs
+++ b/apps/desktop/src-tauri/src/worker_manager.rs
@@ -1,4 +1,4 @@
-use crate::worker_protocol::{WorkerDiagnosticLine, WorkerDiagnostics};
+use crate::worker_protocol::{WorkerDiagnosticLine, WorkerDiagnostics, WorkerEvent};
 use crate::worker_rpc::WorkerRpcRouter;
 use crate::worker_stdio::WorkerStdioTransport;
 use serde::Serialize;
@@ -389,7 +389,15 @@ fn spawn_stdio_rpc_reader<R, W>(
     thread::spawn(move || {
         let buffered = BufReader::new(reader);
         let mut transport = WorkerStdioTransport::new(buffered, writer);
-        if let Err(error) = transport.serve_rust_rpc_requests(&mut router, |_| {}) {
+        let event_inner = inner.clone();
+        let event_sink_for_events = event_sink.clone();
+        if let Err(error) = transport.serve_rust_rpc_requests(&mut router, move |event| {
+            record_worker_protocol_event(
+                event,
+                &event_inner,
+                &event_sink_for_events,
+            );
+        }) {
             let line = format!("worker protocol error: {}", error.message);
             let diagnostic = WorkerDiagnosticLine::new("stderr", line.clone());
             let mut inner = lock_inner(&inner);
@@ -401,6 +409,32 @@ fn spawn_stdio_rpc_reader<R, W>(
             emit_worker_event(&event_sink, WorkerManagerEvent::Diagnostics(diagnostic));
         }
     });
+}
+
+fn record_worker_protocol_event(
+    event: &WorkerEvent,
+    inner: &Arc<Mutex<WorkerManagerInner>>,
+    event_sink: &Arc<Mutex<Option<WorkerEventSink>>>,
+) {
+    if event.event != "diagnostics.log" {
+        return;
+    }
+    let Some(stream) = event.payload.get("stream").and_then(serde_json::Value::as_str) else {
+        return;
+    };
+    let Some(line) = event.payload.get("line").and_then(serde_json::Value::as_str) else {
+        return;
+    };
+    if !matches!(stream, "stdout" | "stderr") {
+        return;
+    }
+    let diagnostic = WorkerDiagnosticLine::new(stream, line);
+    let mut inner = lock_inner(inner);
+    inner
+        .diagnostics
+        .push(diagnostic.stream.clone(), diagnostic.line.clone());
+    drop(inner);
+    emit_worker_event(event_sink, WorkerManagerEvent::Diagnostics(diagnostic));
 }
 
 #[cfg(target_os = "windows")]
@@ -630,6 +664,33 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn manager_records_stdio_worker_diagnostics_events() {
+        let fixture = WorkspaceFixture::new();
+        let manager = WorkerManager::new(20);
+        let router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::default(),
+        );
+
+        manager
+            .start_stdio_rpc(test_stdio_event_worker_spec(), router)
+            .expect("stdio event worker should start");
+
+        let diagnostics = wait_for_diagnostics(&manager, |diagnostics| {
+            has_diagnostic_line(diagnostics, "stdout", "protocol event ready")
+        });
+
+        assert!(has_diagnostic_line(
+            &diagnostics,
+            "stdout",
+            "protocol event ready"
+        ));
+    }
+
     fn test_worker_spec(label: &str) -> WorkerCommandSpec {
         #[cfg(target_os = "windows")]
         {
@@ -694,6 +755,35 @@ mod tests {
                 PathBuf::from("."),
             )
             .with_label("stdio-rpc-worker")
+        }
+    }
+
+    fn test_stdio_event_worker_spec() -> WorkerCommandSpec {
+        #[cfg(target_os = "windows")]
+        {
+            WorkerCommandSpec::new(
+                "powershell",
+                [
+                    "-NoProfile",
+                    "-Command",
+                    r#"$json = '{"protocol_version":"1","trace_id":"trace-event","event":"diagnostics.log","payload":{"stream":"stdout","line":"protocol event ready"}}'; [Console]::Out.WriteLine($json)"#,
+                ],
+                PathBuf::from("."),
+            )
+            .with_label("stdio-event-worker")
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            WorkerCommandSpec::new(
+                "sh",
+                [
+                    "-c",
+                    r#"json='{"protocol_version":"1","trace_id":"trace-event","event":"diagnostics.log","payload":{"stream":"stdout","line":"protocol event ready"}}'; printf '%s\n' "$json""#,
+                ],
+                PathBuf::from("."),
+            )
+            .with_label("stdio-event-worker")
         }
     }
 

--- a/apps/desktop/src-tauri/src/worker_manager.rs
+++ b/apps/desktop/src-tauri/src/worker_manager.rs
@@ -397,20 +397,14 @@ mod tests {
         manager
             .start(test_logging_worker_spec())
             .expect("logging worker should start");
-        std::thread::sleep(std::time::Duration::from_millis(900));
 
-        let events = events.lock().expect("event log should lock");
+        let events = wait_for_events(&events, |events| {
+            has_diagnostics_event(events, "stdout", "worker stdout")
+                && has_diagnostics_event(events, "stderr", "worker stderr")
+        });
 
-        assert!(events.iter().any(|event| matches!(
-            event,
-            WorkerManagerEvent::Diagnostics(line)
-                if line.stream == "stdout" && line.line.contains("worker stdout")
-        )));
-        assert!(events.iter().any(|event| matches!(
-            event,
-            WorkerManagerEvent::Diagnostics(line)
-                if line.stream == "stderr" && line.line.contains("worker stderr")
-        )));
+        assert!(has_diagnostics_event(&events, "stdout", "worker stdout"));
+        assert!(has_diagnostics_event(&events, "stderr", "worker stderr"));
     }
 
     #[test]
@@ -464,16 +458,14 @@ mod tests {
         manager
             .start(test_logging_worker_spec())
             .expect("logging worker should start");
-        std::thread::sleep(std::time::Duration::from_millis(900));
 
-        let diagnostics = manager.status().diagnostics;
+        let diagnostics = wait_for_diagnostics(&manager, |diagnostics| {
+            has_diagnostic_line(diagnostics, "stdout", "worker stdout")
+                && has_diagnostic_line(diagnostics, "stderr", "worker stderr")
+        });
 
-        assert!(diagnostics
-            .iter()
-            .any(|line| line.stream == "stdout" && line.line.contains("worker stdout")));
-        assert!(diagnostics
-            .iter()
-            .any(|line| line.stream == "stderr" && line.line.contains("worker stderr")));
+        assert!(has_diagnostic_line(&diagnostics, "stdout", "worker stdout"));
+        assert!(has_diagnostic_line(&diagnostics, "stderr", "worker stderr"));
     }
 
     #[test]
@@ -542,5 +534,57 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
         manager.health_check()
+    }
+
+    fn wait_for_diagnostics(
+        manager: &WorkerManager,
+        predicate: impl Fn(&[WorkerDiagnosticLine]) -> bool,
+    ) -> Vec<WorkerDiagnosticLine> {
+        for _ in 0..30 {
+            let diagnostics = manager.status().diagnostics;
+            if predicate(&diagnostics) {
+                return diagnostics;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        manager.status().diagnostics
+    }
+
+    fn wait_for_events(
+        events: &Arc<Mutex<Vec<WorkerManagerEvent>>>,
+        predicate: impl Fn(&[WorkerManagerEvent]) -> bool,
+    ) -> Vec<WorkerManagerEvent> {
+        for _ in 0..30 {
+            let snapshot = events.lock().expect("event log should lock").clone();
+            if predicate(&snapshot) {
+                return snapshot;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        events.lock().expect("event log should lock").clone()
+    }
+
+    fn has_diagnostic_line(
+        diagnostics: &[WorkerDiagnosticLine],
+        stream: &str,
+        expected: &str,
+    ) -> bool {
+        diagnostics
+            .iter()
+            .any(|line| line.stream == stream && line.line.contains(expected))
+    }
+
+    fn has_diagnostics_event(
+        events: &[WorkerManagerEvent],
+        stream: &str,
+        expected: &str,
+    ) -> bool {
+        events.iter().any(|event| {
+            matches!(
+                event,
+                WorkerManagerEvent::Diagnostics(line)
+                    if line.stream == stream && line.line.contains(expected)
+            )
+        })
     }
 }

--- a/apps/desktop/src-tauri/src/worker_protocol.rs
+++ b/apps/desktop/src-tauri/src/worker_protocol.rs
@@ -89,6 +89,7 @@ pub struct WorkerEvent {
 pub enum WorkerProtocolErrorCode {
     InvalidProtocol,
     IncompatibleProtocolVersion,
+    CapabilityDenied,
     WorkerError,
 }
 

--- a/apps/desktop/src-tauri/src/worker_protocol.rs
+++ b/apps/desktop/src-tauri/src/worker_protocol.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::VecDeque;
 
-pub const WORKER_PROTOCOL_VERSION: &str = "2026-06-09";
+pub const WORKER_PROTOCOL_VERSION: &str = "1";
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -13,18 +13,25 @@ pub enum WorkerTransportMode {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WorkerRequest {
-    pub jsonrpc: String,
+    pub protocol_version: String,
     pub id: String,
+    pub trace_id: String,
     pub method: String,
     #[serde(default = "empty_json_object")]
     pub params: Value,
 }
 
 impl WorkerRequest {
-    pub fn new(id: impl Into<String>, method: impl Into<String>, params: Value) -> Self {
+    pub fn new(
+        id: impl Into<String>,
+        trace_id: impl Into<String>,
+        method: impl Into<String>,
+        params: Value,
+    ) -> Self {
         Self {
-            jsonrpc: "2.0".to_string(),
+            protocol_version: WORKER_PROTOCOL_VERSION.to_string(),
             id: id.into(),
+            trace_id: trace_id.into(),
             method: method.into(),
             params,
         }
@@ -33,8 +40,9 @@ impl WorkerRequest {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WorkerResponse {
-    pub jsonrpc: String,
+    pub protocol_version: String,
     pub id: String,
+    pub trace_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -42,26 +50,38 @@ pub struct WorkerResponse {
 }
 
 impl WorkerResponse {
-    pub fn success(id: impl Into<String>, result: Value) -> Self {
+    pub fn success(request: &WorkerRequest, result: Value) -> Self {
         Self {
-            jsonrpc: "2.0".to_string(),
-            id: id.into(),
+            protocol_version: WORKER_PROTOCOL_VERSION.to_string(),
+            id: request.id.clone(),
+            trace_id: request.trace_id.clone(),
             result: Some(result),
             error: None,
         }
     }
 
+    pub fn failure(request: &WorkerRequest, error: WorkerProtocolError) -> Self {
+        Self {
+            protocol_version: WORKER_PROTOCOL_VERSION.to_string(),
+            id: request.id.clone(),
+            trace_id: request.trace_id.clone(),
+            result: None,
+            error: Some(error),
+        }
+    }
+
     pub fn matches_request(&self, request: &WorkerRequest) -> bool {
-        self.id == request.id
+        self.id == request.id && self.trace_id == request.trace_id
     }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct WorkerNotification {
-    pub jsonrpc: String,
-    pub method: String,
+pub struct WorkerEvent {
+    pub protocol_version: String,
+    pub trace_id: String,
+    pub event: String,
     #[serde(default = "empty_json_object")]
-    pub params: Value,
+    pub payload: Value,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -69,24 +89,60 @@ pub struct WorkerNotification {
 pub enum WorkerProtocolErrorCode {
     InvalidProtocol,
     IncompatibleProtocolVersion,
+    WorkerError,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerProtocolErrorSource {
+    RustCore,
+    Worker,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WorkerProtocolError {
     pub code: WorkerProtocolErrorCode,
     pub message: String,
+    #[serde(default = "empty_json_object")]
+    pub details: Value,
+    pub retryable: bool,
+    pub source: WorkerProtocolErrorSource,
+}
+
+impl WorkerProtocolError {
+    pub fn new(
+        code: WorkerProtocolErrorCode,
+        message: impl Into<String>,
+        details: Value,
+        retryable: bool,
+        source: WorkerProtocolErrorSource,
+    ) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            details,
+            retryable,
+            source,
+        }
+    }
 }
 
 pub fn validate_protocol_version(version: &str) -> Result<(), WorkerProtocolError> {
     if version == WORKER_PROTOCOL_VERSION {
         return Ok(());
     }
-    Err(WorkerProtocolError {
-        code: WorkerProtocolErrorCode::IncompatibleProtocolVersion,
-        message: format!(
+    Err(WorkerProtocolError::new(
+        WorkerProtocolErrorCode::IncompatibleProtocolVersion,
+        format!(
             "Unsupported worker protocol version '{version}'. Expected '{WORKER_PROTOCOL_VERSION}'."
         ),
-    })
+        serde_json::json!({
+            "actual": version,
+            "expected": WORKER_PROTOCOL_VERSION,
+        }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    ))
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -144,31 +200,39 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn worker_request_response_ids_are_correlated() {
+    fn worker_request_response_ids_and_trace_ids_are_correlated() {
         let request = WorkerRequest::new(
             "req-123",
+            "trace-abc",
             "worker.health",
-            json!({ "protocolVersion": WORKER_PROTOCOL_VERSION }),
+            json!({ "protocol_version": WORKER_PROTOCOL_VERSION }),
         );
-        let response = WorkerResponse::success(&request.id, json!({ "ok": true }));
+        let response = WorkerResponse::success(&request, json!({ "ok": true }));
 
         assert!(response.matches_request(&request));
+        assert_eq!(request.protocol_version, "1");
         assert_eq!(response.id, "req-123");
+        assert_eq!(response.trace_id, "trace-abc");
         assert_eq!(response.result, Some(json!({ "ok": true })));
         assert!(response.error.is_none());
+
+        let value = serde_json::to_value(request).expect("request should serialize");
+        assert!(value.get("jsonrpc").is_none());
     }
 
     #[test]
-    fn worker_notification_without_id_is_event() {
-        let notification: WorkerNotification = serde_json::from_value(json!({
-            "jsonrpc": "2.0",
-            "method": "worker.progress",
-            "params": { "percent": 42 }
+    fn worker_event_without_id_keeps_protocol_and_trace_metadata() {
+        let event: WorkerEvent = serde_json::from_value(json!({
+            "protocol_version": "1",
+            "trace_id": "trace-abc",
+            "event": "diagnostics.log",
+            "payload": { "stream": "stdout", "line": "ready" }
         }))
-        .expect("notification should parse");
+        .expect("event should parse");
 
-        assert_eq!(notification.method, "worker.progress");
-        assert_eq!(notification.params, json!({ "percent": 42 }));
+        assert_eq!(event.event, "diagnostics.log");
+        assert_eq!(event.trace_id, "trace-abc");
+        assert_eq!(event.payload, json!({ "stream": "stdout", "line": "ready" }));
     }
 
     #[test]
@@ -176,7 +240,36 @@ mod tests {
         let error = validate_protocol_version("0.9").expect_err("old worker should be rejected");
 
         assert_eq!(error.code, WorkerProtocolErrorCode::IncompatibleProtocolVersion);
+        assert_eq!(error.source, WorkerProtocolErrorSource::RustCore);
+        assert!(!error.retryable);
+        assert_eq!(error.details["expected"], WORKER_PROTOCOL_VERSION);
         assert!(error.message.contains(WORKER_PROTOCOL_VERSION));
+    }
+
+    #[test]
+    fn worker_error_response_uses_unified_error_shape() {
+        let request = WorkerRequest::new("req-123", "trace-abc", "worker.health", json!({}));
+        let response = WorkerResponse::failure(
+            &request,
+            WorkerProtocolError::new(
+                WorkerProtocolErrorCode::WorkerError,
+                "worker crashed",
+                json!({ "pid": 1234 }),
+                true,
+                WorkerProtocolErrorSource::Worker,
+            ),
+        );
+
+        let value = serde_json::to_value(response).expect("response should serialize");
+
+        assert_eq!(value["protocol_version"], "1");
+        assert_eq!(value["id"], "req-123");
+        assert_eq!(value["trace_id"], "trace-abc");
+        assert_eq!(value["error"]["code"], "worker_error");
+        assert_eq!(value["error"]["message"], "worker crashed");
+        assert_eq!(value["error"]["details"]["pid"], 1234);
+        assert_eq!(value["error"]["retryable"], true);
+        assert_eq!(value["error"]["source"], "worker");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -1,0 +1,374 @@
+use crate::worker_capability::CapabilityPolicy;
+use crate::worker_config::WorkerConfigRpc;
+use crate::worker_diagnostics::WorkerDiagnosticsRpc;
+use crate::worker_protocol::{validate_protocol_version, WorkerRequest, WorkerResponse};
+use crate::worker_session::{SessionMetadata, WorkerSessionRpc};
+use crate::worker_workspace::WorkerWorkspaceRpc;
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub struct WorkerRpcRouter {
+    workspace: WorkerWorkspaceRpc,
+    config: WorkerConfigRpc,
+    session: WorkerSessionRpc,
+    diagnostics: WorkerDiagnosticsRpc,
+}
+
+impl WorkerRpcRouter {
+    pub fn new(
+        workspace_root: PathBuf,
+        config_snapshot: Value,
+        sessions: Vec<SessionMetadata>,
+        diagnostic_capacity: usize,
+        policy: CapabilityPolicy,
+    ) -> Self {
+        Self {
+            workspace: WorkerWorkspaceRpc::new(workspace_root, policy.clone()),
+            config: WorkerConfigRpc::new(config_snapshot, policy.clone()),
+            session: WorkerSessionRpc::new(sessions, policy.clone()),
+            diagnostics: WorkerDiagnosticsRpc::new(diagnostic_capacity, policy),
+        }
+    }
+
+    pub fn dispatch(&mut self, request: &WorkerRequest) -> WorkerResponse {
+        if let Err(error) = validate_protocol_version(&request.protocol_version) {
+            return WorkerResponse::failure(request, error);
+        }
+
+        match self.dispatch_result(request) {
+            Ok(result) => WorkerResponse::success(request, result),
+            Err(error) => WorkerResponse::failure(request, error),
+        }
+    }
+
+    fn dispatch_result(
+        &mut self,
+        request: &WorkerRequest,
+    ) -> Result<Value, crate::worker_protocol::WorkerProtocolError> {
+        match request.method.as_str() {
+            "workspace.resolve_path" => {
+                let params: PathParams = parse_params(request)?;
+                serde_json::to_value(self.workspace.resolve_path(&params.path)?)
+                    .map_err(serialization_error)
+            }
+            "workspace.read_file" => {
+                let params: PathParams = parse_params(request)?;
+                serde_json::to_value(self.workspace.read_file(&params.path)?)
+                    .map_err(serialization_error)
+            }
+            "workspace.write_file" => {
+                let params: WriteFileParams = parse_params(request)?;
+                serde_json::to_value(self.workspace.write_file(&params.path, &params.contents)?)
+                    .map_err(serialization_error)
+            }
+            "workspace.list_files" => {
+                serde_json::to_value(self.workspace.list_files()?).map_err(serialization_error)
+            }
+            "config.get" => {
+                let params: PathParams = parse_params(request)?;
+                serde_json::to_value(self.config.get(&params.path)?).map_err(serialization_error)
+            }
+            "session.get_metadata" => {
+                let params: SessionIdParams = parse_params(request)?;
+                serde_json::to_value(self.session.get_metadata(&params.session_id)?)
+                    .map_err(serialization_error)
+            }
+            "session.list_metadata" => {
+                serde_json::to_value(self.session.list_metadata()?).map_err(serialization_error)
+            }
+            "diagnostics.append" => {
+                let params: DiagnosticsAppendParams = parse_params(request)?;
+                serde_json::to_value(self.diagnostics.append(&params.stream, &params.line)?)
+                    .map_err(serialization_error)
+            }
+            _ => Err(unknown_method_error(request)),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct PathParams {
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct WriteFileParams {
+    path: String,
+    contents: String,
+}
+
+#[derive(Deserialize)]
+struct SessionIdParams {
+    session_id: String,
+}
+
+#[derive(Deserialize)]
+struct DiagnosticsAppendParams {
+    stream: String,
+    line: String,
+}
+
+fn parse_params<T: for<'de> Deserialize<'de>>(
+    request: &WorkerRequest,
+) -> Result<T, crate::worker_protocol::WorkerProtocolError> {
+    serde_json::from_value(request.params.clone()).map_err(|error| {
+        crate::worker_protocol::WorkerProtocolError::new(
+            crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol,
+            "invalid worker request params",
+            serde_json::json!({
+                "method": request.method,
+                "error": error.to_string(),
+            }),
+            false,
+            crate::worker_protocol::WorkerProtocolErrorSource::RustCore,
+        )
+    })
+}
+
+fn serialization_error(error: serde_json::Error) -> crate::worker_protocol::WorkerProtocolError {
+    crate::worker_protocol::WorkerProtocolError::new(
+        crate::worker_protocol::WorkerProtocolErrorCode::WorkerError,
+        "failed to serialize worker RPC result",
+        serde_json::json!({ "error": error.to_string() }),
+        false,
+        crate::worker_protocol::WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn unknown_method_error(request: &WorkerRequest) -> crate::worker_protocol::WorkerProtocolError {
+    crate::worker_protocol::WorkerProtocolError::new(
+        crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol,
+        "unknown worker RPC method",
+        serde_json::json!({ "method": request.method }),
+        false,
+        crate::worker_protocol::WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+    use crate::worker_protocol::WorkerRequest;
+    use crate::worker_rpc::WorkerRpcRouter;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    #[test]
+    fn dispatches_workspace_read_file_request() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("notes/today.md", "hello router");
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead]),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "workspace.read_file",
+            json!({ "path": "notes/today.md" }),
+        );
+
+        let response = router.dispatch(&request);
+
+        assert!(response.matches_request(&request));
+        assert!(response.error.is_none());
+        assert_eq!(
+            response.result,
+            Some(json!({ "path": "notes/today.md", "contents": "hello router" }))
+        );
+    }
+
+    #[test]
+    fn dispatch_returns_capability_error_response() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("notes/today.md", "hello router");
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::default(),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "workspace.read_file",
+            json!({ "path": "notes/today.md" }),
+        );
+
+        let response = router.dispatch(&request);
+
+        let error = response.error.expect("response should contain error");
+        assert_eq!(error.code, crate::worker_protocol::WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.details["capability"], "fs.workspace.read");
+        assert!(response.result.is_none());
+    }
+
+    #[test]
+    fn dispatch_rejects_unknown_method() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead]),
+        );
+        let request = WorkerRequest::new("req-1", "trace-1", "shell.execute", json!({}));
+
+        let response = router.dispatch(&request);
+
+        let error = response.error.expect("response should contain error");
+        assert_eq!(error.code, crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol);
+        assert_eq!(error.details["method"], "shell.execute");
+    }
+
+    #[test]
+    fn dispatch_rejects_invalid_params() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead]),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "workspace.read_file",
+            json!({ "missing_path": "notes/today.md" }),
+        );
+
+        let response = router.dispatch(&request);
+
+        let error = response.error.expect("response should contain error");
+        assert_eq!(error.code, crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol);
+        assert_eq!(error.details["method"], "workspace.read_file");
+    }
+
+    #[test]
+    fn dispatches_config_get_request() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({ "agents": { "defaults": { "model": "gpt-5" } } }),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::ConfigRead]),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "config.get",
+            json!({ "path": "agents.defaults.model" }),
+        );
+
+        let response = router.dispatch(&request);
+
+        assert_eq!(
+            response.result,
+            Some(json!({ "path": "agents.defaults.model", "value": "gpt-5" }))
+        );
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_session_get_metadata_request() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![session_fixture()],
+            20,
+            CapabilityPolicy::new([WorkerCapability::SessionMetadataRead]),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "session.get_metadata",
+            json!({ "session_id": "session-1" }),
+        );
+
+        let response = router.dispatch(&request);
+
+        assert_eq!(response.result.as_ref().unwrap()["session_id"], "session-1");
+        assert_eq!(response.result.as_ref().unwrap()["title"], "Native Core Migration");
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_diagnostics_append_request() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::DiagnosticsWrite]),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "diagnostics.append",
+            json!({ "stream": "stderr", "line": "worker warning" }),
+        );
+
+        let response = router.dispatch(&request);
+
+        assert_eq!(
+            response.result,
+            Some(json!({ "stream": "stderr", "line": "worker warning" }))
+        );
+        assert!(response.error.is_none());
+    }
+
+    fn session_fixture() -> crate::worker_session::SessionMetadata {
+        crate::worker_session::SessionMetadata {
+            session_id: "session-1".to_string(),
+            title: "Native Core Migration".to_string(),
+            workspace_dir: "D:/code/tinybot/tinybot".to_string(),
+            created_at: "2026-06-09T09:00:00Z".to_string(),
+            updated_at: "2026-06-09T09:30:00Z".to_string(),
+            extra: json!({ "mode": "desktop" }),
+        }
+    }
+
+    struct WorkspaceFixture {
+        root: PathBuf,
+    }
+
+    impl WorkspaceFixture {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "tinybot-worker-rpc-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("clock should be after unix epoch")
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&root).expect("workspace fixture should create");
+            Self { root }
+        }
+
+        fn write(&self, relative_path: &str, contents: &str) {
+            let path = self.root.join(relative_path.replace('/', std::path::MAIN_SEPARATOR_STR));
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("fixture parent should create");
+            }
+            std::fs::write(path, contents).expect("fixture file should write");
+        }
+    }
+
+    impl Drop for WorkspaceFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_session.rs
+++ b/apps/desktop/src-tauri/src/worker_session.rs
@@ -1,0 +1,182 @@
+use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+use crate::worker_protocol::{
+    WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug)]
+pub struct WorkerSessionRpc {
+    sessions: Vec<SessionMetadata>,
+    policy: CapabilityPolicy,
+}
+
+impl WorkerSessionRpc {
+    pub fn new(sessions: Vec<SessionMetadata>, policy: CapabilityPolicy) -> Self {
+        Self { sessions, policy }
+    }
+
+    pub fn get_metadata(&self, session_id: &str) -> Result<SessionMetadata, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        validate_session_id(session_id)?;
+        self.sessions
+            .iter()
+            .find(|session| session.session_id == session_id)
+            .cloned()
+            .ok_or_else(|| unknown_session_error(session_id))
+    }
+
+    pub fn list_metadata(&self) -> Result<Vec<SessionMetadata>, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        let mut sessions = self.sessions.clone();
+        sessions.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| left.session_id.cmp(&right.session_id))
+        });
+        Ok(sessions)
+    }
+
+    fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
+        if self.policy.allows(&capability) {
+            return Ok(());
+        }
+        Err(WorkerProtocolError::new(
+            WorkerProtocolErrorCode::CapabilityDenied,
+            "worker capability denied",
+            serde_json::json!({ "capability": capability }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct SessionMetadata {
+    pub session_id: String,
+    pub title: String,
+    pub workspace_dir: String,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub extra: Value,
+}
+
+fn validate_session_id(session_id: &str) -> Result<(), WorkerProtocolError> {
+    if session_id.is_empty()
+        || session_id.contains('\0')
+        || session_id.contains('/')
+        || session_id.contains('\\')
+        || session_id.contains("..")
+    {
+        return Err(WorkerProtocolError::new(
+            WorkerProtocolErrorCode::InvalidProtocol,
+            "invalid session id",
+            serde_json::json!({ "session_id": session_id }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ));
+    }
+    Ok(())
+}
+
+fn unknown_session_error(session_id: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "session metadata not found",
+        serde_json::json!({ "session_id": session_id }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+    use crate::worker_protocol::{WorkerProtocolErrorCode, WorkerProtocolErrorSource};
+    use serde_json::json;
+
+    #[test]
+    fn default_policy_denies_session_metadata_read() {
+        let rpc = WorkerSessionRpc::new(vec![session_fixture()], CapabilityPolicy::default());
+
+        let error = rpc
+            .get_metadata("session-1")
+            .expect_err("session metadata should require capability");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.source, WorkerProtocolErrorSource::RustCore);
+        assert_eq!(error.details["capability"], "session.metadata.read");
+    }
+
+    #[test]
+    fn get_metadata_returns_matching_session_with_capability() {
+        let rpc = WorkerSessionRpc::new(vec![session_fixture()], read_policy());
+
+        let metadata = rpc
+            .get_metadata("session-1")
+            .expect("session metadata should read");
+
+        assert_eq!(metadata.session_id, "session-1");
+        assert_eq!(metadata.title, "Native Core Migration");
+        assert_eq!(metadata.workspace_dir, "D:/code/tinybot/tinybot");
+        assert_eq!(metadata.extra["mode"], "desktop");
+    }
+
+    #[test]
+    fn get_metadata_rejects_unknown_session_id() {
+        let rpc = WorkerSessionRpc::new(vec![session_fixture()], read_policy());
+
+        let error = rpc
+            .get_metadata("missing-session")
+            .expect_err("unknown session should fail");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
+        assert_eq!(error.details["session_id"], "missing-session");
+    }
+
+    #[test]
+    fn get_metadata_rejects_invalid_session_id() {
+        let rpc = WorkerSessionRpc::new(vec![session_fixture()], read_policy());
+
+        assert!(rpc.get_metadata("").is_err());
+        assert!(rpc.get_metadata("../session").is_err());
+        assert!(rpc.get_metadata("session\0id").is_err());
+    }
+
+    #[test]
+    fn list_metadata_returns_sorted_sessions() {
+        let mut later = session_fixture();
+        later.session_id = "session-2".to_string();
+        later.updated_at = "2026-06-09T10:30:00Z".to_string();
+        let mut earlier = session_fixture();
+        earlier.session_id = "session-1".to_string();
+        earlier.updated_at = "2026-06-09T09:30:00Z".to_string();
+        let rpc = WorkerSessionRpc::new(vec![earlier, later], read_policy());
+
+        let sessions = rpc.list_metadata().expect("sessions should list");
+        let ids: Vec<String> = sessions
+            .into_iter()
+            .map(|session| session.session_id)
+            .collect();
+
+        assert_eq!(ids, vec!["session-2", "session-1"]);
+    }
+
+    fn read_policy() -> CapabilityPolicy {
+        CapabilityPolicy::new([WorkerCapability::SessionMetadataRead])
+    }
+
+    fn session_fixture() -> SessionMetadata {
+        SessionMetadata {
+            session_id: "session-1".to_string(),
+            title: "Native Core Migration".to_string(),
+            workspace_dir: "D:/code/tinybot/tinybot".to_string(),
+            created_at: "2026-06-09T09:00:00Z".to_string(),
+            updated_at: "2026-06-09T09:30:00Z".to_string(),
+            extra: json!({ "mode": "desktop" }),
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_stdio.rs
+++ b/apps/desktop/src-tauri/src/worker_stdio.rs
@@ -61,6 +61,43 @@ where
         decode_worker_line(line.trim_end_matches(['\r', '\n'])).map(Some)
     }
 
+    pub fn round_trip(
+        &mut self,
+        request: &WorkerRequest,
+        mut on_event: impl FnMut(&WorkerEvent),
+    ) -> Result<WorkerResponse, WorkerProtocolError> {
+        self.send_request(request)?;
+        loop {
+            let Some(message) = self.read_message()? else {
+                return Err(worker_error(
+                    "worker stream ended before response",
+                    serde_json::json!({
+                        "id": request.id,
+                        "trace_id": request.trace_id,
+                    }),
+                    true,
+                ));
+            };
+            match message {
+                WorkerInboundMessage::Event(event) => on_event(&event),
+                WorkerInboundMessage::Response(response) => {
+                    if response.matches_request(request) {
+                        return Ok(response);
+                    }
+                    return Err(invalid_protocol_error(
+                        "worker response does not match request identity",
+                        serde_json::json!({
+                            "expected_id": request.id,
+                            "expected_trace_id": request.trace_id,
+                            "actual_id": response.id,
+                            "actual_trace_id": response.trace_id,
+                        }),
+                    ));
+                }
+            }
+        }
+    }
+
     pub fn into_writer(self) -> W {
         self.writer
     }
@@ -117,6 +154,16 @@ fn invalid_protocol_error(message: impl Into<String>, details: Value) -> WorkerP
         details,
         false,
         WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn worker_error(message: impl Into<String>, details: Value, retryable: bool) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::WorkerError,
+        message,
+        details,
+        retryable,
+        WorkerProtocolErrorSource::Worker,
     )
 }
 
@@ -234,6 +281,65 @@ mod tests {
             }
             WorkerInboundMessage::Event(_) => panic!("expected response"),
         }
+    }
+
+    #[test]
+    fn round_trip_sends_request_collects_events_until_matching_response() {
+        let input = Cursor::new(
+            concat!(
+                r#"{"protocol_version":"1","trace_id":"trace-abc","event":"diagnostics.log","payload":{"line":"starting"}}"#,
+                "\n",
+                r#"{"protocol_version":"1","id":"req-123","trace_id":"trace-abc","result":{"status":"ok"}}"#,
+                "\n"
+            )
+            .as_bytes()
+            .to_vec(),
+        );
+        let request = WorkerRequest::new("req-123", "trace-abc", "worker.health", json!({}));
+        let mut events = Vec::new();
+        let mut transport = WorkerStdioTransport::new(input, Vec::new());
+
+        let response = transport
+            .round_trip(&request, |event| events.push(event.event.clone()))
+            .expect("round trip should return matching response");
+
+        assert_eq!(response.result, Some(json!({ "status": "ok" })));
+        assert_eq!(events, vec!["diagnostics.log"]);
+
+        let written = String::from_utf8(transport.into_writer()).expect("request is utf-8");
+        assert!(written.contains(r#""method":"worker.health""#));
+    }
+
+    #[test]
+    fn round_trip_rejects_mismatched_response_identity() {
+        let input = Cursor::new(
+            br#"{"protocol_version":"1","id":"other","trace_id":"trace-abc","result":{"status":"ok"}}"#
+                .to_vec(),
+        );
+        let request = WorkerRequest::new("req-123", "trace-abc", "worker.health", json!({}));
+        let mut transport = WorkerStdioTransport::new(input, Vec::new());
+
+        let error = transport
+            .round_trip(&request, |_| {})
+            .expect_err("mismatched response should fail");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
+        assert_eq!(error.details["expected_id"], "req-123");
+        assert_eq!(error.details["actual_id"], "other");
+    }
+
+    #[test]
+    fn round_trip_returns_worker_error_when_eof_arrives_before_response() {
+        let request = WorkerRequest::new("req-123", "trace-abc", "worker.health", json!({}));
+        let mut transport = WorkerStdioTransport::new(Cursor::new(Vec::<u8>::new()), Vec::new());
+
+        let error = transport
+            .round_trip(&request, |_| {})
+            .expect_err("eof before response should fail");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::WorkerError);
+        assert_eq!(error.source, WorkerProtocolErrorSource::Worker);
+        assert!(error.retryable);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_stdio.rs
+++ b/apps/desktop/src-tauri/src/worker_stdio.rs
@@ -1,0 +1,275 @@
+use crate::worker_protocol::{
+    validate_protocol_version, WorkerEvent, WorkerProtocolError, WorkerProtocolErrorCode,
+    WorkerProtocolErrorSource, WorkerRequest, WorkerResponse,
+};
+use serde_json::Value;
+use std::io::{BufRead, Write};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum WorkerInboundMessage {
+    Response(WorkerResponse),
+    Event(WorkerEvent),
+}
+
+#[derive(Debug)]
+pub struct WorkerStdioTransport<R, W> {
+    reader: R,
+    writer: W,
+}
+
+impl<R, W> WorkerStdioTransport<R, W>
+where
+    R: BufRead,
+    W: Write,
+{
+    pub fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+
+    pub fn send_request(&mut self, request: &WorkerRequest) -> Result<(), WorkerProtocolError> {
+        serde_json::to_writer(&mut self.writer, request).map_err(|error| {
+            invalid_protocol_error(
+                "failed to encode worker request",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        self.writer.write_all(b"\n").map_err(|error| {
+            invalid_protocol_error(
+                "failed to write worker request",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        self.writer.flush().map_err(|error| {
+            invalid_protocol_error(
+                "failed to flush worker request",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })
+    }
+
+    pub fn read_message(&mut self) -> Result<Option<WorkerInboundMessage>, WorkerProtocolError> {
+        let mut line = String::new();
+        let bytes = self.reader.read_line(&mut line).map_err(|error| {
+            invalid_protocol_error(
+                "failed to read worker message",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        if bytes == 0 {
+            return Ok(None);
+        }
+        decode_worker_line(line.trim_end_matches(['\r', '\n'])).map(Some)
+    }
+
+    pub fn into_writer(self) -> W {
+        self.writer
+    }
+}
+
+pub fn decode_worker_line(line: &str) -> Result<WorkerInboundMessage, WorkerProtocolError> {
+    let value: Value = serde_json::from_str(line).map_err(|error| {
+        invalid_protocol_error(
+            "worker message is not valid JSON",
+            serde_json::json!({ "error": error.to_string(), "line": line }),
+        )
+    })?;
+    let version = value
+        .get("protocol_version")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            invalid_protocol_error(
+                "worker message missing protocol_version",
+                serde_json::json!({ "message": value }),
+            )
+        })?;
+    validate_protocol_version(version)?;
+
+    if value.get("id").is_some() {
+        let response: WorkerResponse = serde_json::from_value(value).map_err(|error| {
+            invalid_protocol_error(
+                "worker response has invalid shape",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        return Ok(WorkerInboundMessage::Response(response));
+    }
+
+    if value.get("event").is_some() {
+        let event: WorkerEvent = serde_json::from_value(value).map_err(|error| {
+            invalid_protocol_error(
+                "worker event has invalid shape",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        return Ok(WorkerInboundMessage::Event(event));
+    }
+
+    Err(invalid_protocol_error(
+        "worker message is neither response nor event",
+        serde_json::json!({ "message": value }),
+    ))
+}
+
+fn invalid_protocol_error(message: impl Into<String>, details: Value) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        message,
+        details,
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker_protocol::{
+        WorkerProtocolErrorCode, WorkerProtocolErrorSource, WorkerRequest,
+        WorkerTransportMode, WORKER_PROTOCOL_VERSION,
+    };
+    use serde_json::json;
+    use std::io::Cursor;
+
+    #[test]
+    fn transport_writes_request_as_one_json_line() {
+        let request = WorkerRequest::new(
+            "req-123",
+            "trace-abc",
+            "worker.health",
+            json!({ "transport": WorkerTransportMode::Stdio }),
+        );
+        let mut transport = WorkerStdioTransport::new(Cursor::new(Vec::<u8>::new()), Vec::new());
+
+        transport
+            .send_request(&request)
+            .expect("request should write");
+
+        let written = String::from_utf8(transport.into_writer()).expect("request is utf-8");
+        assert!(written.ends_with('\n'));
+
+        let value: serde_json::Value =
+            serde_json::from_str(written.trim_end()).expect("request line should be json");
+        assert_eq!(value["protocol_version"], WORKER_PROTOCOL_VERSION);
+        assert_eq!(value["id"], "req-123");
+        assert_eq!(value["trace_id"], "trace-abc");
+        assert_eq!(value["method"], "worker.health");
+        assert!(value.get("jsonrpc").is_none());
+    }
+
+    #[test]
+    fn transport_reads_fake_worker_response() {
+        let input = Cursor::new(
+            br#"{"protocol_version":"1","id":"req-123","trace_id":"trace-abc","result":{"ok":true}}"#
+                .to_vec(),
+        );
+        let mut transport = WorkerStdioTransport::new(input, Vec::new());
+
+        let message = transport
+            .read_message()
+            .expect("response should parse")
+            .expect("response should exist");
+
+        match message {
+            WorkerInboundMessage::Response(response) => {
+                assert_eq!(response.id, "req-123");
+                assert_eq!(response.trace_id, "trace-abc");
+                assert_eq!(response.result, Some(json!({ "ok": true })));
+                assert!(response.error.is_none());
+            }
+            WorkerInboundMessage::Event(_) => panic!("expected response"),
+        }
+    }
+
+    #[test]
+    fn transport_reads_fake_worker_event() {
+        let input = Cursor::new(
+            br#"{"protocol_version":"1","trace_id":"trace-abc","event":"diagnostics.log","payload":{"stream":"stderr","line":"ready"}}"#
+                .to_vec(),
+        );
+        let mut transport = WorkerStdioTransport::new(input, Vec::new());
+
+        let message = transport
+            .read_message()
+            .expect("event should parse")
+            .expect("event should exist");
+
+        match message {
+            WorkerInboundMessage::Event(event) => {
+                assert_eq!(event.trace_id, "trace-abc");
+                assert_eq!(event.event, "diagnostics.log");
+                assert_eq!(event.payload["line"], "ready");
+            }
+            WorkerInboundMessage::Response(_) => panic!("expected event"),
+        }
+    }
+
+    #[test]
+    fn transport_reads_fake_worker_event_then_response_sequence() {
+        let input = Cursor::new(
+            concat!(
+                r#"{"protocol_version":"1","trace_id":"trace-abc","event":"diagnostics.log","payload":{"line":"starting"}}"#,
+                "\n",
+                r#"{"protocol_version":"1","id":"req-123","trace_id":"trace-abc","result":{"status":"ok"}}"#,
+                "\n"
+            )
+            .as_bytes()
+            .to_vec(),
+        );
+        let mut transport = WorkerStdioTransport::new(input, Vec::new());
+
+        let first = transport
+            .read_message()
+            .expect("event should parse")
+            .expect("event should exist");
+        let second = transport
+            .read_message()
+            .expect("response should parse")
+            .expect("response should exist");
+
+        assert!(matches!(first, WorkerInboundMessage::Event(_)));
+        match second {
+            WorkerInboundMessage::Response(response) => {
+                assert_eq!(response.id, "req-123");
+                assert_eq!(response.result, Some(json!({ "status": "ok" })));
+            }
+            WorkerInboundMessage::Event(_) => panic!("expected response"),
+        }
+    }
+
+    #[test]
+    fn transport_returns_none_at_eof() {
+        let mut transport = WorkerStdioTransport::new(Cursor::new(Vec::<u8>::new()), Vec::new());
+
+        assert_eq!(transport.read_message().expect("eof should not error"), None);
+    }
+
+    #[test]
+    fn transport_rejects_incompatible_protocol_version() {
+        let input = Cursor::new(
+            br#"{"protocol_version":"0","id":"req-123","trace_id":"trace-abc","result":{"ok":true}}"#
+                .to_vec(),
+        );
+        let mut transport = WorkerStdioTransport::new(input, Vec::new());
+
+        let error = transport
+            .read_message()
+            .expect_err("old protocol should be rejected");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::IncompatibleProtocolVersion);
+        assert_eq!(error.source, WorkerProtocolErrorSource::RustCore);
+        assert_eq!(error.details["expected"], WORKER_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn transport_rejects_non_json_line_as_invalid_protocol() {
+        let mut transport = WorkerStdioTransport::new(Cursor::new(b"not-json\n".to_vec()), Vec::new());
+
+        let error = transport
+            .read_message()
+            .expect_err("non-json line should be rejected");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
+        assert_eq!(error.source, WorkerProtocolErrorSource::RustCore);
+        assert!(!error.retryable);
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_stdio.rs
+++ b/apps/desktop/src-tauri/src/worker_stdio.rs
@@ -2,11 +2,13 @@ use crate::worker_protocol::{
     validate_protocol_version, WorkerEvent, WorkerProtocolError, WorkerProtocolErrorCode,
     WorkerProtocolErrorSource, WorkerRequest, WorkerResponse,
 };
+use crate::worker_rpc::WorkerRpcRouter;
 use serde_json::Value;
 use std::io::{BufRead, Write};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum WorkerInboundMessage {
+    Request(WorkerRequest),
     Response(WorkerResponse),
     Event(WorkerEvent),
 }
@@ -47,6 +49,27 @@ where
         })
     }
 
+    pub fn send_response(&mut self, response: &WorkerResponse) -> Result<(), WorkerProtocolError> {
+        serde_json::to_writer(&mut self.writer, response).map_err(|error| {
+            invalid_protocol_error(
+                "failed to encode worker response",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        self.writer.write_all(b"\n").map_err(|error| {
+            invalid_protocol_error(
+                "failed to write worker response",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        self.writer.flush().map_err(|error| {
+            invalid_protocol_error(
+                "failed to flush worker response",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })
+    }
+
     pub fn read_message(&mut self) -> Result<Option<WorkerInboundMessage>, WorkerProtocolError> {
         let mut line = String::new();
         let bytes = self.reader.read_line(&mut line).map_err(|error| {
@@ -79,6 +102,16 @@ where
                 ));
             };
             match message {
+                WorkerInboundMessage::Request(request) => {
+                    return Err(invalid_protocol_error(
+                        "worker RPC request arrived during Rust request round trip",
+                        serde_json::json!({
+                            "id": request.id,
+                            "trace_id": request.trace_id,
+                            "method": request.method,
+                        }),
+                    ));
+                }
                 WorkerInboundMessage::Event(event) => on_event(&event),
                 WorkerInboundMessage::Response(response) => {
                     if response.matches_request(request) {
@@ -96,6 +129,32 @@ where
                 }
             }
         }
+    }
+
+    pub fn serve_rust_rpc_requests(
+        &mut self,
+        router: &mut WorkerRpcRouter,
+        mut on_event: impl FnMut(&WorkerEvent),
+    ) -> Result<(), WorkerProtocolError> {
+        while let Some(message) = self.read_message()? {
+            match message {
+                WorkerInboundMessage::Request(request) => {
+                    let response = router.dispatch(&request);
+                    self.send_response(&response)?;
+                }
+                WorkerInboundMessage::Event(event) => on_event(&event),
+                WorkerInboundMessage::Response(response) => {
+                    return Err(invalid_protocol_error(
+                        "worker response arrived while serving Rust RPC requests",
+                        serde_json::json!({
+                            "id": response.id,
+                            "trace_id": response.trace_id,
+                        }),
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn into_writer(self) -> W {
@@ -120,6 +179,16 @@ pub fn decode_worker_line(line: &str) -> Result<WorkerInboundMessage, WorkerProt
             )
         })?;
     validate_protocol_version(version)?;
+
+    if value.get("method").is_some() {
+        let request: WorkerRequest = serde_json::from_value(value).map_err(|error| {
+            invalid_protocol_error(
+                "worker request has invalid shape",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        return Ok(WorkerInboundMessage::Request(request));
+    }
 
     if value.get("id").is_some() {
         let response: WorkerResponse = serde_json::from_value(value).map_err(|error| {
@@ -174,8 +243,11 @@ mod tests {
         WorkerProtocolErrorCode, WorkerProtocolErrorSource, WorkerRequest,
         WorkerTransportMode, WORKER_PROTOCOL_VERSION,
     };
+    use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+    use crate::worker_rpc::WorkerRpcRouter;
     use serde_json::json;
     use std::io::Cursor;
+    use std::path::PathBuf;
 
     #[test]
     fn transport_writes_request_as_one_json_line() {
@@ -223,7 +295,33 @@ mod tests {
                 assert_eq!(response.result, Some(json!({ "ok": true })));
                 assert!(response.error.is_none());
             }
+            WorkerInboundMessage::Request(_) => panic!("expected response"),
             WorkerInboundMessage::Event(_) => panic!("expected response"),
+        }
+    }
+
+    #[test]
+    fn transport_reads_worker_rpc_request() {
+        let input = Cursor::new(
+            br#"{"protocol_version":"1","id":"req-123","trace_id":"trace-abc","method":"workspace.read_file","params":{"path":"notes/today.md"}}"#
+                .to_vec(),
+        );
+        let mut transport = WorkerStdioTransport::new(input, Vec::new());
+
+        let message = transport
+            .read_message()
+            .expect("request should parse")
+            .expect("request should exist");
+
+        match message {
+            WorkerInboundMessage::Request(request) => {
+                assert_eq!(request.id, "req-123");
+                assert_eq!(request.trace_id, "trace-abc");
+                assert_eq!(request.method, "workspace.read_file");
+                assert_eq!(request.params["path"], "notes/today.md");
+            }
+            WorkerInboundMessage::Response(_) => panic!("expected request"),
+            WorkerInboundMessage::Event(_) => panic!("expected request"),
         }
     }
 
@@ -246,6 +344,7 @@ mod tests {
                 assert_eq!(event.event, "diagnostics.log");
                 assert_eq!(event.payload["line"], "ready");
             }
+            WorkerInboundMessage::Request(_) => panic!("expected event"),
             WorkerInboundMessage::Response(_) => panic!("expected event"),
         }
     }
@@ -279,6 +378,7 @@ mod tests {
                 assert_eq!(response.id, "req-123");
                 assert_eq!(response.result, Some(json!({ "status": "ok" })));
             }
+            WorkerInboundMessage::Request(_) => panic!("expected response"),
             WorkerInboundMessage::Event(_) => panic!("expected response"),
         }
     }
@@ -343,6 +443,43 @@ mod tests {
     }
 
     #[test]
+    fn transport_dispatches_worker_rpc_request_and_writes_response() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("notes/today.md", "hello stdio rpc");
+        let input = Cursor::new(
+            concat!(
+                r#"{"protocol_version":"1","id":"req-123","trace_id":"trace-abc","method":"workspace.read_file","params":{"path":"notes/today.md"}}"#,
+                "\n"
+            )
+            .as_bytes()
+            .to_vec(),
+        );
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead]),
+        );
+        let mut transport = WorkerStdioTransport::new(input, Vec::new());
+
+        transport
+            .serve_rust_rpc_requests(&mut router, |_| {})
+            .expect("worker RPC request should be served");
+
+        let written = String::from_utf8(transport.into_writer()).expect("response is utf-8");
+        let value: serde_json::Value =
+            serde_json::from_str(written.trim_end()).expect("response line should be json");
+
+        assert_eq!(value["protocol_version"], WORKER_PROTOCOL_VERSION);
+        assert_eq!(value["id"], "req-123");
+        assert_eq!(value["trace_id"], "trace-abc");
+        assert_eq!(value["result"]["path"], "notes/today.md");
+        assert_eq!(value["result"]["contents"], "hello stdio rpc");
+        assert!(value.get("error").is_none());
+    }
+
+    #[test]
     fn transport_returns_none_at_eof() {
         let mut transport = WorkerStdioTransport::new(Cursor::new(Vec::<u8>::new()), Vec::new());
 
@@ -377,5 +514,38 @@ mod tests {
         assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
         assert_eq!(error.source, WorkerProtocolErrorSource::RustCore);
         assert!(!error.retryable);
+    }
+
+    struct WorkspaceFixture {
+        root: PathBuf,
+    }
+
+    impl WorkspaceFixture {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "tinybot-worker-stdio-rpc-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("clock should be after unix epoch")
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&root).expect("workspace fixture should create");
+            Self { root }
+        }
+
+        fn write(&self, relative_path: &str, contents: &str) {
+            let path = self.root.join(relative_path.replace('/', std::path::MAIN_SEPARATOR_STR));
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("fixture parent should create");
+            }
+            std::fs::write(path, contents).expect("fixture file should write");
+        }
+    }
+
+    impl Drop for WorkspaceFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/worker_workspace.rs
+++ b/apps/desktop/src-tauri/src/worker_workspace.rs
@@ -1,0 +1,370 @@
+use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+use crate::worker_protocol::{
+    WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
+};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug)]
+pub struct WorkerWorkspaceRpc {
+    root: PathBuf,
+    policy: CapabilityPolicy,
+}
+
+impl WorkerWorkspaceRpc {
+    pub fn new(root: PathBuf, policy: CapabilityPolicy) -> Self {
+        Self { root, policy }
+    }
+
+    pub fn resolve_path(
+        &self,
+        requested_path: &str,
+    ) -> Result<WorkspaceResolvedPath, WorkerProtocolError> {
+        self.require(WorkerCapability::FsWorkspaceRead)?;
+        let relative_path = normalize_workspace_path(requested_path)?;
+        Ok(WorkspaceResolvedPath {
+            absolute_path: join_workspace_relative(&self.root, &relative_path),
+            relative_path,
+        })
+    }
+
+    pub fn read_file(
+        &self,
+        requested_path: &str,
+    ) -> Result<WorkspaceFileContent, WorkerProtocolError> {
+        let resolved = self.resolve_path(requested_path)?;
+        ensure_inside_workspace(&self.root, &resolved.absolute_path)?;
+        let contents = std::fs::read_to_string(&resolved.absolute_path).map_err(|error| {
+            filesystem_error(
+                "failed to read workspace file",
+                serde_json::json!({
+                    "path": resolved.relative_path,
+                    "error": error.to_string(),
+                }),
+            )
+        })?;
+        Ok(WorkspaceFileContent {
+            path: resolved.relative_path,
+            contents,
+        })
+    }
+
+    pub fn list_files(&self) -> Result<Vec<WorkspaceFileEntry>, WorkerProtocolError> {
+        self.require(WorkerCapability::FsWorkspaceRead)?;
+        let root = canonicalize_workspace_root(&self.root)?;
+        let mut entries = Vec::new();
+        collect_workspace_files(&root, &root, &mut entries)?;
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        Ok(entries)
+    }
+
+    fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
+        if self.policy.allows(&capability) {
+            return Ok(());
+        }
+        Err(WorkerProtocolError::new(
+            WorkerProtocolErrorCode::CapabilityDenied,
+            "worker capability denied",
+            serde_json::json!({ "capability": capability }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceResolvedPath {
+    pub relative_path: String,
+    pub absolute_path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceFileContent {
+    pub path: String,
+    pub contents: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceFileEntry {
+    pub path: String,
+    pub size_bytes: u64,
+}
+
+fn collect_workspace_files(
+    root: &Path,
+    current: &Path,
+    entries: &mut Vec<WorkspaceFileEntry>,
+) -> Result<(), WorkerProtocolError> {
+    for entry in std::fs::read_dir(current).map_err(|error| {
+        filesystem_error(
+            "failed to list workspace directory",
+            serde_json::json!({
+                "path": current.display().to_string(),
+                "error": error.to_string(),
+            }),
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            filesystem_error(
+                "failed to inspect workspace directory entry",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        let path = entry.path();
+        ensure_inside_canonical_workspace(root, &path)?;
+        let metadata = entry.metadata().map_err(|error| {
+            filesystem_error(
+                "failed to read workspace file metadata",
+                serde_json::json!({
+                    "path": path.display().to_string(),
+                    "error": error.to_string(),
+                }),
+            )
+        })?;
+        if metadata.is_dir() {
+            collect_workspace_files(root, &path, entries)?;
+        } else if metadata.is_file() {
+            entries.push(WorkspaceFileEntry {
+                path: workspace_relative_path(root, &path)?,
+                size_bytes: metadata.len(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn normalize_workspace_path(requested_path: &str) -> Result<String, WorkerProtocolError> {
+    let normalized = requested_path.replace('\\', "/");
+    if normalized.is_empty()
+        || normalized.starts_with('/')
+        || normalized.contains(':')
+        || normalized.contains('\0')
+        || normalized
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(invalid_workspace_path(requested_path));
+    }
+    Ok(normalized)
+}
+
+fn join_workspace_relative(root: &Path, relative_path: &str) -> PathBuf {
+    relative_path
+        .split('/')
+        .fold(root.to_path_buf(), |path, part| path.join(part))
+}
+
+fn ensure_inside_workspace(root: &Path, path: &Path) -> Result<(), WorkerProtocolError> {
+    let root = canonicalize_workspace_root(root)?;
+    ensure_inside_canonical_workspace(&root, path)
+}
+
+fn ensure_inside_canonical_workspace(root: &Path, path: &Path) -> Result<(), WorkerProtocolError> {
+    let path = path.canonicalize().map_err(|error| {
+        filesystem_error(
+            "failed to resolve workspace path",
+            serde_json::json!({
+                "path": path.display().to_string(),
+                "error": error.to_string(),
+            }),
+        )
+    })?;
+    if path.starts_with(root) {
+        return Ok(());
+    }
+    Err(WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "workspace path escapes workspace root",
+        serde_json::json!({
+            "root": root.display().to_string(),
+            "path": path.display().to_string(),
+        }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    ))
+}
+
+fn workspace_relative_path(root: &Path, path: &Path) -> Result<String, WorkerProtocolError> {
+    path.strip_prefix(root)
+        .map_err(|error| {
+            filesystem_error(
+                "failed to compute workspace relative path",
+                serde_json::json!({
+                    "path": path.display().to_string(),
+                    "error": error.to_string(),
+                }),
+            )
+        })
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+}
+
+fn canonicalize_workspace_root(root: &Path) -> Result<PathBuf, WorkerProtocolError> {
+    root.canonicalize().map_err(|error| {
+        filesystem_error(
+            "failed to resolve workspace root",
+            serde_json::json!({
+                "root": root.display().to_string(),
+                "error": error.to_string(),
+            }),
+        )
+    })
+}
+
+fn invalid_workspace_path(requested_path: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "invalid workspace relative path",
+        serde_json::json!({ "path": requested_path }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn filesystem_error(message: impl Into<String>, details: serde_json::Value) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::WorkerError,
+        message,
+        details,
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+    use crate::worker_protocol::{WorkerProtocolErrorCode, WorkerProtocolErrorSource};
+    use std::path::PathBuf;
+
+    #[test]
+    fn default_policy_denies_workspace_read() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), CapabilityPolicy::default());
+
+        let error = rpc
+            .read_file("AGENTS.md")
+            .expect_err("read should require capability");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.source, WorkerProtocolErrorSource::RustCore);
+        assert_eq!(error.details["capability"], "fs.workspace.read");
+    }
+
+    #[test]
+    fn read_file_returns_utf8_content_with_read_capability() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("AGENTS.md", "hello worker");
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let file = rpc
+            .read_file("AGENTS.md")
+            .expect("allowed workspace file should read");
+
+        assert_eq!(file.path, "AGENTS.md");
+        assert_eq!(file.contents, "hello worker");
+    }
+
+    #[test]
+    fn list_files_returns_workspace_relative_paths() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("AGENTS.md", "agents");
+        fixture.write("memory/MEMORY.md", "memory");
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let files = rpc.list_files().expect("workspace files should list");
+        let paths: Vec<String> = files.into_iter().map(|file| file.path).collect();
+
+        assert_eq!(paths, vec!["AGENTS.md", "memory/MEMORY.md"]);
+    }
+
+    #[test]
+    fn resolve_path_normalizes_slashes_without_touching_filesystem() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let resolved = rpc
+            .resolve_path("memory\\MEMORY.md")
+            .expect("workspace path should resolve");
+
+        assert_eq!(resolved.relative_path, "memory/MEMORY.md");
+        assert_eq!(resolved.absolute_path, fixture.root.join("memory").join("MEMORY.md"));
+    }
+
+    #[test]
+    fn traversal_and_absolute_paths_are_rejected() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        assert!(rpc.resolve_path("../secret.txt").is_err());
+        assert!(rpc.resolve_path("memory/../secret.txt").is_err());
+        assert!(rpc.resolve_path("C:/Windows/System32").is_err());
+        assert!(rpc.resolve_path("/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn symlink_escape_is_rejected_when_reading_existing_file() {
+        let fixture = WorkspaceFixture::new();
+        let outside = fixture.outside.join("secret.txt");
+        std::fs::write(&outside, "secret").expect("outside fixture should write");
+
+        #[cfg(target_os = "windows")]
+        std::os::windows::fs::symlink_file(&outside, fixture.root.join("linked-secret.txt"))
+            .expect("symlink should create");
+
+        #[cfg(not(target_os = "windows"))]
+        std::os::unix::fs::symlink(&outside, fixture.root.join("linked-secret.txt"))
+            .expect("symlink should create");
+
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let error = rpc
+            .read_file("linked-secret.txt")
+            .expect_err("symlink escape should be blocked");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
+    }
+
+    fn read_policy() -> CapabilityPolicy {
+        CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead])
+    }
+
+    struct WorkspaceFixture {
+        root: PathBuf,
+        outside: PathBuf,
+    }
+
+    impl WorkspaceFixture {
+        fn new() -> Self {
+            let base = std::env::temp_dir().join(format!(
+                "tinybot-worker-workspace-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("clock should be after unix epoch")
+                    .as_nanos()
+            ));
+            let root = base.join("workspace");
+            let outside = base.join("outside");
+            std::fs::create_dir_all(&root).expect("workspace fixture should create");
+            std::fs::create_dir_all(&outside).expect("outside fixture should create");
+            Self { root, outside }
+        }
+
+        fn write(&self, relative_path: &str, contents: &str) {
+            let path = self.root.join(relative_path.replace('/', std::path::MAIN_SEPARATOR_STR));
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("fixture parent should create");
+            }
+            std::fs::write(path, contents).expect("fixture file should write");
+        }
+    }
+
+    impl Drop for WorkspaceFixture {
+        fn drop(&mut self) {
+            if let Some(base) = self.root.parent() {
+                let _ = std::fs::remove_dir_all(base);
+            }
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/worker_workspace.rs
+++ b/apps/desktop/src-tauri/src/worker_workspace.rs
@@ -58,6 +58,42 @@ impl WorkerWorkspaceRpc {
         Ok(entries)
     }
 
+    pub fn write_file(
+        &self,
+        requested_path: &str,
+        contents: &str,
+    ) -> Result<WorkspaceWriteResult, WorkerProtocolError> {
+        self.require(WorkerCapability::FsWorkspaceWrite)?;
+        let relative_path = normalize_workspace_path(requested_path)?;
+        let absolute_path = join_workspace_relative(&self.root, &relative_path);
+        ensure_write_target_inside_workspace(&self.root, &absolute_path)?;
+        if let Some(parent) = absolute_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                filesystem_error(
+                    "failed to create workspace file parent directory",
+                    serde_json::json!({
+                        "path": relative_path,
+                        "error": error.to_string(),
+                    }),
+                )
+            })?;
+            ensure_inside_workspace(&self.root, parent)?;
+        }
+        std::fs::write(&absolute_path, contents).map_err(|error| {
+            filesystem_error(
+                "failed to write workspace file",
+                serde_json::json!({
+                    "path": relative_path,
+                    "error": error.to_string(),
+                }),
+            )
+        })?;
+        Ok(WorkspaceWriteResult {
+            path: relative_path,
+            bytes_written: contents.len() as u64,
+        })
+    }
+
     fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
         if self.policy.allows(&capability) {
             return Ok(());
@@ -88,6 +124,12 @@ pub struct WorkspaceFileContent {
 pub struct WorkspaceFileEntry {
     pub path: String,
     pub size_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceWriteResult {
+    pub path: String,
+    pub bytes_written: u64,
 }
 
 fn collect_workspace_files(
@@ -157,6 +199,37 @@ fn join_workspace_relative(root: &Path, relative_path: &str) -> PathBuf {
 fn ensure_inside_workspace(root: &Path, path: &Path) -> Result<(), WorkerProtocolError> {
     let root = canonicalize_workspace_root(root)?;
     ensure_inside_canonical_workspace(&root, path)
+}
+
+fn ensure_write_target_inside_workspace(
+    root: &Path,
+    path: &Path,
+) -> Result<(), WorkerProtocolError> {
+    let root = canonicalize_workspace_root(root)?;
+    if path.exists() {
+        return ensure_inside_canonical_workspace(&root, path);
+    }
+    let parent = path.parent().ok_or_else(|| invalid_workspace_path(""))?;
+    if parent.exists() {
+        return ensure_inside_canonical_workspace(&root, parent);
+    }
+    ensure_new_parent_chain_inside_workspace(&root, parent)
+}
+
+fn ensure_new_parent_chain_inside_workspace(
+    root: &Path,
+    parent: &Path,
+) -> Result<(), WorkerProtocolError> {
+    let existing_parent = parent
+        .ancestors()
+        .find(|candidate| candidate.exists())
+        .ok_or_else(|| {
+            filesystem_error(
+                "failed to locate existing workspace parent directory",
+                serde_json::json!({ "path": parent.display().to_string() }),
+            )
+        })?;
+    ensure_inside_canonical_workspace(root, existing_parent)
 }
 
 fn ensure_inside_canonical_workspace(root: &Path, path: &Path) -> Result<(), WorkerProtocolError> {
@@ -325,8 +398,94 @@ mod tests {
         assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
     }
 
+    #[test]
+    fn default_policy_denies_workspace_write() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), CapabilityPolicy::default());
+
+        let error = rpc
+            .write_file("notes/today.md", "hello")
+            .expect_err("write should require capability");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.details["capability"], "fs.workspace.write");
+    }
+
+    #[test]
+    fn read_policy_does_not_allow_workspace_write() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let error = rpc
+            .write_file("notes/today.md", "hello")
+            .expect_err("read capability should not allow write");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.details["capability"], "fs.workspace.write");
+    }
+
+    #[test]
+    fn write_file_creates_parent_directories_inside_workspace() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), write_policy());
+
+        let written = rpc
+            .write_file("notes/today.md", "hello writer")
+            .expect("write should succeed");
+
+        assert_eq!(written.path, "notes/today.md");
+        assert_eq!(written.bytes_written, 12);
+        assert_eq!(
+            std::fs::read_to_string(fixture.root.join("notes").join("today.md"))
+                .expect("written file should read"),
+            "hello writer"
+        );
+    }
+
+    #[test]
+    fn write_file_rejects_traversal_and_absolute_paths() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), write_policy());
+
+        assert!(rpc.write_file("../secret.txt", "secret").is_err());
+        assert!(rpc.write_file("notes/../secret.txt", "secret").is_err());
+        assert!(rpc.write_file("C:/Windows/System32", "secret").is_err());
+        assert!(rpc.write_file("/etc/passwd", "secret").is_err());
+    }
+
+    #[test]
+    fn write_file_rejects_symlink_escape_overwrite() {
+        let fixture = WorkspaceFixture::new();
+        let outside = fixture.outside.join("secret.txt");
+        std::fs::write(&outside, "secret").expect("outside fixture should write");
+
+        #[cfg(target_os = "windows")]
+        std::os::windows::fs::symlink_file(&outside, fixture.root.join("linked-secret.txt"))
+            .expect("symlink should create");
+
+        #[cfg(not(target_os = "windows"))]
+        std::os::unix::fs::symlink(&outside, fixture.root.join("linked-secret.txt"))
+            .expect("symlink should create");
+
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), write_policy());
+
+        let error = rpc
+            .write_file("linked-secret.txt", "overwrite")
+            .expect_err("symlink escape should be blocked");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
+        assert_eq!(
+            std::fs::read_to_string(outside).expect("outside file should read"),
+            "secret"
+        );
+    }
+
     fn read_policy() -> CapabilityPolicy {
         CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead])
+    }
+
+    fn write_policy() -> CapabilityPolicy {
+        CapabilityPolicy::new([WorkerCapability::FsWorkspaceWrite])
     }
 
     struct WorkspaceFixture {

--- a/apps/desktop/src-tauri/src/worker_workspace.rs
+++ b/apps/desktop/src-tauri/src/worker_workspace.rs
@@ -154,7 +154,7 @@ fn collect_workspace_files(
         })?;
         let path = entry.path();
         ensure_inside_canonical_workspace(root, &path)?;
-        let metadata = entry.metadata().map_err(|error| {
+        let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
             filesystem_error(
                 "failed to read workspace file metadata",
                 serde_json::json!({
@@ -163,6 +163,9 @@ fn collect_workspace_files(
                 }),
             )
         })?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
         if metadata.is_dir() {
             collect_workspace_files(root, &path, entries)?;
         } else if metadata.is_file() {
@@ -349,6 +352,32 @@ mod tests {
         let paths: Vec<String> = files.into_iter().map(|file| file.path).collect();
 
         assert_eq!(paths, vec!["AGENTS.md", "memory/MEMORY.md"]);
+    }
+
+    #[test]
+    fn list_files_skips_symlinked_directories() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("real/NOTE.md", "note");
+        let link = fixture.root.join("linked-real");
+
+        #[cfg(target_os = "windows")]
+        if let Err(error) = std::os::windows::fs::symlink_dir(fixture.root.join("real"), &link) {
+            eprintln!("skipping symlink test because symlink creation failed: {error}");
+            return;
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        if let Err(error) = std::os::unix::fs::symlink(fixture.root.join("real"), &link) {
+            eprintln!("skipping symlink test because symlink creation failed: {error}");
+            return;
+        }
+
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let files = rpc.list_files().expect("workspace files should list");
+        let paths: Vec<String> = files.into_iter().map(|file| file.path).collect();
+
+        assert_eq!(paths, vec!["real/NOTE.md"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a Rust WorkerManager for gateway/worker lifecycle ownership, status tracking, diagnostics capture, and process cleanup.
- Add protocol v1 types and stdio transport for worker request/response/event messages with trace IDs and unified errors.
- Add capability-gated Rust-owned RPCs for workspace, config, session metadata, and diagnostics.
- Add a WorkerRpcRouter and stdio serving path so workers can request Rust-owned native capabilities over stdin/stdout.
- Keep the existing Python gateway as the production compatibility path while Rust takes over native infrastructure boundaries.

## Validation

- `cargo test` from `apps/desktop/src-tauri` passed with 81 tests.
- Pre-commit hooks passed for staged code files during local commits.

## Notes

- This PR intentionally does not migrate AI business logic yet. The current gateway business path remains Python, while the new Rust substrate prepares for a future TS worker business layer.