### PR TITLE
Fix TS worker checkpoint restore for pending input

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -113,6 +113,12 @@ struct WorkerRunAgentInput {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct WorkerRunAgentWithInputInput {
+    input: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct WorkerCancelAgentInput {
     run_id: String,
 }
@@ -392,6 +398,20 @@ fn worker_run_agent(
     worker_run_agent_with_options(
         state.inner(),
         input.spec,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(120),
+    )
+}
+
+#[tauri::command]
+fn worker_run_agent_input(
+    input: WorkerRunAgentWithInputInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_run_agent_input_with_options(
+        state.inner(),
+        input.input,
         ts_agent_worker_workspace_root(),
         experimental_worker_config_snapshot(),
         Duration::from_secs(120),
@@ -1060,6 +1080,48 @@ fn build_worker_run_agent_request(request_id: u128, spec: serde_json::Value) -> 
     )
 }
 
+fn worker_run_agent_input_with_options(
+    shared: &SharedGateway,
+    input: serde_json::Value,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let worker = {
+        let runtime = lock_runtime(shared);
+        runtime.experimental_worker.clone()
+    };
+
+    ensure_ts_agent_worker_running(&worker, workspace_root, config_snapshot)?;
+
+    let request = build_worker_run_agent_input_request(now_unix_ms(), input);
+    let response = worker
+        .send_stdio_request(&request, timeout)
+        .map_err(|error| format!("worker agent run input request failed: {}", error.message))?;
+
+    if let Some(error) = response.error {
+        return Err(format!(
+            "worker agent run input returned error: {}",
+            error.message
+        ));
+    }
+    response
+        .result
+        .ok_or_else(|| "worker agent run input response missing result".to_string())
+}
+
+fn build_worker_run_agent_input_request(
+    request_id: u128,
+    input: serde_json::Value,
+) -> WorkerRequest {
+    WorkerRequest::new(
+        format!("agent-run-input-{request_id}"),
+        format!("trace-agent-run-input-{request_id}"),
+        "agent.run_input",
+        serde_json::json!({ "input": input }),
+    )
+}
+
 fn worker_cancel_agent_with_options(
     shared: &SharedGateway,
     run_id: String,
@@ -1505,6 +1567,7 @@ pub fn run() {
             worker_probe_status,
             worker_echo_agent,
             worker_run_agent,
+            worker_run_agent_input,
             worker_cancel_agent,
             worker_restore_agent_checkpoint,
             worker_submit_agent_form,
@@ -1734,6 +1797,25 @@ mod tests {
         assert_eq!(request.trace_id, "trace-agent-run-42");
         assert_eq!(request.method, "agent.run");
         assert_eq!(request.params, serde_json::json!({ "spec": agent_spec }));
+    }
+
+    #[test]
+    fn worker_run_agent_input_request_wraps_high_level_input_for_ts_worker() {
+        let agent_input = serde_json::json!({
+            "runId": "run-input-1",
+            "sessionId": "session-1",
+            "input": { "content": "hello" },
+            "model": "gpt-5",
+            "maxIterations": 3,
+            "stream": true
+        });
+
+        let request = build_worker_run_agent_input_request(42, agent_input.clone());
+
+        assert_eq!(request.id, "agent-run-input-42");
+        assert_eq!(request.trace_id, "trace-agent-run-input-42");
+        assert_eq!(request.method, "agent.run_input");
+        assert_eq!(request.params, serde_json::json!({ "input": agent_input }));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_manager.rs
+++ b/apps/desktop/src-tauri/src/worker_manager.rs
@@ -495,6 +495,7 @@ mod tests {
     use super::*;
     use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
     use crate::worker_rpc::WorkerRpcRouter;
+    use crate::worker_session::SessionMetadata;
     use serde_json::json;
     use std::path::PathBuf;
 
@@ -1078,6 +1079,110 @@ mod tests {
                         && protocol_event.payload["stopReason"] == "final_response"
             )
         }));
+    }
+
+    #[test]
+    fn manager_runs_real_ts_agent_worker_with_context_input() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let event_log = events.clone();
+        let fixture = WorkspaceFixture::new();
+        fixture.write("AGENTS.md", "agent bootstrap");
+        let session = SessionMetadata {
+            session_id: "desktop-context-session-1".to_string(),
+            title: "Context Input".to_string(),
+            workspace_dir: fixture.root.display().to_string(),
+            created_at: "2026-06-10T09:00:00Z".to_string(),
+            updated_at: "2026-06-10T09:30:00Z".to_string(),
+            extra: json!({
+                "messages": [{ "role": "user", "content": "Earlier context" }],
+                "user_profile": { "name": "Ada" }
+            }),
+        };
+        let manager = WorkerManager::new(20).with_event_sink(move |event| {
+            event_log.lock().expect("event log should lock").push(event);
+        });
+        let router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({
+                "agents": {
+                    "defaults": {
+                        "provider": "fixture",
+                        "model": "fixture-model"
+                    }
+                },
+                "providers": {
+                    "fixture": {
+                        "responses": [
+                            { "content": "context input final", "stopReason": "stop" }
+                        ]
+                    }
+                }
+            }),
+            vec![session],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::ConfigRead,
+                WorkerCapability::DiagnosticsWrite,
+                WorkerCapability::FsWorkspaceRead,
+                WorkerCapability::SessionMetadataRead,
+                WorkerCapability::SessionWrite,
+            ]),
+        );
+
+        manager
+            .start_stdio_rpc(ts_agent_worker_spec(), router)
+            .expect("TS agent worker should start");
+
+        let request = WorkerRequest::new(
+            "agent-run-input-real-ts-1",
+            "trace-real-ts-agent-input",
+            "agent.run_input",
+            json!({
+                "input": {
+                    "runId": "real-ts-run-input-1",
+                    "sessionId": "desktop-context-session-1",
+                    "input": { "content": "Continue from context" },
+                    "channel": "desktop",
+                    "chatId": "chat-1",
+                    "model": "fixture-model",
+                    "maxIterations": 2,
+                    "stream": false
+                }
+            }),
+        );
+        let response = manager
+            .send_stdio_request(&request, std::time::Duration::from_secs(5))
+            .expect("real TS agent worker context input request should complete");
+        let result = response
+            .result
+            .expect("context input run should return result");
+
+        assert_eq!(result["finalContent"], "context input final");
+        assert_eq!(result["contextMetadata"]["historyMessageCount"], 1);
+        assert_eq!(
+            result["contextMetadata"]["bootstrapFiles"],
+            json!(["AGENTS.md"])
+        );
+
+        let events = wait_for_events(&events, |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    WorkerManagerEvent::Protocol(protocol_event)
+                        if protocol_event.event == "agent.context"
+                            && protocol_event.payload["metadata"]["historyMessageCount"] == 1
+                )
+            })
+        });
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                WorkerManagerEvent::Protocol(protocol_event)
+                    if protocol_event.event == "agent.done"
+                        && protocol_event.payload["stopReason"] == "final_response"
+            )
+        }));
+        manager.stop().expect("TS agent worker should stop");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -72,6 +72,11 @@ impl WorkerRpcRouter {
                 serde_json::to_value(self.workspace.read_file(&params.path)?)
                     .map_err(serialization_error)
             }
+            "workspace.read_bootstrap_files" => {
+                let params: BootstrapFilesParams = parse_params(request)?;
+                serde_json::to_value(self.workspace.read_bootstrap_files(&params.files)?)
+                    .map_err(serialization_error)
+            }
             "workspace.write_file" => {
                 let params: WriteFileParams = parse_params(request)?;
                 serde_json::to_value(self.workspace.write_file(&params.path, &params.contents)?)
@@ -88,6 +93,14 @@ impl WorkerRpcRouter {
                 let params: SessionIdParams = parse_params(request)?;
                 serde_json::to_value(self.session.get_metadata(&params.session_id)?)
                     .map_err(serialization_error)
+            }
+            "session.get_history" => {
+                let params: SessionHistoryParams = parse_params(request)?;
+                serde_json::to_value(
+                    self.session
+                        .get_history(&params.session_id, params.limit.unwrap_or(80))?,
+                )
+                .map_err(serialization_error)
             }
             "session.list_metadata" => {
                 serde_json::to_value(self.session.list_metadata()?).map_err(serialization_error)
@@ -150,6 +163,10 @@ impl WorkerRpcRouter {
             "mcp.call_tool" => {
                 let params: McpCallToolParams = parse_params(request)?;
                 self.mcp.call_tool(params)
+            }
+            "runtime.now" => {
+                let params: RuntimeNowParams = parse_params(request)?;
+                Ok(runtime_now(params.timezone))
             }
             _ => Err(unknown_method_error(request)),
         }
@@ -606,6 +623,11 @@ struct PathParams {
 }
 
 #[derive(Deserialize)]
+struct BootstrapFilesParams {
+    files: Vec<String>,
+}
+
+#[derive(Deserialize)]
 struct WriteFileParams {
     path: String,
     contents: String,
@@ -614,6 +636,12 @@ struct WriteFileParams {
 #[derive(Deserialize)]
 struct SessionIdParams {
     session_id: String,
+}
+
+#[derive(Deserialize)]
+struct SessionHistoryParams {
+    session_id: String,
+    limit: Option<usize>,
 }
 
 #[derive(Deserialize)]
@@ -716,6 +744,11 @@ struct MemorySaveParams {
     message_end: Option<usize>,
 }
 
+#[derive(Deserialize)]
+struct RuntimeNowParams {
+    timezone: Option<String>,
+}
+
 fn parse_params<T: for<'de> Deserialize<'de>>(
     request: &WorkerRequest,
 ) -> Result<T, crate::worker_protocol::WorkerProtocolError> {
@@ -730,6 +763,18 @@ fn parse_params<T: for<'de> Deserialize<'de>>(
             false,
             crate::worker_protocol::WorkerProtocolErrorSource::RustCore,
         )
+    })
+}
+
+fn runtime_now(timezone: Option<String>) -> Value {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+    let timezone = timezone.unwrap_or_else(|| "local".to_string());
+    serde_json::json!({
+        "current_time": format!("unix-ms:{millis} {timezone}"),
+        "timezone": timezone,
     })
 }
 
@@ -1431,6 +1476,99 @@ mod tests {
             "Native Core Migration"
         );
         assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_session_get_history_request() {
+        let fixture = WorkspaceFixture::new();
+        let mut session = session_fixture();
+        session.extra = json!({
+            "messages": [
+                { "role": "user", "content": "first" },
+                { "role": "assistant", "content": "second" }
+            ],
+            "user_profile": { "name": "Ada" }
+        });
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![session],
+            20,
+            CapabilityPolicy::new([WorkerCapability::SessionMetadataRead]),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "session.get_history",
+            json!({ "session_id": "session-1", "limit": 1 }),
+        );
+
+        let response = router.dispatch(&request);
+
+        assert_eq!(
+            response.result,
+            Some(json!({
+                "session_id": "session-1",
+                "messages": [{ "role": "assistant", "content": "second" }],
+                "user_profile": { "name": "Ada" },
+                "updated_at": "2026-06-09T09:30:00Z"
+            }))
+        );
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_workspace_read_bootstrap_files_request() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("AGENTS.md", "agent rules");
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead]),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "workspace.read_bootstrap_files",
+            json!({ "files": ["AGENTS.md", "TOOLS.md"] }),
+        );
+
+        let response = router.dispatch(&request);
+
+        assert_eq!(
+            response.result,
+            Some(json!({
+                "files": [{ "path": "AGENTS.md", "contents": "agent rules" }],
+                "missing": ["TOOLS.md"]
+            }))
+        );
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_runtime_now_request() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::default(),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "runtime.now",
+            json!({ "timezone": "Asia/Shanghai" }),
+        );
+
+        let response = router.dispatch(&request);
+
+        assert!(response.error.is_none());
+        assert_eq!(response.result.as_ref().unwrap()["timezone"], "Asia/Shanghai");
+        assert!(response.result.as_ref().unwrap()["current_time"].as_str().is_some());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_session.rs
+++ b/apps/desktop/src-tauri/src/worker_session.rs
@@ -49,6 +49,47 @@ impl WorkerSessionRpc {
         Ok(session.and_then(|session| session.extra.get("runtime_checkpoint").cloned()))
     }
 
+    pub fn get_history(
+        &self,
+        session_id: &str,
+        limit: usize,
+    ) -> Result<SessionHistoryProjection, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        validate_session_id(session_id)?;
+        let Some(session) = self
+            .sessions
+            .iter()
+            .find(|session| session.session_id == session_id)
+        else {
+            return Ok(SessionHistoryProjection {
+                session_id: session_id.to_string(),
+                messages: Vec::new(),
+                user_profile: serde_json::json!({}),
+                updated_at: String::new(),
+            });
+        };
+        let messages = session
+            .extra
+            .get("messages")
+            .and_then(Value::as_array)
+            .map(|items| {
+                let start = items.len().saturating_sub(limit);
+                items[start..].to_vec()
+            })
+            .unwrap_or_default();
+        let user_profile = session
+            .extra
+            .get("user_profile")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        Ok(SessionHistoryProjection {
+            session_id: session.session_id.clone(),
+            messages,
+            user_profile,
+            updated_at: session.updated_at.clone(),
+        })
+    }
+
     pub fn set_checkpoint(
         &mut self,
         session_id: &str,
@@ -143,6 +184,14 @@ pub struct SessionMetadata {
     pub updated_at: String,
     #[serde(default)]
     pub extra: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct SessionHistoryProjection {
+    pub session_id: String,
+    pub messages: Vec<Value>,
+    pub user_profile: Value,
+    pub updated_at: String,
 }
 
 fn validate_session_id(session_id: &str) -> Result<(), WorkerProtocolError> {
@@ -367,6 +416,55 @@ mod tests {
             .expect("missing session should behave like no checkpoint");
 
         assert_eq!(checkpoint, None);
+    }
+
+    #[test]
+    fn get_history_returns_messages_user_profile_and_updated_at() {
+        let mut session = session_fixture();
+        session.extra = json!({
+            "messages": [
+                { "role": "user", "content": "first" },
+                { "role": "assistant", "content": "second" },
+                { "role": "user", "content": "third" }
+            ],
+            "user_profile": {
+                "name": "Ada",
+                "preferences": ["concise"]
+            },
+            "runtime_checkpoint": { "phase": "awaiting_tools" }
+        });
+        let rpc = WorkerSessionRpc::new(vec![session], read_policy());
+
+        let history = rpc
+            .get_history("session-1", 2)
+            .expect("history should read");
+
+        assert_eq!(history.session_id, "session-1");
+        assert_eq!(history.updated_at, "2026-06-09T09:30:00Z");
+        assert_eq!(
+            history.messages,
+            vec![
+                json!({ "role": "assistant", "content": "second" }),
+                json!({ "role": "user", "content": "third" })
+            ]
+        );
+        assert_eq!(
+            history.user_profile,
+            json!({ "name": "Ada", "preferences": ["concise"] })
+        );
+    }
+
+    #[test]
+    fn get_history_returns_empty_projection_for_missing_session() {
+        let rpc = WorkerSessionRpc::new(vec![], read_policy());
+
+        let history = rpc
+            .get_history("desktop-session-1", 80)
+            .expect("missing session should project empty history");
+
+        assert_eq!(history.session_id, "desktop-session-1");
+        assert_eq!(history.messages, Vec::<serde_json::Value>::new());
+        assert_eq!(history.user_profile, json!({}));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_workspace.rs
+++ b/apps/desktop/src-tauri/src/worker_workspace.rs
@@ -5,6 +5,8 @@ use crate::worker_protocol::{
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+const BOOTSTRAP_FILES: &[&str] = &["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"];
+
 #[derive(Clone, Debug)]
 pub struct WorkerWorkspaceRpc {
     root: PathBuf,
@@ -56,6 +58,34 @@ impl WorkerWorkspaceRpc {
         collect_workspace_files(&root, &root, &mut entries)?;
         entries.sort_by(|left, right| left.path.cmp(&right.path));
         Ok(entries)
+    }
+
+    pub fn read_bootstrap_files(
+        &self,
+        files: &[String],
+    ) -> Result<WorkspaceBootstrapFiles, WorkerProtocolError> {
+        self.require(WorkerCapability::FsWorkspaceRead)?;
+        let mut found = Vec::new();
+        let mut missing = Vec::new();
+        for requested in files {
+            if !BOOTSTRAP_FILES.contains(&requested.as_str()) {
+                return Err(WorkerProtocolError::new(
+                    WorkerProtocolErrorCode::InvalidProtocol,
+                    "bootstrap file is not allowlisted",
+                    serde_json::json!({ "path": requested }),
+                    false,
+                    WorkerProtocolErrorSource::RustCore,
+                ));
+            }
+            match self.read_file(requested) {
+                Ok(file) => found.push(file),
+                Err(_) => missing.push(requested.clone()),
+            }
+        }
+        Ok(WorkspaceBootstrapFiles {
+            files: found,
+            missing,
+        })
     }
 
     pub fn write_file(
@@ -124,6 +154,12 @@ pub struct WorkspaceFileContent {
 pub struct WorkspaceFileEntry {
     pub path: String,
     pub size_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceBootstrapFiles {
+    pub files: Vec<WorkspaceFileContent>,
+    pub missing: Vec<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -352,6 +388,39 @@ mod tests {
         let paths: Vec<String> = files.into_iter().map(|file| file.path).collect();
 
         assert_eq!(paths, vec!["AGENTS.md", "memory/MEMORY.md"]);
+    }
+
+    #[test]
+    fn read_bootstrap_files_returns_present_files_and_missing_names() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("USER.md", "user rules");
+        fixture.write("AGENTS.md", "agent rules");
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let result = rpc
+            .read_bootstrap_files(&["AGENTS.md".to_string(), "TOOLS.md".to_string(), "USER.md".to_string()])
+            .expect("bootstrap files should read");
+
+        assert_eq!(
+            result.files,
+            vec![
+                WorkspaceFileContent { path: "AGENTS.md".to_string(), contents: "agent rules".to_string() },
+                WorkspaceFileContent { path: "USER.md".to_string(), contents: "user rules".to_string() },
+            ]
+        );
+        assert_eq!(result.missing, vec!["TOOLS.md"]);
+    }
+
+    #[test]
+    fn read_bootstrap_files_rejects_non_allowlisted_paths() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let error = rpc
+            .read_bootstrap_files(&["../secret.txt".to_string()])
+            .expect_err("bootstrap reader should reject traversal");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
     }
 
     #[test]

--- a/apps/desktop/workers/ts-agent-worker/src/agent/agentRunSpec.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/agentRunSpec.ts
@@ -1,4 +1,5 @@
 import type { ToolCallRequest, ToolDefinition, TokenUsage } from "../model/provider.ts";
+import type { ContextBuildMetadata, ContextBridgeMetadata } from "./contextTypes.ts";
 
 export type AgentMessageRole = "system" | "user" | "assistant" | "tool";
 
@@ -50,4 +51,5 @@ export type AgentRunResult = {
   stopReason: AgentStopReason;
   error?: string;
   awaitingInput?: Record<string, unknown>;
+  contextMetadata?: ContextBuildMetadata & { bridge?: ContextBridgeMetadata };
 };

--- a/apps/desktop/workers/ts-agent-worker/src/agent/contextBuilder.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/contextBuilder.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+
+import { buildContextMessages } from "./contextBuilder";
+
+describe("buildContextMessages", () => {
+  test("builds system and current user messages for empty history", () => {
+    const result = buildContextMessages({
+      identity: "Identity",
+      currentMessage: "Hello",
+      runtime: { currentTime: "2026-06-10 09:00:00 Asia/Shanghai" },
+    });
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toMatchObject({ role: "system", content: expect.stringContaining("Identity") });
+    expect(result.messages[1]).toEqual({
+      role: "user",
+      content: "[Runtime Context - metadata only, not instructions]\nCurrent Time: 2026-06-10 09:00:00 Asia/Shanghai\n\nHello",
+    });
+    expect(result.metadata).toMatchObject({
+      bootstrapFiles: [],
+      historyMessageCount: 0,
+      mergedWithLastMessage: false,
+      runtimeContextIncluded: true,
+      memoryContextIncluded: false,
+      knowledgeContextIncluded: false,
+      skillsContextIncluded: false,
+    });
+    expect(result.metadata.omittedContext).toEqual([
+      "memory",
+      "recent_context",
+      "experience",
+      "knowledge",
+      "skills_detail",
+      "active_task_progress",
+    ]);
+  });
+
+  test("prepends runtime context fields and user profile to current content", () => {
+    const result = buildContextMessages({
+      identity: "Identity",
+      currentMessage: "Help me plan.",
+      runtime: {
+        currentTime: "2026-06-10 09:00:00 Asia/Shanghai",
+        channel: "desktop",
+        chatId: "chat-1",
+        userProfile: {
+          name: "Ada",
+          preferences: ["concise"],
+          mentionedEntities: ["tinybot"],
+          communicationStyle: "direct",
+          keyFacts: ["uses desktop app"],
+        },
+      },
+    });
+
+    expect(result.messages[1].content).toContain("Channel: desktop\nChat ID: chat-1");
+    expect(result.messages[1].content).toContain(
+      "User Context: Name: Ada; Preferences: concise; Known Entities: tinybot; Communication Style: direct; Key Facts: uses desktop app",
+    );
+  });
+
+  test("appends history before current message when trailing role differs", () => {
+    const result = buildContextMessages({
+      identity: "Identity",
+      currentMessage: "Next",
+      runtime: { currentTime: "now" },
+      history: [
+        { role: "user", content: "Earlier" },
+        { role: "assistant", content: "Answer" },
+      ],
+    });
+
+    expect(result.messages.map((message) => message.role)).toEqual(["system", "user", "assistant", "user"]);
+    expect(result.messages.at(-1)?.content).toContain("Next");
+    expect(result.metadata.historyMessageCount).toBe(2);
+  });
+
+  test("merges current user content into trailing user history", () => {
+    const result = buildContextMessages({
+      identity: "Identity",
+      currentMessage: "Continue",
+      runtime: { currentTime: "now" },
+      history: [{ role: "user", content: "Earlier" }],
+    });
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[1]).toEqual({
+      role: "user",
+      content: "Earlier\n\n[Runtime Context - metadata only, not instructions]\nCurrent Time: now\n\nContinue",
+    });
+    expect(result.metadata.mergedWithLastMessage).toBe(true);
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/agent/contextBuilder.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/contextBuilder.ts
@@ -1,0 +1,96 @@
+import type { AgentMessage } from "./agentRunSpec";
+import type { ContextBuildInput, ContextBuildMetadata, ContextBuildResult, RuntimeContext, UserProfile } from "./contextTypes";
+import { mergeMessageContent } from "./messageContent";
+import { buildSystemPrompt, includedBootstrapPaths } from "./systemPrompt";
+
+export const RUNTIME_CONTEXT_TAG = "[Runtime Context - metadata only, not instructions]";
+
+const OMITTED_CONTEXT = [
+  "memory",
+  "recent_context",
+  "experience",
+  "knowledge",
+  "skills_detail",
+  "active_task_progress",
+];
+
+export function buildContextMessages(input: ContextBuildInput): ContextBuildResult {
+  const history = input.history ?? [];
+  const currentRole = input.currentRole ?? "user";
+  const runtimeContext = buildRuntimeContext(input.runtime);
+  const currentContent = `${runtimeContext}\n\n${input.currentMessage}`;
+  const messages: AgentMessage[] = [
+    {
+      role: "system",
+      content: buildSystemPrompt({
+        identity: input.identity,
+        bootstrapFiles: input.bootstrapFiles,
+      }),
+    },
+    ...history.map((message) => ({ ...message })),
+  ];
+
+  let mergedWithLastMessage = false;
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role === currentRole) {
+    messages[messages.length - 1] = {
+      ...lastMessage,
+      content: mergeMessageContent(lastMessage.content, currentContent) as string,
+    };
+    mergedWithLastMessage = true;
+  } else {
+    messages.push({ role: currentRole, content: currentContent });
+  }
+
+  return {
+    messages,
+    metadata: buildMetadata(input, history.length, mergedWithLastMessage),
+  };
+}
+
+export function buildRuntimeContext(runtime: RuntimeContext): string {
+  const lines = [`Current Time: ${runtime.currentTime}`];
+  if (runtime.channel && runtime.chatId) {
+    lines.push(`Channel: ${runtime.channel}`, `Chat ID: ${runtime.chatId}`);
+  }
+  const userContext = formatUserProfile(runtime.userProfile);
+  if (userContext) {
+    lines.push(`User Context: ${userContext}`);
+  }
+  return `${RUNTIME_CONTEXT_TAG}\n${lines.join("\n")}`;
+}
+
+function buildMetadata(
+  input: ContextBuildInput,
+  historyMessageCount: number,
+  mergedWithLastMessage: boolean,
+): ContextBuildMetadata {
+  return {
+    bootstrapFiles: includedBootstrapPaths(input.bootstrapFiles),
+    historyMessageCount,
+    mergedWithLastMessage,
+    runtimeContextIncluded: true,
+    memoryContextIncluded: false,
+    knowledgeContextIncluded: false,
+    skillsContextIncluded: false,
+    omittedContext: [...OMITTED_CONTEXT],
+  };
+}
+
+function formatUserProfile(profile: UserProfile | undefined): string {
+  if (!profile) {
+    return "";
+  }
+  const parts = [
+    profile.name ? `Name: ${profile.name}` : "",
+    nonemptyList(profile.preferences) ? `Preferences: ${profile.preferences.join(", ")}` : "",
+    nonemptyList(profile.mentionedEntities) ? `Known Entities: ${profile.mentionedEntities.join(", ")}` : "",
+    profile.communicationStyle ? `Communication Style: ${profile.communicationStyle}` : "",
+    nonemptyList(profile.keyFacts) ? `Key Facts: ${profile.keyFacts.join(", ")}` : "",
+  ].filter((part) => part.length > 0);
+  return parts.join("; ");
+}
+
+function nonemptyList(value: string[] | undefined): value is string[] {
+  return Array.isArray(value) && value.length > 0;
+}

--- a/apps/desktop/workers/ts-agent-worker/src/agent/contextBuilder.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/contextBuilder.ts
@@ -19,6 +19,7 @@ export function buildContextMessages(input: ContextBuildInput): ContextBuildResu
   const currentRole = input.currentRole ?? "user";
   const runtimeContext = buildRuntimeContext(input.runtime);
   const currentContent = `${runtimeContext}\n\n${input.currentMessage}`;
+  const currentMessage: AgentMessage = { role: currentRole, content: currentContent };
   const messages: AgentMessage[] = [
     {
       role: "system",
@@ -39,11 +40,12 @@ export function buildContextMessages(input: ContextBuildInput): ContextBuildResu
     };
     mergedWithLastMessage = true;
   } else {
-    messages.push({ role: currentRole, content: currentContent });
+    messages.push(currentMessage);
   }
 
   return {
     messages,
+    sessionAppendMessages: [currentMessage],
     metadata: buildMetadata(input, history.length, mergedWithLastMessage),
   };
 }

--- a/apps/desktop/workers/ts-agent-worker/src/agent/contextBuilder.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/contextBuilder.ts
@@ -1,7 +1,7 @@
-import type { AgentMessage } from "./agentRunSpec";
-import type { ContextBuildInput, ContextBuildMetadata, ContextBuildResult, RuntimeContext, UserProfile } from "./contextTypes";
-import { mergeMessageContent } from "./messageContent";
-import { buildSystemPrompt, includedBootstrapPaths } from "./systemPrompt";
+import type { AgentMessage } from "./agentRunSpec.ts";
+import type { ContextBuildInput, ContextBuildMetadata, ContextBuildResult, RuntimeContext, UserProfile } from "./contextTypes.ts";
+import { mergeMessageContent } from "./messageContent.ts";
+import { buildSystemPrompt, includedBootstrapPaths } from "./systemPrompt.ts";
 
 export const RUNTIME_CONTEXT_TAG = "[Runtime Context - metadata only, not instructions]";
 

--- a/apps/desktop/workers/ts-agent-worker/src/agent/contextTypes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/contextTypes.ts
@@ -1,0 +1,59 @@
+import type { AgentMessage, AgentMessageRole } from "./agentRunSpec";
+
+export const BOOTSTRAP_FILE_ORDER = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"] as const;
+
+export type TextContentBlock = {
+  type: "text";
+  text: string;
+};
+
+export type MessageContentBlock = Record<string, unknown> & {
+  type: string;
+};
+
+export type MessageContent = string | MessageContentBlock[];
+
+export type BootstrapFile = {
+  path: string;
+  contents?: string | null;
+};
+
+export type UserProfile = {
+  name?: string;
+  preferences?: string[];
+  mentionedEntities?: string[];
+  communicationStyle?: string;
+  keyFacts?: string[];
+};
+
+export type RuntimeContext = {
+  currentTime: string;
+  channel?: string;
+  chatId?: string;
+  userProfile?: UserProfile;
+};
+
+export type ContextBuildInput = {
+  identity: string;
+  bootstrapFiles?: BootstrapFile[];
+  history?: AgentMessage[];
+  currentMessage: string;
+  currentRole?: Extract<AgentMessageRole, "user" | "system">;
+  runtime: RuntimeContext;
+};
+
+export type ContextBuildMetadata = {
+  bootstrapFiles: string[];
+  historyMessageCount: number;
+  mergedWithLastMessage: boolean;
+  runtimeContextIncluded: boolean;
+  memoryContextIncluded: boolean;
+  knowledgeContextIncluded: boolean;
+  skillsContextIncluded: boolean;
+  omittedContext: string[];
+};
+
+export type ContextBuildResult = {
+  messages: AgentMessage[];
+  metadata: ContextBuildMetadata;
+};

--- a/apps/desktop/workers/ts-agent-worker/src/agent/contextTypes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/contextTypes.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage, AgentMessageRole } from "./agentRunSpec";
+import type { AgentMessage, AgentMessageRole } from "./agentRunSpec.ts";
 
 export const BOOTSTRAP_FILE_ORDER = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"] as const;
 
@@ -42,6 +42,28 @@ export type ContextBuildInput = {
   runtime: RuntimeContext;
 };
 
+export type AgentRunInput = {
+  runId: string;
+  sessionId: string;
+  input: {
+    role?: "user" | "system";
+    content: string;
+    media?: string[];
+  };
+  channel?: string;
+  chatId?: string;
+  model?: string;
+  maxIterations?: number;
+  stream?: boolean;
+  contextWindow?: number;
+  toolResultBudget?: number;
+  temperature?: number;
+  maxTokens?: number;
+  reasoningEffort?: string;
+  failOnToolError?: boolean;
+  metadata?: Record<string, unknown>;
+};
+
 export type ContextBuildMetadata = {
   bootstrapFiles: string[];
   historyMessageCount: number;
@@ -56,4 +78,16 @@ export type ContextBuildMetadata = {
 export type ContextBuildResult = {
   messages: AgentMessage[];
   metadata: ContextBuildMetadata;
+};
+
+export type ContextBridgeMetadata = {
+  missingSession: boolean;
+  malformedHistoryCount: number;
+  missingBootstrapFiles: string[];
+  bootstrapFallbackUsed: boolean;
+};
+
+export type ContextBridgeLoadResult = {
+  input: ContextBuildInput;
+  metadata: ContextBridgeMetadata;
 };

--- a/apps/desktop/workers/ts-agent-worker/src/agent/contextTypes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/contextTypes.ts
@@ -77,6 +77,7 @@ export type ContextBuildMetadata = {
 
 export type ContextBuildResult = {
   messages: AgentMessage[];
+  sessionAppendMessages: AgentMessage[];
   metadata: ContextBuildMetadata;
 };
 

--- a/apps/desktop/workers/ts-agent-worker/src/agent/messageContent.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/messageContent.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+
+import { mergeMessageContent, toTextContentBlocks } from "./messageContent";
+
+describe("messageContent", () => {
+  test("merges two strings with a blank line", () => {
+    expect(mergeMessageContent("first", "second")).toBe("first\n\nsecond");
+  });
+
+  test("uses the right string when the left string is empty", () => {
+    expect(mergeMessageContent("", "second")).toBe("second");
+  });
+
+  test("converts mixed content to text blocks", () => {
+    expect(mergeMessageContent("first", [{ type: "text", text: "second" }])).toEqual([
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+    ]);
+  });
+
+  test("preserves existing blocks and stringifies non-block values", () => {
+    expect(toTextContentBlocks([{ type: "image_url", image_url: { url: "file://image.png" } }, 42])).toEqual([
+      { type: "image_url", image_url: { url: "file://image.png" } },
+      { type: "text", text: "42" },
+    ]);
+  });
+
+  test("handles nullish content as no blocks", () => {
+    expect(toTextContentBlocks(null)).toEqual([]);
+    expect(toTextContentBlocks(undefined)).toEqual([]);
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/agent/messageContent.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/messageContent.ts
@@ -1,4 +1,4 @@
-import type { MessageContent, MessageContentBlock, TextContentBlock } from "./contextTypes";
+import type { MessageContent, MessageContentBlock, TextContentBlock } from "./contextTypes.ts";
 
 export function mergeMessageContent(left: unknown, right: unknown): MessageContent {
   if (typeof left === "string" && typeof right === "string") {

--- a/apps/desktop/workers/ts-agent-worker/src/agent/messageContent.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/messageContent.ts
@@ -1,0 +1,34 @@
+import type { MessageContent, MessageContentBlock, TextContentBlock } from "./contextTypes";
+
+export function mergeMessageContent(left: unknown, right: unknown): MessageContent {
+  if (typeof left === "string" && typeof right === "string") {
+    return left.length > 0 ? `${left}\n\n${right}` : right;
+  }
+  return [...toTextContentBlocks(left), ...toTextContentBlocks(right)];
+}
+
+export function toTextContentBlocks(value: unknown): MessageContentBlock[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      if (isContentBlock(item)) {
+        return item;
+      }
+      return textBlock(String(item));
+    });
+  }
+  if (value === null || value === undefined) {
+    return [];
+  }
+  return [textBlock(String(value))];
+}
+
+function isContentBlock(value: unknown): value is MessageContentBlock {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && typeof (value as { type?: unknown }).type === "string";
+}
+
+function textBlock(text: string): TextContentBlock {
+  return { type: "text", text };
+}

--- a/apps/desktop/workers/ts-agent-worker/src/agent/systemPrompt.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/systemPrompt.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+
+import { buildSystemPrompt } from "./systemPrompt";
+
+describe("buildSystemPrompt", () => {
+  test("includes identity and bootstrap files in deterministic order", () => {
+    const prompt = buildSystemPrompt({
+      identity: "You are TinyBot.",
+      bootstrapFiles: [
+        { path: "USER.md", contents: "User rules" },
+        { path: "AGENTS.md", contents: "Agent rules" },
+      ],
+    });
+
+    expect(prompt).toContain("You are TinyBot.");
+    expect(prompt.indexOf("## AGENTS.md")).toBeLessThan(prompt.indexOf("## USER.md"));
+    expect(prompt).toContain("## AGENTS.md\n\nAgent rules");
+    expect(prompt).toContain("## USER.md\n\nUser rules");
+  });
+
+  test("omits missing bootstrap files and marks deferred skills context", () => {
+    const prompt = buildSystemPrompt({
+      identity: "Identity",
+      bootstrapFiles: [
+        { path: "AGENTS.md", contents: "Agent rules" },
+        { path: "TOOLS.md", contents: "" },
+      ],
+    });
+
+    expect(prompt).toContain("## AGENTS.md");
+    expect(prompt).not.toContain("## TOOLS.md");
+    expect(prompt).toContain("# Active Skills\n\n(deferred in TS context phase 1)");
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/agent/systemPrompt.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/systemPrompt.ts
@@ -1,0 +1,52 @@
+import { BOOTSTRAP_FILE_ORDER, type BootstrapFile } from "./contextTypes";
+
+export type SystemPromptInput = {
+  identity: string;
+  bootstrapFiles?: BootstrapFile[];
+  includeDeferredSkillsPlaceholder?: boolean;
+};
+
+export function buildSystemPrompt(input: SystemPromptInput): string {
+  const parts = [input.identity];
+  const bootstrap = formatBootstrapFiles(input.bootstrapFiles ?? []);
+  if (bootstrap.length > 0) {
+    parts.push(bootstrap);
+  }
+  if (input.includeDeferredSkillsPlaceholder ?? true) {
+    parts.push("# Active Skills\n\n(deferred in TS context phase 1)");
+  }
+  return parts.join("\n\n---\n\n");
+}
+
+export function includedBootstrapPaths(files: BootstrapFile[] = []): string[] {
+  return sortedBootstrapFiles(files)
+    .filter((file) => nonempty(file.contents))
+    .map((file) => file.path);
+}
+
+function formatBootstrapFiles(files: BootstrapFile[]): string {
+  return sortedBootstrapFiles(files)
+    .filter((file) => nonempty(file.contents))
+    .map((file) => `## ${file.path}\n\n${file.contents}`)
+    .join("\n\n");
+}
+
+function sortedBootstrapFiles(files: BootstrapFile[]): BootstrapFile[] {
+  return [...files].sort((left, right) => {
+    const leftIndex = bootstrapIndex(left.path);
+    const rightIndex = bootstrapIndex(right.path);
+    if (leftIndex !== rightIndex) {
+      return leftIndex - rightIndex;
+    }
+    return left.path.localeCompare(right.path);
+  });
+}
+
+function bootstrapIndex(path: string): number {
+  const index = BOOTSTRAP_FILE_ORDER.indexOf(path as (typeof BOOTSTRAP_FILE_ORDER)[number]);
+  return index === -1 ? BOOTSTRAP_FILE_ORDER.length : index;
+}
+
+function nonempty(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.length > 0;
+}

--- a/apps/desktop/workers/ts-agent-worker/src/agent/systemPrompt.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/systemPrompt.ts
@@ -1,4 +1,4 @@
-import { BOOTSTRAP_FILE_ORDER, type BootstrapFile } from "./contextTypes";
+import { BOOTSTRAP_FILE_ORDER, type BootstrapFile } from "./contextTypes.ts";
 
 export type SystemPromptInput = {
   identity: string;

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
@@ -1432,7 +1432,7 @@ describe("AgentWorker", () => {
     expect(cleared).toEqual([{ sessionId: "session-1", traceId: "trace-restore" }]);
   });
 
-  test("keeps awaiting-input checkpoint after restore so form submission can resume", async () => {
+  test("keeps awaiting-input checkpoint after restore without re-appending pending transcript", async () => {
     const appended: Array<{ sessionId: string; messages: AgentMessage[]; traceId: string }> = [];
     const cleared: Array<{ sessionId: string; traceId: string }> = [];
     const worker = new AgentWorker({
@@ -1491,7 +1491,7 @@ describe("AgentWorker", () => {
     const response = await worker.handleRequest(restoreCheckpointRequest("session-1"));
 
     expect(response.result).toMatchObject({ restored: true });
-    expect(appended).toHaveLength(1);
+    expect(appended).toEqual([]);
     expect(cleared).toEqual([]);
   });
 

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
@@ -1432,6 +1432,69 @@ describe("AgentWorker", () => {
     expect(cleared).toEqual([{ sessionId: "session-1", traceId: "trace-restore" }]);
   });
 
+  test("keeps awaiting-input checkpoint after restore so form submission can resume", async () => {
+    const appended: Array<{ sessionId: string; messages: AgentMessage[]; traceId: string }> = [];
+    const cleared: Array<{ sessionId: string; traceId: string }> = [];
+    const worker = new AgentWorker({
+      provider: new QueueProvider([]),
+      tools: new ToolRegistry(),
+      emitEvent: () => undefined,
+      sessionBridge: {
+        setCheckpoint: async () => undefined,
+        clearCheckpoint: async (sessionId, traceId) => {
+          cleared.push({ sessionId, traceId });
+        },
+        appendMessages: async (sessionId, messages, traceId) => {
+          appended.push({ sessionId, messages, traceId });
+        },
+        getCheckpoint: async () => ({
+          runId: "run-1",
+          phase: "tools_completed",
+          iteration: 1,
+          model: "test-model",
+          messages: [
+            { role: "user", content: "collect details" },
+            {
+              role: "assistant",
+              content: "",
+              toolCalls: [{ id: "call-form", name: "request_form", argumentsJson: "{}" }],
+            },
+            {
+              role: "tool",
+              content: "Waiting for form submission.",
+              toolCallId: "call-form",
+              name: "request_form",
+              metadata: {
+                awaitingUserInput: true,
+                stopReason: "awaiting_form",
+                formId: "travel_plan",
+              },
+            },
+          ],
+          completedToolResults: [
+            {
+              role: "tool",
+              content: "Waiting for form submission.",
+              toolCallId: "call-form",
+              name: "request_form",
+              metadata: {
+                awaitingUserInput: true,
+                stopReason: "awaiting_form",
+                formId: "travel_plan",
+              },
+            },
+          ],
+        }),
+      },
+    });
+
+    const response = await worker.handleRequest(restoreCheckpointRequest("session-1"));
+
+    expect(response.result).toMatchObject({ restored: true });
+    expect(appended).toHaveLength(1);
+    expect(cleared).toEqual([]);
+  });
+
   test("accepts snake_case session_id for agent.restore_checkpoint", async () => {
     const worker = new AgentWorker({
       provider: new QueueProvider([]),

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
@@ -241,6 +241,63 @@ describe("AgentWorker", () => {
     }));
   });
 
+  test("appends only new run_input messages to session history", async () => {
+    const provider = new QueueProvider([{ content: "done", toolCalls: [], stopReason: "stop" }]);
+    const appendedSessions: Array<{ sessionId: string; messages: AgentMessage[] }> = [];
+    const worker = new AgentWorker({
+      provider,
+      tools: new ToolRegistry(),
+      emitEvent: () => undefined,
+      sessionBridge: {
+        setCheckpoint: async () => undefined,
+        clearCheckpoint: async () => undefined,
+        appendMessages: async (sessionId, messages) => {
+          appendedSessions.push({ sessionId, messages });
+        },
+        getCheckpoint: async () => null,
+      },
+      contextBridge: {
+        loadContextInput: async (input) => ({
+          input: {
+            identity: "Identity",
+            currentMessage: input.input.content,
+            history: [{ role: "user", content: "Earlier" }],
+            runtime: { currentTime: "now" },
+          },
+          metadata: {
+            missingSession: false,
+            malformedHistoryCount: 0,
+            missingBootstrapFiles: [],
+            bootstrapFallbackUsed: false,
+          },
+        }),
+      },
+    });
+
+    await worker.handleRequest(
+      runInputRequest({
+        input: {
+          runId: "run-input-append-1",
+          sessionId: "session-1",
+          input: { content: "Continue" },
+          model: "test-model",
+          maxIterations: 2,
+          stream: false,
+        },
+      }),
+    );
+
+    expect(appendedSessions).toHaveLength(1);
+    expect(appendedSessions[0]?.sessionId).toBe("session-1");
+    expect(appendedSessions[0]?.messages).toEqual([
+      {
+        role: "user",
+        content: "[Runtime Context - metadata only, not instructions]\nCurrent Time: now\n\nContinue",
+      },
+      { role: "assistant", content: "done" },
+    ]);
+  });
+
   test("accepts snake_case agent.run spec fields", async () => {
     const events: WorkerEvent[] = [];
     const clearedSessions: string[] = [];

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
@@ -33,6 +33,16 @@ function request(params: Record<string, unknown>): WorkerRequest {
   };
 }
 
+function runInputRequest(params: Record<string, unknown>): WorkerRequest {
+  return {
+    protocol_version: "1",
+    id: "run-input-1",
+    trace_id: "trace-run-input",
+    method: "agent.run_input",
+    params,
+  };
+}
+
 function cancelRequest(runId: string): WorkerRequest {
   return {
     protocol_version: "1",
@@ -138,6 +148,95 @@ describe("AgentWorker", () => {
       payload: expect.objectContaining({
         runId: "run-1",
         stopReason: "final_response",
+      }),
+    }));
+  });
+
+  test("routes agent.run_input through context assembly before AgentRunner", async () => {
+    const events: WorkerEvent[] = [];
+    const provider = new QueueProvider([{ content: "done", toolCalls: [], stopReason: "stop" }]);
+    const loadedInputs: Array<{ runId: string; traceId: string }> = [];
+    const worker = new AgentWorker({
+      provider,
+      tools: new ToolRegistry(),
+      emitEvent: (event) => events.push(event),
+      contextBridge: {
+        loadContextInput: async (input, traceId) => {
+          loadedInputs.push({ runId: input.runId, traceId });
+          return {
+            input: {
+              identity: "Identity",
+              currentMessage: input.input.content,
+              history: [
+                { role: "user", content: "Earlier" },
+                { role: "assistant", content: "Earlier answer" },
+              ],
+              bootstrapFiles: [{ path: "AGENTS.md", contents: "Agent rules" }],
+              runtime: {
+                currentTime: "2026-06-10 09:00:00 Asia/Shanghai",
+                channel: input.channel,
+                chatId: input.chatId,
+              },
+            },
+            metadata: {
+              missingSession: false,
+              malformedHistoryCount: 0,
+              missingBootstrapFiles: [],
+              bootstrapFallbackUsed: false,
+            },
+          };
+        },
+      },
+    });
+
+    const response = await worker.handleRequest(
+      runInputRequest({
+        input: {
+          runId: "run-input-1",
+          sessionId: "session-1",
+          input: { content: "Continue" },
+          channel: "desktop",
+          chatId: "chat-1",
+          model: "test-model",
+          maxIterations: 2,
+          stream: false,
+        },
+      }),
+    );
+
+    expect(loadedInputs).toEqual([{ runId: "run-input-1", traceId: "trace-run-input" }]);
+    expect(provider.messages[0]?.map((message) => message.role)).toEqual(["system", "user", "assistant", "user"]);
+    expect(provider.messages[0]?.[0].content).toContain("## AGENTS.md\n\nAgent rules");
+    expect(provider.messages[0]?.at(-1)?.content).toContain("Current Time: 2026-06-10 09:00:00 Asia/Shanghai");
+    expect(response).toMatchObject({
+      protocol_version: "1",
+      id: "run-input-1",
+      trace_id: "trace-run-input",
+      result: {
+        finalContent: "done",
+        stopReason: "final_response",
+        contextMetadata: {
+          historyMessageCount: 2,
+          bootstrapFiles: ["AGENTS.md"],
+          bridge: {
+            missingSession: false,
+            malformedHistoryCount: 0,
+            missingBootstrapFiles: [],
+            bootstrapFallbackUsed: false,
+          },
+        },
+      },
+    });
+    expect(events).toContainEqual(expect.objectContaining({
+      protocol_version: "1",
+      trace_id: "trace-run-input",
+      event: "agent.context",
+      payload: expect.objectContaining({
+        runId: "run-input-1",
+        run_id: "run-input-1",
+        metadata: expect.objectContaining({
+          historyMessageCount: 2,
+        }),
       }),
     }));
   });

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
@@ -160,7 +160,11 @@ export class AgentWorker {
         contextWindow: input.contextWindow,
         toolResultBudget: input.toolResultBudget,
         failOnToolError: input.failOnToolError,
-        metadata: input.metadata,
+        metadata: {
+          ...(input.metadata ?? {}),
+          _contextInitialMessageCount: context.messages.length,
+          _contextSessionAppendMessages: context.sessionAppendMessages,
+        },
       };
       return await this.runSpecForRequest(request, spec, contextMetadata);
     } catch (error) {
@@ -416,7 +420,7 @@ export class AgentWorker {
     if (!this.sessionBridge || !spec.sessionId) {
       return;
     }
-    await this.sessionBridge.appendMessages(spec.sessionId, result.messages, traceId);
+    await this.sessionBridge.appendMessages(spec.sessionId, sessionAppendMessages(spec, result), traceId);
   }
 
   private emitAwaitingInput(traceId: string, runId: string, result: AgentRunResult): void {
@@ -825,6 +829,38 @@ function resumedSpecFromCheckpoint(
 
 function checkpointRunId(checkpoint: Record<string, unknown>): string {
   return checkpointString(checkpoint.runId ?? checkpoint.run_id, "checkpoint.runId");
+}
+
+function sessionAppendMessages(spec: AgentRunSpec, result: AgentRunResult): AgentMessage[] {
+  const contextMessages = internalContextAppendMessages(spec.metadata?._contextSessionAppendMessages);
+  const initialMessageCount = spec.metadata?._contextInitialMessageCount;
+  if (!contextMessages || typeof initialMessageCount !== "number") {
+    return result.messages;
+  }
+  return [
+    ...contextMessages,
+    ...result.messages.slice(initialMessageCount),
+  ];
+}
+
+function internalContextAppendMessages(value: unknown): AgentMessage[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const messages = value.map((item) => {
+    if (!isJsonObject(item) || !isAgentRole(item.role) || typeof item.content !== "string") {
+      return null;
+    }
+    return {
+      role: item.role,
+      content: item.content,
+    };
+  });
+  return messages.every((message) => message !== null) ? (messages as AgentMessage[]) : null;
+}
+
+function isAgentRole(value: unknown): value is AgentMessage["role"] {
+  return value === "system" || value === "user" || value === "assistant" || value === "tool";
 }
 
 function parseRunSpec(params: Record<string, unknown> | undefined): AgentRunSpec {

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
@@ -1,5 +1,7 @@
 import { AgentRunner, type AgentRunnerCheckpoint, type AgentRunnerEvent } from "../agent/agentRunner.ts";
 import type { AgentMessage, AgentRunResult, AgentRunSpec } from "../agent/agentRunSpec.ts";
+import { buildContextMessages } from "../agent/contextBuilder.ts";
+import type { AgentRunInput, ContextBuildMetadata, ContextBridgeMetadata } from "../agent/contextTypes.ts";
 import type { ModelProvider, ToolDefinition } from "../model/provider.ts";
 import {
   isJsonObject,
@@ -10,6 +12,7 @@ import {
   type WorkerResponse,
 } from "../protocol/messages.ts";
 import type { ToolRegistry } from "../tools/toolRegistry.ts";
+import type { ContextBridge } from "./contextBridge.ts";
 
 export type AgentWorkerOptions = {
   provider: ModelProvider;
@@ -17,6 +20,7 @@ export type AgentWorkerOptions = {
   emitEvent: (event: WorkerEvent) => void;
   approvalBridge?: ApprovalBridge;
   sessionBridge?: SessionBridge;
+  contextBridge?: ContextBridge;
 };
 
 type ActiveRun = {
@@ -55,6 +59,7 @@ export class AgentWorker {
   private readonly emitEvent: (event: WorkerEvent) => void;
   private readonly approvalBridge?: ApprovalBridge;
   private readonly sessionBridge?: SessionBridge;
+  private readonly contextBridge?: ContextBridge;
   private readonly activeRuns = new Map<string, ActiveRun>();
   private readonly checkpointWrites = new Map<string, Promise<void>>();
 
@@ -64,6 +69,7 @@ export class AgentWorker {
     this.emitEvent = options.emitEvent;
     this.approvalBridge = options.approvalBridge;
     this.sessionBridge = options.sessionBridge;
+    this.contextBridge = options.contextBridge;
   }
 
   async handleRequest(request: WorkerRequest): Promise<WorkerResponse> {
@@ -95,15 +101,85 @@ export class AgentWorker {
       return this.handleSubmitFormRequest(request);
     }
 
+    if (request.method === "agent.run_input") {
+      return this.handleRunInputRequest(request);
+    }
+
     if (request.method !== "agent.run") {
       return this.failure(request, "unknown worker method", { method: request.method }, "invalid_protocol");
     }
 
+    return this.handleRunRequest(request);
+  }
+
+  private async handleRunRequest(request: WorkerRequest): Promise<WorkerResponse> {
     let runId: string | undefined;
     try {
       const spec = parseRunSpec(request.params);
       runId = spec.runId;
       spec.traceId = request.trace_id;
+      return await this.runSpecForRequest(request, spec);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.emitEvent({
+        protocol_version: WORKER_PROTOCOL_VERSION,
+        trace_id: request.trace_id,
+        event: "agent.error",
+        payload: withNativePayloadAliases(runId ? { runId, message } : { message }),
+      });
+      return this.failure(request, message);
+    }
+  }
+
+  private async handleRunInputRequest(request: WorkerRequest): Promise<WorkerResponse> {
+    let runId: string | undefined;
+    try {
+      const input = parseRunInput(request.params);
+      runId = input.runId;
+      if (!this.contextBridge) {
+        throw new Error("agent.run_input requires a context bridge");
+      }
+      const loaded = await this.contextBridge.loadContextInput(input, request.trace_id);
+      const context = buildContextMessages(loaded.input);
+      const contextMetadata = {
+        ...context.metadata,
+        bridge: loaded.metadata,
+      };
+      this.emitContextMetadata(request.trace_id, input.runId, contextMetadata);
+      const spec: AgentRunSpec = {
+        runId: input.runId,
+        traceId: request.trace_id,
+        sessionId: input.sessionId,
+        messages: context.messages,
+        model: input.model ?? "gpt-4.1-mini",
+        maxIterations: input.maxIterations ?? 2,
+        stream: input.stream ?? false,
+        temperature: input.temperature,
+        maxTokens: input.maxTokens,
+        reasoningEffort: input.reasoningEffort,
+        contextWindow: input.contextWindow,
+        toolResultBudget: input.toolResultBudget,
+        failOnToolError: input.failOnToolError,
+        metadata: input.metadata,
+      };
+      return await this.runSpecForRequest(request, spec, contextMetadata);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.emitEvent({
+        protocol_version: WORKER_PROTOCOL_VERSION,
+        trace_id: request.trace_id,
+        event: "agent.error",
+        payload: withNativePayloadAliases(runId ? { runId, message } : { message }),
+      });
+      return this.failure(request, message);
+    }
+  }
+
+  private async runSpecForRequest(
+    request: WorkerRequest,
+    spec: AgentRunSpec,
+    contextMetadata?: ContextBuildMetadata & { bridge?: ContextBridgeMetadata },
+  ): Promise<WorkerResponse> {
       const activeRun: ActiveRun = { traceId: request.trace_id, cancelled: false };
       this.activeRuns.set(spec.runId, activeRun);
       const runner = new AgentRunner({
@@ -137,18 +213,8 @@ export class AgentWorker {
         protocol_version: WORKER_PROTOCOL_VERSION,
         id: request.id,
         trace_id: request.trace_id,
-        result,
+        result: contextMetadata ? { ...result, contextMetadata } : result,
       };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.emitEvent({
-        protocol_version: WORKER_PROTOCOL_VERSION,
-        trace_id: request.trace_id,
-        event: "agent.error",
-        payload: withNativePayloadAliases(runId ? { runId, message } : { message }),
-      });
-      return this.failure(request, message);
-    }
   }
 
   private handleCancelRequest(request: WorkerRequest): WorkerResponse {
@@ -391,6 +457,19 @@ export class AgentWorker {
           ? { contextWindowTokens: spec.contextWindow, context_window_tokens: spec.contextWindow }
           : {}),
       }),
+    });
+  }
+
+  private emitContextMetadata(
+    traceId: string,
+    runId: string,
+    metadata: ContextBuildMetadata & { bridge?: ContextBridgeMetadata },
+  ): void {
+    this.emitEvent({
+      protocol_version: WORKER_PROTOCOL_VERSION,
+      trace_id: traceId,
+      event: "agent.context",
+      payload: withNativePayloadAliases({ runId, metadata }),
     });
   }
 
@@ -779,6 +858,48 @@ function parseRunSpec(params: Record<string, unknown> | undefined): AgentRunSpec
     model: raw.model,
     maxIterations,
     stream: raw.stream,
+    temperature: numberParam(raw, "temperature", "temperature"),
+    maxTokens: numberParam(raw, "maxTokens", "max_tokens"),
+    reasoningEffort: stringParam(raw, "reasoningEffort", "reasoning_effort"),
+    contextWindow: numberParam(raw, "contextWindow", "context_window"),
+    toolResultBudget: numberParam(raw, "toolResultBudget", "tool_result_budget"),
+    failOnToolError: booleanParam(raw, "failOnToolError", "fail_on_tool_error"),
+    metadata: isJsonObject(raw.metadata) ? raw.metadata : undefined,
+  };
+}
+
+function parseRunInput(params: Record<string, unknown> | undefined): AgentRunInput {
+  if (!isJsonObject(params) || !isJsonObject(params.input)) {
+    throw new Error("agent.run_input requires object params.input");
+  }
+  const raw = params.input;
+  const runId = stringParam(raw, "runId", "run_id");
+  if (!runId) {
+    throw new Error("agent.run_input input.runId must be a string");
+  }
+  const sessionId = stringParam(raw, "sessionId", "session_id");
+  if (!sessionId) {
+    throw new Error("agent.run_input input.sessionId must be a string");
+  }
+  if (!isJsonObject(raw.input) || typeof raw.input.content !== "string") {
+    throw new Error("agent.run_input input.input.content must be a string");
+  }
+  const role = raw.input.role === "system" ? "system" : "user";
+  return {
+    runId,
+    sessionId,
+    input: {
+      role,
+      content: raw.input.content,
+      media: Array.isArray(raw.input.media)
+        ? raw.input.media.filter((item): item is string => typeof item === "string")
+        : undefined,
+    },
+    channel: stringParam(raw, "channel", "channel"),
+    chatId: stringParam(raw, "chatId", "chat_id"),
+    model: stringParam(raw, "model", "model"),
+    maxIterations: numberParam(raw, "maxIterations", "max_iterations"),
+    stream: booleanParam(raw, "stream", "stream"),
     temperature: numberParam(raw, "temperature", "temperature"),
     maxTokens: numberParam(raw, "maxTokens", "max_tokens"),
     reasoningEffort: stringParam(raw, "reasoningEffort", "reasoning_effort"),

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
@@ -266,12 +266,13 @@ export class AgentWorker {
       let restored = false;
       let restoredMessageCount = 0;
       if (checkpoint) {
-        const restoredMessages = materializeCheckpointMessages(checkpoint);
-        restoredMessageCount = restoredMessages.length;
+        const shouldKeepCheckpointForResume = checkpointRequiresUserInputResume(checkpoint);
+        const restoredMessages = shouldKeepCheckpointForResume ? [] : materializeCheckpointMessages(checkpoint);
         if (restoredMessages.length > 0) {
           await this.sessionBridge.appendMessages(sessionId, restoredMessages, request.trace_id);
+          restoredMessageCount = restoredMessages.length;
         }
-        if (!checkpointRequiresUserInputResume(checkpoint)) {
+        if (!shouldKeepCheckpointForResume) {
           await this.sessionBridge.clearCheckpoint(sessionId, request.trace_id);
         }
         restored = true;

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
@@ -271,7 +271,9 @@ export class AgentWorker {
         if (restoredMessages.length > 0) {
           await this.sessionBridge.appendMessages(sessionId, restoredMessages, request.trace_id);
         }
-        await this.sessionBridge.clearCheckpoint(sessionId, request.trace_id);
+        if (!checkpointRequiresUserInputResume(checkpoint)) {
+          await this.sessionBridge.clearCheckpoint(sessionId, request.trace_id);
+        }
         restored = true;
       }
       return {
@@ -1157,4 +1159,26 @@ function errorMessage(error: unknown): string {
 
 function isAwaitingInputResult(result: AgentRunResult): boolean {
   return result.stopReason === "awaiting_user_input" || result.stopReason === "awaiting_approval" || result.stopReason === "awaiting_form";
+}
+
+function checkpointRequiresUserInputResume(checkpoint: Record<string, unknown>): boolean {
+  return checkpointContainsAwaitingInput(checkpoint.messages)
+    || checkpointContainsAwaitingInput(checkpoint.completedToolResults ?? checkpoint.completed_tool_results)
+    || checkpointContainsAwaitingInput(checkpoint.assistantMessage ?? checkpoint.assistant_message);
+}
+
+function checkpointContainsAwaitingInput(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(checkpointContainsAwaitingInput);
+  }
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  const metadata = isJsonObject(value.metadata) ? value.metadata : {};
+  const awaitingUserInput = metadata.awaitingUserInput ?? metadata.awaiting_user_input;
+  const stopReason = metadata.stopReason ?? metadata.stop_reason;
+  return awaitingUserInput === true
+    || stopReason === "awaiting_user_input"
+    || stopReason === "awaiting_approval"
+    || stopReason === "awaiting_form";
 }

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/contextBridge.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/contextBridge.test.ts
@@ -86,6 +86,70 @@ describe("NativeContextBridge", () => {
     });
   });
 
+  test("preserves tool-call fields when normalizing session history", async () => {
+    const rpcClient = new FakeRpcClient({
+      "runtime.now": { current_time: "2026-06-10 09:00:00 Asia/Shanghai" },
+      "session.get_history": {
+        session_id: "session-1",
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            reasoning_content: "Need a tool.",
+            thinking_blocks: [{ type: "thinking", text: "trace" }],
+            tool_calls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: {
+                  name: "read_file",
+                  arguments: "{\"path\":\"README.md\"}",
+                },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            content: "README contents",
+            tool_call_id: "call-1",
+            name: "read_file",
+            metadata: {
+              source: "session",
+              awaiting_user_input: true,
+              stop_reason: "awaiting_form",
+            },
+          },
+        ],
+      },
+      "workspace.read_bootstrap_files": { files: [], missing: [] },
+    });
+    const bridge = new NativeContextBridge(rpcClient);
+
+    const result = await bridge.loadContextInput(runInput(), "trace-1");
+
+    expect(result.input.history).toEqual([
+      {
+        role: "assistant",
+        content: "",
+        reasoningContent: "Need a tool.",
+        thinkingBlocks: [{ type: "thinking", text: "trace" }],
+        toolCalls: [{ id: "call-1", name: "read_file", argumentsJson: "{\"path\":\"README.md\"}" }],
+      },
+      {
+        role: "tool",
+        content: "README contents",
+        toolCallId: "call-1",
+        name: "read_file",
+        metadata: {
+          source: "session",
+          awaiting_user_input: true,
+          stop_reason: "awaiting_form",
+        },
+      },
+    ]);
+    expect(result.metadata.malformedHistoryCount).toBe(0);
+  });
+
   test("falls back to per-file bootstrap reads when the batch RPC is unavailable", async () => {
     const rpcClient = new FakeRpcClient({
       "runtime.now": { current_time: "fixed now" },

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/contextBridge.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/contextBridge.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+
+import { NativeContextBridge } from "./contextBridge";
+import type { AgentRunInput } from "../agent/contextTypes";
+import type { JsonObject } from "../protocol/messages";
+
+class FakeRpcClient {
+  readonly calls: Array<{ traceId: string; method: string; params: JsonObject }> = [];
+
+  constructor(private readonly responses: Record<string, unknown | Error>) {}
+
+  async request(traceId: string, method: string, params: JsonObject): Promise<unknown> {
+    this.calls.push({ traceId, method, params });
+    const response = this.responses[method];
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response;
+  }
+}
+
+function runInput(overrides: Partial<AgentRunInput> = {}): AgentRunInput {
+  return {
+    runId: "run-1",
+    sessionId: "session-1",
+    input: { content: "Continue" },
+    model: "test-model",
+    maxIterations: 2,
+    stream: false,
+    ...overrides,
+  };
+}
+
+describe("NativeContextBridge", () => {
+  test("loads runtime, session history, user profile, and bootstrap files from native RPC", async () => {
+    const rpcClient = new FakeRpcClient({
+      "runtime.now": { current_time: "2026-06-10 09:00:00 Asia/Shanghai" },
+      "session.get_history": {
+        session_id: "session-1",
+        messages: [
+          { role: "user", content: "Earlier" },
+          { role: "unknown", content: "bad role" },
+          { role: "assistant", content: 42 },
+        ],
+        user_profile: {
+          name: "Ada",
+          preferences: ["concise"],
+          mentioned_entities: ["tinybot"],
+        },
+      },
+      "workspace.read_bootstrap_files": {
+        files: [{ path: "AGENTS.md", contents: "Agent rules" }],
+        missing: ["TOOLS.md"],
+      },
+    });
+    const bridge = new NativeContextBridge(rpcClient);
+
+    const result = await bridge.loadContextInput(runInput({ channel: "desktop", chatId: "chat-1" }), "trace-1");
+
+    expect(rpcClient.calls.map((call) => call.method)).toEqual([
+      "runtime.now",
+      "session.get_history",
+      "workspace.read_bootstrap_files",
+    ]);
+    expect(result.input).toMatchObject({
+      identity: expect.stringContaining("TinyBot"),
+      currentMessage: "Continue",
+      history: [{ role: "user", content: "Earlier" }],
+      bootstrapFiles: [{ path: "AGENTS.md", contents: "Agent rules" }],
+      runtime: {
+        currentTime: "2026-06-10 09:00:00 Asia/Shanghai",
+        channel: "desktop",
+        chatId: "chat-1",
+        userProfile: {
+          name: "Ada",
+          preferences: ["concise"],
+          mentionedEntities: ["tinybot"],
+        },
+      },
+    });
+    expect(result.metadata).toEqual({
+      missingSession: false,
+      malformedHistoryCount: 2,
+      missingBootstrapFiles: ["TOOLS.md"],
+      bootstrapFallbackUsed: false,
+    });
+  });
+
+  test("falls back to per-file bootstrap reads when the batch RPC is unavailable", async () => {
+    const rpcClient = new FakeRpcClient({
+      "runtime.now": { current_time: "fixed now" },
+      "session.get_history": new Error("session metadata not found"),
+      "workspace.read_bootstrap_files": new Error("unknown worker method"),
+      "workspace.read_file": { path: "AGENTS.md", contents: "Agent rules" },
+    });
+    const bridge = new NativeContextBridge(rpcClient);
+
+    const result = await bridge.loadContextInput(runInput(), "trace-1");
+
+    expect(rpcClient.calls.map((call) => call.method)).toEqual([
+      "runtime.now",
+      "session.get_history",
+      "workspace.read_bootstrap_files",
+      "workspace.read_file",
+      "workspace.read_file",
+      "workspace.read_file",
+      "workspace.read_file",
+    ]);
+    expect(result.input.history).toEqual([]);
+    expect(result.input.bootstrapFiles).toEqual([{ path: "AGENTS.md", contents: "Agent rules" }]);
+    expect(result.metadata).toMatchObject({
+      missingSession: true,
+      bootstrapFallbackUsed: true,
+    });
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/contextBridge.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/contextBridge.ts
@@ -131,10 +131,44 @@ function normalizeHistoryMessage(value: unknown): AgentMessage | null {
   if (!object || !isAgentRole(object.role) || typeof object.content !== "string") {
     return null;
   }
+  const toolCalls = normalizeToolCalls(object.toolCalls ?? object.tool_calls);
+  const toolCallId = asString(object.toolCallId ?? object.tool_call_id);
+  const reasoningContent = asString(object.reasoningContent ?? object.reasoning_content);
+  const thinkingBlocks = normalizeThinkingBlocks(object.thinkingBlocks ?? object.thinking_blocks);
+  const metadata = asObject(object.metadata);
   return {
     role: object.role,
     content: object.content,
+    ...(reasoningContent !== undefined ? { reasoningContent } : {}),
+    ...(thinkingBlocks.length > 0 ? { thinkingBlocks } : {}),
+    ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    ...(toolCallId ? { toolCallId } : {}),
+    ...(asString(object.name) ? { name: asString(object.name) } : {}),
+    ...(metadata ? { metadata } : {}),
   };
+}
+
+function normalizeToolCalls(value: unknown): AgentMessage["toolCalls"] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => {
+    const object = asObject(entry);
+    if (!object) {
+      return null;
+    }
+    const functionPayload = asObject(object.function);
+    const id = asString(object.id);
+    const name = asString(object.name) ?? asString(functionPayload?.name);
+    const argumentsJson = asString(object.argumentsJson)
+      ?? asString(object.arguments_json)
+      ?? asString(functionPayload?.arguments);
+    return id && name && argumentsJson !== undefined ? { id, name, argumentsJson } : null;
+  }).filter((toolCall): toolCall is NonNullable<AgentMessage["toolCalls"]>[number] => toolCall !== null);
+}
+
+function normalizeThinkingBlocks(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter(isJsonObject) : [];
 }
 
 function normalizeBootstrapFiles(value: unknown): BootstrapFile[] {
@@ -177,4 +211,8 @@ function asObject(value: unknown): JsonObject | null {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/contextBridge.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/contextBridge.ts
@@ -1,0 +1,180 @@
+import type { AgentMessage } from "../agent/agentRunSpec.ts";
+import {
+  BOOTSTRAP_FILE_ORDER,
+  type AgentRunInput,
+  type BootstrapFile,
+  type ContextBridgeLoadResult,
+  type UserProfile,
+} from "../agent/contextTypes.ts";
+import type { JsonObject } from "../protocol/messages.ts";
+import type { NativeRpcClient } from "../tools/nativeToolProxy.ts";
+
+const DEFAULT_IDENTITY = "You are TinyBot running in the desktop native TS worker.";
+const DEFAULT_HISTORY_LIMIT = 80;
+
+export type ContextBridge = {
+  loadContextInput(input: AgentRunInput, traceId: string): Promise<ContextBridgeLoadResult>;
+};
+
+export class NativeContextBridge implements ContextBridge {
+  private readonly rpcClient: NativeRpcClient;
+
+  constructor(rpcClient: NativeRpcClient) {
+    this.rpcClient = rpcClient;
+  }
+
+  async loadContextInput(input: AgentRunInput, traceId: string): Promise<ContextBridgeLoadResult> {
+    const runtime = await this.loadRuntime(input, traceId);
+    const history = await this.loadHistory(input, traceId);
+    const bootstrap = await this.loadBootstrapFiles(traceId);
+    return {
+      input: {
+        identity: DEFAULT_IDENTITY,
+        bootstrapFiles: bootstrap.files,
+        history: history.messages,
+        currentMessage: input.input.content,
+        currentRole: input.input.role ?? "user",
+        runtime: {
+          currentTime: runtime.currentTime,
+          channel: input.channel,
+          chatId: input.chatId,
+          userProfile: history.userProfile,
+        },
+      },
+      metadata: {
+        missingSession: history.missingSession,
+        malformedHistoryCount: history.malformedHistoryCount,
+        missingBootstrapFiles: bootstrap.missing,
+        bootstrapFallbackUsed: bootstrap.fallbackUsed,
+      },
+    };
+  }
+
+  private async loadRuntime(input: AgentRunInput, traceId: string): Promise<{ currentTime: string }> {
+    try {
+      const timezone = typeof input.metadata?.timezone === "string" ? input.metadata.timezone : undefined;
+      const result = asObject(await this.rpcClient.request(traceId, "runtime.now", timezone ? { timezone } : {}));
+      return {
+        currentTime: asString(result?.current_time) ?? asString(result?.currentTime) ?? new Date().toISOString(),
+      };
+    } catch {
+      return { currentTime: new Date().toISOString() };
+    }
+  }
+
+  private async loadHistory(input: AgentRunInput, traceId: string): Promise<{
+    messages: AgentMessage[];
+    userProfile?: UserProfile;
+    missingSession: boolean;
+    malformedHistoryCount: number;
+  }> {
+    try {
+      const result = asObject(await this.rpcClient.request(traceId, "session.get_history", {
+        session_id: input.sessionId,
+        limit: DEFAULT_HISTORY_LIMIT,
+      }));
+      const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
+      const normalizedMessages = rawMessages.map(normalizeHistoryMessage);
+      const messages = normalizedMessages.filter((message): message is AgentMessage => message !== null);
+      return {
+        messages,
+        userProfile: normalizeUserProfile(result?.user_profile ?? result?.userProfile),
+        missingSession: false,
+        malformedHistoryCount: normalizedMessages.length - messages.length,
+      };
+    } catch {
+      return {
+        messages: [],
+        missingSession: true,
+        malformedHistoryCount: 0,
+      };
+    }
+  }
+
+  private async loadBootstrapFiles(traceId: string): Promise<{
+    files: BootstrapFile[];
+    missing: string[];
+    fallbackUsed: boolean;
+  }> {
+    const files = [...BOOTSTRAP_FILE_ORDER];
+    try {
+      const result = asObject(await this.rpcClient.request(traceId, "workspace.read_bootstrap_files", { files }));
+      return {
+        files: normalizeBootstrapFiles(result?.files),
+        missing: normalizeStringArray(result?.missing),
+        fallbackUsed: false,
+      };
+    } catch {
+      const fallbackFiles: BootstrapFile[] = [];
+      const missing: string[] = [];
+      for (const path of files) {
+        try {
+          const result = asObject(await this.rpcClient.request(traceId, "workspace.read_file", { path }));
+          const responsePath = asString(result?.path);
+          const contents = asString(result?.contents);
+          if (responsePath === path && contents !== undefined) {
+            fallbackFiles.push({ path, contents });
+          } else {
+            missing.push(path);
+          }
+        } catch {
+          missing.push(path);
+        }
+      }
+      return { files: fallbackFiles, missing, fallbackUsed: true };
+    }
+  }
+}
+
+function normalizeHistoryMessage(value: unknown): AgentMessage | null {
+  const object = asObject(value);
+  if (!object || !isAgentRole(object.role) || typeof object.content !== "string") {
+    return null;
+  }
+  return {
+    role: object.role,
+    content: object.content,
+  };
+}
+
+function normalizeBootstrapFiles(value: unknown): BootstrapFile[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => {
+    const object = asObject(entry);
+    const path = asString(object?.path);
+    const contents = asString(object?.contents);
+    return path && contents !== undefined ? { path, contents } : null;
+  }).filter((file): file is BootstrapFile => file !== null);
+}
+
+function normalizeUserProfile(value: unknown): UserProfile | undefined {
+  const object = asObject(value);
+  if (!object) {
+    return undefined;
+  }
+  return {
+    name: asString(object.name),
+    preferences: normalizeStringArray(object.preferences),
+    mentionedEntities: normalizeStringArray(object.mentionedEntities ?? object.mentioned_entities),
+    communicationStyle: asString(object.communicationStyle ?? object.communication_style),
+    keyFacts: normalizeStringArray(object.keyFacts ?? object.key_facts),
+  };
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function isAgentRole(value: unknown): value is AgentMessage["role"] {
+  return value === "system" || value === "user" || value === "assistant" || value === "tool";
+}
+
+function asObject(value: unknown): JsonObject | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as JsonObject) : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/createAgentWorkerServer.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/createAgentWorkerServer.ts
@@ -15,6 +15,7 @@ import type { ToolRegistry } from "../tools/toolRegistry.ts";
 import { NativeApprovalBridge } from "./approvalBridge.ts";
 import { AgentWorker } from "./agentWorker.ts";
 import { NativeConfigBridge, modelProviderConfigFromNativeConfig } from "./configBridge.ts";
+import { NativeContextBridge } from "./contextBridge.ts";
 import { createModelProvider, type ModelProviderConfig } from "./providerFactory.ts";
 import { NativeSessionBridge } from "./sessionBridge.ts";
 
@@ -62,6 +63,7 @@ export function createAgentWorkerServer(options: CreateAgentWorkerServerOptions)
     emitEvent: writeEvent,
     approvalBridge: new NativeApprovalBridge(rpcClient),
     sessionBridge: new NativeSessionBridge(rpcClient),
+    contextBridge: new NativeContextBridge(rpcClient),
   });
   return new StdioServer({
     worker,


### PR DESCRIPTION
## Summary
- Preserve TS worker checkpoints that are waiting for form, approval, or user-input resume after `agent.restore_checkpoint`.
- Keep the existing restore behavior for ordinary interrupted tool checkpoints, which are still materialized and cleared.
- Add a regression test covering awaiting-input checkpoint restore behavior.

## Root Cause
`agent.restore_checkpoint` always cleared the saved checkpoint after materializing messages into the session. For checkpoints that intentionally pause on form or approval input, that removed the state required by `agent.submit_form` or `agent.resume_approval`, so the resume request could not continue the run.

## Validation
- `npm test` in `apps/desktop`: 187 files / 800 tests passed
- `npm run build` in `apps/desktop`: passed
- `cargo test worker_` in `apps/desktop/src-tauri`: 134 tests passed

Closes #235