### PR TITLE
Migrate desktop TS worker model provider runtime

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ pub mod worker_protocol;
 pub mod worker_rpc;
 pub mod worker_runtime;
 pub mod worker_session;
+pub mod worker_secret;
 pub mod worker_stdio;
 pub mod worker_workspace;
 
@@ -1395,6 +1396,7 @@ fn experimental_worker_router(
         200,
         CapabilityPolicy::new([
             WorkerCapability::ConfigRead,
+            WorkerCapability::ProviderSecretRead,
             WorkerCapability::FsWorkspaceRead,
             WorkerCapability::DiagnosticsWrite,
             WorkerCapability::ApprovalRequest,

--- a/apps/desktop/src-tauri/src/worker_capability.rs
+++ b/apps/desktop/src-tauri/src/worker_capability.rs
@@ -13,6 +13,8 @@ pub enum WorkerCapability {
     ConfigRead,
     #[serde(rename = "config.write")]
     ConfigWrite,
+    #[serde(rename = "provider.secret.read")]
+    ProviderSecretRead,
     #[serde(rename = "session.metadata.read")]
     SessionMetadataRead,
     #[serde(rename = "session.write")]
@@ -70,6 +72,7 @@ mod tests {
         assert!(!policy.allows(&WorkerCapability::NetworkOpenAi));
         assert!(!policy.allows(&WorkerCapability::FsWorkspaceRead));
         assert!(!policy.allows(&WorkerCapability::SessionMetadataRead));
+        assert!(!policy.allows(&WorkerCapability::ProviderSecretRead));
         assert!(!policy.allows(&WorkerCapability::ApprovalRequest));
         assert!(!policy.allows(&WorkerCapability::ApprovalResolve));
         assert!(!policy.allows(&WorkerCapability::FormRequest));
@@ -203,6 +206,22 @@ mod tests {
             json!({
                 "capability": "mcp.call",
                 "scope": "mcp://configured"
+            })
+        );
+    }
+
+    #[test]
+    fn provider_secret_read_capability_name_serializes_as_protocol_string() {
+        let grant = CapabilityGrant {
+            capability: WorkerCapability::ProviderSecretRead,
+            scope: "provider://runtime".to_string(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(grant).expect("grant should serialize"),
+            json!({
+                "capability": "provider.secret.read",
+                "scope": "provider://runtime"
             })
         );
     }

--- a/apps/desktop/src-tauri/src/worker_config.rs
+++ b/apps/desktop/src-tauri/src/worker_config.rs
@@ -103,10 +103,14 @@ fn redact_sensitive_value(value: &Value) -> Value {
 }
 
 fn is_sensitive_key(key: &str) -> bool {
-    let key = key.to_ascii_lowercase();
+    let key = key
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase();
     matches!(
         key.as_str(),
-        "api_key" | "token" | "secret" | "password" | "credentials"
+        "apikey" | "token" | "secret" | "password" | "credentials"
     )
 }
 
@@ -180,9 +184,17 @@ mod tests {
         let error = rpc
             .get("providers.openai.api_key")
             .expect_err("api_key should be protected");
+        let camel_case_error = rpc
+            .get("providers.openai.apiKey")
+            .expect_err("apiKey should be protected");
 
         assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
         assert_eq!(error.details["path"], "providers.openai.api_key");
+        assert_eq!(
+            camel_case_error.code,
+            WorkerProtocolErrorCode::CapabilityDenied
+        );
+        assert_eq!(camel_case_error.details["path"], "providers.openai.apiKey");
     }
 
     #[test]
@@ -195,6 +207,7 @@ mod tests {
 
         assert_eq!(result.value["provider"], "openai");
         assert_eq!(result.value["api_key"], serde_json::Value::Null);
+        assert_eq!(result.value["apiKey"], serde_json::Value::Null);
     }
 
     #[test]
@@ -208,6 +221,10 @@ mod tests {
         assert_eq!(result.value["providers"]["openai"]["provider"], "openai");
         assert_eq!(
             result.value["providers"]["openai"]["api_key"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            result.value["providers"]["openai"]["apiKey"],
             serde_json::Value::Null
         );
     }
@@ -239,6 +256,7 @@ mod tests {
                 "openai": {
                     "provider": "openai",
                     "api_key": "sk-secret",
+                    "apiKey": "sk-camel-secret",
                     "api_base": "https://api.openai.com/v1"
                 }
             }

--- a/apps/desktop/src-tauri/src/worker_config.rs
+++ b/apps/desktop/src-tauri/src/worker_config.rs
@@ -31,6 +31,13 @@ impl WorkerConfigRpc {
         })
     }
 
+    pub fn snapshot_public(&self) -> Result<ConfigSnapshotPublicResult, WorkerProtocolError> {
+        self.require(WorkerCapability::ConfigRead)?;
+        Ok(ConfigSnapshotPublicResult {
+            value: redact_sensitive_value(&self.snapshot),
+        })
+    }
+
     fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
         if self.policy.allows(&capability) {
             return Ok(());
@@ -48,6 +55,11 @@ impl WorkerConfigRpc {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ConfigGetResult {
     pub path: String,
+    pub value: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ConfigSnapshotPublicResult {
     pub value: Value,
 }
 
@@ -183,6 +195,21 @@ mod tests {
 
         assert_eq!(result.value["provider"], "openai");
         assert_eq!(result.value["api_key"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn config_snapshot_public_redacts_sensitive_descendants() {
+        let rpc = WorkerConfigRpc::new(config_fixture(), read_policy());
+
+        let result = rpc
+            .snapshot_public()
+            .expect("public snapshot should read with redaction");
+
+        assert_eq!(result.value["providers"]["openai"]["provider"], "openai");
+        assert_eq!(
+            result.value["providers"]["openai"]["api_key"],
+            serde_json::Value::Null
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -2,6 +2,7 @@ use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
 use crate::worker_config::WorkerConfigRpc;
 use crate::worker_diagnostics::WorkerDiagnosticsRpc;
 use crate::worker_protocol::{validate_protocol_version, WorkerRequest, WorkerResponse};
+use crate::worker_secret::{ProviderResolveSecretParams, WorkerSecretRpc};
 use crate::worker_session::{SessionMetadata, WorkerSessionRpc};
 use crate::worker_workspace::WorkerWorkspaceRpc;
 use serde::Deserialize;
@@ -18,6 +19,7 @@ use std::{
 pub struct WorkerRpcRouter {
     workspace: WorkerWorkspaceRpc,
     config: WorkerConfigRpc,
+    secret: WorkerSecretRpc,
     session: WorkerSessionRpc,
     diagnostics: WorkerDiagnosticsRpc,
     approval: WorkerApprovalRpc,
@@ -37,6 +39,7 @@ impl WorkerRpcRouter {
         Self {
             workspace: WorkerWorkspaceRpc::new(workspace_root.clone(), policy.clone()),
             config: WorkerConfigRpc::new(config_snapshot.clone(), policy.clone()),
+            secret: WorkerSecretRpc::new(config_snapshot.clone(), policy.clone()),
             session: WorkerSessionRpc::new(sessions, policy.clone()),
             diagnostics: WorkerDiagnosticsRpc::new(diagnostic_capacity, policy.clone()),
             approval: WorkerApprovalRpc::new(policy.clone()),
@@ -88,6 +91,14 @@ impl WorkerRpcRouter {
             "config.get" => {
                 let params: PathParams = parse_params(request)?;
                 serde_json::to_value(self.config.get(&params.path)?).map_err(serialization_error)
+            }
+            "config.snapshot_public" => {
+                serde_json::to_value(self.config.snapshot_public()?).map_err(serialization_error)
+            }
+            "provider.resolve_secret" => {
+                let params: ProviderResolveSecretParams = parse_params(request)?;
+                serde_json::to_value(self.secret.resolve_secret(params)?)
+                    .map_err(serialization_error)
             }
             "session.get_metadata" => {
                 let params: SessionIdParams = parse_params(request)?;
@@ -1447,6 +1458,76 @@ mod tests {
         assert_eq!(
             response.result,
             Some(json!({ "path": "agents.defaults.model", "value": "gpt-5" }))
+        );
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_config_snapshot_public_request() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({
+                "providers": {
+                    "openai": {
+                        "provider": "openai",
+                        "api_key": "sk-secret"
+                    }
+                }
+            }),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::ConfigRead]),
+        );
+        let request = WorkerRequest::new("req-1", "trace-1", "config.snapshot_public", json!({}));
+
+        let response = router.dispatch(&request);
+
+        assert_eq!(
+            response.result.as_ref().unwrap()["value"]["providers"]["openai"]["api_key"],
+            serde_json::Value::Null
+        );
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_provider_resolve_secret_request() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({
+                "providers": {
+                    "profiles": {
+                        "dashscope-search": {
+                            "provider": "dashscope",
+                            "api_key": "profile-secret"
+                        }
+                    }
+                }
+            }),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::ProviderSecretRead]),
+        );
+        let request = WorkerRequest::new(
+            "req-1",
+            "trace-1",
+            "provider.resolve_secret",
+            json!({
+                "providerId": "dashscope",
+                "profileName": "dashscope-search",
+                "apiKeyEnvVars": ["DASHSCOPE_API_KEY"]
+            }),
+        );
+
+        let response = router.dispatch(&request);
+
+        assert_eq!(
+            response.result,
+            Some(json!({
+                "apiKey": "profile-secret",
+                "apiKeySource": "config"
+            }))
         );
         assert!(response.error.is_none());
     }

--- a/apps/desktop/src-tauri/src/worker_secret.rs
+++ b/apps/desktop/src-tauri/src/worker_secret.rs
@@ -1,0 +1,201 @@
+use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+use crate::worker_protocol::{
+    WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug)]
+pub struct WorkerSecretRpc {
+    snapshot: Value,
+    policy: CapabilityPolicy,
+}
+
+impl WorkerSecretRpc {
+    pub fn new(snapshot: Value, policy: CapabilityPolicy) -> Self {
+        Self { snapshot, policy }
+    }
+
+    pub fn resolve_secret(
+        &self,
+        params: ProviderResolveSecretParams,
+    ) -> Result<ProviderResolveSecretResult, WorkerProtocolError> {
+        self.require(WorkerCapability::ProviderSecretRead)?;
+        let provider_id = validate_provider_id(&params.provider_id)?;
+        if let Some(profile_name) = params.profile_name.as_deref() {
+            if let Some(api_key) = config_api_key(
+                self.snapshot
+                    .get("providers")
+                    .and_then(|providers| providers.get("profiles"))
+                    .and_then(|profiles| profiles.get(profile_name)),
+            ) {
+                return Ok(ProviderResolveSecretResult {
+                    api_key: Some(api_key),
+                    api_key_source: Some("config".to_string()),
+                });
+            }
+        }
+        if let Some(api_key) = config_api_key(
+            self.snapshot
+                .get("providers")
+                .and_then(|providers| providers.get(provider_id)),
+        ) {
+            return Ok(ProviderResolveSecretResult {
+                api_key: Some(api_key),
+                api_key_source: Some("config".to_string()),
+            });
+        }
+        for env_name in params.api_key_env_vars {
+            if let Ok(value) = std::env::var(&env_name) {
+                if !value.trim().is_empty() {
+                    return Ok(ProviderResolveSecretResult {
+                        api_key: Some(value),
+                        api_key_source: Some(format!("env:{env_name}")),
+                    });
+                }
+            }
+        }
+        Ok(ProviderResolveSecretResult {
+            api_key: None,
+            api_key_source: None,
+        })
+    }
+
+    fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
+        if self.policy.allows(&capability) {
+            return Ok(());
+        }
+        Err(WorkerProtocolError::new(
+            WorkerProtocolErrorCode::CapabilityDenied,
+            "worker capability denied",
+            serde_json::json!({ "capability": capability }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ProviderResolveSecretParams {
+    #[serde(rename = "providerId", alias = "provider_id")]
+    pub provider_id: String,
+    #[serde(rename = "profileName", alias = "profile_name")]
+    pub profile_name: Option<String>,
+    #[serde(default, rename = "apiKeyEnvVars", alias = "api_key_env_vars")]
+    pub api_key_env_vars: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ProviderResolveSecretResult {
+    #[serde(rename = "apiKey", alias = "api_key")]
+    pub api_key: Option<String>,
+    #[serde(rename = "apiKeySource", alias = "api_key_source")]
+    pub api_key_source: Option<String>,
+}
+
+fn config_api_key(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(|config| config.get("api_key").or_else(|| config.get("apiKey")))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn validate_provider_id(provider_id: &str) -> Result<&str, WorkerProtocolError> {
+    let value = provider_id.trim();
+    if value.is_empty()
+        || value.contains('.')
+        || value.contains('/')
+        || value.contains('\\')
+        || value.contains('\0')
+    {
+        return Err(WorkerProtocolError::new(
+            WorkerProtocolErrorCode::InvalidProtocol,
+            "invalid provider id",
+            serde_json::json!({ "providerId": provider_id }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ));
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+    use serde_json::json;
+
+    #[test]
+    fn resolve_secret_requires_provider_secret_capability() {
+        let rpc = WorkerSecretRpc::new(secret_fixture(), CapabilityPolicy::default());
+
+        let error = rpc
+            .resolve_secret(params("openai"))
+            .expect_err("secret reads should require capability");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
+        assert_eq!(error.details["capability"], "provider.secret.read");
+    }
+
+    #[test]
+    fn resolve_secret_prefers_profile_key() {
+        let rpc = WorkerSecretRpc::new(
+            secret_fixture(),
+            CapabilityPolicy::new([WorkerCapability::ProviderSecretRead]),
+        );
+
+        let result = rpc
+            .resolve_secret(ProviderResolveSecretParams {
+                provider_id: "dashscope".to_string(),
+                profile_name: Some("dashscope-search".to_string()),
+                api_key_env_vars: vec![],
+            })
+            .expect("profile secret should resolve");
+
+        assert_eq!(
+            result,
+            ProviderResolveSecretResult {
+                api_key: Some("profile-secret".to_string()),
+                api_key_source: Some("config".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_secret_rejects_arbitrary_path_provider_ids() {
+        let rpc = WorkerSecretRpc::new(
+            secret_fixture(),
+            CapabilityPolicy::new([WorkerCapability::ProviderSecretRead]),
+        );
+
+        let error = rpc
+            .resolve_secret(params("providers.openai.api_key"))
+            .expect_err("provider id is not a config path");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::InvalidProtocol);
+    }
+
+    fn params(provider_id: &str) -> ProviderResolveSecretParams {
+        ProviderResolveSecretParams {
+            provider_id: provider_id.to_string(),
+            profile_name: None,
+            api_key_env_vars: vec![],
+        }
+    }
+
+    fn secret_fixture() -> Value {
+        json!({
+            "providers": {
+                "openai": { "api_key": "openai-secret" },
+                "profiles": {
+                    "dashscope-search": {
+                        "provider": "dashscope",
+                        "api_key": "profile-secret"
+                    }
+                }
+            }
+        })
+    }
+}

--- a/apps/desktop/workers/ts-agent-worker/src/model/openaiProvider.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/openaiProvider.ts
@@ -1,8 +1,9 @@
-import { createHash } from "node:crypto";
-
 import type { AgentMessage } from "../agent/agentRunSpec.ts";
+import type { RequestTraits } from "../providers/providerCatalog.ts";
+import { buildOpenAIChatRequest } from "./openaiRequestBuilder.ts";
+import { withProviderRetry } from "./providerRetry.ts";
 import { collectChatCompletionStream, type StreamModelResponse } from "./streamParser.ts";
-import type { ModelProvider, ModelRequestOptions, ToolDefinition } from "./provider.ts";
+import type { ModelProvider, ModelRequestOptions } from "./provider.ts";
 
 export type OpenAIChatCompletionsClient = {
   chat: {
@@ -15,40 +16,44 @@ export type OpenAIChatCompletionsClient = {
 export type OpenAIProviderOptions = {
   client: OpenAIChatCompletionsClient;
   defaultModel: string;
+  requestTraits?: Partial<RequestTraits>;
+  extraBodyDefaults?: Record<string, unknown>;
+  enableSearch?: boolean;
 };
 
 export class OpenAIProvider implements ModelProvider {
   private readonly client: OpenAIChatCompletionsClient;
   private readonly defaultModel: string;
+  private readonly requestTraits?: Partial<RequestTraits>;
+  private readonly extraBodyDefaults?: Record<string, unknown>;
+  private readonly enableSearch: boolean;
 
   constructor(options: OpenAIProviderOptions) {
     this.client = options.client;
     this.defaultModel = options.defaultModel;
+    this.requestTraits = options.requestTraits;
+    this.extraBodyDefaults = options.extraBodyDefaults;
+    this.enableSearch = options.enableSearch ?? false;
   }
 
   async complete(messages: AgentMessage[], options: ModelRequestOptions = {}): Promise<StreamModelResponse> {
-    const request: Record<string, unknown> = {
-      model: options.model?.trim() || this.defaultModel,
-      messages: toOpenAIMessages(messages),
-      stream: true,
-      stream_options: { include_usage: true },
-    };
-    if (options.tools?.length) {
-      request.tools = options.tools.map(toOpenAITool);
-      request.tool_choice = "auto";
-    }
-    if (options.temperature !== undefined && supportsTemperature(request.model, options.reasoningEffort)) {
-      request.temperature = options.temperature;
-    }
-    if (options.maxTokens !== undefined) {
-      request.max_tokens = Math.max(1, options.maxTokens);
-    }
-    if (options.reasoningEffort) {
-      request.reasoning_effort = options.reasoningEffort;
-    }
+    const request = buildOpenAIChatRequest({
+      defaultModel: this.defaultModel,
+      messages,
+      options,
+      requestTraits: this.requestTraits,
+      extraBodyDefaults: this.extraBodyDefaults,
+      enableSearch: this.enableSearch,
+    });
     let stream: AsyncIterable<unknown>;
     try {
-      stream = await this.client.chat.completions.create(request);
+      stream = await withProviderRetry(
+        () => this.client.chat.completions.create(request),
+        {
+          retryMode: options.retryMode,
+          onRetryWait: options.onRetryWait,
+        },
+      );
     } catch (error) {
       return {
         content: openAIErrorContent(error),
@@ -58,86 +63,6 @@ export class OpenAIProvider implements ModelProvider {
     }
     return collectChatCompletionStream(stream, options);
   }
-}
-
-function toOpenAIMessages(messages: AgentMessage[]): Record<string, unknown>[] {
-  const toolCallIds = new Map<string, string>();
-  return messages.map((message) => toOpenAIMessage(message, toolCallIds));
-}
-
-function toOpenAIMessage(message: AgentMessage, toolCallIds: Map<string, string>): Record<string, unknown> {
-  if (message.role === "assistant" && message.toolCalls?.length) {
-    return {
-      role: "assistant",
-      content: message.content.length === 0 ? null : message.content,
-      ...(message.reasoningContent !== undefined ? { reasoning_content: message.reasoningContent } : {}),
-      ...(message.thinkingBlocks ? { thinking_blocks: message.thinkingBlocks } : {}),
-      tool_calls: message.toolCalls.map((toolCall) => ({
-        id: mapToolCallId(toolCallIds, toolCall.id),
-        type: "function",
-        function: {
-          name: toolCall.name,
-          arguments: toolCall.argumentsJson,
-        },
-      })),
-    };
-  }
-  if (message.role === "tool") {
-    return {
-      role: "tool",
-      content: sanitizedTextContent(message.content),
-      tool_call_id: message.toolCallId ? mapToolCallId(toolCallIds, message.toolCallId) : message.toolCallId,
-      name: message.name,
-    };
-  }
-  return {
-    role: message.role,
-    content: sanitizedTextContent(message.content),
-    ...(message.role === "assistant" && message.reasoningContent !== undefined
-      ? { reasoning_content: message.reasoningContent }
-      : {}),
-    ...(message.role === "assistant" && message.thinkingBlocks ? { thinking_blocks: message.thinkingBlocks } : {}),
-  };
-}
-
-function sanitizedTextContent(content: string): string {
-  return content.length === 0 ? "(empty)" : content;
-}
-
-function mapToolCallId(toolCallIds: Map<string, string>, toolCallId: string): string {
-  const existing = toolCallIds.get(toolCallId);
-  if (existing) {
-    return existing;
-  }
-  const normalized = normalizeToolCallId(toolCallId);
-  toolCallIds.set(toolCallId, normalized);
-  return normalized;
-}
-
-function normalizeToolCallId(toolCallId: string): string {
-  if (toolCallId.length === 9 && /^[a-z0-9]+$/i.test(toolCallId)) {
-    return toolCallId;
-  }
-  return createHash("sha1").update(toolCallId).digest("hex").slice(0, 9);
-}
-
-function toOpenAITool(tool: ToolDefinition): Record<string, unknown> {
-  return {
-    type: "function",
-    function: {
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters,
-    },
-  };
-}
-
-function supportsTemperature(model: unknown, reasoningEffort: string | undefined): boolean {
-  if (reasoningEffort && reasoningEffort.toLowerCase() !== "none") {
-    return false;
-  }
-  const modelName = typeof model === "string" ? model.toLowerCase() : "";
-  return !["gpt-5", "o1", "o3", "o4"].some((token) => modelName.includes(token));
 }
 
 function openAIErrorContent(error: unknown): string {

--- a/apps/desktop/workers/ts-agent-worker/src/model/openaiRequestBuilder.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/openaiRequestBuilder.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+
+import { findCatalogEntry } from "../providers/providerCatalog";
+import { buildOpenAIChatRequest } from "./openaiRequestBuilder";
+
+describe("buildOpenAIChatRequest", () => {
+  test("uses catalog token parameter and omits temperature for reasoning OpenAI models", () => {
+    const request = buildOpenAIChatRequest({
+      defaultModel: "gpt-5",
+      messages: [{ role: "user", content: "hi" }],
+      options: { maxTokens: 123, temperature: 0.1, reasoningEffort: "medium" },
+      requestTraits: findCatalogEntry("openai")?.requestTraits,
+    });
+
+    expect(request.max_completion_tokens).toBe(123);
+    expect(request).not.toHaveProperty("max_tokens");
+    expect(request).not.toHaveProperty("temperature");
+    expect(request.reasoning_effort).toBe("medium");
+  });
+
+  test("strips gateway provider prefix and merges extra body defaults with run overrides", () => {
+    const request = buildOpenAIChatRequest({
+      defaultModel: "openai/gpt-4o-mini",
+      messages: [{ role: "user", content: "hi" }],
+      options: { extraBody: { run_flag: true } },
+      requestTraits: findCatalogEntry("openrouter")?.requestTraits,
+      extraBodyDefaults: { route: "fallback" },
+    });
+
+    expect(request.model).toBe("gpt-4o-mini");
+    expect(request.extra_body).toEqual({ route: "fallback", run_flag: true });
+  });
+
+  test("sets enable_search in extra body for OpenAI-compatible providers", () => {
+    const request = buildOpenAIChatRequest({
+      defaultModel: "qwen-plus",
+      messages: [{ role: "user", content: "hi" }],
+      options: {},
+      enableSearch: true,
+    });
+
+    expect(request.extra_body).toEqual({ enable_search: true });
+  });
+
+  test("preserves message sanitization and tool-call id normalization", () => {
+    const request = buildOpenAIChatRequest({
+      defaultModel: "gpt-test",
+      messages: [
+        { role: "user", content: "" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-read-file-very-long", name: "read_file", argumentsJson: "{}" }],
+        },
+        { role: "tool", content: "", toolCallId: "call-read-file-very-long", name: "read_file" },
+      ],
+      options: {},
+    });
+
+    expect(request.messages).toEqual([
+      { role: "user", content: "(empty)" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "8314c6a5e",
+            type: "function",
+            function: { name: "read_file", arguments: "{}" },
+          },
+        ],
+      },
+      { role: "tool", content: "(empty)", tool_call_id: "8314c6a5e", name: "read_file" },
+    ]);
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/model/openaiRequestBuilder.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/openaiRequestBuilder.ts
@@ -1,0 +1,147 @@
+import { createHash } from "node:crypto";
+
+import type { AgentMessage } from "../agent/agentRunSpec.ts";
+import type { RequestTraits } from "../providers/providerCatalog.ts";
+import type { ModelRequestOptions, ToolDefinition } from "./provider.ts";
+
+export type BuildOpenAIChatRequestInput = {
+  defaultModel: string;
+  messages: AgentMessage[];
+  options: ModelRequestOptions;
+  requestTraits?: Partial<RequestTraits>;
+  extraBodyDefaults?: Record<string, unknown>;
+  enableSearch?: boolean;
+};
+
+const DEFAULT_REQUEST_TRAITS: RequestTraits = {
+  tokenParameter: "max_tokens",
+  temperaturePolicy: "omit_for_reasoning",
+  stripModelPrefix: false,
+  extraBodyDefaults: {},
+  supportsPromptCaching: false,
+};
+
+export function buildOpenAIChatRequest(input: BuildOpenAIChatRequestInput): Record<string, unknown> {
+  const requestTraits = { ...DEFAULT_REQUEST_TRAITS, ...(input.requestTraits ?? {}) };
+  const modelName = input.options.model?.trim() || input.defaultModel;
+  const request: Record<string, unknown> = {
+    model: requestTraits.stripModelPrefix ? stripModelPrefix(modelName) : modelName,
+    messages: toOpenAIMessages(input.messages),
+    stream: true,
+    stream_options: { include_usage: true },
+  };
+  if (input.options.tools?.length) {
+    request.tools = input.options.tools.map(toOpenAITool);
+    request.tool_choice = input.options.toolChoice ?? "auto";
+  }
+  if (input.options.temperature !== undefined && supportsTemperature(String(request.model), input.options.reasoningEffort, requestTraits.temperaturePolicy)) {
+    request.temperature = input.options.temperature;
+  }
+  if (input.options.maxTokens !== undefined) {
+    request[requestTraits.tokenParameter] = Math.max(1, input.options.maxTokens);
+  }
+  if (input.options.reasoningEffort) {
+    request.reasoning_effort = input.options.reasoningEffort;
+  }
+  const extraBody = {
+    ...requestTraits.extraBodyDefaults,
+    ...(input.extraBodyDefaults ?? {}),
+    ...(input.enableSearch ? { enable_search: true } : {}),
+    ...(input.options.extraBody ?? {}),
+  };
+  if (Object.keys(extraBody).length > 0) {
+    request.extra_body = extraBody;
+  }
+  return request;
+}
+
+function toOpenAIMessages(messages: AgentMessage[]): Record<string, unknown>[] {
+  const toolCallIds = new Map<string, string>();
+  return messages.map((message) => toOpenAIMessage(message, toolCallIds));
+}
+
+function toOpenAIMessage(message: AgentMessage, toolCallIds: Map<string, string>): Record<string, unknown> {
+  if (message.role === "assistant" && message.toolCalls?.length) {
+    return {
+      role: "assistant",
+      content: message.content.length === 0 ? null : message.content,
+      ...(message.reasoningContent !== undefined ? { reasoning_content: message.reasoningContent } : {}),
+      ...(message.thinkingBlocks ? { thinking_blocks: message.thinkingBlocks } : {}),
+      tool_calls: message.toolCalls.map((toolCall) => ({
+        id: mapToolCallId(toolCallIds, toolCall.id),
+        type: "function",
+        function: {
+          name: toolCall.name,
+          arguments: toolCall.argumentsJson,
+        },
+      })),
+    };
+  }
+  if (message.role === "tool") {
+    return {
+      role: "tool",
+      content: sanitizedTextContent(message.content),
+      tool_call_id: message.toolCallId ? mapToolCallId(toolCallIds, message.toolCallId) : message.toolCallId,
+      name: message.name,
+    };
+  }
+  return {
+    role: message.role,
+    content: sanitizedTextContent(message.content),
+    ...(message.role === "assistant" && message.reasoningContent !== undefined
+      ? { reasoning_content: message.reasoningContent }
+      : {}),
+    ...(message.role === "assistant" && message.thinkingBlocks ? { thinking_blocks: message.thinkingBlocks } : {}),
+  };
+}
+
+function sanitizedTextContent(content: string): string {
+  return content.length === 0 ? "(empty)" : content;
+}
+
+function mapToolCallId(toolCallIds: Map<string, string>, toolCallId: string): string {
+  const existing = toolCallIds.get(toolCallId);
+  if (existing) {
+    return existing;
+  }
+  const normalized = normalizeToolCallId(toolCallId);
+  toolCallIds.set(toolCallId, normalized);
+  return normalized;
+}
+
+function normalizeToolCallId(toolCallId: string): string {
+  if (toolCallId.length === 9 && /^[a-z0-9]+$/i.test(toolCallId)) {
+    return toolCallId;
+  }
+  return createHash("sha1").update(toolCallId).digest("hex").slice(0, 9);
+}
+
+function toOpenAITool(tool: ToolDefinition): Record<string, unknown> {
+  return {
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    },
+  };
+}
+
+function supportsTemperature(model: string, reasoningEffort: string | undefined, policy: RequestTraits["temperaturePolicy"]): boolean {
+  if (policy === "omit") {
+    return false;
+  }
+  if (policy === "omit_for_reasoning" && reasoningEffort && reasoningEffort.toLowerCase() !== "none") {
+    return false;
+  }
+  const modelName = model.toLowerCase();
+  if (policy === "omit_for_reasoning") {
+    return !["gpt-5", "o1", "o3", "o4"].some((token) => modelName.includes(token));
+  }
+  return true;
+}
+
+function stripModelPrefix(modelName: string): string {
+  const parts = modelName.split("/");
+  return parts.at(-1)?.trim() || modelName;
+}

--- a/apps/desktop/workers/ts-agent-worker/src/model/provider.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/provider.ts
@@ -45,6 +45,10 @@ export type GenerationRequestOptions = {
 export type ModelRequestOptions = ModelStreamCallbacks & {
   model?: string;
   tools?: ToolDefinition[];
+  toolChoice?: "auto" | "required" | Record<string, unknown>;
+  retryMode?: "standard" | "persistent";
+  extraBody?: Record<string, unknown>;
+  onRetryWait?: (event: { attempt: number; delaySeconds: number; message: string }) => void;
 } & GenerationRequestOptions;
 
 export interface ModelProvider {

--- a/apps/desktop/workers/ts-agent-worker/src/model/providerRetry.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/providerRetry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import { extractRetryAfterSeconds, withProviderRetry } from "./providerRetry";
+
+describe("providerRetry", () => {
+  test("retries transient failures in standard mode", async () => {
+    let attempts = 0;
+    const waits: number[] = [];
+
+    const result = await withProviderRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw Object.assign(new Error("rate limit"), { status: 429 });
+        }
+        return "ok";
+      },
+      {
+        retryMode: "standard",
+        sleep: async (seconds) => {
+          waits.push(seconds);
+        },
+      },
+    );
+
+    expect(result).toBe("ok");
+    expect(attempts).toBe(3);
+    expect(waits).toEqual([1, 2]);
+  });
+
+  test("does not retry non-transient failures", async () => {
+    let attempts = 0;
+
+    await expect(
+      withProviderRetry(
+        async () => {
+          attempts += 1;
+          throw Object.assign(new Error("bad request"), { status: 400 });
+        },
+        { retryMode: "standard", sleep: async () => undefined },
+      ),
+    ).rejects.toThrow("bad request");
+    expect(attempts).toBe(1);
+  });
+
+  test("extracts retry-after from headers and provider body text", () => {
+    expect(extractRetryAfterSeconds({ headers: { "retry-after": "7" } })).toBe(7);
+    expect(extractRetryAfterSeconds({ response: { headers: { get: (name: string) => (name === "retry-after" ? "11" : null) } } })).toBe(11);
+    expect(extractRetryAfterSeconds({ response: { text: "Please try again in 9 seconds." } })).toBe(9);
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/model/providerRetry.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/providerRetry.ts
@@ -1,0 +1,125 @@
+export type ProviderRetryMode = "standard" | "persistent";
+
+export type ProviderRetryOptions = {
+  retryMode?: ProviderRetryMode;
+  sleep?: (seconds: number) => Promise<void>;
+  onRetryWait?: (event: { attempt: number; delaySeconds: number; message: string }) => void;
+};
+
+const STANDARD_DELAYS = [1, 2, 4];
+const PERSISTENT_MAX_ATTEMPTS = 8;
+
+export async function withProviderRetry<T>(
+  operation: () => Promise<T>,
+  options: ProviderRetryOptions = {},
+): Promise<T> {
+  const retryMode = options.retryMode ?? "standard";
+  const delays = retryMode === "persistent" ? persistentDelays() : STANDARD_DELAYS;
+  let attempt = 0;
+  let lastTransientMessage = "";
+  let repeatedTransientCount = 0;
+
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      attempt += 1;
+      if (!isTransientProviderError(error)) {
+        throw error;
+      }
+      const message = errorMessage(error);
+      repeatedTransientCount = message === lastTransientMessage ? repeatedTransientCount + 1 : 1;
+      lastTransientMessage = message;
+      if (retryMode === "persistent" && repeatedTransientCount > PERSISTENT_MAX_ATTEMPTS) {
+        throw error;
+      }
+      const fallbackDelay = delays[Math.min(attempt - 1, delays.length - 1)];
+      if (fallbackDelay === undefined) {
+        throw error;
+      }
+      const delaySeconds = extractRetryAfterSeconds(error) ?? fallbackDelay;
+      options.onRetryWait?.({ attempt, delaySeconds, message });
+      await (options.sleep ?? defaultSleep)(delaySeconds);
+    }
+  }
+}
+
+export function extractRetryAfterSeconds(error: unknown): number | undefined {
+  const headerValue =
+    header(error, "retry-after") ??
+    header(asObject(error)?.response, "retry-after");
+  const parsedHeader = parsePositiveSeconds(headerValue);
+  if (parsedHeader !== undefined) {
+    return parsedHeader;
+  }
+  const body = bodyText(error).toLowerCase();
+  const match = body.match(/(?:retry after|try again in|wait)\s+(\d+(?:\.\d+)?)\s*(?:s|sec|second|seconds)?/);
+  return parsePositiveSeconds(match?.[1]);
+}
+
+function isTransientProviderError(error: unknown): boolean {
+  const status = numericValue(asObject(error)?.status ?? asObject(error)?.statusCode ?? asObject(asObject(error)?.response)?.status);
+  if (status && [408, 409, 429, 500, 502, 503, 504].includes(status)) {
+    return true;
+  }
+  const text = `${errorMessage(error)} ${bodyText(error)}`.toLowerCase();
+  return [
+    "rate limit",
+    "overloaded",
+    "timeout",
+    "timed out",
+    "connection",
+    "temporarily unavailable",
+    "try again",
+    "retry after",
+  ].some((marker) => text.includes(marker));
+}
+
+function persistentDelays(): number[] {
+  return [1, 2, 4, 8, 15, 30, 60, 60];
+}
+
+function defaultSleep(seconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, seconds) * 1000));
+}
+
+function header(value: unknown, name: string): string | undefined {
+  const object = asObject(value);
+  const headers = asObject(object?.headers);
+  const direct = headers?.[name] ?? headers?.[name.toLowerCase()] ?? headers?.[name.toUpperCase()];
+  if (direct !== undefined) {
+    return String(direct);
+  }
+  const get = asObject(object?.headers)?.get;
+  if (typeof get === "function") {
+    const got = get.call(object?.headers, name);
+    return got === null || got === undefined ? undefined : String(got);
+  }
+  return undefined;
+}
+
+function bodyText(error: unknown): string {
+  const object = asObject(error);
+  const body = object?.doc ?? object?.body ?? asObject(object?.response)?.text ?? asObject(object?.response)?.body;
+  return body === undefined || body === null ? "" : String(body);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parsePositiveSeconds(value: unknown): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const parsed = Number(String(value).trim());
+  return Number.isFinite(parsed) && parsed > 0 ? Math.ceil(parsed) : undefined;
+}
+
+function numericValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}

--- a/apps/desktop/workers/ts-agent-worker/src/model/streamParser.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/streamParser.test.ts
@@ -111,6 +111,9 @@ describe("collectChatCompletionStream", () => {
     expect(toolArgumentDeltas.slice(0, 2)).toEqual([
       {
         index: 0,
+        toolCallIndex: 0,
+        providerCallId: undefined,
+        sequence: 1,
         deltaText: "{\"query\"",
         toolCallId: "call-1",
         toolName: "search",
@@ -120,6 +123,9 @@ describe("collectChatCompletionStream", () => {
       },
       {
         index: 0,
+        toolCallIndex: 0,
+        providerCallId: undefined,
+        sequence: 2,
         deltaText: ":\"docs\"}",
         toolCallId: "call-1",
         toolName: "search",
@@ -130,6 +136,9 @@ describe("collectChatCompletionStream", () => {
     ]);
     expect(toolArgumentDeltas.at(-1)).toEqual({
       index: 0,
+      toolCallIndex: 0,
+      providerCallId: undefined,
+      sequence: 3,
       deltaText: "",
       toolCallId: "call-1",
       toolName: "search",
@@ -240,6 +249,9 @@ describe("collectChatCompletionStream", () => {
 
     expect(toolArgumentDeltas.at(-1)).toEqual({
       index: 0,
+      toolCallIndex: 0,
+      providerCallId: undefined,
+      sequence: 2,
       deltaText: "",
       toolCallId: "call-1",
       toolName: "search",
@@ -328,6 +340,9 @@ describe("collectChatCompletionStream", () => {
     expect(toolArgumentDeltas).toEqual([
       {
         index: 0,
+        toolCallIndex: 0,
+        providerCallId: undefined,
+        sequence: 1,
         deltaText: "{\"content\":\"Hi",
         toolCallId: "call-1",
         toolName: "send_message",

--- a/apps/desktop/workers/ts-agent-worker/src/model/streamParser.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/streamParser.ts
@@ -4,6 +4,9 @@ const MAX_TOOL_CALL_DELTA_TEXT = 8192;
 
 export type ToolCallDelta = {
   index: number;
+  toolCallIndex?: number;
+  providerCallId?: string;
+  sequence?: number;
   deltaText: string;
   toolCallId?: string;
   toolName?: string;
@@ -40,6 +43,7 @@ export async function collectChatCompletionStream(
   let stopReason = "stop";
   let usage: TokenUsage | undefined;
   let emittedTerminalToolCalls = false;
+  let sequence = 0;
 
   try {
     for await (const chunk of stream) {
@@ -48,6 +52,7 @@ export async function collectChatCompletionStream(
         continue;
       }
       usage = extractUsage(chunkObject) ?? usage;
+      const providerCallId = typeof chunkObject.id === "string" ? chunkObject.id : undefined;
 
       const choices = Array.isArray(chunkObject.choices) ? chunkObject.choices : [];
       for (const choice of choices) {
@@ -75,11 +80,17 @@ export async function collectChatCompletionStream(
 
           const toolCalls = Array.isArray(delta.tool_calls) ? delta.tool_calls : [];
           for (const toolCall of toolCalls) {
-            collectToolCallDelta(toolCall, toolCallBuffers, callbacks);
+            sequence = collectToolCallDelta(toolCall, toolCallBuffers, callbacks, sequence, providerCallId);
           }
         }
         if (finishReason && !emittedTerminalToolCalls) {
-          emitTerminalToolCallDeltas(toolCallBuffers, callbacks, finishReason === "error" ? "error" : "completed");
+          sequence = emitTerminalToolCallDeltas(
+            toolCallBuffers,
+            callbacks,
+            finishReason === "error" ? "error" : "completed",
+            sequence,
+            providerCallId,
+          );
           emittedTerminalToolCalls = true;
         }
       }
@@ -111,10 +122,12 @@ function collectToolCallDelta(
   rawToolCall: unknown,
   buffers: Map<number, ToolCallBuffer>,
   callbacks: StreamCallbacks,
-): void {
+  sequence: number,
+  providerCallId?: string,
+): number {
   const toolCall = asObject(rawToolCall);
   if (!toolCall) {
-    return;
+    return sequence;
   }
   const index = typeof toolCall.index === "number" ? toolCall.index : 0;
   const buffer = buffers.get(index) ?? { argumentsJson: "" };
@@ -134,8 +147,12 @@ function collectToolCallDelta(
 
   if (deltaText || id || name) {
     const parts = splitToolCallDeltaText(deltaText);
+    sequence += 1;
     callbacks.onToolCallDelta?.({
       index,
+      toolCallIndex: index,
+      providerCallId,
+      sequence,
       deltaText: parts[0] ?? "",
       toolCallId: buffer.id,
       toolName: buffer.name,
@@ -144,8 +161,12 @@ function collectToolCallDelta(
       completed: false,
     });
     for (const part of parts.slice(1)) {
+      sequence += 1;
       callbacks.onToolCallDelta?.({
         index,
+        toolCallIndex: index,
+        providerCallId,
+        sequence,
         deltaText: part,
         toolCallId: buffer.id,
         toolName: buffer.name,
@@ -155,6 +176,7 @@ function collectToolCallDelta(
       });
     }
   }
+  return sequence;
 }
 
 function splitToolCallDeltaText(deltaText: string): string[] {
@@ -172,10 +194,16 @@ function emitTerminalToolCallDeltas(
   buffers: Map<number, ToolCallBuffer>,
   callbacks: StreamCallbacks,
   status: "completed" | "error",
-): void {
+  sequence: number,
+  providerCallId?: string,
+): number {
   for (const [index, buffer] of Array.from(buffers.entries()).sort(([left], [right]) => left - right)) {
+    sequence += 1;
     callbacks.onToolCallDelta?.({
       index,
+      toolCallIndex: index,
+      providerCallId,
+      sequence,
       deltaText: "",
       toolCallId: buffer.id,
       toolName: buffer.name,
@@ -184,6 +212,7 @@ function emitTerminalToolCallDeltas(
       completed: status === "completed",
     });
   }
+  return sequence;
 }
 
 function streamErrorContent(error: unknown): string {

--- a/apps/desktop/workers/ts-agent-worker/src/model/unconfiguredProvider.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/model/unconfiguredProvider.ts
@@ -2,7 +2,13 @@ import type { AgentMessage } from "../agent/agentRunSpec.ts";
 import type { ModelProvider, ModelResponse } from "./provider.ts";
 
 export class UnconfiguredProvider implements ModelProvider {
+  private readonly message: string;
+
+  constructor(message = "model provider is not configured; OpenAI provider migration is pending") {
+    this.message = message;
+  }
+
   async complete(_messages: AgentMessage[]): Promise<ModelResponse> {
-    throw new Error("model provider is not configured; OpenAI provider migration is pending");
+    throw new Error(this.message);
   }
 }

--- a/apps/desktop/workers/ts-agent-worker/src/providers/modelDiscovery.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/modelDiscovery.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import { candidateModelEndpoints, extractModelIds, probeOpenAICompatibleModels } from "./modelDiscovery";
+
+describe("modelDiscovery", () => {
+  test("tries base and v1 model endpoints", () => {
+    expect(candidateModelEndpoints("https://api.example.test")).toEqual([
+      { url: "https://api.example.test/models", resolvedApiBase: "https://api.example.test", usedFallback: false },
+      { url: "https://api.example.test/v1/models", resolvedApiBase: "https://api.example.test/v1", usedFallback: true },
+    ]);
+    expect(candidateModelEndpoints("https://api.example.test/v1")).toEqual([
+      { url: "https://api.example.test/v1/models", resolvedApiBase: "https://api.example.test/v1", usedFallback: false },
+      { url: "https://api.example.test/models", resolvedApiBase: "https://api.example.test", usedFallback: true },
+    ]);
+  });
+
+  test("extracts common model response shapes and filters Vercel language tool models", () => {
+    expect(extractModelIds({ data: [{ id: "model-a" }, { name: "model-b" }, { model: "model-c" }] })).toEqual([
+      "model-a",
+      "model-b",
+      "model-c",
+    ]);
+    expect(
+      extractModelIds(
+        {
+          data: [
+            { id: "openai/gpt-5.4", type: "language", tags: ["tool-use"] },
+            { id: "image-model", type: "image", tags: ["tool-use"] },
+            { id: "language-no-tools", type: "language", tags: ["vision"] },
+          ],
+        },
+        "vercel",
+      ),
+    ).toEqual(["openai/gpt-5.4"]);
+  });
+
+  test("probes fallback v1 base when the initial endpoint fails", async () => {
+    const calls: string[] = [];
+
+    const result = await probeOpenAICompatibleModels({
+      apiBase: "https://api.example.test",
+      headers: { Accept: "application/json" },
+      fetchJson: async (url) => {
+        calls.push(url);
+        if (url === "https://api.example.test/models") {
+          throw new Error("not found");
+        }
+        return { data: [{ id: "model-a" }] };
+      },
+    });
+
+    expect(calls).toEqual(["https://api.example.test/models", "https://api.example.test/v1/models"]);
+    expect(result).toEqual({
+      models: ["model-a"],
+      url: "https://api.example.test/v1/models",
+      resolvedApiBase: "https://api.example.test/v1",
+      suggestedApiBase: "https://api.example.test/v1",
+      usedFallback: true,
+    });
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/providers/modelDiscovery.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/modelDiscovery.ts
@@ -1,0 +1,123 @@
+export type CandidateModelEndpoint = {
+  url: string;
+  resolvedApiBase: string;
+  usedFallback: boolean;
+};
+
+export type ModelDiscoveryResult = {
+  models: string[];
+  url: string;
+  resolvedApiBase: string;
+  suggestedApiBase?: string;
+  usedFallback: boolean;
+};
+
+export type JsonFetcher = (url: string, headers: Record<string, string>) => Promise<unknown>;
+
+export function joinModelsUrl(apiBase: string | undefined): string {
+  const base = apiBase?.trim().replace(/\/+$/, "") ?? "";
+  return base ? `${base}/models` : "";
+}
+
+export function candidateModelEndpoints(apiBase: string | undefined): CandidateModelEndpoint[] {
+  const normalized = apiBase?.trim().replace(/\/+$/, "") ?? "";
+  if (!normalized) {
+    return [];
+  }
+  const alternateBase = normalized.endsWith("/v1")
+    ? normalized.slice(0, -3).replace(/\/+$/, "")
+    : `${normalized}/v1`;
+  const candidates = [
+    { url: joinModelsUrl(normalized), resolvedApiBase: normalized, usedFallback: false },
+  ];
+  if (alternateBase && alternateBase !== normalized) {
+    candidates.push({ url: joinModelsUrl(alternateBase), resolvedApiBase: alternateBase, usedFallback: true });
+  }
+  return candidates.filter((candidate) => candidate.url.length > 0);
+}
+
+export function extractModelIds(payload: unknown, providerId?: string): string[] {
+  const rawItems = rawModelItems(payload);
+  const models: string[] = [];
+  const seen = new Set<string>();
+  for (const item of rawItems) {
+    const modelId = modelIdFromItem(item, providerId);
+    if (!modelId || seen.has(modelId)) {
+      continue;
+    }
+    seen.add(modelId);
+    models.push(modelId);
+  }
+  return models;
+}
+
+export async function probeOpenAICompatibleModels(input: {
+  apiBase: string | undefined;
+  headers: Record<string, string>;
+  providerId?: string;
+  fetchJson: JsonFetcher;
+}): Promise<ModelDiscoveryResult> {
+  const candidates = candidateModelEndpoints(input.apiBase);
+  if (candidates.length === 0) {
+    throw new Error("api_base is required");
+  }
+  const errors: string[] = [];
+  for (const candidate of candidates) {
+    try {
+      const body = await input.fetchJson(candidate.url, input.headers);
+      const models = extractModelIds(body, input.providerId);
+      if (models.length === 0) {
+        throw new Error("no models found in /models response");
+      }
+      const originalBase = input.apiBase?.trim().replace(/\/+$/, "") ?? "";
+      return {
+        models,
+        url: candidate.url,
+        resolvedApiBase: candidate.resolvedApiBase,
+        suggestedApiBase: candidate.usedFallback && candidate.resolvedApiBase !== originalBase ? candidate.resolvedApiBase : undefined,
+        usedFallback: candidate.usedFallback,
+      };
+    } catch (error) {
+      errors.push(`${candidate.url}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  throw new Error(errors.join("; ") || "model discovery failed");
+}
+
+function rawModelItems(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  const object = asObject(payload);
+  if (!object) {
+    return [];
+  }
+  const items = object.data ?? object.models ?? object.items;
+  return Array.isArray(items) ? items : [];
+}
+
+function modelIdFromItem(item: unknown, providerId: string | undefined): string {
+  if (typeof item === "string") {
+    return item;
+  }
+  const object = asObject(item);
+  if (!object) {
+    return "";
+  }
+  if (providerId === "vercel") {
+    const modelType = object.type;
+    const tags = object.tags;
+    if (modelType && modelType !== "language") {
+      return "";
+    }
+    if (Array.isArray(tags) && !tags.includes("tool-use")) {
+      return "";
+    }
+  }
+  const value = object.id ?? object.name ?? object.model;
+  return value ? String(value) : "";
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}

--- a/apps/desktop/workers/ts-agent-worker/src/providers/providerCatalog.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/providerCatalog.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  findCatalogEntry,
+  inferProviderFromModel,
+  listCatalogEntries,
+} from "./providerCatalog";
+
+describe("providerCatalog", () => {
+  test("lists catalog entries in provider match priority order", () => {
+    const entries = listCatalogEntries();
+
+    expect(entries.length).toBeGreaterThan(5);
+    expect(entries[0]?.id).toBe("openai");
+    expect(entries.map((entry) => entry.id)).toEqual(expect.arrayContaining([
+      "dashscope",
+      "openrouter",
+      "ollama",
+      "opencode",
+      "opencode_go",
+      "kilocode",
+      "huggingface",
+      "novita",
+      "nvidia",
+      "xiaomi",
+      "tencent_tokenhub",
+      "arcee",
+      "gmi",
+      "ollama_cloud",
+    ]));
+  });
+
+  test("finds providers by id, display name, and alias", () => {
+    expect(findCatalogEntry("openrouter")?.id).toBe("openrouter");
+    expect(findCatalogEntry("OpenRouter")?.id).toBe("openrouter");
+    expect(findCatalogEntry("open router")?.id).toBe("openrouter");
+    expect(findCatalogEntry("qwen")?.id).toBe("dashscope");
+  });
+
+  test("infers providers from explicit prefixes, curated models, and model family prefixes", () => {
+    expect(inferProviderFromModel("openai/gpt-5.4-mini")?.id).toBe("openai");
+    expect(inferProviderFromModel("moonshot-v1-8k")?.id).toBe("moonshot");
+    expect(inferProviderFromModel("glm-4-plus")?.id).toBe("zhipu");
+    expect(inferProviderFromModel("qwen-max")?.id).toBe("dashscope");
+  });
+
+  test("exposes OpenAI-compatible request traits used by the request builder", () => {
+    expect(findCatalogEntry("openai")?.requestTraits).toMatchObject({
+      tokenParameter: "max_completion_tokens",
+      temperaturePolicy: "omit_for_reasoning",
+    });
+    expect(findCatalogEntry("openrouter")?.requestTraits).toMatchObject({
+      stripModelPrefix: true,
+    });
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/providers/providerCatalog.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/providerCatalog.ts
@@ -1,0 +1,428 @@
+export type ProviderCategory = "built_in" | "aggregator" | "local" | "custom";
+export type ProviderStatus = "ready" | "needs_key" | "no_models" | "unavailable" | "unsupported";
+export type ApiMode = "openai_chat_completions" | "unsupported";
+export type TokenParameter = "max_tokens" | "max_completion_tokens";
+export type TemperaturePolicy = "standard" | "omit_for_reasoning" | "omit";
+
+export type RequestTraits = {
+  tokenParameter: TokenParameter;
+  temperaturePolicy: TemperaturePolicy;
+  stripModelPrefix: boolean;
+  extraBodyDefaults: Record<string, unknown>;
+  supportsPromptCaching: boolean;
+};
+
+export type ProviderCatalogEntry = {
+  id: string;
+  displayName: string;
+  aliases: string[];
+  categories: ProviderCategory[];
+  defaultApiBase?: string;
+  apiKeyEnvVars: string[];
+  apiBaseEnvVars: string[];
+  apiMode: ApiMode;
+  supportsModelDiscovery: boolean;
+  curatedModelIds: string[];
+  modelPrefixes: string[];
+  requestTraits: RequestTraits;
+  backend: "openai";
+  detectByKeyPrefix?: string;
+  detectByBaseKeyword?: string;
+};
+
+const DEFAULT_REQUEST_TRAITS: RequestTraits = {
+  tokenParameter: "max_tokens",
+  temperaturePolicy: "standard",
+  stripModelPrefix: false,
+  extraBodyDefaults: {},
+  supportsPromptCaching: false,
+};
+
+const OPENROUTER_MODELS = [
+  "anthropic/claude-opus-4.7",
+  "anthropic/claude-opus-4.6",
+  "anthropic/claude-sonnet-4.6",
+  "moonshotai/kimi-k2.6",
+  "openrouter/pareto-code",
+  "qwen/qwen3.7-max",
+  "anthropic/claude-haiku-4.5",
+  "openai/gpt-5.5",
+  "openai/gpt-5.5-pro",
+  "openai/gpt-5.4-mini",
+  "openai/gpt-5.4-nano",
+  "openai/gpt-5.3-codex",
+];
+
+const VERCEL_AI_GATEWAY_MODELS = [
+  "moonshotai/kimi-k2.6",
+  "alibaba/qwen3.6-plus",
+  "zai/glm-5.1",
+  "minimax/minimax-m2.7",
+  "anthropic/claude-sonnet-4.6",
+  "anthropic/claude-opus-4.7",
+  "openai/gpt-5.4",
+  "openai/gpt-5.4-mini",
+  "google/gemini-3.1-pro-preview",
+];
+
+const CATALOG: ProviderCatalogEntry[] = [
+  entry({
+    id: "openai",
+    displayName: "OpenAI",
+    aliases: ["gpt", "chatgpt"],
+    defaultApiBase: "https://api.openai.com/v1",
+    apiKeyEnvVars: ["OPENAI_API_KEY"],
+    apiBaseEnvVars: ["OPENAI_BASE_URL"],
+    curatedModelIds: [
+      "gpt-5.5",
+      "gpt-5.5-pro",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.4-nano",
+      "gpt-5-mini",
+      "gpt-5.3-codex",
+      "gpt-4.1",
+      "gpt-4o",
+      "gpt-4o-mini",
+    ],
+    modelPrefixes: ["gpt", "o1", "o3", "o4"],
+    requestTraits: {
+      tokenParameter: "max_completion_tokens",
+      temperaturePolicy: "omit_for_reasoning",
+    },
+  }),
+  entry({
+    id: "deepseek",
+    displayName: "DeepSeek",
+    aliases: ["deep seek"],
+    defaultApiBase: "https://api.deepseek.com",
+    apiKeyEnvVars: ["DEEPSEEK_API_KEY"],
+    apiBaseEnvVars: ["DEEPSEEK_BASE_URL"],
+    curatedModelIds: ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"],
+    modelPrefixes: ["deepseek"],
+  }),
+  entry({
+    id: "dashscope",
+    displayName: "DashScope",
+    aliases: ["alibaba", "alibaba cloud", "aliyun", "qwen"],
+    defaultApiBase: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    apiKeyEnvVars: ["DASHSCOPE_API_KEY"],
+    apiBaseEnvVars: ["DASHSCOPE_BASE_URL"],
+    curatedModelIds: [
+      "qwen-max",
+      "qwen-plus",
+      "qwen-turbo",
+      "qwen3-coder-plus",
+      "qwen3.6-plus",
+      "kimi-k2.5",
+      "qwen3.5-plus",
+      "qwen3-coder-next",
+      "glm-5",
+      "glm-4.7",
+      "MiniMax-M2.5",
+    ],
+    modelPrefixes: ["qwen", "alibaba"],
+  }),
+  entry({
+    id: "openrouter",
+    displayName: "OpenRouter",
+    aliases: ["open router"],
+    categories: ["built_in", "aggregator"],
+    defaultApiBase: "https://openrouter.ai/api/v1",
+    apiKeyEnvVars: ["OPENROUTER_API_KEY", "OPENAI_API_KEY"],
+    apiBaseEnvVars: ["OPENROUTER_BASE_URL"],
+    curatedModelIds: OPENROUTER_MODELS,
+    modelPrefixes: ["openrouter", "anthropic", "openai", "google", "qwen", "moonshotai", "x-ai", "z-ai"],
+    requestTraits: { stripModelPrefix: true },
+    detectByKeyPrefix: "sk-or-",
+    detectByBaseKeyword: "openrouter.ai",
+  }),
+  entry({
+    id: "ollama",
+    displayName: "Ollama",
+    aliases: ["local ollama"],
+    categories: ["local"],
+    defaultApiBase: "http://127.0.0.1:11434/v1",
+    apiKeyEnvVars: [],
+    curatedModelIds: ["llama3.1", "qwen2.5", "mistral"],
+    modelPrefixes: ["ollama", "llama", "mistral"],
+    detectByBaseKeyword: "11434",
+  }),
+  entry({
+    id: "lm_studio",
+    displayName: "LM Studio",
+    aliases: ["lm-studio", "lmstudio"],
+    categories: ["local"],
+    defaultApiBase: "http://127.0.0.1:1234/v1",
+    apiKeyEnvVars: ["LM_API_KEY"],
+    apiBaseEnvVars: ["LM_BASE_URL"],
+    modelPrefixes: ["lmstudio", "lm_studio"],
+    detectByBaseKeyword: "1234",
+  }),
+  entry({
+    id: "custom",
+    displayName: "Custom OpenAI-compatible",
+    aliases: ["custom", "openai compatible", "compatible endpoint"],
+    categories: ["custom"],
+    apiKeyEnvVars: [],
+  }),
+  entry({
+    id: "siliconflow",
+    displayName: "SiliconFlow",
+    aliases: ["silicon flow"],
+    defaultApiBase: "https://api.siliconflow.cn/v1",
+    apiKeyEnvVars: ["SILICONFLOW_API_KEY"],
+    apiBaseEnvVars: ["SILICONFLOW_BASE_URL"],
+    curatedModelIds: ["deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-V3.2", "Qwen/Qwen3.5-397B-A17B"],
+    modelPrefixes: ["siliconflow", "deepseek-ai", "Qwen"],
+    detectByBaseKeyword: "siliconflow.cn",
+  }),
+  entry({
+    id: "moonshot",
+    displayName: "Moonshot AI",
+    aliases: ["moonshot", "kimi", "kimi-coding", "kimi-coding-cn", "kimi-for-coding"],
+    defaultApiBase: "https://api.moonshot.cn/v1",
+    apiKeyEnvVars: ["MOONSHOT_API_KEY", "KIMI_API_KEY"],
+    apiBaseEnvVars: ["MOONSHOT_BASE_URL", "KIMI_BASE_URL"],
+    curatedModelIds: ["kimi-k2.6", "kimi-k2.5", "kimi-for-coding", "kimi-k2-thinking", "moonshot-v1-8k"],
+    modelPrefixes: ["moonshot", "kimi"],
+    detectByBaseKeyword: "moonshot.cn",
+  }),
+  entry({
+    id: "zhipu",
+    displayName: "Zhipu AI",
+    aliases: ["zai", "z-ai", "z.ai", "zhipu", "glm", "bigmodel"],
+    defaultApiBase: "https://open.bigmodel.cn/api/paas/v4",
+    apiKeyEnvVars: ["ZHIPUAI_API_KEY", "ZHIPU_API_KEY", "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"],
+    apiBaseEnvVars: ["ZHIPU_BASE_URL", "GLM_BASE_URL"],
+    curatedModelIds: ["glm-5.1", "glm-5", "glm-5v-turbo", "glm-5-turbo", "glm-4.7", "glm-4.5", "glm-4-plus"],
+    modelPrefixes: ["glm"],
+    detectByBaseKeyword: "bigmodel.cn",
+  }),
+  entry({
+    id: "vercel",
+    displayName: "Vercel AI Gateway",
+    aliases: ["ai-gateway", "aigateway", "vercel-ai-gateway"],
+    categories: ["built_in", "aggregator"],
+    defaultApiBase: "https://ai-gateway.vercel.sh/v1",
+    apiKeyEnvVars: ["AI_GATEWAY_API_KEY", "VERCEL_OIDC_TOKEN"],
+    apiBaseEnvVars: ["AI_GATEWAY_BASE_URL", "VERCEL_AI_GATEWAY_BASE_URL"],
+    curatedModelIds: VERCEL_AI_GATEWAY_MODELS,
+    modelPrefixes: ["vercel", "alibaba", "zai", "minimax", "anthropic", "openai", "google", "xai"],
+    requestTraits: { stripModelPrefix: true },
+    detectByBaseKeyword: "ai-gateway.vercel.sh",
+  }),
+  entry({
+    id: "opencode",
+    displayName: "OpenCode Zen",
+    aliases: ["opencode-zen", "zen"],
+    categories: ["built_in", "aggregator"],
+    apiKeyEnvVars: ["OPENCODE_ZEN_API_KEY"],
+    apiBaseEnvVars: ["OPENCODE_ZEN_BASE_URL"],
+    curatedModelIds: [
+      "kimi-k2.5",
+      "gpt-5.4-pro",
+      "gpt-5.4",
+      "gpt-5.3-codex",
+      "gpt-5.2",
+      "gpt-5.2-codex",
+      "gpt-5.1",
+      "gpt-5.1-codex",
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "gemini-3.1-pro",
+      "gemini-3-flash",
+      "minimax-m2.7",
+      "glm-5",
+      "qwen3-coder",
+    ],
+    modelPrefixes: ["opencode", "kimi", "gpt", "claude", "gemini", "glm", "qwen"],
+  }),
+  entry({
+    id: "opencode_go",
+    displayName: "OpenCode Go",
+    aliases: ["opencode-go", "opencode-go-sub"],
+    categories: ["built_in", "aggregator"],
+    apiKeyEnvVars: ["OPENCODE_GO_API_KEY"],
+    apiBaseEnvVars: ["OPENCODE_GO_BASE_URL"],
+    curatedModelIds: ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "minimax-m2.7", "qwen3.6-plus"],
+    modelPrefixes: ["opencode", "kimi", "glm", "mimo", "minimax", "qwen"],
+  }),
+  entry({
+    id: "kilocode",
+    displayName: "KiloCode",
+    aliases: ["kilo", "kilo-code", "kilo-gateway"],
+    categories: ["built_in", "aggregator"],
+    apiKeyEnvVars: ["KILOCODE_API_KEY"],
+    apiBaseEnvVars: ["KILOCODE_BASE_URL"],
+    curatedModelIds: ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview"],
+    modelPrefixes: ["kilo", "anthropic", "openai", "google"],
+  }),
+  entry({
+    id: "huggingface",
+    displayName: "Hugging Face",
+    aliases: ["hf", "hugging-face", "huggingface-hub"],
+    categories: ["built_in", "aggregator"],
+    defaultApiBase: "https://router.huggingface.co/v1",
+    apiKeyEnvVars: ["HF_TOKEN", "HUGGINGFACE_API_KEY"],
+    apiBaseEnvVars: ["HF_BASE_URL", "HUGGINGFACE_BASE_URL"],
+    curatedModelIds: ["moonshotai/Kimi-K2.5", "Qwen/Qwen3.5-397B-A17B", "deepseek-ai/DeepSeek-V3.2", "MiniMaxAI/MiniMax-M2.5"],
+    modelPrefixes: ["huggingface", "moonshotai", "Qwen", "deepseek-ai", "MiniMaxAI", "zai-org"],
+    detectByBaseKeyword: "huggingface.co",
+  }),
+  entry({
+    id: "novita",
+    displayName: "Novita AI",
+    aliases: ["novita-ai", "novitaai"],
+    categories: ["built_in", "aggregator"],
+    defaultApiBase: "https://api.novita.ai/v3/openai",
+    apiKeyEnvVars: ["NOVITA_API_KEY"],
+    apiBaseEnvVars: ["NOVITA_BASE_URL"],
+    curatedModelIds: ["moonshotai/kimi-k2.5", "minimax/minimax-m2.7", "zai-org/glm-5", "deepseek/deepseek-v3-0324"],
+    modelPrefixes: ["novita", "moonshotai", "minimax", "zai-org", "deepseek", "qwen"],
+    detectByBaseKeyword: "novita.ai",
+  }),
+  entry({
+    id: "nvidia",
+    displayName: "NVIDIA NIM",
+    aliases: ["nim", "nvidia-nim", "build-nvidia", "nemotron"],
+    defaultApiBase: "https://integrate.api.nvidia.com/v1",
+    apiKeyEnvVars: ["NVIDIA_API_KEY"],
+    apiBaseEnvVars: ["NVIDIA_BASE_URL"],
+    curatedModelIds: ["nvidia/nemotron-3-super-120b-a12b", "nvidia/nemotron-3-nano-30b-a3b", "qwen/qwen3.5-397b-a17b"],
+    modelPrefixes: ["nvidia", "nemotron"],
+    detectByBaseKeyword: "nvidia.com",
+  }),
+  entry({
+    id: "xiaomi",
+    displayName: "Xiaomi MiMo",
+    aliases: ["mimo", "xiaomi-mimo"],
+    apiKeyEnvVars: ["XIAOMI_API_KEY"],
+    apiBaseEnvVars: ["XIAOMI_BASE_URL"],
+    curatedModelIds: ["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "mimo-v2-flash"],
+    modelPrefixes: ["mimo", "xiaomi"],
+  }),
+  entry({
+    id: "tencent_tokenhub",
+    displayName: "Tencent TokenHub",
+    aliases: ["tencent-tokenhub", "tencent", "tokenhub", "tencent-cloud", "tencentmaas"],
+    apiKeyEnvVars: ["TOKENHUB_API_KEY", "TENCENT_API_KEY"],
+    apiBaseEnvVars: ["TOKENHUB_BASE_URL"],
+    curatedModelIds: ["hy3-preview"],
+    modelPrefixes: ["hy3", "tencent", "tokenhub"],
+  }),
+  entry({
+    id: "arcee",
+    displayName: "Arcee AI",
+    aliases: ["arcee-ai", "arceeai"],
+    defaultApiBase: "https://api.arcee.ai/api/v1",
+    apiKeyEnvVars: ["ARCEE_API_KEY"],
+    apiBaseEnvVars: ["ARCEE_BASE_URL"],
+    curatedModelIds: ["trinity-large-thinking", "trinity-large-preview", "trinity-mini"],
+    modelPrefixes: ["trinity", "arcee"],
+    detectByBaseKeyword: "arcee.ai",
+  }),
+  entry({
+    id: "gmi",
+    displayName: "GMI Cloud",
+    aliases: ["gmi-cloud", "gmicloud"],
+    defaultApiBase: "https://api.gmi-serving.com/v1",
+    apiKeyEnvVars: ["GMI_API_KEY"],
+    apiBaseEnvVars: ["GMI_BASE_URL"],
+    curatedModelIds: ["zai-org/GLM-5.1-FP8", "deepseek-ai/DeepSeek-V3.2", "moonshotai/Kimi-K2.5", "openai/gpt-5.4"],
+    modelPrefixes: ["gmi", "zai-org", "deepseek-ai", "moonshotai", "google", "anthropic", "openai"],
+    detectByBaseKeyword: "gmi-serving.com",
+  }),
+  entry({
+    id: "ollama_cloud",
+    displayName: "Ollama Cloud",
+    aliases: ["ollama-cloud"],
+    defaultApiBase: "https://ollama.com/v1",
+    apiKeyEnvVars: ["OLLAMA_API_KEY"],
+    apiBaseEnvVars: ["OLLAMA_BASE_URL"],
+    modelPrefixes: ["ollama-cloud"],
+    detectByBaseKeyword: "ollama.com",
+  }),
+];
+
+const ALIAS_INDEX = new Map<string, ProviderCatalogEntry>();
+for (const catalogEntry of CATALOG) {
+  for (const term of [catalogEntry.id, catalogEntry.displayName, ...catalogEntry.aliases]) {
+    ALIAS_INDEX.set(normalize(term), catalogEntry);
+  }
+}
+
+export function listCatalogEntries(): ProviderCatalogEntry[] {
+  return CATALOG;
+}
+
+export function findCatalogEntry(name: string | null | undefined): ProviderCatalogEntry | undefined {
+  if (!name) {
+    return undefined;
+  }
+  return ALIAS_INDEX.get(normalize(name));
+}
+
+export function inferProviderFromModel(model: string | null | undefined): ProviderCatalogEntry | undefined {
+  const modelLower = model?.trim().toLowerCase();
+  if (!modelLower) {
+    return undefined;
+  }
+  const slashPrefix = modelLower.includes("/") ? modelLower.split("/", 1)[0] : "";
+  const prefixed = slashPrefix ? findCatalogEntry(slashPrefix) : undefined;
+  if (prefixed) {
+    return prefixed;
+  }
+  for (const catalogEntry of CATALOG) {
+    if (catalogEntry.curatedModelIds.some((item) => item.toLowerCase() === modelLower)) {
+      return catalogEntry;
+    }
+  }
+  const normalizedModel = normalize(modelLower);
+  for (const catalogEntry of CATALOG) {
+    for (const term of [...catalogEntry.modelPrefixes, ...catalogEntry.aliases]) {
+      const normalizedTerm = normalize(term);
+      if (
+        normalizedTerm &&
+        (normalizedModel === normalizedTerm ||
+          normalizedModel.startsWith(`${normalizedTerm}_`) ||
+          normalizedModel.includes(normalizedTerm))
+      ) {
+        return catalogEntry;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function isGatewayProvider(entry: ProviderCatalogEntry | undefined): boolean {
+  return Boolean(entry?.categories.includes("aggregator"));
+}
+
+export function isLocalProvider(entry: ProviderCatalogEntry | undefined): boolean {
+  return Boolean(entry?.categories.includes("local"));
+}
+
+export function isCustomProvider(entry: ProviderCatalogEntry | undefined): boolean {
+  return Boolean(entry?.categories.includes("custom"));
+}
+
+function entry(value: Partial<ProviderCatalogEntry> & Pick<ProviderCatalogEntry, "id" | "displayName">): ProviderCatalogEntry {
+  return {
+    aliases: [],
+    categories: ["built_in"],
+    apiKeyEnvVars: [],
+    apiBaseEnvVars: [],
+    apiMode: "openai_chat_completions",
+    supportsModelDiscovery: true,
+    curatedModelIds: [],
+    modelPrefixes: [],
+    backend: "openai",
+    ...value,
+    requestTraits: { ...DEFAULT_REQUEST_TRAITS, ...(value.requestTraits ?? {}) },
+  };
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}

--- a/apps/desktop/workers/ts-agent-worker/src/providers/providerModels.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/providerModels.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+
+import { listProviderModels, validateModelForProvider } from "./providerModels";
+
+describe("providerModels", () => {
+  test("merges curated, profile, live, and manual models without duplicate source counts", async () => {
+    const result = await listProviderModels({
+      providerId: "dashscope",
+      profileModels: ["qwen-profile", "qwen-max"],
+      manualModelIds: ["qwen-manual"],
+      refreshLive: true,
+      fetcher: async () => ["qwen-live", "qwen-max"],
+      apiBase: "https://dashscope.test/compatible-mode/v1",
+      apiKey: "key",
+    });
+
+    expect(result.models.slice(0, 3).map((model) => model.id)).toEqual(["qwen-max", "qwen-plus", "qwen-turbo"]);
+    expect(result.sourceCounts).toEqual({ curated: 11, profile: 1, live: 1, manual: 1 });
+    expect(result.ok).toBe(true);
+    expect(result.warning).toBeUndefined();
+    expect(result.models.find((model) => model.id === "qwen-max")?.sources).toEqual(["curated", "profile", "live"]);
+  });
+
+  test("preserves configured models when live discovery fails", async () => {
+    const result = await listProviderModels({
+      providerId: "dashscope",
+      refreshLive: true,
+      apiBase: "https://dashscope.test/compatible-mode/v1",
+      apiKey: "key",
+      fetcher: async () => {
+        throw new Error("network down");
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.models.map((model) => model.id)).toContain("qwen-max");
+    expect(result.warning).toBe("live discovery failed: network down");
+  });
+
+  test("skips live discovery when disabled", async () => {
+    let calls = 0;
+    const result = await listProviderModels({
+      providerId: "dashscope",
+      supportsModelDiscovery: false,
+      refreshLive: true,
+      fetcher: async () => {
+        calls += 1;
+        return ["qwen-live"];
+      },
+    });
+
+    expect(calls).toBe(0);
+    expect(result.sourceCounts.live).toBe(0);
+  });
+
+  test("validates provider mismatch while allowing custom local and gateway providers", () => {
+    expect(validateModelForProvider({ providerId: "deepseek", model: "qwen-max" })).toEqual({
+      ok: false,
+      message: "Model 'qwen-max' appears to belong to provider 'dashscope', not 'deepseek'.",
+    });
+    expect(validateModelForProvider({ providerId: "openrouter", model: "unknown/model" }).ok).toBe(true);
+    expect(validateModelForProvider({ providerId: "custom", model: "anything-local" }).ok).toBe(true);
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/providers/providerModels.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/providerModels.ts
@@ -1,0 +1,144 @@
+import {
+  findCatalogEntry,
+  inferProviderFromModel,
+  isCustomProvider,
+  isGatewayProvider,
+  isLocalProvider,
+} from "./providerCatalog.ts";
+import { joinModelsUrl } from "./modelDiscovery.ts";
+
+export type ProviderModelSource = "curated" | "profile" | "live" | "manual";
+
+export type ProviderModel = {
+  id: string;
+  sources: ProviderModelSource[];
+};
+
+export type ProviderModelList = {
+  ok: boolean;
+  models: ProviderModel[];
+  sourceCounts: Record<ProviderModelSource, number>;
+  warning?: string;
+  url?: string;
+};
+
+export type ListProviderModelsInput = {
+  providerId: string;
+  profileModels?: string[];
+  manualModelIds?: string[];
+  liveModelIds?: string[];
+  supportsModelDiscovery?: boolean;
+  apiKey?: string;
+  apiBase?: string;
+  refreshLive?: boolean;
+  fetcher?: (url: string, headers: Record<string, string>) => Promise<string[]>;
+};
+
+export type ModelValidationResult = {
+  ok: boolean;
+  message?: string;
+};
+
+export async function listProviderModels(input: ListProviderModelsInput): Promise<ProviderModelList> {
+  const catalog = findCatalogEntry(input.providerId);
+  const merged = new Map<string, ProviderModelSource[]>();
+  const sourceCounts: Record<ProviderModelSource, number> = { curated: 0, profile: 0, live: 0, manual: 0 };
+
+  addModels(merged, sourceCounts, "curated", catalog?.curatedModelIds ?? []);
+  addModels(merged, sourceCounts, "profile", input.profileModels ?? []);
+  addModels(merged, sourceCounts, "manual", input.manualModelIds ?? []);
+
+  let warning: string | undefined;
+  const modelsUrl = joinModelsUrl(input.apiBase);
+  if (input.refreshLive) {
+    const allowed = liveDiscoveryAllowed({
+      supportsModelDiscovery: input.supportsModelDiscovery ?? catalog?.supportsModelDiscovery ?? true,
+      apiKey: input.apiKey,
+      apiBase: input.apiBase,
+      keyRequired: Boolean(catalog?.apiKeyEnvVars.length && !isLocalProvider(catalog)),
+    });
+    if (allowed.ok) {
+      try {
+        const liveModels = input.liveModelIds ?? (await input.fetcher?.(modelsUrl, modelRequestHeaders(input.apiKey))) ?? [];
+        addModels(merged, sourceCounts, "live", liveModels);
+      } catch (error) {
+        warning = `live discovery failed: ${error instanceof Error ? error.message : String(error)}`;
+      }
+    } else {
+      warning = allowed.warning;
+    }
+  }
+
+  const models = Array.from(merged.entries()).map(([id, sources]) => ({ id, sources }));
+  return {
+    ok: models.length > 0,
+    models,
+    sourceCounts,
+    warning,
+    url: modelsUrl || undefined,
+  };
+}
+
+export function validateModelForProvider(input: { providerId: string; model: string }): ModelValidationResult {
+  const catalog = findCatalogEntry(input.providerId);
+  const inferred = inferProviderFromModel(input.model);
+  if (catalog && inferred && inferred.id !== catalog.id) {
+    if (isCustomProvider(catalog) || isLocalProvider(catalog) || isGatewayProvider(catalog)) {
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      message: `Model '${input.model}' appears to belong to provider '${inferred.id}', not '${catalog.id}'.`,
+    };
+  }
+  return { ok: true };
+}
+
+function addModels(
+  merged: Map<string, ProviderModelSource[]>,
+  sourceCounts: Record<ProviderModelSource, number>,
+  source: ProviderModelSource,
+  modelIds: string[],
+): void {
+  for (const rawModelId of modelIds) {
+    const modelId = String(rawModelId).trim();
+    if (!modelId) {
+      continue;
+    }
+    const sources = merged.get(modelId) ?? [];
+    if (sources.includes(source)) {
+      continue;
+    }
+    sources.push(source);
+    if (!merged.has(modelId)) {
+      sourceCounts[source] += 1;
+    }
+    merged.set(modelId, sources);
+  }
+}
+
+function liveDiscoveryAllowed(input: {
+  supportsModelDiscovery: boolean;
+  apiKey?: string;
+  apiBase?: string;
+  keyRequired: boolean;
+}): { ok: true } | { ok: false; warning?: string } {
+  if (!input.supportsModelDiscovery) {
+    return { ok: false };
+  }
+  if (!input.apiBase) {
+    return { ok: false, warning: "live discovery skipped: api_base is required" };
+  }
+  if (input.keyRequired && !input.apiKey) {
+    return { ok: false, warning: "live discovery skipped: api key is required" };
+  }
+  return { ok: true };
+}
+
+function modelRequestHeaders(apiKey: string | undefined): Record<string, string> {
+  return {
+    Accept: "application/json",
+    "User-Agent": "tinybot/provider-model-discovery",
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+  };
+}

--- a/apps/desktop/workers/ts-agent-worker/src/providers/providerRuntime.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/providerRuntime.test.ts
@@ -73,6 +73,21 @@ describe("resolveRuntimeProvider", () => {
     expect(resolved.apiKey).toBe("zhipu-key");
   });
 
+  test("does not infer OpenAI from the synthetic fallback model before credential fallback", async () => {
+    const resolved = await resolveRuntimeProvider({
+      config: {
+        agents: { defaults: { provider: "auto" } },
+        providers: {},
+      },
+      env: { DASHSCOPE_API_KEY: "dashscope-key" },
+    });
+
+    expect(resolved.providerId).toBe("dashscope");
+    expect(resolved.model).toBe("gpt-4.1-mini");
+    expect(resolved.source).toBe("credentials");
+    expect(resolved.apiKey).toBe("dashscope-key");
+  });
+
   test("falls back to first provider with usable credentials in catalog order", async () => {
     const resolved = await resolveRuntimeProvider({
       config: {

--- a/apps/desktop/workers/ts-agent-worker/src/providers/providerRuntime.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/providerRuntime.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveRuntimeProvider } from "./providerRuntime";
+
+describe("resolveRuntimeProvider", () => {
+  test("prefers active profile over default provider and model inference", async () => {
+    const resolved = await resolveRuntimeProvider({
+      config: {
+        agents: { defaults: { model: "qwen3-coder-plus", active_profile: "dashscope-coding" } },
+        providers: {
+          profiles: {
+            "dashscope-coding": {
+              provider: "dashscope",
+              api_base: "https://example.test/compatible/v1",
+              models: ["qwen3-coder-plus"],
+              manual_models: "manual-a\nmanual-b",
+              supports_model_discovery: false,
+              extra_body: { enable_search: true },
+            },
+          },
+        },
+      },
+      env: {},
+      secretResolver: async () => ({ apiKey: "profile-key", apiKeySource: "config" }),
+    });
+
+    expect(resolved).toMatchObject({
+      providerId: "dashscope",
+      profileName: "dashscope-coding",
+      source: "profile",
+      apiKey: "profile-key",
+      apiKeySource: "config",
+      apiBase: "https://example.test/compatible/v1",
+      models: ["qwen3-coder-plus"],
+      manualModelIds: ["manual-a", "manual-b"],
+      supportsModelDiscovery: false,
+      extraBody: { enable_search: true },
+    });
+  });
+
+  test("uses explicit catalog provider and environment fallback values", async () => {
+    const resolved = await resolveRuntimeProvider({
+      config: {
+        agents: { defaults: { provider: "open router", model: "openai/gpt-4o-mini" } },
+        providers: {},
+      },
+      env: {
+        OPENROUTER_API_KEY: "env-openrouter-key",
+        OPENROUTER_BASE_URL: "https://custom-openrouter.test/v1",
+      },
+    });
+
+    expect(resolved).toMatchObject({
+      providerId: "openrouter",
+      source: "explicit",
+      apiKey: "env-openrouter-key",
+      apiKeySource: "env:OPENROUTER_API_KEY",
+      apiBase: "https://custom-openrouter.test/v1",
+    });
+  });
+
+  test("infers provider from selected model before credential fallback", async () => {
+    const resolved = await resolveRuntimeProvider({
+      config: {
+        agents: { defaults: { model: "glm-4-plus" } },
+        providers: { zhipu: { api_key: null } },
+      },
+      env: { ZHIPUAI_API_KEY: "zhipu-key" },
+    });
+
+    expect(resolved.providerId).toBe("zhipu");
+    expect(resolved.source).toBe("model");
+    expect(resolved.apiKey).toBe("zhipu-key");
+  });
+
+  test("falls back to first provider with usable credentials in catalog order", async () => {
+    const resolved = await resolveRuntimeProvider({
+      config: {
+        agents: { defaults: { model: "unknown-model" } },
+        providers: { dashscope: { api_key: "dashscope-key" } },
+      },
+      env: {},
+    });
+
+    expect(resolved.providerId).toBe("dashscope");
+    expect(resolved.source).toBe("credentials");
+    expect(resolved.apiKey).toBe("dashscope-key");
+  });
+
+  test("falls back to the first local provider when no remote credentials are configured", async () => {
+    const resolved = await resolveRuntimeProvider({
+      config: { agents: { defaults: { model: "unknown-model" } }, providers: {} },
+      env: {},
+    });
+
+    expect(resolved).toMatchObject({
+      providerId: "ollama",
+      model: "unknown-model",
+      source: "credentials",
+      apiBase: "http://127.0.0.1:11434/v1",
+    });
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/providers/providerRuntime.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/providerRuntime.ts
@@ -1,0 +1,257 @@
+import {
+  findCatalogEntry,
+  inferProviderFromModel,
+  isLocalProvider,
+  listCatalogEntries,
+  type ApiMode,
+  type ProviderCatalogEntry,
+  type RequestTraits,
+} from "./providerCatalog.ts";
+
+export type TinybotPublicConfig = Record<string, unknown>;
+
+export type ProviderSecretResolution = {
+  apiKey?: string;
+  apiKeySource?: "config" | `env:${string}`;
+};
+
+export type ProviderSecretResolver = (input: {
+  providerId: string;
+  profileName?: string;
+  apiKeyEnvVars: string[];
+}) => Promise<ProviderSecretResolution | undefined> | ProviderSecretResolution | undefined;
+
+export type ResolveRuntimeProviderInput = {
+  config: TinybotPublicConfig;
+  env: Record<string, string | undefined>;
+  secretResolver?: ProviderSecretResolver;
+  model?: string;
+  provider?: string;
+};
+
+export type ResolvedRuntimeProvider = {
+  providerId?: string;
+  model: string;
+  profileName?: string;
+  source: "explicit" | "profile" | "model" | "credentials" | "unresolved";
+  apiMode?: ApiMode;
+  apiKey?: string;
+  apiKeySource?: "config" | `env:${string}`;
+  apiBase?: string;
+  models: string[];
+  manualModelIds: string[];
+  supportsModelDiscovery: boolean;
+  requestTraits: RequestTraits;
+  extraBody: Record<string, unknown>;
+  warnings: string[];
+};
+
+export async function resolveRuntimeProvider(input: ResolveRuntimeProviderInput): Promise<ResolvedRuntimeProvider> {
+  const selectedModel = input.model?.trim() || stringAt(input.config, "agents.defaults.model") || "gpt-4.1-mini";
+
+  const explicitOverride = normalizeProviderId(input.provider);
+  if (explicitOverride && explicitOverride !== "auto") {
+    return resolveEntry(input, explicitOverride, selectedModel, "explicit");
+  }
+
+  const activeProfile = stringAt(input.config, "agents.defaults.active_profile") ?? stringAt(input.config, "agents.defaults.activeProfile");
+  const profile = activeProfile ? profileConfig(input.config, activeProfile) : undefined;
+  if (activeProfile && profile) {
+    return resolveEntry(input, normalizeProviderId(stringValue(field(profile, "provider"))), selectedModel, "profile", activeProfile, profile);
+  }
+
+  const explicitProvider = normalizeProviderId(stringAt(input.config, "agents.defaults.provider"));
+  if (explicitProvider && explicitProvider !== "auto") {
+    return resolveEntry(input, explicitProvider, selectedModel, "explicit");
+  }
+
+  const inferred = inferProviderFromModel(selectedModel);
+  if (inferred) {
+    return resolveEntry(input, inferred.id, selectedModel, "model");
+  }
+
+  for (const catalogEntry of listCatalogEntries()) {
+    if (await hasUsableConfig(input, catalogEntry)) {
+      return resolveEntry(input, catalogEntry.id, selectedModel, "credentials");
+    }
+  }
+
+  return unresolved(selectedModel);
+}
+
+async function resolveEntry(
+  input: ResolveRuntimeProviderInput,
+  providerId: string | undefined,
+  model: string,
+  source: ResolvedRuntimeProvider["source"],
+  profileName?: string,
+  explicitProviderConfig?: Record<string, unknown>,
+): Promise<ResolvedRuntimeProvider> {
+  const catalog = findCatalogEntry(providerId);
+  const normalizedId = catalog?.id ?? providerId;
+  if (!normalizedId) {
+    return unresolved(model);
+  }
+  const providerConfig = explicitProviderConfig ?? configForProvider(input.config, normalizedId);
+  const secret = await configuredOrResolvedOrEnvKey(input, providerConfig, catalog, normalizedId, profileName);
+  return {
+    providerId: normalizedId,
+    model,
+    profileName,
+    source,
+    apiMode: catalog?.apiMode,
+    apiKey: secret.apiKey,
+    apiKeySource: secret.apiKeySource,
+    apiBase: stringValue(field(providerConfig, "api_base", "apiBase")) ?? envApiBase(input.env, catalog) ?? catalog?.defaultApiBase,
+    models: stringList(field(providerConfig, "models")),
+    manualModelIds: stringList(field(providerConfig, "manual_models", "manualModels")),
+    supportsModelDiscovery: booleanValue(field(providerConfig, "supports_model_discovery", "supportsModelDiscovery")) ?? catalog?.supportsModelDiscovery ?? true,
+    requestTraits: catalog?.requestTraits ?? {
+      tokenParameter: "max_tokens",
+      temperaturePolicy: "standard",
+      stripModelPrefix: false,
+      extraBodyDefaults: {},
+      supportsPromptCaching: false,
+    },
+    extraBody: recordValue(field(providerConfig, "extra_body", "extraBody")) ?? {},
+    warnings: [],
+  };
+}
+
+async function hasUsableConfig(input: ResolveRuntimeProviderInput, catalog: ProviderCatalogEntry): Promise<boolean> {
+  const providerConfig = configForProvider(input.config, catalog.id);
+  if (stringValue(field(providerConfig, "api_key", "apiKey")) || stringValue(field(providerConfig, "api_base", "apiBase")) || isLocalProvider(catalog)) {
+    return true;
+  }
+  const secret = await configuredOrResolvedOrEnvKey(input, providerConfig, catalog, catalog.id);
+  return Boolean(secret.apiKey || isLocalProvider(catalog));
+}
+
+async function configuredOrResolvedOrEnvKey(
+  input: ResolveRuntimeProviderInput,
+  providerConfig: Record<string, unknown> | undefined,
+  catalog: ProviderCatalogEntry | undefined,
+  providerId: string,
+  profileName?: string,
+): Promise<ProviderSecretResolution> {
+  const configured = stringValue(field(providerConfig, "api_key", "apiKey"));
+  if (configured) {
+    return { apiKey: configured, apiKeySource: "config" };
+  }
+  if (input.secretResolver && catalog) {
+    const resolved = await input.secretResolver({ providerId, profileName, apiKeyEnvVars: catalog.apiKeyEnvVars });
+    if (resolved?.apiKey) {
+      return resolved;
+    }
+  }
+  return envApiKey(input.env, catalog);
+}
+
+function unresolved(model: string): ResolvedRuntimeProvider {
+  return {
+    model,
+    source: "unresolved",
+    models: [],
+    manualModelIds: [],
+    supportsModelDiscovery: true,
+    requestTraits: {
+      tokenParameter: "max_tokens",
+      temperaturePolicy: "standard",
+      stripModelPrefix: false,
+      extraBodyDefaults: {},
+      supportsPromptCaching: false,
+    },
+    extraBody: {},
+    warnings: [],
+  };
+}
+
+function normalizeProviderId(value: unknown): string | undefined {
+  const text = stringValue(value);
+  if (!text) {
+    return undefined;
+  }
+  const catalog = findCatalogEntry(text);
+  if (catalog) {
+    return catalog.id;
+  }
+  return text.trim().toLowerCase().replace(/[-\s]+/g, "_") || undefined;
+}
+
+function configForProvider(config: TinybotPublicConfig, providerId: string): Record<string, unknown> | undefined {
+  return recordValue(pathValue(config, ["providers", providerId]));
+}
+
+function profileConfig(config: TinybotPublicConfig, profileName: string): Record<string, unknown> | undefined {
+  return recordValue(pathValue(config, ["providers", "profiles", profileName]));
+}
+
+function stringAt(config: TinybotPublicConfig, dottedPath: string): string | undefined {
+  return stringValue(pathValue(config, dottedPath.split(".")));
+}
+
+function pathValue(config: TinybotPublicConfig, segments: string[]): unknown {
+  let current: unknown = config;
+  for (const segment of segments) {
+    const object = recordValue(current);
+    if (!object) {
+      return undefined;
+    }
+    current = object[segment];
+  }
+  return current;
+}
+
+function field(object: Record<string, unknown> | undefined, ...names: string[]): unknown {
+  if (!object) {
+    return undefined;
+  }
+  for (const name of names) {
+    if (object[name] !== undefined) {
+      return object[name];
+    }
+  }
+  return undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function stringList(value: unknown): string[] {
+  if (typeof value === "string") {
+    return value.replace(/\n/g, ",").split(",").map((item) => item.trim()).filter(Boolean);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item).trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function envApiKey(env: Record<string, string | undefined>, catalog: ProviderCatalogEntry | undefined): ProviderSecretResolution {
+  for (const envName of catalog?.apiKeyEnvVars ?? []) {
+    const value = env[envName];
+    if (value) {
+      return { apiKey: value, apiKeySource: `env:${envName}` };
+    }
+  }
+  return {};
+}
+
+function envApiBase(env: Record<string, string | undefined>, catalog: ProviderCatalogEntry | undefined): string | undefined {
+  for (const envName of catalog?.apiBaseEnvVars ?? []) {
+    const value = env[envName];
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/apps/desktop/workers/ts-agent-worker/src/providers/providerRuntime.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/providers/providerRuntime.ts
@@ -47,7 +47,8 @@ export type ResolvedRuntimeProvider = {
 };
 
 export async function resolveRuntimeProvider(input: ResolveRuntimeProviderInput): Promise<ResolvedRuntimeProvider> {
-  const selectedModel = input.model?.trim() || stringAt(input.config, "agents.defaults.model") || "gpt-4.1-mini";
+  const configuredModel = input.model?.trim() || stringAt(input.config, "agents.defaults.model");
+  const selectedModel = configuredModel || "gpt-4.1-mini";
 
   const explicitOverride = normalizeProviderId(input.provider);
   if (explicitOverride && explicitOverride !== "auto") {
@@ -65,7 +66,7 @@ export async function resolveRuntimeProvider(input: ResolveRuntimeProviderInput)
     return resolveEntry(input, explicitProvider, selectedModel, "explicit");
   }
 
-  const inferred = inferProviderFromModel(selectedModel);
+  const inferred = configuredModel ? inferProviderFromModel(configuredModel) : undefined;
   if (inferred) {
     return resolveEntry(input, inferred.id, selectedModel, "model");
   }

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/configBridge.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/configBridge.test.ts
@@ -6,10 +6,20 @@ import { NativeConfigBridge, modelProviderConfigFromNativeConfig } from "./confi
 class FakeRpcClient {
   readonly requests: Array<{ traceId: string; method: string; params: JsonObject }> = [];
 
-  constructor(private readonly values: Record<string, unknown>) {}
+  constructor(private readonly values: Record<string, unknown>, private readonly snapshot?: Record<string, unknown>) {}
 
   async request(traceId: string, method: string, params: JsonObject): Promise<unknown> {
+    if (method === "config.snapshot_public") {
+      if (this.snapshot === undefined) {
+        throw new Error("unknown method");
+      }
+      this.requests.push({ traceId, method, params });
+      return { value: this.snapshot ?? null };
+    }
     this.requests.push({ traceId, method, params });
+    if (method === "provider.resolve_secret") {
+      return { apiKey: "native-secret", apiKeySource: "config" };
+    }
     const path = params.path;
     if (typeof path !== "string") {
       throw new Error("config.get path must be a string");
@@ -80,6 +90,54 @@ describe("NativeConfigBridge", () => {
       model: "env-model",
     });
     expect(rpcClient.requests.map((request) => request.params.path)).not.toContain("providers.openai.api_key");
+  });
+
+  test("builds provider config from public snapshot and narrow provider secret RPC", async () => {
+    const rpcClient = new FakeRpcClient(
+      {},
+      {
+        agents: { defaults: { model: "qwen-plus", active_profile: "dashscope-search" } },
+        providers: {
+          profiles: {
+            "dashscope-search": {
+              provider: "dashscope",
+              api_base: "https://dashscope.test/compatible-mode/v1",
+              extra_body: { enable_search: true },
+            },
+          },
+        },
+      },
+    );
+
+    const config = await modelProviderConfigFromNativeConfig(new NativeConfigBridge(rpcClient), {});
+
+    expect(config).toMatchObject({
+      kind: "resolved",
+      resolved: {
+        providerId: "dashscope",
+        profileName: "dashscope-search",
+        apiKey: "native-secret",
+        apiKeySource: "config",
+        apiBase: "https://dashscope.test/compatible-mode/v1",
+        extraBody: { enable_search: true },
+      },
+    });
+    expect(rpcClient.requests).toEqual([
+      {
+        traceId: "worker-config",
+        method: "config.snapshot_public",
+        params: {},
+      },
+      {
+        traceId: "worker-config",
+        method: "provider.resolve_secret",
+        params: {
+          providerId: "dashscope",
+          profileName: "dashscope-search",
+          apiKeyEnvVars: ["DASHSCOPE_API_KEY"],
+        },
+      },
+    ]);
   });
 
   test("uses native default model with env OpenAI key when provider is auto", async () => {

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/configBridge.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/configBridge.ts
@@ -1,6 +1,7 @@
 import type { JsonObject } from "../protocol/messages.ts";
 import type { NativeRpcClient } from "../tools/nativeToolProxy.ts";
 import type { ModelResponse } from "../model/provider.ts";
+import { resolveRuntimeProvider, type ProviderSecretResolution, type TinybotPublicConfig } from "../providers/providerRuntime.ts";
 import { modelProviderConfigFromEnv, type ModelProviderConfig } from "./providerFactory.ts";
 
 const CONFIG_TRACE_ID = "worker-config";
@@ -17,9 +18,65 @@ export class NativeConfigBridge {
     const object = asObject(result);
     return object?.value;
   }
+
+  async snapshotPublic(): Promise<TinybotPublicConfig> {
+    const result = await this.rpcClient.request(CONFIG_TRACE_ID, "config.snapshot_public", {});
+    const object = asObject(result);
+    const value = asObject(object?.value);
+    if (!value) {
+      throw new Error("config.snapshot_public did not return an object snapshot");
+    }
+    return value;
+  }
+
+  async resolveProviderSecret(input: {
+    providerId: string;
+    profileName?: string;
+    apiKeyEnvVars: string[];
+  }): Promise<ProviderSecretResolution | undefined> {
+    const result = await this.rpcClient.request(CONFIG_TRACE_ID, "provider.resolve_secret", {
+      providerId: input.providerId,
+      ...(input.profileName ? { profileName: input.profileName } : {}),
+      apiKeyEnvVars: input.apiKeyEnvVars,
+    });
+    const object = asObject(result);
+    const apiKey = asString(object?.apiKey ?? object?.api_key);
+    if (!apiKey) {
+      return undefined;
+    }
+    return {
+      apiKey,
+      apiKeySource: (asString(object?.apiKeySource ?? object?.api_key_source) as ProviderSecretResolution["apiKeySource"]) ?? "config",
+    };
+  }
 }
 
 export async function modelProviderConfigFromNativeConfig(
+  configBridge: NativeConfigBridge,
+  env: Record<string, string | undefined>,
+): Promise<ModelProviderConfig> {
+  try {
+    const snapshot = await configBridge.snapshotPublic();
+    const provider = asString(pathValue(snapshot, ["agents", "defaults", "provider"]));
+    if (provider === "fixture") {
+      const providerConfig = asObject(pathValue(snapshot, ["providers", "fixture"]));
+      return {
+        kind: "fixture",
+        responses: normalizeFixtureResponses(providerConfig?.responses),
+      };
+    }
+    const resolved = await resolveRuntimeProvider({
+      config: snapshot,
+      env,
+      secretResolver: (input) => configBridge.resolveProviderSecret(input),
+    });
+    return { kind: "resolved", resolved };
+  } catch {
+    return legacyModelProviderConfigFromNativeConfig(configBridge, env);
+  }
+}
+
+async function legacyModelProviderConfigFromNativeConfig(
   configBridge: NativeConfigBridge,
   env: Record<string, string | undefined>,
 ): Promise<ModelProviderConfig> {
@@ -52,6 +109,18 @@ export async function modelProviderConfigFromNativeConfig(
   } catch {
     return modelProviderConfigFromEnv(env);
   }
+}
+
+function pathValue(config: TinybotPublicConfig, segments: string[]): unknown {
+  let current: unknown = config;
+  for (const segment of segments) {
+    const object = asObject(current);
+    if (!object) {
+      return undefined;
+    }
+    current = object[segment];
+  }
+  return current;
 }
 
 function asObject(value: unknown): JsonObject | null {

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/createAgentWorkerServer.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/createAgentWorkerServer.test.ts
@@ -770,21 +770,29 @@ describe("createAgentWorkerServer", () => {
       }),
     );
 
-    await respondToConfigGet(server, lines, "agents.defaults.provider", "openai");
-    await respondToConfigGet(server, lines, "agents.defaults.model", "gpt-5");
-    await respondToConfigGet(server, lines, "providers.openai", {
-      provider: "openai",
-      api_base: "https://api.test/v1",
-      api_key: null,
+    await respondToConfigSnapshot(server, lines, {
+      agents: { defaults: { provider: "openai", model: "gpt-5" } },
+      providers: {
+        openai: {
+          provider: "openai",
+          api_base: "https://api.test/v1",
+          api_key: null,
+        },
+      },
     });
+    await respondToProviderSecret(server, lines, "openai", { apiKey: "env-key", apiKeySource: "env:OPENAI_API_KEY" });
     await run;
 
     expect(createdConfigs).toEqual([
       {
-        kind: "openai",
-        apiKey: "env-key",
-        baseURL: "https://api.test/v1",
-        model: "gpt-5",
+        kind: "resolved",
+        resolved: expect.objectContaining({
+          providerId: "openai",
+          apiKey: "env-key",
+          apiKeySource: "env:OPENAI_API_KEY",
+          apiBase: "https://api.test/v1",
+          model: "gpt-5",
+        }),
       },
     ]);
     expect(parsedLines(lines).at(-1)).toMatchObject({
@@ -1452,6 +1460,43 @@ async function respondToConfigGet(server: ReturnType<typeof createAgentWorkerSer
       id: request.id,
       trace_id: request.trace_id,
       result: { path, value },
+    }),
+  );
+}
+
+async function respondToConfigSnapshot(server: ReturnType<typeof createAgentWorkerServer>, lines: string[], value: unknown): Promise<void> {
+  await waitFor(() => parsedLines(lines).some((line) => line.method === "config.snapshot_public"));
+  const request = parsedLines(lines).find((line) => line.method === "config.snapshot_public");
+  if (!request || typeof request.id !== "string" || typeof request.trace_id !== "string") {
+    throw new Error("missing config.snapshot_public request");
+  }
+  await server.handleLine(
+    JSON.stringify({
+      protocol_version: "1",
+      id: request.id,
+      trace_id: request.trace_id,
+      result: { value },
+    }),
+  );
+}
+
+async function respondToProviderSecret(
+  server: ReturnType<typeof createAgentWorkerServer>,
+  lines: string[],
+  providerId: string,
+  value: unknown,
+): Promise<void> {
+  await waitFor(() => parsedLines(lines).some((line) => line.method === "provider.resolve_secret" && line.params?.providerId === providerId));
+  const request = parsedLines(lines).find((line) => line.method === "provider.resolve_secret" && line.params?.providerId === providerId);
+  if (!request || typeof request.id !== "string" || typeof request.trace_id !== "string") {
+    throw new Error(`missing provider.resolve_secret request for ${providerId}`);
+  }
+  await server.handleLine(
+    JSON.stringify({
+      protocol_version: "1",
+      id: request.id,
+      trace_id: request.trace_id,
+      result: value,
     }),
   );
 }

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/providerFactory.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/providerFactory.test.ts
@@ -65,6 +65,97 @@ describe("createModelProvider", () => {
     ]);
   });
 
+  test("creates an OpenAI-compatible provider from a resolved runtime provider", async () => {
+    const clientOptions: unknown[] = [];
+    const requests: unknown[] = [];
+    const provider = createModelProvider(
+      {
+        kind: "resolved",
+        resolved: {
+          providerId: "openrouter",
+          model: "openai/gpt-4o-mini",
+          source: "explicit",
+          apiMode: "openai_chat_completions",
+          apiKey: "or-key",
+          apiKeySource: "config",
+          apiBase: "https://openrouter.ai/api/v1",
+          models: [],
+          manualModelIds: [],
+          supportsModelDiscovery: true,
+          requestTraits: {
+            tokenParameter: "max_tokens",
+            temperaturePolicy: "standard",
+            stripModelPrefix: true,
+            extraBodyDefaults: {},
+            supportsPromptCaching: false,
+          },
+          extraBody: { route: "fallback" },
+          warnings: [],
+        },
+      },
+      {
+        createOpenAIClient: (options) => {
+          clientOptions.push(options);
+          return {
+            chat: {
+              completions: {
+                create: async (request: unknown) => {
+                  requests.push(request);
+                  return chunks([{ choices: [{ delta: { content: "done" }, finish_reason: "stop" }] }]);
+                },
+              },
+            },
+          };
+        },
+      },
+    );
+
+    const response = await provider.complete([{ role: "user", content: "hello" }]);
+
+    expect(response.content).toBe("done");
+    expect(clientOptions).toEqual([
+      {
+        apiKey: "or-key",
+        baseURL: "https://openrouter.ai/api/v1",
+        maxRetries: 0,
+      },
+    ]);
+    expect(requests).toEqual([
+      expect.objectContaining({
+        model: "gpt-4o-mini",
+        extra_body: { route: "fallback" },
+      }),
+    ]);
+  });
+
+  test("returns an unconfigured provider for unsupported resolved API modes", async () => {
+    const provider = createModelProvider({
+      kind: "resolved",
+      resolved: {
+        providerId: "native_provider",
+        model: "native-model",
+        source: "explicit",
+        apiMode: "unsupported",
+        models: [],
+        manualModelIds: [],
+        supportsModelDiscovery: false,
+        requestTraits: {
+          tokenParameter: "max_tokens",
+          temperaturePolicy: "standard",
+          stripModelPrefix: false,
+          extraBodyDefaults: {},
+          supportsPromptCaching: false,
+        },
+        extraBody: {},
+        warnings: [],
+      },
+    });
+
+    await expect(provider.complete([{ role: "user", content: "hello" }])).rejects.toThrow(
+      "Unsupported provider api_mode: unsupported",
+    );
+  });
+
   test("creates a fixture provider for offline worker integration tests", async () => {
     const provider = createModelProvider({
       kind: "fixture",

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/providerFactory.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/providerFactory.ts
@@ -4,6 +4,7 @@ import { FixtureProvider } from "../model/fixtureProvider.ts";
 import type { ModelProvider, ModelResponse } from "../model/provider.ts";
 import { OpenAIProvider, type OpenAIChatCompletionsClient } from "../model/openaiProvider.ts";
 import { UnconfiguredProvider } from "../model/unconfiguredProvider.ts";
+import type { ResolvedRuntimeProvider } from "../providers/providerRuntime.ts";
 
 type OpenAIClientOptions = {
   apiKey: string;
@@ -20,6 +21,13 @@ export type ModelProviderConfig =
       apiKey: string;
       baseURL?: string;
       model: string;
+      requestTraits?: ResolvedRuntimeProvider["requestTraits"];
+      extraBody?: Record<string, unknown>;
+      enableSearch?: boolean;
+    }
+  | {
+      kind: "resolved";
+      resolved: ResolvedRuntimeProvider;
     }
   | {
       kind: "fixture";
@@ -38,6 +46,9 @@ export function createModelProvider(
     if (config.kind === "fixture") {
       return new FixtureProvider(config.responses);
     }
+    if (config.kind === "resolved") {
+      return createResolvedModelProvider(config.resolved, deps);
+    }
     return new UnconfiguredProvider();
   }
   const createOpenAIClient = deps.createOpenAIClient ?? ((options) => adaptOpenAIClient(new OpenAI(options)));
@@ -48,6 +59,34 @@ export function createModelProvider(
       maxRetries: 0,
     }),
     defaultModel: config.model,
+    requestTraits: config.requestTraits,
+    extraBodyDefaults: config.extraBody,
+    enableSearch: config.enableSearch,
+  });
+}
+
+function createResolvedModelProvider(
+  resolved: ResolvedRuntimeProvider,
+  deps: ModelProviderFactoryDeps,
+): ModelProvider {
+  if (resolved.apiMode && resolved.apiMode !== "openai_chat_completions") {
+    return new UnconfiguredProvider(`Unsupported provider api_mode: ${resolved.apiMode}`);
+  }
+  const localProviderIds = new Set(["ollama", "lm_studio"]);
+  const apiKey = resolved.apiKey ?? (resolved.providerId && localProviderIds.has(resolved.providerId) ? "tinybot-local-provider" : undefined);
+  if (!resolved.providerId || !apiKey) {
+    return new UnconfiguredProvider(`model provider is not configured: ${resolved.providerId ?? "unresolved"}`);
+  }
+  const createOpenAIClient = deps.createOpenAIClient ?? ((options) => adaptOpenAIClient(new OpenAI(options)));
+  return new OpenAIProvider({
+    client: createOpenAIClient({
+      apiKey,
+      baseURL: resolved.apiBase,
+      maxRetries: 0,
+    }),
+    defaultModel: resolved.model,
+    requestTraits: resolved.requestTraits,
+    extraBodyDefaults: resolved.extraBody,
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #237.

Migrate the native desktop TS agent worker from the minimal OpenAI-only provider path to a provider runtime aligned with the Python backend.

## Changes

- Add TS provider catalog, runtime resolution, model discovery/listing, and provider validation helpers.
- Add reusable OpenAI-compatible request builder for request traits such as token parameter selection, temperature policy, model prefix stripping, extra body defaults, and tool-call ID normalization.
- Add provider retry handling around stream creation while keeping OpenAI SDK retries disabled.
- Extend stream tool-call deltas with sequence, provider call ID, and tool-call index metadata.
- Add Rust `config.snapshot_public` and narrow `provider.resolve_secret` RPC support with sensitive config redaction and provider secret capability checks.
- Wire the desktop TS worker lazy provider path through public config snapshots and resolved provider configs.

## Validation

- `npm test`
- `npm run build`
- `cargo test`

Note: a parallel `cargo test` run while `npm test` was also running caused transient worker-manager timing failures; rerunning `cargo test` by itself passed all 151 tests.