### PR TITLE
Migrate desktop TS worker native tool runtime

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod worker_rpc;
 pub mod worker_runtime;
 pub mod worker_session;
 pub mod worker_secret;
+pub mod worker_shell;
 pub mod worker_stdio;
 pub mod worker_workspace;
 
@@ -1398,6 +1399,8 @@ fn experimental_worker_router(
             WorkerCapability::ConfigRead,
             WorkerCapability::ProviderSecretRead,
             WorkerCapability::FsWorkspaceRead,
+            WorkerCapability::FsWorkspaceWrite,
+            WorkerCapability::ShellExecute,
             WorkerCapability::DiagnosticsWrite,
             WorkerCapability::ApprovalRequest,
             WorkerCapability::ApprovalResolve,

--- a/apps/desktop/src-tauri/src/worker_manager.rs
+++ b/apps/desktop/src-tauri/src/worker_manager.rs
@@ -1017,7 +1017,7 @@ mod tests {
                     event,
                     WorkerManagerEvent::Protocol(protocol_event)
                         if protocol_event.event == "agent.tool.result"
-                            && protocol_event.payload["content"] == "hello from native workspace"
+                            && protocol_event.payload["content"].as_str().is_some_and(|content| content.contains("1| hello from native workspace"))
                 )
             });
             let has_done = events.iter().any(|event| {
@@ -1068,7 +1068,7 @@ mod tests {
                 event,
                 WorkerManagerEvent::Protocol(protocol_event)
                     if protocol_event.event == "agent.tool.result"
-                        && protocol_event.payload["content"] == "hello from native workspace"
+                        && protocol_event.payload["content"].as_str().is_some_and(|content| content.contains("1| hello from native workspace"))
             )
         }));
         assert!(events.iter().any(|event| {

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -4,7 +4,8 @@ use crate::worker_diagnostics::WorkerDiagnosticsRpc;
 use crate::worker_protocol::{validate_protocol_version, WorkerRequest, WorkerResponse};
 use crate::worker_secret::{ProviderResolveSecretParams, WorkerSecretRpc};
 use crate::worker_session::{SessionMetadata, WorkerSessionRpc};
-use crate::worker_workspace::WorkerWorkspaceRpc;
+use crate::worker_shell::{ShellExecuteParams, WorkerShellRpc};
+use crate::worker_workspace::{WorkerWorkspaceRpc, WorkspaceReadFormat, WorkspaceReadOptions};
 use serde::Deserialize;
 use serde_json::Value;
 use std::{
@@ -22,6 +23,7 @@ pub struct WorkerRpcRouter {
     secret: WorkerSecretRpc,
     session: WorkerSessionRpc,
     diagnostics: WorkerDiagnosticsRpc,
+    shell: WorkerShellRpc,
     approval: WorkerApprovalRpc,
     form: WorkerFormRpc,
     memory: WorkerMemoryRpc,
@@ -42,6 +44,7 @@ impl WorkerRpcRouter {
             secret: WorkerSecretRpc::new(config_snapshot.clone(), policy.clone()),
             session: WorkerSessionRpc::new(sessions, policy.clone()),
             diagnostics: WorkerDiagnosticsRpc::new(diagnostic_capacity, policy.clone()),
+            shell: WorkerShellRpc::new(workspace_root.clone(), policy.clone()),
             approval: WorkerApprovalRpc::new(policy.clone()),
             form: WorkerFormRpc::new(policy.clone()),
             memory: WorkerMemoryRpc::new(workspace_root, policy.clone()),
@@ -71,8 +74,15 @@ impl WorkerRpcRouter {
                     .map_err(serialization_error)
             }
             "workspace.read_file" => {
-                let params: PathParams = parse_params(request)?;
-                serde_json::to_value(self.workspace.read_file(&params.path)?)
+                let params: ReadFileParams = parse_params(request)?;
+                serde_json::to_value(self.workspace.read_file_with_options(
+                    &params.path,
+                    WorkspaceReadOptions {
+                        offset: params.offset,
+                        limit: params.limit,
+                        format: params.format.unwrap_or(WorkspaceReadFormat::Raw),
+                    },
+                )?)
                     .map_err(serialization_error)
             }
             "workspace.read_bootstrap_files" => {
@@ -84,6 +94,23 @@ impl WorkerRpcRouter {
                 let params: WriteFileParams = parse_params(request)?;
                 serde_json::to_value(self.workspace.write_file(&params.path, &params.contents)?)
                     .map_err(serialization_error)
+            }
+            "workspace.list_dir" => {
+                let params: ListDirParams = parse_params(request)?;
+                serde_json::to_value(self.workspace.list_dir(
+                    &params.path,
+                    params.recursive.unwrap_or(false),
+                    params.max_entries,
+                )?)
+                .map_err(serialization_error)
+            }
+            "workspace.delete_file" => {
+                let params: DeleteFileParams = parse_params(request)?;
+                serde_json::to_value(
+                    self.workspace
+                        .delete_file(&params.path, params.recursive.unwrap_or(false))?,
+                )
+                .map_err(serialization_error)
             }
             "workspace.list_files" => {
                 serde_json::to_value(self.workspace.list_files()?).map_err(serialization_error)
@@ -146,6 +173,10 @@ impl WorkerRpcRouter {
                 let params: DiagnosticsAppendParams = parse_params(request)?;
                 serde_json::to_value(self.diagnostics.append(&params.stream, &params.line)?)
                     .map_err(serialization_error)
+            }
+            "shell.execute" => {
+                let params: ShellExecuteParams = parse_params(request)?;
+                serde_json::to_value(self.shell.execute(params)?).map_err(serialization_error)
             }
             "approval.request" => {
                 let params: ApprovalRequestParams = parse_params(request)?;
@@ -634,6 +665,33 @@ struct PathParams {
 }
 
 #[derive(Deserialize)]
+struct ReadFileParams {
+    path: String,
+    #[serde(default)]
+    offset: Option<usize>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_workspace_read_format")]
+    format: Option<WorkspaceReadFormat>,
+}
+
+#[derive(Deserialize)]
+struct ListDirParams {
+    path: String,
+    #[serde(default)]
+    recursive: Option<bool>,
+    #[serde(default)]
+    max_entries: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct DeleteFileParams {
+    path: String,
+    #[serde(default)]
+    recursive: Option<bool>,
+}
+
+#[derive(Deserialize)]
 struct BootstrapFilesParams {
     files: Vec<String>,
 }
@@ -774,6 +832,25 @@ fn parse_params<T: for<'de> Deserialize<'de>>(
             false,
             crate::worker_protocol::WorkerProtocolErrorSource::RustCore,
         )
+    })
+}
+
+fn deserialize_workspace_read_format<'de, D>(
+    deserializer: D,
+) -> Result<Option<WorkspaceReadFormat>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(match value.as_deref() {
+        None => None,
+        Some("raw") => Some(WorkspaceReadFormat::Raw),
+        Some("numbered_lines") => Some(WorkspaceReadFormat::NumberedLines),
+        Some(other) => {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported workspace read format: {other}"
+            )));
+        }
     })
 }
 
@@ -1354,7 +1431,16 @@ mod tests {
         assert!(response.error.is_none());
         assert_eq!(
             response.result,
-            Some(json!({ "path": "notes/today.md", "contents": "hello router" }))
+            Some(json!({
+                "path": "notes/today.md",
+                "contents": "hello router",
+                "content": "hello router",
+                "content_type": "text",
+                "line_start": null,
+                "line_end": null,
+                "line_total": null,
+                "truncated": false
+            }))
         );
     }
 
@@ -2307,6 +2393,73 @@ mod tests {
                 "sessionId": "session-1"
             }))
         );
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_workspace_list_dir_and_delete_file_requests() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("notes/today.md", "hello");
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead, WorkerCapability::FsWorkspaceWrite]),
+        );
+
+        let list_response = router.dispatch(&WorkerRequest::new(
+            "req-list",
+            "trace-1",
+            "workspace.list_dir",
+            json!({ "path": ".", "recursive": true, "max_entries": 10 }),
+        ));
+        let delete_response = router.dispatch(&WorkerRequest::new(
+            "req-delete",
+            "trace-1",
+            "workspace.delete_file",
+            json!({ "path": "notes", "recursive": true }),
+        ));
+
+        assert_eq!(
+            list_response.result.as_ref().unwrap()["entries"][0]["path"],
+            "notes/"
+        );
+        assert_eq!(
+            list_response.result.as_ref().unwrap()["entries"][1]["path"],
+            "notes/today.md"
+        );
+        assert_eq!(
+            delete_response.result,
+            Some(json!({ "path": "notes", "kind": "dir", "deleted": true }))
+        );
+        assert!(list_response.error.is_none());
+        assert!(delete_response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_shell_execute_request() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::ShellExecute]),
+        );
+
+        let response = router.dispatch(&WorkerRequest::new(
+            "req-shell",
+            "trace-1",
+            "shell.execute",
+            json!({ "command": "echo tinybot", "working_dir": ".", "timeout": 5 }),
+        ));
+
+        let result = response.result.expect("shell.execute should return result");
+        assert_eq!(result["exit_code"], 0);
+        assert_eq!(result["timed_out"], false);
+        assert_eq!(result["blocked"], false);
+        assert!(result["content"].as_str().unwrap().contains("tinybot"));
         assert!(response.error.is_none());
     }
 

--- a/apps/desktop/src-tauri/src/worker_shell.rs
+++ b/apps/desktop/src-tauri/src/worker_shell.rs
@@ -7,6 +7,7 @@ use std::{
     io::Read,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 
@@ -69,6 +70,8 @@ impl WorkerShellRpc {
                 serde_json::json!({ "error": error.to_string() }),
             )
         })?;
+        let stdout_reader = child.stdout.take().map(read_pipe_to_string);
+        let stderr_reader = child.stderr.take().map(read_pipe_to_string);
         let started = Instant::now();
         let timeout_duration = Duration::from_secs(timeout);
         let mut timed_out = false;
@@ -89,20 +92,14 @@ impl WorkerShellRpc {
             std::thread::sleep(Duration::from_millis(20));
         }
 
-        let mut stdout = String::new();
-        let mut stderr = String::new();
-        if let Some(mut pipe) = child.stdout.take() {
-            let _ = pipe.read_to_string(&mut stdout);
-        }
-        if let Some(mut pipe) = child.stderr.take() {
-            let _ = pipe.read_to_string(&mut stderr);
-        }
         let status = child.wait().map_err(|error| {
             shell_error(
                 "failed to wait for shell command",
                 serde_json::json!({ "error": error.to_string() }),
             )
         })?;
+        let stdout = join_pipe_reader(stdout_reader);
+        let stderr = join_pipe_reader(stderr_reader);
         let exit_code = if timed_out {
             -1
         } else {
@@ -176,6 +173,23 @@ impl WorkerShellRpc {
             WorkerProtocolErrorSource::RustCore,
         ))
     }
+}
+
+fn read_pipe_to_string<R>(mut reader: R) -> JoinHandle<String>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut output = String::new();
+        let _ = reader.read_to_string(&mut output);
+        output
+    })
+}
+
+fn join_pipe_reader(reader: Option<JoinHandle<String>>) -> String {
+    reader
+        .and_then(|handle| handle.join().ok())
+        .unwrap_or_default()
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -328,4 +342,67 @@ fn shell_error(message: impl Into<String>, details: serde_json::Value) -> Worker
         false,
         WorkerProtocolErrorSource::RustCore,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execute_drains_large_output_while_command_is_running() {
+        let fixture = ShellFixture::new();
+        let rpc = WorkerShellRpc::new(
+            fixture.root.clone(),
+            CapabilityPolicy::new([WorkerCapability::ShellExecute]),
+        );
+
+        let result = rpc
+            .execute(ShellExecuteParams {
+                command: large_output_command(),
+                working_dir: Some(".".to_string()),
+                timeout: Some(5),
+                restrict_to_workspace: Some(true),
+            })
+            .expect("large output command should complete");
+
+        assert!(!result.timed_out);
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.len() >= 200_000);
+        assert!(result.truncated);
+    }
+
+    #[cfg(target_os = "windows")]
+    fn large_output_command() -> String {
+        "for /L %i in (1,1,40000) do @echo xxxxx".to_string()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn large_output_command() -> String {
+        "yes x | head -c 200000".to_string()
+    }
+
+    struct ShellFixture {
+        root: PathBuf,
+    }
+
+    impl ShellFixture {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "tinybot-worker-shell-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("clock should be after unix epoch")
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&root).expect("shell fixture should create");
+            Self { root }
+        }
+    }
+
+    impl Drop for ShellFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
 }

--- a/apps/desktop/src-tauri/src/worker_shell.rs
+++ b/apps/desktop/src-tauri/src/worker_shell.rs
@@ -1,0 +1,331 @@
+use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+use crate::worker_protocol::{
+    WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
+
+const MAX_TIMEOUT_SECONDS: u64 = 600;
+const MAX_OUTPUT_CHARS: usize = 10_000;
+
+#[derive(Clone, Debug)]
+pub struct WorkerShellRpc {
+    workspace_root: PathBuf,
+    policy: CapabilityPolicy,
+}
+
+impl WorkerShellRpc {
+    pub fn new(workspace_root: PathBuf, policy: CapabilityPolicy) -> Self {
+        Self {
+            workspace_root,
+            policy,
+        }
+    }
+
+    pub fn execute(
+        &self,
+        params: ShellExecuteParams,
+    ) -> Result<ShellExecuteResult, WorkerProtocolError> {
+        self.require(WorkerCapability::ShellExecute)?;
+        let timeout = params
+            .timeout
+            .unwrap_or(60)
+            .clamp(1, MAX_TIMEOUT_SECONDS);
+        let working_dir = self.resolve_working_dir(
+            params.working_dir.as_deref().unwrap_or("."),
+            params.restrict_to_workspace.unwrap_or(true),
+        )?;
+        if let Some(reason) = guard_command(&params.command, &working_dir, &self.workspace_root) {
+            return Ok(ShellExecuteResult {
+                stdout: String::new(),
+                stderr: reason.clone(),
+                exit_code: 1,
+                timed_out: false,
+                blocked: true,
+                truncated: false,
+                content: reason,
+            });
+        }
+
+        let mut command = shell_command(&params.command);
+        command
+            .current_dir(&working_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            command.creation_flags(0x08000000);
+        }
+
+        let mut child = command.spawn().map_err(|error| {
+            shell_error(
+                "failed to start shell command",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        let started = Instant::now();
+        let timeout_duration = Duration::from_secs(timeout);
+        let mut timed_out = false;
+        loop {
+            if let Some(_status) = child.try_wait().map_err(|error| {
+                shell_error(
+                    "failed to poll shell command",
+                    serde_json::json!({ "error": error.to_string() }),
+                )
+            })? {
+                break;
+            }
+            if started.elapsed() >= timeout_duration {
+                timed_out = true;
+                let _ = child.kill();
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        if let Some(mut pipe) = child.stdout.take() {
+            let _ = pipe.read_to_string(&mut stdout);
+        }
+        if let Some(mut pipe) = child.stderr.take() {
+            let _ = pipe.read_to_string(&mut stderr);
+        }
+        let status = child.wait().map_err(|error| {
+            shell_error(
+                "failed to wait for shell command",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        let exit_code = if timed_out {
+            -1
+        } else {
+            status.code().unwrap_or(-1)
+        };
+        let mut content = format_shell_content(&stdout, &stderr, exit_code, timed_out);
+        let truncated = content.chars().count() > MAX_OUTPUT_CHARS;
+        if truncated {
+            content = truncate_head_tail(&content, MAX_OUTPUT_CHARS);
+        }
+        Ok(ShellExecuteResult {
+            stdout,
+            stderr,
+            exit_code,
+            timed_out,
+            blocked: false,
+            truncated,
+            content,
+        })
+    }
+
+    fn resolve_working_dir(
+        &self,
+        requested: &str,
+        restrict_to_workspace: bool,
+    ) -> Result<PathBuf, WorkerProtocolError> {
+        let root = self.workspace_root.canonicalize().map_err(|error| {
+            shell_error(
+                "failed to resolve workspace root",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        let candidate = if requested == "." {
+            root.clone()
+        } else {
+            let normalized = requested.replace('\\', "/");
+            if normalized.starts_with('/') || normalized.contains(':') || normalized.contains('\0') {
+                return Err(invalid_shell_request("working_dir must be workspace-relative"));
+            }
+            if normalized.split('/').any(|part| part.is_empty() || part == "." || part == "..") {
+                return Err(invalid_shell_request("working_dir must be workspace-relative"));
+            }
+            normalized
+                .split('/')
+                .fold(root.clone(), |path, part| path.join(part))
+        };
+        if !candidate.exists() {
+            return Err(invalid_shell_request("working_dir does not exist"));
+        }
+        let canonical = candidate.canonicalize().map_err(|error| {
+            shell_error(
+                "failed to resolve working_dir",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        if restrict_to_workspace && !canonical.starts_with(&root) {
+            return Err(invalid_shell_request("working_dir escapes workspace"));
+        }
+        Ok(canonical)
+    }
+
+    fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
+        if self.policy.allows(&capability) {
+            return Ok(());
+        }
+        Err(WorkerProtocolError::new(
+            WorkerProtocolErrorCode::CapabilityDenied,
+            "worker capability denied",
+            serde_json::json!({ "capability": capability }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ShellExecuteParams {
+    pub command: String,
+    #[serde(default)]
+    pub working_dir: Option<String>,
+    #[serde(default)]
+    pub timeout: Option<u64>,
+    #[serde(default)]
+    pub restrict_to_workspace: Option<bool>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ShellExecuteResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub timed_out: bool,
+    pub blocked: bool,
+    pub truncated: bool,
+    pub content: String,
+}
+
+fn shell_command(command: &str) -> Command {
+    #[cfg(target_os = "windows")]
+    {
+        let mut shell = Command::new("cmd");
+        shell.args(["/C", command]);
+        shell
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let mut shell = Command::new("sh");
+        shell.args(["-c", command]);
+        shell
+    }
+}
+
+fn guard_command(command: &str, working_dir: &Path, workspace_root: &Path) -> Option<String> {
+    let lower = command.trim().to_ascii_lowercase();
+    if lower.contains("rm -rf node_modules")
+        || lower.contains("rm -rf __pycache__")
+        || lower.contains("rm -rf .pytest_cache")
+        || lower.contains("rm -rf dist")
+        || lower.contains("rm -rf build")
+        || lower.contains("rm -rf target")
+        || lower.contains("rm -rf .ruff_cache")
+    {
+        return None;
+    }
+    let denied = [
+        "rm -rf",
+        "rm -fr",
+        "del /f",
+        "del /q",
+        "rmdir /s",
+        "shred",
+        "mkfs",
+        "diskpart",
+        "shutdown",
+        "reboot",
+        "poweroff",
+        "format ",
+        "format\t",
+        "format\n",
+        "sudo rm",
+        "sudo dd",
+    ];
+    if denied.iter().any(|pattern| lower.contains(pattern)) || lower.starts_with("format") {
+        return Some("Error: Command blocked by safety guard (dangerous pattern detected)".to_string());
+    }
+    if lower.contains("../") || lower.contains("..\\") {
+        return Some("Error: Command blocked by safety guard (path traversal detected)".to_string());
+    }
+    if contains_private_url(&lower) {
+        return Some("Error: Command blocked by safety guard (internal/private URL detected)".to_string());
+    }
+    if contains_absolute_path_outside_workspace(command, working_dir, workspace_root) {
+        return Some("Error: Command blocked by safety guard (path outside working dir)".to_string());
+    }
+    None
+}
+
+fn contains_private_url(command: &str) -> bool {
+    ["127.0.0.1", "localhost", "0.0.0.0", "10.", "192.168.", "169.254."]
+        .iter()
+        .any(|needle| command.contains(needle))
+}
+
+fn contains_absolute_path_outside_workspace(command: &str, working_dir: &Path, workspace_root: &Path) -> bool {
+    let root = workspace_root.canonicalize().unwrap_or_else(|_| workspace_root.to_path_buf());
+    let cwd = working_dir.canonicalize().unwrap_or_else(|_| working_dir.to_path_buf());
+    command.split_whitespace().any(|token| {
+        let cleaned = token.trim_matches(|ch| ch == '"' || ch == '\'' || ch == ';' || ch == '|');
+        let path = PathBuf::from(cleaned);
+        if !path.is_absolute() {
+            return false;
+        }
+        let resolved = path.canonicalize().unwrap_or(path);
+        !resolved.starts_with(&cwd) && !resolved.starts_with(&root)
+    })
+}
+
+fn format_shell_content(stdout: &str, stderr: &str, exit_code: i32, timed_out: bool) -> String {
+    if timed_out {
+        return "Error: Command timed out\n\nExit code: -1".to_string();
+    }
+    let mut parts = Vec::new();
+    if !stdout.is_empty() {
+        parts.push(stdout.trim_end().to_string());
+    }
+    if !stderr.trim().is_empty() {
+        parts.push(format!("STDERR:\n{}", stderr.trim_end()));
+    }
+    parts.push(format!("Exit code: {exit_code}"));
+    parts.join("\n\n")
+}
+
+fn truncate_head_tail(content: &str, max_chars: usize) -> String {
+    let chars: Vec<char> = content.chars().collect();
+    if chars.len() <= max_chars {
+        return content.to_string();
+    }
+    let half = max_chars / 2;
+    let head: String = chars[..half].iter().collect();
+    let tail: String = chars[chars.len() - half..].iter().collect();
+    format!(
+        "{head}\n\n... ({} chars truncated) ...\n\n{tail}",
+        chars.len() - max_chars
+    )
+}
+
+fn invalid_shell_request(message: impl Into<String>) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        message,
+        serde_json::json!({}),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn shell_error(message: impl Into<String>, details: serde_json::Value) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::WorkerError,
+        message,
+        details,
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}

--- a/apps/desktop/src-tauri/src/worker_workspace.rs
+++ b/apps/desktop/src-tauri/src/worker_workspace.rs
@@ -6,6 +6,20 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 const BOOTSTRAP_FILES: &[&str] = &["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"];
+const DEFAULT_READ_LIMIT: usize = 2000;
+const IGNORED_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+];
 
 #[derive(Clone, Debug)]
 pub struct WorkerWorkspaceRpc {
@@ -51,6 +65,82 @@ impl WorkerWorkspaceRpc {
         })
     }
 
+    pub fn read_file_with_options(
+        &self,
+        requested_path: &str,
+        options: WorkspaceReadOptions,
+    ) -> Result<WorkspaceReadFileResult, WorkerProtocolError> {
+        let file = self.read_file(requested_path)?;
+        match options.format {
+            WorkspaceReadFormat::Raw => Ok(WorkspaceReadFileResult {
+                path: file.path,
+                contents: file.contents.clone(),
+                content: file.contents,
+                content_type: "text".to_string(),
+                line_start: None,
+                line_end: None,
+                line_total: None,
+                truncated: false,
+            }),
+            WorkspaceReadFormat::NumberedLines => {
+                let lines: Vec<&str> = file.contents.lines().collect();
+                if lines.is_empty() {
+                    return Ok(WorkspaceReadFileResult {
+                        path: file.path,
+                        contents: file.contents,
+                        content: format!("(Empty file: {requested_path})"),
+                        content_type: "text".to_string(),
+                        line_start: Some(1),
+                        line_end: Some(0),
+                        line_total: Some(0),
+                        truncated: false,
+                    });
+                }
+                let total = lines.len();
+                let offset = options.offset.unwrap_or(1).max(1);
+                if offset > total {
+                    return Err(filesystem_error(
+                        "workspace read offset is beyond end of file",
+                        serde_json::json!({
+                            "path": file.path,
+                            "offset": offset,
+                            "line_total": total,
+                        }),
+                    ));
+                }
+                let limit = options.limit.unwrap_or(DEFAULT_READ_LIMIT).max(1);
+                let start = offset - 1;
+                let end_exclusive = (start + limit).min(total);
+                let line_end = end_exclusive;
+                let mut content = lines[start..end_exclusive]
+                    .iter()
+                    .enumerate()
+                    .map(|(index, line)| format!("{}| {}", start + index + 1, line))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let truncated = line_end < total;
+                if truncated {
+                    content.push_str(&format!(
+                        "\n\n(Showing lines {offset}-{line_end} of {total}. Use offset={} to continue.)",
+                        line_end + 1
+                    ));
+                } else {
+                    content.push_str(&format!("\n\n(End of file - {total} lines total)"));
+                }
+                Ok(WorkspaceReadFileResult {
+                    path: file.path,
+                    contents: file.contents,
+                    content,
+                    content_type: "text".to_string(),
+                    line_start: Some(offset),
+                    line_end: Some(line_end),
+                    line_total: Some(total),
+                    truncated,
+                })
+            }
+        }
+    }
+
     pub fn list_files(&self) -> Result<Vec<WorkspaceFileEntry>, WorkerProtocolError> {
         self.require(WorkerCapability::FsWorkspaceRead)?;
         let root = canonicalize_workspace_root(&self.root)?;
@@ -58,6 +148,47 @@ impl WorkerWorkspaceRpc {
         collect_workspace_files(&root, &root, &mut entries)?;
         entries.sort_by(|left, right| left.path.cmp(&right.path));
         Ok(entries)
+    }
+
+    pub fn list_dir(
+        &self,
+        requested_path: &str,
+        recursive: bool,
+        max_entries: Option<usize>,
+    ) -> Result<WorkspaceDirectoryListing, WorkerProtocolError> {
+        self.require(WorkerCapability::FsWorkspaceRead)?;
+        let root = canonicalize_workspace_root(&self.root)?;
+        let relative_path = normalize_workspace_dir_path(requested_path)?;
+        let absolute_path = workspace_dir_absolute_path(&self.root, &relative_path);
+        ensure_inside_workspace(&self.root, &absolute_path)?;
+        if !absolute_path.is_dir() {
+            return Err(filesystem_error(
+                "workspace path is not a directory",
+                serde_json::json!({ "path": relative_path }),
+            ));
+        }
+        let base = absolute_path.canonicalize().map_err(|error| {
+            filesystem_error(
+                "failed to resolve workspace directory",
+                serde_json::json!({
+                    "path": relative_path,
+                    "error": error.to_string(),
+                }),
+            )
+        })?;
+        let mut entries = Vec::new();
+        collect_workspace_dir_entries(&root, &base, &base, recursive, &mut entries)?;
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        let total_entries = entries.len();
+        let cap = max_entries.unwrap_or(200).max(1);
+        let truncated = total_entries > cap;
+        entries.truncate(cap);
+        Ok(WorkspaceDirectoryListing {
+            path: relative_path,
+            entries,
+            total_entries,
+            truncated,
+        })
     }
 
     pub fn read_bootstrap_files(
@@ -124,6 +255,94 @@ impl WorkerWorkspaceRpc {
         })
     }
 
+    pub fn delete_file(
+        &self,
+        requested_path: &str,
+        recursive: bool,
+    ) -> Result<WorkspaceDeleteResult, WorkerProtocolError> {
+        self.require(WorkerCapability::FsWorkspaceWrite)?;
+        let relative_path = normalize_workspace_dir_path(requested_path)?;
+        if relative_path == "." || relative_path == ".git" || relative_path.starts_with(".git/") {
+            return Err(WorkerProtocolError::new(
+                WorkerProtocolErrorCode::InvalidProtocol,
+                "refusing to delete protected workspace path",
+                serde_json::json!({ "path": relative_path }),
+                false,
+                WorkerProtocolErrorSource::RustCore,
+            ));
+        }
+        let absolute_path = workspace_dir_absolute_path(&self.root, &relative_path);
+        if !absolute_path.exists() {
+            return Err(filesystem_error(
+                "workspace path does not exist",
+                serde_json::json!({ "path": relative_path }),
+            ));
+        }
+        ensure_inside_workspace(&self.root, &absolute_path)?;
+        let metadata = std::fs::symlink_metadata(&absolute_path).map_err(|error| {
+            filesystem_error(
+                "failed to inspect workspace path",
+                serde_json::json!({
+                    "path": relative_path,
+                    "error": error.to_string(),
+                }),
+            )
+        })?;
+        if metadata.is_dir() {
+            if recursive {
+                std::fs::remove_dir_all(&absolute_path).map_err(|error| {
+                    filesystem_error(
+                        "failed to delete workspace directory",
+                        serde_json::json!({
+                            "path": relative_path,
+                            "error": error.to_string(),
+                        }),
+                    )
+                })?;
+            } else {
+                std::fs::remove_dir(&absolute_path).map_err(|error| {
+                    let message = if absolute_path.read_dir().map(|mut items| items.next().is_some()).unwrap_or(false) {
+                        "workspace directory is not empty"
+                    } else {
+                        "failed to delete workspace directory"
+                    };
+                    filesystem_error(
+                        message,
+                        serde_json::json!({
+                            "path": relative_path,
+                            "error": error.to_string(),
+                        }),
+                    )
+                })?;
+            }
+            return Ok(WorkspaceDeleteResult {
+                path: relative_path,
+                kind: "dir".to_string(),
+                deleted: true,
+            });
+        }
+        if metadata.is_file() {
+            std::fs::remove_file(&absolute_path).map_err(|error| {
+                filesystem_error(
+                    "failed to delete workspace file",
+                    serde_json::json!({
+                        "path": relative_path,
+                        "error": error.to_string(),
+                    }),
+                )
+            })?;
+            return Ok(WorkspaceDeleteResult {
+                path: relative_path,
+                kind: "file".to_string(),
+                deleted: true,
+            });
+        }
+        Err(filesystem_error(
+            "workspace path is not a regular file or directory",
+            serde_json::json!({ "path": relative_path }),
+        ))
+    }
+
     fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
         if self.policy.allows(&capability) {
             return Ok(());
@@ -151,9 +370,49 @@ pub struct WorkspaceFileContent {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub enum WorkspaceReadFormat {
+    Raw,
+    NumberedLines,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceReadOptions {
+    pub offset: Option<usize>,
+    pub limit: Option<usize>,
+    pub format: WorkspaceReadFormat,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceReadFileResult {
+    pub path: String,
+    pub contents: String,
+    pub content: String,
+    pub content_type: String,
+    pub line_start: Option<usize>,
+    pub line_end: Option<usize>,
+    pub line_total: Option<usize>,
+    pub truncated: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct WorkspaceFileEntry {
     pub path: String,
     pub size_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceDirectoryEntry {
+    pub path: String,
+    pub kind: String,
+    pub size_bytes: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceDirectoryListing {
+    pub path: String,
+    pub entries: Vec<WorkspaceDirectoryEntry>,
+    pub total_entries: usize,
+    pub truncated: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -166,6 +425,13 @@ pub struct WorkspaceBootstrapFiles {
 pub struct WorkspaceWriteResult {
     pub path: String,
     pub bytes_written: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WorkspaceDeleteResult {
+    pub path: String,
+    pub kind: String,
+    pub deleted: bool,
 }
 
 fn collect_workspace_files(
@@ -214,6 +480,74 @@ fn collect_workspace_files(
     Ok(())
 }
 
+fn collect_workspace_dir_entries(
+    root: &Path,
+    base: &Path,
+    current: &Path,
+    recursive: bool,
+    entries: &mut Vec<WorkspaceDirectoryEntry>,
+) -> Result<(), WorkerProtocolError> {
+    for entry in std::fs::read_dir(current).map_err(|error| {
+        filesystem_error(
+            "failed to list workspace directory",
+            serde_json::json!({
+                "path": current.display().to_string(),
+                "error": error.to_string(),
+            }),
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            filesystem_error(
+                "failed to inspect workspace directory entry",
+                serde_json::json!({ "error": error.to_string() }),
+            )
+        })?;
+        let path = entry.path();
+        ensure_inside_canonical_workspace(root, &path)?;
+        let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+            filesystem_error(
+                "failed to read workspace path metadata",
+                serde_json::json!({
+                    "path": path.display().to_string(),
+                    "error": error.to_string(),
+                }),
+            )
+        })?;
+        if metadata.file_type().is_symlink() || ignored_workspace_path(base, &path) {
+            continue;
+        }
+        if metadata.is_dir() {
+            entries.push(WorkspaceDirectoryEntry {
+                path: format!("{}/", workspace_relative_path(base, &path)?),
+                kind: "dir".to_string(),
+                size_bytes: None,
+            });
+            if recursive {
+                collect_workspace_dir_entries(root, base, &path, recursive, entries)?;
+            }
+        } else if metadata.is_file() {
+            entries.push(WorkspaceDirectoryEntry {
+                path: workspace_relative_path(base, &path)?,
+                kind: "file".to_string(),
+                size_bytes: Some(metadata.len()),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn ignored_workspace_path(base: &Path, path: &Path) -> bool {
+    path.strip_prefix(base)
+        .ok()
+        .map(|relative| {
+            relative.components().any(|component| {
+                let name = component.as_os_str().to_string_lossy();
+                IGNORED_DIRS.iter().any(|ignored| *ignored == name)
+            })
+        })
+        .unwrap_or(false)
+}
+
 fn normalize_workspace_path(requested_path: &str) -> Result<String, WorkerProtocolError> {
     let normalized = requested_path.replace('\\', "/");
     if normalized.is_empty()
@@ -229,10 +563,36 @@ fn normalize_workspace_path(requested_path: &str) -> Result<String, WorkerProtoc
     Ok(normalized)
 }
 
+fn normalize_workspace_dir_path(requested_path: &str) -> Result<String, WorkerProtocolError> {
+    let normalized = requested_path.replace('\\', "/");
+    let normalized = normalized.trim_end_matches('/');
+    if normalized == "." {
+        return Ok(".".to_string());
+    }
+    if normalized.is_empty()
+        || normalized.starts_with('/')
+        || normalized.contains(':')
+        || normalized.contains('\0')
+        || normalized
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(invalid_workspace_path(requested_path));
+    }
+    Ok(normalized.to_string())
+}
+
 fn join_workspace_relative(root: &Path, relative_path: &str) -> PathBuf {
     relative_path
         .split('/')
         .fold(root.to_path_buf(), |path, part| path.join(part))
+}
+
+fn workspace_dir_absolute_path(root: &Path, relative_path: &str) -> PathBuf {
+    if relative_path == "." {
+        return root.to_path_buf();
+    }
+    join_workspace_relative(root, relative_path)
 }
 
 fn ensure_inside_workspace(root: &Path, path: &Path) -> Result<(), WorkerProtocolError> {
@@ -576,6 +936,73 @@ mod tests {
             std::fs::read_to_string(outside).expect("outside file should read"),
             "secret"
         );
+    }
+
+    #[test]
+    fn read_file_with_options_returns_numbered_paginated_lines() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("notes/today.md", "one\ntwo\nthree\nfour\n");
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let file = rpc
+            .read_file_with_options(
+                "notes/today.md",
+                WorkspaceReadOptions {
+                    offset: Some(2),
+                    limit: Some(2),
+                    format: WorkspaceReadFormat::NumberedLines,
+                },
+            )
+            .expect("paginated file should read");
+
+        assert_eq!(file.path, "notes/today.md");
+        assert_eq!(file.content, "2| two\n3| three\n\n(Showing lines 2-3 of 4. Use offset=4 to continue.)");
+        assert_eq!(file.content_type, "text");
+        assert_eq!(file.line_start, Some(2));
+        assert_eq!(file.line_end, Some(3));
+        assert_eq!(file.line_total, Some(4));
+        assert!(file.truncated);
+    }
+
+    #[test]
+    fn list_dir_respects_path_recursion_max_entries_and_ignores_noise() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("README.md", "readme");
+        fixture.write("src/main.ts", "main");
+        fixture.write("node_modules/pkg/index.js", "noise");
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let listing = rpc
+            .list_dir(".", true, Some(10))
+            .expect("workspace directory should list");
+        let paths: Vec<String> = listing.entries.into_iter().map(|entry| entry.path).collect();
+
+        assert_eq!(paths, vec!["README.md", "src/", "src/main.ts"]);
+        assert_eq!(listing.path, ".");
+        assert!(!listing.truncated);
+    }
+
+    #[test]
+    fn delete_file_refuses_workspace_root_and_requires_recursive_for_nonempty_dirs() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("notes/today.md", "hello");
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), write_policy());
+
+        let root_error = rpc
+            .delete_file(".", true)
+            .expect_err("workspace root should be protected");
+        let nonempty_error = rpc
+            .delete_file("notes", false)
+            .expect_err("non-empty dir should require recursive");
+        let deleted = rpc
+            .delete_file("notes", true)
+            .expect("recursive delete should delete directory");
+
+        assert_eq!(root_error.code, WorkerProtocolErrorCode::InvalidProtocol);
+        assert_eq!(nonempty_error.message, "workspace directory is not empty");
+        assert_eq!(deleted.path, "notes");
+        assert_eq!(deleted.kind, "dir");
+        assert!(!fixture.root.join("notes").exists());
     }
 
     fn read_policy() -> CapabilityPolicy {

--- a/apps/desktop/src-tauri/src/worker_workspace.rs
+++ b/apps/desktop/src-tauri/src/worker_workspace.rs
@@ -518,7 +518,7 @@ fn collect_workspace_dir_entries(
         }
         if metadata.is_dir() {
             entries.push(WorkspaceDirectoryEntry {
-                path: format!("{}/", workspace_relative_path(base, &path)?),
+                path: format!("{}/", workspace_relative_path(root, &path)?),
                 kind: "dir".to_string(),
                 size_bytes: None,
             });
@@ -527,7 +527,7 @@ fn collect_workspace_dir_entries(
             }
         } else if metadata.is_file() {
             entries.push(WorkspaceDirectoryEntry {
-                path: workspace_relative_path(base, &path)?,
+                path: workspace_relative_path(root, &path)?,
                 kind: "file".to_string(),
                 size_bytes: Some(metadata.len()),
             });
@@ -980,6 +980,22 @@ mod tests {
         assert_eq!(paths, vec!["README.md", "src/", "src/main.ts"]);
         assert_eq!(listing.path, ".");
         assert!(!listing.truncated);
+    }
+
+    #[test]
+    fn list_dir_reports_workspace_relative_paths_from_subdirectories() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("src/main.ts", "main");
+        fixture.write("src/components/button.ts", "button");
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let listing = rpc
+            .list_dir("src", true, Some(10))
+            .expect("subdirectory should list");
+        let paths: Vec<String> = listing.entries.into_iter().map(|entry| entry.path).collect();
+
+        assert_eq!(listing.path, "src");
+        assert_eq!(paths, vec!["src/components/", "src/components/button.ts", "src/main.ts"]);
     }
 
     #[test]

--- a/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.test.ts
@@ -988,6 +988,96 @@ describe("AgentRunner", () => {
     expect(checkpoints.map((checkpoint) => checkpoint.phase)).toEqual(["awaiting_tools", "tools_completed"]);
   });
 
+  test("requests approval before executing a tool that requires approval", async () => {
+    const provider = new QueueProvider([
+      {
+        content: "",
+        toolCalls: [
+          {
+            id: "call-1",
+            name: "write_file",
+            argumentsJson: "{\"path\":\"notes/today.md\",\"content\":\"hello\"}",
+          },
+        ],
+        stopReason: "tool_calls",
+      },
+      {
+        content: "should not be requested",
+        toolCalls: [],
+        stopReason: "stop",
+      },
+    ]);
+    const tools = new ToolRegistry();
+    const executedWrites: Record<string, unknown>[] = [];
+    const approvalRequests: Record<string, unknown>[] = [];
+    tools.register({
+      name: "write_file",
+      description: "Write a file",
+      parameters: { type: "object" },
+      capabilities: ["fs.workspace.write"],
+      requiresApproval: true,
+      execute: async (args) => {
+        executedWrites.push(args);
+        return { content: "written" };
+      },
+    });
+    tools.register({
+      name: "request_approval",
+      description: "Request approval",
+      parameters: { type: "object" },
+      execute: async (args) => {
+        approvalRequests.push(args);
+        return {
+          content: "Waiting for approval.",
+          metadata: {
+            awaitingUserInput: true,
+            stopReason: "awaiting_approval",
+            approvalId: "approval-1",
+            operation: args.operation,
+          },
+        };
+      },
+    });
+    const runner = new AgentRunner({ provider, tools });
+
+    const result = await runner.run(spec());
+
+    expect(executedWrites).toEqual([]);
+    expect(approvalRequests).toEqual([
+      {
+        operation: {
+          toolName: "write_file",
+          arguments: { path: "notes/today.md", content: "hello" },
+          category: "filesystem_write",
+          risk: "medium",
+          reason: "File write, edit, and delete tools can modify workspace state.",
+        },
+      },
+    ]);
+    expect(result.stopReason).toBe("awaiting_approval");
+    expect(result.finalContent).toBe("");
+    expect(result.toolsUsed).toEqual(["write_file"]);
+    expect(provider.requests).toHaveLength(1);
+    expect(result.messages.at(-1)).toEqual({
+      role: "tool",
+      content: "Waiting for approval.",
+      toolCallId: "call-1",
+      name: "write_file",
+      metadata: {
+        awaitingUserInput: true,
+        stopReason: "awaiting_approval",
+        approvalId: "approval-1",
+        operation: {
+          toolName: "write_file",
+          arguments: { path: "notes/today.md", content: "hello" },
+          category: "filesystem_write",
+          risk: "medium",
+          reason: "File write, edit, and delete tools can modify workspace state.",
+        },
+      },
+    });
+  });
+
   test("forwards provider streaming deltas as runner events", async () => {
     const provider = new QueueProvider([{ content: "done", toolCalls: [], stopReason: "stop" }]);
     const events: Array<{ type: string; payload: Record<string, unknown> }> = [];

--- a/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.ts
@@ -106,12 +106,10 @@ export class AgentRunner {
             result = { content: `Error: Tool '${toolCall.name}' not found. Available: ${availableToolNames(spec, this.tools)}` };
           }
           if (!result) {
-            const prepared = prepareToolArguments(this.tools, toolCall.name, args);
+            const prepared = this.tools.prepareCall(toolCall.name, args);
             args = prepared.args;
-            if (prepared.errors.length > 0) {
-              result = {
-                content: `Error: Invalid parameters for tool '${toolCall.name}': ${prepared.errors.join("; ")}`,
-              };
+            if (!prepared.ok) {
+              result = { content: prepared.content };
             } else {
               this.emitEvent({
                 type: "tool_start",
@@ -122,7 +120,7 @@ export class AgentRunner {
                 },
               });
               try {
-                result = await this.tools.execute(toolCall.name, args, {
+                result = await prepared.tool.execute(prepared.args, {
                   runId: spec.runId,
                   traceId: spec.traceId,
                   sessionId: spec.sessionId,
@@ -628,133 +626,6 @@ function errorName(error: unknown): string {
 
 function availableToolNames(spec: AgentRunSpec, tools: ToolRegistry): string {
   return (spec.tools ?? tools.definitions()).map((tool) => tool.name).join(", ");
-}
-
-function prepareToolArguments(
-  tools: ToolRegistry,
-  name: string,
-  args: Record<string, unknown>,
-): { args: Record<string, unknown>; errors: string[] } {
-  const definition = tools.definitions().find((tool) => tool.name === name);
-  const schema = asRecord(definition?.parameters);
-  if (!schema || schema.type !== "object") {
-    return { args, errors: [] };
-  }
-  const castArgs = castJsonSchemaValue(args, schema);
-  const preparedArgs = asRecord(castArgs) ?? args;
-  return {
-    args: preparedArgs,
-    errors: validateJsonSchemaValue(preparedArgs, { ...schema, type: "object" }, ""),
-  };
-}
-
-function castJsonSchemaValue(value: unknown, schema: Record<string, unknown>): unknown {
-  const schemaType = resolveJsonSchemaType(schema.type);
-  if (schemaType === "object") {
-    const objectValue = asRecord(value);
-    if (!objectValue) {
-      return value;
-    }
-    const properties = asRecord(schema.properties) ?? {};
-    return Object.fromEntries(
-      Object.entries(objectValue).map(([key, childValue]) => {
-        const childSchema = asRecord(properties[key]);
-        return [key, childSchema ? castJsonSchemaValue(childValue, childSchema) : childValue];
-      }),
-    );
-  }
-  if (typeof value === "string" && schemaType === "integer") {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isNaN(parsed) ? value : parsed;
-  }
-  if (typeof value === "string" && schemaType === "number") {
-    const parsed = Number.parseFloat(value);
-    return Number.isNaN(parsed) ? value : parsed;
-  }
-  if (typeof value === "string" && schemaType === "boolean") {
-    const lower = value.toLowerCase();
-    if (lower === "true" || lower === "1" || lower === "yes") {
-      return true;
-    }
-    if (lower === "false" || lower === "0" || lower === "no") {
-      return false;
-    }
-  }
-  if (Array.isArray(value) && schemaType === "array") {
-    const itemSchema = asRecord(schema.items);
-    return itemSchema ? value.map((item) => castJsonSchemaValue(item, itemSchema)) : value;
-  }
-  if (schemaType === "string" && value !== null && value !== undefined) {
-    return String(value);
-  }
-  return value;
-}
-
-function validateJsonSchemaValue(value: unknown, schema: Record<string, unknown>, path: string): string[] {
-  const schemaType = resolveJsonSchemaType(schema.type);
-  const label = path || "parameter";
-  if (schemaType === "object") {
-    const objectValue = asRecord(value);
-    if (!objectValue) {
-      return [`${label} should be object`];
-    }
-    const errors: string[] = [];
-    const properties = asRecord(schema.properties) ?? {};
-    const required = Array.isArray(schema.required) ? schema.required : [];
-    for (const key of required) {
-      if (typeof key === "string" && !(key in objectValue)) {
-        errors.push(`missing required ${subpath(path, key)}`);
-      }
-    }
-    for (const [key, childValue] of Object.entries(objectValue)) {
-      const childSchema = asRecord(properties[key]);
-      if (childSchema) {
-        errors.push(...validateJsonSchemaValue(childValue, childSchema, subpath(path, key)));
-      }
-    }
-    return errors;
-  }
-  if (schemaType === "string" && typeof value !== "string") {
-    return [`${label} should be string`];
-  }
-  if (schemaType === "boolean" && typeof value !== "boolean") {
-    return [`${label} should be boolean`];
-  }
-  if (schemaType === "integer" && (!Number.isInteger(value) || typeof value !== "number")) {
-    return [`${label} should be integer`];
-  }
-  if (schemaType === "number" && typeof value !== "number") {
-    return [`${label} should be number`];
-  }
-  if (schemaType === "array" && !Array.isArray(value)) {
-    return [`${label} should be array`];
-  }
-  if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
-    return [`${label} must be one of ${formatJsonSchemaEnum(schema.enum)}`];
-  }
-  return [];
-}
-
-function resolveJsonSchemaType(value: unknown): string | undefined {
-  if (Array.isArray(value)) {
-    return value.find((item): item is string => typeof item === "string" && item !== "null");
-  }
-  return typeof value === "string" ? value : undefined;
-}
-
-function subpath(path: string, key: string): string {
-  return path ? `${path}.${key}` : key;
-}
-
-function formatJsonSchemaEnum(values: unknown[]): string {
-  return `[${values.map((value) => typeof value === "string" ? `'${value}'` : String(value)).join(", ")}]`;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  return value as Record<string, unknown>;
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage, AgentRunResult, AgentRunSpec } from "./agentRunSpec.ts";
 import type { ModelProvider, ModelRequestOptions, TokenUsage, ToolCallRequest, ToolDefinition } from "../model/provider.ts";
-import type { ToolResult } from "../tools/tool.ts";
+import type { Tool, ToolResult } from "../tools/tool.ts";
 import type { ToolRegistry } from "../tools/toolRegistry.ts";
 
 const EMPTY_FINAL_RESPONSE_MESSAGE =
@@ -120,11 +120,14 @@ export class AgentRunner {
                 },
               });
               try {
-                result = await prepared.tool.execute(prepared.args, {
+                const context = {
                   runId: spec.runId,
                   traceId: spec.traceId,
                   sessionId: spec.sessionId,
-                });
+                };
+                result = prepared.tool.requiresApproval
+                  ? await this.requestToolApproval(prepared.tool, prepared.args, context)
+                  : await prepared.tool.execute(prepared.args, context);
               } catch (error) {
                 if (spec.failOnToolError) {
                   const finalContent = `Error: ${errorName(error)}: ${errorMessage(error)}`;
@@ -299,6 +302,20 @@ export class AgentRunner {
       usage,
       stopReason: "max_iterations",
     };
+  }
+
+  private async requestToolApproval(
+    tool: Tool,
+    args: Record<string, unknown>,
+    context: { runId: string; traceId?: string; sessionId?: string },
+  ): Promise<ToolResult> {
+    const prepared = this.tools.prepareCall("request_approval", {
+      operation: approvalOperation(tool, args),
+    });
+    if (!prepared.ok) {
+      return { content: prepared.content };
+    }
+    return prepared.tool.execute(prepared.args, context);
   }
 
   private requestOptions(spec: AgentRunSpec): ModelRequestOptions {
@@ -480,6 +497,48 @@ function awaitingInputFromMetadata(metadata: Record<string, unknown> | undefined
     ...metadata,
     stopReason,
   };
+}
+
+function approvalOperation(tool: Tool, args: Record<string, unknown>): Record<string, unknown> {
+  const category = approvalCategory(tool);
+  return {
+    toolName: tool.name,
+    arguments: args,
+    category,
+    risk: approvalRisk(category),
+    reason: approvalReason(category),
+  };
+}
+
+function approvalCategory(tool: Tool): string {
+  const capabilities = tool.capabilities ?? [];
+  if (capabilities.includes("fs.workspace.write")) {
+    return "filesystem_write";
+  }
+  if (capabilities.includes("shell.execute")) {
+    return "shell_execute";
+  }
+  if (capabilities.includes("memory.write")) {
+    return "memory_write";
+  }
+  return "tool_execution";
+}
+
+function approvalRisk(category: string): "medium" | "high" {
+  return category === "shell_execute" ? "high" : "medium";
+}
+
+function approvalReason(category: string): string {
+  switch (category) {
+    case "filesystem_write":
+      return "File write, edit, and delete tools can modify workspace state.";
+    case "shell_execute":
+      return "Shell commands can modify files, start processes, or affect the local environment.";
+    case "memory_write":
+      return "Memory writes can persist information beyond the current run.";
+    default:
+      return "This tool requires user approval before execution.";
+  }
 }
 
 function memoryReferencesFromMetadata(metadata: Record<string, unknown> | undefined): unknown[] | undefined {

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/createAgentWorkerServer.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/createAgentWorkerServer.test.ts
@@ -211,7 +211,7 @@ describe("createAgentWorkerServer", () => {
       id: "worker-req-1",
       trace_id: "trace-1",
       method: "workspace.read_file",
-      params: { path: "README.md" },
+      params: { path: "README.md", format: "numbered_lines" },
     });
 
     await server.handleLine(

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/createAgentWorkerServer.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/createAgentWorkerServer.ts
@@ -10,7 +10,10 @@ import {
   createNativeMemoryTools,
   createNativeRagTools,
   createNativeReadOnlyTools,
+  createNativeShellTools,
+  createNativeWriteTools,
 } from "../tools/nativeToolProxy.ts";
+import { registerToolsByPolicy } from "../tools/toolPolicy.ts";
 import type { ToolRegistry } from "../tools/toolRegistry.ts";
 import { NativeApprovalBridge } from "./approvalBridge.ts";
 import { AgentWorker } from "./agentWorker.ts";
@@ -23,6 +26,8 @@ export type CreateAgentWorkerServerOptions = {
   provider?: ModelProvider;
   tools: ToolRegistry;
   env?: Record<string, string | undefined>;
+  capabilities?: string[];
+  channel?: string;
   createModelProvider?: (config: ModelProviderConfig) => ModelProvider;
   writeLine: (line: string) => void;
   writeLog: (line: string) => void;
@@ -30,24 +35,23 @@ export type CreateAgentWorkerServerOptions = {
 
 export function createAgentWorkerServer(options: CreateAgentWorkerServerOptions): StdioServer {
   const rpcClient = new RpcClient({ writeLine: options.writeLine });
-  for (const tool of createNativeReadOnlyTools(rpcClient)) {
-    options.tools.register(tool);
-  }
-  for (const tool of createNativeApprovalTools(rpcClient)) {
-    options.tools.register(tool);
-  }
-  for (const tool of createNativeFormTools(rpcClient)) {
-    options.tools.register(tool);
-  }
-  for (const tool of createNativeMemoryTools(rpcClient)) {
-    options.tools.register(tool);
-  }
-  for (const tool of createNativeRagTools(rpcClient)) {
-    options.tools.register(tool);
-  }
-  for (const tool of createNativeMcpTools(rpcClient)) {
-    options.tools.register(tool);
-  }
+  registerToolsByPolicy(
+    options.tools,
+    [
+      ...createNativeReadOnlyTools(rpcClient),
+      ...createNativeWriteTools(rpcClient),
+      ...createNativeShellTools(rpcClient),
+      ...createNativeApprovalTools(rpcClient),
+      ...createNativeFormTools(rpcClient),
+      ...createNativeMemoryTools(rpcClient),
+      ...createNativeRagTools(rpcClient),
+      ...createNativeMcpTools(rpcClient),
+    ],
+    {
+      capabilities: options.capabilities ?? DEFAULT_NATIVE_TOOL_CAPABILITIES,
+      channel: options.channel ?? "agent_ui",
+    },
+  );
   const writeEvent = (event: WorkerEvent): void => {
     options.writeLine(JSON.stringify(event));
   };
@@ -72,6 +76,17 @@ export function createAgentWorkerServer(options: CreateAgentWorkerServerOptions)
     writeLog: options.writeLog,
   });
 }
+
+const DEFAULT_NATIVE_TOOL_CAPABILITIES = [
+  "fs.workspace.read",
+  "fs.workspace.write",
+  "shell.execute",
+  "approval.request",
+  "form.request",
+  "memory.read",
+  "memory.write",
+  "mcp.call",
+];
 
 class LazyModelProvider implements ModelProvider {
   private provider: Promise<ModelProvider> | null = null;

--- a/apps/desktop/workers/ts-agent-worker/src/tools/nativeToolProxy.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/nativeToolProxy.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, test } from "vitest";
 import type { JsonObject } from "../protocol/messages";
 import {
   createNativeApprovalTools,
+  createNativeShellTools,
   createNativeFormTools,
+  createNativeWriteTools,
   createNativeMcpTools,
   createNativeMemoryTools,
   createNativeRagTools,
@@ -29,41 +31,167 @@ class FakeRpcClient {
 }
 
 describe("createNativeReadOnlyTools", () => {
-  test("creates a read_file tool backed by workspace.read_file", async () => {
-    const rpc = new FakeRpcClient([{ path: "README.md", contents: "hello\nworld" }]);
+  test("creates a read_file tool backed by paginated workspace.read_file", async () => {
+    const rpc = new FakeRpcClient([{ path: "README.md", content: "2| hello\n3| world" }]);
     const [readFile] = createNativeReadOnlyTools(rpc);
 
-    const result = await readFile.execute({ path: "README.md" }, { runId: "run-1", traceId: "trace-1" });
+    const result = await readFile.execute({ path: "README.md", offset: 2, limit: 2 }, { runId: "run-1", traceId: "trace-1" });
 
     expect(readFile.name).toBe("read_file");
-    expect(result.content).toBe("hello\nworld");
+    expect(readFile.readOnly).toBe(true);
+    expect(readFile.concurrencySafe).toBe(true);
+    expect(result.content).toBe("2| hello\n3| world");
     expect(rpc.requests).toEqual([
       {
         traceId: "trace-1",
         method: "workspace.read_file",
-        params: { path: "README.md" },
+        params: { path: "README.md", offset: 2, limit: 2, format: "numbered_lines" },
       },
     ]);
   });
 
-  test("creates a list_dir tool backed by workspace.list_files", async () => {
+  test("creates a list_dir tool backed by path-aware workspace.list_dir", async () => {
     const rpc = new FakeRpcClient([
-      [
-        { path: "README.md", kind: "file", bytes: 12 },
-        { path: "src/index.ts", kind: "file", bytes: 100 },
-      ],
+      {
+        entries: [
+          { path: "src/", kind: "dir" },
+          { path: "src/index.ts", kind: "file", size_bytes: 100 },
+        ],
+      },
     ]);
     const [, listDir] = createNativeReadOnlyTools(rpc);
 
-    const result = await listDir.execute({}, { runId: "run-1", traceId: "trace-1" });
+    const result = await listDir.execute(
+      { path: ".", recursive: true, max_entries: 20 },
+      { runId: "run-1", traceId: "trace-1" },
+    );
 
     expect(listDir.name).toBe("list_dir");
-    expect(result.content).toBe("README.md\nsrc/index.ts");
+    expect(listDir.readOnly).toBe(true);
+    expect(listDir.concurrencySafe).toBe(true);
+    expect(result.content).toBe("src/\nsrc/index.ts");
     expect(rpc.requests).toEqual([
       {
         traceId: "trace-1",
-        method: "workspace.list_files",
-        params: {},
+        method: "workspace.list_dir",
+        params: { path: ".", recursive: true, max_entries: 20 },
+      },
+    ]);
+  });
+});
+
+describe("createNativeWriteTools", () => {
+  test("creates a write_file tool backed by workspace.write_file", async () => {
+    const rpc = new FakeRpcClient([{ path: "notes/today.md", bytes_written: 5 }]);
+    const [writeFile] = createNativeWriteTools(rpc);
+
+    const result = await writeFile.execute(
+      { path: "notes/today.md", content: "hello" },
+      { runId: "run-1", traceId: "trace-1" },
+    );
+
+    expect(writeFile.name).toBe("write_file");
+    expect(result.content).toBe("Wrote 5 bytes to notes/today.md.");
+    expect(rpc.requests).toEqual([
+      {
+        traceId: "trace-1",
+        method: "workspace.write_file",
+        params: { path: "notes/today.md", contents: "hello" },
+      },
+    ]);
+  });
+
+  test("creates an edit_file tool that reads raw content and writes the replacement", async () => {
+    const rpc = new FakeRpcClient([
+      { path: "notes/today.md", content: "hello world", content_type: "text" },
+      { path: "notes/today.md", bytes_written: 12 },
+    ]);
+    const [, editFile] = createNativeWriteTools(rpc);
+
+    const result = await editFile.execute(
+      { path: "notes/today.md", old_text: "world", new_text: "desktop" },
+      { runId: "run-1", traceId: "trace-1" },
+    );
+
+    expect(editFile.name).toBe("edit_file");
+    expect(result.content).toBe("Edited notes/today.md.");
+    expect(rpc.requests).toEqual([
+      {
+        traceId: "trace-1",
+        method: "workspace.read_file",
+        params: { path: "notes/today.md", format: "raw" },
+      },
+      {
+        traceId: "trace-1",
+        method: "workspace.write_file",
+        params: { path: "notes/today.md", contents: "hello desktop" },
+      },
+    ]);
+  });
+
+  test("edit_file warns when a replacement is ambiguous", async () => {
+    const rpc = new FakeRpcClient([{ path: "notes/today.md", content: "repeat\nrepeat\n", content_type: "text" }]);
+    const [, editFile] = createNativeWriteTools(rpc);
+
+    const result = await editFile.execute(
+      { path: "notes/today.md", old_text: "repeat", new_text: "once" },
+      { runId: "run-1", traceId: "trace-1" },
+    );
+
+    expect(result.content).toBe("Warning: old_text appears 2 times. Provide more context to make it unique, or set replace_all=true.");
+    expect(rpc.requests).toHaveLength(1);
+  });
+
+  test("creates a delete_file tool backed by workspace.delete_file", async () => {
+    const rpc = new FakeRpcClient([{ path: "notes", deleted: true, kind: "dir" }]);
+    const [, , deleteFile] = createNativeWriteTools(rpc);
+
+    const result = await deleteFile.execute(
+      { path: "notes", recursive: true },
+      { runId: "run-1", traceId: "trace-1" },
+    );
+
+    expect(deleteFile.name).toBe("delete_file");
+    expect(result.content).toBe("Deleted dir notes.");
+    expect(rpc.requests).toEqual([
+      {
+        traceId: "trace-1",
+        method: "workspace.delete_file",
+        params: { path: "notes", recursive: true },
+      },
+    ]);
+  });
+});
+
+describe("createNativeShellTools", () => {
+  test("creates an exec tool backed by shell.execute", async () => {
+    const rpc = new FakeRpcClient([
+      {
+        stdout: "hello\n",
+        stderr: "",
+        exit_code: 0,
+        timed_out: false,
+        blocked: false,
+        truncated: false,
+        content: "hello\n\nExit code: 0",
+      },
+    ]);
+    const [exec] = createNativeShellTools(rpc);
+
+    const result = await exec.execute(
+      { command: "echo hello", working_dir: ".", timeout: 5 },
+      { runId: "run-1", traceId: "trace-1" },
+    );
+
+    expect(exec.name).toBe("exec");
+    expect(exec.exclusive).toBe(true);
+    expect(result.content).toBe("hello\n\nExit code: 0");
+    expect(result.metadata).toEqual({ exitCode: 0, timedOut: false, blocked: false, truncated: false });
+    expect(rpc.requests).toEqual([
+      {
+        traceId: "trace-1",
+        method: "shell.execute",
+        params: { command: "echo hello", working_dir: ".", timeout: 5, restrict_to_workspace: true },
       },
     ]);
   });

--- a/apps/desktop/workers/ts-agent-worker/src/tools/nativeToolProxy.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/nativeToolProxy.ts
@@ -9,6 +9,14 @@ export function createNativeReadOnlyTools(rpcClient: NativeRpcClient): Tool[] {
   return [createReadFileTool(rpcClient), createListDirTool(rpcClient)];
 }
 
+export function createNativeWriteTools(rpcClient: NativeRpcClient): Tool[] {
+  return [createWriteFileTool(rpcClient), createEditFileTool(rpcClient), createDeleteFileTool(rpcClient)];
+}
+
+export function createNativeShellTools(rpcClient: NativeRpcClient): Tool[] {
+  return [createExecTool(rpcClient)];
+}
+
 export function createNativeApprovalTools(rpcClient: NativeRpcClient): Tool[] {
   return [createRequestApprovalTool(rpcClient)];
 }
@@ -32,19 +40,37 @@ export function createNativeMcpTools(rpcClient: NativeRpcClient): Tool[] {
 function createReadFileTool(rpcClient: NativeRpcClient): Tool {
   return {
     name: "read_file",
-    description: "Read the contents of a workspace file.",
+    description: "Read the contents of a file. Returns numbered lines. Use offset and limit to paginate through large files.",
+    readOnly: true,
+    concurrencySafe: true,
+    capabilities: ["fs.workspace.read"],
     parameters: {
       type: "object",
       properties: {
         path: { type: "string", description: "The workspace-relative file path to read" },
+        offset: { type: "integer", minimum: 1, description: "Line number to start reading from (1-indexed, default 1)" },
+        limit: { type: "integer", minimum: 1, description: "Maximum number of lines to read (default 2000)" },
       },
       required: ["path"],
     },
     execute: async (args, context) => {
       const path = stringArg(args, "path");
-      const result = await rpcClient.request(requireTraceId(context.traceId), "workspace.read_file", { path });
+      const offset = optionalIntegerArg(args, "offset");
+      const limit = optionalIntegerArg(args, "limit");
+      const params: JsonObject = { path, format: "numbered_lines" };
+      if (offset !== undefined) {
+        params.offset = offset;
+      }
+      if (limit !== undefined) {
+        params.limit = limit;
+      }
+      const result = await rpcClient.request(requireTraceId(context.traceId), "workspace.read_file", params);
       const file = asObject(result);
-      const contents = file && typeof file.contents === "string" ? file.contents : "";
+      const contents = typeof file?.content === "string"
+        ? file.content
+        : typeof file?.contents === "string"
+          ? file.contents
+          : "";
       return { content: contents };
     },
   };
@@ -53,24 +79,181 @@ function createReadFileTool(rpcClient: NativeRpcClient): Tool {
 function createListDirTool(rpcClient: NativeRpcClient): Tool {
   return {
     name: "list_dir",
-    description: "List workspace files.",
+    description: "List the contents of a directory. Set recursive=true to explore nested structure.",
+    readOnly: true,
+    concurrencySafe: true,
+    capabilities: ["fs.workspace.read"],
     parameters: {
       type: "object",
       properties: {
-        path: { type: "string", description: "Ignored for now; the native gateway lists the active workspace" },
+        path: { type: "string", description: "The workspace-relative directory path to list" },
+        recursive: { type: "boolean", description: "Recursively list all files (default false)" },
+        max_entries: { type: "integer", minimum: 1, description: "Maximum entries to return (default 200)" },
       },
+      required: ["path"],
     },
-    execute: async (_args, context) => {
-      const result = await rpcClient.request(requireTraceId(context.traceId), "workspace.list_files", {});
-      const entries = Array.isArray(result) ? result : [];
+    execute: async (args, context) => {
+      const path = stringArg(args, "path");
+      const recursive = optionalBooleanArg(args, "recursive");
+      const maxEntries = optionalIntegerArg(args, "max_entries");
+      const params: JsonObject = { path };
+      if (recursive !== undefined) {
+        params.recursive = recursive;
+      }
+      if (maxEntries !== undefined) {
+        params.max_entries = maxEntries;
+      }
+      const result = await rpcClient.request(requireTraceId(context.traceId), "workspace.list_dir", params);
+      const response = asObject(result);
+      const entries = Array.isArray(response?.entries) ? response.entries : Array.isArray(result) ? result : [];
       return {
         content: entries
           .map((entry) => {
             const object = asObject(entry);
-            return typeof object?.path === "string" ? object.path : null;
+            if (typeof object?.path !== "string") {
+              return null;
+            }
+            return object.kind === "dir" && !object.path.endsWith("/") ? `${object.path}/` : object.path;
           })
           .filter((path): path is string => path !== null)
           .join("\n"),
+      };
+    },
+  };
+}
+
+function createWriteFileTool(rpcClient: NativeRpcClient): Tool {
+  return {
+    name: "write_file",
+    description: "Write content to a file at the given path. Creates parent directories if needed.",
+    capabilities: ["fs.workspace.write"],
+    requiresApproval: true,
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["path", "content"],
+    },
+    execute: async (args, context) => {
+      const path = stringArg(args, "path");
+      const content = stringArgAllowEmpty(args, "content");
+      const result = asObject(await rpcClient.request(requireTraceId(context.traceId), "workspace.write_file", {
+        path,
+        contents: content,
+      })) ?? {};
+      const resultPath = asString(result.path) ?? path;
+      const bytesWritten = typeof result.bytes_written === "number" ? result.bytes_written : content.length;
+      return { content: `Wrote ${bytesWritten} bytes to ${resultPath}.` };
+    },
+  };
+}
+
+function createEditFileTool(rpcClient: NativeRpcClient): Tool {
+  return {
+    name: "edit_file",
+    description: "Edit a file by replacing old_text with new_text. Set replace_all=true to replace every occurrence.",
+    capabilities: ["fs.workspace.write"],
+    requiresApproval: true,
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        old_text: { type: "string" },
+        new_text: { type: "string" },
+        replace_all: { type: "boolean" },
+      },
+      required: ["path", "old_text", "new_text"],
+    },
+    execute: async (args, context) => {
+      const path = stringArg(args, "path");
+      const oldText = stringArgAllowEmpty(args, "old_text");
+      const newText = stringArgAllowEmpty(args, "new_text");
+      const replaceAll = optionalBooleanArg(args, "replace_all") ?? false;
+      const traceId = requireTraceId(context.traceId);
+      const file = asObject(await rpcClient.request(traceId, "workspace.read_file", { path, format: "raw" })) ?? {};
+      const rawContent = typeof file.content === "string"
+        ? file.content
+        : typeof file.contents === "string"
+          ? file.contents
+          : "";
+      const edit = applyTextEdit(rawContent, oldText, newText, replaceAll, path);
+      if (!edit.ok) {
+        return { content: edit.content };
+      }
+      await rpcClient.request(traceId, "workspace.write_file", { path, contents: edit.content });
+      return { content: `Edited ${path}.` };
+    },
+  };
+}
+
+function createDeleteFileTool(rpcClient: NativeRpcClient): Tool {
+  return {
+    name: "delete_file",
+    description: "Delete a file or directory. Directories must be empty unless recursive=true.",
+    capabilities: ["fs.workspace.write"],
+    requiresApproval: true,
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        recursive: { type: "boolean" },
+      },
+      required: ["path"],
+    },
+    execute: async (args, context) => {
+      const path = stringArg(args, "path");
+      const recursive = optionalBooleanArg(args, "recursive") ?? false;
+      const result = asObject(await rpcClient.request(requireTraceId(context.traceId), "workspace.delete_file", {
+        path,
+        recursive,
+      })) ?? {};
+      const resultPath = asString(result.path) ?? path;
+      const kind = asString(result.kind) ?? "path";
+      return { content: `Deleted ${kind} ${resultPath}.` };
+    },
+  };
+}
+
+function createExecTool(rpcClient: NativeRpcClient): Tool {
+  return {
+    name: "exec",
+    description: "Execute a shell command in the workspace and return output. Use with caution.",
+    exclusive: true,
+    capabilities: ["shell.execute"],
+    requiresApproval: true,
+    parameters: {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+        working_dir: { type: "string" },
+        timeout: { type: "integer", minimum: 1, maximum: 600 },
+      },
+      required: ["command"],
+    },
+    execute: async (args, context) => {
+      const params: JsonObject = {
+        command: stringArg(args, "command"),
+        restrict_to_workspace: true,
+      };
+      const workingDir = optionalStringArg(args, "working_dir");
+      const timeout = optionalIntegerArg(args, "timeout");
+      if (workingDir !== undefined) {
+        params.working_dir = workingDir;
+      }
+      if (timeout !== undefined) {
+        params.timeout = timeout;
+      }
+      const result = asObject(await rpcClient.request(requireTraceId(context.traceId), "shell.execute", params)) ?? {};
+      return {
+        content: asString(result.content) ?? formatShellResult(result),
+        metadata: {
+          exitCode: typeof result.exit_code === "number" ? result.exit_code : undefined,
+          timedOut: result.timed_out === true,
+          blocked: result.blocked === true,
+          truncated: result.truncated === true,
+        },
       };
     },
   };
@@ -80,6 +263,7 @@ function createRequestFormTool(rpcClient: NativeRpcClient): Tool {
   return {
     name: "request_form",
     description: "Request structured user input through the native Agent UI form renderer.",
+    capabilities: ["form.request"],
     parameters: {
       type: "object",
       properties: {
@@ -128,6 +312,7 @@ function createRequestApprovalTool(rpcClient: NativeRpcClient): Tool {
   return {
     name: "request_approval",
     description: "Request user approval for a pending native operation before it is executed.",
+    capabilities: ["approval.request"],
     parameters: {
       type: "object",
       properties: {
@@ -167,6 +352,9 @@ function createSearchMemoryNotesTool(rpcClient: NativeRpcClient): Tool {
   return {
     name: "search_memory_notes",
     description: "Search Memory Notes by query, type, status, and limit without mixing in Experience or Knowledge Base.",
+    readOnly: true,
+    concurrencySafe: true,
+    capabilities: ["memory.read"],
     parameters: {
       type: "object",
       properties: {
@@ -201,6 +389,9 @@ function createQueryRagTool(rpcClient: NativeRpcClient): Tool {
   return {
     name: "query_rag",
     description: "Query the native retrieval index for workspace knowledge relevant to the current task.",
+    readOnly: true,
+    concurrencySafe: true,
+    capabilities: ["fs.workspace.read"],
     parameters: {
       type: "object",
       properties: {
@@ -234,6 +425,8 @@ function createSaveMemoryNoteTool(rpcClient: NativeRpcClient): Tool {
     name: "save_memory_note",
     description:
       "Save durable agent-side memory as a typed Memory Note. Use this only for durable preferences, instructions, project facts, decisions, fixes, or followups.",
+    capabilities: ["memory.write"],
+    requiresApproval: true,
     parameters: {
       type: "object",
       properties: {
@@ -302,6 +495,7 @@ function createCallMcpTool(rpcClient: NativeRpcClient): Tool {
   return {
     name: "call_mcp_tool",
     description: "Call an allowlisted tool on a configured native MCP server.",
+    capabilities: ["mcp.call"],
     parameters: {
       type: "object",
       properties: {
@@ -348,6 +542,14 @@ function optionalStringArg(args: Record<string, unknown>, key: string): string |
   return value;
 }
 
+function stringArgAllowEmpty(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string") {
+    throw new Error(`${key} must be a string`);
+  }
+  return value;
+}
+
 function objectArg(args: Record<string, unknown>, key: string): JsonObject {
   const value = args[key];
   const object = asObject(value);
@@ -379,6 +581,17 @@ function optionalIntegerArg(args: Record<string, unknown>, key: string): number 
   return value;
 }
 
+function optionalBooleanArg(args: Record<string, unknown>, key: string): boolean | undefined {
+  const value = args[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`${key} must be a boolean when provided`);
+  }
+  return value;
+}
+
 function copyOptionalStringArg(args: Record<string, unknown>, params: JsonObject, key: string): void {
   const value = optionalStringArg(args, key);
   if (value !== undefined) {
@@ -399,6 +612,67 @@ function asObject(value: unknown): JsonObject | null {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function applyTextEdit(
+  content: string,
+  oldText: string,
+  newText: string,
+  replaceAll: boolean,
+  path: string,
+): { ok: true; content: string } | { ok: false; content: string } {
+  const usesCrLf = content.includes("\r\n");
+  const normalizedContent = content.replace(/\r\n/g, "\n");
+  const normalizedOld = oldText.replace(/\r\n/g, "\n");
+  const normalizedNew = newText.replace(/\r\n/g, "\n");
+  const match = findTextMatch(normalizedContent, normalizedOld);
+  if (!match.fragment) {
+    return { ok: false, content: `Error: old_text not found in ${path}. Verify the file content.` };
+  }
+  if (match.count > 1 && !replaceAll) {
+    return {
+      ok: false,
+      content: `Warning: old_text appears ${match.count} times. Provide more context to make it unique, or set replace_all=true.`,
+    };
+  }
+  const updated = replaceAll
+    ? normalizedContent.split(match.fragment).join(normalizedNew)
+    : normalizedContent.replace(match.fragment, normalizedNew);
+  return { ok: true, content: usesCrLf ? updated.replace(/\n/g, "\r\n") : updated };
+}
+
+function findTextMatch(content: string, oldText: string): { fragment: string | null; count: number } {
+  if (oldText.length > 0 && content.includes(oldText)) {
+    return { fragment: oldText, count: content.split(oldText).length - 1 };
+  }
+  const oldLines = oldText.split("\n");
+  if (oldLines.length === 0) {
+    return { fragment: null, count: 0 };
+  }
+  const strippedOld = oldLines.map((line) => line.trim());
+  const contentLines = content.split("\n");
+  const candidates: string[] = [];
+  for (let index = 0; index <= contentLines.length - strippedOld.length; index += 1) {
+    const window = contentLines.slice(index, index + strippedOld.length);
+    if (window.map((line) => line.trim()).join("\n") === strippedOld.join("\n")) {
+      candidates.push(window.join("\n"));
+    }
+  }
+  return { fragment: candidates[0] ?? null, count: candidates.length };
+}
+
+function formatShellResult(result: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof result.stdout === "string" && result.stdout.length > 0) {
+    parts.push(result.stdout);
+  }
+  if (typeof result.stderr === "string" && result.stderr.trim().length > 0) {
+    parts.push(`STDERR:\n${result.stderr}`);
+  }
+  if (typeof result.exit_code === "number") {
+    parts.push(`Exit code: ${result.exit_code}`);
+  }
+  return parts.join("\n").trim() || "(no output)";
 }
 
 function formatMemoryNotes(notes: unknown[]): string {

--- a/apps/desktop/workers/ts-agent-worker/src/tools/tool.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/tool.ts
@@ -11,9 +11,51 @@ export type ToolResult = {
   metadata?: Record<string, unknown>;
 };
 
+export type ToolMetadata = {
+  readOnly?: boolean;
+  exclusive?: boolean;
+  concurrencySafe?: boolean;
+  capabilities?: string[];
+  requiresApproval?: boolean;
+};
+
+export type ToolDefinition = {
+  name: string;
+  description: string;
+  parameters: JsonSchema;
+};
+
+export type ToolExecutionErrorKind = "unknown_tool" | "invalid_params" | "native_error" | "exception";
+
+export type ToolExecutionError = {
+  kind: ToolExecutionErrorKind;
+  message: string;
+  details?: Record<string, unknown>;
+};
+
+export type ToolExecutionResult = ToolResult & {
+  ok: boolean;
+  error?: ToolExecutionError;
+};
+
+export type PreparedToolCall =
+  | { ok: true; tool: Tool; args: Record<string, unknown> }
+  | {
+      ok: false;
+      content: string;
+      tool?: Tool;
+      args: Record<string, unknown>;
+      error: ToolExecutionError;
+    };
+
 export interface Tool {
   name: string;
   description: string;
   parameters: JsonSchema;
+  readOnly?: boolean;
+  exclusive?: boolean;
+  concurrencySafe?: boolean;
+  capabilities?: string[];
+  requiresApproval?: boolean;
   execute(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult>;
 }

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolPolicy.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolPolicy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import type { Tool } from "./tool";
+import { filterToolsByPolicy, registerToolsByPolicy } from "./toolPolicy";
+import { ToolRegistry } from "./toolRegistry";
+
+function tool(name: string, capabilities: string[] = []): Tool {
+  return {
+    name,
+    description: name,
+    parameters: { type: "object" },
+    capabilities,
+    execute: async () => ({ content: name }),
+  };
+}
+
+describe("toolPolicy", () => {
+  test("filters tools whose required capabilities are missing", () => {
+    const tools = [
+      tool("read_file", ["fs.workspace.read"]),
+      tool("write_file", ["fs.workspace.write"]),
+      tool("exec", ["shell.execute"]),
+      tool("local", []),
+    ];
+
+    expect(filterToolsByPolicy(tools, { capabilities: ["fs.workspace.read"] }).map((item) => item.name)).toEqual([
+      "read_file",
+      "local",
+    ]);
+  });
+
+  test("keeps form tools only for channels that can render forms", () => {
+    const formTool = tool("request_form", ["form.request"]);
+
+    expect(filterToolsByPolicy([formTool], { capabilities: ["form.request"], channel: "agent_ui" })).toEqual([
+      formTool,
+    ]);
+    expect(filterToolsByPolicy([formTool], { capabilities: ["form.request"], channel: "stdio" })).toEqual([]);
+  });
+
+  test("registers only policy-enabled tools", () => {
+    const registry = new ToolRegistry();
+
+    registerToolsByPolicy(registry, [tool("read_file", ["fs.workspace.read"]), tool("exec", ["shell.execute"])], {
+      capabilities: ["fs.workspace.read"],
+    });
+
+    expect(registry.toolNames).toEqual(["read_file"]);
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolPolicy.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolPolicy.ts
@@ -1,0 +1,33 @@
+import type { Tool } from "./tool.ts";
+import type { ToolRegistry } from "./toolRegistry.ts";
+
+export type ToolPolicyOptions = {
+  capabilities: Iterable<string>;
+  channel?: "agent_ui" | "stdio" | "headless" | string;
+};
+
+export function filterToolsByPolicy(tools: Iterable<Tool>, options: ToolPolicyOptions): Tool[] {
+  const capabilities = new Set(options.capabilities);
+  return Array.from(tools).filter((tool) => toolAllowedByPolicy(tool, capabilities, options.channel));
+}
+
+export function registerToolsByPolicy(
+  registry: ToolRegistry,
+  tools: Iterable<Tool>,
+  options: ToolPolicyOptions,
+): void {
+  for (const tool of filterToolsByPolicy(tools, options)) {
+    registry.register(tool);
+  }
+}
+
+function toolAllowedByPolicy(tool: Tool, capabilities: Set<string>, channel: string | undefined): boolean {
+  const requiredCapabilities = tool.capabilities ?? [];
+  if (!requiredCapabilities.every((capability) => capabilities.has(capability))) {
+    return false;
+  }
+  if (tool.name === "request_form" && channel !== undefined && channel !== "agent_ui") {
+    return false;
+  }
+  return true;
+}

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolRegistry.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolRegistry.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+
+import type { Tool } from "./tool";
+import { ToolRegistry } from "./toolRegistry";
+
+function echoTool(overrides: Partial<Tool> = {}): Tool {
+  return {
+    name: "echo",
+    description: "Echo text",
+    parameters: {
+      type: "object",
+      properties: { text: { type: "string" }, count: { type: "integer" } },
+      required: ["text"],
+    },
+    execute: async (args) => ({ content: `echo:${String(args.text)}:${String(args.count)}` }),
+    ...overrides,
+  };
+}
+
+describe("ToolRegistry", () => {
+  test("supports register, get, has, and unregister", () => {
+    const registry = new ToolRegistry();
+    const tool = echoTool();
+
+    registry.register(tool);
+
+    expect(registry.has("echo")).toBe(true);
+    expect(registry.get("echo")).toBe(tool);
+
+    registry.unregister("echo");
+
+    expect(registry.has("echo")).toBe(false);
+    expect(registry.get("echo")).toBeUndefined();
+  });
+
+  test("definitions omit internal tool metadata", () => {
+    const registry = new ToolRegistry();
+    registry.register(echoTool({
+      readOnly: true,
+      exclusive: true,
+      concurrencySafe: true,
+      capabilities: ["fs.workspace.read"],
+      requiresApproval: true,
+    }));
+
+    expect(registry.definitions()).toEqual([
+      {
+        name: "echo",
+        description: "Echo text",
+        parameters: {
+          type: "object",
+          properties: { text: { type: "string" }, count: { type: "integer" } },
+          required: ["text"],
+        },
+      },
+    ]);
+  });
+
+  test("filtered returns a registry that shares included tool instances", () => {
+    const registry = new ToolRegistry();
+    const echo = echoTool();
+    const hidden = echoTool({ name: "hidden" });
+    registry.register(echo);
+    registry.register(hidden);
+
+    const filtered = registry.filtered({ exclude: new Set(["hidden"]) });
+
+    expect(filtered).not.toBe(registry);
+    expect(filtered.get("echo")).toBe(echo);
+    expect(filtered.has("hidden")).toBe(false);
+  });
+
+  test("prepareCall returns a model-visible error for unknown tools", () => {
+    const registry = new ToolRegistry();
+    registry.register(echoTool());
+
+    expect(registry.prepareCall("missing", { text: "hello" })).toEqual({
+      ok: false,
+      args: { text: "hello" },
+      content: "Error: Tool 'missing' not found. Available: echo",
+      error: {
+        kind: "unknown_tool",
+        message: "Tool 'missing' not found.",
+      },
+    });
+  });
+
+  test("prepareCall casts arguments before validating them", () => {
+    const registry = new ToolRegistry();
+    const tool = echoTool();
+    registry.register(tool);
+
+    expect(registry.prepareCall("echo", { text: 12, count: "3" })).toEqual({
+      ok: true,
+      tool,
+      args: { text: "12", count: 3 },
+    });
+  });
+
+  test("prepareCall returns validation errors without executing the tool", () => {
+    const registry = new ToolRegistry();
+    registry.register(echoTool());
+
+    expect(registry.prepareCall("echo", { count: "bad" })).toEqual({
+      ok: false,
+      tool: registry.get("echo"),
+      args: { count: "bad" },
+      content: "Error: Invalid parameters for tool 'echo': missing required text; count should be integer",
+      error: {
+        kind: "invalid_params",
+        message: "missing required text; count should be integer",
+      },
+    });
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolRegistry.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolRegistry.test.ts
@@ -46,7 +46,7 @@ describe("ToolRegistry", () => {
     expect(registry.definitions()).toEqual([
       {
         name: "echo",
-        description: "Echo text",
+        description: "Echo text\nRequires user approval before execution.",
         parameters: {
           type: "object",
           properties: { text: { type: "string" }, count: { type: "integer" } },

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolRegistry.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolRegistry.ts
@@ -23,7 +23,9 @@ export class ToolRegistry {
   definitions(): ToolDefinition[] {
     return Array.from(this.tools.values()).map((tool) => ({
       name: tool.name,
-      description: tool.description,
+      description: tool.requiresApproval
+        ? `${tool.description}\nRequires user approval before execution.`
+        : tool.description,
       parameters: tool.parameters,
     }));
   }

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolRegistry.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolRegistry.ts
@@ -1,4 +1,5 @@
-import type { Tool, ToolContext, ToolResult } from "./tool.ts";
+import type { PreparedToolCall, Tool, ToolContext, ToolDefinition, ToolResult } from "./tool.ts";
+import { castJsonSchemaValue, validateJsonSchemaValue } from "./toolSchema.ts";
 
 export class ToolRegistry {
   private readonly tools = new Map<string, Tool>();
@@ -7,11 +8,19 @@ export class ToolRegistry {
     this.tools.set(tool.name, tool);
   }
 
+  unregister(name: string): void {
+    this.tools.delete(name);
+  }
+
+  get(name: string): Tool | undefined {
+    return this.tools.get(name);
+  }
+
   has(name: string): boolean {
     return this.tools.has(name);
   }
 
-  definitions(): Array<Pick<Tool, "name" | "description" | "parameters">> {
+  definitions(): ToolDefinition[] {
     return Array.from(this.tools.values()).map((tool) => ({
       name: tool.name,
       description: tool.description,
@@ -19,11 +28,92 @@ export class ToolRegistry {
     }));
   }
 
-  async execute(name: string, args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
+  filtered(options: { exclude?: Set<string> | string[] } = {}): ToolRegistry {
+    const exclude = new Set(options.exclude ?? []);
+    if (exclude.size === 0) {
+      return this;
+    }
+    const registry = new ToolRegistry();
+    for (const [name, tool] of this.tools.entries()) {
+      if (!exclude.has(name)) {
+        registry.register(tool);
+      }
+    }
+    return registry;
+  }
+
+  prepareCall(name: string, args: Record<string, unknown>): PreparedToolCall {
     const tool = this.tools.get(name);
     if (!tool) {
-      throw new Error(`unknown tool: ${name}`);
+      return {
+        ok: false,
+        args,
+        content: `Error: Tool '${name}' not found. Available: ${this.toolNames.join(", ")}`,
+        error: {
+          kind: "unknown_tool",
+          message: `Tool '${name}' not found.`,
+        },
+      };
     }
-    return tool.execute(args, context);
+
+    const preparedArgs = prepareToolArguments(tool, args);
+    const errors = validateToolArguments(tool, preparedArgs);
+    if (errors.length > 0) {
+      const message = errors.join("; ");
+      return {
+        ok: false,
+        tool,
+        args: preparedArgs,
+        content: `Error: Invalid parameters for tool '${name}': ${message}`,
+        error: {
+          kind: "invalid_params",
+          message,
+        },
+      };
+    }
+    return {
+      ok: true,
+      tool,
+      args: preparedArgs,
+    };
   }
+
+  async execute(name: string, args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
+    const prepared = this.prepareCall(name, args);
+    if (!prepared.ok) {
+      return { content: prepared.content };
+    }
+    return prepared.tool.execute(prepared.args, context);
+  }
+
+  get toolNames(): string[] {
+    return Array.from(this.tools.keys());
+  }
+}
+
+function prepareToolArguments(tool: Tool, args: Record<string, unknown>): Record<string, unknown> {
+  const schema = asRecord(tool.parameters);
+  if (!schema || schema.type !== "object") {
+    return args;
+  }
+  const castArgs = castJsonSchemaValue(args, schema);
+  return asRecord(castArgs) ?? args;
+}
+
+function validateToolArguments(tool: Tool, args: Record<string, unknown>): string[] {
+  const schema = asRecord(tool.parameters);
+  if (!schema) {
+    return [];
+  }
+  if (schema.type !== undefined && schema.type !== "object") {
+    return [`parameters schema must be object type, got ${String(schema.type)}`];
+  }
+  return validateJsonSchemaValue(args, { ...schema, type: "object" });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
 }

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolRuntime.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolRuntime.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+
+import { ToolRegistry } from "./toolRegistry";
+import { ToolRuntime } from "./toolRuntime";
+
+const retryHint = "\n\n[Analyze the error above and try a different approach.]";
+
+describe("ToolRuntime", () => {
+  test("returns prepared-call errors as tool results with a retry hint", async () => {
+    const runtime = new ToolRuntime(new ToolRegistry());
+
+    await expect(runtime.execute("missing", {}, { runId: "run-1" })).resolves.toEqual({
+      ok: false,
+      content: `Error: Tool 'missing' not found. Available: ${retryHint}`,
+      error: {
+        kind: "unknown_tool",
+        message: "Tool 'missing' not found.",
+      },
+    });
+  });
+
+  test("wraps thrown tool exceptions as model-visible errors", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "fail",
+      description: "Fail",
+      parameters: { type: "object" },
+      execute: async () => {
+        throw new Error("boom");
+      },
+    });
+    const runtime = new ToolRuntime(registry);
+
+    await expect(runtime.execute("fail", {}, { runId: "run-1" })).resolves.toEqual({
+      ok: false,
+      content: `Error executing fail: boom${retryHint}`,
+      error: {
+        kind: "exception",
+        message: "boom",
+      },
+    });
+  });
+
+  test("adds a retry hint to Error-like tool content while preserving metadata", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "guarded",
+      description: "Guarded",
+      parameters: { type: "object" },
+      execute: async () => ({ content: "Error: blocked", metadata: { blocked: true } }),
+    });
+    const runtime = new ToolRuntime(registry);
+
+    await expect(runtime.execute("guarded", {}, { runId: "run-1" })).resolves.toEqual({
+      ok: false,
+      content: `Error: blocked${retryHint}`,
+      metadata: { blocked: true },
+      error: {
+        kind: "native_error",
+        message: "Error: blocked",
+      },
+    });
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolRuntime.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolRuntime.ts
@@ -1,0 +1,64 @@
+import type { ToolContext, ToolExecutionErrorKind, ToolExecutionResult } from "./tool.ts";
+import type { ToolRegistry } from "./toolRegistry.ts";
+
+const TOOL_RETRY_HINT = "\n\n[Analyze the error above and try a different approach.]";
+
+export class ToolRuntime {
+  constructor(private readonly registry: ToolRegistry) {}
+
+  async execute(name: string, args: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const prepared = this.registry.prepareCall(name, args);
+    if (!prepared.ok) {
+      return {
+        ok: false,
+        content: appendRetryHint(prepared.content),
+        error: prepared.error,
+      };
+    }
+
+    try {
+      const result = await prepared.tool.execute(prepared.args, context);
+      if (isErrorContent(result.content)) {
+        return {
+          ok: false,
+          content: appendRetryHint(result.content),
+          metadata: result.metadata,
+          error: {
+            kind: "native_error",
+            message: result.content,
+          },
+        };
+      }
+      return {
+        ok: true,
+        ...result,
+      };
+    } catch (error) {
+      const message = errorMessage(error);
+      return errorResult("exception", `Error executing ${name}: ${message}`, message);
+    }
+  }
+}
+
+function errorResult(kind: ToolExecutionErrorKind, content: string, message: string): ToolExecutionResult {
+  return {
+    ok: false,
+    content: appendRetryHint(content),
+    error: {
+      kind,
+      message,
+    },
+  };
+}
+
+function isErrorContent(content: string): boolean {
+  return content.startsWith("Error");
+}
+
+function appendRetryHint(content: string): string {
+  return content.includes(TOOL_RETRY_HINT) ? content : `${content}${TOOL_RETRY_HINT}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolSchema.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolSchema.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+
+import { castJsonSchemaValue, validateJsonSchemaValue } from "./toolSchema";
+
+describe("toolSchema", () => {
+  test("casts string primitives using JSON schema types", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        count: { type: "integer" },
+        score: { type: "number" },
+        enabled: { type: "boolean" },
+        label: { type: "string" },
+      },
+    };
+
+    expect(castJsonSchemaValue({ count: "10", score: "0.75", enabled: "yes", label: 42 }, schema)).toEqual({
+      count: 10,
+      score: 0.75,
+      enabled: true,
+      label: "42",
+    });
+  });
+
+  test("casts nested object properties and array items", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        filters: {
+          type: "object",
+          properties: {
+            limit: { type: "integer" },
+            recursive: { type: "boolean" },
+          },
+        },
+        values: {
+          type: "array",
+          items: { type: "integer" },
+        },
+      },
+    };
+
+    expect(castJsonSchemaValue({ filters: { limit: "5", recursive: "false" }, values: ["1", "2"] }, schema)).toEqual({
+      filters: { limit: 5, recursive: false },
+      values: [1, 2],
+    });
+  });
+
+  test("accepts nullable schema types", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        value: { type: ["integer", "null"] },
+      },
+      required: ["value"],
+    };
+
+    expect(validateJsonSchemaValue({ value: null }, schema)).toEqual([]);
+  });
+
+  test("validates required fields, enum values, bounds, lengths, and array items", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        mode: { type: "string", enum: ["fast", "slow"] },
+        count: { type: "integer", minimum: 1, maximum: 3 },
+        title: { type: "string", minLength: 2, maxLength: 4 },
+        values: { type: "array", minItems: 1, maxItems: 2, items: { type: "integer" } },
+      },
+      required: ["mode", "count", "title", "values"],
+    };
+
+    expect(validateJsonSchemaValue({ mode: "medium", count: 4, title: "a", values: ["x", 2, 3] }, schema)).toEqual([
+      "mode must be one of ['fast', 'slow']",
+      "count must be <= 3",
+      "title must be at least 2 chars",
+      "values must be at most 2 items",
+      "values[0] should be integer",
+    ]);
+  });
+});

--- a/apps/desktop/workers/ts-agent-worker/src/tools/toolSchema.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/toolSchema.ts
@@ -1,0 +1,156 @@
+export function castJsonSchemaValue(value: unknown, schema: Record<string, unknown>): unknown {
+  const schemaType = resolveJsonSchemaType(schema.type);
+  if (schemaType === "object") {
+    const objectValue = asRecord(value);
+    if (!objectValue) {
+      return value;
+    }
+    const properties = asRecord(schema.properties) ?? {};
+    return Object.fromEntries(
+      Object.entries(objectValue).map(([key, childValue]) => {
+        const childSchema = asRecord(properties[key]);
+        return [key, childSchema ? castJsonSchemaValue(childValue, childSchema) : childValue];
+      }),
+    );
+  }
+  if (typeof value === "string" && schemaType === "integer") {
+    const parsed = Number(value);
+    return Number.isInteger(parsed) ? parsed : value;
+  }
+  if (typeof value === "string" && schemaType === "number") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : value;
+  }
+  if (typeof value === "string" && schemaType === "boolean") {
+    const lower = value.toLowerCase();
+    if (lower === "true" || lower === "1" || lower === "yes") {
+      return true;
+    }
+    if (lower === "false" || lower === "0" || lower === "no") {
+      return false;
+    }
+  }
+  if (Array.isArray(value) && schemaType === "array") {
+    const itemSchema = asRecord(schema.items);
+    return itemSchema ? value.map((item) => castJsonSchemaValue(item, itemSchema)) : value;
+  }
+  if (schemaType === "string" && value !== null && value !== undefined) {
+    return String(value);
+  }
+  return value;
+}
+
+export function validateJsonSchemaValue(value: unknown, schema: Record<string, unknown>, path = ""): string[] {
+  const rawType = schema.type;
+  const nullable = (Array.isArray(rawType) && rawType.includes("null")) || schema.nullable === true;
+  const schemaType = resolveJsonSchemaType(rawType);
+  const label = path || "parameter";
+
+  if (nullable && value === null) {
+    return [];
+  }
+  const typeError = validateJsonSchemaType(value, schemaType, label);
+  if (typeError) {
+    return [typeError];
+  }
+
+  const errors: string[] = [];
+  if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
+    errors.push(`${label} must be one of ${formatJsonSchemaEnum(schema.enum)}`);
+  }
+  if ((schemaType === "integer" || schemaType === "number") && typeof value === "number") {
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      errors.push(`${label} must be >= ${schema.minimum}`);
+    }
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      errors.push(`${label} must be <= ${schema.maximum}`);
+    }
+  }
+  if (schemaType === "string" && typeof value === "string") {
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      errors.push(`${label} must be at least ${schema.minLength} chars`);
+    }
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+      errors.push(`${label} must be at most ${schema.maxLength} chars`);
+    }
+  }
+  if (schemaType === "object") {
+    const objectValue = asRecord(value) ?? {};
+    const properties = asRecord(schema.properties) ?? {};
+    const required = Array.isArray(schema.required) ? schema.required : [];
+    for (const key of required) {
+      if (typeof key === "string" && !(key in objectValue)) {
+        errors.push(`missing required ${subpath(path, key)}`);
+      }
+    }
+    for (const [key, childValue] of Object.entries(objectValue)) {
+      const childSchema = asRecord(properties[key]);
+      if (childSchema) {
+        errors.push(...validateJsonSchemaValue(childValue, childSchema, subpath(path, key)));
+      }
+    }
+  }
+  if (schemaType === "array" && Array.isArray(value)) {
+    if (typeof schema.minItems === "number" && value.length < schema.minItems) {
+      errors.push(`${label} must have at least ${schema.minItems} items`);
+    }
+    if (typeof schema.maxItems === "number" && value.length > schema.maxItems) {
+      errors.push(`${label} must be at most ${schema.maxItems} items`);
+    }
+    const itemSchema = asRecord(schema.items);
+    if (itemSchema) {
+      for (let index = 0; index < value.length; index += 1) {
+        errors.push(...validateJsonSchemaValue(value[index], itemSchema, arrayPath(path, index)));
+      }
+    }
+  }
+  return errors;
+}
+
+export function resolveJsonSchemaType(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    return value.find((item): item is string => typeof item === "string" && item !== "null");
+  }
+  return typeof value === "string" ? value : undefined;
+}
+
+function validateJsonSchemaType(value: unknown, schemaType: string | undefined, label: string): string | undefined {
+  if (schemaType === "integer" && (typeof value !== "number" || !Number.isInteger(value))) {
+    return `${label} should be integer`;
+  }
+  if (schemaType === "number" && (typeof value !== "number" || !Number.isFinite(value))) {
+    return `${label} should be number`;
+  }
+  if (schemaType === "string" && typeof value !== "string") {
+    return `${label} should be string`;
+  }
+  if (schemaType === "boolean" && typeof value !== "boolean") {
+    return `${label} should be boolean`;
+  }
+  if (schemaType === "object" && !asRecord(value)) {
+    return `${label} should be object`;
+  }
+  if (schemaType === "array" && !Array.isArray(value)) {
+    return `${label} should be array`;
+  }
+  return undefined;
+}
+
+function subpath(path: string, key: string): string {
+  return path ? `${path}.${key}` : key;
+}
+
+function arrayPath(path: string, index: number): string {
+  return path ? `${path}[${index}]` : `[${index}]`;
+}
+
+function formatJsonSchemaEnum(values: unknown[]): string {
+  return `[${values.map((value) => typeof value === "string" ? `'${value}'` : String(value)).join(", ")}]`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary

Closes #239.

- Add TS tool schema casting/validation, registry preparation, and runtime error wrapping.
- Migrate native filesystem tools to the TS worker with Rust RPC-backed read/list/write/edit/delete behavior.
- Add Rust `shell.execute` support and expose the TS `exec` tool without executing commands in TS.
- Add capability metadata and policy-based native tool registration for the desktop TS worker.

## Validation

- `npm test` in `apps/desktop` (197 files / 849 tests passed)
- `npm run build` in `apps/desktop`
- `cargo test -- --test-threads=1` in `apps/desktop/src-tauri` (156 tests passed)

## Notes

This PR intentionally leaves Memory/MCP/RAG domain migrations beyond the existing native proxies for later dedicated migration work. Phase 7 read-only parallel tool execution remains optional and is not enabled here.