### PR TITLE
Fix native startup stalls

### DIFF
--- a/apps/desktop/src-tauri/src/worker_workspace.rs
+++ b/apps/desktop/src-tauri/src/worker_workspace.rs
@@ -12,10 +12,12 @@ const BOOTSTRAP_FILES: &[&str] = &["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"
 const DEFAULT_READ_LIMIT: usize = 2000;
 const IGNORED_DIRS: &[&str] = &[
     ".git",
+    ".codegraph",
     "node_modules",
     "__pycache__",
     ".venv",
     "venv",
+    "target",
     "dist",
     "build",
     ".tox",
@@ -581,7 +583,7 @@ fn collect_workspace_files(
                 }),
             )
         })?;
-        if metadata.file_type().is_symlink() {
+        if metadata.file_type().is_symlink() || ignored_workspace_path(root, &path) {
             continue;
         }
         if metadata.is_dir() {
@@ -1020,6 +1022,22 @@ mod tests {
         let paths: Vec<String> = files.into_iter().map(|file| file.path).collect();
 
         assert_eq!(paths, vec!["real/NOTE.md"]);
+    }
+
+    #[test]
+    fn list_files_ignores_workspace_noise_directories() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("README.md", "readme");
+        fixture.write("src/main.ts", "main");
+        fixture.write("node_modules/pkg/index.js", "noise");
+        fixture.write(".git/objects/pack.idx", "noise");
+        fixture.write("target/debug/app.exe", "noise");
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
+
+        let files = rpc.list_files().expect("workspace files should list");
+        let paths: Vec<String> = files.into_iter().map(|file| file.path).collect();
+
+        assert_eq!(paths, vec!["README.md", "src/main.ts"]);
     }
 
     #[test]

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -325,6 +325,8 @@ async function bootDesktopWebUi(): Promise<void> {
       syncNativeRuntimeMetadata();
       startupTrace.complete("nativeChromeBindings");
       hydrateNativeStartupPanes(startupTrace);
+      void ensureNativeCoworkRuntimeRolloutSynced(startupTrace);
+      scheduleNativeApprovalTasksRefresh(startupTrace);
       startupTrace.mark("native.ready", {
         gatewayHttp: gatewayConfig.httpBaseUrl,
         mode: workbenchMode.mode,
@@ -434,12 +436,13 @@ function hydrateNativeStartupPanes(startupTrace?: DesktopNativeStartupTrace): vo
   startupTrace?.mark("workspaceFilesHydration.skipped", {
     reason: "deferred-until-opened",
   });
-  startupTrace?.mark("taskRefresh.skipped", {
+  startupTrace?.mark("coworkTasksRefresh.skipped", {
     reason: "deferred-until-opened",
   });
 }
 
 const nativeRouteHydratedModules = new Set<string>();
+let nativeCoworkRuntimeRolloutSyncPromise: Promise<void> | null = null;
 
 function installNativeRouteHydration(startupTrace?: DesktopNativeStartupTrace): void {
   window.addEventListener("tinybot:desktop-route", (event) => {
@@ -522,12 +525,17 @@ function hydrateNativeToolsSkillsPaneOnce(startupTrace?: DesktopNativeStartupTra
 
 function hydrateNativeCoworkPaneOnce(startupTrace?: DesktopNativeStartupTrace): void {
   traceNativeRouteBackgroundOnce("coworkPaneHydration", async () => {
+    await ensureNativeCoworkRuntimeRolloutSynced(startupTrace);
     const pane = await loadNativeCoworkPane();
     setNativeCoworkPane(pane);
     logDesktopNativeDebug("cowork.load.lazy.complete", {
       sessionCount: pane.sessionRows.length,
     });
   }, startupTrace);
+}
+
+function scheduleNativeApprovalTasksRefresh(startupTrace?: DesktopNativeStartupTrace): void {
+  traceNativeRouteBackgroundOnce("approvalTasksRefresh", () => refreshNativeApprovalTasks(), startupTrace);
 }
 
 function hydrateNativeWorkspaceFilesOnce(startupTrace?: DesktopNativeStartupTrace): void {
@@ -555,6 +563,24 @@ function traceNativeRouteBackgroundOnce(
       error: stringifyError(error),
     });
   });
+}
+
+function ensureNativeCoworkRuntimeRolloutSynced(startupTrace?: DesktopNativeStartupTrace): Promise<void> {
+  if (nativeCoworkRuntimeRolloutSyncPromise) {
+    return nativeCoworkRuntimeRolloutSyncPromise;
+  }
+  startupTrace?.start("coworkRolloutSync");
+  nativeCoworkRuntimeRolloutSyncPromise = gatewayApi.config.get().then((config) => {
+    syncTsCoworkRuntimeRollout(config);
+    startupTrace?.complete("coworkRolloutSync");
+  }).catch((error) => {
+    nativeCoworkRuntimeRolloutSyncPromise = null;
+    startupTrace?.fail("coworkRolloutSync", error);
+    logDesktopNativeDebug("cowork.rollout.sync.failed", {
+      error: stringifyError(error),
+    });
+  });
+  return nativeCoworkRuntimeRolloutSyncPromise;
 }
 
 async function resolveNativeWebSocketSessionExists(sessionId: string): Promise<boolean | undefined> {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -27,7 +27,14 @@ import {
   type DesktopKnowledgePaneModel,
 } from "./desktopKnowledgeTraceability";
 import { installWebUiRenderGlobals } from "./desktopMarkdownGlobals";
-import { logDesktopNativeChatDebug, logDesktopNativeDebug, summarizeDebugText } from "./desktopNativeChatDebug";
+import {
+  createDesktopNativeStartupTrace,
+  logDesktopNativeChatDebug,
+  logDesktopNativeDebug,
+  summarizeDebugText,
+  traceDesktopNativeDebugAsync,
+  type DesktopNativeStartupTrace,
+} from "./desktopNativeChatDebug";
 import { applyNativeConfigPatch } from "./desktopNativeConfigPatch";
 import { saveDesktopSettingsConfig } from "./desktopSettingsSave";
 import { buildDesktopTsAgentFormSubmissionInput } from "./desktopTsAgentFormActions";
@@ -197,22 +204,42 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 async function bootDesktopWebUi(): Promise<void> {
+  const startupTrace = createDesktopNativeStartupTrace();
+  startupTrace.mark("boot.invoked", {
+    gatewayHttp: gatewayConfig.httpBaseUrl,
+    hasTauriRuntime: hasTauriRuntime(),
+  });
   logDesktopNativeDebug("bootstrap.start", {
     gatewayHttp: gatewayConfig.httpBaseUrl,
-    hasTauriRuntime,
+    hasTauriRuntime: hasTauriRuntime(),
   });
   setStartupState(document, "Starting local gateway...", null, false);
   try {
+    startupTrace.start("gatewayReady", {
+      gatewayHttp: gatewayConfig.httpBaseUrl,
+    });
     const status = await ensureGatewayReady(gatewayConfig, { invoke, hasTauriRuntime });
+    startupTrace.complete("gatewayReady", {
+      owner: status?.owner ?? "",
+      runtimeState: status?.state ?? "",
+    });
     nativeRuntimeStatus = status;
     updateNativeGatewayTask(buildDesktopGatewayTaskOperation("startup", status));
+    startupTrace.start("channelRuntime");
     await startDesktopNativeChannelRuntime({
       nativeTransport: gatewayClientOptions.nativeTransport,
       logDebug: logDesktopNativeDebug,
     });
+    startupTrace.complete("channelRuntime");
+    startupTrace.start("startupMode");
     const workbenchMode = resolveDesktopWorkbenchStartupMode();
     document.documentElement.dataset.desktopWorkbenchMode = workbenchMode.mode;
     document.documentElement.dataset.desktopWorkbenchRequestedMode = workbenchMode.requestedMode;
+    startupTrace.complete("startupMode", {
+      fallbackReason: workbenchMode.fallbackReason ?? "",
+      mode: workbenchMode.mode,
+      requestedMode: workbenchMode.requestedMode,
+    });
     if (workbenchMode.fallbackReason) {
       logDesktopNativeDebug("bootstrap.fallback", {
         fallbackReason: workbenchMode.fallbackReason,
@@ -221,6 +248,7 @@ async function bootDesktopWebUi(): Promise<void> {
       });
       console.info("Tinybot desktop loading root WebUI fallback", workbenchMode);
     }
+    startupTrace.start("gatewayBridge");
     installDesktopGatewayBridge({
       config: gatewayConfig,
       nativeTransport: gatewayClientOptions.nativeTransport,
@@ -231,13 +259,21 @@ async function bootDesktopWebUi(): Promise<void> {
       }),
     });
     installWebUiRenderGlobals();
+    startupTrace.complete("gatewayBridge");
     if (workbenchMode.mode === "native-workbench") {
+      startupTrace.start("nativeChatRuntime");
       const nativeChatRuntime = await loadNativeChatRuntime();
-      const settingsPane = await loadNativeSettingsPane();
-      syncNativeRuntimeMetadata();
-      const knowledgePane = await loadNativeKnowledgePane();
-      const toolsSkillsPane = await loadNativeToolsSkillsPane();
-      const coworkPane = await loadNativeCoworkPane();
+      startupTrace.complete("nativeChatRuntime", {
+        activeSessionKey: nativeChatRuntime.chat.activeSessionKey ?? "",
+        sessionCount: nativeChatRuntime.chat.sessions.length,
+      });
+      startupTrace.start("initialPaneModels");
+      const settingsPane = buildInitialNativeSettingsPane();
+      const knowledgePane = buildInitialNativeKnowledgePane();
+      const toolsSkillsPane = buildInitialNativeToolsSkillsPane();
+      const coworkPane = buildInitialNativeCoworkPane();
+      startupTrace.complete("initialPaneModels");
+      startupTrace.start("nativeShellInstall");
       installDesktopWorkbenchShell({
         runtimeStatus: status,
         chat: nativeChatRuntime.chat,
@@ -277,15 +313,23 @@ async function bootDesktopWebUi(): Promise<void> {
           },
         },
       });
+      startupTrace.complete("nativeShellInstall");
+      startupTrace.start("nativeChromeBindings");
       installNativeChatRuntimeActions();
       installNativeFileUploadActions();
-      installNativeWorkspaceFileActions();
       installNativeCommandPalette();
-      installTauriNavigation();
-      installTauriMenuCommandRouting();
+      installTauriNavigation({ routeDocsInWorkbench: true });
+      installTauriMenuCommandRouting({ routeDocsInWorkbench: true });
+      installNativeRouteHydration(startupTrace);
       installTauriWindowFrame(status);
-      void refreshNativeCoworkTasks();
-      void refreshNativeApprovalTasks();
+      syncNativeRuntimeMetadata();
+      startupTrace.complete("nativeChromeBindings");
+      hydrateNativeStartupPanes(startupTrace);
+      startupTrace.mark("native.ready", {
+        gatewayHttp: gatewayConfig.httpBaseUrl,
+        mode: workbenchMode.mode,
+        runtimeState: status?.state ?? "",
+      });
       logDesktopNativeDebug("bootstrap.native.initialized", {
         gatewayHttp: gatewayConfig.httpBaseUrl,
         mode: workbenchMode.mode,
@@ -294,8 +338,13 @@ async function bootDesktopWebUi(): Promise<void> {
       console.info("Tinybot desktop native workbench initialized", status);
       return;
     }
+    startupTrace.start("webUiShell");
     installWebUiShell(webUiHtml);
+    startupTrace.complete("webUiShell");
+    startupTrace.start("webUiEntryImport");
     await import(/* @vite-ignore */ WEBUI_ENTRY);
+    startupTrace.complete("webUiEntryImport");
+    startupTrace.start("rootWorkbenchAdapter");
     installDesktopRootWebUiWorkbenchAdapter();
     installDesktopCommandPalette({
       gatewayOrigin: gatewayConfig.httpBaseUrl,
@@ -305,6 +354,12 @@ async function bootDesktopWebUi(): Promise<void> {
     installRootWebUiDesktopAdapters();
     installTauriNavigation();
     installTauriWindowFrame(status);
+    startupTrace.complete("rootWorkbenchAdapter");
+    startupTrace.mark("webui.ready", {
+      gatewayHttp: gatewayConfig.httpBaseUrl,
+      mode: workbenchMode.mode,
+      runtimeState: status?.state ?? "",
+    });
     logDesktopNativeDebug("bootstrap.webui.initialized", {
       gatewayHttp: gatewayConfig.httpBaseUrl,
       mode: workbenchMode.mode,
@@ -312,6 +367,9 @@ async function bootDesktopWebUi(): Promise<void> {
     });
     console.info("Tinybot desktop WebUI initialized", status);
   } catch (error) {
+    startupTrace.fail("boot", error, {
+      gatewayHttp: gatewayConfig.httpBaseUrl,
+    });
     logDesktopNativeDebug("bootstrap.failed", {
       error: stringifyError(error),
       gatewayHttp: gatewayConfig.httpBaseUrl,
@@ -323,6 +381,180 @@ async function bootDesktopWebUi(): Promise<void> {
       true,
     );
   }
+}
+
+function buildInitialNativeSettingsPane(): DesktopSettingsPaneModel {
+  const state = buildDesktopSettingsFormState({});
+  nativeSettingsConfig = {};
+  nativeSettingsState = state;
+  nativeSettingsLastSavedState = state;
+  nativeSettingsProviderCatalog = [];
+  return buildDesktopSettingsPaneModel(state, {
+    lastSavedState: state,
+    providerCatalog: [],
+    saveStatus: "idle",
+  });
+}
+
+function buildInitialNativeKnowledgePane(): DesktopKnowledgePaneModel {
+  nativeKnowledgePane = buildDesktopKnowledgePaneModel();
+  return nativeKnowledgePane;
+}
+
+function buildInitialNativeToolsSkillsPane(): DesktopToolsSkillsPaneModel {
+  nativeToolsPayload = {};
+  nativeSkillsPayload = {};
+  nativeToolsSkillsConfig = {};
+  nativeToolsSkillsPane = buildDesktopToolsSkillsPaneModel();
+  return nativeToolsSkillsPane;
+}
+
+function buildInitialNativeCoworkPane(): DesktopCoworkPaneModel {
+  nativeCoworkPane = {
+    sessionRows: [],
+    cockpitView: null,
+  };
+  return nativeCoworkPane;
+}
+
+function hydrateNativeStartupPanes(startupTrace?: DesktopNativeStartupTrace): void {
+  startupTrace?.mark("hydration.scheduled");
+  startupTrace?.mark("settingsPaneHydration.skipped", {
+    reason: "deferred-until-opened",
+  });
+  startupTrace?.mark("knowledgePaneHydration.skipped", {
+    reason: "deferred-until-opened",
+  });
+  startupTrace?.mark("toolsSkillsPaneHydration.skipped", {
+    reason: "deferred-until-opened",
+  });
+  startupTrace?.mark("coworkPaneHydration.skipped", {
+    reason: "deferred-until-opened",
+  });
+  startupTrace?.mark("workspaceFilesHydration.skipped", {
+    reason: "deferred-until-opened",
+  });
+  startupTrace?.mark("taskRefresh.skipped", {
+    reason: "deferred-until-opened",
+  });
+}
+
+const nativeRouteHydratedModules = new Set<string>();
+
+function installNativeRouteHydration(startupTrace?: DesktopNativeStartupTrace): void {
+  window.addEventListener("tinybot:desktop-route", (event) => {
+    const href = routeHydrationHref(event);
+    if (!href) {
+      return;
+    }
+    hydrateNativeRouteTarget(href, startupTrace);
+  });
+}
+
+function routeHydrationHref(event: Event): string {
+  const detail = event instanceof CustomEvent ? event.detail : null;
+  return typeof detail?.href === "string" ? detail.href : "";
+}
+
+function hydrateNativeRouteTarget(href: string, startupTrace?: DesktopNativeStartupTrace): void {
+  const pathname = new URL(href, window.location.href).pathname;
+  if (pathname.startsWith("/settings")) {
+    hydrateNativeSettingsPaneOnce(startupTrace);
+    return;
+  }
+  if (pathname.startsWith("/knowledge")) {
+    hydrateNativeKnowledgePaneOnce(startupTrace);
+    return;
+  }
+  if (pathname.startsWith("/tools") || pathname.startsWith("/skills")) {
+    hydrateNativeToolsSkillsPaneOnce(startupTrace);
+    return;
+  }
+  if (pathname.startsWith("/cowork")) {
+    hydrateNativeCoworkPaneOnce(startupTrace);
+    traceNativeRouteBackgroundOnce("coworkTasksRefresh", () => refreshNativeCoworkTasks(), startupTrace);
+    return;
+  }
+  if (pathname.startsWith("/files")) {
+    hydrateNativeWorkspaceFilesOnce(startupTrace);
+  }
+}
+
+function hydrateNativeSettingsPaneOnce(startupTrace?: DesktopNativeStartupTrace): void {
+  traceNativeRouteBackgroundOnce("settingsPaneHydration", async () => {
+    const pane = await loadNativeSettingsPane();
+    updateDesktopSettingsPane(document, pane, {
+      onSettingsAction: (event) => {
+        void handleNativeSettingsAction(event);
+      },
+    });
+    syncNativeRuntimeMetadata();
+    logDesktopNativeDebug("settings.load.lazy.complete", {
+      groupCount: pane.groups.length,
+    });
+  }, startupTrace);
+}
+
+function hydrateNativeKnowledgePaneOnce(startupTrace?: DesktopNativeStartupTrace): void {
+  traceNativeRouteBackgroundOnce("knowledgePaneHydration", async () => {
+    const pane = await loadNativeKnowledgePane();
+    updateDesktopKnowledgePane(document, pane, {
+      onKnowledgeAction: (event) => {
+        void handleNativeKnowledgeAction(event);
+      },
+    });
+    logDesktopNativeDebug("knowledge.load.lazy.complete", {
+      documentCount: pane.documentRows.length,
+    });
+  }, startupTrace);
+}
+
+function hydrateNativeToolsSkillsPaneOnce(startupTrace?: DesktopNativeStartupTrace): void {
+  traceNativeRouteBackgroundOnce("toolsSkillsPaneHydration", async () => {
+    const pane = await loadNativeToolsSkillsPane();
+    setNativeToolsSkillsPane(pane);
+    logDesktopNativeDebug("toolsSkills.load.lazy.complete", {
+      skillCount: pane.skillRows.length,
+      toolCount: pane.toolRows.length,
+    });
+  }, startupTrace);
+}
+
+function hydrateNativeCoworkPaneOnce(startupTrace?: DesktopNativeStartupTrace): void {
+  traceNativeRouteBackgroundOnce("coworkPaneHydration", async () => {
+    const pane = await loadNativeCoworkPane();
+    setNativeCoworkPane(pane);
+    logDesktopNativeDebug("cowork.load.lazy.complete", {
+      sessionCount: pane.sessionRows.length,
+    });
+  }, startupTrace);
+}
+
+function hydrateNativeWorkspaceFilesOnce(startupTrace?: DesktopNativeStartupTrace): void {
+  traceNativeRouteBackgroundOnce("workspaceFilesHydration", async () => {
+    await installNativeWorkspaceFileActions();
+  }, startupTrace);
+}
+
+function traceNativeRouteBackgroundOnce(
+  phase: string,
+  run: () => Promise<void>,
+  startupTrace?: DesktopNativeStartupTrace,
+): void {
+  if (nativeRouteHydratedModules.has(phase)) {
+    return;
+  }
+  nativeRouteHydratedModules.add(phase);
+  startupTrace?.start(phase);
+  void run().then(() => {
+    startupTrace?.complete(phase);
+  }).catch((error) => {
+    nativeRouteHydratedModules.delete(phase);
+    startupTrace?.fail(phase, error);
+    logDesktopNativeDebug(`${phase}.lazy.failed`, {
+      error: stringifyError(error),
+    });
+  });
 }
 
 async function resolveNativeWebSocketSessionExists(sessionId: string): Promise<boolean | undefined> {
@@ -1445,22 +1677,47 @@ async function loadNativeToolsSkillsPane(
     selectedSkillName: selectedSkillName ?? "",
   });
   const [tools, skills, config] = await Promise.all([
-    gatewayApi.tools.list(),
-    gatewayApi.skills.list(),
-    gatewayApi.config.get(),
+    traceDesktopNativeDebugAsync("toolsSkills.load.tools.list", () => gatewayApi.tools.list(), {
+      selectedSkillName: selectedSkillName ?? "",
+    }),
+    traceDesktopNativeDebugAsync("toolsSkills.load.skills.list", () => gatewayApi.skills.list(), {
+      selectedSkillName: selectedSkillName ?? "",
+    }),
+    traceDesktopNativeDebugAsync("toolsSkills.load.config.get", () => gatewayApi.config.get(), {
+      selectedSkillName: selectedSkillName ?? "",
+    }),
   ]);
   nativeToolsPayload = tools;
   nativeSkillsPayload = skills;
   nativeToolsSkillsConfig = config;
-  const firstSkill = selectedSkillName || buildDesktopSkillRows(skills, config)[0]?.name;
-  const detail = selectedSkillDetail ?? (firstSkill ? await gatewayApi.skills.detail(firstSkill).catch(() => null) : null);
-  nativeToolsSkillsPane = buildDesktopToolsSkillsPaneModel({
-    toolsPayload: tools,
-    skillsPayload: skills,
-    config,
-    selectedSkillName: firstSkill,
-    selectedSkillDetail: detail,
-  });
+  const skillRows = await traceDesktopNativeDebugAsync(
+    "toolsSkills.load.skillRows.build",
+    async () => buildDesktopSkillRows(skills, config),
+    {
+      selectedSkillName: selectedSkillName ?? "",
+    },
+  );
+  const firstSkill = selectedSkillName || skillRows[0]?.name;
+  const detail = selectedSkillDetail ?? (firstSkill
+    ? await traceDesktopNativeDebugAsync(
+      "toolsSkills.load.skills.detail",
+      () => gatewayApi.skills.detail(firstSkill),
+      { selectedSkillName: firstSkill },
+    ).catch(() => null)
+    : null);
+  nativeToolsSkillsPane = await traceDesktopNativeDebugAsync(
+    "toolsSkills.load.model.build",
+    async () => buildDesktopToolsSkillsPaneModel({
+      toolsPayload: tools,
+      skillsPayload: skills,
+      config,
+      selectedSkillName: firstSkill,
+      selectedSkillDetail: detail,
+    }),
+    {
+      selectedSkillName: firstSkill ?? "",
+    },
+  );
   logDesktopNativeDebug("toolsSkills.load.complete", {
     selectedSkillName: nativeToolsSkillsPane.selectedSkill?.name ?? "",
     skillCount: nativeToolsSkillsPane.skillRows.length,
@@ -1804,8 +2061,8 @@ async function loadNativeCommandPaletteData(): Promise<DesktopCommandPaletteInpu
   };
 }
 
-function installNativeWorkspaceFileActions(): void {
-  installDesktopWorkspaceFileActions({
+function installNativeWorkspaceFileActions(): Promise<void> {
+  return installDesktopWorkspaceFileActions({
     listWorkspaceFiles: () => gatewayApi.workspace.files(),
     loadWorkspaceFile: (path) => gatewayApi.workspace.file(path),
     saveWorkspaceFile: (path, body) => gatewayApi.workspace.putFile(path, body),
@@ -2052,7 +2309,9 @@ function hasTauriRuntime(): boolean {
   return "__TAURI_INTERNALS__" in window;
 }
 
-function installTauriMenuCommandRouting(): void {
+function installTauriMenuCommandRouting(
+  options: { routeDocsInWorkbench?: boolean } = {},
+): void {
   if (!hasTauriRuntime()) {
     return;
   }
@@ -2063,16 +2322,20 @@ function installTauriMenuCommandRouting(): void {
         handler(event.payload.id);
       }),
     openExternal: (href) => openUrl(href),
+    routeDocsInWorkbench: options.routeDocsInWorkbench,
   });
 }
 
-function installTauriNavigation(): void {
+function installTauriNavigation(
+  options: { routeDocsInWorkbench?: boolean } = {},
+): void {
   if (!hasTauriRuntime()) {
     return;
   }
   installDesktopNavigation({
     gatewayOrigin: gatewayConfig.httpBaseUrl,
     openExternal: (href) => openUrl(href),
+    routeDocsInWorkbench: options.routeDocsInWorkbench,
   });
 }
 

--- a/apps/desktop/src/desktopBootstrapOrder.test.ts
+++ b/apps/desktop/src/desktopBootstrapOrder.test.ts
@@ -31,6 +31,23 @@ describe("desktop root WebUI bootstrap order", () => {
     expect(chatOptionPosition).toBeGreaterThan(nativeShellPosition);
   });
 
+  test("native startup defers secondary pane and task hydration", () => {
+    const nativeShellPosition = callPosition("installDesktopWorkbenchShell({");
+    const hydrationStart = callPosition("function hydrateNativeStartupPanes(");
+    const hydrationEnd = bootstrapSource.indexOf("const nativeRouteHydratedModules", hydrationStart);
+    expect(hydrationEnd).toBeGreaterThan(hydrationStart);
+    const hydrationSource = bootstrapSource.slice(hydrationStart, hydrationEnd);
+
+    expect(nativeShellPosition).toBeGreaterThanOrEqual(0);
+    expect(hydrationSource).not.toContain("loadNativeSettingsPane()");
+    expect(hydrationSource).not.toContain("loadNativeKnowledgePane()");
+    expect(hydrationSource).not.toContain("loadNativeToolsSkillsPane()");
+    expect(hydrationSource).not.toContain("loadNativeCoworkPane()");
+    expect(hydrationSource).not.toContain("refreshNativeCoworkTasks()");
+    expect(hydrationSource).not.toContain("refreshNativeApprovalTasks()");
+    expect(hydrationSource).not.toContain("installNativeWorkspaceFileActions()");
+  });
+
   test("installs native chat runtime actions after the native shell exists", () => {
     const nativeShellPosition = callPosition("installDesktopWorkbenchShell({");
     const actionInstallPosition = callPosition("installNativeChatRuntimeActions();");

--- a/apps/desktop/src/desktopBootstrapOrder.test.ts
+++ b/apps/desktop/src/desktopBootstrapOrder.test.ts
@@ -31,7 +31,7 @@ describe("desktop root WebUI bootstrap order", () => {
     expect(chatOptionPosition).toBeGreaterThan(nativeShellPosition);
   });
 
-  test("native startup defers secondary pane and task hydration", () => {
+  test("native startup defers secondary pane and cowork task hydration", () => {
     const nativeShellPosition = callPosition("installDesktopWorkbenchShell({");
     const hydrationStart = callPosition("function hydrateNativeStartupPanes(");
     const hydrationEnd = bootstrapSource.indexOf("const nativeRouteHydratedModules", hydrationStart);
@@ -44,8 +44,36 @@ describe("desktop root WebUI bootstrap order", () => {
     expect(hydrationSource).not.toContain("loadNativeToolsSkillsPane()");
     expect(hydrationSource).not.toContain("loadNativeCoworkPane()");
     expect(hydrationSource).not.toContain("refreshNativeCoworkTasks()");
-    expect(hydrationSource).not.toContain("refreshNativeApprovalTasks()");
     expect(hydrationSource).not.toContain("installNativeWorkspaceFileActions()");
+  });
+
+  test("native startup refreshes approvals after the shell is available", () => {
+    const nativeShellPosition = callPosition("installDesktopWorkbenchShell({");
+    const approvalRefreshPosition = callPosition("scheduleNativeApprovalTasksRefresh(startupTrace);");
+
+    expect(approvalRefreshPosition).toBeGreaterThan(nativeShellPosition);
+  });
+
+  test("native startup syncs cowork rollout without hydrating settings", () => {
+    const nativeShellPosition = callPosition("installDesktopWorkbenchShell({");
+    const rolloutSyncPosition = callPosition("ensureNativeCoworkRuntimeRolloutSynced(startupTrace);");
+    const settingsHydrationPosition = callPosition("hydrateNativeSettingsPaneOnce(startupTrace);");
+
+    expect(rolloutSyncPosition).toBeGreaterThan(nativeShellPosition);
+    expect(rolloutSyncPosition).toBeLessThan(settingsHydrationPosition);
+  });
+
+  test("native cowork hydration waits for rollout config before loading cowork data", () => {
+    const coworkHydrationStart = callPosition("function hydrateNativeCoworkPaneOnce(");
+    const coworkHydrationEnd = bootstrapSource.indexOf("function hydrateNativeWorkspaceFilesOnce", coworkHydrationStart);
+    expect(coworkHydrationEnd).toBeGreaterThan(coworkHydrationStart);
+    const coworkHydrationSource = bootstrapSource.slice(coworkHydrationStart, coworkHydrationEnd);
+
+    const rolloutSyncPosition = coworkHydrationSource.indexOf("await ensureNativeCoworkRuntimeRolloutSynced(startupTrace);");
+    const loadCoworkPosition = coworkHydrationSource.indexOf("const pane = await loadNativeCoworkPane();");
+
+    expect(rolloutSyncPosition).toBeGreaterThanOrEqual(0);
+    expect(loadCoworkPosition).toBeGreaterThan(rolloutSyncPosition);
   });
 
   test("installs native chat runtime actions after the native shell exists", () => {

--- a/apps/desktop/src/desktopCommandNavigation.test.ts
+++ b/apps/desktop/src/desktopCommandNavigation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
   DESKTOP_CHROME_COMMANDS,
   DESKTOP_HELP_COMMANDS,
@@ -300,6 +300,42 @@ describe("desktop command navigation", () => {
     } as unknown as Event);
     expect(targetDocument.dispatched).toContain("tinybot:open-shortcut-help");
     expect(targetDocument.dispatched).toContain("tinybot:open-page-help");
+  });
+
+  test("keeps docs menu navigation inside the native workbench when requested", () => {
+    const targetDocument = new FakeCommandDocument();
+    const assign = vi.fn();
+    const pushState = vi.fn();
+    const dispatched: string[] = [];
+    const targetWindow = {
+      location: { assign, origin: "http://localhost:1420" },
+      history: { pushState },
+      dispatchEvent: (event: Event) => {
+        dispatched.push(event.type);
+        return true;
+      },
+    };
+    installDesktopMenuCommandRouting({
+      gatewayOrigin: "http://127.0.0.1:18790",
+      listenToMenuCommand: () => undefined,
+      routeDocsInWorkbench: true,
+      targetDocument: targetDocument as unknown as Document,
+      targetWindow: targetWindow as unknown as Window,
+    } as never);
+
+    let prevented = false;
+    targetDocument.dispatchEvent({
+      type: "keydown",
+      key: "F1",
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as unknown as Event);
+
+    expect(prevented).toBe(true);
+    expect(assign).not.toHaveBeenCalled();
+    expect(pushState).toHaveBeenCalledWith({ tinybotDesktopRoute: "http://localhost:1420/docs" }, "", "http://localhost:1420/docs");
+    expect(dispatched).toContain("tinybot:desktop-route");
   });
 
   test("dispatches stop-generation action when a response is active", () => {

--- a/apps/desktop/src/desktopCommandNavigation.ts
+++ b/apps/desktop/src/desktopCommandNavigation.ts
@@ -51,6 +51,7 @@ export interface InstallDesktopMenuCommandRoutingOptions {
   gatewayOrigin: string;
   listenToMenuCommand: (handler: (id: string) => void) => void | Promise<unknown>;
   openExternal?: (href: string) => Promise<void> | void;
+  routeDocsInWorkbench?: boolean;
   targetDocument?: Document;
   targetWindow?: Window;
 }
@@ -172,6 +173,7 @@ export function routeDesktopMenuCommand(id: string, context: DesktopMenuCommandC
 export function installDesktopMenuCommandRouting({
   gatewayOrigin,
   listenToMenuCommand,
+  routeDocsInWorkbench = false,
   targetDocument = document,
   targetWindow = window,
 }: InstallDesktopMenuCommandRoutingOptions): void {
@@ -182,18 +184,18 @@ export function installDesktopMenuCommandRouting({
     }
     event.preventDefault();
     const result = routeDesktopMenuCommand(id, readCommandContext(targetDocument));
-    applyDesktopMenuCommandResult(result, { gatewayOrigin, targetDocument, targetWindow });
+    applyDesktopMenuCommandResult(result, { gatewayOrigin, routeDocsInWorkbench, targetDocument, targetWindow });
   });
   targetDocument.addEventListener("desktop-menu-command", (event) => {
     const id = (event as CustomEvent<{ id?: unknown }>).detail?.id;
     if (typeof id === "string") {
       const result = routeDesktopMenuCommand(id, readCommandContext(targetDocument));
-      applyDesktopMenuCommandResult(result, { gatewayOrigin, targetDocument, targetWindow });
+      applyDesktopMenuCommandResult(result, { gatewayOrigin, routeDocsInWorkbench, targetDocument, targetWindow });
     }
   });
   void listenToMenuCommand((id) => {
     const result = routeDesktopMenuCommand(id, readCommandContext(targetDocument));
-    applyDesktopMenuCommandResult(result, { gatewayOrigin, targetDocument, targetWindow });
+    applyDesktopMenuCommandResult(result, { gatewayOrigin, routeDocsInWorkbench, targetDocument, targetWindow });
   });
 }
 
@@ -256,7 +258,7 @@ function readCommandContext(targetDocument: Document): DesktopMenuCommandContext
 
 function applyDesktopMenuCommandResult(
   result: DesktopMenuCommandResult,
-  options: Pick<InstallDesktopMenuCommandRoutingOptions, "gatewayOrigin" | "targetDocument" | "targetWindow"> & {
+  options: Pick<InstallDesktopMenuCommandRoutingOptions, "gatewayOrigin" | "routeDocsInWorkbench" | "targetDocument" | "targetWindow"> & {
     openExternal?: (href: string) => Promise<void> | void;
     targetDocument: Document;
     targetWindow: Window;
@@ -277,7 +279,7 @@ function applyDesktopMenuCommandResult(
 
 function routeMenuNavigation(
   href: string,
-  { gatewayOrigin, openExternal, targetDocument, targetWindow }: Pick<InstallDesktopMenuCommandRoutingOptions, "gatewayOrigin" | "openExternal"> & {
+  { gatewayOrigin, openExternal, routeDocsInWorkbench, targetDocument, targetWindow }: Pick<InstallDesktopMenuCommandRoutingOptions, "gatewayOrigin" | "openExternal" | "routeDocsInWorkbench"> & {
     targetDocument: Document;
     targetWindow: Window;
   },
@@ -291,12 +293,15 @@ function routeMenuNavigation(
   updateRouteStatus(targetDocument, target);
 
   if (target.kind === "internal-docs") {
+    if (routeDocsInWorkbench) {
+      routeWorkbenchTarget(target, targetWindow);
+      return;
+    }
     targetWindow.location.assign(target.href);
     return;
   }
   if (target.kind === "workbench-route") {
-    targetWindow.history.pushState({ tinybotDesktopRoute: target.href }, "", target.href);
-    targetWindow.dispatchEvent(new CustomEvent("tinybot:desktop-route", { detail: target }));
+    routeWorkbenchTarget(target, targetWindow);
     return;
   }
   if (target.kind === "gateway-action") {
@@ -310,6 +315,11 @@ function routeMenuNavigation(
     }
     targetWindow.open(target.href, "_blank", "noopener");
   }
+}
+
+function routeWorkbenchTarget(target: DesktopNavigationTarget, targetWindow: Window): void {
+  targetWindow.history.pushState({ tinybotDesktopRoute: target.href }, "", target.href);
+  targetWindow.dispatchEvent(new CustomEvent("tinybot:desktop-route", { detail: target }));
 }
 
 function applyCommandAction(result: Extract<DesktopMenuCommandResult, { kind: "action" }>, targetDocument: Document): void {

--- a/apps/desktop/src/desktopNativeChatDebug.ts
+++ b/apps/desktop/src/desktopNativeChatDebug.ts
@@ -9,6 +9,13 @@ export interface DesktopNativeDebugEntry {
 
 export type DesktopNativeChatDebugEntry = DesktopNativeDebugEntry;
 
+export interface DesktopNativeStartupTrace {
+  complete(phase: string, details?: Record<string, unknown>): void;
+  fail(phase: string, error: unknown, details?: Record<string, unknown>): void;
+  mark(stage: string, details?: Record<string, unknown>): void;
+  start(phase: string, details?: Record<string, unknown>): void;
+}
+
 declare global {
   interface Window {
     __tinybotNativeChatDebug?: DesktopNativeDebugEntry[];
@@ -52,6 +59,75 @@ export function logDesktopNativeChatDebug(
   logDesktopNativeDebug(stage, details);
 }
 
+export async function traceDesktopNativeDebugAsync<T>(
+  stage: DesktopNativeDebugStage,
+  run: () => Promise<T>,
+  details: Record<string, unknown> = {},
+  options: { now?: () => number } = {},
+): Promise<T> {
+  const now = options.now ?? readMonotonicNow;
+  const startedAt = now();
+  logDesktopNativeDebug(`${stage}.start`, details);
+  try {
+    const result = await run();
+    logDesktopNativeDebug(`${stage}.complete`, {
+      ...details,
+      durationMs: roundedDuration(now() - startedAt),
+    });
+    return result;
+  } catch (error) {
+    logDesktopNativeDebug(`${stage}.failed`, {
+      ...details,
+      durationMs: roundedDuration(now() - startedAt),
+      error: stringifyDebugError(error),
+    });
+    throw error;
+  }
+}
+
+export function createDesktopNativeStartupTrace(
+  options: { now?: () => number } = {},
+): DesktopNativeStartupTrace {
+  const now = options.now ?? readMonotonicNow;
+  const startedAt = now();
+  const activePhases = new Map<string, number>();
+
+  const elapsedDetails = (at: number, details: Record<string, unknown> = {}) => ({
+    ...details,
+    sinceStartMs: roundedDuration(at - startedAt),
+  });
+
+  return {
+    mark(stage, details = {}) {
+      logDesktopNativeDebug(`startup.${stage}`, elapsedDetails(now(), details));
+    },
+    start(phase, details = {}) {
+      const phaseStartedAt = now();
+      activePhases.set(phase, phaseStartedAt);
+      logDesktopNativeDebug(`startup.${phase}.start`, elapsedDetails(phaseStartedAt, details));
+    },
+    complete(phase, details = {}) {
+      const completedAt = now();
+      const phaseStartedAt = activePhases.get(phase) ?? completedAt;
+      activePhases.delete(phase);
+      logDesktopNativeDebug(`startup.${phase}.complete`, elapsedDetails(completedAt, {
+        ...details,
+        durationMs: roundedDuration(completedAt - phaseStartedAt),
+      }));
+    },
+    fail(phase, error, details = {}) {
+      const failedAt = now();
+      const phaseStartedAt = activePhases.get(phase) ?? failedAt;
+      activePhases.delete(phase);
+      logDesktopNativeDebug(`startup.${phase}.failed`, elapsedDetails(failedAt, {
+        ...details,
+        durationMs: roundedDuration(failedAt - phaseStartedAt),
+        error: stringifyDebugError(error),
+      }));
+    },
+  };
+}
+
 export function summarizeDebugText(value: string | undefined): { length: number; preview: string } {
   const text = value ?? "";
   return {
@@ -89,6 +165,20 @@ function isTestRuntime(): boolean {
     process?: { env?: Record<string, string | undefined> };
   };
   return processLike.process?.env?.VITEST === "true" || processLike.process?.env?.NODE_ENV === "test";
+}
+
+function readMonotonicNow(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+function roundedDuration(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function stringifyDebugError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function sanitizeDebugDetails(details: Record<string, unknown>): Record<string, unknown> {

--- a/apps/desktop/src/desktopNativeDebug.test.ts
+++ b/apps/desktop/src/desktopNativeDebug.test.ts
@@ -2,7 +2,11 @@
 
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { createDesktopNativeWorkbenchRuntime } from "./desktopNativeWorkbenchRuntime";
-import { logDesktopNativeDebug } from "./desktopNativeChatDebug";
+import {
+  createDesktopNativeStartupTrace,
+  logDesktopNativeDebug,
+  traceDesktopNativeDebugAsync,
+} from "./desktopNativeChatDebug";
 import { DEFAULT_GATEWAY_CONFIG } from "./gatewayConfig";
 import { createGatewayApiClient } from "./gatewayHttpClient";
 
@@ -35,6 +39,62 @@ describe("desktop native debug logger", () => {
       },
     });
     expect(info).toHaveBeenCalledWith("[Tinybot native]", "session.delete.start", window.__tinybotNativeDebug?.[0]?.details);
+  });
+
+  test("records startup trace phase timings", () => {
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    window.localStorage.setItem("tinybot.desktop.nativeDebug", "on");
+    const times = [0, 5, 10, 40, 50, 80];
+    const trace = createDesktopNativeStartupTrace({
+      now: () => times.shift() ?? 220.3,
+    });
+
+    trace.mark("dom.ready", { mode: "native" });
+    trace.start("gatewayReady");
+    trace.complete("gatewayReady", { state: "running" });
+    trace.start("chatRuntime");
+    trace.fail("chatRuntime", new Error("slow chat"));
+
+    expect(window.__tinybotNativeDebug?.map((entry) => entry.stage)).toEqual([
+      "startup.dom.ready",
+      "startup.gatewayReady.start",
+      "startup.gatewayReady.complete",
+      "startup.chatRuntime.start",
+      "startup.chatRuntime.failed",
+    ]);
+    expect(window.__tinybotNativeDebug?.[2].details).toMatchObject({
+      durationMs: 30,
+      sinceStartMs: 40,
+      state: "running",
+    });
+    expect(window.__tinybotNativeDebug?.[4].details).toMatchObject({
+      durationMs: 30,
+      sinceStartMs: 80,
+      error: "slow chat",
+    });
+  });
+
+  test("records async debug phase durations", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    window.localStorage.setItem("tinybot.desktop.nativeDebug", "on");
+    const times = [10, 52.24];
+
+    const result = await traceDesktopNativeDebugAsync(
+      "toolsSkills.load.tools.list",
+      async () => ({ count: 24 }),
+      { source: "startup" },
+      { now: () => times.shift() ?? 52.24 },
+    );
+
+    expect(result).toEqual({ count: 24 });
+    expect(window.__tinybotNativeDebug?.map((entry) => entry.stage)).toEqual([
+      "toolsSkills.load.tools.list.start",
+      "toolsSkills.load.tools.list.complete",
+    ]);
+    expect(window.__tinybotNativeDebug?.[1].details).toMatchObject({
+      durationMs: 42.2,
+      source: "startup",
+    });
   });
 
   test("logs meaningful runtime and session stages for native chat operations", async () => {

--- a/apps/desktop/src/desktopNativeWebui.test.ts
+++ b/apps/desktop/src/desktopNativeWebui.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, test, vi } from "vitest";
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createDesktopNativeWebuiApi } from "./desktopNativeWebui";
 
 describe("desktop native WebUI API", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    window.__tinybotNativeDebug = [];
+    window.__tinybotNativeChatDebug = [];
+    vi.restoreAllMocks();
+  });
+
   test("routes WebUI control requests through the worker command", async () => {
     const invoke = vi.fn(async (_command: string, _args?: unknown) => ({
       status: 200,
@@ -34,6 +43,33 @@ describe("desktop native WebUI API", () => {
         path: "/webui/refresh-token",
         headers: { Authorization: "Bearer token-1" },
       },
+    });
+  });
+
+  test("logs native WebUI route duration", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    window.localStorage.setItem("tinybot.desktop.nativeDebug", "on");
+    const invoke = vi.fn(async (_command: string, _args?: unknown) => ({
+      status: 200,
+      body: { ok: true },
+    }));
+    const times = [100, 123.45];
+    const api = createDesktopNativeWebuiApi({
+      invoke,
+      now: () => times.shift() ?? 123.45,
+    });
+
+    await expect(api.route({ method: "GET", path: "/api/tools" })).resolves.toEqual({ ok: true });
+
+    expect(window.__tinybotNativeDebug?.map((entry) => entry.stage)).toEqual([
+      "nativeWebui.route.start",
+      "nativeWebui.route.complete",
+    ]);
+    expect(window.__tinybotNativeDebug?.[1].details).toMatchObject({
+      durationMs: 23.5,
+      method: "GET",
+      path: "/api/tools",
+      status: 200,
     });
   });
 });

--- a/apps/desktop/src/desktopNativeWebui.ts
+++ b/apps/desktop/src/desktopNativeWebui.ts
@@ -1,10 +1,30 @@
 import type { NativeWebuiRouteRequest, NativeWebuiRouteResponse } from "./gatewayHttpClient";
+import { logDesktopNativeDebug } from "./desktopNativeChatDebug";
 
 type InvokeFn = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
 
-export function createDesktopNativeWebuiApi(options: { invoke: InvokeFn }) {
-  const routeResponse = (request: NativeWebuiRouteRequest) =>
-    options.invoke("worker_webui_route", { input: request }).then(normalizeWebuiRouteResponse);
+export function createDesktopNativeWebuiApi(options: { invoke: InvokeFn; now?: () => number }) {
+  const now = options.now ?? readMonotonicNow;
+  const routeResponse = async (request: NativeWebuiRouteRequest) => {
+    const startedAt = now();
+    logDesktopNativeDebug("nativeWebui.route.start", summarizeRouteRequest(request));
+    try {
+      const response = normalizeWebuiRouteResponse(await options.invoke("worker_webui_route", { input: request }));
+      logDesktopNativeDebug("nativeWebui.route.complete", {
+        ...summarizeRouteRequest(request),
+        durationMs: roundedDuration(now() - startedAt),
+        status: response.status,
+      });
+      return response;
+    } catch (error) {
+      logDesktopNativeDebug("nativeWebui.route.failed", {
+        ...summarizeRouteRequest(request),
+        durationMs: roundedDuration(now() - startedAt),
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  };
   return {
     route: (request: NativeWebuiRouteRequest) => routeResponse(request).then(unwrapWebuiRouteResponse),
     routeResponse,
@@ -27,4 +47,21 @@ function unwrapWebuiRouteResponse(response: NativeWebuiRouteResponse): unknown {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function summarizeRouteRequest(request: NativeWebuiRouteRequest): Record<string, unknown> {
+  return {
+    method: request.method,
+    path: request.path,
+  };
+}
+
+function readMonotonicNow(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+function roundedDuration(value: number): number {
+  return Math.round(value * 10) / 10;
 }

--- a/apps/desktop/src/desktopNavigation.test.ts
+++ b/apps/desktop/src/desktopNavigation.test.ts
@@ -86,6 +86,47 @@ describe("desktop navigation", () => {
     });
   });
 
+  test("can keep docs navigation inside the native workbench route stack", async () => {
+    const preventDefault = vi.fn();
+    const assign = vi.fn();
+    const pushState = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    const handled = await handleDesktopNavigationClick(
+      {
+        button: 0,
+        preventDefault,
+        target: {
+          closest: () => ({
+            getAttribute: (name: string) => (name === "href" ? "/docs" : null),
+            hasAttribute: () => false,
+          }),
+        },
+      },
+      {
+        desktopOrigin,
+        gatewayOrigin,
+        openExternal: vi.fn(),
+        routeDocsInWorkbench: true,
+        targetWindow: {
+          location: { assign, origin: desktopOrigin },
+          history: { pushState },
+          document: {
+            documentElement: { dataset: {} },
+            querySelector: () => null,
+          },
+          dispatchEvent,
+        } as unknown as Window,
+      } as never,
+    );
+
+    expect(handled).toBe(true);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(assign).not.toHaveBeenCalled();
+    expect(pushState).toHaveBeenCalledWith({ tinybotDesktopRoute: "http://tauri.localhost/docs" }, "", "http://tauri.localhost/docs");
+    expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "tinybot:desktop-route" }));
+  });
+
   test("routes workbench links without leaving the current webview", async () => {
     const preventDefault = vi.fn();
     const navigateInternal = vi.fn();

--- a/apps/desktop/src/desktopNavigation.ts
+++ b/apps/desktop/src/desktopNavigation.ts
@@ -16,6 +16,7 @@ export interface DesktopNavigationOptions {
   openExternal: (href: string) => Promise<void>;
   navigateInternal?: (target: DesktopNavigationTarget) => void | Promise<void>;
   routeGatewayAction?: (target: DesktopNavigationTarget) => void | Promise<void>;
+  routeDocsInWorkbench?: boolean;
   targetWindow?: Window;
 }
 
@@ -150,10 +151,18 @@ async function routeInternalNavigation(target: DesktopNavigationTarget, options:
 
   const targetWindow = options.targetWindow ?? window;
   if (target.kind === "internal-docs") {
+    if (options.routeDocsInWorkbench) {
+      routeWorkbenchTarget(target, targetWindow);
+      return;
+    }
     targetWindow.location.assign(target.href);
     return;
   }
 
+  routeWorkbenchTarget(target, targetWindow);
+}
+
+function routeWorkbenchTarget(target: DesktopNavigationTarget, targetWindow: Window): void {
   targetWindow.history.pushState({ tinybotDesktopRoute: target.href }, "", target.href);
   targetWindow.document.documentElement.dataset.desktopNavigationKind = target.kind;
   targetWindow.document.documentElement.dataset.desktopNavigationHref = target.href;

--- a/apps/desktop/src/desktopWindowFrame.test.ts
+++ b/apps/desktop/src/desktopWindowFrame.test.ts
@@ -543,7 +543,9 @@ describe("desktop window frame", () => {
     expect(styleText).toContain("width: 12px !important;");
     expect(styleText).toContain("height: 12px !important;");
     expect(styleText).toContain("border-radius: 999px;");
-    expect(styleText).toContain("right: 18px;");
+    expect(styleText).toContain("margin-left: 78px;");
+    expect(styleText).toContain("left: 18px;");
+    expect(styleText).toContain("left: 12px;");
     expect(styleText).toContain("grid-template-columns: repeat(3, 12px);");
     expect(styleText).toContain("radial-gradient(circle at 6px 6px, #ff5f57 0 5px, transparent 6px)");
     expect(styleText).toContain(".desktop-window-button-close");

--- a/apps/desktop/src/desktopWindowFrame.ts
+++ b/apps/desktop/src/desktopWindowFrame.ts
@@ -346,6 +346,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       display: flex;
       align-items: center;
       gap: 2px;
+      margin-left: 78px;
       min-width: 0;
       overflow: visible;
     }
@@ -454,7 +455,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
     body.desktop-custom-frame .desktop-window-controls {
       position: absolute;
       top: 50%;
-      right: 18px;
+      left: 18px;
       display: grid;
       grid-template-columns: repeat(3, 12px);
       align-items: center;
@@ -594,7 +595,7 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       }
 
       body.desktop-custom-frame .desktop-window-controls {
-        right: 12px;
+        left: 12px;
       }
     }
 

--- a/apps/desktop/src/desktopWorkspaceFiles.test.ts
+++ b/apps/desktop/src/desktopWorkspaceFiles.test.ts
@@ -346,6 +346,41 @@ describe("desktop workspace file adapter", () => {
     ]);
   });
 
+  test("resolves installation only after the initial workspace file list loads", async () => {
+    const targetDocument = new FakeDocument();
+    createWorkspaceShell(targetDocument);
+    let resolveList: (payload: unknown) => void = () => undefined;
+    const listStarted: string[] = [];
+    const installation = installDesktopWorkspaceFileActions({
+      targetDocument: targetDocument as unknown as Document,
+      listWorkspaceFiles: async () => {
+        listStarted.push("started");
+        return new Promise((resolve) => {
+          resolveList = resolve;
+        });
+      },
+      loadWorkspaceFile: async (path) => ({ path, content: "", exists: true }),
+      saveWorkspaceFile: async () => ({ saved: true }),
+    });
+    let resolved = false;
+    void installation.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+
+    expect(listStarted).toEqual(["started"]);
+    expect(resolved).toBe(false);
+
+    resolveList({
+      items: [{ path: "AGENTS.md", exists: true, updated_at: "2026-05-31T10:00:00+00:00" }],
+    });
+    await installation;
+
+    expect(resolved).toBe(true);
+    expect(targetDocument.getElementById("desktop-workspace-recent-files")?.textContent).toContain("AGENTS.md");
+  });
+
   test("filters workspace files, marks the active row, shows size, and reloads after a save conflict", async () => {
     const targetDocument = new FakeDocument();
     createWorkspaceShell(targetDocument);

--- a/apps/desktop/src/desktopWorkspaceFiles.ts
+++ b/apps/desktop/src/desktopWorkspaceFiles.ts
@@ -241,7 +241,7 @@ export function installDesktopWorkspaceFileActions({
   revealWorkspaceFile,
   exportWorkspaceFile,
   onFileTaskUpdated,
-}: DesktopWorkspaceFileActions): void {
+}: DesktopWorkspaceFileActions): Promise<void> {
   let state = createDesktopWorkspaceFileState();
   const editor = targetDocument.querySelector<HTMLTextAreaElement>("#desktop-workspace-editor");
   const search = targetDocument.querySelector<HTMLInputElement>("#desktop-workspace-search");
@@ -287,7 +287,7 @@ export function installDesktopWorkspaceFileActions({
     void exportActiveWorkspaceFile();
   });
 
-  void loadWorkspaceFiles();
+  return loadWorkspaceFiles();
 
   async function loadWorkspaceFiles(): Promise<void> {
     try {

--- a/apps/desktop/workers/ts-agent-worker/src/protocol/stdioServer.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/protocol/stdioServer.test.ts
@@ -139,6 +139,47 @@ describe("StdioServer", () => {
     expect(logs).toEqual([]);
   });
 
+  test("logs WebUI worker route queue and handler timings", async () => {
+    const lines: string[] = [];
+    const logs: string[] = [];
+    const worker = new AgentWorker({
+      provider: new QueueProvider([]),
+      tools: new ToolRegistry(),
+      emitEvent: () => undefined,
+    });
+    const times = [2000, 2042.3];
+    const server = new StdioServer({
+      worker,
+      now: () => times.shift() ?? 2042.3,
+      writeLine: (line) => lines.push(line),
+      writeLog: (line) => logs.push(line),
+    });
+
+    await server.handleLine(
+      JSON.stringify({
+        protocol_version: "1",
+        id: "webui-route-1000",
+        trace_id: "trace-webui-route-1000",
+        method: "webui.handle_request",
+        params: {
+          method: "GET",
+          path: "/api/tools",
+        },
+      }),
+    );
+
+    expect(logs).toEqual([
+      "worker.request.start method=webui.handle_request id=webui-route-1000 route=GET /api/tools queuedMs=1000",
+      "worker.request.complete method=webui.handle_request id=webui-route-1000 route=GET /api/tools durationMs=42.3 status=ok",
+    ]);
+    expect(JSON.parse(lines[0])).toMatchObject({
+      id: "webui-route-1000",
+      result: {
+        status: 200,
+      },
+    });
+  });
+
   test("handles agent.cancel while an agent.run request is still pending", async () => {
     const lines: string[] = [];
     const provider = new DeferredProvider();

--- a/apps/desktop/workers/ts-agent-worker/src/protocol/stdioServer.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/protocol/stdioServer.ts
@@ -7,6 +7,7 @@ export type StdioServerOptions = {
   worker: AgentWorker;
   diagnosticsBridge?: DiagnosticsBridge;
   rpcClient?: RpcClient;
+  now?: () => number;
   writeLine: (line: string) => void;
   writeLog: (line: string) => void;
 };
@@ -15,6 +16,7 @@ export class StdioServer {
   private readonly worker: AgentWorker;
   private readonly diagnosticsBridge?: DiagnosticsBridge;
   private readonly rpcClient?: RpcClient;
+  private readonly now: () => number;
   private readonly writeLine: (line: string) => void;
   private readonly writeLog: (line: string) => void;
 
@@ -22,6 +24,7 @@ export class StdioServer {
     this.worker = options.worker;
     this.diagnosticsBridge = options.diagnosticsBridge ?? (options.rpcClient ? new NativeDiagnosticsBridge(options.rpcClient) : undefined);
     this.rpcClient = options.rpcClient;
+    this.now = options.now ?? Date.now;
     this.writeLine = options.writeLine;
     this.writeLog = options.writeLog;
   }
@@ -42,7 +45,9 @@ export class StdioServer {
     if (!request) {
       return;
     }
+    const trace = this.traceRequestStart(request);
     const response = await this.worker.handleRequest(request);
+    this.traceRequestComplete(request, response, trace);
     this.writeLine(JSON.stringify(response));
   }
 
@@ -91,6 +96,43 @@ export class StdioServer {
       this.writeLog(`failed to append native diagnostic: ${message}`);
     });
   }
+
+  private traceRequestStart(request: WorkerRequest): { startedAt: number; traced: boolean } {
+    const startedAt = this.now();
+    if (!shouldTraceRequest(request)) {
+      return { startedAt, traced: false };
+    }
+    const route = routeSummary(request);
+    const queuedMs = queuedDurationMs(request, startedAt);
+    this.logDiagnostic([
+      "worker.request.start",
+      `method=${request.method}`,
+      `id=${request.id}`,
+      route ? `route=${route}` : "",
+      queuedMs === null ? "" : `queuedMs=${roundedDuration(queuedMs)}`,
+    ].filter(Boolean).join(" "));
+    return { startedAt, traced: true };
+  }
+
+  private traceRequestComplete(
+    request: WorkerRequest,
+    response: WorkerResponse,
+    trace: { startedAt: number; traced: boolean },
+  ): void {
+    if (!trace.traced) {
+      return;
+    }
+    const route = routeSummary(request);
+    const status = response.error ? "error" : "ok";
+    this.logDiagnostic([
+      "worker.request.complete",
+      `method=${request.method}`,
+      `id=${request.id}`,
+      route ? `route=${route}` : "",
+      `durationMs=${roundedDuration(this.now() - trace.startedAt)}`,
+      `status=${status}`,
+    ].filter(Boolean).join(" "));
+  }
 }
 
 function isWorkerResponse(message: Record<string, unknown>): message is WorkerResponse {
@@ -101,4 +143,27 @@ function isWorkerResponse(message: Record<string, unknown>): message is WorkerRe
     ("result" in message || "error" in message) &&
     !("method" in message)
   );
+}
+
+function shouldTraceRequest(request: WorkerRequest): boolean {
+  return request.method === "webui.handle_request";
+}
+
+function routeSummary(request: WorkerRequest): string {
+  const method = typeof request.params?.method === "string" ? request.params.method : "";
+  const path = typeof request.params?.path === "string" ? request.params.path : "";
+  return method || path ? `${method || "?"} ${path || "?"}` : "";
+}
+
+function queuedDurationMs(request: WorkerRequest, startedAt: number): number | null {
+  const match = /^webui-route-(\d+)$/.exec(request.id);
+  if (!match) {
+    return null;
+  }
+  const enqueuedAt = Number(match[1]);
+  return Number.isFinite(enqueuedAt) ? Math.max(0, startedAt - enqueuedAt) : null;
+}
+
+function roundedDuration(value: number): number {
+  return Math.round(value * 10) / 10;
 }


### PR DESCRIPTION
## Summary

- Move native window traffic lights to the left side for the custom desktop frame.
- Keep the native workbench shell responsive by deferring secondary pane hydration until the user opens those routes.
- Add startup and route timing diagnostics for native WebUI requests and worker-handled routes.
- Prevent the workspace file list from recursively scanning ignored dependency/build directories such as `.git`, `node_modules`, `.codegraph`, and `target`.

## Root Cause

The native startup path eagerly hydrated several secondary panes. After that was deferred, the remaining visible hang came from `/api/workspace/files`: Rust workspace file listing recursively entered large ignored directories, so the worker route could hit the renderer-side timeout before returning.

## Validation

- `cargo test worker_workspace --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `npx vitest run src/desktopWorkspaceFiles.test.ts src/desktopBootstrapOrder.test.ts src/desktopNativeWebui.test.ts src/desktopNativeDebug.test.ts src/desktopNavigation.test.ts src/desktopCommandNavigation.test.ts src/desktopWorkbenchShell.test.ts src/desktopWindowFrame.test.ts workers/ts-agent-worker/src/protocol/stdioServer.test.ts`
- `npm run build`
- `git diff --check`