### PR TITLE
Redesign native Knowledge workbench

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -120,6 +120,7 @@ import {
 import {
   desktopUploadPickerOptions,
   installDesktopFileUploadActions,
+  type DesktopFileUploadActions,
   type DesktopPickedUploadFile,
   type DesktopUploadKind,
 } from "./desktopFileUpload";
@@ -501,11 +502,7 @@ function hydrateNativeSettingsPaneOnce(startupTrace?: DesktopNativeStartupTrace)
 function hydrateNativeKnowledgePaneOnce(startupTrace?: DesktopNativeStartupTrace): void {
   traceNativeRouteBackgroundOnce("knowledgePaneHydration", async () => {
     const pane = await loadNativeKnowledgePane();
-    updateDesktopKnowledgePane(document, pane, {
-      onKnowledgeAction: (event) => {
-        void handleNativeKnowledgeAction(event);
-      },
-    });
+    setNativeKnowledgePane(pane);
     logDesktopNativeDebug("knowledge.load.lazy.complete", {
       documentCount: pane.documentRows.length,
     });
@@ -1692,6 +1689,7 @@ function setNativeKnowledgePane(pane: DesktopKnowledgePaneModel): void {
       void handleNativeKnowledgeAction(event);
     },
   });
+  refreshNativeFileUploadActions();
 }
 
 function mergeNativeKnowledgeGraphPayload(graphPayload: unknown, graphragPayload: unknown): unknown {
@@ -2112,8 +2110,10 @@ function installNativeWorkspaceFileActions(): Promise<void> {
   });
 }
 
+let nativeFileUploadActions: DesktopFileUploadActions | null = null;
+
 function installNativeFileUploadActions(): void {
-  installDesktopFileUploadActions({
+  nativeFileUploadActions = {
     pickFile: (kind: DesktopUploadKind) =>
       invoke<DesktopPickedUploadFile | null>("pick_upload_file", {
         options: desktopUploadPickerOptions(kind),
@@ -2124,7 +2124,15 @@ function installNativeFileUploadActions(): void {
     listSessionTemporaryFiles: (sessionKey) => gatewayApi.sessions.temporaryFiles(sessionKey),
     getSessionKey: () => nativeWorkbenchRuntime?.chat.activeSessionKey ?? "",
     uploadWorkspaceFile: (path, body) => gatewayApi.workspace.putFile(path, body),
-  });
+  };
+  refreshNativeFileUploadActions();
+}
+
+function refreshNativeFileUploadActions(): void {
+  if (!nativeFileUploadActions) {
+    return;
+  }
+  installDesktopFileUploadActions(nativeFileUploadActions);
 }
 
 function installRootWebUiDesktopAdapters(): void {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -1613,6 +1613,10 @@ async function handleNativeKnowledgeAction(event: DesktopKnowledgeActionEvent): 
       document.getElementById("desktop-knowledge-upload")?.click();
       return;
     }
+    if (event.action === "settings") {
+      outcome = "ignored";
+      return;
+    }
     if (event.action === "runQuery" && event.pane.actions.query) {
       const result = await gatewayApi.knowledge.query(event.pane.query.request);
       const pane = await loadNativeKnowledgePane({
@@ -1622,7 +1626,7 @@ async function handleNativeKnowledgeAction(event: DesktopKnowledgeActionEvent): 
       setNativeKnowledgePane(pane);
       return;
     }
-    if (event.action === "refreshGraph") {
+    if (event.action === "refreshGraph" || event.action === "refreshAll") {
       const pane = await loadNativeKnowledgePane({
         queryResultPayload: nativeKnowledgeQueryResult,
         selectedDocumentId: event.pane.selectedDocument?.id,
@@ -1643,8 +1647,18 @@ async function handleNativeKnowledgeAction(event: DesktopKnowledgeActionEvent): 
       setNativeKnowledgePane(pane);
       return;
     }
-    if (event.action === "deleteDocument" && event.pane.selectedDocument) {
-      await gatewayApi.knowledge.deleteDocument(event.pane.selectedDocument.id);
+    if (event.action === "deleteDocument") {
+      const documentId = event.documentId || event.pane.selectedDocument?.id;
+      if (!documentId) {
+        outcome = "ignored";
+        return;
+      }
+      const confirmed = window.confirm("Delete this knowledge document? This will remove it from the global knowledge base.");
+      if (!confirmed) {
+        outcome = "ignored";
+        return;
+      }
+      await gatewayApi.knowledge.deleteDocument(documentId);
       const pane = await loadNativeKnowledgePane({ queryResultPayload: nativeKnowledgeQueryResult });
       setNativeKnowledgePane(pane);
       return;

--- a/apps/desktop/src/desktopFileUpload.test.ts
+++ b/apps/desktop/src/desktopFileUpload.test.ts
@@ -74,6 +74,44 @@ describe("desktop file upload adapters", () => {
     expect([...form.keys()]).toEqual(["file"]);
   });
 
+  test("keeps knowledge upload binding after the upload control is replaced", async () => {
+    const targetDocument = createUploadTestDocument();
+    const status = targetDocument.createElement("p");
+    status.setAttribute("id", "desktop-file-upload-status");
+    const button = targetDocument.createElement("button");
+    button.setAttribute("id", "desktop-knowledge-upload");
+    targetDocument.body.append(button, status);
+    const pickedKinds: string[] = [];
+    const uploadedNames: string[] = [];
+
+    const install = () => installDesktopFileUploadActions({
+      targetDocument: targetDocument as unknown as Document,
+      pickFile: async (kind) => {
+        pickedKinds.push(kind);
+        return pickedFile;
+      },
+      uploadKnowledgeDocument: async (form) => {
+        uploadedNames.push((form.get("file") as File).name);
+      },
+      uploadSessionTemporaryFile: async () => undefined,
+    });
+
+    install();
+    install();
+    targetDocument.querySelector("#desktop-knowledge-upload")?.click();
+    await flushPromises();
+
+    const nextButton = targetDocument.createElement("button");
+    nextButton.setAttribute("id", "desktop-knowledge-upload");
+    targetDocument.body.replaceChildren(nextButton, status);
+    install();
+    targetDocument.querySelector("#desktop-knowledge-upload")?.click();
+    await flushPromises();
+
+    expect(pickedKinds).toEqual(["knowledge-document", "knowledge-document"]);
+    expect(uploadedNames).toEqual(["notes.md", "notes.md"]);
+  });
+
   test("classifies accepted and rejected dropped files for knowledge imports", () => {
     const accepted = new File(["# notes"], "notes.md", { type: "text/markdown" });
     const rejected = new File(["binary"], "installer.exe", { type: "application/x-msdownload" });
@@ -447,6 +485,7 @@ class UploadTestElement {
 }
 
 class UploadTestDocument {
+  public documentElement = new UploadTestElement("html");
   public body = new UploadTestElement("body");
   private listeners = new Map<string, ((event: { type: string; detail?: unknown }) => void)[]>();
 

--- a/apps/desktop/src/desktopFileUpload.ts
+++ b/apps/desktop/src/desktopFileUpload.ts
@@ -40,6 +40,13 @@ export interface DesktopFileUploadActions {
   onWorkspaceFileImported?: (path: string) => Promise<void>;
 }
 
+type DesktopUploadBoundElement = HTMLElement & {
+  dataset: DOMStringMap & {
+    desktopFileUploadClickBound?: string;
+    desktopFileDropBound?: string;
+  };
+};
+
 export interface DesktopDroppedFileRejection {
   name: string;
   reason: string;
@@ -352,11 +359,11 @@ export function installDesktopFileUploadActions({
     await refreshSessionTemporaryFiles(sessionKey);
   };
 
-  targetDocument.querySelector<HTMLButtonElement>("#desktop-knowledge-upload")?.addEventListener("click", () => {
+  bindClickOnce(targetDocument.querySelector<HTMLButtonElement>("#desktop-knowledge-upload"), "knowledge-upload", () => {
     void runKnowledgeUpload({ targetDocument, pickFile, uploadKnowledgeDocument, onKnowledgeUploaded, onKnowledgeTaskUpdated });
   });
 
-  targetDocument.querySelector<HTMLButtonElement>("#desktop-session-file-upload")?.addEventListener("click", () => {
+  bindClickOnce(targetDocument.querySelector<HTMLButtonElement>("#desktop-session-file-upload"), "session-file-upload", () => {
     const sessionKey = (
       getSessionKey?.() ||
       targetDocument.querySelector<HTMLInputElement>("#desktop-session-upload-key")?.value ||
@@ -372,7 +379,7 @@ export function installDesktopFileUploadActions({
     });
   });
 
-  targetDocument.querySelector<HTMLButtonElement>("#desktop-session-files-refresh")?.addEventListener("click", () => {
+  bindClickOnce(targetDocument.querySelector<HTMLButtonElement>("#desktop-session-files-refresh"), "session-files-refresh", () => {
     const sessionKey = (
       getSessionKey?.() ||
       targetDocument.querySelector<HTMLInputElement>("#desktop-session-upload-key")?.value ||
@@ -384,7 +391,7 @@ export function installDesktopFileUploadActions({
     });
   });
 
-  targetDocument.querySelector<HTMLElement>("#desktop-workspace-file-drop")?.addEventListener("click", (event) => {
+  bindClickOnce(targetDocument.querySelector<HTMLElement>("#desktop-workspace-file-drop"), "workspace-file-drop", (event) => {
     if (!uploadWorkspaceFile) {
       return;
     }
@@ -397,15 +404,19 @@ export function installDesktopFileUploadActions({
     });
   });
 
-  targetDocument.addEventListener("tinybot:desktop-session-key-changed", (event) => {
-    const sessionKey = ((event as CustomEvent<{ sessionKey?: string }>).detail?.sessionKey ?? "").trim();
-    void refreshSessionTemporaryFiles(sessionKey).catch((error) => {
-      setUploadStatus(targetDocument, `Temporary file refresh failed: ${stringifyError(error)}`);
+  if (targetDocument.documentElement.dataset.desktopFileUploadSessionKeyListenerBound !== "true") {
+    targetDocument.documentElement.dataset.desktopFileUploadSessionKeyListenerBound = "true";
+    targetDocument.addEventListener("tinybot:desktop-session-key-changed", (event) => {
+      const sessionKey = ((event as CustomEvent<{ sessionKey?: string }>).detail?.sessionKey ?? "").trim();
+      void refreshSessionTemporaryFiles(sessionKey).catch((error) => {
+        setUploadStatus(targetDocument, `Temporary file refresh failed: ${stringifyError(error)}`);
+      });
     });
-  });
+  }
 
   const initialSessionKey = (getSessionKey?.() || targetDocument.querySelector<HTMLInputElement>("#desktop-session-upload-key")?.value || "").trim();
-  if (initialSessionKey) {
+  if (initialSessionKey && targetDocument.documentElement.dataset.desktopFileUploadInitialSessionRefresh !== "true") {
+    targetDocument.documentElement.dataset.desktopFileUploadInitialSessionRefresh = "true";
     void refreshSessionTemporaryFiles(initialSessionKey).catch((error) => {
       setUploadStatus(targetDocument, `Temporary file refresh failed: ${stringifyError(error)}`);
     });
@@ -424,6 +435,22 @@ export function installDesktopFileUploadActions({
       onWorkspaceFileImported,
     });
   }
+}
+
+function bindClickOnce(
+  target: HTMLElement | null | undefined,
+  bindingId: string,
+  listener: (event: MouseEvent) => void,
+): void {
+  if (!target) {
+    return;
+  }
+  const boundTarget = target as DesktopUploadBoundElement;
+  if (boundTarget.dataset.desktopFileUploadClickBound === bindingId) {
+    return;
+  }
+  boundTarget.dataset.desktopFileUploadClickBound = bindingId;
+  target.addEventListener("click", listener);
 }
 
 async function runWorkspaceFileImport({
@@ -463,6 +490,12 @@ function installDesktopFileDropActions({
     "uploadKnowledgeDocument" | "uploadSessionTemporaryFile" | "getSessionKey" | "onKnowledgeUploaded" | "onKnowledgeTaskUpdated" | "onSessionFileUploaded" | "onWorkspaceFileImported"
   >): void {
   targetDocument.querySelectorAll<HTMLElement>("[data-desktop-drop-target]").forEach((target) => {
+    const boundTarget = target as DesktopUploadBoundElement;
+    if (boundTarget.dataset.desktopFileDropBound === "true") {
+      return;
+    }
+    boundTarget.dataset.desktopFileDropBound = "true";
+
     target.addEventListener("dragover", (event) => {
       if (!event.dataTransfer) {
         return;

--- a/apps/desktop/src/desktopKnowledgeTraceability.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.ts
@@ -25,6 +25,9 @@ export interface DesktopKnowledgeDocumentRow {
   title: string;
   path: string;
   category: string;
+  typeLabel?: string;
+  sizeLabel?: string;
+  addedLabel?: string;
   tags: string[];
   chunkCount: number;
   status: string;
@@ -171,6 +174,7 @@ export interface DesktopKnowledgePaneGraph {
 
 export interface DesktopKnowledgePaneModel {
   status: string;
+  lastIndexedLabel: string;
   readiness: DesktopKnowledgeReadinessView;
   configHints: string[];
   documentRows: DesktopKnowledgeDocumentRow[];
@@ -248,6 +252,37 @@ function booleanValue(value: unknown): boolean {
 function formatNumber(value: unknown): string {
   const number = Number(value);
   return Number.isFinite(number) ? number.toFixed(number >= 10 ? 0 : 3) : "";
+}
+
+function formatFileSize(value: unknown): string {
+  const bytes = numberValue(value);
+  if (bytes <= 0) {
+    return "-";
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(bytes >= 10 * 1024 * 1024 ? 0 : 2)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${Math.round(bytes)} B`;
+}
+
+function fileExtension(path: string): string {
+  const match = path.match(/\.([a-z0-9]+)$/i);
+  return match ? match[1].toUpperCase() : "";
+}
+
+function formatKnowledgeTimestamp(value: unknown): string {
+  const text = asText(value);
+  if (!text) {
+    return "Not indexed";
+  }
+  const iso = text.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/);
+  if (iso) {
+    return `${iso[1]} ${iso[2]}`;
+  }
+  return text;
 }
 
 function stageEntriesFor(stats: UnknownRecord, stages: string[]): UnknownRecord[] {
@@ -442,6 +477,7 @@ export function buildDesktopKnowledgePaneModel(input: DesktopKnowledgePaneInput 
 
   return {
     status: `${documentRows.length} ${documentRows.length === 1 ? "doc" : "docs"} / readiness ${readiness.score}% / graph ${graphView.nodes.length} nodes / ${graphView.edges.length} ${edgeLabel}`,
+    lastIndexedLabel: knowledgeLastIndexedLabel(input.statsPayload, documentRows),
     readiness,
     configHints: buildKnowledgeConfigHints(input.config),
     documentRows,
@@ -469,6 +505,16 @@ export function buildDesktopKnowledgePaneModel(input: DesktopKnowledgePaneInput 
   };
 }
 
+function knowledgeLastIndexedLabel(statsPayload: unknown, documentRows: DesktopKnowledgeDocumentRow[]): string {
+  const stats = asRecord(statsPayload);
+  return formatKnowledgeTimestamp(
+    stats.last_indexed_at
+      ?? stats.lastIndexedAt
+      ?? stats.last_indexed
+      ?? documentRows.find((document) => document.addedLabel)?.addedLabel,
+  );
+}
+
 export function buildDesktopKnowledgeDocumentRows(payload: unknown): DesktopKnowledgeDocumentRow[] {
   const root = asRecord(payload);
   const documents = Array.isArray(payload) ? payload : asArray(root.items).length ? asArray(root.items) : asArray(root.documents);
@@ -477,8 +523,11 @@ export function buildDesktopKnowledgeDocumentRows(payload: unknown): DesktopKnow
     const title = firstNonEmpty(document.title, document.name, document.path, id);
     const path = firstNonEmpty(document.path, document.file_path);
     const category = firstNonEmpty(document.category, document.type);
+    const typeLabel = firstNonEmpty(category, document.mime_type, document.file_type, fileExtension(path), "DOC");
+    const sizeLabel = formatFileSize(document.size_bytes ?? document.sizeBytes ?? document.file_size ?? document.size);
     const status = firstNonEmpty(document.status, document.index_status);
-    const updatedAt = firstNonEmpty(document.updated_at, document.updatedAt, document.modified_at);
+    const updatedAt = firstNonEmpty(document.updated_at, document.updatedAt, document.created_at, document.createdAt, document.modified_at);
+    const addedLabel = formatKnowledgeTimestamp(updatedAt);
     const chunkCount = numberValue(document.chunk_count ?? document.chunks);
     const tags = asArray(document.tags).map(asText).filter(Boolean);
     const meta = [
@@ -487,7 +536,7 @@ export function buildDesktopKnowledgeDocumentRows(payload: unknown): DesktopKnow
       chunkCount ? `${chunkCount} chunks` : "",
       updatedAt,
     ].filter(Boolean).join(" / ");
-    return { id, title, path, category, tags, chunkCount, status, updatedAt, meta };
+    return { id, title, path, category, typeLabel, sizeLabel, addedLabel, tags, chunkCount, status, updatedAt, meta };
   });
 }
 

--- a/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
@@ -165,7 +165,7 @@ describe("desktop workbench shell static Vue imports", () => {
   test("statically imports the knowledge sub-islands", () => {
     const source = readFileSync(resolve(__dirname, "desktopWorkbenchShell.ts"), "utf8");
 
-    expect(source).toContain('import { mountKnowledgeActionsIsland } from "./native-vue/knowledgeActionsIsland";');
+    expect(source).not.toContain('import { mountKnowledgeActionsIsland } from "./native-vue/knowledgeActionsIsland";');
     expect(source).not.toContain('void import("./native-vue/knowledgeActionsIsland")');
     expect(source).toContain('import { mountKnowledgeDocumentDetailIsland } from "./native-vue/knowledgeDocumentDetailIsland";');
     expect(source).not.toContain('void import("./native-vue/knowledgeDocumentDetailIsland")');
@@ -173,7 +173,7 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("./native-vue/knowledgeDocumentsIsland")');
     expect(source).toContain('import { mountKnowledgeGraphIsland } from "./native-vue/knowledgeGraphIsland";');
     expect(source).not.toContain('void import("./native-vue/knowledgeGraphIsland")');
-    expect(source).toContain('import { mountKnowledgeQueryIsland } from "./native-vue/knowledgeQueryIsland";');
+    expect(source).not.toContain('import { mountKnowledgeQueryIsland } from "./native-vue/knowledgeQueryIsland";');
     expect(source).not.toContain('void import("./native-vue/knowledgeQueryIsland")');
     expect(source).toContain('import { mountKnowledgeReadinessIsland } from "./native-vue/knowledgeReadinessIsland";');
     expect(source).not.toContain('void import("./native-vue/knowledgeReadinessIsland")');

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2878,6 +2878,7 @@ describe("desktop workbench shell", () => {
       statsPayload: {
         total_documents: 1,
         total_chunks: 4,
+        last_indexed_at: "2026-06-14T09:41:00Z",
         indexed_dense: 4,
         indexed_sparse: 4,
         claims_ready: true,
@@ -2888,7 +2889,7 @@ describe("desktop workbench shell", () => {
         },
       },
       config: { knowledge: { enabled: true, retrieval_mode: "hybrid", max_chunks: 5 } },
-      documentsPayload: { documents: [{ id: "doc-1", title: "Desktop UX", path: "docs/desktop.md", chunk_count: 4, status: "indexed" }] },
+      documentsPayload: { documents: [{ id: "doc-1", title: "Desktop UX", path: "docs/desktop.md", category: "MD", size_bytes: 86000, chunk_count: 4, status: "indexed", updated_at: "2h ago" }] },
       selectedDocumentId: "doc-1",
       queryDraft: { query: "desktop", mode: "hybrid", topK: 5 },
       queryResultPayload: { data: [{ doc_id: "doc-1", doc_name: "Desktop UX", content: "Desktop knowledge pane", score: 0.7 }] },
@@ -2913,34 +2914,66 @@ describe("desktop workbench shell", () => {
 
     const pane = targetDocument.body.querySelector(".desktop-knowledge-pane");
     expect(pane?.getAttribute("aria-label")).toBe("Knowledge workbench");
-    expect(pane?.querySelector(".desktop-knowledge-workbench-grid")?.getAttribute("data-desktop-knowledge-layout")).toBe(
-      "filters-graph-detail-results",
+    expect(pane?.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Refresh All");
+    expect(pane?.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Settings");
+    expect(pane?.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Upload Documents");
+    expect(pane?.querySelector(".desktop-knowledge-management-grid")?.getAttribute("data-desktop-knowledge-layout")).toBe(
+      "source-left-graph-right",
     );
     expect(pane?.querySelectorAll("[data-desktop-knowledge-region]").map((node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
-      "filters",
+      "overview",
+      "upload",
+      "queue",
+      "documents",
       "graph",
-      "detail",
-      "results",
+      "pipeline",
     ]);
-    expect(pane?.textContent).toContain("Knowledge");
+    expect(pane?.textContent).toContain("Knowledge Base");
+    expect(pane?.textContent).toContain("Manage your knowledge base, monitor ingestion, and explore the knowledge graph.");
     expect(pane?.textContent).toContain("1 doc / readiness 100% / graph 1 nodes / 0 edges");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Documents");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Graph Nodes");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Last Indexed");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("2026-06-14 09:41");
+    expect(targetDocument.body.querySelector(".desktop-file-actions")).toBeNull();
+    expect(targetDocument.body.textContent).not.toContain("File imports");
+    const uploadRegion = pane?.querySelector('[data-desktop-knowledge-region="upload"]');
+    expect(uploadRegion?.querySelector(".desktop-knowledge-drop-zone")?.getAttribute("data-desktop-drop-target")).toBe("knowledge-document");
+    expect(uploadRegion?.textContent).toContain("Drag & drop files here or click to browse");
+    expect(uploadRegion?.textContent).toContain("Max 200MB per file");
+    expect(uploadRegion?.querySelector("#desktop-knowledge-upload")?.getAttribute("data-desktop-file-upload")).toBe("knowledge-document");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Ingestion Queue");
+    const documentsRegion = pane?.querySelector('[data-desktop-knowledge-region="documents"]');
+    expect(documentsRegion?.textContent).toContain("Documents (1)");
+    expect(documentsRegion?.querySelector("[data-desktop-knowledge-document-search]")?.getAttribute("placeholder")).toBe("Search documents...");
+    expect(documentsRegion?.querySelector("[data-desktop-knowledge-documents-table]")?.textContent).toContain("Actions");
+    expect(documentsRegion?.querySelector('[data-desktop-knowledge-document-action="deleteDocument"]')?.textContent).toContain("Delete");
     expect(pane?.textContent).toContain("Knowledge enabled");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="filters"]')?.textContent).toContain("Desktop UX: indexed / 4 chunks");
+    expect(documentsRegion?.textContent).toContain("Desktop UX");
     expect(findEntityRow(pane, "knowledge", "doc-1")?.textContent).toContain("Desktop UX");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="detail"]')?.textContent).toContain("Document detail: Desktop UX");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="detail"]')?.textContent).toContain("docs/desktop.md / indexed / 4 chunks");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="results"]')?.textContent).toContain("Query: desktop");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="results"]')?.textContent).toContain("Results: 1");
+    expect(documentsRegion?.textContent).toContain("Document detail: Desktop UX");
+    expect(documentsRegion?.textContent).toContain("docs/desktop.md / indexed / 4 chunks");
     expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Graph: 1 nodes / 0 edges / 0 evidence");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Build Graph");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Refresh Graph");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Fit View");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Layout");
+    expect(pane?.querySelector(".desktop-knowledge-graph-tools")?.textContent).toContain("Zoom in");
+    expect(pane?.querySelector(".desktop-knowledge-graph-legend")?.textContent).toContain("Entity");
+    expect(pane?.querySelector(".desktop-knowledge-graph-minimap")).not.toBeNull();
+    expect(pane?.querySelector('[data-desktop-knowledge-region="pipeline"]')?.textContent).toContain("Graph Build");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="pipeline"]')?.textContent).toContain("6 steps");
     expect(pane?.textContent).toContain("Community: Desktop cluster");
     expect(pane?.textContent).toContain("Report: Desktop report");
     expect(pane?.textContent).toContain("Claim: Desktop knowledge pane");
 
-    pane?.querySelector('[data-desktop-knowledge-action="runQuery"]')?.click();
+    pane?.querySelector('[data-desktop-knowledge-action="refreshAll"]')?.click();
+    pane?.querySelector('[data-desktop-knowledge-action="settings"]')?.click();
+    pane?.querySelector('[data-desktop-knowledge-action="uploadDocument"]')?.click();
     pane?.querySelector('[data-desktop-knowledge-action="refreshGraph"]')?.click();
     pane?.querySelector('[data-desktop-knowledge-action="rebuildIndex"]')?.click();
-    pane?.querySelector('[data-desktop-knowledge-action="deleteDocument"]')?.click();
-    expect(actionEvents).toEqual(["runQuery", "refreshGraph", "rebuildIndex", "deleteDocument"]);
+    pane?.querySelector('[data-desktop-knowledge-document-action="deleteDocument"]')?.click();
+    expect(actionEvents).toEqual(["refreshAll", "settings", "uploadDocument", "refreshGraph", "rebuildIndex", "deleteDocument"]);
   });
 
   test("renders a desktop Cowork cockpit with session list, graph, inspector, actions, and task feed", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -98,12 +98,10 @@ import { mountHeaderPanelControlIsland } from "./native-vue/headerPanelControlIs
 import { mountHelpSurfaceIsland } from "./native-vue/helpSurfaceIsland";
 import { mountInspectorRegionIsland } from "./native-vue/inspectorRegionIsland";
 import { mountInspectorViewIsland } from "./native-vue/inspectorViewIsland";
-import { mountKnowledgeActionsIsland } from "./native-vue/knowledgeActionsIsland";
 import { mountKnowledgeDocumentDetailIsland } from "./native-vue/knowledgeDocumentDetailIsland";
 import { mountKnowledgeDocumentsIsland } from "./native-vue/knowledgeDocumentsIsland";
 import { mountKnowledgeGraphIsland } from "./native-vue/knowledgeGraphIsland";
 import { mountKnowledgePaneIsland } from "./native-vue/knowledgePaneIsland";
-import { mountKnowledgeQueryIsland } from "./native-vue/knowledgeQueryIsland";
 import { mountKnowledgeReadinessIsland } from "./native-vue/knowledgeReadinessIsland";
 import { mountKnowledgeReferenceRowIsland } from "./native-vue/knowledgeReferenceRowIsland";
 import { mountMainUtilitiesRegionIsland } from "./native-vue/mainUtilitiesRegionIsland";
@@ -251,11 +249,12 @@ interface DesktopSettingsActionOptions {
   onSettingsAction?: (event: DesktopSettingsActionEvent) => void;
 }
 
-export type DesktopKnowledgeActionId = "runQuery" | "refreshGraph" | "rebuildIndex" | "deleteDocument" | "uploadDocument";
+export type DesktopKnowledgeActionId = "refreshAll" | "settings" | "runQuery" | "refreshGraph" | "rebuildIndex" | "deleteDocument" | "uploadDocument";
 
 export interface DesktopKnowledgeActionEvent {
   action: DesktopKnowledgeActionId;
   pane: DesktopKnowledgePaneModel;
+  documentId?: string;
 }
 
 interface DesktopKnowledgeActionOptions {
@@ -1358,7 +1357,7 @@ function createMainRegion(
   utilities.className = "desktop-utility-surfaces";
   utilities.append(
     createCommandPalette(targetDocument),
-    createFileActions(targetDocument, chat),
+    ...(knowledgePane ? [] : [createFileActions(targetDocument, chat)]),
     createDesktopHelpSurface(targetDocument),
     createAgentUiFormsSurface(targetDocument, agentUiForms, agentUiActions),
     createWorkspaceFilesSurface(targetDocument),
@@ -3837,21 +3836,15 @@ function createKnowledgePane(
   section.className = "desktop-workbench-section desktop-knowledge-pane";
   section.setAttribute("data-desktop-module-surface", "knowledge");
   section.setAttribute("aria-label", "Knowledge workbench");
-  const header = targetDocument.createElement("div");
-  header.className = "desktop-knowledge-header";
-  header.append(createText(targetDocument, "h2", "Knowledge"), createText(targetDocument, "p", pane.status));
 
-  const actions: Array<[DesktopKnowledgeActionId, string, boolean]> = [
-    ["uploadDocument", "Upload document", pane.actions.upload],
-    ["runQuery", "Run query", pane.actions.query],
-    ["refreshGraph", "Refresh graph", pane.actions.refreshGraph],
-    ["rebuildIndex", "Rebuild index", pane.actions.rebuild],
-    ["deleteDocument", "Delete document", pane.actions.deleteDocument],
-  ];
-  const actionRow = targetDocument.createElement("div");
-  actionRow.className = "desktop-knowledge-actions";
-  for (const [action, label, enabled] of actions) {
+  const createKnowledgeButton = (
+    action: DesktopKnowledgeActionId,
+    label: string,
+    enabled: boolean,
+    variant: "primary" | "secondary",
+  ): HTMLButtonElement => {
     const button = targetDocument.createElement("button");
+    button.className = `desktop-knowledge-action-button desktop-knowledge-action-button-${variant}`;
     button.setAttribute("type", "button");
     button.setAttribute("data-desktop-knowledge-action", action);
     if (!enabled) {
@@ -3861,67 +3854,177 @@ function createKnowledgePane(
     button.addEventListener("click", () => {
       knowledgeActions.onKnowledgeAction?.({ action, pane });
     });
-    actionRow.append(button);
-  }
-  mountKnowledgeActionsVueIsland(actionRow, actions, pane, knowledgeActions);
-  header.append(actionRow);
+    return button;
+  };
+
+  const header = targetDocument.createElement("div");
+  header.className = "desktop-knowledge-header";
+  const titleBlock = targetDocument.createElement("div");
+  titleBlock.className = "desktop-knowledge-title-block";
+  titleBlock.append(
+    createText(targetDocument, "p", "Knowledge Base", "desktop-knowledge-kicker"),
+    createText(targetDocument, "h2", "Knowledge Base"),
+    createText(targetDocument, "p", "Manage your knowledge base, monitor ingestion, and explore the knowledge graph."),
+    createText(targetDocument, "p", pane.status, "desktop-knowledge-status"),
+  );
+  const toolbar = targetDocument.createElement("div");
+  toolbar.className = "desktop-knowledge-toolbar";
+  toolbar.append(
+    createKnowledgeButton("refreshAll", "Refresh All", true, "secondary"),
+    createKnowledgeButton("settings", "Settings", true, "secondary"),
+    createKnowledgeButton("uploadDocument", "Upload Documents", pane.actions.upload, "primary"),
+  );
+  header.append(titleBlock, toolbar);
   section.append(header);
 
   const grid = targetDocument.createElement("div");
-  grid.className = "desktop-knowledge-workbench-grid";
-  grid.setAttribute("data-desktop-knowledge-layout", "filters-graph-detail-results");
+  grid.className = "desktop-knowledge-management-grid";
+  grid.setAttribute("data-desktop-knowledge-layout", "source-left-graph-right");
 
-  const readiness = targetDocument.createElement("section");
-  readiness.className = "desktop-knowledge-readiness";
-  readiness.append(createText(targetDocument, "h2", "Readiness"));
-  for (const hint of pane.configHints) {
-    readiness.append(createText(targetDocument, "p", hint));
+  const overview = targetDocument.createElement("section");
+  overview.className = "desktop-knowledge-region desktop-knowledge-overview";
+  overview.setAttribute("data-desktop-knowledge-region", "overview");
+  overview.setAttribute("aria-label", "Knowledge base overview");
+  const metrics: Array<[string, string, string]> = [
+    ["Documents", String(pane.documentRows.length), "Uploaded sources"],
+    ["Readiness", `${pane.readiness.score}%`, `${pane.documentRows.reduce((total, row) => total + row.chunkCount, 0)} indexed chunks`],
+    ["Graph Nodes", String(pane.graph.view.nodes.length), `${pane.graph.evidence.length} evidence`],
+    ["Relations", String(pane.graph.view.edges.length), "Graph edges"],
+    ["Last Indexed", pane.lastIndexedLabel, "Knowledge freshness"],
+  ];
+  for (const [label, value, detail] of metrics) {
+    const metric = targetDocument.createElement("article");
+    metric.className = "desktop-knowledge-metric";
+    metric.append(
+      createText(targetDocument, "span", label, "desktop-knowledge-metric-label"),
+      createText(targetDocument, "strong", value),
+      createText(targetDocument, "span", detail, "desktop-knowledge-metric-detail"),
+    );
+    overview.append(metric);
   }
-  for (const row of pane.readiness.rows) {
-    readiness.append(createText(targetDocument, "p", `${row.id}: ${row.tone}`));
+  grid.append(overview);
+
+  const uploadRegion = targetDocument.createElement("section");
+  uploadRegion.className = "desktop-knowledge-region desktop-knowledge-upload-region";
+  uploadRegion.setAttribute("data-desktop-knowledge-region", "upload");
+  uploadRegion.setAttribute("aria-label", "Upload knowledge documents");
+  const uploadHeader = createKnowledgeRegionHeader(
+    targetDocument,
+    "Upload Documents",
+    "Add files to your knowledge base. We'll parse, chunk, and index them.",
+  );
+  uploadHeader.append(createKnowledgeButton("uploadDocument", "Upload Documents", pane.actions.upload, "primary"));
+  const dropZone = targetDocument.createElement("div");
+  dropZone.className = "desktop-knowledge-drop-zone";
+  dropZone.setAttribute("data-desktop-drop-target", "knowledge-document");
+  dropZone.append(
+    createText(targetDocument, "strong", "Drag & drop files here or click to browse"),
+    createText(targetDocument, "span", "PDF, DOCX, MD, TXT, CSV, JSON"),
+    createText(targetDocument, "small", "Max 200MB per file"),
+  );
+  uploadRegion.append(uploadHeader, dropZone, createKnowledgeUploadControl(targetDocument));
+  grid.append(uploadRegion);
+
+  const queue = targetDocument.createElement("section");
+  queue.className = "desktop-knowledge-region desktop-knowledge-queue-region";
+  queue.setAttribute("data-desktop-knowledge-region", "queue");
+  queue.setAttribute("aria-label", "Knowledge ingestion queue");
+  queue.append(createKnowledgeRegionHeader(
+    targetDocument,
+    `Ingestion Queue${pane.documentRows.length ? ` (${Math.min(pane.documentRows.length, 2)})` : ""}`,
+    "Track files as they move through parsing and indexing.",
+  ));
+  for (const [index, document] of pane.documentRows.slice(0, 2).entries()) {
+    const progress = document.status === "indexed" ? 100 : document.status === "indexing" ? 45 : 0;
+    const stage = document.status === "indexed" ? "Indexed" : document.status === "indexing" ? "Parsing" : "Queued";
+    const row = targetDocument.createElement("article");
+    row.className = "desktop-knowledge-queue-row";
+    row.append(
+      createText(targetDocument, "strong", document.title),
+      createText(targetDocument, "span", `${document.typeLabel || "DOC"} / ${document.sizeLabel || "-"} / ${stage}`),
+      createText(targetDocument, "span", progress ? `${progress}%` : "-", "desktop-knowledge-queue-percent"),
+    );
+    const pause = targetDocument.createElement("button");
+    pause.setAttribute("type", "button");
+    pause.setAttribute("data-desktop-knowledge-queue-action", "pause");
+    if (index > 0) pause.setAttribute("disabled", "true");
+    pause.textContent = "Pause";
+    const cancel = targetDocument.createElement("button");
+    cancel.setAttribute("type", "button");
+    cancel.setAttribute("data-desktop-knowledge-queue-action", "cancel");
+    cancel.textContent = "Cancel";
+    row.append(pause, cancel);
+    queue.append(row);
   }
-  mountKnowledgeReadinessVueIsland(readiness, pane);
+  if (!pane.documentRows.length) {
+    queue.append(createText(targetDocument, "p", "No ingestion jobs running.", "desktop-knowledge-empty-note"));
+  }
+  grid.append(queue);
+
+  const documentsRegion = targetDocument.createElement("section");
+  documentsRegion.className = "desktop-knowledge-region desktop-knowledge-documents-region";
+  documentsRegion.setAttribute("data-desktop-knowledge-region", "documents");
+  documentsRegion.setAttribute("aria-label", "Knowledge documents");
+  documentsRegion.append(createKnowledgeRegionHeader(
+    targetDocument,
+    `Documents (${pane.documentRows.length})`,
+    "Search, filter, inspect, re-index, and delete knowledge sources.",
+  ));
 
   const documents = targetDocument.createElement("section");
   documents.className = "desktop-knowledge-documents";
-  documents.append(createText(targetDocument, "h2", "Documents"));
+  const documentToolbar = targetDocument.createElement("div");
+  documentToolbar.className = "desktop-knowledge-documents-toolbar";
+  const search = targetDocument.createElement("input");
+  search.setAttribute("type", "search");
+  search.setAttribute("placeholder", "Search documents...");
+  search.setAttribute("data-desktop-knowledge-document-search", "");
+  const filter = targetDocument.createElement("button");
+  filter.setAttribute("type", "button");
+  filter.setAttribute("data-desktop-knowledge-document-filter", "");
+  filter.textContent = "Filter";
+  documentToolbar.append(search, filter);
+  const table = targetDocument.createElement("table");
+  table.className = "desktop-knowledge-documents-table";
+  table.setAttribute("data-desktop-knowledge-documents-table", "");
+  const thead = targetDocument.createElement("thead");
+  const headerRow = targetDocument.createElement("tr");
+  for (const heading of ["Name", "Type", "Size", "Status", "Added", "Actions"]) {
+    headerRow.append(createText(targetDocument, "th", heading));
+  }
+  thead.append(headerRow);
+  const tbody = targetDocument.createElement("tbody");
   for (const document of pane.documentRows) {
-    const row = createText(targetDocument, "p", `${document.title}: ${document.meta}`);
+    const row = targetDocument.createElement("tr");
     setDesktopEntityHook(row, "knowledge", document.id || document.path);
-    documents.append(row);
+    row.append(
+      createText(targetDocument, "td", document.title),
+      createText(targetDocument, "td", document.typeLabel || document.category || "DOC"),
+      createText(targetDocument, "td", document.sizeLabel || "-"),
+      createText(targetDocument, "td", document.status || "unknown"),
+      createText(targetDocument, "td", document.addedLabel || "-"),
+    );
+    const actions = targetDocument.createElement("td");
+    const deleteButton = targetDocument.createElement("button");
+    deleteButton.className = "desktop-knowledge-action-button desktop-knowledge-action-button-secondary";
+    deleteButton.setAttribute("type", "button");
+    deleteButton.setAttribute("data-desktop-knowledge-action", "deleteDocument");
+    deleteButton.setAttribute("data-desktop-knowledge-document-action", "deleteDocument");
+    if (!pane.actions.deleteDocument) {
+      deleteButton.setAttribute("disabled", "true");
+    }
+    deleteButton.textContent = "Delete";
+    deleteButton.addEventListener("click", () => {
+      knowledgeActions.onKnowledgeAction?.({ action: "deleteDocument", pane, documentId: document.id || document.path });
+    });
+    actions.append(deleteButton);
+    row.append(actions);
+    tbody.append(row);
   }
+  table.append(thead, tbody);
+  documents.append(documentToolbar, table);
   mountKnowledgeDocumentsVueIsland(documents, pane);
-
-  const filters = targetDocument.createElement("section");
-  filters.className = "desktop-knowledge-region desktop-knowledge-filters";
-  filters.setAttribute("data-desktop-knowledge-region", "filters");
-  filters.setAttribute("aria-label", "Knowledge filters");
-  filters.append(readiness, documents);
-  grid.append(filters);
-
-  const graph = targetDocument.createElement("section");
-  graph.className = "desktop-knowledge-region desktop-knowledge-graph";
-  graph.setAttribute("data-desktop-knowledge-region", "graph");
-  graph.setAttribute("aria-label", "Knowledge graph");
-  graph.append(createText(targetDocument, "h2", `Graph: ${pane.graph.summary}`));
-  appendKnowledgeReferenceRows(targetDocument, graph, "Community", pane.graph.communities);
-  appendKnowledgeReferenceRows(targetDocument, graph, "Report", pane.graph.reports);
-  appendKnowledgeReferenceRows(targetDocument, graph, "Claim", pane.graph.claims);
-  appendKnowledgeReferenceRows(targetDocument, graph, "Relation", pane.graph.relations);
-  appendKnowledgeReferenceRows(targetDocument, graph, "Conflict", pane.graph.conflicts);
-  for (const evidence of pane.graph.evidence.slice(0, 4)) {
-    graph.append(createText(targetDocument, "p", `Evidence: ${evidence.title} / ${evidence.docName}`));
-  }
-  mountKnowledgeGraphVueIsland(graph, pane);
-  grid.append(graph);
-
-  const detailRegion = targetDocument.createElement("section");
-  detailRegion.className = "desktop-knowledge-region desktop-knowledge-detail-drawer";
-  detailRegion.setAttribute("data-desktop-knowledge-region", "detail");
-  detailRegion.setAttribute("aria-label", "Knowledge detail");
-  if (workItems.length) {
-    detailRegion.append(createModuleWorkSection(targetDocument, "Knowledge jobs", workItems));
-  }
+  documentsRegion.append(documents);
 
   if (pane.selectedDocument) {
     const detail = targetDocument.createElement("section");
@@ -3932,31 +4035,121 @@ function createKnowledgePane(
       createText(targetDocument, "p", `Tags: ${pane.selectedDocument.tags.join(", ") || "none"}`),
     );
     mountKnowledgeDocumentDetailVueIsland(detail, pane.selectedDocument);
-    detailRegion.append(detail);
+    const documentActions = targetDocument.createElement("div");
+    documentActions.className = "desktop-knowledge-action-row";
+    documentActions.append(createKnowledgeButton("deleteDocument", "Delete Document", pane.actions.deleteDocument, "secondary"));
+    documentsRegion.append(detail, documentActions);
   }
-  grid.append(detailRegion);
+  grid.append(documentsRegion);
 
-  const results = targetDocument.createElement("section");
-  results.className = "desktop-knowledge-region desktop-knowledge-results-drawer";
-  results.setAttribute("data-desktop-knowledge-region", "results");
-  results.setAttribute("aria-label", "Knowledge query results");
-  const query = targetDocument.createElement("section");
-  query.className = "desktop-knowledge-query";
-  query.append(
-    createText(targetDocument, "h2", `Query: ${pane.query.draft.query || "empty"}`),
-    createText(targetDocument, "p", `Mode: ${pane.query.draft.mode} / top ${pane.query.draft.topK}`),
-    createText(targetDocument, "p", `Results: ${pane.query.results.summary.count}`),
+  const graph = targetDocument.createElement("section");
+  graph.className = "desktop-knowledge-region desktop-knowledge-graph-region";
+  graph.setAttribute("data-desktop-knowledge-region", "graph");
+  graph.setAttribute("aria-label", "Knowledge graph");
+  const graphHeader = createKnowledgeRegionHeader(
+    targetDocument,
+    "Knowledge Graph",
+    "Build and inspect entities, relations, communities, and evidence.",
   );
-  for (const row of pane.query.results.rows.slice(0, 4)) {
-    query.append(createText(targetDocument, "p", `${row.docName}: ${row.content}`));
+  const graphActions = targetDocument.createElement("div");
+  graphActions.className = "desktop-knowledge-action-row";
+  graphActions.append(
+    createKnowledgeButton("rebuildIndex", "Build Graph", pane.actions.rebuild, "secondary"),
+    createKnowledgeButton("refreshGraph", "Refresh Graph", pane.actions.refreshGraph, "secondary"),
+  );
+  for (const label of ["Fit View", "Layout"]) {
+    const button = targetDocument.createElement("button");
+    button.className = "desktop-knowledge-action-button desktop-knowledge-action-button-secondary";
+    button.setAttribute("type", "button");
+    button.textContent = label;
+    graphActions.append(button);
   }
-  mountKnowledgeQueryVueIsland(query, pane);
-  results.append(query);
-  grid.append(results);
+  graphHeader.append(graphActions);
+  const graphSurface = targetDocument.createElement("section");
+  graphSurface.className = "desktop-knowledge-graph";
+  const graphTools = targetDocument.createElement("div");
+  graphTools.className = "desktop-knowledge-graph-tools";
+  for (const label of ["Select", "Zoom in", "Zoom out", "Center", "Layers", "Filter"]) {
+    const button = targetDocument.createElement("button");
+    button.setAttribute("type", "button");
+    button.textContent = label;
+    graphTools.append(button);
+  }
+  graphSurface.append(graphTools);
+  graphSurface.append(createText(targetDocument, "h2", `Graph: ${pane.graph.summary}`));
+  appendKnowledgeReferenceRows(targetDocument, graphSurface, "Community", pane.graph.communities);
+  appendKnowledgeReferenceRows(targetDocument, graphSurface, "Report", pane.graph.reports);
+  appendKnowledgeReferenceRows(targetDocument, graphSurface, "Claim", pane.graph.claims);
+  appendKnowledgeReferenceRows(targetDocument, graphSurface, "Relation", pane.graph.relations);
+  appendKnowledgeReferenceRows(targetDocument, graphSurface, "Conflict", pane.graph.conflicts);
+  for (const evidence of pane.graph.evidence.slice(0, 4)) {
+    graphSurface.append(createText(targetDocument, "p", `Evidence: ${evidence.title} / ${evidence.docName}`));
+  }
+  const legend = targetDocument.createElement("div");
+  legend.className = "desktop-knowledge-graph-legend";
+  legend.textContent = "Entity Edge";
+  const minimap = targetDocument.createElement("div");
+  minimap.className = "desktop-knowledge-graph-minimap";
+  graphSurface.append(legend, minimap);
+  mountKnowledgeGraphVueIsland(graphSurface, pane);
+  graph.append(graphHeader, graphSurface);
+  grid.append(graph);
+
+  const pipeline = targetDocument.createElement("section");
+  pipeline.className = "desktop-knowledge-region desktop-knowledge-pipeline";
+  pipeline.setAttribute("data-desktop-knowledge-region", "pipeline");
+  pipeline.setAttribute("aria-label", "Knowledge indexing pipeline");
+  pipeline.append(createKnowledgeRegionHeader(
+    targetDocument,
+    "Indexing Pipeline",
+    "Track readiness and active knowledge jobs.",
+  ));
+  const readiness = targetDocument.createElement("section");
+  readiness.className = "desktop-knowledge-readiness";
+  for (const step of ["Upload", "Parse", "Chunk", "Embed", "Graph Build", "Complete"]) {
+    readiness.append(createText(targetDocument, "span", step));
+  }
+  readiness.append(createText(targetDocument, "p", `${pane.readiness.score >= 100 ? 6 : Math.max(1, Math.round((pane.readiness.score / 100) * 6))} / 6 steps`));
+  for (const hint of pane.configHints) {
+    readiness.append(createText(targetDocument, "p", hint));
+  }
+  for (const row of pane.readiness.rows) {
+    readiness.append(createText(targetDocument, "p", `${row.id}: ${row.tone}`));
+  }
+  mountKnowledgeReadinessVueIsland(readiness, pane);
+  pipeline.append(readiness);
+  if (workItems.length) {
+    pipeline.append(createModuleWorkSection(targetDocument, "Knowledge jobs", workItems));
+  }
+  grid.append(pipeline);
   section.append(grid);
 
   mountKnowledgePaneVueIsland(section, targetDocument, pane, knowledgeActions, workItems);
   return section;
+}
+
+function createKnowledgeRegionHeader(targetDocument: Document, title: string, detail: string): HTMLElement {
+  const header = targetDocument.createElement("div");
+  header.className = "desktop-knowledge-region-header";
+  const text = targetDocument.createElement("div");
+  text.append(
+    createText(targetDocument, "h3", title),
+    createText(targetDocument, "p", detail),
+  );
+  header.append(text);
+  return header;
+}
+
+function createKnowledgeUploadControl(targetDocument: Document): HTMLButtonElement {
+  const control = targetDocument.createElement("button");
+  control.id = "desktop-knowledge-upload";
+  control.className = "desktop-knowledge-upload-control";
+  control.setAttribute("type", "button");
+  control.setAttribute("tabindex", "-1");
+  control.setAttribute("aria-hidden", "true");
+  control.setAttribute("data-desktop-file-upload", "knowledge-document");
+  control.textContent = "Upload knowledge document";
+  return control;
 }
 
 function mountKnowledgePaneVueIsland(
@@ -3975,23 +4168,6 @@ function mountKnowledgePaneVueIsland(
     onInspectWorkItem: (item) => renderTaskWorkLens(targetDocument, item),
     onKnowledgeAction: (event) => {
       knowledgeActions.onKnowledgeAction?.(event);
-    },
-  });
-}
-
-function mountKnowledgeActionsVueIsland(
-  actionRow: HTMLElement,
-  actions: Array<[DesktopKnowledgeActionId, string, boolean]>,
-  pane: DesktopKnowledgePaneModel,
-  knowledgeActions: DesktopKnowledgeActionOptions,
-): void {
-  if (!canMountVueIsland(actionRow)) {
-    return;
-  }
-  mountKnowledgeActionsIsland(actionRow, {
-    actions: actions.map(([action, label, enabled]) => ({ action, label, enabled })),
-    onAction: (action) => {
-      knowledgeActions.onKnowledgeAction?.({ action, pane });
     },
   });
 }
@@ -4027,19 +4203,6 @@ function mountKnowledgeDocumentDetailVueIsland(
     return;
   }
   mountKnowledgeDocumentDetailIsland(detail, { document });
-}
-
-function mountKnowledgeQueryVueIsland(
-  query: HTMLElement,
-  pane: DesktopKnowledgePaneModel,
-): void {
-  if (!canMountVueIsland(query)) {
-    return;
-  }
-  mountKnowledgeQueryIsland(query, {
-    draft: pane.query.draft,
-    results: pane.query.results,
-  });
 }
 
 function mountKnowledgeGraphVueIsland(
@@ -7889,8 +8052,11 @@ function createWorkbenchLink(targetDocument: Document, label: string, href: stri
   return link;
 }
 
-function createText(targetDocument: Document, tagName: keyof HTMLElementTagNameMap, text: string): HTMLElement {
+function createText(targetDocument: Document, tagName: keyof HTMLElementTagNameMap, text: string, className = ""): HTMLElement {
   const element = targetDocument.createElement(tagName);
+  if (className) {
+    element.className = className;
+  }
   element.textContent = text;
   return element;
 }
@@ -8603,42 +8769,317 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-knowledge-pane {
       align-content: start;
-      gap: 12px;
+      gap: 16px;
       min-width: 0;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-workbench,
+    body.desktop-native-workbench .desktop-knowledge-workbench {
+      display: grid;
+      gap: 18px;
+      min-width: 0;
+    }
+
     body.desktop-native-workbench .desktop-knowledge-header {
       display: grid;
-      gap: 10px;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 18px;
+      min-width: 0;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: var(--radius-lg, 12px);
+      padding: 22px 24px;
+      background: var(--surface-soft, #f5f0e8);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-title-block {
+      display: grid;
+      gap: 6px;
       min-width: 0;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-header {
-      grid-template-columns: minmax(0, 1fr) auto;
-      align-items: end;
+    body.desktop-native-workbench .desktop-knowledge-kicker,
+    body.desktop-native-workbench .desktop-knowledge-status,
+    body.desktop-native-workbench .desktop-knowledge-region-header p,
+    body.desktop-native-workbench .desktop-knowledge-upload-panel p,
+    body.desktop-native-workbench .desktop-knowledge-metric-detail {
+      color: var(--text-muted, #6c6a64);
+      font: 600 13px/1.4 var(--font-sans, system-ui, sans-serif);
+      letter-spacing: 0;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-header h2,
-    body.desktop-native-workbench .desktop-knowledge-header p {
-      grid-column: 1;
+    body.desktop-native-workbench .desktop-knowledge-title-block h2,
+    body.desktop-native-workbench .desktop-knowledge-region-header h3,
+    body.desktop-native-workbench .desktop-knowledge-upload-panel h4 {
       margin: 0;
+      color: var(--text, #141413);
+      letter-spacing: 0;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-actions {
-      grid-column: 2;
-      grid-row: 1 / span 2;
+    body.desktop-native-workbench .desktop-knowledge-title-block h2 {
+      font: 500 30px/1.08 var(--font-display, Georgia, serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-title-block p {
+      margin: 0;
+      max-width: 720px;
+      color: var(--text-body, #3d3d3a);
+      font: 500 15px/1.45 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-kicker {
+      color: var(--accent, #cc785c);
+      text-transform: uppercase;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-status {
+      color: var(--text-muted, #6c6a64);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-action-row {
       display: flex;
       flex-wrap: wrap;
-      justify-content: end;
+      gap: 8px;
+      justify-content: flex-end;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
       gap: 8px;
       min-width: 0;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-actions button {
+    body.desktop-native-workbench .desktop-knowledge-action-button {
+      min-height: 44px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: var(--radius-md, 8px);
+      padding: 0 16px;
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
+      font: 750 14px/1.2 var(--font-sans, system-ui, sans-serif);
+      cursor: pointer;
+      transition: background-color 180ms ease, border-color 180ms ease, color 180ms ease, box-shadow 180ms ease;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-action-button-primary {
+      border-color: var(--accent, #cc785c);
+      background: var(--accent, #cc785c);
+      color: var(--on-primary, #ffffff);
+      box-shadow: 0 10px 24px var(--accent-glow, rgba(204, 120, 92, 0.15));
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-action-button-secondary:hover,
+    body.desktop-native-workbench .desktop-knowledge-action-button-secondary:focus-visible {
+      border-color: var(--accent, #cc785c);
+      background: var(--accent-soft, rgba(204, 120, 92, 0.12));
+      color: var(--accent-hover, #a9583e);
+      outline: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-action-button-primary:hover,
+    body.desktop-native-workbench .desktop-knowledge-action-button-primary:focus-visible {
+      border-color: var(--accent-hover, #a9583e);
+      background: var(--accent-hover, #a9583e);
+      outline: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-action-button:focus-visible {
+      box-shadow: 0 0 0 3px var(--accent-glow-strong, rgba(204, 120, 92, 0.24));
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-action-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-management-grid {
+      display: grid;
+      grid-template-columns: minmax(340px, 0.84fr) minmax(520px, 1.16fr);
+      grid-template-areas:
+        "overview overview"
+        "upload graph"
+        "queue graph"
+        "documents graph"
+        "documents pipeline";
+      gap: 14px;
+      align-items: start;
+      min-width: 0;
+      width: 100%;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-region {
+      min-width: 0;
+      min-height: 0;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: var(--radius-lg, 12px);
+      padding: 16px;
+      background: var(--panel, #faf9f5);
+      color: var(--text, #141413);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-overview {
+      grid-area: overview;
+      display: grid;
+      grid-template-columns: repeat(5, minmax(120px, 1fr));
+      gap: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-upload-region {
+      grid-area: upload;
+      display: grid;
+      gap: 14px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-region {
+      grid-area: queue;
+      display: grid;
+      gap: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-documents-region {
+      grid-area: documents;
+      display: grid;
+      gap: 14px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-region {
+      grid-area: graph;
+      display: grid;
+      gap: 14px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-pipeline {
+      grid-area: pipeline;
+      display: grid;
+      gap: 14px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-region-header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 12px;
+      align-items: start;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-region-header h3 {
+      font: 750 18px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-region-header p,
+    body.desktop-native-workbench .desktop-knowledge-upload-panel p {
+      margin: 5px 0 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-metric {
+      display: grid;
+      gap: 5px;
+      min-width: 0;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: var(--radius-md, 8px);
+      padding: 14px;
+      background: var(--surface-card, #efe9de);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-metric strong {
+      color: var(--text, #141413);
+      font: 760 28px/1 var(--font-sans, system-ui, sans-serif);
+      letter-spacing: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-metric-label {
+      color: var(--text-body, #3d3d3a);
+      font: 750 12px/1.2 var(--font-sans, system-ui, sans-serif);
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-drop-zone,
+    body.desktop-native-workbench .desktop-knowledge-upload-panel {
+      display: grid;
+      gap: 8px;
+      place-items: center;
+      min-height: 112px;
+      border: 1px dashed rgba(204, 120, 92, 0.45);
+      border-radius: var(--radius-md, 8px);
+      padding: 16px;
+      background: var(--accent-soft, rgba(204, 120, 92, 0.12));
+      color: var(--text-body, #3d3d3a);
+      text-align: center;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-drop-zone strong {
+      color: var(--text, #141413);
+      font: 750 14px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-drop-zone span,
+    body.desktop-native-workbench .desktop-knowledge-drop-zone small,
+    body.desktop-native-workbench .desktop-knowledge-empty-note {
+      color: var(--text-muted, #6c6a64);
+      font: 600 12px/1.4 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-upload-panel h4 {
+      font: 750 16px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-list,
+    body.desktop-native-workbench .desktop-knowledge-queue-row {
+      display: grid;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-row {
+      grid-template-columns: minmax(0, 1fr) minmax(90px, 160px) auto auto auto;
+      align-items: center;
+      border-top: 1px solid var(--border-subtle, #ebe6df);
+      padding-top: 10px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-file {
+      display: grid;
+      gap: 3px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-file strong,
+    body.desktop-native-workbench .desktop-knowledge-queue-file span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-file span,
+    body.desktop-native-workbench .desktop-knowledge-queue-percent {
+      color: var(--text-muted, #6c6a64);
+      font-size: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-progress {
+      height: 4px;
+      overflow: hidden;
+      border-radius: var(--radius-full, 9999px);
+      background: var(--surface-soft, #f5f0e8);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-progress span {
+      display: block;
+      height: 100%;
+      border-radius: inherit;
+      background: var(--accent, #cc785c);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-queue-row button,
+    body.desktop-native-workbench .desktop-knowledge-documents-toolbar button,
+    body.desktop-native-workbench .desktop-knowledge-documents-table button,
+    body.desktop-native-workbench .desktop-knowledge-graph-tools button {
       min-height: 32px;
       border: 1px solid var(--border, #e6dfd8);
-      border-radius: 6px;
+      border-radius: var(--radius-md, 8px);
       padding: 0 10px;
       background: var(--panel, #faf9f5);
       color: var(--text, #141413);
@@ -8646,56 +9087,161 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       cursor: pointer;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-actions button:disabled {
-      cursor: not-allowed;
-      opacity: 0.55;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-workbench-grid {
+    body.desktop-native-workbench .desktop-knowledge-documents {
       display: grid;
-      grid-template-columns: minmax(180px, 0.62fr) minmax(320px, 1.35fr) minmax(220px, 0.78fr);
-      grid-template-areas:
-        "filters graph detail"
-        "filters graph results";
-      gap: 12px;
-      align-items: stretch;
-      min-width: 0;
-      width: 100%;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-region,
-    body.desktop-native-workbench .desktop-knowledge-graph[data-desktop-knowledge-region="graph"] {
-      min-width: 0;
-      min-height: 0;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: 8px;
-      padding: 10px;
-      background: var(--panel, #faf9f5);
-      color: var(--text, #141413);
-      overflow: auto;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-filters {
-      grid-area: filters;
-      display: grid;
-      align-content: start;
       gap: 10px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-documents-toolbar {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto auto;
+      gap: 8px;
+      align-items: center;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-documents-toolbar input {
+      min-width: 0;
+      min-height: 34px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: var(--radius-md, 8px);
+      padding: 0 10px;
+      background: var(--bg, #faf9f5);
+      color: var(--text, #141413);
+      font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-documents-table {
+      width: 100%;
+      border-collapse: collapse;
+      font: 600 12px/1.35 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-documents-table th,
+    body.desktop-native-workbench .desktop-knowledge-documents-table td {
+      border-top: 1px solid var(--border-subtle, #ebe6df);
+      padding: 8px 6px;
+      color: var(--text-body, #3d3d3a);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-documents-table th {
+      color: var(--text-muted, #6c6a64);
+      font-size: 11px;
+      text-transform: uppercase;
     }
 
     body.desktop-native-workbench .desktop-knowledge-graph {
-      grid-area: graph;
+      position: relative;
+      display: grid;
+      gap: 10px;
+      min-height: 320px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-workspace {
+      position: relative;
+      min-height: 440px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-canvas {
+      min-height: 360px;
+      border: 1px solid var(--border-subtle, #ebe6df);
+      border-radius: var(--radius-lg, 12px);
+      background:
+        radial-gradient(circle at 1px 1px, rgba(20, 20, 19, 0.08) 1px, transparent 0) 0 0 / 18px 18px,
+        var(--bg, #faf9f5);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-canvas svg {
+      width: 100%;
       min-height: 360px;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-detail-drawer {
-      grid-area: detail;
-      display: grid;
-      align-content: start;
-      gap: 10px;
+    body.desktop-native-workbench .desktop-knowledge-graph-node circle {
+      fill: var(--surface-card, #efe9de);
+      stroke: var(--accent, #cc785c);
+      stroke-width: 2;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-results-drawer {
-      grid-area: results;
+    body.desktop-native-workbench .desktop-knowledge-graph-node text {
+      fill: var(--text-body, #3d3d3a);
+      font: 600 11px/1 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-edge {
+      stroke: var(--accent, #cc785c);
+      stroke-width: 1.5;
+      opacity: 0.72;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-tools {
+      position: absolute;
+      z-index: 2;
+      top: 14px;
+      left: 14px;
+      display: grid;
+      gap: 6px;
+      max-width: 86px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-legend,
+    body.desktop-native-workbench .desktop-knowledge-graph-minimap {
+      position: absolute;
+      right: 14px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: var(--radius-md, 8px);
+      background: rgba(250, 249, 245, 0.92);
+      color: var(--text-body, #3d3d3a);
+      font: 700 11px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-legend {
+      bottom: 102px;
+      display: grid;
+      gap: 6px;
+      padding: 8px 10px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-minimap {
+      bottom: 14px;
+      width: 96px;
+      height: 72px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-pipeline-workspace,
+    body.desktop-native-workbench .desktop-knowledge-pipeline-steps {
+      display: grid;
+      gap: 12px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-pipeline-steps {
+      grid-template-columns: repeat(6, minmax(64px, 1fr));
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-pipeline-step {
+      display: grid;
+      gap: 4px;
+      justify-items: center;
+      color: var(--text-muted, #6c6a64);
+      text-align: center;
+      font-size: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-pipeline-dot {
+      width: 34px;
+      height: 34px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: var(--radius-full, 9999px);
+      background: var(--surface-soft, #f5f0e8);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-pipeline-step-done .desktop-knowledge-pipeline-dot,
+    body.desktop-native-workbench .desktop-knowledge-pipeline-step-active .desktop-knowledge-pipeline-dot {
+      border-color: var(--accent, #cc785c);
+      background: var(--accent-soft, rgba(204, 120, 92, 0.12));
     }
 
     body.desktop-native-workbench .desktop-knowledge-readiness,
@@ -8705,24 +9251,56 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
     }
 
+    body.desktop-native-workbench .desktop-knowledge-upload-control {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      border: 0;
+      padding: 0;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
+    }
+
     @media (max-width: 1180px) {
       body.desktop-native-workbench .desktop-knowledge-header {
         grid-template-columns: minmax(0, 1fr);
       }
 
-      body.desktop-native-workbench .desktop-knowledge-actions {
-        grid-column: 1;
-        grid-row: auto;
+      body.desktop-native-workbench .desktop-knowledge-action-row {
         justify-content: start;
       }
 
-      body.desktop-native-workbench .desktop-knowledge-workbench-grid {
+      body.desktop-native-workbench .desktop-knowledge-management-grid {
         grid-template-columns: minmax(0, 1fr);
         grid-template-areas:
-          "filters"
+          "overview"
+          "upload"
+          "queue"
+          "documents"
           "graph"
-          "detail"
-          "results";
+          "pipeline";
+      }
+
+      body.desktop-native-workbench .desktop-knowledge-overview {
+        grid-template-columns: repeat(2, minmax(120px, 1fr));
+      }
+
+      body.desktop-native-workbench .desktop-knowledge-upload-panel,
+      body.desktop-native-workbench .desktop-knowledge-region-header {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+
+    @media (max-width: 640px) {
+      body.desktop-native-workbench .desktop-knowledge-overview {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      body.desktop-native-workbench .desktop-knowledge-pipeline-steps {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
     }
 

--- a/apps/desktop/src/native-vue/knowledgeDocumentsIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeDocumentsIsland.test.ts
@@ -10,6 +10,9 @@ const documents: DesktopKnowledgeDocumentRow[] = [
     title: "Desktop UX",
     path: "docs/desktop.md",
     category: "docs",
+    typeLabel: "MD",
+    sizeLabel: "86 KB",
+    addedLabel: "2026-06-05 08:00",
     tags: ["desktop", "ux"],
     chunkCount: 4,
     status: "indexed",
@@ -21,6 +24,9 @@ const documents: DesktopKnowledgeDocumentRow[] = [
     title: "Inbox note",
     path: "notes/inbox.md",
     category: "notes",
+    typeLabel: "MD",
+    sizeLabel: "12 KB",
+    addedLabel: "Not indexed",
     tags: [],
     chunkCount: 1,
     status: "queued",
@@ -37,14 +43,21 @@ describe("knowledge documents Vue island", () => {
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("knowledge-documents");
     expect(host.className).toContain("desktop-knowledge-documents");
-    expect(host.querySelector("h2")?.textContent).toBe("Documents");
+    expect(host.querySelector("[data-desktop-knowledge-document-search]")?.getAttribute("placeholder")).toBe("Search documents...");
+    expect(host.querySelector("[data-desktop-knowledge-document-filter]")?.textContent).toContain("Filter");
+    expect(host.querySelector("[data-desktop-knowledge-documents-table]")?.textContent).toContain("Name");
+    expect(host.querySelector("[data-desktop-knowledge-documents-table]")?.textContent).toContain("Actions");
     const first = host.querySelector<HTMLElement>('[data-desktop-entity-id="doc-1"]');
     const second = host.querySelector<HTMLElement>('[data-desktop-entity-id="notes/inbox.md"]');
     expect(first?.getAttribute("data-desktop-entity-module")).toBe("knowledge");
-    expect(first?.textContent).toContain("Desktop UX: indexed / 4 chunks");
-    expect(first?.textContent).toContain("desktop");
+    expect(first?.textContent).toContain("Desktop UX");
+    expect(first?.textContent).toContain("MD");
+    expect(first?.textContent).toContain("86 KB");
+    expect(first?.textContent).toContain("indexed");
+    expect(first?.textContent).toContain("Delete");
     expect(second?.getAttribute("data-desktop-entity-module")).toBe("knowledge");
-    expect(second?.textContent).toContain("Inbox note: queued / 1 chunk");
+    expect(second?.textContent).toContain("Inbox note");
+    expect(second?.textContent).toContain("queued");
 
     mounted.unmount();
     expect(host.textContent).toBe("");

--- a/apps/desktop/src/native-vue/knowledgeDocumentsIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeDocumentsIsland.ts
@@ -1,10 +1,11 @@
 import { createApp, defineComponent, h, type App } from "vue";
-import { NConfigProvider, NEmpty, NList, NListItem, NSpace, NTag } from "naive-ui";
+import { NConfigProvider, NEmpty, NTag } from "naive-ui";
 import type { DesktopKnowledgeDocumentRow } from "../desktopKnowledgeTraceability";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 export interface KnowledgeDocumentsIslandOptions {
   documents: DesktopKnowledgeDocumentRow[];
+  onDeleteDocument?: (document: DesktopKnowledgeDocumentRow) => void;
 }
 
 export interface MountedKnowledgeDocumentsIsland {
@@ -33,12 +34,21 @@ function createKnowledgeDocumentsApp(options: KnowledgeDocumentsIslandOptions): 
     setup() {
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => [
-          h("h2", "Documents"),
+          h("div", { class: "desktop-knowledge-documents-toolbar" }, [
+            h("input", {
+              "aria-label": "Search documents",
+              "data-desktop-knowledge-document-search": "",
+              placeholder: "Search documents...",
+              type: "search",
+            }),
+            h("button", { "data-desktop-knowledge-document-filter": "", type: "button" }, "Filter"),
+            h("button", { "aria-label": "Document actions", type: "button" }, "More"),
+          ]),
           options.documents.length
-            ? renderDocuments(options.documents)
+            ? renderDocumentsTable(options)
             : h(NEmpty, {
               class: "desktop-knowledge-documents-empty",
-              description: "No knowledge documents loaded.",
+              description: "No documents yet",
               size: "small",
             }),
         ],
@@ -47,29 +57,50 @@ function createKnowledgeDocumentsApp(options: KnowledgeDocumentsIslandOptions): 
   }));
 }
 
-function renderDocuments(documents: DesktopKnowledgeDocumentRow[]) {
-  return h(NList, { bordered: false, hoverable: true }, {
-    default: () => documents.map((document) => h(NListItem, {
+function renderDocumentsTable(options: KnowledgeDocumentsIslandOptions) {
+  return h("table", { class: "desktop-knowledge-documents-table", "data-desktop-knowledge-documents-table": "" }, [
+    h("thead", [
+      h("tr", [
+        h("th", "Name"),
+        h("th", "Type"),
+        h("th", "Size"),
+        h("th", "Status"),
+        h("th", "Added"),
+        h("th", "Actions"),
+      ]),
+    ]),
+    h("tbody", options.documents.map((document) => h("tr", {
       "data-desktop-entity-module": "knowledge",
       "data-desktop-entity-id": document.id || document.path,
-    }, {
-      default: () => h(NSpace, { vertical: true, size: 4 }, {
-        default: () => [
-          h("span", `${document.title}: ${document.meta}`),
-          renderDocumentTags(document),
-        ],
-      }),
-    })),
-  });
+    }, [
+      h("td", [
+        h("strong", document.title),
+        h("span", { class: "desktop-knowledge-document-meta" }, document.meta),
+      ]),
+      h("td", document.typeLabel || document.category || "DOC"),
+      h("td", document.sizeLabel || "-"),
+      h("td", renderStatusTag(document)),
+      h("td", document.addedLabel || "-"),
+      h("td", [
+        h("button", {
+          "data-desktop-knowledge-document-action": "reindexDocument",
+          type: "button",
+        }, "Re-index"),
+        h("button", {
+          "data-desktop-knowledge-document-action": "deleteDocument",
+          type: "button",
+          onClick: () => options.onDeleteDocument?.(document),
+        }, "Delete"),
+      ]),
+    ]))),
+  ]);
 }
 
-function renderDocumentTags(document: DesktopKnowledgeDocumentRow) {
-  const tags = document.tags.length ? document.tags : [document.category || document.status];
-  return h(NSpace, { size: 4, wrap: true }, {
-    default: () => tags.filter(Boolean).map((tag) => h(NTag, {
-      size: "small",
-      round: true,
-      type: document.status === "indexed" ? "success" : "default",
-    }, { default: () => tag })),
-  });
+function renderStatusTag(document: DesktopKnowledgeDocumentRow) {
+  const status = document.status || "unknown";
+  return h(NTag, {
+    size: "small",
+    round: true,
+    type: status === "indexed" ? "success" : status === "failed" ? "error" : "warning",
+  }, { default: () => status });
 }

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
@@ -56,4 +56,41 @@ describe("knowledge graph Vue island", () => {
     mounted.unmount();
     expect(host.textContent).toBe("");
   });
+
+  test("draws graph edges between their source and target nodes", () => {
+    const host = document.createElement("section");
+    const mounted = mountKnowledgeGraphIsland(host, {
+      graph: {
+        ...graph,
+        view: {
+          nodes: [
+            { id: "center", label: "Center", type: "entity", raw: {} },
+            { id: "source", label: "Source", type: "entity", raw: {} },
+            { id: "target", label: "Target", type: "entity", raw: {} },
+          ],
+          edges: [{
+            id: "edge-source-target",
+            title: "Source relates to Target",
+            sourceId: "source",
+            targetId: "target",
+            sourceLabel: "Source",
+            targetLabel: "Target",
+            predicate: "relates",
+            confidenceLabel: "",
+            evidenceCount: 1,
+            raw: {},
+          }],
+          evidenceRows: [],
+        },
+      },
+    });
+
+    const edge = host.querySelector('[data-desktop-knowledge-graph-edge="edge-source-target"]');
+    expect(edge?.getAttribute("x1")).toBe("320");
+    expect(edge?.getAttribute("y1")).toBe("65");
+    expect(edge?.getAttribute("x2")).toBe("320");
+    expect(edge?.getAttribute("y2")).toBe("295");
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
@@ -84,10 +84,16 @@ function renderGraphCanvas(graph: DesktopKnowledgePaneGraph) {
       h("p", "Upload documents, then build the graph to inspect entities and relationships."),
     ]);
   }
+  const visibleNodes = graph.view.nodes.slice(0, 12);
+  const nodePoints = new Map(visibleNodes.map((node, index) => [node.id, graphPoint(index, visibleNodes.length)]));
+  const visibleEdges = graph.view.edges
+    .slice(0, 10)
+    .map((edge) => ({ edge, source: nodePoints.get(edge.sourceId), target: nodePoints.get(edge.targetId) }))
+    .filter((entry): entry is { edge: DesktopKnowledgeGraphEdge; source: GraphPoint; target: GraphPoint } => Boolean(entry.source && entry.target));
   return h("div", { class: "desktop-knowledge-graph-canvas" }, [
     h("svg", { viewBox: "0 0 640 360", role: "img", "aria-label": graph.summary }, [
-      ...graph.view.edges.slice(0, 10).map((edge, index) => renderGraphEdge(edge, index)),
-      ...graph.view.nodes.slice(0, 12).map((node, index) => renderGraphNode(node, index, graph.view.nodes.length)),
+      ...visibleEdges.map(({ edge, source, target }) => renderGraphEdge(edge, source, target)),
+      ...visibleNodes.map((node, index) => renderGraphNode(node, index, visibleNodes.length)),
     ]),
   ]);
 }
@@ -101,9 +107,7 @@ function renderGraphNode(node: DesktopKnowledgeGraphNode, index: number, total: 
   ]);
 }
 
-function renderGraphEdge(edge: DesktopKnowledgeGraphEdge, index: number) {
-  const start = graphPoint(0, 1);
-  const end = graphPoint(index + 1, 8);
+function renderGraphEdge(edge: DesktopKnowledgeGraphEdge, start: GraphPoint, end: GraphPoint) {
   return h("line", {
     class: "desktop-knowledge-graph-edge",
     "data-desktop-knowledge-graph-edge": edge.id,
@@ -114,7 +118,12 @@ function renderGraphEdge(edge: DesktopKnowledgeGraphEdge, index: number) {
   });
 }
 
-function graphPoint(index: number, total: number) {
+interface GraphPoint {
+  x: number;
+  y: number;
+}
+
+function graphPoint(index: number, total: number): GraphPoint {
   if (index === 0) {
     return { x: 320, y: 180 };
   }

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
@@ -1,6 +1,12 @@
 import { createApp, defineComponent, h, type App } from "vue";
-import { NCard, NConfigProvider, NList, NListItem, NSpace, NTag } from "naive-ui";
-import type { DesktopKnowledgeEvidenceRow, DesktopKnowledgePaneGraph, DesktopKnowledgePaneReferenceRow } from "../desktopKnowledgeTraceability";
+import { NConfigProvider, NList, NListItem, NSpace, NTag } from "naive-ui";
+import type {
+  DesktopKnowledgeEvidenceRow,
+  DesktopKnowledgeGraphEdge,
+  DesktopKnowledgeGraphNode,
+  DesktopKnowledgePaneGraph,
+  DesktopKnowledgePaneReferenceRow,
+} from "../desktopKnowledgeTraceability";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 const KNOWLEDGE_GRAPH_REFERENCE_LIMIT = 4;
@@ -35,8 +41,24 @@ function createKnowledgeGraphApp(options: KnowledgeGraphIslandOptions): App {
     name: "KnowledgeGraphIsland",
     setup() {
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => h(NCard, { size: "small", bordered: false }, {
-          default: () => [
+        default: () => h("div", { class: "desktop-knowledge-graph-workspace" }, [
+          h("div", { class: "desktop-knowledge-graph-tools", "aria-label": "Graph interaction tools" }, [
+            graphTool("Select"),
+            graphTool("Zoom in"),
+            graphTool("Zoom out"),
+            graphTool("Center"),
+            graphTool("Layers"),
+            graphTool("Filter"),
+          ]),
+          renderGraphCanvas(options.graph),
+          h("div", { class: "desktop-knowledge-graph-legend" }, [
+            h("span", [h("i", { class: "desktop-knowledge-legend-node" }), "Entity"]),
+            h("span", [h("i", { class: "desktop-knowledge-legend-edge" }), "Edge"]),
+          ]),
+          h("div", { class: "desktop-knowledge-graph-minimap", "aria-label": "Graph minimap" }, [
+            h("span"),
+          ]),
+          h("div", { class: "desktop-knowledge-graph-references" }, [
             h("h2", `Graph: ${options.graph.summary}`),
             renderReferenceGroup("Community", options.graph.communities),
             renderReferenceGroup("Report", options.graph.reports),
@@ -44,11 +66,63 @@ function createKnowledgeGraphApp(options: KnowledgeGraphIslandOptions): App {
             renderReferenceGroup("Relation", options.graph.relations),
             renderReferenceGroup("Conflict", options.graph.conflicts),
             renderEvidence(options.graph.evidence),
-          ],
-        }),
+          ]),
+        ]),
       });
     },
   }));
+}
+
+function graphTool(label: string) {
+  return h("button", { "aria-label": label, type: "button" }, label);
+}
+
+function renderGraphCanvas(graph: DesktopKnowledgePaneGraph) {
+  if (!graph.view.nodes.length) {
+    return h("div", { class: "desktop-knowledge-graph-canvas desktop-knowledge-graph-empty" }, [
+      h("strong", "No graph built yet"),
+      h("p", "Upload documents, then build the graph to inspect entities and relationships."),
+    ]);
+  }
+  return h("div", { class: "desktop-knowledge-graph-canvas" }, [
+    h("svg", { viewBox: "0 0 640 360", role: "img", "aria-label": graph.summary }, [
+      ...graph.view.edges.slice(0, 10).map((edge, index) => renderGraphEdge(edge, index)),
+      ...graph.view.nodes.slice(0, 12).map((node, index) => renderGraphNode(node, index, graph.view.nodes.length)),
+    ]),
+  ]);
+}
+
+function renderGraphNode(node: DesktopKnowledgeGraphNode, index: number, total: number) {
+  const point = graphPoint(index, total);
+  const radius = index === 0 ? 34 : 18;
+  return h("g", { class: "desktop-knowledge-graph-node", "data-desktop-knowledge-graph-node": node.id }, [
+    h("circle", { cx: point.x, cy: point.y, r: radius }),
+    h("text", { x: point.x, y: point.y + radius + 16, "text-anchor": "middle" }, node.label),
+  ]);
+}
+
+function renderGraphEdge(edge: DesktopKnowledgeGraphEdge, index: number) {
+  const start = graphPoint(0, 1);
+  const end = graphPoint(index + 1, 8);
+  return h("line", {
+    class: "desktop-knowledge-graph-edge",
+    "data-desktop-knowledge-graph-edge": edge.id,
+    x1: start.x,
+    y1: start.y,
+    x2: end.x,
+    y2: end.y,
+  });
+}
+
+function graphPoint(index: number, total: number) {
+  if (index === 0) {
+    return { x: 320, y: 180 };
+  }
+  const angle = ((index - 1) / Math.max(total - 1, 1)) * Math.PI * 2 - Math.PI / 2;
+  return {
+    x: 320 + Math.cos(angle) * 185,
+    y: 180 + Math.sin(angle) * 115,
+  };
 }
 
 function renderReferenceGroup(label: string, rows: DesktopKnowledgePaneReferenceRow[]) {

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
@@ -9,6 +9,7 @@ const pane = buildDesktopKnowledgePaneModel({
   statsPayload: {
     total_documents: 2,
     total_chunks: 18,
+    last_indexed_at: "2026-06-14T09:41:00Z",
     indexed_dense: 18,
     indexed_sparse: 18,
     claim_count: 3,
@@ -32,8 +33,8 @@ const pane = buildDesktopKnowledgePaneModel({
   },
   documentsPayload: {
     documents: [
-      { id: "doc-1", title: "Desktop UX", path: "docs/desktop.md", tags: ["desktop"], chunk_count: 10, status: "indexed" },
-      { id: "doc-2", title: "Gateway", path: "docs/gateway.md", chunk_count: 8, status: "indexed" },
+      { id: "doc-1", title: "Desktop UX", path: "docs/desktop.md", tags: ["desktop"], category: "MD", size_bytes: 86000, chunk_count: 10, status: "indexed", updated_at: "2h ago" },
+      { id: "doc-2", title: "Gateway", path: "docs/gateway.md", category: "PDF", size_bytes: 1260000, chunk_count: 8, status: "indexing", updated_at: "5h ago" },
     ],
   },
   selectedDocumentId: "doc-1",
@@ -99,47 +100,94 @@ describe("knowledge pane Vue island", () => {
     expect(host.getAttribute("data-desktop-vue-island")).toBe("knowledge-pane");
     expect(host.getAttribute("data-desktop-module-surface")).toBe("knowledge");
     expect(host.getAttribute("aria-label")).toBe("Knowledge workbench");
-    expect(host.querySelector(".desktop-knowledge-workbench-grid")?.getAttribute("data-desktop-knowledge-layout")).toBe(
-      "filters-graph-detail-results",
+    expect(host.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Refresh All");
+    expect(host.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Settings");
+    expect(host.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Upload Documents");
+    expect(host.querySelector(".desktop-knowledge-management-grid")?.getAttribute("data-desktop-knowledge-layout")).toBe(
+      "source-left-graph-right",
     );
     expect(Array.from(host.querySelectorAll("[data-desktop-knowledge-region]"), (node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
-      "filters",
+      "overview",
+      "upload",
+      "queue",
+      "documents",
       "graph",
-      "detail",
-      "results",
+      "pipeline",
     ]);
-    expect(host.textContent).toContain("Knowledge");
+    expect(host.querySelector(".desktop-knowledge-title-block h2")?.textContent).toBe("Knowledge Base");
+    expect(host.textContent).toContain("Manage your knowledge base, monitor ingestion, and explore the knowledge graph.");
     expect(host.textContent).toContain("2 docs / readiness 100% / graph 2 nodes / 1 edge");
 
-    expect(host.querySelector(".desktop-knowledge-actions")?.getAttribute("data-desktop-vue-island")).toBe("knowledge-actions");
-    expect(host.querySelector('[data-desktop-knowledge-action="runQuery"]')?.textContent).toContain("Run query");
-    expect(host.querySelector('[data-desktop-knowledge-region="filters"] .desktop-knowledge-readiness')?.getAttribute("data-desktop-vue-island")).toBe(
-      "knowledge-readiness",
+    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Documents");
+    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("2");
+    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Graph Nodes");
+    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Relations");
+    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Last Indexed");
+    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("2026-06-14 09:41");
+    expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.textContent).toContain("Drag & drop files here or click to browse");
+    expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.textContent).toContain("PDF, DOCX, MD, TXT, CSV, JSON");
+    expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.textContent).toContain("Max 200MB per file");
+    expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.getAttribute("data-desktop-drop-target")).toBe(
+      "knowledge-document",
     );
-    expect(host.querySelector('[data-desktop-knowledge-region="filters"] .desktop-knowledge-readiness')?.textContent).toContain("Readiness");
-    expect(host.querySelector('[data-desktop-knowledge-region="filters"] .desktop-knowledge-documents')?.getAttribute("data-desktop-vue-island")).toBe(
+    expect(host.querySelector('[data-desktop-knowledge-region="upload"] [data-desktop-knowledge-action="uploadDocument"]')?.textContent).toContain("Upload Documents");
+    expect(host.querySelector('[data-desktop-knowledge-region="upload"] #desktop-knowledge-upload')?.getAttribute("data-desktop-file-upload")).toBe(
+      "knowledge-document",
+    );
+    expect(host.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Ingestion Queue");
+    expect(host.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Desktop UX");
+    expect(host.querySelector('[data-desktop-knowledge-queue-action="pause"]')?.getAttribute("type")).toBe("button");
+    expect(host.querySelector('[data-desktop-knowledge-queue-action="cancel"]')?.getAttribute("type")).toBe("button");
+    expect(host.querySelector('[data-desktop-knowledge-region="documents"]')?.textContent).toContain("Documents (2)");
+    expect(host.querySelector('[data-desktop-knowledge-document-search]')?.getAttribute("placeholder")).toBe("Search documents...");
+    expect(host.querySelector('[data-desktop-knowledge-document-filter]')?.textContent).toContain("Filter");
+    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Name");
+    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Type");
+    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Size");
+    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Status");
+    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Actions");
+    expect(host.querySelector('[data-desktop-knowledge-document-action="deleteDocument"]')?.textContent).toContain("Delete");
+    expect(host.querySelector('[data-desktop-knowledge-region="documents"] .desktop-knowledge-documents')?.getAttribute("data-desktop-vue-island")).toBe(
       "knowledge-documents",
     );
     expect(host.querySelector('[data-desktop-entity-module="knowledge"]')?.getAttribute("data-desktop-entity-id")).toBe("doc-1");
-    expect(host.querySelector('[data-desktop-knowledge-region="detail"] .desktop-knowledge-document-detail')?.getAttribute("data-desktop-vue-island")).toBe(
+    expect(host.querySelector('[data-desktop-knowledge-region="documents"] .desktop-knowledge-document-detail')?.getAttribute("data-desktop-vue-island")).toBe(
       "knowledge-document-detail",
     );
-    expect(host.querySelector('[data-desktop-knowledge-region="detail"] .desktop-knowledge-document-detail')?.textContent).toContain("Document detail: Desktop UX");
-    expect(host.querySelector('[data-desktop-knowledge-region="results"] .desktop-knowledge-query')?.getAttribute("data-desktop-vue-island")).toBe(
-      "knowledge-query",
-    );
-    expect(host.querySelector('[data-desktop-knowledge-query-result]')?.textContent).toContain("Desktop panes expose graph evidence.");
-    expect(host.querySelector('[data-desktop-knowledge-region="graph"].desktop-knowledge-graph')?.getAttribute("data-desktop-vue-island")).toBe(
+    expect(host.querySelector('[data-desktop-knowledge-region="documents"] .desktop-knowledge-document-detail')?.textContent).toContain("Document detail: Desktop UX");
+    expect(host.querySelector('[data-desktop-knowledge-region="graph"] .desktop-knowledge-graph')?.getAttribute("data-desktop-vue-island")).toBe(
       "knowledge-graph",
     );
+    expect(host.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Build Graph");
+    expect(host.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Refresh Graph");
+    expect(host.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Fit View");
+    expect(host.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Layout");
+    expect(host.querySelector(".desktop-knowledge-graph-tools")?.textContent).toContain("Zoom in");
+    expect(host.querySelector(".desktop-knowledge-graph-legend")?.textContent).toContain("Entity");
+    expect(host.querySelector(".desktop-knowledge-graph-minimap")).not.toBeNull();
     expect(host.querySelector('[data-desktop-knowledge-graph-reference="Community:community-1"]')?.textContent).toContain("Desktop cluster");
-    expect(host.querySelector('[data-desktop-knowledge-region="detail"] .desktop-module-work')?.getAttribute("data-desktop-vue-island")).toBe("module-work");
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.getAttribute("data-desktop-vue-island")).toBe(
+      "knowledge-readiness",
+    );
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.textContent).toContain("Upload");
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.textContent).toContain("Parse");
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.textContent).toContain("Chunk");
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.textContent).toContain("Embed");
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.textContent).toContain("Graph Build");
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.textContent).toContain("Complete");
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.textContent).toContain("6 steps");
+    expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-module-work')?.getAttribute("data-desktop-vue-island")).toBe("module-work");
     expect(host.querySelector('[data-desktop-module-work="knowledge:rebuild"]')?.textContent).toContain("Rebuild knowledge index");
 
-    host.querySelector<HTMLButtonElement>('[data-desktop-knowledge-action="runQuery"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-knowledge-action="refreshAll"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-knowledge-action="settings"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-knowledge-action="uploadDocument"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-knowledge-action="refreshGraph"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-knowledge-action="rebuildIndex"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-knowledge-document-action="deleteDocument"]')?.click();
     host.querySelector<HTMLButtonElement>('[data-desktop-module-work="knowledge:rebuild"]')?.click();
 
-    expect(actions).toEqual(["runQuery"]);
+    expect(actions).toEqual(["refreshAll", "settings", "uploadDocument", "refreshGraph", "rebuildIndex", "deleteDocument"]);
     expect(inspected).toEqual(["knowledge:rebuild"]);
 
     mounted.unmount();

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.ts
@@ -1,23 +1,23 @@
-import { createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, type App } from "vue";
+import { createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, type App, type Ref } from "vue";
 import { NConfigProvider } from "naive-ui";
 import type { DesktopTaskCenterItem } from "../desktopTaskCenter";
 import type {
+  DesktopKnowledgeDocumentRow,
   DesktopKnowledgePaneModel,
 } from "../desktopKnowledgeTraceability";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
-import { mountKnowledgeActionsIsland, type KnowledgeActionItem } from "./knowledgeActionsIsland";
 import { mountKnowledgeDocumentDetailIsland } from "./knowledgeDocumentDetailIsland";
 import { mountKnowledgeDocumentsIsland } from "./knowledgeDocumentsIsland";
 import { mountKnowledgeGraphIsland } from "./knowledgeGraphIsland";
-import { mountKnowledgeQueryIsland } from "./knowledgeQueryIsland";
 import { mountKnowledgeReadinessIsland } from "./knowledgeReadinessIsland";
 import { mountModuleWorkSectionIsland } from "./moduleWorkSectionIsland";
 
-export type KnowledgePaneActionId = "runQuery" | "refreshGraph" | "rebuildIndex" | "deleteDocument" | "uploadDocument";
+export type KnowledgePaneActionId = "refreshAll" | "settings" | "runQuery" | "refreshGraph" | "rebuildIndex" | "deleteDocument" | "uploadDocument";
 
 export interface KnowledgePaneActionEvent {
   action: KnowledgePaneActionId;
   pane: DesktopKnowledgePaneModel;
+  documentId?: string;
 }
 
 export interface KnowledgePaneIslandOptions {
@@ -55,19 +55,13 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
     name: "KnowledgePaneIsland",
     setup() {
       const mountedChildren: Array<{ unmount: () => void }> = [];
-      const actions = ref<HTMLElement | null>(null);
       const work = ref<HTMLElement | null>(null);
       const readiness = ref<HTMLElement | null>(null);
       const documents = ref<HTMLElement | null>(null);
       const documentDetail = ref<HTMLElement | null>(null);
-      const query = ref<HTMLElement | null>(null);
       const graph = ref<HTMLElement | null>(null);
 
       onMounted(() => {
-        mountChild(mountedChildren, actions.value, (host) => mountKnowledgeActionsIsland(host, {
-          actions: knowledgeActions(options.pane),
-          onAction: (action) => options.onKnowledgeAction?.({ action, pane: options.pane }),
-        }));
         if (options.workItems?.length) {
           mountChild(mountedChildren, work.value, (host) => mountModuleWorkSectionIsland(host, {
             title: "Knowledge jobs",
@@ -81,16 +75,17 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
         }));
         mountChild(mountedChildren, documents.value, (host) => mountKnowledgeDocumentsIsland(host, {
           documents: options.pane.documentRows,
+          onDeleteDocument: (document) => options.onKnowledgeAction?.({
+            action: "deleteDocument",
+            pane: options.pane,
+            documentId: document.id || document.path,
+          }),
         }));
         if (options.pane.selectedDocument) {
           mountChild(mountedChildren, documentDetail.value, (host) => mountKnowledgeDocumentDetailIsland(host, {
             document: options.pane.selectedDocument!,
           }));
         }
-        mountChild(mountedChildren, query.value, (host) => mountKnowledgeQueryIsland(host, {
-          draft: options.pane.query.draft,
-          results: options.pane.query.results,
-        }));
         mountChild(mountedChildren, graph.value, (host) => mountKnowledgeGraphIsland(host, {
           graph: options.pane.graph,
         }));
@@ -104,44 +99,21 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
 
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => h("div", { class: "desktop-knowledge-workbench" }, [
-          h("div", { class: "desktop-knowledge-header" }, [
-            h("h2", "Knowledge"),
-            h("p", options.pane.status),
-            h("div", { ref: actions }),
-          ]),
+          renderKnowledgeHeader(options),
           h("div", {
-            class: "desktop-knowledge-workbench-grid",
-            "data-desktop-knowledge-layout": "filters-graph-detail-results",
+            class: "desktop-knowledge-management-grid",
+            "data-desktop-knowledge-layout": "source-left-graph-right",
           }, [
             h("section", {
-              class: "desktop-knowledge-region desktop-knowledge-filters",
-              "data-desktop-knowledge-region": "filters",
-              "aria-label": "Knowledge filters",
-            }, [
-              h("section", { ref: readiness }),
-              h("section", { ref: documents }),
-            ]),
-            h("section", {
-              ref: graph,
-              class: "desktop-knowledge-region desktop-knowledge-graph",
-              "data-desktop-knowledge-region": "graph",
-              "aria-label": "Knowledge graph",
-            }),
-            h("section", {
-              class: "desktop-knowledge-region desktop-knowledge-detail-drawer",
-              "data-desktop-knowledge-region": "detail",
-              "aria-label": "Knowledge detail",
-            }, [
-              options.workItems?.length ? h("section", { ref: work }) : null,
-              options.pane.selectedDocument ? h("section", { ref: documentDetail }) : null,
-            ]),
-            h("section", {
-              class: "desktop-knowledge-region desktop-knowledge-results-drawer",
-              "data-desktop-knowledge-region": "results",
-              "aria-label": "Knowledge query results",
-            }, [
-              h("section", { ref: query }),
-            ]),
+              class: "desktop-knowledge-region desktop-knowledge-overview",
+              "data-desktop-knowledge-region": "overview",
+              "aria-label": "Knowledge base overview",
+            }, renderKnowledgeOverview(options.pane)),
+            renderKnowledgeUploadRegion(options),
+            renderKnowledgeQueueRegion(options),
+            renderKnowledgeDocumentsRegion(options, documents, documentDetail),
+            renderKnowledgeGraphRegion(options, graph),
+            renderKnowledgePipelineRegion(options, readiness, work),
           ]),
         ]),
       });
@@ -149,14 +121,213 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
   }));
 }
 
-function knowledgeActions(pane: DesktopKnowledgePaneModel): KnowledgeActionItem[] {
+function renderKnowledgeHeader(options: KnowledgePaneIslandOptions) {
+  return h("div", { class: "desktop-knowledge-header" }, [
+    h("div", { class: "desktop-knowledge-title-block" }, [
+      h("p", { class: "desktop-knowledge-kicker" }, "Knowledge Base"),
+      h("h2", "Knowledge Base"),
+      h("p", "Manage your knowledge base, monitor ingestion, and explore the knowledge graph."),
+      h("p", { class: "desktop-knowledge-status" }, options.pane.status),
+    ]),
+    h("div", { class: "desktop-knowledge-toolbar" }, [
+      renderKnowledgeActionButton(options, "refreshAll", "Refresh All", "secondary"),
+      renderKnowledgeActionButton(options, "settings", "Settings", "secondary"),
+      renderKnowledgeActionButton(options, "uploadDocument", "Upload Documents", "primary"),
+    ]),
+  ]);
+}
+
+function renderKnowledgeUploadRegion(options: KnowledgePaneIslandOptions) {
+  return h("section", {
+    class: "desktop-knowledge-region desktop-knowledge-upload-region",
+    "data-desktop-knowledge-region": "upload",
+    "aria-label": "Upload knowledge documents",
+  }, [
+    h("div", { class: "desktop-knowledge-region-header" }, [
+      h("div", [
+        h("h3", "Upload Documents"),
+        h("p", "Add files to your knowledge base. We'll parse, chunk, and index them."),
+      ]),
+      renderKnowledgeActionButton(options, "uploadDocument", "Upload Documents", "primary"),
+    ]),
+    h("div", {
+      class: "desktop-knowledge-drop-zone",
+      "data-desktop-drop-target": "knowledge-document",
+    }, [
+      h("strong", "Drag & drop files here or click to browse"),
+      h("span", "PDF, DOCX, MD, TXT, CSV, JSON"),
+      h("small", "Max 200MB per file"),
+    ]),
+    renderKnowledgeUploadControl(),
+  ]);
+}
+
+function renderKnowledgeQueueRegion(options: KnowledgePaneIslandOptions) {
+  const queueRows = options.pane.documentRows.slice(0, 2);
+  return h("section", {
+    class: "desktop-knowledge-region desktop-knowledge-queue-region",
+    "data-desktop-knowledge-region": "queue",
+    "aria-label": "Knowledge ingestion queue",
+  }, [
+    h("div", { class: "desktop-knowledge-region-header" }, [
+      h("div", [
+        h("h3", `Ingestion Queue${queueRows.length ? ` (${queueRows.length})` : ""}`),
+        h("p", "Track files as they move through parsing and indexing."),
+      ]),
+    ]),
+    queueRows.length
+      ? h("div", { class: "desktop-knowledge-queue-list" }, queueRows.map((document, index) => renderKnowledgeQueueRow(document, index)))
+      : h("p", { class: "desktop-knowledge-empty-note" }, "No ingestion jobs running."),
+  ]);
+}
+
+function renderKnowledgeDocumentsRegion(
+  options: KnowledgePaneIslandOptions,
+  documents: Ref<HTMLElement | null>,
+  documentDetail: Ref<HTMLElement | null>,
+) {
+  return h("section", {
+    class: "desktop-knowledge-region desktop-knowledge-documents-region",
+    "data-desktop-knowledge-region": "documents",
+    "aria-label": "Knowledge documents",
+  }, [
+    h("div", { class: "desktop-knowledge-region-header" }, [
+      h("div", [
+        h("h3", `Documents (${options.pane.documentRows.length})`),
+        h("p", "Search, filter, inspect, re-index, and delete knowledge sources."),
+      ]),
+    ]),
+    h("section", { ref: documents }),
+    options.pane.selectedDocument ? h("section", { ref: documentDetail }) : null,
+  ]);
+}
+
+function renderKnowledgeGraphRegion(options: KnowledgePaneIslandOptions, graph: Ref<HTMLElement | null>) {
+  return h("section", {
+    class: "desktop-knowledge-region desktop-knowledge-graph-region",
+    "data-desktop-knowledge-region": "graph",
+    "aria-label": "Knowledge graph",
+  }, [
+    h("div", { class: "desktop-knowledge-region-header" }, [
+      h("div", [
+        h("h3", "Knowledge Graph"),
+        h("p", "Explore entities and their relationships."),
+      ]),
+      h("div", { class: "desktop-knowledge-action-row" }, [
+        renderKnowledgeActionButton(options, "rebuildIndex", "Build Graph", "secondary"),
+        renderKnowledgeActionButton(options, "refreshGraph", "Refresh Graph", "secondary"),
+        h("button", { class: "desktop-knowledge-action-button desktop-knowledge-action-button-secondary", type: "button" }, "Fit View"),
+        h("button", { class: "desktop-knowledge-action-button desktop-knowledge-action-button-secondary", type: "button" }, "Layout"),
+      ]),
+    ]),
+    h("section", { ref: graph }),
+  ]);
+}
+
+function renderKnowledgePipelineRegion(
+  options: KnowledgePaneIslandOptions,
+  readiness: Ref<HTMLElement | null>,
+  work: Ref<HTMLElement | null>,
+) {
+  return h("section", {
+    class: "desktop-knowledge-region desktop-knowledge-pipeline",
+    "data-desktop-knowledge-region": "pipeline",
+    "aria-label": "Knowledge indexing pipeline",
+  }, [
+    h("div", { class: "desktop-knowledge-region-header" }, [
+      h("div", [
+        h("h3", "Indexing Pipeline"),
+        h("p", "Track ingestion and indexing progress."),
+      ]),
+    ]),
+    h("section", { ref: readiness }),
+    options.workItems?.length ? h("section", { ref: work }) : null,
+  ]);
+}
+
+function renderKnowledgeQueueRow(document: DesktopKnowledgeDocumentRow, index: number) {
+  const progress = document.status === "indexed" ? 100 : document.status === "indexing" ? 45 : 0;
+  const stage = document.status === "indexed" ? "Indexed" : document.status === "indexing" ? "Parsing" : "Queued";
+  return h("article", { class: "desktop-knowledge-queue-row" }, [
+    h("div", { class: "desktop-knowledge-queue-file" }, [
+      h("strong", document.title),
+      h("span", `${document.typeLabel || "DOC"} / ${document.sizeLabel || "-"} / ${stage}`),
+    ]),
+    h("div", { class: "desktop-knowledge-queue-progress", "aria-label": `${stage} ${progress}%` }, [
+      h("span", { style: { width: `${progress}%` } }),
+    ]),
+    h("span", { class: "desktop-knowledge-queue-percent" }, progress ? `${progress}%` : "-"),
+    h("button", { "data-desktop-knowledge-queue-action": "pause", type: "button", disabled: index > 0 }, "Pause"),
+    h("button", { "data-desktop-knowledge-queue-action": "cancel", type: "button" }, "Cancel"),
+  ]);
+}
+
+function renderKnowledgeUploadControl() {
+  return h("button", {
+    id: "desktop-knowledge-upload",
+    class: "desktop-knowledge-upload-control",
+    "aria-hidden": "true",
+    "data-desktop-file-upload": "knowledge-document",
+    tabindex: "-1",
+    type: "button",
+  }, "Upload knowledge document");
+}
+
+function renderKnowledgeOverview(pane: DesktopKnowledgePaneModel) {
+  const documentCount = pane.documentRows.length;
+  const chunkCount = pane.documentRows.reduce((total, row) => total + row.chunkCount, 0);
+  const nodeCount = pane.graph.view.nodes.length;
+  const edgeCount = pane.graph.view.edges.length;
   return [
-    { action: "uploadDocument", label: "Upload document", enabled: pane.actions.upload },
-    { action: "runQuery", label: "Run query", enabled: pane.actions.query },
-    { action: "refreshGraph", label: "Refresh graph", enabled: pane.actions.refreshGraph },
-    { action: "rebuildIndex", label: "Rebuild index", enabled: pane.actions.rebuild },
-    { action: "deleteDocument", label: "Delete document", enabled: pane.actions.deleteDocument },
+    renderKnowledgeMetric("Documents", String(documentCount), "Uploaded sources"),
+    renderKnowledgeMetric("Readiness", `${pane.readiness.score}%`, `${chunkCount} indexed chunks`),
+    renderKnowledgeMetric("Graph Nodes", String(nodeCount), `${pane.graph.evidence.length} evidence`),
+    renderKnowledgeMetric("Relations", String(edgeCount), "Graph edges"),
+    renderKnowledgeMetric("Last Indexed", pane.lastIndexedLabel, "Knowledge freshness"),
   ];
+}
+
+function renderKnowledgeMetric(label: string, value: string, detail: string) {
+  return h("article", { class: "desktop-knowledge-metric" }, [
+    h("span", { class: "desktop-knowledge-metric-label" }, label),
+    h("strong", value),
+    h("span", { class: "desktop-knowledge-metric-detail" }, detail),
+  ]);
+}
+
+function renderKnowledgeActionButton(
+  options: KnowledgePaneIslandOptions,
+  action: KnowledgePaneActionId,
+  label: string,
+  variant: "primary" | "secondary",
+) {
+  const enabled = knowledgeActionEnabled(options.pane, action);
+  return h("button", {
+    class: `desktop-knowledge-action-button desktop-knowledge-action-button-${variant}`,
+    "data-desktop-knowledge-action": action,
+    disabled: !enabled,
+    type: "button",
+    onClick: () => options.onKnowledgeAction?.({ action, pane: options.pane }),
+  }, label);
+}
+
+function knowledgeActionEnabled(pane: DesktopKnowledgePaneModel, action: KnowledgePaneActionId): boolean {
+  if (action === "uploadDocument") {
+    return pane.actions.upload;
+  }
+  if (action === "refreshGraph") {
+    return pane.actions.refreshGraph;
+  }
+  if (action === "runQuery") {
+    return pane.actions.query;
+  }
+  if (action === "rebuildIndex") {
+    return pane.actions.rebuild;
+  }
+  if (action === "deleteDocument") {
+    return pane.actions.deleteDocument;
+  }
+  return true;
 }
 
 function mountChild<T extends { unmount: () => void }>(

--- a/apps/desktop/src/native-vue/knowledgeReadinessIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeReadinessIsland.test.ts
@@ -43,12 +43,17 @@ describe("knowledge readiness Vue island", () => {
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("knowledge-readiness");
     expect(host.className).toContain("desktop-knowledge-readiness");
-    expect(host.querySelector("h2")?.textContent).toBe("Readiness");
+    expect(host.textContent).toContain("Upload");
+    expect(host.textContent).toContain("Parse");
+    expect(host.textContent).toContain("Chunk");
+    expect(host.textContent).toContain("Embed");
+    expect(host.textContent).toContain("Graph Build");
+    expect(host.textContent).toContain("Complete");
     expect(host.textContent).toContain("Knowledge enabled");
     expect(host.textContent).toContain("Retrieval hybrid");
     expect(host.textContent).toContain("retrieval: ready");
     expect(host.textContent).toContain("graph: warn");
-    expect(host.textContent).toContain("80%");
+    expect(host.textContent).toContain("3 / 6 steps");
 
     mounted.unmount();
     expect(host.textContent).toBe("");

--- a/apps/desktop/src/native-vue/knowledgeReadinessIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeReadinessIsland.ts
@@ -1,5 +1,5 @@
 import { createApp, defineComponent, h, type App } from "vue";
-import { NCard, NConfigProvider, NProgress, NSpace, NTag } from "naive-ui";
+import { NConfigProvider, NProgress, NSpace, NTag } from "naive-ui";
 import type { DesktopKnowledgeReadinessRow, DesktopKnowledgeReadinessView } from "../desktopKnowledgeTraceability";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
@@ -33,23 +33,43 @@ function createKnowledgeReadinessApp(options: KnowledgeReadinessIslandOptions): 
     name: "KnowledgeReadinessIsland",
     setup() {
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => h(NCard, { size: "small", bordered: false }, {
-          default: () => [
-            h("h2", "Readiness"),
-            h(NProgress, {
-              percentage: options.readiness.score,
-              processing: options.readiness.partialAvailability,
-              status: progressStatus(options.readiness),
-              type: "line",
-            }),
-            h("p", `Score: ${options.readiness.score}%`),
-            renderHints(options.configHints),
-            renderRows(options.readiness.rows),
-          ],
-        }),
+        default: () => h("div", { class: "desktop-knowledge-pipeline-workspace" }, [
+          h("div", { class: "desktop-knowledge-pipeline-steps" }, pipelineSteps(options.readiness).map((step) => h("article", {
+            class: `desktop-knowledge-pipeline-step desktop-knowledge-pipeline-step-${step.state}`,
+          }, [
+            h("span", { class: "desktop-knowledge-pipeline-dot" }),
+            h("strong", step.label),
+            h("span", step.detail),
+          ]))),
+          h(NProgress, {
+            percentage: options.readiness.score,
+            processing: options.readiness.partialAvailability,
+            status: progressStatus(options.readiness),
+            type: "line",
+          }),
+          h("p", `${completedStepCount(options.readiness)} / 6 steps`),
+          renderHints(options.configHints),
+          renderRows(options.readiness.rows),
+        ]),
       });
     },
   }));
+}
+
+function pipelineSteps(readiness: DesktopKnowledgeReadinessView) {
+  const readyRows = new Set(readiness.rows.filter((row) => row.tone === "ready").map((row) => row.id));
+  return [
+    { label: "Upload", detail: readiness.score > 0 ? "Sources loaded" : "No files", state: readiness.score > 0 ? "done" : "wait" },
+    { label: "Parse", detail: readyRows.has("retrieval") ? "Ready" : "Wait", state: readyRows.has("retrieval") ? "done" : "active" },
+    { label: "Chunk", detail: readyRows.has("retrieval") ? "Chunks indexed" : "Wait", state: readyRows.has("retrieval") ? "done" : "wait" },
+    { label: "Embed", detail: readiness.partialAvailability ? "In progress" : "Ready", state: readiness.partialAvailability ? "active" : "done" },
+    { label: "Graph Build", detail: readyRows.has("graph") ? "Ready" : "Wait", state: readyRows.has("graph") ? "done" : "wait" },
+    { label: "Complete", detail: readiness.score >= 100 ? "Complete" : "-", state: readiness.score >= 100 ? "done" : "wait" },
+  ];
+}
+
+function completedStepCount(readiness: DesktopKnowledgeReadinessView): number {
+  return pipelineSteps(readiness).filter((step) => step.state === "done").length;
 }
 
 function renderHints(configHints: string[]) {

--- a/apps/desktop/src/native-vue/mainUtilitiesRegionIsland.test.ts
+++ b/apps/desktop/src/native-vue/mainUtilitiesRegionIsland.test.ts
@@ -6,6 +6,7 @@ import {
   buildDesktopSettingsFormState,
   buildDesktopSettingsPaneModel,
 } from "../desktopSettingsProviders";
+import { buildDesktopKnowledgePaneModel } from "../desktopKnowledgeTraceability";
 import type { AgentUiForm } from "../agentUiEvents";
 import type { DesktopSettingsActionEvent } from "../desktopWorkbenchShell";
 import { mountMainUtilitiesRegionIsland } from "./mainUtilitiesRegionIsland";
@@ -91,5 +92,23 @@ describe("main utilities region Vue island", () => {
 
     mounted.unmount();
     expect(host.textContent).toBe("");
+  });
+
+  test("omits the generic file imports surface when the Knowledge pane is active", async () => {
+    const host = document.createElement("div");
+    const mounted = mountMainUtilitiesRegionIsland(host, {
+      activeSessionKey: "session-1",
+      agentUiForms: [],
+      knowledgePane: buildDesktopKnowledgePaneModel(),
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(host.querySelector(".desktop-file-actions")).toBeNull();
+    expect(host.textContent).not.toContain("File imports");
+    expect(host.querySelector(".desktop-knowledge-pane")).not.toBeNull();
+    expect(host.querySelector("#desktop-knowledge-upload")?.getAttribute("data-desktop-file-upload")).toBe("knowledge-document");
+
+    mounted.unmount();
   });
 });

--- a/apps/desktop/src/native-vue/mainUtilitiesRegionIsland.ts
+++ b/apps/desktop/src/native-vue/mainUtilitiesRegionIsland.ts
@@ -98,9 +98,11 @@ function createMainUtilitiesRegionApp(options: MainUtilitiesRegionIslandOptions)
 
       onMounted(() => {
         mountChild(mountedChildren, commandPalette.value, (host) => mountCommandPaletteIsland(host));
-        mountChild(mountedChildren, fileActions.value, (host) => mountFileActionsSurfaceIsland(host, {
-          activeSessionKey: options.activeSessionKey ?? null,
-        }));
+        if (!options.knowledgePane) {
+          mountChild(mountedChildren, fileActions.value, (host) => mountFileActionsSurfaceIsland(host, {
+            activeSessionKey: options.activeSessionKey ?? null,
+          }));
+        }
         mountChild(mountedChildren, helpSurface.value, (host) => mountHelpSurfaceIsland(host, {
           onAction: options.onHelpAction,
         }));
@@ -161,7 +163,7 @@ function createMainUtilitiesRegionApp(options: MainUtilitiesRegionIslandOptions)
         }, {
           default: () => [
             h("section", { ref: commandPalette }),
-            h("section", { ref: fileActions }),
+            options.knowledgePane ? null : h("section", { ref: fileActions }),
             h("section", { ref: helpSurface }),
             h("section", { ref: agentUiForms }),
             h("section", { ref: workspaceFiles }),


### PR DESCRIPTION
﻿## Summary
- Redesign the native Knowledge page as a global knowledge base workbench.
- Remove the generic file imports surface from the Knowledge pane and replace it with upload, ingestion queue, document management, graph exploration, and indexing pipeline modules.
- Add Knowledge-focused model fields and test coverage for the new page structure and actions.

## Validation
- `git diff --check`
- `npx vitest run src/native-vue/knowledgePaneIsland.test.ts src/native-vue/mainUtilitiesRegionIsland.test.ts src/native-vue/knowledgeGraphIsland.test.ts src/native-vue/knowledgeDocumentsIsland.test.ts src/native-vue/knowledgeReadinessIsland.test.ts src/native-vue/knowledgeQueryIsland.test.ts src/native-vue/knowledgeDocumentDetailIsland.test.ts src/native-vue/knowledgeReferenceRowIsland.test.ts src/desktopWorkbenchShell.test.ts`
- `npm run build`

## Notes
- Unrelated local changes, generated files, design/spec/progress docs, and `.gitignore` were intentionally left out of this PR.
- The Vite build still reports existing chunk and mixed static/dynamic import warnings.
