### PR TITLE
Disable standalone Cowork page while under construction

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -444,6 +444,7 @@ function hydrateNativeStartupPanes(startupTrace?: DesktopNativeStartupTrace): vo
 
 const nativeRouteHydratedModules = new Set<string>();
 let nativeCoworkRuntimeRolloutSyncPromise: Promise<void> | null = null;
+const DESKTOP_COWORK_STANDALONE_AVAILABLE = false;
 
 function installNativeRouteHydration(startupTrace?: DesktopNativeStartupTrace): void {
   window.addEventListener("tinybot:desktop-route", (event) => {
@@ -475,6 +476,15 @@ function hydrateNativeRouteTarget(href: string, startupTrace?: DesktopNativeStar
     return;
   }
   if (pathname.startsWith("/cowork")) {
+    if (!DESKTOP_COWORK_STANDALONE_AVAILABLE) {
+      startupTrace?.mark("coworkPaneHydration.skipped", {
+        reason: "under-construction",
+      });
+      startupTrace?.mark("coworkTasksRefresh.skipped", {
+        reason: "under-construction",
+      });
+      return;
+    }
     hydrateNativeCoworkPaneOnce(startupTrace);
     traceNativeRouteBackgroundOnce("coworkTasksRefresh", () => refreshNativeCoworkTasks(), startupTrace);
     return;

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -1946,7 +1946,7 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Index Desktop UX Notes in Work Lens");
   });
 
-  test("routes Cowork session selection into the right-side Work Lens", () => {
+  test("renders Cowork as unavailable without routing session selection", () => {
     const targetDocument = new FakeDocument();
     const session = {
       id: "cowork-1",
@@ -1973,17 +1973,16 @@ describe("desktop workbench shell", () => {
       },
     });
 
-    targetDocument.body.querySelector('[data-desktop-cowork-session="cowork-1"]')?.click();
-
+    const pane = targetDocument.body.querySelector(".desktop-cowork-cockpit");
+    expect(pane?.getAttribute("aria-label")).toBe("Cowork unavailable");
+    expect(pane?.textContent).toContain("Cowork is under construction");
+    expect(pane?.textContent).toContain("This page is temporarily unavailable.");
+    expect(pane?.textContent).toContain("暂不开放");
+    expect(targetDocument.body.querySelector('[data-desktop-cowork-session="cowork-1"]')).toBeNull();
     const inspector = targetDocument.body.querySelector('[data-workbench-region="inspector"]');
     const lens = inspector?.querySelector(".desktop-work-lens");
-    expect(lens?.getAttribute("data-desktop-work-lens-kind")).toBe("coworkRun");
-    expect(lens?.textContent).toContain("Review desktop release");
-    expect(lens?.textContent).toContain("Reason: 1 blocker");
-    expect(lens?.textContent).toContain("Progress: 1/2");
-    expect(lens?.textContent).toContain("What did it use?");
-    expect(lens?.textContent).toContain("What changed?");
-    expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Inspecting Review desktop release in Work Lens");
+    expect(lens?.getAttribute("data-desktop-work-lens-kind")).not.toBe("coworkRun");
+    expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).not.toContain("Review desktop release");
   });
 
   test("routes Chat module run selection into the right-side Work Lens", () => {
@@ -3026,80 +3025,20 @@ describe("desktop workbench shell", () => {
     });
 
     const pane = targetDocument.body.querySelector(".desktop-cowork-cockpit");
-    const goal = pane?.querySelector('[data-desktop-cowork-input="goal"]');
-    const message = pane?.querySelector('[data-desktop-cowork-input="message"]');
-    const budgetMaxRounds = pane?.querySelector('[data-desktop-cowork-input="budgetMaxRounds"]');
-    if (goal) {
-      goal.value = "Create a desktop run";
-    }
-    if (message) {
-      message.value = "Continue with the next unit";
-    }
-    if (budgetMaxRounds) {
-      budgetMaxRounds.value = "7";
-    }
-    expect(pane?.getAttribute("aria-label")).toBe("Cowork cockpit");
-    expect(pane?.textContent).toContain("Desktop migration");
-    expect(pane?.textContent).toContain("Move Cowork into a desktop cockpit");
-    expect(pane?.textContent).toContain("blocked / Adaptive Starter / 1 agent / 0/1 tasks");
-    expect(pane?.querySelectorAll(".desktop-cowork-session-row").map((row) => row.getAttribute("data-desktop-cowork-session"))).toEqual(["cowork-1"]);
-    expect(pane?.querySelector(".desktop-cowork-session-row")?.getAttribute("data-desktop-entity-module")).toBe("cowork");
-    expect(pane?.querySelector(".desktop-cowork-session-row")?.getAttribute("data-desktop-entity-id")).toBe("cowork-1");
-    expect(pane?.querySelector(".desktop-cowork-graph")?.textContent).toContain("2 nodes / 1 edge");
-    expect(pane?.querySelector(".desktop-cowork-graph")?.textContent).toContain("Planner");
-    expect(pane?.querySelector(".desktop-cowork-inspector")?.textContent).toContain("Map cockpit layout");
-    expect(pane?.querySelector(".desktop-cowork-inspector")?.textContent).toContain("Owner: agent-1");
-    pane?.querySelector('[data-desktop-cowork-entity="agent-1"]')?.click();
-    expect(pane?.querySelector(".desktop-cowork-inspector")?.textContent).toContain("Selected: Planner");
-    expect(pane?.querySelector(".desktop-cowork-inspector")?.textContent).toContain("Status: running");
-    pane?.querySelector('[data-desktop-cowork-entity-action="loadAgentActivity"]')?.click();
-    expect(pane?.querySelectorAll(".desktop-cowork-action").map((row) => row.getAttribute("data-desktop-cowork-action")).filter(Boolean)).toEqual([
-      "blueprintValidate",
-      "blueprintPreview",
-      "create",
-      "run",
-      "pause",
-      "resume",
-      "emergencyStop",
-      "delete",
-      "message",
-      "summary",
-      "blueprint",
-      "trace",
-      "dag",
-      "artifacts",
-      "organization",
-      "queues",
-      "branches",
-      "updateBudget",
-      "addTask",
-    ]);
-    for (const action of ["create", "run", "pause", "resume", "emergencyStop", "delete", "message", "summary", "blueprint", "trace", "dag", "artifacts", "organization", "queues", "branches", "updateBudget"]) {
-      pane?.querySelector(`[data-desktop-cowork-action="${action}"]`)?.click();
-    }
-    expect(actionEvents).toEqual([
-      { action: "loadAgentActivity", sessionId: "cowork-1", goal: "", message: "", agentId: "agent-1", limit: 20 },
-      { action: "createSession", sessionId: "", goal: "Create a desktop run", message: "" },
-      { action: "runSession", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "pauseSession", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "resumeSession", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "emergencyStopSession", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "deleteSession", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "sendMessage", sessionId: "cowork-1", goal: "", message: "Continue with the next unit" },
-      { action: "loadSummary", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "loadBlueprint", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "loadTrace", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "loadDag", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "loadArtifacts", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "loadOrganization", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "loadQueues", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "loadBranches", sessionId: "cowork-1", goal: "", message: "" },
-      { action: "updateBudget", sessionId: "cowork-1", goal: "", message: "", maxRounds: 7 },
-    ]);
-    expect(pane?.querySelector(".desktop-cowork-task-feed")?.textContent).toContain("1 blocker");
+    expect(pane?.getAttribute("aria-label")).toBe("Cowork unavailable");
+    expect(pane?.textContent).toContain("Cowork is under construction");
+    expect(pane?.textContent).toContain("This page is temporarily unavailable.");
+    expect(pane?.textContent).toContain("暂不开放");
+    expect(pane?.textContent).not.toContain("Desktop migration");
+    expect(pane?.querySelector(".desktop-cowork-session-row")).toBeNull();
+    expect(pane?.querySelector(".desktop-cowork-action")).toBeNull();
+    expect(pane?.querySelector(".desktop-cowork-graph")).toBeNull();
+    expect(pane?.querySelector(".desktop-cowork-inspector")).toBeNull();
+    expect(pane?.querySelector(".desktop-cowork-task-feed")).toBeNull();
+    expect(actionEvents).toEqual([]);
   });
 
-  test("routes Cowork blueprint validate and preview actions from the cockpit", () => {
+  test("does not expose Cowork blueprint actions while the page is unavailable", () => {
     const targetDocument = new FakeDocument();
     const actionEvents: Array<{ action: string; blueprintText: string; preview: boolean }> = [];
     const session = {
@@ -3131,19 +3070,12 @@ describe("desktop workbench shell", () => {
     });
 
     const pane = targetDocument.body.querySelector(".desktop-cowork-cockpit");
-    const blueprint = pane?.querySelector('[data-desktop-cowork-input="blueprint"]');
-    if (blueprint) {
-      blueprint.value = "{\"agents\":[]}";
-    }
-
-    expect(pane?.textContent).toContain("Blueprint: Valid / 1 warning(s)");
-    pane?.querySelector('[data-desktop-cowork-action="blueprintValidate"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-action="blueprintPreview"]')?.click();
-
-    expect(actionEvents).toEqual([
-      { action: "validateBlueprint", blueprintText: "{\"agents\":[]}", preview: false },
-      { action: "validateBlueprint", blueprintText: "{\"agents\":[]}", preview: true },
-    ]);
+    expect(pane?.textContent).toContain("Cowork is under construction");
+    expect(pane?.textContent).not.toContain("Blueprint: Valid / 1 warning(s)");
+    expect(pane?.querySelector('[data-desktop-cowork-input="blueprint"]')).toBeNull();
+    expect(pane?.querySelector('[data-desktop-cowork-action="blueprintValidate"]')).toBeNull();
+    expect(pane?.querySelector('[data-desktop-cowork-action="blueprintPreview"]')).toBeNull();
+    expect(actionEvents).toEqual([]);
   });
 
   test("renders Cowork observability tabs and preserves selected inspector while switching panels", () => {
@@ -3184,34 +3116,10 @@ describe("desktop workbench shell", () => {
     });
 
     const pane = targetDocument.body.querySelector(".desktop-cowork-cockpit");
-    expect(pane?.querySelectorAll(".desktop-cowork-observability-tab").map((row) => row.getAttribute("data-desktop-cowork-panel"))).toEqual([
-      "graph",
-      "focus",
-      "metrics",
-      "architecture",
-      "swarm",
-      "workUnits",
-      "taskDag",
-      "agents",
-      "tasks",
-      "mailbox",
-      "threads",
-      "trace",
-      "artifacts",
-      "outputs",
-      "finalDraft",
-      "blockers",
-      "evaluations",
-      "status",
-    ]);
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).toContain("Graph");
-
-    pane?.querySelector('[data-desktop-cowork-panel="metrics"]')?.click();
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).toContain("Round efficiency: 82%");
-    expect(pane?.querySelector(".desktop-cowork-inspector")?.textContent).toContain("Selected: Planner");
-
-    pane?.querySelector('[data-desktop-cowork-panel="finalDraft"]')?.click();
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).toContain("Ship the desktop Cowork cockpit.");
+    expect(pane?.textContent).toContain("Cowork is under construction");
+    expect(pane?.querySelectorAll(".desktop-cowork-observability-tab")).toHaveLength(0);
+    expect(pane?.querySelector(".desktop-cowork-observability-panel")).toBeNull();
+    expect(pane?.querySelector(".desktop-cowork-inspector")).toBeNull();
   });
 
   test("constrains large Cowork sessions with bounded rendering and observability filtering", () => {
@@ -3266,28 +3174,10 @@ describe("desktop workbench shell", () => {
     });
 
     const pane = targetDocument.body.querySelector(".desktop-cowork-cockpit");
-    expect(pane?.querySelectorAll(".desktop-cowork-graph-node")).toHaveLength(24);
-    expect(pane?.querySelector(".desktop-cowork-graph")?.textContent).toContain("Showing 24 of 60 nodes");
-    expect(pane?.querySelector(".desktop-cowork-graph")?.textContent).toContain("Showing 12 of 40 edges");
-
-    pane?.querySelector('[data-desktop-cowork-panel="tasks"]')?.click();
-    expect(pane?.querySelectorAll(".desktop-cowork-observability-row")).toHaveLength(24);
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).toContain("Showing 24 of 70 rows");
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).not.toContain("Task 25");
-
-    pane?.querySelector('[data-desktop-cowork-panel="trace"]')?.click();
-    expect(pane?.querySelectorAll(".desktop-cowork-observability-row")).toHaveLength(24);
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).toContain("Showing 24 of 80 rows");
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).not.toContain("Trace span 25");
-
-    const filter = pane?.querySelector('[data-desktop-cowork-filter="observability"]');
-    if (filter) {
-      filter.value = "Trace span 70";
-      filter.dispatchEvent({ type: "input", target: filter });
-    }
-
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).toContain("Showing 1 of 1 matching rows (80 total)");
-    expect(pane?.querySelector(".desktop-cowork-observability-panel")?.textContent).toContain("Trace span 70");
+    expect(pane?.textContent).toContain("Cowork is under construction");
+    expect(pane?.querySelectorAll(".desktop-cowork-graph-node")).toHaveLength(0);
+    expect(pane?.querySelectorAll(".desktop-cowork-observability-row")).toHaveLength(0);
+    expect(pane?.querySelector('[data-desktop-cowork-filter="observability"]')).toBeNull();
   });
 
   test("routes Cowork task, work-unit, and branch operations from desktop controls", () => {
@@ -3356,53 +3246,13 @@ describe("desktop workbench shell", () => {
     });
 
     const pane = targetDocument.body.querySelector(".desktop-cowork-cockpit");
-    const taskTitle = pane?.querySelector('[data-desktop-cowork-input="taskTitle"]');
-    const taskAgents = pane?.querySelectorAll('[data-desktop-cowork-input="assignedAgentId"]') ?? [];
-    if (taskTitle) {
-      taskTitle.value = "Write migration notes";
-    }
-    for (const taskAgent of taskAgents) {
-      taskAgent.value = "agent-2";
-    }
-    pane?.querySelector('[data-desktop-cowork-action="addTask"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="assignTask"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="retryTask"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="reviewTask"]')?.click();
-
-    pane?.querySelector('[data-desktop-cowork-entity="agent-1"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="loadAgentActivity"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="loadObservation"]')?.click();
-
-    pane?.querySelector('[data-desktop-cowork-entity="wu-1"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="retryWorkUnit"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="skipWorkUnit"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="cancelWorkUnit"]')?.click();
-
-    pane?.querySelector('[data-desktop-cowork-entity="branch-a"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="selectBranch"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="deriveBranch"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="selectBranchResult"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="mergeBranchResults"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="selectFinalResult"]')?.click();
-    pane?.querySelector('[data-desktop-cowork-entity-action="mergeFinalResult"]')?.click();
-
-    expect(actionEvents).toEqual([
-      { action: "addTask", sessionId: "cowork-1", title: "Write migration notes", assignedAgentId: "agent-2" },
-      { action: "task", sessionId: "cowork-1", taskId: "task-1", taskAction: "assign", assignedAgentId: "agent-2" },
-      { action: "task", sessionId: "cowork-1", taskId: "task-1", taskAction: "retry" },
-      { action: "task", sessionId: "cowork-1", taskId: "task-1", taskAction: "review" },
-      { action: "loadAgentActivity", sessionId: "cowork-1" },
-      { action: "loadObservation", sessionId: "cowork-1", detailRef: "detail-1", requesterAgentId: "agent-1" },
-      { action: "workUnit", sessionId: "cowork-1", workUnitId: "wu-1", workUnitAction: "retry" },
-      { action: "workUnit", sessionId: "cowork-1", workUnitId: "wu-1", workUnitAction: "skip" },
-      { action: "workUnit", sessionId: "cowork-1", workUnitId: "wu-1", workUnitAction: "cancel" },
-      { action: "selectBranch", sessionId: "cowork-1", branchId: "branch-a" },
-      { action: "deriveBranch", sessionId: "cowork-1", sourceBranchId: "branch-a", targetArchitecture: "swarm" },
-      { action: "selectBranchResult", sessionId: "cowork-1", branchId: "branch-a", resultId: "result-a" },
-      { action: "mergeBranchResults", sessionId: "cowork-1", branchIds: ["branch-a", "branch-b"] },
-      { action: "selectFinalResult", sessionId: "cowork-1", branchId: "branch-a", resultId: "result-a" },
-      { action: "mergeFinalResult", sessionId: "cowork-1", branchIds: ["branch-a", "branch-b"] },
-    ]);
+    expect(pane?.textContent).toContain("Cowork is under construction");
+    expect(pane?.querySelector('[data-desktop-cowork-action="addTask"]')).toBeNull();
+    expect(pane?.querySelector('[data-desktop-cowork-entity-action="assignTask"]')).toBeNull();
+    expect(pane?.querySelector('[data-desktop-cowork-entity="agent-1"]')).toBeNull();
+    expect(pane?.querySelector('[data-desktop-cowork-entity="wu-1"]')).toBeNull();
+    expect(pane?.querySelector('[data-desktop-cowork-entity="branch-a"]')).toBeNull();
+    expect(actionEvents).toEqual([]);
   });
 
   test("handles ownership-aware gateway runtime actions", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -152,6 +152,7 @@ import { mountWorkbenchPanelIsland } from "./native-vue/workbenchPanelIsland";
 import { mountWorkspaceBrowserIsland } from "./native-vue/workspaceBrowserIsland";
 
 const desktopPinnedChatSessions = new WeakMap<Document, Set<string>>();
+const DESKTOP_COWORK_STANDALONE_AVAILABLE = false;
 
 type ConversationToolActivityRenderOptions = ToolActivityIslandOptions;
 
@@ -4220,6 +4221,12 @@ function createCoworkCockpitPane(
   pane: DesktopCoworkPaneModel,
   coworkActions: DesktopCoworkActionOptions = {},
 ): HTMLElement {
+  if (!DESKTOP_COWORK_STANDALONE_AVAILABLE) {
+    const section = createCoworkUnavailablePane(targetDocument);
+    mountCoworkPaneVueIsland(section, targetDocument, pane, coworkActions);
+    return section;
+  }
+
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-cowork-cockpit";
   section.setAttribute("data-desktop-module-surface", "cowork");
@@ -4277,6 +4284,23 @@ function createCoworkCockpitPane(
   section.append(createCoworkTaskFeed(targetDocument, view));
 
   mountCoworkPaneVueIsland(section, targetDocument, pane, coworkActions);
+  return section;
+}
+
+function createCoworkUnavailablePane(targetDocument: Document): HTMLElement {
+  const section = targetDocument.createElement("section");
+  section.className = "desktop-workbench-section desktop-cowork-cockpit";
+  section.setAttribute("data-desktop-module-surface", "cowork");
+  section.setAttribute("aria-label", "Cowork unavailable");
+  const placeholder = targetDocument.createElement("section");
+  placeholder.className = "desktop-cowork-unavailable";
+  placeholder.append(
+    createText(targetDocument, "p", "Cowork", "desktop-cowork-unavailable-kicker"),
+    createText(targetDocument, "h2", "Cowork is under construction"),
+    createText(targetDocument, "p", "This page is temporarily unavailable."),
+    createText(targetDocument, "p", "暂不开放"),
+  );
+  section.append(placeholder);
   return section;
 }
 
@@ -13133,6 +13157,35 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       grid-template-columns: minmax(160px, 220px) minmax(220px, 1fr) minmax(180px, 260px);
       align-items: start;
       min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-cowork-unavailable {
+      grid-column: 1 / -1;
+      display: grid;
+      gap: 8px;
+      max-width: 520px;
+      min-height: 220px;
+      align-content: center;
+      justify-self: center;
+      text-align: center;
+      color: var(--text, #1f1d1b);
+    }
+
+    body.desktop-native-workbench .desktop-cowork-unavailable h2 {
+      font-size: 20px;
+      text-transform: none;
+    }
+
+    body.desktop-native-workbench .desktop-cowork-unavailable p {
+      margin: 0;
+      color: var(--muted, #7d746c);
+    }
+
+    body.desktop-native-workbench .desktop-cowork-unavailable-kicker {
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: var(--primary, #cc785c);
     }
 
     body.desktop-native-workbench .desktop-cowork-cockpit > h2 {

--- a/apps/desktop/src/native-vue/coworkPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/coworkPaneIsland.test.ts
@@ -1,9 +1,8 @@
 // @vitest-environment happy-dom
 
 import { describe, expect, test } from "vitest";
-import { nextTick } from "vue";
 import { buildDesktopCoworkCockpitView, buildDesktopCoworkSessionRows } from "../desktopCowork";
-import type { DesktopCoworkActionEvent, DesktopCoworkPaneModel } from "../desktopWorkbenchShell";
+import type { DesktopCoworkPaneModel } from "../desktopWorkbenchShell";
 import { mountCoworkPaneIsland } from "./coworkPaneIsland";
 
 const session = {
@@ -94,66 +93,24 @@ const pane: DesktopCoworkPaneModel = {
 };
 
 describe("cowork pane Vue island", () => {
-  test("renders the Cowork cockpit and forwards actions", async () => {
+  test("renders an unavailable placeholder while Cowork is under construction", () => {
     const host = document.createElement("section");
-    const selectedSessions: string[] = [];
-    const graphSelections: string[] = [];
-    const actions: string[] = [];
 
     const mounted = mountCoworkPaneIsland(host, {
       pane,
-      onCoworkAction: (event: DesktopCoworkActionEvent) => {
-        if (event.action === "task") {
-          actions.push(`${event.action}:${event.taskAction}:${event.taskId}:${event.assignedAgentId ?? ""}`);
-          return;
-        }
-        actions.push(`${event.action}:${event.sessionId ?? ""}:${event.goal ?? ""}`);
-      },
-      onGraphSelect: (selection) => graphSelections.push(`${selection.type}:${selection.id}:${selection.label}`),
-      onSessionSelect: (row) => selectedSessions.push(row.id),
     });
 
     expect(host.className).toBe("desktop-workbench-section desktop-cowork-cockpit");
     expect(host.getAttribute("data-desktop-vue-island")).toBe("cowork-pane");
     expect(host.getAttribute("data-desktop-module-surface")).toBe("cowork");
-    expect(host.getAttribute("aria-label")).toBe("Cowork cockpit");
-    expect(host.querySelector(".n-space.desktop-cowork-stack")).not.toBeNull();
-    expect(host.textContent).toContain("Cowork");
-
-    expect(host.querySelector(".desktop-cowork-sessions")?.getAttribute("data-desktop-vue-island")).toBe("cowork-sessions");
-    expect(host.querySelector('[data-desktop-cowork-session="cowork-1"]')?.textContent).toContain("Desktop migration");
-    expect(host.querySelector(".desktop-cowork-header")?.getAttribute("data-desktop-vue-island")).toBe("cowork-header");
-    expect(host.querySelector(".desktop-cowork-header")?.textContent).toContain("Desktop migration");
-    expect(host.querySelector(".desktop-cowork-actions")?.getAttribute("data-desktop-vue-island")).toBe("cowork-actions");
-    expect(host.querySelector(".desktop-cowork-actions")?.textContent).toContain("Blueprint ready");
-    expect(host.querySelector(".desktop-cowork-graph")?.getAttribute("data-desktop-vue-island")).toBe("cowork-graph");
-    expect(host.querySelector('[data-desktop-cowork-entity="task-1"]')?.textContent).toContain("Map helpers");
-    expect(host.querySelector(".desktop-cowork-observability")?.getAttribute("data-desktop-vue-island")).toBe("cowork-observability");
-    expect(host.querySelector(".desktop-cowork-observability")?.textContent).toContain("Observability");
-    expect(host.querySelector(".desktop-cowork-inspector")?.getAttribute("data-desktop-vue-island")).toBe("cowork-inspector");
-    expect(host.querySelector(".desktop-cowork-inspector")?.textContent).toContain("Selected: Review blocker");
-    expect(host.querySelector(".desktop-cowork-task-feed")?.getAttribute("data-desktop-vue-island")).toBe("cowork-task-feed");
-    expect(host.querySelector(".desktop-cowork-task-feed")?.textContent).toContain("agents");
-
-    host.querySelector<HTMLButtonElement>('[data-desktop-cowork-session="cowork-1"]')?.click();
-    const goal = host.querySelector<HTMLTextAreaElement>('[data-desktop-cowork-input="goal"]');
-    goal!.value = "Create native shell";
-    host.querySelector<HTMLButtonElement>('[data-desktop-cowork-action="create"]')?.click();
-    host.querySelector<HTMLButtonElement>('[data-desktop-cowork-action="run"]')?.click();
-    host.querySelector<HTMLButtonElement>('[data-desktop-cowork-entity="task-1"]')?.click();
-    await nextTick();
-    const assignee = host.querySelector<HTMLInputElement>('.desktop-cowork-inspector [data-desktop-cowork-input="assignedAgentId"]');
-    assignee!.value = "agent-2";
-    assignee?.dispatchEvent(new Event("input", { bubbles: true }));
-    host.querySelector<HTMLButtonElement>('[data-desktop-cowork-entity-action="assignTask"]')?.click();
-
-    expect(selectedSessions).toEqual(["cowork-1"]);
-    expect(graphSelections).toEqual(["task:task-1:Map helpers"]);
-    expect(actions).toEqual([
-      "createSession::Create native shell",
-      "runSession:cowork-1:",
-      "task:assign:task-1:agent-2",
-    ]);
+    expect(host.getAttribute("aria-label")).toBe("Cowork unavailable");
+    expect(host.querySelector(".desktop-cowork-unavailable")).not.toBeNull();
+    expect(host.textContent).toContain("Cowork is under construction");
+    expect(host.textContent).toContain("This page is temporarily unavailable.");
+    expect(host.textContent).toContain("暂不开放");
+    expect(host.querySelector(".desktop-cowork-sessions")).toBeNull();
+    expect(host.querySelector(".desktop-cowork-actions")).toBeNull();
+    expect(host.querySelector(".desktop-cowork-graph")).toBeNull();
 
     mounted.unmount();
     expect(host.textContent).toBe("");

--- a/apps/desktop/src/native-vue/coworkPaneIsland.ts
+++ b/apps/desktop/src/native-vue/coworkPaneIsland.ts
@@ -1,20 +1,12 @@
-import { createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, type App } from "vue";
-import { NConfigProvider, NSpace } from "naive-ui";
-import {
-  buildDesktopCoworkCockpitView,
-  type DesktopCoworkObservabilityPanel,
-  type DesktopCoworkSelectionType,
-  type DesktopCoworkSessionRow,
+import { createApp, defineComponent, h, type App } from "vue";
+import { NConfigProvider } from "naive-ui";
+import type {
+  DesktopCoworkObservabilityPanel,
+  DesktopCoworkSelectionType,
+  DesktopCoworkSessionRow,
 } from "../desktopCowork";
 import type { DesktopCoworkActionEvent, DesktopCoworkPaneModel } from "../desktopWorkbenchShell";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
-import { mountCoworkActionsIsland } from "./coworkActionsIsland";
-import { mountCoworkGraphIsland } from "./coworkGraphIsland";
-import { mountCoworkHeaderIsland } from "./coworkHeaderIsland";
-import { mountCoworkInspectorIsland } from "./coworkInspectorIsland";
-import { mountCoworkObservabilityIsland } from "./coworkObservabilityIsland";
-import { mountCoworkSessionsIsland } from "./coworkSessionsIsland";
-import { mountCoworkTaskFeedIsland } from "./coworkTaskFeedIsland";
 
 export interface CoworkPaneGraphSelection {
   type: DesktopCoworkSelectionType;
@@ -43,7 +35,7 @@ export function mountCoworkPaneIsland(
   host.setAttribute("data-desktop-vue-island", "cowork-pane");
   host.className = "desktop-workbench-section desktop-cowork-cockpit";
   host.setAttribute("data-desktop-module-surface", "cowork");
-  host.setAttribute("aria-label", "Cowork cockpit");
+  host.setAttribute("aria-label", "Cowork unavailable");
 
   const app = createCoworkPaneApp(options);
   app.mount(host);
@@ -56,123 +48,20 @@ export function mountCoworkPaneIsland(
 }
 
 function createCoworkPaneApp(options: CoworkPaneIslandOptions): App {
+  void options;
   return createApp(defineComponent({
     name: "CoworkPaneIsland",
-    setup() {
-      const selectedView = ref(options.pane.cockpitView ?? null);
-      const mountedChildren: Array<{ unmount: () => void }> = [];
-      const mountedViewChildren: Array<{ unmount: () => void }> = [];
-      const sessions = ref<HTMLElement | null>(null);
-      const actions = ref<HTMLElement | null>(null);
-      const header = ref<HTMLElement | null>(null);
-      const graph = ref<HTMLElement | null>(null);
-      const observability = ref<HTMLElement | null>(null);
-      const inspector = ref<HTMLElement | null>(null);
-      const taskFeed = ref<HTMLElement | null>(null);
-
-      const mountViewChildren = (): void => {
-        while (mountedViewChildren.length) {
-          mountedViewChildren.pop()?.unmount();
-        }
-        const view = selectedView.value;
-        if (!view) {
-          return;
-        }
-        mountChild(mountedViewChildren, header.value, (host) => mountCoworkHeaderIsland(host, { header: view.header }));
-        mountChild(mountedViewChildren, graph.value, (host) => mountCoworkGraphIsland(host, {
-          graph: view.graph,
-          onSelect: (selection) => {
-            if (!selectedView.value) {
-              return;
-            }
-            selectedView.value = buildDesktopCoworkCockpitView(selectedView.value.raw, {
-              selected: { type: selection.type, id: selection.id },
-            });
-            options.onGraphSelect?.(selection);
-            mountViewChildren();
-          },
-        }));
-        mountChild(mountedViewChildren, observability.value, (host) => mountCoworkObservabilityIsland(host, {
-          panels: view.observabilityPanels,
-          onPanelSelected: options.onObservabilityPanelSelected,
-        }));
-        mountChild(mountedViewChildren, inspector.value, (host) => mountCoworkInspectorIsland(host, {
-          view,
-          onAction: (event) => emitAction(options, event),
-        }));
-        mountChild(mountedViewChildren, taskFeed.value, (host) => mountCoworkTaskFeedIsland(host, {
-          items: view.taskCenterItems,
-          totals: {
-            agents: view.agents.length,
-            tasks: view.tasks.length,
-            mailbox: view.mailbox.length,
-            artifacts: view.artifacts.length,
-          },
-        }));
-      };
-
-      onMounted(() => {
-        mountChild(mountedChildren, sessions.value, (host) => mountCoworkSessionsIsland(host, {
-          sessions: options.pane.sessionRows,
-          onSelect: options.onSessionSelect,
-        }));
-        mountChild(mountedChildren, actions.value, (host) => mountCoworkActionsIsland(host, {
-          sessionId: selectedView.value?.header.id ?? "",
-          agents: selectedView.value?.agents ?? [],
-          actionStatus: options.pane.actionStatus,
-          summaryText: options.pane.summaryText,
-          blueprintDiagnostics: options.pane.blueprintDiagnostics,
-          onAction: (event) => emitAction(options, event),
-        }));
-        mountViewChildren();
-      });
-
-      onBeforeUnmount(() => {
-        while (mountedViewChildren.length) {
-          mountedViewChildren.pop()?.unmount();
-        }
-        while (mountedChildren.length) {
-          mountedChildren.pop()?.unmount();
-        }
-      });
-
-      return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => h(NSpace, {
-          class: "desktop-cowork-stack",
-          vertical: true,
-          size: 12,
-        }, {
-          default: () => [
-            h("h2", "Cowork"),
-            h("section", { ref: sessions }),
-            h("section", { ref: actions }),
-            selectedView.value
-              ? [
-                h("section", { ref: header }),
-                h("section", { ref: graph }),
-                h("section", { ref: observability }),
-                h("section", { ref: inspector }),
-                h("section", { ref: taskFeed }),
-              ]
-              : h("p", "Select a Cowork session to open the cockpit."),
-          ],
-        }),
-      });
-    },
+    setup: () => () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
+      default: () => renderCoworkUnavailable(),
+    }),
   }));
 }
 
-function mountChild<T extends { unmount: () => void }>(
-  mountedChildren: Array<{ unmount: () => void }>,
-  host: HTMLElement | null,
-  mount: (host: HTMLElement) => T,
-): void {
-  if (!host) {
-    return;
-  }
-  mountedChildren.push(mount(host));
-}
-
-function emitAction(options: CoworkPaneIslandOptions, event: CoworkPaneActionEvent): void {
-  options.onCoworkAction?.({ ...event, pane: options.pane } as DesktopCoworkActionEvent);
+function renderCoworkUnavailable() {
+  return h("section", { class: "desktop-cowork-unavailable" }, [
+    h("p", { class: "desktop-cowork-unavailable-kicker" }, "Cowork"),
+    h("h2", "Cowork is under construction"),
+    h("p", "This page is temporarily unavailable."),
+    h("p", "暂不开放"),
+  ]);
 }


### PR DESCRIPTION
## Summary
- Replace the standalone native Cowork page with an under-construction unavailable placeholder.
- Hide Cowork sessions, cockpit controls, graph, inspector, and action surfaces while the page is closed.
- Skip Cowork route hydration and task refresh while the standalone page is unavailable.

## Validation
- `git diff --check`
- `npx vitest run src/native-vue/coworkPaneIsland.test.ts src/desktopWorkbenchShell.test.ts src/native-vue/mainUtilitiesRegionIsland.test.ts`
- `npm run build`

Closes #244