### PR TITLE
Fix desktop workspace file scanning scope

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -939,7 +939,7 @@ fn pick_upload_file(options: UploadFilePickerOptions) -> Result<Option<PickedUpl
 
 #[tauri::command]
 fn reveal_workspace_file(path: String) -> Result<(), String> {
-    let target_path = allowed_workspace_file_path(&repo_root(), &path)?;
+    let target_path = reveal_workspace_file_path(&path)?;
     reveal_file_in_folder(&target_path)
 }
 
@@ -1104,6 +1104,18 @@ fn allowed_workspace_file_path(repo_root: &Path, requested_path: &str) -> Result
         return Err("workspace file is not revealable".to_string());
     }
     Ok(repo_root.join(normalized))
+}
+
+fn reveal_workspace_file_path(requested_path: &str) -> Result<PathBuf, String> {
+    reveal_workspace_file_path_from_config_path(&default_tinybot_config_path(), requested_path)
+}
+
+fn reveal_workspace_file_path_from_config_path(
+    config_path: &Path,
+    requested_path: &str,
+) -> Result<PathBuf, String> {
+    let root = resolve_ts_agent_worker_workspace_root_from_config_path(config_path);
+    allowed_workspace_file_path(&root, requested_path)
 }
 
 fn normalize_workspace_file_path(requested_path: &str) -> Option<String> {
@@ -2939,6 +2951,7 @@ fn experimental_worker_router(
             WorkerCapability::SessionWrite,
         ]),
     )
+    .with_builtin_skills_root(repo_root())
 }
 
 fn experimental_worker_router_with_runtime_restart(
@@ -3392,6 +3405,56 @@ mod tests {
             ),
             workspace_root
         );
+    }
+
+    #[test]
+    fn workspace_reveal_uses_configured_tinybot_workspace_root() {
+        let fixture = WorkspaceFixture::new();
+        let workspace_root = fixture.root.join("workspace");
+        fixture.write(
+            "config.json",
+            &serde_json::json!({
+                "agents": {
+                    "defaults": {
+                        "workspace": workspace_root.display().to_string()
+                    }
+                }
+            })
+            .to_string(),
+        );
+
+        assert_eq!(
+            reveal_workspace_file_path_from_config_path(
+                &fixture.root.join("config.json"),
+                "AGENTS.md"
+            )
+                .expect("allowed workspace file should resolve"),
+            workspace_root.join("AGENTS.md")
+        );
+    }
+
+    #[test]
+    fn experimental_worker_router_keeps_builtin_skills_root_separate_from_workspace_root() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = experimental_worker_router(fixture.root.clone(), serde_json::json!({}));
+        let request = WorkerRequest::new("req-1", "trace-1", "skills.list", serde_json::json!({}));
+
+        let response = router.dispatch(&request);
+        let skills = response
+            .result
+            .as_ref()
+            .and_then(|result| result.get("skills"))
+            .and_then(serde_json::Value::as_array)
+            .expect("skills.list should return skills array");
+
+        assert!(response.error.is_none());
+        assert!(skills.iter().any(|skill| {
+            skill.get("source").and_then(serde_json::Value::as_str) == Some("builtin")
+                && skill
+                    .get("path")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|path| path.starts_with("tinybot/skills/"))
+        }));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1205,12 +1205,18 @@ fn persist_gateway_exit_policy(path: &Path, keep_running: bool) -> Result<(), St
 }
 
 fn default_tinybot_config_path() -> PathBuf {
+    tinybot_home_dir().join(".tinybot").join("config.json")
+}
+
+fn tinybot_home_dir() -> PathBuf {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
         .unwrap_or_else(std::env::temp_dir)
-        .join(".tinybot")
-        .join("config.json")
+}
+
+fn default_tinybot_workspace_root() -> PathBuf {
+    tinybot_home_dir().join(".tinybot").join("workspace")
 }
 
 fn apply_config_patch_result_to_path(
@@ -2975,7 +2981,41 @@ fn experimental_worker_workspace_root() -> PathBuf {
 }
 
 fn ts_agent_worker_workspace_root() -> PathBuf {
-    repo_root()
+    let root =
+        resolve_ts_agent_worker_workspace_root_from_config_path(&default_tinybot_config_path());
+    let _ = std::fs::create_dir_all(&root);
+    root
+}
+
+fn resolve_ts_agent_worker_workspace_root_from_config_path(config_path: &Path) -> PathBuf {
+    configured_tinybot_workspace(config_path)
+        .map(|workspace| expand_tinybot_workspace_path(&workspace))
+        .unwrap_or_else(default_tinybot_workspace_root)
+}
+
+fn configured_tinybot_workspace(config_path: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(config_path).ok()?;
+    let config = serde_json::from_str::<serde_json::Value>(&contents).ok()?;
+    config
+        .pointer("/agents/defaults/workspace")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|workspace| !workspace.is_empty())
+        .map(str::to_string)
+}
+
+fn expand_tinybot_workspace_path(workspace: &str) -> PathBuf {
+    let workspace = workspace.trim();
+    if workspace == "~" {
+        return tinybot_home_dir();
+    }
+    if let Some(relative) = workspace
+        .strip_prefix("~/")
+        .or_else(|| workspace.strip_prefix("~\\"))
+    {
+        return tinybot_home_dir().join(relative);
+    }
+    PathBuf::from(workspace)
 }
 
 fn experimental_worker_config_snapshot() -> serde_json::Value {
@@ -3318,8 +3358,40 @@ mod tests {
     }
 
     #[test]
-    fn ts_agent_worker_uses_repo_workspace_root() {
-        assert_eq!(ts_agent_worker_workspace_root(), repo_root());
+    fn ts_agent_worker_uses_default_tinybot_workspace_root() {
+        let fixture = WorkspaceFixture::new();
+        let expected = default_tinybot_workspace_root();
+
+        assert_eq!(
+            resolve_ts_agent_worker_workspace_root_from_config_path(
+                &fixture.root.join("missing.json")
+            ),
+            expected
+        );
+    }
+
+    #[test]
+    fn ts_agent_worker_uses_configured_workspace_root() {
+        let fixture = WorkspaceFixture::new();
+        let workspace_root = fixture.root.join("workspace");
+        fixture.write(
+            "config.json",
+            &serde_json::json!({
+                "agents": {
+                    "defaults": {
+                        "workspace": workspace_root.display().to_string()
+                    }
+                }
+            })
+            .to_string(),
+        );
+
+        assert_eq!(
+            resolve_ts_agent_worker_workspace_root_from_config_path(
+                &fixture.root.join("config.json")
+            ),
+            workspace_root
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -160,6 +160,11 @@ impl WorkerRpcRouter {
         self
     }
 
+    pub fn with_builtin_skills_root(mut self, builtin_skills_root: PathBuf) -> Self {
+        self.workspace = self.workspace.with_builtin_skills_root(builtin_skills_root);
+        self
+    }
+
     pub fn dispatch(&mut self, request: &WorkerRequest) -> WorkerResponse {
         if let Err(error) = validate_protocol_version(&request.protocol_version) {
             return WorkerResponse::failure(request, error);

--- a/apps/desktop/src-tauri/src/worker_workspace.rs
+++ b/apps/desktop/src-tauri/src/worker_workspace.rs
@@ -29,12 +29,22 @@ const IGNORED_DIRS: &[&str] = &[
 #[derive(Clone, Debug)]
 pub struct WorkerWorkspaceRpc {
     root: PathBuf,
+    builtin_skills_root: PathBuf,
     policy: CapabilityPolicy,
 }
 
 impl WorkerWorkspaceRpc {
     pub fn new(root: PathBuf, policy: CapabilityPolicy) -> Self {
-        Self { root, policy }
+        Self {
+            builtin_skills_root: root.clone(),
+            root,
+            policy,
+        }
+    }
+
+    pub fn with_builtin_skills_root(mut self, builtin_skills_root: PathBuf) -> Self {
+        self.builtin_skills_root = builtin_skills_root;
+        self
     }
 
     pub fn resolve_path(
@@ -231,11 +241,12 @@ impl WorkerWorkspaceRpc {
     pub fn list_skills(&self) -> Result<WorkspaceSkillsList, WorkerProtocolError> {
         self.require(WorkerCapability::FsWorkspaceRead)?;
         let root = canonicalize_workspace_root(&self.root)?;
+        let builtin_skills_root = canonicalize_workspace_root(&self.builtin_skills_root)?;
         let mut skills = Vec::new();
         let mut seen_names = Vec::new();
         collect_skill_entries(&root, "skills", "workspace", &mut skills, &mut seen_names)?;
         collect_skill_entries(
-            &root,
+            &builtin_skills_root,
             "tinybot/skills",
             "builtin",
             &mut skills,
@@ -1041,6 +1052,48 @@ mod tests {
     }
 
     #[test]
+    fn list_skills_uses_separate_builtin_root_with_workspace_precedence() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write(
+            "skills/planner/SKILL.md",
+            "---\nname: planner\ndescription: Workspace planner\n---\nWorkspace body",
+        );
+        fixture.write_outside(
+            "tinybot/skills/planner/SKILL.md",
+            "---\nname: planner\ndescription: Builtin planner\n---\nBuiltin body",
+        );
+        fixture.write_outside(
+            "tinybot/skills/tmux/SKILL.md",
+            "---\nname: tmux\ndescription: Terminal sessions\n---\nTmux body",
+        );
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy())
+            .with_builtin_skills_root(fixture.outside.clone());
+
+        let result = rpc.list_skills().expect("skills should list");
+        let skills: Vec<(String, String, String)> = result
+            .skills
+            .into_iter()
+            .map(|skill| (skill.name, skill.source, skill.path))
+            .collect();
+
+        assert_eq!(
+            skills,
+            vec![
+                (
+                    "planner".to_string(),
+                    "workspace".to_string(),
+                    "skills/planner/SKILL.md".to_string()
+                ),
+                (
+                    "tmux".to_string(),
+                    "builtin".to_string(),
+                    "tinybot/skills/tmux/SKILL.md".to_string()
+                )
+            ]
+        );
+    }
+
+    #[test]
     fn resolve_path_normalizes_slashes_without_touching_filesystem() {
         let fixture = WorkspaceFixture::new();
         let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_policy());
@@ -1335,6 +1388,16 @@ mod tests {
                 std::fs::create_dir_all(parent).expect("fixture parent should create");
             }
             std::fs::write(path, contents).expect("fixture file should write");
+        }
+
+        fn write_outside(&self, relative_path: &str, contents: &str) {
+            let path = self
+                .outside
+                .join(relative_path.replace('/', std::path::MAIN_SEPARATOR_STR));
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("outside fixture parent should create");
+            }
+            std::fs::write(path, contents).expect("outside fixture file should write");
         }
     }
 


### PR DESCRIPTION
## Summary
- Scope the native TS agent worker workspace root to the configured TinyBot workspace instead of the repository root.
- Fall back to the default `%USERPROFILE%/.tinybot/workspace` location when no config workspace is set.
- Add regression coverage for default and configured workspace root resolution.

Fixes #246.

## Verification
- `cargo test ts_agent_worker_uses` from `apps/desktop/src-tauri`
- `cargo test worker_workspace::tests::list_files` from `apps/desktop/src-tauri`
- `cargo check` from `apps/desktop/src-tauri`
- `git diff --check`