### PR TITLE
Implement knowledge UKS roadmap and stabilize native graph extraction

### DIFF
--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -19,6 +19,16 @@ pub struct WorkerKnowledgeRpc {
     policy: CapabilityPolicy,
 }
 
+const CONTROLLED_RELATION_PREDICATES: &[&str] = &[
+    "depends_on",
+    "causes",
+    "implements",
+    "configures",
+    "mentions",
+    "conflicts_with",
+    "supports",
+];
+
 impl WorkerKnowledgeRpc {
     pub fn new(root: PathBuf, policy: CapabilityPolicy) -> Self {
         Self { root, policy }
@@ -2033,6 +2043,19 @@ fn validate_entity_graph_relations(
         {
             continue;
         }
+        if !controlled_relation_predicate(relation.predicate.trim()) {
+            return Err(invalid_knowledge_request_with_details(
+                "unsupported relation predicate",
+                serde_json::json!({
+                    "doc_id": document.id,
+                    "relation_index": index,
+                    "source": relation.source,
+                    "target": relation.target,
+                    "predicate": relation.predicate,
+                    "allowed_predicates": CONTROLLED_RELATION_PREDICATES
+                }),
+            ));
+        }
         let evidence_texts = relation
             .evidence
             .iter()
@@ -2073,6 +2096,12 @@ fn validate_entity_graph_relations(
         }
     }
     Ok(())
+}
+
+fn controlled_relation_predicate(predicate: &str) -> bool {
+    CONTROLLED_RELATION_PREDICATES
+        .iter()
+        .any(|allowed| predicate.eq_ignore_ascii_case(allowed))
 }
 
 fn find_document(

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -637,6 +637,9 @@ impl WorkerKnowledgeRpc {
             result.sparse_rank = index + 1;
         }
         results.truncate(limit);
+        for result in &mut results {
+            populate_knowledge_score_metadata(result);
+        }
         Ok(KnowledgeQueryResultSet {
             results,
             retrieval_plan,
@@ -1411,6 +1414,38 @@ impl KnowledgeQueryResult {
             projection_metadata: Vec::new(),
         }
     }
+}
+
+fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
+    if result.sparse_contribution > 0
+        && !result
+            .matched_methods
+            .iter()
+            .any(|method| method == "keyword")
+    {
+        result.matched_methods.push("keyword".to_string());
+    }
+    result.score_metadata = serde_json::json!({
+        "object": "knowledge_score_metadata",
+        "score_model": "deterministic_sparse_v1",
+        "final_score": result.score,
+        "components": {
+            "sparse": {
+                "score": result.bm25_score,
+                "rank": result.sparse_rank,
+                "contribution": result.sparse_contribution
+            }
+        },
+        "route_contributions": [
+            {
+                "route": "keyword",
+                "method": "sparse",
+                "score": result.bm25_score,
+                "rank": result.sparse_rank,
+                "contribution": result.sparse_contribution
+            }
+        ]
+    });
 }
 
 fn empty_knowledge_context() -> KnowledgeContextResult {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -712,23 +712,24 @@ impl WorkerKnowledgeRpc {
         if max_chunks == 0 {
             return Ok(empty_knowledge_context());
         }
-        let persistent_results = if params.use_persistent_knowledge == Some(false) {
-            Vec::new()
-        } else {
-            self.query(KnowledgeQueryParams {
-                query: params.current_message.clone(),
-                category: None,
-                tags: None,
-                limit: Some(max_chunks),
-                include_structure_context: None,
-                include_graph_context: None,
-                graph_relation_filters: None,
-                graph_max_hops: None,
-                graph_min_confidence: None,
-                graph_max_added_chunks: None,
-            })?
-            .results
-        };
+        let (persistent_results, retrieval_plan) =
+            if params.use_persistent_knowledge == Some(false) {
+                (Vec::new(), serde_json::json!({}))
+            } else {
+                let query_result = self.query(KnowledgeQueryParams {
+                    query: params.current_message.clone(),
+                    category: None,
+                    tags: None,
+                    limit: Some(max_chunks),
+                    include_structure_context: None,
+                    include_graph_context: None,
+                    graph_relation_filters: None,
+                    graph_max_hops: None,
+                    graph_min_confidence: None,
+                    graph_max_added_chunks: None,
+                })?;
+                (query_result.results, query_result.retrieval_plan)
+            };
         let session_results = session_temporary_context_results(
             params.session_key.as_deref(),
             &session_files,
@@ -750,6 +751,7 @@ impl WorkerKnowledgeRpc {
             persistent_results,
             session_results,
             references,
+            retrieval_plan,
         })
     }
 
@@ -1293,6 +1295,7 @@ pub struct KnowledgeContextResult {
     pub persistent_results: Vec<KnowledgeQueryResult>,
     pub session_results: Vec<Value>,
     pub references: Vec<Value>,
+    pub retrieval_plan: Value,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -2216,6 +2219,7 @@ fn empty_knowledge_context() -> KnowledgeContextResult {
         persistent_results: Vec::new(),
         session_results: Vec::new(),
         references: Vec::new(),
+        retrieval_plan: serde_json::json!({}),
     }
 }
 

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -341,6 +341,7 @@ impl WorkerKnowledgeRpc {
         let Some(document) = find_document(&self.root, &params.doc_id)? else {
             return Err(unknown_knowledge_document(&params.doc_id));
         };
+        validate_entity_graph_relations(&document, &params)?;
         let store = KnowledgeStorePaths::new(&self.root);
         let source_hash = document_content_hash(&document);
         let mut nodes = read_jsonl::<KnowledgeGraphNode>(&store.entity_graph_nodes_file)?;
@@ -2021,6 +2022,59 @@ fn value_usize(value: &Value, key: &str) -> Option<usize> {
         .map(|number| number as usize)
 }
 
+fn validate_entity_graph_relations(
+    document: &KnowledgeDocument,
+    params: &KnowledgeEntityGraphExtractionParams,
+) -> Result<(), WorkerProtocolError> {
+    for (index, relation) in params.relations.iter().enumerate() {
+        if relation.source.trim().is_empty()
+            || relation.target.trim().is_empty()
+            || relation.predicate.trim().is_empty()
+        {
+            continue;
+        }
+        let evidence_texts = relation
+            .evidence
+            .iter()
+            .filter_map(|evidence| {
+                value_string(evidence, "text")
+                    .or_else(|| value_string(evidence, "quote"))
+                    .map(|text| text.trim().to_string())
+            })
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>();
+        if evidence_texts.is_empty() {
+            return Err(invalid_knowledge_request_with_details(
+                "relation evidence is required",
+                serde_json::json!({
+                    "doc_id": document.id,
+                    "relation_index": index,
+                    "source": relation.source,
+                    "target": relation.target,
+                    "predicate": relation.predicate
+                }),
+            ));
+        }
+        if let Some(text) = evidence_texts
+            .iter()
+            .find(|text| !document.content.contains(text.as_str()))
+        {
+            return Err(invalid_knowledge_request_with_details(
+                "relation evidence must match document content",
+                serde_json::json!({
+                    "doc_id": document.id,
+                    "relation_index": index,
+                    "source": relation.source,
+                    "target": relation.target,
+                    "predicate": relation.predicate,
+                    "evidence": text
+                }),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn find_document(
     root: &Path,
     doc_id: &str,
@@ -3254,10 +3308,14 @@ fn knowledge_score(content: &str, terms: &[String]) -> usize {
 }
 
 fn invalid_knowledge_request(message: &str) -> WorkerProtocolError {
+    invalid_knowledge_request_with_details(message, serde_json::json!({}))
+}
+
+fn invalid_knowledge_request_with_details(message: &str, details: Value) -> WorkerProtocolError {
     WorkerProtocolError::new(
         WorkerProtocolErrorCode::InvalidProtocol,
         message,
-        serde_json::json!({}),
+        details,
         false,
         WorkerProtocolErrorSource::RustCore,
     )

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -596,6 +596,14 @@ impl WorkerKnowledgeRpc {
                 if !entry.matched_child_snippets.contains(&chunk.content) {
                     entry.matched_child_snippets.push(chunk.content.clone());
                 }
+                if !entry
+                    .matched_child_section_paths
+                    .contains(&chunk.section_path)
+                {
+                    entry
+                        .matched_child_section_paths
+                        .push(chunk.section_path.clone());
+                }
             }
         }
         let mut results: Vec<KnowledgeQueryResult> = results_by_parent.into_values().collect();
@@ -863,6 +871,14 @@ pub struct KnowledgeChunk {
     #[serde(default)]
     pub section_path: String,
     #[serde(default)]
+    pub section_id: String,
+    #[serde(default)]
+    pub section_title: String,
+    #[serde(default)]
+    pub parent_section_id: String,
+    #[serde(default)]
+    pub section_ordinal: usize,
+    #[serde(default)]
     pub block_type: String,
 }
 
@@ -900,6 +916,13 @@ impl KnowledgeChunk {
             category: params.category.clone().unwrap_or_default(),
             tags: params.tags.clone().unwrap_or_default(),
             section_path: section.section_path.clone(),
+            section_id: section_id(doc_id, index),
+            section_title: section.section_title.clone(),
+            parent_section_id: section
+                .parent_section_index
+                .map(|parent_index| section_id(doc_id, parent_index))
+                .unwrap_or_else(|| "section-root".to_string()),
+            section_ordinal: section.section_ordinal,
             block_type: "text".to_string(),
         }
     }
@@ -913,6 +936,9 @@ impl KnowledgeChunk {
         child_index: usize,
         line: &SectionLine,
         section_path: &str,
+        section_title: &str,
+        parent_section_id: &str,
+        section_ordinal: usize,
         params: &KnowledgeAddDocumentParams,
         created_at: &str,
     ) -> Self {
@@ -939,6 +965,10 @@ impl KnowledgeChunk {
             category: params.category.clone().unwrap_or_default(),
             tags: params.tags.clone().unwrap_or_default(),
             section_path: section_path.to_string(),
+            section_id: section_id(doc_id, parent_index),
+            section_title: section_title.to_string(),
+            parent_section_id: parent_section_id.to_string(),
+            section_ordinal,
             block_type: "text".to_string(),
         }
     }
@@ -952,6 +982,9 @@ struct ParentSection {
     line_start: usize,
     line_end: usize,
     section_path: String,
+    section_title: String,
+    parent_section_index: Option<usize>,
+    section_ordinal: usize,
     child_lines: Vec<SectionLine>,
 }
 
@@ -1238,6 +1271,7 @@ pub struct KnowledgeQueryResult {
     pub content: String,
     pub matched_child_ids: Vec<String>,
     pub matched_child_snippets: Vec<String>,
+    pub matched_child_section_paths: Vec<String>,
     pub doc_name: String,
     pub file_path: String,
     pub start_char: usize,
@@ -1247,6 +1281,10 @@ pub struct KnowledgeQueryResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<usize>,
     pub section_path: String,
+    pub section_id: String,
+    pub section_title: String,
+    pub parent_section_id: String,
+    pub section_ordinal: usize,
     pub block_type: String,
     pub score: usize,
     pub rrf_score: usize,
@@ -1282,6 +1320,7 @@ impl KnowledgeQueryResult {
             content: chunk.content,
             matched_child_ids: Vec::new(),
             matched_child_snippets: Vec::new(),
+            matched_child_section_paths: Vec::new(),
             doc_name: chunk.doc_name,
             file_path: chunk.file_path,
             start_char: chunk.start_char,
@@ -1290,6 +1329,10 @@ impl KnowledgeQueryResult {
             line_end: chunk.line_end,
             page: chunk.page,
             section_path: chunk.section_path,
+            section_id: chunk.section_id,
+            section_title: chunk.section_title,
+            parent_section_id: chunk.parent_section_id,
+            section_ordinal: chunk.section_ordinal,
             block_type: chunk.block_type,
             score,
             rrf_score: score,
@@ -2361,6 +2404,10 @@ fn build_document_chunks(
             continue;
         }
         for (child_index, line) in section.child_lines.iter().enumerate() {
+            let parent_section_id = section
+                .parent_section_index
+                .map(|parent_index| section_id(doc_id, parent_index))
+                .unwrap_or_else(|| "section-root".to_string());
             chunks.push(KnowledgeChunk::child(
                 doc_id,
                 doc_name,
@@ -2370,6 +2417,9 @@ fn build_document_chunks(
                 child_index,
                 line,
                 &section.section_path,
+                &section.section_title,
+                &parent_section_id,
+                section.section_ordinal,
                 params,
                 created_at,
             ));
@@ -2388,6 +2438,9 @@ fn split_parent_sections(content: &str) -> Vec<ParentSection> {
             line_start: 1,
             line_end: 1,
             section_path: String::new(),
+            section_title: String::new(),
+            parent_section_index: None,
+            section_ordinal: 0,
             child_lines: Vec::new(),
         }];
     }
@@ -2395,18 +2448,33 @@ fn split_parent_sections(content: &str) -> Vec<ParentSection> {
     let mut current_start = 0usize;
     let mut current_line_start = 1usize;
     let mut current_section_path = first_markdown_heading(content).unwrap_or_default();
+    let mut current_heading_level = first_markdown_heading_level(content).unwrap_or(0);
+    let mut current_parent_section_index = None;
     let mut current_child_lines = Vec::new();
+    let mut heading_stack: Vec<(usize, usize)> = Vec::new();
     for (index, line) in line_spans.iter().enumerate() {
         if line.is_heading && index != current_start {
+            let closed_section_index = sections.len();
             sections.push(parent_section_from_lines(
                 &line_spans[current_start..index],
                 current_line_start,
                 current_section_path,
+                current_parent_section_index,
+                closed_section_index,
                 current_child_lines,
             ));
+            if current_heading_level > 0 {
+                heading_stack.retain(|(level, _)| *level < current_heading_level);
+                heading_stack.push((current_heading_level, closed_section_index));
+            }
             current_start = index;
             current_line_start = line.line_number;
             current_section_path = line.heading.clone().unwrap_or_default();
+            current_heading_level = line.heading_level.unwrap_or(0);
+            heading_stack.retain(|(level, _)| *level < current_heading_level);
+            current_parent_section_index = heading_stack
+                .last()
+                .map(|(_, section_index)| *section_index);
             current_child_lines = Vec::new();
         }
         if !line.is_heading && !line.trimmed.is_empty() {
@@ -2422,6 +2490,8 @@ fn split_parent_sections(content: &str) -> Vec<ParentSection> {
         &line_spans[current_start..],
         current_line_start,
         current_section_path,
+        current_parent_section_index,
+        sections.len(),
         current_child_lines,
     ));
     sections
@@ -2431,6 +2501,8 @@ fn parent_section_from_lines(
     lines: &[LineSpan],
     line_start: usize,
     section_path: String,
+    parent_section_index: Option<usize>,
+    section_ordinal: usize,
     child_lines: Vec<SectionLine>,
 ) -> ParentSection {
     let content = lines
@@ -2450,7 +2522,10 @@ fn parent_section_from_lines(
         end_char,
         line_start,
         line_end,
+        section_title: section_path.clone(),
         section_path,
+        parent_section_index,
+        section_ordinal,
         child_lines,
     }
 }
@@ -2464,6 +2539,7 @@ struct LineSpan {
     line_number: usize,
     is_heading: bool,
     heading: Option<String>,
+    heading_level: Option<usize>,
 }
 
 fn content_line_spans(content: &str) -> Vec<LineSpan> {
@@ -2472,7 +2548,7 @@ fn content_line_spans(content: &str) -> Vec<LineSpan> {
     for (index, line) in content.split_inclusive('\n').enumerate() {
         let line_without_newline = line.trim_end_matches(['\r', '\n']);
         let trimmed = line_without_newline.trim().to_string();
-        let heading = markdown_heading_text(&trimmed);
+        let heading = markdown_heading(&trimmed);
         let end_char = offset + line.chars().count();
         spans.push(LineSpan {
             original: line.to_string(),
@@ -2481,14 +2557,15 @@ fn content_line_spans(content: &str) -> Vec<LineSpan> {
             end_char,
             line_number: index + 1,
             is_heading: heading.is_some(),
-            heading,
+            heading: heading.as_ref().map(|(_, title)| title.clone()),
+            heading_level: heading.map(|(level, _)| level),
         });
         offset = end_char;
     }
     if offset < content.chars().count() {
         let remainder = &content[offset..];
         let trimmed = remainder.trim().to_string();
-        let heading = markdown_heading_text(&trimmed);
+        let heading = markdown_heading(&trimmed);
         spans.push(LineSpan {
             original: remainder.to_string(),
             trimmed,
@@ -2496,7 +2573,8 @@ fn content_line_spans(content: &str) -> Vec<LineSpan> {
             end_char: content.chars().count(),
             line_number: spans.len() + 1,
             is_heading: heading.is_some(),
-            heading,
+            heading: heading.as_ref().map(|(_, title)| title.clone()),
+            heading_level: heading.map(|(level, _)| level),
         });
     }
     spans
@@ -2516,13 +2594,33 @@ fn first_markdown_heading(content: &str) -> Option<String> {
         .find_map(|line| markdown_heading_text(line.trim()))
 }
 
+fn first_markdown_heading_level(content: &str) -> Option<usize> {
+    content
+        .lines()
+        .find_map(|line| markdown_heading(line.trim()).map(|(level, _)| level))
+}
+
 fn markdown_heading_text(trimmed: &str) -> Option<String> {
-    let title = trimmed.trim_start_matches('#').trim();
-    if trimmed.starts_with('#') && !title.is_empty() {
-        Some(title.to_string())
-    } else {
-        None
+    markdown_heading(trimmed).map(|(_, title)| title)
+}
+
+fn markdown_heading(trimmed: &str) -> Option<(usize, String)> {
+    let level = trimmed
+        .chars()
+        .take_while(|character| *character == '#')
+        .count();
+    if level == 0 || level > 6 {
+        return None;
     }
+    let title = trimmed[level..].trim();
+    if title.is_empty() {
+        return None;
+    }
+    Some((level, title.to_string()))
+}
+
+fn section_id(doc_id: &str, section_ordinal: usize) -> String {
+    format!("section_{doc_id}_{section_ordinal}")
 }
 
 fn knowledge_query_terms(query: &str) -> Vec<String> {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -576,15 +576,8 @@ impl WorkerKnowledgeRpc {
             .collect();
         let mut results_by_parent: HashMap<String, KnowledgeQueryResult> = HashMap::new();
         for chunk in chunks {
-            if let Some(category) = params.category.as_deref().filter(|value| !value.is_empty()) {
-                if chunk.category != category {
-                    continue;
-                }
-            }
-            if let Some(tags) = params.tags.as_ref().filter(|tags| !tags.is_empty()) {
-                if !tags.iter().any(|tag| chunk.tags.contains(tag)) {
-                    continue;
-                }
+            if !knowledge_chunk_matches_query_filters(&chunk, &params) {
+                continue;
             }
             let score = knowledge_score(&chunk.retrieval_text, &query_terms);
             if score == 0 {
@@ -624,6 +617,19 @@ impl WorkerKnowledgeRpc {
                         .push(chunk.section_path.clone());
                 }
             }
+        }
+        if params.include_graph_context == Some(true) {
+            let store = KnowledgeStorePaths::new(&self.root);
+            let entity_nodes = read_jsonl::<KnowledgeGraphNode>(&store.entity_graph_nodes_file)?;
+            let entity_evidence = read_jsonl::<Value>(&store.entity_graph_evidence_file)?;
+            expand_query_with_entity_graph(
+                &mut results_by_parent,
+                &parents,
+                &entity_nodes,
+                &entity_evidence,
+                &query_terms,
+                &params,
+            );
         }
         let mut results: Vec<KnowledgeQueryResult> = results_by_parent.into_values().collect();
         results.sort_by(|left, right| {
@@ -675,6 +681,7 @@ impl WorkerKnowledgeRpc {
                 tags: None,
                 limit: Some(max_chunks),
                 include_structure_context: None,
+                include_graph_context: None,
             })?
             .results
         };
@@ -1138,6 +1145,8 @@ pub struct KnowledgeQueryParams {
     pub limit: Option<usize>,
     #[serde(default)]
     pub include_structure_context: Option<bool>,
+    #[serde(default)]
+    pub include_graph_context: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1424,6 +1433,125 @@ impl KnowledgeQueryResult {
     }
 }
 
+fn knowledge_chunk_matches_query_filters(
+    chunk: &KnowledgeChunk,
+    params: &KnowledgeQueryParams,
+) -> bool {
+    if let Some(category) = params.category.as_deref().filter(|value| !value.is_empty()) {
+        if chunk.category != category {
+            return false;
+        }
+    }
+    if let Some(tags) = params.tags.as_ref().filter(|tags| !tags.is_empty()) {
+        if !tags.iter().any(|tag| chunk.tags.contains(tag)) {
+            return false;
+        }
+    }
+    true
+}
+
+fn expand_query_with_entity_graph(
+    results_by_parent: &mut HashMap<String, KnowledgeQueryResult>,
+    parent_chunks: &HashMap<String, KnowledgeChunk>,
+    nodes: &[KnowledgeGraphNode],
+    evidence_records: &[Value],
+    query_terms: &[String],
+    params: &KnowledgeQueryParams,
+) {
+    for node in nodes
+        .iter()
+        .filter(|node| entity_graph_node_matches_query(node, query_terms))
+    {
+        if node.attributes.get("stale").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        let evidence_ids = graph_evidence_ids(&node.attributes);
+        for evidence in evidence_records.iter().filter(|evidence| {
+            value_string(evidence, "doc_id").as_deref() == Some(node.doc_id.as_str())
+                && value_string(evidence, "owner_id").as_deref() == Some(node.id.as_str())
+                && value_string(evidence, "owner_type").as_deref() == Some("entity")
+                && value_string(evidence, "id")
+                    .as_ref()
+                    .map(|id| evidence_ids.contains(id))
+                    .unwrap_or(false)
+        }) {
+            let Some(chunk) = graph_evidence_parent_chunk(parent_chunks, evidence, params) else {
+                continue;
+            };
+            let entry = results_by_parent
+                .entry(chunk.id.clone())
+                .or_insert_with(|| KnowledgeQueryResult::from_chunk(chunk.clone(), 0));
+            if entry.score == 0 {
+                entry.score = 1;
+                entry.rrf_score = 1;
+                entry.method = "graph".to_string();
+                entry.retrieval_method = "graph".to_string();
+            }
+            if !entry.matched_methods.iter().any(|method| method == "graph") {
+                entry.matched_methods.push("graph".to_string());
+            }
+            let node_value = serde_json::to_value(node).unwrap_or_else(|_| serde_json::json!({}));
+            if !entry.matched_entities.contains(&node_value) {
+                entry.matched_entities.push(node_value);
+            }
+            if !entry.source_snippets.contains(evidence) {
+                entry.source_snippets.push(evidence.clone());
+            }
+        }
+    }
+}
+
+fn entity_graph_node_matches_query(node: &KnowledgeGraphNode, query_terms: &[String]) -> bool {
+    let label = node.label.to_ascii_lowercase();
+    query_terms
+        .iter()
+        .any(|term| label.contains(term) || term.contains(label.as_str()))
+}
+
+fn graph_evidence_ids(attributes: &Value) -> HashSet<String> {
+    attributes
+        .get("evidence_ids")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn graph_evidence_parent_chunk(
+    parent_chunks: &HashMap<String, KnowledgeChunk>,
+    evidence: &Value,
+    params: &KnowledgeQueryParams,
+) -> Option<KnowledgeChunk> {
+    let doc_id = value_string(evidence, "doc_id")?;
+    let line_start = value_usize(evidence, "line_start").unwrap_or(1);
+    let line_end = value_usize(evidence, "line_end").unwrap_or(line_start);
+    let mut candidates = parent_chunks
+        .values()
+        .filter(|chunk| {
+            chunk.doc_id == doc_id
+                && knowledge_chunk_matches_query_filters(chunk, params)
+                && ranges_overlap(chunk.line_start, chunk.line_end, line_start, line_end)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|chunk| (chunk.line_start, chunk.chunk_index));
+    candidates.into_iter().next()
+}
+
+fn ranges_overlap(
+    left_start: usize,
+    left_end: usize,
+    right_start: usize,
+    right_end: usize,
+) -> bool {
+    left_start <= right_end && right_start <= left_end
+}
+
 fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
     if result.sparse_contribution > 0
         && !result
@@ -1433,26 +1561,61 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
     {
         result.matched_methods.push("keyword".to_string());
     }
+    let graph_contribution = if result
+        .matched_methods
+        .iter()
+        .any(|method| method == "graph")
+    {
+        1
+    } else {
+        0
+    };
+    let mut components = serde_json::Map::new();
+    let mut route_contributions = Vec::new();
+    if result.sparse_contribution > 0 {
+        components.insert(
+            "sparse".to_string(),
+            serde_json::json!({
+                "score": result.bm25_score,
+                "rank": result.sparse_rank,
+                "contribution": result.sparse_contribution
+            }),
+        );
+        route_contributions.push(serde_json::json!({
+            "route": "keyword",
+            "method": "sparse",
+            "score": result.bm25_score,
+            "rank": result.sparse_rank,
+            "contribution": result.sparse_contribution
+        }));
+    }
+    if graph_contribution > 0 {
+        components.insert(
+            "graph".to_string(),
+            serde_json::json!({
+                "score": graph_contribution,
+                "rank": result.sparse_rank,
+                "contribution": graph_contribution
+            }),
+        );
+        route_contributions.push(serde_json::json!({
+            "route": "graph",
+            "method": "entity_evidence",
+            "score": graph_contribution,
+            "rank": result.sparse_rank,
+            "contribution": graph_contribution
+        }));
+    }
     result.score_metadata = serde_json::json!({
         "object": "knowledge_score_metadata",
-        "score_model": "deterministic_sparse_v1",
-        "final_score": result.score,
-        "components": {
-            "sparse": {
-                "score": result.bm25_score,
-                "rank": result.sparse_rank,
-                "contribution": result.sparse_contribution
-            }
+        "score_model": if graph_contribution > 0 {
+            "deterministic_sparse_graph_v1"
+        } else {
+            "deterministic_sparse_v1"
         },
-        "route_contributions": [
-            {
-                "route": "keyword",
-                "method": "sparse",
-                "score": result.bm25_score,
-                "rank": result.sparse_rank,
-                "contribution": result.sparse_contribution
-            }
-        ]
+        "final_score": result.score,
+        "components": components,
+        "route_contributions": route_contributions
     });
 }
 

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -2278,7 +2278,7 @@ fn compact_knowledge_excerpt(content: &str) -> String {
 }
 
 fn knowledge_reference_metadata(result: &KnowledgeQueryResult) -> Value {
-    serde_json::json!({
+    let mut reference = serde_json::json!({
         "doc_id": result.doc_id,
         "doc_name": result.doc_name,
         "chunk_id": result.id,
@@ -2286,7 +2286,39 @@ fn knowledge_reference_metadata(result: &KnowledgeQueryResult) -> Value {
         "line_start": result.line_start,
         "line_end": result.line_end,
         "retrieval_method": result.retrieval_method
-    })
+    });
+    let has_rich_evidence_metadata = !result.source_snippets.is_empty()
+        || !result.projection_metadata.is_empty()
+        || !result.conflict_metadata.is_empty();
+    if let Some(map) = reference.as_object_mut() {
+        if !result.source_snippets.is_empty() {
+            map.insert(
+                "source_snippets".to_string(),
+                Value::Array(result.source_snippets.clone()),
+            );
+        }
+        if !result.projection_metadata.is_empty() {
+            map.insert(
+                "projection_metadata".to_string(),
+                Value::Array(result.projection_metadata.clone()),
+            );
+        }
+        if !result.conflict_metadata.is_empty() {
+            map.insert(
+                "conflict_metadata".to_string(),
+                Value::Array(result.conflict_metadata.clone()),
+            );
+        }
+        if has_rich_evidence_metadata
+            && !result
+                .score_metadata
+                .as_object()
+                .map_or(true, |map| map.is_empty())
+        {
+            map.insert("score_metadata".to_string(), result.score_metadata.clone());
+        }
+    }
+    reference
 }
 
 fn knowledge_session_reference_metadata(result: &Value) -> Value {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -389,6 +389,7 @@ impl WorkerKnowledgeRpc {
             if let Some(index) = entity_node_indexes.get(&id).copied() {
                 merge_entity_graph_node(&mut nodes[index], entity, evidence_ids);
             } else {
+                let evidence_status = entity_graph_evidence_status(&evidence_ids);
                 nodes.push(KnowledgeGraphNode {
                     id: id.clone(),
                     label: entity.name.trim().to_string(),
@@ -401,6 +402,7 @@ impl WorkerKnowledgeRpc {
                         "confidence": entity.confidence,
                         "source_hash": source_hash,
                         "stale": false,
+                        "evidence_status": evidence_status,
                         "evidence_ids": evidence_ids
                     }),
                 });
@@ -527,6 +529,11 @@ impl WorkerKnowledgeRpc {
         nodes.truncate(limit);
         let stale = mark_entity_graph_staleness(&self.root, &mut nodes, &mut edges)?;
         let conflicts = entity_graph_conflicts(&nodes, &edges);
+        let verified_node_count = nodes
+            .iter()
+            .filter(|node| entity_graph_node_evidence_status(&node.attributes) == "verified")
+            .count();
+        let unverified_node_count = nodes.len().saturating_sub(verified_node_count);
         let entity_ready = !nodes.is_empty() || !edges.is_empty();
         Ok(KnowledgeGraphResult {
             object: "knowledge_graph".to_string(),
@@ -538,6 +545,8 @@ impl WorkerKnowledgeRpc {
                 "total_relations": edges.len(),
                 "total_mentions": edges.iter().map(|edge| edge.evidence.len()).sum::<usize>(),
                 "conflict_count": conflicts.len(),
+                "verified_node_count": verified_node_count,
+                "unverified_node_count": unverified_node_count,
                 "stale_count": stale.node_count + stale.edge_count,
                 "stale_node_count": stale.node_count,
                 "stale_edge_count": stale.edge_count,
@@ -2321,6 +2330,7 @@ fn merge_entity_graph_node(
 ) {
     if let Value::Object(attributes) = &mut node.attributes {
         append_unique_json_strings(attributes, "evidence_ids", evidence_ids);
+        update_entity_graph_evidence_status(attributes);
 
         let alias = entity.name.trim();
         if !alias.is_empty() && alias != node.label {
@@ -2373,6 +2383,50 @@ fn append_unique_json_strings(
     attributes.insert(key.to_string(), Value::Array(existing));
 }
 
+fn update_entity_graph_evidence_status(attributes: &mut serde_json::Map<String, Value>) {
+    let evidence_ids = attributes
+        .get("evidence_ids")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|id| !id.trim().is_empty())
+                .count()
+        })
+        .unwrap_or(0);
+    let status = if evidence_ids == 0 {
+        "missing"
+    } else {
+        "verified"
+    };
+    attributes.insert(
+        "evidence_status".to_string(),
+        Value::String(status.to_string()),
+    );
+}
+
+fn entity_graph_evidence_status(evidence_ids: &[String]) -> &'static str {
+    if evidence_ids.iter().any(|id| !id.trim().is_empty()) {
+        "verified"
+    } else {
+        "missing"
+    }
+}
+
+fn entity_graph_node_evidence_status(attributes: &Value) -> &str {
+    attributes
+        .get("evidence_status")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| {
+            if graph_evidence_ids(attributes).is_empty() {
+                "missing"
+            } else {
+                "verified"
+            }
+        })
+}
+
 fn normalize_entity_graph_type(value: &str) -> String {
     value.trim().to_ascii_lowercase()
 }
@@ -2393,6 +2447,7 @@ fn entity_graph_stub_node(
             "entity_type": "",
             "source_hash": source_hash,
             "stale": false,
+            "evidence_status": "missing",
             "evidence_ids": []
         }),
     }

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -1756,11 +1756,14 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
     let mut components = serde_json::Map::new();
     let mut route_contributions = Vec::new();
     if result.sparse_contribution > 0 {
+        let normalized_score =
+            normalized_route_score(result.sparse_contribution as f64, result.score);
         components.insert(
             "sparse".to_string(),
             serde_json::json!({
                 "score": result.bm25_score,
                 "rank": result.sparse_rank,
+                "normalized_score": normalized_score,
                 "contribution": result.sparse_contribution
             }),
         );
@@ -1769,15 +1772,18 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
             "method": "sparse",
             "score": result.bm25_score,
             "rank": result.sparse_rank,
+            "normalized_score": normalized_score,
             "contribution": result.sparse_contribution
         }));
     }
     if graph_contribution > 0 {
+        let normalized_score = normalized_route_score(graph_contribution as f64, result.score);
         components.insert(
             "graph".to_string(),
             serde_json::json!({
                 "score": graph_contribution,
                 "rank": result.sparse_rank,
+                "normalized_score": normalized_score,
                 "contribution": graph_contribution
             }),
         );
@@ -1786,6 +1792,7 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
             "method": "graph_evidence",
             "score": graph_contribution,
             "rank": result.sparse_rank,
+            "normalized_score": normalized_score,
             "contribution": graph_contribution
         }));
     }
@@ -1800,6 +1807,14 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
         "components": components,
         "route_contributions": route_contributions
     });
+}
+
+fn normalized_route_score(contribution: f64, final_score: usize) -> f64 {
+    if final_score == 0 {
+        0.0
+    } else {
+        (contribution / final_score as f64).clamp(0.0, 1.0)
+    }
 }
 
 fn populate_knowledge_structure_context(

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -1882,7 +1882,13 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
         "score_model": knowledge_score_model(graph_contribution > 0, structure_score > 0),
         "final_score": result.score,
         "components": components,
-        "route_contributions": route_contributions
+        "route_contributions": route_contributions,
+        "rerank": {
+            "object": "knowledge_rerank_metadata",
+            "method": "deterministic_score_path_id_v1",
+            "sort_keys": ["score_desc", "file_path_asc", "chunk_id_asc"],
+            "rank": result.sparse_rank
+        }
     });
 }
 

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -1524,10 +1524,16 @@ fn expand_query_with_entity_graph(
         .iter()
         .map(|node| (node.id.clone(), node))
         .collect::<HashMap<_, _>>();
+    let mut graph_frontier = HashSet::new();
     for node in nodes
         .iter()
         .filter(|node| entity_graph_node_matches_query(node, query_terms))
     {
+        if node.attributes.get("stale").and_then(Value::as_bool) != Some(true)
+            && graph_record_confidence(&node.attributes) >= min_confidence
+        {
+            graph_frontier.insert(node.id.clone());
+        }
         if added_chunks >= max_added_chunks {
             break;
         }
@@ -1569,46 +1575,93 @@ fn expand_query_with_entity_graph(
     if max_hops == 0 {
         return;
     }
-    for edge in edges.iter().filter(|edge| {
-        relation_graph_edge_matches_query(edge, &node_lookup, query_terms)
-            && relation_graph_edge_matches_filters(edge, params)
-            && graph_record_confidence(&edge.attributes) >= min_confidence
-    }) {
+    let mut visited_edges = HashSet::new();
+    for hop in 1..=max_hops {
         if added_chunks >= max_added_chunks {
             break;
         }
-        if edge.attributes.get("stale").and_then(Value::as_bool) == Some(true) {
-            continue;
-        }
-        let evidence_ids = graph_evidence_ids(&edge.attributes);
-        for evidence in evidence_records.iter().filter(|evidence| {
-            value_string(evidence, "doc_id").as_deref() == Some(edge.doc_id.as_str())
-                && value_string(evidence, "owner_id").as_deref() == Some(edge.id.as_str())
-                && value_string(evidence, "owner_type").as_deref() == Some("relation")
-                && value_string(evidence, "id")
-                    .as_ref()
-                    .map(|id| evidence_ids.contains(id))
-                    .unwrap_or(false)
+        let mut next_frontier = HashSet::new();
+        for edge in edges.iter().filter(|edge| {
+            relation_graph_edge_matches_filters(edge, params)
+                && graph_record_confidence(&edge.attributes) >= min_confidence
+                && edge.attributes.get("stale").and_then(Value::as_bool) != Some(true)
+                && (relation_graph_edge_matches_frontier(edge, &graph_frontier)
+                    || (hop == 1
+                        && relation_graph_edge_matches_query(edge, &node_lookup, query_terms)))
         }) {
-            let Some(chunk) = graph_evidence_parent_chunk(parent_chunks, evidence, params) else {
+            if !visited_edges.insert(edge.id.clone()) {
                 continue;
-            };
-            let edge_value = serde_json::to_value(edge).unwrap_or_else(|_| serde_json::json!({}));
-            let inserted = add_graph_evidence_query_result(
+            }
+            if add_relation_graph_evidence_query_results(
                 results_by_parent,
-                chunk,
-                evidence,
-                None,
-                Some(edge_value),
-            );
-            if inserted {
-                added_chunks += 1;
-                if added_chunks >= max_added_chunks {
-                    break;
-                }
+                parent_chunks,
+                evidence_records,
+                edge,
+                params,
+                &mut added_chunks,
+                max_added_chunks,
+            ) {
+                next_frontier.insert(edge.source.clone());
+                next_frontier.insert(edge.target.clone());
+            }
+            if added_chunks >= max_added_chunks {
+                break;
+            }
+        }
+        if next_frontier.is_empty() {
+            break;
+        }
+        graph_frontier = next_frontier;
+    }
+}
+
+fn relation_graph_edge_matches_frontier(
+    edge: &KnowledgeGraphEdge,
+    frontier: &HashSet<String>,
+) -> bool {
+    frontier.contains(&edge.source) || frontier.contains(&edge.target)
+}
+
+fn add_relation_graph_evidence_query_results(
+    results_by_parent: &mut HashMap<String, KnowledgeQueryResult>,
+    parent_chunks: &HashMap<String, KnowledgeChunk>,
+    evidence_records: &[Value],
+    edge: &KnowledgeGraphEdge,
+    params: &KnowledgeQueryParams,
+    added_chunks: &mut usize,
+    max_added_chunks: usize,
+) -> bool {
+    let mut added = false;
+    let evidence_ids = graph_evidence_ids(&edge.attributes);
+    for evidence in evidence_records.iter().filter(|evidence| {
+        value_string(evidence, "doc_id").as_deref() == Some(edge.doc_id.as_str())
+            && value_string(evidence, "owner_id").as_deref() == Some(edge.id.as_str())
+            && value_string(evidence, "owner_type").as_deref() == Some("relation")
+            && value_string(evidence, "id")
+                .as_ref()
+                .map(|id| evidence_ids.contains(id))
+                .unwrap_or(false)
+    }) {
+        let Some(chunk) = graph_evidence_parent_chunk(parent_chunks, evidence, params) else {
+            continue;
+        };
+        let edge_value = serde_json::to_value(edge).unwrap_or_else(|_| serde_json::json!({}));
+        let inserted = add_graph_evidence_query_result(
+            results_by_parent,
+            chunk,
+            evidence,
+            None,
+            Some(edge_value),
+        );
+        if inserted {
+            added = true;
+            *added_chunks += 1;
+            if *added_chunks >= max_added_chunks {
+                break;
             }
         }
     }
+    added
 }
 
 fn add_graph_evidence_query_result(

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -554,9 +554,11 @@ impl WorkerKnowledgeRpc {
     ) -> Result<KnowledgeQueryResultSet, WorkerProtocolError> {
         self.require(WorkerCapability::KnowledgeRead)?;
         let limit = params.limit.unwrap_or(5).min(20);
+        let retrieval_plan = build_knowledge_retrieval_plan(&params.query, limit);
         if limit == 0 {
             return Ok(KnowledgeQueryResultSet {
                 results: Vec::new(),
+                retrieval_plan,
             });
         }
         let query_terms = knowledge_query_terms(&params.query);
@@ -635,7 +637,10 @@ impl WorkerKnowledgeRpc {
             result.sparse_rank = index + 1;
         }
         results.truncate(limit);
-        Ok(KnowledgeQueryResultSet { results })
+        Ok(KnowledgeQueryResultSet {
+            results,
+            retrieval_plan,
+        })
     }
 
     pub fn context(
@@ -1192,6 +1197,7 @@ pub struct KnowledgeDeleteDocumentResult {
 #[derive(Clone, Debug, Serialize)]
 pub struct KnowledgeQueryResultSet {
     pub results: Vec<KnowledgeQueryResult>,
+    pub retrieval_plan: Value,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -2741,6 +2747,69 @@ fn markdown_heading(trimmed: &str) -> Option<(usize, String)> {
 
 fn section_id(doc_id: &str, section_ordinal: usize) -> String {
     format!("section_{doc_id}_{section_ordinal}")
+}
+
+fn build_knowledge_retrieval_plan(query: &str, limit: usize) -> Value {
+    let terms = knowledge_query_terms(query);
+    let exact_query = query.contains('.')
+        || query.contains('_')
+        || terms.iter().any(|term| {
+            matches!(
+                term.as_str(),
+                "api" | "id" | "ids" | "config" | "key" | "keys" | "path" | "method"
+            )
+        });
+    if exact_query {
+        serde_json::json!({
+            "object": "knowledge_retrieval_plan",
+            "classification": "exact",
+            "selected_routes": ["keyword"],
+            "route_reasons": [
+                {
+                    "route": "keyword",
+                    "reason": "query contains exact identifiers or API/config-like terms"
+                }
+            ],
+            "budgets": {
+                "limit": limit,
+                "keyword": limit,
+                "semantic": 0,
+                "graph": 0,
+                "tree": 0
+            },
+            "fallback_behavior": "fallback_to_hybrid_when_no_results",
+            "fallback_routes": ["keyword", "tree", "graph"]
+        })
+    } else {
+        serde_json::json!({
+            "object": "knowledge_retrieval_plan",
+            "classification": "hybrid",
+            "selected_routes": ["keyword", "tree", "graph"],
+            "route_reasons": [
+                {
+                    "route": "keyword",
+                    "reason": "baseline sparse retrieval remains available for all queries"
+                },
+                {
+                    "route": "tree",
+                    "reason": "section metadata can expand local structure context"
+                },
+                {
+                    "route": "graph",
+                    "reason": "entity graph expansion can be added when graph evidence is ready"
+                }
+            ],
+            "budgets": {
+                "limit": limit,
+                "keyword": limit,
+                "semantic": 0,
+                "graph": 0,
+                "tree": 0
+            },
+            "fallback_behavior": "fallback_to_keyword_sparse",
+            "fallback_routes": ["keyword"]
+        })
+    }
 }
 
 fn knowledge_query_terms(query: &str) -> Vec<String> {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -598,6 +598,8 @@ impl WorkerKnowledgeRpc {
                 "query must contain at least one searchable term",
             ));
         }
+        let include_structure_context =
+            knowledge_query_should_include_structure_context(&params, &query_terms);
         let include_graph_context =
             knowledge_query_should_include_graph_context(&params, &query_terms);
         let chunks =
@@ -679,7 +681,7 @@ impl WorkerKnowledgeRpc {
         }
         results.truncate(limit);
         for result in &mut results {
-            if params.include_structure_context == Some(true) {
+            if include_structure_context {
                 populate_knowledge_structure_context(result, &parents);
             }
             populate_knowledge_score_metadata(result);
@@ -3655,16 +3657,16 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
             )
         });
     if exact_query {
+        let mut exact_route_reasons = vec![serde_json::json!({
+            "route": "keyword",
+            "reason": "query contains exact identifiers or API/config-like terms"
+        })];
+        exact_route_reasons.extend(route_reasons.into_iter().skip(1));
         serde_json::json!({
             "object": "knowledge_retrieval_plan",
             "classification": "exact",
-            "selected_routes": ["keyword"],
-            "route_reasons": [
-                {
-                    "route": "keyword",
-                    "reason": "query contains exact identifiers or API/config-like terms"
-                }
-            ],
+            "selected_routes": selected_routes,
+            "route_reasons": exact_route_reasons,
             "budgets": budgets,
             "fallback_behavior": "fallback_to_hybrid_when_no_results",
             "fallback_routes": ["keyword", "tree", "graph"],
@@ -3688,17 +3690,19 @@ fn knowledge_retrieval_plan_routes(
     params: &KnowledgeQueryParams,
 ) -> (Vec<&'static str>, Vec<Value>) {
     let terms = knowledge_query_terms(&params.query);
+    let include_structure_context =
+        knowledge_query_should_include_structure_context(params, &terms);
     let include_graph_context = knowledge_query_should_include_graph_context(params, &terms);
     let mut selected_routes = vec!["keyword"];
     let mut route_reasons = vec![serde_json::json!({
         "route": "keyword",
         "reason": "baseline sparse retrieval remains available for all queries"
     })];
-    if params.include_structure_context.unwrap_or(false) {
+    if include_structure_context {
         selected_routes.push("tree");
         route_reasons.push(serde_json::json!({
             "route": "tree",
-            "reason": "section metadata is requested for local structure context"
+            "reason": if params.include_structure_context == Some(true) { "section metadata is requested for local structure context" } else { "query terms indicate section, chapter, or location navigation intent" }
         }));
     }
     if include_graph_context {
@@ -3718,7 +3722,7 @@ fn knowledge_retrieval_plan_budgets(params: &KnowledgeQueryParams, limit: usize)
     } else {
         0
     };
-    let tree_budget = if params.include_structure_context.unwrap_or(false) {
+    let tree_budget = if knowledge_query_should_include_structure_context(params, &terms) {
         limit
     } else {
         0
@@ -3741,6 +3745,34 @@ fn knowledge_retrieval_plan_graph_options(params: &KnowledgeQueryParams) -> Valu
         "min_confidence": params.graph_min_confidence.unwrap_or(0.0).clamp(0.0, 1.0),
         "max_added_chunks": params.graph_max_added_chunks.unwrap_or(5).min(20)
     })
+}
+
+fn knowledge_query_should_include_structure_context(
+    params: &KnowledgeQueryParams,
+    terms: &[String],
+) -> bool {
+    match params.include_structure_context {
+        Some(value) => value,
+        None => terms.iter().any(|term| {
+            matches!(
+                term.as_str(),
+                "where"
+                    | "section"
+                    | "sections"
+                    | "chapter"
+                    | "chapters"
+                    | "heading"
+                    | "headings"
+                    | "location"
+                    | "located"
+                    | "parent"
+                    | "sibling"
+                    | "siblings"
+                    | "child"
+                    | "children"
+            )
+        }),
+    }
 }
 
 fn knowledge_query_should_include_graph_context(

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -229,9 +229,9 @@ impl WorkerKnowledgeRpc {
     ) -> Result<KnowledgeJob, WorkerProtocolError> {
         self.require(WorkerCapability::KnowledgeWrite)?;
         let rebuild_type = params.rebuild_type.unwrap_or_else(|| "bm25".to_string());
-        if !matches!(rebuild_type.as_str(), "bm25" | "semantic" | "all") {
+        if !matches!(rebuild_type.as_str(), "bm25" | "semantic" | "tree" | "all") {
             return Err(invalid_knowledge_request(
-                "type must be bm25, semantic, or all",
+                "type must be bm25, semantic, tree, or all",
             ));
         }
         let stats = self.stats()?;
@@ -241,10 +241,12 @@ impl WorkerKnowledgeRpc {
                 refresh_document_graph(&self.root)?;
                 result
             }
+            "tree" => knowledge_tree_rebuild_result(&self.root)?,
             "semantic" => knowledge_semantic_unavailable_result(),
             "all" => {
                 let result = serde_json::json!({
                     "bm25": knowledge_bm25_rebuild_result(&self.root)?,
+                    "tree": knowledge_tree_rebuild_result(&self.root)?,
                     "semantic": knowledge_semantic_unavailable_result()
                 });
                 refresh_document_graph(&self.root)?;
@@ -2370,9 +2372,22 @@ fn completed_rebuild_job(
     };
     let (processed, total, message) = match rebuild_type {
         "all" => (
-            3,
-            3,
+            4,
+            4,
             "Native available knowledge indexes are rebuilt; semantic index is not available natively",
+        ),
+        "tree" => (
+            result
+                .get("sections_indexed")
+                .and_then(Value::as_u64)
+                .map(|value| value as usize)
+                .unwrap_or(stats.total_chunks),
+            result
+                .get("sections_indexed")
+                .and_then(Value::as_u64)
+                .map(|value| value as usize)
+                .unwrap_or(stats.total_chunks),
+            "Tree index is available from section-aware knowledge chunks",
         ),
         "semantic" => (2, 2, "Semantic index is not available in native TS worker"),
         _ => (
@@ -2424,6 +2439,22 @@ fn knowledge_bm25_rebuild_result(root: &Path) -> Result<Value, WorkerProtocolErr
         "chunks_indexed": chunks_indexed,
         "terms_created": terms.len(),
         "total_docs": documents.len()
+    }))
+}
+
+fn knowledge_tree_rebuild_result(root: &Path) -> Result<Value, WorkerProtocolError> {
+    let store = KnowledgeStorePaths::new(root);
+    let documents = read_jsonl::<KnowledgeDocument>(&store.documents_file)?;
+    let chunks = read_jsonl::<KnowledgeChunk>(&store.chunks_file)?;
+    let sections_indexed = chunks
+        .iter()
+        .filter(|chunk| chunk.chunk_type == "parent")
+        .count();
+    Ok(serde_json::json!({
+        "available": true,
+        "documents_scanned": documents.len(),
+        "sections_indexed": sections_indexed,
+        "tree_ready": sections_indexed > 0
     }))
 }
 

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -583,7 +583,7 @@ impl WorkerKnowledgeRpc {
     ) -> Result<KnowledgeQueryResultSet, WorkerProtocolError> {
         self.require(WorkerCapability::KnowledgeRead)?;
         let limit = params.limit.unwrap_or(5).min(20);
-        let retrieval_plan = build_knowledge_retrieval_plan(&params.query, limit);
+        let retrieval_plan = build_knowledge_retrieval_plan(&params, limit);
         if limit == 0 {
             return Ok(KnowledgeQueryResultSet {
                 results: Vec::new(),
@@ -3604,8 +3604,10 @@ fn section_id(doc_id: &str, section_ordinal: usize) -> String {
     format!("section_{doc_id}_{section_ordinal}")
 }
 
-fn build_knowledge_retrieval_plan(query: &str, limit: usize) -> Value {
+fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -> Value {
+    let query = params.query.as_str();
     let terms = knowledge_query_terms(query);
+    let graph_options = knowledge_retrieval_plan_graph_options(params);
     let exact_query = query.contains('.')
         || query.contains('_')
         || terms.iter().any(|term| {
@@ -3633,7 +3635,8 @@ fn build_knowledge_retrieval_plan(query: &str, limit: usize) -> Value {
                 "tree": 0
             },
             "fallback_behavior": "fallback_to_hybrid_when_no_results",
-            "fallback_routes": ["keyword", "tree", "graph"]
+            "fallback_routes": ["keyword", "tree", "graph"],
+            "graph_options": graph_options
         })
     } else {
         serde_json::json!({
@@ -3662,9 +3665,20 @@ fn build_knowledge_retrieval_plan(query: &str, limit: usize) -> Value {
                 "tree": 0
             },
             "fallback_behavior": "fallback_to_keyword_sparse",
-            "fallback_routes": ["keyword"]
+            "fallback_routes": ["keyword"],
+            "graph_options": graph_options
         })
     }
+}
+
+fn knowledge_retrieval_plan_graph_options(params: &KnowledgeQueryParams) -> Value {
+    serde_json::json!({
+        "include_graph_context": params.include_graph_context.unwrap_or(false),
+        "max_hops": params.graph_max_hops.unwrap_or(1).min(4),
+        "relation_filters": params.graph_relation_filters.clone().unwrap_or_default(),
+        "min_confidence": params.graph_min_confidence.unwrap_or(0.0).clamp(0.0, 1.0),
+        "max_added_chunks": params.graph_max_added_chunks.unwrap_or(5).min(20)
+    })
 }
 
 fn knowledge_query_terms(query: &str) -> Vec<String> {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -3642,6 +3642,7 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
     let query = params.query.as_str();
     let terms = knowledge_query_terms(query);
     let budgets = knowledge_retrieval_plan_budgets(params, limit);
+    let (selected_routes, route_reasons) = knowledge_retrieval_plan_routes(params);
     let graph_options = knowledge_retrieval_plan_graph_options(params);
     let exact_query = query.contains('.')
         || query.contains('_')
@@ -3671,27 +3672,39 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
         serde_json::json!({
             "object": "knowledge_retrieval_plan",
             "classification": "hybrid",
-            "selected_routes": ["keyword", "tree", "graph"],
-            "route_reasons": [
-                {
-                    "route": "keyword",
-                    "reason": "baseline sparse retrieval remains available for all queries"
-                },
-                {
-                    "route": "tree",
-                    "reason": "section metadata can expand local structure context"
-                },
-                {
-                    "route": "graph",
-                    "reason": "entity graph expansion can be added when graph evidence is ready"
-                }
-            ],
+            "selected_routes": selected_routes,
+            "route_reasons": route_reasons,
             "budgets": budgets,
             "fallback_behavior": "fallback_to_keyword_sparse",
             "fallback_routes": ["keyword"],
             "graph_options": graph_options
         })
     }
+}
+
+fn knowledge_retrieval_plan_routes(
+    params: &KnowledgeQueryParams,
+) -> (Vec<&'static str>, Vec<Value>) {
+    let mut selected_routes = vec!["keyword"];
+    let mut route_reasons = vec![serde_json::json!({
+        "route": "keyword",
+        "reason": "baseline sparse retrieval remains available for all queries"
+    })];
+    if params.include_structure_context.unwrap_or(false) {
+        selected_routes.push("tree");
+        route_reasons.push(serde_json::json!({
+            "route": "tree",
+            "reason": "section metadata is requested for local structure context"
+        }));
+    }
+    if params.include_graph_context.unwrap_or(false) {
+        selected_routes.push("graph");
+        route_reasons.push(serde_json::json!({
+            "route": "graph",
+            "reason": "entity graph expansion is requested for evidence recall"
+        }));
+    }
+    (selected_routes, route_reasons)
 }
 
 fn knowledge_retrieval_plan_budgets(params: &KnowledgeQueryParams, limit: usize) -> Value {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -2103,6 +2103,23 @@ fn validate_entity_graph_relations(
                 }),
             ));
         }
+        if let Some(evidence_doc_id) = relation.evidence.iter().find_map(|evidence| {
+            value_string(evidence, "doc_id")
+                .map(|doc_id| doc_id.trim().to_string())
+                .filter(|doc_id| !doc_id.is_empty() && doc_id != &document.id)
+        }) {
+            return Err(invalid_knowledge_request_with_details(
+                "relation evidence doc_id must match document",
+                serde_json::json!({
+                    "doc_id": document.id,
+                    "relation_index": index,
+                    "source": relation.source,
+                    "target": relation.target,
+                    "predicate": relation.predicate,
+                    "evidence_doc_id": evidence_doc_id
+                }),
+            ));
+        }
     }
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -133,6 +133,23 @@ impl WorkerKnowledgeRpc {
         })
     }
 
+    pub fn document_tree(
+        &self,
+        params: KnowledgeDocumentIdParams,
+    ) -> Result<KnowledgeDocumentTreeResult, WorkerProtocolError> {
+        self.require(WorkerCapability::KnowledgeRead)?;
+        if find_document(&self.root, &params.doc_id)?.is_none() {
+            return Err(unknown_knowledge_document(&params.doc_id));
+        }
+        let chunks =
+            read_jsonl::<KnowledgeChunk>(&KnowledgeStorePaths::new(&self.root).chunks_file)?;
+        let parent_chunks = chunks
+            .into_iter()
+            .filter(|chunk| chunk.doc_id == params.doc_id && chunk.chunk_type == "parent")
+            .collect::<Vec<_>>();
+        Ok(build_knowledge_document_tree(&params.doc_id, parent_chunks))
+    }
+
     pub fn delete_document(
         &self,
         params: KnowledgeDocumentIdParams,
@@ -1134,6 +1151,36 @@ pub struct KnowledgeDocumentsResult {
 pub struct KnowledgeGetDocumentResult {
     pub document: KnowledgeDocument,
     pub content: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct KnowledgeDocumentTreeResult {
+    pub object: String,
+    pub doc_id: String,
+    pub root: KnowledgeDocumentTreeRoot,
+    pub sections: Vec<KnowledgeDocumentTreeSection>,
+    pub section_count: usize,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct KnowledgeDocumentTreeRoot {
+    pub id: String,
+    pub children: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct KnowledgeDocumentTreeSection {
+    pub id: String,
+    pub doc_id: String,
+    pub chunk_id: String,
+    pub title: String,
+    pub section_path: String,
+    pub parent_id: String,
+    pub children: Vec<String>,
+    pub ordinal: usize,
+    pub line_start: usize,
+    pub line_end: usize,
+    pub chunk_count: usize,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -2426,6 +2473,79 @@ fn build_document_chunks(
         }
     }
     chunks
+}
+
+fn build_knowledge_document_tree(
+    doc_id: &str,
+    mut parent_chunks: Vec<KnowledgeChunk>,
+) -> KnowledgeDocumentTreeResult {
+    parent_chunks.sort_by(|left, right| {
+        left.section_ordinal
+            .cmp(&right.section_ordinal)
+            .then_with(|| left.chunk_index.cmp(&right.chunk_index))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let mut children_by_parent: HashMap<String, Vec<String>> = HashMap::new();
+    for chunk in &parent_chunks {
+        let section_id = knowledge_chunk_section_id(chunk);
+        let parent_id = if chunk.parent_section_id.is_empty() {
+            "section-root".to_string()
+        } else {
+            chunk.parent_section_id.clone()
+        };
+        children_by_parent
+            .entry(parent_id)
+            .or_default()
+            .push(section_id);
+    }
+    let sections = parent_chunks
+        .into_iter()
+        .map(|chunk| {
+            let section_id = knowledge_chunk_section_id(&chunk);
+            KnowledgeDocumentTreeSection {
+                id: section_id.clone(),
+                doc_id: chunk.doc_id,
+                chunk_id: chunk.id,
+                title: if chunk.section_title.is_empty() {
+                    chunk.section_path.clone()
+                } else {
+                    chunk.section_title
+                },
+                section_path: chunk.section_path,
+                parent_id: if chunk.parent_section_id.is_empty() {
+                    "section-root".to_string()
+                } else {
+                    chunk.parent_section_id
+                },
+                children: children_by_parent.remove(&section_id).unwrap_or_default(),
+                ordinal: chunk.section_ordinal,
+                line_start: chunk.line_start,
+                line_end: chunk.line_end,
+                chunk_count: 1,
+            }
+        })
+        .collect::<Vec<_>>();
+    let section_count = sections.len();
+    KnowledgeDocumentTreeResult {
+        object: "knowledge_document_tree".to_string(),
+        doc_id: doc_id.to_string(),
+        root: KnowledgeDocumentTreeRoot {
+            id: "section-root".to_string(),
+            children: children_by_parent
+                .remove("section-root")
+                .unwrap_or_default(),
+        },
+        sections,
+        section_count,
+    }
+}
+
+fn knowledge_chunk_section_id(chunk: &KnowledgeChunk) -> String {
+    if chunk.section_id.is_empty() {
+        section_id(&chunk.doc_id, chunk.section_ordinal)
+    } else {
+        chunk.section_id.clone()
+    }
 }
 
 fn split_parent_sections(content: &str) -> Vec<ParentSection> {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -598,6 +598,8 @@ impl WorkerKnowledgeRpc {
                 "query must contain at least one searchable term",
             ));
         }
+        let include_graph_context =
+            knowledge_query_should_include_graph_context(&params, &query_terms);
         let chunks =
             read_jsonl::<KnowledgeChunk>(&KnowledgeStorePaths::new(&self.root).chunks_file)?;
         let parents: HashMap<String, KnowledgeChunk> = chunks
@@ -649,7 +651,7 @@ impl WorkerKnowledgeRpc {
                 }
             }
         }
-        if params.include_graph_context == Some(true) {
+        if include_graph_context {
             let store = KnowledgeStorePaths::new(&self.root);
             let entity_nodes = read_jsonl::<KnowledgeGraphNode>(&store.entity_graph_nodes_file)?;
             let entity_edges = read_jsonl::<KnowledgeGraphEdge>(&store.entity_graph_edges_file)?;
@@ -3685,6 +3687,8 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
 fn knowledge_retrieval_plan_routes(
     params: &KnowledgeQueryParams,
 ) -> (Vec<&'static str>, Vec<Value>) {
+    let terms = knowledge_query_terms(&params.query);
+    let include_graph_context = knowledge_query_should_include_graph_context(params, &terms);
     let mut selected_routes = vec!["keyword"];
     let mut route_reasons = vec![serde_json::json!({
         "route": "keyword",
@@ -3697,18 +3701,19 @@ fn knowledge_retrieval_plan_routes(
             "reason": "section metadata is requested for local structure context"
         }));
     }
-    if params.include_graph_context.unwrap_or(false) {
+    if include_graph_context {
         selected_routes.push("graph");
         route_reasons.push(serde_json::json!({
             "route": "graph",
-            "reason": "entity graph expansion is requested for evidence recall"
+            "reason": if params.include_graph_context == Some(true) { "entity graph expansion is requested for evidence recall" } else { "query terms indicate dependency, causal, relation, or why/how graph intent" }
         }));
     }
     (selected_routes, route_reasons)
 }
 
 fn knowledge_retrieval_plan_budgets(params: &KnowledgeQueryParams, limit: usize) -> Value {
-    let graph_budget = if params.include_graph_context.unwrap_or(false) {
+    let terms = knowledge_query_terms(&params.query);
+    let graph_budget = if knowledge_query_should_include_graph_context(params, &terms) {
         params.graph_max_added_chunks.unwrap_or(5).min(20)
     } else {
         0
@@ -3728,13 +3733,47 @@ fn knowledge_retrieval_plan_budgets(params: &KnowledgeQueryParams, limit: usize)
 }
 
 fn knowledge_retrieval_plan_graph_options(params: &KnowledgeQueryParams) -> Value {
+    let terms = knowledge_query_terms(&params.query);
     serde_json::json!({
-        "include_graph_context": params.include_graph_context.unwrap_or(false),
+        "include_graph_context": knowledge_query_should_include_graph_context(params, &terms),
         "max_hops": params.graph_max_hops.unwrap_or(1).min(4),
         "relation_filters": params.graph_relation_filters.clone().unwrap_or_default(),
         "min_confidence": params.graph_min_confidence.unwrap_or(0.0).clamp(0.0, 1.0),
         "max_added_chunks": params.graph_max_added_chunks.unwrap_or(5).min(20)
     })
+}
+
+fn knowledge_query_should_include_graph_context(
+    params: &KnowledgeQueryParams,
+    terms: &[String],
+) -> bool {
+    match params.include_graph_context {
+        Some(value) => value,
+        None => terms.iter().any(|term| {
+            matches!(
+                term.as_str(),
+                "why"
+                    | "how"
+                    | "depend"
+                    | "depends"
+                    | "dependency"
+                    | "dependencies"
+                    | "cause"
+                    | "causes"
+                    | "causal"
+                    | "relation"
+                    | "relations"
+                    | "relationship"
+                    | "relationships"
+                    | "configure"
+                    | "configures"
+                    | "conflict"
+                    | "conflicts"
+                    | "support"
+                    | "supports"
+            )
+        }),
+    }
 }
 
 fn knowledge_query_terms(query: &str) -> Vec<String> {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -1576,6 +1576,13 @@ fn expand_query_with_entity_graph(
                 Some(node_value),
                 None,
                 None,
+                Some(entity_graph_query_projection_metadata(
+                    "entity",
+                    &node.id,
+                    &node.label,
+                    &node.attributes,
+                    evidence,
+                )),
             );
             if inserted {
                 added_chunks += 1;
@@ -1668,6 +1675,13 @@ fn add_relation_graph_evidence_query_results(
             None,
             Some(edge_value),
             graph_query_conflict_metadata(edge, node_lookup, evidence),
+            Some(entity_graph_query_projection_metadata(
+                "relation",
+                &edge.id,
+                &edge.label,
+                &edge.attributes,
+                evidence,
+            )),
         );
         if inserted {
             added = true;
@@ -1687,6 +1701,7 @@ fn add_graph_evidence_query_result(
     matched_entity: Option<Value>,
     matched_relation: Option<Value>,
     conflict_metadata: Option<Value>,
+    projection_metadata: Option<Value>,
 ) -> bool {
     let inserted = !results_by_parent.contains_key(&chunk.id);
     let entry = results_by_parent
@@ -1719,10 +1734,47 @@ fn add_graph_evidence_query_result(
             entry.conflict_metadata.push(conflict);
         }
     }
+    if let Some(projection) = projection_metadata {
+        if !entry.projection_metadata.contains(&projection) {
+            entry.projection_metadata.push(projection);
+        }
+    }
     if !entry.source_snippets.contains(evidence) {
         entry.source_snippets.push(evidence.clone());
     }
     inserted
+}
+
+fn entity_graph_query_projection_metadata(
+    owner_type: &str,
+    owner_id: &str,
+    owner_label: &str,
+    attributes: &Value,
+    evidence: &Value,
+) -> Value {
+    serde_json::json!({
+        "object": "knowledge_projection_metadata",
+        "projection": "entity_graph",
+        "owner_type": owner_type,
+        "owner_id": owner_id,
+        "owner_label": owner_label,
+        "evidence_id": value_string(evidence, "id").unwrap_or_default(),
+        "evidence_status": attributes
+            .get("evidence_status")
+            .and_then(Value::as_str)
+            .unwrap_or("verified"),
+        "confidence": graph_record_confidence(attributes),
+        "source_hash": attributes
+            .get("source_hash")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        "current_source_hash": attributes
+            .get("current_source_hash")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        "stale": attributes.get("stale").and_then(Value::as_bool).unwrap_or(false),
+        "doc_id": value_string(evidence, "doc_id").unwrap_or_default()
+    })
 }
 
 fn graph_query_conflict_metadata(

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -714,6 +714,7 @@ impl WorkerKnowledgeRpc {
                 include_structure_context: None,
                 include_graph_context: None,
                 graph_relation_filters: None,
+                graph_max_hops: None,
                 graph_min_confidence: None,
                 graph_max_added_chunks: None,
             })?
@@ -1198,6 +1199,8 @@ pub struct KnowledgeQueryParams {
     #[serde(default)]
     pub graph_relation_filters: Option<Vec<String>>,
     #[serde(default)]
+    pub graph_max_hops: Option<usize>,
+    #[serde(default)]
     pub graph_min_confidence: Option<f64>,
     #[serde(default)]
     pub graph_max_added_chunks: Option<usize>,
@@ -1515,6 +1518,7 @@ fn expand_query_with_entity_graph(
 ) {
     let mut added_chunks = 0usize;
     let max_added_chunks = params.graph_max_added_chunks.unwrap_or(5).min(20);
+    let max_hops = params.graph_max_hops.unwrap_or(1).min(4);
     let min_confidence = params.graph_min_confidence.unwrap_or(0.0).clamp(0.0, 1.0);
     let node_lookup = nodes
         .iter()
@@ -1561,6 +1565,9 @@ fn expand_query_with_entity_graph(
                 }
             }
         }
+    }
+    if max_hops == 0 {
+        return;
     }
     for edge in edges.iter().filter(|edge| {
         relation_graph_edge_matches_query(edge, &node_lookup, query_terms)

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -639,6 +639,9 @@ impl WorkerKnowledgeRpc {
         results.truncate(limit);
         for result in &mut results {
             populate_knowledge_score_metadata(result);
+            if params.include_structure_context == Some(true) {
+                populate_knowledge_structure_context(result, &parents);
+            }
         }
         Ok(KnowledgeQueryResultSet {
             results,
@@ -671,6 +674,7 @@ impl WorkerKnowledgeRpc {
                 category: None,
                 tags: None,
                 limit: Some(max_chunks),
+                include_structure_context: None,
             })?
             .results
         };
@@ -1132,6 +1136,8 @@ pub struct KnowledgeQueryParams {
     pub tags: Option<Vec<String>>,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_structure_context: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1354,6 +1360,7 @@ pub struct KnowledgeQueryResult {
     pub method: String,
     pub retrieval_method: String,
     pub score_metadata: Value,
+    pub structure_context: Value,
     pub source_snippets: Vec<Value>,
     pub matched_methods: Vec<String>,
     pub matched_entities: Vec<Value>,
@@ -1402,6 +1409,7 @@ impl KnowledgeQueryResult {
             method: "sparse".to_string(),
             retrieval_method: "sparse".to_string(),
             score_metadata: serde_json::json!({}),
+            structure_context: serde_json::json!({}),
             source_snippets: Vec::new(),
             matched_methods: Vec::new(),
             matched_entities: Vec::new(),
@@ -1446,6 +1454,84 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
             }
         ]
     });
+}
+
+fn populate_knowledge_structure_context(
+    result: &mut KnowledgeQueryResult,
+    parent_chunks: &HashMap<String, KnowledgeChunk>,
+) {
+    let Some(section_chunk) = parent_chunks.get(&result.id) else {
+        return;
+    };
+    let parent_section =
+        if result.parent_section_id.is_empty() || result.parent_section_id == "section-root" {
+            Value::Null
+        } else {
+            parent_chunks
+                .values()
+                .find(|chunk| {
+                    chunk.doc_id == result.doc_id
+                        && knowledge_chunk_section_id(chunk) == result.parent_section_id
+                })
+                .map(knowledge_structure_context_section)
+                .unwrap_or(Value::Null)
+        };
+    let mut sibling_sections = parent_chunks
+        .values()
+        .filter(|chunk| {
+            chunk.doc_id == result.doc_id
+                && knowledge_chunk_parent_section_id(chunk) == result.parent_section_id
+                && knowledge_chunk_section_id(chunk) != result.section_id
+        })
+        .collect::<Vec<_>>();
+    sibling_sections.sort_by_key(|chunk| chunk.section_ordinal);
+    let sibling_sections = sibling_sections
+        .into_iter()
+        .map(knowledge_structure_context_section)
+        .collect::<Vec<_>>();
+    let mut child_sections = parent_chunks
+        .values()
+        .filter(|chunk| {
+            chunk.doc_id == result.doc_id
+                && knowledge_chunk_parent_section_id(chunk) == result.section_id
+        })
+        .collect::<Vec<_>>();
+    child_sections.sort_by_key(|chunk| chunk.section_ordinal);
+    let child_sections = child_sections
+        .into_iter()
+        .map(knowledge_structure_context_section)
+        .collect::<Vec<_>>();
+    result.structure_context = serde_json::json!({
+        "object": "knowledge_structure_context",
+        "section": knowledge_structure_context_section(section_chunk),
+        "parent_section": parent_section,
+        "sibling_sections": sibling_sections,
+        "child_sections": child_sections
+    });
+}
+
+fn knowledge_structure_context_section(chunk: &KnowledgeChunk) -> Value {
+    serde_json::json!({
+        "id": knowledge_chunk_section_id(chunk),
+        "chunk_id": chunk.id,
+        "title": if chunk.section_title.is_empty() {
+            chunk.section_path.clone()
+        } else {
+            chunk.section_title.clone()
+        },
+        "section_path": chunk.section_path,
+        "ordinal": chunk.section_ordinal,
+        "line_start": chunk.line_start,
+        "line_end": chunk.line_end
+    })
+}
+
+fn knowledge_chunk_parent_section_id(chunk: &KnowledgeChunk) -> String {
+    if chunk.parent_section_id.is_empty() {
+        "section-root".to_string()
+    } else {
+        chunk.parent_section_id.clone()
+    }
 }
 
 fn empty_knowledge_context() -> KnowledgeContextResult {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -1675,11 +1675,9 @@ fn add_relation_graph_evidence_query_results(
             None,
             Some(edge_value),
             graph_query_conflict_metadata(edge, node_lookup, evidence),
-            Some(entity_graph_query_projection_metadata(
-                "relation",
-                &edge.id,
-                &edge.label,
-                &edge.attributes,
+            Some(relation_graph_query_projection_metadata(
+                edge,
+                node_lookup,
                 evidence,
             )),
         );
@@ -1775,6 +1773,42 @@ fn entity_graph_query_projection_metadata(
         "stale": attributes.get("stale").and_then(Value::as_bool).unwrap_or(false),
         "doc_id": value_string(evidence, "doc_id").unwrap_or_default()
     })
+}
+
+fn relation_graph_query_projection_metadata(
+    edge: &KnowledgeGraphEdge,
+    node_lookup: &HashMap<String, &KnowledgeGraphNode>,
+    evidence: &Value,
+) -> Value {
+    let mut metadata = entity_graph_query_projection_metadata(
+        "relation",
+        &edge.id,
+        &edge.label,
+        &edge.attributes,
+        evidence,
+    );
+    if let Some(map) = metadata.as_object_mut() {
+        map.insert("predicate".to_string(), Value::String(edge.label.clone()));
+        map.insert(
+            "source_label".to_string(),
+            Value::String(
+                node_lookup
+                    .get(&edge.source)
+                    .map(|node| node.label.clone())
+                    .unwrap_or_else(|| edge.source.clone()),
+            ),
+        );
+        map.insert(
+            "target_label".to_string(),
+            Value::String(
+                node_lookup
+                    .get(&edge.target)
+                    .map(|node| node.label.clone())
+                    .unwrap_or_else(|| edge.target.clone()),
+            ),
+        );
+    }
+    metadata
 }
 
 fn graph_query_conflict_metadata(

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -621,11 +621,13 @@ impl WorkerKnowledgeRpc {
         if params.include_graph_context == Some(true) {
             let store = KnowledgeStorePaths::new(&self.root);
             let entity_nodes = read_jsonl::<KnowledgeGraphNode>(&store.entity_graph_nodes_file)?;
+            let entity_edges = read_jsonl::<KnowledgeGraphEdge>(&store.entity_graph_edges_file)?;
             let entity_evidence = read_jsonl::<Value>(&store.entity_graph_evidence_file)?;
             expand_query_with_entity_graph(
                 &mut results_by_parent,
                 &parents,
                 &entity_nodes,
+                &entity_edges,
                 &entity_evidence,
                 &query_terms,
                 &params,
@@ -682,6 +684,9 @@ impl WorkerKnowledgeRpc {
                 limit: Some(max_chunks),
                 include_structure_context: None,
                 include_graph_context: None,
+                graph_relation_filters: None,
+                graph_min_confidence: None,
+                graph_max_added_chunks: None,
             })?
             .results
         };
@@ -1147,6 +1152,12 @@ pub struct KnowledgeQueryParams {
     pub include_structure_context: Option<bool>,
     #[serde(default)]
     pub include_graph_context: Option<bool>,
+    #[serde(default)]
+    pub graph_relation_filters: Option<Vec<String>>,
+    #[serde(default)]
+    pub graph_min_confidence: Option<f64>,
+    #[serde(default)]
+    pub graph_max_added_chunks: Option<usize>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1454,15 +1465,29 @@ fn expand_query_with_entity_graph(
     results_by_parent: &mut HashMap<String, KnowledgeQueryResult>,
     parent_chunks: &HashMap<String, KnowledgeChunk>,
     nodes: &[KnowledgeGraphNode],
+    edges: &[KnowledgeGraphEdge],
     evidence_records: &[Value],
     query_terms: &[String],
     params: &KnowledgeQueryParams,
 ) {
+    let mut added_chunks = 0usize;
+    let max_added_chunks = params.graph_max_added_chunks.unwrap_or(5).min(20);
+    let min_confidence = params.graph_min_confidence.unwrap_or(0.0).clamp(0.0, 1.0);
+    let node_lookup = nodes
+        .iter()
+        .map(|node| (node.id.clone(), node))
+        .collect::<HashMap<_, _>>();
     for node in nodes
         .iter()
         .filter(|node| entity_graph_node_matches_query(node, query_terms))
     {
+        if added_chunks >= max_added_chunks {
+            break;
+        }
         if node.attributes.get("stale").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        if graph_record_confidence(&node.attributes) < min_confidence {
             continue;
         }
         let evidence_ids = graph_evidence_ids(&node.attributes);
@@ -1478,34 +1503,149 @@ fn expand_query_with_entity_graph(
             let Some(chunk) = graph_evidence_parent_chunk(parent_chunks, evidence, params) else {
                 continue;
             };
-            let entry = results_by_parent
-                .entry(chunk.id.clone())
-                .or_insert_with(|| KnowledgeQueryResult::from_chunk(chunk.clone(), 0));
-            if entry.score == 0 {
-                entry.score = 1;
-                entry.rrf_score = 1;
-                entry.method = "graph".to_string();
-                entry.retrieval_method = "graph".to_string();
-            }
-            if !entry.matched_methods.iter().any(|method| method == "graph") {
-                entry.matched_methods.push("graph".to_string());
-            }
             let node_value = serde_json::to_value(node).unwrap_or_else(|_| serde_json::json!({}));
-            if !entry.matched_entities.contains(&node_value) {
-                entry.matched_entities.push(node_value);
-            }
-            if !entry.source_snippets.contains(evidence) {
-                entry.source_snippets.push(evidence.clone());
+            let inserted = add_graph_evidence_query_result(
+                results_by_parent,
+                chunk,
+                evidence,
+                Some(node_value),
+                None,
+            );
+            if inserted {
+                added_chunks += 1;
+                if added_chunks >= max_added_chunks {
+                    break;
+                }
             }
         }
     }
+    for edge in edges.iter().filter(|edge| {
+        relation_graph_edge_matches_query(edge, &node_lookup, query_terms)
+            && relation_graph_edge_matches_filters(edge, params)
+            && graph_record_confidence(&edge.attributes) >= min_confidence
+    }) {
+        if added_chunks >= max_added_chunks {
+            break;
+        }
+        if edge.attributes.get("stale").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        let evidence_ids = graph_evidence_ids(&edge.attributes);
+        for evidence in evidence_records.iter().filter(|evidence| {
+            value_string(evidence, "doc_id").as_deref() == Some(edge.doc_id.as_str())
+                && value_string(evidence, "owner_id").as_deref() == Some(edge.id.as_str())
+                && value_string(evidence, "owner_type").as_deref() == Some("relation")
+                && value_string(evidence, "id")
+                    .as_ref()
+                    .map(|id| evidence_ids.contains(id))
+                    .unwrap_or(false)
+        }) {
+            let Some(chunk) = graph_evidence_parent_chunk(parent_chunks, evidence, params) else {
+                continue;
+            };
+            let edge_value = serde_json::to_value(edge).unwrap_or_else(|_| serde_json::json!({}));
+            let inserted = add_graph_evidence_query_result(
+                results_by_parent,
+                chunk,
+                evidence,
+                None,
+                Some(edge_value),
+            );
+            if inserted {
+                added_chunks += 1;
+                if added_chunks >= max_added_chunks {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn add_graph_evidence_query_result(
+    results_by_parent: &mut HashMap<String, KnowledgeQueryResult>,
+    chunk: KnowledgeChunk,
+    evidence: &Value,
+    matched_entity: Option<Value>,
+    matched_relation: Option<Value>,
+) -> bool {
+    let inserted = !results_by_parent.contains_key(&chunk.id);
+    let entry = results_by_parent
+        .entry(chunk.id.clone())
+        .or_insert_with(|| KnowledgeQueryResult::from_chunk(chunk, 0));
+    if entry.score == 0 {
+        entry.score = 1;
+        entry.rrf_score = 1;
+        entry.method = "graph".to_string();
+        entry.retrieval_method = "graph".to_string();
+    }
+    if !entry.matched_methods.iter().any(|method| method == "graph") {
+        entry.matched_methods.push("graph".to_string());
+    }
+    if let Some(entity) = matched_entity {
+        if !entry.matched_entities.contains(&entity) {
+            entry.matched_entities.push(entity);
+        }
+    }
+    if let Some(relation) = matched_relation {
+        if !entry.matched_relations.contains(&relation) {
+            entry.matched_relations.push(relation);
+        }
+        if !entry.matched_relation_evidence.contains(evidence) {
+            entry.matched_relation_evidence.push(evidence.clone());
+        }
+    }
+    if !entry.source_snippets.contains(evidence) {
+        entry.source_snippets.push(evidence.clone());
+    }
+    inserted
 }
 
 fn entity_graph_node_matches_query(node: &KnowledgeGraphNode, query_terms: &[String]) -> bool {
     let label = node.label.to_ascii_lowercase();
     query_terms
         .iter()
-        .any(|term| label.contains(term) || term.contains(label.as_str()))
+        .any(|term| graph_text_matches_query_term(&label, term))
+}
+
+fn relation_graph_edge_matches_query(
+    edge: &KnowledgeGraphEdge,
+    node_lookup: &HashMap<String, &KnowledgeGraphNode>,
+    query_terms: &[String],
+) -> bool {
+    let source_label = node_lookup
+        .get(&edge.source)
+        .map(|node| node.label.to_ascii_lowercase())
+        .unwrap_or_default();
+    let target_label = node_lookup
+        .get(&edge.target)
+        .map(|node| node.label.to_ascii_lowercase())
+        .unwrap_or_default();
+    let predicate = edge.label.to_ascii_lowercase();
+    query_terms.iter().any(|term| {
+        graph_text_matches_query_term(&source_label, term)
+            || graph_text_matches_query_term(&target_label, term)
+            || graph_text_matches_query_term(&predicate, term)
+    })
+}
+
+fn graph_text_matches_query_term(value: &str, term: &str) -> bool {
+    !value.is_empty() && (value.contains(term) || term.contains(value))
+}
+
+fn relation_graph_edge_matches_filters(
+    edge: &KnowledgeGraphEdge,
+    params: &KnowledgeQueryParams,
+) -> bool {
+    let Some(filters) = params
+        .graph_relation_filters
+        .as_ref()
+        .filter(|filters| !filters.is_empty())
+    else {
+        return true;
+    };
+    filters
+        .iter()
+        .any(|filter| filter.eq_ignore_ascii_case(&edge.label))
 }
 
 fn graph_evidence_ids(attributes: &Value) -> HashSet<String> {
@@ -1600,7 +1740,7 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
         );
         route_contributions.push(serde_json::json!({
             "route": "graph",
-            "method": "entity_evidence",
+            "method": "graph_evidence",
             "score": graph_contribution,
             "rank": result.sparse_rank,
             "contribution": graph_contribution

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -669,6 +669,9 @@ impl WorkerKnowledgeRpc {
             );
         }
         let mut results: Vec<KnowledgeQueryResult> = results_by_parent.into_values().collect();
+        for result in &mut results {
+            apply_knowledge_evidence_quality_bonus(result);
+        }
         results.sort_by(|left, right| {
             right
                 .score
@@ -1864,6 +1867,7 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
         0
     };
     let structure_score = knowledge_structure_score(&result.structure_context);
+    let evidence_quality_bonus = knowledge_evidence_quality_bonus(result);
     let mut components = serde_json::Map::new();
     let mut route_contributions = Vec::new();
     if result.sparse_contribution > 0 {
@@ -1926,9 +1930,24 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
             "contribution": 0
         }));
     }
+    if evidence_quality_bonus > 0 {
+        components.insert(
+            "evidence_quality_bonus".to_string(),
+            serde_json::json!({
+                "score": evidence_quality_bonus,
+                "verified_evidence_count": result.source_snippets.len(),
+                "normalized_score": normalized_route_score(evidence_quality_bonus as f64, result.score),
+                "contribution": evidence_quality_bonus
+            }),
+        );
+    }
     result.score_metadata = serde_json::json!({
         "object": "knowledge_score_metadata",
-        "score_model": knowledge_score_model(graph_contribution > 0, structure_score > 0),
+        "score_model": knowledge_score_model(
+            graph_contribution > 0,
+            structure_score > 0,
+            evidence_quality_bonus > 0,
+        ),
         "final_score": result.score,
         "components": components,
         "route_contributions": route_contributions,
@@ -1941,6 +1960,19 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
     });
 }
 
+fn apply_knowledge_evidence_quality_bonus(result: &mut KnowledgeQueryResult) {
+    let bonus = knowledge_evidence_quality_bonus(result);
+    if bonus == 0 {
+        return;
+    }
+    result.score += bonus;
+    result.rrf_score += bonus;
+}
+
+fn knowledge_evidence_quality_bonus(result: &KnowledgeQueryResult) -> usize {
+    usize::from(!result.source_snippets.is_empty())
+}
+
 fn sort_knowledge_matched_methods(methods: &mut [String]) {
     methods.sort_by_key(|method| match method.as_str() {
         "keyword" => 0,
@@ -1950,12 +1982,20 @@ fn sort_knowledge_matched_methods(methods: &mut [String]) {
     });
 }
 
-fn knowledge_score_model(has_graph: bool, has_structure: bool) -> &'static str {
-    match (has_graph, has_structure) {
-        (true, true) => "deterministic_sparse_graph_structure_v1",
-        (true, false) => "deterministic_sparse_graph_v1",
-        (false, true) => "deterministic_sparse_structure_v1",
-        (false, false) => "deterministic_sparse_v1",
+fn knowledge_score_model(
+    has_graph: bool,
+    has_structure: bool,
+    has_evidence_quality_bonus: bool,
+) -> &'static str {
+    match (has_graph, has_structure, has_evidence_quality_bonus) {
+        (true, true, true) => "deterministic_sparse_graph_structure_evidence_v1",
+        (true, true, false) => "deterministic_sparse_graph_structure_v1",
+        (true, false, true) => "deterministic_sparse_graph_evidence_v1",
+        (true, false, false) => "deterministic_sparse_graph_v1",
+        (false, true, true) => "deterministic_sparse_structure_evidence_v1",
+        (false, true, false) => "deterministic_sparse_structure_v1",
+        (false, false, true) => "deterministic_sparse_evidence_v1",
+        (false, false, false) => "deterministic_sparse_v1",
     }
 }
 

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -748,9 +748,12 @@ impl WorkerKnowledgeRpc {
         let store = KnowledgeStorePaths::new(&self.root);
         let documents = read_jsonl::<KnowledgeDocument>(&store.documents_file)?;
         let chunks = read_jsonl::<KnowledgeChunk>(&store.chunks_file)?;
-        let entity_nodes = read_jsonl::<KnowledgeGraphNode>(&store.entity_graph_nodes_file)?;
-        let entity_edges = read_jsonl::<KnowledgeGraphEdge>(&store.entity_graph_edges_file)?;
+        let mut entity_nodes = read_jsonl::<KnowledgeGraphNode>(&store.entity_graph_nodes_file)?;
+        let mut entity_edges = read_jsonl::<KnowledgeGraphEdge>(&store.entity_graph_edges_file)?;
         let entity_evidence = read_jsonl::<Value>(&store.entity_graph_evidence_file)?;
+        let graph_stale =
+            mark_entity_graph_staleness(&self.root, &mut entity_nodes, &mut entity_edges)?;
+        let graph_stale_count = graph_stale.node_count + graph_stale.edge_count;
         let parent_chunk_count = chunks
             .iter()
             .filter(|chunk| chunk.chunk_type == "parent")
@@ -784,6 +787,13 @@ impl WorkerKnowledgeRpc {
             "failed": 0,
             "stale": 0
         });
+        let graph_projection_status = if graph_stale_count > 0 {
+            "stale"
+        } else if graph_ready {
+            "ready"
+        } else {
+            "not_configured"
+        };
         let stage_readiness = serde_json::json!({
             "sparse_indexing": sparse_stage,
             "dense_indexing": { "ready": false, "status": "not_configured", "processed": 0, "total": 0, "failed": 0, "stale": 0, "skipped": parent_chunk_count },
@@ -791,7 +801,7 @@ impl WorkerKnowledgeRpc {
             "claim_validation": { "ready": false, "status": "not_configured", "processed": 0, "total": 0, "failed": 0, "stale": 0, "skipped": parent_chunk_count },
             "relation_extraction": { "ready": relations_ready, "status": if relations_ready { "ready" } else { "not_configured" }, "processed": entity_edges.len(), "total": entity_edges.len(), "failed": 0, "stale": 0, "skipped": if relations_ready { 0 } else { parent_chunk_count } },
             "relation_validation": { "ready": relations_ready, "status": if relations_ready { "ready" } else { "not_configured" }, "processed": entity_edges.len(), "total": entity_edges.len(), "failed": 0, "stale": 0, "skipped": if relations_ready { 0 } else { parent_chunk_count } },
-            "graph_projection": { "ready": graph_ready, "status": if graph_ready { "ready" } else { "not_configured" }, "processed": entity_nodes.len() + entity_edges.len(), "total": entity_nodes.len() + entity_edges.len(), "failed": 0, "stale": 0, "skipped": if graph_ready { 0 } else { parent_chunk_count } },
+            "graph_projection": { "ready": graph_ready, "status": graph_projection_status, "processed": entity_nodes.len() + entity_edges.len(), "total": entity_nodes.len() + entity_edges.len(), "failed": 0, "stale": graph_stale_count, "skipped": if graph_ready { 0 } else { parent_chunk_count } },
             "community_report_projection": { "ready": false, "status": "not_configured", "processed": 0, "total": 0, "failed": 0, "stale": 0, "skipped": parent_chunk_count }
         });
         let stage_coverage = serde_json::json!({
@@ -829,7 +839,7 @@ impl WorkerKnowledgeRpc {
             stage_readiness,
             stage_coverage,
             failed_stage_count: 0,
-            stale_stage_count: 0,
+            stale_stage_count: usize::from(graph_stale_count > 0),
             retrieval_ready,
             claims_ready,
             relations_ready,

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -1572,6 +1572,7 @@ fn expand_query_with_entity_graph(
                 evidence,
                 Some(node_value),
                 None,
+                None,
             );
             if inserted {
                 added_chunks += 1;
@@ -1606,6 +1607,7 @@ fn expand_query_with_entity_graph(
                 parent_chunks,
                 evidence_records,
                 edge,
+                &node_lookup,
                 params,
                 &mut added_chunks,
                 max_added_chunks,
@@ -1636,6 +1638,7 @@ fn add_relation_graph_evidence_query_results(
     parent_chunks: &HashMap<String, KnowledgeChunk>,
     evidence_records: &[Value],
     edge: &KnowledgeGraphEdge,
+    node_lookup: &HashMap<String, &KnowledgeGraphNode>,
     params: &KnowledgeQueryParams,
     added_chunks: &mut usize,
     max_added_chunks: usize,
@@ -1661,6 +1664,7 @@ fn add_relation_graph_evidence_query_results(
             evidence,
             None,
             Some(edge_value),
+            graph_query_conflict_metadata(edge, node_lookup, evidence),
         );
         if inserted {
             added = true;
@@ -1679,6 +1683,7 @@ fn add_graph_evidence_query_result(
     evidence: &Value,
     matched_entity: Option<Value>,
     matched_relation: Option<Value>,
+    conflict_metadata: Option<Value>,
 ) -> bool {
     let inserted = !results_by_parent.contains_key(&chunk.id);
     let entry = results_by_parent
@@ -1706,10 +1711,45 @@ fn add_graph_evidence_query_result(
             entry.matched_relation_evidence.push(evidence.clone());
         }
     }
+    if let Some(conflict) = conflict_metadata {
+        if !entry.conflict_metadata.contains(&conflict) {
+            entry.conflict_metadata.push(conflict);
+        }
+    }
     if !entry.source_snippets.contains(evidence) {
         entry.source_snippets.push(evidence.clone());
     }
     inserted
+}
+
+fn graph_query_conflict_metadata(
+    edge: &KnowledgeGraphEdge,
+    node_lookup: &HashMap<String, &KnowledgeGraphNode>,
+    evidence: &Value,
+) -> Option<Value> {
+    if !entity_graph_edge_is_conflict(edge) {
+        return None;
+    }
+    Some(serde_json::json!({
+        "id": edge.id,
+        "type": "relation_conflict",
+        "edge_id": edge.id,
+        "source": edge.source,
+        "source_label": node_lookup
+            .get(&edge.source)
+            .map(|node| node.label.as_str())
+            .unwrap_or(edge.source.as_str()),
+        "target": edge.target,
+        "target_label": node_lookup
+            .get(&edge.target)
+            .map(|node| node.label.as_str())
+            .unwrap_or(edge.target.as_str()),
+        "predicate": edge.label,
+        "confidence": graph_record_confidence(&edge.attributes),
+        "doc_id": edge.doc_id,
+        "stale": edge.attributes.get("stale").and_then(Value::as_bool).unwrap_or(false),
+        "evidence": [evidence]
+    }))
 }
 
 fn entity_graph_node_matches_query(node: &KnowledgeGraphNode, query_terms: &[String]) -> bool {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -3607,6 +3607,7 @@ fn section_id(doc_id: &str, section_ordinal: usize) -> String {
 fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -> Value {
     let query = params.query.as_str();
     let terms = knowledge_query_terms(query);
+    let budgets = knowledge_retrieval_plan_budgets(params, limit);
     let graph_options = knowledge_retrieval_plan_graph_options(params);
     let exact_query = query.contains('.')
         || query.contains('_')
@@ -3627,13 +3628,7 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
                     "reason": "query contains exact identifiers or API/config-like terms"
                 }
             ],
-            "budgets": {
-                "limit": limit,
-                "keyword": limit,
-                "semantic": 0,
-                "graph": 0,
-                "tree": 0
-            },
+            "budgets": budgets,
             "fallback_behavior": "fallback_to_hybrid_when_no_results",
             "fallback_routes": ["keyword", "tree", "graph"],
             "graph_options": graph_options
@@ -3657,18 +3652,32 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
                     "reason": "entity graph expansion can be added when graph evidence is ready"
                 }
             ],
-            "budgets": {
-                "limit": limit,
-                "keyword": limit,
-                "semantic": 0,
-                "graph": 0,
-                "tree": 0
-            },
+            "budgets": budgets,
             "fallback_behavior": "fallback_to_keyword_sparse",
             "fallback_routes": ["keyword"],
             "graph_options": graph_options
         })
     }
+}
+
+fn knowledge_retrieval_plan_budgets(params: &KnowledgeQueryParams, limit: usize) -> Value {
+    let graph_budget = if params.include_graph_context.unwrap_or(false) {
+        params.graph_max_added_chunks.unwrap_or(5).min(20)
+    } else {
+        0
+    };
+    let tree_budget = if params.include_structure_context.unwrap_or(false) {
+        limit
+    } else {
+        0
+    };
+    serde_json::json!({
+        "limit": limit,
+        "keyword": limit,
+        "semantic": 0,
+        "graph": graph_budget,
+        "tree": tree_budget
+    })
 }
 
 fn knowledge_retrieval_plan_graph_options(params: &KnowledgeQueryParams) -> Value {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -2291,6 +2291,16 @@ fn knowledge_reference_metadata(result: &KnowledgeQueryResult) -> Value {
         || !result.projection_metadata.is_empty()
         || !result.conflict_metadata.is_empty();
     if let Some(map) = reference.as_object_mut() {
+        if !result
+            .structure_context
+            .as_object()
+            .map_or(true, |map| map.is_empty())
+        {
+            map.insert(
+                "structure_context".to_string(),
+                result.structure_context.clone(),
+            );
+        }
         if !result.source_snippets.is_empty() {
             map.insert(
                 "source_snippets".to_string(),

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -754,6 +754,10 @@ impl WorkerKnowledgeRpc {
         let graph_stale =
             mark_entity_graph_staleness(&self.root, &mut entity_nodes, &mut entity_edges)?;
         let graph_stale_count = graph_stale.node_count + graph_stale.edge_count;
+        let conflict_count = entity_edges
+            .iter()
+            .filter(|edge| entity_graph_edge_is_conflict(edge))
+            .count();
         let parent_chunk_count = chunks
             .iter()
             .filter(|chunk| chunk.chunk_type == "parent")
@@ -825,7 +829,7 @@ impl WorkerKnowledgeRpc {
             claim_count: 0,
             relation_count: entity_edges.len(),
             source_count: entity_evidence.len(),
-            conflict_count: 0,
+            conflict_count,
             stage_status_count: 0,
             candidate_diagnostic_count: 0,
             community_count: 0,
@@ -2496,10 +2500,7 @@ fn entity_graph_conflicts(
         .collect::<HashMap<_, _>>();
     edges
         .iter()
-        .filter(|edge| {
-            edge.label.eq_ignore_ascii_case("conflicts_with")
-                || edge.edge_type.eq_ignore_ascii_case("conflicts_with")
-        })
+        .filter(|edge| entity_graph_edge_is_conflict(edge))
         .map(|edge| {
             serde_json::json!({
                 "id": edge.id,
@@ -2517,6 +2518,11 @@ fn entity_graph_conflicts(
             })
         })
         .collect()
+}
+
+fn entity_graph_edge_is_conflict(edge: &KnowledgeGraphEdge) -> bool {
+    edge.label.eq_ignore_ascii_case("conflicts_with")
+        || edge.edge_type.eq_ignore_ascii_case("conflicts_with")
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -526,6 +526,7 @@ impl WorkerKnowledgeRpc {
         let limit = params.limit.unwrap_or(80).clamp(1, 500);
         nodes.truncate(limit);
         let stale = mark_entity_graph_staleness(&self.root, &mut nodes, &mut edges)?;
+        let conflicts = entity_graph_conflicts(&nodes, &edges);
         let entity_ready = !nodes.is_empty() || !edges.is_empty();
         Ok(KnowledgeGraphResult {
             object: "knowledge_graph".to_string(),
@@ -536,6 +537,7 @@ impl WorkerKnowledgeRpc {
                 "total_entities": nodes.len(),
                 "total_relations": edges.len(),
                 "total_mentions": edges.iter().map(|edge| edge.evidence.len()).sum::<usize>(),
+                "conflict_count": conflicts.len(),
                 "stale_count": stale.node_count + stale.edge_count,
                 "stale_node_count": stale.node_count,
                 "stale_edge_count": stale.edge_count,
@@ -560,7 +562,7 @@ impl WorkerKnowledgeRpc {
             communities: Vec::new(),
             reports: Vec::new(),
             claims: Vec::new(),
-            conflicts: Vec::new(),
+            conflicts,
             stage_readiness: serde_json::json!({}),
             stage_coverage: serde_json::json!({}),
         })
@@ -2400,6 +2402,39 @@ fn graph_record_confidence(attributes: &Value) -> f64 {
         .and_then(Value::as_f64)
         .unwrap_or(1.0)
         .clamp(0.0, 1.0)
+}
+
+fn entity_graph_conflicts(
+    nodes: &[KnowledgeGraphNode],
+    edges: &[KnowledgeGraphEdge],
+) -> Vec<Value> {
+    let labels = nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node.label.as_str()))
+        .collect::<HashMap<_, _>>();
+    edges
+        .iter()
+        .filter(|edge| {
+            edge.label.eq_ignore_ascii_case("conflicts_with")
+                || edge.edge_type.eq_ignore_ascii_case("conflicts_with")
+        })
+        .map(|edge| {
+            serde_json::json!({
+                "id": edge.id,
+                "type": "relation_conflict",
+                "edge_id": edge.id,
+                "source": edge.source,
+                "source_label": labels.get(edge.source.as_str()).copied().unwrap_or(edge.source.as_str()),
+                "target": edge.target,
+                "target_label": labels.get(edge.target.as_str()).copied().unwrap_or(edge.target.as_str()),
+                "predicate": edge.label,
+                "confidence": graph_record_confidence(&edge.attributes),
+                "doc_id": edge.doc_id,
+                "stale": edge.attributes.get("stale").and_then(Value::as_bool).unwrap_or(false),
+                "evidence": edge.evidence
+            })
+        })
+        .collect()
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -781,6 +781,7 @@ impl WorkerKnowledgeRpc {
             .map(|document| document.content.chars().count())
             .sum();
         let retrieval_ready = parent_chunk_count > 0;
+        let tree_ready = parent_chunk_count > 0;
         let claims_ready = false;
         let relations_ready = !entity_edges.is_empty();
         let graph_ready = !entity_nodes.is_empty() || !entity_edges.is_empty();
@@ -801,6 +802,7 @@ impl WorkerKnowledgeRpc {
         };
         let stage_readiness = serde_json::json!({
             "sparse_indexing": sparse_stage,
+            "tree_index": { "ready": tree_ready, "status": if tree_ready { "ready" } else { "empty" }, "processed": parent_chunk_count, "total": parent_chunk_count, "failed": 0, "stale": 0, "skipped": 0 },
             "dense_indexing": { "ready": false, "status": "not_configured", "processed": 0, "total": 0, "failed": 0, "stale": 0, "skipped": parent_chunk_count },
             "claim_extraction": { "ready": false, "status": "not_configured", "processed": 0, "total": 0, "failed": 0, "stale": 0, "skipped": parent_chunk_count },
             "claim_validation": { "ready": false, "status": "not_configured", "processed": 0, "total": 0, "failed": 0, "stale": 0, "skipped": parent_chunk_count },
@@ -811,6 +813,7 @@ impl WorkerKnowledgeRpc {
         });
         let stage_coverage = serde_json::json!({
             "sparse_indexing": if retrieval_ready { 1.0 } else { 0.0 },
+            "tree_index": if tree_ready { 1.0 } else { 0.0 },
             "dense_indexing": 0.0,
             "claim_extraction": 0.0,
             "claim_validation": 0.0,

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -363,6 +363,7 @@ impl WorkerKnowledgeRpc {
             .retain(|item| value_string(item, "doc_id").as_deref() != Some(document.id.as_str()));
 
         let mut entity_ids = HashMap::new();
+        let mut entity_node_indexes = HashMap::new();
         for entity in params
             .entities
             .iter()
@@ -385,20 +386,26 @@ impl WorkerKnowledgeRpc {
                     )
                 })
                 .collect::<Vec<_>>();
-            nodes.push(KnowledgeGraphNode {
-                id,
-                label: entity.name.trim().to_string(),
-                node_type: "entity".to_string(),
-                doc_id: document.id.clone(),
-                evidence: Vec::new(),
-                attributes: serde_json::json!({
-                    "entity_type": entity.entity_type,
-                    "confidence": entity.confidence,
-                    "source_hash": source_hash,
-                    "stale": false,
-                    "evidence_ids": evidence_ids
-                }),
-            });
+            if let Some(index) = entity_node_indexes.get(&id).copied() {
+                merge_entity_graph_node(&mut nodes[index], entity, evidence_ids);
+            } else {
+                nodes.push(KnowledgeGraphNode {
+                    id: id.clone(),
+                    label: entity.name.trim().to_string(),
+                    node_type: "entity".to_string(),
+                    doc_id: document.id.clone(),
+                    evidence: Vec::new(),
+                    attributes: serde_json::json!({
+                        "entity_type": normalize_entity_graph_type(&entity.entity_type),
+                        "aliases": [],
+                        "confidence": entity.confidence,
+                        "source_hash": source_hash,
+                        "stale": false,
+                        "evidence_ids": evidence_ids
+                    }),
+                });
+                entity_node_indexes.insert(id, nodes.len() - 1);
+            }
         }
         for relation in params.relations.iter().filter(|relation| {
             !relation.source.trim().is_empty()
@@ -2286,6 +2293,69 @@ fn completed_entity_graph_job(
             "diagnostics": params.diagnostics
         }),
     }
+}
+
+fn merge_entity_graph_node(
+    node: &mut KnowledgeGraphNode,
+    entity: &KnowledgeExtractedEntity,
+    evidence_ids: Vec<String>,
+) {
+    if let Value::Object(attributes) = &mut node.attributes {
+        append_unique_json_strings(attributes, "evidence_ids", evidence_ids);
+
+        let alias = entity.name.trim();
+        if !alias.is_empty() && alias != node.label {
+            append_unique_json_strings(attributes, "aliases", vec![alias.to_string()]);
+        }
+
+        let entity_type = normalize_entity_graph_type(&entity.entity_type);
+        let existing_type = attributes
+            .get("entity_type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim();
+        if existing_type.is_empty() && !entity_type.is_empty() {
+            attributes.insert("entity_type".to_string(), Value::String(entity_type));
+        }
+
+        if let Some(confidence) = entity.confidence {
+            let existing_confidence = attributes.get("confidence").and_then(Value::as_f64);
+            if existing_confidence.map_or(true, |existing| confidence > existing) {
+                attributes.insert("confidence".to_string(), serde_json::json!(confidence));
+            }
+        }
+    }
+}
+
+fn append_unique_json_strings(
+    attributes: &mut serde_json::Map<String, Value>,
+    key: &str,
+    values: Vec<String>,
+) {
+    let mut existing = attributes
+        .get(key)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut seen = existing
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect::<HashSet<_>>();
+    for value in values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        if seen.insert(value.clone()) {
+            existing.push(Value::String(value));
+        }
+    }
+    attributes.insert(key.to_string(), Value::Array(existing));
+}
+
+fn normalize_entity_graph_type(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
 }
 
 fn entity_graph_stub_node(

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -675,10 +675,10 @@ impl WorkerKnowledgeRpc {
         }
         results.truncate(limit);
         for result in &mut results {
-            populate_knowledge_score_metadata(result);
             if params.include_structure_context == Some(true) {
                 populate_knowledge_structure_context(result, &parents);
             }
+            populate_knowledge_score_metadata(result);
         }
         Ok(KnowledgeQueryResultSet {
             results,
@@ -1744,6 +1744,7 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
     {
         result.matched_methods.push("keyword".to_string());
     }
+    sort_knowledge_matched_methods(&mut result.matched_methods);
     let graph_contribution = if result
         .matched_methods
         .iter()
@@ -1753,6 +1754,7 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
     } else {
         0
     };
+    let structure_score = knowledge_structure_score(&result.structure_context);
     let mut components = serde_json::Map::new();
     let mut route_contributions = Vec::new();
     if result.sparse_contribution > 0 {
@@ -1796,17 +1798,82 @@ fn populate_knowledge_score_metadata(result: &mut KnowledgeQueryResult) {
             "contribution": graph_contribution
         }));
     }
+    if structure_score > 0 {
+        components.insert(
+            "structure".to_string(),
+            serde_json::json!({
+                "score": structure_score,
+                "rank": result.sparse_rank,
+                "normalized_score": 0.0,
+                "contribution": 0
+            }),
+        );
+        route_contributions.push(serde_json::json!({
+            "route": "tree",
+            "method": "structure_context",
+            "score": structure_score,
+            "rank": result.sparse_rank,
+            "normalized_score": 0.0,
+            "contribution": 0
+        }));
+    }
     result.score_metadata = serde_json::json!({
         "object": "knowledge_score_metadata",
-        "score_model": if graph_contribution > 0 {
-            "deterministic_sparse_graph_v1"
-        } else {
-            "deterministic_sparse_v1"
-        },
+        "score_model": knowledge_score_model(graph_contribution > 0, structure_score > 0),
         "final_score": result.score,
         "components": components,
         "route_contributions": route_contributions
     });
+}
+
+fn sort_knowledge_matched_methods(methods: &mut [String]) {
+    methods.sort_by_key(|method| match method.as_str() {
+        "keyword" => 0,
+        "graph" => 1,
+        "structure" => 2,
+        _ => 10,
+    });
+}
+
+fn knowledge_score_model(has_graph: bool, has_structure: bool) -> &'static str {
+    match (has_graph, has_structure) {
+        (true, true) => "deterministic_sparse_graph_structure_v1",
+        (true, false) => "deterministic_sparse_graph_v1",
+        (false, true) => "deterministic_sparse_structure_v1",
+        (false, false) => "deterministic_sparse_v1",
+    }
+}
+
+fn knowledge_structure_score(structure_context: &Value) -> usize {
+    if structure_context.get("object").and_then(Value::as_str)
+        != Some("knowledge_structure_context")
+    {
+        return 0;
+    }
+    let mut score = 0usize;
+    if structure_context
+        .get("section")
+        .is_some_and(Value::is_object)
+    {
+        score += 1;
+    }
+    if structure_context
+        .get("parent_section")
+        .is_some_and(Value::is_object)
+    {
+        score += 1;
+    }
+    score += structure_context
+        .get("sibling_sections")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    score += structure_context
+        .get("child_sections")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    score
 }
 
 fn normalized_route_score(contribution: f64, final_score: usize) -> f64 {
@@ -1869,6 +1936,13 @@ fn populate_knowledge_structure_context(
         "sibling_sections": sibling_sections,
         "child_sections": child_sections
     });
+    if !result
+        .matched_methods
+        .iter()
+        .any(|method| method == "structure")
+    {
+        result.matched_methods.push("structure".to_string());
+    }
 }
 
 fn knowledge_structure_context_section(chunk: &KnowledgeChunk) -> Value {

--- a/apps/desktop/src-tauri/src/worker_knowledge.rs
+++ b/apps/desktop/src-tauri/src/worker_knowledge.rs
@@ -3814,6 +3814,7 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
     let budgets = knowledge_retrieval_plan_budgets(params, limit);
     let (selected_routes, route_reasons) = knowledge_retrieval_plan_routes(params);
     let graph_options = knowledge_retrieval_plan_graph_options(params);
+    let tree_options = knowledge_retrieval_plan_tree_options(params, limit);
     let exact_query = query.contains('.')
         || query.contains('_')
         || terms.iter().any(|term| {
@@ -3836,7 +3837,8 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
             "budgets": budgets,
             "fallback_behavior": "fallback_to_hybrid_when_no_results",
             "fallback_routes": ["keyword", "tree", "graph"],
-            "graph_options": graph_options
+            "graph_options": graph_options,
+            "tree_options": tree_options
         })
     } else {
         serde_json::json!({
@@ -3847,7 +3849,8 @@ fn build_knowledge_retrieval_plan(params: &KnowledgeQueryParams, limit: usize) -
             "budgets": budgets,
             "fallback_behavior": "fallback_to_keyword_sparse",
             "fallback_routes": ["keyword"],
-            "graph_options": graph_options
+            "graph_options": graph_options,
+            "tree_options": tree_options
         })
     }
 }
@@ -3910,6 +3913,22 @@ fn knowledge_retrieval_plan_graph_options(params: &KnowledgeQueryParams) -> Valu
         "relation_filters": params.graph_relation_filters.clone().unwrap_or_default(),
         "min_confidence": params.graph_min_confidence.unwrap_or(0.0).clamp(0.0, 1.0),
         "max_added_chunks": params.graph_max_added_chunks.unwrap_or(5).min(20)
+    })
+}
+
+fn knowledge_retrieval_plan_tree_options(params: &KnowledgeQueryParams, limit: usize) -> Value {
+    let terms = knowledge_query_terms(&params.query);
+    let include_structure_context =
+        knowledge_query_should_include_structure_context(params, &terms);
+    serde_json::json!({
+        "include_structure_context": include_structure_context,
+        "context_budget": if include_structure_context { limit } else { 0 },
+        "trigger": match params.include_structure_context {
+            Some(true) => "explicit",
+            Some(false) => "disabled",
+            None if include_structure_context => "auto",
+            None => "none",
+        }
     })
 }
 

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8282,6 +8282,119 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_can_expand_from_relation_graph_evidence() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-query-1",
+            "trace-relation-query",
+            "knowledge.add_document",
+            json!({
+                "name": "Relation Expansion Notes",
+                "content": "# Relation Expansion Notes\n\nThe orchestration layer coordinates background jobs.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-query-2",
+            "trace-relation-query",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Relation Expansion Notes",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.93 },
+                    { "name": "RuntimeScheduler", "type": "component", "confidence": 0.91 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "RuntimeScheduler",
+                        "predicate": "depends_on",
+                        "confidence": 0.88,
+                        "evidence": [
+                            {
+                                "text": "The orchestration layer coordinates background jobs.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    },
+                    {
+                        "source": "TinyBot",
+                        "target": "Unrelated",
+                        "predicate": "mentions",
+                        "confidence": 0.95,
+                        "evidence": [
+                            {
+                                "text": "The orchestration layer coordinates background jobs.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-query-3",
+            "trace-relation-query",
+            "knowledge.query",
+            json!({
+                "query": "TinyBot",
+                "category": "desktop",
+                "limit": 3,
+                "include_graph_context": true,
+                "graph_relation_filters": ["depends_on"],
+                "graph_min_confidence": 0.8,
+                "graph_max_added_chunks": 1
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let result = &query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result")["results"][0];
+        assert_eq!(result["id"], format!("chunk_{doc_id}_0"));
+        assert_eq!(result["retrieval_method"], "graph");
+        assert_eq!(result["matched_methods"], json!(["graph"]));
+        assert_eq!(result["matched_entities"], json!([]));
+        assert_eq!(result["matched_relations"].as_array().unwrap().len(), 1);
+        assert_eq!(result["matched_relations"][0]["label"], "depends_on");
+        assert_eq!(
+            result["matched_relation_evidence"][0]["text"],
+            "The orchestration layer coordinates background jobs."
+        );
+        assert_eq!(result["source_snippets"][0]["owner_type"], "relation");
+        assert_eq!(
+            result["score_metadata"]["route_contributions"][0]["method"],
+            "graph_evidence"
+        );
+    }
+
+    #[test]
     fn knowledge_query_returns_deterministic_retrieval_plan() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8537,6 +8537,25 @@ mod tests {
             result["score_metadata"]["route_contributions"][0]["method"],
             "graph_evidence"
         );
+        assert_eq!(
+            result["projection_metadata"][0]["object"],
+            "knowledge_projection_metadata"
+        );
+        assert_eq!(
+            result["projection_metadata"][0]["projection"],
+            "entity_graph"
+        );
+        assert_eq!(result["projection_metadata"][0]["owner_type"], "relation");
+        assert_eq!(
+            result["projection_metadata"][0]["owner_label"],
+            "depends_on"
+        );
+        assert_eq!(result["projection_metadata"][0]["predicate"], "depends_on");
+        assert_eq!(result["projection_metadata"][0]["source_label"], "TinyBot");
+        assert_eq!(
+            result["projection_metadata"][0]["target_label"],
+            "RuntimeScheduler"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8406,6 +8406,24 @@ mod tests {
                 "contribution": 1
             })
         );
+        assert_eq!(
+            result["projection_metadata"][0]["object"],
+            "knowledge_projection_metadata"
+        );
+        assert_eq!(
+            result["projection_metadata"][0]["projection"],
+            "entity_graph"
+        );
+        assert_eq!(result["projection_metadata"][0]["owner_type"], "entity");
+        assert_eq!(result["projection_metadata"][0]["owner_label"], "TinyBot");
+        assert_eq!(
+            result["projection_metadata"][0]["evidence_status"],
+            "verified"
+        );
+        assert_eq!(result["projection_metadata"][0]["confidence"], 0.93);
+        assert_eq!(result["projection_metadata"][0]["stale"], false);
+        assert!(result["projection_metadata"][0]["source_hash"].is_string());
+        assert!(result["projection_metadata"][0]["evidence_id"].is_string());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8005,6 +8005,76 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_returns_score_component_metadata() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-score-1",
+            "trace-score",
+            "knowledge.add_document",
+            json!({
+                "name": "Score Metadata Notes",
+                "content": "# Score Metadata Notes\n\nSparse retrieval ranking should explain sparse score contribution.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        assert_eq!(add_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-score-2",
+            "trace-score",
+            "knowledge.query",
+            json!({
+                "query": "sparse retrieval",
+                "category": "desktop",
+                "limit": 3
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let result = &query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result")["results"][0];
+        assert_eq!(result["score"], 2);
+        assert_eq!(result["matched_methods"], json!(["keyword"]));
+        assert_eq!(
+            result["score_metadata"],
+            json!({
+                "object": "knowledge_score_metadata",
+                "score_model": "deterministic_sparse_v1",
+                "final_score": 2,
+                "components": {
+                    "sparse": {
+                        "score": 2,
+                        "rank": 1,
+                        "contribution": 2
+                    }
+                },
+                "route_contributions": [
+                    {
+                        "route": "keyword",
+                        "method": "sparse",
+                        "score": 2,
+                        "rank": 1,
+                        "contribution": 2
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
     fn knowledge_query_returns_deterministic_retrieval_plan() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8492,6 +8492,101 @@ mod tests {
     }
 
     #[test]
+    fn entity_graph_flags_entities_without_evidence() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-entity-evidence-status-1",
+            "trace-entity-evidence-status",
+            "knowledge.add_document",
+            json!({
+                "name": "Entity Evidence Status",
+                "content": "# Entity Evidence Status\n\nTinyBot has direct entity evidence.\n",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-entity-evidence-status-2",
+            "trace-entity-evidence-status",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Entity Evidence Status",
+                "model": "knowledge-model",
+                "entities": [
+                    {
+                        "name": "TinyBot",
+                        "type": "project",
+                        "confidence": 0.91,
+                        "evidence": [
+                            {
+                                "text": "TinyBot has direct entity evidence.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    },
+                    {
+                        "name": "UnverifiedEntity",
+                        "type": "concept",
+                        "confidence": 0.64
+                    }
+                ],
+                "relations": [],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let graph_response = router.dispatch(&WorkerRequest::new(
+            "req-entity-evidence-status-3",
+            "trace-entity-evidence-status",
+            "knowledge.graph",
+            json!({
+                "graph_type": "entity",
+                "doc_id": doc_id,
+                "include_orphans": true
+            }),
+        ));
+
+        assert_eq!(graph_response.error, None);
+        let graph = graph_response
+            .result
+            .as_ref()
+            .expect("knowledge.graph should return result");
+        assert_eq!(graph["stats"]["verified_node_count"], 1);
+        assert_eq!(graph["stats"]["unverified_node_count"], 1);
+        let nodes = graph["nodes"].as_array().expect("nodes should be an array");
+        let verified = nodes
+            .iter()
+            .find(|node| node["label"] == "TinyBot")
+            .expect("verified entity should be present");
+        let missing = nodes
+            .iter()
+            .find(|node| node["label"] == "UnverifiedEntity")
+            .expect("unverified entity should be present");
+        assert_eq!(verified["attributes"]["evidence_status"], "verified");
+        assert_eq!(missing["attributes"]["evidence_status"], "missing");
+    }
+
+    #[test]
     fn save_entity_graph_extraction_rejects_relation_without_evidence() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -9581,6 +9581,11 @@ mod tests {
         assert_eq!(stats["failed_stage_count"], 0);
         assert_eq!(stats["stale_stage_count"], 0);
         assert_eq!(stats["stage_readiness"]["sparse_indexing"]["ready"], true);
+        assert_eq!(stats["stage_readiness"]["tree_index"]["ready"], true);
+        assert_eq!(stats["stage_readiness"]["tree_index"]["status"], "ready");
+        assert_eq!(stats["stage_readiness"]["tree_index"]["processed"], 2);
+        assert_eq!(stats["stage_readiness"]["tree_index"]["total"], 2);
+        assert_eq!(stats["stage_readiness"]["tree_index"]["stale"], 0);
         assert_eq!(
             stats["stage_readiness"]["claim_extraction"]["status"],
             "not_configured"
@@ -9597,6 +9602,7 @@ mod tests {
         );
         assert_eq!(stats["stage_readiness"]["graph_projection"]["total"], 0);
         assert_eq!(stats["stage_coverage"]["sparse_indexing"], 1.0);
+        assert_eq!(stats["stage_coverage"]["tree_index"], 1.0);
         assert_eq!(stats["stage_details"], json!([]));
     }
 

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -9648,6 +9648,11 @@ mod tests {
                     "relation_filters": [],
                     "min_confidence": 0.0,
                     "max_added_chunks": 5
+                },
+                "tree_options": {
+                    "include_structure_context": false,
+                    "context_budget": 0,
+                    "trigger": "none"
                 }
             })
         );
@@ -9766,6 +9771,14 @@ mod tests {
                 "relation_filters": ["depends_on", "configures"],
                 "min_confidence": 0.75,
                 "max_added_chunks": 3
+            })
+        );
+        assert_eq!(
+            result["retrieval_plan"]["tree_options"],
+            json!({
+                "include_structure_context": true,
+                "context_budget": 3,
+                "trigger": "explicit"
             })
         );
         assert_eq!(result["retrieval_plan"]["budgets"]["graph"], 3);

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -9357,6 +9357,7 @@ mod tests {
                 "query": "TinyBot dependency graph",
                 "category": "desktop",
                 "limit": 3,
+                "include_structure_context": true,
                 "include_graph_context": true,
                 "graph_max_hops": 2,
                 "graph_relation_filters": ["depends_on", "configures"],
@@ -9380,6 +9381,8 @@ mod tests {
                 "max_added_chunks": 3
             })
         );
+        assert_eq!(result["retrieval_plan"]["budgets"]["graph"], 3);
+        assert_eq!(result["retrieval_plan"]["budgets"]["tree"], 3);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -9579,6 +9579,12 @@ mod tests {
         assert_eq!(stats["relation_count"], 1);
         assert_eq!(stats["source_count"], 2);
         assert_eq!(stats["graph_ready"], true);
+        assert_eq!(stats["stale_stage_count"], 1);
+        assert_eq!(
+            stats["stage_readiness"]["graph_projection"]["status"],
+            "stale"
+        );
+        assert_eq!(stats["stage_readiness"]["graph_projection"]["stale"], 3);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -10779,6 +10779,81 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_context_references_preserve_tree_structure_metadata() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let content = [
+            "# Context Tree Notes",
+            "",
+            "Root overview.",
+            "",
+            "## Retrieval Pipeline",
+            "",
+            "The uniquetreecontext marker belongs to retrieval.",
+            "",
+            "### Ranking Details",
+            "",
+            "Ranking details should be listed as a child section.",
+        ]
+        .join("\n");
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-context-tree-1",
+            "trace-context-tree",
+            "knowledge.add_document",
+            json!({
+                "name": "Context Tree Notes",
+                "content": content,
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        assert_eq!(add_response.error, None);
+
+        let context_response = router.dispatch(&WorkerRequest::new(
+            "req-context-tree-2",
+            "trace-context-tree",
+            "knowledge.context",
+            json!({
+                "current_message": "where uniquetreecontext",
+                "session_key": "desktop:session-tree",
+                "max_chunks": 3,
+                "use_persistent_knowledge": true
+            }),
+        ));
+
+        assert_eq!(context_response.error, None);
+        let result = context_response
+            .result
+            .as_ref()
+            .expect("knowledge.context should return result");
+        assert_eq!(
+            result["persistent_results"][0]["matched_methods"],
+            json!(["keyword", "structure"])
+        );
+        assert_eq!(
+            result["references"][0]["structure_context"]["section"]["title"],
+            "Retrieval Pipeline"
+        );
+        assert_eq!(
+            result["references"][0]["structure_context"]["parent_section"]["title"],
+            "Context Tree Notes"
+        );
+        assert_eq!(
+            result["references"][0]["structure_context"]["child_sections"][0]["title"],
+            "Ranking Details"
+        );
+    }
+
+    #[test]
     fn dispatches_knowledge_context_with_session_temporary_files() {
         let fixture = WorkspaceFixture::new();
         let mut session = session_fixture();

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8641,6 +8641,85 @@ mod tests {
     }
 
     #[test]
+    fn save_entity_graph_extraction_rejects_relation_evidence_from_other_document() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-validate-source-1",
+            "trace-validate-source",
+            "knowledge.add_document",
+            json!({
+                "name": "Source Identity",
+                "content": "# Source Identity\n\nTinyBot validates relation source identity.\n",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-validate-source-2",
+            "trace-validate-source",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Source Identity",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.9 },
+                    { "name": "SourceIdentity", "type": "concept", "confidence": 0.9 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "SourceIdentity",
+                        "predicate": "supports",
+                        "confidence": 0.82,
+                        "evidence": [
+                            {
+                                "doc_id": "other_doc",
+                                "text": "TinyBot validates relation source identity.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+
+        let error = save_response
+            .error
+            .expect("wrong-document relation evidence should be rejected");
+        assert_eq!(
+            error.code,
+            crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol
+        );
+        assert_eq!(
+            error.message,
+            "relation evidence doc_id must match document"
+        );
+        assert_eq!(error.details["relation_index"], 0);
+        assert_eq!(error.details["evidence_doc_id"], "other_doc");
+        assert_eq!(error.details["doc_id"], doc_id);
+    }
+
+    #[test]
     fn save_entity_graph_extraction_rejects_unsupported_relation_predicate() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8220,6 +8220,94 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_auto_routes_tree_location_questions() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let content = [
+            "# Desktop Knowledge Notes",
+            "",
+            "Root overview.",
+            "",
+            "## Retrieval Pipeline",
+            "",
+            "The uniquetree marker belongs to retrieval.",
+            "",
+            "### Ranking Details",
+            "",
+            "Ranking details should be listed as a child section.",
+            "",
+            "## Operational Notes",
+            "",
+            "Operational notes should be listed as a sibling section.",
+        ]
+        .join("\n");
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-auto-tree-1",
+            "trace-auto-tree",
+            "knowledge.add_document",
+            json!({
+                "name": "Auto Tree Notes",
+                "content": content,
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-auto-tree-2",
+            "trace-auto-tree",
+            "knowledge.query",
+            json!({
+                "query": "where uniquetree",
+                "category": "desktop",
+                "limit": 3
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let response = query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result");
+        assert_eq!(
+            response["retrieval_plan"]["selected_routes"],
+            json!(["keyword", "tree"])
+        );
+        assert_eq!(response["retrieval_plan"]["budgets"]["tree"], 3);
+        let result = &response["results"][0];
+        assert_eq!(result["id"], format!("chunk_{doc_id}_1"));
+        assert_eq!(result["matched_methods"], json!(["keyword", "structure"]));
+        assert_eq!(
+            result["structure_context"]["section"]["title"],
+            "Retrieval Pipeline"
+        );
+        assert_eq!(
+            result["structure_context"]["parent_section"]["title"],
+            "Desktop Knowledge Notes"
+        );
+        assert_eq!(
+            result["structure_context"]["child_sections"][0]["title"],
+            "Ranking Details"
+        );
+    }
+
+    #[test]
     fn knowledge_query_can_expand_from_entity_graph_evidence() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(
@@ -9414,6 +9502,61 @@ mod tests {
             })
         );
         assert_eq!(result["results"][0]["retrieval_method"], "sparse");
+    }
+
+    #[test]
+    fn knowledge_query_exact_retrieval_plan_includes_enabled_tree_route() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-plan-exact-tree-1",
+            "trace-plan-exact-tree",
+            "knowledge.add_document",
+            json!({
+                "name": "Knowledge API Tree Notes",
+                "content": "# Knowledge API Tree Notes\n\nThe knowledge.document_tree API exposes exact section hierarchy.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        assert_eq!(add_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-plan-exact-tree-2",
+            "trace-plan-exact-tree",
+            "knowledge.query",
+            json!({
+                "query": "where knowledge.document_tree API",
+                "category": "desktop",
+                "limit": 3
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let result = query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result");
+        assert_eq!(result["retrieval_plan"]["classification"], "exact");
+        assert_eq!(
+            result["retrieval_plan"]["selected_routes"],
+            json!(["keyword", "tree"])
+        );
+        assert_eq!(result["retrieval_plan"]["budgets"]["tree"], 3);
+        assert_eq!(
+            result["results"][0]["matched_methods"],
+            json!(["keyword", "structure"])
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -9689,6 +9689,25 @@ mod tests {
         assert_eq!(rebuild["stage"], "completed");
         assert_eq!(rebuild["result"]["semantic"]["available"], false);
         assert_eq!(rebuild["result"]["bm25"]["chunks_indexed"], 1);
+
+        let tree_rebuild_response = router.dispatch(&WorkerRequest::new(
+            "req-5",
+            "trace-1",
+            "knowledge.rebuild_index",
+            json!({ "type": "tree" }),
+        ));
+        assert_eq!(tree_rebuild_response.error, None);
+        let tree_rebuild = tree_rebuild_response
+            .result
+            .as_ref()
+            .expect("knowledge.rebuild_index tree should return result");
+        assert_eq!(tree_rebuild["id"], "kjob_rebuild_tree");
+        assert_eq!(tree_rebuild["name"], "rebuild:tree");
+        assert_eq!(tree_rebuild["status"], "completed");
+        assert_eq!(tree_rebuild["result"]["available"], true);
+        assert_eq!(tree_rebuild["result"]["documents_scanned"], 1);
+        assert_eq!(tree_rebuild["result"]["sections_indexed"], 1);
+        assert_eq!(tree_rebuild["result"]["tree_ready"], true);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -9309,10 +9309,77 @@ mod tests {
                     "tree": 0
                 },
                 "fallback_behavior": "fallback_to_hybrid_when_no_results",
-                "fallback_routes": ["keyword", "tree", "graph"]
+                "fallback_routes": ["keyword", "tree", "graph"],
+                "graph_options": {
+                    "include_graph_context": false,
+                    "max_hops": 1,
+                    "relation_filters": [],
+                    "min_confidence": 0.0,
+                    "max_added_chunks": 5
+                }
             })
         );
         assert_eq!(result["results"][0]["retrieval_method"], "sparse");
+    }
+
+    #[test]
+    fn knowledge_query_retrieval_plan_exposes_graph_options() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-plan-graph-1",
+            "trace-plan-graph",
+            "knowledge.add_document",
+            json!({
+                "name": "Knowledge Graph Notes",
+                "content": "# Knowledge Graph Notes\n\nTinyBot depends on WorkerPool through RuntimeScheduler.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        assert_eq!(add_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-plan-graph-2",
+            "trace-plan-graph",
+            "knowledge.query",
+            json!({
+                "query": "TinyBot dependency graph",
+                "category": "desktop",
+                "limit": 3,
+                "include_graph_context": true,
+                "graph_max_hops": 2,
+                "graph_relation_filters": ["depends_on", "configures"],
+                "graph_min_confidence": 0.75,
+                "graph_max_added_chunks": 3
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let result = query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result");
+        assert_eq!(
+            result["retrieval_plan"]["graph_options"],
+            json!({
+                "include_graph_context": true,
+                "max_hops": 2,
+                "relation_filters": ["depends_on", "configures"],
+                "min_confidence": 0.75,
+                "max_added_chunks": 3
+            })
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8544,6 +8544,91 @@ mod tests {
     }
 
     #[test]
+    fn save_entity_graph_extraction_rejects_unsupported_relation_predicate() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-validate-predicate-1",
+            "trace-validate-predicate",
+            "knowledge.add_document",
+            json!({
+                "name": "Predicate Source",
+                "content": "# Predicate Source\n\nTinyBot validates controlled predicates.\n",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-validate-predicate-2",
+            "trace-validate-predicate",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Predicate Source",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.9 },
+                    { "name": "PredicateRegistry", "type": "concept", "confidence": 0.9 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "PredicateRegistry",
+                        "predicate": "stores",
+                        "confidence": 0.82,
+                        "evidence": [
+                            {
+                                "text": "TinyBot validates controlled predicates.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+
+        let error = save_response
+            .error
+            .expect("unsupported predicate should be rejected");
+        assert_eq!(
+            error.code,
+            crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol
+        );
+        assert_eq!(error.message, "unsupported relation predicate");
+        assert_eq!(error.details["predicate"], "stores");
+        assert_eq!(
+            error.details["allowed_predicates"],
+            json!([
+                "depends_on",
+                "causes",
+                "implements",
+                "configures",
+                "mentions",
+                "conflicts_with",
+                "supports"
+            ])
+        );
+    }
+
+    #[test]
     fn knowledge_query_returns_deterministic_retrieval_plan() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(
@@ -9043,7 +9128,7 @@ mod tests {
                     { "name": "knowledge graph", "type": "concept", "confidence": 0.86 }
                 ],
                 "relations": [
-                    { "source": "TinyBot", "target": "knowledge graph", "predicate": "stores", "confidence": 0.82, "evidence": [{ "text": "TinyBot stores knowledge graph evidence.", "line_start": 3, "line_end": 3 }] }
+                    { "source": "TinyBot", "target": "knowledge graph", "predicate": "supports", "confidence": 0.82, "evidence": [{ "text": "TinyBot stores knowledge graph evidence.", "line_start": 3, "line_end": 3 }] }
                 ],
                 "diagnostics": { "chunks_used": 1 }
             }),
@@ -9062,7 +9147,7 @@ mod tests {
             .contains("TinyBot"));
         assert!(fixture
             .read("knowledge/entity_graph_edges.jsonl")
-            .contains("stores"));
+            .contains("supports"));
         assert!(fixture
             .read("knowledge/entity_graph_evidence.jsonl")
             .contains("knowledge graph evidence"));
@@ -9178,7 +9263,7 @@ mod tests {
                     { "name": "TinyBot", "type": "project", "confidence": 0.91, "evidence": [{ "text": "TinyBot deletion evidence should disappear.", "line_start": 3, "line_end": 3 }] }
                 ],
                 "relations": [
-                    { "source": "TinyBot", "target": "Deletion", "predicate": "removes", "confidence": 0.82, "evidence": [{ "text": "TinyBot deletion evidence should disappear.", "line_start": 3, "line_end": 3 }] }
+                    { "source": "TinyBot", "target": "Deletion", "predicate": "conflicts_with", "confidence": 0.82, "evidence": [{ "text": "TinyBot deletion evidence should disappear.", "line_start": 3, "line_end": 3 }] }
                 ]
             }),
         ));
@@ -9197,7 +9282,7 @@ mod tests {
             .contains("TinyBot"));
         assert!(!fixture
             .read("knowledge/entity_graph_edges.jsonl")
-            .contains("removes"));
+            .contains("conflicts_with"));
         assert!(!fixture
             .read("knowledge/entity_graph_evidence.jsonl")
             .contains("deletion evidence"));
@@ -9321,8 +9406,8 @@ mod tests {
                     { "name": "LowConfidence", "type": "concept", "confidence": 0.25 }
                 ],
                 "relations": [
-                    { "source": "HighConfidence", "target": "HighConfidence", "predicate": "supports", "confidence": 0.96 },
-                    { "source": "HighConfidence", "target": "LowConfidence", "predicate": "mentions", "confidence": 0.20 }
+                    { "source": "HighConfidence", "target": "HighConfidence", "predicate": "supports", "confidence": 0.96, "evidence": [{ "text": "High and low confidence graph data.", "line_start": 3, "line_end": 3 }] },
+                    { "source": "HighConfidence", "target": "LowConfidence", "predicate": "mentions", "confidence": 0.20, "evidence": [{ "text": "High and low confidence graph data.", "line_start": 3, "line_end": 3 }] }
                 ]
             }),
         ));

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8384,6 +8384,7 @@ mod tests {
             .as_ref()
             .expect("knowledge.query should return result")["results"][0];
         assert_eq!(result["id"], format!("chunk_{doc_id}_0"));
+        assert_eq!(result["score"], 2);
         assert_eq!(result["retrieval_method"], "graph");
         assert_eq!(result["matched_methods"], json!(["graph"]));
         assert_eq!(result["matched_entities"][0]["label"], "TinyBot");
@@ -8395,6 +8396,15 @@ mod tests {
         assert_eq!(
             result["score_metadata"]["route_contributions"][0]["route"],
             "graph"
+        );
+        assert_eq!(
+            result["score_metadata"]["components"]["evidence_quality_bonus"],
+            json!({
+                "score": 1,
+                "verified_evidence_count": 1,
+                "normalized_score": 0.5,
+                "contribution": 1
+            })
         );
     }
 

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8418,6 +8418,95 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_can_disable_relation_hop_graph_expansion() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-hop-query-1",
+            "trace-relation-hop-query",
+            "knowledge.add_document",
+            json!({
+                "name": "Relation Hop Notes",
+                "content": "# Relation Hop Notes\n\nThe orchestration layer coordinates background jobs.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-hop-query-2",
+            "trace-relation-hop-query",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Relation Hop Notes",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.93 },
+                    { "name": "RuntimeScheduler", "type": "component", "confidence": 0.91 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "RuntimeScheduler",
+                        "predicate": "depends_on",
+                        "confidence": 0.88,
+                        "evidence": [
+                            {
+                                "text": "The orchestration layer coordinates background jobs.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-hop-query-3",
+            "trace-relation-hop-query",
+            "knowledge.query",
+            json!({
+                "query": "TinyBot",
+                "category": "desktop",
+                "limit": 3,
+                "include_graph_context": true,
+                "graph_max_hops": 0,
+                "graph_relation_filters": ["depends_on"],
+                "graph_min_confidence": 0.8,
+                "graph_max_added_chunks": 1
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        assert_eq!(
+            query_response
+                .result
+                .as_ref()
+                .expect("knowledge.query should return result")["results"],
+            json!([])
+        );
+    }
+
+    #[test]
     fn save_entity_graph_extraction_merges_duplicate_entity_aliases() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -9386,6 +9386,58 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_retrieval_plan_selects_only_enabled_routes() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-plan-routes-1",
+            "trace-plan-routes",
+            "knowledge.add_document",
+            json!({
+                "name": "Concept Recall Notes",
+                "content": "# Concept Recall Notes\n\nHybrid concept recall should still describe only enabled routes.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        assert_eq!(add_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-plan-routes-2",
+            "trace-plan-routes",
+            "knowledge.query",
+            json!({
+                "query": "concept recall",
+                "category": "desktop",
+                "limit": 3
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let result = query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result");
+        assert_eq!(result["retrieval_plan"]["classification"], "hybrid");
+        assert_eq!(
+            result["retrieval_plan"]["selected_routes"],
+            json!(["keyword"])
+        );
+        assert_eq!(result["retrieval_plan"]["budgets"]["graph"], 0);
+        assert_eq!(result["retrieval_plan"]["budgets"]["tree"], 0);
+    }
+
+    #[test]
     fn knowledge_document_tree_returns_markdown_section_hierarchy() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8190,6 +8190,27 @@ mod tests {
                 ]
             })
         );
+        assert_eq!(result["matched_methods"], json!(["keyword", "structure"]));
+        assert_eq!(
+            result["score_metadata"]["components"]["structure"],
+            json!({
+                "score": 4,
+                "rank": 1,
+                "normalized_score": 0.0,
+                "contribution": 0
+            })
+        );
+        assert_eq!(
+            result["score_metadata"]["route_contributions"][1],
+            json!({
+                "route": "tree",
+                "method": "structure_context",
+                "score": 4,
+                "rank": 1,
+                "normalized_score": 0.0,
+                "contribution": 0
+            })
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8071,7 +8071,13 @@ mod tests {
                         "normalized_score": 1.0,
                         "contribution": 2
                     }
-                ]
+                ],
+                "rerank": {
+                    "object": "knowledge_rerank_metadata",
+                    "method": "deterministic_score_path_id_v1",
+                    "sort_keys": ["score_desc", "file_path_asc", "chunk_id_asc"],
+                    "rank": 1
+                }
             })
         );
     }

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -501,6 +501,11 @@ impl WorkerRpcRouter {
                 serde_json::to_value(self.knowledge.get_document(params)?)
                     .map_err(serialization_error)
             }
+            "knowledge.document_tree" => {
+                let params: KnowledgeDocumentIdParams = parse_params(request)?;
+                serde_json::to_value(self.knowledge.document_tree(params)?)
+                    .map_err(serialization_error)
+            }
             "knowledge.delete_document" => {
                 let params: KnowledgeDocumentIdParams = parse_params(request)?;
                 serde_json::to_value(self.knowledge.delete_document(params)?)
@@ -7997,6 +8002,136 @@ mod tests {
             json!(["The child snippet contains uniqueneedle evidence for ranking."])
         );
         assert_eq!(result["retrieval_method"], "sparse");
+    }
+
+    #[test]
+    fn knowledge_document_tree_returns_markdown_section_hierarchy() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let content = [
+            "# Desktop Knowledge Notes",
+            "",
+            "Root overview.",
+            "",
+            "## Retrieval Pipeline",
+            "",
+            "Sparse retrieval should find parent sections.",
+            "",
+            "### Ranking Details",
+            "",
+            "RRF and sparse scores are tracked.",
+            "",
+            "## Operational Notes",
+            "",
+            "Unrelated final section.",
+        ]
+        .join("\n");
+
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-tree-1",
+            "trace-tree",
+            "knowledge.add_document",
+            json!({
+                "name": "Tree Knowledge Notes",
+                "content": content,
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let tree_response = router.dispatch(&WorkerRequest::new(
+            "req-tree-2",
+            "trace-tree",
+            "knowledge.document_tree",
+            json!({ "doc_id": doc_id }),
+        ));
+
+        assert_eq!(tree_response.error, None);
+        let tree = tree_response
+            .result
+            .as_ref()
+            .expect("knowledge.document_tree should return result");
+        assert_eq!(tree["object"], "knowledge_document_tree");
+        assert_eq!(tree["doc_id"], doc_id);
+        assert_eq!(tree["root"]["id"], "section-root");
+        assert_eq!(
+            tree["root"]["children"],
+            json!([format!("section_{doc_id}_0")])
+        );
+        assert_eq!(tree["section_count"], 4);
+        assert_eq!(
+            tree["sections"],
+            json!([
+                {
+                    "id": format!("section_{doc_id}_0"),
+                    "doc_id": doc_id,
+                    "chunk_id": format!("chunk_{doc_id}_0"),
+                    "title": "Desktop Knowledge Notes",
+                    "section_path": "Desktop Knowledge Notes",
+                    "parent_id": "section-root",
+                    "children": [format!("section_{doc_id}_1"), format!("section_{doc_id}_3")],
+                    "ordinal": 0,
+                    "line_start": 1,
+                    "line_end": 4,
+                    "chunk_count": 1
+                },
+                {
+                    "id": format!("section_{doc_id}_1"),
+                    "doc_id": doc_id,
+                    "chunk_id": format!("chunk_{doc_id}_1"),
+                    "title": "Retrieval Pipeline",
+                    "section_path": "Retrieval Pipeline",
+                    "parent_id": format!("section_{doc_id}_0"),
+                    "children": [format!("section_{doc_id}_2")],
+                    "ordinal": 1,
+                    "line_start": 5,
+                    "line_end": 8,
+                    "chunk_count": 1
+                },
+                {
+                    "id": format!("section_{doc_id}_2"),
+                    "doc_id": doc_id,
+                    "chunk_id": format!("chunk_{doc_id}_2"),
+                    "title": "Ranking Details",
+                    "section_path": "Ranking Details",
+                    "parent_id": format!("section_{doc_id}_1"),
+                    "children": [],
+                    "ordinal": 2,
+                    "line_start": 9,
+                    "line_end": 12,
+                    "chunk_count": 1
+                },
+                {
+                    "id": format!("section_{doc_id}_3"),
+                    "doc_id": doc_id,
+                    "chunk_id": format!("chunk_{doc_id}_3"),
+                    "title": "Operational Notes",
+                    "section_path": "Operational Notes",
+                    "parent_id": format!("section_{doc_id}_0"),
+                    "children": [],
+                    "ordinal": 3,
+                    "line_start": 13,
+                    "line_end": 15,
+                    "chunk_count": 1
+                }
+            ])
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8191,6 +8191,97 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_can_expand_from_entity_graph_evidence() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-graph-query-1",
+            "trace-graph-query",
+            "knowledge.add_document",
+            json!({
+                "name": "Graph Expansion Notes",
+                "content": "# Graph Expansion Notes\n\nThe orchestration layer coordinates background jobs.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-graph-query-2",
+            "trace-graph-query",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Graph Expansion Notes",
+                "model": "knowledge-model",
+                "entities": [
+                    {
+                        "name": "TinyBot",
+                        "type": "project",
+                        "confidence": 0.93,
+                        "evidence": [
+                            {
+                                "text": "The orchestration layer coordinates background jobs.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "relations": [],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-graph-query-3",
+            "trace-graph-query",
+            "knowledge.query",
+            json!({
+                "query": "TinyBot dependency",
+                "category": "desktop",
+                "limit": 3,
+                "include_graph_context": true
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let result = &query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result")["results"][0];
+        assert_eq!(result["id"], format!("chunk_{doc_id}_0"));
+        assert_eq!(result["retrieval_method"], "graph");
+        assert_eq!(result["matched_methods"], json!(["graph"]));
+        assert_eq!(result["matched_entities"][0]["label"], "TinyBot");
+        assert_eq!(
+            result["source_snippets"][0]["text"],
+            "The orchestration layer coordinates background jobs."
+        );
+        assert_eq!(result["source_snippets"][0]["owner_type"], "entity");
+        assert_eq!(
+            result["score_metadata"]["route_contributions"][0]["route"],
+            "graph"
+        );
+    }
+
+    #[test]
     fn knowledge_query_returns_deterministic_retrieval_plan() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -7852,48 +7852,28 @@ mod tests {
             }),
         ));
         assert_eq!(query_response.error, None);
+        let query_result = &query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result")["results"][0];
+        assert_eq!(query_result["id"], json!(format!("chunk_{doc_id}_0")));
+        assert_eq!(query_result["doc_id"], json!(doc_id));
         assert_eq!(
-            query_response.result.as_ref().unwrap()["results"][0],
-            json!({
-                "id": format!("chunk_{doc_id}_0"),
-                "doc_id": doc_id,
-                "parent_id": format!("chunk_{doc_id}_0"),
-                "chunk_type": "parent",
-                "content": "# Desktop Knowledge Notes\n\nTS worker knowledge store should persist chunks for sparse retrieval.\n",
-                "matched_child_ids": [],
-                "matched_child_snippets": [],
-                "doc_name": "Desktop Knowledge Notes",
-                "file_path": format!("knowledge/files/{doc_id}.md"),
-                "start_char": 0,
-                "end_char": 97,
-                "line_start": 1,
-                "line_end": 3,
-                "section_path": "Desktop Knowledge Notes",
-                "block_type": "text",
-                "score": 2,
-                "rrf_score": 2,
-                "semantic_score": null,
-                "bm25_score": 2,
-                "dense_distance": null,
-                "dense_rank": null,
-                "sparse_rank": 1,
-                "dense_contribution": null,
-                "sparse_contribution": 2,
-                "method": "sparse",
-                "retrieval_method": "sparse",
-                "score_metadata": {},
-                "source_snippets": [],
-                "matched_methods": [],
-                "matched_entities": [],
-                "matched_claims": [],
-                "matched_claim_evidence": [],
-                "matched_relations": [],
-                "matched_relation_evidence": [],
-                "matched_communities": [],
-                "conflict_metadata": [],
-                "projection_metadata": []
-            })
+            query_result["parent_id"],
+            json!(format!("chunk_{doc_id}_0"))
         );
+        assert_eq!(query_result["chunk_type"], "parent");
+        assert_eq!(query_result["doc_name"], "Desktop Knowledge Notes");
+        assert_eq!(query_result["section_path"], "Desktop Knowledge Notes");
+        assert_eq!(query_result["section_id"], format!("section_{doc_id}_0"));
+        assert_eq!(query_result["section_title"], "Desktop Knowledge Notes");
+        assert_eq!(query_result["parent_section_id"], "section-root");
+        assert_eq!(query_result["section_ordinal"], 0);
+        assert_eq!(query_result["matched_child_ids"], json!([]));
+        assert_eq!(query_result["matched_child_snippets"], json!([]));
+        assert_eq!(query_result["matched_child_section_paths"], json!([]));
+        assert_eq!(query_result["score"], 2);
+        assert_eq!(query_result["retrieval_method"], "sparse");
 
         let delete_response = router.dispatch(&WorkerRequest::new(
             "req-5",
@@ -7996,6 +7976,14 @@ mod tests {
         assert_eq!(result["parent_id"], format!("chunk_{doc_id}_1"));
         assert_eq!(result["chunk_type"], "parent");
         assert_eq!(result["section_path"], "Retrieval Pipeline");
+        assert_eq!(result["section_id"], format!("section_{doc_id}_1"));
+        assert_eq!(result["section_title"], "Retrieval Pipeline");
+        assert_eq!(result["parent_section_id"], format!("section_{doc_id}_0"));
+        assert_eq!(result["section_ordinal"], 1);
+        assert_eq!(
+            result["matched_child_section_paths"],
+            json!(["Retrieval Pipeline"])
+        );
         assert!(result["content"]
             .as_str()
             .expect("result content should be string")

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8395,6 +8395,103 @@ mod tests {
     }
 
     #[test]
+    fn save_entity_graph_extraction_merges_duplicate_entity_aliases() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-entity-alias-1",
+            "trace-entity-alias",
+            "knowledge.add_document",
+            json!({
+                "name": "Entity Alias Source",
+                "content": "# Entity Alias Source\n\nTinyBot validates entity aliases.\ntinybot records duplicate evidence.\n",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-entity-alias-2",
+            "trace-entity-alias",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Entity Alias Source",
+                "model": "knowledge-model",
+                "entities": [
+                    {
+                        "name": "TinyBot",
+                        "type": "Project",
+                        "confidence": 0.91,
+                        "evidence": [
+                            {
+                                "text": "TinyBot validates entity aliases.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    },
+                    {
+                        "name": " tinybot ",
+                        "type": "project",
+                        "confidence": 0.86,
+                        "evidence": [
+                            {
+                                "text": "tinybot records duplicate evidence.",
+                                "line_start": 4,
+                                "line_end": 4
+                            }
+                        ]
+                    }
+                ],
+                "relations": [],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let graph_response = router.dispatch(&WorkerRequest::new(
+            "req-entity-alias-3",
+            "trace-entity-alias",
+            "knowledge.graph",
+            json!({
+                "graph_type": "entity",
+                "doc_id": doc_id,
+                "include_orphans": true
+            }),
+        ));
+
+        assert_eq!(graph_response.error, None);
+        let result = graph_response
+            .result
+            .as_ref()
+            .expect("knowledge.graph should return result");
+        assert_eq!(result["stats"]["node_count"], 1);
+        assert_eq!(result["nodes"][0]["label"], "TinyBot");
+        assert_eq!(result["nodes"][0]["attributes"]["entity_type"], "project");
+        assert_eq!(
+            result["nodes"][0]["attributes"]["aliases"],
+            json!(["tinybot"])
+        );
+        assert_eq!(result["nodes"][0]["evidence"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
     fn save_entity_graph_extraction_rejects_relation_without_evidence() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8058,6 +8058,7 @@ mod tests {
                     "sparse": {
                         "score": 2,
                         "rank": 1,
+                        "normalized_score": 1.0,
                         "contribution": 2
                     }
                 },
@@ -8067,6 +8068,7 @@ mod tests {
                         "method": "sparse",
                         "score": 2,
                         "rank": 1,
+                        "normalized_score": 1.0,
                         "contribution": 2
                     }
                 ]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8726,6 +8726,96 @@ mod tests {
     }
 
     #[test]
+    fn entity_graph_exposes_conflicting_relations_with_evidence() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-conflict-graph-1",
+            "trace-conflict-graph",
+            "knowledge.add_document",
+            json!({
+                "name": "Conflict Source",
+                "content": "# Conflict Source\n\nTinyBot conflicts with LegacyBot behavior.\n",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-conflict-graph-2",
+            "trace-conflict-graph",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Conflict Source",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.91 },
+                    { "name": "LegacyBot", "type": "project", "confidence": 0.88 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "LegacyBot",
+                        "predicate": "conflicts_with",
+                        "confidence": 0.84,
+                        "evidence": [
+                            {
+                                "text": "TinyBot conflicts with LegacyBot behavior.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let graph_response = router.dispatch(&WorkerRequest::new(
+            "req-conflict-graph-3",
+            "trace-conflict-graph",
+            "knowledge.graph",
+            json!({
+                "graph_type": "entity",
+                "doc_id": doc_id,
+                "include_orphans": true
+            }),
+        ));
+
+        assert_eq!(graph_response.error, None);
+        let graph = graph_response
+            .result
+            .as_ref()
+            .expect("knowledge.graph should return result");
+        assert_eq!(graph["stats"]["conflict_count"], 1);
+        assert_eq!(graph["conflicts"].as_array().unwrap().len(), 1);
+        assert_eq!(graph["conflicts"][0]["source_label"], "TinyBot");
+        assert_eq!(graph["conflicts"][0]["target_label"], "LegacyBot");
+        assert_eq!(graph["conflicts"][0]["predicate"], "conflicts_with");
+        assert_eq!(
+            graph["conflicts"][0]["evidence"][0]["text"],
+            "TinyBot conflicts with LegacyBot behavior."
+        );
+    }
+
+    #[test]
     fn knowledge_query_returns_deterministic_retrieval_plan() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -10854,6 +10854,77 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_context_returns_retrieval_plan_for_persistent_results() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let content = [
+            "# Context Plan Notes",
+            "",
+            "Root overview.",
+            "",
+            "## Retrieval Location",
+            "",
+            "The uniquetreeplan marker belongs under the retrieval location section.",
+        ]
+        .join("\n");
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-context-plan-1",
+            "trace-context-plan",
+            "knowledge.add_document",
+            json!({
+                "name": "Context Plan Notes",
+                "content": content,
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        assert_eq!(add_response.error, None);
+
+        let context_response = router.dispatch(&WorkerRequest::new(
+            "req-context-plan-2",
+            "trace-context-plan",
+            "knowledge.context",
+            json!({
+                "current_message": "where uniquetreeplan",
+                "session_key": "desktop:session-plan",
+                "max_chunks": 3,
+                "use_persistent_knowledge": true
+            }),
+        ));
+
+        assert_eq!(context_response.error, None);
+        let result = context_response
+            .result
+            .as_ref()
+            .expect("knowledge.context should return result");
+        assert_eq!(
+            result["retrieval_plan"]["selected_routes"],
+            json!(["keyword", "tree"])
+        );
+        assert_eq!(
+            result["retrieval_plan"]["tree_options"],
+            json!({
+                "include_structure_context": true,
+                "context_budget": 3,
+                "trigger": "auto"
+            })
+        );
+        assert_eq!(
+            result["persistent_results"][0]["matched_methods"],
+            json!(["keyword", "structure"])
+        );
+    }
+
+    #[test]
     fn dispatches_knowledge_context_with_session_temporary_files() {
         let fixture = WorkspaceFixture::new();
         let mut session = session_fixture();

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -10682,6 +10682,103 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_context_references_preserve_graph_evidence_metadata() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-context-graph-1",
+            "trace-context-graph",
+            "knowledge.add_document",
+            json!({
+                "name": "Context Graph Notes",
+                "content": "# Context Graph Notes\n\nThe orchestration layer coordinates background jobs.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-context-graph-2",
+            "trace-context-graph",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Context Graph Notes",
+                "model": "knowledge-model",
+                "entities": [
+                    {
+                        "name": "TinyBot",
+                        "type": "project",
+                        "confidence": 0.93,
+                        "evidence": [
+                            {
+                                "text": "The orchestration layer coordinates background jobs.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "relations": [],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let context_response = router.dispatch(&WorkerRequest::new(
+            "req-context-graph-3",
+            "trace-context-graph",
+            "knowledge.context",
+            json!({
+                "current_message": "TinyBot dependency",
+                "session_key": "desktop:session-graph",
+                "max_chunks": 3,
+                "use_persistent_knowledge": true
+            }),
+        ));
+
+        assert_eq!(context_response.error, None);
+        let result = context_response
+            .result
+            .as_ref()
+            .expect("knowledge.context should return result");
+        assert_eq!(result["persistent_results"][0]["retrieval_method"], "graph");
+        assert_eq!(result["references"][0]["retrieval_method"], "graph");
+        assert_eq!(
+            result["references"][0]["source_snippets"][0]["text"],
+            "The orchestration layer coordinates background jobs."
+        );
+        assert_eq!(
+            result["references"][0]["projection_metadata"][0]["projection"],
+            "entity_graph"
+        );
+        assert_eq!(
+            result["references"][0]["projection_metadata"][0]["owner_label"],
+            "TinyBot"
+        );
+        assert_eq!(
+            result["references"][0]["score_metadata"]["components"]["evidence_quality_bonus"]["score"],
+            1
+        );
+    }
+
+    #[test]
     fn dispatches_knowledge_context_with_session_temporary_files() {
         let fixture = WorkspaceFixture::new();
         let mut session = session_fixture();

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8987,6 +8987,19 @@ mod tests {
             graph["conflicts"][0]["evidence"][0]["text"],
             "TinyBot conflicts with LegacyBot behavior."
         );
+
+        let stats_response = router.dispatch(&WorkerRequest::new(
+            "req-conflict-graph-4",
+            "trace-conflict-graph",
+            "knowledge.stats",
+            json!({}),
+        ));
+        assert_eq!(stats_response.error, None);
+        let stats = stats_response
+            .result
+            .as_ref()
+            .expect("knowledge.stats should return result");
+        assert_eq!(stats["conflict_count"], 1);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8075,6 +8075,122 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_can_return_tree_structure_context() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let content = [
+            "# Desktop Knowledge Notes",
+            "",
+            "Root overview.",
+            "",
+            "## Retrieval Pipeline",
+            "",
+            "The uniquetree marker belongs to retrieval.",
+            "",
+            "### Ranking Details",
+            "",
+            "Ranking details should be listed as a child section.",
+            "",
+            "## Operational Notes",
+            "",
+            "Operational notes should be listed as a sibling section.",
+        ]
+        .join("\n");
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-structure-1",
+            "trace-structure",
+            "knowledge.add_document",
+            json!({
+                "name": "Structured Knowledge Notes",
+                "content": content,
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-structure-2",
+            "trace-structure",
+            "knowledge.query",
+            json!({
+                "query": "uniquetree",
+                "category": "desktop",
+                "limit": 3,
+                "include_structure_context": true
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let result = &query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result")["results"][0];
+        assert_eq!(result["id"], format!("chunk_{doc_id}_1"));
+        assert_eq!(
+            result["structure_context"],
+            json!({
+                "object": "knowledge_structure_context",
+                "section": {
+                    "id": format!("section_{doc_id}_1"),
+                    "chunk_id": format!("chunk_{doc_id}_1"),
+                    "title": "Retrieval Pipeline",
+                    "section_path": "Retrieval Pipeline",
+                    "ordinal": 1,
+                    "line_start": 5,
+                    "line_end": 8
+                },
+                "parent_section": {
+                    "id": format!("section_{doc_id}_0"),
+                    "chunk_id": format!("chunk_{doc_id}_0"),
+                    "title": "Desktop Knowledge Notes",
+                    "section_path": "Desktop Knowledge Notes",
+                    "ordinal": 0,
+                    "line_start": 1,
+                    "line_end": 4
+                },
+                "sibling_sections": [
+                    {
+                        "id": format!("section_{doc_id}_3"),
+                        "chunk_id": format!("chunk_{doc_id}_3"),
+                        "title": "Operational Notes",
+                        "section_path": "Operational Notes",
+                        "ordinal": 3,
+                        "line_start": 13,
+                        "line_end": 15
+                    }
+                ],
+                "child_sections": [
+                    {
+                        "id": format!("section_{doc_id}_2"),
+                        "chunk_id": format!("chunk_{doc_id}_2"),
+                        "title": "Ranking Details",
+                        "section_path": "Ranking Details",
+                        "ordinal": 2,
+                        "line_start": 9,
+                        "line_end": 12
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
     fn knowledge_query_returns_deterministic_retrieval_plan() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8395,6 +8395,155 @@ mod tests {
     }
 
     #[test]
+    fn save_entity_graph_extraction_rejects_relation_without_evidence() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-validate-relation-1",
+            "trace-validate-relation",
+            "knowledge.add_document",
+            json!({
+                "name": "Validation Source",
+                "content": "# Validation Source\n\nTinyBot validates relation evidence.\n",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-validate-relation-2",
+            "trace-validate-relation",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Validation Source",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.9 },
+                    { "name": "EvidenceValidation", "type": "concept", "confidence": 0.9 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "EvidenceValidation",
+                        "predicate": "supports",
+                        "confidence": 0.82
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+
+        let error = save_response
+            .error
+            .expect("relation without evidence should be rejected");
+        assert_eq!(
+            error.code,
+            crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol
+        );
+        assert_eq!(error.message, "relation evidence is required");
+        assert_eq!(error.details["relation_index"], 0);
+        let edges_path = fixture.root.join("knowledge/entity_graph_edges.jsonl");
+        let edges_content = std::fs::read_to_string(edges_path).unwrap_or_default();
+        assert_eq!(edges_content.trim(), "");
+    }
+
+    #[test]
+    fn save_entity_graph_extraction_rejects_relation_evidence_not_in_document() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-validate-evidence-1",
+            "trace-validate-evidence",
+            "knowledge.add_document",
+            json!({
+                "name": "Validation Source",
+                "content": "# Validation Source\n\nTinyBot validates relation evidence.\n",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-validate-evidence-2",
+            "trace-validate-evidence",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Validation Source",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.9 },
+                    { "name": "EvidenceValidation", "type": "concept", "confidence": 0.9 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "EvidenceValidation",
+                        "predicate": "supports",
+                        "confidence": 0.82,
+                        "evidence": [
+                            {
+                                "text": "This sentence is not in the document.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+
+        let error = save_response
+            .error
+            .expect("mismatched relation evidence should be rejected");
+        assert_eq!(
+            error.code,
+            crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol
+        );
+        assert_eq!(
+            error.message,
+            "relation evidence must match document content"
+        );
+        assert_eq!(error.details["relation_index"], 0);
+        assert_eq!(
+            error.details["evidence"],
+            "This sentence is not in the document."
+        );
+    }
+
+    #[test]
     fn knowledge_query_returns_deterministic_retrieval_plan() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8507,6 +8507,132 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_can_expand_relation_graph_two_hops() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-two-hop-1",
+            "trace-relation-two-hop",
+            "knowledge.add_document",
+            json!({
+                "name": "Relation Two Hop Notes",
+                "content": "# Relation Two Hop Notes\n\n## Runtime\n\nThe orchestration layer coordinates background jobs.\n\n## Worker Pool\n\nThe scheduler configures worker pool slots.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-two-hop-2",
+            "trace-relation-two-hop",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Relation Two Hop Notes",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.93 },
+                    { "name": "RuntimeScheduler", "type": "component", "confidence": 0.91 },
+                    { "name": "WorkerPool", "type": "component", "confidence": 0.9 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "RuntimeScheduler",
+                        "predicate": "depends_on",
+                        "confidence": 0.88,
+                        "evidence": [
+                            {
+                                "text": "The orchestration layer coordinates background jobs.",
+                                "line_start": 5,
+                                "line_end": 5
+                            }
+                        ]
+                    },
+                    {
+                        "source": "RuntimeScheduler",
+                        "target": "WorkerPool",
+                        "predicate": "configures",
+                        "confidence": 0.86,
+                        "evidence": [
+                            {
+                                "text": "The scheduler configures worker pool slots.",
+                                "line_start": 9,
+                                "line_end": 9
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 2 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-relation-two-hop-3",
+            "trace-relation-two-hop",
+            "knowledge.query",
+            json!({
+                "query": "TinyBot",
+                "category": "desktop",
+                "limit": 3,
+                "include_graph_context": true,
+                "graph_max_hops": 2,
+                "graph_min_confidence": 0.8,
+                "graph_max_added_chunks": 2
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let results = query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result")["results"]
+            .as_array()
+            .expect("results should be an array");
+        assert_eq!(results.len(), 2);
+        let relation_labels = results
+            .iter()
+            .flat_map(|result| {
+                result["matched_relations"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|relation| relation["label"].as_str())
+            })
+            .collect::<Vec<_>>();
+        assert!(relation_labels.contains(&"depends_on"));
+        assert!(relation_labels.contains(&"configures"));
+        let snippets = results
+            .iter()
+            .flat_map(|result| {
+                result["source_snippets"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|snippet| snippet["text"].as_str())
+            })
+            .collect::<Vec<_>>();
+        assert!(snippets.contains(&"The orchestration layer coordinates background jobs."));
+        assert!(snippets.contains(&"The scheduler configures worker pool slots."));
+    }
+
+    #[test]
     fn save_entity_graph_extraction_merges_duplicate_entity_aliases() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -9429,6 +9429,109 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_returns_conflict_metadata_for_graph_conflicts() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-query-conflict-1",
+            "trace-query-conflict",
+            "knowledge.add_document",
+            json!({
+                "name": "Query Conflict Source",
+                "content": "# Query Conflict Source\n\nTinyBot conflicts with LegacyBot behavior.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-query-conflict-2",
+            "trace-query-conflict",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Query Conflict Source",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.91 },
+                    { "name": "LegacyBot", "type": "project", "confidence": 0.88 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "LegacyBot",
+                        "predicate": "conflicts_with",
+                        "confidence": 0.84,
+                        "evidence": [
+                            {
+                                "text": "TinyBot conflicts with LegacyBot behavior.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-query-conflict-3",
+            "trace-query-conflict",
+            "knowledge.query",
+            json!({
+                "query": "TinyBot conflict LegacyBot",
+                "category": "desktop",
+                "limit": 3
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let response = query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result");
+        assert_eq!(
+            response["retrieval_plan"]["selected_routes"],
+            json!(["keyword", "graph"])
+        );
+        let result = &response["results"][0];
+        assert_eq!(result["matched_relations"][0]["label"], "conflicts_with");
+        assert_eq!(
+            result["matched_relation_evidence"][0]["text"],
+            "TinyBot conflicts with LegacyBot behavior."
+        );
+        assert_eq!(result["conflict_metadata"].as_array().unwrap().len(), 1);
+        assert_eq!(result["conflict_metadata"][0]["source_label"], "TinyBot");
+        assert_eq!(result["conflict_metadata"][0]["target_label"], "LegacyBot");
+        assert_eq!(
+            result["conflict_metadata"][0]["predicate"],
+            "conflicts_with"
+        );
+        assert_eq!(
+            result["conflict_metadata"][0]["evidence"][0]["text"],
+            "TinyBot conflicts with LegacyBot behavior."
+        );
+    }
+
+    #[test]
     fn knowledge_query_returns_deterministic_retrieval_plan() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8513,6 +8513,100 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_auto_routes_graph_intent_questions() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-auto-graph-query-1",
+            "trace-auto-graph-query",
+            "knowledge.add_document",
+            json!({
+                "name": "Auto Graph Notes",
+                "content": "# Auto Graph Notes\n\nThe orchestration layer coordinates background jobs.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        let doc_id = add_response
+            .result
+            .as_ref()
+            .expect("knowledge.add_document should return result")["document"]["id"]
+            .as_str()
+            .expect("document id should be present")
+            .to_string();
+        let save_response = router.dispatch(&WorkerRequest::new(
+            "req-auto-graph-query-2",
+            "trace-auto-graph-query",
+            "knowledge.save_entity_graph_extraction",
+            json!({
+                "doc_id": doc_id,
+                "doc_name": "Auto Graph Notes",
+                "model": "knowledge-model",
+                "entities": [
+                    { "name": "TinyBot", "type": "project", "confidence": 0.93 },
+                    { "name": "RuntimeScheduler", "type": "component", "confidence": 0.91 }
+                ],
+                "relations": [
+                    {
+                        "source": "TinyBot",
+                        "target": "RuntimeScheduler",
+                        "predicate": "depends_on",
+                        "confidence": 0.88,
+                        "evidence": [
+                            {
+                                "text": "The orchestration layer coordinates background jobs.",
+                                "line_start": 3,
+                                "line_end": 3
+                            }
+                        ]
+                    }
+                ],
+                "diagnostics": { "chunks_used": 1 }
+            }),
+        ));
+        assert_eq!(save_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-auto-graph-query-3",
+            "trace-auto-graph-query",
+            "knowledge.query",
+            json!({
+                "query": "why TinyBot dependency RuntimeScheduler",
+                "category": "desktop",
+                "limit": 3,
+                "graph_min_confidence": 0.8
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let response = query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result");
+        assert_eq!(
+            response["retrieval_plan"]["selected_routes"],
+            json!(["keyword", "graph"])
+        );
+        let result = &response["results"][0];
+        assert_eq!(result["id"], format!("chunk_{doc_id}_0"));
+        assert_eq!(result["retrieval_method"], "graph");
+        assert_eq!(result["matched_relations"][0]["label"], "depends_on");
+        assert_eq!(
+            result["matched_relation_evidence"][0]["text"],
+            "The orchestration layer coordinates background jobs."
+        );
+    }
+
+    #[test]
     fn knowledge_query_can_expand_relation_graph_two_hops() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -8005,6 +8005,75 @@ mod tests {
     }
 
     #[test]
+    fn knowledge_query_returns_deterministic_retrieval_plan() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::KnowledgeRead,
+                WorkerCapability::KnowledgeWrite,
+            ]),
+        );
+
+        let add_response = router.dispatch(&WorkerRequest::new(
+            "req-plan-1",
+            "trace-plan",
+            "knowledge.add_document",
+            json!({
+                "name": "Knowledge API Notes",
+                "content": "# Knowledge API Notes\n\nThe knowledge.document_tree API returns section hierarchy for exact navigation.\n",
+                "category": "desktop",
+                "file_type": "md"
+            }),
+        ));
+        assert_eq!(add_response.error, None);
+
+        let query_response = router.dispatch(&WorkerRequest::new(
+            "req-plan-2",
+            "trace-plan",
+            "knowledge.query",
+            json!({
+                "query": "knowledge.document_tree API",
+                "category": "desktop",
+                "limit": 4
+            }),
+        ));
+
+        assert_eq!(query_response.error, None);
+        let result = query_response
+            .result
+            .as_ref()
+            .expect("knowledge.query should return result");
+        assert_eq!(
+            result["retrieval_plan"],
+            json!({
+                "object": "knowledge_retrieval_plan",
+                "classification": "exact",
+                "selected_routes": ["keyword"],
+                "route_reasons": [
+                    {
+                        "route": "keyword",
+                        "reason": "query contains exact identifiers or API/config-like terms"
+                    }
+                ],
+                "budgets": {
+                    "limit": 4,
+                    "keyword": 4,
+                    "semantic": 0,
+                    "graph": 0,
+                    "tree": 0
+                },
+                "fallback_behavior": "fallback_to_hybrid_when_no_results",
+                "fallback_routes": ["keyword", "tree", "graph"]
+            })
+        );
+        assert_eq!(result["results"][0]["retrieval_method"], "sparse");
+    }
+
+    #[test]
     fn knowledge_document_tree_returns_markdown_section_hierarchy() {
         let fixture = WorkspaceFixture::new();
         let mut router = WorkerRpcRouter::new(

--- a/apps/desktop/src/desktopKnowledgeTraceability.test.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.test.ts
@@ -418,6 +418,43 @@ describe("desktop knowledge and traceability helpers", () => {
     expect(view.rows[0].traceabilitySections.map((section) => section.kind)).toEqual(["source", "claims"]);
   });
 
+  test("summarizes query retrieval plan metadata for UI inspection", () => {
+    const view = buildDesktopKnowledgeQueryResultRows({
+      retrieval_plan: {
+        classification: "hybrid",
+        selected_routes: ["keyword", "tree", "graph"],
+        budgets: { keyword: 3, tree: 3, graph: 2, semantic: 0 },
+        tree_options: {
+          include_structure_context: true,
+          context_budget: 3,
+          trigger: "auto",
+        },
+        graph_options: {
+          include_graph_context: true,
+          max_hops: 2,
+          max_added_chunks: 2,
+        },
+      },
+      data: [
+        {
+          doc_id: "doc-1",
+          doc_name: "Runtime Notes",
+          content: "Runtime scheduler details.",
+          matched_methods: ["keyword", "structure"],
+          score: 1,
+        },
+      ],
+    });
+
+    expect(view.summary.retrievalPlan).toEqual({
+      classification: "hybrid",
+      routes: ["keyword", "tree", "graph"],
+      budgetLabel: "keyword 3 / tree 3 / graph 2 / semantic 0",
+      treeLabel: "tree auto, context 3",
+      graphLabel: "graph hops 2, adds 2",
+    });
+  });
+
   test("normalizes graph evidence and traceability inspections", () => {
     const graph = buildDesktopKnowledgeGraphView({
       nodes: [

--- a/apps/desktop/src/desktopKnowledgeTraceability.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.ts
@@ -67,8 +67,17 @@ export interface DesktopKnowledgeQueryResultView {
     count: number;
     docs: string[];
     lowConfidence: boolean;
+    retrievalPlan?: DesktopKnowledgeRetrievalPlanSummary;
   };
   rows: DesktopKnowledgeQueryResultRow[];
+}
+
+export interface DesktopKnowledgeRetrievalPlanSummary {
+  classification: string;
+  routes: string[];
+  budgetLabel: string;
+  treeLabel: string;
+  graphLabel: string;
 }
 
 export interface DesktopKnowledgeQueryResultRow {
@@ -841,14 +850,64 @@ export function buildDesktopKnowledgeQueryResultRows(resultInput: unknown, optio
   const result = asRecord(resultInput);
   const items = asArray(result.data).map(asRecord);
   const rows = items.map((item, index) => buildQueryResultRow(item, options.query || asText(result.query), index));
+  const retrievalPlan = buildKnowledgeRetrievalPlanSummary(result.retrieval_plan ?? result.retrievalPlan);
   return {
     summary: {
       count: rows.length,
       docs: Array.from(new Set(rows.map((row) => row.docName).filter(Boolean))).slice(0, 3),
       lowConfidence: rows.length > 0 && rows.every((row) => row.relevance === "low"),
+      ...(retrievalPlan ? { retrievalPlan } : {}),
     },
     rows,
   };
+}
+
+function buildKnowledgeRetrievalPlanSummary(input: unknown): DesktopKnowledgeRetrievalPlanSummary | undefined {
+  const plan = asRecord(input);
+  if (!Object.keys(plan).length) {
+    return undefined;
+  }
+  const routes = asArray(plan.selected_routes ?? plan.selectedRoutes).map(asText).filter(Boolean);
+  const budgets = asRecord(plan.budgets);
+  const treeOptions = asRecord(plan.tree_options ?? plan.treeOptions);
+  const graphOptions = asRecord(plan.graph_options ?? plan.graphOptions);
+  return {
+    classification: firstNonEmpty(plan.classification, "unknown"),
+    routes,
+    budgetLabel: formatRetrievalPlanBudgets(budgets),
+    treeLabel: formatTreeRetrievalOptions(treeOptions),
+    graphLabel: formatGraphRetrievalOptions(graphOptions),
+  };
+}
+
+function formatRetrievalPlanBudgets(budgets: UnknownRecord): string {
+  return ["keyword", "tree", "graph", "semantic"]
+    .map((route) => {
+      const value = budgets[route];
+      return value == null ? "" : `${route} ${numberValue(value)}`;
+    })
+    .filter(Boolean)
+    .join(" / ");
+}
+
+function formatTreeRetrievalOptions(options: UnknownRecord): string {
+  if (!Object.keys(options).length) {
+    return "";
+  }
+  return [
+    `tree ${firstNonEmpty(options.trigger, "none")}`,
+    `context ${numberValue(options.context_budget ?? options.contextBudget)}`,
+  ].join(", ");
+}
+
+function formatGraphRetrievalOptions(options: UnknownRecord): string {
+  if (!Object.keys(options).length) {
+    return "";
+  }
+  return [
+    `graph hops ${numberValue(options.max_hops ?? options.maxHops)}`,
+    `adds ${numberValue(options.max_added_chunks ?? options.maxAddedChunks)}`,
+  ].join(", ");
 }
 
 function buildQueryResultRow(item: UnknownRecord, query: string, index: number): DesktopKnowledgeQueryResultRow {

--- a/apps/desktop/src/desktopNativeWebui.test.ts
+++ b/apps/desktop/src/desktopNativeWebui.test.ts
@@ -72,4 +72,16 @@ describe("desktop native WebUI API", () => {
       status: 200,
     });
   });
+
+  test("surfaces native WebUI error body messages", async () => {
+    const invoke = vi.fn(async (_command: string, _args?: unknown) => ({
+      status: 500,
+      body: { error: { message: "Error extracting knowledge graph: unsupported relation predicate" } },
+    }));
+    const api = createDesktopNativeWebuiApi({ invoke });
+
+    await expect(api.route({ method: "POST", path: "/v1/knowledge/graph/extract" }))
+      .rejects
+      .toThrow("Error extracting knowledge graph: unsupported relation predicate");
+  });
 });

--- a/apps/desktop/src/desktopNativeWebui.ts
+++ b/apps/desktop/src/desktopNativeWebui.ts
@@ -42,7 +42,15 @@ function unwrapWebuiRouteResponse(response: NativeWebuiRouteResponse): unknown {
   if (response.status >= 200 && response.status < 300) {
     return response.body;
   }
-  throw new Error(`Native WebUI route failed: HTTP ${response.status}`);
+  throw new Error(nativeWebuiRouteErrorMessage(response));
+}
+
+function nativeWebuiRouteErrorMessage(response: NativeWebuiRouteResponse): string {
+  const body = isRecord(response.body) ? response.body : {};
+  const error = isRecord(body.error) ? body.error : {};
+  return typeof error.message === "string" && error.message.trim()
+    ? error.message
+    : `Native WebUI route failed: HTTP ${response.status}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/gateway.test.ts
+++ b/apps/desktop/src/gateway.test.ts
@@ -1240,6 +1240,13 @@ describe("gateway HTTP client", () => {
         path: "/v1/knowledge/rebuild-index?type=semantic&async_index=true",
       },
     });
+    await expect(client.knowledge.rebuildIndex("tree")).resolves.toEqual({
+      native: true,
+      request: {
+        method: "POST",
+        path: "/v1/knowledge/rebuild-index?type=tree&async_index=true",
+      },
+    });
     await expect(client.knowledge.graph()).resolves.toEqual({
       native: true,
       request: {

--- a/apps/desktop/src/gateway.test.ts
+++ b/apps/desktop/src/gateway.test.ts
@@ -1338,6 +1338,25 @@ describe("gateway HTTP client", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
+  test("does not fallback to gateway HTTP when native graph extraction fails", async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
+    const nativeWebui = {
+      route: vi.fn(async () => {
+        throw new Error("Error extracting knowledge graph: unsupported relation predicate");
+      }),
+    };
+    const client = createGatewayApiClient({
+      config: DEFAULT_GATEWAY_CONFIG,
+      fetchFn,
+      nativeWebui,
+    });
+
+    await expect(client.knowledge.extractGraph({ docId: "doc-1" }))
+      .rejects
+      .toThrow("unsupported relation predicate");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
   test("keeps unsupported Knowledge uploads on the HTTP gateway fallback", async () => {
     const fetchFn = vi.fn(async (url: RequestInfo | URL, _init?: RequestInit) => {
       if (String(url).endsWith("/webui/bootstrap")) {

--- a/apps/desktop/src/gatewayHttpClient.ts
+++ b/apps/desktop/src/gatewayHttpClient.ts
@@ -570,7 +570,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
       rebuildIndex: (type: string = "all") => {
         const path = `/v1/knowledge/rebuild-index?type=${encodeURIComponent(type)}&async_index=true`;
         return nativeOrGateway(
-          () => ["bm25", "all", "semantic"].includes(type) ? options.nativeWebui?.route({ method: "POST", path }) : undefined,
+          () => ["bm25", "all", "semantic", "tree"].includes(type) ? options.nativeWebui?.route({ method: "POST", path }) : undefined,
           () => request(path, { method: "POST" }),
           "knowledge.rebuildIndex",
         );

--- a/apps/desktop/src/gatewayHttpClient.ts
+++ b/apps/desktop/src/gatewayHttpClient.ts
@@ -604,6 +604,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
           }),
           () => request("/v1/knowledge/graph/extract", jsonRequest("POST", body)),
           "knowledge.extractGraph",
+          false,
         );
       },
       graphrag: (graphRagOptions: KnowledgeGraphRagOptions = {}) => {

--- a/apps/desktop/src/native-vue/knowledgeQueryIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeQueryIsland.test.ts
@@ -60,4 +60,35 @@ describe("knowledge query Vue island", () => {
     mounted.unmount();
     expect(host.textContent).toBe("");
   });
+
+  test("renders retrieval plan inspection metadata", () => {
+    const host = document.createElement("section");
+
+    const mounted = mountKnowledgeQueryIsland(host, {
+      draft,
+      results: {
+        summary: {
+          count: 1,
+          docs: ["Doc 1"],
+          lowConfidence: false,
+          retrievalPlan: {
+            classification: "hybrid",
+            routes: ["keyword", "tree", "graph"],
+            budgetLabel: "keyword 3 / tree 3 / graph 2 / semantic 0",
+            treeLabel: "tree auto, context 3",
+            graphLabel: "graph hops 2, adds 2",
+          },
+        },
+        rows: [queryRow(1)],
+      },
+    });
+
+    expect(host.textContent).toContain("Plan: hybrid");
+    expect(host.textContent).toContain("Routes: keyword + tree + graph");
+    expect(host.textContent).toContain("keyword 3 / tree 3 / graph 2 / semantic 0");
+    expect(host.textContent).toContain("tree auto, context 3");
+    expect(host.textContent).toContain("graph hops 2, adds 2");
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/knowledgeQueryIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeQueryIsland.ts
@@ -44,6 +44,7 @@ function createKnowledgeQueryApp(options: KnowledgeQueryIslandOptions): App {
             h("h2", `Query: ${options.draft.query || "empty"}`),
             h("p", `Mode: ${options.draft.mode} / top ${options.draft.topK}`),
             h("p", `Results: ${options.results.summary.count}`),
+            renderRetrievalPlan(options.results.summary.retrievalPlan),
             options.results.rows.length
               ? renderResults(options.results.rows)
               : h(NEmpty, {
@@ -56,6 +57,25 @@ function createKnowledgeQueryApp(options: KnowledgeQueryIslandOptions): App {
       });
     },
   }));
+}
+
+function renderRetrievalPlan(plan: DesktopKnowledgeQueryResultView["summary"]["retrievalPlan"]) {
+  if (!plan) {
+    return null;
+  }
+  return h(NSpace, {
+    class: "desktop-knowledge-query-plan",
+    size: 4,
+    wrap: true,
+  }, {
+    default: () => [
+      h(NTag, { size: "small", round: true, type: "info" }, { default: () => `Plan: ${plan.classification}` }),
+      plan.routes.length ? h(NTag, { size: "small", round: true }, { default: () => `Routes: ${plan.routes.join(" + ")}` }) : null,
+      plan.budgetLabel ? h(NTag, { size: "small", round: true }, { default: () => plan.budgetLabel }) : null,
+      plan.treeLabel ? h(NTag, { size: "small", round: true }, { default: () => plan.treeLabel }) : null,
+      plan.graphLabel ? h(NTag, { size: "small", round: true }, { default: () => plan.graphLabel }) : null,
+    ],
+  });
 }
 
 function renderResults(rows: DesktopKnowledgeQueryResultRow[]) {

--- a/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.test.ts
@@ -31,6 +31,7 @@ describe("knowledge graph extraction backend", () => {
     const prompt = buildKnowledgeGraphExtractionPrompt("Knowledge.md", "TinyBot stores knowledge.", 640);
 
     expect(prompt).toContain("Return strict JSON only");
+    expect(prompt).toContain("Allowed relation predicates: depends_on, causes, implements, configures, mentions, conflicts_with, supports.");
     expect(prompt).toContain("Token budget for the answer: 640.");
     expect(prompt).toContain("Document: Knowledge.md");
     expect(prompt).toContain("TinyBot stores knowledge.");
@@ -56,11 +57,31 @@ describe("knowledge graph extraction backend", () => {
       relations: [{
         source: "TinyBot",
         target: "Knowledge",
-        predicate: "stores",
+        predicate: "mentions",
         confidence: 0,
         evidence: [{ text: "TinyBot stores knowledge.", line_start: 1, line_end: 1 }],
       }],
     });
+  });
+
+  test("drops extracted relations that cannot satisfy native graph validation", () => {
+    const result = parseKnowledgeGraphExtractionJson(JSON.stringify({
+      entities: [],
+      relations: [
+        { source: "TinyBot", target: "Knowledge", predicate: "uses", confidence: 0.8, evidence: [] },
+        { source: "TinyBot", target: "Runtime", predicate: "depends on", confidence: 0.8, evidence: [{ text: "TinyBot uses Runtime." }] },
+      ],
+    }));
+
+    expect(result.relations).toEqual([
+      {
+        source: "TinyBot",
+        target: "Runtime",
+        predicate: "depends_on",
+        confidence: 0.8,
+        evidence: [{ text: "TinyBot uses Runtime.", line_start: 1, line_end: 1 }],
+      },
+    ]);
   });
 
   test("resolves explicit and scope-all extraction document ids", async () => {
@@ -189,7 +210,7 @@ describe("knowledge graph extraction backend", () => {
       token_estimate: { total_tokens: 500, max_tokens: 640 },
       extraction_scope: { max_chunks: 1, chunk_count: 1, original_chunk_count: 1 },
       entities: [{ name: "TinyBot", type: "project", confidence: 0.9, evidence: [] }],
-      relations: [{ source: "TinyBot", target: "Knowledge", predicate: "stores", confidence: 0.8, evidence: [] }],
+      relations: [],
     })]);
   });
 

--- a/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.test.ts
@@ -70,6 +70,7 @@ describe("knowledge graph extraction backend", () => {
       relations: [
         { source: "TinyBot", target: "Knowledge", predicate: "uses", confidence: 0.8, evidence: [] },
         { source: "TinyBot", target: "Runtime", predicate: "depends on", confidence: 0.8, evidence: [{ text: "TinyBot uses Runtime." }] },
+        { source: "Outage", target: "Config drift", predicate: "caused_by", confidence: 0.7, evidence: [{ text: "The outage was caused by config drift." }] },
       ],
     }));
 
@@ -80,6 +81,13 @@ describe("knowledge graph extraction backend", () => {
         predicate: "depends_on",
         confidence: 0.8,
         evidence: [{ text: "TinyBot uses Runtime.", line_start: 1, line_end: 1 }],
+      },
+      {
+        source: "Config drift",
+        target: "Outage",
+        predicate: "causes",
+        confidence: 0.7,
+        evidence: [{ text: "The outage was caused by config drift.", line_start: 1, line_end: 1 }],
       },
     ]);
   });

--- a/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.ts
@@ -479,44 +479,64 @@ function normalizeExtractedEntity(value: unknown): Record<string, unknown> {
   };
 }
 
+type NormalizedRelationPredicate = {
+  predicate: string;
+  inverse: boolean;
+};
+
 function normalizeExtractedRelation(value: unknown): Record<string, unknown> {
   const relation = asObject(value) ?? {};
+  const source = stringValue(relation.source) ?? "";
+  const target = stringValue(relation.target) ?? "";
+  const normalizedPredicate = normalizeRelationPredicate(stringValue(relation.predicate) ?? stringValue(relation.type));
   return {
-    source: stringValue(relation.source) ?? "",
-    target: stringValue(relation.target) ?? "",
-    predicate: normalizeRelationPredicate(stringValue(relation.predicate) ?? stringValue(relation.type)),
+    source: normalizedPredicate.inverse ? target : source,
+    target: normalizedPredicate.inverse ? source : target,
+    predicate: normalizedPredicate.predicate,
     confidence: normalizedConfidence(relation.confidence),
     evidence: arrayFromUnknown(relation.evidence).map(normalizeExtractionEvidence),
   };
 }
 
-function normalizeRelationPredicate(value: string | undefined): string {
+function normalizeRelationPredicate(value: string | undefined): NormalizedRelationPredicate {
   const normalized = (value ?? "")
     .trim()
     .toLowerCase()
     .replace(/[\s-]+/g, "_");
   if ((CONTROLLED_RELATION_PREDICATES as readonly string[]).includes(normalized)) {
-    return normalized;
+    return { predicate: normalized, inverse: false };
   }
   if (["depends", "depends_on", "dependency", "requires", "uses", "relies_on"].includes(normalized)) {
-    return "depends_on";
+    return { predicate: "depends_on", inverse: false };
   }
-  if (["cause", "caused_by", "leads_to", "produces"].includes(normalized)) {
-    return "causes";
+  if (["cause", "leads_to", "produces"].includes(normalized)) {
+    return { predicate: "causes", inverse: false };
   }
-  if (["implement", "implemented_by", "built_by"].includes(normalized)) {
-    return "implements";
+  if (normalized === "caused_by") {
+    return { predicate: "causes", inverse: true };
   }
-  if (["configure", "configured_by", "sets", "controls"].includes(normalized)) {
-    return "configures";
+  if (["implement", "built_by"].includes(normalized)) {
+    return { predicate: "implements", inverse: false };
+  }
+  if (normalized === "implemented_by") {
+    return { predicate: "implements", inverse: true };
+  }
+  if (["configure", "sets", "controls"].includes(normalized)) {
+    return { predicate: "configures", inverse: false };
+  }
+  if (normalized === "configured_by") {
+    return { predicate: "configures", inverse: true };
   }
   if (["conflict", "conflicts", "contradicts", "opposes"].includes(normalized)) {
-    return "conflicts_with";
+    return { predicate: "conflicts_with", inverse: false };
   }
-  if (["support", "supported_by", "validates"].includes(normalized)) {
-    return "supports";
+  if (["support", "validates"].includes(normalized)) {
+    return { predicate: "supports", inverse: false };
   }
-  return "mentions";
+  if (normalized === "supported_by") {
+    return { predicate: "supports", inverse: true };
+  }
+  return { predicate: "mentions", inverse: false };
 }
 
 function normalizeExtractionEvidence(value: unknown): Record<string, unknown> {

--- a/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.ts
@@ -50,6 +50,16 @@ const KNOWLEDGE_GRAPH_EXTRACTION_STAGES = [
   "persisted_entity_graph",
 ] as const;
 
+const CONTROLLED_RELATION_PREDICATES = [
+  "depends_on",
+  "causes",
+  "implements",
+  "configures",
+  "mentions",
+  "conflicts_with",
+  "supports",
+] as const;
+
 export async function resolveKnowledgeGraphExtractionDocIds(
   body: Record<string, unknown>,
   provider: KnowledgeGraphExtractionProvider,
@@ -433,6 +443,8 @@ export function buildKnowledgeGraphExtractionPrompt(docName: string, content: st
     "You extract a knowledge entity graph from one document.",
     "Return strict JSON only, with no markdown fences.",
     "Schema: {\"entities\":[{\"name\":\"\",\"type\":\"\",\"confidence\":0.0,\"evidence\":[{\"text\":\"\",\"line_start\":1,\"line_end\":1}]}],\"relations\":[{\"source\":\"\",\"target\":\"\",\"predicate\":\"\",\"confidence\":0.0,\"evidence\":[{\"text\":\"\",\"line_start\":1,\"line_end\":1}]}]}",
+    `Allowed relation predicates: ${CONTROLLED_RELATION_PREDICATES.join(", ")}.`,
+    "Use mentions for generic, containment, storage, or unclear relations.",
     "Only include entities and relations directly supported by source evidence.",
     `Token budget for the answer: ${maxTokens}.`,
     `Document: ${docName}`,
@@ -446,9 +458,14 @@ export function parseKnowledgeGraphExtractionJson(raw: string): KnowledgeGraphEx
   const root = asObject(parsed) ?? {};
   return {
     entities: arrayFromUnknown(root.entities).map(normalizeExtractedEntity).filter((entity) => stringValue(entity.name)),
-    relations: arrayFromUnknown(root.relations).map(normalizeExtractedRelation).filter((relation) =>
-      stringValue(relation.source) && stringValue(relation.target) && stringValue(relation.predicate)
-    ),
+    relations: arrayFromUnknown(root.relations)
+      .map(normalizeExtractedRelation)
+      .filter((relation) =>
+        stringValue(relation.source)
+        && stringValue(relation.target)
+        && stringValue(relation.predicate)
+        && arrayFromUnknown(relation.evidence).some((evidence) => Boolean(stringValue(asObject(evidence)?.text)))
+      ),
   };
 }
 
@@ -467,10 +484,39 @@ function normalizeExtractedRelation(value: unknown): Record<string, unknown> {
   return {
     source: stringValue(relation.source) ?? "",
     target: stringValue(relation.target) ?? "",
-    predicate: stringValue(relation.predicate) ?? stringValue(relation.type) ?? "related_to",
+    predicate: normalizeRelationPredicate(stringValue(relation.predicate) ?? stringValue(relation.type)),
     confidence: normalizedConfidence(relation.confidence),
     evidence: arrayFromUnknown(relation.evidence).map(normalizeExtractionEvidence),
   };
+}
+
+function normalizeRelationPredicate(value: string | undefined): string {
+  const normalized = (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if ((CONTROLLED_RELATION_PREDICATES as readonly string[]).includes(normalized)) {
+    return normalized;
+  }
+  if (["depends", "depends_on", "dependency", "requires", "uses", "relies_on"].includes(normalized)) {
+    return "depends_on";
+  }
+  if (["cause", "caused_by", "leads_to", "produces"].includes(normalized)) {
+    return "causes";
+  }
+  if (["implement", "implemented_by", "built_by"].includes(normalized)) {
+    return "implements";
+  }
+  if (["configure", "configured_by", "sets", "controls"].includes(normalized)) {
+    return "configures";
+  }
+  if (["conflict", "conflicts", "contradicts", "opposes"].includes(normalized)) {
+    return "conflicts_with";
+  }
+  if (["support", "supported_by", "validates"].includes(normalized)) {
+    return "supports";
+  }
+  return "mentions";
 }
 
 function normalizeExtractionEvidence(value: unknown): Record<string, unknown> {

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
@@ -2761,6 +2761,15 @@ describe("AgentWorker", () => {
         query: async (body, traceId) => {
           calls.push({ method: "query", traceId, params: body });
           return {
+            retrieval_plan: {
+              object: "knowledge_retrieval_plan",
+              classification: "exact",
+              selected_routes: ["keyword"],
+              route_reasons: [{ route: "keyword", reason: "exact API term" }],
+              budgets: { limit: 3, keyword: 3, semantic: 0, graph: 0, tree: 0 },
+              fallback_behavior: "fallback_to_hybrid_when_no_results",
+              fallback_routes: ["keyword", "tree", "graph"],
+            },
             results: [{
               id: "chunk-1",
               doc_id: "doc-1",
@@ -3080,6 +3089,15 @@ describe("AgentWorker", () => {
           object: "list",
           query: "native knowledge",
           mode: "sparse",
+          retrieval_plan: {
+            object: "knowledge_retrieval_plan",
+            classification: "exact",
+            selected_routes: ["keyword"],
+            route_reasons: [{ route: "keyword", reason: "exact API term" }],
+            budgets: { limit: 3, keyword: 3, semantic: 0, graph: 0, tree: 0 },
+            fallback_behavior: "fallback_to_hybrid_when_no_results",
+            fallback_routes: ["keyword", "tree", "graph"],
+          },
           total: 1,
           data: [expect.objectContaining({ id: "chunk-1", doc_id: "doc-1", score: 3 })],
         },

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
@@ -2777,6 +2777,13 @@ describe("AgentWorker", () => {
               content: "TS native knowledge API route.",
               score: 3,
               sparse_rank: 1,
+              structure_context: {
+                object: "knowledge_structure_context",
+                section: { id: "section-doc-1-1", title: "API", ordinal: 1 },
+                parent_section: { id: "section-doc-1-0", title: "Root", ordinal: 0 },
+                sibling_sections: [{ id: "section-doc-1-2", title: "Operations", ordinal: 2 }],
+                child_sections: [],
+              },
             }],
           };
         },
@@ -3099,7 +3106,18 @@ describe("AgentWorker", () => {
             fallback_routes: ["keyword", "tree", "graph"],
           },
           total: 1,
-          data: [expect.objectContaining({ id: "chunk-1", doc_id: "doc-1", score: 3 })],
+          data: [expect.objectContaining({
+            id: "chunk-1",
+            doc_id: "doc-1",
+            score: 3,
+            structure_context: {
+              object: "knowledge_structure_context",
+              section: { id: "section-doc-1-1", title: "API", ordinal: 1 },
+              parent_section: { id: "section-doc-1-0", title: "Root", ordinal: 0 },
+              sibling_sections: [{ id: "section-doc-1-2", title: "Operations", ordinal: 2 }],
+              child_sections: [],
+            },
+          })],
         },
       },
     });

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/knowledgeBridge.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/knowledgeBridge.ts
@@ -24,7 +24,7 @@ export class NativeKnowledgeBridge implements WebuiKnowledgeProvider {
     return this.rpcClient.request(traceId, "knowledge.get_job", { job_id: jobId });
   }
 
-  rebuildIndex(type: "bm25" | "semantic" | "all", traceId: string): Promise<unknown> {
+  rebuildIndex(type: "bm25" | "semantic" | "tree" | "all", traceId: string): Promise<unknown> {
     return this.rpcClient.request(traceId, "knowledge.rebuild_index", { type });
   }
 

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
@@ -1365,6 +1365,64 @@ describe("WebUI route temporary files", () => {
 });
 
 describe("WebUI knowledge diagnostics", () => {
+  test("routes tree index rebuilds through the knowledge provider", async () => {
+    const rebuilds: Array<{ type: string; traceId: string }> = [];
+    const knowledgeProvider: WebuiKnowledgeProvider = {
+      listDocuments: () => ({ documents: [] }),
+      addDocument: () => ({ document: { id: "doc-1" } }),
+      getDocument: () => null,
+      deleteDocument: () => ({ deleted: false }),
+      query: () => ({ results: [] }),
+      stats: () => ({ total_documents: 1, total_chunks: 2, retrieval_ready: true }),
+      rebuildIndex: (type, traceId) => {
+        rebuilds.push({ type, traceId });
+        return {
+          id: `kjob_rebuild_${type}`,
+          result: {
+            available: true,
+            documents_scanned: 1,
+            sections_indexed: 2,
+            tree_ready: true,
+          },
+        };
+      },
+    };
+
+    const response = await handleWebuiRouteRequest(
+      {
+        method: "POST",
+        path: "/v1/knowledge/rebuild-index?type=tree",
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      knowledgeProvider,
+      undefined,
+      "trace-tree-rebuild",
+    );
+
+    expect(response).toEqual({
+      status: 200,
+      body: {
+        message: "Knowledge tree index rebuilt successfully",
+        available: true,
+        documents_scanned: 1,
+        sections_indexed: 2,
+        tree_ready: true,
+      },
+    });
+    expect(rebuilds).toEqual([{ type: "tree", traceId: "trace-tree-rebuild" }]);
+  });
+
   test("auto-extracts a graph after upload when graph auto extract is enabled", async () => {
     const saves: Array<Record<string, unknown>> = [];
     const configProvider: WebuiConfigProvider = {

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
@@ -252,7 +252,7 @@ describe("WebUI knowledge graph extraction routes", () => {
       doc_name: "Knowledge.md",
       model: "graph-model",
       entities: [{ name: "TinyBot", type: "project", confidence: 0.91 }],
-      relations: [{ source: "TinyBot", target: "knowledge graph", predicate: "stores", confidence: 0.82 }],
+      relations: [{ source: "TinyBot", target: "knowledge graph", predicate: "mentions", confidence: 0.82 }],
       token_estimate: { max_tokens: 640 },
     });
   });

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
@@ -2245,6 +2245,7 @@ function knowledgeQueryItem(value: Record<string, unknown>): Record<string, unkn
     method: value.method,
     retrieval_method: value.retrieval_method ?? value.method,
     score_metadata: isJsonObject(value.score_metadata) ? value.score_metadata : {},
+    structure_context: isJsonObject(value.structure_context) ? value.structure_context : {},
     source_snippets: Array.isArray(value.source_snippets) ? value.source_snippets : [],
     matched_methods: Array.isArray(value.matched_methods) ? value.matched_methods : [],
     matched_entities: Array.isArray(value.matched_entities) ? value.matched_entities : [],

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
@@ -287,6 +287,8 @@ export type WebuiKnowledgeListRequest = {
   limit?: number;
 };
 
+type KnowledgeRebuildType = "bm25" | "semantic" | "tree" | "all";
+
 export type WebuiKnowledgeProvider = {
   listDocuments(
     request: WebuiKnowledgeListRequest,
@@ -295,7 +297,7 @@ export type WebuiKnowledgeProvider = {
   addDocument(body: Record<string, unknown>, traceId: string): Promise<unknown> | unknown;
   startIndexJob?(docId: string, traceId: string): Promise<unknown> | unknown;
   getJob?(jobId: string, traceId: string): Promise<unknown> | unknown;
-  rebuildIndex?(type: "bm25" | "semantic" | "all", traceId: string): Promise<unknown> | unknown;
+  rebuildIndex?(type: KnowledgeRebuildType, traceId: string): Promise<unknown> | unknown;
   graph?(request: Record<string, unknown>, traceId: string): Promise<unknown> | unknown;
   saveEntityGraphExtraction?(body: Record<string, unknown>, traceId: string): Promise<unknown> | unknown;
   getDocument(docId: string, traceId: string): Promise<unknown> | unknown;
@@ -1438,6 +1440,14 @@ async function knowledgeJobResponse(
       return knowledgeServerError("Error getting knowledge job", error);
     }
   }
+  if (jobId === "kjob_rebuild_tree") {
+    try {
+      const stats = knowledgeStatsBody(await provider.stats(traceId));
+      return { status: 200, body: completedKnowledgeTreeRebuildJob(stats, knowledgeTreeRebuildResult(stats)) };
+    } catch (error) {
+      return knowledgeServerError("Error getting knowledge job", error);
+    }
+  }
   const docId = knowledgeUploadJobDocumentId(jobId);
   if (!docId) {
     return { status: 404, body: knowledgeApiError(404, `Knowledge job ${jobId} not found`) };
@@ -1465,13 +1475,13 @@ async function knowledgeRebuildIndexResponse(
     return { status: 503, body: knowledgeApiError(503, "Knowledge store not initialized") };
   }
   const rebuildTypeRaw = query.get("type") ?? "bm25";
-  if (rebuildTypeRaw !== "bm25" && rebuildTypeRaw !== "all" && rebuildTypeRaw !== "semantic") {
+  if (!isKnowledgeRebuildType(rebuildTypeRaw)) {
     return {
       status: 400,
-      body: knowledgeApiError(400, `Invalid rebuild type '${rebuildTypeRaw}'. Valid options: bm25, semantic, all`),
+      body: knowledgeApiError(400, `Invalid rebuild type '${rebuildTypeRaw}'. Valid options: bm25, semantic, tree, all`),
     };
   }
-  const rebuildType: "bm25" | "semantic" | "all" = rebuildTypeRaw;
+  const rebuildType = rebuildTypeRaw;
 
   const asyncIndex = booleanQuery(query.get("async_index"));
   logKnowledgeDiagnostic(diagnosticsLogger, traceId, "knowledge.rebuild_index.start", {
@@ -1489,20 +1499,7 @@ async function knowledgeRebuildIndexResponse(
       if (!asyncIndex) {
         return {
           status: 200,
-          body: rebuildType === "all"
-            ? {
-                message: "All available native knowledge indexes rebuilt successfully",
-                ...result,
-              }
-            : rebuildType === "semantic"
-              ? {
-                  message: "Semantic index is not available in native TS worker",
-                  ...result,
-                }
-            : {
-                message: "BM25 index rebuilt successfully",
-                ...result,
-              },
+          body: knowledgeRebuildSuccessBody(rebuildType, result),
         };
       }
       return {
@@ -1520,6 +1517,8 @@ async function knowledgeRebuildIndexResponse(
       ? knowledgeAllRebuildResult(stats)
       : rebuildType === "semantic"
         ? knowledgeSemanticUnavailableResult()
+        : rebuildType === "tree"
+          ? knowledgeTreeRebuildResult(stats)
         : knowledgeBm25RebuildResult(stats);
     logKnowledgeDiagnostic(diagnosticsLogger, traceId, "knowledge.rebuild_index.complete", {
       type: rebuildType,
@@ -1529,20 +1528,7 @@ async function knowledgeRebuildIndexResponse(
     if (!asyncIndex) {
       return {
         status: 200,
-        body: rebuildType === "all"
-          ? {
-              message: "All available native knowledge indexes rebuilt successfully",
-              ...result,
-            }
-          : rebuildType === "semantic"
-            ? {
-                message: "Semantic index is not available in native TS worker",
-                ...result,
-              }
-          : {
-              message: "BM25 index rebuilt successfully",
-              ...result,
-            },
+        body: knowledgeRebuildSuccessBody(rebuildType, result),
       };
     }
 
@@ -1550,6 +1536,8 @@ async function knowledgeRebuildIndexResponse(
       ? completedKnowledgeAllRebuildJob(stats, result)
       : rebuildType === "semantic"
         ? completedKnowledgeSemanticRebuildJob(stats)
+        : rebuildType === "tree"
+          ? completedKnowledgeTreeRebuildJob(stats, result)
       : completedKnowledgeBm25RebuildJob(stats, result);
     return {
       status: 202,
@@ -1933,10 +1921,51 @@ function knowledgeSemanticUnavailableResult(): Record<string, unknown> {
   };
 }
 
+function knowledgeTreeRebuildResult(stats: Record<string, unknown>): Record<string, unknown> {
+  const stageReadiness = asObject(stats.stage_readiness) ?? {};
+  const treeIndex = asObject(stageReadiness.tree_index) ?? {};
+  const sectionsIndexed = numberValue(treeIndex.processed) ?? numberValue(stats.total_chunks) ?? 0;
+  return {
+    available: true,
+    documents_scanned: numberValue(stats.total_documents) ?? 0,
+    sections_indexed: sectionsIndexed,
+    tree_ready: Boolean(treeIndex.ready) || sectionsIndexed > 0,
+  };
+}
+
 function knowledgeAllRebuildResult(stats: Record<string, unknown>): Record<string, unknown> {
   return {
     bm25: knowledgeBm25RebuildResult(stats),
+    tree: knowledgeTreeRebuildResult(stats),
     semantic: knowledgeSemanticUnavailableResult(),
+  };
+}
+
+function knowledgeRebuildSuccessBody(
+  rebuildType: KnowledgeRebuildType,
+  result: Record<string, unknown>,
+): Record<string, unknown> {
+  if (rebuildType === "all") {
+    return {
+      message: "All available native knowledge indexes rebuilt successfully",
+      ...result,
+    };
+  }
+  if (rebuildType === "semantic") {
+    return {
+      message: "Semantic index is not available in native TS worker",
+      ...result,
+    };
+  }
+  if (rebuildType === "tree") {
+    return {
+      message: "Knowledge tree index rebuilt successfully",
+      ...result,
+    };
+  }
+  return {
+    message: "BM25 index rebuilt successfully",
+    ...result,
   };
 }
 
@@ -2289,6 +2318,10 @@ function booleanQuery(value: string | null): boolean {
   return value !== null && ["1", "true", "yes", "on"].includes(value.toLowerCase());
 }
 
+function isKnowledgeRebuildType(value: string): value is KnowledgeRebuildType {
+  return value === "bm25" || value === "semantic" || value === "tree" || value === "all";
+}
+
 function booleanQueryDefault(value: string | null, fallback: boolean): boolean {
   if (value === null) {
     return fallback;
@@ -2393,6 +2426,34 @@ function completedKnowledgeAllRebuildJob(
     message: "Native available knowledge indexes are rebuilt; semantic index is not available natively",
     processed: 3,
     total: 3,
+    error: "",
+    ...lifecycle,
+    stage_details: Array.isArray(stats.stage_details) ? stats.stage_details : [],
+    failed_stage_count: numberValue(stats.failed_stage_count) ?? 0,
+    stale_stage_count: numberValue(stats.stale_stage_count) ?? 0,
+    retrieval_ready: retrievalReady,
+    graph_ready: graphReady,
+    partial_availability: retrievalReady && !graphReady,
+    result,
+  };
+}
+
+function completedKnowledgeTreeRebuildJob(
+  stats: Record<string, unknown>,
+  result: Record<string, unknown>,
+): Record<string, unknown> {
+  const sectionsIndexed = numberValue(result.sections_indexed) ?? 0;
+  const retrievalReady = Boolean(stats.retrieval_ready) || sectionsIndexed > 0;
+  const graphReady = Boolean(stats.graph_ready);
+  const lifecycle = completedKnowledgeJobLifecycle();
+  return {
+    id: "kjob_rebuild_tree",
+    name: "rebuild:tree",
+    status: "completed",
+    stage: "completed",
+    message: "Knowledge tree index rebuilt successfully",
+    processed: sectionsIndexed,
+    total: sectionsIndexed,
     error: "",
     ...lifecycle,
     stage_details: Array.isArray(stats.stage_details) ? stats.stage_details : [],

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
@@ -1789,11 +1789,17 @@ async function knowledgeQueryResponse(
   });
   try {
     const result = await provider.query(request, traceId);
+    const resultObject = asObject(result) ?? {};
     const data = arrayFromResult(result, "results");
+    const retrievalPlan = isJsonObject(resultObject.retrieval_plan) ? resultObject.retrieval_plan : undefined;
     logKnowledgeDiagnostic(diagnosticsLogger, traceId, "knowledge.query.complete", {
       mode: stringValue(request.mode) ?? "hybrid",
       top_k: numberValue(request.top_k) ?? 5,
       total: data.length,
+      retrieval_plan_classification: retrievalPlan ? stringValue(retrievalPlan.classification) : undefined,
+      selected_routes: retrievalPlan && Array.isArray(retrievalPlan.selected_routes)
+        ? retrievalPlan.selected_routes
+        : undefined,
     });
     return {
       status: 200,
@@ -1801,6 +1807,7 @@ async function knowledgeQueryResponse(
         object: "list",
         query,
         mode,
+        ...(retrievalPlan ? { retrieval_plan: retrievalPlan } : {}),
         data: data.map(knowledgeQueryItem),
         total: data.length,
       },


### PR DESCRIPTION
## Summary

Closes #256.

This PR implements the local Tinybot Knowledge UKS roadmap pass and fixes the native graph extraction failure surfaced from the desktop app.

## Changes

- Add native knowledge tree/query/graph retrieval metadata, including route plans, graph/tree options, projection metadata, conflict metadata, and score explanations.
- Preserve graph and tree evidence metadata through `knowledge.context` references and expose context-level retrieval plans.
- Add desktop UI inspection for retrieval plan classification, routes, budgets, and graph/tree options.
- Stabilize native knowledge graph extraction by normalizing LLM relation predicates to the controlled native set, dropping relation candidates without evidence, surfacing native route error bodies, and preventing unsupported HTTP gateway fallback after native extraction errors.

## Root Cause

Native Rust persistence now validates relation predicates and evidence strictly, but the TS graph extraction path still forwarded arbitrary LLM predicates such as `stores`. That produced native route failures. The desktop client then retried the old HTTP gateway endpoint, which does not serve this POST route, causing the misleading 405/CORS error.

## Validation

- `cargo test knowledge_context --lib`
- `cargo test knowledge_query --lib`
- `npm test -- desktopKnowledgeTraceability.test.ts knowledgeQueryIsland.test.ts`
- `npm test -- workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.test.ts workers/ts-agent-worker/src/webui/webuiRoutes.test.ts desktopNativeWebui.test.ts gateway.test.ts`
- `npm run build`

Note: local planning/docs files and `.gitignore` changes were intentionally not committed or pushed.