### PR TITLE
fix: stream graph extraction job diagnostics

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -70,7 +70,6 @@ fn desktop_status() -> DesktopStatus {
 type SharedGateway = Arc<Mutex<GatewayRuntime>>;
 const WORKER_CRON_TIMER_MAX_POLL: Duration = Duration::from_secs(30);
 const WORKER_WEBUI_ROUTE_TIMEOUT: Duration = Duration::from_secs(10);
-const WORKER_WEBUI_LONG_ROUTE_TIMEOUT: Duration = Duration::from_secs(120);
 
 struct GatewayRuntime {
     worker: WorkerManager,
@@ -2137,10 +2136,7 @@ fn worker_webui_route_with_options(
 }
 
 fn worker_webui_route_timeout(input: &WorkerWebuiRouteInput) -> Duration {
-    let path = input.path.split('?').next().unwrap_or(input.path.as_str());
-    if input.method.eq_ignore_ascii_case("POST") && path == "/v1/knowledge/graph/extract" {
-        return WORKER_WEBUI_LONG_ROUTE_TIMEOUT;
-    }
+    let _ = input;
     WORKER_WEBUI_ROUTE_TIMEOUT
 }
 
@@ -3918,7 +3914,7 @@ mod tests {
     }
 
     #[test]
-    fn worker_webui_route_uses_extended_timeout_for_graph_extraction() {
+    fn worker_webui_route_uses_default_timeout_for_graph_extraction_start() {
         assert_eq!(
             worker_webui_route_timeout(&WorkerWebuiRouteInput {
                 method: "POST".to_string(),
@@ -3926,7 +3922,7 @@ mod tests {
                 body: None,
                 headers: None,
             }),
-            Duration::from_secs(120)
+            Duration::from_secs(10)
         );
         assert_eq!(
             worker_webui_route_timeout(&WorkerWebuiRouteInput {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -1686,6 +1686,11 @@ async function handleNativeKnowledgeAction(event: DesktopKnowledgeActionEvent): 
       const operation = buildDesktopKnowledgeTaskOperation(result);
       if (operation) {
         updateNativeKnowledgeTask(operation);
+        const resultRecord = asRecord(result);
+        const jobId = stringValue(resultRecord.job_id || resultRecord.jobId || asRecord(resultRecord.job)?.id);
+        if (jobId) {
+          void pollNativeKnowledgeGraphExtractionJob(jobId, documentId);
+        }
       } else {
         const resultRecord = asRecord(result);
         const skipped = resultRecord.skipped === true;
@@ -2264,6 +2269,36 @@ function updateNativeKnowledgeTask(operation: DesktopTaskSourceOperation): void 
   nativeKnowledgeTaskOperations.set(operation.id, operation);
   logDesktopNativeDebug("task.operation.update", summarizeTaskOperation("knowledge", operation));
   publishNativeTaskCenterItems();
+}
+
+async function pollNativeKnowledgeGraphExtractionJob(jobId: string, selectedDocumentId: string): Promise<void> {
+  for (let attempt = 0; attempt < 1800; attempt += 1) {
+    try {
+      const job = await gatewayApi.knowledge.job(jobId);
+      const operation = buildDesktopKnowledgeTaskOperation(job);
+      if (operation) {
+        updateNativeKnowledgeTask(operation);
+      }
+      const jobRecord = asRecord(job);
+      const status = stringValue(jobRecord.status || asRecord(jobRecord.job)?.status);
+      if (status === "completed" || status === "failed" || status === "cancelled") {
+        const pane = await loadNativeKnowledgePane({
+          queryResultPayload: nativeKnowledgeQueryResult,
+          selectedDocumentId,
+        });
+        setNativeKnowledgePane(pane);
+        return;
+      }
+    } catch (error) {
+      logDesktopNativeDebug("knowledge.graph_extract.poll.failed", {
+        jobId,
+        selectedDocumentId,
+        error: stringifyError(error),
+      });
+    }
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 2000));
+  }
+  logDesktopNativeDebug("knowledge.graph_extract.poll.timeout", { jobId, selectedDocumentId });
 }
 
 function buildDesktopKnowledgeGraphExtractionTaskOperation(input: {

--- a/apps/desktop/src/desktopKnowledgeTraceability.test.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.test.ts
@@ -246,6 +246,9 @@ describe("desktop knowledge and traceability helpers", () => {
           status: "running",
           stage: "llm_extraction",
           message: "Extracting entity graph",
+          llm_output_chars: 128,
+          llm_reasoning_chars: 24,
+          llm_preview: "{\"entities\":[{\"name\":\"TinyBot\"}],\"relations\":[]}",
           progress: {
             stage: "llm_extraction",
             completed: 6,
@@ -315,7 +318,7 @@ describe("desktop knowledge and traceability helpers", () => {
         detail: "Extracting entity graph / llm_extraction / 1 document: 6/8 stages",
         progress: { completed: 6, total: 8 },
         canonical: { module: "knowledge", entityId: "doc-1", href: "/knowledge" },
-        diagnostics: "Architecture.md: llm_extraction, 6/8 stages, 512/1200 tokens, 2/4 chunks",
+        diagnostics: "Architecture.md: llm_extraction, 6/8 stages, 512/1200 tokens, 2/4 chunks\nLLM output: 128 chars; reasoning: 24 chars; preview: {\"entities\":[{\"name\":\"TinyBot\"}],\"relations\":[]}",
         retryable: false,
         updatedAt: "",
       },

--- a/apps/desktop/src/desktopKnowledgeTraceability.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.ts
@@ -710,9 +710,10 @@ export function buildDesktopKnowledgeTaskOperation(payload: unknown): DesktopTas
   const total = optionalNumberValue(progressPayload.total) ?? numberValue(job.total);
   const progressSummary = formatKnowledgeProgressSummary(progressPayload);
   const progressDiagnostics = formatKnowledgeProgressDiagnostics(progressPayload);
+  const llmDiagnostics = formatKnowledgeLlmDiagnostics(job, root);
   const sourceTitle = firstNonEmpty(job.source_title, job.doc_name, job.document_name, root.source_title, root.doc_name, root.document_name, name, docId);
   const sourceDetail = firstNonEmpty(job.source_path, job.path, job.file_path, root.source_path, root.path, root.file_path, stage);
-  const diagnostics = firstNonEmpty(job.error, root.error, progressDiagnostics);
+  const diagnostics = firstNonEmpty(job.error, root.error, joinKnowledgeDiagnostics(progressDiagnostics, llmDiagnostics));
   return {
     id: `knowledge:${id}`,
     title: knowledgeTaskTitle(name),
@@ -757,6 +758,24 @@ export function buildDesktopKnowledgeUploadTaskOperation(fileName: string): Desk
     retryable: false,
     updatedAt: "",
   };
+}
+
+function joinKnowledgeDiagnostics(...items: string[]): string {
+  return items.filter(Boolean).join("\n");
+}
+
+function formatKnowledgeLlmDiagnostics(job: UnknownRecord, root: UnknownRecord): string {
+  const outputChars = optionalNumberValue(job.llm_output_chars ?? job.llmOutputChars ?? root.llm_output_chars ?? root.llmOutputChars);
+  const reasoningChars = optionalNumberValue(job.llm_reasoning_chars ?? job.llmReasoningChars ?? root.llm_reasoning_chars ?? root.llmReasoningChars);
+  const preview = firstNonEmpty(job.llm_preview, job.llmPreview, root.llm_preview, root.llmPreview);
+  if (outputChars === undefined && reasoningChars === undefined && !preview) {
+    return "";
+  }
+  return [
+    `LLM output: ${outputChars ?? 0} chars`,
+    reasoningChars !== undefined ? `reasoning: ${reasoningChars} chars` : "",
+    preview ? `preview: ${preview}` : "",
+  ].filter(Boolean).join("; ");
 }
 
 function normalizeKnowledgeJobPayload(root: UnknownRecord): UnknownRecord {

--- a/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.ts
@@ -18,6 +18,8 @@ export type KnowledgeGraphOpenAiCompatProvider = {
       chatId: string;
       model: string;
       timeoutSeconds: number;
+      onContentDelta?: (delta: string) => void;
+      onReasoningDelta?: (delta: string) => void;
     },
     traceId: string,
   ): Promise<string> | string;
@@ -159,6 +161,8 @@ export async function runKnowledgeGraphExtractionPlan(options: {
   maxTokens: number;
   timeoutSeconds: number;
   traceId: string;
+  onContentDelta?: (delta: string) => void;
+  onReasoningDelta?: (delta: string) => void;
 }): Promise<Record<string, unknown>> {
   const extractionText = await options.openAiCompatProvider.completeChat({
     content: buildKnowledgeGraphExtractionPrompt(options.plan.docName, options.plan.content, options.maxTokens),
@@ -166,6 +170,8 @@ export async function runKnowledgeGraphExtractionPlan(options: {
     chatId: "knowledge-graph-extraction",
     model: options.model,
     timeoutSeconds: options.timeoutSeconds,
+    onContentDelta: options.onContentDelta,
+    onReasoningDelta: options.onReasoningDelta,
   }, options.traceId);
   const extraction = parseKnowledgeGraphExtractionJson(extractionText);
   const savePayload = {

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
@@ -3354,7 +3354,21 @@ export class AgentWorker {
             messages: [{ role: "user", content: chatRequest.content }],
             model: chatRequest.model,
             maxIterations: 20,
-            stream: false,
+            stream: Boolean(chatRequest.onContentDelta || chatRequest.onReasoningDelta),
+            emitEvent: (event) => {
+              if (event.type === "content_delta") {
+                const delta = typeof event.payload.delta === "string" ? event.payload.delta : "";
+                if (delta) {
+                  chatRequest.onContentDelta?.(delta);
+                }
+              }
+              if (event.type === "reasoning_delta") {
+                const delta = typeof event.payload.delta === "string" ? event.payload.delta : "";
+                if (delta) {
+                  chatRequest.onReasoningDelta?.(delta);
+                }
+              }
+            },
             metadata: { channel: "api", chatId: chatRequest.chatId },
           };
           const response = await this.runOpenAiChatSpec({

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
@@ -179,8 +179,9 @@ describe("WebUI knowledge graph extraction routes", () => {
       status: 202,
       body: {
         message: "Knowledge graph extraction started",
-        job_id: expect.stringMatching(/^kjob_extract_graph_/),
+        job_id: "kjob_extract_graph_doc-async",
         job: {
+          id: "kjob_extract_graph_doc-async",
           status: expect.stringMatching(/queued|running/),
           stage: expect.stringMatching(/queued|planning|llm_extraction/),
           doc_id: "doc-async",
@@ -318,6 +319,7 @@ describe("WebUI knowledge graph extraction routes", () => {
       "trace-stream-extract",
     );
     const jobId = String((response.body as Record<string, unknown>).job_id);
+    expect(jobId).toBe("kjob_extract_graph_doc-stream");
 
     await waitForExpectation(async () => {
       const completedJob = await handleWebuiRouteRequest(

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
@@ -11,6 +11,23 @@ import {
   type WebuiSessionProvider,
 } from "./webuiRoutes.ts";
 
+async function waitForExpectation(assertion: () => Promise<void> | void, timeoutMs = 250): Promise<void> {
+  const startedAt = Date.now();
+  let lastError: unknown;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      await assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  if (lastError) {
+    throw lastError;
+  }
+}
+
 describe("WebUI OpenAI-compatible routes", () => {
   test("retries empty chat completions once before returning the Python fallback", async () => {
     const completions: Array<{ content: string; sessionKey: string; traceId: string; timeoutSeconds: number }> = [];
@@ -78,6 +95,264 @@ describe("WebUI OpenAI-compatible routes", () => {
 });
 
 describe("WebUI knowledge graph extraction routes", () => {
+  test("starts manual LLM graph extraction as a background job without waiting for chat completion", async () => {
+    let resolveCompletion: ((value: string) => void) | undefined;
+    const saves: Array<Record<string, unknown>> = [];
+    const configProvider: WebuiConfigProvider = {
+      getConfig: () => ({
+        agents: { defaults: { model: "knowledge-model" } },
+        knowledge: {
+          enabled: true,
+          graph_extraction_enabled: true,
+          graph_extraction_model: "graph-model",
+          graph_extraction_max_tokens: 640,
+        },
+      }),
+      patchConfig: () => ({}),
+    };
+    const openAiCompatProvider: WebuiOpenAiCompatProvider = {
+      completeChat: () => new Promise((resolve) => {
+        resolveCompletion = resolve;
+      }),
+    };
+    const knowledgeProvider: WebuiKnowledgeProvider = {
+      listDocuments: () => ({ documents: [] }),
+      addDocument: () => ({ document: {} }),
+      getDocument: () => ({
+        document: { id: "doc-async", name: "Async.md", chunk_count: 1 },
+        content: "# Async\nTinyBot stores knowledge asynchronously.\n",
+      }),
+      deleteDocument: () => ({ deleted: false }),
+      query: () => ({ results: [] }),
+      stats: () => ({ total_documents: 1, total_chunks: 1, retrieval_ready: true }),
+      saveEntityGraphExtraction: (payload) => {
+        saves.push(payload);
+        return {
+          id: "kjob_extract_graph_doc-async",
+          doc_id: "doc-async",
+          name: "extract_graph:Async.md",
+          status: "completed",
+          stage: "entity_graph_extracted",
+          processed: 1,
+          total: 1,
+          result: { entities: 1, relations: 0, evidence: 1 },
+        };
+      },
+    };
+
+    const responsePromise = handleWebuiRouteRequest(
+      {
+        method: "POST",
+        path: "/v1/knowledge/graph/extract",
+        body: { doc_id: "doc-async" },
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      configProvider,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      openAiCompatProvider,
+      knowledgeProvider,
+      undefined,
+      "trace-async-extract",
+    );
+    const early = await Promise.race([
+      responsePromise.then((response) => ({ kind: "response" as const, response })),
+      new Promise<{ kind: "pending" }>((resolve) => setTimeout(() => resolve({ kind: "pending" }), 25)),
+    ]);
+    if (early.kind === "pending") {
+      resolveCompletion?.(JSON.stringify({ entities: [], relations: [] }));
+      await responsePromise;
+    }
+
+    expect(early.kind).toBe("response");
+    if (early.kind !== "response") {
+      return;
+    }
+    expect(early.response).toMatchObject({
+      status: 202,
+      body: {
+        message: "Knowledge graph extraction started",
+        job_id: expect.stringMatching(/^kjob_extract_graph_/),
+        job: {
+          status: expect.stringMatching(/queued|running/),
+          stage: expect.stringMatching(/queued|planning|llm_extraction/),
+          doc_id: "doc-async",
+        },
+      },
+    });
+    expect(saves).toHaveLength(0);
+
+    const jobId = String((early.response.body as Record<string, unknown>).job_id);
+    const runningJob = await handleWebuiRouteRequest(
+      { method: "GET", path: `/v1/knowledge/jobs/${jobId}` },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      configProvider,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      openAiCompatProvider,
+      knowledgeProvider,
+      undefined,
+      "trace-async-extract",
+    );
+    expect(runningJob.status).toBe(200);
+
+    resolveCompletion?.(JSON.stringify({
+      entities: [{ name: "TinyBot", type: "project", confidence: 0.91, evidence: [{ text: "TinyBot stores knowledge asynchronously." }] }],
+      relations: [],
+    }));
+    await waitForExpectation(async () => {
+      const completedJob = await handleWebuiRouteRequest(
+        { method: "GET", path: `/v1/knowledge/jobs/${jobId}` },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        configProvider,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        openAiCompatProvider,
+        knowledgeProvider,
+        undefined,
+        "trace-async-extract",
+      );
+      expect(completedJob).toMatchObject({
+        status: 200,
+        body: {
+          status: "completed",
+          stage: "completed",
+          result: { entities: 1, relations: 0, evidence: 1 },
+        },
+      });
+    });
+    expect(saves).toHaveLength(1);
+  });
+
+  test("records streamed LLM extraction output details on the background job", async () => {
+    const configProvider: WebuiConfigProvider = {
+      getConfig: () => ({
+        agents: { defaults: { model: "knowledge-model" } },
+        knowledge: {
+          enabled: true,
+          graph_extraction_enabled: true,
+          graph_extraction_model: "graph-model",
+          graph_extraction_max_tokens: 640,
+        },
+      }),
+      patchConfig: () => ({}),
+    };
+    const openAiCompatProvider: WebuiOpenAiCompatProvider = {
+      completeChat: (request) => {
+        const callbacks = request as typeof request & {
+          onContentDelta?: (delta: string) => void;
+          onReasoningDelta?: (delta: string) => void;
+        };
+        callbacks.onReasoningDelta?.("checking graph candidates");
+        callbacks.onContentDelta?.("{\"entities\"");
+        callbacks.onContentDelta?.(":[{\"name\":\"TinyBot\"}],\"relations\":[]}");
+        return JSON.stringify({
+          entities: [{ name: "TinyBot", type: "project", confidence: 0.91 }],
+          relations: [],
+        });
+      },
+    };
+    const knowledgeProvider: WebuiKnowledgeProvider = {
+      listDocuments: () => ({ documents: [] }),
+      addDocument: () => ({ document: {} }),
+      getDocument: () => ({
+        document: { id: "doc-stream", name: "Stream.md", chunk_count: 1 },
+        content: "# Stream\nTinyBot streams graph extraction diagnostics.\n",
+      }),
+      deleteDocument: () => ({ deleted: false }),
+      query: () => ({ results: [] }),
+      stats: () => ({ total_documents: 1, total_chunks: 1, retrieval_ready: true }),
+      saveEntityGraphExtraction: () => ({
+        id: "kjob_extract_graph_doc-stream",
+        doc_id: "doc-stream",
+        name: "extract_graph:Stream.md",
+        status: "completed",
+        stage: "entity_graph_extracted",
+        processed: 1,
+        total: 1,
+        result: { entities: 1, relations: 0, evidence: 0 },
+      }),
+    };
+
+    const response = await handleWebuiRouteRequest(
+      {
+        method: "POST",
+        path: "/v1/knowledge/graph/extract",
+        body: { doc_id: "doc-stream" },
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      configProvider,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      openAiCompatProvider,
+      knowledgeProvider,
+      undefined,
+      "trace-stream-extract",
+    );
+    const jobId = String((response.body as Record<string, unknown>).job_id);
+
+    await waitForExpectation(async () => {
+      const completedJob = await handleWebuiRouteRequest(
+        { method: "GET", path: `/v1/knowledge/jobs/${jobId}` },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        configProvider,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        openAiCompatProvider,
+        knowledgeProvider,
+        undefined,
+        "trace-stream-extract",
+      );
+      expect(completedJob).toMatchObject({
+        status: 200,
+        body: {
+          status: "completed",
+          llm_output_chars: expect.any(Number),
+          llm_preview: expect.stringContaining("\"entities\""),
+          llm_reasoning_chars: expect.any(Number),
+          stage_details: expect.arrayContaining([
+            expect.objectContaining({ stage: "llm_delta", doc_id: "doc-stream" }),
+          ]),
+        },
+      });
+    });
+  });
+
   test("estimates and persists manual LLM graph extraction", async () => {
     const completions: Array<{ content: string; sessionKey: string; model: string; timeoutSeconds: number }> = [];
     const saves: Array<Record<string, unknown>> = [];
@@ -216,30 +491,33 @@ describe("WebUI knowledge graph extraction routes", () => {
     expect(extraction).toMatchObject({
       status: 202,
       body: {
-        message: "Knowledge graph extraction completed",
-        job_id: "kjob_extract_graph_doc-1",
+        message: "Knowledge graph extraction started",
+        job_id: expect.stringMatching(/^kjob_extract_graph_/),
         job: {
-          id: "kjob_extract_graph_doc-1",
-          stage: "entity_graph_extracted",
+          id: expect.stringMatching(/^kjob_extract_graph_/),
+          doc_id: "doc-1",
+          stage: expect.stringMatching(/queued|llm_extraction/),
           progress: {
-            stage: "completed",
-            completed: 8,
+            stage: "running",
+            completed: 5,
             total: 8,
             documents: [
               {
                 doc_id: "doc-1",
-                status: "completed",
-                stage: "persisted_entity_graph",
-                completed: 8,
+                status: "running",
+                stage: "budget_checked",
+                completed: 5,
                 total: 8,
               },
             ],
           },
-          result: { entities: 1, relations: 1, evidence: 2 },
         },
       },
     });
-    expect(completions).toHaveLength(1);
+    await waitForExpectation(() => {
+      expect(completions).toHaveLength(1);
+      expect(saves).toHaveLength(1);
+    });
     expect(completions[0]).toMatchObject({
       sessionKey: "knowledge:graph-extraction",
       model: "graph-model",
@@ -462,28 +740,28 @@ describe("WebUI knowledge graph extraction routes", () => {
     expect(extraction).toMatchObject({
       status: 202,
       body: {
-        message: "Knowledge graph extraction completed",
+        message: "Knowledge graph extraction started",
         document_count: 2,
-        jobs: [
-          { id: "kjob_extract_graph_doc-1", doc_id: "doc-1", progress: { completed: 8, total: 8 } },
-          { id: "kjob_extract_graph_doc-2", doc_id: "doc-2", progress: { completed: 8, total: 8 } },
-        ],
+        runnable_document_count: 2,
+        job_id: expect.stringMatching(/^kjob_extract_graph_/),
         progress: {
-          stage: "completed",
-          completed: 16,
-          total: 16,
+          stage: "running",
+          completed: 5,
+          total: 8,
           documents: [
-            { doc_id: "doc-1", status: "completed", completed: 8, total: 8 },
-            { doc_id: "doc-2", status: "completed", completed: 8, total: 8 },
+            { doc_id: "doc-1", status: "running", completed: 5, total: 8 },
+            { doc_id: "doc-2", status: "running", completed: 5, total: 8 },
           ],
         },
       },
     });
-    expect(completions).toHaveLength(2);
+    await waitForExpectation(() => {
+      expect(completions).toHaveLength(2);
+      expect(saves).toHaveLength(2);
+    });
     expect(completions[0].content).toContain("# One");
     expect(completions[0].content).toContain("first chunk");
     expect(completions[0].content).not.toContain("third chunk");
-    expect(saves).toHaveLength(2);
     expect(saves[0]).toMatchObject({
       doc_id: "doc-1",
       extraction_scope: { max_chunks: 2, chunk_count: 2, original_chunk_count: 4 },
@@ -727,7 +1005,9 @@ describe("WebUI knowledge graph extraction routes", () => {
         runnable_document_count: 2,
       },
     });
-    expect(completions).toBe(2);
+    await waitForExpectation(() => {
+      expect(completions).toBe(2);
+    });
   });
 
   test("honors graph extraction concurrency for batch LLM calls", async () => {
@@ -807,10 +1087,13 @@ describe("WebUI knowledge graph extraction routes", () => {
       status: 202,
       body: {
         document_count: 3,
-        job_ids: ["kjob_extract_graph_doc-1", "kjob_extract_graph_doc-2", "kjob_extract_graph_doc-3"],
+        runnable_document_count: 3,
+        job_id: expect.stringMatching(/^kjob_extract_graph_/),
       },
     });
-    expect(maxActiveCompletions).toBe(2);
+    await waitForExpectation(() => {
+      expect(maxActiveCompletions).toBe(2);
+    });
   });
 
   test("skips existing entity graph extraction unless force is requested", async () => {
@@ -964,11 +1247,13 @@ describe("WebUI knowledge graph extraction routes", () => {
     expect(forced).toMatchObject({
       status: 202,
       body: {
-        job_id: "kjob_extract_graph_doc-1",
+        job_id: expect.stringMatching(/^kjob_extract_graph_/),
       },
     });
-    expect(completions).toBe(1);
-    expect(saves).toHaveLength(1);
+    await waitForExpectation(() => {
+      expect(completions).toBe(1);
+      expect(saves).toHaveLength(1);
+    });
   });
 
   test("re-extracts existing entity graphs when the native graph is stale", async () => {
@@ -1056,11 +1341,13 @@ describe("WebUI knowledge graph extraction routes", () => {
     expect(extraction).toMatchObject({
       status: 202,
       body: {
-        job_id: "kjob_extract_graph_doc-1",
+        job_id: expect.stringMatching(/^kjob_extract_graph_/),
       },
     });
-    expect(completions).toBe(1);
-    expect(saves).toHaveLength(1);
+    await waitForExpectation(() => {
+      expect(completions).toBe(1);
+      expect(saves).toHaveLength(1);
+    });
   });
 });
 
@@ -1506,13 +1793,15 @@ describe("WebUI knowledge diagnostics", () => {
       body: {
         id: "doc-1",
         graph_extraction_job: {
-          id: "kjob_extract_graph_doc-1",
+          id: expect.stringMatching(/^kjob_extract_graph_/),
           doc_id: "doc-1",
-          stage: "entity_graph_extracted",
+          stage: expect.stringMatching(/queued|llm_extraction/),
         },
       },
     });
-    expect(saves).toHaveLength(1);
+    await waitForExpectation(() => {
+      expect(saves).toHaveLength(1);
+    });
     expect(saves[0]).toMatchObject({ doc_id: "doc-1", doc_name: "RAG.md" });
   });
 

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
@@ -10,6 +10,8 @@ import {
   buildKnowledgeGraphExtractionPlan,
   buildKnowledgeGraphSingleEstimateBody,
   findExistingKnowledgeGraphExtractionSkips,
+  type KnowledgeGraphExtractionPlan,
+  type KnowledgeGraphSkippedDoc,
   resolveKnowledgeGraphExtractionDocIds,
   runKnowledgeGraphExtractionPlan,
   runKnowledgeGraphExtractionPlans,
@@ -289,6 +291,36 @@ export type WebuiKnowledgeListRequest = {
 
 type KnowledgeRebuildType = "bm25" | "semantic" | "tree" | "all";
 
+type KnowledgeGraphExtractionJob = {
+  id: string;
+  doc_id: string;
+  name: string;
+  status: "queued" | "running" | "completed" | "failed";
+  stage: string;
+  message: string;
+  processed: number;
+  total: number;
+  error: string;
+  created_at: string;
+  updated_at: string;
+  completed_at: string;
+  stage_details?: Record<string, unknown>[];
+  llm_preview?: string;
+  llm_output_chars?: number;
+  llm_reasoning_chars?: number;
+  last_llm_delta_at?: string;
+  progress?: Record<string, unknown>;
+  result?: unknown;
+  jobs?: Record<string, unknown>[];
+  job_ids?: unknown[];
+  skipped_docs?: KnowledgeGraphSkippedDoc[];
+};
+
+const knowledgeGraphExtractionJobs = new Map<string, KnowledgeGraphExtractionJob>();
+let knowledgeGraphExtractionJobCounter = 0;
+const KNOWLEDGE_GRAPH_LLM_PREVIEW_LIMIT = 4096;
+const KNOWLEDGE_GRAPH_STAGE_DETAILS_LIMIT = 24;
+
 export type WebuiKnowledgeProvider = {
   listDocuments(
     request: WebuiKnowledgeListRequest,
@@ -317,6 +349,8 @@ export type WebuiOpenAiChatRequest = {
   chatId: string;
   model: string;
   timeoutSeconds: number;
+  onContentDelta?: (delta: string) => void;
+  onReasoningDelta?: (delta: string) => void;
 };
 
 export type WebuiOpenAiCompatProvider = {
@@ -1399,6 +1433,10 @@ async function knowledgeJobResponse(
   provider: WebuiKnowledgeProvider | undefined,
   traceId: string,
 ): Promise<WebuiRouteResponse> {
+  const localJob = knowledgeGraphExtractionJobSnapshot(jobId);
+  if (localJob) {
+    return { status: 200, body: localJob };
+  }
   if (!provider) {
     return { status: 503, body: knowledgeApiError(503, "Knowledge store not initialized") };
   }
@@ -1641,70 +1679,31 @@ async function knowledgeGraphExtractResponse(
     if (!areKnowledgeGraphPlansWithinJobBudget(runnablePlans, maxJobTokens)) {
       return { status: 400, body: knowledgeApiError(400, "Graph extraction token estimate exceeds configured job budget") };
     }
-    const jobs: Record<string, unknown>[] = await runKnowledgeGraphExtractionPlans(
+    const job = createKnowledgeGraphExtractionJob(plans, runnablePlans, skippedDocs);
+    void runKnowledgeGraphExtractionJob({
+      jobId: job.id,
+      plans,
       runnablePlans,
-      knowledgeGraphExtractionConcurrency(config),
-      async (plan) => runKnowledgeGraphExtractionPlan({
-        plan,
-        provider,
-        openAiCompatProvider,
-        model,
-        maxTokens,
-        timeoutSeconds: knowledgeSemanticTimeoutSeconds(config),
-        traceId,
-      }),
-    );
-    const completedProgress = buildKnowledgeGraphExtractionProgress(plans, skippedDocs, "completed", jobs);
-    const progressByDocId = new Map(
-      (Array.isArray(completedProgress.documents) ? completedProgress.documents : [])
-        .map((item) => asObject(item))
-        .filter((item): item is Record<string, unknown> => Boolean(item?.doc_id))
-        .map((item) => [String(item.doc_id), item]),
-    );
-    const jobsWithProgress: Record<string, unknown>[] = jobs.map((job, index) => {
-      const docId = stringValue(job.doc_id) ?? runnablePlans[index]?.docId;
-      const documentProgress = docId ? progressByDocId.get(docId) : undefined;
-      return {
-        ...job,
-        ...(documentProgress
-          ? {
-            progress: {
-              stage: completedProgress.stage,
-              completed: documentProgress.completed,
-              total: documentProgress.total,
-              documents: [documentProgress],
-            },
-          }
-          : {}),
-      };
+      skippedDocs,
+      provider,
+      openAiCompatProvider,
+      model,
+      maxTokens,
+      concurrency: knowledgeGraphExtractionConcurrency(config),
+      timeoutSeconds: knowledgeSemanticTimeoutSeconds(config),
+      traceId,
+      diagnosticsLogger,
     });
-    logKnowledgeDiagnostic(diagnosticsLogger, traceId, "knowledge.graph_extract.complete", {
-      document_count: runnablePlans.length,
-      job_count: jobs.length,
-      skipped_count: skippedDocs.length,
-    });
-    if (jobs.length === 1 && skippedDocs.length === 0) {
-      const job = jobsWithProgress[0] ?? {};
-      return {
-        status: 202,
-        body: {
-          message: "Knowledge graph extraction completed",
-          job,
-          job_id: job["id"],
-          progress: completedProgress,
-        },
-      };
-    }
     return {
       status: 202,
       body: {
-        message: "Knowledge graph extraction completed",
+        message: "Knowledge graph extraction started",
         document_count: plans.length,
-        runnable_document_count: jobsWithProgress.length,
+        runnable_document_count: runnablePlans.length,
         skipped_count: skippedDocs.length,
-        jobs: jobsWithProgress,
-        job_ids: jobsWithProgress.map((job) => job["id"]).filter(Boolean),
-        progress: completedProgress,
+        job: knowledgeGraphExtractionJobSnapshot(job.id),
+        job_id: job.id,
+        progress: job.progress,
         ...(skippedDocs.length ? { skipped_docs: skippedDocs } : {}),
       },
     };
@@ -1715,6 +1714,255 @@ async function knowledgeGraphExtractResponse(
     });
     return knowledgeValueError(error) ?? knowledgeServerError("Error extracting knowledge graph", error);
   }
+}
+
+function createKnowledgeGraphExtractionJob(
+  plans: KnowledgeGraphExtractionPlan[],
+  runnablePlans: KnowledgeGraphExtractionPlan[],
+  skippedDocs: KnowledgeGraphSkippedDoc[],
+): KnowledgeGraphExtractionJob {
+  knowledgeGraphExtractionJobCounter += 1;
+  const primaryPlan = runnablePlans[0] ?? plans[0];
+  const timestamp = nowIsoString();
+  const jobId = `kjob_extract_graph_${Date.now().toString(36)}_${knowledgeGraphExtractionJobCounter.toString(36)}`;
+  const job: KnowledgeGraphExtractionJob = {
+    id: jobId,
+    doc_id: primaryPlan?.docId ?? "",
+    name: runnablePlans.length === 1 && primaryPlan
+      ? `extract_graph:${primaryPlan.docName}`
+      : `extract_graph:${runnablePlans.length}_documents`,
+    status: "queued",
+    stage: "queued",
+    message: "Queued for knowledge graph extraction",
+    processed: 0,
+    total: Math.max(1, runnablePlans.length * 8),
+    error: "",
+    created_at: timestamp,
+    updated_at: timestamp,
+    completed_at: "",
+    stage_details: [{
+      stage: "queued",
+      message: "Queued for knowledge graph extraction",
+      updated_at: timestamp,
+    }],
+    progress: buildKnowledgeGraphExtractionProgress(plans, skippedDocs, "running"),
+    ...(skippedDocs.length ? { skipped_docs: skippedDocs } : {}),
+  };
+  knowledgeGraphExtractionJobs.set(job.id, job);
+  return job;
+}
+
+async function runKnowledgeGraphExtractionJob(options: {
+  jobId: string;
+  plans: KnowledgeGraphExtractionPlan[];
+  runnablePlans: KnowledgeGraphExtractionPlan[];
+  skippedDocs: KnowledgeGraphSkippedDoc[];
+  provider: WebuiKnowledgeProvider;
+  openAiCompatProvider: WebuiOpenAiCompatProvider;
+  model: string;
+  maxTokens: number;
+  concurrency: number;
+  timeoutSeconds: number;
+  traceId: string;
+  diagnosticsLogger?: WebuiDiagnosticsLogger;
+}): Promise<void> {
+  const startedAt = Date.now();
+  updateKnowledgeGraphExtractionJob(options.jobId, {
+    status: "running",
+    stage: "llm_extraction",
+    message: "Extracting entity graph with LLM",
+    processed: 0,
+    progress: buildKnowledgeGraphExtractionProgress(options.plans, options.skippedDocs, "running"),
+    stage_details: appendKnowledgeGraphStageDetail(
+      knowledgeGraphExtractionJobs.get(options.jobId)?.stage_details,
+      { stage: "llm_extraction", message: "Starting LLM extraction", updated_at: nowIsoString() },
+    ),
+  });
+  const heartbeat = setInterval(() => {
+    const current = knowledgeGraphExtractionJobs.get(options.jobId);
+    if (!current || current.status !== "running") {
+      return;
+    }
+    const elapsedSeconds = Math.max(1, Math.round((Date.now() - startedAt) / 1000));
+    updateKnowledgeGraphExtractionJob(options.jobId, {
+      message: `Waiting for LLM response (${elapsedSeconds}s elapsed)`,
+      stage_details: appendKnowledgeGraphStageDetail(current.stage_details, {
+        stage: "llm_waiting",
+        message: `Waiting for LLM response (${elapsedSeconds}s elapsed)`,
+        elapsed_seconds: elapsedSeconds,
+        updated_at: nowIsoString(),
+      }),
+    });
+  }, 5000);
+  try {
+    const jobs: Record<string, unknown>[] = await runKnowledgeGraphExtractionPlans(
+      options.runnablePlans,
+      options.concurrency,
+      async (plan) => runKnowledgeGraphExtractionPlan({
+        plan,
+        provider: options.provider,
+        openAiCompatProvider: options.openAiCompatProvider,
+        model: options.model,
+        maxTokens: options.maxTokens,
+        timeoutSeconds: options.timeoutSeconds,
+        traceId: options.traceId,
+        onContentDelta: (delta) => recordKnowledgeGraphLlmDelta(options.jobId, plan, "content", delta),
+        onReasoningDelta: (delta) => recordKnowledgeGraphLlmDelta(options.jobId, plan, "reasoning", delta),
+      }),
+    );
+    const completedProgress = buildKnowledgeGraphExtractionProgress(options.plans, options.skippedDocs, "completed", jobs);
+    const jobsWithProgress = knowledgeGraphExtractionJobsWithProgress(jobs, options.runnablePlans, completedProgress);
+    const result = jobsWithProgress.length === 1
+      ? asObject(jobsWithProgress[0]?.result) ?? asObject(jobsWithProgress[0]) ?? {}
+      : {
+        document_count: options.plans.length,
+        runnable_document_count: jobsWithProgress.length,
+        skipped_count: options.skippedDocs.length,
+      };
+    updateKnowledgeGraphExtractionJob(options.jobId, {
+      status: "completed",
+      stage: "completed",
+      message: "Knowledge graph extraction completed",
+      processed: Math.max(1, options.runnablePlans.length * 8),
+      total: Math.max(1, options.runnablePlans.length * 8),
+      completed_at: nowIsoString(),
+      progress: completedProgress,
+      result,
+      jobs: jobsWithProgress,
+      job_ids: jobsWithProgress.map((job) => job["id"]).filter(Boolean),
+    });
+    logKnowledgeDiagnostic(options.diagnosticsLogger, options.traceId, "knowledge.graph_extract.complete", {
+      document_count: options.runnablePlans.length,
+      job_count: jobs.length,
+      skipped_count: options.skippedDocs.length,
+    });
+  } catch (error) {
+    updateKnowledgeGraphExtractionJob(options.jobId, {
+      status: "failed",
+      stage: "failed",
+      message: "Knowledge graph extraction failed",
+      error: errorMessage(error),
+      completed_at: nowIsoString(),
+    });
+    logKnowledgeDiagnostic(options.diagnosticsLogger, options.traceId, "knowledge.graph_extract.failed", {
+      doc_id: options.runnablePlans[0]?.docId ?? "",
+      error: errorMessage(error),
+    });
+  } finally {
+    clearInterval(heartbeat);
+  }
+}
+
+function knowledgeGraphExtractionJobsWithProgress(
+  jobs: Record<string, unknown>[],
+  runnablePlans: KnowledgeGraphExtractionPlan[],
+  completedProgress: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const progressByDocId = new Map(
+    (Array.isArray(completedProgress.documents) ? completedProgress.documents : [])
+      .map((item) => asObject(item))
+      .filter((item): item is Record<string, unknown> => Boolean(item?.doc_id))
+      .map((item) => [String(item.doc_id), item]),
+  );
+  return jobs.map((job, index) => {
+    const docId = stringValue(job.doc_id) ?? runnablePlans[index]?.docId;
+    const documentProgress = docId ? progressByDocId.get(docId) : undefined;
+    return {
+      ...job,
+      ...(documentProgress
+        ? {
+          progress: {
+            stage: completedProgress.stage,
+            completed: documentProgress.completed,
+            total: documentProgress.total,
+            documents: [documentProgress],
+          },
+        }
+        : {}),
+    };
+  });
+}
+
+function recordKnowledgeGraphLlmDelta(
+  jobId: string,
+  plan: KnowledgeGraphExtractionPlan,
+  kind: "content" | "reasoning",
+  delta: string,
+): void {
+  if (!delta) {
+    return;
+  }
+  const current = knowledgeGraphExtractionJobs.get(jobId);
+  if (!current) {
+    return;
+  }
+  const timestamp = nowIsoString();
+  const outputChars = (current.llm_output_chars ?? 0) + (kind === "content" ? delta.length : 0);
+  const reasoningChars = (current.llm_reasoning_chars ?? 0) + (kind === "reasoning" ? delta.length : 0);
+  const preview = kind === "content"
+    ? trimKnowledgeGraphLlmPreview(`${current.llm_preview ?? ""}${delta}`)
+    : current.llm_preview;
+  updateKnowledgeGraphExtractionJob(jobId, {
+    status: "running",
+    stage: "llm_extraction",
+    message: kind === "content"
+      ? `Receiving LLM graph JSON (${outputChars} chars)`
+      : `Receiving LLM reasoning (${reasoningChars} chars)`,
+    llm_output_chars: outputChars,
+    llm_reasoning_chars: reasoningChars,
+    last_llm_delta_at: timestamp,
+    ...(preview !== undefined ? { llm_preview: preview } : {}),
+    stage_details: appendKnowledgeGraphStageDetail(current.stage_details, {
+      stage: "llm_delta",
+      kind,
+      doc_id: plan.docId,
+      doc_name: plan.docName,
+      delta_chars: delta.length,
+      output_chars: outputChars,
+      reasoning_chars: reasoningChars,
+      preview: kind === "content" ? trimKnowledgeGraphLlmPreview(delta) : undefined,
+      updated_at: timestamp,
+    }),
+  });
+}
+
+function appendKnowledgeGraphStageDetail(
+  details: Record<string, unknown>[] | undefined,
+  detail: Record<string, unknown>,
+): Record<string, unknown>[] {
+  return [...(details ?? []), compactKnowledgeGraphStageDetail(detail)]
+    .slice(-KNOWLEDGE_GRAPH_STAGE_DETAILS_LIMIT);
+}
+
+function compactKnowledgeGraphStageDetail(detail: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(detail).filter(([, value]) => value !== undefined));
+}
+
+function trimKnowledgeGraphLlmPreview(value: string): string {
+  return value.length <= KNOWLEDGE_GRAPH_LLM_PREVIEW_LIMIT
+    ? value
+    : value.slice(value.length - KNOWLEDGE_GRAPH_LLM_PREVIEW_LIMIT);
+}
+
+function updateKnowledgeGraphExtractionJob(jobId: string, patch: Partial<KnowledgeGraphExtractionJob>): void {
+  const current = knowledgeGraphExtractionJobs.get(jobId);
+  if (!current) {
+    return;
+  }
+  knowledgeGraphExtractionJobs.set(jobId, {
+    ...current,
+    ...patch,
+    updated_at: nowIsoString(),
+  });
+}
+
+function knowledgeGraphExtractionJobSnapshot(jobId: string): Record<string, unknown> | undefined {
+  const job = knowledgeGraphExtractionJobs.get(jobId);
+  return job ? { ...job } : undefined;
+}
+
+function nowIsoString(): string {
+  return new Date().toISOString();
 }
 
 async function knowledgeGraphResponse(

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
@@ -1724,7 +1724,9 @@ function createKnowledgeGraphExtractionJob(
   knowledgeGraphExtractionJobCounter += 1;
   const primaryPlan = runnablePlans[0] ?? plans[0];
   const timestamp = nowIsoString();
-  const jobId = `kjob_extract_graph_${Date.now().toString(36)}_${knowledgeGraphExtractionJobCounter.toString(36)}`;
+  const jobId = runnablePlans.length === 1 && primaryPlan?.docId
+    ? `kjob_extract_graph_${primaryPlan.docId}`
+    : `kjob_extract_graph_${Date.now().toString(36)}_${knowledgeGraphExtractionJobCounter.toString(36)}`;
   const job: KnowledgeGraphExtractionJob = {
     id: jobId,
     doc_id: primaryPlan?.docId ?? "",


### PR DESCRIPTION
﻿## Summary
- run native WebUI graph extraction as a background job instead of waiting for the LLM request in the route
- stream graph extraction LLM deltas into the job snapshot as preview, output counts, reasoning counts, and stage details
- poll graph extraction jobs from the desktop task center and surface LLM diagnostics in task output

## Root cause
The native route timeout was only a symptom. Graph extraction had moved to a background job, but the LLM call still waited for the final chat response without intermediate job updates, so the UI looked stuck until the LLM timeout fired.

## Validation
- `npm test -- workers/ts-agent-worker/src/webui/webuiRoutes.test.ts src/desktopKnowledgeTraceability.test.ts src/gateway.test.ts workers/ts-agent-worker/src/knowledge/knowledgeGraphExtraction.test.ts`
- `cargo test worker_webui_route --lib`
- `git diff --check -- <changed files>`
- `npm run build`
