### PR TITLE
fix: clarify unconfigured GraphRAG report hint

### DIFF
--- a/apps/desktop/src/desktopKnowledgeTraceability.test.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.test.ts
@@ -200,6 +200,28 @@ describe("desktop knowledge and traceability helpers", () => {
     expect(pane.configHints).not.toContain("GraphRAG reports use deterministic summaries");
   });
 
+  test("reads canonical GraphRAG enabled config key when building report hints", () => {
+    const pane = buildDesktopKnowledgePaneModel({
+      statsPayload: {
+        total_documents: 1,
+        total_chunks: 12,
+        retrieval_ready: true,
+      },
+      config: {
+        knowledge: {
+          enabled: true,
+          retrieval_mode: "hybrid",
+          max_chunks: 5,
+          graphragEnabled: false,
+          graphrag_report_llm_enabled: false,
+        },
+      },
+    });
+
+    expect(pane.configHints).toContain("GraphRAG reports not configured");
+    expect(pane.configHints).not.toContain("GraphRAG reports use deterministic summaries");
+  });
+
   test("normalizes root WebUI list envelopes for native knowledge documents", () => {
     expect(
       buildDesktopKnowledgeDocumentRows({

--- a/apps/desktop/src/desktopKnowledgeTraceability.test.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.test.ts
@@ -172,6 +172,34 @@ describe("desktop knowledge and traceability helpers", () => {
     });
   });
 
+  test("does not advertise deterministic GraphRAG reports when report projection is not configured", () => {
+    const pane = buildDesktopKnowledgePaneModel({
+      statsPayload: {
+        total_documents: 1,
+        total_chunks: 135,
+        retrieval_ready: true,
+        stage_readiness: {
+          sparse_indexing: { status: "ready", ready: true, processed: 135, total: 135 },
+          claim_extraction: { status: "not_configured", ready: false, processed: 0, total: 0, skipped: 135 },
+          relation_extraction: { status: "not_configured", ready: false, processed: 0, total: 0, skipped: 135 },
+          graph_projection: { status: "not_configured", ready: false, processed: 0, total: 0, skipped: 135 },
+          community_report_projection: { status: "not_configured", ready: false, processed: 0, total: 0, skipped: 135 },
+        },
+      },
+      config: {
+        knowledge: {
+          enabled: true,
+          retrieval_mode: "hybrid",
+          max_chunks: 5,
+          graphrag_report_llm_enabled: false,
+        },
+      },
+    });
+
+    expect(pane.configHints).toContain("GraphRAG reports not configured");
+    expect(pane.configHints).not.toContain("GraphRAG reports use deterministic summaries");
+  });
+
   test("normalizes root WebUI list envelopes for native knowledge documents", () => {
     expect(
       buildDesktopKnowledgeDocumentRows({

--- a/apps/desktop/src/desktopKnowledgeTraceability.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.ts
@@ -244,17 +244,24 @@ function normalizeKnowledgeQueryDraft(input: Partial<DesktopKnowledgeQueryReques
   };
 }
 
-function buildKnowledgeConfigHints(configInput: unknown): string[] {
+function buildKnowledgeConfigHints(configInput: unknown, statsInput: unknown = {}): string[] {
   const knowledge = asRecord(asRecord(configInput).knowledge);
   const enabled = knowledge.enabled !== false;
   const retrievalMode = firstNonEmpty(knowledge.retrieval_mode, knowledge.retrievalMode, "hybrid");
   const maxChunks = numberValue(knowledge.max_chunks ?? knowledge.maxChunks) || 5;
+  const graphRagEnabled = knowledge.graphrag_enabled !== false && knowledge.graphRagEnabled !== false;
   const reportLlm = knowledge.graphrag_report_llm_enabled === true || knowledge.graphRagReportLlmEnabled === true;
+  const reportStages = summarizeStages(asRecord(statsInput), ["community_report_projection"]);
+  const reportHint = !graphRagEnabled || reportStages.status === "not_configured"
+    ? "GraphRAG reports not configured"
+    : reportLlm
+      ? "GraphRAG reports use LLM summaries"
+      : "GraphRAG reports use deterministic summaries";
   return [
     enabled ? "Knowledge enabled" : "Knowledge disabled",
     `Retrieval ${retrievalMode}`,
     `Max chunks ${maxChunks}`,
-    reportLlm ? "GraphRAG reports use LLM summaries" : "GraphRAG reports use deterministic summaries",
+    reportHint,
   ];
 }
 
@@ -551,7 +558,7 @@ export function buildDesktopKnowledgePaneModel(input: DesktopKnowledgePaneInput 
     status: `${documentRows.length} ${documentRows.length === 1 ? "doc" : "docs"} / readiness ${readiness.score}% / graph ${graphView.nodes.length} nodes / ${graphView.edges.length} ${edgeLabel}`,
     lastIndexedLabel: knowledgeLastIndexedLabel(input.statsPayload, documentRows),
     readiness,
-    configHints: buildKnowledgeConfigHints(input.config),
+    configHints: buildKnowledgeConfigHints(input.config, input.statsPayload),
     documentRows,
     selectedDocument: selectedDocumentRow
       ? {

--- a/apps/desktop/src/desktopKnowledgeTraceability.ts
+++ b/apps/desktop/src/desktopKnowledgeTraceability.ts
@@ -249,7 +249,9 @@ function buildKnowledgeConfigHints(configInput: unknown, statsInput: unknown = {
   const enabled = knowledge.enabled !== false;
   const retrievalMode = firstNonEmpty(knowledge.retrieval_mode, knowledge.retrievalMode, "hybrid");
   const maxChunks = numberValue(knowledge.max_chunks ?? knowledge.maxChunks) || 5;
-  const graphRagEnabled = knowledge.graphrag_enabled !== false && knowledge.graphRagEnabled !== false;
+  const graphRagEnabled = knowledge.graphrag_enabled !== false
+    && knowledge.graphragEnabled !== false
+    && knowledge.graphRagEnabled !== false;
   const reportLlm = knowledge.graphrag_report_llm_enabled === true || knowledge.graphRagReportLlmEnabled === true;
   const reportStages = summarizeStages(asRecord(statsInput), ["community_report_projection"]);
   const reportHint = !graphRagEnabled || reportStages.status === "not_configured"


### PR DESCRIPTION
## Summary
- show `GraphRAG reports not configured` when report projection is not configured
- keep deterministic/LLM summary hints for configured report stages
- add regression coverage for the readiness state from #260

Fixes #260

## Validation
- `npm test -- src/desktopKnowledgeTraceability.test.ts`
- `npm run typecheck:worker`
- `npm run build`
- `git diff --check -- apps/desktop/src/desktopKnowledgeTraceability.ts apps/desktop/src/desktopKnowledgeTraceability.test.ts`