### PR TITLE
Refresh desktop backend log status

### DIFF
--- a/apps/desktop/scripts/verify-ts-worker-runtime.mjs
+++ b/apps/desktop/scripts/verify-ts-worker-runtime.mjs
@@ -7,6 +7,7 @@ const sourceRoot = path.join(workerRoot, "src");
 const importPattern = /(?:import|export)\s+(?:[^'"]*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const parameterPropertyPattern = /constructor\s*\([^)]*\b(?:public|private|protected|readonly)\s+\w+/gs;
 const allowedImportExtensions = /\.(ts|js|json|node)$/;
+const workerReadyTimeoutMs = 15_000;
 
 const sourceFiles = await collectRuntimeSourceFiles(sourceRoot);
 const issues = [];
@@ -69,8 +70,8 @@ function verifyWorkerStarts() {
     let stderr = "";
     const timer = setTimeout(() => {
       child.kill();
-      reject(new Error(`ts-agent-worker did not report ready within 5000ms\nstdout:\n${stdout}\nstderr:\n${stderr}`));
-    }, 5000);
+      reject(new Error(`ts-agent-worker did not report ready within ${workerReadyTimeoutMs}ms\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    }, workerReadyTimeoutMs);
     child.stdout.on("data", (chunk) => {
       stdout += chunk.toString();
     });

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -39,8 +39,7 @@ pub mod worker_workspace;
 use crate::config_store::{ConfigPatchApplyResult, ConfigPatchBridgeResult, ConfigStore};
 use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
 use crate::worker_manager::{
-    WorkerCommandSpec, WorkerManager, WorkerManagerError, WorkerManagerEvent, WorkerManagerState,
-    WorkerManagerStatus,
+    WorkerCommandSpec, WorkerManager, WorkerManagerEvent, WorkerManagerState, WorkerManagerStatus,
 };
 use crate::worker_protocol::WorkerRequest;
 use crate::worker_rpc::WorkerRpcRouter;
@@ -845,47 +844,32 @@ fn apply_config_patch_result(
 
 #[tauri::command]
 fn start_gateway(state: State<'_, SharedGateway>) -> Result<GatewayRuntimeStatus, String> {
-    match gateway_bootstrap_probe() {
-        GatewayBootstrapProbe::Ready => {
-            push_log(
-                state.inner(),
-                "gateway already reachable; treating process as external",
-            );
-            return Ok(current_status(state.inner()));
-        }
-        GatewayBootstrapProbe::Incompatible { detail } => {
-            push_log(state.inner(), &detail);
-            return Ok(current_status(state.inner()));
-        }
-        GatewayBootstrapProbe::BootstrapError { detail, .. } => {
-            push_log(state.inner(), &detail);
-            return Ok(current_status(state.inner()));
-        }
-        GatewayBootstrapProbe::Offline(_) => {}
-    }
-
     let repo_root = repo_root();
     let worker = {
         let runtime = lock_runtime(state.inner());
-        runtime.worker.clone()
+        runtime.experimental_worker.clone()
     };
-    match worker.start(gateway_worker_command_spec()) {
+    match ensure_ts_agent_worker_running(
+        &worker,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+    ) {
         Ok(()) => {
             let mut runtime = lock_runtime(state.inner());
             runtime.last_error = None;
             append_log(
                 &mut runtime,
-                "started shell-owned gateway with `uv run tinybot gateway`",
+                "started native TS backend with `node workers/ts-agent-worker/src/index.ts`",
             );
         }
-        Err(WorkerManagerError::AlreadyRunning) => {
+        Err(error) if error.contains("AlreadyRunning") => {
             push_log(
                 state.inner(),
-                "shell-owned gateway worker is already running",
+                "native TS backend worker is already running",
             );
         }
         Err(error) => {
-            let message = format!("failed to start gateway: {error:?}");
+            let message = format!("failed to start native TS backend: {error}");
             let mut runtime = lock_runtime(state.inner());
             runtime.last_error = Some(message.clone());
             return Err(message);
@@ -896,7 +880,7 @@ fn start_gateway(state: State<'_, SharedGateway>) -> Result<GatewayRuntimeStatus
         let mut runtime = lock_runtime(state.inner());
         append_log(
             &mut runtime,
-            &format!("gateway worker cwd: {}", repo_root.display()),
+            &format!("native TS backend cwd: {}", repo_root.display()),
         );
     }
 
@@ -921,9 +905,9 @@ fn set_gateway_keep_running(
         append_log(
             &mut runtime,
             if keep_running {
-                "configured shell-owned gateway to keep running after desktop exits"
+                "configured native TS backend to keep running after desktop exits"
             } else {
-                "configured shell-owned gateway to stop when desktop exits"
+                "configured native TS backend to stop when desktop exits"
             },
         );
     }
@@ -1264,22 +1248,17 @@ fn current_status(shared: &SharedGateway) -> GatewayRuntimeStatus {
     let probe = gateway_bootstrap_probe();
     let http_ok = probe.is_ready();
     let runtime = lock_runtime(shared);
-    let worker_status = runtime.worker.status();
-    let worker_running = worker_status.state == WorkerManagerState::Running;
+    let worker_status = runtime.experimental_worker.status();
 
-    let owner = if worker_running {
+    let owner = if worker_status.state == WorkerManagerState::Running {
         "shell"
-    } else if http_ok {
-        "external"
     } else {
         "none"
     };
-    let state = if http_ok {
+    let state = if worker_status.state == WorkerManagerState::Running {
         "running"
-    } else if probe.is_conflict_or_error() {
+    } else if worker_status.state == WorkerManagerState::Failed || probe.is_conflict_or_error() {
         "failed"
-    } else if worker_running {
-        "starting"
     } else {
         "offline"
     };
@@ -1295,7 +1274,7 @@ fn current_status(shared: &SharedGateway) -> GatewayRuntimeStatus {
         http_ok,
         gateway_http: "http://127.0.0.1:18790",
         gateway_ws: "ws://127.0.0.1:18790/ws",
-        command: "uv run tinybot gateway",
+        command: "node workers/ts-agent-worker/src/index.ts",
         port: 18790,
         repo_root: repo_root().display().to_string(),
         logs: gateway_runtime_logs(&runtime.logs, &worker_status.diagnostics),
@@ -1407,11 +1386,6 @@ fn http_response_body(response: &str) -> &str {
         .map(|(_, body)| body)
         .or_else(|| response.split_once("\n\n").map(|(_, body)| body))
         .unwrap_or(response)
-}
-
-fn gateway_worker_command_spec() -> WorkerCommandSpec {
-    WorkerCommandSpec::new("uv", ["run", "tinybot", "gateway"], repo_root())
-        .with_label("tinybot-gateway")
 }
 
 fn worker_echo_agent_with_options(
@@ -3059,16 +3033,16 @@ fn stop_owned_gateway(shared: &SharedGateway, explicit: bool) -> Result<(), Stri
     let (worker, experimental_worker) = {
         let runtime = lock_runtime(shared);
         if !explicit && runtime.keep_background {
-            let experimental_worker = runtime.experimental_worker.clone();
+            let worker = runtime.worker.clone();
             drop(runtime);
-            let _ = experimental_worker.stop();
-            push_log(shared, "leaving shell-owned gateway running in background");
+            let _ = worker.stop();
+            push_log(shared, "leaving native TS backend running in background");
             return Ok(());
         }
         (runtime.worker.clone(), runtime.experimental_worker.clone())
     };
 
-    let was_running = worker.status().state == WorkerManagerState::Running;
+    let was_running = experimental_worker.status().state == WorkerManagerState::Running;
     worker
         .stop()
         .map_err(|error| format!("failed to stop gateway: {error:?}"))?;
@@ -3077,7 +3051,7 @@ fn stop_owned_gateway(shared: &SharedGateway, explicit: bool) -> Result<(), Stri
         .map_err(|error| format!("failed to stop experimental worker: {error:?}"))?;
     if was_running {
         let mut runtime = lock_runtime(shared);
-        append_log(&mut runtime, "stopped shell-owned gateway");
+        append_log(&mut runtime, "stopped native TS backend");
     }
     Ok(())
 }
@@ -3265,45 +3239,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn close_shutdown_stops_shell_owned_gateway_child() {
+    fn close_shutdown_stops_native_ts_backend_child() {
         let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
         {
             let runtime = lock_runtime(&shared);
             runtime
-                .worker
-                .start(test_gateway_worker_spec("gateway-close-worker"))
+                .experimental_worker
+                .start(test_gateway_worker_spec("ts-backend-close-worker"))
                 .expect("test worker should start");
         }
 
-        stop_owned_gateway(&shared, false).expect("shell-owned gateway child should stop");
+        stop_owned_gateway(&shared, false).expect("native TS backend child should stop");
 
         let runtime = lock_runtime(&shared);
         assert_eq!(
-            runtime.worker.status().state,
+            runtime.experimental_worker.status().state,
             crate::worker_manager::WorkerManagerState::Stopped
         );
         assert!(runtime
             .logs
             .iter()
-            .any(|line| line == "stopped shell-owned gateway"));
+            .any(|line| line == "stopped native TS backend"));
     }
 
     #[test]
-    fn gateway_worker_command_spec_uses_uv_gateway_in_repo_root() {
-        let spec = gateway_worker_command_spec();
-
-        assert_eq!(spec.label, "tinybot-gateway");
-        assert_eq!(spec.program, "uv");
-        assert_eq!(spec.args, vec!["run", "tinybot", "gateway"]);
-        assert_eq!(spec.cwd, repo_root());
-    }
-
-    #[test]
-    fn gateway_status_uses_worker_manager_for_shell_owned_process() {
+    fn gateway_status_uses_ts_worker_manager_for_native_backend() {
         let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
         let worker = {
             let runtime = lock_runtime(&shared);
-            runtime.worker.clone()
+            runtime.experimental_worker.clone()
         };
         worker
             .start(test_gateway_short_worker_spec("gateway-status-worker"))
@@ -3312,14 +3276,7 @@ mod tests {
         let status = current_status(&shared);
 
         assert_eq!(status.owner, "shell");
-        assert_eq!(
-            status.state,
-            if status.http_ok {
-                "running"
-            } else {
-                "starting"
-            }
-        );
+        assert_eq!(status.state, "running");
     }
 
     #[test]
@@ -3327,7 +3284,7 @@ mod tests {
         let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
         let worker = {
             let runtime = lock_runtime(&shared);
-            runtime.worker.clone()
+            runtime.experimental_worker.clone()
         };
         worker
             .start(test_gateway_short_worker_spec("gateway-runtime-worker"))
@@ -3344,6 +3301,48 @@ mod tests {
             Some(crate::worker_protocol::WorkerTransportMode::Stdio)
         );
         assert!(!status.worker_runtime.gateway_compatibility_available);
+    }
+
+    #[test]
+    fn gateway_status_reports_ts_worker_diagnostics_instead_of_legacy_gateway_logs() {
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let (legacy_worker, ts_worker) = {
+            let runtime = lock_runtime(&shared);
+            (runtime.worker.clone(), runtime.experimental_worker.clone())
+        };
+        legacy_worker
+            .start(test_logging_sleep_worker_spec(
+                "tinybot-gateway",
+                "legacy python backend",
+            ))
+            .expect("legacy worker should start");
+        ts_worker
+            .start(test_logging_sleep_worker_spec(
+                "ts-agent-worker",
+                "ts native backend",
+            ))
+            .expect("ts worker should start");
+        let _ = wait_for_worker_diagnostics(&ts_worker, |diagnostics| {
+            diagnostics
+                .iter()
+                .any(|line| line.line.contains("ts native backend"))
+        });
+
+        let status = current_status(&shared);
+        let log_text = status.logs.join("\n");
+        let diagnostic_text = status
+            .worker_runtime
+            .diagnostics
+            .iter()
+            .map(|line| line.line.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(log_text.contains("ts native backend"));
+        assert!(!log_text.contains("legacy python backend"));
+        assert!(diagnostic_text.contains("ts native backend"));
+        assert!(!diagnostic_text.contains("legacy python backend"));
+        assert_eq!(status.command, "node workers/ts-agent-worker/src/index.ts");
     }
 
     #[test]
@@ -4313,7 +4312,7 @@ mod tests {
             http_ok: true,
             gateway_http: "http://127.0.0.1:18790",
             gateway_ws: "ws://127.0.0.1:18790/ws",
-            command: "uv run tinybot gateway",
+            command: "node workers/ts-agent-worker/src/index.ts",
             port: 18790,
             repo_root: "/repo".to_string(),
             logs: vec![],
@@ -4619,6 +4618,34 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         manager.status()
+    }
+
+    fn test_logging_sleep_worker_spec(
+        label: &str,
+        message: &str,
+    ) -> crate::worker_manager::WorkerCommandSpec {
+        #[cfg(target_os = "windows")]
+        {
+            crate::worker_manager::WorkerCommandSpec::new(
+                "cmd",
+                [
+                    "/C",
+                    &format!("echo {message} & ping -n 3 127.0.0.1 > NUL"),
+                ],
+                PathBuf::from("."),
+            )
+            .with_label(label)
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            crate::worker_manager::WorkerCommandSpec::new(
+                "sh",
+                ["-c", &format!("echo {message}; sleep 2")],
+                PathBuf::from("."),
+            )
+            .with_label(label)
+        }
     }
 
     fn wait_for_worker_diagnostics(

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -162,6 +162,10 @@ const nativeFileTaskOperations = new Map<string, DesktopTaskSourceOperation>();
 const nativeGatewayTaskOperations = new Map<string, DesktopTaskSourceOperation>();
 const nativeApprovalTaskOperations = new Map<string, DesktopTaskSourceOperation>();
 let nativeRuntimeStatus: GatewayRuntimeStatus | null = null;
+let nativeRuntimeStatusEventsInstalled = false;
+let nativeRuntimeStatusRefreshTimer: number | null = null;
+let nativeRuntimeStatusRefreshInFlight = false;
+let nativeRuntimeStatusRefreshPending = false;
 let nativeSettingsConfig: unknown = {};
 let nativeSettingsState: DesktopSettingsFormState | null = null;
 let nativeSettingsLastSavedState: DesktopSettingsFormState | null = null;
@@ -228,6 +232,7 @@ async function bootDesktopWebUi(): Promise<void> {
       runtimeState: status?.state ?? "",
     });
     nativeRuntimeStatus = status;
+    installNativeRuntimeStatusEventRouting();
     updateNativeGatewayTask(buildDesktopGatewayTaskOperation("startup", status));
     startupTrace.start("channelRuntime");
     await startDesktopNativeChannelRuntime({
@@ -2403,6 +2408,65 @@ async function handleNativeGatewayRuntimeAction(event: DesktopGatewayRuntimeActi
       action: event.action,
       error: message,
     });
+  }
+}
+
+function installNativeRuntimeStatusEventRouting(): void {
+  if (!hasTauriRuntime() || nativeRuntimeStatusEventsInstalled) {
+    return;
+  }
+  nativeRuntimeStatusEventsInstalled = true;
+  void listen("diagnostics.log", () => {
+    scheduleNativeRuntimeStatusRefresh("diagnostics.log");
+  });
+  void listen("worker.status", () => {
+    scheduleNativeRuntimeStatusRefresh("worker.status");
+  });
+}
+
+function scheduleNativeRuntimeStatusRefresh(reason: string): void {
+  if (nativeRuntimeStatusRefreshTimer !== null) {
+    nativeRuntimeStatusRefreshPending = true;
+    return;
+  }
+  nativeRuntimeStatusRefreshTimer = window.setTimeout(() => {
+    nativeRuntimeStatusRefreshTimer = null;
+    void refreshNativeRuntimeStatus(reason);
+  }, 250);
+}
+
+async function refreshNativeRuntimeStatus(reason: string): Promise<void> {
+  if (nativeRuntimeStatusRefreshInFlight) {
+    nativeRuntimeStatusRefreshPending = true;
+    return;
+  }
+  nativeRuntimeStatusRefreshInFlight = true;
+  try {
+    const nextStatus = await invokeGatewayRuntimeCommand("gateway_status");
+    nativeRuntimeStatus = nextStatus;
+    updateDesktopGatewayRuntimeStatus(document, nextStatus, gatewayConfig.httpBaseUrl, {
+      onGatewayRuntimeAction: (nextEvent) => {
+        void handleNativeGatewayRuntimeAction(nextEvent);
+      },
+    });
+    setDesktopWindowRuntimeStatus(nextStatus);
+    updateNativeGatewayTask(buildDesktopGatewayTaskOperation("startup", nextStatus));
+    logDesktopNativeDebug("gatewayRuntime.status.refresh", {
+      reason,
+      workerDiagnostics: nextStatus.worker_runtime?.diagnostics?.length ?? 0,
+      runtimeLogs: nextStatus.logs.length,
+    });
+  } catch (error) {
+    logDesktopNativeDebug("gatewayRuntime.status.refresh.failed", {
+      reason,
+      error: stringifyError(error),
+    });
+  } finally {
+    nativeRuntimeStatusRefreshInFlight = false;
+    if (nativeRuntimeStatusRefreshPending) {
+      nativeRuntimeStatusRefreshPending = false;
+      scheduleNativeRuntimeStatusRefresh(reason);
+    }
   }
 }
 

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2497,7 +2497,7 @@ function failedGatewayRuntimeStatus(
     http_ok: false,
     gateway_http: previousStatus?.gateway_http ?? gatewayConfig.httpBaseUrl,
     gateway_ws: previousStatus?.gateway_ws ?? gatewayConfig.wsUrl,
-    command: previousStatus?.command ?? "uv run tinybot gateway",
+    command: previousStatus?.command ?? "node workers/ts-agent-worker/src/index.ts",
     port: previousStatus?.port ?? 18790,
     repo_root: previousStatus?.repo_root ?? "",
     logs: [...(previousStatus?.logs ?? []), `error: ${message}`].slice(-12),

--- a/apps/desktop/src/desktopGatewayRuntimeControls.test.ts
+++ b/apps/desktop/src/desktopGatewayRuntimeControls.test.ts
@@ -14,7 +14,7 @@ describe("desktop gateway runtime controls", () => {
       http_ok: false,
       gateway_http: "http://127.0.0.1:18790",
       gateway_ws: "ws://127.0.0.1:18790/ws",
-      command: "uv run tinybot gateway",
+      command: "node workers/ts-agent-worker/src/index.ts",
       port: 18790,
       repo_root: "D:/Code/py/tinybot",
       logs: ["stdout: booting", "stderr: warning", "stdout: listening"],
@@ -25,12 +25,12 @@ describe("desktop gateway runtime controls", () => {
     expect(buildDesktopGatewayRuntimeRows(status, "http://127.0.0.1:18790")).toEqual([
       { label: "State", value: "Starting" },
       { label: "Owner", value: "Shell-owned" },
-      { label: "Command", value: "uv run tinybot gateway" },
+      { label: "Command", value: "node workers/ts-agent-worker/src/index.ts" },
       { label: "Port", value: "18790" },
       { label: "Repo root", value: "D:/Code/py/tinybot" },
       { label: "Recent logs", value: "stdout: booting\nstderr: warning\nstdout: listening" },
       { label: "Last error", value: "HTTP 503" },
-      { label: "Exit policy", value: "Stop shell-owned gateway on exit" },
+      { label: "Exit policy", value: "Stop native TS backend on exit" },
     ]);
   });
 
@@ -41,7 +41,7 @@ describe("desktop gateway runtime controls", () => {
       http_ok: true,
       gateway_http: "http://127.0.0.1:18790",
       gateway_ws: "ws://127.0.0.1:18790/ws",
-      command: "uv run tinybot gateway",
+      command: "node workers/ts-agent-worker/src/index.ts",
       port: 18790,
       repo_root: "D:/Code/py/tinybot",
       logs: ["external gateway reachable"],
@@ -81,7 +81,7 @@ describe("desktop gateway runtime controls", () => {
       http_ok: true,
       gateway_http: "http://127.0.0.1:18790",
       gateway_ws: "ws://127.0.0.1:18790/ws",
-      command: "uv run tinybot gateway",
+      command: "node workers/ts-agent-worker/src/index.ts",
       port: 18790,
       repo_root: "D:/Code/py/tinybot",
       logs: [],
@@ -107,14 +107,14 @@ describe("desktop gateway runtime controls", () => {
     expect(commands).toEqual(["stop_gateway", "start_gateway"]);
   });
 
-  test("toggles shell-owned gateway exit policy through a persisted runtime command", async () => {
+  test("toggles native TS backend exit policy through a persisted runtime command", async () => {
     const status: GatewayRuntimeStatus = {
       state: "running",
       owner: "shell",
       http_ok: true,
       gateway_http: "http://127.0.0.1:18790",
       gateway_ws: "ws://127.0.0.1:18790/ws",
-      command: "uv run tinybot gateway",
+      command: "node workers/ts-agent-worker/src/index.ts",
       port: 18790,
       repo_root: "D:/Code/py/tinybot",
       logs: [],
@@ -149,7 +149,7 @@ describe("desktop gateway runtime controls", () => {
       http_ok: false,
       gateway_http: "http://127.0.0.1:18790",
       gateway_ws: "ws://127.0.0.1:18790/ws",
-      command: "uv run tinybot gateway",
+      command: "node workers/ts-agent-worker/src/index.ts",
       port: 18790,
       repo_root: "D:/Code/py/tinybot",
       logs: [],
@@ -175,7 +175,7 @@ describe("desktop gateway runtime controls", () => {
       http_ok: true,
       gateway_http: "http://127.0.0.1:18790",
       gateway_ws: "ws://127.0.0.1:18790/ws",
-      command: "uv run tinybot gateway",
+      command: "node workers/ts-agent-worker/src/index.ts",
       port: 18790,
       repo_root: "D:/Code/py/tinybot",
       logs: [],

--- a/apps/desktop/src/desktopGatewayRuntimeControls.ts
+++ b/apps/desktop/src/desktopGatewayRuntimeControls.ts
@@ -20,7 +20,7 @@ export interface DesktopGatewayRuntimeAction {
   label: string;
 }
 
-export type DesktopGatewayRuntimeCommand = "start_gateway" | "stop_gateway" | "set_gateway_keep_running";
+export type DesktopGatewayRuntimeCommand = "gateway_status" | "start_gateway" | "stop_gateway" | "set_gateway_keep_running";
 
 export type DesktopGatewayRuntimeCommandPayload = { keep_running: boolean };
 

--- a/apps/desktop/src/desktopGatewayRuntimeControls.ts
+++ b/apps/desktop/src/desktopGatewayRuntimeControls.ts
@@ -51,7 +51,7 @@ export function buildDesktopGatewayRuntimeRows(
   return [
     { label: "State", value: formatState(status?.state ?? "running") },
     { label: "Owner", value: formatOwner(status?.owner ?? "external") },
-    { label: "Command", value: status?.command || "uv run tinybot gateway" },
+    { label: "Command", value: status?.command || "node workers/ts-agent-worker/src/index.ts" },
     { label: "Port", value: formatPort(status?.port, gatewayHttp) },
     { label: "Repo root", value: status?.repo_root || "Unknown" },
     { label: "Recent logs", value: logs.length ? logs.join("\n") : "No recent logs" },
@@ -185,7 +185,7 @@ function formatExitPolicy(policy: GatewayRuntimeStatus["exit_policy"], owner: Ga
     return "External gateway is not managed by desktop";
   }
   if (policy === "keep_running") {
-    return "Keep shell-owned gateway running after exit";
+    return "Keep native TS backend running after exit";
   }
-  return "Stop shell-owned gateway on exit";
+  return "Stop native TS backend on exit";
 }

--- a/apps/desktop/src/desktopGatewayStartup.test.ts
+++ b/apps/desktop/src/desktopGatewayStartup.test.ts
@@ -17,9 +17,10 @@ function status(owner: GatewayRuntimeStatus["owner"], state: GatewayRuntimeStatu
 }
 
 describe("desktop gateway startup", () => {
-  test("attaches to an already reachable external gateway without invoking Tauri commands", async () => {
+  test("uses gateway_status for an already reachable gateway in Tauri so runtime logs are available", async () => {
+    const reachable = status("shell", "running", true);
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ token: "token-1" }), { status: 200 }));
-    const invoke = vi.fn();
+    const invoke = vi.fn(async () => reachable);
 
     const result = await ensureGatewayReady(DEFAULT_GATEWAY_CONFIG, {
       fetchFn,
@@ -27,11 +28,25 @@ describe("desktop gateway startup", () => {
       hasTauriRuntime: () => true,
     });
 
-    expect(result).toBeNull();
+    expect(result).toBe(reachable);
     expect(fetchFn).toHaveBeenCalledWith(
       "http://127.0.0.1:18790/webui/bootstrap",
       expect.objectContaining({ cache: "no-store", signal: expect.any(AbortSignal) }),
     );
+    expect(invoke).toHaveBeenCalledWith("gateway_status");
+  });
+
+  test("attaches to an already reachable external gateway outside Tauri without runtime logs", async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ token: "token-1" }), { status: 200 }));
+    const invoke = vi.fn();
+
+    const result = await ensureGatewayReady(DEFAULT_GATEWAY_CONFIG, {
+      fetchFn,
+      invoke,
+      hasTauriRuntime: () => false,
+    });
+
+    expect(result).toBeNull();
     expect(invoke).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/desktopGatewayStartup.test.ts
+++ b/apps/desktop/src/desktopGatewayStartup.test.ts
@@ -9,7 +9,7 @@ function status(owner: GatewayRuntimeStatus["owner"], state: GatewayRuntimeStatu
     http_ok: httpOk,
     gateway_http: DEFAULT_GATEWAY_CONFIG.httpBaseUrl,
     gateway_ws: DEFAULT_GATEWAY_CONFIG.wsUrl,
-    command: "uv run tinybot gateway",
+    command: "node workers/ts-agent-worker/src/index.ts",
     repo_root: "D:/Code/py/tinybot",
     logs: [],
     last_error: null,
@@ -17,9 +17,9 @@ function status(owner: GatewayRuntimeStatus["owner"], state: GatewayRuntimeStatu
 }
 
 describe("desktop gateway startup", () => {
-  test("uses gateway_status for an already reachable gateway in Tauri so runtime logs are available", async () => {
+  test("uses gateway_status for native Tauri startup without probing the Python gateway", async () => {
     const reachable = status("shell", "running", true);
-    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ token: "token-1" }), { status: 200 }));
+    const fetchFn = vi.fn();
     const invoke = vi.fn(async () => reachable);
 
     const result = await ensureGatewayReady(DEFAULT_GATEWAY_CONFIG, {
@@ -29,10 +29,7 @@ describe("desktop gateway startup", () => {
     });
 
     expect(result).toBe(reachable);
-    expect(fetchFn).toHaveBeenCalledWith(
-      "http://127.0.0.1:18790/webui/bootstrap",
-      expect.objectContaining({ cache: "no-store", signal: expect.any(AbortSignal) }),
-    );
+    expect(fetchFn).not.toHaveBeenCalled();
     expect(invoke).toHaveBeenCalledWith("gateway_status");
   });
 
@@ -76,40 +73,40 @@ describe("desktop gateway startup", () => {
     ).rejects.toThrow("Tauri runtime commands are unavailable: connect ECONNREFUSED");
   });
 
-  test("uses gateway_status when Tauri reports an externally reachable gateway", async () => {
-    const external = status("external", "running", true);
+  test("starts the native TS worker when Tauri reports no running backend", async () => {
+    const offline = status("none", "offline", false);
+    const running = status("shell", "running", false);
     const invoke = vi.fn(async (command: string) => {
-      expect(command).toBe("gateway_status");
-      return external;
+      if (command === "gateway_status") {
+        return offline;
+      }
+      expect(command).toBe("start_gateway");
+      return running;
     });
 
     const result = await ensureGatewayReady(DEFAULT_GATEWAY_CONFIG, {
-      fetchFn: vi.fn(async () => new Response("{}", { status: 503 })),
+      fetchFn: vi.fn(),
       invoke,
       hasTauriRuntime: () => true,
     });
 
-    expect(result).toBe(external);
-    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(result).toBe(running);
+    expect(invoke.mock.calls.map((call) => call[0])).toEqual(["gateway_status", "start_gateway"]);
   });
 
-  test("starts a shell-owned gateway and waits for bootstrap readiness", async () => {
+  test("does not wait for Python bootstrap readiness after starting the native TS worker", async () => {
     const offline = status("none", "offline", false);
-    const starting = status("shell", "starting", false);
     const running = status("shell", "running", true);
     const invoke = vi.fn(async (command: string) => {
-      if (command === "gateway_status" && invoke.mock.calls.length === 1) {
+      if (command === "gateway_status") {
         return offline;
       }
       if (command === "start_gateway") {
-        return starting;
+        return running;
       }
-      return running;
+      throw new Error(`unexpected command: ${command}`);
     });
-    const fetchFn = vi
-      .fn()
-      .mockResolvedValueOnce(new Response("{}", { status: 503 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ token: "token-1" }), { status: 200 }));
+    const fetchFn = vi.fn(async () => new Response("{}", { status: 503 }));
 
     const result = await ensureGatewayReady(DEFAULT_GATEWAY_CONFIG, {
       fetchFn,
@@ -119,24 +116,22 @@ describe("desktop gateway startup", () => {
     });
 
     expect(result).toBe(running);
-    expect(invoke.mock.calls.map((call) => call[0])).toEqual(["gateway_status", "start_gateway", "gateway_status"]);
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(invoke.mock.calls.map((call) => call[0])).toEqual(["gateway_status", "start_gateway"]);
   });
 
-  test("reports shell startup timeout with the last readiness error", async () => {
+  test("reports native TS worker startup errors", async () => {
     const invoke = vi
       .fn()
       .mockResolvedValueOnce(status("none", "offline", false))
-      .mockResolvedValueOnce(status("shell", "starting", false));
-    const now = vi.fn().mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValueOnce(31_000);
+      .mockRejectedValueOnce(new Error("TS worker failed"));
 
     await expect(
       ensureGatewayReady(DEFAULT_GATEWAY_CONFIG, {
-        fetchFn: vi.fn(async () => new Response("{}", { status: 503 })),
+        fetchFn: vi.fn(),
         invoke,
         hasTauriRuntime: () => true,
-        delay: async () => undefined,
-        now,
       }),
-    ).rejects.toThrow("Gateway did not become ready after start_gateway. Last status: starting/shell. HTTP 503");
+    ).rejects.toThrow("TS worker failed");
   });
 });

--- a/apps/desktop/src/desktopGatewayStartup.test.ts
+++ b/apps/desktop/src/desktopGatewayStartup.test.ts
@@ -94,6 +94,28 @@ describe("desktop gateway startup", () => {
     expect(invoke.mock.calls.map((call) => call[0])).toEqual(["gateway_status", "start_gateway"]);
   });
 
+  test("rejects native startup when start_gateway returns a non-running status", async () => {
+    const offline = status("none", "offline", false);
+    const failed = status("shell", "failed", false);
+    failed.last_error = "worker exited immediately";
+    const invoke = vi.fn(async (command: string) => {
+      if (command === "gateway_status") {
+        return offline;
+      }
+      expect(command).toBe("start_gateway");
+      return failed;
+    });
+
+    await expect(
+      ensureGatewayReady(DEFAULT_GATEWAY_CONFIG, {
+        fetchFn: vi.fn(),
+        invoke,
+        hasTauriRuntime: () => true,
+      }),
+    ).rejects.toThrow("Gateway failed to start");
+    expect(invoke.mock.calls.map((call) => call[0])).toEqual(["gateway_status", "start_gateway"]);
+  });
+
   test("does not wait for Python bootstrap readiness after starting the native TS worker", async () => {
     const offline = status("none", "offline", false);
     const running = status("shell", "running", true);

--- a/apps/desktop/src/desktopGatewayStartup.ts
+++ b/apps/desktop/src/desktopGatewayStartup.ts
@@ -43,47 +43,20 @@ export async function ensureGatewayReady(
   config: GatewayConfig,
   deps: GatewayStartupDeps,
 ): Promise<GatewayRuntimeStatus | null> {
+  if ((deps.hasTauriRuntime ?? hasTauriRuntime)()) {
+    const status = await deps.invoke("gateway_status");
+    if (status.state === "running") {
+      return status;
+    }
+    return deps.invoke("start_gateway");
+  }
+
   const externalBootstrap = await fetchBootstrap(config, deps);
   if (externalBootstrap.ok) {
-    if ((deps.hasTauriRuntime ?? hasTauriRuntime)()) {
-      return deps.invoke("gateway_status");
-    }
     return null;
   }
 
-  if (!(deps.hasTauriRuntime ?? hasTauriRuntime)()) {
-    throw new Error(`Gateway is unreachable and Tauri runtime commands are unavailable: ${externalBootstrap.error}`);
-  }
-
-  const beforeStart = await deps.invoke("gateway_status");
-  if (beforeStart.http_ok) {
-    return beforeStart;
-  }
-
-  const started = await deps.invoke("start_gateway");
-  const ready = await waitForBootstrap(config, 30_000, deps);
-  if (!ready.ok) {
-    throw new Error(
-      `Gateway did not become ready after start_gateway. Last status: ${started.state}/${started.owner}. ${ready.error}`,
-    );
-  }
-  return deps.invoke("gateway_status");
-}
-
-async function waitForBootstrap(config: GatewayConfig, timeoutMs: number, deps: GatewayStartupDeps): Promise<BootstrapResult> {
-  const now = deps.now ?? Date.now;
-  const delay = deps.delay ?? defaultDelay;
-  const startedAt = now();
-  let lastError = "not checked";
-  while (now() - startedAt < timeoutMs) {
-    const result = await fetchBootstrap(config, deps);
-    if (result.ok) {
-      return { ok: true };
-    }
-    lastError = result.error;
-    await delay(500);
-  }
-  return { ok: false, error: lastError };
+  throw new Error(`Gateway is unreachable and Tauri runtime commands are unavailable: ${externalBootstrap.error}`);
 }
 
 async function fetchBootstrap(config: GatewayConfig, deps: GatewayStartupDeps): Promise<BootstrapResult> {
@@ -120,10 +93,6 @@ async function fetchBootstrap(config: GatewayConfig, deps: GatewayStartupDeps): 
 
 function hasTauriRuntime(): boolean {
   return "__TAURI_INTERNALS__" in globalThis;
-}
-
-function defaultDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
 function stringifyError(error: unknown): string {

--- a/apps/desktop/src/desktopGatewayStartup.ts
+++ b/apps/desktop/src/desktopGatewayStartup.ts
@@ -48,7 +48,11 @@ export async function ensureGatewayReady(
     if (status.state === "running") {
       return status;
     }
-    return deps.invoke("start_gateway");
+    const started = await deps.invoke("start_gateway");
+    if (started.state !== "running") {
+      throw new Error(formatNativeStartupStatusError(started));
+    }
+    return started;
   }
 
   const externalBootstrap = await fetchBootstrap(config, deps);
@@ -93,6 +97,16 @@ async function fetchBootstrap(config: GatewayConfig, deps: GatewayStartupDeps): 
 
 function hasTauriRuntime(): boolean {
   return "__TAURI_INTERNALS__" in globalThis;
+}
+
+function formatNativeStartupStatusError(status: GatewayRuntimeStatus): string {
+  const details = [
+    `state=${status.state}`,
+    `owner=${status.owner}`,
+    status.last_error ? `last_error=${status.last_error}` : null,
+    status.recovery_hint ? `recovery_hint=${status.recovery_hint}` : null,
+  ].filter(Boolean);
+  return `Gateway failed to start (${details.join(", ")})`;
 }
 
 function stringifyError(error: unknown): string {

--- a/apps/desktop/src/desktopGatewayStartup.ts
+++ b/apps/desktop/src/desktopGatewayStartup.ts
@@ -45,6 +45,9 @@ export async function ensureGatewayReady(
 ): Promise<GatewayRuntimeStatus | null> {
   const externalBootstrap = await fetchBootstrap(config, deps);
   if (externalBootstrap.ok) {
+    if ((deps.hasTauriRuntime ?? hasTauriRuntime)()) {
+      return deps.invoke("gateway_status");
+    }
     return null;
   }
 

--- a/apps/desktop/src/desktopKnowledgeWorkbenchProjection.test.ts
+++ b/apps/desktop/src/desktopKnowledgeWorkbenchProjection.test.ts
@@ -89,7 +89,7 @@ describe("desktop knowledge workbench projection", () => {
       id: "doc-1",
       title: "Native app overview",
       status: "indexed",
-      meta: "native / indexed / 8 chunks / 2026-06-02T08:00:00Z",
+      meta: "native / Indexed / 8 chunks / 2026-06-02T08:00:00Z",
       selected: true,
     });
     expect(projection.mainView).toEqual({

--- a/apps/desktop/src/desktopTaskCenterSources.ts
+++ b/apps/desktop/src/desktopTaskCenterSources.ts
@@ -52,7 +52,7 @@ export function buildDesktopGatewayTaskOperation(
     : status?.state === "running" || status === null
       ? "completed"
       : status?.state || "starting";
-  const command = status?.command || "uv run tinybot gateway";
+  const command = status?.command || "node workers/ts-agent-worker/src/index.ts";
   const owner = status?.owner || "external";
   const diagnostics = status?.last_error || (status?.logs ?? []).slice(-4).join("\n");
   return {

--- a/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
@@ -177,7 +177,7 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("./native-vue/knowledgeQueryIsland")');
     expect(source).toContain('import { mountKnowledgeReadinessIsland } from "./native-vue/knowledgeReadinessIsland";');
     expect(source).not.toContain('void import("./native-vue/knowledgeReadinessIsland")');
-    expect(source).toContain('import { mountKnowledgeReferenceRowIsland } from "./native-vue/knowledgeReferenceRowIsland";');
+    expect(source).not.toContain('import { mountKnowledgeReferenceRowIsland } from "./native-vue/knowledgeReferenceRowIsland";');
     expect(source).not.toContain('void import("./native-vue/knowledgeReferenceRowIsland")');
   });
 

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -9,6 +9,7 @@ import { buildDesktopWorkLensProjection } from "./desktopWorkLens";
 import { createDefaultWorkbenchLayout } from "./desktopWorkbenchLayout";
 import {
   installDesktopWorkbenchShell,
+  updateDesktopGatewayRuntimeStatus,
   updateDesktopKnowledgePane,
   updateDesktopNativeChat,
   updateDesktopSettingsPane,
@@ -979,6 +980,33 @@ describe("desktop workbench shell", () => {
     expect(backendLogsDialog?.textContent).toContain("gateway ready");
     expect(backendLogsDialog?.textContent).toContain("[knowledge]");
     expect(backendLogsDialog?.textContent).toContain("RAG.md");
+
+    updateDesktopGatewayRuntimeStatus(
+      targetDocument as unknown as Document,
+      {
+        state: "running",
+        owner: "shell",
+        http_ok: true,
+        gateway_http: "http://127.0.0.1:18790",
+        gateway_ws: "ws://127.0.0.1:18790/ws",
+        command: "tinybot gateway",
+        repo_root: "D:/code/tinybot/tinybot",
+        logs: ["gateway ready", "knowledge upload accepted", "graph extraction streamed"],
+        last_error: null,
+        worker_runtime: {
+          state: "running",
+          transport_mode: "stdio",
+          diagnostics: [
+            { stream: "stderr", line: "[knowledge] {\"stage\":\"knowledge.upload_document.start\",\"name\":\"RAG.md\"}" },
+            { stream: "stderr", line: "[graph] {\"stage\":\"knowledge.graph.extract.progress\",\"percent\":60}" },
+          ],
+        },
+      },
+      "http://127.0.0.1:18790",
+    );
+
+    expect(backendLogsDialog?.textContent).toContain("graph extraction streamed");
+    expect(backendLogsDialog?.textContent).toContain("knowledge.graph.extract.progress");
 
     help?.querySelector('[data-desktop-help-action="help-tour"]')?.click();
     const inspector = targetDocument.body.querySelector('[data-workbench-region="inspector"]');
@@ -2466,7 +2494,7 @@ describe("desktop workbench shell", () => {
       "Repo root: D:/Code/py/tinybot",
       "Recent logs: stdout: ready",
       "Last error: No recent error",
-      "Exit policy: Keep shell-owned gateway running after exit",
+      "Exit policy: Keep native TS backend running after exit",
     ]);
   });
 
@@ -2954,8 +2982,6 @@ describe("desktop workbench shell", () => {
     const pane = targetDocument.body.querySelector(".desktop-knowledge-pane");
     expect(pane?.getAttribute("aria-label")).toBe("Knowledge workbench");
     expect(pane?.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Refresh All");
-    expect(pane?.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Settings");
-    expect(pane?.querySelector(".desktop-knowledge-toolbar")?.textContent).toContain("Upload Documents");
     expect(pane?.querySelector(".desktop-knowledge-management-grid")?.getAttribute("data-desktop-knowledge-layout")).toBe(
       "source-left-graph-right",
     );
@@ -2964,6 +2990,7 @@ describe("desktop workbench shell", () => {
       "upload",
       "queue",
       "documents",
+      "query",
       "graph",
       "pipeline",
     ]);
@@ -2981,7 +3008,7 @@ describe("desktop workbench shell", () => {
     expect(uploadRegion?.textContent).toContain("Drag & drop files here or click to browse");
     expect(uploadRegion?.textContent).toContain("Max 200MB per file");
     expect(uploadRegion?.querySelector("#desktop-knowledge-upload")?.getAttribute("data-desktop-file-upload")).toBe("knowledge-document");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Ingestion Queue");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Knowledge Jobs");
     const documentsRegion = pane?.querySelector('[data-desktop-knowledge-region="documents"]');
     expect(documentsRegion?.textContent).toContain("Documents (1)");
     expect(documentsRegion?.querySelector("[data-desktop-knowledge-document-search]")?.getAttribute("placeholder")).toBe("Search documents...");
@@ -2994,11 +3021,7 @@ describe("desktop workbench shell", () => {
     expect(documentsRegion?.textContent).toContain("docs/desktop.md / Indexed / 4 chunks");
     expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Graph: 1 nodes / 0 edges / 0 evidence");
     expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Extract Graph");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Build Graph");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Refresh Graph");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Fit View");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Layout");
-    expect(pane?.querySelector(".desktop-knowledge-graph-tools")?.textContent).toContain("Zoom in");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Rebuild Index");
     expect(pane?.querySelector(".desktop-knowledge-graph-legend")?.textContent).toContain("Entity");
     expect(pane?.querySelector(".desktop-knowledge-graph-minimap")).not.toBeNull();
     expect(pane?.querySelector('[data-desktop-knowledge-region="pipeline"]')?.textContent).toContain("Graph Build");
@@ -3008,13 +3031,11 @@ describe("desktop workbench shell", () => {
     expect(pane?.textContent).toContain("Claim: Desktop knowledge pane");
 
     pane?.querySelector('[data-desktop-knowledge-action="refreshAll"]')?.click();
-    pane?.querySelector('[data-desktop-knowledge-action="settings"]')?.click();
     pane?.querySelector('[data-desktop-knowledge-action="uploadDocument"]')?.click();
     pane?.querySelector('[data-desktop-knowledge-action="extractGraph"]')?.click();
-    pane?.querySelector('[data-desktop-knowledge-action="refreshGraph"]')?.click();
     pane?.querySelector('[data-desktop-knowledge-action="rebuildIndex"]')?.click();
     pane?.querySelector('[data-desktop-knowledge-document-action="deleteDocument"]')?.click();
-    expect(actionEvents).toEqual(["refreshAll", "settings", "uploadDocument", "extractGraph", "refreshGraph", "rebuildIndex", "deleteDocument"]);
+    expect(actionEvents).toEqual(["refreshAll", "uploadDocument", "extractGraph", "rebuildIndex", "deleteDocument"]);
   });
 
   test("refreshes knowledge pane with active upload task feedback", () => {
@@ -3049,8 +3070,8 @@ describe("desktop workbench shell", () => {
     );
 
     const pane = targetDocument.body.querySelector(".desktop-knowledge-pane");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="pipeline"]')?.textContent).toContain("Knowledge jobs");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="pipeline"]')?.textContent).toContain("Upload notes.md");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Knowledge jobs");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Upload notes.md");
   });
 
   test("renders a desktop Cowork cockpit with session list, graph, inspector, actions, and task feed", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -507,6 +507,20 @@ export function updateDesktopGatewayRuntimeStatus(
   }
   const next = createGatewayRuntimeSurface(targetDocument, runtimeStatus, gatewayHttp, gatewayActions);
   runtime.replaceChildren(...Array.from(next.children));
+  refreshOpenDesktopBackendLogs(targetDocument, runtimeStatus, gatewayHttp);
+}
+
+function refreshOpenDesktopBackendLogs(
+  targetDocument: Document,
+  runtimeStatus: GatewayRuntimeStatus | null,
+  gatewayHttp: string,
+): void {
+  const existing = targetDocument.getElementById("desktop-backend-logs-dialog") as HTMLElement | null;
+  if (!existing || existing.hidden) {
+    return;
+  }
+  const logText = formatDesktopBackendLogs(runtimeStatus, gatewayHttp);
+  existing.replaceChildren(createDesktopBackendLogsPanel(targetDocument, existing, logText));
 }
 
 export function updateDesktopSettingsPane(

--- a/apps/desktop/src/native-vue/gatewayRuntimeIsland.test.ts
+++ b/apps/desktop/src/native-vue/gatewayRuntimeIsland.test.ts
@@ -39,7 +39,7 @@ describe("gateway runtime Vue island", () => {
       "Repo rootD:/Code/py/tinybot",
       "Recent logsstdout: ready",
       "Last errorNo recent error",
-      "Exit policyStop shell-owned gateway on exit",
+      "Exit policyStop native TS backend on exit",
     ]);
 
     host.querySelector<HTMLButtonElement>('[data-desktop-gateway-action="stop"]')?.click();

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
@@ -3527,7 +3527,7 @@ describe("AgentWorker", () => {
         status: 400,
         body: {
           error: {
-            message: "Invalid rebuild type 'vector'. Valid options: bm25, semantic, all",
+            message: "Invalid rebuild type 'vector'. Valid options: bm25, semantic, tree, all",
             type: "invalid_request_error",
             code: 400,
           },


### PR DESCRIPTION
## Summary
- treat the native desktop backend as the TS agent worker instead of the legacy Python gateway
- start/query the TS worker for native runtime status, so Backend Logs shows TS worker diagnostics such as Knowledge route and graph extraction logs
- refresh the desktop runtime snapshot when native `diagnostics.log` or `worker.status` events arrive
- debounce runtime-status refreshes during streaming diagnostics to avoid one status call per chunk
- make the TS worker startup verifier less flaky by allowing 15s for cold imports

Closes #268.

## Verification
- `npm test -- src/desktopGatewayStartup.test.ts src/desktopGatewayRuntimeControls.test.ts`
- `cargo test gateway_status`
- `npm run build`

## Notes
- `npm test -- src/desktopGatewayStartup.test.ts src/desktopGatewayRuntimeControls.test.ts src/desktopWorkbenchShell.test.ts` still has 2 existing Knowledge pane assertion failures unrelated to this change (`Settings` toolbar text and `Knowledge jobs` pipeline copy).