### PR TITLE
Fix native desktop knowledge route fallback

### DIFF
--- a/apps/desktop/src/desktopGatewayBridge.test.ts
+++ b/apps/desktop/src/desktopGatewayBridge.test.ts
@@ -178,6 +178,77 @@ describe("desktop gateway bridge", () => {
     bridge.restore();
   });
 
+  test("does not fallback to gateway HTTP for native Knowledge fetch failures", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
+    const nativeWebui = {
+      routeResponse: vi.fn(async () => {
+        throw new Error("native knowledge route unavailable");
+      }),
+    };
+    const target = {
+      location: { origin: pageOrigin },
+      fetch: fetchMock,
+      WebSocket: class TestWebSocket {} as unknown as typeof WebSocket,
+    } as unknown as typeof globalThis;
+    const bridge = installDesktopGatewayBridge({
+      config: DEFAULT_GATEWAY_CONFIG,
+      pageOrigin,
+      fetchTarget: target,
+      webSocketTarget: target,
+      nativeWebui,
+    });
+
+    const response = await target.fetch("/v1/knowledge/graph?graph_type=entity");
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        message: "Native WebUI route failed: native knowledge route unavailable",
+      },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    bridge.restore();
+  });
+
+  test("does not fallback to gateway HTTP for unsupported native Knowledge fetch bodies", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
+    const nativeWebui = {
+      routeResponse: vi.fn(async () => ({
+        status: 200,
+        body: { native: true },
+      })),
+    };
+    const target = {
+      location: { origin: pageOrigin },
+      fetch: fetchMock,
+      WebSocket: class TestWebSocket {} as unknown as typeof WebSocket,
+    } as unknown as typeof globalThis;
+    const bridge = installDesktopGatewayBridge({
+      config: DEFAULT_GATEWAY_CONFIG,
+      pageOrigin,
+      fetchTarget: target,
+      webSocketTarget: target,
+      nativeWebui,
+    });
+    const body = new FormData();
+    body.append("file", new File(["%PDF-1.4"], "paper.pdf", { type: "application/pdf" }));
+
+    const response = await target.fetch("/v1/knowledge/documents/upload?async_index=true", {
+      method: "POST",
+      body,
+    });
+
+    expect(response.status).toBe(415);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        message: "Native WebUI route does not support this request body: /v1/knowledge/documents/upload",
+      },
+    });
+    expect(nativeWebui.routeResponse).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    bridge.restore();
+  });
+
   test("routes WebUI WebSocket URLs with original query parameters", () => {
     expect(String(rewriteGatewayWebSocketUrl("/ws?token=abc&chat=1", DEFAULT_GATEWAY_CONFIG, pageOrigin))).toBe(
       "ws://127.0.0.1:18790/ws?token=abc&chat=1",

--- a/apps/desktop/src/desktopGatewayBridge.ts
+++ b/apps/desktop/src/desktopGatewayBridge.ts
@@ -143,8 +143,18 @@ async function nativeWebuiFetchResponse(
   nativeWebui: DesktopNativeWebuiFetchApi,
   pageOrigin: string,
 ): Promise<Response | undefined> {
-  const request = await nativeWebuiRouteRequest(input, init, pageOrigin);
+  const sourceUrl = requestUrl(input, pageOrigin);
+  if (!sourceUrl || sourceUrl.origin !== pageOrigin || !isGatewayHttpPath(sourceUrl.pathname)) {
+    return undefined;
+  }
+  const request = await nativeWebuiRouteRequestForUrl(sourceUrl, input, init);
   if (!request) {
+    if (isNativeOnlyGatewayPath(sourceUrl.pathname)) {
+      return nativeOnlyGatewayErrorResponse(
+        415,
+        `Native WebUI route does not support this request body: ${sourceUrl.pathname}`,
+      );
+    }
     return undefined;
   }
   try {
@@ -157,20 +167,22 @@ async function nativeWebuiFetchResponse(
       return undefined;
     }
     return webuiFetchResponse(response);
-  } catch {
+  } catch (error) {
+    if (isNativeOnlyGatewayPath(sourceUrl.pathname)) {
+      return nativeOnlyGatewayErrorResponse(
+        502,
+        `Native WebUI route failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     return undefined;
   }
 }
 
-async function nativeWebuiRouteRequest(
+async function nativeWebuiRouteRequestForUrl(
+  sourceUrl: URL,
   input: RequestInfo | URL,
   init: RequestInit | undefined,
-  pageOrigin: string,
 ): Promise<NativeWebuiRouteRequest | undefined> {
-  const sourceUrl = requestUrl(input, pageOrigin);
-  if (!sourceUrl || sourceUrl.origin !== pageOrigin || !isGatewayHttpPath(sourceUrl.pathname)) {
-    return undefined;
-  }
   const method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
   const headers = headersRecord(init?.headers ?? (input instanceof Request ? input.headers : undefined));
   const body = await jsonFetchBody(input, init, headers);
@@ -183,6 +195,21 @@ async function nativeWebuiRouteRequest(
     ...(headers ? { headers } : {}),
     ...(body.value !== undefined ? { body: body.value } : {}),
   };
+}
+
+function isNativeOnlyGatewayPath(pathname: string): boolean {
+  return pathname === "/v1/knowledge" || pathname.startsWith("/v1/knowledge/");
+}
+
+function nativeOnlyGatewayErrorResponse(status: number, message: string): Response {
+  return webuiFetchResponse({
+    status,
+    body: {
+      error: {
+        message,
+      },
+    },
+  });
 }
 
 async function jsonFetchBody(

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -16,6 +16,7 @@ import {
   updateDesktopTaskCenterItems,
   updateDesktopToolsSkillsPane,
 } from "./desktopWorkbenchShell";
+import type { GatewayRuntimeStatus } from "./desktopGatewayStartup";
 import type { NativeChatMessage, NativeChatSession } from "./nativeChat";
 
 class FakeElement {
@@ -1013,6 +1014,59 @@ describe("desktop workbench shell", () => {
     expect(inspector?.textContent).toContain("Desktop help tour");
     expect(inspector?.textContent).toContain("Step 1: Activity rail");
     expect(inspector?.textContent).toContain("Inspector - Review run-chain, task, gateway, file, and help details");
+  });
+
+  test("refreshes an open backend logs dialog even when the runtime panel is not mounted", () => {
+    const targetDocument = new FakeDocument();
+    const runtimeStatus: GatewayRuntimeStatus = {
+      state: "running",
+      owner: "shell",
+      http_ok: true,
+      gateway_http: "http://127.0.0.1:18790",
+      gateway_ws: "ws://127.0.0.1:18790/ws",
+      command: "tinybot gateway",
+      repo_root: "D:/code/tinybot/tinybot",
+      logs: ["gateway ready"],
+      last_error: null,
+      worker_runtime: {
+        state: "running",
+        transport_mode: "stdio",
+        diagnostics: [{ stream: "stderr", line: "[ts-agent-worker] ready" }],
+      },
+    };
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      runtimeStatus,
+    });
+    targetDocument.dispatchEvent({ type: "tinybot:open-backend-logs" });
+    const backendLogsDialog = targetDocument.body.querySelector("#desktop-backend-logs-dialog");
+    const runtime = targetDocument.body.querySelector(".desktop-gateway-runtime");
+    if (runtime) {
+      runtime.className = "desktop-gateway-runtime-unmounted";
+    }
+
+    updateDesktopGatewayRuntimeStatus(
+      targetDocument as unknown as Document,
+      {
+        ...runtimeStatus,
+        logs: ["gateway ready", "route handled natively"],
+        worker_runtime: {
+          state: "running",
+          transport_mode: "stdio",
+          diagnostics: [
+            { stream: "stderr", line: "[ts-agent-worker] ready" },
+            { stream: "stderr", line: "worker.request.complete method=webui.handle_request route=GET /v1/knowledge/jobs/kjob_1" },
+          ],
+        },
+      },
+      "http://127.0.0.1:18790",
+    );
+
+    expect(backendLogsDialog?.textContent).toContain("route handled natively");
+    expect(backendLogsDialog?.textContent).toContain("GET /v1/knowledge/jobs/kjob_1");
   });
 
   test("marks compact activity controls with predictable focus order and accessible labels", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -501,13 +501,13 @@ export function updateDesktopGatewayRuntimeStatus(
   gatewayActions: DesktopGatewayRuntimeActionOptions = {},
 ): void {
   desktopRuntimeStatusSnapshots.set(targetDocument, { gatewayHttp, runtimeStatus });
+  refreshOpenDesktopBackendLogs(targetDocument, runtimeStatus, gatewayHttp);
   const runtime = targetDocument.querySelector<HTMLElement>(".desktop-gateway-runtime");
   if (!runtime) {
     return;
   }
   const next = createGatewayRuntimeSurface(targetDocument, runtimeStatus, gatewayHttp, gatewayActions);
   runtime.replaceChildren(...Array.from(next.children));
-  refreshOpenDesktopBackendLogs(targetDocument, runtimeStatus, gatewayHttp);
 }
 
 function refreshOpenDesktopBackendLogs(

--- a/apps/desktop/src/gateway.test.ts
+++ b/apps/desktop/src/gateway.test.ts
@@ -1364,7 +1364,31 @@ describe("gateway HTTP client", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
-  test("keeps unsupported Knowledge uploads on the HTTP gateway fallback", async () => {
+  test("does not fallback to gateway HTTP for native Knowledge graph read routes", async () => {
+    const fetchFn = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).endsWith("/webui/bootstrap")) {
+        return new Response(JSON.stringify({ token: "token-1" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ gateway: true }), { status: 200 });
+    });
+    const nativeWebui = {
+      route: vi.fn(async () => {
+        throw new Error("native knowledge route unavailable");
+      }),
+    };
+    const client = createGatewayApiClient({
+      config: DEFAULT_GATEWAY_CONFIG,
+      fetchFn,
+      nativeWebui,
+    });
+
+    await expect(client.knowledge.job("kjob_1")).rejects.toThrow("native knowledge route unavailable");
+    await expect(client.knowledge.graph({ graphType: "entity" })).rejects.toThrow("native knowledge route unavailable");
+    await expect(client.knowledge.graphrag()).rejects.toThrow("native knowledge route unavailable");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  test("rejects unsupported native Knowledge uploads without gateway HTTP fallback", async () => {
     const fetchFn = vi.fn(async (url: RequestInfo | URL, _init?: RequestInit) => {
       if (String(url).endsWith("/webui/bootstrap")) {
         return new Response(JSON.stringify({ token: "token-1" }), { status: 200 });
@@ -1384,16 +1408,11 @@ describe("gateway HTTP client", () => {
     const form = new FormData();
     form.append("file", new File(["%PDF-1.4"], "paper.pdf", { type: "application/pdf" }));
 
-    await expect(client.knowledge.uploadDocument(form)).resolves.toEqual({ gateway: true });
+    await expect(client.knowledge.uploadDocument(form))
+      .rejects
+      .toThrow("Native Knowledge uploads only support txt, md, json, and csv files.");
     expect(nativeWebui.route).not.toHaveBeenCalled();
-    expect(fetchFn.mock.calls.map((call) => String((call as unknown[])[0]))).toEqual([
-      "http://127.0.0.1:18790/webui/bootstrap",
-      "http://127.0.0.1:18790/v1/knowledge/documents/upload?async_index=true",
-    ]);
-    expect(fetchFn.mock.calls[1][1]).toMatchObject({
-      method: "POST",
-      body: form,
-    });
+    expect(fetchFn).not.toHaveBeenCalled();
   });
 
   test("falls back to gateway skills operations when native skills are unavailable", async () => {
@@ -2653,33 +2672,33 @@ describe("gateway HTTP client", () => {
             { status: 200 },
           );
         }
-        if (path === "/v1/knowledge/documents/upload") {
-          return new Response(JSON.stringify({ gateway: true }), { status: 200 });
+        if (path === "/api/sessions") {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
         }
         return new Response(JSON.stringify({ error: "unexpected route" }), { status: 404 });
       });
       const nativeWebui = {
-        route: vi.fn(async (request: { method: string; path: string; headers?: Record<string, unknown> }) => ({
-          token: "token-2",
-          refresh_token_path: "/webui/refresh-token",
-          token_ttl_s: 300,
-          request,
-        })),
+        route: vi.fn(async (request: { method: string; path: string; headers?: Record<string, unknown> }) => {
+          if (request.path === "/webui/refresh-token") {
+            return {
+              token: "token-2",
+              refresh_token_path: "/webui/refresh-token",
+              token_ttl_s: 300,
+              request,
+            };
+          }
+          throw new Error("native sessions unavailable");
+        }),
       };
       const client = createGatewayApiClient({
         config: DEFAULT_GATEWAY_CONFIG,
         fetchFn,
         nativeWebui,
       });
-      const form = () => {
-        const data = new FormData();
-        data.append("file", new File(["%PDF-1.4"], "native.pdf", { type: "application/pdf" }));
-        return data;
-      };
 
-      await client.knowledge.uploadDocument(form());
+      await client.sessions.list();
       vi.setSystemTime(new Date("2026-06-08T10:04:15.000Z"));
-      await client.knowledge.uploadDocument(form());
+      await client.sessions.list();
 
       expect(nativeWebui.route).toHaveBeenCalledWith({
         method: "POST",
@@ -2688,8 +2707,8 @@ describe("gateway HTTP client", () => {
       });
       expect(fetchFn.mock.calls.map((call) => String(call[0]))).toEqual([
         "http://127.0.0.1:18790/webui/bootstrap",
-        "http://127.0.0.1:18790/v1/knowledge/documents/upload?async_index=true",
-        "http://127.0.0.1:18790/v1/knowledge/documents/upload?async_index=true",
+        "http://127.0.0.1:18790/api/sessions",
+        "http://127.0.0.1:18790/api/sessions",
       ]);
     } finally {
       vi.useRealTimers();

--- a/apps/desktop/src/gatewayHttpClient.ts
+++ b/apps/desktop/src/gatewayHttpClient.ts
@@ -519,12 +519,14 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
           () => options.nativeWebui?.route({ method: "GET", path }),
           () => request(path),
           "knowledge.documents",
+          false,
         );
       },
       addDocument: (body: unknown) => nativeOrGateway(
         () => options.nativeWebui?.route({ method: "POST", path: "/v1/knowledge/documents", body }),
         () => request("/v1/knowledge/documents", jsonRequest("POST", body)),
         "knowledge.addDocument",
+        false,
       ),
       document: (documentId: string) => {
         const path = `/v1/knowledge/documents/${encodePathSegment(documentId)}`;
@@ -532,6 +534,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
           () => options.nativeWebui?.route({ method: "GET", path }),
           () => request(path),
           "knowledge.document",
+          false,
         );
       },
       uploadDocument: (body: FormData) => nativeOrGateway(
@@ -546,10 +549,11 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
               path: "/v1/knowledge/documents/upload?async_index=true",
               body: payload,
             }))
-            : undefined;
+            : Promise.reject(new Error("Native Knowledge uploads only support txt, md, json, and csv files."));
         },
         () => request("/v1/knowledge/documents/upload?async_index=true", formRequest("POST", body)),
         "knowledge.uploadDocument",
+        false,
       ),
       deleteDocument: (documentId: string) => {
         const path = `/v1/knowledge/documents/${encodePathSegment(documentId)}`;
@@ -557,6 +561,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
           () => options.nativeWebui?.route({ method: "DELETE", path }),
           () => request(path, { method: "DELETE" }),
           "knowledge.deleteDocument",
+          false,
         );
       },
       job: (jobId: string) => {
@@ -565,20 +570,23 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
           () => options.nativeWebui?.route({ method: "GET", path }),
           () => request(path),
           "knowledge.job",
+          false,
         );
       },
       rebuildIndex: (type: string = "all") => {
         const path = `/v1/knowledge/rebuild-index?type=${encodeURIComponent(type)}&async_index=true`;
         return nativeOrGateway(
-          () => ["bm25", "all", "semantic", "tree"].includes(type) ? options.nativeWebui?.route({ method: "POST", path }) : undefined,
+          () => options.nativeWebui?.route({ method: "POST", path }),
           () => request(path, { method: "POST" }),
           "knowledge.rebuildIndex",
+          false,
         );
       },
       stats: () => nativeOrGateway(
         () => options.nativeWebui?.route({ method: "GET", path: "/v1/knowledge/stats" }),
         () => request("/v1/knowledge/stats"),
         "knowledge.stats",
+        false,
       ),
       graph: (graphOptions: KnowledgeGraphOptions = {}) => {
         const path = knowledgeGraphPath(graphOptions);
@@ -586,6 +594,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
           () => options.nativeWebui?.route({ method: "GET", path }),
           () => request(path),
           "knowledge.graph",
+          false,
         );
       },
       extractGraph: (extractOptions: KnowledgeGraphExtractionOptions) => {
@@ -616,12 +625,14 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
           }),
           () => request(path),
           "knowledge.graphrag",
+          false,
         );
       },
       query: (body: unknown) => nativeOrGateway(
         () => options.nativeWebui?.route({ method: "POST", path: "/v1/knowledge/query", body }),
         () => request("/v1/knowledge/query", jsonRequest("POST", body)),
         "knowledge.query",
+        false,
       ),
     },
     workspace: {


### PR DESCRIPTION
## Summary
- keep native desktop Knowledge requests on the TS native route instead of falling back to the HTTP gateway
- prevent root WebUI Knowledge fetch failures and unsupported request bodies from being rewritten to gateway HTTP
- refresh the open Backend Logs dialog even when the runtime panel is not mounted

## Tests
- npm test -- desktopGatewayBridge.test.ts desktopWorkbenchShell.test.ts gateway.test.ts
- npm run build
- npm test