### PR TITLE
Fix knowledge layout density

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -3042,14 +3042,20 @@ describe("desktop workbench shell", () => {
     expect(pane?.querySelector(".desktop-knowledge-management-grid")?.getAttribute("data-desktop-knowledge-layout")).toBe(
       "source-left-graph-right",
     );
+    const sourceColumn = pane?.querySelector('[data-desktop-knowledge-column="source"]');
+    const inspectorColumn = pane?.querySelector('[data-desktop-knowledge-column="inspector"]');
+    expect(sourceColumn?.querySelector('[data-desktop-knowledge-region="upload"]')?.textContent).toContain("Upload Documents");
+    expect(sourceColumn?.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Knowledge Jobs");
+    expect(sourceColumn?.querySelector('[data-desktop-knowledge-region="documents"]')?.textContent).toContain("Documents (1)");
+    expect(inspectorColumn?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Knowledge Graph");
     expect(pane?.querySelectorAll("[data-desktop-knowledge-region]").map((node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
       "overview",
       "upload",
       "queue",
       "documents",
       "query",
-      "graph",
       "pipeline",
+      "graph",
     ]);
     expect(pane?.textContent).toContain("Knowledge Base");
     expect(pane?.textContent).toContain("Manage your knowledge base, monitor ingestion, and explore the knowledge graph.");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -3900,6 +3900,13 @@ function createKnowledgePane(
   const grid = targetDocument.createElement("div");
   grid.className = "desktop-knowledge-management-grid";
   grid.setAttribute("data-desktop-knowledge-layout", "source-left-graph-right");
+  const sourceColumn = targetDocument.createElement("div");
+  sourceColumn.className = "desktop-knowledge-source-column";
+  sourceColumn.setAttribute("data-desktop-knowledge-column", "source");
+  const inspectorColumn = targetDocument.createElement("div");
+  inspectorColumn.className = "desktop-knowledge-inspector-column";
+  inspectorColumn.setAttribute("data-desktop-knowledge-column", "inspector");
+  grid.append(sourceColumn, inspectorColumn);
 
   const overview = targetDocument.createElement("section");
   overview.className = "desktop-knowledge-region desktop-knowledge-overview";
@@ -3922,7 +3929,7 @@ function createKnowledgePane(
     );
     overview.append(metric);
   }
-  grid.append(overview);
+  sourceColumn.append(overview);
 
   const uploadRegion = targetDocument.createElement("section");
   uploadRegion.className = "desktop-knowledge-region desktop-knowledge-upload-region";
@@ -3943,7 +3950,7 @@ function createKnowledgePane(
     createText(targetDocument, "small", "Max 200MB per file"),
   );
   uploadRegion.append(uploadHeader, dropZone, createKnowledgeUploadControl(targetDocument));
-  grid.append(uploadRegion);
+  sourceColumn.append(uploadRegion);
 
   const queue = targetDocument.createElement("section");
   queue.className = "desktop-knowledge-region desktop-knowledge-queue-region";
@@ -3957,7 +3964,7 @@ function createKnowledgePane(
   queue.append(workItems.length
     ? createModuleWorkSection(targetDocument, "Knowledge jobs", workItems)
     : createText(targetDocument, "p", "No knowledge jobs running.", "desktop-knowledge-empty-note"));
-  grid.append(queue);
+  sourceColumn.append(queue);
 
   const documentsRegion = targetDocument.createElement("section");
   documentsRegion.className = "desktop-knowledge-region desktop-knowledge-documents-region";
@@ -4040,7 +4047,7 @@ function createKnowledgePane(
     documentActions.append(createKnowledgeButton("deleteDocument", "Delete Document", pane.actions.deleteDocument, "secondary"));
     documentsRegion.append(detail, documentActions);
   }
-  grid.append(documentsRegion);
+  sourceColumn.append(documentsRegion);
 
   const queryRegion = targetDocument.createElement("section");
   queryRegion.className = "desktop-knowledge-region desktop-knowledge-query-region";
@@ -4104,7 +4111,7 @@ function createKnowledgePane(
     querySurface.append(createText(targetDocument, "p", `${result.docName}: ${result.content}`));
   }
   queryRegion.append(querySurface);
-  grid.append(queryRegion);
+  sourceColumn.append(queryRegion);
 
   const graph = targetDocument.createElement("section");
   graph.className = "desktop-knowledge-region desktop-knowledge-graph-region";
@@ -4141,7 +4148,7 @@ function createKnowledgePane(
   graphSurface.append(legend, minimap);
   mountKnowledgeGraphVueIsland(graphSurface, pane);
   graph.append(graphHeader, graphSurface);
-  grid.append(graph);
+  inspectorColumn.append(graph);
 
   const pipeline = targetDocument.createElement("section");
   pipeline.className = "desktop-knowledge-region desktop-knowledge-pipeline";
@@ -4166,7 +4173,7 @@ function createKnowledgePane(
   }
   mountKnowledgeReadinessVueIsland(readiness, pane);
   pipeline.append(readiness);
-  grid.append(pipeline);
+  sourceColumn.append(pipeline);
   section.append(grid);
 
   mountKnowledgePaneVueIsland(section, targetDocument, pane, knowledgeActions, workItems);
@@ -8375,6 +8382,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-module-work-row {
       min-width: 0;
       min-height: 34px;
+      max-width: 100%;
       border: 1px solid var(--border, #e6dfd8);
       border-radius: 6px;
       padding: 6px 8px;
@@ -8384,6 +8392,15 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       text-align: left;
       overflow-wrap: anywhere;
       cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-module-work-row .n-button__content {
+      display: block;
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     body.desktop-native-workbench .desktop-empty-session h1 {
@@ -9091,17 +9108,30 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-knowledge-management-grid {
       display: grid;
-      grid-template-columns: minmax(340px, 0.84fr) minmax(520px, 1.16fr);
-      grid-template-areas:
-        "overview overview"
-        "upload graph"
-        "queue graph"
-        "documents graph"
-        "documents pipeline";
+      grid-template-columns: minmax(420px, 1fr) clamp(500px, 42vw, 720px);
       gap: 14px;
       align-items: start;
       min-width: 0;
       width: 100%;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-source-column,
+    body.desktop-native-workbench .desktop-knowledge-inspector-column {
+      display: grid;
+      align-content: start;
+      gap: 14px;
+      min-width: 0;
+      min-height: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-source-column > .desktop-knowledge-region,
+    body.desktop-native-workbench .desktop-knowledge-inspector-column > .desktop-knowledge-region {
+      grid-area: auto;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-inspector-column {
+      position: sticky;
+      top: 14px;
     }
 
     body.desktop-native-workbench .desktop-knowledge-region {
@@ -9142,7 +9172,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-knowledge-graph-region {
       grid-area: graph;
       display: grid;
+      grid-template-rows: auto minmax(0, 1fr);
       gap: 14px;
+      max-height: calc(100vh - 96px);
     }
 
     body.desktop-native-workbench .desktop-knowledge-pipeline {
@@ -9330,17 +9362,24 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       position: relative;
       display: grid;
       gap: 10px;
-      min-height: 320px;
+      min-height: 0;
       min-width: 0;
     }
 
     body.desktop-native-workbench .desktop-knowledge-graph-workspace {
       position: relative;
-      min-height: 440px;
+      display: grid;
+      grid-template-rows: minmax(280px, 0.92fr) minmax(180px, 1fr);
+      gap: 10px;
+      min-width: 0;
+      min-height: min(720px, calc(100vh - 176px));
+      max-height: calc(100vh - 176px);
     }
 
     body.desktop-native-workbench .desktop-knowledge-graph-canvas {
-      min-height: 360px;
+      min-width: 0;
+      min-height: 280px;
+      overflow: hidden;
       border: 1px solid var(--border-subtle, #ebe6df);
       border-radius: var(--radius-lg, 12px);
       background:
@@ -9350,7 +9389,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-knowledge-graph-canvas svg {
       width: 100%;
-      min-height: 360px;
+      min-height: 280px;
     }
 
     body.desktop-native-workbench .desktop-knowledge-graph-node circle {
@@ -9392,6 +9431,47 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       bottom: 14px;
       width: 96px;
       height: 72px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-references {
+      min-width: 0;
+      min-height: 0;
+      overflow: auto;
+      border: 1px solid var(--border-subtle, #ebe6df);
+      border-radius: var(--radius-lg, 12px);
+      background: var(--bg, #faf9f5);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-references h2 {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      margin: 0;
+      border-bottom: 1px solid var(--border-subtle, #ebe6df);
+      padding: 8px 10px;
+      background: var(--bg, #faf9f5);
+      color: var(--text, #141413);
+      font: 750 12px/1.2 var(--font-sans, system-ui, sans-serif);
+      text-transform: uppercase;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-references .n-list {
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-references .n-list-item {
+      min-width: 0;
+      padding: 8px 10px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-references .n-space {
+      min-width: 0;
+      max-width: 100%;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-references .n-space > span:last-child {
+      min-width: 0;
+      overflow-wrap: anywhere;
     }
 
     body.desktop-native-workbench .desktop-knowledge-pipeline-workspace,
@@ -9459,13 +9539,18 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
       body.desktop-native-workbench .desktop-knowledge-management-grid {
         grid-template-columns: minmax(0, 1fr);
-        grid-template-areas:
-          "overview"
-          "upload"
-          "queue"
-          "documents"
-          "graph"
-          "pipeline";
+      }
+
+      body.desktop-native-workbench .desktop-knowledge-inspector-column {
+        position: static;
+      }
+
+      body.desktop-native-workbench .desktop-knowledge-graph-region {
+        max-height: none;
+      }
+
+      body.desktop-native-workbench .desktop-knowledge-graph-workspace {
+        max-height: none;
       }
 
       body.desktop-native-workbench .desktop-knowledge-overview {

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
@@ -43,6 +43,8 @@ describe("knowledge graph Vue island", () => {
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("knowledge-graph");
     expect(host.className).toContain("desktop-knowledge-graph");
+    expect(host.querySelector('[data-desktop-knowledge-graph-pane="canvas"]')).not.toBeNull();
+    expect(host.querySelector('[data-desktop-knowledge-graph-pane="references"]')).not.toBeNull();
     expect(host.querySelector("h2")?.textContent).toBe("Graph: 2 nodes / 1 edge / 5 evidence");
     expect(host.textContent).toContain("Community: Desktop cluster - Cluster summary");
     expect(host.textContent).toContain("Report: Desktop report - Report summary");

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
@@ -50,7 +50,10 @@ function createKnowledgeGraphApp(options: KnowledgeGraphIslandOptions): App {
           h("div", { class: "desktop-knowledge-graph-minimap", "aria-label": "Graph minimap" }, [
             h("span"),
           ]),
-          h("div", { class: "desktop-knowledge-graph-references" }, [
+          h("div", {
+            class: "desktop-knowledge-graph-references",
+            "data-desktop-knowledge-graph-pane": "references",
+          }, [
             h("h2", `Graph: ${options.graph.summary}`),
             renderReferenceGroup("Community", options.graph.communities),
             renderReferenceGroup("Report", options.graph.reports),
@@ -67,7 +70,10 @@ function createKnowledgeGraphApp(options: KnowledgeGraphIslandOptions): App {
 
 function renderGraphCanvas(graph: DesktopKnowledgePaneGraph) {
   if (!graph.view.nodes.length) {
-    return h("div", { class: "desktop-knowledge-graph-canvas desktop-knowledge-graph-empty" }, [
+    return h("div", {
+      class: "desktop-knowledge-graph-canvas desktop-knowledge-graph-empty",
+      "data-desktop-knowledge-graph-pane": "canvas",
+    }, [
       h("strong", "No graph built yet"),
       h("p", "Upload documents, then build the graph to inspect entities and relationships."),
     ]);
@@ -78,7 +84,10 @@ function renderGraphCanvas(graph: DesktopKnowledgePaneGraph) {
     .slice(0, 10)
     .map((edge) => ({ edge, source: nodePoints.get(edge.sourceId), target: nodePoints.get(edge.targetId) }))
     .filter((entry): entry is { edge: DesktopKnowledgeGraphEdge; source: GraphPoint; target: GraphPoint } => Boolean(entry.source && entry.target));
-  return h("div", { class: "desktop-knowledge-graph-canvas" }, [
+  return h("div", {
+    class: "desktop-knowledge-graph-canvas",
+    "data-desktop-knowledge-graph-pane": "canvas",
+  }, [
     h("svg", { viewBox: "0 0 640 360", role: "img", "aria-label": graph.summary }, [
       ...visibleEdges.map(({ edge, source, target }) => renderGraphEdge(edge, source, target)),
       ...visibleNodes.map((node, index) => renderGraphNode(node, index, visibleNodes.length)),

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
@@ -106,14 +106,27 @@ describe("knowledge pane Vue island", () => {
     expect(host.querySelector(".desktop-knowledge-management-grid")?.getAttribute("data-desktop-knowledge-layout")).toBe(
       "source-left-graph-right",
     );
+    const sourceColumn = host.querySelector('[data-desktop-knowledge-column="source"]');
+    const inspectorColumn = host.querySelector('[data-desktop-knowledge-column="inspector"]');
+    expect(Array.from(sourceColumn?.children ?? [], (node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
+      "overview",
+      "upload",
+      "queue",
+      "documents",
+      "query",
+      "pipeline",
+    ]);
+    expect(Array.from(inspectorColumn?.children ?? [], (node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
+      "graph",
+    ]);
     expect(Array.from(host.querySelectorAll("[data-desktop-knowledge-region]"), (node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
       "overview",
       "upload",
       "queue",
       "documents",
       "query",
-      "graph",
       "pipeline",
+      "graph",
     ]);
     expect(host.querySelector(".desktop-knowledge-title-block h2")?.textContent).toBe("Knowledge Base");
     expect(host.textContent).toContain("Manage your knowledge base, monitor ingestion, and explore the knowledge graph.");

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.ts
@@ -118,17 +118,27 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
             class: "desktop-knowledge-management-grid",
             "data-desktop-knowledge-layout": "source-left-graph-right",
           }, [
-            h("section", {
-              class: "desktop-knowledge-region desktop-knowledge-overview",
-              "data-desktop-knowledge-region": "overview",
-              "aria-label": "Knowledge base overview",
-            }, renderKnowledgeOverview(options.pane)),
-            renderKnowledgeUploadRegion(options, uploadStatus),
-            renderKnowledgeQueueRegion(options, work),
-            renderKnowledgeDocumentsRegion(options, documents, documentDetail),
-            renderKnowledgeQueryRegion(query),
-            renderKnowledgeGraphRegion(options, graph),
-            renderKnowledgePipelineRegion(readiness),
+            h("div", {
+              class: "desktop-knowledge-source-column",
+              "data-desktop-knowledge-column": "source",
+            }, [
+              h("section", {
+                class: "desktop-knowledge-region desktop-knowledge-overview",
+                "data-desktop-knowledge-region": "overview",
+                "aria-label": "Knowledge base overview",
+              }, renderKnowledgeOverview(options.pane)),
+              renderKnowledgeUploadRegion(options, uploadStatus),
+              renderKnowledgeQueueRegion(options, work),
+              renderKnowledgeDocumentsRegion(options, documents, documentDetail),
+              renderKnowledgeQueryRegion(query),
+              renderKnowledgePipelineRegion(readiness),
+            ]),
+            h("div", {
+              class: "desktop-knowledge-inspector-column",
+              "data-desktop-knowledge-column": "inspector",
+            }, [
+              renderKnowledgeGraphRegion(options, graph),
+            ]),
           ]),
         ]),
       });


### PR DESCRIPTION
## Summary
- Split the native Knowledge surface into source and inspector columns so jobs/documents stay constrained to the left side.
- Add graph canvas/reference panes with internal scrolling for evidence lists.
- Tighten Knowledge job row overflow handling and responsive inspector behavior.

## Tests
- npm test -- src/native-vue/knowledgePaneIsland.test.ts src/native-vue/knowledgeGraphIsland.test.ts src/desktopWorkbenchShell.test.ts
- npm test
- npm run build