### PR TITLE
Polish native desktop UI and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+output/
 
 # Distribution / packaging
 .Python

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -70,6 +70,7 @@ type SharedGateway = Arc<Mutex<GatewayRuntime>>;
 const WORKER_CRON_TIMER_MAX_POLL: Duration = Duration::from_secs(30);
 const WORKER_WEBUI_ROUTE_TIMEOUT: Duration = Duration::from_secs(10);
 const NATIVE_BACKEND_LOG_MAX_BYTES: u64 = 5 * 1024 * 1024;
+const NATIVE_BACKEND_LOG_TAIL_LINES: usize = 100;
 
 struct GatewayRuntime {
     worker: WorkerManager,
@@ -110,6 +111,7 @@ struct GatewayRuntimeStatus {
     port: u16,
     repo_root: String,
     log_path: String,
+    log_tail: Vec<String>,
     logs: Vec<String>,
     last_error: Option<String>,
     exit_policy: &'static str,
@@ -1294,6 +1296,10 @@ fn current_status(shared: &SharedGateway) -> GatewayRuntimeStatus {
         port: 18790,
         repo_root: repo_root().display().to_string(),
         log_path: runtime.persistent_log_path.display().to_string(),
+        log_tail: read_native_backend_log_tail(
+            &runtime.persistent_log_path,
+            NATIVE_BACKEND_LOG_TAIL_LINES,
+        ),
         logs: gateway_runtime_logs(&runtime.logs, &worker_status.diagnostics),
         last_error: runtime
             .last_error
@@ -3183,6 +3189,23 @@ fn gateway_runtime_logs(
         .collect()
 }
 
+fn read_native_backend_log_tail(path: &Path, max_lines: usize) -> Vec<String> {
+    if max_lines == 0 {
+        return Vec::new();
+    }
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let lines = contents
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].to_vec()
+}
+
 fn worker_manager_frontend_event(event: WorkerManagerEvent) -> (String, serde_json::Value) {
     match event {
         WorkerManagerEvent::Status(status) => (
@@ -4390,6 +4413,35 @@ mod tests {
     }
 
     #[test]
+    fn gateway_status_exposes_recent_persistent_backend_log_tail() {
+        let fixture = WorkspaceFixture::new();
+        let log_path = fixture.root.join("logs").join("native-backend.log");
+        std::fs::create_dir_all(log_path.parent().expect("log path should have parent"))
+            .expect("log directory should create");
+        std::fs::write(
+            &log_path,
+            "older line\nworker.request.start route=POST /v1/knowledge/graph/extract\nknowledge.graph.extract.progress percent=60\n",
+        )
+        .expect("persistent log should write");
+        let shared = Arc::new(Mutex::new(GatewayRuntime {
+            persistent_log_path: log_path,
+            ..GatewayRuntime::default()
+        }));
+
+        let status = current_status(&shared);
+
+        assert_eq!(status.log_tail.len(), 3);
+        assert!(status
+            .log_tail
+            .iter()
+            .any(|line| line.contains("POST /v1/knowledge/graph/extract")));
+        assert!(status
+            .log_tail
+            .iter()
+            .any(|line| line.contains("knowledge.graph.extract.progress")));
+    }
+
+    #[test]
     fn persistent_backend_log_rotates_when_size_limit_is_exceeded() {
         let fixture = WorkspaceFixture::new();
         let log_path = fixture.root.join("logs").join("native-backend.log");
@@ -4480,6 +4532,7 @@ mod tests {
             port: 18790,
             repo_root: "/repo".to_string(),
             log_path: "/logs/native-backend.log".to_string(),
+            log_tail: vec![],
             logs: vec![],
             last_error: None,
             exit_policy: "stop_on_exit",

--- a/apps/desktop/src/desktopGatewayStartup.ts
+++ b/apps/desktop/src/desktopGatewayStartup.ts
@@ -10,6 +10,7 @@ export type GatewayRuntimeStatus = {
   port?: number | string | null;
   repo_root: string;
   log_path?: string | null;
+  log_tail?: string[];
   logs: string[];
   last_error: string | null;
   exit_policy?: "stop_on_exit" | "keep_running" | string | null;

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -3106,25 +3106,26 @@ describe("desktop workbench shell", () => {
     const sourceColumn = pane?.querySelector('[data-desktop-knowledge-column="source"]');
     const inspectorColumn = pane?.querySelector('[data-desktop-knowledge-column="inspector"]');
     expect(sourceColumn?.querySelector('[data-desktop-knowledge-region="upload"]')?.textContent).toContain("Upload Documents");
-    expect(sourceColumn?.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Knowledge Jobs");
+    expect(sourceColumn?.querySelector('[data-desktop-knowledge-region="queue"]')).toBeNull();
     expect(sourceColumn?.querySelector('[data-desktop-knowledge-region="documents"]')?.textContent).toContain("Documents (1)");
     expect(inspectorColumn?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Knowledge Graph");
     expect(pane?.querySelectorAll("[data-desktop-knowledge-region]").map((node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
       "overview",
       "upload",
-      "queue",
       "documents",
       "query",
       "pipeline",
       "graph",
     ]);
     expect(pane?.textContent).toContain("Knowledge Base");
+    expect(pane?.querySelector(".desktop-knowledge-kicker")).toBeNull();
+    expect(pane?.querySelector(".desktop-knowledge-status")).toBeNull();
     expect(pane?.textContent).toContain("Manage your knowledge base, monitor ingestion, and explore the knowledge graph.");
-    expect(pane?.textContent).toContain("1 doc / readiness 100% / graph 1 nodes / 0 edges");
+    expect(pane?.textContent).not.toContain("1 doc / readiness 100% / graph 1 nodes / 0 edges");
     expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Documents");
     expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Graph Nodes");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Last Indexed");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("2026-06-14 09:41");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).not.toContain("Last Indexed");
+    expect(pane?.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).not.toContain("2026-06-14 09:41");
     expect(targetDocument.body.querySelector(".desktop-file-actions")).toBeNull();
     expect(targetDocument.body.textContent).not.toContain("File imports");
     const uploadRegion = pane?.querySelector('[data-desktop-knowledge-region="upload"]');
@@ -3132,7 +3133,6 @@ describe("desktop workbench shell", () => {
     expect(uploadRegion?.textContent).toContain("Drag & drop files here or click to browse");
     expect(uploadRegion?.textContent).toContain("Max 200MB per file");
     expect(uploadRegion?.querySelector("#desktop-knowledge-upload")?.getAttribute("data-desktop-file-upload")).toBe("knowledge-document");
-    expect(pane?.querySelector('[data-desktop-knowledge-region="queue"]')?.textContent).toContain("Knowledge Jobs");
     const documentsRegion = pane?.querySelector('[data-desktop-knowledge-region="documents"]');
     expect(documentsRegion?.textContent).toContain("Documents (1)");
     expect(documentsRegion?.querySelector("[data-desktop-knowledge-document-search]")?.getAttribute("placeholder")).toBe("Search documents...");

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -997,6 +997,10 @@ describe("desktop workbench shell", () => {
         command: "tinybot gateway",
         repo_root: "D:/code/tinybot/tinybot",
         log_path: "C:/Users/me/AppData/Local/tinybot/logs/native-backend.log",
+        log_tail: [
+          "2026-06-19T12:00:00.000Z stderr worker.request.start method=webui.handle_request route=POST /v1/knowledge/graph/extract",
+          "2026-06-19T12:00:01.000Z stderr knowledge.graph.extract.progress percent=60",
+        ],
         logs: ["gateway ready", "knowledge upload accepted"],
         last_error: null,
         worker_runtime: {
@@ -1041,6 +1045,9 @@ describe("desktop workbench shell", () => {
     expect(backendLogsDialog?.getAttribute("aria-modal")).toBe("true");
     expect(backendLogsDialog?.textContent).toContain("Backend Logs");
     expect(backendLogsDialog?.textContent).toContain("Log file: C:/Users/me/AppData/Local/tinybot/logs/native-backend.log");
+    expect(backendLogsDialog?.textContent).toContain("Persistent log tail (2)");
+    expect(backendLogsDialog?.textContent).toContain("POST /v1/knowledge/graph/extract");
+    expect(backendLogsDialog?.textContent).toContain("knowledge.graph.extract.progress");
     expect(backendLogsDialog?.textContent).toContain("gateway ready");
     expect(backendLogsDialog?.textContent).toContain("[knowledge]");
     expect(backendLogsDialog?.textContent).toContain("RAG.md");

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -3136,7 +3136,8 @@ describe("desktop workbench shell", () => {
     const documentsRegion = pane?.querySelector('[data-desktop-knowledge-region="documents"]');
     expect(documentsRegion?.textContent).toContain("Documents (1)");
     expect(documentsRegion?.querySelector("[data-desktop-knowledge-document-search]")?.getAttribute("placeholder")).toBe("Search documents...");
-    expect(documentsRegion?.querySelector("[data-desktop-knowledge-documents-table]")?.textContent).toContain("Actions");
+    expect(documentsRegion?.querySelector("[data-desktop-knowledge-documents-table]")).toBeNull();
+    expect(documentsRegion?.querySelector("[data-desktop-knowledge-documents-list]")?.textContent).toContain("Desktop UX");
     expect(documentsRegion?.querySelector('[data-desktop-knowledge-document-action="deleteDocument"]')?.textContent).toContain("Delete");
     expect(pane?.textContent).toContain("Knowledge enabled");
     expect(documentsRegion?.textContent).toContain("Desktop UX");

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -3147,8 +3147,8 @@ describe("desktop workbench shell", () => {
     expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Graph: 1 nodes / 0 edges / 0 evidence");
     expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Extract Graph");
     expect(pane?.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).toContain("Rebuild Index");
-    expect(pane?.querySelector(".desktop-knowledge-graph-legend")?.textContent).toContain("Entity");
-    expect(pane?.querySelector(".desktop-knowledge-graph-minimap")).not.toBeNull();
+    expect(pane?.querySelector(".desktop-knowledge-graph-legend")).toBeNull();
+    expect(pane?.querySelector(".desktop-knowledge-graph-minimap")).toBeNull();
     expect(pane?.querySelector('[data-desktop-knowledge-region="pipeline"]')?.textContent).toContain("Graph Build");
     expect(pane?.querySelector('[data-desktop-knowledge-region="pipeline"]')?.textContent).toContain("6 steps");
     expect(pane?.textContent).toContain("Community: Desktop cluster");

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -36,6 +36,7 @@ class FakeElement {
     setProperty: (name: string, value: string) => {
       this.style.values.set(name, value);
     },
+    getPropertyValue: (name: string) => this.style.values.get(name) ?? "",
   };
 
   constructor(public readonly tagName: string, private readonly ownerDocument?: FakeDocument) {}
@@ -77,6 +78,10 @@ class FakeElement {
     this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
   }
 
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.set(type, (this.listeners.get(type) ?? []).filter((candidate) => candidate !== listener));
+  }
+
   dispatchEvent(event: { type: string } & Record<string, unknown>): boolean {
     for (const listener of this.listeners.get(event.type) ?? []) {
       listener(event);
@@ -93,6 +98,10 @@ class FakeElement {
       this.ownerDocument.activeElement = this;
     }
   }
+
+  setPointerCapture(): void {}
+
+  releasePointerCapture(): void {}
 
   getBoundingClientRect(): DOMRect {
     return {
@@ -173,6 +182,10 @@ class FakeDocument {
 
   addEventListener(type: string, listener: (event: unknown) => void): void {
     this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.set(type, (this.listeners.get(type) ?? []).filter((candidate) => candidate !== listener));
   }
 
   dispatchEvent(event: { type: string } & Record<string, unknown>): boolean {
@@ -257,6 +270,54 @@ describe("desktop workbench shell", () => {
     const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
     expect(styleText).toContain(".desktop-workbench-shell {\n      height: 100vh;");
     expect(styleText).not.toContain("height: calc(100vh - var(--desktop-window-frame-height");
+  });
+
+  test("resizes the sidebar with a drag handle and collapses after overshooting the minimum", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+      },
+    });
+
+    const shell = targetDocument.getElementById("desktop-workbench-shell");
+    const sidebar = targetDocument.body.querySelector('[data-workbench-region="sidebar"]');
+    const handle = targetDocument.body.querySelector('[data-desktop-sidebar-resizer]');
+
+    expect(handle?.getAttribute("role")).toBe("separator");
+    expect(handle?.getAttribute("aria-orientation")).toBe("vertical");
+    expect(handle?.getAttribute("aria-valuemin")).toBe("220");
+    expect(handle?.getAttribute("aria-valuemax")).toBe("300");
+    expect(handle?.getAttribute("aria-valuenow")).toBe("260");
+
+    handle?.dispatchEvent({
+      type: "pointerdown",
+      button: 0,
+      clientX: 260,
+      preventDefault: () => {},
+      pointerId: 1,
+    });
+    targetDocument.dispatchEvent({ type: "pointermove", clientX: 230, preventDefault: () => {} });
+    expect(shell?.style.values.get("--desktop-sidebar-size")).toBe("230px");
+    expect(sidebar?.style.values.get("--region-size")).toBe("230px");
+    expect(handle?.getAttribute("aria-valuenow")).toBe("230");
+    expect(shell?.getAttribute("data-sidebar-visible")).toBe("true");
+
+    targetDocument.dispatchEvent({ type: "pointermove", clientX: 90, preventDefault: () => {} });
+    expect(shell?.style.values.get("--desktop-sidebar-size")).toBe("220px");
+    expect(sidebar?.style.values.get("--region-size")).toBe("220px");
+    expect(shell?.getAttribute("data-sidebar-visible")).toBe("false");
+    expect(sidebar?.getAttribute("data-visible")).toBe("false");
+    expect(handle?.getAttribute("aria-valuenow")).toBe("220");
+
+    targetDocument.dispatchEvent({ type: "pointerup", clientX: 90 });
   });
 
   test("renders dense empty-chat context instead of a browser-style blank page", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -3887,10 +3887,8 @@ function createKnowledgePane(
   const titleBlock = targetDocument.createElement("div");
   titleBlock.className = "desktop-knowledge-title-block";
   titleBlock.append(
-    createText(targetDocument, "p", "Knowledge Base", "desktop-knowledge-kicker"),
     createText(targetDocument, "h2", "Knowledge Base"),
     createText(targetDocument, "p", "Manage your knowledge base, monitor ingestion, and explore the knowledge graph."),
-    createText(targetDocument, "p", pane.status, "desktop-knowledge-status"),
   );
   const toolbar = targetDocument.createElement("div");
   toolbar.className = "desktop-knowledge-toolbar";
@@ -3920,7 +3918,6 @@ function createKnowledgePane(
     ["Readiness", `${pane.readiness.score}%`, `${pane.documentRows.reduce((total, row) => total + row.chunkCount, 0)} indexed chunks`],
     ["Graph Nodes", String(pane.graph.view.nodes.length), `${pane.graph.evidence.length} evidence`],
     ["Relations", String(pane.graph.view.edges.length), "Graph edges"],
-    ["Last Indexed", pane.lastIndexedLabel, "Knowledge freshness"],
   ];
   for (const [label, value, detail] of metrics) {
     const metric = targetDocument.createElement("article");
@@ -3955,19 +3952,19 @@ function createKnowledgePane(
   uploadRegion.append(uploadHeader, dropZone, createKnowledgeUploadControl(targetDocument));
   sourceColumn.append(uploadRegion);
 
-  const queue = targetDocument.createElement("section");
-  queue.className = "desktop-knowledge-region desktop-knowledge-queue-region";
-  queue.setAttribute("data-desktop-knowledge-region", "queue");
-  queue.setAttribute("aria-label", "Knowledge jobs");
-  queue.append(createKnowledgeRegionHeader(
-    targetDocument,
-    `Knowledge Jobs${workItems.length ? ` (${workItems.length})` : ""}`,
-    "Track active indexing, rebuild, upload, and graph extraction jobs.",
-  ));
-  queue.append(workItems.length
-    ? createModuleWorkSection(targetDocument, "Knowledge jobs", workItems)
-    : createText(targetDocument, "p", "No knowledge jobs running.", "desktop-knowledge-empty-note"));
-  sourceColumn.append(queue);
+  if (workItems.length) {
+    const queue = targetDocument.createElement("section");
+    queue.className = "desktop-knowledge-region desktop-knowledge-queue-region";
+    queue.setAttribute("data-desktop-knowledge-region", "queue");
+    queue.setAttribute("aria-label", "Knowledge jobs");
+    queue.append(createKnowledgeRegionHeader(
+      targetDocument,
+      `Knowledge Jobs (${workItems.length})`,
+      "Track active indexing, rebuild, upload, and graph extraction jobs.",
+    ));
+    queue.append(createModuleWorkSection(targetDocument, "Knowledge jobs", workItems));
+    sourceColumn.append(queue);
+  }
 
   const documentsRegion = targetDocument.createElement("section");
   documentsRegion.className = "desktop-knowledge-region desktop-knowledge-documents-region";
@@ -9120,7 +9117,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-knowledge-workbench {
       display: grid;
-      gap: 18px;
+      gap: 14px;
       min-width: 0;
     }
 
@@ -9132,8 +9129,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       border: 1px solid var(--border, #e6dfd8);
       border-radius: var(--radius-lg, 12px);
-      padding: 22px 24px;
-      background: var(--surface-soft, #f5f0e8);
+      padding: 14px 16px;
+      background: var(--panel, #faf9f5);
     }
 
     body.desktop-native-workbench .desktop-knowledge-title-block {
@@ -9161,23 +9158,14 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-knowledge-title-block h2 {
-      font: 500 30px/1.08 var(--font-display, Georgia, serif);
+      font: 750 20px/1.15 var(--font-sans, system-ui, sans-serif);
     }
 
     body.desktop-native-workbench .desktop-knowledge-title-block p {
       margin: 0;
       max-width: 720px;
       color: var(--text-body, #3d3d3a);
-      font: 500 15px/1.45 var(--font-sans, system-ui, sans-serif);
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-kicker {
-      color: var(--accent, #cc785c);
-      text-transform: uppercase;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-status {
-      color: var(--text-muted, #6c6a64);
+      font: 600 13px/1.35 var(--font-sans, system-ui, sans-serif);
     }
 
     body.desktop-native-workbench .desktop-knowledge-action-row {
@@ -9280,7 +9268,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-knowledge-overview {
       grid-area: overview;
       display: grid;
-      grid-template-columns: repeat(5, minmax(120px, 1fr));
+      grid-template-columns: repeat(4, minmax(120px, 1fr));
       gap: 12px;
     }
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -3985,38 +3985,27 @@ function createKnowledgePane(
   search.setAttribute("placeholder", "Search documents...");
   search.setAttribute("data-desktop-knowledge-document-search", "");
   documentToolbar.append(search);
-  const table = targetDocument.createElement("table");
-  table.className = "desktop-knowledge-documents-table";
-  table.setAttribute("data-desktop-knowledge-documents-table", "");
-  const colgroup = targetDocument.createElement("colgroup");
-  for (const column of ["name", "type", "size", "status", "added", "actions"]) {
-    const col = targetDocument.createElement("col");
-    col.className = `desktop-knowledge-documents-col-${column}`;
-    colgroup.append(col);
-  }
-  const thead = targetDocument.createElement("thead");
-  const headerRow = targetDocument.createElement("tr");
-  for (const heading of ["Name", "Type", "Size", "Status", "Added", "Actions"]) {
-    headerRow.append(createText(targetDocument, "th", heading));
-  }
-  thead.append(headerRow);
-  const tbody = targetDocument.createElement("tbody");
+  const documentList = targetDocument.createElement("div");
+  documentList.className = "desktop-knowledge-documents-list";
+  documentList.setAttribute("data-desktop-knowledge-documents-list", "");
   for (const document of pane.documentRows) {
-    const row = targetDocument.createElement("tr");
+    const row = targetDocument.createElement("article");
+    row.className = "desktop-knowledge-document-row";
     setDesktopEntityHook(row, "knowledge", document.id || document.path);
-    const nameCell = createText(targetDocument, "td", document.title);
-    nameCell.className = "desktop-knowledge-documents-cell-name";
-    const typeCell = createText(targetDocument, "td", document.typeLabel || document.category || "DOC");
-    typeCell.className = "desktop-knowledge-documents-cell-type";
-    const sizeCell = createText(targetDocument, "td", document.sizeLabel || "-");
-    sizeCell.className = "desktop-knowledge-documents-cell-size";
-    const statusCell = createText(targetDocument, "td", document.status || "unknown");
-    statusCell.className = "desktop-knowledge-documents-cell-status";
-    const addedCell = createText(targetDocument, "td", document.addedLabel || "-");
-    addedCell.className = "desktop-knowledge-documents-cell-added";
-    row.append(nameCell, typeCell, sizeCell, statusCell, addedCell);
-    const actions = targetDocument.createElement("td");
-    actions.className = "desktop-knowledge-documents-cell-actions";
+    const summary = targetDocument.createElement("div");
+    summary.className = "desktop-knowledge-document-summary";
+    summary.append(
+      createText(targetDocument, "strong", document.title),
+      createText(targetDocument, "span", document.meta, "desktop-knowledge-document-meta"),
+    );
+    const attributes = targetDocument.createElement("div");
+    attributes.className = "desktop-knowledge-document-attributes";
+    const documentAttributes = [document.typeLabel || document.category || "DOC", document.sizeLabel, document.addedLabel]
+      .filter((value): value is string => Boolean(value));
+    for (const attribute of documentAttributes) {
+      attributes.append(createText(targetDocument, "span", attribute, "desktop-knowledge-document-attribute"));
+    }
+    attributes.append(createText(targetDocument, "span", document.status || "unknown", "desktop-knowledge-document-status"));
     const deleteButton = targetDocument.createElement("button");
     deleteButton.className = "desktop-knowledge-action-button desktop-knowledge-action-button-secondary";
     deleteButton.setAttribute("type", "button");
@@ -4029,22 +4018,16 @@ function createKnowledgePane(
     deleteButton.addEventListener("click", () => {
       knowledgeActions.onKnowledgeAction?.({ action: "deleteDocument", pane, documentId: document.id || document.path });
     });
-    actions.append(deleteButton);
-    row.append(actions);
-    tbody.append(row);
+    row.append(summary, attributes, deleteButton);
+    documentList.append(row);
   }
   search.addEventListener("input", () => {
     const query = search.value.trim().toLowerCase();
-    for (const row of Array.from(tbody.querySelectorAll<HTMLTableRowElement>("tr"))) {
+    for (const row of Array.from(documentList.querySelectorAll<HTMLElement>(".desktop-knowledge-document-row"))) {
       row.hidden = Boolean(query) && !row.textContent?.toLowerCase().includes(query);
     }
   });
-  table.append(colgroup, thead, tbody);
-  const tableViewport = targetDocument.createElement("div");
-  tableViewport.className = "desktop-knowledge-documents-table-viewport";
-  tableViewport.setAttribute("data-desktop-knowledge-documents-table-viewport", "");
-  tableViewport.append(table);
-  documents.append(documentToolbar, tableViewport);
+  documents.append(documentToolbar, documentList);
   mountKnowledgeDocumentsVueIsland(documents, pane);
   documentsRegion.append(documents);
 
@@ -4116,15 +4099,19 @@ function createKnowledgePane(
     });
   });
   queryControls.append(queryInput, modeSelect, topKInput, runQueryButton);
-  querySurface.append(
-    createText(targetDocument, "h2", "Knowledge Query"),
-    queryControls,
-    createText(targetDocument, "p", `Mode: ${pane.query.draft.mode} / top ${pane.query.draft.topK}`),
-    createText(targetDocument, "p", `Results: ${pane.query.results.summary.count}`),
+  const queryPanel = targetDocument.createElement("div");
+  queryPanel.className = "desktop-knowledge-query-panel";
+  const querySummary = targetDocument.createElement("p");
+  querySummary.className = "desktop-knowledge-query-summary";
+  querySummary.append(
+    createText(targetDocument, "span", `Mode: ${pane.query.draft.mode} / top ${pane.query.draft.topK}`),
+    createText(targetDocument, "span", `Results: ${pane.query.results.summary.count}`),
   );
+  queryPanel.append(queryControls, querySummary);
   for (const result of pane.query.results.rows.slice(0, 4)) {
-    querySurface.append(createText(targetDocument, "p", `${result.docName}: ${result.content}`));
+    queryPanel.append(createText(targetDocument, "p", `${result.docName}: ${result.content}`));
   }
+  querySurface.append(queryPanel);
   queryRegion.append(querySurface);
   sourceColumn.append(queryRegion);
 
@@ -9268,8 +9255,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-knowledge-overview {
       grid-area: overview;
       display: grid;
-      grid-template-columns: repeat(4, minmax(120px, 1fr));
-      gap: 12px;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
     }
 
     body.desktop-native-workbench .desktop-knowledge-upload-region {
@@ -9327,7 +9314,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       border: 1px solid var(--border, #e6dfd8);
       border-radius: var(--radius-md, 8px);
-      padding: 14px;
+      padding: 12px;
       background: var(--surface-card, #efe9de);
     }
 
@@ -9349,7 +9336,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: grid;
       gap: 8px;
       place-items: center;
-      min-height: 112px;
+      min-height: 92px;
       border: 1px dashed rgba(204, 120, 92, 0.45);
       border-radius: var(--radius-md, 8px);
       padding: 16px;
@@ -9423,7 +9410,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-knowledge-queue-row button,
     body.desktop-native-workbench .desktop-knowledge-documents-toolbar button,
-    body.desktop-native-workbench .desktop-knowledge-documents-table button {
+    body.desktop-native-workbench .desktop-knowledge-document-row button,
+    body.desktop-native-workbench .desktop-knowledge-query-controls button {
       min-height: 32px;
       border: 1px solid var(--border, #e6dfd8);
       border-radius: var(--radius-md, 8px);
@@ -9460,60 +9448,29 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
     }
 
-    body.desktop-native-workbench .desktop-knowledge-documents-table {
-      width: 100%;
+    body.desktop-native-workbench .desktop-knowledge-documents-list {
+      display: grid;
+      gap: 8px;
       min-width: 0;
-      border-collapse: collapse;
-      table-layout: fixed;
-      font: 600 12px/1.35 var(--font-sans, system-ui, sans-serif);
     }
 
-    body.desktop-native-workbench .desktop-knowledge-documents-table-viewport {
+    body.desktop-native-workbench .desktop-knowledge-document-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 8px 10px;
+      align-items: center;
       min-width: 0;
-      max-width: 100%;
-      overflow-x: auto;
-      overflow-y: hidden;
       border-top: 1px solid var(--border-subtle, #ebe6df);
+      padding-top: 10px;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-documents-col-name {
-      width: 38%;
+    body.desktop-native-workbench .desktop-knowledge-document-summary {
+      display: grid;
+      gap: 2px;
+      min-width: 0;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-documents-col-type,
-    body.desktop-native-workbench .desktop-knowledge-documents-col-size {
-      width: 10%;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-documents-col-status,
-    body.desktop-native-workbench .desktop-knowledge-documents-col-added {
-      width: 15%;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-documents-col-actions {
-      width: 76px;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-documents-table th,
-    body.desktop-native-workbench .desktop-knowledge-documents-table td {
-      max-width: 0;
-      overflow: hidden;
-      border-top: 1px solid var(--border-subtle, #ebe6df);
-      padding: 8px 6px;
-      color: var(--text-body, #3d3d3a);
-      text-align: left;
-      text-overflow: ellipsis;
-      vertical-align: top;
-      white-space: nowrap;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-documents-table th {
-      color: var(--text-muted, #6c6a64);
-      font-size: 11px;
-      text-transform: uppercase;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-documents-cell-name strong,
+    body.desktop-native-workbench .desktop-knowledge-document-summary strong,
     body.desktop-native-workbench .desktop-knowledge-document-meta {
       display: block;
       min-width: 0;
@@ -9523,8 +9480,64 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       white-space: nowrap;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-documents-cell-actions button {
+    body.desktop-native-workbench .desktop-knowledge-document-attributes {
+      display: flex;
+      flex-wrap: wrap;
+      grid-column: 1 / -1;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-document-attribute,
+    body.desktop-native-workbench .desktop-knowledge-document-status {
+      display: inline-flex;
+      align-items: center;
+      min-height: 22px;
       max-width: 100%;
+      border: 1px solid var(--border-subtle, #ebe6df);
+      border-radius: var(--radius-full, 9999px);
+      padding: 0 8px;
+      color: var(--text-muted, #6c6a64);
+      font: 650 11px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-document-row button {
+      max-width: 100%;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-query-panel {
+      display: grid;
+      gap: 10px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-query-controls {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(84px, auto) 64px auto;
+      gap: 8px;
+      align-items: center;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-query-controls input,
+    body.desktop-native-workbench .desktop-knowledge-query-controls select {
+      min-width: 0;
+      min-height: 34px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: var(--radius-md, 8px);
+      padding: 0 10px;
+      background: var(--bg, #faf9f5);
+      color: var(--text, #141413);
+      font: 600 12px/1.2 var(--font-sans, system-ui, sans-serif);
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-query-summary {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 12px;
+      margin: 0;
+      color: var(--text-muted, #6c6a64);
+      font: 650 12px/1.4 var(--font-sans, system-ui, sans-serif);
     }
 
     body.desktop-native-workbench .desktop-knowledge-graph {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -4142,12 +4142,6 @@ function createKnowledgePane(
   for (const evidence of pane.graph.evidence.slice(0, 4)) {
     graphSurface.append(createText(targetDocument, "p", `Evidence: ${evidence.title} / ${evidence.docName}`));
   }
-  const legend = targetDocument.createElement("div");
-  legend.className = "desktop-knowledge-graph-legend";
-  legend.textContent = "Entity Edge";
-  const minimap = targetDocument.createElement("div");
-  minimap.className = "desktop-knowledge-graph-minimap";
-  graphSurface.append(legend, minimap);
   mountKnowledgeGraphVueIsland(graphSurface, pane);
   graph.append(graphHeader, graphSurface);
   inspectorColumn.append(graph);
@@ -9589,30 +9583,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       stroke: var(--accent, #cc785c);
       stroke-width: 1.5;
       opacity: 0.72;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-graph-legend,
-    body.desktop-native-workbench .desktop-knowledge-graph-minimap {
-      position: absolute;
-      right: 14px;
-      border: 1px solid var(--border, #e6dfd8);
-      border-radius: var(--radius-md, 8px);
-      background: rgba(250, 249, 245, 0.92);
-      color: var(--text-body, #3d3d3a);
-      font: 700 11px/1.2 var(--font-sans, system-ui, sans-serif);
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-graph-legend {
-      bottom: 102px;
-      display: grid;
-      gap: 6px;
-      padding: 8px 10px;
-    }
-
-    body.desktop-native-workbench .desktop-knowledge-graph-minimap {
-      bottom: 14px;
-      width: 96px;
-      height: 72px;
     }
 
     body.desktop-native-workbench .desktop-knowledge-graph-references {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -7946,11 +7946,15 @@ function createDesktopBackendLogsPanel(targetDocument: Document, dialog: HTMLEle
 
 function formatDesktopBackendLogs(runtimeStatus: GatewayRuntimeStatus | null, gatewayHttp: string): string {
   const runtimeLogs = runtimeStatus?.logs ?? [];
+  const persistentLogTail = runtimeStatus?.log_tail ?? [];
   const workerDiagnostics = runtimeStatus?.worker_runtime?.diagnostics ?? [];
   return [
     `Gateway: ${runtimeStatus?.gateway_http || gatewayHttp || "unknown"}`,
-    "Source: bounded in-memory runtime buffers",
+    "Source: bounded in-memory runtime buffers + persistent log file tail",
     `Log file: ${runtimeStatus?.log_path || "not configured"}`,
+    "",
+    `Persistent log tail (${persistentLogTail.length})`,
+    persistentLogTail.length ? persistentLogTail.join("\n") : "No persistent backend log lines.",
     "",
     `Gateway runtime logs (${runtimeLogs.length})`,
     runtimeLogs.length ? runtimeLogs.join("\n") : "No recent gateway logs.",

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -407,6 +407,9 @@ const COWORK_GRAPH_NODE_LIMIT = 24;
 const COWORK_GRAPH_EDGE_LIMIT = 12;
 const COWORK_OBSERVABILITY_ROW_LIMIT = 24;
 const COWORK_TASK_FEED_LIMIT = 20;
+const DESKTOP_SIDEBAR_MIN_SIZE = 220;
+const DESKTOP_SIDEBAR_MAX_SIZE = 300;
+const DESKTOP_SIDEBAR_COLLAPSE_OVERSHOOT = DESKTOP_SIDEBAR_MIN_SIZE * 0.5;
 type DesktopPanelControlId = "sidebar" | "inspector" | "bottom";
 interface DesktopWorkbenchLiveState {
   runChainItems: DesktopRunChainItem[];
@@ -7415,7 +7418,89 @@ function createPanel(
   panel.style.setProperty("--region-size", `${state.size}px`);
   panel.append(content);
   mountWorkbenchPanelVueIsland(panel, region, state, content);
+  if (region === "sidebar") {
+    panel.append(createSidebarResizer(targetDocument, state.size));
+  }
   return panel;
+}
+
+function createSidebarResizer(targetDocument: Document, initialSize: number): HTMLElement {
+  const handle = targetDocument.createElement("div");
+  handle.className = "desktop-workbench-sidebar-resizer";
+  handle.setAttribute("data-desktop-sidebar-resizer", "");
+  handle.setAttribute("role", "separator");
+  handle.setAttribute("aria-label", "Resize session list");
+  handle.setAttribute("aria-orientation", "vertical");
+  handle.setAttribute("aria-valuemin", String(DESKTOP_SIDEBAR_MIN_SIZE));
+  handle.setAttribute("aria-valuemax", String(DESKTOP_SIDEBAR_MAX_SIZE));
+  handle.setAttribute("aria-valuenow", String(clampDesktopSidebarSize(initialSize)));
+  handle.setAttribute("tabindex", "0");
+
+  handle.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    handle.setAttribute("data-dragging", "true");
+    handle.setPointerCapture?.(event.pointerId);
+    const startX = event.clientX;
+    const startSize = currentDesktopSidebarSize(targetDocument);
+    const onPointerMove = (moveEvent: PointerEvent) => {
+      moveEvent.preventDefault();
+      const requestedSize = startSize + moveEvent.clientX - startX;
+      if (requestedSize <= DESKTOP_SIDEBAR_MIN_SIZE - DESKTOP_SIDEBAR_COLLAPSE_OVERSHOOT) {
+        applyDesktopSidebarSize(targetDocument, DESKTOP_SIDEBAR_MIN_SIZE);
+        setDesktopPanelVisible(targetDocument, "sidebar", false);
+        return;
+      }
+      setDesktopPanelVisible(targetDocument, "sidebar", true);
+      applyDesktopSidebarSize(targetDocument, requestedSize);
+    };
+    const stopDrag = (upEvent: PointerEvent) => {
+      handle.removeAttribute("data-dragging");
+      handle.releasePointerCapture?.(upEvent.pointerId);
+      targetDocument.removeEventListener("pointermove", onPointerMove);
+      targetDocument.removeEventListener("pointerup", stopDrag);
+      targetDocument.removeEventListener("pointercancel", stopDrag);
+    };
+    targetDocument.addEventListener("pointermove", onPointerMove);
+    targetDocument.addEventListener("pointerup", stopDrag);
+    targetDocument.addEventListener("pointercancel", stopDrag);
+  });
+
+  handle.addEventListener("keydown", (event) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+      return;
+    }
+    event.preventDefault();
+    const direction = event.key === "ArrowLeft" ? -1 : 1;
+    setDesktopPanelVisible(targetDocument, "sidebar", true);
+    applyDesktopSidebarSize(targetDocument, currentDesktopSidebarSize(targetDocument) + direction * 12);
+  });
+
+  return handle;
+}
+
+function currentDesktopSidebarSize(targetDocument: Document): number {
+  const shell = targetDocument.getElementById(SHELL_ID);
+  const panel = targetDocument.querySelector<HTMLElement>('[data-workbench-region="sidebar"]');
+  const rawSize = shell?.style.getPropertyValue("--desktop-sidebar-size") || panel?.style.getPropertyValue("--region-size") || "";
+  const parsed = Number.parseFloat(rawSize);
+  return clampDesktopSidebarSize(Number.isFinite(parsed) ? parsed : 260);
+}
+
+function applyDesktopSidebarSize(targetDocument: Document, requestedSize: number): void {
+  const nextSize = clampDesktopSidebarSize(requestedSize);
+  const shell = targetDocument.getElementById(SHELL_ID);
+  const panel = targetDocument.querySelector<HTMLElement>('[data-workbench-region="sidebar"]');
+  const handle = targetDocument.querySelector<HTMLElement>("[data-desktop-sidebar-resizer]");
+  shell?.style.setProperty("--desktop-sidebar-size", `${nextSize}px`);
+  panel?.style.setProperty("--region-size", `${nextSize}px`);
+  handle?.setAttribute("aria-valuenow", String(nextSize));
+}
+
+function clampDesktopSidebarSize(size: number): number {
+  return Math.min(DESKTOP_SIDEBAR_MAX_SIZE, Math.max(DESKTOP_SIDEBAR_MIN_SIZE, Math.round(size)));
 }
 
 function mountWorkbenchPanelVueIsland(
@@ -8332,8 +8417,41 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-workbench-sidebar {
+      position: relative;
       grid-column: 2;
       width: var(--region-size);
+    }
+
+    body.desktop-native-workbench .desktop-workbench-sidebar-resizer {
+      position: absolute;
+      top: 0;
+      right: -5px;
+      z-index: 8;
+      width: 10px;
+      height: 100%;
+      border: 0;
+      background: transparent;
+      cursor: col-resize;
+      touch-action: none;
+    }
+
+    body.desktop-native-workbench .desktop-workbench-sidebar-resizer::after {
+      position: absolute;
+      top: 24px;
+      right: 4px;
+      bottom: 24px;
+      width: 2px;
+      border-radius: var(--radius-full, 9999px);
+      background: transparent;
+      content: "";
+      transition: background-color 160ms ease, box-shadow 160ms ease;
+    }
+
+    body.desktop-native-workbench .desktop-workbench-sidebar-resizer:hover::after,
+    body.desktop-native-workbench .desktop-workbench-sidebar-resizer:focus-visible::after,
+    body.desktop-native-workbench .desktop-workbench-sidebar-resizer[data-dragging="true"]::after {
+      background: var(--accent, #cc785c);
+      box-shadow: 0 0 0 2px var(--accent-soft, rgba(204, 120, 92, 0.12));
     }
 
     body.desktop-native-workbench .desktop-workbench-inspector {

--- a/apps/desktop/src/native-vue/knowledgeDocumentsIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeDocumentsIsland.test.ts
@@ -53,11 +53,12 @@ describe("knowledge documents Vue island", () => {
     expect(host.querySelector("[data-desktop-knowledge-document-search]")?.getAttribute("placeholder")).toBe("Search documents...");
     expect(host.querySelector("[data-desktop-knowledge-document-filter]")).toBeNull();
     expect(host.querySelector('[aria-label="Document actions"]')).toBeNull();
-    expect(host.querySelector("[data-desktop-knowledge-documents-table]")?.textContent).toContain("Name");
-    expect(host.querySelector("[data-desktop-knowledge-documents-table]")?.textContent).toContain("Actions");
-    expect(host.querySelector("[data-desktop-knowledge-documents-table-viewport]")).not.toBeNull();
-    expect(host.querySelector(".desktop-knowledge-documents-col-name")).not.toBeNull();
-    expect(host.querySelector(".desktop-knowledge-documents-cell-name")).not.toBeNull();
+    expect(host.querySelector("[data-desktop-knowledge-documents-table]")).toBeNull();
+    expect(host.querySelector("[data-desktop-knowledge-documents-table-viewport]")).toBeNull();
+    expect(host.querySelector("[data-desktop-knowledge-documents-list]")).not.toBeNull();
+    expect(host.querySelector(".desktop-knowledge-document-row")).not.toBeNull();
+    expect(host.querySelector(".desktop-knowledge-document-summary")).not.toBeNull();
+    expect(host.querySelector(".desktop-knowledge-document-attributes")).not.toBeNull();
     expect(host.querySelector(".desktop-knowledge-document-meta")).not.toBeNull();
     expect(host.querySelector('[data-desktop-knowledge-document-action="reindexDocument"]')).toBeNull();
     const first = host.querySelector<HTMLElement>('[data-desktop-entity-id="doc-1"]');

--- a/apps/desktop/src/native-vue/knowledgeDocumentsIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeDocumentsIsland.ts
@@ -55,7 +55,7 @@ function createKnowledgeDocumentsApp(options: KnowledgeDocumentsIslandOptions): 
             }),
           ]),
           filteredDocuments.value.length
-            ? renderDocumentsTable(filteredDocuments.value, options)
+            ? renderDocumentsList(filteredDocuments.value, options)
             : h(NEmpty, {
               class: "desktop-knowledge-documents-empty",
               description: options.documents.length ? "No matching documents" : "No documents yet",
@@ -79,52 +79,36 @@ function documentMatchesSearch(document: DesktopKnowledgeDocumentRow, query: str
   ].some((value) => String(value ?? "").toLowerCase().includes(query));
 }
 
-function renderDocumentsTable(documents: DesktopKnowledgeDocumentRow[], options: KnowledgeDocumentsIslandOptions) {
+function renderDocumentsList(documents: DesktopKnowledgeDocumentRow[], options: KnowledgeDocumentsIslandOptions) {
   return h("div", {
-    class: "desktop-knowledge-documents-table-viewport",
-    "data-desktop-knowledge-documents-table-viewport": "",
-  }, [
-    h("table", { class: "desktop-knowledge-documents-table", "data-desktop-knowledge-documents-table": "" }, [
-      h("colgroup", [
-        h("col", { class: "desktop-knowledge-documents-col-name" }),
-        h("col", { class: "desktop-knowledge-documents-col-type" }),
-        h("col", { class: "desktop-knowledge-documents-col-size" }),
-        h("col", { class: "desktop-knowledge-documents-col-status" }),
-        h("col", { class: "desktop-knowledge-documents-col-added" }),
-        h("col", { class: "desktop-knowledge-documents-col-actions" }),
+    class: "desktop-knowledge-documents-list",
+    "data-desktop-knowledge-documents-list": "",
+  }, documents.map((document) => {
+    const attributes = [
+      document.typeLabel || document.category || "DOC",
+      document.sizeLabel,
+      document.addedLabel,
+    ].filter((value): value is string => Boolean(value));
+    return h("article", {
+      class: "desktop-knowledge-document-row",
+      "data-desktop-entity-module": "knowledge",
+      "data-desktop-entity-id": document.id || document.path,
+    }, [
+      h("div", { class: "desktop-knowledge-document-summary" }, [
+        h("strong", document.title),
+        h("span", { class: "desktop-knowledge-document-meta" }, document.meta),
       ]),
-      h("thead", [
-        h("tr", [
-          h("th", "Name"),
-          h("th", "Type"),
-          h("th", "Size"),
-          h("th", "Status"),
-          h("th", "Added"),
-          h("th", "Actions"),
-        ]),
+      h("div", { class: "desktop-knowledge-document-attributes" }, [
+        ...attributes.map((attribute) => h("span", { class: "desktop-knowledge-document-attribute" }, attribute)),
+        renderStatusTag(document),
       ]),
-      h("tbody", documents.map((document) => h("tr", {
-        "data-desktop-entity-module": "knowledge",
-        "data-desktop-entity-id": document.id || document.path,
-      }, [
-        h("td", { class: "desktop-knowledge-documents-cell-name" }, [
-          h("strong", document.title),
-          h("span", { class: "desktop-knowledge-document-meta" }, document.meta),
-        ]),
-        h("td", { class: "desktop-knowledge-documents-cell-type" }, document.typeLabel || document.category || "DOC"),
-        h("td", { class: "desktop-knowledge-documents-cell-size" }, document.sizeLabel || "-"),
-        h("td", { class: "desktop-knowledge-documents-cell-status" }, renderStatusTag(document)),
-        h("td", { class: "desktop-knowledge-documents-cell-added" }, document.addedLabel || "-"),
-        h("td", { class: "desktop-knowledge-documents-cell-actions" }, [
-          h("button", {
-            "data-desktop-knowledge-document-action": "deleteDocument",
-            type: "button",
-            onClick: () => options.onDeleteDocument?.(document),
-          }, "Delete"),
-        ]),
-      ]))),
-    ]),
-  ]);
+      h("button", {
+        "data-desktop-knowledge-document-action": "deleteDocument",
+        type: "button",
+        onClick: () => options.onDeleteDocument?.(document),
+      }, "Delete"),
+    ]);
+  }));
 }
 
 function renderStatusTag(document: DesktopKnowledgeDocumentRow) {

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
@@ -45,6 +45,10 @@ describe("knowledge graph Vue island", () => {
     expect(host.className).toContain("desktop-knowledge-graph");
     expect(host.querySelector('[data-desktop-knowledge-graph-pane="canvas"]')).not.toBeNull();
     expect(host.querySelector('[data-desktop-knowledge-graph-pane="references"]')).not.toBeNull();
+    expect(host.querySelector(".desktop-knowledge-graph-legend")).toBeNull();
+    expect(host.querySelector(".desktop-knowledge-graph-minimap")).toBeNull();
+    expect(host.textContent).not.toContain("Entity");
+    expect(host.textContent).not.toContain("Edge");
     expect(host.querySelector("h2")?.textContent).toBe("Graph: 2 nodes / 1 edge / 5 evidence");
     expect(host.textContent).toContain("Community: Desktop cluster - Cluster summary");
     expect(host.textContent).toContain("Report: Desktop report - Report summary");

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
@@ -43,13 +43,6 @@ function createKnowledgeGraphApp(options: KnowledgeGraphIslandOptions): App {
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => h("div", { class: "desktop-knowledge-graph-workspace" }, [
           renderGraphCanvas(options.graph),
-          h("div", { class: "desktop-knowledge-graph-legend" }, [
-            h("span", [h("i", { class: "desktop-knowledge-legend-node" }), "Entity"]),
-            h("span", [h("i", { class: "desktop-knowledge-legend-edge" }), "Edge"]),
-          ]),
-          h("div", { class: "desktop-knowledge-graph-minimap", "aria-label": "Graph minimap" }, [
-            h("span"),
-          ]),
           h("div", {
             class: "desktop-knowledge-graph-references",
             "data-desktop-knowledge-graph-pane": "references",

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
@@ -195,8 +195,8 @@ describe("knowledge pane Vue island", () => {
     expect(host.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).not.toContain("Fit View");
     expect(host.querySelector('[data-desktop-knowledge-region="graph"]')?.textContent).not.toContain("Layout");
     expect(host.querySelector(".desktop-knowledge-graph-tools")).toBeNull();
-    expect(host.querySelector(".desktop-knowledge-graph-legend")?.textContent).toContain("Entity");
-    expect(host.querySelector(".desktop-knowledge-graph-minimap")).not.toBeNull();
+    expect(host.querySelector(".desktop-knowledge-graph-legend")).toBeNull();
+    expect(host.querySelector(".desktop-knowledge-graph-minimap")).toBeNull();
     expect(host.querySelector('[data-desktop-knowledge-graph-reference="Community:community-1"]')?.textContent).toContain("Desktop cluster");
     expect(host.querySelector('[data-desktop-knowledge-region="pipeline"] .desktop-knowledge-readiness')?.getAttribute("data-desktop-vue-island")).toBe(
       "knowledge-readiness",

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
@@ -119,7 +119,8 @@ describe("knowledge pane Vue island", () => {
     expect(Array.from(inspectorColumn?.children ?? [], (node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
       "graph",
     ]);
-    expect(Array.from(host.querySelectorAll("[data-desktop-knowledge-region]"), (node) => node.getAttribute("data-desktop-knowledge-region"))).toEqual([
+    const renderedRegions = Array.from(host.querySelectorAll("[data-desktop-knowledge-region]"), (node) => node.getAttribute("data-desktop-knowledge-region"));
+    expect(renderedRegions).toEqual([
       "overview",
       "upload",
       "queue",
@@ -129,24 +130,24 @@ describe("knowledge pane Vue island", () => {
       "graph",
     ]);
     expect(host.querySelector(".desktop-knowledge-title-block h2")?.textContent).toBe("Knowledge Base");
+    expect(host.querySelector(".desktop-knowledge-kicker")).toBeNull();
+    expect(host.querySelector(".desktop-knowledge-status")).toBeNull();
     expect(host.textContent).toContain("Manage your knowledge base, monitor ingestion, and explore the knowledge graph.");
-    expect(host.textContent).toContain("2 docs / readiness 100% / graph 2 nodes / 1 edge");
+    expect(host.textContent).not.toContain("2 docs / readiness 100% / graph 2 nodes / 1 edge");
 
     expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Documents");
     expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("2");
     expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Graph Nodes");
     expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Relations");
-    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("Last Indexed");
-    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).toContain("2026-06-14 09:41");
+    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).not.toContain("Last Indexed");
+    expect(host.querySelector('[data-desktop-knowledge-region="overview"]')?.textContent).not.toContain("2026-06-14 09:41");
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.textContent).toContain("Drag & drop files here or click to browse");
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.textContent).toContain("PDF, DOCX, MD, TXT, CSV, JSON");
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.textContent).toContain("Max 200MB per file");
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.getAttribute("data-desktop-drop-target")).toBe(
       "knowledge-document",
     );
-    expect(host.querySelector('[data-desktop-knowledge-region="upload"] #desktop-file-upload-status')?.textContent).toContain(
-      "No file operation running.",
-    );
+    expect(host.querySelector('[data-desktop-knowledge-region="upload"] #desktop-file-upload-status')).toBeNull();
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] [data-desktop-knowledge-action="uploadDocument"]')?.textContent).toContain("Upload Documents");
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] #desktop-knowledge-upload')?.getAttribute("data-desktop-file-upload")).toBe(
       "knowledge-document",

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
@@ -147,7 +147,7 @@ describe("knowledge pane Vue island", () => {
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] .desktop-knowledge-drop-zone')?.getAttribute("data-desktop-drop-target")).toBe(
       "knowledge-document",
     );
-    expect(host.querySelector('[data-desktop-knowledge-region="upload"] #desktop-file-upload-status')).toBeNull();
+    expect(host.querySelector('[data-desktop-knowledge-region="upload"] #desktop-file-upload-status')?.textContent).toBe("No file operation running.");
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] [data-desktop-knowledge-action="uploadDocument"]')?.textContent).toContain("Upload Documents");
     expect(host.querySelector('[data-desktop-knowledge-region="upload"] #desktop-knowledge-upload')?.getAttribute("data-desktop-file-upload")).toBe(
       "knowledge-document",

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.test.ts
@@ -163,11 +163,11 @@ describe("knowledge pane Vue island", () => {
     expect(host.querySelector('[data-desktop-knowledge-document-filter]')).toBeNull();
     expect(host.querySelector('[aria-label="Document actions"]')).toBeNull();
     expect(host.querySelector('[data-desktop-knowledge-document-action="reindexDocument"]')).toBeNull();
-    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Name");
-    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Type");
-    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Size");
-    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Status");
-    expect(host.querySelector('[data-desktop-knowledge-documents-table]')?.textContent).toContain("Actions");
+    expect(host.querySelector('[data-desktop-knowledge-documents-table]')).toBeNull();
+    expect(host.querySelector('[data-desktop-knowledge-documents-list]')?.textContent).toContain("Desktop UX");
+    expect(host.querySelector('[data-desktop-knowledge-documents-list]')?.textContent).toContain("MD");
+    expect(host.querySelector('[data-desktop-knowledge-documents-list]')?.textContent).toContain("84 KB");
+    expect(host.querySelector('[data-desktop-knowledge-documents-list]')?.textContent).toContain("indexed");
     expect(host.querySelector('[data-desktop-knowledge-document-action="deleteDocument"]')?.textContent).toContain("Delete");
     expect(host.querySelector('[data-desktop-knowledge-region="documents"] .desktop-knowledge-documents')?.getAttribute("data-desktop-vue-island")).toBe(
       "knowledge-documents",
@@ -181,6 +181,8 @@ describe("knowledge pane Vue island", () => {
       "knowledge-query",
     );
     expect(host.querySelector('[data-desktop-knowledge-region="query"]')?.textContent).toContain("Knowledge Query");
+    expect(host.querySelector('[data-desktop-knowledge-region="query"] .desktop-knowledge-query-panel')).not.toBeNull();
+    expect(host.querySelector('[data-desktop-knowledge-region="query"] .desktop-knowledge-query-summary')).not.toBeNull();
     expect(host.querySelector('[data-desktop-knowledge-query-input]')?.getAttribute("value")).toBe("desktop graph");
     expect(host.querySelector('[data-desktop-knowledge-action="runQuery"]')?.textContent).toContain("Run Query");
     expect(host.querySelector('[data-desktop-knowledge-query-result="doc-1:0"]')?.textContent).toContain("Desktop panes expose graph evidence.");

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.ts
@@ -9,6 +9,7 @@ import { mountKnowledgeGraphIsland } from "./knowledgeGraphIsland";
 import { mountKnowledgeQueryIsland } from "./knowledgeQueryIsland";
 import { mountKnowledgeReadinessIsland } from "./knowledgeReadinessIsland";
 import { mountModuleWorkSectionIsland } from "./moduleWorkSectionIsland";
+import { mountFileUploadStatusIsland } from "./fileUploadStatusIsland";
 
 export type KnowledgePaneActionId = "refreshAll" | "runQuery" | "extractGraph" | "rebuildIndex" | "deleteDocument" | "uploadDocument";
 
@@ -60,6 +61,7 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
       const documentDetail = ref<HTMLElement | null>(null);
       const query = ref<HTMLElement | null>(null);
       const graph = ref<HTMLElement | null>(null);
+      const uploadStatus = ref<HTMLElement | null>(null);
 
       onMounted(() => {
         if (options.workItems?.length) {
@@ -98,6 +100,9 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
         mountChild(mountedChildren, graph.value, (host) => mountKnowledgeGraphIsland(host, {
           graph: options.pane.graph,
         }));
+        mountChild(mountedChildren, uploadStatus.value, (host) => mountFileUploadStatusIsland(host, {
+          message: "No file operation running.",
+        }));
       });
 
       onBeforeUnmount(() => {
@@ -122,7 +127,7 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
                 "data-desktop-knowledge-region": "overview",
                 "aria-label": "Knowledge base overview",
               }, renderKnowledgeOverview(options.pane)),
-              renderKnowledgeUploadRegion(options),
+              renderKnowledgeUploadRegion(options, uploadStatus),
               options.workItems?.length ? renderKnowledgeQueueRegion(options, work) : null,
               renderKnowledgeDocumentsRegion(options, documents, documentDetail),
               renderKnowledgeQueryRegion(query),
@@ -153,7 +158,7 @@ function renderKnowledgeHeader(options: KnowledgePaneIslandOptions) {
   ]);
 }
 
-function renderKnowledgeUploadRegion(options: KnowledgePaneIslandOptions) {
+function renderKnowledgeUploadRegion(options: KnowledgePaneIslandOptions, uploadStatus: Ref<HTMLElement | null>) {
   return h("section", {
     class: "desktop-knowledge-region desktop-knowledge-upload-region",
     "data-desktop-knowledge-region": "upload",
@@ -175,6 +180,7 @@ function renderKnowledgeUploadRegion(options: KnowledgePaneIslandOptions) {
       h("small", "Max 200MB per file"),
     ]),
     renderKnowledgeUploadControl(),
+    h("p", { ref: uploadStatus }),
   ]);
 }
 

--- a/apps/desktop/src/native-vue/knowledgePaneIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgePaneIsland.ts
@@ -3,7 +3,6 @@ import { NConfigProvider } from "naive-ui";
 import type { DesktopTaskCenterItem } from "../desktopTaskCenter";
 import type { DesktopKnowledgePaneModel } from "../desktopKnowledgeTraceability";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
-import { mountFileUploadStatusIsland } from "./fileUploadStatusIsland";
 import { mountKnowledgeDocumentDetailIsland } from "./knowledgeDocumentDetailIsland";
 import { mountKnowledgeDocumentsIsland } from "./knowledgeDocumentsIsland";
 import { mountKnowledgeGraphIsland } from "./knowledgeGraphIsland";
@@ -57,7 +56,6 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
       const mountedChildren: Array<{ unmount: () => void }> = [];
       const work = ref<HTMLElement | null>(null);
       const readiness = ref<HTMLElement | null>(null);
-      const uploadStatus = ref<HTMLElement | null>(null);
       const documents = ref<HTMLElement | null>(null);
       const documentDetail = ref<HTMLElement | null>(null);
       const query = ref<HTMLElement | null>(null);
@@ -74,9 +72,6 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
         mountChild(mountedChildren, readiness.value, (host) => mountKnowledgeReadinessIsland(host, {
           readiness: options.pane.readiness,
           configHints: options.pane.configHints,
-        }));
-        mountChild(mountedChildren, uploadStatus.value, (host) => mountFileUploadStatusIsland(host, {
-          message: "No file operation running.",
         }));
         mountChild(mountedChildren, documents.value, (host) => mountKnowledgeDocumentsIsland(host, {
           documents: options.pane.documentRows,
@@ -127,8 +122,8 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
                 "data-desktop-knowledge-region": "overview",
                 "aria-label": "Knowledge base overview",
               }, renderKnowledgeOverview(options.pane)),
-              renderKnowledgeUploadRegion(options, uploadStatus),
-              renderKnowledgeQueueRegion(options, work),
+              renderKnowledgeUploadRegion(options),
+              options.workItems?.length ? renderKnowledgeQueueRegion(options, work) : null,
               renderKnowledgeDocumentsRegion(options, documents, documentDetail),
               renderKnowledgeQueryRegion(query),
               renderKnowledgePipelineRegion(readiness),
@@ -149,10 +144,8 @@ function createKnowledgePaneApp(options: KnowledgePaneIslandOptions): App {
 function renderKnowledgeHeader(options: KnowledgePaneIslandOptions) {
   return h("div", { class: "desktop-knowledge-header" }, [
     h("div", { class: "desktop-knowledge-title-block" }, [
-      h("p", { class: "desktop-knowledge-kicker" }, "Knowledge Base"),
       h("h2", "Knowledge Base"),
       h("p", "Manage your knowledge base, monitor ingestion, and explore the knowledge graph."),
-      h("p", { class: "desktop-knowledge-status" }, options.pane.status),
     ]),
     h("div", { class: "desktop-knowledge-toolbar" }, [
       renderKnowledgeActionButton(options, "refreshAll", "Refresh All", "secondary"),
@@ -160,7 +153,7 @@ function renderKnowledgeHeader(options: KnowledgePaneIslandOptions) {
   ]);
 }
 
-function renderKnowledgeUploadRegion(options: KnowledgePaneIslandOptions, uploadStatus: Ref<HTMLElement | null>) {
+function renderKnowledgeUploadRegion(options: KnowledgePaneIslandOptions) {
   return h("section", {
     class: "desktop-knowledge-region desktop-knowledge-upload-region",
     "data-desktop-knowledge-region": "upload",
@@ -181,7 +174,6 @@ function renderKnowledgeUploadRegion(options: KnowledgePaneIslandOptions, upload
       h("span", "PDF, DOCX, MD, TXT, CSV, JSON"),
       h("small", "Max 200MB per file"),
     ]),
-    h("p", { ref: uploadStatus }),
     renderKnowledgeUploadControl(),
   ]);
 }
@@ -299,7 +291,6 @@ function renderKnowledgeOverview(pane: DesktopKnowledgePaneModel) {
     renderKnowledgeMetric("Readiness", `${pane.readiness.score}%`, `${chunkCount} indexed chunks`),
     renderKnowledgeMetric("Graph Nodes", String(nodeCount), `${pane.graph.evidence.length} evidence`),
     renderKnowledgeMetric("Relations", String(edgeCount), "Graph edges"),
-    renderKnowledgeMetric("Last Indexed", pane.lastIndexedLabel, "Knowledge freshness"),
   ];
 }
 

--- a/apps/desktop/src/native-vue/knowledgeQueryIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeQueryIsland.test.ts
@@ -52,12 +52,13 @@ describe("knowledge query Vue island", () => {
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("knowledge-query");
     expect(host.className).toContain("desktop-knowledge-query");
-    expect(host.querySelector("h2")?.textContent).toBe("Knowledge Query");
+    expect(host.querySelector("h2")).toBeNull();
+    expect(host.querySelector(".desktop-knowledge-query-panel")).not.toBeNull();
+    expect(host.querySelector(".desktop-knowledge-query-summary")?.textContent).toContain("Mode: hybrid");
+    expect(host.querySelector(".desktop-knowledge-query-summary")?.textContent).toContain("Results: 5");
     expect(host.querySelector<HTMLInputElement>("[data-desktop-knowledge-query-input]")?.value).toBe("desktop");
     expect(host.querySelector<HTMLSelectElement>("[data-desktop-knowledge-query-mode]")?.value).toBe("hybrid");
     expect(host.querySelector<HTMLInputElement>("[data-desktop-knowledge-query-top-k]")?.value).toBe("5");
-    expect(host.textContent).toContain("Mode: hybrid / top 5");
-    expect(host.textContent).toContain("Results: 5");
     expect(host.textContent).toContain("Doc 1: Knowledge result 1");
     expect(host.textContent).toContain("Doc 4: Knowledge result 4");
     expect(host.textContent).not.toContain("Doc 5: Knowledge result 5");

--- a/apps/desktop/src/native-vue/knowledgeQueryIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeQueryIsland.ts
@@ -1,5 +1,5 @@
 import { createApp, defineComponent, h, ref, type App } from "vue";
-import { NCard, NConfigProvider, NEmpty, NList, NListItem, NSpace, NTag } from "naive-ui";
+import { NConfigProvider, NEmpty, NList, NListItem, NSpace, NTag } from "naive-ui";
 import type {
   DesktopKnowledgePaneModel,
   DesktopKnowledgeQueryResultRow,
@@ -50,9 +50,7 @@ function createKnowledgeQueryApp(options: KnowledgeQueryIslandOptions): App {
         });
       };
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => h(NCard, { size: "small", bordered: false }, {
-          default: () => [
-            h("h2", "Knowledge Query"),
+        default: () => h("div", { class: "desktop-knowledge-query-panel" }, [
             h("div", { class: "desktop-knowledge-query-controls" }, [
               h("input", {
                 "aria-label": "Knowledge query",
@@ -94,8 +92,10 @@ function createKnowledgeQueryApp(options: KnowledgeQueryIslandOptions): App {
                 onClick: runQuery,
               }, "Run Query"),
             ]),
-            h("p", `Mode: ${options.draft.mode} / top ${options.draft.topK}`),
-            h("p", `Results: ${options.results.summary.count}`),
+            h("p", { class: "desktop-knowledge-query-summary" }, [
+              h("span", `Mode: ${options.draft.mode} / top ${options.draft.topK}`),
+              h("span", `Results: ${options.results.summary.count}`),
+            ]),
             renderRetrievalPlan(options.results.summary.retrievalPlan),
             options.results.rows.length
               ? renderResults(options.results.rows)
@@ -104,8 +104,7 @@ function createKnowledgeQueryApp(options: KnowledgeQueryIslandOptions): App {
                 description: "No knowledge query results.",
                 size: "small",
               }),
-          ],
-        }),
+          ]),
       });
     },
   }));


### PR DESCRIPTION
## Summary
- Add resizable/collapsible native desktop sidebar behavior.
- Refine the Knowledge page layout, density, graph legend, and document panel overflow behavior.
- Show the persistent native backend log tail in Backend Logs.
- Ignore generated output files.

## Validation
- npm test -- src/desktopWorkbenchShell.test.ts
- npm run build
- npm test
- cargo test gateway_status

Full cargo test was also run during the backend log change and had unrelated existing/flaky failures in worker restart, stdio worker diagnostics, and large output timeout tests.