### PR TITLE
Polish native desktop panels and 3D knowledge graph

### DIFF
--- a/apps/desktop/src/desktopWindowFrame.test.ts
+++ b/apps/desktop/src/desktopWindowFrame.test.ts
@@ -148,6 +148,7 @@ function matchesSelector(element: FakeElement, selector: string): boolean {
 describe("desktop window frame", () => {
   test("installs a custom draggable frame with working window controls", () => {
     const targetDocument = new FakeDocument();
+    targetDocument.documentElement.dataset.desktopWorkbenchMode = "native-workbench";
     const currentWindow = {
       minimize: vi.fn(async () => {}),
       toggleMaximize: vi.fn(async () => {}),
@@ -552,6 +553,7 @@ describe("desktop window frame", () => {
     expect(frame?.textContent).not.toContain("Tinybot");
     expect(frame?.textContent).not.toContain("WebUI shell");
     expect(targetDocument.body.querySelector("#desktop-window-context")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-frame-panel-controls")).toBeNull();
 
     targetDocument.documentElement.dataset.desktopWorkbenchMode = "native-workbench";
     installDesktopWindowFrame({

--- a/apps/desktop/src/desktopWindowFrame.test.ts
+++ b/apps/desktop/src/desktopWindowFrame.test.ts
@@ -90,6 +90,7 @@ class FakeDocument {
   public head = new FakeHead();
   public documentElement = { dataset: {} as Record<string, string> };
   public dispatched: string[] = [];
+  public dispatchedEvents: Event[] = [];
   private listeners = new Map<string, Array<(event: Event) => void>>();
 
   createElement(tagName: string): FakeElement {
@@ -106,6 +107,7 @@ class FakeDocument {
 
   dispatchEvent(event: Event): boolean {
     this.dispatched.push(event.type);
+    this.dispatchedEvents.push(event);
     for (const listener of this.listeners.get(event.type) ?? []) {
       listener(event);
     }
@@ -127,6 +129,10 @@ function matchesSelector(element: FakeElement, selector: string): boolean {
   const menuCommand = selector.match(/^\[data-desktop-menu-command="(.+)"\]$/);
   if (menuCommand) {
     return element.getAttribute("data-desktop-menu-command") === menuCommand[1];
+  }
+  const panelControl = selector.match(/^\[data-desktop-panel-control="(.+)"\]$/);
+  if (panelControl) {
+    return element.getAttribute("data-desktop-panel-control") === panelControl[1];
   }
   const runtimeCommand = selector.match(/^\[data-desktop-runtime-command="(.+)"\]$/);
   if (runtimeCommand) {
@@ -169,16 +175,48 @@ describe("desktop window frame", () => {
     expect(targetDocument.body.querySelector('[data-window-action="minimize"]')?.className).toContain("desktop-window-traffic-light");
     expect(targetDocument.body.querySelector('[data-window-action="maximize"]')?.className).toContain("desktop-window-traffic-light");
     expect(targetDocument.body.querySelector('[data-window-action="close"]')?.className).toContain("desktop-window-traffic-light");
+    expect(targetDocument.body.querySelector(".desktop-frame-panel-controls")).toBeTruthy();
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Collapse session list");
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-pressed")).toBe("true");
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-label")).toBe("Open Activity inspector");
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-pressed")).toBe("false");
 
     targetDocument.body.querySelector('[data-window-action="minimize"]')?.click();
     targetDocument.body.querySelector('[data-window-action="maximize"]')?.click();
     targetDocument.body.querySelector('[data-window-action="close"]')?.click();
+    targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.click();
     frame?.dispatch("pointerdown");
 
     expect(currentWindow.minimize).toHaveBeenCalledTimes(1);
     expect(currentWindow.toggleMaximize).toHaveBeenCalledTimes(1);
     expect(currentWindow.close).toHaveBeenCalledTimes(1);
     expect(currentWindow.startDragging).toHaveBeenCalledTimes(1);
+    const panelEvent = targetDocument.dispatchedEvents.find((event) => event.type === "tinybot:desktop-panel-toggle") as CustomEvent | undefined;
+    expect(panelEvent?.detail).toEqual({ panel: "inspector" });
+  });
+
+  test("initializes frame panel controls from the active workbench shell state", () => {
+    const targetDocument = new FakeDocument();
+    const shell = targetDocument.createElement("main");
+    shell.setAttribute("id", "desktop-workbench-shell");
+    shell.setAttribute("data-sidebar-visible", "false");
+    shell.setAttribute("data-inspector-visible", "true");
+    targetDocument.body.append(shell);
+
+    installDesktopWindowFrame({
+      targetDocument: targetDocument as unknown as Document,
+      currentWindow: {
+        minimize: vi.fn(async () => {}),
+        toggleMaximize: vi.fn(async () => {}),
+        close: vi.fn(async () => {}),
+        startDragging: vi.fn(async () => {}),
+      },
+    });
+
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-pressed")).toBe("false");
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Expand session list");
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-pressed")).toBe("true");
+    expect(targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-label")).toBe("Close Activity inspector");
   });
 
   test("maps runtime ownership to a compact desktop status view", () => {

--- a/apps/desktop/src/desktopWindowFrame.ts
+++ b/apps/desktop/src/desktopWindowFrame.ts
@@ -55,8 +55,6 @@ export function installDesktopWindowFrame({
 
   const appMenu = createApplicationMenu(targetDocument);
 
-  const panelControls = createFramePanelControls(targetDocument);
-
   const controls = targetDocument.createElement("div");
   controls.className = "desktop-window-controls";
   controls.append(
@@ -65,7 +63,11 @@ export function installDesktopWindowFrame({
     createWindowButton(targetDocument, "maximize", "Maximize", () => currentWindow.toggleMaximize()),
   );
 
-  frame.append(appMenu, panelControls, controls);
+  frame.append(appMenu);
+  if (shouldRenderFramePanelControls(targetDocument)) {
+    frame.append(createFramePanelControls(targetDocument));
+  }
+  frame.append(controls);
   frame.addEventListener("pointerdown", () => {
     void currentWindow.startDragging().catch(logWindowFrameError);
   });
@@ -74,6 +76,11 @@ export function installDesktopWindowFrame({
   });
 
   targetDocument.body.prepend(frame);
+}
+
+function shouldRenderFramePanelControls(targetDocument: Document): boolean {
+  return targetDocument.documentElement.dataset.desktopWorkbenchMode === "native-workbench"
+    || Boolean(targetDocument.getElementById("desktop-workbench-shell"));
 }
 
 function createFramePanelControls(targetDocument: Document): HTMLElement {

--- a/apps/desktop/src/desktopWindowFrame.ts
+++ b/apps/desktop/src/desktopWindowFrame.ts
@@ -55,6 +55,8 @@ export function installDesktopWindowFrame({
 
   const appMenu = createApplicationMenu(targetDocument);
 
+  const panelControls = createFramePanelControls(targetDocument);
+
   const controls = targetDocument.createElement("div");
   controls.className = "desktop-window-controls";
   controls.append(
@@ -63,7 +65,7 @@ export function installDesktopWindowFrame({
     createWindowButton(targetDocument, "maximize", "Maximize", () => currentWindow.toggleMaximize()),
   );
 
-  frame.append(appMenu, controls);
+  frame.append(appMenu, panelControls, controls);
   frame.addEventListener("pointerdown", () => {
     void currentWindow.startDragging().catch(logWindowFrameError);
   });
@@ -72,6 +74,77 @@ export function installDesktopWindowFrame({
   });
 
   targetDocument.body.prepend(frame);
+}
+
+function createFramePanelControls(targetDocument: Document): HTMLElement {
+  const controls = targetDocument.createElement("div");
+  controls.className = "desktop-frame-panel-controls";
+  controls.setAttribute("aria-label", "Global workbench panel controls");
+  controls.append(
+    createFramePanelControl(targetDocument, "sidebar", framePanelVisible(targetDocument, "sidebar", true), "Collapse session list", "Expand session list"),
+    createFramePanelControl(targetDocument, "inspector", framePanelVisible(targetDocument, "inspector", false), "Close Activity inspector", "Open Activity inspector"),
+  );
+  return controls;
+}
+
+function framePanelVisible(targetDocument: Document, panel: "sidebar" | "inspector", fallback: boolean): boolean {
+  const shell = targetDocument.getElementById("desktop-workbench-shell");
+  const value = shell?.getAttribute(`data-${panel}-visible`);
+  return value === null || value === undefined ? fallback : value !== "false";
+}
+
+function createFramePanelControl(
+  targetDocument: Document,
+  panel: "sidebar" | "inspector",
+  visible: boolean,
+  pressedLabel: string,
+  unpressedLabel: string,
+): HTMLElement {
+  const button = targetDocument.createElement("button");
+  button.type = "button";
+  button.className = "desktop-frame-panel-control";
+  button.setAttribute("data-desktop-panel-control", panel);
+  button.setAttribute("data-desktop-panel-label-pressed", pressedLabel);
+  button.setAttribute("data-desktop-panel-label-unpressed", unpressedLabel);
+  button.setAttribute("aria-label", visible ? pressedLabel : unpressedLabel);
+  button.setAttribute("title", visible ? pressedLabel : unpressedLabel);
+  button.setAttribute("aria-pressed", String(visible));
+  button.append(createFramePanelIcon(targetDocument, panel));
+  button.addEventListener("pointerdown", (event) => event.stopPropagation());
+  button.addEventListener("dblclick", (event) => event.stopPropagation());
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    dispatchFramePanelToggle(targetDocument, panel);
+  });
+  return button;
+}
+
+function createFramePanelIcon(targetDocument: Document, panel: "sidebar" | "inspector"): HTMLElement {
+  const icon = targetDocument.createElement("span");
+  icon.className = "desktop-frame-panel-icon";
+  icon.setAttribute("data-panel-icon", panel === "sidebar" ? "collapse-left" : "collapse-right");
+  icon.setAttribute("aria-hidden", "true");
+  icon.append(
+    createFramePanelIconPart(targetDocument, "frame"),
+    createFramePanelIconPart(targetDocument, "rail"),
+  );
+  return icon;
+}
+
+function createFramePanelIconPart(targetDocument: Document, part: "frame" | "rail"): HTMLElement {
+  const node = targetDocument.createElement("span");
+  node.className = `desktop-frame-panel-icon-${part}`;
+  return node;
+}
+
+function dispatchFramePanelToggle(targetDocument: Document, panel: "sidebar" | "inspector"): void {
+  const CustomEventConstructor = targetDocument.defaultView?.CustomEvent
+    ?? (typeof CustomEvent !== "undefined" ? CustomEvent : null);
+  if (CustomEventConstructor) {
+    targetDocument.dispatchEvent(new CustomEventConstructor("tinybot:desktop-panel-toggle", { detail: { panel } }));
+    return;
+  }
+  targetDocument.dispatchEvent({ type: "tinybot:desktop-panel-toggle", detail: { panel } } as unknown as Event);
 }
 
 function syncDesktopWindowIcon(
@@ -450,6 +523,72 @@ function ensureDesktopWindowFrameStyle(targetDocument: Document): void {
       justify-self: end;
       color: var(--text-muted, #6c6a64);
       font-size: 12px;
+    }
+
+    body.desktop-custom-frame .desktop-frame-panel-controls {
+      position: absolute;
+      top: 50%;
+      right: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 6px;
+      min-width: 0;
+      transform: translateY(-50%);
+    }
+
+    body.desktop-custom-frame .desktop-frame-panel-control {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 30px;
+      min-width: 30px;
+      height: 28px;
+      min-height: 28px;
+      border: 1px solid var(--border, #e6dfd8);
+      border-radius: 6px;
+      padding: 0;
+      background: #ffffff;
+      color: #59544f;
+      cursor: default;
+    }
+
+    body.desktop-custom-frame .desktop-frame-panel-control:hover,
+    body.desktop-custom-frame .desktop-frame-panel-control:focus-visible {
+      background: #f2ede7;
+      outline: 0;
+    }
+
+    body.desktop-custom-frame .desktop-frame-panel-icon {
+      position: relative;
+      display: block;
+      width: 17px;
+      height: 17px;
+      color: currentColor;
+    }
+
+    body.desktop-custom-frame .desktop-frame-panel-icon-frame {
+      position: absolute;
+      inset: 2px;
+      border: 1.5px solid currentColor;
+      border-radius: 4px;
+    }
+
+    body.desktop-custom-frame .desktop-frame-panel-icon-rail {
+      position: absolute;
+      top: 5px;
+      bottom: 5px;
+      width: 3px;
+      border-radius: 2px;
+      background: currentColor;
+    }
+
+    body.desktop-custom-frame .desktop-frame-panel-icon[data-panel-icon="collapse-left"] .desktop-frame-panel-icon-rail {
+      left: 5px;
+    }
+
+    body.desktop-custom-frame .desktop-frame-panel-icon[data-panel-icon="collapse-right"] .desktop-frame-panel-icon-rail {
+      right: 5px;
     }
 
     body.desktop-custom-frame .desktop-window-controls {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -23,6 +23,7 @@ class FakeElement {
   public id = "";
   public className = "";
   public children: FakeElement[] = [];
+  public parentElement: FakeElement | null = null;
   public attributes = new Map<string, string>();
   public value = "";
   public checked = false;
@@ -71,6 +72,9 @@ class FakeElement {
   }
 
   append(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parentElement = this;
+    }
     this.children.push(...children);
   }
 
@@ -118,7 +122,21 @@ class FakeElement {
   }
 
   replaceChildren(...children: FakeElement[]): void {
+    for (const child of this.children) {
+      child.parentElement = null;
+    }
+    for (const child of children) {
+      child.parentElement = this;
+    }
     this.children = children;
+  }
+
+  remove(): void {
+    if (!this.parentElement) {
+      return;
+    }
+    this.parentElement.children = this.parentElement.children.filter((child) => child !== this);
+    this.parentElement = null;
   }
 
   querySelector(selector: string): FakeElement | null {
@@ -882,28 +900,11 @@ describe("desktop workbench shell", () => {
     expect(composerModel?.textContent).toContain("Tinybot Pro");
 
     const inspector = targetDocument.body.querySelector(".desktop-inspector-content");
-    const runTabs = targetDocument.body.querySelector(".desktop-run-chain-tabs");
-    const runCards = targetDocument.body.querySelector(".desktop-run-chain-cards");
     expect(inspector).toBeTruthy();
-    expect(runTabs).toBeTruthy();
-    expect(runCards).toBeTruthy();
-    expect(inspector?.textContent).toContain("Activity");
-    expect(inspector?.textContent).not.toContain("Run Chain");
-    expect(runTabs?.textContent).toBe("ContextFilesTasksApprovalsActivity");
-    expect(runCards?.textContent).toContain("Gateway");
-    targetDocument.body.querySelector('[data-desktop-run-chain-tab="files"]')?.click();
-    expect(runCards?.textContent).toContain("Files");
-    expect(targetDocument.body.querySelectorAll(".desktop-run-chain-new-item")).toHaveLength(0);
-    targetDocument.body.querySelector('[data-desktop-run-chain-tab="tasks"]')?.click();
-    const runNewItem = targetDocument.body.querySelector(".desktop-run-chain-new-item");
-    expect(runNewItem?.textContent).toContain("New Activity Item");
-    expect(runCards?.textContent).toContain("No chain items yet.");
-    targetDocument.body.querySelector('[data-desktop-run-chain-tab="approvals"]')?.click();
-    expect(runCards?.textContent).toContain("Approvals");
-    expect(runCards?.textContent).toContain("No pending approvals");
-    targetDocument.body.querySelector('[data-desktop-run-chain-tab="activity"]')?.click();
-    expect(runCards?.textContent).toContain("Activity Feed");
-    expect(runCards?.textContent).toContain("Gateway events, tool calls, and runtime logs appear here.");
+    expect(inspector?.textContent).not.toContain("Activity");
+    expect(inspector?.textContent).not.toContain("Gateway");
+    expect(targetDocument.body.querySelector(".desktop-run-chain-tabs")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-run-chain-cards")).toBeNull();
   });
 
   test("renders explicit desktop navigation links for workbench, docs, gateway, and external routes", () => {
@@ -1201,7 +1202,7 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector(".desktop-chat-header")?.textContent).not.toContain("New session");
   });
 
-  test("keeps chat header actions compact and owns sidebar and run-chain toggles there", () => {
+  test("keeps panel controls out of the workbench chrome and chat header", () => {
     const targetDocument = new FakeDocument();
 
     installDesktopWorkbenchShell({
@@ -1226,26 +1227,13 @@ describe("desktop workbench shell", () => {
     expect(header?.querySelector(".desktop-chat-menu")?.textContent).toBe("...");
     const titleRow = header?.querySelector(".desktop-chat-title-row");
     const headerActions = header?.querySelector(".desktop-chat-header-actions");
-    expect(titleRow?.children[0]?.getAttribute("data-desktop-panel-control")).toBe("sidebar");
-    expect(titleRow?.children[1]?.className).toBe("desktop-chat-title-group");
+    expect(titleRow?.children[0]?.className).toBe("desktop-chat-title-group");
+    expect(titleRow?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
     expect(headerActions?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
-    expect(headerActions?.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-label")).toBe("Open Activity inspector");
-    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Collapse session list");
-    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-label")).toBe("Open Activity inspector");
-    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.textContent).toBe("");
-    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.textContent).toBe("");
-    expect(
-      header?.querySelector('[data-desktop-panel-control="sidebar"]')?.querySelector(".desktop-chat-header-panel-icon")?.getAttribute("data-panel-icon"),
-    ).toBe("collapse-left");
-    expect(
-      header?.querySelector('[data-desktop-panel-control="inspector"]')?.querySelector(".desktop-chat-header-panel-icon")?.getAttribute("data-panel-icon"),
-    ).toBe("collapse-right");
+    expect(headerActions?.querySelector('[data-desktop-panel-control="inspector"]')).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-global-panel-controls")).toBeNull();
+    expect(targetDocument.body.querySelectorAll("[data-desktop-panel-control]")).toEqual([]);
     expect(targetDocument.body.querySelector("[data-desktop-inspector-restore]")).toBeNull();
-
-    header?.querySelector('[data-desktop-panel-control="sidebar"]')?.click();
-    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("false");
-    expect(targetDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("false");
-    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.getAttribute("aria-label")).toBe("Expand session list");
   });
 
   test("keeps the chat header focused on title actions and stop state", () => {
@@ -1364,8 +1352,9 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.body.querySelector('[data-desktop-session-key]')?.querySelector(".desktop-sidebar-row-label")?.textContent).toBe(
       "Renamed session",
     );
-    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')?.textContent).toBe("");
-    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')?.textContent).toBe("");
+    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
+    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-global-panel-controls")).toBeNull();
   });
 
   test("anchors the chat header menu popover inside the main work area", () => {
@@ -1424,7 +1413,7 @@ describe("desktop workbench shell", () => {
     expect(refreshedHeader?.querySelector('[data-desktop-chat-menu-action="pin"]')?.textContent).toBe("Unpin session");
   });
 
-  test("renders keyboard-operable panel controls with accessible labels", () => {
+  test("does not render duplicate panel controls inside the workbench shell", () => {
     const targetDocument = new FakeDocument();
 
     installDesktopWorkbenchShell({
@@ -1433,32 +1422,12 @@ describe("desktop workbench shell", () => {
       gatewayHttp: "http://127.0.0.1:18790",
     });
 
-    const controls = targetDocument.body.querySelectorAll(".desktop-chat-header-panel-button");
-    expect(controls.map((node) => node.getAttribute("data-desktop-panel-control"))).toEqual(["sidebar", "inspector"]);
-    expect(controls.map((node) => node.getAttribute("aria-label"))).toEqual([
-      "Collapse session list",
-      "Open Activity inspector",
-    ]);
-    expect(controls.map((node) => node.getAttribute("aria-pressed"))).toEqual(["true", "false"]);
-    expect(controls[0].querySelector(".desktop-chat-header-panel-icon")?.getAttribute("data-panel-icon")).toBe("collapse-left");
-
-    let prevented = false;
-    controls[1].dispatchEvent({
-      type: "keydown",
-      key: "Enter",
-      preventDefault: () => {
-        prevented = true;
-      },
-    });
-
-    expect(prevented).toBe(true);
-    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("true");
-    expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("true");
-    expect(controls[1].getAttribute("aria-pressed")).toBe("true");
-    expect(targetDocument.body.querySelector("[data-desktop-route-status]")?.textContent).toContain("Activity inspector panel shown");
+    expect(targetDocument.body.querySelector(".desktop-global-panel-controls")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-chat-header")?.querySelector("[data-desktop-panel-control]")).toBeNull();
+    expect(targetDocument.body.querySelectorAll("[data-desktop-panel-control]")).toEqual([]);
   });
 
-  test("makes the native Run Chain overview compact, switchable, and recoverable after close", () => {
+  test("toggles workbench panels from the desktop window frame event bridge", () => {
     const targetDocument = new FakeDocument();
 
     installDesktopWorkbenchShell({
@@ -1467,63 +1436,55 @@ describe("desktop workbench shell", () => {
       gatewayHttp: "http://127.0.0.1:18790",
     });
 
-    const overview = targetDocument.body.querySelector(".desktop-run-chain-overview");
-    const panel = overview?.querySelector(".desktop-run-chain-panel");
-    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Gateway");
-    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("Idle");
-    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("0 items");
-    expect(overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.getAttribute("aria-label")).toBe("Gateway: Connected");
-    expect(overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.getAttribute("title")).toBe("Gateway: Connected");
-    expect(overview?.querySelector('[data-desktop-run-chain-summary="run"]')?.getAttribute("aria-label")).toBe("Run: Idle");
-    expect(overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.className).toContain("desktop-run-chain-status-pill");
-    expect(overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.getAttribute("data-status-tone")).toBe("connected");
-    expect(overview?.querySelector('[data-desktop-run-chain-summary="run"]')?.getAttribute("data-status-tone")).toBe("muted");
-    expect(overview?.querySelector(".desktop-run-chain-status-dot")).not.toBeNull();
-    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("context");
-    expect(panel?.textContent).toContain("Endpoint");
+    targetDocument.dispatchEvent({
+      type: "tinybot:desktop-panel-toggle",
+      detail: { panel: "inspector" },
+    });
 
-    overview?.querySelector('[data-desktop-run-chain-tab="files"]')?.click();
-    expect(overview?.querySelector('[data-desktop-run-chain-tab="files"]')?.getAttribute("aria-selected")).toBe("true");
-    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("files");
-    expect(panel?.textContent).toContain("Files");
-    expect(panel?.textContent).toContain("Open Files");
-
-    overview?.querySelector('[data-desktop-run-chain-tab="tasks"]')?.click();
-    expect(overview?.querySelector('[data-desktop-run-chain-tab="tasks"]')?.getAttribute("aria-selected")).toBe("true");
-    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("tasks");
-    expect(panel?.textContent).toContain("Tasks");
-    expect(panel?.textContent).toContain("Task center: Available");
-    expect(panel?.textContent).toContain("No chain items yet.");
-    expect(panel?.textContent).toContain("New Activity Item");
-    expect(panel?.querySelector(".desktop-run-chain-new-item")?.getAttribute("data-button-variant")).toBe("secondary");
-
-    overview?.querySelector('[data-desktop-run-chain-summary="gateway"]')?.click();
-    expect(overview?.querySelector('[data-desktop-run-chain-tab="context"]')?.getAttribute("aria-selected")).toBe("true");
-    expect(overview?.querySelector('[data-desktop-run-chain-tab="tasks"]')?.getAttribute("aria-selected")).toBe("false");
-    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("context");
-
-    overview?.querySelector('[data-desktop-run-chain-summary="items"]')?.click();
-    expect(overview?.querySelector('[data-desktop-run-chain-tab="context"]')?.getAttribute("aria-selected")).toBe("false");
-    expect(overview?.querySelector('[data-desktop-run-chain-tab="activity"]')?.getAttribute("aria-selected")).toBe("true");
-    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("activity");
-
-    const pin = overview?.querySelector('[data-desktop-run-chain-control="pin"]');
-    expect(pin?.getAttribute("data-button-variant")).toBe("ghost");
-    expect(pin?.getAttribute("aria-label")).toBe("Pin panel");
-    expect(overview?.querySelector('[data-desktop-run-chain-control="close"]')?.getAttribute("title")).toBe("Close panel");
-    expect(overview?.querySelector('[data-desktop-run-chain-action="Open Task Center"]')?.getAttribute("data-button-variant")).toBe("primary");
-    expect(pin?.getAttribute("aria-pressed")).toBe("false");
-    pin?.click();
-    expect(pin?.getAttribute("aria-pressed")).toBe("true");
-
-    overview?.querySelector('[data-desktop-run-chain-control="close"]')?.click();
-    const restore = targetDocument.body.querySelector("[data-desktop-inspector-restore]");
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
-    expect(restore).toBeNull();
-    targetDocument.body.querySelector(".desktop-chat-header")?.querySelector('[data-desktop-panel-control="inspector"]')?.click();
-    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("true");
-    expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("true");
-    expect(targetDocument.body.querySelectorAll('[data-desktop-panel-control="inspector"]').map((node) => node.getAttribute("aria-pressed"))).toContain("true");
+    expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("false");
+
+    targetDocument.dispatchEvent({
+      type: "tinybot:desktop-panel-toggle",
+      detail: { panel: "sidebar" },
+    });
+
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("false");
+    expect(targetDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("false");
+  });
+
+  test("omits the Activity overview when the inspector has no real content", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: {
+        ...createDefaultWorkbenchLayout(),
+        inspector: { visible: true, size: 360 },
+      },
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    expect(targetDocument.body.querySelector(".desktop-run-chain-overview")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-inspector-content")?.textContent).toBe("");
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
+  });
+
+  test("styles the initial Activity inspector as a flush native sidebar", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
+    expect(styleText).toMatch(/\.desktop-workbench-inspector \{[\s\S]*?border-left: 1px solid var\(--border\);[\s\S]*?background: #fbfaf7;/);
+    expect(styleText).toMatch(/\.desktop-inspector-content \{[\s\S]*?grid-template-rows: minmax\(0, 1fr\);[\s\S]*?gap: 0;[\s\S]*?padding: 0;/);
+    expect(styleText).toMatch(/\.desktop-run-chain-overview \{[\s\S]*?height: 100%;[\s\S]*?padding: 14px 16px 12px;[\s\S]*?background: transparent;/);
+    expect(styleText).toMatch(/\.desktop-run-chain-panel-section \{[\s\S]*?border-radius: 6px;[\s\S]*?box-shadow: none;/);
+    expect(styleText).not.toContain("padding: 18px 20px;");
   });
 
   test("renders live approval queue in the native Run Chain overview", () => {
@@ -1573,11 +1534,8 @@ describe("desktop workbench shell", () => {
     });
 
     let overview = targetDocument.body.querySelector(".desktop-run-chain-overview");
-    let panel = overview?.querySelector(".desktop-run-chain-panel");
-    overview?.querySelector('[data-desktop-run-chain-tab="approvals"]')?.click();
-    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("approvals");
-    expect(panel?.textContent).toContain("Pending: 0");
-    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("0 approvals");
+    expect(overview).toBeNull();
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
 
     updateDesktopTaskCenterItems(targetDocument as unknown as Document, buildDesktopTaskCenterItems({
       approvals: [
@@ -1593,7 +1551,8 @@ describe("desktop workbench shell", () => {
     }));
 
     overview = targetDocument.body.querySelector(".desktop-run-chain-overview");
-    panel = overview?.querySelector(".desktop-run-chain-panel");
+    const panel = overview?.querySelector(".desktop-run-chain-panel");
+    overview?.querySelector('[data-desktop-run-chain-tab="approvals"]')?.click();
     expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("approvals");
     expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("1 approval");
     expect(panel?.textContent).toContain("Pending: 1");
@@ -1602,11 +1561,8 @@ describe("desktop workbench shell", () => {
     updateDesktopTaskCenterItems(targetDocument as unknown as Document, []);
 
     overview = targetDocument.body.querySelector(".desktop-run-chain-overview");
-    panel = overview?.querySelector(".desktop-run-chain-panel");
-    expect(panel?.getAttribute("data-desktop-run-chain-panel")).toBe("approvals");
-    expect(overview?.querySelector(".desktop-run-chain-summary-strip")?.textContent).toContain("0 approvals");
-    expect(panel?.textContent).toContain("Pending: 0");
-    expect(panel?.textContent).toContain("No pending approvals");
+    expect(overview).toBeNull();
+    expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
   });
 
   test("renders a persistent run-chain inspector pane with selectable details", () => {
@@ -1659,7 +1615,6 @@ describe("desktop workbench shell", () => {
     targetDocument.body.querySelector('[data-desktop-run-chain-control="close"]')?.click();
     expect(targetDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-inspector-visible")).toBe("false");
     expect(targetDocument.body.querySelector('[data-workbench-region="inspector"]')?.getAttribute("data-visible")).toBe("false");
-    expect(targetDocument.body.querySelector('[data-desktop-panel-control="inspector"]')?.getAttribute("aria-pressed")).toBe("false");
   });
 
   test("opens the run-chain inspector detail when a conversation tool activity is selected", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -55,7 +55,6 @@ import { mountAgentUiFormFieldIsland } from "./native-vue/agentUiFormFieldIsland
 import { mountAgentUiFormsSurfaceIsland } from "./native-vue/agentUiFormsSurfaceIsland";
 import { mountBottomRegionIsland } from "./native-vue/bottomRegionIsland";
 import { mountActivityRailIsland } from "./native-vue/activityRailIsland";
-import { mountChatHeaderActionsIsland } from "./native-vue/chatHeaderActionsIsland";
 import { mountChatMenuActionIsland } from "./native-vue/chatMenuActionIsland";
 import { mountChatMenuButtonIsland } from "./native-vue/chatMenuButtonIsland";
 import { mountChatMenuEmptyIsland } from "./native-vue/chatMenuEmptyIsland";
@@ -94,7 +93,6 @@ import { mountFileOperationStatusIsland } from "./native-vue/fileOperationStatus
 import { mountFileUploadStatusIsland } from "./native-vue/fileUploadStatusIsland";
 import { mountFormatChipListIsland } from "./native-vue/formatChipListIsland";
 import { mountGatewayRuntimeIsland } from "./native-vue/gatewayRuntimeIsland";
-import { mountHeaderPanelControlIsland } from "./native-vue/headerPanelControlIsland";
 import { mountHelpSurfaceIsland } from "./native-vue/helpSurfaceIsland";
 import { mountInspectorRegionIsland } from "./native-vue/inspectorRegionIsland";
 import { mountInspectorViewIsland } from "./native-vue/inspectorViewIsland";
@@ -105,7 +103,6 @@ import { mountKnowledgePaneIsland } from "./native-vue/knowledgePaneIsland";
 import { mountKnowledgeReadinessIsland } from "./native-vue/knowledgeReadinessIsland";
 import { mountMainUtilitiesRegionIsland } from "./native-vue/mainUtilitiesRegionIsland";
 import { mountModuleWorkSectionIsland } from "./native-vue/moduleWorkSectionIsland";
-import { mountPanelIconPartIsland } from "./native-vue/panelIconPartIsland";
 import { mountPersistentRagToggleIsland } from "./native-vue/persistentRagToggleIsland";
 import { mountRecentChatRowIsland } from "./native-vue/recentChatRowIsland";
 import { mountRunChainInspectorIsland } from "./native-vue/runChainInspectorIsland";
@@ -422,6 +419,7 @@ const desktopRuntimeStatusSnapshots = new WeakMap<Document, {
   runtimeStatus: GatewayRuntimeStatus | null;
 }>();
 const desktopNativeChatModels = new WeakMap<Document, DesktopNativeChatModel>();
+const desktopPanelFrameEventDocuments = new WeakSet<Document>();
 const desktopChatTimelineContexts = new WeakMap<Document, {
   agentUiActions: DesktopAgentUiFormActionOptions;
   agentUiForms: AgentUiForm[];
@@ -471,6 +469,7 @@ export function installDesktopWorkbenchShell({
     runChainItems,
     taskCenterItems,
   });
+  installDesktopPanelFrameEventBridge(targetDocument);
   targetDocument.body.replaceChildren(createWorkbenchShell(targetDocument, layout, runtimeStatus, chat, chatActions, agentUiForms, agentUiActions, gatewayHttp, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, runChainItems, selectedRunChainItemKey, workLens, workLensActions, taskActions, gatewayActions));
   if (chat) {
     syncNativeChatDocumentState(targetDocument, chat);
@@ -651,7 +650,7 @@ export function updateDesktopNativeChat(
   syncNativeChatDocumentState(targetDocument, chat);
   const header = targetDocument.querySelector<HTMLElement>(".desktop-chat-header");
   if (header) {
-    const next = createChatHeader(targetDocument, chat, readCurrentWorkbenchLayout(targetDocument), chatActions);
+    const next = createChatHeader(targetDocument, chat, chatActions);
     header.replaceChildren(...Array.from(next.children));
   }
 
@@ -832,21 +831,25 @@ function createWorkbenchShell(
   taskActions: DesktopTaskCenterActionOptions,
   gatewayActions: DesktopGatewayRuntimeActionOptions,
 ): HTMLElement {
+  const inspectorContent = createInspector(targetDocument, runChainItems, taskCenterItems, selectedRunChainItemKey, workLens, workLensActions);
+  const inspectorState = hasInspectorContent(inspectorContent)
+    ? layout.inspector
+    : { ...layout.inspector, visible: false };
   const shell = targetDocument.createElement("main");
   shell.id = SHELL_ID;
   shell.className = "desktop-workbench-shell";
   shell.setAttribute("data-sidebar-visible", String(layout.sidebar.visible));
-  shell.setAttribute("data-inspector-visible", String(layout.inspector.visible));
+  shell.setAttribute("data-inspector-visible", String(inspectorState.visible));
   shell.setAttribute("data-bottom-visible", String(layout.bottom.visible));
   shell.style.setProperty("--desktop-sidebar-size", `${layout.sidebar.size}px`);
-  shell.style.setProperty("--desktop-inspector-size", `${layout.inspector.size}px`);
+  shell.style.setProperty("--desktop-inspector-size", `${inspectorState.size}px`);
   shell.style.setProperty("--desktop-bottom-size", `${layout.bottom.size}px`);
 
   shell.append(
     createActivityRail(targetDocument),
     createPanel(targetDocument, "sidebar", layout.sidebar, createSidebar(targetDocument, chat, chatActions)),
     createMainRegion(targetDocument, gatewayHttp, layout, chat, chatActions, agentUiForms, agentUiActions, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, workLens, workLensActions),
-    createPanel(targetDocument, "inspector", layout.inspector, createInspector(targetDocument, runChainItems, taskCenterItems, selectedRunChainItemKey, workLens, workLensActions)),
+    createPanel(targetDocument, "inspector", inspectorState, inspectorContent),
     createPanel(targetDocument, "bottom", layout.bottom, createBottomRegion(targetDocument, runtimeStatus, gatewayHttp, taskCenterItems, taskActions, gatewayActions)),
   );
 
@@ -1369,7 +1372,7 @@ function createMainRegion(
   const workbench = targetDocument.createElement("div");
   workbench.className = "desktop-empty-session desktop-chat-workbench";
   const workbenchChildren = [
-    createChatHeader(targetDocument, chat, layout, chatActions),
+    createChatHeader(targetDocument, chat, chatActions),
     createConversationThread(targetDocument, chat),
   ];
   if (showEmptySession) {
@@ -1614,7 +1617,6 @@ function mountMainUtilitiesRegionVueIsland(
 function createChatHeader(
   targetDocument: Document,
   chat: DesktopNativeChatModel | null,
-  layout: WorkbenchLayoutState,
   chatActions: DesktopNativeChatActionOptions = {},
 ): HTMLElement {
   const header = targetDocument.createElement("header");
@@ -1640,14 +1642,6 @@ function createChatHeader(
   if (headerStatus) {
     titleGroup.append(headerStatus);
   }
-  const sidebarControl = createHeaderPanelControl(targetDocument, {
-    panel: "sidebar",
-    visible: layout.sidebar.visible,
-    label: "Sidebar",
-    pressedLabel: "Collapse session list",
-    unpressedLabel: "Expand session list",
-  });
-
   const menu = targetDocument.createElement("button");
   menu.type = "button";
   menu.className = "desktop-chat-menu";
@@ -1670,40 +1664,10 @@ function createChatHeader(
     closeChatMenuPopover(menu, popover);
   });
 
-  titleRow.append(sidebarControl, titleGroup, menu, popover);
+  titleRow.append(titleGroup, menu, popover);
 
   const actions = targetDocument.createElement("div");
   actions.className = "desktop-chat-header-actions";
-  actions.append(
-    createHeaderPanelControl(targetDocument, {
-      panel: "sidebar",
-      visible: layout.sidebar.visible,
-      label: "▏",
-      pressedLabel: "Collapse session list",
-      unpressedLabel: "Expand session list",
-    }),
-    createHeaderPanelControl(targetDocument, {
-      panel: "inspector",
-      visible: layout.inspector.visible,
-      label: "▌",
-      pressedLabel: "Close Activity inspector",
-      unpressedLabel: "Open Activity inspector",
-    }),
-  );
-  const inspectorControl = actions.querySelector<HTMLElement>('[data-desktop-panel-control="inspector"]');
-  if (inspectorControl) {
-    actions.replaceChildren(inspectorControl);
-  }
-
-  mountChatHeaderActionsVueIsland(actions, targetDocument, [
-    {
-      panel: "inspector",
-      visible: layout.inspector.visible,
-      label: "Activity",
-      pressedLabel: "Close Activity inspector",
-      unpressedLabel: "Open Activity inspector",
-    },
-  ]);
 
   header.append(titleRow, actions);
   return header;
@@ -1744,26 +1708,6 @@ function mountChatMenuButtonVueIsland(menu: HTMLElement, popover: HTMLElement): 
   mountChatMenuButtonIsland(menu, {
     expanded: menu.getAttribute("aria-expanded") === "true",
     onToggle: toggle,
-  });
-}
-
-function mountChatHeaderActionsVueIsland(
-  actions: HTMLElement,
-  targetDocument: Document,
-  items: ReadonlyArray<{
-    panel: "sidebar" | "inspector";
-    visible: boolean;
-    label: string;
-    pressedLabel: string;
-    unpressedLabel: string;
-  }>,
-): void {
-  if (!canMountVueIsland(actions)) {
-    return;
-  }
-  mountChatHeaderActionsIsland(actions, {
-    actions: [...items],
-    onToggle: (panel) => toggleDesktopPanel(targetDocument, panel),
   });
 }
 
@@ -2078,119 +2022,6 @@ function setSessionRowPinIcon(targetDocument: Document, titleWrap: HTMLElement, 
 function findSessionRow(targetDocument: Document, sessionKey: string): HTMLElement | null {
   return Array.from(targetDocument.querySelectorAll<HTMLElement>("[data-desktop-session-key]"))
     .find((row) => row.getAttribute("data-desktop-session-key") === sessionKey) ?? null;
-}
-
-function readCurrentWorkbenchLayout(targetDocument: Document): WorkbenchLayoutState {
-  const shell = targetDocument.getElementById(SHELL_ID);
-  return {
-    sidebar: {
-      visible: shell?.getAttribute("data-sidebar-visible") !== "false",
-      size: 260,
-    },
-    inspector: {
-      visible: shell?.getAttribute("data-inspector-visible") !== "false",
-      size: 360,
-    },
-    bottom: {
-      visible: shell?.getAttribute("data-bottom-visible") === "true",
-      size: 220,
-    },
-  };
-}
-
-function createHeaderPanelControl(
-  targetDocument: Document,
-  {
-    panel,
-    visible,
-    label,
-    pressedLabel,
-    unpressedLabel,
-  }: {
-    panel: DesktopPanelControlId;
-    visible: boolean;
-    label: string;
-    pressedLabel: string;
-    unpressedLabel: string;
-  },
-): HTMLElement {
-  const button = targetDocument.createElement("button");
-  button.type = "button";
-  button.className = "desktop-chat-header-panel-button";
-  button.setAttribute("data-desktop-panel-control", panel);
-  button.setAttribute("data-desktop-panel-label-pressed", pressedLabel);
-  button.setAttribute("data-desktop-panel-label-unpressed", unpressedLabel);
-  button.setAttribute("aria-label", visible ? pressedLabel : unpressedLabel);
-  button.setAttribute("title", visible ? pressedLabel : unpressedLabel);
-  button.setAttribute("aria-pressed", String(visible));
-  const iconDirection = panel === "sidebar" ? "collapse-left" : panel === "inspector" ? "collapse-right" : "";
-  if (iconDirection) {
-    const icon = targetDocument.createElement("span");
-    icon.className = "desktop-chat-header-panel-icon";
-    icon.setAttribute("data-panel-icon", iconDirection);
-    icon.setAttribute("aria-hidden", "true");
-    icon.append(
-      createPanelIconPart(targetDocument, "frame"),
-      createPanelIconPart(targetDocument, "rail"),
-    );
-    button.append(icon);
-  } else {
-    button.textContent = label;
-  }
-  mountHeaderPanelControlVueIsland(button, targetDocument, {
-    panel,
-    visible,
-    label,
-    pressedLabel,
-    unpressedLabel,
-  });
-  return button;
-}
-
-function mountHeaderPanelControlVueIsland(
-  button: HTMLElement,
-  targetDocument: Document,
-  options: {
-    panel: DesktopPanelControlId;
-    visible: boolean;
-    label: string;
-    pressedLabel: string;
-    unpressedLabel: string;
-  },
-): void {
-  const toggle = () => toggleDesktopPanel(targetDocument, options.panel);
-  const installFallback = () => {
-    button.addEventListener("click", toggle);
-    button.addEventListener("keydown", (event) => {
-      if (event.key !== "Enter" && event.key !== " ") {
-        return;
-      }
-      event.preventDefault();
-      toggle();
-    });
-  };
-  if (!canMountVueIsland(button)) {
-    installFallback();
-    return;
-  }
-  mountHeaderPanelControlIsland(button, {
-    ...options,
-    onToggle: () => toggle(),
-  });
-}
-
-function createPanelIconPart(targetDocument: Document, part: "frame" | "rail"): HTMLElement {
-  const node = targetDocument.createElement("span");
-  node.className = `desktop-chat-header-panel-icon-${part}`;
-  mountPanelIconPartVueIsland(node, part);
-  return node;
-}
-
-function mountPanelIconPartVueIsland(node: HTMLElement, part: "frame" | "rail"): void {
-  if (!canMountVueIsland(node)) {
-    return;
-  }
-  mountPanelIconPartIsland(node, { part });
 }
 
 function createConversationThread(
@@ -6141,9 +5972,29 @@ function toggleDesktopPanel(targetDocument: Document, panel: DesktopPanelControl
   setDesktopPanelVisible(targetDocument, panel, currentValue === "false");
 }
 
+function installDesktopPanelFrameEventBridge(targetDocument: Document): void {
+  if (desktopPanelFrameEventDocuments.has(targetDocument)) {
+    return;
+  }
+  desktopPanelFrameEventDocuments.add(targetDocument);
+  targetDocument.addEventListener("tinybot:desktop-panel-toggle", (event) => {
+    const panel = (event as CustomEvent<{ panel?: unknown }>).detail?.panel;
+    if (panel !== "sidebar" && panel !== "inspector") {
+      return;
+    }
+    toggleDesktopPanel(targetDocument, panel);
+  });
+}
+
 function setDesktopPanelVisible(targetDocument: Document, panel: DesktopPanelControlId, nextVisible: boolean): void {
   const shell = targetDocument.getElementById(SHELL_ID);
   const panelElement = targetDocument.querySelector<HTMLElement>(`[data-workbench-region="${panel}"]`);
+  if (panel === "inspector" && nextVisible && panelElement) {
+    const inspectorContent = panelElement.querySelector<HTMLElement>(".desktop-inspector-content");
+    if (inspectorContent && !hasInspectorContent(inspectorContent)) {
+      nextVisible = false;
+    }
+  }
   const stateAttribute = `data-${panel}-visible`;
   shell?.setAttribute(stateAttribute, String(nextVisible));
   panelElement?.setAttribute("data-visible", String(nextVisible));
@@ -6233,14 +6084,23 @@ function createInspector(
 ): HTMLElement {
   const inspector = targetDocument.createElement("aside");
   inspector.className = "desktop-inspector-content";
-  inspector.append(createRunChainOverviewPanel(targetDocument, runChainItems, taskCenterItems));
+  const hasRunChainOverview = runChainItems.length > 0 || taskCenterItems.length > 0;
+  if (hasRunChainOverview) {
+    inspector.append(createRunChainOverviewPanel(targetDocument, runChainItems, taskCenterItems));
+  }
   if (workLens) {
     inspector.append(createWorkLensPane(targetDocument, workLens, workLensActions));
   } else if (runChainItems.length) {
     inspector.append(createRunChainInspectorPane(targetDocument, runChainItems, selectedRunChainItemKey));
   }
-  mountInspectorRegionVueIsland(inspector, targetDocument, runChainItems, taskCenterItems, selectedRunChainItemKey, workLens, workLensActions);
+  if (hasInspectorContent(inspector)) {
+    mountInspectorRegionVueIsland(inspector, targetDocument, runChainItems, taskCenterItems, selectedRunChainItemKey, workLens, workLensActions);
+  }
   return inspector;
+}
+
+function hasInspectorContent(inspector: HTMLElement): boolean {
+  return inspector.children.length > 0;
 }
 
 function mountInspectorRegionVueIsland(
@@ -6391,7 +6251,21 @@ function refreshRunChainOverviewFromTaskCenter(
   liveState: DesktopWorkbenchLiveState,
 ): void {
   const current = targetDocument.querySelector<HTMLElement>(".desktop-run-chain-overview");
+  const shouldRenderOverview = liveState.runChainItems.length > 0 || liveState.taskCenterItems.length > 0;
+  if (!shouldRenderOverview) {
+    current?.remove();
+    const inspectorContent = targetDocument.querySelector<HTMLElement>(".desktop-inspector-content");
+    if (inspectorContent && !hasInspectorContent(inspectorContent)) {
+      setDesktopPanelVisible(targetDocument, "inspector", false);
+    }
+    return;
+  }
   if (!current) {
+    const inspectorContent = targetDocument.querySelector<HTMLElement>(".desktop-inspector-content");
+    if (!inspectorContent) {
+      return;
+    }
+    inspectorContent.append(createRunChainOverviewPanel(targetDocument, liveState.runChainItems, liveState.taskCenterItems));
     return;
   }
   const selectedTab = currentRunChainOverviewTab(current);
@@ -8439,6 +8313,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workbench-inspector {
       grid-column: 4;
       width: var(--region-size);
+      border-right: 0;
+      border-left: 1px solid var(--border);
+      background: #fbfaf7;
     }
 
     body.desktop-native-workbench .desktop-workbench-inspector[data-visible="false"],
@@ -9557,6 +9434,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-knowledge-graph-canvas {
+      position: relative;
+      display: grid;
+      grid-template-rows: minmax(0, 1fr) auto;
       min-width: 0;
       min-height: 280px;
       overflow: hidden;
@@ -9567,26 +9447,40 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
         var(--bg, #faf9f5);
     }
 
-    body.desktop-native-workbench .desktop-knowledge-graph-canvas svg {
+    body.desktop-native-workbench .desktop-knowledge-graph-3d-host {
       width: 100%;
-      min-height: 280px;
+      min-width: 0;
+      min-height: 0;
+      cursor: grab;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-graph-node circle {
-      fill: var(--surface-card, #efe9de);
-      stroke: var(--accent, #cc785c);
-      stroke-width: 2;
+    body.desktop-native-workbench .desktop-knowledge-graph-3d-host:active {
+      cursor: grabbing;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-graph-node text {
-      fill: var(--text-body, #3d3d3a);
-      font: 600 11px/1 var(--font-sans, system-ui, sans-serif);
+    body.desktop-native-workbench .desktop-knowledge-graph-3d-host canvas {
+      display: block;
+      outline: none;
     }
 
-    body.desktop-native-workbench .desktop-knowledge-graph-edge {
-      stroke: var(--accent, #cc785c);
-      stroke-width: 1.5;
-      opacity: 0.72;
+    body.desktop-native-workbench .desktop-knowledge-graph-3d-hint {
+      position: absolute;
+      left: 10px;
+      right: 10px;
+      bottom: 10px;
+      z-index: 1;
+      width: fit-content;
+      max-width: calc(100% - 20px);
+      border: 1px solid rgba(226, 217, 210, 0.9);
+      border-radius: 999px;
+      padding: 5px 9px;
+      background: rgba(255, 253, 249, 0.88);
+      color: var(--text-muted, #6c6a64);
+      font: 650 11px/1.2 var(--font-sans, system-ui, sans-serif);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      pointer-events: none;
     }
 
     body.desktop-native-workbench .desktop-knowledge-graph-references {
@@ -9628,6 +9522,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-knowledge-graph-references .n-space > span:last-child {
       min-width: 0;
       overflow-wrap: anywhere;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-selection-empty {
+      margin: 0;
+      padding: 10px;
+      color: var(--text-muted, #6c6a64);
+      font: 600 12px/1.45 var(--font-sans, system-ui, sans-serif);
     }
 
     body.desktop-native-workbench .desktop-knowledge-pipeline-workspace,
@@ -13057,12 +12958,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-inspector-content {
       display: grid;
-      grid-template-rows: auto minmax(0, 1fr);
-      gap: 16px;
+      grid-template-rows: minmax(0, 1fr);
+      grid-auto-rows: min-content;
+      gap: 0;
       height: 100%;
       min-height: 0;
-      padding: 18px 20px;
-      overflow-y: auto;
+      padding: 0;
+      overflow-y: hidden;
       overflow-x: hidden;
       background: #fbfaf7;
     }
@@ -13070,9 +12972,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-run-chain-overview {
       display: grid;
       grid-template-rows: auto auto auto minmax(0, 1fr) auto;
-      gap: 10px;
+      gap: 8px;
+      height: 100%;
       min-width: 0;
       min-height: 0;
+      padding: 14px 16px 12px;
+      overflow: hidden;
+      background: transparent;
     }
 
     body.desktop-native-workbench .desktop-run-chain-header {
@@ -13081,6 +12987,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       justify-content: space-between;
       gap: 10px;
       min-width: 0;
+      padding-bottom: 2px;
     }
 
     body.desktop-native-workbench .desktop-run-chain-header h2,
@@ -13215,10 +13122,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       overflow-x: auto;
       overflow-y: hidden;
       scrollbar-width: none;
-      border: 0;
-      border-radius: 8px;
+      border: 1px solid #ebe3dc;
+      border-radius: 7px;
       padding: 3px;
-      background: #f2eee8;
+      background: #f8f4ef;
     }
 
     body.desktop-native-workbench .desktop-run-chain-tabs::-webkit-scrollbar {
@@ -13266,9 +13173,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       gap: 7px;
       min-width: 0;
       border: 1px solid #ebe3dc;
-      border-radius: 8px;
-      padding: 12px;
+      border-radius: 6px;
+      padding: 10px 11px;
       background: #fffdf9;
+      box-shadow: none;
     }
 
     body.desktop-native-workbench .desktop-run-chain-card-row {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -9463,6 +9463,46 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       outline: none;
     }
 
+    body.desktop-native-workbench .desktop-knowledge-graph-fallback svg {
+      display: block;
+      width: 100%;
+      min-width: 0;
+      min-height: 280px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-edge line {
+      stroke: rgba(217, 120, 87, 0.56);
+      stroke-width: 2;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-edge text,
+    body.desktop-native-workbench .desktop-knowledge-graph-node text {
+      fill: var(--text-muted, #6c6a64);
+      font: 650 12px/1 var(--font-sans, system-ui, sans-serif);
+      text-anchor: middle;
+      paint-order: stroke;
+      stroke: rgba(255, 253, 249, 0.86);
+      stroke-width: 4px;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-node {
+      cursor: pointer;
+      outline: none;
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-node circle {
+      fill: #f2eadf;
+      stroke: var(--primary, #cc785c);
+      stroke-width: 2.5;
+      filter: drop-shadow(0 8px 14px rgba(75, 54, 38, 0.12));
+    }
+
+    body.desktop-native-workbench .desktop-knowledge-graph-node[data-selected="true"] circle,
+    body.desktop-native-workbench .desktop-knowledge-graph-node:focus-visible circle {
+      fill: #fff7ef;
+      stroke-width: 4;
+    }
+
     body.desktop-native-workbench .desktop-knowledge-graph-3d-hint {
       position: absolute;
       left: 10px;

--- a/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
@@ -200,7 +200,7 @@ describe("desktop workbench shell Vue integration", () => {
     expect(popover?.querySelector(".desktop-chat-menu-popover-card")).toBeNull();
   });
 
-  test("renders chat header panel actions through the Vue shell island", () => {
+  test("keeps panel actions out of the Vue shell island", () => {
     document.body.replaceChildren();
     document.head.replaceChildren();
 
@@ -213,21 +213,13 @@ describe("desktop workbench shell Vue integration", () => {
     const shell = document.getElementById("desktop-workbench-shell");
     const titleRow = document.querySelector<HTMLElement>(".desktop-chat-title-row");
     const actions = document.querySelector<HTMLElement>(".desktop-chat-header-actions");
-    const sidebar = titleRow?.querySelector<HTMLButtonElement>('[data-desktop-panel-control="sidebar"]');
-    const inspector = actions?.querySelector<HTMLButtonElement>('[data-desktop-panel-control="inspector"]');
 
-    expect(actions?.getAttribute("data-desktop-vue-island")).toBe("chat-header-actions");
+    expect(document.querySelector(".desktop-global-panel-controls")).toBeNull();
+    expect(titleRow?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
     expect(actions?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
-    expect(titleRow?.children[0]?.getAttribute("data-desktop-panel-control")).toBe("sidebar");
-    expect(sidebar?.getAttribute("aria-label")).toBe("Collapse session list");
-    expect(sidebar?.getAttribute("aria-pressed")).toBe("true");
-    expect(inspector?.getAttribute("aria-label")).toBe("Open Activity inspector");
-    expect(inspector?.getAttribute("aria-pressed")).toBe("false");
+    expect(actions?.querySelector('[data-desktop-panel-control="inspector"]')).toBeNull();
+    expect(titleRow?.children[0]?.className).toBe("desktop-chat-title-group");
     expect(shell?.getAttribute("data-sidebar-visible")).toBe("true");
-
-    sidebar?.click();
-
-    expect(shell?.getAttribute("data-sidebar-visible")).toBe("false");
   });
 
   test("renders the chat workbench chrome through the Vue shell island", () => {

--- a/apps/desktop/src/native-vue/inspectorRegionIsland.ts
+++ b/apps/desktop/src/native-vue/inspectorRegionIsland.ts
@@ -6,7 +6,7 @@ import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 import { mountRunChainInspectorIsland } from "./runChainInspectorIsland";
 import { mountRunChainOverviewIsland, type RunChainOverviewIslandAction } from "./runChainOverviewIsland";
 import { mountWorkLensIsland } from "./workLensIsland";
-import { NCard, NConfigProvider } from "naive-ui";
+import { NConfigProvider } from "naive-ui";
 
 export interface InspectorRegionWorkLensActionEvent {
   action: DesktopWorkLensActionId;
@@ -50,16 +50,19 @@ function createInspectorRegionApp(options: InspectorRegionIslandOptions): App {
     name: "InspectorRegionIsland",
     setup() {
       const mountedChildren: Array<{ unmount: () => void }> = [];
+      const hasOverview = options.runChainItems.length > 0 || Boolean(options.taskItems?.length);
       const overview = ref<HTMLElement | null>(null);
       const lens = ref<HTMLElement | null>(null);
       const inspector = ref<HTMLElement | null>(null);
 
       onMounted(() => {
-        mountChild(mountedChildren, overview.value, (host) => mountRunChainOverviewIsland(host, {
-          items: options.runChainItems,
-          taskItems: options.taskItems,
-          onAction: options.onRunChainAction,
-        }));
+        if (hasOverview) {
+          mountChild(mountedChildren, overview.value, (host) => mountRunChainOverviewIsland(host, {
+            items: options.runChainItems,
+            taskItems: options.taskItems,
+            onAction: options.onRunChainAction,
+          }));
+        }
         if (options.workLens) {
           mountChild(mountedChildren, lens.value, (host) => mountWorkLensIsland(host, {
             workLens: options.workLens!,
@@ -84,20 +87,14 @@ function createInspectorRegionApp(options: InspectorRegionIslandOptions): App {
       });
 
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => h(NCard, {
-          class: "desktop-inspector-content-card",
-          size: "small",
-          bordered: false,
-        }, {
-          default: () => [
-            h("section", { ref: overview }),
-            options.workLens
-              ? h("section", { ref: lens })
-              : options.runChainItems.length
-                ? h("section", { ref: inspector })
-                : null,
-          ],
-        }),
+        default: () => [
+          hasOverview ? h("section", { ref: overview }) : null,
+          options.workLens
+            ? h("section", { ref: lens })
+            : options.runChainItems.length
+              ? h("section", { ref: inspector })
+              : null,
+        ],
       });
     },
   }));

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
@@ -1,8 +1,33 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import type { DesktopKnowledgeEvidenceRow, DesktopKnowledgePaneGraph } from "../desktopKnowledgeTraceability";
 import { buildKnowledgeGraph3dData, buildKnowledgeGraphSelection, mountKnowledgeGraphIsland } from "./knowledgeGraphIsland";
+
+vi.mock("3d-force-graph", () => {
+  class ForceGraph3DMock {
+    backgroundColor() { return this; }
+    showNavInfo() { return this; }
+    graphData() { return this; }
+    nodeLabel() { return this; }
+    nodeVal() { return this; }
+    nodeColor() { return this; }
+    linkLabel() { return this; }
+    linkColor() { return this; }
+    linkWidth() { return this; }
+    linkDirectionalParticles() { return this; }
+    linkDirectionalParticleSpeed() { return this; }
+    cooldownTicks() { return this; }
+    d3VelocityDecay() { return this; }
+    onNodeClick() { return this; }
+    onLinkClick() { return this; }
+    width() { return this; }
+    height() { return this; }
+    cameraPosition() { return this; }
+    _destructor() {}
+  }
+  return { default: ForceGraph3DMock };
+});
 
 function evidence(index: number): DesktopKnowledgeEvidenceRow {
   return {
@@ -36,6 +61,10 @@ const graph: DesktopKnowledgePaneGraph = {
 };
 
 describe("knowledge graph Vue island", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test("renders graph references and limits evidence rows with existing copy", () => {
     const host = document.createElement("section");
 
@@ -64,6 +93,7 @@ describe("knowledge graph Vue island", () => {
   });
 
   test("renders an interactive 3D graph host instead of the legacy SVG graph", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({} as CanvasRenderingContext2D);
     const host = document.createElement("section");
     const mounted = mountKnowledgeGraphIsland(host, {
       graph: graphWithEdges(),
@@ -75,6 +105,25 @@ describe("knowledge graph Vue island", () => {
     expect(canvas?.textContent).toContain("Drag to orbit");
     expect(canvas?.querySelector(".desktop-knowledge-graph-3d-host")).not.toBeNull();
     expect(canvas?.querySelector("svg")).toBeNull();
+
+    mounted.unmount();
+  });
+
+  test("renders a visible 2D fallback graph when WebGL is unavailable", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+    const host = document.createElement("section");
+    const mounted = mountKnowledgeGraphIsland(host, {
+      graph: graphWithEdges(),
+    });
+
+    const canvas = host.querySelector('[data-desktop-knowledge-graph-pane="canvas"]');
+    expect(canvas?.getAttribute("data-desktop-knowledge-graph-mode")).toBe("2d-fallback");
+    expect(canvas?.getAttribute("role")).toBe("img");
+    expect(canvas?.textContent).toContain("WebGL unavailable");
+    expect(canvas?.querySelector("svg")).not.toBeNull();
+    expect(canvas?.querySelector('[data-desktop-knowledge-graph-node="source"]')).not.toBeNull();
+    expect(canvas?.querySelector('[data-desktop-knowledge-graph-edge="edge-source-target"]')).not.toBeNull();
+    expect(canvas?.querySelector(".desktop-knowledge-graph-3d-host")).toBeNull();
 
     mounted.unmount();
   });

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from "vitest";
 import type { DesktopKnowledgeEvidenceRow, DesktopKnowledgePaneGraph } from "../desktopKnowledgeTraceability";
-import { mountKnowledgeGraphIsland } from "./knowledgeGraphIsland";
+import { buildKnowledgeGraph3dData, buildKnowledgeGraphSelection, mountKnowledgeGraphIsland } from "./knowledgeGraphIsland";
 
 function evidence(index: number): DesktopKnowledgeEvidenceRow {
   return {
@@ -63,40 +63,103 @@ describe("knowledge graph Vue island", () => {
     expect(host.textContent).toBe("");
   });
 
-  test("draws graph edges between their source and target nodes", () => {
+  test("renders an interactive 3D graph host instead of the legacy SVG graph", () => {
     const host = document.createElement("section");
     const mounted = mountKnowledgeGraphIsland(host, {
-      graph: {
-        ...graph,
-        view: {
-          nodes: [
-            { id: "center", label: "Center", type: "entity", raw: {} },
-            { id: "source", label: "Source", type: "entity", raw: {} },
-            { id: "target", label: "Target", type: "entity", raw: {} },
-          ],
-          edges: [{
-            id: "edge-source-target",
-            title: "Source relates to Target",
-            sourceId: "source",
-            targetId: "target",
-            sourceLabel: "Source",
-            targetLabel: "Target",
-            predicate: "relates",
-            confidenceLabel: "",
-            evidenceCount: 1,
-            raw: {},
-          }],
-          evidenceRows: [],
-        },
-      },
+      graph: graphWithEdges(),
     });
 
-    const edge = host.querySelector('[data-desktop-knowledge-graph-edge="edge-source-target"]');
-    expect(edge?.getAttribute("x1")).toBe("320");
-    expect(edge?.getAttribute("y1")).toBe("65");
-    expect(edge?.getAttribute("x2")).toBe("320");
-    expect(edge?.getAttribute("y2")).toBe("295");
+    const canvas = host.querySelector('[data-desktop-knowledge-graph-pane="canvas"]');
+    expect(canvas?.getAttribute("data-desktop-knowledge-graph-mode")).toBe("3d");
+    expect(canvas?.getAttribute("role")).toBe("application");
+    expect(canvas?.textContent).toContain("Drag to orbit");
+    expect(canvas?.querySelector(".desktop-knowledge-graph-3d-host")).not.toBeNull();
+    expect(canvas?.querySelector("svg")).toBeNull();
 
     mounted.unmount();
   });
+
+  test("maps knowledge graph nodes and edges into 3D force graph data", () => {
+    const data = buildKnowledgeGraph3dData(graphWithEdges());
+
+    expect(data.nodes.map((node) => node.id)).toEqual(["center", "source", "target"]);
+    expect(data.nodes[0]).toMatchObject({
+      id: "center",
+      name: "Center",
+      type: "entity",
+      val: 8,
+    });
+    expect(data.links).toEqual([
+      {
+        id: "edge-source-target",
+        source: "source",
+        target: "target",
+        label: "relates",
+        title: "Source relates to Target",
+        evidenceCount: 1,
+      },
+    ]);
+  });
+
+  test("filters references and evidence to the selected graph node", () => {
+    const selection = buildKnowledgeGraphSelection(graphWithEdges(), "source");
+
+    expect(selection.node?.label).toBe("Source");
+    expect(selection.relations.map((row) => row.id)).toEqual(["edge-source-target"]);
+    expect(selection.evidence.map((row) => row.id)).toEqual(["evidence-source-target"]);
+    expect(selection.isFiltered).toBe(true);
+  });
+
+  test("shows an empty selection message when a selected node has no references", () => {
+    const selection = buildKnowledgeGraphSelection(graphWithEdges(), "center");
+
+    expect(selection.node?.label).toBe("Center");
+    expect(selection.relations).toEqual([]);
+    expect(selection.evidence).toEqual([]);
+    expect(selection.isFiltered).toBe(true);
+  });
 });
+
+function graphWithEdges(): DesktopKnowledgePaneGraph {
+  return {
+    ...graph,
+    view: {
+      nodes: [
+        { id: "center", label: "Center", type: "entity", raw: {} },
+        { id: "source", label: "Source", type: "entity", raw: {} },
+        { id: "target", label: "Target", type: "entity", raw: {} },
+      ],
+      edges: [{
+        id: "edge-source-target",
+        title: "Source relates to Target",
+        sourceId: "source",
+        targetId: "target",
+        sourceLabel: "Source",
+        targetLabel: "Target",
+        predicate: "relates",
+        confidenceLabel: "",
+        evidenceCount: 1,
+        raw: {},
+      }],
+      evidenceRows: [evidenceRowForEdge("evidence-source-target", "edge-source-target", "source", "target")],
+    },
+    relations: [{ id: "edge-source-target", title: "Source relates to Target", meta: "relation", text: "relates" }],
+    evidence: [evidenceRowForEdge("evidence-source-target", "edge-source-target", "source", "target")],
+  };
+}
+
+function evidenceRowForEdge(id: string, edgeId: string, sourceNodeId: string, targetNodeId: string): DesktopKnowledgeEvidenceRow {
+  return {
+    id,
+    edgeId,
+    sourceNodeId,
+    targetNodeId,
+    title: "Source relates to Target",
+    docName: "Graph.md",
+    location: "",
+    meta: "",
+    evidenceText: "Source relates to Target.",
+    confidenceLabel: "",
+    claimId: "",
+  };
+}

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
@@ -120,10 +120,14 @@ const KnowledgeGraph3dScene = defineComponent({
   setup(props, { emit }) {
     const host = ref<HTMLElement | null>(null);
     const selected = ref<string>("Drag to orbit, scroll to zoom, click a node to focus.");
+    const hasWebGl = ref(canRenderKnowledgeGraph3d());
     const graphInstance = shallowRef<KnowledgeGraph3dInstance | null>(null);
     let resizeObserver: ResizeObserver | null = null;
 
     onMounted(() => {
+      if (!hasWebGl.value) {
+        return;
+      }
       void mountKnowledgeGraph3dScene(host.value, props.graph, selected, (nodeId) => {
         selected.value = props.graph.view.nodes.find((node) => node.id === nodeId)?.label ?? selected.value;
         emit("selectNode", nodeId);
@@ -131,6 +135,9 @@ const KnowledgeGraph3dScene = defineComponent({
         graphInstance.value = instance;
       }, (observer) => {
         resizeObserver = observer;
+      }).catch((error) => {
+        console.warn("Tinybot knowledge graph 3D scene failed to mount", error);
+        hasWebGl.value = false;
       });
     });
 
@@ -140,7 +147,7 @@ const KnowledgeGraph3dScene = defineComponent({
       graphInstance.value = null;
     });
 
-    return () => h("div", {
+    return () => hasWebGl.value ? h("div", {
       class: "desktop-knowledge-graph-canvas",
       "data-desktop-knowledge-graph-pane": "canvas",
       "data-desktop-knowledge-graph-mode": "3d",
@@ -154,7 +161,10 @@ const KnowledgeGraph3dScene = defineComponent({
         "data-desktop-knowledge-graph-3d-host": "",
       }),
       h("div", { class: "desktop-knowledge-graph-3d-hint" }, selected.value),
-    ]);
+    ]) : renderKnowledgeGraph2dFallback(props.graph, props.selectedNodeId ?? "", (nodeId) => {
+      selected.value = props.graph.view.nodes.find((node) => node.id === nodeId)?.label ?? selected.value;
+      emit("selectNode", nodeId);
+    });
   },
 });
 
@@ -256,6 +266,104 @@ export function buildKnowledgeGraph3dData(graph: DesktopKnowledgePaneGraph): Kno
       evidenceCount: edge.evidenceCount,
     }));
   return { nodes, links };
+}
+
+function renderKnowledgeGraph2dFallback(
+  graph: DesktopKnowledgePaneGraph,
+  selectedNodeId: string,
+  selectNode: (nodeId: string) => void,
+) {
+  const graphData = buildKnowledgeGraph3dData(graph);
+  const points = new Map(graphData.nodes.map((node, index) => [node.id, knowledgeGraphFallbackPoint(index, graphData.nodes.length)]));
+  return h("div", {
+    class: "desktop-knowledge-graph-canvas desktop-knowledge-graph-fallback",
+    "data-desktop-knowledge-graph-pane": "canvas",
+    "data-desktop-knowledge-graph-mode": "2d-fallback",
+    "data-desktop-knowledge-selected-node": selectedNodeId,
+    role: "img",
+    "aria-label": `${graph.summary}. WebGL unavailable; showing a 2D fallback graph.`,
+  }, [
+    h("svg", {
+      viewBox: "0 0 640 320",
+      role: "presentation",
+      "aria-hidden": "true",
+    }, [
+      h("g", { class: "desktop-knowledge-graph-fallback-edges" }, graphData.links.map((link) => {
+        const sourceId = knowledgeGraph3dLinkNodeId(link.source);
+        const targetId = knowledgeGraph3dLinkNodeId(link.target);
+        const source = points.get(sourceId);
+        const target = points.get(targetId);
+        if (!source || !target) {
+          return null;
+        }
+        return h("g", {
+          class: "desktop-knowledge-graph-edge",
+          "data-desktop-knowledge-graph-edge": link.id,
+        }, [
+          h("line", {
+            x1: source.x,
+            y1: source.y,
+            x2: target.x,
+            y2: target.y,
+          }),
+          h("text", {
+            x: (source.x + target.x) / 2,
+            y: (source.y + target.y) / 2 - 8,
+          }, link.label),
+        ]);
+      })),
+      h("g", { class: "desktop-knowledge-graph-fallback-nodes" }, graphData.nodes.map((node) => {
+        const point = points.get(node.id) ?? { x: 320, y: 160 };
+        const isSelected = selectedNodeId === node.id;
+        return h("g", {
+          class: "desktop-knowledge-graph-node",
+          "data-desktop-knowledge-graph-node": node.id,
+          "data-selected": String(isSelected),
+          role: "button",
+          tabindex: "0",
+          "aria-label": `Select ${node.name}`,
+          onClick: () => selectNode(node.id),
+          onKeydown: (event: KeyboardEvent) => {
+            if (event.key !== "Enter" && event.key !== " ") {
+              return;
+            }
+            event.preventDefault();
+            selectNode(node.id);
+          },
+        }, [
+          h("circle", {
+            cx: point.x,
+            cy: point.y,
+            r: node.val + 8,
+          }),
+          h("text", {
+            x: point.x,
+            y: point.y + node.val + 24,
+          }, node.name),
+        ]);
+      })),
+    ]),
+    h("div", { class: "desktop-knowledge-graph-3d-hint" }, "WebGL unavailable; showing a 2D fallback."),
+  ]);
+}
+
+function knowledgeGraphFallbackPoint(index: number, total: number): { x: number; y: number } {
+  if (index === 0) {
+    return { x: 320, y: 160 };
+  }
+  const orbitIndex = index - 1;
+  const orbitTotal = Math.max(1, total - 1);
+  const angle = (orbitIndex / orbitTotal) * Math.PI * 2 - Math.PI / 2;
+  const radiusX = 210;
+  const radiusY = 96;
+  return {
+    x: 320 + Math.cos(angle) * radiusX,
+    y: 160 + Math.sin(angle) * radiusY,
+  };
+}
+
+function knowledgeGraph3dLinkNodeId(node: string | KnowledgeGraph3dNode): string {
+  return typeof node === "string" ? node : node.id;
 }
 
 export function buildKnowledgeGraphSelection(graph: DesktopKnowledgePaneGraph, selectedNodeId: string | null): KnowledgeGraphSelection {

--- a/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
+++ b/apps/desktop/src/native-vue/knowledgeGraphIsland.ts
@@ -1,9 +1,7 @@
-import { createApp, defineComponent, h, type App } from "vue";
+import { computed, createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, shallowRef, type App, type PropType, type Ref } from "vue";
 import { NConfigProvider, NList, NListItem, NSpace, NTag } from "naive-ui";
 import type {
   DesktopKnowledgeEvidenceRow,
-  DesktopKnowledgeGraphEdge,
-  DesktopKnowledgeGraphNode,
   DesktopKnowledgePaneGraph,
   DesktopKnowledgePaneReferenceRow,
 } from "../desktopKnowledgeTraceability";
@@ -11,6 +9,35 @@ import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 const KNOWLEDGE_GRAPH_REFERENCE_LIMIT = 4;
 const KNOWLEDGE_GRAPH_EVIDENCE_LIMIT = 4;
+
+export interface KnowledgeGraph3dNode {
+  id: string;
+  name: string;
+  type: string;
+  val: number;
+  raw: unknown;
+}
+
+export interface KnowledgeGraph3dLink {
+  id: string;
+  source: string | KnowledgeGraph3dNode;
+  target: string | KnowledgeGraph3dNode;
+  label: string;
+  title: string;
+  evidenceCount: number;
+}
+
+export interface KnowledgeGraph3dData {
+  nodes: KnowledgeGraph3dNode[];
+  links: KnowledgeGraph3dLink[];
+}
+
+export interface KnowledgeGraphSelection {
+  node: { id: string; label: string } | null;
+  relations: DesktopKnowledgePaneReferenceRow[];
+  evidence: DesktopKnowledgeEvidenceRow[];
+  isFiltered: boolean;
+}
 
 export interface KnowledgeGraphIslandOptions {
   graph: DesktopKnowledgePaneGraph;
@@ -40,20 +67,17 @@ function createKnowledgeGraphApp(options: KnowledgeGraphIslandOptions): App {
   return createApp(defineComponent({
     name: "KnowledgeGraphIsland",
     setup() {
+      const selectedNodeId = ref<string | null>(null);
+      const selection = computed(() => buildKnowledgeGraphSelection(options.graph, selectedNodeId.value));
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => h("div", { class: "desktop-knowledge-graph-workspace" }, [
-          renderGraphCanvas(options.graph),
+          renderGraphCanvas(options.graph, selectedNodeId),
           h("div", {
             class: "desktop-knowledge-graph-references",
             "data-desktop-knowledge-graph-pane": "references",
+            "data-desktop-knowledge-graph-filtered": String(selection.value.isFiltered),
           }, [
-            h("h2", `Graph: ${options.graph.summary}`),
-            renderReferenceGroup("Community", options.graph.communities),
-            renderReferenceGroup("Report", options.graph.reports),
-            renderReferenceGroup("Claim", options.graph.claims),
-            renderReferenceGroup("Relation", options.graph.relations),
-            renderReferenceGroup("Conflict", options.graph.conflicts),
-            renderEvidence(options.graph.evidence),
+            renderSelectionReferences(options.graph, selection.value),
           ]),
         ]),
       });
@@ -61,7 +85,7 @@ function createKnowledgeGraphApp(options: KnowledgeGraphIslandOptions): App {
   }));
 }
 
-function renderGraphCanvas(graph: DesktopKnowledgePaneGraph) {
+function renderGraphCanvas(graph: DesktopKnowledgePaneGraph, selectedNodeId: Ref<string | null>) {
   if (!graph.view.nodes.length) {
     return h("div", {
       class: "desktop-knowledge-graph-canvas desktop-knowledge-graph-empty",
@@ -71,58 +95,215 @@ function renderGraphCanvas(graph: DesktopKnowledgePaneGraph) {
       h("p", "Upload documents, then build the graph to inspect entities and relationships."),
     ]);
   }
-  const visibleNodes = graph.view.nodes.slice(0, 12);
-  const nodePoints = new Map(visibleNodes.map((node, index) => [node.id, graphPoint(index, visibleNodes.length)]));
-  const visibleEdges = graph.view.edges
-    .slice(0, 10)
-    .map((edge) => ({ edge, source: nodePoints.get(edge.sourceId), target: nodePoints.get(edge.targetId) }))
-    .filter((entry): entry is { edge: DesktopKnowledgeGraphEdge; source: GraphPoint; target: GraphPoint } => Boolean(entry.source && entry.target));
-  return h("div", {
-    class: "desktop-knowledge-graph-canvas",
-    "data-desktop-knowledge-graph-pane": "canvas",
-  }, [
-    h("svg", { viewBox: "0 0 640 360", role: "img", "aria-label": graph.summary }, [
-      ...visibleEdges.map(({ edge, source, target }) => renderGraphEdge(edge, source, target)),
-      ...visibleNodes.map((node, index) => renderGraphNode(node, index, visibleNodes.length)),
-    ]),
-  ]);
-}
-
-function renderGraphNode(node: DesktopKnowledgeGraphNode, index: number, total: number) {
-  const point = graphPoint(index, total);
-  const radius = index === 0 ? 34 : 18;
-  return h("g", { class: "desktop-knowledge-graph-node", "data-desktop-knowledge-graph-node": node.id }, [
-    h("circle", { cx: point.x, cy: point.y, r: radius }),
-    h("text", { x: point.x, y: point.y + radius + 16, "text-anchor": "middle" }, node.label),
-  ]);
-}
-
-function renderGraphEdge(edge: DesktopKnowledgeGraphEdge, start: GraphPoint, end: GraphPoint) {
-  return h("line", {
-    class: "desktop-knowledge-graph-edge",
-    "data-desktop-knowledge-graph-edge": edge.id,
-    x1: start.x,
-    y1: start.y,
-    x2: end.x,
-    y2: end.y,
+  return h(KnowledgeGraph3dScene, {
+    graph,
+    selectedNodeId: selectedNodeId.value ?? "",
+    onSelectNode: (nodeId: string) => {
+      selectedNodeId.value = nodeId;
+    },
   });
 }
 
-interface GraphPoint {
-  x: number;
-  y: number;
+const KnowledgeGraph3dScene = defineComponent({
+  name: "KnowledgeGraph3dScene",
+  props: {
+    graph: {
+      type: Object as PropType<DesktopKnowledgePaneGraph>,
+      required: true,
+    },
+    selectedNodeId: {
+      type: String,
+      default: "",
+    },
+  },
+  emits: ["selectNode"],
+  setup(props, { emit }) {
+    const host = ref<HTMLElement | null>(null);
+    const selected = ref<string>("Drag to orbit, scroll to zoom, click a node to focus.");
+    const graphInstance = shallowRef<KnowledgeGraph3dInstance | null>(null);
+    let resizeObserver: ResizeObserver | null = null;
+
+    onMounted(() => {
+      void mountKnowledgeGraph3dScene(host.value, props.graph, selected, (nodeId) => {
+        selected.value = props.graph.view.nodes.find((node) => node.id === nodeId)?.label ?? selected.value;
+        emit("selectNode", nodeId);
+      }, (instance) => {
+        graphInstance.value = instance;
+      }, (observer) => {
+        resizeObserver = observer;
+      });
+    });
+
+    onBeforeUnmount(() => {
+      resizeObserver?.disconnect();
+      graphInstance.value?._destructor?.();
+      graphInstance.value = null;
+    });
+
+    return () => h("div", {
+      class: "desktop-knowledge-graph-canvas",
+      "data-desktop-knowledge-graph-pane": "canvas",
+      "data-desktop-knowledge-graph-mode": "3d",
+      "data-desktop-knowledge-selected-node": props.selectedNodeId ?? "",
+      role: "application",
+      "aria-label": `${props.graph.summary}. Drag to orbit, scroll to zoom, click nodes to focus.`,
+    }, [
+      h("div", {
+        ref: host,
+        class: "desktop-knowledge-graph-3d-host",
+        "data-desktop-knowledge-graph-3d-host": "",
+      }),
+      h("div", { class: "desktop-knowledge-graph-3d-hint" }, selected.value),
+    ]);
+  },
+});
+
+async function mountKnowledgeGraph3dScene(
+  host: HTMLElement | null,
+  graph: DesktopKnowledgePaneGraph,
+  selected: { value: string },
+  selectNode: (nodeId: string) => void,
+  setInstance: (instance: KnowledgeGraph3dInstance) => void,
+  setResizeObserver: (observer: ResizeObserver) => void,
+): Promise<void> {
+  if (!host || !canRenderKnowledgeGraph3d()) {
+    return;
+  }
+  const { default: ForceGraph3D } = await import("3d-force-graph");
+  const ForceGraph3DConstructor = ForceGraph3D as unknown as new (element: HTMLElement, configOptions?: object) => KnowledgeGraph3dInstance;
+  const instance = new ForceGraph3DConstructor(host, { controlType: "orbit" });
+  setInstance(instance);
+
+  const graphData = buildKnowledgeGraph3dData(graph);
+  const resize = () => {
+    const rect = host.getBoundingClientRect();
+    instance.width(Math.max(320, Math.floor(rect.width || 640)));
+    instance.height(Math.max(260, Math.floor(rect.height || 360)));
+  };
+
+  instance
+    .backgroundColor("#fffdf9")
+    .showNavInfo(false)
+    .graphData(graphData)
+    .nodeLabel((node: KnowledgeGraph3dNode) => node.name)
+    .nodeVal((node: KnowledgeGraph3dNode) => node.val)
+    .nodeColor((node: KnowledgeGraph3dNode) => node.type === "document" ? "#d97857" : "#8f6d49")
+    .linkLabel((link: KnowledgeGraph3dLink) => link.title)
+    .linkColor(() => "rgba(217, 120, 87, 0.48)")
+    .linkWidth((link: KnowledgeGraph3dLink) => Math.max(1.5, Math.min(4, link.evidenceCount + 1)))
+    .linkDirectionalParticles(1)
+    .linkDirectionalParticleSpeed(0.004)
+    .cooldownTicks(80)
+    .d3VelocityDecay(0.34)
+    .onNodeClick((node: KnowledgeGraph3dNode) => {
+      selected.value = node.name;
+      selectNode(node.id);
+      const positionedNode = node as KnowledgeGraph3dNode & { x?: number; y?: number; z?: number };
+      const distance = 140;
+      const distRatio = 1 + distance / Math.hypot(positionedNode.x ?? 1, positionedNode.y ?? 1, positionedNode.z ?? 1);
+      instance.cameraPosition(
+        {
+          x: (positionedNode.x ?? 1) * distRatio,
+          y: (positionedNode.y ?? 1) * distRatio,
+          z: (positionedNode.z ?? 1) * distRatio,
+        },
+        positionedNode,
+        700,
+      );
+    })
+    .onLinkClick((link: KnowledgeGraph3dLink) => {
+      selected.value = link.title || link.label;
+      const sourceId = typeof link.source === "string" ? link.source : link.source.id;
+      if (sourceId) {
+        selectNode(sourceId);
+      }
+    });
+
+  resize();
+  if (typeof ResizeObserver !== "undefined") {
+    const observer = new ResizeObserver(resize);
+    observer.observe(host);
+    setResizeObserver(observer);
+  }
 }
 
-function graphPoint(index: number, total: number): GraphPoint {
-  if (index === 0) {
-    return { x: 320, y: 180 };
+function canRenderKnowledgeGraph3d(): boolean {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return false;
   }
-  const angle = ((index - 1) / Math.max(total - 1, 1)) * Math.PI * 2 - Math.PI / 2;
+  const canvas = document.createElement("canvas");
+  return typeof canvas.getContext === "function" && Boolean(canvas.getContext("webgl") || canvas.getContext("experimental-webgl"));
+}
+
+export function buildKnowledgeGraph3dData(graph: DesktopKnowledgePaneGraph): KnowledgeGraph3dData {
+  const nodes = graph.view.nodes.slice(0, 64).map((node, index) => ({
+    id: node.id,
+    name: node.label,
+    type: node.type,
+    val: index === 0 ? 8 : 4,
+    raw: node.raw,
+  }));
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const links = graph.view.edges
+    .filter((edge) => nodeIds.has(edge.sourceId) && nodeIds.has(edge.targetId))
+    .slice(0, 96)
+    .map((edge) => ({
+      id: edge.id,
+      source: edge.sourceId,
+      target: edge.targetId,
+      label: edge.predicate || "related",
+      title: edge.title,
+      evidenceCount: edge.evidenceCount,
+    }));
+  return { nodes, links };
+}
+
+export function buildKnowledgeGraphSelection(graph: DesktopKnowledgePaneGraph, selectedNodeId: string | null): KnowledgeGraphSelection {
+  if (!selectedNodeId) {
+    return {
+      node: null,
+      relations: graph.relations,
+      evidence: graph.evidence,
+      isFiltered: false,
+    };
+  }
+  const selectedNode = graph.view.nodes.find((node) => node.id === selectedNodeId) ?? null;
+  const relatedEdges = graph.view.edges.filter((edge) => edge.sourceId === selectedNodeId || edge.targetId === selectedNodeId);
+  const relatedEdgeIds = new Set(relatedEdges.map((edge) => edge.id));
+  const relatedRelationTitles = new Set(relatedEdges.map((edge) => edge.title));
+  const relations = graph.relations.filter((row) => relatedEdgeIds.has(row.id) || relatedRelationTitles.has(row.title));
+  const evidence = graph.evidence.filter(
+    (row) => row.sourceNodeId === selectedNodeId || row.targetNodeId === selectedNodeId || relatedEdgeIds.has(row.edgeId),
+  );
   return {
-    x: 320 + Math.cos(angle) * 185,
-    y: 180 + Math.sin(angle) * 115,
+    node: selectedNode ? { id: selectedNode.id, label: selectedNode.label } : null,
+    relations,
+    evidence,
+    isFiltered: true,
   };
 }
+
+type KnowledgeGraph3dInstance = {
+  backgroundColor: (value: string) => KnowledgeGraph3dInstance;
+  showNavInfo: (value: boolean) => KnowledgeGraph3dInstance;
+  graphData: (value: KnowledgeGraph3dData) => KnowledgeGraph3dInstance;
+  nodeLabel: (value: (node: KnowledgeGraph3dNode) => string) => KnowledgeGraph3dInstance;
+  nodeVal: (value: (node: KnowledgeGraph3dNode) => number) => KnowledgeGraph3dInstance;
+  nodeColor: (value: (node: KnowledgeGraph3dNode) => string) => KnowledgeGraph3dInstance;
+  linkLabel: (value: (link: KnowledgeGraph3dLink) => string) => KnowledgeGraph3dInstance;
+  linkColor: (value: (link: KnowledgeGraph3dLink) => string) => KnowledgeGraph3dInstance;
+  linkWidth: (value: (link: KnowledgeGraph3dLink) => number) => KnowledgeGraph3dInstance;
+  linkDirectionalParticles: (value: number) => KnowledgeGraph3dInstance;
+  linkDirectionalParticleSpeed: (value: number) => KnowledgeGraph3dInstance;
+  cooldownTicks: (value: number) => KnowledgeGraph3dInstance;
+  d3VelocityDecay: (value: number) => KnowledgeGraph3dInstance;
+  onNodeClick: (value: (node: KnowledgeGraph3dNode) => void) => KnowledgeGraph3dInstance;
+  onLinkClick: (value: (link: KnowledgeGraph3dLink) => void) => KnowledgeGraph3dInstance;
+  width: (value: number) => KnowledgeGraph3dInstance;
+  height: (value: number) => KnowledgeGraph3dInstance;
+  cameraPosition: (position: { x: number; y: number; z: number }, lookAt: object, duration: number) => KnowledgeGraph3dInstance;
+  _destructor?: () => void;
+};
 
 function renderReferenceGroup(label: string, rows: DesktopKnowledgePaneReferenceRow[]) {
   if (!rows.length) {
@@ -140,6 +321,30 @@ function renderReferenceGroup(label: string, rows: DesktopKnowledgePaneReference
       }),
     })),
   });
+}
+
+function renderSelectionReferences(graph: DesktopKnowledgePaneGraph, selection: KnowledgeGraphSelection) {
+  if (!selection.isFiltered) {
+    return [
+      h("h2", `Graph: ${graph.summary}`),
+      renderReferenceGroup("Community", graph.communities),
+      renderReferenceGroup("Report", graph.reports),
+      renderReferenceGroup("Claim", graph.claims),
+      renderReferenceGroup("Relation", graph.relations),
+      renderReferenceGroup("Conflict", graph.conflicts),
+      renderEvidence(graph.evidence),
+    ];
+  }
+  const hasSelectionRows = selection.relations.length > 0 || selection.evidence.length > 0;
+  return [
+    h("h2", `Selected: ${selection.node?.label ?? "Unknown node"}`),
+    hasSelectionRows
+      ? [
+          renderReferenceGroup("Relation", selection.relations),
+          renderEvidence(selection.evidence),
+        ]
+      : h("p", { class: "desktop-knowledge-graph-selection-empty" }, "No relations or evidence for this node yet."),
+  ];
 }
 
 function renderEvidence(rows: DesktopKnowledgeEvidenceRow[]) {


### PR DESCRIPTION
## Summary
- move native panel controls into the window frame and bridge them to the workbench shell
- hide the empty Activity inspector content by default
- upgrade the Knowledge Graph view to an interactive 3D graph and filter references by selected node

## Validation
- npm test -- desktopWindowFrame.test.ts desktopWorkbenchShell.test.ts desktopWorkbenchShell.vue.test.ts knowledgeGraphIsland.test.ts knowledgePaneIsland.test.ts
- npm run build
- git diff --check

Note: native visual verification via Computer Use/Playwright was blocked by local tool/browser installation issues, but unit tests and production build passed.