### PR TITLE
Split desktop settings into section pages

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2767,6 +2767,11 @@ describe("desktop workbench shell", () => {
       "deepseek",
       "ollama",
     ]);
+    const providerSave = pane?.querySelector('[data-desktop-settings-action="save"]');
+    expect(providerSave).not.toBeNull();
+    providerSave?.click();
+    expect(settingsActions).toEqual(["save"]);
+    settingsActions.length = 0;
     pane?.querySelector('[data-desktop-settings-nav="general"]')?.click();
     expect(pane?.querySelector('[data-desktop-settings-group="general"]')?.getAttribute("id")).toBe("desktop-settings-group-general");
     expect(pane?.textContent).toContain("Settings / General");

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2898,12 +2898,13 @@ describe("desktop workbench shell", () => {
       gatewayHttp: "http://127.0.0.1:18790",
       settingsPane: firstPane,
     });
+    targetDocument.body.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
     updateDesktopSettingsPane(targetDocument as unknown as Document, nextPane);
 
     const pane = targetDocument.body.querySelector(".desktop-settings-pane");
     expect(pane?.querySelector(".desktop-settings-status-card")).toBeNull();
-    expect(pane?.querySelector(".desktop-settings-default-llm-card")).not.toBeNull();
-    pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
+    expect(pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.getAttribute("data-active")).toBe("true");
+    expect(pane?.querySelector(".desktop-settings-default-llm-card")).toBeNull();
     expect(pane?.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
   });
 

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -2730,7 +2730,7 @@ describe("desktop workbench shell", () => {
 
     const pane = targetDocument.body.querySelector(".desktop-settings-pane");
     expect(pane?.getAttribute("aria-label")).toBe("Settings and providers");
-    expect(pane?.getAttribute("data-settings-layout")).toBe("capability-center");
+    expect(pane?.getAttribute("data-settings-layout")).toBe("section-pages");
     expect(pane?.querySelector(".desktop-settings-search")?.getAttribute("placeholder")).toBe("Search settings...");
     expect(pane?.querySelectorAll(".desktop-settings-nav-item").map((item) => item.textContent)).toEqual([
       "General",
@@ -2746,24 +2746,13 @@ describe("desktop workbench shell", () => {
       "Logs & Diagnostics",
     ]);
     expect(pane?.querySelector(".desktop-settings-nav-item")?.getAttribute("data-active")).toBe("true");
-    expect(pane?.querySelector(".desktop-settings-content")?.textContent).toContain("Settings / Capability Center");
-    expect(pane?.querySelector(".desktop-settings-capability-map")?.getAttribute("data-desktop-settings-center")).toBe("capability-boundaries");
-    expect(pane?.querySelectorAll("[data-desktop-settings-capability]").map((node) => node.getAttribute("data-desktop-settings-capability"))).toEqual([
-      "provider-models",
-      "knowledge",
-      "tools-approvals",
-      "files-workspace",
-      "gateway-runtime",
-      "logs-diagnostics",
-    ]);
-    expect(pane?.querySelector('[data-desktop-settings-capability="provider-models"]')?.textContent).toContain("OpenAI");
-    expect(pane?.querySelector('[data-desktop-settings-capability="knowledge"]')?.textContent).toContain("Knowledge On");
-    expect(pane?.querySelector('[data-desktop-settings-capability="tools-approvals"]')?.textContent).toContain("Shell Off");
-    expect(pane?.querySelector('[data-desktop-settings-capability="gateway-runtime"]')?.textContent).toContain("Gateway 0.0.0.0:18790");
+    expect(pane?.querySelector(".desktop-settings-content")?.textContent).toContain("Settings / General");
+    expect(pane?.querySelector(".desktop-settings-capability-map")).toBeNull();
     expect(pane?.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("默认 LLM");
     expect(pane?.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("提供商");
     expect(pane?.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("模型");
     expect(pane?.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("这里设置全局默认的 LLM 模型");
+    pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
     expect(pane?.querySelector(".desktop-settings-provider-section")?.textContent).toContain("提供商");
     expect(pane?.querySelector(".desktop-settings-provider-search")?.getAttribute("placeholder")).toBe("搜索提供商...");
     expect(pane?.querySelector('[data-desktop-settings-action="addProvider"]')?.textContent).toBe("+ 添加提供商");
@@ -2778,9 +2767,10 @@ describe("desktop workbench shell", () => {
       "deepseek",
       "ollama",
     ]);
+    pane?.querySelector('[data-desktop-settings-nav="general"]')?.click();
     expect(pane?.querySelector('[data-desktop-settings-group="general"]')?.getAttribute("id")).toBe("desktop-settings-group-general");
-    expect(pane?.textContent).toContain("Settings / Capability Center");
-    expect(pane?.textContent).toContain("Model: ");
+    expect(pane?.textContent).toContain("Settings / General");
+    expect(pane?.querySelector('[data-desktop-settings-control="model"]')?.tagName).toBe("select");
     expect(pane?.querySelector(".desktop-settings-status-card")).toBeNull();
     expect(pane?.textContent).not.toContain("Save: HTTP 400");
     expect(pane?.textContent).not.toContain("Catalog: OpenAI (ready)");
@@ -2788,29 +2778,36 @@ describe("desktop workbench shell", () => {
     expect(pane?.textContent).not.toContain("Shortcut help");
     expect(pane?.querySelector('[data-desktop-settings-control="model"]')?.getAttribute("aria-invalid")).toBe("true");
     expect(pane?.querySelector('[data-desktop-settings-control="timezone"]')?.getAttribute("aria-invalid")).toBe("true");
-    expect(pane?.querySelector('[data-desktop-settings-control="enabled"]')?.checked).toBe(true);
-    expect(pane?.querySelector('[data-desktop-settings-control="mcpServers"]')?.tagName).toBe("textarea");
     expect(pane?.querySelector('[data-desktop-settings-action="save"]')?.getAttribute("disabled")).toBe("true");
-    expect(pane?.querySelector('[data-desktop-settings-action="discoverModels"]')?.textContent).toBe("Refresh models");
 
     const modelInput = pane?.querySelector('[data-desktop-settings-control="model"]');
     expect(modelInput?.tagName).toBe("select");
     modelInput!.value = "gpt-4.1";
     modelInput?.dispatchEvent({ type: "change", target: modelInput });
 
+    pane?.querySelector('[data-desktop-settings-nav="knowledge"]')?.click();
+    expect(pane?.querySelector('[data-desktop-settings-control="enabled"]')?.checked).toBe(true);
     const knowledgeToggle = pane?.querySelector('[data-desktop-settings-control="enabled"]');
     knowledgeToggle!.checked = false;
     knowledgeToggle?.dispatchEvent({ type: "change", target: knowledgeToggle });
 
+    pane?.querySelector('[data-desktop-settings-nav="tools-approvals"]')?.click();
+    expect(pane?.querySelector('[data-desktop-settings-control="mcpServers"]')?.tagName).toBe("textarea");
+
+    pane?.querySelector('[data-desktop-settings-nav="general"]')?.click();
     pane?.querySelector('[data-desktop-settings-action="save"]')?.click();
+    pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
+    expect(pane?.querySelector('[data-desktop-settings-action="discoverModels"]')?.textContent).toBe("Refresh models");
     pane?.querySelector('[data-desktop-settings-action="discoverModels"]')?.click();
     expect(settingsActions).toEqual(["edit:model:gpt-4.1", "edit:enabled:false", "save", "discoverModels"]);
 
+    pane?.querySelector('[data-desktop-settings-nav="general"]')?.click();
     const defaultProviderSelect = pane?.querySelector('[data-desktop-settings-control="provider"]');
     defaultProviderSelect!.value = "deepseek";
     defaultProviderSelect?.dispatchEvent({ type: "change", target: defaultProviderSelect });
     expect(settingsActions[settingsActions.length - 1]).toBe("edit:provider:deepseek");
 
+    pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
     const providerSearch = pane?.querySelector(".desktop-settings-provider-search");
     providerSearch!.value = "deep";
     providerSearch?.dispatchEvent({ type: "input", target: providerSearch });
@@ -2906,6 +2903,7 @@ describe("desktop workbench shell", () => {
     const pane = targetDocument.body.querySelector(".desktop-settings-pane");
     expect(pane?.querySelector(".desktop-settings-status-card")).toBeNull();
     expect(pane?.querySelector(".desktop-settings-default-llm-card")).not.toBeNull();
+    pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
     expect(pane?.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
   });
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -5071,7 +5071,7 @@ function createSettingsActivePage(
   activeGroupId: DesktopSettingsPaneGroup["id"],
 ): HTMLElement[] {
   const activeGroup = getDesktopSettingsActiveGroup(pane, activeGroupId);
-  const nodes = [createSettingsPageHeader(targetDocument, activeGroup)];
+  const nodes = [createSettingsPageHeader(targetDocument, pane, settingsActions, activeGroup)];
   if (activeGroup?.id === "general") {
     nodes.push(createDefaultLlmSettingsCard(targetDocument, pane, settingsActions));
   }
@@ -5093,6 +5093,8 @@ function createSettingsActivePage(
 
 function createSettingsPageHeader(
   targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions,
   group: DesktopSettingsPaneGroup | null,
 ): HTMLElement {
   const header = targetDocument.createElement("header");
@@ -5105,8 +5107,37 @@ function createSettingsPageHeader(
     description.className = "desktop-settings-header-description";
     breadcrumb.append(description);
   }
-  header.append(breadcrumb);
+  header.append(breadcrumb, createSettingsSaveButton(targetDocument, pane, settingsActions));
   return header;
+}
+
+function createSettingsSaveButton(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions,
+): HTMLElement {
+  const save = targetDocument.createElement("button");
+  save.className = "desktop-settings-save-status-button";
+  save.setAttribute("type", "button");
+  save.setAttribute("data-desktop-settings-action", "save");
+  if (!pane.save.canSave) {
+    save.setAttribute("disabled", "true");
+  }
+  save.textContent = getDesktopSettingsSaveLabel(pane);
+  save.addEventListener("click", () => {
+    settingsActions.onSettingsAction?.({ action: "save", pane });
+  });
+  return save;
+}
+
+function getDesktopSettingsSaveLabel(pane: DesktopSettingsPaneModel): string {
+  if (pane.save.status === "saving") {
+    return "保存中";
+  }
+  if (pane.save.status === "saved" || !pane.dirty) {
+    return "已保存";
+  }
+  return "保存设置";
 }
 
 function createSettingsGroupSection(
@@ -5203,19 +5234,6 @@ function createDefaultLlmSettingsCard(
   if (model) {
     form.append(createSettingsControlField(targetDocument, pane, model, "模型", settingsActions));
   }
-
-  const save = targetDocument.createElement("button");
-  save.className = "desktop-settings-save-status-button";
-  save.setAttribute("type", "button");
-  save.setAttribute("data-desktop-settings-action", "save");
-  if (!pane.save.canSave) {
-    save.setAttribute("disabled", "true");
-  }
-  save.textContent = pane.save.status === "saving" ? "保存中" : pane.save.status === "saved" ? "已保存" : pane.dirty ? "保存设置" : "已保存";
-  save.addEventListener("click", () => {
-    settingsActions.onSettingsAction?.({ action: "save", pane });
-  });
-  form.append(save);
 
   const copy = createText(targetDocument, "p", "这里设置全局默认的 LLM 模型。你也可以在聊天页面为具体 Agent 单独选择使用的模型。");
   copy.className = "desktop-settings-default-llm-copy";

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -5043,67 +5043,105 @@ function createSettingsProvidersPane(
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-settings-pane";
   section.setAttribute("data-desktop-module-surface", "settings");
-  section.setAttribute("data-settings-layout", "capability-center");
+  section.setAttribute("data-settings-layout", "section-pages");
   section.setAttribute("aria-label", "Settings and providers");
-
-  section.append(createSettingsSidebar(targetDocument, pane));
 
   const content = targetDocument.createElement("div");
   content.className = "desktop-settings-content";
 
+  const renderActiveGroup = (groupId: DesktopSettingsPaneGroup["id"]) => {
+    setDesktopSettingsActiveNav(targetDocument, groupId);
+    content.replaceChildren(...createSettingsActivePage(targetDocument, pane, settingsActions, groupId));
+  };
+
+  section.append(createSettingsSidebar(targetDocument, pane, renderActiveGroup));
+  renderActiveGroup(pane.groups[0]?.id ?? "general");
+  section.append(content);
+  mountSettingsPaneVueIsland(section, targetDocument, pane, settingsActions);
+  return section;
+}
+
+function createSettingsActivePage(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions,
+  activeGroupId: DesktopSettingsPaneGroup["id"],
+): HTMLElement[] {
+  const activeGroup = getDesktopSettingsActiveGroup(pane, activeGroupId);
+  const nodes = [createSettingsPageHeader(targetDocument, activeGroup)];
+  if (activeGroup?.id === "general") {
+    nodes.push(createDefaultLlmSettingsCard(targetDocument, pane, settingsActions));
+  }
+  if (activeGroup?.id === "provider-models") {
+    nodes.push(createProviderManagementSection(targetDocument, pane, settingsActions));
+  }
+  if (activeGroup) {
+    const grid = targetDocument.createElement("div");
+    grid.className = "desktop-settings-grid";
+    const groupSection = createSettingsGroupSection(targetDocument, pane, activeGroup, settingsActions);
+    if (groupSection) {
+      grid.append(groupSection);
+      mountSettingsGroupsVueIsland(grid, pane, settingsActions);
+      nodes.push(grid);
+    }
+  }
+  return nodes;
+}
+
+function createSettingsPageHeader(
+  targetDocument: Document,
+  group: DesktopSettingsPaneGroup | null,
+): HTMLElement {
   const header = targetDocument.createElement("header");
   header.className = "desktop-settings-header";
   const breadcrumb = targetDocument.createElement("div");
   breadcrumb.className = "desktop-settings-breadcrumb";
-  breadcrumb.append(createText(targetDocument, "h2", "Settings / Capability Center"));
-  header.append(breadcrumb);
-  content.append(header);
-
-  content.append(createSettingsCapabilityMap(targetDocument, pane));
-  content.append(createDefaultLlmSettingsCard(targetDocument, pane, settingsActions));
-  content.append(createProviderManagementSection(targetDocument, pane, settingsActions));
-
-  const grid = targetDocument.createElement("div");
-  grid.className = "desktop-settings-grid";
-
-  for (const group of pane.groups) {
-    const fields = getSettingsGroupDisplayFields(group);
-    if (!fields.length) {
-      continue;
-    }
-    const groupSection = targetDocument.createElement("section");
-    groupSection.className = "desktop-settings-group";
-    groupSection.setAttribute("id", `desktop-settings-group-${group.id}`);
-    groupSection.setAttribute("data-desktop-settings-group", group.id);
-    groupSection.append(createText(targetDocument, "h2", group.label));
-    const description = getSettingsGroupDescription(group.id);
-    if (description) {
-      const copy = createText(targetDocument, "p", description);
-      copy.className = "desktop-settings-group-description";
-      groupSection.append(copy);
-    }
-    const primaryFields = fields.filter((field) => !field.advanced);
-    const advancedFields = fields.filter((field) => field.advanced);
-    for (const field of primaryFields) {
-      groupSection.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
-    }
-    if (advancedFields.length) {
-      const details = targetDocument.createElement("details");
-      details.className = "desktop-settings-advanced-fields";
-      details.append(createText(targetDocument, "summary", "Advanced"));
-      for (const field of advancedFields) {
-        details.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
-      }
-      groupSection.append(details);
-    }
-    grid.append(groupSection);
+  breadcrumb.append(createText(targetDocument, "h2", `Settings / ${group?.label ?? "General"}`));
+  if (group) {
+    const description = createText(targetDocument, "p", getSettingsGroupDescription(group.id));
+    description.className = "desktop-settings-header-description";
+    breadcrumb.append(description);
   }
+  header.append(breadcrumb);
+  return header;
+}
 
-  content.append(grid);
-  mountSettingsGroupsVueIsland(grid, pane, settingsActions);
-  section.append(content);
-  mountSettingsPaneVueIsland(section, targetDocument, pane, settingsActions);
-  return section;
+function createSettingsGroupSection(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  group: DesktopSettingsPaneGroup,
+  settingsActions: DesktopSettingsActionOptions,
+): HTMLElement | null {
+  const fields = getSettingsGroupDisplayFields(group);
+  if (!fields.length) {
+    return null;
+  }
+  const groupSection = targetDocument.createElement("section");
+  groupSection.className = "desktop-settings-group";
+  groupSection.setAttribute("id", `desktop-settings-group-${group.id}`);
+  groupSection.setAttribute("data-desktop-settings-group", group.id);
+  groupSection.append(createText(targetDocument, "h2", group.label));
+  const description = getSettingsGroupDescription(group.id);
+  if (description) {
+    const copy = createText(targetDocument, "p", description);
+    copy.className = "desktop-settings-group-description";
+    groupSection.append(copy);
+  }
+  const primaryFields = fields.filter((field) => !field.advanced);
+  const advancedFields = fields.filter((field) => field.advanced);
+  for (const field of primaryFields) {
+    groupSection.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
+  }
+  if (advancedFields.length) {
+    const details = targetDocument.createElement("details");
+    details.className = "desktop-settings-advanced-fields";
+    details.append(createText(targetDocument, "summary", "Advanced"));
+    for (const field of advancedFields) {
+      details.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
+    }
+    groupSection.append(details);
+  }
+  return groupSection;
 }
 
 function mountSettingsPaneVueIsland(
@@ -5528,104 +5566,6 @@ function getSettingsGroupDisplayFields(group: DesktopSettingsPaneGroup): Desktop
   return group.fields;
 }
 
-function createSettingsCapabilityMap(targetDocument: Document, pane: DesktopSettingsPaneModel): HTMLElement {
-  const section = targetDocument.createElement("section");
-  section.className = "desktop-settings-capability-map";
-  section.setAttribute("data-desktop-settings-center", "capability-boundaries");
-  section.setAttribute("aria-label", "Capability boundaries");
-  for (const card of getSettingsCapabilityCards(pane)) {
-    const link = targetDocument.createElement("a");
-    link.className = "desktop-settings-capability-card";
-    link.setAttribute("href", `#desktop-settings-group-${card.id}`);
-    link.setAttribute("data-desktop-settings-capability", card.id);
-    link.addEventListener("click", (event) => {
-      scrollToDesktopSettingsGroup(event, targetDocument, card.id);
-    });
-
-    const label = targetDocument.createElement("span");
-    label.className = "desktop-settings-capability-label";
-    label.textContent = card.label;
-    const status = targetDocument.createElement("strong");
-    status.className = "desktop-settings-capability-status";
-    status.textContent = card.status;
-    const detail = targetDocument.createElement("span");
-    detail.className = "desktop-settings-capability-detail";
-    detail.textContent = card.detail;
-    link.append(label, status, detail);
-    section.append(link);
-  }
-  return section;
-}
-
-function getSettingsCapabilityCards(pane: DesktopSettingsPaneModel): Array<{
-  id: DesktopSettingsPaneGroup["id"];
-  label: string;
-  status: string;
-  detail: string;
-}> {
-  const selectedProvider = pane.providerEditor.selectedProvider;
-  const providerLabel = pane.providerCatalog.find((provider) => provider.id === selectedProvider)?.label || selectedProvider || "Auto";
-  const knowledgeEnabled = isSettingsFieldChecked(pane, "knowledge", "enabled");
-  const webEnabled = isSettingsFieldChecked(pane, "tools-approvals", "webEnable");
-  const shellEnabled = isSettingsFieldChecked(pane, "tools-approvals", "execEnable");
-  const gatewayHost = getSettingsFieldValue(pane, "gateway-runtime", "host") || "localhost";
-  const gatewayPort = getSettingsFieldValue(pane, "gateway-runtime", "port") || "auto";
-  return [
-    {
-      id: "provider-models",
-      label: "Provider & Models",
-      status: providerLabel,
-      detail: pane.providerEditor.models.length ? pane.providerEditor.models.slice(0, 2).join(", ") : "Model catalog not loaded",
-    },
-    {
-      id: "knowledge",
-      label: "Knowledge",
-      status: knowledgeEnabled ? "Knowledge On" : "Knowledge Off",
-      detail: `${getSettingsFieldValue(pane, "knowledge", "retrievalMode") || "hybrid"} retrieval / top ${getSettingsFieldValue(pane, "knowledge", "maxChunks") || "auto"}`,
-    },
-    {
-      id: "tools-approvals",
-      label: "Tools & Approvals",
-      status: `Web ${webEnabled ? "On" : "Off"} / Shell ${shellEnabled ? "On" : "Off"}`,
-      detail: getSettingsFieldValue(pane, "tools-approvals", "mcpServers") === "Configured" ? "MCP configured" : "MCP allowlist empty",
-    },
-    {
-      id: "files-workspace",
-      label: "Files & Workspace",
-      status: "Three scopes",
-      detail: "Session files / Knowledge documents / Workspace files",
-    },
-    {
-      id: "gateway-runtime",
-      label: "Gateway & Runtime",
-      status: `Gateway ${gatewayHost}:${gatewayPort}`,
-      detail: isSettingsFieldChecked(pane, "gateway-runtime", "heartbeat") ? "Heartbeat enabled" : "Heartbeat disabled",
-    },
-    {
-      id: "logs-diagnostics",
-      label: "Logs & Diagnostics",
-      status: pane.validationErrors.length ? `${pane.validationErrors.length} issues` : "Ready",
-      detail: pane.validationErrors.length ? pane.validationErrors.map((error) => error.field).join(", ") : "Diagnostics export and runtime logs",
-    },
-  ];
-}
-
-function getSettingsFieldValue(
-  pane: DesktopSettingsPaneModel,
-  groupId: DesktopSettingsPaneGroup["id"],
-  fieldId: string,
-): string {
-  return findSettingsPaneField(pane, groupId, fieldId)?.value ?? "";
-}
-
-function isSettingsFieldChecked(
-  pane: DesktopSettingsPaneModel,
-  groupId: DesktopSettingsPaneGroup["id"],
-  fieldId: string,
-): boolean {
-  return findSettingsPaneField(pane, groupId, fieldId)?.checked === true;
-}
-
 function getProviderCards(pane: DesktopSettingsPaneModel): DesktopProviderCardModel[] {
   const selectedProvider = pane.providerEditor.selectedProvider || "provider";
   const catalog = pane.providerCatalog.length
@@ -5683,7 +5623,11 @@ function formatProviderStatus(status: string): string {
   }[status] ?? status;
 }
 
-function createSettingsSidebar(targetDocument: Document, pane: DesktopSettingsPaneModel): HTMLElement {
+function createSettingsSidebar(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  onSelectGroup?: (groupId: DesktopSettingsPaneGroup["id"]) => void,
+): HTMLElement {
   const sidebar = targetDocument.createElement("aside");
   sidebar.className = "desktop-settings-sidebar";
   sidebar.setAttribute("aria-label", "Settings navigation");
@@ -5711,10 +5655,10 @@ function createSettingsSidebar(targetDocument: Document, pane: DesktopSettingsPa
     }
     const item = targetDocument.createElement("a");
     item.className = "desktop-settings-nav-item";
-    item.setAttribute("href", `#desktop-settings-group-${group.id}`);
+    item.setAttribute("href", "#");
     item.setAttribute("data-desktop-settings-nav", group.id);
     item.addEventListener("click", (event) => {
-      scrollToDesktopSettingsGroup(event, targetDocument, group.id);
+      selectDesktopSettingsGroup(event, targetDocument, group.id, onSelectGroup);
     });
     if (index === 0) {
       item.setAttribute("data-active", "true");
@@ -5729,10 +5673,15 @@ function createSettingsSidebar(targetDocument: Document, pane: DesktopSettingsPa
   return sidebar;
 }
 
-function scrollToDesktopSettingsGroup(event: Event, targetDocument: Document, groupId: string): void {
-  event.preventDefault();
+function selectDesktopSettingsGroup(
+  event: Event,
+  targetDocument: Document,
+  groupId: DesktopSettingsPaneGroup["id"],
+  onSelectGroup?: (groupId: DesktopSettingsPaneGroup["id"]) => void,
+): void {
+  event.preventDefault?.();
   setDesktopSettingsActiveNav(targetDocument, groupId);
-  targetDocument.getElementById(`desktop-settings-group-${groupId}`)?.scrollIntoView({ block: "start", behavior: "smooth" });
+  onSelectGroup?.(groupId);
 }
 
 function setDesktopSettingsActiveNav(targetDocument: Document, groupId: string): void {
@@ -5746,6 +5695,13 @@ function setDesktopSettingsActiveNav(targetDocument: Document, groupId: string):
       item.removeAttribute("aria-current");
     }
   }
+}
+
+function getDesktopSettingsActiveGroup(
+  pane: DesktopSettingsPaneModel,
+  activeGroupId: DesktopSettingsPaneGroup["id"],
+): DesktopSettingsPaneGroup | null {
+  return pane.groups.find((group) => group.id === activeGroupId) ?? pane.groups[0] ?? null;
 }
 
 function mountSettingsSidebarVueIsland(sidebar: HTMLElement, pane: DesktopSettingsPaneModel): void {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -534,7 +534,8 @@ export function updateDesktopSettingsPane(
   if (!pane) {
     return;
   }
-  const next = createSettingsProvidersPane(targetDocument, settingsPane, settingsActions);
+  const activeGroupId = getCurrentDesktopSettingsActiveGroupId(pane, settingsPane);
+  const next = createSettingsProvidersPane(targetDocument, settingsPane, settingsActions, activeGroupId);
   pane.replaceChildren(...Array.from(next.children));
 }
 
@@ -5039,12 +5040,14 @@ function createSettingsProvidersPane(
   targetDocument: Document,
   pane: DesktopSettingsPaneModel,
   settingsActions: DesktopSettingsActionOptions = {},
+  initialActiveGroupId?: DesktopSettingsPaneGroup["id"],
 ): HTMLElement {
   const section = targetDocument.createElement("section");
   section.className = "desktop-workbench-section desktop-settings-pane";
   section.setAttribute("data-desktop-module-surface", "settings");
   section.setAttribute("data-settings-layout", "section-pages");
   section.setAttribute("aria-label", "Settings and providers");
+  const activeGroupId = getDesktopSettingsActiveGroup(pane, initialActiveGroupId)?.id ?? "general";
 
   const content = targetDocument.createElement("div");
   content.className = "desktop-settings-content";
@@ -5054,10 +5057,10 @@ function createSettingsProvidersPane(
     content.replaceChildren(...createSettingsActivePage(targetDocument, pane, settingsActions, groupId));
   };
 
-  section.append(createSettingsSidebar(targetDocument, pane, renderActiveGroup));
-  renderActiveGroup(pane.groups[0]?.id ?? "general");
+  section.append(createSettingsSidebar(targetDocument, pane, renderActiveGroup, activeGroupId));
+  renderActiveGroup(activeGroupId);
   section.append(content);
-  mountSettingsPaneVueIsland(section, targetDocument, pane, settingsActions);
+  mountSettingsPaneVueIsland(section, targetDocument, pane, settingsActions, activeGroupId);
   return section;
 }
 
@@ -5149,12 +5152,14 @@ function mountSettingsPaneVueIsland(
   targetDocument: Document,
   pane: DesktopSettingsPaneModel,
   settingsActions: DesktopSettingsActionOptions,
+  initialActiveGroupId: DesktopSettingsPaneGroup["id"],
 ): void {
   if (!canMountVueIsland(section)) {
     return;
   }
   mountSettingsPaneIsland(section, {
     pane,
+    initialActiveGroupId,
     onSettingsAction: settingsActions.onSettingsAction,
     promptProviderId: () => promptForSettingsProviderId(targetDocument),
     onFocusSettingsControl: (fieldId) => focusDesktopSettingsControl(targetDocument, fieldId),
@@ -5627,6 +5632,7 @@ function createSettingsSidebar(
   targetDocument: Document,
   pane: DesktopSettingsPaneModel,
   onSelectGroup?: (groupId: DesktopSettingsPaneGroup["id"]) => void,
+  initialActiveGroupId: DesktopSettingsPaneGroup["id"] = pane.groups[0]?.id ?? "general",
 ): HTMLElement {
   const sidebar = targetDocument.createElement("aside");
   sidebar.className = "desktop-settings-sidebar";
@@ -5660,7 +5666,7 @@ function createSettingsSidebar(
     item.addEventListener("click", (event) => {
       selectDesktopSettingsGroup(event, targetDocument, group.id, onSelectGroup);
     });
-    if (index === 0) {
+    if (group.id === initialActiveGroupId) {
       item.setAttribute("data-active", "true");
       item.setAttribute("aria-current", "page");
     }
@@ -5699,9 +5705,19 @@ function setDesktopSettingsActiveNav(targetDocument: Document, groupId: string):
 
 function getDesktopSettingsActiveGroup(
   pane: DesktopSettingsPaneModel,
-  activeGroupId: DesktopSettingsPaneGroup["id"],
+  activeGroupId?: string | null,
 ): DesktopSettingsPaneGroup | null {
   return pane.groups.find((group) => group.id === activeGroupId) ?? pane.groups[0] ?? null;
+}
+
+function getCurrentDesktopSettingsActiveGroupId(
+  pane: HTMLElement,
+  nextSettingsPane: DesktopSettingsPaneModel,
+): DesktopSettingsPaneGroup["id"] {
+  const activeGroupId = Array.from(pane.querySelectorAll<HTMLElement>("[data-desktop-settings-nav]"))
+    .find((item) => item.getAttribute("data-active") === "true")
+    ?.getAttribute("data-desktop-settings-nav");
+  return getDesktopSettingsActiveGroup(nextSettingsPane, activeGroupId)?.id ?? nextSettingsPane.groups[0]?.id ?? "general";
 }
 
 function mountSettingsSidebarVueIsland(sidebar: HTMLElement, pane: DesktopSettingsPaneModel): void {

--- a/apps/desktop/src/native-vue/mainUtilitiesRegionIsland.test.ts
+++ b/apps/desktop/src/native-vue/mainUtilitiesRegionIsland.test.ts
@@ -79,11 +79,13 @@ describe("main utilities region Vue island", () => {
     expect(host.querySelector(".desktop-help-pane")?.textContent).toContain("Help tour");
     expect(host.querySelector(".desktop-agent-ui-forms")?.textContent).toContain("Approve import");
     expect(host.querySelector(".desktop-workspace-files")?.textContent).toContain("Workspace files");
-    expect(host.querySelector(".desktop-settings-pane")?.textContent).toContain("Settings / Capability Center");
-    expect(host.querySelector(".desktop-settings-capability-map")?.getAttribute("data-desktop-settings-center")).toBe("capability-boundaries");
+    expect(host.querySelector(".desktop-settings-pane")?.textContent).toContain("Settings / General");
+    expect(host.querySelector(".desktop-settings-capability-map")).toBeNull();
 
     host.querySelector<HTMLButtonElement>('[data-desktop-help-action="page-help"]')?.click();
     host.querySelector<HTMLButtonElement>('[data-agent-ui-form-action="cancel"]')?.click();
+    host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]')?.click();
+    await nextTick();
     host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="discoverModels"]')?.click();
 
     expect(helpActions).toEqual(["page-help"]);

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -47,6 +47,23 @@ const pane = buildDesktopSettingsPaneModel(draftState, {
 });
 
 describe("settings pane Vue island", () => {
+  test("renders the provided initial settings section", async () => {
+    const host = document.createElement("section");
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane,
+      initialActiveGroupId: "provider-models",
+    });
+    await nextTick();
+
+    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Provider & Models");
+    expect(host.querySelector('[data-desktop-settings-nav="provider-models"]')?.getAttribute("data-active")).toBe("true");
+    expect(host.querySelector(".desktop-settings-provider-section")).not.toBeNull();
+    expect(host.querySelector(".desktop-settings-default-llm-card")).toBeNull();
+
+    mounted.unmount();
+  });
+
   test("renders settings shell and forwards settings actions", async () => {
     const host = document.createElement("section");
     const focused: string[] = [];

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -113,6 +113,9 @@ describe("settings pane Vue island", () => {
     expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
     expect(host.querySelector('[data-desktop-settings-field="apiKey"] input')?.getAttribute("type")).toBe("password");
     expect(host.querySelector<HTMLInputElement>('[data-desktop-settings-control="apiKey"]')?.value).toBe("********");
+    const providerSave = host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="save"]');
+    expect(providerSave).not.toBeNull();
+    providerSave?.click();
 
     const navFiles = host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="files-workspace"]');
     navFiles?.click();
@@ -145,6 +148,7 @@ describe("settings pane Vue island", () => {
     apiKey?.dispatchEvent(new Event("input", { bubbles: true }));
 
     expect(actions).toEqual([
+      "save",
       "edit:model:gpt-4.1-mini",
       "save",
       "discoverModels",

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -68,52 +68,59 @@ describe("settings pane Vue island", () => {
     expect(host.className).toBe("desktop-workbench-section desktop-settings-pane");
     expect(host.getAttribute("data-desktop-vue-island")).toBe("settings-pane");
     expect(host.getAttribute("data-desktop-module-surface")).toBe("settings");
-    expect(host.getAttribute("data-settings-layout")).toBe("capability-center");
+    expect(host.getAttribute("data-settings-layout")).toBe("section-pages");
     expect(host.getAttribute("aria-label")).toBe("Settings and providers");
 
     expect(host.querySelector(".desktop-settings-sidebar")?.textContent).toContain("General");
-    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Capability Center");
-    expect(host.querySelector(".desktop-settings-capability-map")?.getAttribute("data-desktop-settings-center")).toBe("capability-boundaries");
-    expect(Array.from(
-      host.querySelectorAll("[data-desktop-settings-capability]"),
-      (node) => node.getAttribute("data-desktop-settings-capability"),
-    )).toEqual([
-      "provider-models",
-      "knowledge",
-      "tools-approvals",
-      "files-workspace",
-      "gateway-runtime",
-      "logs-diagnostics",
-    ]);
-    expect(host.querySelector('[data-desktop-settings-capability="provider-models"]')?.textContent).toContain("OpenAI");
-    expect(host.querySelector('[data-desktop-settings-capability="knowledge"]')?.textContent).toContain("Knowledge On");
-    expect(host.querySelector('[data-desktop-settings-capability="tools-approvals"]')?.textContent).toContain("Shell Off");
-    expect(host.querySelector('[data-desktop-settings-capability="gateway-runtime"]')?.textContent).toContain("Gateway");
+    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / General");
+    expect(host.querySelector(".desktop-settings-capability-map")).toBeNull();
     expect(host.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("Default LLM");
-    expect(host.querySelector(".desktop-settings-provider-section")?.textContent).toContain("Providers");
-    expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
+    expect(host.querySelector(".desktop-settings-provider-section")).toBeNull();
     expect(host.querySelector(".desktop-settings-status-card")).toBeNull();
-    expect(host.querySelector('[data-desktop-settings-group="knowledge"]')?.textContent).toContain("Knowledge");
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-group]"),
+      (node) => node.getAttribute("data-desktop-settings-group"),
+    )).toEqual(["general"]);
+    expect(host.querySelector('[data-desktop-settings-group="knowledge"]')).toBeNull();
     expect(host.querySelector('[data-desktop-settings-field="timezone"] .desktop-settings-field-meta')?.textContent).toContain("Required");
     expect(host.querySelector('[data-desktop-settings-field="timezone"] .desktop-settings-field-meta')?.textContent).toContain("Free text");
-    expect(host.querySelector('[data-desktop-settings-field="apiKey"] input')?.getAttribute("type")).toBe("password");
-    expect(host.querySelector<HTMLInputElement>('[data-desktop-settings-control="apiKey"]')?.value).toBe("********");
     expect(host.querySelector('[data-desktop-settings-group="general"] details.desktop-settings-advanced-fields summary')?.textContent).toContain("Advanced");
     expect(host.querySelector('[data-desktop-settings-field="temperature"]')?.closest("details")?.className).toContain("desktop-settings-advanced-fields");
-    expect(host.querySelector('[data-desktop-settings-field="sessionFiles"] output')?.textContent).toContain("Session file");
-    expect(host.querySelector('[data-desktop-settings-field="sessionFiles"] [data-desktop-settings-control="sessionFiles"]')).toBeNull();
+
+    const navProvider = host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]');
+    navProvider?.click();
+    await nextTick();
+    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Provider & Models");
+    expect(host.querySelector(".desktop-settings-default-llm-card")).toBeNull();
+    expect(host.querySelector(".desktop-settings-provider-section")?.textContent).toContain("Providers");
+    expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
+    expect(host.querySelector('[data-desktop-settings-field="apiKey"] input')?.getAttribute("type")).toBe("password");
+    expect(host.querySelector<HTMLInputElement>('[data-desktop-settings-control="apiKey"]')?.value).toBe("********");
+
     const navFiles = host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="files-workspace"]');
     navFiles?.click();
     await nextTick();
+    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Files & Workspace");
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-group]"),
+      (node) => node.getAttribute("data-desktop-settings-group"),
+    )).toEqual(["files-workspace"]);
+    expect(host.querySelector('[data-desktop-settings-field="sessionFiles"] output')?.textContent).toContain("Session file");
+    expect(host.querySelector('[data-desktop-settings-field="sessionFiles"] [data-desktop-settings-control="sessionFiles"]')).toBeNull();
     expect(host.querySelector('[data-desktop-settings-nav="general"]')?.getAttribute("data-active")).toBeNull();
     const activeNavFiles = host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="files-workspace"]');
     expect(activeNavFiles?.getAttribute("data-active")).toBe("true");
     expect(activeNavFiles?.getAttribute("aria-current")).toBe("page");
 
+    host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="general"]')?.click();
+    await nextTick();
     const model = host.querySelector<HTMLSelectElement>('[data-desktop-settings-control="model"]');
     model!.value = "gpt-4.1-mini";
     model?.dispatchEvent(new Event("change", { bubbles: true }));
     host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="save"]')?.click();
+
+    host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]')?.click();
+    await nextTick();
     host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="discoverModels"]')?.click();
     host.querySelector<HTMLButtonElement>('[data-desktop-settings-provider-action="settings"]')?.click();
     const apiKey = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="apiKey"]');

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -10,6 +10,7 @@ import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 export interface SettingsPaneIslandOptions {
   pane: DesktopSettingsPaneModel;
+  initialActiveGroupId?: DesktopSettingsPaneGroup["id"];
   onSettingsAction?: (event: DesktopSettingsActionEvent) => void;
   promptProviderId?: () => string | null;
   onFocusSettingsControl?: (fieldId: string) => void;
@@ -57,7 +58,7 @@ function createSettingsPaneApp(options: SettingsPaneIslandOptions): App {
     name: "SettingsPaneIsland",
     setup() {
       const providerSearch = ref("");
-      const activeGroupId = ref(options.pane.groups[0]?.id ?? "general");
+      const activeGroupId = ref(getActiveSettingsGroup(options.pane, options.initialActiveGroupId)?.id ?? "general");
       const setActiveGroupId = (groupId: DesktopSettingsPaneGroup["id"]) => {
         activeGroupId.value = groupId;
       };
@@ -588,7 +589,7 @@ function shouldHideProviderCard(provider: ProviderCardModel, query: string): boo
 
 function getActiveSettingsGroup(
   pane: DesktopSettingsPaneModel,
-  activeGroupId: DesktopSettingsPaneGroup["id"],
+  activeGroupId?: DesktopSettingsPaneGroup["id"] | null,
 ): DesktopSettingsPaneGroup | null {
   return pane.groups.find((group) => group.id === activeGroupId) ?? pane.groups[0] ?? null;
 }

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -39,7 +39,7 @@ export function mountSettingsPaneIsland(
   host.setAttribute("data-desktop-vue-island", "settings-pane");
   host.className = "desktop-workbench-section desktop-settings-pane";
   host.setAttribute("data-desktop-module-surface", "settings");
-  host.setAttribute("data-settings-layout", "capability-center");
+  host.setAttribute("data-settings-layout", "section-pages");
   host.setAttribute("aria-label", "Settings and providers");
 
   const app = createSettingsPaneApp(options);
@@ -65,13 +65,10 @@ function createSettingsPaneApp(options: SettingsPaneIslandOptions): App {
         default: () => [
           renderSidebar(options.pane, activeGroupId.value, setActiveGroupId),
           h("div", { class: "desktop-settings-content" }, [
-            renderHeader(),
-            renderCapabilityMap(options.pane, setActiveGroupId),
-            renderDefaultLlmCard(options),
-            renderProviderManagement(options, providerSearch.value, (value) => {
+            renderHeader(options.pane, activeGroupId.value),
+            renderActiveSettingsSection(options, activeGroupId.value, providerSearch.value, (value) => {
               providerSearch.value = value;
             }),
-            renderSettingsGroups(options),
           ]),
         ],
       });
@@ -79,32 +76,17 @@ function createSettingsPaneApp(options: SettingsPaneIslandOptions): App {
   }));
 }
 
-function renderHeader() {
+function renderHeader(
+  pane: DesktopSettingsPaneModel,
+  activeGroupId: DesktopSettingsPaneGroup["id"],
+) {
+  const activeGroup = getActiveSettingsGroup(pane, activeGroupId);
   return h("header", { class: "desktop-settings-header" }, [
     h("div", { class: "desktop-settings-breadcrumb" }, [
-      h("h2", "Settings / Capability Center"),
+      h("h2", `Settings / ${activeGroup?.label ?? "General"}`),
+      activeGroup ? h("p", { class: "desktop-settings-header-description" }, getSettingsGroupDescription(activeGroup.id)) : null,
     ]),
   ]);
-}
-
-function renderCapabilityMap(
-  pane: DesktopSettingsPaneModel,
-  setActiveGroupId: (groupId: DesktopSettingsPaneGroup["id"]) => void,
-) {
-  return h("section", {
-    class: "desktop-settings-capability-map",
-    "data-desktop-settings-center": "capability-boundaries",
-    "aria-label": "Capability boundaries",
-  }, capabilityCards(pane).map((card) => h("a", {
-    class: "desktop-settings-capability-card",
-    href: `#desktop-settings-group-${card.id}`,
-    "data-desktop-settings-capability": card.id,
-    onClick: (event: Event) => scrollToSettingsGroup(event, card.id, setActiveGroupId),
-  }, [
-    h("span", { class: "desktop-settings-capability-label" }, card.label),
-    h("strong", { class: "desktop-settings-capability-status" }, card.status),
-    h("span", { class: "desktop-settings-capability-detail" }, card.detail),
-  ])));
 }
 
 function renderSidebar(
@@ -143,14 +125,37 @@ function renderNavigation(
     }
     nodes.push(h("a", {
       class: "desktop-settings-nav-item",
-      href: `#desktop-settings-group-${group.id}`,
+      href: "#",
       "data-desktop-settings-nav": group.id,
       "data-active": group.id === activeGroupId ? "true" : undefined,
       "aria-current": group.id === activeGroupId ? "page" : undefined,
-      onClick: (event: Event) => scrollToSettingsGroup(event, group.id, setActiveGroupId),
+      onClick: (event: Event) => selectSettingsGroup(event, group.id, setActiveGroupId),
     }, getSettingsNavLabel(group.id)));
   });
   return nodes;
+}
+
+function renderActiveSettingsSection(
+  options: SettingsPaneIslandOptions,
+  activeGroupId: DesktopSettingsPaneGroup["id"],
+  providerSearch: string,
+  setProviderSearch: (value: string) => void,
+) {
+  const group = getActiveSettingsGroup(options.pane, activeGroupId);
+  const groupNode = group ? renderSettingsGroup(options, group) : null;
+  if (activeGroupId === "general") {
+    return [
+      renderDefaultLlmCard(options),
+      groupNode ? renderSingleSettingsGroup(groupNode) : null,
+    ];
+  }
+  if (activeGroupId === "provider-models") {
+    return [
+      renderProviderManagement(options, providerSearch, setProviderSearch),
+      groupNode ? renderSingleSettingsGroup(groupNode) : null,
+    ];
+  }
+  return groupNode ? renderSingleSettingsGroup(groupNode) : null;
 }
 
 function renderDefaultLlmCard(options: SettingsPaneIslandOptions) {
@@ -304,10 +309,8 @@ function renderProviderCard(
   });
 }
 
-function renderSettingsGroups(options: SettingsPaneIslandOptions) {
-  return h("div", { class: "desktop-settings-grid" }, options.pane.groups
-    .map((group) => renderSettingsGroup(options, group))
-    .filter(Boolean));
+function renderSingleSettingsGroup(groupNode: ReturnType<typeof renderSettingsGroup>) {
+  return h("div", { class: "desktop-settings-grid" }, [groupNode]);
 }
 
 function renderSettingsGroup(options: SettingsPaneIslandOptions, group: DesktopSettingsPaneGroup) {
@@ -555,17 +558,13 @@ function toggleProvider(options: SettingsPaneIslandOptions, provider: ProviderCa
   emitEdit(options, `providerEnabled:${provider.id}`, !provider.connected);
 }
 
-function scrollToSettingsGroup(
+function selectSettingsGroup(
   event: Event,
   groupId: DesktopSettingsPaneGroup["id"],
   setActiveGroupId?: (groupId: DesktopSettingsPaneGroup["id"]) => void,
 ): void {
   event.preventDefault();
   setActiveGroupId?.(groupId);
-  const link = event.currentTarget as HTMLElement | null;
-  const document = link?.ownerDocument;
-  const target = document?.getElementById(`desktop-settings-group-${groupId}`);
-  target?.scrollIntoView({ block: "start", behavior: "smooth" });
 }
 
 function providerInitials(label: string): string {
@@ -587,73 +586,11 @@ function shouldHideProviderCard(provider: ProviderCardModel, query: string): boo
   return !`${provider.id} ${provider.label} ${provider.statusLabel} ${provider.baseUrl} ${provider.apiKey} ${provider.models}`.toLowerCase().includes(normalizedQuery);
 }
 
-function capabilityCards(pane: DesktopSettingsPaneModel): Array<{
-  id: DesktopSettingsPaneGroup["id"];
-  label: string;
-  status: string;
-  detail: string;
-}> {
-  const selectedProvider = pane.providerEditor.selectedProvider;
-  const providerLabel = pane.providerCatalog.find((provider) => provider.id === selectedProvider)?.label || selectedProvider || "Auto";
-  const knowledgeEnabled = checkedSettingsField(pane, "knowledge", "enabled");
-  const webEnabled = checkedSettingsField(pane, "tools-approvals", "webEnable");
-  const shellEnabled = checkedSettingsField(pane, "tools-approvals", "execEnable");
-  const gatewayHost = settingsFieldValue(pane, "gateway-runtime", "host") || "localhost";
-  const gatewayPort = settingsFieldValue(pane, "gateway-runtime", "port") || "auto";
-  return [
-    {
-      id: "provider-models",
-      label: "Provider & Models",
-      status: providerLabel,
-      detail: pane.providerEditor.models.length ? pane.providerEditor.models.slice(0, 2).join(", ") : "Model catalog not loaded",
-    },
-    {
-      id: "knowledge",
-      label: "Knowledge",
-      status: knowledgeEnabled ? "Knowledge On" : "Knowledge Off",
-      detail: `${settingsFieldValue(pane, "knowledge", "retrievalMode") || "hybrid"} retrieval / top ${settingsFieldValue(pane, "knowledge", "maxChunks") || "auto"}`,
-    },
-    {
-      id: "tools-approvals",
-      label: "Tools & Approvals",
-      status: `Web ${webEnabled ? "On" : "Off"} / Shell ${shellEnabled ? "On" : "Off"}`,
-      detail: settingsFieldValue(pane, "tools-approvals", "mcpServers") === "Configured" ? "MCP configured" : "MCP allowlist empty",
-    },
-    {
-      id: "files-workspace",
-      label: "Files & Workspace",
-      status: "Three scopes",
-      detail: "Session files / Knowledge documents / Workspace files",
-    },
-    {
-      id: "gateway-runtime",
-      label: "Gateway & Runtime",
-      status: `Gateway ${gatewayHost}:${gatewayPort}`,
-      detail: checkedSettingsField(pane, "gateway-runtime", "heartbeat") ? "Heartbeat enabled" : "Heartbeat disabled",
-    },
-    {
-      id: "logs-diagnostics",
-      label: "Logs & Diagnostics",
-      status: pane.validationErrors.length ? `${pane.validationErrors.length} issues` : "Ready",
-      detail: pane.validationErrors.length ? pane.validationErrors.map((error) => error.field).join(", ") : "Diagnostics export and runtime logs",
-    },
-  ];
-}
-
-function settingsFieldValue(
+function getActiveSettingsGroup(
   pane: DesktopSettingsPaneModel,
-  groupId: DesktopSettingsPaneGroup["id"],
-  fieldId: string,
-): string {
-  return findPaneField(pane, groupId, fieldId)?.value ?? "";
-}
-
-function checkedSettingsField(
-  pane: DesktopSettingsPaneModel,
-  groupId: DesktopSettingsPaneGroup["id"],
-  fieldId: string,
-): boolean {
-  return findPaneField(pane, groupId, fieldId)?.checked === true;
+  activeGroupId: DesktopSettingsPaneGroup["id"],
+): DesktopSettingsPaneGroup | null {
+  return pane.groups.find((group) => group.id === activeGroupId) ?? pane.groups[0] ?? null;
 }
 
 function saveLabel(pane: DesktopSettingsPaneModel): string {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -66,7 +66,7 @@ function createSettingsPaneApp(options: SettingsPaneIslandOptions): App {
         default: () => [
           renderSidebar(options.pane, activeGroupId.value, setActiveGroupId),
           h("div", { class: "desktop-settings-content" }, [
-            renderHeader(options.pane, activeGroupId.value),
+            renderHeader(options, activeGroupId.value),
             renderActiveSettingsSection(options, activeGroupId.value, providerSearch.value, (value) => {
               providerSearch.value = value;
             }),
@@ -78,15 +78,17 @@ function createSettingsPaneApp(options: SettingsPaneIslandOptions): App {
 }
 
 function renderHeader(
-  pane: DesktopSettingsPaneModel,
+  options: SettingsPaneIslandOptions,
   activeGroupId: DesktopSettingsPaneGroup["id"],
 ) {
+  const pane = options.pane;
   const activeGroup = getActiveSettingsGroup(pane, activeGroupId);
   return h("header", { class: "desktop-settings-header" }, [
     h("div", { class: "desktop-settings-breadcrumb" }, [
       h("h2", `Settings / ${activeGroup?.label ?? "General"}`),
       activeGroup ? h("p", { class: "desktop-settings-header-description" }, getSettingsGroupDescription(activeGroup.id)) : null,
     ]),
+    renderSaveButton(options),
   ]);
 }
 
@@ -174,7 +176,6 @@ function renderDefaultLlmCard(options: SettingsPaneIslandOptions) {
         h("div", { class: "desktop-settings-default-llm-form" }, [
           provider ? renderInlineField(options, provider, "Provider") : null,
           model ? renderInlineField(options, model, "Model") : null,
-          renderSaveButton(options),
         ]),
         h("p", { class: "desktop-settings-default-llm-copy" }, "Configure the global default LLM model. Individual agents can still choose a different model."),
       ],


### PR DESCRIPTION
﻿## Summary
- Split the desktop Settings pane into sidebar-driven section pages instead of one long capability-center page.
- Show default LLM controls only on General, provider management only on Provider & Models, and each remaining settings group on its own page.
- Keep the fallback DOM renderer aligned with the Vue island behavior and update coverage for section navigation.

## Validation
- npm test -- settingsPaneIsland.test.ts mainUtilitiesRegionIsland.test.ts desktopWorkbenchShell.test.ts
- npm run typecheck:worker
- npm run build
