### PR TITLE
Fix native WebUI session key casing

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -227,6 +227,8 @@ struct WorkerTransportWebSocketDispatchInput {
     #[serde(default)]
     max_iterations: Option<u32>,
     #[serde(default)]
+    run_id: Option<String>,
+    #[serde(default)]
     stream: Option<bool>,
 }
 
@@ -248,6 +250,7 @@ struct WorkerChannelLoginInput {
 struct WorkerTransportWebSocketDispatchOptions {
     model: Option<String>,
     max_iterations: Option<u32>,
+    run_id: Option<String>,
     stream: Option<bool>,
 }
 
@@ -2328,6 +2331,7 @@ fn worker_transport_dispatch_websocket_message_with_options(
     let dispatch_options = WorkerTransportWebSocketDispatchOptions {
         model: input.model,
         max_iterations: input.max_iterations,
+        run_id: input.run_id,
         stream: input.stream,
     };
     let Some(run_request) = build_worker_transport_websocket_run_input_request(
@@ -2379,11 +2383,18 @@ fn build_worker_transport_websocket_run_input_request(
         .unwrap_or_default();
     metadata.insert("_wants_stream".to_string(), serde_json::Value::Bool(true));
 
-    let mut input = serde_json::json!({
-        "runId": format!(
+    let run_id = options.run_id.unwrap_or_else(|| {
+        format!(
             "websocket-{}-{request_id}",
-            sanitize_worker_run_id_part(if chat_id.is_empty() { session_id } else { chat_id })
-        ),
+            sanitize_worker_run_id_part(if chat_id.is_empty() {
+                session_id
+            } else {
+                chat_id
+            })
+        )
+    });
+    let mut input = serde_json::json!({
+        "runId": run_id,
         "sessionId": session_id,
         "input": {
             "role": "user",
@@ -4184,6 +4195,7 @@ mod tests {
                 model: Some("gpt-5".to_string()),
                 max_iterations: Some(6),
                 stream: None,
+                ..WorkerTransportWebSocketDispatchOptions::default()
             },
         )
         .expect("message mapper result should build a run request");
@@ -4217,6 +4229,39 @@ mod tests {
             WorkerTransportWebSocketDispatchOptions::default(),
         )
         .is_none());
+    }
+
+    #[test]
+    fn worker_transport_websocket_dispatch_uses_preallocated_run_id_for_streaming() {
+        let mapper_result = serde_json::json!({
+            "kind": "message",
+            "chatId": "chat-1",
+            "sessionId": "websocket:chat-1",
+            "frames": [],
+            "inbound": {
+                "channel": "websocket",
+                "sender_id": "client-1",
+                "chat_id": "chat-1",
+                "content": "hello",
+                "metadata": {},
+                "session_key": "websocket:chat-1"
+            }
+        });
+
+        let request = build_worker_transport_websocket_run_input_request(
+            42,
+            &mapper_result,
+            WorkerTransportWebSocketDispatchOptions {
+                run_id: Some("websocket-chat-1-preallocated".to_string()),
+                ..WorkerTransportWebSocketDispatchOptions::default()
+            },
+        )
+        .expect("message mapper result should build a run request");
+
+        assert_eq!(
+            request.params["input"]["runId"],
+            serde_json::Value::String("websocket-chat-1-preallocated".to_string())
+        );
     }
 
     #[test]

--- a/apps/desktop/src/desktopChatSessionController.test.ts
+++ b/apps/desktop/src/desktopChatSessionController.test.ts
@@ -170,6 +170,44 @@ describe("desktop chat session controller", () => {
     ]);
   });
 
+  test("keeps a new chat in recent sessions when the gateway list has not persisted it yet", async () => {
+    const sent: unknown[] = [];
+    const controller = createDesktopChatSessionController({
+      api: {
+        listSessions: vi.fn(async () => ({ items: [] })),
+        loadMessages: vi.fn(async () => ({ messages: [] })),
+      },
+      sendSocketMessage: (message) => sent.push(message),
+      now: () => "2026-06-22T05:30:00.000Z",
+    });
+
+    expect(controller.submitMessage("  live question  ")).toEqual({
+      status: "creating",
+      pendingContent: "live question",
+    });
+
+    await expect(controller.handleGatewayEvent({ kind: "chat.created", chatId: "chat-live", raw: {} })).resolves.toEqual({
+      pendingMessageSent: true,
+      loadedMessagesForChatId: "",
+      reloadedSessions: true,
+    });
+
+    expect(controller.state.sessions).toMatchObject([
+      {
+        key: sessionKeyForChat("chat-live"),
+        chatId: "chat-live",
+        title: "live question",
+      },
+    ]);
+    expect(controller.state.messages.get(sessionKeyForChat("chat-live"))).toMatchObject([
+      { role: "user", content: "live question" },
+    ]);
+    expect(sent).toEqual([
+      { type: "new_chat" },
+      { type: "message", chat_id: "chat-live", content: "live question", use_persistent_rag: true },
+    ]);
+  });
+
   test("sends active chat messages, interrupt requests, and attached message loads through existing gateway shapes", async () => {
     const sent: unknown[] = [];
     const controller = createDesktopChatSessionController({

--- a/apps/desktop/src/desktopChatSessionController.ts
+++ b/apps/desktop/src/desktopChatSessionController.ts
@@ -228,6 +228,9 @@ export function createDesktopChatSessionController({
 
     if (event.kind === "chat.created") {
       await loadSessions();
+      if (!state.sessions.some((session) => session.chatId === event.chatId)) {
+        activateSession(state, sessionKeyForChat(event.chatId), event.chatId);
+      }
       result.reloadedSessions = true;
       if (pendingMessage) {
         const { content, usePersistentRag } = pendingMessage;

--- a/apps/desktop/src/desktopNativeTransport.ts
+++ b/apps/desktop/src/desktopNativeTransport.ts
@@ -22,6 +22,7 @@ export type NativeTransportWebSocketMessageRequest = {
 export type NativeTransportWebSocketDispatchRequest = NativeTransportWebSocketMessageRequest & {
   model?: string;
   maxIterations?: number;
+  runId?: string;
   stream?: boolean;
 };
 

--- a/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
@@ -98,6 +98,69 @@ describe("desktop native WebSocket bridge", () => {
     expect(unlisteners.every((unlisten) => vi.mocked(unlisten).mock.calls.length === 1)).toBe(true);
   });
 
+  test("registers native message runs before dispatch completes so stream deltas render live", async () => {
+    const handlers = new Map<DesktopNativeWebSocketAgentEventName, (payload: unknown) => void>();
+    const dispatched: unknown[] = [];
+    const dispatch = deferred<unknown>();
+    const nativeTransport: NativeTransportApi = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async (request) => {
+        dispatched.push(request);
+        return dispatch.promise;
+      }),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const socket = createDesktopNativeWebSocket({
+      url: "/ws",
+      nativeTransport,
+      listenToAgentEvent: (eventName, handler) => {
+        handlers.set(eventName, handler);
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+    socket.addEventListener("message", (event) => {
+      events.push(JSON.parse(String((event as MessageEvent).data)) as Record<string, unknown>);
+    });
+
+    await flushMicrotasks();
+    socket.send(JSON.stringify({ type: "message", chat_id: "chat-native", content: "hello" }));
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const runId = (dispatched[0] as { runId?: string } | undefined)?.runId;
+    expect(runId).toMatch(/^websocket-chat-native-/);
+
+    handlers.get("agent.delta")?.({ runId, delta: "live", messageId: "message-live" });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "delta",
+      chat_id: "chat-native",
+      message_id: "message-live",
+      text: "live",
+      is_reasoning: false,
+    });
+
+    dispatch.resolve({
+      transport: {
+        kind: "message",
+        chatId: "chat-native",
+        sessionId: "websocket:chat-native",
+        frames: [],
+      },
+      agent: {
+        runId,
+        finalContent: "live final",
+        stopReason: "final_response",
+      },
+    });
+    await flushMicrotasks();
+  });
+
   test("projects TS worker cowork events into legacy WebUI WebSocket frames", async () => {
     const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {

--- a/apps/desktop/src/desktopNativeWebSocketBridge.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.ts
@@ -145,6 +145,7 @@ class DesktopNativeWebSocket extends EventTarget {
   private async dispatchFrame(frame: Record<string, unknown>): Promise<void> {
     const sessionExists = await this.resolveAttachSessionExists(frame);
     const model = stringValue(frame.model);
+    const run = optimisticRunForFrame(frame);
     const request: NativeTransportWebSocketDispatchRequest = {
       clientId: this.clientId,
       frame,
@@ -152,10 +153,17 @@ class DesktopNativeWebSocket extends EventTarget {
       ...(sessionExists !== undefined ? { sessionExists } : {}),
       ...(this.editablePaths ? { editablePaths: this.editablePaths } : {}),
       ...(model ? { model } : {}),
+      ...(run ? { runId: run.runId } : {}),
     };
+    if (run) {
+      this.registerRun(run.runId, run);
+    }
     try {
       this.applyDispatchResult(await this.nativeTransport.dispatchWebsocketMessage(request));
     } catch (error) {
+      if (run) {
+        this.activeRuns.delete(run.runId);
+      }
       this.emitJson({ event: "error", message: error instanceof Error ? error.message : String(error) });
     }
   }
@@ -560,6 +568,24 @@ function createClientId(): string {
   return Math.random().toString(16).slice(2, 14).padEnd(12, "0");
 }
 
+function optimisticRunForFrame(frame: Record<string, unknown>): (ActiveRun & { runId: string }) | null {
+  if (stringValue(frame.type) !== "message") {
+    return null;
+  }
+  const chatId = stringValue(frame.chat_id) || stringValue(frame.chatId);
+  if (!chatId) {
+    return null;
+  }
+  const runId = `websocket-${sanitizeRunIdPart(chatId)}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    runId,
+    chatId,
+    sessionId: `websocket:${chatId}`,
+    messageId: runId,
+    streamed: false,
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -590,6 +616,10 @@ function numberValue(value: unknown): number | null {
     return Number.isFinite(parsed) ? parsed : null;
   }
   return null;
+}
+
+function sanitizeRunIdPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.:-]/g, "-") || "chat";
 }
 
 function referenceMetadata(payload: Record<string, unknown>): Record<string, unknown> {

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
@@ -1354,6 +1354,52 @@ describe("WebUI knowledge graph extraction routes", () => {
 });
 
 describe("WebUI route temporary files", () => {
+  test("normalizes WebSocket session keys to the provider channel casing for messages", async () => {
+    const requestedSessionIds: string[] = [];
+    const sessionProvider: WebuiSessionProvider = {
+      channelName: "websocket",
+      listSessions: () => [],
+      getSessionMessages: (sessionId) => {
+        requestedSessionIds.push(sessionId);
+        return sessionId === "websocket:chat-1"
+          ? {
+              sessionId,
+              messages: [{ role: "user", content: "Hello", timestamp: "2026-06-22T03:50:00.000Z" }],
+            }
+          : null;
+      },
+    };
+
+    const response = await handleWebuiRouteRequest(
+      {
+        method: "GET",
+        path: "/api/sessions/WebSocket%3Achat-1/messages",
+      },
+      undefined,
+      undefined,
+      sessionProvider,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "trace-uppercase-websocket",
+    );
+
+    expect(response.status).toBe(200);
+    expect(requestedSessionIds).toEqual(["websocket:chat-1"]);
+    expect(response.body).toEqual({
+      key: "websocket:chat-1",
+      messages: [{ role: "user", content: "Hello", timestamp: "2026-06-22T03:50:00.000Z" }],
+    });
+  });
+
   test("restores task progress cards when session history only has the internal notification", async () => {
     const progressRequests: Array<{ planId: string; traceId: string }> = [];
     const sessionProvider: WebuiSessionProvider = {

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
@@ -1400,6 +1400,50 @@ describe("WebUI route temporary files", () => {
     });
   });
 
+  test("normalizes WebSocket session keys to the provider channel casing for deletes", async () => {
+    const deletedSessionIds: string[] = [];
+    const sessionProvider: WebuiSessionProvider = {
+      channelName: "websocket",
+      listSessions: () => [],
+      deleteSession: (sessionId) => {
+        deletedSessionIds.push(sessionId);
+        return {
+          sessionId,
+          deleted: sessionId === "websocket:chat-1",
+        };
+      },
+    };
+
+    const response = await handleWebuiRouteRequest(
+      {
+        method: "DELETE",
+        path: "/api/sessions/WebSocket%3Achat-1",
+      },
+      undefined,
+      undefined,
+      sessionProvider,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "trace-delete-uppercase-websocket",
+    );
+
+    expect(response.status).toBe(200);
+    expect(deletedSessionIds).toEqual(["websocket:chat-1"]);
+    expect(response.body).toEqual({
+      key: "websocket:chat-1",
+      deleted: true,
+    });
+  });
+
   test("restores task progress cards when session history only has the internal notification", async () => {
     const progressRequests: Array<{ planId: string; traceId: string }> = [];
     const sessionProvider: WebuiSessionProvider = {

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
@@ -788,7 +788,10 @@ export async function handleWebuiRouteRequest(
     if (!sessionProvider?.deleteSession) {
       return { status: 503, body: { error: "session manager not available" } };
     }
-    const result = await sessionProvider.deleteSession(deleteSessionKey, traceId);
+    const result = await sessionProvider.deleteSession(
+      normalizeWebuiSessionKey(deleteSessionKey, sessionProvider),
+      traceId,
+    );
     if (!result.deleted) {
       return { status: 404, body: { error: "session not found" } };
     }

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
@@ -713,7 +713,8 @@ export async function handleWebuiRouteRequest(
     if (!sessionProvider?.getSessionMessages) {
       return { status: 503, body: { error: "session manager not available" } };
     }
-    const session = await sessionProvider.getSessionMessages(sessionMessagesKey, traceId);
+    const sessionKey = normalizeWebuiSessionKey(sessionMessagesKey, sessionProvider);
+    const session = await sessionProvider.getSessionMessages(sessionKey, traceId);
     if (!session) {
       return { status: 404, body: { error: "session not found" } };
     }
@@ -724,7 +725,10 @@ export async function handleWebuiRouteRequest(
     if (!sessionProvider?.getSessionProfile) {
       return { status: 503, body: { error: "session manager not available" } };
     }
-    const session = await sessionProvider.getSessionProfile(sessionProfileKey, traceId);
+    const session = await sessionProvider.getSessionProfile(
+      normalizeWebuiSessionKey(sessionProfileKey, sessionProvider),
+      traceId,
+    );
     if (!session) {
       return { status: 404, body: { error: "session not found" } };
     }
@@ -739,7 +743,11 @@ export async function handleWebuiRouteRequest(
       return { status: 400, body: { error: "invalid json body" } };
     }
     const metadata = isJsonObject(request.body.metadata) ? request.body.metadata : {};
-    const session = await sessionProvider.patchSessionMetadata(patchSessionKey, metadata, traceId);
+    const session = await sessionProvider.patchSessionMetadata(
+      normalizeWebuiSessionKey(patchSessionKey, sessionProvider),
+      metadata,
+      traceId,
+    );
     if (!session) {
       return { status: 404, body: { error: "session not found" } };
     }
@@ -747,18 +755,19 @@ export async function handleWebuiRouteRequest(
   }
   const temporaryFilesKey = temporaryFilesPathKey(method, path);
   if (temporaryFilesKey !== undefined) {
+    const sessionKey = normalizeWebuiSessionKey(temporaryFilesKey, sessionProvider);
     if (method === "POST") {
-      return webuiTemporaryFileUploadResponse(temporaryFilesKey, request.body, sessionProvider, traceId);
+      return webuiTemporaryFileUploadResponse(sessionKey, request.body, sessionProvider, traceId);
     }
     if (method === "DELETE") {
-      return webuiTemporaryFilesClearResponse(temporaryFilesKey, sessionProvider, traceId);
+      return webuiTemporaryFilesClearResponse(sessionKey, sessionProvider, traceId);
     }
     if (!sessionProvider?.listTemporaryFiles) {
       return { status: 200, body: { items: [] } };
     }
     return {
       status: 200,
-      body: webuiTemporaryFilesBody(await sessionProvider.listTemporaryFiles(temporaryFilesKey, traceId)),
+      body: webuiTemporaryFilesBody(await sessionProvider.listTemporaryFiles(sessionKey, traceId)),
     };
   }
   const clearSessionKey = clearSessionPathKey(method, path);
@@ -768,7 +777,10 @@ export async function handleWebuiRouteRequest(
     }
     return {
       status: 200,
-      body: webuiClearSessionBody(await sessionProvider.clearSession(clearSessionKey, traceId)),
+      body: webuiClearSessionBody(await sessionProvider.clearSession(
+        normalizeWebuiSessionKey(clearSessionKey, sessionProvider),
+        traceId,
+      )),
     };
   }
   const deleteSessionKey = deleteSessionPathKey(method, path);
@@ -3299,6 +3311,22 @@ function webuiPatchSessionBody(session: WebuiPatchSessionResult): Record<string,
     metadata: session.metadata,
     updated_at: session.updatedAt,
   };
+}
+
+function normalizeWebuiSessionKey(
+  sessionId: string,
+  sessionProvider: WebuiSessionProvider | undefined,
+): string {
+  const channelName = sessionProvider?.channelName ?? "websocket";
+  const separator = sessionId.indexOf(":");
+  if (separator <= 0) {
+    return sessionId;
+  }
+  const prefix = sessionId.slice(0, separator);
+  if (prefix.toLowerCase() !== channelName.toLowerCase()) {
+    return sessionId;
+  }
+  return `${channelName}:${sessionId.slice(separator + 1)}`;
 }
 
 function webuiTemporaryFilesBody(session: WebuiSessionTemporaryFiles): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- Normalize native WebUI session keys to the session provider channel casing before lookup.
- Preallocate native WebSocket run IDs so TS worker deltas can render live while dispatch is still running.
- Keep newly created native chats visible in Recent Chats while the gateway session list has not persisted them yet.
- Cover uppercase `WebSocket:` message routes, native live delta projection, and optimistic recent-chat retention with regression tests.

Closes #284
Closes #286

## Verification
- `npm test -- webuiRoutes.test.ts`
- `npm test -- desktopNativeWebSocketBridge.test.ts desktopChatSessionController.test.ts desktopNativeTransport.test.ts desktopGatewayBridge.test.ts`
- `npm run typecheck:worker`
- `cargo test worker_transport_websocket`
- `npm run build`

Note: `cargo fmt --check` currently reports pre-existing formatting diffs across unrelated Rust files; I did not run `cargo fmt` to avoid unrelated churn.