### PR TITLE
Fix native chat stream delta forwarding

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -701,17 +701,24 @@ fn worker_transport_websocket_message(
 }
 
 #[tauri::command]
-fn worker_transport_dispatch_websocket_message(
+async fn worker_transport_dispatch_websocket_message(
     input: WorkerTransportWebSocketDispatchInput,
     state: State<'_, SharedGateway>,
 ) -> Result<serde_json::Value, String> {
-    worker_transport_dispatch_websocket_message_with_options(
-        state.inner(),
-        input,
-        ts_agent_worker_workspace_root(),
-        experimental_worker_config_snapshot(),
-        Duration::from_secs(60),
-    )
+    let shared = state.inner().clone();
+    let workspace_root = ts_agent_worker_workspace_root();
+    let config_snapshot = experimental_worker_config_snapshot();
+    tauri::async_runtime::spawn_blocking(move || {
+        worker_transport_dispatch_websocket_message_with_options(
+            &shared,
+            input,
+            workspace_root,
+            config_snapshot,
+            Duration::from_secs(60),
+        )
+    })
+    .await
+    .map_err(|error| format!("worker transport websocket dispatch task failed: {error}"))?
 }
 
 #[tauri::command]
@@ -3220,18 +3227,22 @@ fn read_native_backend_log_tail(path: &Path, max_lines: usize) -> Vec<String> {
 fn worker_manager_frontend_event(event: WorkerManagerEvent) -> (String, serde_json::Value) {
     match event {
         WorkerManagerEvent::Status(status) => (
-            "worker.status".to_string(),
+            tauri_safe_event_name("worker.status"),
             serde_json::to_value(status).unwrap_or_else(|_| serde_json::json!({})),
         ),
         WorkerManagerEvent::Diagnostics(line) => (
-            "diagnostics.log".to_string(),
+            tauri_safe_event_name("diagnostics.log"),
             serde_json::to_value(line).unwrap_or_else(|_| serde_json::json!({})),
         ),
         WorkerManagerEvent::Protocol(event) => (
-            event.event,
+            tauri_safe_event_name(&event.event),
             serde_json::to_value(event.payload).unwrap_or_else(|_| serde_json::json!({})),
         ),
     }
+}
+
+fn tauri_safe_event_name(event_name: &str) -> String {
+    event_name.replace('.', ":")
 }
 
 fn emit_worker_manager_frontend_event<R: Runtime>(
@@ -4618,7 +4629,7 @@ mod tests {
                 last_error: None,
             }));
 
-        assert_eq!(event_name, "worker.status");
+        assert_eq!(event_name, "worker:status");
         assert_eq!(payload["state"], "running");
         assert_eq!(payload["label"], "tinybot-gateway");
         assert_eq!(payload["pid"], 1234);
@@ -4630,7 +4641,7 @@ mod tests {
             crate::worker_protocol::WorkerDiagnosticLine::new("stderr", "worker ready"),
         ));
 
-        assert_eq!(event_name, "diagnostics.log");
+        assert_eq!(event_name, "diagnostics:log");
         assert_eq!(payload["stream"], "stderr");
         assert_eq!(payload["line"], "worker ready");
     }
@@ -4646,7 +4657,7 @@ mod tests {
             },
         ));
 
-        assert_eq!(event_name, "agent.delta");
+        assert_eq!(event_name, "agent:delta");
         assert_eq!(payload["message"], "starting");
     }
 

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -113,6 +113,7 @@ import { createDesktopNativeSkillsApi } from "./desktopNativeSkills";
 import { createDesktopNativeWebuiApi } from "./desktopNativeWebui";
 import { startDesktopNativeChannelRuntime } from "./desktopNativeChannelLifecycle";
 import { createDesktopNativeTransportApi } from "./desktopNativeTransport";
+import { toDesktopNativeTauriEventName } from "./desktopNativeTauriEvents";
 import { normalizeSessionsPayload } from "./nativeChat";
 import {
   flushGatewaySocketQueue,
@@ -263,7 +264,7 @@ async function bootDesktopWebUi(): Promise<void> {
       nativeTransport: gatewayClientOptions.nativeTransport,
       nativeWebui: gatewayClientOptions.nativeWebui,
       resolveNativeWebSocketSessionExists,
-      listenToNativeAgentEvent: (eventName, handler) => listen(eventName, (event) => {
+      listenToNativeAgentEvent: (eventName, handler) => listen(toDesktopNativeTauriEventName(eventName), (event) => {
         handler(event.payload);
       }),
     });
@@ -686,7 +687,7 @@ function installNativeTsAgentEventListeners(): void {
     "agent.done",
     "agent.error",
   ] as const) {
-    void listen(eventName, (event) => {
+    void listen(toDesktopNativeTauriEventName(eventName), (event) => {
       handleNativeTsAgentWorkerEvent(eventName, event.payload);
     });
   }
@@ -2416,10 +2417,10 @@ function installNativeRuntimeStatusEventRouting(): void {
     return;
   }
   nativeRuntimeStatusEventsInstalled = true;
-  void listen("diagnostics.log", () => {
+  void listen(toDesktopNativeTauriEventName("diagnostics.log"), () => {
     scheduleNativeRuntimeStatusRefresh("diagnostics.log");
   });
-  void listen("worker.status", () => {
+  void listen(toDesktopNativeTauriEventName("worker.status"), () => {
     scheduleNativeRuntimeStatusRefresh("worker.status");
   });
 }

--- a/apps/desktop/src/desktopGatewayBridge.test.ts
+++ b/apps/desktop/src/desktopGatewayBridge.test.ts
@@ -275,6 +275,59 @@ describe("desktop gateway bridge", () => {
     bridge.restore();
   });
 
+  test("waits for native OpenAI stream listeners before dispatching", async () => {
+    const listenerReady = deferred<() => void>();
+    const handlers = new Map<string, (payload: unknown) => void>();
+    const nativeTransport = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async () => ({
+        transport: { kind: "message", chatId: "chat-1", frames: [] },
+        agent: { finalContent: "hello", stopReason: "stop" },
+      })),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const target = {
+      location: { origin: pageOrigin },
+      fetch: vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 })),
+      WebSocket: class TestWebSocket {} as unknown as typeof WebSocket,
+    } as unknown as typeof globalThis;
+    const bridge = installDesktopGatewayBridge({
+      config: DEFAULT_GATEWAY_CONFIG,
+      pageOrigin,
+      fetchTarget: target,
+      webSocketTarget: target,
+      nativeTransport,
+      listenToNativeAgentEvent: (eventName, handler) => {
+        handlers.set(eventName, handler);
+        return listenerReady;
+      },
+    });
+
+    await target.fetch("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "test-model",
+        session_id: "chat-1",
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    await flushMicrotasks();
+
+    expect(nativeTransport.dispatchWebsocketMessage).not.toHaveBeenCalled();
+
+    listenerReady.resolve(() => handlers.clear());
+    await flushMicrotasks();
+
+    expect(nativeTransport.dispatchWebsocketMessage).toHaveBeenCalledOnce();
+    bridge.restore();
+  });
+
   test("does not fallback to gateway HTTP for native Knowledge fetch failures", async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {

--- a/apps/desktop/src/desktopGatewayBridge.test.ts
+++ b/apps/desktop/src/desktopGatewayBridge.test.ts
@@ -178,6 +178,103 @@ describe("desktop gateway bridge", () => {
     bridge.restore();
   });
 
+  test("preserves native WebUI SSE responses for root WebUI fetches", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
+    const nativeWebui = {
+      routeResponse: vi.fn(async () => ({
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+        body: "data: {\"delta\":\"hel\"}\n\ndata: [DONE]\n\n",
+      })),
+    };
+    const target = {
+      location: { origin: pageOrigin },
+      fetch: fetchMock,
+      WebSocket: class TestWebSocket {} as unknown as typeof WebSocket,
+    } as unknown as typeof globalThis;
+    const bridge = installDesktopGatewayBridge({
+      config: DEFAULT_GATEWAY_CONFIG,
+      pageOrigin,
+      fetchTarget: target,
+      webSocketTarget: target,
+      nativeWebui,
+    });
+
+    const response = await target.fetch("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ stream: true, messages: [{ role: "user", content: "hello" }] }),
+    });
+
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+    await expect(response.text()).resolves.toBe("data: {\"delta\":\"hel\"}\n\ndata: [DONE]\n\n");
+    expect(fetchMock).not.toHaveBeenCalled();
+    bridge.restore();
+  });
+
+  test("streams native OpenAI chat completion deltas before dispatch completes", async () => {
+    const dispatch = deferred<unknown>();
+    const handlers = new Map<string, (payload: unknown) => void>();
+    const nativeTransport = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async () => dispatch),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const target = {
+      location: { origin: pageOrigin },
+      fetch: vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 })),
+      WebSocket: class TestWebSocket {} as unknown as typeof WebSocket,
+    } as unknown as typeof globalThis;
+    const bridge = installDesktopGatewayBridge({
+      config: DEFAULT_GATEWAY_CONFIG,
+      pageOrigin,
+      fetchTarget: target,
+      webSocketTarget: target,
+      nativeTransport,
+      listenToNativeAgentEvent: (eventName, handler) => {
+        handlers.set(eventName, handler);
+        return () => handlers.delete(eventName);
+      },
+    });
+
+    const response = await target.fetch("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "test-model",
+        session_id: "chat-1",
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
+
+    const dispatchMock = nativeTransport.dispatchWebsocketMessage as unknown as {
+      mock: { calls: Array<[{ runId?: string }]> };
+    };
+    const dispatched = dispatchMock.mock.calls[0]?.[0];
+    const dispatchedRunId = dispatched?.runId;
+    expect(dispatchedRunId).toMatch(/^openai-chat-chat-1-/);
+    handlers.get("agent.delta")?.({ runId: dispatchedRunId, delta: "hel" });
+    const firstChunk = await reader?.read();
+
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+    expect(new TextDecoder().decode(firstChunk?.value)).toContain('"content":"hel"');
+    expect(dispatch.settled).toBe(false);
+
+    dispatch.resolve({
+      transport: { kind: "message", chatId: "chat-1", frames: [] },
+      agent: { runId: dispatchedRunId, finalContent: "hello", stopReason: "stop" },
+    });
+    await flushMicrotasks();
+    bridge.restore();
+  });
+
   test("does not fallback to gateway HTTP for native Knowledge fetch failures", async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {
@@ -470,4 +567,17 @@ describe("desktop gateway bridge", () => {
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function deferred<T>(): Promise<T> & { resolve: (value: T) => void; settled: boolean } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  }) as Promise<T> & { resolve: (value: T) => void; settled: boolean };
+  promise.resolve = (value: T) => {
+    promise.settled = true;
+    resolve(value);
+  };
+  promise.settled = false;
+  return promise;
 }

--- a/apps/desktop/src/desktopGatewayBridge.ts
+++ b/apps/desktop/src/desktopGatewayBridge.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_GATEWAY_CONFIG, resolveGatewayConfig, type GatewayConfig } from "./gatewayConfig";
 import {
   createDesktopNativeWebSocket,
+  type DesktopNativeWebSocketAgentEventName,
   type DesktopNativeWebSocketAgentEventListener,
 } from "./desktopNativeWebSocketBridge";
 import type { NativeTransportApi } from "./desktopNativeTransport";
@@ -99,6 +100,12 @@ export function installDesktopGatewayBridge(options: DesktopGatewayBridgeOptions
   const listenToNativeAgentEvent = options.listenToNativeAgentEvent;
 
   fetchTarget.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const nativeStreamingResponse = nativeTransport && listenToNativeAgentEvent
+      ? await nativeOpenAiStreamingFetchResponse(input, init, nativeTransport, listenToNativeAgentEvent, pageOrigin)
+      : undefined;
+    if (nativeStreamingResponse) {
+      return nativeStreamingResponse;
+    }
     const nativeResponse = nativeWebui
       ? await nativeWebuiFetchResponse(input, init, nativeWebui, pageOrigin)
       : undefined;
@@ -196,6 +203,150 @@ async function nativeWebuiFetchResponse(
     }
     return undefined;
   }
+}
+
+async function nativeOpenAiStreamingFetchResponse(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  nativeTransport: NativeTransportApi,
+  listenToAgentEvent: DesktopNativeWebSocketAgentEventListener,
+  pageOrigin: string,
+): Promise<Response | undefined> {
+  const sourceUrl = requestUrl(input, pageOrigin);
+  if (!sourceUrl || sourceUrl.origin !== pageOrigin || sourceUrl.pathname !== "/v1/chat/completions") {
+    return undefined;
+  }
+  const request = await nativeWebuiRouteRequestForUrl(sourceUrl, input, init);
+  if (!request || !isRecord(request.body) || request.body.stream !== true) {
+    return undefined;
+  }
+  const content = openAiUserMessageContent(request.body.messages);
+  if (!content) {
+    return undefined;
+  }
+  const chatId = stringValue(request.body.session_id) || "default";
+  const runId = `openai-chat-${sanitizeRunIdPart(chatId)}-${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+  const model = stringValue(request.body.model);
+  const encoder = new TextEncoder();
+  const unlisteners: Array<() => void> = [];
+  let closed = false;
+  let emittedContent = false;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const enqueue = (text: string) => {
+        if (!closed) {
+          controller.enqueue(encoder.encode(text));
+        }
+      };
+      const close = () => {
+        if (!closed) {
+          closed = true;
+          controller.close();
+          while (unlisteners.length) {
+            unlisteners.pop()?.();
+          }
+        }
+      };
+      const listen = (eventName: DesktopNativeWebSocketAgentEventName, handler: (payload: Record<string, unknown>) => void) => {
+        const unlisten = listenToAgentEvent(eventName, (payload) => {
+          const record = isRecord(payload) ? payload : {};
+          if ((stringValue(record.runId) || stringValue(record.run_id)) === runId) {
+            handler(record);
+          }
+        });
+        if (typeof unlisten === "function") {
+          unlisteners.push(unlisten);
+        } else if (unlisten && typeof (unlisten as Promise<() => void>).then === "function") {
+          void (unlisten as Promise<() => void>).then((resolved) => {
+            if (closed) {
+              resolved();
+            } else {
+              unlisteners.push(resolved);
+            }
+          });
+        }
+      };
+
+      listen("agent.delta", (payload) => {
+        const delta = stringValue(payload.delta) || stringValue(payload.text) || stringValue(payload.content);
+        if (!delta) {
+          return;
+        }
+        emittedContent = true;
+        enqueue(openAiSseData(openAiChatCompletionChunk(model, { content: delta })));
+      });
+      listen("agent.reasoning_delta", (payload) => {
+        const delta = stringValue(payload.delta) || stringValue(payload.text) || stringValue(payload.content);
+        if (delta) {
+          enqueue(openAiSseData(openAiChatCompletionChunk(model, { reasoning_content: delta })));
+        }
+      });
+      listen("agent.done", () => {
+        enqueue(openAiSseData({
+          ...openAiChatCompletionChunk(model, {}),
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        }));
+        enqueue("data: [DONE]\n\n");
+        close();
+      });
+      listen("agent.error", (payload) => {
+        enqueue(openAiSseData({
+          error: { message: stringValue(payload.message) || "agent error" },
+        }));
+        enqueue("data: [DONE]\n\n");
+        close();
+      });
+
+      void nativeTransport.dispatchWebsocketMessage({
+        clientId: "openai-sse",
+        frame: { type: "message", chat_id: chatId, content },
+        attachedChatId: chatId,
+        sessionExists: true,
+        model,
+        runId,
+        stream: true,
+      }).then((result) => {
+        if (closed) {
+          return;
+        }
+        const agent = isRecord(result) && isRecord(result.agent) ? result.agent : {};
+        const finalContent = stringValue(agent.finalContent) || stringValue(agent.final_content);
+        if (!emittedContent && finalContent) {
+          enqueue(openAiSseData(openAiChatCompletionChunk(model, { content: finalContent })));
+        }
+        enqueue(openAiSseData({
+          ...openAiChatCompletionChunk(model, {}),
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        }));
+        enqueue("data: [DONE]\n\n");
+        close();
+      }).catch((error) => {
+        if (closed) {
+          return;
+        }
+        enqueue(openAiSseData({
+          error: { message: error instanceof Error ? error.message : String(error) },
+        }));
+        enqueue("data: [DONE]\n\n");
+        close();
+      });
+    },
+    cancel() {
+      closed = true;
+      while (unlisteners.length) {
+        unlisteners.pop()?.();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+    },
+  });
 }
 
 async function nativeWebuiRouteRequestForUrl(
@@ -300,13 +451,69 @@ function headersRecord(headers: HeadersInit | undefined): Record<string, unknown
 
 function webuiFetchResponse(response: NativeWebuiRouteResponse): Response {
   const status = response.status;
+  const responseHeaders = headersRecordFromUnknown(response.headers);
+  const contentType = headerValue(responseHeaders, "content-type");
   const body = status === 204 || status === 205 || status === 304
     ? null
-    : JSON.stringify(response.body ?? null);
+    : contentType?.toLowerCase().includes("text/event-stream") && typeof response.body === "string"
+      ? response.body
+      : JSON.stringify(response.body ?? null);
   return new Response(body, {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: responseHeaders ?? { "Content-Type": "application/json" },
   });
+}
+
+function headersRecordFromUnknown(headers: Record<string, unknown> | undefined): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined) {
+      result[key] = String(value);
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function headerValue(headers: Record<string, string> | undefined, name: string): string | undefined {
+  return Object.entries(headers ?? {}).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1];
+}
+
+function openAiUserMessageContent(messages: unknown): string {
+  if (!Array.isArray(messages) || messages.length !== 1 || !isRecord(messages[0]) || messages[0].role !== "user") {
+    return "";
+  }
+  const content = messages[0].content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((part) => isRecord(part) && part.type === "text" ? stringValue(part.text) : "")
+    .filter(Boolean)
+    .join(" ");
+}
+
+function openAiSseData(value: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(value)}\n\n`;
+}
+
+function openAiChatCompletionChunk(model: string, delta: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: `chatcmpl-${Math.random().toString(16).slice(2, 14).padEnd(12, "0")}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{ index: 0, delta, finish_reason: null }],
+  };
+}
+
+function sanitizeRunIdPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.:-]/g, "-") || "default";
 }
 
 function requestUrl(input: RequestInfo | URL, pageOrigin: string): URL | null {
@@ -318,4 +525,12 @@ function requestUrl(input: RequestInfo | URL, pageOrigin: string): URL | null {
   } catch {
     return null;
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }

--- a/apps/desktop/src/desktopGatewayBridge.ts
+++ b/apps/desktop/src/desktopGatewayBridge.ts
@@ -229,6 +229,7 @@ async function nativeOpenAiStreamingFetchResponse(
   const model = stringValue(request.body.model);
   const encoder = new TextEncoder();
   const unlisteners: Array<() => void> = [];
+  const listenerReadyPromises: Array<Promise<void>> = [];
   let closed = false;
   let emittedContent = false;
 
@@ -258,13 +259,13 @@ async function nativeOpenAiStreamingFetchResponse(
         if (typeof unlisten === "function") {
           unlisteners.push(unlisten);
         } else if (unlisten && typeof (unlisten as Promise<() => void>).then === "function") {
-          void (unlisten as Promise<() => void>).then((resolved) => {
+          listenerReadyPromises.push((unlisten as Promise<() => void>).then((resolved) => {
             if (closed) {
               resolved();
             } else {
               unlisteners.push(resolved);
             }
-          });
+          }));
         }
       };
 
@@ -298,16 +299,21 @@ async function nativeOpenAiStreamingFetchResponse(
         close();
       });
 
-      void nativeTransport.dispatchWebsocketMessage({
-        clientId: "openai-sse",
-        frame: { type: "message", chat_id: chatId, content },
-        attachedChatId: chatId,
-        sessionExists: true,
-        model,
-        runId,
-        stream: true,
-      }).then((result) => {
+      void Promise.all(listenerReadyPromises).then(() => {
         if (closed) {
+          return undefined;
+        }
+        return nativeTransport.dispatchWebsocketMessage({
+          clientId: "openai-sse",
+          frame: { type: "message", chat_id: chatId, content },
+          attachedChatId: chatId,
+          sessionExists: true,
+          model,
+          runId,
+          stream: true,
+        });
+      }).then((result) => {
+        if (closed || !result) {
           return;
         }
         const agent = isRecord(result) && isRecord(result.agent) ? result.agent : {};

--- a/apps/desktop/src/desktopNativeTauriEvents.test.ts
+++ b/apps/desktop/src/desktopNativeTauriEvents.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+import { toDesktopNativeTauriEventName } from "./desktopNativeTauriEvents";
+
+describe("desktop native Tauri events", () => {
+  test("maps worker protocol event names to Tauri-safe names", () => {
+    expect(toDesktopNativeTauriEventName("agent.delta")).toBe("agent:delta");
+    expect(toDesktopNativeTauriEventName("agent.tool_call.delta")).toBe("agent:tool_call:delta");
+    expect(toDesktopNativeTauriEventName("diagnostics.log")).toBe("diagnostics:log");
+    expect(toDesktopNativeTauriEventName("worker.status")).toBe("worker:status");
+  });
+});

--- a/apps/desktop/src/desktopNativeTauriEvents.ts
+++ b/apps/desktop/src/desktopNativeTauriEvents.ts
@@ -1,0 +1,3 @@
+export function toDesktopNativeTauriEventName(eventName: string): string {
+  return eventName.replace(/\./g, ":");
+}

--- a/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
-import { createDesktopNativeWebSocket, type DesktopNativeWebSocketAgentEventName } from "./desktopNativeWebSocketBridge";
+import { createDesktopNativeWebSocket } from "./desktopNativeWebSocketBridge";
 import type { NativeTransportApi } from "./desktopNativeTransport";
+import { toDesktopNativeTauriEventName } from "./desktopNativeTauriEvents";
 
 describe("desktop native WebSocket bridge", () => {
   test("projects TS worker stream events into legacy WebUI WebSocket frames", async () => {
-    const handlers = new Map<DesktopNativeWebSocketAgentEventName, (payload: unknown) => void>();
+    const handlers = new Map<string, (payload: unknown) => void>();
     const unlisteners: Array<() => void> = [];
     const dispatch = deferred<unknown>();
     const nativeTransport: NativeTransportApi = {
@@ -38,13 +39,13 @@ describe("desktop native WebSocket bridge", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(handlers.get("agent.delta")).toBeDefined();
-    expect(handlers.get("agent.reasoning_delta")).toBeDefined();
-    expect(handlers.get("agent.done")).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.delta"))).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.reasoning_delta"))).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.done"))).toBeDefined();
 
-    handlers.get("agent.delta")?.({ runId: "run-1", delta: "hello", messageId: "message-1" });
-    handlers.get("agent.reasoning_delta")?.({ run_id: "run-1", delta: "thinking", message_id: "message-1" });
-    handlers.get("agent.done")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.delta"))?.({ runId: "run-1", delta: "hello", messageId: "message-1" });
+    handlers.get(toDesktopNativeTauriEventName("agent.reasoning_delta"))?.({ run_id: "run-1", delta: "thinking", message_id: "message-1" });
+    handlers.get(toDesktopNativeTauriEventName("agent.done"))?.({
       runId: "run-1",
       stopReason: "final_response",
       _memory_references: [{ note_id: "note-1" }],
@@ -99,7 +100,7 @@ describe("desktop native WebSocket bridge", () => {
   });
 
   test("registers native message runs before dispatch completes so stream deltas render live", async () => {
-    const handlers = new Map<DesktopNativeWebSocketAgentEventName, (payload: unknown) => void>();
+    const handlers = new Map<string, (payload: unknown) => void>();
     const dispatched: unknown[] = [];
     const dispatch = deferred<unknown>();
     const nativeTransport: NativeTransportApi = {
@@ -134,7 +135,7 @@ describe("desktop native WebSocket bridge", () => {
     const runId = (dispatched[0] as { runId?: string } | undefined)?.runId;
     expect(runId).toMatch(/^websocket-chat-native-/);
 
-    handlers.get("agent.delta")?.({ runId, delta: "live", messageId: "message-live" });
+    handlers.get(toDesktopNativeTauriEventName("agent.delta"))?.({ runId, delta: "live", messageId: "message-live" });
     await flushMicrotasks();
 
     expect(events).toContainEqual({
@@ -159,6 +160,160 @@ describe("desktop native WebSocket bridge", () => {
       },
     });
     await flushMicrotasks();
+  });
+
+  test("does not emit final fallback content after a streamed run when dispatch result omits run id", async () => {
+    const handlers = new Map<string, (payload: unknown) => void>();
+    const dispatched: unknown[] = [];
+    const dispatch = deferred<unknown>();
+    const nativeTransport: NativeTransportApi = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async (request) => {
+        dispatched.push(request);
+        return dispatch.promise;
+      }),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const socket = createDesktopNativeWebSocket({
+      url: "/ws",
+      nativeTransport,
+      listenToAgentEvent: (eventName, handler) => {
+        handlers.set(eventName, handler);
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+    socket.addEventListener("message", (event) => {
+      events.push(JSON.parse(String((event as MessageEvent).data)) as Record<string, unknown>);
+    });
+
+    await flushMicrotasks();
+    socket.send(JSON.stringify({ type: "message", chat_id: "chat-native", content: "hello" }));
+    await flushMicrotasks();
+
+    const runId = (dispatched[0] as { runId?: string } | undefined)?.runId;
+    handlers.get(toDesktopNativeTauriEventName("agent.delta"))?.({ runId, delta: "live" });
+    dispatch.resolve({
+      transport: {
+        kind: "message",
+        chatId: "chat-native",
+        sessionId: "websocket:chat-native",
+        frames: [],
+      },
+      agent: {
+        finalContent: "live final",
+        stopReason: "final_response",
+      },
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "delta",
+      chat_id: "chat-native",
+      text: "live",
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      event: "message",
+      chat_id: "chat-native",
+      text: "live final",
+    }));
+  });
+
+  test("does not emit final fallback content after done completes a streamed run first", async () => {
+    const handlers = new Map<string, (payload: unknown) => void>();
+    const dispatched: unknown[] = [];
+    const dispatch = deferred<unknown>();
+    const nativeTransport: NativeTransportApi = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async (request) => {
+        dispatched.push(request);
+        return dispatch.promise;
+      }),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const socket = createDesktopNativeWebSocket({
+      url: "/ws",
+      nativeTransport,
+      listenToAgentEvent: (eventName, handler) => {
+        handlers.set(eventName, handler);
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+    socket.addEventListener("message", (event) => {
+      events.push(JSON.parse(String((event as MessageEvent).data)) as Record<string, unknown>);
+    });
+
+    await flushMicrotasks();
+    socket.send(JSON.stringify({ type: "message", chat_id: "chat-native", content: "hello" }));
+    await flushMicrotasks();
+
+    const runId = (dispatched[0] as { runId?: string } | undefined)?.runId;
+    handlers.get(toDesktopNativeTauriEventName("agent.delta"))?.({ runId, delta: "live" });
+    handlers.get(toDesktopNativeTauriEventName("agent.done"))?.({ runId, stopReason: "final_response" });
+    dispatch.resolve({
+      transport: {
+        kind: "message",
+        chatId: "chat-native",
+        sessionId: "websocket:chat-native",
+        frames: [],
+      },
+      agent: {
+        finalContent: "live final",
+        stopReason: "final_response",
+      },
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "delta",
+      chat_id: "chat-native",
+      text: "live",
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "stream_end",
+      chat_id: "chat-native",
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      event: "message",
+      chat_id: "chat-native",
+      text: "live final",
+    }));
+  });
+
+  test("waits for async native agent event listeners before opening the socket", async () => {
+    const listenerReady = deferred<() => void>();
+    const nativeTransport: NativeTransportApi = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const socket = createDesktopNativeWebSocket({
+      url: "/ws",
+      nativeTransport,
+      listenToAgentEvent: () => listenerReady.promise,
+    });
+
+    await flushMicrotasks();
+
+    expect(socket.readyState).toBe(WebSocket.CONNECTING);
+    expect(() => socket.send(JSON.stringify({ type: "message", chat_id: "chat-native", content: "hello" }))).toThrow("WebSocket is not open");
+    expect(nativeTransport.dispatchWebsocketMessage).not.toHaveBeenCalled();
+
+    listenerReady.resolve(vi.fn());
+    await flushMicrotasks();
+
+    expect(socket.readyState).toBe(WebSocket.OPEN);
   });
 
   test("projects TS worker cowork events into legacy WebUI WebSocket frames", async () => {
@@ -335,7 +490,7 @@ describe("desktop native WebSocket bridge", () => {
   });
 
   test("projects TS worker tool progress into legacy WebUI message frames", async () => {
-    const handlers = new Map<DesktopNativeWebSocketAgentEventName, (payload: unknown) => void>();
+    const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {
       gatewayFrame: vi.fn(),
       websocketMessage: vi.fn(),
@@ -373,19 +528,19 @@ describe("desktop native WebSocket bridge", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    handlers.get("agent.tool_call.delta")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.tool_call.delta"))?.({
       runId: "run-2",
       index: 0,
       deltaText: "{\"path\":\"AGENTS.md\"}",
       toolCallId: "call-read",
       toolName: "read_file",
     });
-    handlers.get("agent.tool.start")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.tool.start"))?.({
       runId: "run-2",
       toolCallId: "call-read",
       toolName: "read_file",
     });
-    handlers.get("agent.tool.result")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.tool.result"))?.({
       runId: "run-2",
       toolCallId: "call-read",
       toolName: "read_file",
@@ -427,7 +582,7 @@ describe("desktop native WebSocket bridge", () => {
   });
 
   test("projects TS worker awaiting interaction events into legacy WebUI frames", async () => {
-    const handlers = new Map<DesktopNativeWebSocketAgentEventName, (payload: unknown) => void>();
+    const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {
       gatewayFrame: vi.fn(),
       websocketMessage: vi.fn(),
@@ -465,10 +620,10 @@ describe("desktop native WebSocket bridge", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(handlers.get("agent.awaiting_form")).toBeDefined();
-    expect(handlers.get("agent.awaiting_approval")).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.awaiting_form"))).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.awaiting_approval"))).toBeDefined();
 
-    handlers.get("agent.awaiting_form")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.awaiting_form"))?.({
       runId: "run-3",
       formId: "travel-form",
       form: {
@@ -479,7 +634,7 @@ describe("desktop native WebSocket bridge", () => {
       },
       stopReason: "awaiting_form",
     });
-    handlers.get("agent.awaiting_approval")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.awaiting_approval"))?.({
       runId: "run-3",
       approvalId: "approval-1",
       stopReason: "awaiting_approval",
@@ -513,7 +668,7 @@ describe("desktop native WebSocket bridge", () => {
   });
 
   test("projects TS worker memory references and task progress into legacy WebUI message frames", async () => {
-    const handlers = new Map<DesktopNativeWebSocketAgentEventName, (payload: unknown) => void>();
+    const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {
       gatewayFrame: vi.fn(),
       websocketMessage: vi.fn(),
@@ -551,14 +706,14 @@ describe("desktop native WebSocket bridge", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(handlers.get("agent.memory_reference")).toBeDefined();
-    expect(handlers.get("agent.task_progress")).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.memory_reference"))).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.task_progress"))).toBeDefined();
 
-    handlers.get("agent.memory_reference")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.memory_reference"))?.({
       runId: "run-4",
       references: [{ note_id: "note-1", content: "Remembered preference" }],
     });
-    handlers.get("agent.task_progress")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.task_progress"))?.({
       runId: "run-4",
       toolCallId: "task-call",
       toolName: "task",
@@ -589,7 +744,7 @@ describe("desktop native WebSocket bridge", () => {
   });
 
   test("projects TS worker browser frames into legacy WebUI browser frame events", async () => {
-    const handlers = new Map<DesktopNativeWebSocketAgentEventName, (payload: unknown) => void>();
+    const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {
       gatewayFrame: vi.fn(),
       websocketMessage: vi.fn(),
@@ -627,9 +782,9 @@ describe("desktop native WebSocket bridge", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(handlers.get("agent.browser_frame")).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.browser_frame"))).toBeDefined();
 
-    handlers.get("agent.browser_frame")?.({
+    handlers.get(toDesktopNativeTauriEventName("agent.browser_frame"))?.({
       runId: "run-5",
       imageUrl: "data:image/png;base64,abc",
       sourceCommand: "opencli browser state",
@@ -646,7 +801,7 @@ describe("desktop native WebSocket bridge", () => {
   });
 
   test("projects TS worker cancellation events into legacy WebUI interrupted frames", async () => {
-    const handlers = new Map<DesktopNativeWebSocketAgentEventName, (payload: unknown) => void>();
+    const handlers = new Map<string, (payload: unknown) => void>();
     const dispatch = deferred<unknown>();
     const nativeTransport: NativeTransportApi = {
       gatewayFrame: vi.fn(),
@@ -674,9 +829,9 @@ describe("desktop native WebSocket bridge", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(handlers.get("agent.cancelled")).toBeDefined();
+    expect(handlers.get(toDesktopNativeTauriEventName("agent.cancelled"))).toBeDefined();
 
-    handlers.get("agent.cancelled")?.({ runId: "run-6", cancelled: true });
+    handlers.get(toDesktopNativeTauriEventName("agent.cancelled"))?.({ runId: "run-6", cancelled: true });
     dispatch.resolve({
       transport: {
         kind: "message",
@@ -711,6 +866,8 @@ describe("desktop native WebSocket bridge", () => {
 });
 
 async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
 }

--- a/apps/desktop/src/desktopNativeWebSocketBridge.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.ts
@@ -1,4 +1,6 @@
 import type { NativeTransportApi, NativeTransportWebSocketDispatchRequest } from "./desktopNativeTransport";
+import { logDesktopNativeDebug, summarizeDebugText } from "./desktopNativeChatDebug";
+import { toDesktopNativeTauriEventName } from "./desktopNativeTauriEvents";
 
 export type DesktopNativeWebSocketOptions = {
   url: string | URL;
@@ -32,7 +34,7 @@ export type DesktopNativeWebSocketAgentEventName =
   | "agent.error";
 export type DesktopNativeWebSocketAgentEventHandler = (payload: unknown) => void;
 export type DesktopNativeWebSocketAgentEventListener = (
-  eventName: DesktopNativeWebSocketAgentEventName,
+  eventName: string,
   handler: DesktopNativeWebSocketAgentEventHandler,
 ) => Promise<() => void> | (() => void) | void;
 
@@ -101,6 +103,7 @@ class DesktopNativeWebSocket extends EventTarget {
   private readonly activeRuns = new Map<string, ActiveRun>();
   private readonly activeToolCallDeltas = new Map<string, ActiveToolCallDelta>();
   private readonly completedStreamedRunIds = new Set<string>();
+  private readonly completedStreamedRunIdsByChat = new Map<string, string>();
   private attachedChatId?: string;
 
   constructor(options: DesktopNativeWebSocketOptions) {
@@ -111,15 +114,17 @@ class DesktopNativeWebSocket extends EventTarget {
     this.editablePaths = options.editablePaths ?? ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md", "HEARTBEAT.md", "memory/MEMORY.md"];
     this.resolveSessionExists = options.resolveSessionExists;
     this.listenToAgentEvent = options.listenToAgentEvent;
-    this.registerAgentEventListeners();
-    queueMicrotask(() => {
-      if (this.readyState !== DesktopNativeWebSocket.CONNECTING) {
-        return;
-      }
-      this.readyState = DesktopNativeWebSocket.OPEN;
-      this.emit("open", new Event("open"));
-      this.emitJson({ event: "ready", client_id: this.clientId });
-    });
+    void this.openWhenAgentEventListenersReady();
+  }
+
+  private async openWhenAgentEventListenersReady(): Promise<void> {
+    await this.registerAgentEventListeners();
+    if (this.readyState !== DesktopNativeWebSocket.CONNECTING) {
+      return;
+    }
+    this.readyState = DesktopNativeWebSocket.OPEN;
+    this.emit("open", new Event("open"));
+    this.emitJson({ event: "ready", client_id: this.clientId });
   }
 
   send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
@@ -146,6 +151,12 @@ class DesktopNativeWebSocket extends EventTarget {
     const sessionExists = await this.resolveAttachSessionExists(frame);
     const model = stringValue(frame.model);
     const run = optimisticRunForFrame(frame);
+    logDesktopNativeDebug("nativeWebSocket.dispatchFrame", {
+      chatId: stringValue(frame.chat_id),
+      hasRun: Boolean(run),
+      model: model || "",
+      type: stringValue(frame.type),
+    });
     const request: NativeTransportWebSocketDispatchRequest = {
       clientId: this.clientId,
       frame,
@@ -201,9 +212,9 @@ class DesktopNativeWebSocket extends EventTarget {
         this.emitJson(frame);
       }
     }
-    const agent = isRecord(payload.agent) ? payload.agent : undefined;
-    const runId = stringValue(agent?.runId) || stringValue(agent?.run_id);
     const chatId = stringValue(transport.chatId) || stringValue(transport.chat_id);
+    const agent = isRecord(payload.agent) ? payload.agent : undefined;
+    const runId = stringValue(agent?.runId) || stringValue(agent?.run_id) || this.activeRunIdForChat(chatId);
     if (runId && chatId) {
       this.registerRun(runId, {
         chatId,
@@ -231,12 +242,26 @@ class DesktopNativeWebSocket extends EventTarget {
     }
   }
 
-  private registerAgentEventListeners(): void {
+  private activeRunIdForChat(chatId: string): string {
+    if (!chatId) {
+      return "";
+    }
+    for (const [runId, run] of this.activeRuns) {
+      if (run.chatId === chatId) {
+        return runId;
+      }
+    }
+    return this.completedStreamedRunIdsByChat.get(chatId) ?? "";
+  }
+
+  private async registerAgentEventListeners(): Promise<void> {
     if (!this.listenToAgentEvent) {
       return;
     }
+    const registrations: Array<Promise<void>> = [];
     for (const eventName of AGENT_EVENT_NAMES) {
-      const unlisten = this.listenToAgentEvent(eventName, (payload) => {
+      const tauriEventName = toDesktopNativeTauriEventName(eventName);
+      const unlisten = this.listenToAgentEvent(tauriEventName, (payload) => {
         this.handleAgentEvent(eventName, payload);
       });
       if (typeof unlisten === "function") {
@@ -244,15 +269,21 @@ class DesktopNativeWebSocket extends EventTarget {
         continue;
       }
       if (unlisten && typeof (unlisten as Promise<() => void>).then === "function") {
-        void (unlisten as Promise<() => void>).then((resolvedUnlisten) => {
+        registrations.push((unlisten as Promise<() => void>).then((resolvedUnlisten) => {
           if (this.readyState === DesktopNativeWebSocket.CLOSED) {
             resolvedUnlisten();
           } else {
             this.agentEventUnlisteners.push(resolvedUnlisten);
           }
-        });
+        }).catch((error) => {
+          logDesktopNativeDebug("nativeWebSocket.agentEvent.listener.failed", {
+            error: error instanceof Error ? error.message : String(error),
+            eventName,
+          });
+        }));
       }
     }
+    await Promise.all(registrations);
   }
 
   private unlistenAgentEvents(): void {
@@ -264,6 +295,7 @@ class DesktopNativeWebSocket extends EventTarget {
     this.activeRuns.clear();
     this.activeToolCallDeltas.clear();
     this.completedStreamedRunIds.clear();
+    this.completedStreamedRunIdsByChat.clear();
   }
 
   private registerRun(runId: string, run: ActiveRun): void {
@@ -289,6 +321,13 @@ class DesktopNativeWebSocket extends EventTarget {
       return;
     }
     const runId = stringValue(record.runId) || stringValue(record.run_id);
+    logDesktopNativeDebug("nativeWebSocket.agentEvent.received", {
+      activeRunCount: this.activeRuns.size,
+      eventName,
+      hasRun: runId ? this.activeRuns.has(runId) : false,
+      runId,
+      text: summarizeDebugText(stringValue(record.delta) || stringValue(record.text) || stringValue(record.content)),
+    });
     if (!runId) {
       return;
     }
@@ -296,6 +335,11 @@ class DesktopNativeWebSocket extends EventTarget {
       const events = this.pendingAgentEvents.get(runId) ?? [];
       events.push({ eventName, payload: record });
       this.pendingAgentEvents.set(runId, events);
+      logDesktopNativeDebug("nativeWebSocket.agentEvent.queued", {
+        eventName,
+        pendingCount: events.length,
+        runId,
+      });
       return;
     }
     this.projectAgentEvent(eventName, record, runId);
@@ -313,9 +357,21 @@ class DesktopNativeWebSocket extends EventTarget {
     if (eventName === "agent.delta" || eventName === "agent.reasoning_delta") {
       const text = stringValue(payload.delta) || stringValue(payload.text) || stringValue(payload.content);
       if (!text) {
+        logDesktopNativeDebug("nativeWebSocket.agentEvent.dropped", {
+          eventName,
+          reason: "empty delta",
+          runId,
+        });
         return;
       }
       run.streamed = true;
+      logDesktopNativeDebug("nativeWebSocket.agentEvent.projected", {
+        chatId: run.chatId,
+        eventName,
+        messageId: run.messageId,
+        runId,
+        text: summarizeDebugText(text),
+      });
       this.emitJson({
         event: "delta",
         chat_id: run.chatId,
@@ -422,6 +478,7 @@ class DesktopNativeWebSocket extends EventTarget {
       });
       this.activeRuns.delete(runId);
       this.completedStreamedRunIds.add(runId);
+      this.completedStreamedRunIdsByChat.set(run.chatId, runId);
       this.clearToolCallDeltas(runId);
       return;
     }
@@ -446,6 +503,7 @@ class DesktopNativeWebSocket extends EventTarget {
       });
       this.activeRuns.delete(runId);
       this.completedStreamedRunIds.add(runId);
+      this.completedStreamedRunIdsByChat.set(run.chatId, runId);
       this.clearToolCallDeltas(runId);
     }
   }

--- a/apps/desktop/src/desktopNativeWebui.ts
+++ b/apps/desktop/src/desktopNativeWebui.ts
@@ -35,7 +35,11 @@ function normalizeWebuiRouteResponse(value: unknown): NativeWebuiRouteResponse {
   if (!isRecord(value) || typeof value.status !== "number") {
     return { status: 200, body: value };
   }
-  return { status: value.status, body: value.body };
+  return {
+    status: value.status,
+    body: value.body,
+    headers: isRecord(value.headers) ? value.headers : undefined,
+  };
 }
 
 function unwrapWebuiRouteResponse(response: NativeWebuiRouteResponse): unknown {

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.test.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.test.ts
@@ -1012,7 +1012,10 @@ describe("desktop native workbench runtime", () => {
     expect(runtime.chat.status).toBe("gateway stream failed");
   });
 
-  test("ignores direct TS agent stream events for gateway websocket runs", async () => {
+  test.each([
+    "websocket-chat-gateway-stream-run",
+    "openai-chat-chat-gateway-stream-run",
+  ])("ignores direct TS agent stream events for %s gateway runs", async (runId) => {
     const runtime = createDesktopNativeWorkbenchRuntime({
       api: {
         listSessions: async () => ({
@@ -1027,22 +1030,22 @@ describe("desktop native workbench runtime", () => {
     await runtime.handleGatewayEvent({
       kind: "message.delta",
       chatId: "chat-gateway-stream",
-      messageId: "websocket-chat-gateway-stream-run",
+      messageId: runId,
       text: "hello",
       reasoning: false,
       raw: {},
     });
     runtime.handleTsAgentWorkerEvent("agent.delta", {
-      runId: "websocket-chat-gateway-stream-run",
+      runId,
       delta: "hello",
     });
     runtime.handleTsAgentWorkerEvent("agent.done", {
-      runId: "websocket-chat-gateway-stream-run",
+      runId,
       stopReason: "final_response",
     });
 
     expect(runtime.chat.messages).toMatchObject([
-      { role: "assistant", content: "hello", messageId: "websocket-chat-gateway-stream-run" },
+      { role: "assistant", content: "hello", messageId: runId },
     ]);
     expect(runtime.chat.messages).toHaveLength(1);
   });

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.test.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.test.ts
@@ -1012,6 +1012,41 @@ describe("desktop native workbench runtime", () => {
     expect(runtime.chat.status).toBe("gateway stream failed");
   });
 
+  test("ignores direct TS agent stream events for gateway websocket runs", async () => {
+    const runtime = createDesktopNativeWorkbenchRuntime({
+      api: {
+        listSessions: async () => ({
+          items: [{ key: "WebSocket:chat-gateway-stream", chat_id: "chat-gateway-stream", title: "Gateway stream" }],
+        }),
+        loadMessages: async () => ({ messages: [] }),
+      },
+      sendSocketMessage: () => undefined,
+    });
+    await runtime.loadInitialChatState();
+
+    await runtime.handleGatewayEvent({
+      kind: "message.delta",
+      chatId: "chat-gateway-stream",
+      messageId: "websocket-chat-gateway-stream-run",
+      text: "hello",
+      reasoning: false,
+      raw: {},
+    });
+    runtime.handleTsAgentWorkerEvent("agent.delta", {
+      runId: "websocket-chat-gateway-stream-run",
+      delta: "hello",
+    });
+    runtime.handleTsAgentWorkerEvent("agent.done", {
+      runId: "websocket-chat-gateway-stream-run",
+      stopReason: "final_response",
+    });
+
+    expect(runtime.chat.messages).toMatchObject([
+      { role: "assistant", content: "hello", messageId: "websocket-chat-gateway-stream-run" },
+    ]);
+    expect(runtime.chat.messages).toHaveLength(1);
+  });
+
   test("exposes stream deltas when the active gateway session uses a bare key", async () => {
     const runtime = createDesktopNativeWorkbenchRuntime({
       api: {

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
@@ -896,7 +896,7 @@ function tsAgentToolCallDeltaKey(runId: string, index: number): string {
 }
 
 function isNativeWebSocketRunId(runId: string): boolean {
-  return runId.startsWith("websocket-");
+  return runId.startsWith("websocket-") || runId.startsWith("openai-chat-");
 }
 
 function isAwaitingTsAgentStopReason(value: unknown): boolean {

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
@@ -360,6 +360,22 @@ export function createDesktopNativeWorkbenchRuntime({
       return;
     }
     const runId = stringValue(frame.runId ?? frame.run_id);
+    if (isNativeWebSocketRunId(runId)) {
+      return;
+    }
+    if (eventName === "agent.usage") {
+      setRuntimeMetadata({
+        tokenUsage: formatTsAgentTokenUsage(frame.usage, frame.contextWindowTokens ?? frame.context_window_tokens),
+      });
+      chatStatus = "TS agent usage updated.";
+      return;
+    }
+    if (eventName === "agent.checkpoint") {
+      const checkpoint = formatTsAgentCheckpoint(frame);
+      setRuntimeMetadata({ tsAgentCheckpoint: checkpoint });
+      chatStatus = `TS agent checkpoint: ${labelTsAgentCheckpointPhase(frame.phase)}.`;
+      return;
+    }
     const chatId = activeTsAgentRuns.get(runId) || chatController.state.activeChatId;
     if (!runId || !chatId) {
       return;
@@ -480,19 +496,6 @@ export function createDesktopNativeWorkbenchRuntime({
       deleteTsAgentToolCallDelta(runId, toolCallId);
       keepTsAgentRunResponding(chatId);
       composerState = "sending";
-      return;
-    }
-    if (eventName === "agent.usage") {
-      setRuntimeMetadata({
-        tokenUsage: formatTsAgentTokenUsage(frame.usage, frame.contextWindowTokens ?? frame.context_window_tokens),
-      });
-      chatStatus = "TS agent usage updated.";
-      return;
-    }
-    if (eventName === "agent.checkpoint") {
-      const checkpoint = formatTsAgentCheckpoint(frame);
-      setRuntimeMetadata({ tsAgentCheckpoint: checkpoint });
-      chatStatus = `TS agent checkpoint: ${labelTsAgentCheckpointPhase(frame.phase)}.`;
       return;
     }
     if (eventName === "agent.cancelled") {
@@ -890,6 +893,10 @@ function stringValue(value: unknown): string {
 
 function tsAgentToolCallDeltaKey(runId: string, index: number): string {
   return `${runId}:${index}`;
+}
+
+function isNativeWebSocketRunId(runId: string): boolean {
+  return runId.startsWith("websocket-");
 }
 
 function isAwaitingTsAgentStopReason(value: unknown): boolean {

--- a/apps/desktop/src/gatewayHttpClient.ts
+++ b/apps/desktop/src/gatewayHttpClient.ts
@@ -87,6 +87,7 @@ export type NativeWebuiRouteRequest = {
 export type NativeWebuiRouteResponse = {
   status: number;
   body?: unknown;
+  headers?: Record<string, unknown>;
 };
 
 export type NativeWebuiApi = {

--- a/apps/desktop/src/nativeChat.test.ts
+++ b/apps/desktop/src/nativeChat.test.ts
@@ -305,6 +305,38 @@ describe("native chat state", () => {
     ]);
   });
 
+  test("does not append a completed message for a stream message with the same id", () => {
+    const state = createNativeChatState();
+    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
+
+    applyChatEvent(state, {
+      kind: "message.delta",
+      chatId: "chat-1",
+      messageId: "m-stream",
+      text: "Streamed answer",
+      reasoning: false,
+      raw: {},
+    });
+    applyChatEvent(state, {
+      kind: "message.completed",
+      chatId: "chat-1",
+      messageId: "m-stream",
+      text: "Streamed answer",
+      raw: {
+        _memory_references: [{ note_id: "note_stream", content: "Stream memory" }],
+      },
+    });
+
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
+      {
+        content: "Streamed answer",
+        messageId: "m-stream",
+        references: [{ kind: "memory", title: "note_stream", detail: "Stream memory" }],
+      },
+    ]);
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toHaveLength(1);
+  });
+
   test("clears responding state when a stream is interrupted or errors", () => {
     const state = createNativeChatState();
     applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });

--- a/apps/desktop/src/nativeChat.ts
+++ b/apps/desktop/src/nativeChat.ts
@@ -222,6 +222,25 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
     const toolMessage = nativeToolMessageFromEvent(event);
     const references = normalizeMessageReferences(event.raw);
     const bucket = ensureMessageBucket(state, sessionKey);
+    const existingMessage = event.messageId
+      ? bucket.find((message) => message.messageId === event.messageId && message.role === "assistant")
+      : undefined;
+    if (!toolMessage && existingMessage) {
+      if (!existingMessage.content && event.text) {
+        existingMessage.content = event.text;
+      }
+      if (references.length) {
+        existingMessage.references = [...(existingMessage.references ?? []), ...references];
+      }
+      state.respondingSessionKeys.delete(sessionKey);
+      state.error = "";
+      logDesktopNativeChatDebug("state.event.after", {
+        event: summarizeChatEvent(event),
+        state: summarizeNativeChatState(state),
+        targetSessionKey: sessionKey,
+      });
+      return;
+    }
     if (toolMessage && upsertToolActivityMessage(bucket, toolMessage)) {
       state.respondingSessionKeys.delete(sessionKey);
       state.error = "";

--- a/apps/desktop/workers/ts-agent-worker/src/channels/channelManager.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/channels/channelManager.test.ts
@@ -310,7 +310,7 @@ describe("ChannelManager", () => {
     ]);
   });
 
-  test("coalesces consecutive stream deltas for the same channel and chat", async () => {
+  test("preserves consecutive stream deltas for the same channel and chat", async () => {
     const bus = new MessageBus();
     const websocket = adapter();
     const manager = new ChannelManager({ bus, channels: [websocket] });
@@ -319,12 +319,13 @@ describe("ChannelManager", () => {
     await bus.publishOutbound(outbound({ content: "lo", metadata: { _stream_delta: true, _stream_end: true } }));
     await bus.publishOutbound(outbound({ content: "separate", chatId: "chat-2", metadata: { _stream_delta: true } }));
 
-    await expect(manager.dispatchAvailable()).resolves.toBe(2);
-    expect(websocket.sendDelta).toHaveBeenNthCalledWith(1, "chat-1", "hello", {
+    await expect(manager.dispatchAvailable()).resolves.toBe(3);
+    expect(websocket.sendDelta).toHaveBeenNthCalledWith(1, "chat-1", "hel", { _stream_delta: true });
+    expect(websocket.sendDelta).toHaveBeenNthCalledWith(2, "chat-1", "lo", {
       _stream_delta: true,
       _stream_end: true,
     });
-    expect(websocket.sendDelta).toHaveBeenNthCalledWith(2, "chat-2", "separate", { _stream_delta: true });
+    expect(websocket.sendDelta).toHaveBeenNthCalledWith(3, "chat-2", "separate", { _stream_delta: true });
   });
 
   test("retries failed sends and records final failures without throwing", async () => {

--- a/apps/desktop/workers/ts-agent-worker/src/channels/channelManager.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/channels/channelManager.ts
@@ -215,9 +215,6 @@ export class ChannelManager {
         });
         continue;
       }
-      if (message.metadata._stream_delta && !message.metadata._stream_end) {
-        message = this.coalesceStreamDeltas(message);
-      }
       const channel = this.channels.get(message.channel);
       if (!channel) {
         this.dispatchDiagnostics.push({
@@ -247,32 +244,6 @@ export class ChannelManager {
 
   private nextOutbound(): OutboundMessage | null {
     return this.pendingOutbound.shift() ?? this.bus.tryConsumeOutbound();
-  }
-
-  private coalesceStreamDeltas(first: OutboundMessage): OutboundMessage {
-    const targetChannel = first.channel;
-    const targetChat = first.chatId;
-    let content = first.content;
-    const metadata = { ...first.metadata };
-
-    while (!metadata._stream_end) {
-      const next = this.bus.tryConsumeOutbound();
-      if (next === null) {
-        break;
-      }
-      const sameTarget = next.channel === targetChannel && next.chatId === targetChat;
-      const isDelta = Boolean(next.metadata._stream_delta);
-      if (!sameTarget || !isDelta) {
-        this.pendingOutbound.push(next);
-        break;
-      }
-      content += next.content;
-      if (next.metadata._stream_end) {
-        metadata._stream_end = true;
-      }
-    }
-
-    return { ...first, content, metadata };
   }
 
   private async sendOnce(channel: ChannelAdapter, message: OutboundMessage): Promise<void> {

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.test.ts
@@ -29,6 +29,60 @@ async function waitForExpectation(assertion: () => Promise<void> | void, timeout
 }
 
 describe("WebUI OpenAI-compatible routes", () => {
+  test("streams chat completions as OpenAI-compatible SSE chunks", async () => {
+    const configProvider: WebuiConfigProvider = {
+      getConfig: () => ({
+        agents: { defaults: { model: "test-model" } },
+        api: { timeout: 3 },
+      }),
+      patchConfig: () => ({}),
+    };
+    const openAiCompatProvider: WebuiOpenAiCompatProvider = {
+      completeChat: (request) => {
+        request.onContentDelta?.("hel");
+        request.onContentDelta?.("lo");
+        return "hello";
+      },
+    };
+
+    const response = await handleWebuiRouteRequest(
+      {
+        method: "POST",
+        path: "/v1/chat/completions",
+        body: {
+          model: "test-model",
+          session_id: "streamed",
+          stream: true,
+          messages: [{ role: "user", content: "hello" }],
+        },
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      configProvider,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      openAiCompatProvider,
+      undefined,
+      undefined,
+      "trace-openai-stream",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response).toMatchObject({
+      headers: { "Content-Type": "text/event-stream" },
+    });
+    expect(String(response.body)).toContain('"object":"chat.completion.chunk"');
+    expect(String(response.body)).toContain('"content":"hel"');
+    expect(String(response.body)).toContain('"content":"lo"');
+    expect(String(response.body)).toContain("data: [DONE]");
+  });
+
   test("retries empty chat completions once before returning the Python fallback", async () => {
     const completions: Array<{ content: string; sessionKey: string; traceId: string; timeoutSeconds: number }> = [];
     const configProvider: WebuiConfigProvider = {

--- a/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/webui/webuiRoutes.ts
@@ -59,6 +59,7 @@ export type WebuiRouteRequest = {
 export type WebuiRouteResponse = {
   status: number;
   body: unknown;
+  headers?: Record<string, unknown>;
 };
 
 export type WebuiStatusSnapshot = {
@@ -924,6 +925,9 @@ async function openAiChatCompletionsResponse(
       model: parsed.model,
       timeoutSeconds: openAiRequestTimeoutSeconds(config),
     };
+    if (parsed.stream) {
+      return openAiStreamingChatCompletionResponse(completionRequest, openAiCompatProvider, traceId);
+    }
     let content = await openAiCompatProvider.completeChat(completionRequest, traceId);
     if (content.trim().length === 0) {
       content = await openAiCompatProvider.completeChat(completionRequest, traceId);
@@ -943,13 +947,10 @@ async function openAiChatCompletionsResponse(
 function parseOpenAiChatRequest(
   body: JsonObject,
   configuredModel: string,
-): { ok: true; content: string; sessionKey: string; model: string } | { ok: false; message: string } {
+): { ok: true; content: string; sessionKey: string; model: string; stream: boolean } | { ok: false; message: string } {
   const messages = Array.isArray(body.messages) ? body.messages : undefined;
   if (!messages || messages.length !== 1) {
     return { ok: false, message: "Only a single user message is supported" };
-  }
-  if (pythonTruthy(body.stream)) {
-    return { ok: false, message: "stream=true is not supported yet. Set stream=false or omit it." };
   }
   if (!isJsonObject(messages[0]) || messages[0].role !== "user") {
     return { ok: false, message: "Only a single user message is supported" };
@@ -965,6 +966,56 @@ function parseOpenAiChatRequest(
     content,
     sessionKey: sessionId ? `api:${sessionId}` : "api:default",
     model: configuredModel,
+    stream: pythonTruthy(body.stream),
+  };
+}
+
+async function openAiStreamingChatCompletionResponse(
+  completionRequest: WebuiOpenAiChatRequest,
+  openAiCompatProvider: WebuiOpenAiCompatProvider,
+  traceId: string,
+): Promise<WebuiRouteResponse> {
+  const chunks: string[] = [];
+  let emittedContent = "";
+  const content = await openAiCompatProvider.completeChat({
+    ...completionRequest,
+    onContentDelta: (delta) => {
+      emittedContent += delta;
+      chunks.push(openAiSseData(openAiChatCompletionChunk(completionRequest.model, { content: delta })));
+    },
+    onReasoningDelta: (delta) => {
+      chunks.push(openAiSseData(openAiChatCompletionChunk(completionRequest.model, { reasoning_content: delta })));
+    },
+  }, traceId);
+  if (!emittedContent && content) {
+    chunks.push(openAiSseData(openAiChatCompletionChunk(completionRequest.model, { content })));
+  }
+  chunks.push(openAiSseData({
+    ...openAiChatCompletionChunk(completionRequest.model, {}),
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+  }));
+  chunks.push("data: [DONE]\n\n");
+  return {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+    },
+    body: chunks.join(""),
+  };
+}
+
+function openAiSseData(value: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(value)}\n\n`;
+}
+
+function openAiChatCompletionChunk(model: string, delta: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: `chatcmpl-${Math.random().toString(16).slice(2, 14).padEnd(12, "0")}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{ index: 0, delta, finish_reason: null }],
   };
 }
 


### PR DESCRIPTION
## Summary
- Forward native desktop agent stream events through Tauri-safe event names and wait for listeners before opening the native WebSocket bridge.
- Preserve live `agent.delta` rendering while preventing direct TS agent listeners from double-consuming `websocket-*` runs.
- Suppress final `AgentRunResult.finalContent` fallback rendering after a streamed native chat run, including when `agent.done` arrives before dispatch resolves.
- Make native chat completed-message handling idempotent for an existing streamed assistant `messageId`.
- Add regression coverage for SSE/native fetch bridging, native WebSocket stream projection, Tauri event naming, runtime duplicate suppression, and native chat reducer deduplication.

Closes #287.
Fixes #289.

## Verification
- `npm test -- desktopNativeWebSocketBridge.test.ts nativeChat.test.ts`
- `npm test -- desktopNativeTauriEvents.test.ts desktopNativeWebSocketBridge.test.ts desktopNativeWorkbenchRuntime.test.ts nativeChat.test.ts gateway.test.ts`
- `npm run typecheck:worker`
- `npm run build`
- `cargo check`
- `cargo test frontend --lib`
- `git diff --check -- apps/desktop/src/desktopNativeWebSocketBridge.ts apps/desktop/src/desktopNativeWebSocketBridge.test.ts apps/desktop/src/nativeChat.ts apps/desktop/src/nativeChat.test.ts`