### PR TITLE
Polish native session list actions

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -278,7 +278,8 @@ async function bootDesktopWebUi(): Promise<void> {
         sessionCount: nativeChatRuntime.chat.sessions.length,
       });
       startupTrace.start("initialPaneModels");
-      const settingsPane = buildInitialNativeSettingsPane();
+      const settingsPane = await loadNativeSettingsPane();
+      nativeChatRuntime.setRuntimeMetadata(nativeRuntimeMetadataFromSettings());
       const knowledgePane = buildInitialNativeKnowledgePane();
       const toolsSkillsPane = buildInitialNativeToolsSkillsPane();
       const coworkPane = buildInitialNativeCoworkPane();
@@ -393,19 +394,6 @@ async function bootDesktopWebUi(): Promise<void> {
       true,
     );
   }
-}
-
-function buildInitialNativeSettingsPane(): DesktopSettingsPaneModel {
-  const state = buildDesktopSettingsFormState({});
-  nativeSettingsConfig = {};
-  nativeSettingsState = state;
-  nativeSettingsLastSavedState = state;
-  nativeSettingsProviderCatalog = [];
-  return buildDesktopSettingsPaneModel(state, {
-    lastSavedState: state,
-    providerCatalog: [],
-    saveStatus: "idle",
-  });
 }
 
 function buildInitialNativeKnowledgePane(): DesktopKnowledgePaneModel {
@@ -751,14 +739,18 @@ function syncNativeRuntimeMetadata(): void {
   if (!nativeWorkbenchRuntime) {
     return;
   }
-  nativeWorkbenchRuntime.setRuntimeMetadata({
+  nativeWorkbenchRuntime.setRuntimeMetadata(nativeRuntimeMetadataFromSettings());
+  updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
+}
+
+function nativeRuntimeMetadataFromSettings(): NonNullable<DesktopNativeWorkbenchRuntime["chat"]["runtime"]> {
+  return {
     provider: nativeSettingsState?.agent.provider || undefined,
     model: nativeSettingsState?.agent.model || undefined,
     contextWindowTokens: nativeSettingsState?.agent.contextWindowTokens ?? undefined,
     maxToolIterations: nativeSettingsState?.agent.maxToolIterations ?? undefined,
     gatewayHttp: gatewayConfig.httpBaseUrl,
-  });
-  updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
+  };
 }
 
 async function handleNativeChatGatewayEvent(event: NormalizedGatewayEvent): Promise<void> {
@@ -805,6 +797,9 @@ function nativeChatActions() {
     onAttachSessionFile: () => {
       document.getElementById("desktop-session-file-upload")?.click();
     },
+    onSelectModel: () => {
+      void selectNativeComposerModel();
+    },
     onNewChat: () => {
       if (!nativeWorkbenchRuntime) {
         return;
@@ -833,6 +828,70 @@ function nativeChatActions() {
       updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
     },
   };
+}
+
+async function selectNativeComposerModel(): Promise<void> {
+  if (!nativeWorkbenchRuntime) {
+    return;
+  }
+  if (!nativeSettingsState) {
+    await loadNativeSettingsPane();
+  }
+  if (!nativeSettingsState) {
+    return;
+  }
+  const currentModel = nativeSettingsState.agent.model || nativeWorkbenchRuntime.chat.runtime?.model || "";
+  const modelOptions = nativeComposerModelOptions(nativeSettingsState);
+  const selectedModel = promptNativeComposerModel(document, modelOptions, currentModel);
+  if (!selectedModel || selectedModel === currentModel) {
+    return;
+  }
+  nativeSettingsState = applyDesktopSettingsFieldEdit(nativeSettingsState, "model", selectedModel);
+  syncNativeRuntimeMetadata();
+  await saveNativeSettingsPane();
+}
+
+function nativeComposerModelOptions(state: DesktopSettingsFormState): string[] {
+  const providerId = state.agent.provider && state.agent.provider !== "auto"
+    ? state.agent.provider
+    : state.providerEditor.selectedProvider;
+  const provider = state.providerSummaries.find((summary) => summary.id === providerId);
+  const rawModels = provider?.modelsText || state.providerEditor.modelsText;
+  const models = rawModels
+    .split(/\r?\n|,/)
+    .map((model) => model.trim())
+    .filter(Boolean);
+  if (state.agent.model && !models.includes(state.agent.model)) {
+    models.unshift(state.agent.model);
+  }
+  return Array.from(new Set(models));
+}
+
+function promptNativeComposerModel(
+  targetDocument: Document,
+  models: string[],
+  currentModel: string,
+): string | null {
+  const prompt = targetDocument.defaultView?.prompt;
+  if (typeof prompt !== "function") {
+    return null;
+  }
+  if (!models.length) {
+    return prompt("Model", currentModel || "")?.trim() || null;
+  }
+  const message = [
+    "Select model by number or enter a model id:",
+    ...models.map((model, index) => `${index + 1}. ${model}${model === currentModel ? " (current)" : ""}`),
+  ].join("\n");
+  const value = prompt(message, currentModel || models[0])?.trim();
+  if (!value) {
+    return null;
+  }
+  const index = Number(value);
+  if (Number.isInteger(index) && index >= 1 && index <= models.length) {
+    return models[index - 1];
+  }
+  return value;
 }
 
 function summarizeNativeGatewayEvent(event: NormalizedGatewayEvent): Record<string, unknown> {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -747,6 +747,7 @@ function nativeRuntimeMetadataFromSettings(): NonNullable<DesktopNativeWorkbench
   return {
     provider: nativeSettingsState?.agent.provider || undefined,
     model: nativeSettingsState?.agent.model || undefined,
+    modelOptions: nativeSettingsState ? nativeComposerModelOptions(nativeSettingsState) : undefined,
     contextWindowTokens: nativeSettingsState?.agent.contextWindowTokens ?? undefined,
     maxToolIterations: nativeSettingsState?.agent.maxToolIterations ?? undefined,
     gatewayHttp: gatewayConfig.httpBaseUrl,
@@ -797,8 +798,8 @@ function nativeChatActions() {
     onAttachSessionFile: () => {
       document.getElementById("desktop-session-file-upload")?.click();
     },
-    onSelectModel: () => {
-      void selectNativeComposerModel();
+    onSelectModel: (model: string) => {
+      void selectNativeComposerModel(model);
     },
     onNewChat: () => {
       if (!nativeWorkbenchRuntime) {
@@ -830,7 +831,7 @@ function nativeChatActions() {
   };
 }
 
-async function selectNativeComposerModel(): Promise<void> {
+async function selectNativeComposerModel(selectedModel: string): Promise<void> {
   if (!nativeWorkbenchRuntime) {
     return;
   }
@@ -840,13 +841,15 @@ async function selectNativeComposerModel(): Promise<void> {
   if (!nativeSettingsState) {
     return;
   }
-  const currentModel = nativeSettingsState.agent.model || nativeWorkbenchRuntime.chat.runtime?.model || "";
-  const modelOptions = nativeComposerModelOptions(nativeSettingsState);
-  const selectedModel = promptNativeComposerModel(document, modelOptions, currentModel);
-  if (!selectedModel || selectedModel === currentModel) {
+  const nextModel = selectedModel.trim();
+  if (!nextModel) {
     return;
   }
-  nativeSettingsState = applyDesktopSettingsFieldEdit(nativeSettingsState, "model", selectedModel);
+  const currentModel = nativeSettingsState.agent.model || nativeWorkbenchRuntime.chat.runtime?.model || "";
+  if (nextModel === currentModel) {
+    return;
+  }
+  nativeSettingsState = applyDesktopSettingsFieldEdit(nativeSettingsState, "model", nextModel);
   syncNativeRuntimeMetadata();
   await saveNativeSettingsPane();
 }
@@ -865,33 +868,6 @@ function nativeComposerModelOptions(state: DesktopSettingsFormState): string[] {
     models.unshift(state.agent.model);
   }
   return Array.from(new Set(models));
-}
-
-function promptNativeComposerModel(
-  targetDocument: Document,
-  models: string[],
-  currentModel: string,
-): string | null {
-  const prompt = targetDocument.defaultView?.prompt;
-  if (typeof prompt !== "function") {
-    return null;
-  }
-  if (!models.length) {
-    return prompt("Model", currentModel || "")?.trim() || null;
-  }
-  const message = [
-    "Select model by number or enter a model id:",
-    ...models.map((model, index) => `${index + 1}. ${model}${model === currentModel ? " (current)" : ""}`),
-  ].join("\n");
-  const value = prompt(message, currentModel || models[0])?.trim();
-  if (!value) {
-    return null;
-  }
-  const index = Number(value);
-  if (Number.isInteger(index) && index >= 1 && index <= models.length) {
-    return models[index - 1];
-  }
-  return value;
 }
 
 function summarizeNativeGatewayEvent(event: NormalizedGatewayEvent): Record<string, unknown> {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -947,14 +947,15 @@ describe("desktop workbench shell", () => {
     const primaryAction = targetDocument.body.querySelector(".desktop-sidebar-primary-action");
     const sidebarSearch = targetDocument.body.querySelector(".desktop-sidebar-search");
     const workspaceList = targetDocument.body.querySelector(".desktop-workspace-list");
+    const workspaceSection = targetDocument.body.querySelector(".desktop-sidebar-list-section-workspaces");
     const recentChats = targetDocument.body.querySelector(".desktop-recent-chat-list");
     expect(primaryAction).toBeTruthy();
     expect(sidebarSearch).toBeTruthy();
-    expect(workspaceList).toBeTruthy();
+    expect(workspaceSection).toBeNull();
+    expect(workspaceList).toBeNull();
     expect(recentChats).toBeTruthy();
     expect(primaryAction?.textContent).toContain("New chat");
     expect(sidebarSearch?.getAttribute("placeholder")).toBe("Search");
-    expect(workspaceList?.textContent).toContain("tinybot");
     expect(recentChats?.textContent).toContain("Design native workbench");
     const sidebarStyle = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
     expect(sidebarStyle).toContain("flex-direction: column;");
@@ -1030,7 +1031,8 @@ describe("desktop workbench shell", () => {
       },
     });
 
-    expect(targetDocument.body.querySelector(".desktop-sidebar-list-section-workspaces")?.textContent).toContain("tinybot");
+    expect(targetDocument.body.querySelector(".desktop-sidebar-list-section-workspaces")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-workspace-list")).toBeNull();
     expect(targetDocument.body.querySelector(".desktop-sidebar-list-section-recent")?.textContent).toContain("Live session");
     expect(targetDocument.body.querySelectorAll(".desktop-workbench-link")).toHaveLength(0);
     expect(targetDocument.body.querySelectorAll("[data-sidebar-command]")).toHaveLength(0);

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -510,17 +510,19 @@ describe("desktop workbench shell", () => {
         activeSessionKey: "",
         activeChatId: "",
         messages: [],
-        runtime: { model: "deepseek-reasoner" },
+        runtime: { model: "deepseek-reasoner", modelOptions: ["deepseek-chat", "deepseek-reasoner"] },
       },
       chatActions: {
-        onSelectModel: () => selections.push("model"),
+        onSelectModel: (model) => selections.push(model),
       },
     });
 
     const model = targetDocument.body.querySelector('[data-desktop-composer-action="model-select"]') as HTMLButtonElement | null;
     expect(model?.textContent).toContain("deepseek-reasoner");
     model?.click();
-    expect(selections).toEqual(["model"]);
+    expect(model?.querySelector('[role="listbox"]')?.textContent).toContain("deepseek-chat");
+    (model?.querySelector('[data-desktop-composer-model-option="deepseek-chat"]') as HTMLButtonElement | null)?.click();
+    expect(selections).toEqual(["deepseek-chat"]);
   });
 
   test("overlays recent chat timestamps and delete actions in the same right slot", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -510,9 +510,18 @@ describe("desktop workbench shell", () => {
     expect(styleText).toMatch(
       /body\.desktop-native-workbench \.desktop-sidebar-chat-row \.desktop-sidebar-row-main \{\s*grid-template-columns: minmax\(0, 1fr\);\s*\}/,
     );
-    expect(styleText).toMatch(
-      /body\.desktop-native-workbench \.desktop-sidebar-delete-session \{[\s\S]*display: inline-flex;[\s\S]*right: 10px;[\s\S]*width: 64px;[\s\S]*padding: 0 8px;[\s\S]*justify-content: flex-end;/,
-    );
+    const deleteRule = styleText.match(
+      /body\.desktop-native-workbench \.desktop-sidebar-delete-session \{(?<rule>[\s\S]*?)\n    \}/,
+    )?.groups?.rule ?? "";
+    const confirmRule = styleText.match(
+      /body\.desktop-native-workbench \.desktop-sidebar-delete-session\[data-confirming="true"\] \{(?<rule>[\s\S]*?)\n    \}/,
+    )?.groups?.rule ?? "";
+    expect(deleteRule).toContain("display: inline-flex;");
+    expect(deleteRule).toContain("right: 10px;");
+    expect(deleteRule).toContain("width: 24px;");
+    expect(deleteRule).toContain("padding: 0;");
+    expect(deleteRule).toContain("justify-content: center;");
+    expect(confirmRule).toContain("width: 64px;");
     expect(styleText).toMatch(
       /body\.desktop-native-workbench \.desktop-sidebar-row-meta \{[\s\S]*position: absolute;[\s\S]*right: 10px;[\s\S]*width: 64px;/,
     );

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -511,10 +511,13 @@ describe("desktop workbench shell", () => {
       /body\.desktop-native-workbench \.desktop-sidebar-chat-row \.desktop-sidebar-row-main \{\s*grid-template-columns: minmax\(0, 1fr\);\s*\}/,
     );
     expect(styleText).toMatch(
-      /body\.desktop-native-workbench \.desktop-sidebar-delete-session \{[\s\S]*right: 10px;[\s\S]*width: 64px;/,
+      /body\.desktop-native-workbench \.desktop-sidebar-delete-session \{[\s\S]*display: inline-flex;[\s\S]*right: 10px;[\s\S]*width: 64px;[\s\S]*padding: 0 8px;[\s\S]*justify-content: flex-end;/,
     );
     expect(styleText).toMatch(
       /body\.desktop-native-workbench \.desktop-sidebar-row-meta \{[\s\S]*position: absolute;[\s\S]*right: 10px;[\s\S]*width: 64px;/,
+    );
+    expect(styleText).toMatch(
+      /body\.desktop-native-workbench \.desktop-sidebar-chat-row:hover \.desktop-sidebar-delete-session,\s*body\.desktop-native-workbench \.desktop-sidebar-chat-row:focus-within \.desktop-sidebar-delete-session,\s*body\.desktop-native-workbench \.desktop-sidebar-delete-session\[data-deleting="true"\] \{[\s\S]*background: #f2efec;/,
     );
   });
 

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { buildDesktopCoworkCockpitView, buildDesktopCoworkSessionRows } from "./desktopCowork";
 import { buildDesktopKnowledgePaneModel } from "./desktopKnowledgeTraceability";
 import { buildDesktopRunChainItems } from "./desktopRunChainInspector";
@@ -255,6 +255,10 @@ function findEntityRow(root: FakeElement | null | undefined, module: string, ent
 }
 
 describe("desktop workbench shell", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test("renders persistent desktop regions from layout state", () => {
     const targetDocument = new FakeDocument();
 
@@ -448,12 +452,49 @@ describe("desktop workbench shell", () => {
     deleteButton?.click();
     expect(deletedSessions).toEqual([]);
     expect(deleteButton?.getAttribute("aria-label")).toBe("Confirm delete chat Live gateway session");
-    expect(deleteButton?.textContent).toBe("Confirm");
+    expect(deleteButton?.textContent).toBe("确认");
     deleteButton?.click();
     expect(deleteButton?.getAttribute("data-deleting")).toBe("true");
     expect(deleteButton?.getAttribute("disabled")).toBe("");
-    expect(deleteButton?.textContent).toBe("Deleting");
+    expect(deleteButton?.textContent).toBe("删除中");
     expect(deletedSessions).toEqual(["WebSocket:chat-live"]);
+  });
+
+  test("renders recent chat timestamps as single relative units", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-22T12:00:00.000Z"));
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [
+          {
+            key: "WebSocket:chat-min",
+            chatId: "chat-min",
+            title: "Minute",
+            createdAt: "",
+            updatedAt: `unix-ms:${new Date("2026-06-22T11:30:00.000Z").getTime()}`,
+          },
+          { key: "WebSocket:chat-hour", chatId: "chat-hour", title: "Hour", createdAt: "", updatedAt: "2026-06-22T07:00:00.000Z" },
+          { key: "WebSocket:chat-day", chatId: "chat-day", title: "Day", createdAt: "", updatedAt: "2026-06-19T12:00:00.000Z" },
+          { key: "WebSocket:chat-week", chatId: "chat-week", title: "Week", createdAt: "", updatedAt: "2026-06-07T12:00:00.000Z" },
+          { key: "WebSocket:chat-month", chatId: "chat-month", title: "Month", createdAt: "", updatedAt: "2026-04-13T12:00:00.000Z" },
+        ],
+        activeSessionKey: "WebSocket:chat-min",
+        activeChatId: "chat-min",
+        messages: [],
+      },
+    });
+
+    const labels = targetDocument.body
+      .querySelector(".desktop-recent-chat-list")
+      ?.querySelectorAll(".desktop-sidebar-row-meta")
+      .map((node) => node.textContent);
+
+    expect(labels).toEqual(["30分", "5小时", "3天", "2周", "2月"]);
   });
 
   test("updates native chat regions without reinstalling the whole workbench", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -497,6 +497,32 @@ describe("desktop workbench shell", () => {
     expect(labels).toEqual(["30分", "5小时", "3天", "2周", "2月"]);
   });
 
+  test("renders the configured composer model and routes model selection", () => {
+    const targetDocument = new FakeDocument();
+    const selections: string[] = [];
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [],
+        activeSessionKey: "",
+        activeChatId: "",
+        messages: [],
+        runtime: { model: "deepseek-reasoner" },
+      },
+      chatActions: {
+        onSelectModel: () => selections.push("model"),
+      },
+    });
+
+    const model = targetDocument.body.querySelector('[data-desktop-composer-action="model-select"]') as HTMLButtonElement | null;
+    expect(model?.textContent).toContain("deepseek-reasoner");
+    model?.click();
+    expect(selections).toEqual(["model"]);
+  });
+
   test("overlays recent chat timestamps and delete actions in the same right slot", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -497,6 +497,27 @@ describe("desktop workbench shell", () => {
     expect(labels).toEqual(["30分", "5小时", "3天", "2周", "2月"]);
   });
 
+  test("overlays recent chat timestamps and delete actions in the same right slot", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
+    expect(styleText).toMatch(
+      /body\.desktop-native-workbench \.desktop-sidebar-chat-row \.desktop-sidebar-row-main \{\s*grid-template-columns: minmax\(0, 1fr\);\s*\}/,
+    );
+    expect(styleText).toMatch(
+      /body\.desktop-native-workbench \.desktop-sidebar-delete-session \{[\s\S]*right: 10px;[\s\S]*width: 64px;/,
+    );
+    expect(styleText).toMatch(
+      /body\.desktop-native-workbench \.desktop-sidebar-row-meta \{[\s\S]*position: absolute;[\s\S]*right: 10px;[\s\S]*width: 64px;/,
+    );
+  });
+
   test("updates native chat regions without reinstalling the whole workbench", () => {
     const targetDocument = new FakeDocument();
 

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -214,7 +214,7 @@ interface DesktopNativeChatActionOptions {
   onDeleteSession?: (event: DesktopNativeChatDeleteSessionEvent) => unknown | Promise<unknown>;
   onPinSession?: (event: DesktopNativeChatPinSessionEvent) => void;
   onRenameSession?: (event: DesktopNativeChatRenameSessionEvent) => void;
-  onSelectModel?: () => void;
+  onSelectModel?: (model: string) => void;
   onPersistentRagChange?: (enabled: boolean) => void;
 }
 
@@ -383,6 +383,7 @@ export interface DesktopNativeChatModel {
   runtime?: {
     provider?: string;
     model?: string;
+    modelOptions?: string[];
     temperature?: number | null;
     maxTokens?: number | null;
     reasoningEffort?: string | null;
@@ -2909,11 +2910,12 @@ function mountComposerSurfaceVueIsland(
     activeSessionKey: chat?.activeSessionKey || null,
     composerState: nativeComposerState(chat),
     model: chat?.runtime?.model || null,
+    modelOptions: chat?.runtime?.modelOptions || [],
     responding: chat?.responding === true,
     tokenUsage: chat?.runtime?.tokenUsage || "-",
     usePersistentRag: chat?.usePersistentRag !== false,
     onAttach: () => chatActions.onAttachSessionFile?.(),
-    onModelSelect: () => chatActions.onSelectModel?.(),
+    onModelSelect: (model) => chatActions.onSelectModel?.(model),
     onPersistentRagChange: (enabled) => chatActions.onPersistentRagChange?.(enabled),
     onSend: (event) => chatActions.onComposerSubmit?.(event),
   });
@@ -2982,9 +2984,10 @@ function mountComposerRuntimeVueIsland(
   }
   mountComposerRuntimeIsland(runtime, {
     model: chat?.runtime?.model || null,
+    modelOptions: chat?.runtime?.modelOptions || [],
     persistentRag: chat?.usePersistentRag !== false,
     tokenUsage: chat?.runtime?.tokenUsage || "-",
-    onModelSelect: () => chatActions.onSelectModel?.(),
+    onModelSelect: (model) => chatActions.onSelectModel?.(model),
     onPersistentRagChange: (enabled) => chatActions.onPersistentRagChange?.(enabled),
   });
 }
@@ -3067,30 +3070,124 @@ function createComposerModelControl(
   chatActions: DesktopNativeChatActionOptions = {},
 ): HTMLElement {
   const button = targetDocument.createElement("button");
+  const currentModel = chat?.runtime?.model || "Tinybot Pro";
+  const modelOptions = normalizeComposerModelOptions(currentModel, chat?.runtime?.modelOptions);
   button.type = "button";
   button.className = "desktop-native-composer-model";
   button.setAttribute("data-desktop-composer-action", "model-select");
   button.setAttribute("aria-label", "Select model");
-  button.textContent = chat?.runtime?.model || "Tinybot Pro";
-  mountComposerModelControlVueIsland(button, chat?.runtime?.model || null, chatActions);
+  button.textContent = currentModel;
+  mountComposerModelControlVueIsland(button, chat?.runtime?.model || null, modelOptions, chatActions);
   return button;
 }
 
 function mountComposerModelControlVueIsland(
   button: HTMLElement,
   model: string | null,
+  modelOptions: string[],
   chatActions: DesktopNativeChatActionOptions,
 ): void {
   if (!canMountVueIsland(button)) {
-    button.addEventListener("click", () => {
-      chatActions.onSelectModel?.();
-    });
+    installFallbackComposerModelMenu(button, model || "Tinybot Pro", modelOptions, chatActions);
     return;
   }
   mountComposerModelControlIsland(button, {
     model,
-    onModelSelect: () => chatActions.onSelectModel?.(),
+    modelOptions,
+    onModelSelect: (selectedModel) => chatActions.onSelectModel?.(selectedModel),
   });
+}
+
+function installFallbackComposerModelMenu(
+  button: HTMLElement,
+  currentModel: string,
+  modelOptions: string[],
+  chatActions: DesktopNativeChatActionOptions,
+): void {
+  const targetDocument = button.ownerDocument;
+  const label = targetDocument.createElement("span");
+  label.className = "desktop-native-composer-model-label";
+  label.textContent = currentModel;
+  button.textContent = "";
+  button.replaceChildren(label);
+  button.addEventListener("click", () => {
+    const existingMenu = button.querySelector('[role="listbox"]');
+    if (existingMenu) {
+      existingMenu.remove();
+      return;
+    }
+    button.append(createFallbackComposerModelMenu(targetDocument, currentModel, modelOptions, chatActions));
+  });
+}
+
+function createFallbackComposerModelMenu(
+  targetDocument: Document,
+  currentModel: string,
+  modelOptions: string[],
+  chatActions: DesktopNativeChatActionOptions,
+): HTMLElement {
+  const menu = targetDocument.createElement("span");
+  menu.className = "desktop-native-composer-model-menu";
+  menu.setAttribute("role", "listbox");
+  menu.setAttribute("aria-label", "Model");
+  menu.addEventListener("click", (event) => {
+    (event as { stopPropagation?: () => void }).stopPropagation?.();
+  });
+
+  const title = targetDocument.createElement("span");
+  title.className = "desktop-native-composer-model-menu-title";
+  title.textContent = "Model";
+  menu.append(title);
+
+  for (const optionModel of normalizeComposerModelOptions(currentModel, modelOptions)) {
+    const option = targetDocument.createElement("span");
+    option.className = "desktop-native-composer-model-option";
+    option.setAttribute("role", "option");
+    option.setAttribute("aria-selected", String(optionModel === currentModel));
+    option.setAttribute("data-desktop-composer-model-option", optionModel);
+
+    const optionLabel = targetDocument.createElement("span");
+    optionLabel.className = "desktop-native-composer-model-option-label";
+    optionLabel.textContent = optionModel;
+    option.append(optionLabel);
+    if (optionModel === currentModel) {
+      option.append(createComposerModelCheckIcon(targetDocument));
+    }
+    option.addEventListener("click", (event) => {
+      (event as { stopPropagation?: () => void }).stopPropagation?.();
+      menu.remove();
+      chatActions.onSelectModel?.(optionModel);
+    });
+    menu.append(option);
+  }
+  return menu;
+}
+
+function normalizeComposerModelOptions(currentModel: string, modelOptions: string[] | undefined): string[] {
+  const options = (modelOptions ?? [])
+    .map((option) => option.trim())
+    .filter(Boolean);
+  if (currentModel && !options.includes(currentModel)) {
+    options.unshift(currentModel);
+  }
+  return Array.from(new Set(options));
+}
+
+function createComposerModelCheckIcon(targetDocument: Document): SVGElement {
+  const icon = targetDocument.createElement("svg") as unknown as SVGElement;
+  icon.setAttribute("class", "desktop-native-composer-model-check");
+  icon.setAttribute("aria-hidden", "true");
+  icon.setAttribute("viewBox", "0 0 20 20");
+  icon.setAttribute("focusable", "false");
+  const path = targetDocument.createElement("path") as unknown as SVGPathElement;
+  path.setAttribute("d", "M16.5 5.5 8.25 13.75 4 9.5");
+  path.setAttribute("fill", "none");
+  path.setAttribute("stroke", "currentColor");
+  path.setAttribute("stroke-width", "2");
+  path.setAttribute("stroke-linecap", "round");
+  path.setAttribute("stroke-linejoin", "round");
+  icon.append(path);
+  return icon;
 }
 
 function createPersistentRagToggle(
@@ -12169,6 +12266,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-native-composer-model {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       min-height: 34px;
       border: 0;
       border-radius: 999px;
@@ -12178,6 +12279,58 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       font: 600 12px/1.2 var(--font-sans);
       box-shadow: none;
       cursor: pointer;
+      white-space: nowrap;
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-model-menu {
+      position: absolute;
+      right: 0;
+      bottom: calc(100% + 10px);
+      z-index: 40;
+      display: flex;
+      min-width: 220px;
+      max-width: min(320px, 70vw);
+      padding: 8px;
+      flex-direction: column;
+      gap: 2px;
+      border: 1px solid #ded8d0;
+      border-radius: 16px;
+      background: #ffffff;
+      color: #262522;
+      box-shadow: 0 18px 38px rgba(53, 45, 34, 0.16);
+      text-align: left;
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-model-menu-title {
+      padding: 4px 10px 6px;
+      color: #77736f;
+      font: 500 12px/1.2 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-model-option {
+      display: flex;
+      min-height: 34px;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      border-radius: 10px;
+      padding: 0 10px;
+      color: #262522;
+      font: 500 14px/1.2 var(--font-sans);
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-model-option:hover,
+    body.desktop-native-workbench .desktop-native-composer-model-option:focus-visible {
+      background: #f5f1ec;
+      outline: 0;
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-model-check {
+      width: 18px;
+      height: 18px;
+      flex: 0 0 auto;
+      color: #5f5a55;
     }
 
     body.desktop-native-workbench .desktop-native-composer-model:hover,
@@ -13990,6 +14143,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header-panel-button,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-popover,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-menu,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-token-orb {
       background: var(--panel-strong);
@@ -13999,6 +14153,15 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-action {
+      color: var(--text);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-menu-title {
+      color: var(--text-muted);
+    }
+
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-option,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-check {
       color: var(--text);
     }
 
@@ -14014,6 +14177,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu:focus-visible,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-action:hover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-action:focus-visible,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-option:hover,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-option:focus-visible,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header-panel-button:hover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header-panel-button:focus-visible,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model:hover,

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -10440,13 +10440,17 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-sidebar-delete-session {
       position: absolute;
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-end;
       right: 10px;
       top: 50%;
       transform: translateY(-50%);
       width: 64px;
       min-height: 24px;
       border: 1px solid transparent;
-      border-radius: 5px;
+      border-radius: 999px;
+      padding: 0 8px;
       background: transparent;
       color: #8b5b4e;
       font: 600 11px/1 var(--font-sans);
@@ -10461,6 +10465,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       border-color: #f2c9c2;
       background: #fff0ee;
       color: #9f2f25;
+      justify-content: center;
       opacity: 1;
       pointer-events: auto;
     }
@@ -10480,6 +10485,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-sidebar-chat-row:hover .desktop-sidebar-delete-session,
     body.desktop-native-workbench .desktop-sidebar-chat-row:focus-within .desktop-sidebar-delete-session,
     body.desktop-native-workbench .desktop-sidebar-delete-session[data-deleting="true"] {
+      background: #f2efec;
       opacity: 1;
       pointer-events: auto;
     }

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -10442,15 +10442,15 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       position: absolute;
       display: inline-flex;
       align-items: center;
-      justify-content: flex-end;
+      justify-content: center;
       right: 10px;
       top: 50%;
       transform: translateY(-50%);
-      width: 64px;
+      width: 24px;
       min-height: 24px;
       border: 1px solid transparent;
       border-radius: 999px;
-      padding: 0 8px;
+      padding: 0;
       background: transparent;
       color: #8b5b4e;
       font: 600 11px/1 var(--font-sans);

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -112,7 +112,6 @@ import { mountSidebarContentIsland } from "./native-vue/sidebarContentIsland";
 import { mountSidebarRecentChatsIsland, type SidebarRecentChatRow } from "./native-vue/sidebarRecentChatsIsland";
 import { mountSidebarRowIsland } from "./native-vue/sidebarRowIsland";
 import { mountSidebarSectionHeadingIsland } from "./native-vue/sidebarSectionHeadingIsland";
-import { mountSidebarWorkspaceListIsland } from "./native-vue/sidebarWorkspaceListIsland";
 import { mountSettingsDefaultLlmIsland } from "./native-vue/settingsDefaultLlmIsland";
 import { mountSettingsGroupsIsland } from "./native-vue/settingsGroupsIsland";
 import { mountSettingsPaneIsland } from "./native-vue/settingsPaneIsland";
@@ -670,12 +669,6 @@ export function updateDesktopNativeChat(
 
   syncChatWorkbenchChrome(targetDocument, chat);
 
-  const workspaceList = targetDocument.querySelector<HTMLElement>(".desktop-workspace-list");
-  if (workspaceList) {
-    const next = createSidebarWorkspaceList(targetDocument, chat).querySelector<HTMLElement>(".desktop-workspace-list");
-    workspaceList.replaceChildren(...Array.from(next?.children ?? []));
-  }
-
   const recentChats = targetDocument.querySelector<HTMLElement>(".desktop-recent-chat-list");
   const recentChatsSection = targetDocument.querySelector<HTMLElement>(".desktop-sidebar-list-section-recent");
   if (recentChatsSection && canMountVueIsland(recentChatsSection)) {
@@ -921,7 +914,6 @@ function createSidebar(
   sidebar.className = "desktop-sidebar-content";
   sidebar.append(
     createSidebarActions(targetDocument),
-    createSidebarWorkspaceList(targetDocument, chat),
     createSidebarRecentChats(targetDocument, chat, chatActions),
   );
   if (chat) {
@@ -949,12 +941,6 @@ function mountSidebarContentVueIsland(
     recentChats,
     resourceItems: [],
     targetDocument,
-    workspaceRows: [{
-      active: true,
-      entityId: "tinybot",
-      meta: chat.activeSessionKey ? "Active session" : "Ready",
-      title: "tinybot",
-    }],
   });
 }
 
@@ -985,53 +971,6 @@ function mountSidebarActionsVueIsland(section: HTMLElement): void {
     return;
   }
   mountSidebarActionsIsland(section);
-}
-
-function createSidebarWorkspaceList(targetDocument: Document, chat: DesktopNativeChatModel | null): HTMLElement {
-  const section = targetDocument.createElement("section");
-  section.className = "desktop-sidebar-list-section desktop-sidebar-list-section-workspaces";
-  section.append(createSidebarSectionHeading(targetDocument, "Workspaces", "+"));
-
-  const list = targetDocument.createElement("div");
-  list.className = "desktop-workspace-list";
-  list.setAttribute("role", "list");
-  const rows = chat ? [["tinybot", chat.activeSessionKey ? "Active session" : "Ready", true]] as const : [
-    ["tinybot", "1m ago", true],
-    ["ai-rvc", "2h ago", false],
-    ["ai-light", "Yesterday", false],
-    ["ai-tv", "2d ago", false],
-    ["ai-fridge", "3d ago", false],
-    ["genie", "4d ago", false],
-    ["docs", "May 26", false],
-    ["archive", "May 20", false],
-  ] as const;
-  for (const [name, meta, active] of rows) {
-    list.append(createSidebarRow(targetDocument, name, meta, active, "folder", "workspace", name));
-  }
-
-  section.append(list);
-  mountSidebarWorkspaceListVueIsland(section, rows.map(([name, meta, active]) => ({
-    active,
-    entityId: name,
-    meta,
-    title: name,
-  })));
-  return section;
-}
-
-function mountSidebarWorkspaceListVueIsland(
-  section: HTMLElement,
-  rows: Array<{
-    active: boolean;
-    entityId: string;
-    meta: string;
-    title: string;
-  }>,
-): void {
-  if (!canMountVueIsland(section)) {
-    return;
-  }
-  mountSidebarWorkspaceListIsland(section, { rows });
 }
 
 function createSidebarRecentChats(

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -214,6 +214,7 @@ interface DesktopNativeChatActionOptions {
   onDeleteSession?: (event: DesktopNativeChatDeleteSessionEvent) => unknown | Promise<unknown>;
   onPinSession?: (event: DesktopNativeChatPinSessionEvent) => void;
   onRenameSession?: (event: DesktopNativeChatRenameSessionEvent) => void;
+  onSelectModel?: () => void;
   onPersistentRagChange?: (enabled: boolean) => void;
 }
 
@@ -2861,7 +2862,7 @@ function createNativeComposerSurface(
   runtime.setAttribute("data-desktop-composer-region", "runtime-status");
   runtime.setAttribute("aria-label", "Runtime status");
   runtime.append(
-    createComposerModelControl(targetDocument, chat),
+    createComposerModelControl(targetDocument, chat, chatActions),
     createPersistentRagToggle(targetDocument, chat, chatActions),
     createTokenUsageOrb(targetDocument, chat?.runtime?.tokenUsage || "-"),
   );
@@ -2912,6 +2913,7 @@ function mountComposerSurfaceVueIsland(
     tokenUsage: chat?.runtime?.tokenUsage || "-",
     usePersistentRag: chat?.usePersistentRag !== false,
     onAttach: () => chatActions.onAttachSessionFile?.(),
+    onModelSelect: () => chatActions.onSelectModel?.(),
     onPersistentRagChange: (enabled) => chatActions.onPersistentRagChange?.(enabled),
     onSend: (event) => chatActions.onComposerSubmit?.(event),
   });
@@ -2982,6 +2984,7 @@ function mountComposerRuntimeVueIsland(
     model: chat?.runtime?.model || null,
     persistentRag: chat?.usePersistentRag !== false,
     tokenUsage: chat?.runtime?.tokenUsage || "-",
+    onModelSelect: () => chatActions.onSelectModel?.(),
     onPersistentRagChange: (enabled) => chatActions.onPersistentRagChange?.(enabled),
   });
 }
@@ -3058,21 +3061,36 @@ function parseSessionTimestampMs(value: string): number | null {
   return Number.isNaN(timestamp) ? null : timestamp;
 }
 
-function createComposerModelControl(targetDocument: Document, chat: DesktopNativeChatModel | null = null): HTMLElement {
+function createComposerModelControl(
+  targetDocument: Document,
+  chat: DesktopNativeChatModel | null = null,
+  chatActions: DesktopNativeChatActionOptions = {},
+): HTMLElement {
   const button = targetDocument.createElement("button");
   button.type = "button";
   button.className = "desktop-native-composer-model";
+  button.setAttribute("data-desktop-composer-action", "model-select");
   button.setAttribute("aria-label", "Select model");
   button.textContent = chat?.runtime?.model || "Tinybot Pro";
-  mountComposerModelControlVueIsland(button, chat?.runtime?.model || null);
+  mountComposerModelControlVueIsland(button, chat?.runtime?.model || null, chatActions);
   return button;
 }
 
-function mountComposerModelControlVueIsland(button: HTMLElement, model: string | null): void {
+function mountComposerModelControlVueIsland(
+  button: HTMLElement,
+  model: string | null,
+  chatActions: DesktopNativeChatActionOptions,
+): void {
   if (!canMountVueIsland(button)) {
+    button.addEventListener("click", () => {
+      chatActions.onSelectModel?.();
+    });
     return;
   }
-  mountComposerModelControlIsland(button, { model });
+  mountComposerModelControlIsland(button, {
+    model,
+    onModelSelect: () => chatActions.onSelectModel?.(),
+  });
 }
 
 function createPersistentRagToggle(

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -10417,12 +10417,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       min-height: 34px;
       border: 0;
-      padding: 0 34px 0 10px;
+      padding: 0 82px 0 10px;
       background: transparent;
     }
 
     body.desktop-native-workbench .desktop-sidebar-chat-row .desktop-sidebar-row-main {
-      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-columns: minmax(0, 1fr);
     }
 
     body.desktop-native-workbench .desktop-sidebar-row-title {
@@ -10440,10 +10440,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-sidebar-delete-session {
       position: absolute;
-      right: 5px;
+      right: 10px;
       top: 50%;
       transform: translateY(-50%);
-      width: 24px;
+      width: 64px;
       min-height: 24px;
       border: 1px solid transparent;
       border-radius: 5px;
@@ -10516,9 +10516,15 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-sidebar-row-meta {
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 64px;
       color: #77736f;
       font-size: 12px;
       font-weight: 400;
+      pointer-events: none;
       text-align: right;
       transition: opacity 120ms ease;
     }

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -1110,7 +1110,7 @@ function recentChatRowModel(
     routeId,
     sessionKey: session.key,
     title,
-    updatedLabel: session.updatedAt ? `Updated ${formatCompactTime(session.updatedAt)}` : session.chatId,
+    updatedLabel: formatSessionRelativeTime(session.updatedAt || session.createdAt) || session.chatId,
   };
 }
 
@@ -1179,7 +1179,7 @@ function createRecentChatRow(
 
   const title = session.title || "New session";
   const href = `/chat/${encodeURIComponent(routeId)}`;
-  const updatedLabel = session.updatedAt ? `Updated ${formatCompactTime(session.updatedAt)}` : session.chatId;
+  const updatedLabel = formatSessionRelativeTime(session.updatedAt || session.createdAt) || session.chatId;
 
   const link = targetDocument.createElement("a");
   link.className = "desktop-sidebar-row desktop-sidebar-row-main";
@@ -1215,12 +1215,12 @@ function createRecentChatRow(
       confirmDelete = true;
       deleteButton.setAttribute("aria-label", `Confirm delete chat ${title}`);
       deleteButton.setAttribute("data-confirming", "true");
-      deleteButton.textContent = "Confirm";
+      deleteButton.textContent = "确认";
       return;
     }
     deleteButton.setAttribute("disabled", "");
     deleteButton.setAttribute("data-deleting", "true");
-    deleteButton.textContent = "Deleting";
+    deleteButton.textContent = "删除中";
     chatActions.onDeleteSession?.({
       sessionKey: session.key,
       chatId: session.chatId,
@@ -3078,6 +3078,45 @@ function formatCompactTime(value: string): string {
   }
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? value : date.toLocaleTimeString();
+}
+
+function formatSessionRelativeTime(value: string): string {
+  const timestamp = parseSessionTimestampMs(value);
+  if (timestamp === null) {
+    return "";
+  }
+  const elapsedMs = Math.max(0, Date.now() - timestamp);
+  const minuteMs = 60_000;
+  const hourMs = 60 * minuteMs;
+  const dayMs = 24 * hourMs;
+  const weekMs = 7 * dayMs;
+  const monthMs = 30 * dayMs;
+  if (elapsedMs < hourMs) {
+    return `${Math.max(1, Math.floor(elapsedMs / minuteMs))}分`;
+  }
+  if (elapsedMs < dayMs) {
+    return `${Math.max(1, Math.floor(elapsedMs / hourMs))}小时`;
+  }
+  if (elapsedMs < weekMs) {
+    return `${Math.max(1, Math.floor(elapsedMs / dayMs))}天`;
+  }
+  if (elapsedMs < monthMs) {
+    return `${Math.max(1, Math.floor(elapsedMs / weekMs))}周`;
+  }
+  return `${Math.max(1, Math.floor(elapsedMs / monthMs))}月`;
+}
+
+function parseSessionTimestampMs(value: string): number | null {
+  if (!value) {
+    return null;
+  }
+  const unixMs = value.match(/^unix-ms:(\d+)$/);
+  if (unixMs) {
+    const timestamp = Number(unixMs[1]);
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
 }
 
 function createComposerModelControl(targetDocument: Document, chat: DesktopNativeChatModel | null = null): HTMLElement {
@@ -10362,7 +10401,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-sidebar-chat-row {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-columns: minmax(0, 1fr);
       align-items: center;
       gap: 6px;
       min-width: 0;
@@ -10370,6 +10409,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       border: 1px solid transparent;
       border-radius: 7px;
       padding: 0 5px 0 0;
+      position: relative;
       transition: background-color 120ms ease, border-color 120ms ease;
     }
 
@@ -10377,8 +10417,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       min-height: 34px;
       border: 0;
-      padding: 0 4px 0 10px;
+      padding: 0 34px 0 10px;
       background: transparent;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-chat-row .desktop-sidebar-row-main {
+      grid-template-columns: minmax(0, 1fr) auto;
     }
 
     body.desktop-native-workbench .desktop-sidebar-row-title {
@@ -10395,6 +10439,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-sidebar-delete-session {
+      position: absolute;
+      right: 5px;
+      top: 50%;
+      transform: translateY(-50%);
       width: 24px;
       min-height: 24px;
       border: 1px solid transparent;
@@ -10403,15 +10451,37 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       color: #8b5b4e;
       font: 600 11px/1 var(--font-sans);
       cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 120ms ease, background-color 120ms ease, border-color 120ms ease, color 120ms ease;
     }
 
     body.desktop-native-workbench .desktop-sidebar-delete-session[data-confirming="true"] {
       width: 64px;
+      border-color: #f2c9c2;
+      background: #fff0ee;
+      color: #9f2f25;
+      opacity: 1;
+      pointer-events: auto;
     }
 
     body.desktop-native-workbench .desktop-sidebar-chat-row:hover {
       border-color: #eee4dd;
       background: #fffdfb;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-chat-row:hover .desktop-sidebar-row-meta,
+    body.desktop-native-workbench .desktop-sidebar-chat-row:focus-within .desktop-sidebar-row-meta,
+    body.desktop-native-workbench .desktop-sidebar-chat-row:has(.desktop-sidebar-delete-session[data-confirming="true"]) .desktop-sidebar-row-meta,
+    body.desktop-native-workbench .desktop-sidebar-chat-row:has(.desktop-sidebar-delete-session[data-deleting="true"]) .desktop-sidebar-row-meta {
+      opacity: 0;
+    }
+
+    body.desktop-native-workbench .desktop-sidebar-chat-row:hover .desktop-sidebar-delete-session,
+    body.desktop-native-workbench .desktop-sidebar-chat-row:focus-within .desktop-sidebar-delete-session,
+    body.desktop-native-workbench .desktop-sidebar-delete-session[data-deleting="true"] {
+      opacity: 1;
+      pointer-events: auto;
     }
 
     body.desktop-native-workbench .desktop-sidebar-delete-session:hover,
@@ -10449,6 +10519,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       color: #77736f;
       font-size: 12px;
       font-weight: 400;
+      text-align: right;
+      transition: opacity 120ms ease;
     }
 
     body.desktop-native-workbench .desktop-workbench-main {

--- a/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.vue.test.ts
@@ -331,7 +331,7 @@ describe("desktop workbench shell Vue integration", () => {
     const sidebar = document.querySelector<HTMLElement>(".desktop-sidebar-content");
     expect(sidebar?.getAttribute("data-desktop-vue-island")).toBe("sidebar-content");
     expect(sidebar?.querySelector(".desktop-sidebar-actions")?.getAttribute("data-desktop-vue-island")).toBe("sidebar-actions");
-    expect(sidebar?.querySelector(".desktop-sidebar-list-section-workspaces")?.getAttribute("data-desktop-vue-island")).toBe("sidebar-workspace-list");
+    expect(sidebar?.querySelector(".desktop-sidebar-list-section-workspaces")).toBeNull();
     expect(sidebar?.querySelector(".desktop-sidebar-list-section-recent")?.getAttribute("data-desktop-vue-island")).toBe("sidebar-recent-chats");
     expect(sidebar?.querySelector('[data-desktop-session-key="WebSocket:chat-live"]')?.textContent).toContain("Live session");
   });
@@ -352,7 +352,7 @@ describe("desktop workbench shell Vue integration", () => {
     expect(actions?.querySelector(".desktop-sidebar-search")?.getAttribute("type")).toBe("search");
   });
 
-  test("renders sidebar workspace list through the Vue shell island without an active chat", () => {
+  test("does not render the removed sidebar workspace list without an active chat", () => {
     document.body.replaceChildren();
     document.head.replaceChildren();
 
@@ -363,12 +363,7 @@ describe("desktop workbench shell Vue integration", () => {
     });
 
     const workspaces = document.querySelector<HTMLElement>(".desktop-sidebar-list-section-workspaces");
-    const row = workspaces?.querySelector<HTMLAnchorElement>(".desktop-sidebar-row");
-    expect(workspaces?.getAttribute("data-desktop-vue-island")).toBe("sidebar-workspace-list");
-    expect(workspaces?.querySelector(".desktop-sidebar-section-heading h2")?.textContent).toBe("Workspaces");
-    expect(row?.getAttribute("href")).toBe("/files");
-    expect(row?.getAttribute("data-desktop-entity-id")).toBe("tinybot");
-    expect(row?.getAttribute("data-active")).toBe("true");
+    expect(workspaces).toBeNull();
   });
 
   test("renders sidebar recent chats through the Vue shell island without an active chat", () => {

--- a/apps/desktop/src/native-vue/composerModelControlIsland.test.ts
+++ b/apps/desktop/src/native-vue/composerModelControlIsland.test.ts
@@ -6,9 +6,11 @@ import { mountComposerModelControlIsland } from "./composerModelControlIsland";
 describe("composer model control Vue island", () => {
   test("renders the desktop composer model selector host", () => {
     const host = document.createElement("button");
+    const selections: string[] = [];
 
     const mounted = mountComposerModelControlIsland(host, {
       model: "deepseek-chat",
+      onModelSelect: () => selections.push("model"),
     });
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("composer-model-control");
@@ -16,6 +18,9 @@ describe("composer model control Vue island", () => {
     expect(host.getAttribute("type")).toBe("button");
     expect(host.getAttribute("aria-label")).toBe("Select model");
     expect(host.textContent).toContain("deepseek-chat");
+
+    host.click();
+    expect(selections).toEqual(["model"]);
 
     mounted.unmount();
     expect(host.textContent).toBe("");

--- a/apps/desktop/src/native-vue/composerModelControlIsland.test.ts
+++ b/apps/desktop/src/native-vue/composerModelControlIsland.test.ts
@@ -1,16 +1,18 @@
 // @vitest-environment happy-dom
 
 import { describe, expect, test } from "vitest";
+import { nextTick } from "vue";
 import { mountComposerModelControlIsland } from "./composerModelControlIsland";
 
 describe("composer model control Vue island", () => {
-  test("renders the desktop composer model selector host", () => {
+  test("renders a selectable desktop composer model menu", async () => {
     const host = document.createElement("button");
     const selections: string[] = [];
 
     const mounted = mountComposerModelControlIsland(host, {
       model: "deepseek-chat",
-      onModelSelect: () => selections.push("model"),
+      modelOptions: ["deepseek-chat", "deepseek-reasoner"],
+      onModelSelect: (model) => selections.push(model),
     });
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("composer-model-control");
@@ -18,9 +20,18 @@ describe("composer model control Vue island", () => {
     expect(host.getAttribute("type")).toBe("button");
     expect(host.getAttribute("aria-label")).toBe("Select model");
     expect(host.textContent).toContain("deepseek-chat");
+    expect(host.querySelector('[role="listbox"]')).toBeNull();
 
     host.click();
-    expect(selections).toEqual(["model"]);
+    await nextTick();
+    const menu = host.querySelector('[role="listbox"]');
+    expect(menu?.textContent).toContain("Model");
+    expect(menu?.textContent).toContain("deepseek-chat");
+    expect(menu?.textContent).toContain("deepseek-reasoner");
+    expect(menu?.querySelector('[aria-selected="true"]')?.textContent).toContain("deepseek-chat");
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-composer-model-option="deepseek-reasoner"]')?.click();
+    expect(selections).toEqual(["deepseek-reasoner"]);
 
     mounted.unmount();
     expect(host.textContent).toBe("");

--- a/apps/desktop/src/native-vue/composerModelControlIsland.ts
+++ b/apps/desktop/src/native-vue/composerModelControlIsland.ts
@@ -1,10 +1,11 @@
-import { createApp, defineComponent, h, type App } from "vue";
+import { createApp, defineComponent, h, onBeforeUnmount, onMounted, ref, type App } from "vue";
 import { NConfigProvider, NText } from "naive-ui";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 export interface ComposerModelControlIslandOptions {
   model?: string | null;
-  onModelSelect?: () => void;
+  modelOptions?: string[];
+  onModelSelect?: (model: string) => void;
 }
 
 export interface MountedComposerModelControlIsland {
@@ -20,8 +21,7 @@ export function mountComposerModelControlIsland(
   host.className = "desktop-native-composer-model";
   host.setAttribute("aria-label", "Select model");
   host.setAttribute("data-desktop-composer-action", "model-select");
-  host.addEventListener("click", () => options.onModelSelect?.());
-  const app = createComposerModelControlApp(options);
+  const app = createComposerModelControlApp(host, options);
   app.mount(host);
   return {
     unmount: () => {
@@ -31,14 +31,79 @@ export function mountComposerModelControlIsland(
   };
 }
 
-function createComposerModelControlApp(options: ComposerModelControlIslandOptions): App {
-  const model = options.model || "Tinybot Pro";
+function createComposerModelControlApp(host: HTMLElement, options: ComposerModelControlIslandOptions): App {
   return createApp(defineComponent({
     name: "ComposerModelControlIsland",
     setup() {
+      const open = ref(false);
+      const toggleOpen = () => {
+        open.value = !open.value;
+      };
+      const currentModel = () => options.model || "Tinybot Pro";
+      const modelOptions = () => normalizeComposerModelOptions(currentModel(), options.modelOptions);
+      const selectModel = (event: MouseEvent, model: string) => {
+        event.stopPropagation();
+        open.value = false;
+        options.onModelSelect?.(model);
+      };
+      onMounted(() => {
+        host.addEventListener("click", toggleOpen);
+      });
+      onBeforeUnmount(() => {
+        host.removeEventListener("click", toggleOpen);
+      });
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => h(NText, { strong: true }, { default: () => model }),
+        default: () => [
+          h("span", {
+            class: "desktop-native-composer-model-label",
+          }, h(NText, { strong: true }, { default: () => currentModel() })),
+          open.value ? h("span", {
+            class: "desktop-native-composer-model-menu",
+            role: "listbox",
+            "aria-label": "Model",
+            onClick: (event: MouseEvent) => event.stopPropagation(),
+          }, [
+            h("span", { class: "desktop-native-composer-model-menu-title" }, "Model"),
+            ...modelOptions().map((model) => h("span", {
+              key: model,
+              class: "desktop-native-composer-model-option",
+              role: "option",
+              "aria-selected": String(model === currentModel()),
+              "data-desktop-composer-model-option": model,
+              onClick: (event: MouseEvent) => selectModel(event, model),
+            }, [
+              h("span", { class: "desktop-native-composer-model-option-label" }, model),
+              model === currentModel() ? renderModelCheckIcon() : null,
+            ])),
+          ]) : null,
+        ],
       });
     },
+  }));
+}
+
+function normalizeComposerModelOptions(currentModel: string, modelOptions: string[] | undefined): string[] {
+  const options = (modelOptions ?? [])
+    .map((model) => model.trim())
+    .filter(Boolean);
+  if (currentModel && !options.includes(currentModel)) {
+    options.unshift(currentModel);
+  }
+  return Array.from(new Set(options));
+}
+
+function renderModelCheckIcon() {
+  return h("svg", {
+    class: "desktop-native-composer-model-check",
+    "aria-hidden": "true",
+    viewBox: "0 0 20 20",
+    focusable: "false",
+  }, h("path", {
+    d: "M16.5 5.5 8.25 13.75 4 9.5",
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "2",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
   }));
 }

--- a/apps/desktop/src/native-vue/composerModelControlIsland.ts
+++ b/apps/desktop/src/native-vue/composerModelControlIsland.ts
@@ -4,6 +4,7 @@ import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 export interface ComposerModelControlIslandOptions {
   model?: string | null;
+  onModelSelect?: () => void;
 }
 
 export interface MountedComposerModelControlIsland {
@@ -18,6 +19,8 @@ export function mountComposerModelControlIsland(
   host.setAttribute("type", "button");
   host.className = "desktop-native-composer-model";
   host.setAttribute("aria-label", "Select model");
+  host.setAttribute("data-desktop-composer-action", "model-select");
+  host.addEventListener("click", () => options.onModelSelect?.());
   const app = createComposerModelControlApp(options);
   app.mount(host);
   return {

--- a/apps/desktop/src/native-vue/composerRuntimeIsland.test.ts
+++ b/apps/desktop/src/native-vue/composerRuntimeIsland.test.ts
@@ -1,19 +1,21 @@
 // @vitest-environment happy-dom
 
 import { describe, expect, test } from "vitest";
+import { nextTick } from "vue";
 import { mountComposerRuntimeIsland } from "./composerRuntimeIsland";
 
 describe("composer runtime Vue island", () => {
-  test("renders runtime affordances and dispatches RAG toggles", () => {
+  test("renders runtime affordances and dispatches RAG toggles", async () => {
     const host = document.createElement("div");
     const modelSelections: string[] = [];
     const toggles: boolean[] = [];
 
     const mounted = mountComposerRuntimeIsland(host, {
       model: "deepseek-chat",
+      modelOptions: ["deepseek-chat", "deepseek-reasoner"],
       persistentRag: false,
       tokenUsage: "42%",
-      onModelSelect: () => modelSelections.push("model"),
+      onModelSelect: (model) => modelSelections.push(model),
       onPersistentRagChange: (enabled) => toggles.push(enabled),
     });
 
@@ -35,8 +37,11 @@ describe("composer runtime Vue island", () => {
     expect(token?.style.getPropertyValue("--token-usage-fill")).toBe("42%");
 
     host.querySelector<HTMLButtonElement>('[data-desktop-composer-action="model-select"]')?.click();
+    await nextTick();
+    expect(host.querySelector('[role="listbox"]')?.textContent).toContain("deepseek-reasoner");
+    host.querySelector<HTMLButtonElement>('[data-desktop-composer-model-option="deepseek-reasoner"]')?.click();
     rag?.click();
-    expect(modelSelections).toEqual(["model"]);
+    expect(modelSelections).toEqual(["deepseek-reasoner"]);
     expect(toggles).toEqual([true]);
 
     mounted.unmount();

--- a/apps/desktop/src/native-vue/composerRuntimeIsland.test.ts
+++ b/apps/desktop/src/native-vue/composerRuntimeIsland.test.ts
@@ -6,12 +6,14 @@ import { mountComposerRuntimeIsland } from "./composerRuntimeIsland";
 describe("composer runtime Vue island", () => {
   test("renders runtime affordances and dispatches RAG toggles", () => {
     const host = document.createElement("div");
+    const modelSelections: string[] = [];
     const toggles: boolean[] = [];
 
     const mounted = mountComposerRuntimeIsland(host, {
       model: "deepseek-chat",
       persistentRag: false,
       tokenUsage: "42%",
+      onModelSelect: () => modelSelections.push("model"),
       onPersistentRagChange: (enabled) => toggles.push(enabled),
     });
 
@@ -32,7 +34,9 @@ describe("composer runtime Vue island", () => {
     expect(token?.getAttribute("data-token-usage")).toBe("42");
     expect(token?.style.getPropertyValue("--token-usage-fill")).toBe("42%");
 
+    host.querySelector<HTMLButtonElement>('[data-desktop-composer-action="model-select"]')?.click();
     rag?.click();
+    expect(modelSelections).toEqual(["model"]);
     expect(toggles).toEqual([true]);
 
     mounted.unmount();

--- a/apps/desktop/src/native-vue/composerRuntimeIsland.ts
+++ b/apps/desktop/src/native-vue/composerRuntimeIsland.ts
@@ -6,6 +6,7 @@ export interface ComposerRuntimeIslandOptions {
   model?: string | null;
   persistentRag: boolean;
   tokenUsage: string;
+  onModelSelect?: () => void;
   onPersistentRagChange?: (enabled: boolean) => void;
 }
 
@@ -59,18 +60,20 @@ export function renderComposerRuntimeSurface(options: ComposerRuntimeIslandOptio
 
 export function renderComposerRuntimeContent(options: ComposerRuntimeIslandOptions) {
   return [
-    renderModelControl(options.model),
+    renderModelControl(options),
     renderPersistentRagToggle(options),
     renderTokenUsageOrb(options.tokenUsage),
   ];
 }
 
-function renderModelControl(model?: string | null) {
+function renderModelControl(options: ComposerRuntimeIslandOptions) {
   return h("button", {
     type: "button",
     class: "desktop-native-composer-model",
+    "data-desktop-composer-action": "model-select",
     "aria-label": "Select model",
-  }, h(NText, { strong: true }, { default: () => model || "Tinybot Pro" }));
+    onClick: () => options.onModelSelect?.(),
+  }, h(NText, { strong: true }, { default: () => options.model || "Tinybot Pro" }));
 }
 
 function renderPersistentRagToggle(options: ComposerRuntimeIslandOptions) {

--- a/apps/desktop/src/native-vue/composerRuntimeIsland.ts
+++ b/apps/desktop/src/native-vue/composerRuntimeIsland.ts
@@ -1,12 +1,13 @@
-import { createApp, defineComponent, h, type App } from "vue";
+import { createApp, defineComponent, h, ref, type App, type PropType, type Ref } from "vue";
 import { NConfigProvider, NText } from "naive-ui";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 export interface ComposerRuntimeIslandOptions {
   model?: string | null;
+  modelOptions?: string[];
   persistentRag: boolean;
   tokenUsage: string;
-  onModelSelect?: () => void;
+  onModelSelect?: (model: string) => void;
   onPersistentRagChange?: (enabled: boolean) => void;
 }
 
@@ -42,7 +43,7 @@ function createComposerRuntimeApp(options: ComposerRuntimeIslandOptions): App {
     name: "ComposerRuntimeIsland",
     setup() {
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
-        default: () => renderComposerRuntimeContent(options),
+        default: () => h(ComposerRuntimeContent, { options }),
       });
     },
   }));
@@ -55,25 +56,68 @@ export function renderComposerRuntimeSurface(options: ComposerRuntimeIslandOptio
     "data-desktop-vue-island": "composer-runtime",
     "data-desktop-composer-region": "runtime-status",
     "aria-label": "Runtime status",
-  }, renderComposerRuntimeContent(options));
+  }, h(ComposerRuntimeContent, { options }));
 }
 
-export function renderComposerRuntimeContent(options: ComposerRuntimeIslandOptions) {
+const ComposerRuntimeContent = defineComponent({
+  name: "ComposerRuntimeContent",
+  props: {
+    options: {
+      type: Object as PropType<ComposerRuntimeIslandOptions>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const modelMenuOpen = ref(false);
+    return () => renderComposerRuntimeContent(props.options, modelMenuOpen);
+  },
+});
+
+export function renderComposerRuntimeContent(options: ComposerRuntimeIslandOptions, modelMenuOpen: Ref<boolean>) {
   return [
-    renderModelControl(options),
+    renderModelControl(options, modelMenuOpen),
     renderPersistentRagToggle(options),
     renderTokenUsageOrb(options.tokenUsage),
   ];
 }
 
-function renderModelControl(options: ComposerRuntimeIslandOptions) {
+function renderModelControl(options: ComposerRuntimeIslandOptions, modelMenuOpen: Ref<boolean>) {
+  const currentModel = options.model || "Tinybot Pro";
+  const modelOptions = normalizeComposerModelOptions(currentModel, options.modelOptions);
   return h("button", {
     type: "button",
     class: "desktop-native-composer-model",
     "data-desktop-composer-action": "model-select",
     "aria-label": "Select model",
-    onClick: () => options.onModelSelect?.(),
-  }, h(NText, { strong: true }, { default: () => options.model || "Tinybot Pro" }));
+    onClick: () => {
+      modelMenuOpen.value = !modelMenuOpen.value;
+    },
+  }, [
+    h("span", { class: "desktop-native-composer-model-label" }, h(NText, { strong: true }, { default: () => currentModel })),
+    modelMenuOpen.value ? h("span", {
+      class: "desktop-native-composer-model-menu",
+      role: "listbox",
+      "aria-label": "Model",
+      onClick: (event: MouseEvent) => event.stopPropagation(),
+    }, [
+      h("span", { class: "desktop-native-composer-model-menu-title" }, "Model"),
+      ...modelOptions.map((model) => h("span", {
+        key: model,
+        class: "desktop-native-composer-model-option",
+        role: "option",
+        "aria-selected": String(model === currentModel),
+        "data-desktop-composer-model-option": model,
+        onClick: (event: MouseEvent) => {
+          event.stopPropagation();
+          modelMenuOpen.value = false;
+          options.onModelSelect?.(model);
+        },
+      }, [
+        h("span", { class: "desktop-native-composer-model-option-label" }, model),
+        model === currentModel ? renderModelCheckIcon() : null,
+      ])),
+    ]) : null,
+  ]);
 }
 
 function renderPersistentRagToggle(options: ComposerRuntimeIslandOptions) {
@@ -111,4 +155,30 @@ function parseTokenUsagePercent(tokenUsage: string): number {
     return 0;
   }
   return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function normalizeComposerModelOptions(currentModel: string, modelOptions: string[] | undefined): string[] {
+  const options = (modelOptions ?? [])
+    .map((model) => model.trim())
+    .filter(Boolean);
+  if (currentModel && !options.includes(currentModel)) {
+    options.unshift(currentModel);
+  }
+  return Array.from(new Set(options));
+}
+
+function renderModelCheckIcon() {
+  return h("svg", {
+    class: "desktop-native-composer-model-check",
+    "aria-hidden": "true",
+    viewBox: "0 0 20 20",
+    focusable: "false",
+  }, h("path", {
+    d: "M16.5 5.5 8.25 13.75 4 9.5",
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "2",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+  }));
 }

--- a/apps/desktop/src/native-vue/composerSurfaceIsland.test.ts
+++ b/apps/desktop/src/native-vue/composerSurfaceIsland.test.ts
@@ -9,6 +9,7 @@ describe("composer surface Vue island", () => {
     const host = document.createElement("form");
     const sends: unknown[] = [];
     const attaches: string[] = [];
+    const modelSelections: string[] = [];
     const rags: boolean[] = [];
 
     const mounted = mountComposerSurfaceIsland(host, {
@@ -19,6 +20,7 @@ describe("composer surface Vue island", () => {
       tokenUsage: "42%",
       usePersistentRag: false,
       onAttach: () => attaches.push("attach"),
+      onModelSelect: () => modelSelections.push("model"),
       onPersistentRagChange: (enabled) => rags.push(enabled),
       onSend: (event) => sends.push(event),
     });
@@ -55,6 +57,7 @@ describe("composer surface Vue island", () => {
     expect(host.querySelector(".desktop-native-token-orb")?.getAttribute("data-token-usage")).toBe("42");
 
     host.querySelector<HTMLButtonElement>('[data-desktop-composer-action="attach"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-composer-action="model-select"]')?.click();
     host.querySelector<HTMLButtonElement>('[data-desktop-composer-action="rag-toggle"]')?.click();
     input!.value = "Run live composer";
     input!.dispatchEvent(new Event("input", { bubbles: true }));
@@ -63,6 +66,7 @@ describe("composer surface Vue island", () => {
     send?.click();
 
     expect(attaches).toEqual(["attach"]);
+    expect(modelSelections).toEqual(["model"]);
     expect(rags).toEqual([true]);
     expect(sends).toEqual([{ content: "Run live composer", usePersistentRag: false }]);
 

--- a/apps/desktop/src/native-vue/composerSurfaceIsland.test.ts
+++ b/apps/desktop/src/native-vue/composerSurfaceIsland.test.ts
@@ -16,11 +16,12 @@ describe("composer surface Vue island", () => {
       activeSessionKey: "WebSocket:chat-live",
       composerState: "idle",
       model: "deepseek-chat",
+      modelOptions: ["deepseek-chat", "deepseek-reasoner"],
       responding: false,
       tokenUsage: "42%",
       usePersistentRag: false,
       onAttach: () => attaches.push("attach"),
-      onModelSelect: () => modelSelections.push("model"),
+      onModelSelect: (model) => modelSelections.push(model),
       onPersistentRagChange: (enabled) => rags.push(enabled),
       onSend: (event) => sends.push(event),
     });
@@ -58,6 +59,9 @@ describe("composer surface Vue island", () => {
 
     host.querySelector<HTMLButtonElement>('[data-desktop-composer-action="attach"]')?.click();
     host.querySelector<HTMLButtonElement>('[data-desktop-composer-action="model-select"]')?.click();
+    await nextTick();
+    expect(host.querySelector('[role="listbox"]')?.textContent).toContain("deepseek-reasoner");
+    host.querySelector<HTMLButtonElement>('[data-desktop-composer-model-option="deepseek-reasoner"]')?.click();
     host.querySelector<HTMLButtonElement>('[data-desktop-composer-action="rag-toggle"]')?.click();
     input!.value = "Run live composer";
     input!.dispatchEvent(new Event("input", { bubbles: true }));
@@ -66,7 +70,7 @@ describe("composer surface Vue island", () => {
     send?.click();
 
     expect(attaches).toEqual(["attach"]);
-    expect(modelSelections).toEqual(["model"]);
+    expect(modelSelections).toEqual(["deepseek-reasoner"]);
     expect(rags).toEqual([true]);
     expect(sends).toEqual([{ content: "Run live composer", usePersistentRag: false }]);
 

--- a/apps/desktop/src/native-vue/composerSurfaceIsland.ts
+++ b/apps/desktop/src/native-vue/composerSurfaceIsland.ts
@@ -15,11 +15,12 @@ export interface ComposerSurfaceIslandOptions {
   activeSessionKey?: string | null;
   composerState: ComposerSurfaceState;
   model?: string | null;
+  modelOptions?: string[];
   responding: boolean;
   tokenUsage: string;
   usePersistentRag: boolean;
   onAttach?: () => void;
-  onModelSelect?: () => void;
+  onModelSelect?: (model: string) => void;
   onPersistentRagChange?: (enabled: boolean) => void;
   onSend?: (event: ComposerSurfaceSubmitEvent) => void;
 }
@@ -150,6 +151,7 @@ function createComposerSurfaceApp(state: Ref<ComposerSurfaceIslandOptions>): App
           }, h(NText, { strong: true }, { default: () => "+" })),
           renderComposerRuntimeSurface({
             model: state.value.model,
+            modelOptions: state.value.modelOptions,
             persistentRag: state.value.usePersistentRag,
             tokenUsage: state.value.tokenUsage,
             onModelSelect: state.value.onModelSelect,

--- a/apps/desktop/src/native-vue/composerSurfaceIsland.ts
+++ b/apps/desktop/src/native-vue/composerSurfaceIsland.ts
@@ -19,6 +19,7 @@ export interface ComposerSurfaceIslandOptions {
   tokenUsage: string;
   usePersistentRag: boolean;
   onAttach?: () => void;
+  onModelSelect?: () => void;
   onPersistentRagChange?: (enabled: boolean) => void;
   onSend?: (event: ComposerSurfaceSubmitEvent) => void;
 }
@@ -151,6 +152,7 @@ function createComposerSurfaceApp(state: Ref<ComposerSurfaceIslandOptions>): App
             model: state.value.model,
             persistentRag: state.value.usePersistentRag,
             tokenUsage: state.value.tokenUsage,
+            onModelSelect: state.value.onModelSelect,
             onPersistentRagChange: state.value.onPersistentRagChange,
           }),
           h("button", {

--- a/apps/desktop/src/native-vue/recentChatRowIsland.test.ts
+++ b/apps/desktop/src/native-vue/recentChatRowIsland.test.ts
@@ -16,7 +16,7 @@ describe("recent chat row Vue island", () => {
       routeId: "chat-1",
       sessionKey: "WebSocket:chat-1",
       title: "Session one",
-      updatedLabel: "Updated 2m ago",
+      updatedLabel: "2分",
     });
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("recent-chat-row");
@@ -34,7 +34,7 @@ describe("recent chat row Vue island", () => {
     expect(link?.getAttribute("data-desktop-entity-module")).toBe("chat");
     expect(link?.getAttribute("data-desktop-entity-id")).toBe("chat-1");
     expect(link?.querySelector(".desktop-sidebar-row-label")?.textContent).toBe("Session one");
-    expect(link?.querySelector(".desktop-sidebar-row-meta")?.textContent).toBe("Updated 2m ago");
+    expect(link?.querySelector(".desktop-sidebar-row-meta")?.textContent).toBe("2分");
     expect(link?.querySelector("[data-desktop-session-pin-icon]")?.textContent).toBe("📌");
 
     const deleteButton = host.querySelector<HTMLButtonElement>("[data-desktop-chat-delete]");
@@ -63,7 +63,7 @@ describe("recent chat row Vue island", () => {
         { kind: "knowledge", label: "Knowledge On" },
       ],
       title: "Session one",
-      updatedLabel: "Updated 2m ago",
+      updatedLabel: "2分",
     });
 
     expect(host.querySelector(".desktop-sidebar-row-status")).toBeNull();
@@ -95,13 +95,13 @@ describe("recent chat row Vue island", () => {
     expect(deletes).toEqual([]);
     expect(deleteButton?.getAttribute("aria-label")).toBe("Confirm delete chat Session two");
     expect(deleteButton?.getAttribute("data-confirming")).toBe("true");
-    expect(deleteButton?.textContent).toBe("Confirm");
+    expect(deleteButton?.textContent).toBe("确认");
 
     deleteButton?.click();
     await nextTick();
     expect(deletes).toEqual([{ chatId: "chat-2", sessionKey: "WebSocket:chat-2", title: "Session two" }]);
     expect(deleteButton?.getAttribute("disabled")).toBe("");
     expect(deleteButton?.getAttribute("data-deleting")).toBe("true");
-    expect(deleteButton?.textContent).toBe("Deleting");
+    expect(deleteButton?.textContent).toBe("删除中");
   });
 });

--- a/apps/desktop/src/native-vue/recentChatRowIsland.ts
+++ b/apps/desktop/src/native-vue/recentChatRowIsland.ts
@@ -107,7 +107,7 @@ function createRecentChatRowApp(options: RecentChatRowIslandOptions): App {
             disabled: deleting.value ? "" : null,
             onClick: onDeleteClick,
             type: "button",
-          }, deleting.value ? "Deleting" : confirming.value ? "Confirm" : "x"),
+          }, deleting.value ? "删除中" : confirming.value ? "确认" : "x"),
         ],
       });
     },

--- a/apps/desktop/src/native-vue/sidebarContentIsland.test.ts
+++ b/apps/desktop/src/native-vue/sidebarContentIsland.test.ts
@@ -30,9 +30,6 @@ describe("sidebar content Vue island", () => {
         { href: "/workspace", id: "workspace", kind: "link", label: "Workspace" },
       ],
       resourceLabel: "Resources",
-      workspaceRows: [
-        { active: true, entityId: "tinybot", meta: "Active session", title: "tinybot" },
-      ],
     });
 
     expect(host.getAttribute("data-desktop-vue-island")).toBe("sidebar-content");
@@ -41,8 +38,8 @@ describe("sidebar content Vue island", () => {
     expect(host.querySelector(".desktop-sidebar-actions")?.getAttribute("data-desktop-vue-island")).toBe("sidebar-actions");
     expect(host.querySelector(".desktop-sidebar-primary-action")?.getAttribute("href")).toBe("/chat/new");
     expect(host.querySelector(".desktop-sidebar-search")?.getAttribute("type")).toBe("search");
-    expect(host.querySelector(".desktop-sidebar-list-section-workspaces")?.getAttribute("data-desktop-vue-island")).toBe("sidebar-workspace-list");
-    expect(host.querySelector(".desktop-workspace-list")?.textContent).toContain("tinybot");
+    expect(host.querySelector(".desktop-sidebar-list-section-workspaces")).toBeNull();
+    expect(host.querySelector(".desktop-workspace-list")).toBeNull();
     expect(host.querySelector(".desktop-sidebar-list-section-recent")?.getAttribute("data-desktop-vue-island")).toBe("sidebar-recent-chats");
     expect(host.querySelector("[data-desktop-session-key]")?.getAttribute("data-pinned")).toBe("true");
     expect(host.querySelector('[data-sidebar-item-id="workspace"]')?.closest(".desktop-workbench-section")?.getAttribute("data-desktop-vue-island")).toBe("shared-sidebar-links");

--- a/apps/desktop/src/native-vue/sidebarContentIsland.ts
+++ b/apps/desktop/src/native-vue/sidebarContentIsland.ts
@@ -4,7 +4,6 @@ import { mountSharedSidebarCommandsIsland, type SharedSidebarCommandItem } from 
 import { mountSharedSidebarLinksIsland, type SharedSidebarLinkItem } from "./sharedSidebarLinksIsland";
 import { mountSidebarActionsIsland } from "./sidebarActionsIsland";
 import { mountSidebarRecentChatsIsland, type SidebarRecentChatRow } from "./sidebarRecentChatsIsland";
-import { mountSidebarWorkspaceListIsland, type SidebarWorkspaceListRow } from "./sidebarWorkspaceListIsland";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 
 export interface SidebarContentIslandOptions {
@@ -14,7 +13,6 @@ export interface SidebarContentIslandOptions {
   resourceItems: SharedSidebarLinkItem[];
   resourceLabel?: string;
   targetDocument?: Document;
-  workspaceRows: SidebarWorkspaceListRow[];
 }
 
 type MountedSidebarContentOptions = SidebarContentIslandOptions & { targetDocument: Document };
@@ -48,16 +46,12 @@ function createSidebarContentApp(options: MountedSidebarContentOptions): App {
     setup() {
       const mountedChildren: Array<{ unmount: () => void }> = [];
       const actions = ref<HTMLElement | null>(null);
-      const workspaces = ref<HTMLElement | null>(null);
       const recent = ref<HTMLElement | null>(null);
       const links = ref<HTMLElement | null>(null);
       const commands = ref<HTMLElement | null>(null);
 
       onMounted(() => {
         mountChild(mountedChildren, actions.value, (host) => mountSidebarActionsIsland(host));
-        mountChild(mountedChildren, workspaces.value, (host) => mountSidebarWorkspaceListIsland(host, {
-          rows: options.workspaceRows,
-        }));
         mountChild(mountedChildren, recent.value, (host) => mountSidebarRecentChatsIsland(host, {
           rows: options.recentChats,
         }));
@@ -90,7 +84,6 @@ function createSidebarContentApp(options: MountedSidebarContentOptions): App {
         }, {
           default: () => [
             h("section", { ref: actions }),
-            h("section", { ref: workspaces }),
             h("section", { ref: recent }),
             options.resourceItems.length ? h("section", { ref: links }) : null,
             options.commandItems.length ? h("section", { ref: commands }) : null,

--- a/apps/desktop/src/native-vue/sidebarRecentChatsIsland.test.ts
+++ b/apps/desktop/src/native-vue/sidebarRecentChatsIsland.test.ts
@@ -59,6 +59,9 @@ describe("sidebar recent chats Vue island", () => {
     const deleteButton = rows[1]?.querySelector<HTMLButtonElement>("[data-desktop-chat-delete]");
     deleteButton?.click();
     await nextTick();
+    expect(deletes).toEqual([]);
+    expect(deleteButton?.getAttribute("data-confirming")).toBe("true");
+    expect(deleteButton?.textContent).toBe("确认");
     deleteButton?.click();
     await nextTick();
 

--- a/apps/desktop/src/native-vue/sidebarRecentChatsIsland.ts
+++ b/apps/desktop/src/native-vue/sidebarRecentChatsIsland.ts
@@ -164,7 +164,7 @@ const RecentChatRowComponent = defineComponent<{
         disabled: deleting.value ? "" : null,
         onClick: onDeleteClick,
         type: "button",
-      }, deleting.value ? "Deleting" : confirming.value ? "Confirm" : "x"),
+      }, deleting.value ? "删除中" : confirming.value ? "确认" : "x"),
     ]);
   },
 });


### PR DESCRIPTION
Summary: Render native recent chat timestamps as single relative units, hide the delete action until row hover or focus, and require a second confirm click before invoking the existing session delete flow. Verification: npm test -- src/desktopWorkbenchShell.test.ts src/native-vue/recentChatRowIsland.test.ts src/native-vue/sidebarRecentChatsIsland.test.ts; npm test -- src/desktopWorkbenchShell.vue.test.ts src/desktopNativeWorkbenchRuntime.test.ts src/desktopChatSessionController.test.ts; npm run build.