### PR TITLE
Harden desktop settings experience

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2108,6 +2108,10 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     logDesktopNativeDebug("settings.files.action.requested", { action: event.action });
     return;
   }
+  if (event.action === "setupChannelIntegrations") {
+    logDesktopNativeDebug("settings.channels.action.requested", { action: event.action });
+    return;
+  }
   if (!nativeSettingsState) {
     logDesktopNativeDebug("settings.action.skipped", { action: event.action, reason: "state unavailable" });
     return;

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -57,6 +57,7 @@ import {
   buildDesktopSettingsFormState,
   buildDesktopSettingsPaneModel,
   buildDesktopSettingsSavePatch,
+  reconcileDesktopSettingsSavedState,
   type DesktopSettingsFormState,
   type DesktopSettingsPaneModel,
 } from "./desktopSettingsProviders";
@@ -2146,15 +2147,22 @@ async function saveNativeSettingsPane(): Promise<void> {
       logDesktopNativeDebug("settings.save.validationFailed", { fields: savePatch.validationErrors.map((error) => error.field) });
       return;
     }
-    nativeSettingsConfig = await saveDesktopSettingsConfig(nativeSettingsConfig, savePatch.patch, {
+    const effectiveConfig = await saveDesktopSettingsConfig(nativeSettingsConfig, savePatch.patch, {
       applyNativeConfigPatch,
       applyGatewayConfigPatch: (fallbackPatch) => gatewayApi.config.patch(fallbackPatch),
       onNativeFallback: (fallbackError) => {
         logDesktopNativeDebug("settings.save.nativeFallback", { error: stringifyError(fallbackError) });
       },
     });
+    const reconciled = reconcileDesktopSettingsSavedState(nativeSettingsState, effectiveConfig, nativeSettingsProviderCatalog);
+    if (!reconciled.ok) {
+      updateNativeSettingsPane("failed", `Saved settings did not apply: ${reconciled.mismatchedPaths.join(", ")}`);
+      logDesktopNativeDebug("settings.save.reconcileFailed", { paths: reconciled.mismatchedPaths });
+      return;
+    }
+    nativeSettingsConfig = effectiveConfig;
     syncTsCoworkRuntimeRollout(nativeSettingsConfig);
-    nativeSettingsState = buildDesktopSettingsFormState(nativeSettingsConfig, nativeSettingsProviderCatalog);
+    nativeSettingsState = reconciled.state;
     nativeSettingsLastSavedState = nativeSettingsState;
     updateNativeSettingsPane("saved");
     logDesktopNativeDebug("settings.save.complete");

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -56,7 +56,7 @@ import {
   buildDesktopProviderModelRequest,
   buildDesktopSettingsFormState,
   buildDesktopSettingsPaneModel,
-  createDesktopSettingsPatch,
+  buildDesktopSettingsSavePatch,
   type DesktopSettingsFormState,
   type DesktopSettingsPaneModel,
 } from "./desktopSettingsProviders";
@@ -2135,12 +2135,18 @@ async function saveNativeSettingsPane(): Promise<void> {
   logDesktopNativeDebug("settings.save.start");
   updateNativeSettingsPane("saving");
   try {
-    const patch = createDesktopSettingsPatch(
+    const savePatch = buildDesktopSettingsSavePatch(
       nativeSettingsState,
       nativeSettingsConfig,
       nativeSettingsProviderCatalog,
     );
-    nativeSettingsConfig = await saveDesktopSettingsConfig(nativeSettingsConfig, patch, {
+    if (!savePatch.ok) {
+      const invalidFields = savePatch.validationErrors.map((error) => error.field).join(", ");
+      updateNativeSettingsPane("failed", `Settings validation failed: ${invalidFields}`);
+      logDesktopNativeDebug("settings.save.validationFailed", { fields: savePatch.validationErrors.map((error) => error.field) });
+      return;
+    }
+    nativeSettingsConfig = await saveDesktopSettingsConfig(nativeSettingsConfig, savePatch.patch, {
       applyNativeConfigPatch,
       applyGatewayConfigPatch: (fallbackPatch) => gatewayApi.config.patch(fallbackPatch),
       onNativeFallback: (fallbackError) => {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2147,13 +2147,14 @@ async function saveNativeSettingsPane(): Promise<void> {
       logDesktopNativeDebug("settings.save.validationFailed", { fields: savePatch.validationErrors.map((error) => error.field) });
       return;
     }
-    const effectiveConfig = await saveDesktopSettingsConfig(nativeSettingsConfig, savePatch.patch, {
+    const saveResult = await saveDesktopSettingsConfig(nativeSettingsConfig, savePatch.patch, {
       applyNativeConfigPatch,
       applyGatewayConfigPatch: (fallbackPatch) => gatewayApi.config.patch(fallbackPatch),
       onNativeFallback: (fallbackError) => {
         logDesktopNativeDebug("settings.save.nativeFallback", { error: stringifyError(fallbackError) });
       },
     });
+    const effectiveConfig = saveResult.config;
     const reconciled = reconcileDesktopSettingsSavedState(nativeSettingsState, effectiveConfig, nativeSettingsProviderCatalog);
     if (!reconciled.ok) {
       updateNativeSettingsPane("failed", `Saved settings did not apply: ${reconciled.mismatchedPaths.join(", ")}`);
@@ -2165,7 +2166,14 @@ async function saveNativeSettingsPane(): Promise<void> {
     nativeSettingsState = reconciled.state;
     nativeSettingsLastSavedState = nativeSettingsState;
     updateNativeSettingsPane("saved");
-    logDesktopNativeDebug("settings.save.complete");
+    logDesktopNativeDebug("settings.save.complete", {
+      transport: saveResult.transport,
+      updatedFields: saveResult.updatedFields,
+      applied: saveResult.applied,
+      restartRequired: saveResult.restartRequired,
+      reloadRequired: saveResult.reloadRequired,
+      warnings: saveResult.warnings,
+    });
   } catch (error) {
     const message = stringifyError(error);
     updateNativeSettingsPane("failed", `Failed to save settings: ${message}`);

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2083,7 +2083,7 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     return;
   }
   if (event.action === "copyDiagnostics") {
-    await copyNativeSettingsDiagnostics(event.pane.save.message);
+    await copyNativeSettingsDiagnostics(event.pane.save.diagnostics || event.pane.save.message);
     return;
   }
   if (event.action === "restartGateway") {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2086,6 +2086,20 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     await copyNativeSettingsDiagnostics(event.pane.save.message);
     return;
   }
+  if (event.action === "restartGateway") {
+    await handleNativeGatewayRuntimeAction({
+      action: "restart",
+      status: nativeRuntimeStatus,
+      diagnostics: "",
+    });
+    return;
+  }
+  if (event.action === "reloadWorkspace") {
+    await retryLoadNativeSettingsPane();
+    scheduleNativeRuntimeStatusRefresh("settings.workspace.reload");
+    logDesktopNativeDebug("settings.workspace.reload.requested");
+    return;
+  }
   if (!nativeSettingsState) {
     logDesktopNativeDebug("settings.action.skipped", { action: event.action, reason: "state unavailable" });
     return;

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2076,6 +2076,14 @@ async function loadNativeSettingsPane(): Promise<DesktopSettingsPaneModel> {
 }
 
 async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Promise<void> {
+  if (event.action === "retryLoad") {
+    await retryLoadNativeSettingsPane();
+    return;
+  }
+  if (event.action === "copyDiagnostics") {
+    await copyNativeSettingsDiagnostics(event.pane.save.message);
+    return;
+  }
   if (!nativeSettingsState) {
     logDesktopNativeDebug("settings.action.skipped", { action: event.action, reason: "state unavailable" });
     return;
@@ -2095,6 +2103,28 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     return;
   }
   await refreshNativeProviderModels();
+}
+
+async function retryLoadNativeSettingsPane(): Promise<void> {
+  logDesktopNativeDebug("settings.load.retry.start");
+  const pane = await loadNativeSettingsPane();
+  updateDesktopSettingsPane(document, pane, {
+    onSettingsAction: (event) => {
+      void handleNativeSettingsAction(event);
+    },
+  });
+  syncNativeRuntimeMetadata();
+  logDesktopNativeDebug("settings.load.retry.complete", { status: pane.save.status });
+}
+
+async function copyNativeSettingsDiagnostics(diagnostics: string): Promise<void> {
+  const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+  if (!clipboard?.writeText) {
+    logDesktopNativeDebug("settings.diagnostics.copy.skipped", { reason: "clipboard unavailable" });
+    return;
+  }
+  await clipboard.writeText(diagnostics || "No settings diagnostics");
+  logDesktopNativeDebug("settings.diagnostics.copy.complete");
 }
 
 async function saveNativeSettingsPane(): Promise<void> {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2114,6 +2114,12 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     logDesktopNativeDebug("settings.action.complete", { action: event.action, fieldId: event.fieldId });
     return;
   }
+  if (event.action === "reset") {
+    nativeSettingsState = nativeSettingsLastSavedState;
+    updateNativeSettingsPane("idle");
+    logDesktopNativeDebug("settings.action.complete", { action: event.action });
+    return;
+  }
   if (event.action === "save") {
     await saveNativeSettingsPane();
     return;

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2104,6 +2104,10 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     logDesktopNativeDebug("settings.provider.test.requested", { providerId: event.providerId });
     return;
   }
+  if (["chooseWorkspace", "openWorkspace", "openSessionFiles", "openKnowledgeDocuments"].includes(event.action)) {
+    logDesktopNativeDebug("settings.files.action.requested", { action: event.action });
+    return;
+  }
   if (!nativeSettingsState) {
     logDesktopNativeDebug("settings.action.skipped", { action: event.action, reason: "state unavailable" });
     return;

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -39,7 +39,7 @@ import {
   type DesktopNativeStartupTrace,
 } from "./desktopNativeChatDebug";
 import { applyNativeConfigPatch } from "./desktopNativeConfigPatch";
-import { saveDesktopSettingsConfig } from "./desktopSettingsSave";
+import { saveDesktopSettingsConfig, type DesktopSettingsSaveResult } from "./desktopSettingsSave";
 import { buildDesktopTsAgentFormSubmissionInput } from "./desktopTsAgentFormActions";
 import { installDesktopNavigation } from "./desktopNavigation";
 import { applyDesktopWorkbenchRouteState } from "./desktopEntityFocus";
@@ -60,6 +60,7 @@ import {
   reconcileDesktopSettingsSavedState,
   type DesktopSettingsFormState,
   type DesktopSettingsPaneModel,
+  type DesktopSettingsPaneSaveDetails,
 } from "./desktopSettingsProviders";
 import { bindStartupRetry, setStartupState } from "./desktopStartupView";
 import { buildDesktopTaskCenterItems, type DesktopTaskSourceOperation } from "./desktopTaskCenter";
@@ -2165,7 +2166,7 @@ async function saveNativeSettingsPane(): Promise<void> {
     syncTsCoworkRuntimeRollout(nativeSettingsConfig);
     nativeSettingsState = reconciled.state;
     nativeSettingsLastSavedState = nativeSettingsState;
-    updateNativeSettingsPane("saved");
+    updateNativeSettingsPane("saved", undefined, buildNativeSettingsPaneSaveDetails(saveResult));
     logDesktopNativeDebug("settings.save.complete", {
       transport: saveResult.transport,
       updatedFields: saveResult.updatedFields,
@@ -2239,6 +2240,7 @@ function syncTsCoworkRuntimeRollout(config: unknown): void {
 function updateNativeSettingsPane(
   saveStatus: "idle" | "saving" | "saved" | "failed",
   saveError?: string,
+  saveDetails?: DesktopSettingsPaneSaveDetails | null,
 ): void {
   if (!nativeSettingsState) {
     return;
@@ -2248,12 +2250,24 @@ function updateNativeSettingsPane(
     providerCatalog: nativeSettingsProviderCatalog,
     saveStatus,
     saveError,
+    saveDetails,
   }), {
     onSettingsAction: (event) => {
       void handleNativeSettingsAction(event);
     },
   });
   syncNativeRuntimeMetadata();
+}
+
+function buildNativeSettingsPaneSaveDetails(saveResult: DesktopSettingsSaveResult): DesktopSettingsPaneSaveDetails {
+  return {
+    transport: saveResult.transport,
+    updatedFields: saveResult.updatedFields,
+    applied: saveResult.applied,
+    restartRequired: saveResult.restartRequired,
+    reloadRequired: saveResult.reloadRequired,
+    warnings: saveResult.warnings,
+  };
 }
 
 function installNativeCommandPalette(): void {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2083,7 +2083,7 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     return;
   }
   if (event.action === "copyDiagnostics") {
-    await copyNativeSettingsDiagnostics(event.pane.save.diagnostics || event.pane.save.message);
+    await copyNativeSettingsDiagnostics(event.pane.diagnostics?.runtimeSummary || event.pane.save.diagnostics || event.pane.save.message);
     return;
   }
   if (event.action === "restartGateway") {
@@ -2110,6 +2110,14 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
   }
   if (event.action === "setupChannelIntegrations") {
     logDesktopNativeDebug("settings.channels.action.requested", { action: event.action });
+    return;
+  }
+  if (["openDiagnosticsLogs", "exportDiagnosticsBundle", "clearDiagnosticsLogs", "resetLocalUiState"].includes(event.action)) {
+    logDesktopNativeDebug("settings.diagnostics.action.requested", { action: event.action });
+    return;
+  }
+  if (event.action === "setDiagnosticsLogLevel") {
+    logDesktopNativeDebug("settings.diagnostics.log_level.requested", { logLevel: event.logLevel });
     return;
   }
   if (!nativeSettingsState) {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -2100,6 +2100,10 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     logDesktopNativeDebug("settings.workspace.reload.requested");
     return;
   }
+  if (event.action === "testProviderConnection") {
+    logDesktopNativeDebug("settings.provider.test.requested", { providerId: event.providerId });
+    return;
+  }
   if (!nativeSettingsState) {
     logDesktopNativeDebug("settings.action.skipped", { action: event.action, reason: "state unavailable" });
     return;

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -12,6 +12,7 @@ import {
   findDesktopProfileIdForProvider,
   getDesktopProviderProfileConfig,
   parseDesktopProviderModelList,
+  reconcileDesktopSettingsSavedState,
   resolveDesktopSecretValue,
   validateDesktopSettingsForm,
 } from "./desktopSettingsProviders";
@@ -638,6 +639,49 @@ describe("desktop settings and provider helpers", () => {
       ok: true,
       patch: { knowledge: { enabled: false } },
     });
+  });
+
+  test("reconciles saved config only when it reflects touched draft values", () => {
+    const providerCatalog = [{ id: "openai", displayName: "OpenAI", status: "ready" }];
+    const existingConfig = {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            api_base: "https://api.openai.com/v1",
+          },
+        },
+      },
+    };
+    const draft = applyDesktopSettingsFieldEdit(
+      buildDesktopSettingsFormState(existingConfig, providerCatalog),
+      "timezone",
+      "Asia/Shanghai",
+    );
+
+    const staleResult = reconcileDesktopSettingsSavedState(draft, existingConfig, providerCatalog);
+    expect(staleResult).toEqual({
+      ok: false,
+      mismatchedPaths: ["agents.defaults.timezone"],
+      state: draft,
+    });
+    expect(createDesktopSettingsPatch(staleResult.state, existingConfig, providerCatalog)).toEqual({
+      agents: { defaults: { timezone: "Asia/Shanghai" } },
+    });
+
+    const savedResult = reconcileDesktopSettingsSavedState(draft, {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "Asia/Shanghai" } },
+      providers: existingConfig.providers,
+    }, providerCatalog);
+    expect(savedResult.ok).toBe(true);
+    if (savedResult.ok) {
+      expect(savedResult.state.touchedPaths).toBeUndefined();
+      expect(createDesktopSettingsPatch(savedResult.state, savedResult.state.serverSnapshot, providerCatalog)).toMatchObject({
+        agents: { defaults: { timezone: "Asia/Shanghai" } },
+      });
+    }
   });
 
   test("classifies settings fields by requirement, input mode, and advanced visibility", () => {

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -7,6 +7,7 @@ import {
   buildDesktopProviderModelRequest,
   buildDesktopSecretField,
   buildDesktopSettingsFormState,
+  buildDesktopSettingsSavePatch,
   createDesktopSettingsPatch,
   findDesktopProfileIdForProvider,
   getDesktopProviderProfileConfig,
@@ -606,6 +607,37 @@ describe("desktop settings and provider helpers", () => {
       const state = buildDesktopSettingsFormState(existingConfig, providerCatalog);
       expect(createDesktopSettingsPatch(applyDesktopSettingsFieldEdit(state, fieldId, value), existingConfig, providerCatalog), groupName).toEqual(expectedPatch);
     }
+  });
+
+  test("validates the full draft before producing a touched-path save patch", () => {
+    const providerCatalog = [{ id: "openai", displayName: "OpenAI", status: "ready" }];
+    const existingConfig = {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            api_base: "https://api.openai.com/v1",
+          },
+        },
+      },
+      knowledge: { enabled: true },
+    };
+    const state = buildDesktopSettingsFormState(existingConfig, providerCatalog);
+    const invalidDraft = applyDesktopSettingsFieldEdit(state, "model", "");
+    const invalidWithKnowledgeEdit = applyDesktopSettingsFieldEdit(invalidDraft, "enabled", false);
+
+    expect(buildDesktopSettingsSavePatch(invalidWithKnowledgeEdit, existingConfig, providerCatalog)).toEqual({
+      ok: false,
+      validationErrors: [{ field: "model", errorKey: "modelEmpty" }],
+    });
+
+    const validWithKnowledgeEdit = applyDesktopSettingsFieldEdit(state, "enabled", false);
+    expect(buildDesktopSettingsSavePatch(validWithKnowledgeEdit, existingConfig, providerCatalog)).toEqual({
+      ok: true,
+      patch: { knowledge: { enabled: false } },
+    });
   });
 
   test("classifies settings fields by requirement, input mode, and advanced visibility", () => {

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -740,6 +740,65 @@ describe("desktop settings and provider helpers", () => {
     expect(fields["memory-experience.memory"]).toMatchObject({ control: "readonly", requirement: "readonly", configurationMode: "readonly" });
   });
 
+  test("adds shared settings metadata to groups and fields", () => {
+    const state = buildDesktopSettingsFormState({
+      agents: {
+        defaults: {
+          model: "deepseek-chat",
+          provider: "deepseek",
+          active_profile: "deepseek",
+          workspace: "D:/workspace",
+          timezone: "UTC",
+        },
+      },
+      providers: {
+        profiles: {
+          deepseek: {
+            provider: "deepseek",
+            api_key: "sk-live",
+            api_base: "https://api.deepseek.com",
+            models: ["deepseek-chat"],
+          },
+        },
+      },
+      gateway: { host: "127.0.0.1", port: 18790 },
+      tools: { mcp: { servers: { local: { command: "node" } } } },
+    }, [{ id: "deepseek", displayName: "DeepSeek", status: "ready" }]);
+
+    const pane = buildDesktopSettingsPaneModel(state, {
+      providerCatalog: [{ id: "deepseek", displayName: "DeepSeek", status: "ready" }],
+    });
+    const groups = Object.fromEntries(pane.groups.map((group) => [group.id, group]));
+    const fields = Object.fromEntries(pane.groups.flatMap((group) => group.fields.map((field) => [`${group.id}.${field.id}`, field])));
+
+    expect(groups.general).toMatchObject({
+      description: "Default model, provider routing, timezone, and desktop workspace defaults.",
+      aliases: ["default model", "profile", "timezone", "workspace"],
+      i18nKey: "settings.groups.general",
+    });
+    expect(fields["general.timezone"]).toMatchObject({
+      description: "Timezone used for timestamps, reminders, and scheduled work.",
+      aliases: ["time zone", "locale", "schedule timezone"],
+      validationField: "timezone",
+      i18nKey: "settings.fields.general.timezone",
+    });
+    expect(fields["provider-models.apiKey"]).toMatchObject({
+      sensitive: true,
+      i18nKey: "settings.fields.provider-models.apiKey",
+    });
+    expect(fields["general.workspace"]).toMatchObject({
+      applyEffect: "workspace-reload",
+    });
+    expect(fields["gateway-runtime.host"]).toMatchObject({
+      applyEffect: "gateway-restart",
+      aliases: ["bind host", "listen address", "gateway endpoint"],
+    });
+    expect(fields["tools-approvals.mcpServers"]).toMatchObject({
+      validationField: "mcpServers",
+      i18nKey: "settings.fields.tools-approvals.mcpServers",
+    });
+  });
+
   test("keeps provider editing separate from the default LLM provider", () => {
     const state = buildDesktopSettingsFormState({
       agents: { defaults: { model: "gpt-4.1", provider: "openai", active_profile: "work" } },

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -552,6 +552,62 @@ describe("desktop settings and provider helpers", () => {
     expect(createDesktopSettingsPatch(applyDesktopSettingsFieldEdit(state, "apiBase", "https://api.openai.com/v1"))).toEqual({});
   });
 
+  test("omits unrelated fields from patches for each settings group", () => {
+    const providerCatalog = [{ id: "openai", displayName: "OpenAI", status: "ready" }];
+    const existingConfig = {
+      agents: {
+        defaults: {
+          model: "gpt-4.1-mini",
+          provider: "openai",
+          active_profile: "work",
+          timezone: "UTC",
+        },
+      },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            api_base: "https://api.openai.com/v1",
+            models: ["gpt-4.1-mini"],
+          },
+        },
+        openai: {
+          api_key: "sk-live",
+          api_base: "https://api.openai.com/v1",
+        },
+      },
+      knowledge: { enabled: true, auto_retrieve: false },
+      tools: { exec: { enable: true, timeout: 120 }, web: { enable: true, search: { provider: "duckduckgo" } } },
+      channels: { send_progress: true, send_tool_hints: false, send_max_retries: 3 },
+      gateway: { host: "127.0.0.1", port: 18790, heartbeat: { enabled: true, interval_s: 1800 } },
+    };
+
+    const cases: Array<[string, string, string | boolean, unknown]> = [
+      ["general", "model", "gpt-4.1", { agents: { defaults: { model: "gpt-4.1" } } }],
+      ["provider-models", "apiKey", "sk-replacement", {
+        providers: {
+          openai: { api_key: "sk-replacement" },
+          profiles: { work: { api_key: "sk-replacement" } },
+        },
+      }],
+      ["knowledge", "autoRetrieve", true, { knowledge: { auto_retrieve: true } }],
+      ["tools-approvals", "execTimeout", "90", { tools: { exec: { timeout: 90 } } }],
+      ["channels", "sendMaxRetries", "5", { channels: { send_max_retries: 5 } }],
+      ["gateway-runtime", "heartbeatIntervalS", "900", { gateway: { heartbeat: { interval_s: 900 } } }],
+      ["files-workspace", "sessionFiles", "ignored", {}],
+      ["memory-experience", "memory", "ignored", {}],
+      ["skills", "skills", "ignored", {}],
+      ["automations", "automations", "ignored", {}],
+      ["logs-diagnostics", "diagnostics", "ignored", {}],
+    ];
+
+    for (const [groupName, fieldId, value, expectedPatch] of cases) {
+      const state = buildDesktopSettingsFormState(existingConfig, providerCatalog);
+      expect(createDesktopSettingsPatch(applyDesktopSettingsFieldEdit(state, fieldId, value), existingConfig, providerCatalog), groupName).toEqual(expectedPatch);
+    }
+  });
+
   test("classifies settings fields by requirement, input mode, and advanced visibility", () => {
     const state = buildDesktopSettingsFormState({
       agents: {
@@ -726,9 +782,7 @@ describe("desktop settings and provider helpers", () => {
       lastSavedState: savedState,
       providerCatalog,
     }).dirty).toBe(false);
-    expect(createDesktopSettingsPatch(browsingState, config, providerCatalog)).toEqual(
-      createDesktopSettingsPatch(savedState, config, providerCatalog),
-    );
+    expect(createDesktopSettingsPatch(browsingState, config, providerCatalog)).toEqual({});
   });
 
   test("prevents disabling the current default provider until another route is selected", () => {

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -930,4 +930,51 @@ describe("desktop settings and provider helpers", () => {
     expect(pane.save.applied).toEqual(["agents.defaults.model"]);
     expect(pane.save.warnings).toEqual(["Native patch failed; gateway fallback applied."]);
   });
+
+  test("promotes saved restart and reload side effects to distinct save states", () => {
+    const state = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            models: ["gpt-4.1-mini"],
+          },
+        },
+      },
+    }, [{ id: "openai", displayName: "OpenAI", status: "ready" }]);
+
+    const restartPane = buildDesktopSettingsPaneModel(state, {
+      lastSavedState: state,
+      providerCatalog: [{ id: "openai", displayName: "OpenAI", status: "ready" }],
+      saveStatus: "saved",
+      saveDetails: {
+        transport: "native",
+        updatedFields: ["gateway.port"],
+        applied: ["gatewayRuntimeChanged"],
+        restartRequired: ["gatewayRestartRequired"],
+        reloadRequired: [],
+        warnings: [],
+      },
+    });
+    const reloadPane = buildDesktopSettingsPaneModel(state, {
+      lastSavedState: state,
+      providerCatalog: [{ id: "openai", displayName: "OpenAI", status: "ready" }],
+      saveStatus: "saved",
+      saveDetails: {
+        transport: "native",
+        updatedFields: ["agents.defaults.workspace"],
+        applied: ["workspaceChanged"],
+        restartRequired: [],
+        reloadRequired: ["workspaceReloadRequired"],
+        warnings: [],
+      },
+    });
+
+    expect(restartPane.save.status).toBe("restart-required");
+    expect(restartPane.save.message).toBe("Settings saved. Gateway restart required");
+    expect(reloadPane.save.status).toBe("reload-required");
+    expect(reloadPane.save.message).toBe("Settings saved. Workspace reload required");
+  });
 });

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -340,7 +340,7 @@ describe("desktop settings and provider helpers", () => {
       ["general", "General"],
       ["provider-models", "Provider & Models"],
       ["knowledge", "Knowledge"],
-      ["tools-approvals", "Tools & Approvals"],
+      ["tools-approvals", "Tools & MCP"],
       ["files-workspace", "Files & Workspace"],
       ["memory-experience", "Memory & Experience"],
       ["skills", "Skills"],
@@ -836,6 +836,10 @@ describe("desktop settings and provider helpers", () => {
     expect(fields["tools-approvals.mcpServers"]).toMatchObject({
       validationField: "mcpServers",
       i18nKey: "settings.fields.tools-approvals.mcpServers",
+    });
+    expect(groups["tools-approvals"]).toMatchObject({
+      label: "Tools & MCP",
+      description: "Tool toggles and MCP server access. Approval controls are not exposed here yet.",
     });
   });
 

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -497,6 +497,34 @@ describe("desktop settings and provider helpers", () => {
     });
   });
 
+  test("omits reverted touched fields from patches and dirty state", () => {
+    const providerCatalog = [{ id: "openai", displayName: "OpenAI", status: "ready" }];
+    const existingConfig = {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            api_base: "https://api.openai.com/v1",
+          },
+        },
+        openai: {
+          api_key: "sk-live",
+          api_base: "https://api.openai.com/v1",
+        },
+      },
+    };
+    const savedState = buildDesktopSettingsFormState(existingConfig, providerCatalog);
+    const sameTimezone = applyDesktopSettingsFieldEdit(savedState, "timezone", "UTC");
+    const sameProviderApiBase = applyDesktopSettingsFieldEdit(savedState, "apiBase", "https://api.openai.com/v1");
+
+    expect(createDesktopSettingsPatch(sameTimezone, existingConfig, providerCatalog)).toEqual({});
+    expect(createDesktopSettingsPatch(sameProviderApiBase, existingConfig, providerCatalog)).toEqual({});
+    expect(buildDesktopSettingsPaneModel(sameTimezone, { lastSavedState: savedState, providerCatalog }).dirty).toBe(false);
+    expect(buildDesktopSettingsPaneModel(sameProviderApiBase, { lastSavedState: savedState, providerCatalog }).dirty).toBe(false);
+  });
+
   test("classifies settings fields by requirement, input mode, and advanced visibility", () => {
     const state = buildDesktopSettingsFormState({
       agents: {

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -742,6 +742,29 @@ describe("desktop settings and provider helpers", () => {
     expect(fields["memory-experience.memory"]).toMatchObject({ control: "readonly", requirement: "readonly", configurationMode: "readonly" });
   });
 
+  test("disables dependent Knowledge controls when parent features are off", () => {
+    const state = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "deepseek-chat" } },
+      knowledge: {
+        enabled: false,
+        rerank_enabled: false,
+        graph_extraction_enabled: false,
+      },
+    });
+
+    const pane = buildDesktopSettingsPaneModel(state);
+    const fields = Object.fromEntries(pane.groups.flatMap((group) => group.fields.map((field) => [`${group.id}.${field.id}`, field])));
+
+    expect(fields["knowledge.enabled"]).toMatchObject({ disabled: false });
+    expect(fields["knowledge.autoRetrieve"]).toMatchObject({ disabled: true });
+    expect(fields["knowledge.retrievalMode"]).toMatchObject({ disabled: true });
+    expect(fields["knowledge.maxChunks"]).toMatchObject({ disabled: true });
+    expect(fields["knowledge.rerankModel"]).toMatchObject({ disabled: true });
+    expect(fields["knowledge.rerankApiBase"]).toMatchObject({ disabled: true });
+    expect(fields["knowledge.graphAutoExtract"]).toMatchObject({ disabled: true });
+    expect(fields["knowledge.graphExtractionModel"]).toMatchObject({ disabled: true });
+  });
+
   test("adds shared settings metadata to groups and fields", () => {
     const state = buildDesktopSettingsFormState({
       agents: {

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -525,6 +525,33 @@ describe("desktop settings and provider helpers", () => {
     expect(buildDesktopSettingsPaneModel(sameProviderApiBase, { lastSavedState: savedState, providerCatalog }).dirty).toBe(false);
   });
 
+  test("uses the loaded server snapshot when touched patches are generated without an explicit config", () => {
+    const providerCatalog = [{ id: "openai", displayName: "OpenAI", status: "ready" }];
+    const existingConfig = {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            api_base: "https://api.openai.com/v1",
+          },
+        },
+        openai: {
+          api_key: "sk-live",
+          api_base: "https://api.openai.com/v1",
+        },
+      },
+    };
+    const state = buildDesktopSettingsFormState(existingConfig, providerCatalog);
+
+    expect(createDesktopSettingsPatch(applyDesktopSettingsFieldEdit(state, "timezone", "UTC"))).toEqual({});
+    expect(createDesktopSettingsPatch(applyDesktopSettingsFieldEdit(state, "timezone", "Asia/Shanghai"))).toEqual({
+      agents: { defaults: { timezone: "Asia/Shanghai" } },
+    });
+    expect(createDesktopSettingsPatch(applyDesktopSettingsFieldEdit(state, "apiBase", "https://api.openai.com/v1"))).toEqual({});
+  });
+
   test("classifies settings fields by requirement, input mode, and advanced visibility", () => {
     const state = buildDesktopSettingsFormState({
       agents: {

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -359,9 +359,11 @@ describe("desktop settings and provider helpers", () => {
       expect.objectContaining({ id: "models", label: "Models", control: "textarea", requirement: "optional", configurationMode: "list" }),
     ]));
     expect(pane.groups.find((group) => group.id === "files-workspace")?.fields).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "workspace", label: "Workspace", value: "~/.tinybot/workspace", control: "text", requirement: "required", configurationMode: "freeform" }),
       expect.objectContaining({ id: "sessionFiles", label: "Session files", value: "Session file", control: "readonly", requirement: "readonly", configurationMode: "readonly" }),
       expect.objectContaining({ id: "workspaceFiles", label: "Workspace files", value: "Workspace file", control: "readonly", requirement: "readonly", configurationMode: "readonly" }),
     ]));
+    expect(pane.groups.find((group) => group.id === "general")?.fields.find((field) => field.id === "workspace")).toBeUndefined();
     expect(pane.groups.find((group) => group.id === "gateway-runtime")?.fields).toEqual(expect.arrayContaining([
       expect.objectContaining({ id: "host", label: "Host", requirement: "required", configurationMode: "freeform" }),
       expect.objectContaining({ id: "port", label: "Port", state: "normal", requirement: "required", configurationMode: "numeric" }),
@@ -772,10 +774,24 @@ describe("desktop settings and provider helpers", () => {
     const fields = Object.fromEntries(pane.groups.flatMap((group) => group.fields.map((field) => [`${group.id}.${field.id}`, field])));
 
     expect(groups.general).toMatchObject({
-      description: "Default model, provider routing, timezone, and desktop workspace defaults.",
+      description: "Default model, provider routing, and timezone behavior.",
       aliases: ["default model", "profile", "timezone", "workspace"],
+      navigationArea: "core",
+      navigationMode: "section",
       i18nKey: "settings.groups.general",
     });
+    expect(groups["files-workspace"]).toMatchObject({
+      navigationArea: "application",
+      navigationMode: "section",
+    });
+    expect(groups["gateway-runtime"]).toMatchObject({
+      navigationArea: "system",
+      navigationMode: "section",
+    });
+    expect(groups["memory-experience"]).toMatchObject({
+      navigationMode: "preview",
+    });
+    expect(fields["general.workspace"]).toBeUndefined();
     expect(fields["general.timezone"]).toMatchObject({
       description: "Timezone used for timestamps, reminders, and scheduled work.",
       aliases: ["time zone", "locale", "schedule timezone"],
@@ -786,8 +802,9 @@ describe("desktop settings and provider helpers", () => {
       sensitive: true,
       i18nKey: "settings.fields.provider-models.apiKey",
     });
-    expect(fields["general.workspace"]).toMatchObject({
+    expect(fields["files-workspace.workspace"]).toMatchObject({
       applyEffect: "workspace-reload",
+      i18nKey: "settings.fields.files-workspace.workspace",
     });
     expect(fields["gateway-runtime.host"]).toMatchObject({
       applyEffect: "gateway-restart",

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -421,6 +421,82 @@ describe("desktop settings and provider helpers", () => {
     expect(patch.gateway).toMatchObject({ port: 18888 });
   });
 
+  test("generates touched-path patches for individual field edits without hidden settings", () => {
+    const existingConfig = {
+      agents: {
+        defaults: {
+          model: "gpt-4.1-mini",
+          provider: "openai",
+          timezone: "UTC",
+          hidden_backend_only: "preserve",
+          embedding: {
+            provider: "dashscope",
+            model_name: "text-embedding-v3",
+            hidden_embedding_only: true,
+          },
+        },
+      },
+      knowledge: {
+        enabled: true,
+        hidden_graph_backend_only: { preserve: true },
+      },
+      gateway: {
+        host: "127.0.0.1",
+        port: 18790,
+        hidden_gateway_only: "preserve",
+      },
+    };
+    const state = buildDesktopSettingsFormState(existingConfig, [{ id: "openai", displayName: "OpenAI", status: "ready" }]);
+
+    const withTimezone = applyDesktopSettingsFieldEdit(state, "timezone", "Asia/Shanghai");
+    const withKnowledgeDisabled = applyDesktopSettingsFieldEdit(state, "enabled", false);
+    const withGatewayPort = applyDesktopSettingsFieldEdit(state, "port", "18888");
+
+    expect(createDesktopSettingsPatch(withTimezone, existingConfig, [{ id: "openai", displayName: "OpenAI", status: "ready" }])).toEqual({
+      agents: { defaults: { timezone: "Asia/Shanghai" } },
+    });
+    expect(createDesktopSettingsPatch(withKnowledgeDisabled, existingConfig, [{ id: "openai", displayName: "OpenAI", status: "ready" }])).toEqual({
+      knowledge: { enabled: false },
+    });
+    expect(createDesktopSettingsPatch(withGatewayPort, existingConfig, [{ id: "openai", displayName: "OpenAI", status: "ready" }])).toEqual({
+      gateway: { port: 18888 },
+    });
+  });
+
+  test("generates touched-path patches for provider profile edits only", () => {
+    const providerCatalog = [{ id: "openai", displayName: "OpenAI", status: "ready" }];
+    const existingConfig = {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            api_base: "https://api.openai.com/v1",
+            models: ["gpt-4.1-mini"],
+            hidden_profile_only: "preserve",
+          },
+        },
+        openai: {
+          api_key: "sk-live",
+          api_base: "https://api.openai.com/v1",
+          hidden_provider_only: "preserve",
+        },
+      },
+    };
+    const state = buildDesktopSettingsFormState(existingConfig, providerCatalog);
+    const withProviderApiBase = applyDesktopSettingsFieldEdit(state, "apiBase", "https://proxy.example/v1");
+
+    expect(createDesktopSettingsPatch(withProviderApiBase, existingConfig, providerCatalog)).toEqual({
+      providers: {
+        openai: { api_base: "https://proxy.example/v1" },
+        profiles: {
+          work: { api_base: "https://proxy.example/v1" },
+        },
+      },
+    });
+  });
+
   test("classifies settings fields by requirement, input mode, and advanced visibility", () => {
     const state = buildDesktopSettingsFormState({
       agents: {
@@ -559,8 +635,6 @@ describe("desktop settings and provider helpers", () => {
       providers: {
         deepseek: {
           enabled: false,
-          api_base: "https://api.deepseek.com",
-          api_key: "sk-deepseek",
         },
       },
     });

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -977,4 +977,38 @@ describe("desktop settings and provider helpers", () => {
     expect(reloadPane.save.status).toBe("reload-required");
     expect(reloadPane.save.message).toBe("Settings saved. Workspace reload required");
   });
+
+  test("builds copyable save diagnostics for fallback and warning results", () => {
+    const state = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            models: ["gpt-4.1-mini"],
+          },
+        },
+      },
+    }, [{ id: "openai", displayName: "OpenAI", status: "ready" }]);
+
+    const pane = buildDesktopSettingsPaneModel(state, {
+      lastSavedState: state,
+      providerCatalog: [{ id: "openai", displayName: "OpenAI", status: "ready" }],
+      saveStatus: "saved",
+      saveDetails: {
+        transport: "gateway-fallback",
+        updatedFields: ["agents.defaults.model"],
+        applied: [],
+        restartRequired: [],
+        reloadRequired: [],
+        warnings: ["Saved through gateway fallback after native config patch failed: boom"],
+      },
+    });
+
+    expect(pane.save.diagnostics).toContain("Status: saved");
+    expect(pane.save.diagnostics).toContain("Transport: gateway-fallback");
+    expect(pane.save.diagnostics).toContain("Updated fields: agents.defaults.model");
+    expect(pane.save.diagnostics).toContain("Warnings: Saved through gateway fallback after native config patch failed: boom");
+  });
 });

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -187,6 +187,27 @@ describe("desktop settings and provider helpers", () => {
     ]);
   });
 
+  test("accepts UTC, GMT, and IANA timezone defaults while rejecting invalid timezone values", () => {
+    for (const timezone of ["UTC", "GMT", "Asia/Shanghai"]) {
+      const state = buildDesktopSettingsFormState({
+        agents: { defaults: { model: "gpt-4.1", timezone } },
+      });
+
+      expect(validateDesktopSettingsForm(state).filter((error) => error.field === "timezone")).toEqual([]);
+    }
+
+    for (const timezone of ["", "Shanghai", "Mars/Base"]) {
+      const state = buildDesktopSettingsFormState({
+        agents: { defaults: { model: "gpt-4.1", timezone } },
+      });
+      state.agent.timezone = timezone;
+
+      expect(validateDesktopSettingsForm(state)).toEqual(expect.arrayContaining([
+        { field: "timezone", errorKey: "timezoneError" },
+      ]));
+    }
+  });
+
   test("builds provider model discovery requests and applies model results", () => {
     const state = buildDesktopSettingsFormState({
       agents: { defaults: { provider: "openai", active_profile: "work" } },
@@ -363,6 +384,22 @@ describe("desktop settings and provider helpers", () => {
     });
   });
 
+  test("reports invalid dirty settings as needing attention beside save", () => {
+    const savedState = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "gpt-4.1", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: { profiles: { work: { provider: "openai", api_key: "sk-live", models: ["gpt-4.1"] } } },
+    }, [{ id: "openai", displayName: "OpenAI", status: "ready" }]);
+    const invalidState = applyDesktopSettingsFieldEdit(savedState, "timezone", "Shanghai");
+
+    const pane = buildDesktopSettingsPaneModel(invalidState, {
+      lastSavedState: savedState,
+      providerCatalog: [{ id: "openai", displayName: "OpenAI", status: "ready" }],
+    });
+
+    expect(pane.save.canSave).toBe(false);
+    expect(pane.save.message).toBe("1 setting needs attention");
+  });
+
   test("applies desktop settings field edits to the saved config patch shape", () => {
     const state = buildDesktopSettingsFormState({
       agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work" } },
@@ -526,6 +563,77 @@ describe("desktop settings and provider helpers", () => {
           api_key: "sk-deepseek",
         },
       },
+    });
+  });
+
+  test("does not dirty settings or change the patch when only browsing provider cards", () => {
+    const providerCatalog = [
+      { id: "openai", displayName: "OpenAI", status: "ready" },
+      { id: "deepseek", displayName: "DeepSeek", status: "ready" },
+    ];
+    const config = {
+      agents: { defaults: { model: "gpt-4.1", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-openai",
+            api_base: "https://api.openai.com/v1",
+            models: ["gpt-4.1"],
+          },
+          deepseek: {
+            provider: "deepseek",
+            api_key: "sk-deepseek",
+            api_base: "https://api.deepseek.com",
+            models: ["deepseek-chat"],
+          },
+        },
+      },
+    };
+    const savedState = buildDesktopSettingsFormState(config, providerCatalog);
+    const browsingState = applyDesktopSettingsFieldEdit(savedState, "selectedProvider", "deepseek");
+
+    expect(buildDesktopSettingsPaneModel(browsingState, {
+      lastSavedState: savedState,
+      providerCatalog,
+    }).dirty).toBe(false);
+    expect(createDesktopSettingsPatch(browsingState, config, providerCatalog)).toEqual(
+      createDesktopSettingsPatch(savedState, config, providerCatalog),
+    );
+  });
+
+  test("prevents disabling the current default provider until another route is selected", () => {
+    const providerCatalog = [
+      { id: "openai", displayName: "OpenAI", status: "ready" },
+      { id: "deepseek", displayName: "DeepSeek", status: "ready" },
+    ];
+    const state = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "gpt-4.1", provider: "openai", active_profile: "work" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            enabled: true,
+            api_key: "sk-openai",
+            models: ["gpt-4.1"],
+          },
+          deepseek: {
+            provider: "deepseek",
+            enabled: true,
+            api_key: "sk-deepseek",
+            models: ["deepseek-chat"],
+          },
+        },
+      },
+    }, providerCatalog);
+
+    const attemptedDisable = applyDesktopSettingsFieldEdit(state, "providerEnabled:openai", false);
+
+    expect(buildDesktopSettingsPaneModel(attemptedDisable, { providerCatalog }).providerCatalog).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "openai", enabled: true }),
+    ]));
+    expect(createDesktopSettingsPatch(attemptedDisable, {}, providerCatalog).providers).not.toMatchObject({
+      openai: { enabled: false },
     });
   });
 });

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -895,4 +895,39 @@ describe("desktop settings and provider helpers", () => {
       openai: { enabled: false },
     });
   });
+
+  test("preserves save warnings and gateway fallback details in the pane model", () => {
+    const state = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            models: ["gpt-4.1-mini"],
+          },
+        },
+      },
+    }, [{ id: "openai", displayName: "OpenAI", status: "ready" }]);
+
+    const pane = buildDesktopSettingsPaneModel(state, {
+      lastSavedState: state,
+      providerCatalog: [{ id: "openai", displayName: "OpenAI", status: "ready" }],
+      saveStatus: "saved",
+      saveDetails: {
+        transport: "gateway-fallback",
+        updatedFields: ["agents.defaults.model"],
+        applied: ["agents.defaults.model"],
+        restartRequired: [],
+        reloadRequired: [],
+        warnings: ["Native patch failed; gateway fallback applied."],
+      },
+    });
+
+    expect(pane.save.message).toBe("Settings saved through gateway fallback");
+    expect(pane.save.transport).toBe("gateway-fallback");
+    expect(pane.save.updatedFields).toEqual(["agents.defaults.model"]);
+    expect(pane.save.applied).toEqual(["agents.defaults.model"]);
+    expect(pane.save.warnings).toEqual(["Native patch failed; gateway fallback applied."]);
+  });
 });

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -150,7 +150,7 @@ export interface DesktopSecretField {
   empty: boolean;
 }
 
-export type DesktopSettingsSaveStatus = "idle" | "saving" | "saved" | "failed";
+export type DesktopSettingsSaveStatus = "idle" | "saving" | "saved" | "failed" | "restart-required" | "reload-required";
 export type DesktopSettingsSaveTransport = "native" | "gateway-fallback";
 export interface DesktopSettingsPaneSaveDetails {
   transport: DesktopSettingsSaveTransport;
@@ -879,8 +879,8 @@ export function buildDesktopSettingsPaneModel(
   const dirty = options.lastSavedState
     ? desktopSettingsStateDirty(state, options.lastSavedState)
     : false;
-  const saveStatus = options.saveStatus ?? "idle";
   const saveDetails = normalizeDesktopSettingsSaveDetails(options.saveDetails);
+  const saveStatus = resolveDesktopSettingsSaveStatus(options.saveStatus ?? "idle", saveDetails);
   return {
     dirty,
     validationErrors,
@@ -1933,6 +1933,22 @@ function normalizeDesktopSettingsSaveDetails(
   };
 }
 
+function resolveDesktopSettingsSaveStatus(
+  status: DesktopSettingsSaveStatus,
+  saveDetails: DesktopSettingsPaneSaveDetails | null,
+): DesktopSettingsSaveStatus {
+  if (status !== "saved") {
+    return status;
+  }
+  if (saveDetails?.restartRequired.length) {
+    return "restart-required";
+  }
+  if (saveDetails?.reloadRequired.length) {
+    return "reload-required";
+  }
+  return status;
+}
+
 function formatDesktopSettingsSaveMessage(
   status: DesktopSettingsSaveStatus,
   dirty: boolean,
@@ -1950,6 +1966,12 @@ function formatDesktopSettingsSaveMessage(
       return "Settings saved with warnings";
     }
     return "Settings saved";
+  }
+  if (status === "restart-required") {
+    return "Settings saved. Gateway restart required";
+  }
+  if (status === "reload-required") {
+    return "Settings saved. Workspace reload required";
   }
   if (validationErrorCount > 0) {
     return `${validationErrorCount} ${validationErrorCount === 1 ? "setting needs" : "settings need"} attention`;

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -452,6 +452,13 @@ export interface DesktopSettingsPaneModel {
     models?: string[];
     canDiscoverModels?: boolean;
   }>;
+  defaultRouting?: {
+    mode: "auto" | "provider";
+    providerId: string;
+    providerLabel: string;
+    model: string | null;
+    message: string;
+  };
   providerEditor: {
     selectedProvider: string;
     profileId: string;
@@ -1106,23 +1113,25 @@ export function buildDesktopSettingsPaneModel(
     save.warnings = saveDetails.warnings;
     save.diagnostics = formatDesktopSettingsSaveDiagnostics(saveStatus, saveDetails);
   }
+  const providerCatalog = providerSummaries.map((provider) => ({
+    id: provider.id,
+    label: provider.label,
+    profileId: provider.profileId,
+    status: provider.status || "unknown",
+    enabled: provider.enabled,
+    enabledConfigured: provider.enabledConfigured,
+    baseUrl: provider.apiBase,
+    apiKey: buildDesktopSecretField(provider.apiKey),
+    models: parseDesktopProviderModelList(provider.modelsText),
+    canDiscoverModels: provider.supportsModelDiscovery,
+  })).filter((provider) => provider.id);
   return {
     dirty,
     validationErrors,
     save,
     groups: buildDesktopSettingsPaneGroups(state, validationErrors, providerSummaries),
-    providerCatalog: providerSummaries.map((provider) => ({
-      id: provider.id,
-      label: provider.label,
-      profileId: provider.profileId,
-      status: provider.status || "unknown",
-      enabled: provider.enabled,
-      enabledConfigured: provider.enabledConfigured,
-      baseUrl: provider.apiBase,
-      apiKey: buildDesktopSecretField(provider.apiKey),
-      models: parseDesktopProviderModelList(provider.modelsText),
-      canDiscoverModels: provider.supportsModelDiscovery,
-    })).filter((provider) => provider.id),
+    providerCatalog,
+    defaultRouting: buildDesktopDefaultRouting(state, providerCatalog),
     providerEditor: {
       selectedProvider: state.providerEditor.selectedProvider,
       profileId: state.providerEditor.profileId,
@@ -1144,6 +1153,30 @@ export function buildDesktopProviderModelRequest(
     api_key: state.providerEditor.apiKey || "",
     api_base: state.providerEditor.apiBase || "",
     refresh,
+  };
+}
+
+function buildDesktopDefaultRouting(
+  state: DesktopSettingsFormState,
+  providerCatalog: DesktopSettingsPaneModel["providerCatalog"],
+): DesktopSettingsPaneModel["defaultRouting"] {
+  const model = state.agent.model;
+  const mode = state.agent.provider === "auto" ? "auto" : "provider";
+  const enabledProviders = providerCatalog.filter((provider) => provider.enabled !== false);
+  const configuredProvider = providerCatalog.find((provider) => provider.id === state.agent.provider);
+  const resolvedProvider = mode === "auto"
+    ? enabledProviders.find((provider) => model ? provider.models?.includes(model) : false) ?? enabledProviders[0] ?? providerCatalog[0]
+    : configuredProvider ?? providerCatalog[0];
+  const providerLabel = resolvedProvider?.label || resolvedProvider?.id || "Unavailable";
+  const providerId = resolvedProvider?.id || "";
+  return {
+    mode,
+    providerId,
+    providerLabel,
+    model,
+    message: mode === "auto"
+      ? `Auto resolves to ${providerLabel}${model ? ` / ${model}` : ""}`
+      : `${providerLabel}${model ? ` / ${model}` : ""}`,
   };
 }
 

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -188,6 +188,8 @@ export interface DesktopSettingsPaneFieldMetadata {
   validationField?: DesktopSettingsValidationField;
   sensitive?: boolean;
   applyEffect?: DesktopSettingsPaneApplyEffect;
+  unit?: string;
+  recommendation?: string;
 }
 
 export interface DesktopSettingsPaneGroupMetadata {
@@ -208,6 +210,8 @@ export interface DesktopSettingsPaneField {
   validationField?: DesktopSettingsValidationField;
   sensitive?: boolean;
   applyEffect?: DesktopSettingsPaneApplyEffect;
+  unit?: string;
+  recommendation?: string;
   value: string;
   state: "normal" | "invalid";
   control: DesktopSettingsPaneFieldControl;
@@ -372,6 +376,20 @@ const DESKTOP_SETTINGS_FIELD_METADATA: Record<string, DesktopSettingsPaneFieldMe
     applyEffect: "workspace-reload",
     i18nKey: "settings.fields.files-workspace.workspace",
   },
+  "general.temperature": {
+    label: "Temperature",
+    description: "Sampling temperature for default chat and agent responses.",
+    aliases: ["creativity", "sampling"],
+    recommendation: "Recommended 0.1",
+    i18nKey: "settings.fields.general.temperature",
+  },
+  "general.maxTokens": {
+    label: "Max tokens",
+    description: "Maximum generated tokens for a default response.",
+    aliases: ["output tokens", "completion tokens"],
+    unit: "tokens",
+    i18nKey: "settings.fields.general.maxTokens",
+  },
   "provider-models.apiKey": {
     label: "API key",
     description: "Secret credential used by the selected provider profile.",
@@ -407,6 +425,7 @@ const DESKTOP_SETTINGS_FIELD_METADATA: Record<string, DesktopSettingsPaneFieldMe
     aliases: ["gateway port", "listen port"],
     validationField: "gatewayPort",
     applyEffect: "gateway-restart",
+    unit: "TCP port",
     i18nKey: "settings.fields.gateway-runtime.port",
   },
 };
@@ -2202,6 +2221,8 @@ function enrichDesktopSettingsPaneField(
     validationField: metadata.validationField ?? field.validationField,
     sensitive: metadata.sensitive,
     applyEffect: metadata.applyEffect,
+    unit: metadata.unit,
+    recommendation: metadata.recommendation,
   };
 }
 

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -227,6 +227,7 @@ export interface DesktopSettingsPaneModel {
     restartRequired?: string[];
     reloadRequired?: string[];
     warnings?: string[];
+    diagnostics?: string;
   };
   groups: DesktopSettingsPaneGroup[];
   providerCatalog: Array<{
@@ -881,20 +882,24 @@ export function buildDesktopSettingsPaneModel(
     : false;
   const saveDetails = normalizeDesktopSettingsSaveDetails(options.saveDetails);
   const saveStatus = resolveDesktopSettingsSaveStatus(options.saveStatus ?? "idle", saveDetails);
+  const save: DesktopSettingsPaneModel["save"] = {
+    status: saveStatus,
+    message: saveStatus === "failed" ? options.saveError || "Save failed" : formatDesktopSettingsSaveMessage(saveStatus, dirty, validationErrors.length, saveDetails),
+    canSave: dirty && validationErrors.length === 0 && saveStatus !== "saving",
+  };
+  if (saveDetails) {
+    save.transport = saveDetails.transport;
+    save.updatedFields = saveDetails.updatedFields;
+    save.applied = saveDetails.applied;
+    save.restartRequired = saveDetails.restartRequired;
+    save.reloadRequired = saveDetails.reloadRequired;
+    save.warnings = saveDetails.warnings;
+    save.diagnostics = formatDesktopSettingsSaveDiagnostics(saveStatus, saveDetails);
+  }
   return {
     dirty,
     validationErrors,
-    save: {
-      status: saveStatus,
-      message: saveStatus === "failed" ? options.saveError || "Save failed" : formatDesktopSettingsSaveMessage(saveStatus, dirty, validationErrors.length, saveDetails),
-      canSave: dirty && validationErrors.length === 0 && saveStatus !== "saving",
-      transport: saveDetails?.transport,
-      updatedFields: saveDetails?.updatedFields,
-      applied: saveDetails?.applied,
-      restartRequired: saveDetails?.restartRequired,
-      reloadRequired: saveDetails?.reloadRequired,
-      warnings: saveDetails?.warnings,
-    },
+    save,
     groups: buildDesktopSettingsPaneGroups(state, validationErrors, providerSummaries),
     providerCatalog: providerSummaries.map((provider) => ({
       id: provider.id,
@@ -1977,6 +1982,27 @@ function formatDesktopSettingsSaveMessage(
     return `${validationErrorCount} ${validationErrorCount === 1 ? "setting needs" : "settings need"} attention`;
   }
   return dirty ? "Unsaved changes" : "No changes";
+}
+
+function formatDesktopSettingsSaveDiagnostics(
+  status: DesktopSettingsSaveStatus,
+  saveDetails: DesktopSettingsPaneSaveDetails | null,
+): string {
+  const rows = [`Status: ${status}`];
+  if (!saveDetails) {
+    return rows.join("\n");
+  }
+  rows.push(`Transport: ${saveDetails.transport}`);
+  rows.push(`Updated fields: ${formatDiagnosticList(saveDetails.updatedFields)}`);
+  rows.push(`Applied: ${formatDiagnosticList(saveDetails.applied)}`);
+  rows.push(`Restart required: ${formatDiagnosticList(saveDetails.restartRequired)}`);
+  rows.push(`Reload required: ${formatDiagnosticList(saveDetails.reloadRequired)}`);
+  rows.push(`Warnings: ${formatDiagnosticList(saveDetails.warnings)}`);
+  return rows.join("\n");
+}
+
+function formatDiagnosticList(values: string[]): string {
+  return values.length ? values.join(", ") : "none";
 }
 
 function formatDesktopSettingsFieldValue(value: unknown): string {

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -100,6 +100,7 @@ export interface DesktopSettingsFormState {
   };
   providerEditor: DesktopSettingsProviderEditorState;
   providerSummaries: DesktopSettingsProviderSummary[];
+  providerEditorDirty?: boolean;
 }
 
 export type DesktopSettingsValidationField =
@@ -439,10 +440,10 @@ export function createDesktopSettingsPatch(
   providerCatalog: DesktopProviderCatalogItem[] = [],
 ): UnknownRecord {
   const providerIds = providerCatalog.map((provider) => stringValue(provider.id)).filter(Boolean);
-  const providerName = providerIds.includes(state.providerEditor.selectedProvider)
-    ? state.providerEditor.selectedProvider
-    : state.providerEditor.selectedProvider || "deepseek";
-  const profileId = stringOrNull(state.providerEditor.profileId) || state.agent.activeProfile;
+  const providerDraft = getDesktopSettingsPersistedProviderDraft(state, providerIds);
+  const providerName = providerDraft.providerName;
+  const profileId = providerDraft.profileId;
+  const providerEditor = providerDraft.editor;
   const existingProfiles = { ...getDesktopProviderProfiles(asRecord(asRecord(existingConfig).providers)) };
   const providers: UnknownRecord = {};
 
@@ -452,18 +453,18 @@ export function createDesktopSettingsPatch(
       [profileId]: {
         provider: providerName,
         enabled: state.providerSummaries.find((provider) => provider.id === providerName)?.enabled,
-        api_key: state.providerEditor.apiKey || "",
-        api_base: state.providerEditor.apiBase,
-        models: parseDesktopProviderModelList(state.providerEditor.modelsText),
-        supports_model_discovery: state.providerEditor.supportsModelDiscovery,
+        api_key: providerEditor.apiKey || "",
+        api_base: providerEditor.apiBase,
+        models: parseDesktopProviderModelList(providerEditor.modelsText),
+        supports_model_discovery: providerEditor.supportsModelDiscovery,
       },
     };
   }
 
   providers[providerName] = {
     enabled: state.providerSummaries.find((provider) => provider.id === providerName)?.enabled,
-    api_key: state.providerEditor.apiKey || "",
-    api_base: state.providerEditor.apiBase,
+    api_key: providerEditor.apiKey || "",
+    api_base: providerEditor.apiBase,
   };
 
   for (const provider of state.providerSummaries) {
@@ -579,7 +580,7 @@ export function validateDesktopSettingsForm(state: DesktopSettingsFormState): De
   if (!state.agent.model?.trim()) {
     errors.push({ field: "model", errorKey: "modelEmpty" });
   }
-  if (state.agent.timezone && !validateDesktopTimezone(state.agent.timezone)) {
+  if (!validateDesktopTimezone(state.agent.timezone || "")) {
     errors.push({ field: "timezone", errorKey: "timezoneError" });
   }
   if (state.gateway.port !== null && !validateDesktopPortRange(state.gateway.port)) {
@@ -620,7 +621,7 @@ export function buildDesktopSettingsPaneModel(
     validationErrors,
     save: {
       status: saveStatus,
-      message: saveStatus === "failed" ? options.saveError || "Save failed" : formatDesktopSettingsSaveMessage(saveStatus, dirty),
+      message: saveStatus === "failed" ? options.saveError || "Save failed" : formatDesktopSettingsSaveMessage(saveStatus, dirty, validationErrors.length),
       canSave: dirty && validationErrors.length === 0 && saveStatus !== "saving",
     },
     groups: buildDesktopSettingsPaneGroups(state, validationErrors, providerSummaries),
@@ -677,6 +678,7 @@ export function applyDesktopProviderModels(
     };
   }
   nextState.providerEditor.modelsText = models.join("\n");
+  nextState.providerEditorDirty = true;
   syncDesktopProviderSummaryFromEditor(nextState);
   if (!nextState.agent.model && models[0]) {
     nextState.agent.model = models[0];
@@ -734,22 +736,27 @@ export function applyDesktopSettingsFieldEdit(
       break;
     case "selectedProvider":
       selectDesktopProviderEditor(nextState, stringOrNullInput(text) || "deepseek");
+      nextState.providerEditorDirty = false;
       break;
     case "profileId":
       nextState.providerEditor.profileId = text.trim();
       nextState.agent.activeProfile = stringOrNullInput(text);
+      nextState.providerEditorDirty = true;
       syncDesktopProviderSummaryFromEditor(nextState);
       break;
     case "apiKey":
       nextState.providerEditor.apiKey = resolveDesktopSecretValue(text, nextState.providerEditor.apiKey);
+      nextState.providerEditorDirty = true;
       syncDesktopProviderSummaryFromEditor(nextState);
       break;
     case "apiBase":
       nextState.providerEditor.apiBase = stringOrNullInput(text);
+      nextState.providerEditorDirty = true;
       syncDesktopProviderSummaryFromEditor(nextState);
       break;
     case "models":
       nextState.providerEditor.modelsText = text;
+      nextState.providerEditorDirty = true;
       syncDesktopProviderSummaryFromEditor(nextState);
       break;
     case "enabled":
@@ -906,15 +913,19 @@ export function findDesktopProfileIdForProvider(providers: unknown, providerName
 }
 
 export function validateDesktopTimezone(value: string): boolean {
-  if (!value) {
+  const timezone = value.trim();
+  if (!timezone) {
     return false;
   }
-  const parts = value.split("/");
-  if (parts.length < 2) {
+  if (["UTC", "GMT"].includes(timezone)) {
+    return true;
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    return true;
+  } catch {
     return false;
   }
-  const validPrefixes = ["Africa", "America", "Asia", "Atlantic", "Australia", "Europe", "Indian", "Pacific", "UTC", "GMT"];
-  return validPrefixes.includes(parts[0]) || parts[0] === "Etc";
 }
 
 export function validateDesktopUrl(value: string): boolean {
@@ -966,6 +977,43 @@ function cloneSettingsState(state: DesktopSettingsFormState): DesktopSettingsFor
     channels: { ...state.channels },
     providerEditor: { ...state.providerEditor },
     providerSummaries: (state.providerSummaries ?? []).map((provider) => ({ ...provider })),
+    providerEditorDirty: state.providerEditorDirty,
+  };
+}
+
+function getDesktopSettingsPersistedProviderDraft(
+  state: DesktopSettingsFormState,
+  providerIds: string[],
+): { providerName: string; profileId: string | null; editor: DesktopSettingsProviderEditorState } {
+  if (state.providerEditorDirty !== false) {
+    const providerName = providerIds.includes(state.providerEditor.selectedProvider)
+      ? state.providerEditor.selectedProvider
+      : state.providerEditor.selectedProvider || "deepseek";
+    return {
+      providerName,
+      profileId: stringOrNull(state.providerEditor.profileId) || state.agent.activeProfile,
+      editor: state.providerEditor,
+    };
+  }
+
+  const profileId = state.agent.activeProfile;
+  const defaultProvider = state.agent.provider && state.agent.provider !== "auto" ? state.agent.provider : null;
+  const summary = state.providerSummaries.find((provider) => (
+    (profileId && provider.profileId === profileId)
+    || (defaultProvider && provider.id === defaultProvider)
+  ));
+  const providerName = defaultProvider || summary?.id || state.providerEditor.selectedProvider || "deepseek";
+  return {
+    providerName,
+    profileId: profileId || summary?.profileId || providerName,
+    editor: {
+      selectedProvider: providerName,
+      profileId: profileId || summary?.profileId || providerName,
+      apiKey: summary?.apiKey || "",
+      apiBase: summary?.apiBase ?? null,
+      modelsText: summary?.modelsText || "",
+      supportsModelDiscovery: summary?.supportsModelDiscovery ?? true,
+    },
   };
 }
 
@@ -1057,6 +1105,9 @@ function syncDesktopProviderSummaryFromEditor(state: DesktopSettingsFormState): 
 function setDesktopProviderEnabled(state: DesktopSettingsFormState, providerId: string, enabled: boolean): void {
   const normalizedProviderId = providerId.trim();
   if (!normalizedProviderId) {
+    return;
+  }
+  if (!enabled && state.agent.provider && state.agent.provider !== "auto" && state.agent.provider === normalizedProviderId) {
     return;
   }
   let summary = state.providerSummaries.find((provider) => provider.id === normalizedProviderId);
@@ -1487,12 +1538,15 @@ function buildDesktopSettingsPaneGroups(
   ];
 }
 
-function formatDesktopSettingsSaveMessage(status: DesktopSettingsSaveStatus, dirty: boolean): string {
+function formatDesktopSettingsSaveMessage(status: DesktopSettingsSaveStatus, dirty: boolean, validationErrorCount = 0): string {
   if (status === "saving") {
     return "Saving settings";
   }
   if (status === "saved") {
     return "Settings saved";
+  }
+  if (validationErrorCount > 0) {
+    return `${validationErrorCount} ${validationErrorCount === 1 ? "setting needs" : "settings need"} attention`;
   }
   return dirty ? "Unsaved changes" : "No changes";
 }

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -151,6 +151,15 @@ export interface DesktopSecretField {
 }
 
 export type DesktopSettingsSaveStatus = "idle" | "saving" | "saved" | "failed";
+export type DesktopSettingsSaveTransport = "native" | "gateway-fallback";
+export interface DesktopSettingsPaneSaveDetails {
+  transport: DesktopSettingsSaveTransport;
+  updatedFields: string[];
+  applied: string[];
+  restartRequired: string[];
+  reloadRequired: string[];
+  warnings: string[];
+}
 export type DesktopSettingsPaneFieldControl = "text" | "number" | "checkbox" | "textarea" | "select" | "password" | "readonly";
 export type DesktopSettingsPaneFieldRequirement = "required" | "optional" | "readonly";
 export type DesktopSettingsPaneFieldConfigurationMode =
@@ -212,6 +221,12 @@ export interface DesktopSettingsPaneModel {
     status: DesktopSettingsSaveStatus;
     message: string;
     canSave: boolean;
+    transport?: DesktopSettingsSaveTransport;
+    updatedFields?: string[];
+    applied?: string[];
+    restartRequired?: string[];
+    reloadRequired?: string[];
+    warnings?: string[];
   };
   groups: DesktopSettingsPaneGroup[];
   providerCatalog: Array<{
@@ -856,6 +871,7 @@ export function buildDesktopSettingsPaneModel(
     providerCatalog?: DesktopProviderCatalogItem[];
     saveStatus?: DesktopSettingsSaveStatus;
     saveError?: string | null;
+    saveDetails?: DesktopSettingsPaneSaveDetails | null;
   } = {},
 ): DesktopSettingsPaneModel {
   const validationErrors = validateDesktopSettingsForm(state);
@@ -864,13 +880,20 @@ export function buildDesktopSettingsPaneModel(
     ? desktopSettingsStateDirty(state, options.lastSavedState)
     : false;
   const saveStatus = options.saveStatus ?? "idle";
+  const saveDetails = normalizeDesktopSettingsSaveDetails(options.saveDetails);
   return {
     dirty,
     validationErrors,
     save: {
       status: saveStatus,
-      message: saveStatus === "failed" ? options.saveError || "Save failed" : formatDesktopSettingsSaveMessage(saveStatus, dirty, validationErrors.length),
+      message: saveStatus === "failed" ? options.saveError || "Save failed" : formatDesktopSettingsSaveMessage(saveStatus, dirty, validationErrors.length, saveDetails),
       canSave: dirty && validationErrors.length === 0 && saveStatus !== "saving",
+      transport: saveDetails?.transport,
+      updatedFields: saveDetails?.updatedFields,
+      applied: saveDetails?.applied,
+      restartRequired: saveDetails?.restartRequired,
+      reloadRequired: saveDetails?.reloadRequired,
+      warnings: saveDetails?.warnings,
     },
     groups: buildDesktopSettingsPaneGroups(state, validationErrors, providerSummaries),
     providerCatalog: providerSummaries.map((provider) => ({
@@ -1894,11 +1917,38 @@ function buildDesktopSettingsPaneGroups(
   ];
 }
 
-function formatDesktopSettingsSaveMessage(status: DesktopSettingsSaveStatus, dirty: boolean, validationErrorCount = 0): string {
+function normalizeDesktopSettingsSaveDetails(
+  details: DesktopSettingsPaneSaveDetails | null | undefined,
+): DesktopSettingsPaneSaveDetails | null {
+  if (!details) {
+    return null;
+  }
+  return {
+    transport: details.transport,
+    updatedFields: [...details.updatedFields],
+    applied: [...details.applied],
+    restartRequired: [...details.restartRequired],
+    reloadRequired: [...details.reloadRequired],
+    warnings: [...details.warnings],
+  };
+}
+
+function formatDesktopSettingsSaveMessage(
+  status: DesktopSettingsSaveStatus,
+  dirty: boolean,
+  validationErrorCount = 0,
+  saveDetails: DesktopSettingsPaneSaveDetails | null = null,
+): string {
   if (status === "saving") {
     return "Saving settings";
   }
   if (status === "saved") {
+    if (saveDetails?.transport === "gateway-fallback") {
+      return "Settings saved through gateway fallback";
+    }
+    if (saveDetails?.warnings.length) {
+      return "Settings saved with warnings";
+    }
     return "Settings saved";
   }
   if (validationErrorCount > 0) {

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -101,6 +101,7 @@ export interface DesktopSettingsFormState {
   providerEditor: DesktopSettingsProviderEditorState;
   providerSummaries: DesktopSettingsProviderSummary[];
   providerEditorDirty?: boolean;
+  touchedPaths?: string[];
 }
 
 export type DesktopSettingsValidationField =
@@ -439,6 +440,17 @@ export function createDesktopSettingsPatch(
   existingConfig: unknown = {},
   providerCatalog: DesktopProviderCatalogItem[] = [],
 ): UnknownRecord {
+  if (state.touchedPaths?.length) {
+    return createDesktopSettingsTouchedPatch(state);
+  }
+  return createDesktopSettingsFullPatch(state, existingConfig, providerCatalog);
+}
+
+function createDesktopSettingsFullPatch(
+  state: DesktopSettingsFormState,
+  existingConfig: unknown = {},
+  providerCatalog: DesktopProviderCatalogItem[] = [],
+): UnknownRecord {
   const providerIds = providerCatalog.map((provider) => stringValue(provider.id)).filter(Boolean);
   const providerDraft = getDesktopSettingsPersistedProviderDraft(state, providerIds);
   const providerName = providerDraft.providerName;
@@ -575,6 +587,175 @@ export function createDesktopSettingsPatch(
   };
 }
 
+function createDesktopSettingsTouchedPatch(state: DesktopSettingsFormState): UnknownRecord {
+  const patch: UnknownRecord = {};
+  for (const path of state.touchedPaths ?? []) {
+    setDesktopSettingsPatchPath(patch, path, getDesktopSettingsPatchPathValue(state, path));
+  }
+  return patch;
+}
+
+function getDesktopSettingsPatchPathValue(state: DesktopSettingsFormState, path: string): unknown {
+  switch (path) {
+    case "agents.defaults.model":
+      return state.agent.model;
+    case "agents.defaults.active_profile":
+      return state.agent.activeProfile;
+    case "agents.defaults.provider":
+      return state.agent.provider;
+    case "agents.defaults.workspace":
+      return state.agent.workspace;
+    case "agents.defaults.temperature":
+      return state.agent.temperature;
+    case "agents.defaults.max_tokens":
+      return state.agent.maxTokens;
+    case "agents.defaults.context_window_tokens":
+      return state.agent.contextWindowTokens;
+    case "agents.defaults.max_tool_iterations":
+      return state.agent.maxToolIterations;
+    case "agents.defaults.reasoning_effort":
+      return state.agent.reasoningEffort;
+    case "agents.defaults.timezone":
+      return state.agent.timezone;
+    case "agents.defaults.embedding.provider":
+      return state.embedding.provider;
+    case "agents.defaults.embedding.model_name":
+      return state.embedding.modelName;
+    case "agents.defaults.embedding.api_key":
+      return state.embedding.apiKey || "";
+    case "agents.defaults.embedding.api_base":
+      return state.embedding.apiBase;
+    case "knowledge.enabled":
+      return state.knowledge.enabled;
+    case "knowledge.auto_retrieve":
+      return state.knowledge.autoRetrieve;
+    case "knowledge.max_chunks":
+      return state.knowledge.maxChunks;
+    case "knowledge.chunk_size":
+      return state.knowledge.chunkSize;
+    case "knowledge.chunk_overlap":
+      return state.knowledge.chunkOverlap;
+    case "knowledge.retrieval_mode":
+      return state.knowledge.retrievalMode;
+    case "knowledge.rerank_enabled":
+      return state.knowledge.rerankEnabled;
+    case "knowledge.rerank_model":
+      return state.knowledge.rerankModel;
+    case "knowledge.rerank_api_key":
+      return state.knowledge.rerankApiKey;
+    case "knowledge.rerank_api_key_env_var":
+      return state.knowledge.rerankApiKeyEnvVar;
+    case "knowledge.rerank_api_base":
+      return state.knowledge.rerankApiBase;
+    case "knowledge.rerank_top_n":
+      return state.knowledge.rerankTopN;
+    case "knowledge.generate_summary":
+      return state.knowledge.generateSummary;
+    case "knowledge.semantic_extraction_mode":
+      return state.knowledge.semanticExtractionMode;
+    case "knowledge.semantic_llm_max_tokens":
+      return state.knowledge.semanticLlmMaxTokens;
+    case "knowledge.semantic_llm_timeout":
+      return state.knowledge.semanticLlmTimeout;
+    case "knowledge.graph_extraction_enabled":
+      return state.knowledge.graphExtractionEnabled;
+    case "knowledge.graph_auto_extract":
+      return state.knowledge.graphAutoExtract;
+    case "knowledge.graph_extraction_model":
+      return state.knowledge.graphExtractionModel;
+    case "knowledge.graph_extraction_max_tokens":
+      return state.knowledge.graphExtractionMaxTokens;
+    case "knowledge.graph_extraction_max_job_tokens":
+      return state.knowledge.graphExtractionMaxJobTokens;
+    case "knowledge.graph_extraction_concurrency":
+      return state.knowledge.graphExtractionConcurrency;
+    case "knowledge.graphrag_community_algorithm":
+      return state.knowledge.graphRagCommunityAlgorithm;
+    case "knowledge.graphrag_community_level":
+      return state.knowledge.graphRagCommunityLevel;
+    case "knowledge.graphrag_report_llm_enabled":
+      return state.knowledge.graphRagReportLlmEnabled;
+    case "knowledge.graphrag_report_max_tokens":
+      return state.knowledge.graphRagReportMaxTokens;
+    case "knowledge.graphrag_entity_summary_enabled":
+      return state.knowledge.graphRagEntitySummaryEnabled;
+    case "tools.web.enable":
+      return state.tools.webEnable;
+    case "tools.web.proxy":
+      return state.tools.webProxy;
+    case "tools.web.search.provider":
+      return state.tools.searchProvider;
+    case "tools.exec.enable":
+      return state.tools.execEnable;
+    case "tools.exec.timeout":
+      return state.tools.execTimeout;
+    case "tools.mcp_servers":
+      return parseDesktopJsonObject(state.tools.mcpServersText);
+    case "tools.restrict_to_workspace":
+      return state.tools.restrictToWorkspace;
+    case "gateway.host":
+      return state.gateway.host;
+    case "gateway.port":
+      return state.gateway.port;
+    case "gateway.heartbeat.enabled":
+      return state.gateway.heartbeatEnabled;
+    case "gateway.heartbeat.interval_s":
+      return state.gateway.heartbeatIntervalS;
+    case "channels.send_progress":
+      return state.channels.sendProgress;
+    case "channels.send_tool_hints":
+      return state.channels.sendToolHints;
+    case "channels.send_max_retries":
+      return state.channels.sendMaxRetries;
+  }
+
+  const providerEnabledPath = path.match(/^providers\.([^.]+)\.enabled$/);
+  if (providerEnabledPath) {
+    return state.providerSummaries.find((provider) => provider.id === providerEnabledPath[1])?.enabled ?? false;
+  }
+  const providerApiKeyPath = path.match(/^providers\.([^.]+)\.api_key$/);
+  if (providerApiKeyPath) {
+    return state.providerSummaries.find((provider) => provider.id === providerApiKeyPath[1])?.apiKey || "";
+  }
+  const providerApiBasePath = path.match(/^providers\.([^.]+)\.api_base$/);
+  if (providerApiBasePath) {
+    return state.providerSummaries.find((provider) => provider.id === providerApiBasePath[1])?.apiBase ?? null;
+  }
+  const profilePath = path.match(/^providers\.profiles\.([^.]+)\.([^.]+)$/);
+  if (profilePath) {
+    const [, profileId, field] = profilePath;
+    const summary = state.providerSummaries.find((provider) => provider.profileId === profileId);
+    switch (field) {
+      case "provider":
+        return summary?.id || state.providerEditor.selectedProvider;
+      case "enabled":
+        return summary?.enabled ?? false;
+      case "api_key":
+        return summary?.apiKey || "";
+      case "api_base":
+        return summary?.apiBase ?? null;
+      case "models":
+        return parseDesktopProviderModelList(summary?.modelsText ?? "");
+      case "supports_model_discovery":
+        return summary?.supportsModelDiscovery ?? true;
+    }
+  }
+
+  return undefined;
+}
+
+function setDesktopSettingsPatchPath(patch: UnknownRecord, path: string, value: unknown): void {
+  const parts = path.split(".");
+  let cursor = patch;
+  for (const part of parts.slice(0, -1)) {
+    if (!isRecordValue(cursor[part])) {
+      cursor[part] = {};
+    }
+    cursor = cursor[part] as UnknownRecord;
+  }
+  cursor[parts[parts.length - 1]] = value;
+}
+
 export function validateDesktopSettingsForm(state: DesktopSettingsFormState): DesktopSettingsValidationError[] {
   const errors: DesktopSettingsValidationError[] = [];
   if (!state.agent.model?.trim()) {
@@ -680,8 +861,10 @@ export function applyDesktopProviderModels(
   nextState.providerEditor.modelsText = models.join("\n");
   nextState.providerEditorDirty = true;
   syncDesktopProviderSummaryFromEditor(nextState);
+  markDesktopProviderEditorTouched(nextState, "models");
   if (!nextState.agent.model && models[0]) {
     nextState.agent.model = models[0];
+    markDesktopSettingsTouched(nextState, "agents.defaults.model");
   }
   return {
     state: nextState,
@@ -700,39 +883,51 @@ export function applyDesktopSettingsFieldEdit(
   const nextState = cloneSettingsState(state);
   const text = String(value);
   if (fieldId.startsWith("providerEnabled:")) {
-    setDesktopProviderEnabled(nextState, fieldId.slice("providerEnabled:".length), Boolean(value));
+    const providerId = fieldId.slice("providerEnabled:".length);
+    setDesktopProviderEnabled(nextState, providerId, Boolean(value));
+    markDesktopProviderEnabledTouched(nextState, providerId);
     return nextState;
   }
   switch (fieldId) {
     case "model":
       nextState.agent.model = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.model");
       break;
     case "provider":
       nextState.agent.provider = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.provider");
       break;
     case "activeProfile":
       nextState.agent.activeProfile = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.active_profile");
       break;
     case "workspace":
       nextState.agent.workspace = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.workspace");
       break;
     case "temperature":
       nextState.agent.temperature = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.temperature");
       break;
     case "maxTokens":
       nextState.agent.maxTokens = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.max_tokens");
       break;
     case "contextWindowTokens":
       nextState.agent.contextWindowTokens = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.context_window_tokens");
       break;
     case "maxToolIterations":
       nextState.agent.maxToolIterations = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.max_tool_iterations");
       break;
     case "reasoningEffort":
       nextState.agent.reasoningEffort = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.reasoning_effort");
       break;
     case "timezone":
       nextState.agent.timezone = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "agents.defaults.timezone");
       break;
     case "selectedProvider":
       selectDesktopProviderEditor(nextState, stringOrNullInput(text) || "deepseek");
@@ -743,111 +938,146 @@ export function applyDesktopSettingsFieldEdit(
       nextState.agent.activeProfile = stringOrNullInput(text);
       nextState.providerEditorDirty = true;
       syncDesktopProviderSummaryFromEditor(nextState);
+      markDesktopSettingsTouched(nextState, "agents.defaults.active_profile");
+      markDesktopProviderEditorTouched(nextState, "profile");
       break;
     case "apiKey":
       nextState.providerEditor.apiKey = resolveDesktopSecretValue(text, nextState.providerEditor.apiKey);
       nextState.providerEditorDirty = true;
       syncDesktopProviderSummaryFromEditor(nextState);
+      markDesktopProviderEditorTouched(nextState, "api_key");
       break;
     case "apiBase":
       nextState.providerEditor.apiBase = stringOrNullInput(text);
       nextState.providerEditorDirty = true;
       syncDesktopProviderSummaryFromEditor(nextState);
+      markDesktopProviderEditorTouched(nextState, "api_base");
       break;
     case "models":
       nextState.providerEditor.modelsText = text;
       nextState.providerEditorDirty = true;
       syncDesktopProviderSummaryFromEditor(nextState);
+      markDesktopProviderEditorTouched(nextState, "models");
       break;
     case "enabled":
       nextState.knowledge.enabled = Boolean(value);
+      markDesktopSettingsTouched(nextState, "knowledge.enabled");
       break;
     case "autoRetrieve":
       nextState.knowledge.autoRetrieve = Boolean(value);
+      markDesktopSettingsTouched(nextState, "knowledge.auto_retrieve");
       break;
     case "retrievalMode":
       nextState.knowledge.retrievalMode = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.retrieval_mode");
       break;
     case "maxChunks":
       nextState.knowledge.maxChunks = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.max_chunks");
       break;
     case "chunkSize":
       nextState.knowledge.chunkSize = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.chunk_size");
       break;
     case "chunkOverlap":
       nextState.knowledge.chunkOverlap = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.chunk_overlap");
       break;
     case "rerankEnabled":
       nextState.knowledge.rerankEnabled = Boolean(value);
+      markDesktopSettingsTouched(nextState, "knowledge.rerank_enabled");
       break;
     case "rerankModel":
       nextState.knowledge.rerankModel = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.rerank_model");
       break;
     case "rerankApiBase":
       nextState.knowledge.rerankApiBase = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.rerank_api_base");
       break;
     case "rerankTopN":
       nextState.knowledge.rerankTopN = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.rerank_top_n");
       break;
     case "graphExtractionEnabled":
       nextState.knowledge.graphExtractionEnabled = Boolean(value);
+      markDesktopSettingsTouched(nextState, "knowledge.graph_extraction_enabled");
       break;
     case "graphAutoExtract":
       nextState.knowledge.graphAutoExtract = Boolean(value);
+      markDesktopSettingsTouched(nextState, "knowledge.graph_auto_extract");
       break;
     case "graphExtractionModel":
       nextState.knowledge.graphExtractionModel = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.graph_extraction_model");
       break;
     case "graphExtractionMaxTokens":
       nextState.knowledge.graphExtractionMaxTokens = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.graph_extraction_max_tokens");
       break;
     case "graphExtractionMaxJobTokens":
       nextState.knowledge.graphExtractionMaxJobTokens = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.graph_extraction_max_job_tokens");
       break;
     case "graphExtractionConcurrency":
       nextState.knowledge.graphExtractionConcurrency = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "knowledge.graph_extraction_concurrency");
       break;
     case "webEnable":
       nextState.tools.webEnable = Boolean(value);
+      markDesktopSettingsTouched(nextState, "tools.web.enable");
       break;
     case "webProxy":
       nextState.tools.webProxy = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "tools.web.proxy");
       break;
     case "searchProvider":
       nextState.tools.searchProvider = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "tools.web.search.provider");
       break;
     case "execEnable":
       nextState.tools.execEnable = Boolean(value);
+      markDesktopSettingsTouched(nextState, "tools.exec.enable");
       break;
     case "execTimeout":
       nextState.tools.execTimeout = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "tools.exec.timeout");
       break;
     case "mcpServers":
       nextState.tools.mcpServersText = text;
+      markDesktopSettingsTouched(nextState, "tools.mcp_servers");
       break;
     case "restrictToWorkspace":
       nextState.tools.restrictToWorkspace = Boolean(value);
+      markDesktopSettingsTouched(nextState, "tools.restrict_to_workspace");
       break;
     case "host":
       nextState.gateway.host = stringOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "gateway.host");
       break;
     case "port":
       nextState.gateway.port = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "gateway.port");
       break;
     case "heartbeat":
       nextState.gateway.heartbeatEnabled = Boolean(value);
+      markDesktopSettingsTouched(nextState, "gateway.heartbeat.enabled");
       break;
     case "heartbeatIntervalS":
       nextState.gateway.heartbeatIntervalS = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "gateway.heartbeat.interval_s");
       break;
     case "sendProgress":
       nextState.channels.sendProgress = Boolean(value);
+      markDesktopSettingsTouched(nextState, "channels.send_progress");
       break;
     case "sendToolHints":
       nextState.channels.sendToolHints = Boolean(value);
+      markDesktopSettingsTouched(nextState, "channels.send_tool_hints");
       break;
     case "sendMaxRetries":
       nextState.channels.sendMaxRetries = numberOrNullInput(text);
+      markDesktopSettingsTouched(nextState, "channels.send_max_retries");
       break;
   }
   return nextState;
@@ -978,7 +1208,49 @@ function cloneSettingsState(state: DesktopSettingsFormState): DesktopSettingsFor
     providerEditor: { ...state.providerEditor },
     providerSummaries: (state.providerSummaries ?? []).map((provider) => ({ ...provider })),
     providerEditorDirty: state.providerEditorDirty,
+    touchedPaths: state.touchedPaths ? [...state.touchedPaths] : undefined,
   };
+}
+
+function markDesktopSettingsTouched(state: DesktopSettingsFormState, path: string): void {
+  const touchedPaths = state.touchedPaths ?? [];
+  if (!touchedPaths.includes(path)) {
+    touchedPaths.push(path);
+  }
+  state.touchedPaths = touchedPaths;
+}
+
+function markDesktopProviderEditorTouched(
+  state: DesktopSettingsFormState,
+  field: "profile" | "enabled" | "api_key" | "api_base" | "models" | "supports_model_discovery",
+): void {
+  const providerId = state.providerEditor.selectedProvider || "deepseek";
+  const profileId = state.providerEditor.profileId || providerId;
+  if (field === "profile") {
+    markDesktopSettingsTouched(state, `providers.profiles.${profileId}.provider`);
+    markDesktopSettingsTouched(state, `providers.profiles.${profileId}.enabled`);
+    markDesktopSettingsTouched(state, `providers.profiles.${profileId}.api_key`);
+    markDesktopSettingsTouched(state, `providers.profiles.${profileId}.api_base`);
+    markDesktopSettingsTouched(state, `providers.profiles.${profileId}.models`);
+    markDesktopSettingsTouched(state, `providers.profiles.${profileId}.supports_model_discovery`);
+    return;
+  }
+  if (field === "api_key" || field === "api_base") {
+    markDesktopSettingsTouched(state, `providers.${providerId}.${field}`);
+  }
+  markDesktopSettingsTouched(state, `providers.profiles.${profileId}.${field}`);
+}
+
+function markDesktopProviderEnabledTouched(state: DesktopSettingsFormState, providerId: string): void {
+  const normalizedProviderId = providerId.trim();
+  if (!normalizedProviderId) {
+    return;
+  }
+  markDesktopSettingsTouched(state, `providers.${normalizedProviderId}.enabled`);
+  const summary = state.providerSummaries.find((provider) => provider.id === normalizedProviderId);
+  if (summary?.profileId) {
+    markDesktopSettingsTouched(state, `providers.profiles.${summary.profileId}.enabled`);
+  }
 }
 
 function getDesktopSettingsPersistedProviderDraft(

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -459,6 +459,13 @@ export interface DesktopSettingsPaneModel {
     warnings?: string[];
     diagnostics?: string;
   };
+  runtime?: {
+    intent: "local-only" | "local-network" | "advanced-custom";
+    currentEndpoint: string;
+    pendingEndpoint: string;
+    portStatus: string;
+    heartbeatDependency: string;
+  };
   groups: DesktopSettingsPaneGroup[];
   providerCatalog: Array<{
     id: string;
@@ -1133,6 +1140,7 @@ export function buildDesktopSettingsPaneModel(
     save.warnings = saveDetails.warnings;
     save.diagnostics = formatDesktopSettingsSaveDiagnostics(saveStatus, saveDetails);
   }
+  const runtime = buildDesktopSettingsRuntimeSummary(state, options.lastSavedState ?? state, save);
   const providerCatalog = providerSummaries.map((provider) => ({
     id: provider.id,
     label: provider.label,
@@ -1149,6 +1157,7 @@ export function buildDesktopSettingsPaneModel(
     dirty,
     validationErrors,
     save,
+    runtime,
     groups: buildDesktopSettingsPaneGroups(state, validationErrors, providerSummaries),
     providerCatalog,
     defaultRouting: buildDesktopDefaultRouting(state, providerCatalog),
@@ -1174,6 +1183,46 @@ export function buildDesktopProviderModelRequest(
     api_base: state.providerEditor.apiBase || "",
     refresh,
   };
+}
+
+function buildDesktopSettingsRuntimeSummary(
+  state: DesktopSettingsFormState,
+  lastSavedState: DesktopSettingsFormState,
+  save: DesktopSettingsPaneModel["save"],
+): NonNullable<DesktopSettingsPaneModel["runtime"]> {
+  const pendingEndpoint = formatDesktopGatewayEndpoint(state.gateway.host, state.gateway.port);
+  const currentEndpoint = save.restartRequired?.length
+    ? formatDesktopGatewayEndpoint(lastSavedState.gateway.host, lastSavedState.gateway.port)
+    : pendingEndpoint;
+  const intent = classifyDesktopGatewayIntent(state.gateway.host);
+  const port = state.gateway.port;
+  return {
+    intent,
+    currentEndpoint,
+    pendingEndpoint,
+    portStatus: port && validateDesktopPortRange(port)
+      ? `Port ${port} will be checked for availability before the gateway restarts.`
+      : "Port availability cannot be checked until a valid port is configured.",
+    heartbeatDependency: state.gateway.heartbeatEnabled
+      ? "Heartbeat interval is active while heartbeat is enabled."
+      : "Heartbeat interval is disabled while heartbeat is off.",
+  };
+}
+
+function classifyDesktopGatewayIntent(host: string | null): NonNullable<DesktopSettingsPaneModel["runtime"]>["intent"] {
+  if (host === "127.0.0.1" || host === "localhost" || host === "::1") {
+    return "local-only";
+  }
+  if (host === "0.0.0.0" || host === "::") {
+    return "local-network";
+  }
+  return "advanced-custom";
+}
+
+function formatDesktopGatewayEndpoint(host: string | null, port: number | null): string {
+  const safeHost = host || "127.0.0.1";
+  const safePort = port ?? 18790;
+  return `${safeHost}:${safePort}`;
 }
 
 function buildDesktopDefaultRouting(
@@ -2185,6 +2234,7 @@ function buildDesktopSettingsPaneGroups(
           control: "number",
           configurationMode: "numeric",
           advanced: true,
+          disabled: !state.gateway.heartbeatEnabled,
           min: 1,
           step: 1,
         }),

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -102,6 +102,7 @@ export interface DesktopSettingsFormState {
   providerSummaries: DesktopSettingsProviderSummary[];
   providerEditorDirty?: boolean;
   touchedPaths?: string[];
+  serverSnapshot?: unknown;
 }
 
 export type DesktopSettingsValidationField =
@@ -340,6 +341,7 @@ export function buildDesktopSettingsFormState(
       supportsModelDiscovery: pick(providerProfile, "supportsModelDiscovery", "supports_model_discovery") !== false,
     },
     providerSummaries,
+    serverSnapshot: cloneDesktopSettingsSnapshot(config),
   };
 }
 
@@ -437,13 +439,14 @@ export function buildDesktopProviderSummaries(
 
 export function createDesktopSettingsPatch(
   state: DesktopSettingsFormState,
-  existingConfig: unknown = {},
+  existingConfig?: unknown,
   providerCatalog: DesktopProviderCatalogItem[] = [],
 ): UnknownRecord {
+  const comparisonConfig = existingConfig === undefined ? state.serverSnapshot ?? {} : existingConfig;
   if (state.touchedPaths?.length) {
-    return createDesktopSettingsTouchedPatch(state, existingConfig);
+    return createDesktopSettingsTouchedPatch(state, comparisonConfig);
   }
-  return createDesktopSettingsFullPatch(state, existingConfig, providerCatalog);
+  return createDesktopSettingsFullPatch(state, comparisonConfig, providerCatalog);
 }
 
 function createDesktopSettingsFullPatch(
@@ -1240,6 +1243,7 @@ function cloneSettingsState(state: DesktopSettingsFormState): DesktopSettingsFor
     providerSummaries: (state.providerSummaries ?? []).map((provider) => ({ ...provider })),
     providerEditorDirty: state.providerEditorDirty,
     touchedPaths: state.touchedPaths ? [...state.touchedPaths] : undefined,
+    serverSnapshot: cloneDesktopSettingsSnapshot(state.serverSnapshot),
   };
 }
 
@@ -1879,6 +1883,17 @@ function asRecord(value: unknown): UnknownRecord {
 
 function isRecordValue(value: unknown): value is UnknownRecord {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneDesktopSettingsSnapshot(value: unknown): unknown {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value)) as unknown;
+  } catch {
+    return value;
+  }
 }
 
 function stringValue(value: unknown): string {

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -220,6 +220,7 @@ export interface DesktopSettingsPaneField {
   options?: DesktopSettingsPaneFieldOption[];
   requirement: DesktopSettingsPaneFieldRequirement;
   configurationMode: DesktopSettingsPaneFieldConfigurationMode;
+  disabled?: boolean;
   advanced?: boolean;
   placeholder?: string;
   min?: number;
@@ -1859,6 +1860,7 @@ function buildDesktopSettingsPaneGroups(
       inputValue?: string;
       requirement?: DesktopSettingsPaneFieldRequirement;
       configurationMode?: DesktopSettingsPaneFieldConfigurationMode;
+      disabled?: boolean;
       advanced?: boolean;
       placeholder?: string;
       min?: number;
@@ -1877,6 +1879,7 @@ function buildDesktopSettingsPaneGroups(
     options: config.options,
     requirement: config.requirement ?? fieldRequirementForControl(config.control ?? "text"),
     configurationMode: config.configurationMode ?? fieldModeForControl(config.control ?? "text"),
+    disabled: config.disabled ?? false,
     advanced: config.advanced,
     placeholder: config.placeholder,
     min: config.min,
@@ -1884,6 +1887,9 @@ function buildDesktopSettingsPaneGroups(
     step: config.step,
   });
   const secretField = buildDesktopSecretField(state.providerEditor.apiKey);
+  const knowledgeDisabled = !state.knowledge.enabled;
+  const rerankDisabled = knowledgeDisabled || !state.knowledge.rerankEnabled;
+  const graphExtractionDisabled = knowledgeDisabled || !state.knowledge.graphExtractionEnabled;
   return enrichDesktopSettingsPaneGroups([
     {
       id: "general",
@@ -1993,21 +1999,24 @@ function buildDesktopSettingsPaneGroups(
       id: "knowledge",
       label: "Knowledge",
       fields: [
-        field("enabled", "Enabled", state.knowledge.enabled, { control: "checkbox" }),
-        field("autoRetrieve", "Auto retrieve", state.knowledge.autoRetrieve, { control: "checkbox" }),
+        field("enabled", "Enabled", state.knowledge.enabled, { control: "checkbox", disabled: false }),
+        field("autoRetrieve", "Auto retrieve", state.knowledge.autoRetrieve, { control: "checkbox", disabled: knowledgeDisabled }),
         field("retrievalMode", "Retrieval mode", state.knowledge.retrievalMode, {
           control: "select",
           options: fixedOptions(["dense", "sparse", "hybrid"]),
+          disabled: knowledgeDisabled,
         }),
         field("maxChunks", "Max chunks", state.knowledge.maxChunks, {
           control: "number",
           configurationMode: "numeric",
+          disabled: knowledgeDisabled,
           min: 1,
           step: 1,
         }),
         field("chunkSize", "Chunk size", state.knowledge.chunkSize, {
           control: "number",
           configurationMode: "numeric",
+          disabled: knowledgeDisabled,
           advanced: true,
           min: 1,
           step: 1,
@@ -2015,34 +2024,39 @@ function buildDesktopSettingsPaneGroups(
         field("chunkOverlap", "Chunk overlap", state.knowledge.chunkOverlap, {
           control: "number",
           configurationMode: "numeric",
+          disabled: knowledgeDisabled,
           advanced: true,
           min: 0,
           step: 1,
         }),
-        field("rerankEnabled", "Rerank", state.knowledge.rerankEnabled, { control: "checkbox", advanced: true }),
-        field("rerankModel", "Rerank model", state.knowledge.rerankModel, { advanced: true }),
+        field("rerankEnabled", "Rerank", state.knowledge.rerankEnabled, { control: "checkbox", disabled: knowledgeDisabled, advanced: true }),
+        field("rerankModel", "Rerank model", state.knowledge.rerankModel, { disabled: rerankDisabled, advanced: true }),
         field("rerankApiBase", "Rerank API base", state.knowledge.rerankApiBase, {
           validationField: "rerankApiBase",
           requirement: "optional",
           configurationMode: "url",
+          disabled: rerankDisabled,
           advanced: true,
         }),
         field("rerankTopN", "Rerank top N", state.knowledge.rerankTopN, {
           control: "number",
           configurationMode: "numeric",
+          disabled: rerankDisabled,
           advanced: true,
           min: 0,
           step: 1,
         }),
-        field("graphExtractionEnabled", "Graph extraction", state.knowledge.graphExtractionEnabled, { control: "checkbox" }),
-        field("graphAutoExtract", "Auto extract graph", state.knowledge.graphAutoExtract, { control: "checkbox", advanced: true }),
+        field("graphExtractionEnabled", "Graph extraction", state.knowledge.graphExtractionEnabled, { control: "checkbox", disabled: knowledgeDisabled }),
+        field("graphAutoExtract", "Auto extract graph", state.knowledge.graphAutoExtract, { control: "checkbox", disabled: graphExtractionDisabled, advanced: true }),
         field("graphExtractionModel", "Graph extraction model", state.knowledge.graphExtractionModel, {
+          disabled: graphExtractionDisabled,
           advanced: true,
           placeholder: "defaults to semantic/chat model",
         }),
         field("graphExtractionMaxTokens", "Graph extraction max tokens", state.knowledge.graphExtractionMaxTokens, {
           control: "number",
           configurationMode: "numeric",
+          disabled: graphExtractionDisabled,
           advanced: true,
           min: 1,
           step: 1,
@@ -2050,6 +2064,7 @@ function buildDesktopSettingsPaneGroups(
         field("graphExtractionMaxJobTokens", "Graph extraction max job tokens", state.knowledge.graphExtractionMaxJobTokens, {
           control: "number",
           configurationMode: "numeric",
+          disabled: graphExtractionDisabled,
           advanced: true,
           min: 0,
           step: 1,
@@ -2057,6 +2072,7 @@ function buildDesktopSettingsPaneGroups(
         field("graphExtractionConcurrency", "Graph extraction concurrency", state.knowledge.graphExtractionConcurrency, {
           control: "number",
           configurationMode: "numeric",
+          disabled: graphExtractionDisabled,
           advanced: true,
           min: 1,
           step: 1,

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -195,6 +195,8 @@ export interface DesktopSettingsPaneGroupMetadata {
   description: string;
   aliases: string[];
   i18nKey: string;
+  navigationArea: "core" | "application" | "system";
+  navigationMode: "section" | "preview" | "hidden";
 }
 
 export interface DesktopSettingsPaneField {
@@ -238,6 +240,8 @@ export interface DesktopSettingsPaneGroup {
   description?: string;
   aliases?: string[];
   i18nKey?: string;
+  navigationArea?: DesktopSettingsPaneGroupMetadata["navigationArea"];
+  navigationMode?: DesktopSettingsPaneGroupMetadata["navigationMode"];
   fields: DesktopSettingsPaneField[];
 }
 
@@ -246,69 +250,91 @@ type DesktopSettingsPaneGroupId = DesktopSettingsPaneGroup["id"];
 const DESKTOP_SETTINGS_GROUP_METADATA: Record<DesktopSettingsPaneGroupId, DesktopSettingsPaneGroupMetadata> = {
   general: {
     label: "General",
-    description: "Default model, provider routing, timezone, and desktop workspace defaults.",
+    description: "Default model, provider routing, and timezone behavior.",
     aliases: ["default model", "profile", "timezone", "workspace"],
     i18nKey: "settings.groups.general",
+    navigationArea: "core",
+    navigationMode: "section",
   },
   "provider-models": {
     label: "Provider & Models",
     description: "Provider profiles, endpoints, credentials, and model catalogs.",
     aliases: ["providers", "models", "api key", "credentials"],
     i18nKey: "settings.groups.provider-models",
+    navigationArea: "core",
+    navigationMode: "section",
   },
   knowledge: {
     label: "Knowledge",
     description: "Retrieval, indexing, reranking, and graph extraction behavior.",
     aliases: ["rag", "retrieval", "embeddings", "graph"],
     i18nKey: "settings.groups.knowledge",
+    navigationArea: "core",
+    navigationMode: "section",
   },
   "tools-approvals": {
     label: "Tools & Approvals",
     description: "Browser, command execution, approval policy, and MCP server access.",
     aliases: ["tools", "mcp", "approvals", "security"],
     i18nKey: "settings.groups.tools-approvals",
+    navigationArea: "core",
+    navigationMode: "section",
   },
   "files-workspace": {
     label: "Files & Workspace",
     description: "Session files, knowledge documents, and editable workspace file boundaries.",
     aliases: ["files", "storage", "workspace"],
     i18nKey: "settings.groups.files-workspace",
+    navigationArea: "application",
+    navigationMode: "section",
   },
   "memory-experience": {
     label: "Memory & Experience",
     description: "Memory and experience controls for contextual continuity.",
     aliases: ["memory", "experience"],
     i18nKey: "settings.groups.memory-experience",
+    navigationArea: "application",
+    navigationMode: "preview",
   },
   skills: {
     label: "Skills",
     description: "Skill availability and loading policy.",
     aliases: ["skills", "capabilities"],
     i18nKey: "settings.groups.skills",
+    navigationArea: "application",
+    navigationMode: "preview",
   },
   channels: {
     label: "Channels",
     description: "Streaming and retry behavior for desktop channels.",
     aliases: ["streaming", "progress", "retries"],
     i18nKey: "settings.groups.channels",
+    navigationArea: "application",
+    navigationMode: "section",
   },
   automations: {
     label: "Automations",
     description: "Automation and scheduling capabilities planned after core stability.",
     aliases: ["automation", "scheduling"],
     i18nKey: "settings.groups.automations",
+    navigationArea: "application",
+    navigationMode: "preview",
   },
   "gateway-runtime": {
     label: "Gateway & Runtime",
     description: "Local gateway connection, heartbeat, and runtime controls.",
     aliases: ["gateway", "runtime", "host", "port"],
     i18nKey: "settings.groups.gateway-runtime",
+    navigationArea: "system",
+    navigationMode: "section",
   },
   "logs-diagnostics": {
     label: "Logs & Diagnostics",
     description: "Runtime logs, diagnostics export, and local state recovery.",
     aliases: ["logs", "diagnostics", "debug"],
     i18nKey: "settings.groups.logs-diagnostics",
+    navigationArea: "system",
+    navigationMode: "section",
   },
 };
 
@@ -339,12 +365,12 @@ const DESKTOP_SETTINGS_FIELD_METADATA: Record<string, DesktopSettingsPaneFieldMe
     validationField: "timezone",
     i18nKey: "settings.fields.general.timezone",
   },
-  "general.workspace": {
+  "files-workspace.workspace": {
     label: "Workspace",
     description: "Default desktop workspace path for local files and agent work.",
     aliases: ["workspace folder", "working directory", "files"],
     applyEffect: "workspace-reload",
-    i18nKey: "settings.fields.general.workspace",
+    i18nKey: "settings.fields.files-workspace.workspace",
   },
   "provider-models.apiKey": {
     label: "API key",
@@ -1834,12 +1860,6 @@ function buildDesktopSettingsPaneGroups(
           configurationMode: "freeform",
           placeholder: "Asia/Shanghai",
         }),
-        field("workspace", "Workspace", state.agent.workspace, {
-          requirement: "required",
-          configurationMode: "freeform",
-          advanced: true,
-          placeholder: "~/.tinybot/workspace",
-        }),
         field("temperature", "Temperature", state.agent.temperature, {
           control: "number",
           requirement: "optional",
@@ -2032,6 +2052,11 @@ function buildDesktopSettingsPaneGroups(
       id: "files-workspace",
       label: "Files & Workspace",
       fields: [
+        field("workspace", "Workspace", state.agent.workspace, {
+          requirement: "required",
+          configurationMode: "freeform",
+          placeholder: "~/.tinybot/workspace",
+        }),
         field("sessionFiles", "Session files", buildWorkbenchFileScopeLabel("session").label, { control: "readonly" }),
         field("knowledgeDocuments", "Knowledge documents", buildWorkbenchFileScopeLabel("knowledge").label, { control: "readonly" }),
         field("workspaceFiles", "Workspace files", buildWorkbenchFileScopeLabel("workspace").label, { control: "readonly" }),
@@ -2116,6 +2141,8 @@ function enrichDesktopSettingsPaneGroups(groups: DesktopSettingsPaneGroup[]): De
       description: groupMetadata.description,
       aliases: [...groupMetadata.aliases],
       i18nKey: groupMetadata.i18nKey,
+      navigationArea: groupMetadata.navigationArea,
+      navigationMode: groupMetadata.navigationMode,
       fields: group.fields.map((field) => enrichDesktopSettingsPaneField(group.id, field)),
     };
   });

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -278,9 +278,9 @@ const DESKTOP_SETTINGS_GROUP_METADATA: Record<DesktopSettingsPaneGroupId, Deskto
     navigationMode: "section",
   },
   "tools-approvals": {
-    label: "Tools & Approvals",
-    description: "Browser, command execution, approval policy, and MCP server access.",
-    aliases: ["tools", "mcp", "approvals", "security"],
+    label: "Tools & MCP",
+    description: "Tool toggles and MCP server access. Approval controls are not exposed here yet.",
+    aliases: ["tools", "mcp", "security"],
     i18nKey: "settings.groups.tools-approvals",
     navigationArea: "core",
     navigationMode: "section",

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -119,6 +119,10 @@ export interface DesktopSettingsValidationError {
   errorKey: "modelEmpty" | "timezoneError" | "portRange" | "jsonObjectError" | "urlError";
 }
 
+export type DesktopSettingsSavePatchResult =
+  | { ok: true; patch: UnknownRecord }
+  | { ok: false; validationErrors: DesktopSettingsValidationError[] };
+
 export interface DesktopProviderModelRequest {
   provider: string;
   profile: string;
@@ -447,6 +451,21 @@ export function createDesktopSettingsPatch(
     return createDesktopSettingsTouchedPatch(state, comparisonConfig);
   }
   return createDesktopSettingsFullPatch(state, comparisonConfig, providerCatalog);
+}
+
+export function buildDesktopSettingsSavePatch(
+  state: DesktopSettingsFormState,
+  existingConfig?: unknown,
+  providerCatalog: DesktopProviderCatalogItem[] = [],
+): DesktopSettingsSavePatchResult {
+  const validationErrors = validateDesktopSettingsForm(state);
+  if (validationErrors.length) {
+    return { ok: false, validationErrors };
+  }
+  return {
+    ok: true,
+    patch: createDesktopSettingsPatch(state, existingConfig, providerCatalog),
+  };
 }
 
 function createDesktopSettingsFullPatch(

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -441,7 +441,7 @@ export function createDesktopSettingsPatch(
   providerCatalog: DesktopProviderCatalogItem[] = [],
 ): UnknownRecord {
   if (state.touchedPaths?.length) {
-    return createDesktopSettingsTouchedPatch(state);
+    return createDesktopSettingsTouchedPatch(state, existingConfig);
   }
   return createDesktopSettingsFullPatch(state, existingConfig, providerCatalog);
 }
@@ -587,10 +587,14 @@ function createDesktopSettingsFullPatch(
   };
 }
 
-function createDesktopSettingsTouchedPatch(state: DesktopSettingsFormState): UnknownRecord {
+function createDesktopSettingsTouchedPatch(state: DesktopSettingsFormState, existingConfig: unknown): UnknownRecord {
   const patch: UnknownRecord = {};
   for (const path of state.touchedPaths ?? []) {
-    setDesktopSettingsPatchPath(patch, path, getDesktopSettingsPatchPathValue(state, path));
+    const value = getDesktopSettingsPatchPathValue(state, path);
+    if (desktopSettingsValuesEqual(value, getDesktopSettingsExistingConfigPathValue(existingConfig, path))) {
+      continue;
+    }
+    setDesktopSettingsPatchPath(patch, path, value);
   }
   return patch;
 }
@@ -756,6 +760,18 @@ function setDesktopSettingsPatchPath(patch: UnknownRecord, path: string, value: 
   cursor[parts[parts.length - 1]] = value;
 }
 
+function getDesktopSettingsExistingConfigPathValue(existingConfig: unknown, path: string): unknown {
+  let cursor: unknown = existingConfig;
+  for (const part of path.split(".")) {
+    cursor = asRecord(cursor)[part];
+  }
+  return cursor;
+}
+
+function desktopSettingsValuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
 export function validateDesktopSettingsForm(state: DesktopSettingsFormState): DesktopSettingsValidationError[] {
   const errors: DesktopSettingsValidationError[] = [];
   if (!state.agent.model?.trim()) {
@@ -794,7 +810,7 @@ export function buildDesktopSettingsPaneModel(
   const validationErrors = validateDesktopSettingsForm(state);
   const providerSummaries = getDesktopStateProviderSummaries(state, options.providerCatalog ?? []);
   const dirty = options.lastSavedState
-    ? JSON.stringify(createDesktopSettingsPatch(state)) !== JSON.stringify(createDesktopSettingsPatch(options.lastSavedState))
+    ? desktopSettingsStateDirty(state, options.lastSavedState)
     : false;
   const saveStatus = options.saveStatus ?? "idle";
   return {
@@ -1156,6 +1172,21 @@ export function validateDesktopTimezone(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function desktopSettingsStateDirty(
+  state: DesktopSettingsFormState,
+  lastSavedState: DesktopSettingsFormState,
+): boolean {
+  if (state.touchedPaths?.length) {
+    return state.touchedPaths.some((path) => (
+      !desktopSettingsValuesEqual(
+        getDesktopSettingsPatchPathValue(state, path),
+        getDesktopSettingsPatchPathValue(lastSavedState, path),
+      )
+    ));
+  }
+  return JSON.stringify(createDesktopSettingsPatch(state)) !== JSON.stringify(createDesktopSettingsPatch(lastSavedState));
 }
 
 export function validateDesktopUrl(value: string): boolean {

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -123,6 +123,10 @@ export type DesktopSettingsSavePatchResult =
   | { ok: true; patch: UnknownRecord }
   | { ok: false; validationErrors: DesktopSettingsValidationError[] };
 
+export type DesktopSettingsSaveReconcileResult =
+  | { ok: true; state: DesktopSettingsFormState }
+  | { ok: false; state: DesktopSettingsFormState; mismatchedPaths: string[] };
+
 export interface DesktopProviderModelRequest {
   provider: string;
   profile: string;
@@ -465,6 +469,31 @@ export function buildDesktopSettingsSavePatch(
   return {
     ok: true,
     patch: createDesktopSettingsPatch(state, existingConfig, providerCatalog),
+  };
+}
+
+export function reconcileDesktopSettingsSavedState(
+  draftState: DesktopSettingsFormState,
+  effectiveConfig: unknown,
+  providerCatalog: DesktopProviderCatalogItem[] = [],
+): DesktopSettingsSaveReconcileResult {
+  const savedState = buildDesktopSettingsFormState(effectiveConfig, providerCatalog);
+  const mismatchedPaths = (draftState.touchedPaths ?? []).filter((path) => (
+    !desktopSettingsValuesEqual(
+      getDesktopSettingsPatchPathValue(draftState, path),
+      getDesktopSettingsPatchPathValue(savedState, path),
+    )
+  ));
+  if (mismatchedPaths.length) {
+    return {
+      ok: false,
+      state: draftState,
+      mismatchedPaths,
+    };
+  }
+  return {
+    ok: true,
+    state: savedState,
   };
 }
 

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -173,15 +173,39 @@ export type DesktopSettingsPaneFieldConfigurationMode =
   | "toggle"
   | "url";
 export type DesktopSettingsEditableValue = string | boolean;
+export type DesktopSettingsPaneApplyEffect = "immediate" | "gateway-restart" | "workspace-reload";
 
 export interface DesktopSettingsPaneFieldOption {
   value: string;
   label: string;
 }
 
+export interface DesktopSettingsPaneFieldMetadata {
+  label: string;
+  description: string;
+  aliases: string[];
+  i18nKey: string;
+  validationField?: DesktopSettingsValidationField;
+  sensitive?: boolean;
+  applyEffect?: DesktopSettingsPaneApplyEffect;
+}
+
+export interface DesktopSettingsPaneGroupMetadata {
+  label: string;
+  description: string;
+  aliases: string[];
+  i18nKey: string;
+}
+
 export interface DesktopSettingsPaneField {
   id: string;
   label: string;
+  description?: string;
+  aliases?: string[];
+  i18nKey?: string;
+  validationField?: DesktopSettingsValidationField;
+  sensitive?: boolean;
+  applyEffect?: DesktopSettingsPaneApplyEffect;
   value: string;
   state: "normal" | "invalid";
   control: DesktopSettingsPaneFieldControl;
@@ -211,7 +235,167 @@ export interface DesktopSettingsPaneGroup {
     | "gateway-runtime"
     | "logs-diagnostics";
   label: string;
+  description?: string;
+  aliases?: string[];
+  i18nKey?: string;
   fields: DesktopSettingsPaneField[];
+}
+
+type DesktopSettingsPaneGroupId = DesktopSettingsPaneGroup["id"];
+
+const DESKTOP_SETTINGS_GROUP_METADATA: Record<DesktopSettingsPaneGroupId, DesktopSettingsPaneGroupMetadata> = {
+  general: {
+    label: "General",
+    description: "Default model, provider routing, timezone, and desktop workspace defaults.",
+    aliases: ["default model", "profile", "timezone", "workspace"],
+    i18nKey: "settings.groups.general",
+  },
+  "provider-models": {
+    label: "Provider & Models",
+    description: "Provider profiles, endpoints, credentials, and model catalogs.",
+    aliases: ["providers", "models", "api key", "credentials"],
+    i18nKey: "settings.groups.provider-models",
+  },
+  knowledge: {
+    label: "Knowledge",
+    description: "Retrieval, indexing, reranking, and graph extraction behavior.",
+    aliases: ["rag", "retrieval", "embeddings", "graph"],
+    i18nKey: "settings.groups.knowledge",
+  },
+  "tools-approvals": {
+    label: "Tools & Approvals",
+    description: "Browser, command execution, approval policy, and MCP server access.",
+    aliases: ["tools", "mcp", "approvals", "security"],
+    i18nKey: "settings.groups.tools-approvals",
+  },
+  "files-workspace": {
+    label: "Files & Workspace",
+    description: "Session files, knowledge documents, and editable workspace file boundaries.",
+    aliases: ["files", "storage", "workspace"],
+    i18nKey: "settings.groups.files-workspace",
+  },
+  "memory-experience": {
+    label: "Memory & Experience",
+    description: "Memory and experience controls for contextual continuity.",
+    aliases: ["memory", "experience"],
+    i18nKey: "settings.groups.memory-experience",
+  },
+  skills: {
+    label: "Skills",
+    description: "Skill availability and loading policy.",
+    aliases: ["skills", "capabilities"],
+    i18nKey: "settings.groups.skills",
+  },
+  channels: {
+    label: "Channels",
+    description: "Streaming and retry behavior for desktop channels.",
+    aliases: ["streaming", "progress", "retries"],
+    i18nKey: "settings.groups.channels",
+  },
+  automations: {
+    label: "Automations",
+    description: "Automation and scheduling capabilities planned after core stability.",
+    aliases: ["automation", "scheduling"],
+    i18nKey: "settings.groups.automations",
+  },
+  "gateway-runtime": {
+    label: "Gateway & Runtime",
+    description: "Local gateway connection, heartbeat, and runtime controls.",
+    aliases: ["gateway", "runtime", "host", "port"],
+    i18nKey: "settings.groups.gateway-runtime",
+  },
+  "logs-diagnostics": {
+    label: "Logs & Diagnostics",
+    description: "Runtime logs, diagnostics export, and local state recovery.",
+    aliases: ["logs", "diagnostics", "debug"],
+    i18nKey: "settings.groups.logs-diagnostics",
+  },
+};
+
+const DESKTOP_SETTINGS_FIELD_METADATA: Record<string, DesktopSettingsPaneFieldMetadata> = {
+  "general.model": {
+    label: "Model",
+    description: "Model used for default chat and agent responses.",
+    aliases: ["default model", "chat model", "agent model"],
+    validationField: "model",
+    i18nKey: "settings.fields.general.model",
+  },
+  "general.provider": {
+    label: "Provider",
+    description: "Provider routing for the selected model.",
+    aliases: ["default provider", "routing"],
+    i18nKey: "settings.fields.general.provider",
+  },
+  "general.activeProfile": {
+    label: "Profile",
+    description: "Named provider profile with credentials and endpoint settings.",
+    aliases: ["active profile", "provider profile"],
+    i18nKey: "settings.fields.general.activeProfile",
+  },
+  "general.timezone": {
+    label: "Timezone",
+    description: "Timezone used for timestamps, reminders, and scheduled work.",
+    aliases: ["time zone", "locale", "schedule timezone"],
+    validationField: "timezone",
+    i18nKey: "settings.fields.general.timezone",
+  },
+  "general.workspace": {
+    label: "Workspace",
+    description: "Default desktop workspace path for local files and agent work.",
+    aliases: ["workspace folder", "working directory", "files"],
+    applyEffect: "workspace-reload",
+    i18nKey: "settings.fields.general.workspace",
+  },
+  "provider-models.apiKey": {
+    label: "API key",
+    description: "Secret credential used by the selected provider profile.",
+    aliases: ["secret", "credential", "token"],
+    sensitive: true,
+    i18nKey: "settings.fields.provider-models.apiKey",
+  },
+  "provider-models.apiBase": {
+    label: "API base",
+    description: "OpenAI-compatible endpoint for this provider.",
+    aliases: ["base url", "endpoint", "provider url"],
+    validationField: "providerApiBase",
+    i18nKey: "settings.fields.provider-models.apiBase",
+  },
+  "tools-approvals.mcpServers": {
+    label: "MCP servers",
+    description: "JSON object of MCP server definitions.",
+    aliases: ["mcp", "servers", "tools json"],
+    validationField: "mcpServers",
+    sensitive: true,
+    i18nKey: "settings.fields.tools-approvals.mcpServers",
+  },
+  "gateway-runtime.host": {
+    label: "Host",
+    description: "Host interface where the desktop gateway listens.",
+    aliases: ["bind host", "listen address", "gateway endpoint"],
+    applyEffect: "gateway-restart",
+    i18nKey: "settings.fields.gateway-runtime.host",
+  },
+  "gateway-runtime.port": {
+    label: "Port",
+    description: "Port used by the local gateway endpoint.",
+    aliases: ["gateway port", "listen port"],
+    validationField: "gatewayPort",
+    applyEffect: "gateway-restart",
+    i18nKey: "settings.fields.gateway-runtime.port",
+  },
+};
+
+export function getDesktopSettingsGroupMetadata(
+  groupId: DesktopSettingsPaneGroupId,
+): DesktopSettingsPaneGroupMetadata {
+  return DESKTOP_SETTINGS_GROUP_METADATA[groupId];
+}
+
+export function getDesktopSettingsFieldMetadata(
+  groupId: DesktopSettingsPaneGroupId,
+  fieldId: string,
+): DesktopSettingsPaneFieldMetadata | null {
+  return DESKTOP_SETTINGS_FIELD_METADATA[`${groupId}.${fieldId}`] ?? null;
 }
 
 export interface DesktopSettingsPaneModel {
@@ -1606,6 +1790,7 @@ function buildDesktopSettingsPaneGroups(
   ): DesktopSettingsPaneField => ({
     id,
     label,
+    validationField: config.validationField,
     value: formatDesktopSettingsFieldValue(value),
     state: config.validationField && invalidFields.has(config.validationField) ? "invalid" : "normal",
     control: config.control ?? "text",
@@ -1621,7 +1806,7 @@ function buildDesktopSettingsPaneGroups(
     step: config.step,
   });
   const secretField = buildDesktopSecretField(state.providerEditor.apiKey);
-  return [
+  return enrichDesktopSettingsPaneGroups([
     {
       id: "general",
       label: "General",
@@ -1919,7 +2104,45 @@ function buildDesktopSettingsPaneGroups(
         field("diagnostics", "Diagnostics", "Export diagnostics and inspect runtime logs", { control: "readonly" }),
       ],
     },
-  ];
+  ]);
+}
+
+function enrichDesktopSettingsPaneGroups(groups: DesktopSettingsPaneGroup[]): DesktopSettingsPaneGroup[] {
+  return groups.map((group) => {
+    const groupMetadata = getDesktopSettingsGroupMetadata(group.id);
+    return {
+      ...group,
+      label: groupMetadata.label,
+      description: groupMetadata.description,
+      aliases: [...groupMetadata.aliases],
+      i18nKey: groupMetadata.i18nKey,
+      fields: group.fields.map((field) => enrichDesktopSettingsPaneField(group.id, field)),
+    };
+  });
+}
+
+function enrichDesktopSettingsPaneField(
+  groupId: DesktopSettingsPaneGroupId,
+  field: DesktopSettingsPaneField,
+): DesktopSettingsPaneField {
+  const metadata = getDesktopSettingsFieldMetadata(groupId, field.id);
+  if (!metadata) {
+    return {
+      ...field,
+      aliases: field.aliases ?? [],
+      i18nKey: field.i18nKey ?? `settings.fields.${groupId}.${field.id}`,
+    };
+  }
+  return {
+    ...field,
+    label: metadata.label,
+    description: metadata.description,
+    aliases: [...metadata.aliases],
+    i18nKey: metadata.i18nKey,
+    validationField: metadata.validationField ?? field.validationField,
+    sensitive: metadata.sensitive,
+    applyEffect: metadata.applyEffect,
+  };
 }
 
 function normalizeDesktopSettingsSaveDetails(

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -443,7 +443,7 @@ export function createDesktopSettingsPatch(
   providerCatalog: DesktopProviderCatalogItem[] = [],
 ): UnknownRecord {
   const comparisonConfig = existingConfig === undefined ? state.serverSnapshot ?? {} : existingConfig;
-  if (state.touchedPaths?.length) {
+  if (state.touchedPaths) {
     return createDesktopSettingsTouchedPatch(state, comparisonConfig);
   }
   return createDesktopSettingsFullPatch(state, comparisonConfig, providerCatalog);
@@ -900,6 +900,7 @@ export function applyDesktopSettingsFieldEdit(
   value: DesktopSettingsEditableValue,
 ): DesktopSettingsFormState {
   const nextState = cloneSettingsState(state);
+  nextState.touchedPaths = nextState.touchedPaths ?? [];
   const text = String(value);
   if (fieldId.startsWith("providerEnabled:")) {
     const providerId = fieldId.slice("providerEnabled:".length);
@@ -1181,7 +1182,7 @@ function desktopSettingsStateDirty(
   state: DesktopSettingsFormState,
   lastSavedState: DesktopSettingsFormState,
 ): boolean {
-  if (state.touchedPaths?.length) {
+  if (state.touchedPaths) {
     return state.touchedPaths.some((path) => (
       !desktopSettingsValuesEqual(
         getDesktopSettingsPatchPathValue(state, path),

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -466,6 +466,14 @@ export interface DesktopSettingsPaneModel {
     portStatus: string;
     heartbeatDependency: string;
   };
+  diagnostics?: {
+    runtimeSummary: string;
+    gatewayOwnership: string;
+    version: string;
+    activeConfigPath: string;
+    lastConfigError: string;
+    logLevel: "error" | "info" | "debug";
+  };
   groups: DesktopSettingsPaneGroup[];
   providerCatalog: Array<{
     id: string;
@@ -1141,6 +1149,7 @@ export function buildDesktopSettingsPaneModel(
     save.diagnostics = formatDesktopSettingsSaveDiagnostics(saveStatus, saveDetails);
   }
   const runtime = buildDesktopSettingsRuntimeSummary(state, options.lastSavedState ?? state, save);
+  const diagnostics = buildDesktopSettingsDiagnosticsSummary(runtime, save);
   const providerCatalog = providerSummaries.map((provider) => ({
     id: provider.id,
     label: provider.label,
@@ -1158,6 +1167,7 @@ export function buildDesktopSettingsPaneModel(
     validationErrors,
     save,
     runtime,
+    diagnostics,
     groups: buildDesktopSettingsPaneGroups(state, validationErrors, providerSummaries),
     providerCatalog,
     defaultRouting: buildDesktopDefaultRouting(state, providerCatalog),
@@ -1182,6 +1192,23 @@ export function buildDesktopProviderModelRequest(
     api_key: state.providerEditor.apiKey || "",
     api_base: state.providerEditor.apiBase || "",
     refresh,
+  };
+}
+
+function buildDesktopSettingsDiagnosticsSummary(
+  runtime: NonNullable<DesktopSettingsPaneModel["runtime"]>,
+  save: DesktopSettingsPaneModel["save"],
+): NonNullable<DesktopSettingsPaneModel["diagnostics"]> {
+  const saveStatus = `Settings save status: ${save.status}`;
+  return {
+    runtimeSummary: `Runtime summary: current ${runtime.currentEndpoint}; pending ${runtime.pendingEndpoint}; ${saveStatus}.`,
+    gatewayOwnership: "Gateway ownership: Desktop-managed local gateway.",
+    version: "Version: Current desktop build.",
+    activeConfigPath: "Active config path: Managed by native runtime.",
+    lastConfigError: save.status === "failed"
+      ? `Last config error: ${save.message}`
+      : "Last config error: None.",
+    logLevel: "info",
   };
 }
 

--- a/apps/desktop/src/desktopSettingsSave.test.ts
+++ b/apps/desktop/src/desktopSettingsSave.test.ts
@@ -63,6 +63,30 @@ describe("desktop settings native save bridge", () => {
     expect(applyGatewayConfigPatch).toHaveBeenCalledWith(patch);
   });
 
+  test("unwraps gateway fallback config envelopes before returning the effective config", async () => {
+    const currentConfig = {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai" } },
+    };
+    const patch = { agents: { defaults: { model: "gpt-4.1" } } };
+    const gatewayConfig = {
+      agents: { defaults: { model: "gpt-4.1", provider: "openai" } },
+    };
+    const applyNativeConfigPatch = vi.fn().mockRejectedValue(new Error("command not found"));
+    const applyGatewayConfigPatch = vi.fn().mockResolvedValue({
+      updated: true,
+      updated_fields: ["agents.defaults.model"],
+      config: gatewayConfig,
+    });
+
+    await expect(saveDesktopSettingsConfig(currentConfig, patch, {
+      applyNativeConfigPatch,
+      applyGatewayConfigPatch,
+    })).resolves.toMatchObject({
+      config: gatewayConfig,
+      transport: "gateway-fallback",
+    });
+  });
+
   test("preserves native warnings without using gateway fallback", async () => {
     const currentConfig = {
       agents: { defaults: { model: "gpt-4.1-mini", provider: "openai" } },

--- a/apps/desktop/src/desktopSettingsSave.test.ts
+++ b/apps/desktop/src/desktopSettingsSave.test.ts
@@ -21,7 +21,15 @@ describe("desktop settings native save bridge", () => {
     await expect(saveDesktopSettingsConfig(currentConfig, patch, {
       applyNativeConfigPatch,
       applyGatewayConfigPatch,
-    })).resolves.toBe(nativeConfig);
+    })).resolves.toEqual({
+      config: nativeConfig,
+      transport: "native",
+      updatedFields: ["agents.defaults.model"],
+      applied: ["providerRuntimeChanged"],
+      restartRequired: [],
+      reloadRequired: [],
+      warnings: [],
+    });
 
     expect(applyNativeConfigPatch).toHaveBeenCalledWith(currentConfig, patch);
     expect(applyGatewayConfigPatch).not.toHaveBeenCalled();
@@ -41,9 +49,62 @@ describe("desktop settings native save bridge", () => {
     await expect(saveDesktopSettingsConfig(currentConfig, patch, {
       applyNativeConfigPatch,
       applyGatewayConfigPatch,
-    })).resolves.toBe(gatewayConfig);
+    })).resolves.toEqual({
+      config: gatewayConfig,
+      transport: "gateway-fallback",
+      updatedFields: [],
+      applied: [],
+      restartRequired: [],
+      reloadRequired: [],
+      warnings: ["Saved through gateway fallback after native config patch failed: command not found"],
+    });
 
     expect(applyNativeConfigPatch).toHaveBeenCalledWith(currentConfig, patch);
     expect(applyGatewayConfigPatch).toHaveBeenCalledWith(patch);
+  });
+
+  test("splits native restart and reload requirements", async () => {
+    const currentConfig = {
+      agents: { defaults: { workspace: "old" } },
+      gateway: { port: 18790 },
+    };
+    const patch = {
+      agents: { defaults: { workspace: "new" } },
+      gateway: { port: 18888 },
+    };
+    const nativeConfig = {
+      agents: { defaults: { workspace: "new" } },
+      gateway: { port: 18888 },
+    };
+    const applyNativeConfigPatch = vi.fn().mockResolvedValue({
+      ok: true,
+      config: nativeConfig,
+      updatedFields: ["agents.defaults.workspace", "gateway.port"],
+      sideEffects: {
+        applied: [],
+        restartRequired: ["workspaceReloadRequired", "gatewayRestartRequired"],
+        warnings: [
+          "agents.defaults.workspace requires an explicit workspace reload",
+          "gateway host or port changes require restart",
+        ],
+      },
+    });
+    const applyGatewayConfigPatch = vi.fn().mockResolvedValue({ unreachable: true });
+
+    await expect(saveDesktopSettingsConfig(currentConfig, patch, {
+      applyNativeConfigPatch,
+      applyGatewayConfigPatch,
+    })).resolves.toMatchObject({
+      config: nativeConfig,
+      transport: "native",
+      updatedFields: ["agents.defaults.workspace", "gateway.port"],
+      applied: [],
+      restartRequired: ["gatewayRestartRequired"],
+      reloadRequired: ["workspaceReloadRequired"],
+      warnings: [
+        "agents.defaults.workspace requires an explicit workspace reload",
+        "gateway host or port changes require restart",
+      ],
+    });
   });
 });

--- a/apps/desktop/src/desktopSettingsSave.test.ts
+++ b/apps/desktop/src/desktopSettingsSave.test.ts
@@ -63,6 +63,43 @@ describe("desktop settings native save bridge", () => {
     expect(applyGatewayConfigPatch).toHaveBeenCalledWith(patch);
   });
 
+  test("preserves native warnings without using gateway fallback", async () => {
+    const currentConfig = {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai" } },
+    };
+    const patch = { providers: { openai: { api_base: "https://api.openai.com/v1" } } };
+    const nativeConfig = {
+      agents: { defaults: { model: "gpt-4.1-mini", provider: "openai" } },
+      providers: { openai: { api_base: "https://api.openai.com/v1" } },
+    };
+    const applyNativeConfigPatch = vi.fn().mockResolvedValue({
+      ok: true,
+      config: nativeConfig,
+      updatedFields: ["providers.openai.api_base"],
+      sideEffects: {
+        applied: ["providerRuntimeChanged"],
+        restartRequired: [],
+        warnings: ["provider runtime will use the new base URL on the next request"],
+      },
+    });
+    const applyGatewayConfigPatch = vi.fn().mockResolvedValue({ unreachable: true });
+
+    await expect(saveDesktopSettingsConfig(currentConfig, patch, {
+      applyNativeConfigPatch,
+      applyGatewayConfigPatch,
+    })).resolves.toEqual({
+      config: nativeConfig,
+      transport: "native",
+      updatedFields: ["providers.openai.api_base"],
+      applied: ["providerRuntimeChanged"],
+      restartRequired: [],
+      reloadRequired: [],
+      warnings: ["provider runtime will use the new base URL on the next request"],
+    });
+
+    expect(applyGatewayConfigPatch).not.toHaveBeenCalled();
+  });
+
   test("splits native restart and reload requirements", async () => {
     const currentConfig = {
       agents: { defaults: { workspace: "old" } },

--- a/apps/desktop/src/desktopSettingsSave.ts
+++ b/apps/desktop/src/desktopSettingsSave.ts
@@ -37,8 +37,9 @@ export async function saveDesktopSettingsConfig(
       deps.onNativeFallback?.(error);
     }
   }
+  const gatewayResult = await deps.applyGatewayConfigPatch(patch);
   return {
-    config: await deps.applyGatewayConfigPatch(patch),
+    config: unwrapGatewayConfigPatchResult(gatewayResult),
     transport: "gateway-fallback",
     updatedFields: [],
     applied: [],
@@ -46,6 +47,13 @@ export async function saveDesktopSettingsConfig(
     reloadRequired: [],
     warnings: fallbackError ? [`Saved through gateway fallback after native config patch failed: ${stringifyError(fallbackError)}`] : [],
   };
+}
+
+function unwrapGatewayConfigPatchResult(result: unknown): unknown {
+  if (result && typeof result === "object" && !Array.isArray(result) && "config" in result) {
+    return (result as { config?: unknown }).config;
+  }
+  return result;
 }
 
 function buildNativeSaveResult(result: DesktopNativeConfigPatchResponse): DesktopSettingsSaveResult {

--- a/apps/desktop/src/desktopSettingsSave.ts
+++ b/apps/desktop/src/desktopSettingsSave.ts
@@ -6,21 +6,65 @@ export type DesktopSettingsSaveDeps = {
   onNativeFallback?: (error: unknown) => void;
 };
 
+export type DesktopSettingsSaveTransport = "native" | "gateway-fallback";
+
+export type DesktopSettingsSaveResult = {
+  config: unknown;
+  transport: DesktopSettingsSaveTransport;
+  updatedFields: string[];
+  applied: string[];
+  restartRequired: string[];
+  reloadRequired: string[];
+  warnings: string[];
+};
+
 export async function saveDesktopSettingsConfig(
   currentConfig: unknown,
   patch: unknown,
   deps: DesktopSettingsSaveDeps,
-): Promise<unknown> {
+): Promise<DesktopSettingsSaveResult> {
+  let fallbackError: unknown = null;
   if (deps.applyNativeConfigPatch) {
     try {
       const result = await deps.applyNativeConfigPatch(currentConfig, patch);
       if (result.ok) {
-        return result.config;
+        return buildNativeSaveResult(result);
       }
-      deps.onNativeFallback?.(new Error(result.error ?? "native config patch failed"));
+      fallbackError = new Error(result.error ?? "native config patch failed");
+      deps.onNativeFallback?.(fallbackError);
     } catch (error) {
+      fallbackError = error;
       deps.onNativeFallback?.(error);
     }
   }
-  return deps.applyGatewayConfigPatch(patch);
+  return {
+    config: await deps.applyGatewayConfigPatch(patch),
+    transport: "gateway-fallback",
+    updatedFields: [],
+    applied: [],
+    restartRequired: [],
+    reloadRequired: [],
+    warnings: fallbackError ? [`Saved through gateway fallback after native config patch failed: ${stringifyError(fallbackError)}`] : [],
+  };
+}
+
+function buildNativeSaveResult(result: DesktopNativeConfigPatchResponse): DesktopSettingsSaveResult {
+  const restartRequired = result.sideEffects.restartRequired.filter((effect) => effect !== "workspaceReloadRequired");
+  const reloadRequired = result.sideEffects.restartRequired.filter((effect) => effect === "workspaceReloadRequired");
+  return {
+    config: result.config,
+    transport: "native",
+    updatedFields: result.updatedFields,
+    applied: result.sideEffects.applied,
+    restartRequired,
+    reloadRequired,
+    warnings: result.sideEffects.warnings,
+  };
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === "string" ? error : JSON.stringify(error);
 }

--- a/apps/desktop/src/desktopWorkbenchShell.settingsRenderer.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.settingsRenderer.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, test, vi } from "vitest";
+
+describe("desktop settings renderer ownership", () => {
+  test("mounts the normal settings Vue app without preconstructing the imperative settings page", async () => {
+    vi.resetModules();
+    const mountObservations: Array<{ className: string; childCount: number; hasImperativeContent: boolean }> = [];
+    const mountSettingsPaneIsland = vi.fn((host: HTMLElement) => {
+      mountObservations.push({
+        className: host.className,
+        childCount: host.children.length,
+        hasImperativeContent: Boolean(host.querySelector(".desktop-settings-content")),
+      });
+      host.setAttribute("data-desktop-vue-island", "settings-pane");
+      return {
+        unmount: () => undefined,
+        update: () => undefined,
+      };
+    });
+    vi.doMock("./native-vue/settingsPaneIsland", () => ({
+      mountOrUpdateSettingsPaneIsland: vi.fn(),
+      mountSettingsPaneIsland,
+    }));
+    const [
+      { buildDesktopSettingsFormState, buildDesktopSettingsPaneModel },
+      { createDefaultWorkbenchLayout },
+      { installDesktopWorkbenchShell },
+    ] = await Promise.all([
+      import("./desktopSettingsProviders"),
+      import("./desktopWorkbenchLayout"),
+      import("./desktopWorkbenchShell"),
+    ]);
+
+    document.body.replaceChildren();
+    document.head.replaceChildren();
+    const state = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "deepseek-chat", provider: "deepseek", active_profile: "work" } },
+      providers: { profiles: { work: { provider: "deepseek", api_key: "sk-live", models: ["deepseek-chat"] } } },
+    }, [{ id: "deepseek", displayName: "DeepSeek", status: "ready" }]);
+
+    installDesktopWorkbenchShell({
+      targetDocument: document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      settingsPane: buildDesktopSettingsPaneModel(state, {
+        lastSavedState: state,
+        providerCatalog: [{ id: "deepseek", displayName: "DeepSeek", status: "ready" }],
+      }),
+    });
+
+    const workbenchSettingsPaneMount = mountObservations.find((observation) => observation.className.includes("desktop-settings-pane"));
+    expect(workbenchSettingsPaneMount).toEqual({
+      className: "desktop-workbench-section desktop-settings-pane",
+      childCount: 0,
+      hasImperativeContent: false,
+    });
+  }, 30000);
+});

--- a/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.static-vue-imports.test.ts
@@ -219,19 +219,16 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("./native-vue/workLensIsland")');
   });
 
-  test("statically imports the settings sub-islands", () => {
+  test("statically imports only the unified settings pane island from the shell", () => {
     const source = readFileSync(resolve(__dirname, "desktopWorkbenchShell.ts"), "utf8");
 
-    expect(source).toContain('import { mountSettingsDefaultLlmIsland } from "./native-vue/settingsDefaultLlmIsland";');
-    expect(source).not.toContain('void import("./native-vue/settingsDefaultLlmIsland")');
-    expect(source).toContain('import { mountSettingsGroupsIsland } from "./native-vue/settingsGroupsIsland";');
-    expect(source).not.toContain('void import("./native-vue/settingsGroupsIsland")');
-    expect(source).toContain('import { mountSettingsProviderDetailIsland } from "./native-vue/settingsProviderDetailIsland";');
-    expect(source).not.toContain('void import("./native-vue/settingsProviderDetailIsland")');
-    expect(source).toContain('import { mountSettingsProviderManagementIsland } from "./native-vue/settingsProviderManagementIsland";');
-    expect(source).not.toContain('void import("./native-vue/settingsProviderManagementIsland")');
-    expect(source).toContain('import { mountSettingsSidebarIsland } from "./native-vue/settingsSidebarIsland";');
-    expect(source).not.toContain('void import("./native-vue/settingsSidebarIsland")');
+    expect(source).toContain('import { mountOrUpdateSettingsPaneIsland } from "./native-vue/settingsPaneIsland";');
+    expect(source).toContain('import { mountSettingsPaneIsland } from "./native-vue/settingsPaneIsland";');
+    expect(source).not.toContain('import { mountSettingsDefaultLlmIsland } from "./native-vue/settingsDefaultLlmIsland";');
+    expect(source).not.toContain('import { mountSettingsGroupsIsland } from "./native-vue/settingsGroupsIsland";');
+    expect(source).not.toContain('import { mountSettingsProviderDetailIsland } from "./native-vue/settingsProviderDetailIsland";');
+    expect(source).not.toContain('import { mountSettingsProviderManagementIsland } from "./native-vue/settingsProviderManagementIsland";');
+    expect(source).not.toContain('import { mountSettingsSidebarIsland } from "./native-vue/settingsSidebarIsland";');
     expect(source).not.toContain('import { mountSettingsStatusIsland } from "./native-vue/settingsStatusIsland";');
     expect(source).not.toContain('import { mountSettingsStatusItemIsland } from "./native-vue/settingsStatusItemIsland";');
   });

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -224,12 +224,17 @@ interface DesktopAgentUiFormActionOptions {
   onAgentUiFormAction?: (event: DesktopAgentUiFormActionEvent) => void;
 }
 
-export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "edit";
+export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "testProviderConnection" | "edit";
 
 export type DesktopSettingsActionEvent =
   | {
       action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset";
       pane: DesktopSettingsPaneModel;
+    }
+  | {
+      action: "testProviderConnection";
+      pane: DesktopSettingsPaneModel;
+      providerId: string;
     }
   | {
       action: "edit";

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -12399,13 +12399,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-settings-pane {
-      grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+      grid-template-columns: minmax(190px, 230px) minmax(0, 1fr);
       justify-content: stretch;
       align-items: start;
-      gap: 28px;
+      gap: 24px;
       min-width: 0;
       width: 100%;
-      max-width: 1180px;
+      max-width: 1220px;
       margin: 0 auto;
     }
 
@@ -12418,9 +12418,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       top: 0;
       display: grid;
       align-content: start;
-      gap: 16px;
+      gap: 14px;
       min-width: 0;
-      padding-top: 6px;
+      border: 1px solid #ebe4dd;
+      border-radius: 8px;
+      padding: 12px;
+      background: #fffdfa;
     }
 
     body.desktop-native-workbench .desktop-settings-search {
@@ -12437,7 +12440,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-settings-nav {
       display: grid;
-      gap: 5px;
+      gap: 3px;
       min-width: 0;
     }
 
@@ -12458,6 +12461,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       color: #3a332e;
       font: 650 13px/1.25 var(--font-sans);
       text-decoration: none;
+      transition: background 140ms ease, color 140ms ease;
     }
 
     body.desktop-native-workbench .desktop-settings-nav-item:hover,
@@ -12469,7 +12473,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-settings-content {
       display: grid;
-      gap: 26px;
+      gap: 22px;
       width: 100%;
       min-width: 0;
     }
@@ -12480,7 +12484,29 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       justify-content: space-between;
       gap: 16px;
       min-width: 0;
-      padding-top: 22px;
+      padding-top: 12px;
+    }
+
+    body.desktop-native-workbench .desktop-settings-save-region {
+      display: flex;
+      align-items: center;
+      justify-content: end;
+      gap: 10px;
+      min-width: min(340px, 100%);
+    }
+
+    body.desktop-native-workbench .desktop-settings-save-status {
+      min-width: 0;
+      border: 1px solid #ebe4dd;
+      border-radius: 8px;
+      padding: 8px 10px;
+      background: #fffdfa;
+      color: #5f574f;
+      font: 650 12px/1.3 var(--font-sans);
+    }
+
+    body.desktop-native-workbench .desktop-settings-save-status p {
+      margin: 0;
     }
 
     body.desktop-native-workbench .desktop-settings-breadcrumb h2 {
@@ -12554,7 +12580,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       gap: 12px;
       border: 1px solid #ebe4dd;
       border-radius: 8px;
-      padding: 34px 40px;
+      padding: 24px 28px;
       background: #fffdfa;
     }
 
@@ -12672,6 +12698,16 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       border-color: #f07a2b;
       background: #ff7a1a;
       color: #ffffff;
+    }
+
+    body.desktop-native-workbench .desktop-settings-provider-icon-button {
+      min-width: 82px;
+      width: auto;
+      color: #25211d;
+    }
+
+    body.desktop-native-workbench .desktop-settings-provider-icon-button::before {
+      content: none;
     }
 
     body.desktop-native-workbench .desktop-settings-provider-grid {
@@ -12962,6 +12998,71 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       padding: 0 18px 14px;
     }
 
+    body.desktop-native-workbench .desktop-settings-files-actions,
+    body.desktop-native-workbench .desktop-settings-channels-summary,
+    body.desktop-native-workbench .desktop-settings-runtime-summary,
+    body.desktop-native-workbench .desktop-settings-diagnostics-actions,
+    body.desktop-native-workbench .desktop-settings-mcp-server-list,
+    body.desktop-native-workbench .desktop-settings-secret-controls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+      margin: 0 18px 14px;
+      border: 1px solid #eee8e1;
+      border-radius: 8px;
+      padding: 10px;
+      background: #fbf8f3;
+    }
+
+    body.desktop-native-workbench .desktop-settings-runtime-summary,
+    body.desktop-native-workbench .desktop-settings-diagnostics-actions,
+    body.desktop-native-workbench .desktop-settings-mcp-server-list {
+      display: grid;
+      align-items: stretch;
+    }
+
+    body.desktop-native-workbench .desktop-settings-files-actions p,
+    body.desktop-native-workbench .desktop-settings-channels-summary p,
+    body.desktop-native-workbench .desktop-settings-runtime-summary p,
+    body.desktop-native-workbench .desktop-settings-diagnostics-actions p {
+      flex: 1 1 100%;
+      min-width: 0;
+      margin: 0;
+      color: #5f574f;
+      font: 600 12px/1.45 var(--font-sans);
+      overflow-wrap: anywhere;
+    }
+
+    body.desktop-native-workbench .desktop-settings-files-actions button,
+    body.desktop-native-workbench .desktop-settings-channels-summary button,
+    body.desktop-native-workbench .desktop-settings-runtime-summary button,
+    body.desktop-native-workbench .desktop-settings-diagnostics-actions button,
+    body.desktop-native-workbench .desktop-settings-secret-controls button {
+      min-height: 30px;
+      border: 1px solid #d8d0c8;
+      border-radius: 6px;
+      padding: 0 10px;
+      background: #fffdfa;
+      color: #25211d;
+      font: 700 12px/1.2 var(--font-sans);
+      cursor: pointer;
+    }
+
+    body.desktop-native-workbench .desktop-settings-runtime-intents,
+    body.desktop-native-workbench .desktop-settings-diagnostics-action-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    body.desktop-native-workbench .desktop-settings-runtime-intents button[data-active="true"] {
+      border-color: #3d72e8;
+      background: #eef4ff;
+      color: #214fba;
+    }
+
     body.desktop-native-workbench .desktop-settings-field {
       display: grid;
       grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
@@ -13066,6 +13167,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-settings-actions button:focus-visible,
+    body.desktop-native-workbench .desktop-settings-files-actions button:focus-visible,
+    body.desktop-native-workbench .desktop-settings-channels-summary button:focus-visible,
+    body.desktop-native-workbench .desktop-settings-runtime-summary button:focus-visible,
+    body.desktop-native-workbench .desktop-settings-diagnostics-actions button:focus-visible,
+    body.desktop-native-workbench .desktop-settings-secret-controls button:focus-visible,
     body.desktop-native-workbench .desktop-settings-save-status-button:focus-visible,
     body.desktop-native-workbench .desktop-settings-search:focus-visible,
     body.desktop-native-workbench .desktop-settings-provider-search:focus-visible,
@@ -13113,6 +13219,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       }
 
       body.desktop-native-workbench .desktop-settings-provider-header {
+        align-items: stretch;
+        flex-direction: column;
+      }
+
+      body.desktop-native-workbench .desktop-settings-header,
+      body.desktop-native-workbench .desktop-settings-save-region {
         align-items: stretch;
         flex-direction: column;
       }
@@ -13933,6 +14045,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-provider-icon-button,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-provider-add,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-provider-card-actions button,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-files-actions button,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-channels-summary button,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-runtime-summary button,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-diagnostics-actions button,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-secret-controls button,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-provider-detail input,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field input,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field select,
@@ -13966,6 +14083,14 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-status-card,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-group,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-sidebar,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-save-status,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-files-actions,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-channels-summary,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-runtime-summary,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-diagnostics-actions,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-mcp-server-list,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-secret-controls,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-capability-card,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-default-llm-card,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-provider-card {
@@ -13974,7 +14099,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-status-item,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field {
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-field,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-files-actions,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-channels-summary,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-runtime-summary,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-diagnostics-actions,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-mcp-server-list,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-secret-controls {
       border-color: var(--border);
     }
 
@@ -13999,6 +14130,11 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-provider-detail,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-provider-advanced,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-status-item,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-save-status,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-files-actions p,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-channels-summary p,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-runtime-summary p,
+    html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-diagnostics-actions p,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-settings-nav-heading {
       color: var(--muted);
     }

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -229,11 +229,11 @@ interface DesktopAgentUiFormActionOptions {
   onAgentUiFormAction?: (event: DesktopAgentUiFormActionEvent) => void;
 }
 
-export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "edit";
+export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "edit";
 
 export type DesktopSettingsActionEvent =
   | {
-      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics";
+      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace";
       pane: DesktopSettingsPaneModel;
     }
   | {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -224,11 +224,11 @@ interface DesktopAgentUiFormActionOptions {
   onAgentUiFormAction?: (event: DesktopAgentUiFormActionEvent) => void;
 }
 
-export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "testProviderConnection" | "edit";
+export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "testProviderConnection" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "edit";
 
 export type DesktopSettingsActionEvent =
   | {
-      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset";
+      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments";
       pane: DesktopSettingsPaneModel;
     }
   | {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -224,12 +224,17 @@ interface DesktopAgentUiFormActionOptions {
   onAgentUiFormAction?: (event: DesktopAgentUiFormActionEvent) => void;
 }
 
-export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "testProviderConnection" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "setupChannelIntegrations" | "edit";
+export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "testProviderConnection" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "setupChannelIntegrations" | "openDiagnosticsLogs" | "exportDiagnosticsBundle" | "clearDiagnosticsLogs" | "resetLocalUiState" | "setDiagnosticsLogLevel" | "edit";
 
 export type DesktopSettingsActionEvent =
   | {
-      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "setupChannelIntegrations";
+      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "setupChannelIntegrations" | "openDiagnosticsLogs" | "exportDiagnosticsBundle" | "clearDiagnosticsLogs" | "resetLocalUiState";
       pane: DesktopSettingsPaneModel;
+    }
+  | {
+      action: "setDiagnosticsLogLevel";
+      pane: DesktopSettingsPaneModel;
+      logLevel: string;
     }
   | {
       action: "testProviderConnection";

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -224,11 +224,11 @@ interface DesktopAgentUiFormActionOptions {
   onAgentUiFormAction?: (event: DesktopAgentUiFormActionEvent) => void;
 }
 
-export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "testProviderConnection" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "edit";
+export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "testProviderConnection" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "setupChannelIntegrations" | "edit";
 
 export type DesktopSettingsActionEvent =
   | {
-      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments";
+      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "setupChannelIntegrations";
       pane: DesktopSettingsPaneModel;
     }
   | {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -5152,6 +5152,10 @@ function createSettingsProvidersPane(
   section.setAttribute("data-settings-layout", "section-pages");
   section.setAttribute("aria-label", "Settings and providers");
   const activeGroupId = getDesktopSettingsActiveGroup(pane, initialActiveGroupId)?.id ?? "general";
+  if (canMountVueIsland(section)) {
+    mountSettingsPaneVueIsland(section, targetDocument, pane, settingsActions, activeGroupId);
+    return section;
+  }
 
   const content = targetDocument.createElement("div");
   content.className = "desktop-settings-content";

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -112,13 +112,8 @@ import { mountSidebarContentIsland } from "./native-vue/sidebarContentIsland";
 import { mountSidebarRecentChatsIsland, type SidebarRecentChatRow } from "./native-vue/sidebarRecentChatsIsland";
 import { mountSidebarRowIsland } from "./native-vue/sidebarRowIsland";
 import { mountSidebarSectionHeadingIsland } from "./native-vue/sidebarSectionHeadingIsland";
-import { mountSettingsDefaultLlmIsland } from "./native-vue/settingsDefaultLlmIsland";
-import { mountSettingsGroupsIsland } from "./native-vue/settingsGroupsIsland";
 import { mountOrUpdateSettingsPaneIsland } from "./native-vue/settingsPaneIsland";
 import { mountSettingsPaneIsland } from "./native-vue/settingsPaneIsland";
-import { mountSettingsProviderDetailIsland } from "./native-vue/settingsProviderDetailIsland";
-import { mountSettingsProviderManagementIsland } from "./native-vue/settingsProviderManagementIsland";
-import { mountSettingsSidebarIsland } from "./native-vue/settingsSidebarIsland";
 import { mountOrUpdateSessionFileListIsland } from "./native-vue/sessionFileListIsland";
 import { mountSessionUploadCardIsland } from "./native-vue/sessionUploadCardIsland";
 import { mountShortcutHelpDialogIsland } from "./native-vue/shortcutHelpDialogIsland";
@@ -5192,7 +5187,6 @@ function createSettingsActivePage(
     const groupSection = createSettingsGroupSection(targetDocument, pane, activeGroup, settingsActions);
     if (groupSection) {
       grid.append(groupSection);
-      mountSettingsGroupsVueIsland(grid, pane, settingsActions);
       nodes.push(grid);
     }
   }
@@ -5305,20 +5299,6 @@ function mountSettingsPaneVueIsland(
   });
 }
 
-function mountSettingsGroupsVueIsland(
-  grid: HTMLElement,
-  pane: DesktopSettingsPaneModel,
-  settingsActions: DesktopSettingsActionOptions,
-): void {
-  if (!canMountVueIsland(grid)) {
-    return;
-  }
-  mountSettingsGroupsIsland(grid, {
-    pane,
-    onSettingsAction: settingsActions.onSettingsAction,
-  });
-}
-
 function createDefaultLlmSettingsCard(
   targetDocument: Document,
   pane: DesktopSettingsPaneModel,
@@ -5347,22 +5327,7 @@ function createDefaultLlmSettingsCard(
   copy.className = "desktop-settings-default-llm-copy";
 
   card.append(heading, form, copy);
-  mountSettingsDefaultLlmVueIsland(card, pane, settingsActions);
   return card;
-}
-
-function mountSettingsDefaultLlmVueIsland(
-  card: HTMLElement,
-  pane: DesktopSettingsPaneModel,
-  settingsActions: DesktopSettingsActionOptions,
-): void {
-  if (!canMountVueIsland(card)) {
-    return;
-  }
-  mountSettingsDefaultLlmIsland(card, {
-    pane,
-    onSettingsAction: settingsActions.onSettingsAction,
-  });
 }
 
 function createProviderManagementSection(
@@ -5424,25 +5389,7 @@ function createProviderManagementSection(
   });
 
   section.append(header, cards);
-  mountSettingsProviderManagementVueIsland(section, targetDocument, pane, settingsActions);
   return section;
-}
-
-function mountSettingsProviderManagementVueIsland(
-  section: HTMLElement,
-  targetDocument: Document,
-  pane: DesktopSettingsPaneModel,
-  settingsActions: DesktopSettingsActionOptions,
-): void {
-  if (!canMountVueIsland(section)) {
-    return;
-  }
-  mountSettingsProviderManagementIsland(section, {
-    pane,
-    onSettingsAction: settingsActions.onSettingsAction,
-    promptProviderId: () => promptForSettingsProviderId(targetDocument),
-    onFocusSettingsControl: (fieldId) => focusDesktopSettingsControl(targetDocument, fieldId),
-  });
 }
 
 function createSettingsControlField(
@@ -5608,15 +5555,7 @@ function createSettingsProviderDetail(targetDocument: Document, label: string, v
   const text = createText(targetDocument, "span", `${label}: ${value}`);
   text.className = "desktop-settings-provider-detail-text";
   row.append(createText(targetDocument, "span", `${label}: `), input, text);
-  mountSettingsProviderDetailVueIsland(row, label, value);
   return row;
-}
-
-function mountSettingsProviderDetailVueIsland(row: HTMLElement, label: string, value: string): void {
-  if (!canMountVueIsland(row)) {
-    return;
-  }
-  mountSettingsProviderDetailIsland(row, { label, value });
 }
 
 function filterSettingsProviderCards(cards: HTMLElement, query: string): void {
@@ -5801,7 +5740,6 @@ function createSettingsSidebar(
   });
 
   sidebar.append(nav);
-  mountSettingsSidebarVueIsland(sidebar, pane);
   return sidebar;
 }
 
@@ -5844,13 +5782,6 @@ function getCurrentDesktopSettingsActiveGroupId(
     .find((item) => item.getAttribute("data-active") === "true")
     ?.getAttribute("data-desktop-settings-nav");
   return getDesktopSettingsActiveGroup(nextSettingsPane, activeGroupId)?.id ?? nextSettingsPane.groups[0]?.id ?? "general";
-}
-
-function mountSettingsSidebarVueIsland(sidebar: HTMLElement, pane: DesktopSettingsPaneModel): void {
-  if (!canMountVueIsland(sidebar)) {
-    return;
-  }
-  mountSettingsSidebarIsland(sidebar, { groups: pane.groups });
 }
 
 function getSettingsNavLabel(groupId: DesktopSettingsPaneModel["groups"][number]["id"]): string {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -224,11 +224,11 @@ interface DesktopAgentUiFormActionOptions {
   onAgentUiFormAction?: (event: DesktopAgentUiFormActionEvent) => void;
 }
 
-export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "edit";
+export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "edit";
 
 export type DesktopSettingsActionEvent =
   | {
-      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace";
+      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset";
       pane: DesktopSettingsPaneModel;
     }
   | {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -229,11 +229,11 @@ interface DesktopAgentUiFormActionOptions {
   onAgentUiFormAction?: (event: DesktopAgentUiFormActionEvent) => void;
 }
 
-export type DesktopSettingsActionId = "save" | "discoverModels" | "edit";
+export type DesktopSettingsActionId = "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "edit";
 
 export type DesktopSettingsActionEvent =
   | {
-      action: "save" | "discoverModels";
+      action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics";
       pane: DesktopSettingsPaneModel;
     }
   | {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -77,6 +77,10 @@ describe("settings pane Vue island", () => {
           actions.push(`${event.action}:${event.fieldId}:${String(event.value)}`);
           return;
         }
+        if (event.action === "testProviderConnection") {
+          actions.push(`${event.action}:${event.providerId}`);
+          return;
+        }
         actions.push(event.action);
       },
       promptProviderId: () => "openai",
@@ -135,9 +139,13 @@ describe("settings pane Vue island", () => {
     expect(host.querySelector(".desktop-settings-default-llm-card")).toBeNull();
     expect(host.querySelector(".desktop-settings-provider-section")?.textContent).toContain("Providers");
     expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
+    expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("2 models");
+    expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("Configured profile");
     expect(host.querySelector('[data-desktop-settings-field="apiKey"] input')?.getAttribute("type")).toBe("password");
     expect(host.querySelector<HTMLInputElement>('[data-desktop-settings-control="apiKey"]')?.value).toBe("********");
     expect(host.querySelector('[data-desktop-settings-field="apiKey"] .desktop-settings-field-meta')?.textContent).toContain("Sensitive");
+    expect(host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="discoverModels"]')?.getAttribute("aria-label")).toBe("Refresh models for openai");
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-provider-action="testConnection"]')?.click();
     const providerSave = host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="save"]');
     expect(providerSave).not.toBeNull();
     providerSave?.click();
@@ -187,6 +195,7 @@ describe("settings pane Vue island", () => {
     apiKey?.dispatchEvent(new Event("input", { bubbles: true }));
 
     expect(actions).toEqual([
+      "testProviderConnection:openai",
       "save",
       "edit:model:custom-model-id",
       "save",

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -160,8 +160,9 @@ describe("settings pane Vue island", () => {
     expect(host.textContent).toBe("");
   });
 
-  test("renders group and field descriptions from the pane model", async () => {
+  test("renders labels, descriptions, validation, dirty state, and save actions from the pane model", async () => {
     const host = document.createElement("section");
+    const actions: string[] = [];
     const metadataPane = buildDesktopSettingsPaneModel(draftState, {
       lastSavedState: savedState,
       providerCatalog,
@@ -170,18 +171,54 @@ describe("settings pane Vue island", () => {
     metadataPane.groups[0] = {
       ...metadataPane.groups[0],
       description: "Model-owned group description",
-      fields: metadataPane.groups[0].fields.map((field) => field.id === "timezone"
-        ? { ...field, description: "Model-owned timezone description" }
-        : field),
+      fields: metadataPane.groups[0].fields.map((field) => {
+        if (field.id === "model") {
+          return { ...field, label: "Model-owned default model label" };
+        }
+        if (field.id === "provider") {
+          return { ...field, label: "Model-owned provider label" };
+        }
+        if (field.id === "timezone") {
+          return {
+            ...field,
+            description: "Model-owned timezone description",
+            state: "invalid",
+            validationField: "gatewayPort",
+          } as typeof field;
+        }
+        return field;
+      }),
+    };
+    metadataPane.validationErrors = [{ field: "gatewayPort", errorKey: "portRange" }];
+    metadataPane.dirty = true;
+    metadataPane.save = {
+      ...metadataPane.save,
+      message: "Model-owned dirty state",
+      canSave: false,
     };
 
     const mounted = mountSettingsPaneIsland(host, {
       pane: metadataPane,
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        actions.push(event.action);
+      },
     });
     await nextTick();
 
+    expect(host.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("Model-owned provider label");
+    expect(host.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("Model-owned default model label");
     expect(host.querySelector(".desktop-settings-header-description")?.textContent).toContain("Model-owned group description");
     expect(host.querySelector('[data-desktop-settings-field="timezone"] .desktop-settings-field-description')?.textContent).toContain("Model-owned timezone description");
+    expect(host.querySelector('[data-desktop-settings-status="save"]')?.textContent).toContain("Model-owned dirty state");
+
+    const save = host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="save"]');
+    expect(save?.disabled).toBe(true);
+    save?.click();
+    expect(actions).toEqual([]);
+
+    const timezone = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="timezone"]');
+    expect(timezone?.getAttribute("aria-invalid")).toBe("true");
+    expect(host.querySelector("#desktop-settings-timezone-error")?.textContent).toContain("Port must be between 1 and 65535.");
 
     mounted.unmount();
   });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -457,4 +457,48 @@ describe("settings pane Vue island", () => {
     mounted.unmount();
     host.remove();
   });
+
+  test("shows Auto model suggestions from enabled provider catalog instead of the provider editor", async () => {
+    const host = document.createElement("section");
+    const autoState = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "openai-fast", provider: "auto", active_profile: "deepseek", timezone: "UTC" } },
+      providers: {
+        profiles: {
+          openai: {
+            provider: "openai",
+            api_key: "sk-openai",
+            models: ["openai-fast"],
+          },
+          deepseek: {
+            provider: "deepseek",
+            api_key: "sk-deepseek",
+            models: ["deepseek-chat"],
+          },
+        },
+      },
+    }, [
+      { id: "openai", displayName: "OpenAI", status: "ready" },
+      { id: "deepseek", displayName: "DeepSeek", status: "ready" },
+    ]);
+    const autoPane = buildDesktopSettingsPaneModel(autoState, {
+      providerCatalog: [
+        { id: "openai", displayName: "OpenAI", status: "ready" },
+        { id: "deepseek", displayName: "DeepSeek", status: "ready" },
+      ],
+    });
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: autoPane,
+    });
+    await nextTick();
+
+    expect(host.querySelector('[data-desktop-settings-control="provider"]')?.textContent).toContain("Auto");
+    expect(Array.from(
+      host.querySelectorAll("#desktop-settings-model-options option"),
+      (node) => node.getAttribute("value"),
+    )).toEqual(["openai-fast", "deepseek-chat"]);
+    expect(host.querySelector("[data-desktop-settings-auto-resolution]")?.textContent).toContain("Auto resolves to OpenAI / openai-fast");
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -159,9 +159,15 @@ describe("settings pane Vue island", () => {
 
     host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="general"]')?.click();
     await nextTick();
-    const model = host.querySelector<HTMLSelectElement>('[data-desktop-settings-control="model"]');
-    model!.value = "gpt-4.1-mini";
-    model?.dispatchEvent(new Event("change", { bubbles: true }));
+    const model = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="model"]');
+    expect(model?.getAttribute("role")).toBe("combobox");
+    expect(model?.getAttribute("list")).toBe("desktop-settings-model-options");
+    expect(Array.from(
+      host.querySelectorAll("#desktop-settings-model-options option"),
+      (node) => node.getAttribute("value"),
+    )).toEqual(["gpt-4.1", "gpt-4.1-mini"]);
+    model!.value = "custom-model-id";
+    model?.dispatchEvent(new Event("input", { bubbles: true }));
     host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="save"]')?.click();
 
     host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]')?.click();
@@ -174,7 +180,7 @@ describe("settings pane Vue island", () => {
 
     expect(actions).toEqual([
       "save",
-      "edit:model:gpt-4.1-mini",
+      "edit:model:custom-model-id",
       "save",
       "discoverModels",
       "edit:apiKey:sk-replacement",

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -639,4 +639,26 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("clarifies Channels scope, retry semantics, and setup routes", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    const mounted = mountSettingsPaneIsland(host, {
+      pane,
+      initialActiveGroupId: "channels",
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        actions.push(event.action);
+      },
+    });
+    await nextTick();
+
+    expect(host.querySelector("[data-desktop-settings-channels-scope]")?.textContent).toContain("Global defaults");
+    expect(host.querySelector("[data-desktop-settings-channels-retry]")?.textContent).toContain("Max retries are additional attempts");
+    expect(host.querySelector("[data-desktop-settings-channels-empty]")?.textContent).toContain("No integration-specific overrides");
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-channel-action="setupIntegrations"]')?.click();
+
+    expect(actions).toEqual(["setupChannelIntegrations"]);
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -557,4 +557,30 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("renders provider secret replacement and clear controls", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    document.body.replaceChildren(host);
+    const mounted = mountSettingsPaneIsland(host, {
+      pane,
+      initialActiveGroupId: "provider-models",
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        if (event.action === "edit") {
+          actions.push(`${event.action}:${event.fieldId}:${String(event.value)}`);
+        }
+      },
+    });
+    await nextTick();
+
+    const apiKey = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="apiKey"]');
+    expect(host.querySelector("[data-desktop-settings-secret-policy]")?.textContent).toContain("Reveal is disabled");
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-secret-action="replace"]')?.click();
+    expect(document.activeElement).toBe(apiKey);
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-secret-action="clear"]')?.click();
+    expect(actions).toEqual(["edit:apiKey:"]);
+
+    mounted.unmount();
+    host.remove();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -162,6 +162,7 @@ describe("settings pane Vue island", () => {
 
   test("renders visible save failure and field validation errors accessibly", async () => {
     const host = document.createElement("section");
+    const actions: string[] = [];
     const invalidState = buildDesktopSettingsFormState({
       agents: { defaults: { model: "", provider: "openai", active_profile: "work", timezone: "Shanghai" } },
       providers: {
@@ -184,6 +185,9 @@ describe("settings pane Vue island", () => {
 
     const mounted = mountSettingsPaneIsland(host, {
       pane: invalidPane,
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        actions.push(event.action);
+      },
     });
     await nextTick();
 
@@ -191,12 +195,35 @@ describe("settings pane Vue island", () => {
     expect(status?.getAttribute("aria-live")).toBe("polite");
     expect(status?.textContent).toContain("HTTP 400");
     expect(host.querySelector('[data-desktop-settings-alert="save"]')?.textContent).toContain("HTTP 400");
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="retryLoad"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="copyDiagnostics"]')?.click();
+    expect(actions).toEqual(["retryLoad", "copyDiagnostics"]);
 
     const timezone = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="timezone"]');
     const describedBy = timezone?.getAttribute("aria-describedby");
     expect(timezone?.getAttribute("aria-invalid")).toBe("true");
     expect(describedBy).toContain("desktop-settings-timezone-error");
     expect(host.querySelector("#desktop-settings-timezone-error")?.textContent).toContain("Invalid timezone");
+
+    mounted.unmount();
+  });
+
+  test("does not label failed clean settings as saved", async () => {
+    const host = document.createElement("section");
+    const failedPane = buildDesktopSettingsPaneModel(savedState, {
+      lastSavedState: savedState,
+      providerCatalog,
+      saveStatus: "failed",
+      saveError: "Failed to load settings: offline",
+    });
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: failedPane,
+    });
+    await nextTick();
+
+    expect(host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="save"]')?.textContent).toBe("Save failed");
+    expect(host.querySelector('[data-desktop-settings-alert="save"]')?.textContent).toContain("Failed to load settings: offline");
 
     mounted.unmount();
   });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -230,6 +230,7 @@ describe("settings pane Vue island", () => {
 
   test("renders native save warnings and gateway fallback status", async () => {
     const host = document.createElement("section");
+    const actions: string[] = [];
     const fallbackPane = buildDesktopSettingsPaneModel(savedState, {
       lastSavedState: savedState,
       providerCatalog,
@@ -246,6 +247,9 @@ describe("settings pane Vue island", () => {
 
     const mounted = mountSettingsPaneIsland(host, {
       pane: fallbackPane,
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        actions.push(event.action);
+      },
     });
     await nextTick();
 
@@ -260,7 +264,10 @@ describe("settings pane Vue island", () => {
     )).toEqual([
       "Saved through gateway fallback",
       "Native patch failed; gateway fallback applied.",
+      "Copy diagnostics",
     ]);
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="copyDiagnostics"]')?.click();
+    expect(actions).toEqual(["copyDiagnostics"]);
 
     mounted.unmount();
   });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -661,4 +661,53 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("renders Runtime intent controls, endpoint transition, port status, and heartbeat dependency", async () => {
+    const host = document.createElement("section");
+    const savedRuntimeState = buildDesktopSettingsFormState({
+      gateway: {
+        host: "127.0.0.1",
+        port: 18790,
+        heartbeat: { enabled: true, interval_s: 1800 },
+      },
+    }, providerCatalog);
+    const pendingRuntimeState = buildDesktopSettingsFormState({
+      gateway: {
+        host: "0.0.0.0",
+        port: 18888,
+        heartbeat: { enabled: false, interval_s: 1800 },
+      },
+    }, providerCatalog);
+    const runtimePane = buildDesktopSettingsPaneModel(pendingRuntimeState, {
+      lastSavedState: savedRuntimeState,
+      saveStatus: "saved",
+      saveDetails: {
+        transport: "native",
+        updatedFields: ["gateway.host", "gateway.port", "gateway.heartbeat.enabled"],
+        applied: ["gatewayRuntimeChanged"],
+        restartRequired: ["gatewayRestartRequired"],
+        reloadRequired: [],
+        warnings: [],
+      },
+    });
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: runtimePane,
+      initialActiveGroupId: "gateway-runtime",
+    });
+    await nextTick();
+
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-runtime-intent]"),
+      (node) => node.textContent,
+    )).toEqual(["Local only", "Local network", "Advanced custom"]);
+    expect(host.querySelector('[data-desktop-settings-runtime-intent="local-network"]')?.getAttribute("data-active")).toBe("true");
+    expect(host.querySelector("[data-desktop-settings-runtime-current-endpoint]")?.textContent).toContain("127.0.0.1:18790");
+    expect(host.querySelector("[data-desktop-settings-runtime-pending-endpoint]")?.textContent).toContain("0.0.0.0:18888");
+    expect(host.querySelector("[data-desktop-settings-runtime-port-status]")?.textContent).toContain("Port 18888");
+    expect(host.querySelector("[data-desktop-settings-runtime-heartbeat-dependency]")?.textContent).toContain("Heartbeat interval is disabled");
+    expect(host.querySelector<HTMLInputElement>('[data-desktop-settings-control="heartbeatIntervalS"]')?.disabled).toBe(true);
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -509,4 +509,43 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("uses a guided provider setup flow instead of prompt creation", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    const mounted = mountSettingsPaneIsland(host, {
+      pane,
+      initialActiveGroupId: "provider-models",
+      promptProviderId: () => {
+        throw new Error("prompt should not be used");
+      },
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        if (event.action === "edit") {
+          actions.push(`${event.action}:${event.fieldId}:${String(event.value)}`);
+        }
+      },
+    });
+    await nextTick();
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="addProvider"]')?.click();
+    await nextTick();
+    const providerId = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="newProviderId"]');
+    expect(providerId?.getAttribute("aria-describedby")).toBe("desktop-settings-provider-setup-guidance");
+    expect(host.querySelector("[data-desktop-settings-provider-setup]")?.textContent).toContain("Add provider");
+    expect(host.querySelector("#desktop-settings-provider-setup-guidance")?.textContent).toContain("API key");
+
+    providerId!.value = "openai";
+    providerId?.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(host.querySelector("[data-desktop-settings-provider-setup-error]")?.textContent).toContain("already exists");
+
+    providerId!.value = "localai";
+    providerId?.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-provider-setup-action="create"]')?.click();
+
+    expect(actions).toEqual(["edit:selectedProvider:localai"]);
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -583,4 +583,32 @@ describe("settings pane Vue island", () => {
     mounted.unmount();
     host.remove();
   });
+
+  test("renders MCP servers as a structured list with advanced JSON editing", async () => {
+    const host = document.createElement("section");
+    const mcpState = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "gpt-4.1" } },
+      tools: {
+        mcp_servers: {
+          docs: { command: "docs-mcp", args: ["serve"] },
+          web: { url: "http://127.0.0.1:3000/mcp" },
+        },
+      },
+    });
+    const mcpPane = buildDesktopSettingsPaneModel(mcpState);
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: mcpPane,
+      initialActiveGroupId: "tools-approvals",
+    });
+    await nextTick();
+
+    expect(host.querySelector('[data-desktop-settings-mcp-server="docs"]')?.textContent).toContain("docs-mcp");
+    expect(host.querySelector('[data-desktop-settings-mcp-server="docs"]')?.textContent).toContain("command");
+    expect(host.querySelector('[data-desktop-settings-mcp-server="web"]')?.textContent).toContain("http://127.0.0.1:3000/mcp");
+    expect(host.querySelector('[data-desktop-settings-field="mcpServers"]')?.closest("details")?.className).toContain("desktop-settings-advanced-fields");
+    expect(host.querySelector<HTMLTextAreaElement>('[data-desktop-settings-control="mcpServers"]')?.value).toContain("docs-mcp");
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -710,4 +710,48 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("turns Diagnostics into an action page with runtime metadata", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    const mounted = mountSettingsPaneIsland(host, {
+      pane,
+      initialActiveGroupId: "logs-diagnostics",
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        actions.push(event.action);
+      },
+    });
+    await nextTick();
+
+    expect(host.querySelector("[data-desktop-settings-diagnostics-runtime-summary]")?.textContent).toContain("Runtime summary");
+    expect(host.querySelector("[data-desktop-settings-diagnostics-gateway-ownership]")?.textContent).toContain("Gateway ownership");
+    expect(host.querySelector("[data-desktop-settings-diagnostics-version]")?.textContent).toContain("Version");
+    expect(host.querySelector("[data-desktop-settings-diagnostics-config-path]")?.textContent).toContain("Active config path");
+    expect(host.querySelector("[data-desktop-settings-diagnostics-config-error]")?.textContent).toContain("Last config error");
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-diagnostics-action]"),
+      (node) => node.textContent,
+    )).toEqual(["Open logs", "Copy runtime summary", "Export redacted diagnostics", "Clear logs", "Reset local UI"]);
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-diagnostics-action="openLogs"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-diagnostics-action="copyRuntimeSummary"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-diagnostics-action="exportDiagnosticsBundle"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-diagnostics-action="clearLogs"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-diagnostics-action="resetLocalUiState"]')?.click();
+    const logLevel = host.querySelector<HTMLSelectElement>("[data-desktop-settings-diagnostics-log-level]");
+    expect(logLevel?.value).toBe("info");
+    logLevel!.value = "debug";
+    logLevel?.dispatchEvent(new Event("change"));
+
+    expect(actions).toEqual([
+      "openDiagnosticsLogs",
+      "copyDiagnostics",
+      "exportDiagnosticsBundle",
+      "clearDiagnosticsLogs",
+      "resetLocalUiState",
+      "setDiagnosticsLogLevel",
+    ]);
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -264,4 +264,40 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("renders restart and reload required actions", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    const pendingPane = buildDesktopSettingsPaneModel(savedState, {
+      lastSavedState: savedState,
+      providerCatalog,
+      saveStatus: "saved",
+      saveDetails: {
+        transport: "native",
+        updatedFields: ["gateway.port", "agents.defaults.workspace"],
+        applied: ["gatewayRuntimeChanged", "workspaceChanged"],
+        restartRequired: ["gatewayRestartRequired"],
+        reloadRequired: ["workspaceReloadRequired"],
+        warnings: [],
+      },
+    });
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: pendingPane,
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        actions.push(event.action);
+      },
+    });
+    await nextTick();
+
+    const status = host.querySelector('[data-desktop-settings-status="save"]');
+    expect(status?.textContent).toContain("Gateway restart required");
+    expect(status?.textContent).toContain("Workspace reload required");
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="restartGateway"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="reloadWorkspace"]')?.click();
+
+    expect(actions).toEqual(["restartGateway", "reloadWorkspace"]);
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -611,4 +611,32 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("renders Files and Storage workspace actions", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    const mounted = mountSettingsPaneIsland(host, {
+      pane,
+      initialActiveGroupId: "files-workspace",
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        actions.push(event.action);
+      },
+    });
+    await nextTick();
+
+    expect(host.querySelector("[data-desktop-settings-workspace-permission]")?.textContent).toContain("Permission");
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-file-action="chooseWorkspace"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-file-action="openWorkspace"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-file-action="openSessionFiles"]')?.click();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-file-action="openKnowledgeDocuments"]')?.click();
+
+    expect(actions).toEqual([
+      "chooseWorkspace",
+      "openWorkspace",
+      "openSessionFiles",
+      "openKnowledgeDocuments",
+    ]);
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -395,4 +395,60 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("searches shared settings metadata and activates non-sensitive results", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    document.body.replaceChildren(host);
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane,
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        actions.push(event.action);
+      },
+    });
+    await nextTick();
+
+    const search = host.querySelector<HTMLInputElement>('[data-desktop-settings-search="query"]');
+    search!.value = "workspace";
+    search?.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-search-result]"),
+      (node) => node.getAttribute("data-desktop-settings-search-result"),
+    )).toContain("files-workspace.workspace");
+    const workspaceResult = host.querySelector<HTMLButtonElement>('[data-desktop-settings-search-result="files-workspace.workspace"]');
+    expect(workspaceResult?.textContent).toContain("Workspace");
+    expect(workspaceResult?.textContent).toContain("Files & Workspace");
+    workspaceResult?.click();
+    await nextTick();
+
+    const workspace = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="workspace"]');
+    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Files & Workspace");
+    expect(document.activeElement).toBe(workspace);
+    expect(host.querySelector('[data-desktop-settings-field="workspace"]')?.getAttribute("data-highlighted")).toBe("true");
+
+    search!.value = "temperature";
+    search?.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-search-result="general.temperature"]')?.click();
+    await nextTick();
+    expect(host.querySelector('[data-desktop-settings-group="general"] details.desktop-settings-advanced-fields')?.hasAttribute("open")).toBe(true);
+    expect(document.activeElement).toBe(host.querySelector('[data-desktop-settings-control="temperature"]'));
+
+    search!.value = "sk-live";
+    search?.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(host.querySelector("[data-desktop-settings-search-result]")).toBeNull();
+    expect(host.querySelector('[data-desktop-settings-search-empty="true"]')?.textContent).toContain("No settings found");
+    expect(host.textContent).not.toContain("sk-live");
+
+    expect(host.querySelector('[data-desktop-settings-dirty-summary]')?.textContent).toContain("Unsaved changes");
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="reset"]')?.click();
+    expect(actions).toEqual(["reset"]);
+
+    mounted.unmount();
+    host.remove();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -227,4 +227,41 @@ describe("settings pane Vue island", () => {
 
     mounted.unmount();
   });
+
+  test("renders native save warnings and gateway fallback status", async () => {
+    const host = document.createElement("section");
+    const fallbackPane = buildDesktopSettingsPaneModel(savedState, {
+      lastSavedState: savedState,
+      providerCatalog,
+      saveStatus: "saved",
+      saveDetails: {
+        transport: "gateway-fallback",
+        updatedFields: ["agents.defaults.model"],
+        applied: ["agents.defaults.model"],
+        restartRequired: [],
+        reloadRequired: [],
+        warnings: ["Native patch failed; gateway fallback applied."],
+      },
+    });
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: fallbackPane,
+    });
+    await nextTick();
+
+    const status = host.querySelector('[data-desktop-settings-status="save"]');
+    expect(status?.getAttribute("aria-live")).toBe("polite");
+    expect(status?.textContent).toContain("Settings saved through gateway fallback");
+    expect(host.querySelector("[data-desktop-settings-save-details]")?.textContent).toContain("Saved through gateway fallback");
+    expect(host.querySelector("[data-desktop-settings-save-details]")?.textContent).toContain("Native patch failed; gateway fallback applied.");
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-save-detail]"),
+      (node) => node.textContent,
+    )).toEqual([
+      "Saved through gateway fallback",
+      "Native patch failed; gateway fallback applied.",
+    ]);
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -95,6 +95,30 @@ describe("settings pane Vue island", () => {
     expect(host.querySelector(".desktop-settings-provider-section")).toBeNull();
     expect(host.querySelector(".desktop-settings-status-card")).toBeNull();
     expect(Array.from(
+      host.querySelectorAll(".desktop-settings-nav-heading"),
+      (node) => node.textContent,
+    )).toEqual(["Core", "Application", "System"]);
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-nav]"),
+      (node) => node.getAttribute("data-desktop-settings-nav"),
+    )).toEqual([
+      "general",
+      "provider-models",
+      "knowledge",
+      "tools-approvals",
+      "files-workspace",
+      "channels",
+      "gateway-runtime",
+      "logs-diagnostics",
+    ]);
+    expect(host.querySelector('[data-desktop-settings-nav="memory-experience"]')).toBeNull();
+    expect(host.querySelector('[data-desktop-settings-nav="skills"]')).toBeNull();
+    expect(host.querySelector('[data-desktop-settings-nav="automations"]')).toBeNull();
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-preview]"),
+      (node) => node.getAttribute("data-desktop-settings-preview"),
+    )).toEqual(["memory-experience", "skills", "automations"]);
+    expect(Array.from(
       host.querySelectorAll("[data-desktop-settings-group]"),
       (node) => node.getAttribute("data-desktop-settings-group"),
     )).toEqual(["general"]);
@@ -125,6 +149,7 @@ describe("settings pane Vue island", () => {
       host.querySelectorAll("[data-desktop-settings-group]"),
       (node) => node.getAttribute("data-desktop-settings-group"),
     )).toEqual(["files-workspace"]);
+    expect(host.querySelector('[data-desktop-settings-field="workspace"] input')?.getAttribute("placeholder")).toBe("~/.tinybot/workspace");
     expect(host.querySelector('[data-desktop-settings-field="sessionFiles"] output')?.textContent).toContain("Session file");
     expect(host.querySelector('[data-desktop-settings-field="sessionFiles"] [data-desktop-settings-control="sessionFiles"]')).toBeNull();
     expect(host.querySelector('[data-desktop-settings-nav="general"]')?.getAttribute("data-active")).toBeNull();

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -159,4 +159,45 @@ describe("settings pane Vue island", () => {
     mounted.unmount();
     expect(host.textContent).toBe("");
   });
+
+  test("renders visible save failure and field validation errors accessibly", async () => {
+    const host = document.createElement("section");
+    const invalidState = buildDesktopSettingsFormState({
+      agents: { defaults: { model: "", provider: "openai", active_profile: "work", timezone: "Shanghai" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            api_base: "https://api.openai.com/v1",
+            models: ["gpt-4.1-mini"],
+          },
+        },
+      },
+    }, providerCatalog);
+    const invalidPane = buildDesktopSettingsPaneModel(invalidState, {
+      lastSavedState: savedState,
+      providerCatalog,
+      saveStatus: "failed",
+      saveError: "HTTP 400",
+    });
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: invalidPane,
+    });
+    await nextTick();
+
+    const status = host.querySelector('[data-desktop-settings-status="save"]');
+    expect(status?.getAttribute("aria-live")).toBe("polite");
+    expect(status?.textContent).toContain("HTTP 400");
+    expect(host.querySelector('[data-desktop-settings-alert="save"]')?.textContent).toContain("HTTP 400");
+
+    const timezone = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="timezone"]');
+    const describedBy = timezone?.getAttribute("aria-describedby");
+    expect(timezone?.getAttribute("aria-invalid")).toBe("true");
+    expect(describedBy).toContain("desktop-settings-timezone-error");
+    expect(host.querySelector("#desktop-settings-timezone-error")?.textContent).toContain("Invalid timezone");
+
+    mounted.unmount();
+  });
 });

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -137,6 +137,7 @@ describe("settings pane Vue island", () => {
     expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
     expect(host.querySelector('[data-desktop-settings-field="apiKey"] input')?.getAttribute("type")).toBe("password");
     expect(host.querySelector<HTMLInputElement>('[data-desktop-settings-control="apiKey"]')?.value).toBe("********");
+    expect(host.querySelector('[data-desktop-settings-field="apiKey"] .desktop-settings-field-meta')?.textContent).toContain("Sensitive");
     const providerSave = host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="save"]');
     expect(providerSave).not.toBeNull();
     providerSave?.click();
@@ -156,9 +157,16 @@ describe("settings pane Vue island", () => {
     const activeNavFiles = host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="files-workspace"]');
     expect(activeNavFiles?.getAttribute("data-active")).toBe("true");
     expect(activeNavFiles?.getAttribute("aria-current")).toBe("page");
+    expect(host.querySelector('[data-desktop-settings-field="workspace"] .desktop-settings-field-meta')?.textContent).toContain("Reload required");
+
+    host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="gateway-runtime"]')?.click();
+    await nextTick();
+    expect(host.querySelector('[data-desktop-settings-field="port"] .desktop-settings-field-meta')?.textContent).toContain("TCP port");
+    expect(host.querySelector('[data-desktop-settings-field="port"] .desktop-settings-field-meta')?.textContent).toContain("Restart required");
 
     host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="general"]')?.click();
     await nextTick();
+    expect(host.querySelector('[data-desktop-settings-field="temperature"] .desktop-settings-field-meta')?.textContent).toContain("Recommended 0.1");
     const model = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="model"]');
     expect(model?.getAttribute("role")).toBe("combobox");
     expect(model?.getAttribute("list")).toBe("desktop-settings-model-options");

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -160,6 +160,32 @@ describe("settings pane Vue island", () => {
     expect(host.textContent).toBe("");
   });
 
+  test("renders group and field descriptions from the pane model", async () => {
+    const host = document.createElement("section");
+    const metadataPane = buildDesktopSettingsPaneModel(draftState, {
+      lastSavedState: savedState,
+      providerCatalog,
+      saveStatus: "idle",
+    });
+    metadataPane.groups[0] = {
+      ...metadataPane.groups[0],
+      description: "Model-owned group description",
+      fields: metadataPane.groups[0].fields.map((field) => field.id === "timezone"
+        ? { ...field, description: "Model-owned timezone description" }
+        : field),
+    };
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: metadataPane,
+    });
+    await nextTick();
+
+    expect(host.querySelector(".desktop-settings-header-description")?.textContent).toContain("Model-owned group description");
+    expect(host.querySelector('[data-desktop-settings-field="timezone"] .desktop-settings-field-description')?.textContent).toContain("Model-owned timezone description");
+
+    mounted.unmount();
+  });
+
   test("renders visible save failure and field validation errors accessibly", async () => {
     const host = document.createElement("section");
     const actions: string[] = [];

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -110,6 +110,7 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>): App {
             renderSidebar(options.pane, selectedGroupId, setActiveGroupId),
             h("div", { class: "desktop-settings-content" }, [
               renderHeader(options, selectedGroupId),
+              renderSaveAlert(options.pane),
               renderActiveSettingsSection(options, selectedGroupId, providerSearch.value, (value) => {
                 providerSearch.value = value;
               }),
@@ -132,7 +133,32 @@ function renderHeader(
       h("h2", `Settings / ${activeGroup?.label ?? "General"}`),
       activeGroup ? h("p", { class: "desktop-settings-header-description" }, getSettingsGroupDescription(activeGroup.id)) : null,
     ]),
-    renderSaveButton(options),
+    h("div", { class: "desktop-settings-save-region" }, [
+      renderSaveStatus(pane),
+      renderSaveButton(options),
+    ]),
+  ]);
+}
+
+function renderSaveStatus(pane: DesktopSettingsPaneModel) {
+  return h("p", {
+    class: "desktop-settings-save-status",
+    "data-desktop-settings-status": "save",
+    "aria-live": "polite",
+  }, pane.save.message);
+}
+
+function renderSaveAlert(pane: DesktopSettingsPaneModel) {
+  if (pane.save.status !== "failed") {
+    return null;
+  }
+  return h("div", {
+    class: "desktop-settings-error-banner",
+    role: "alert",
+    "data-desktop-settings-alert": "save",
+  }, [
+    h("strong", "Settings save failed"),
+    h("p", pane.save.message),
   ]);
 }
 
@@ -401,6 +427,7 @@ function renderSettingsField(
       renderSettingsFieldMeta(field),
     ]),
     renderSettingsControl(options, field),
+    renderSettingsFieldError(options.pane, field),
   ]);
 }
 
@@ -428,6 +455,7 @@ function renderModelSelect(options: SettingsPaneIslandOptions, field: DesktopSet
     "data-desktop-settings-control": field.id,
     "data-state": field.state,
     "aria-invalid": field.state === "invalid" ? "true" : undefined,
+    "aria-describedby": getSettingsFieldErrorId(options.pane, field),
     value: field.inputValue,
     onChange: (event: Event) => emitEdit(options, field.id, String((event.target as HTMLSelectElement | null)?.value ?? "")),
   }, values.map((value) => h("option", {
@@ -448,6 +476,7 @@ function renderSettingsControl(options: SettingsPaneIslandOptions, field: Deskto
     "data-desktop-settings-control": field.id,
     "data-state": field.state,
     "aria-invalid": field.state === "invalid" ? "true" : undefined,
+    "aria-describedby": getSettingsFieldErrorId(options.pane, field),
     placeholder: field.placeholder,
     min: field.min,
     max: field.max,
@@ -485,6 +514,44 @@ function renderSettingsControl(options: SettingsPaneIslandOptions, field: Deskto
     value: field.inputValue,
     onInput: (event: Event) => emitEdit(options, field.id, String((event.target as HTMLInputElement | null)?.value ?? "")),
   });
+}
+
+function renderSettingsFieldError(pane: DesktopSettingsPaneModel, field: DesktopSettingsPaneField) {
+  const message = getSettingsFieldErrorMessage(pane, field);
+  if (!message) {
+    return null;
+  }
+  return h("p", {
+    id: `desktop-settings-${field.id}-error`,
+    class: "desktop-settings-field-error",
+    "data-desktop-settings-error": field.id,
+  }, message);
+}
+
+function getSettingsFieldErrorId(pane: DesktopSettingsPaneModel, field: DesktopSettingsPaneField): string | undefined {
+  return getSettingsFieldErrorMessage(pane, field) ? `desktop-settings-${field.id}-error` : undefined;
+}
+
+function getSettingsFieldErrorMessage(pane: DesktopSettingsPaneModel, field: DesktopSettingsPaneField): string {
+  const validationField = settingsValidationFieldForControl(field.id);
+  const error = pane.validationErrors.find((validationError) => validationError.field === validationField);
+  if (!error) {
+    return "";
+  }
+  return {
+    modelEmpty: "Model is required.",
+    timezoneError: "Invalid timezone.",
+    portRange: "Port must be between 1 and 65535.",
+    jsonObjectError: "Must be a JSON object.",
+    urlError: "Must be a valid URL.",
+  }[error.errorKey] ?? "Invalid setting.";
+}
+
+function settingsValidationFieldForControl(fieldId: string): string {
+  return {
+    port: "gatewayPort",
+    apiBase: "providerApiBase",
+  }[fieldId] ?? fieldId;
 }
 
 function renderSettingsFieldMeta(field: DesktopSettingsPaneField) {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -134,14 +134,15 @@ function renderHeader(
       activeGroup ? h("p", { class: "desktop-settings-header-description" }, getSettingsGroupDescription(activeGroup.id)) : null,
     ]),
     h("div", { class: "desktop-settings-save-region" }, [
-      renderSaveStatus(pane),
+      renderSaveStatus(options),
       renderSaveButton(options),
     ]),
   ]);
 }
 
-function renderSaveStatus(pane: DesktopSettingsPaneModel) {
-  const saveDetails = renderSaveDetails(pane);
+function renderSaveStatus(options: SettingsPaneIslandOptions) {
+  const pane = options.pane;
+  const saveDetails = renderSaveDetails(options);
   return h("div", {
     class: "desktop-settings-save-status",
     "data-desktop-settings-status": "save",
@@ -152,21 +153,50 @@ function renderSaveStatus(pane: DesktopSettingsPaneModel) {
   ]);
 }
 
-function renderSaveDetails(pane: DesktopSettingsPaneModel) {
-  const details: string[] = [];
-  if (pane.save.transport === "gateway-fallback") {
-    details.push("Saved through gateway fallback");
+function renderSaveDetails(options: SettingsPaneIslandOptions) {
+  const pane = options.pane;
+  const details: Array<{
+    text: string;
+    action?: "restartGateway" | "reloadWorkspace";
+    label?: string;
+  }> = [];
+  if (pane.save.restartRequired?.length) {
+    details.push({
+      text: "Gateway restart required",
+      action: "restartGateway",
+      label: "Restart gateway now",
+    });
   }
-  details.push(...(pane.save.warnings ?? []));
+  if (pane.save.reloadRequired?.length) {
+    details.push({
+      text: "Workspace reload required",
+      action: "reloadWorkspace",
+      label: "Reload workspace",
+    });
+  }
+  if (pane.save.transport === "gateway-fallback") {
+    details.push({ text: "Saved through gateway fallback" });
+  }
+  details.push(...(pane.save.warnings ?? []).map((warning) => ({ text: warning })));
   if (details.length === 0) {
     return null;
   }
   return h("ul", {
     class: "desktop-settings-save-details",
     "data-desktop-settings-save-details": "",
-  }, details.map((detail) => h("li", {
-    "data-desktop-settings-save-detail": "",
-  }, detail)));
+  }, details.map((detail) => {
+    const action = detail.action;
+    return h("li", {
+      "data-desktop-settings-save-detail": "",
+    }, [
+      h("span", detail.text),
+      action ? h("button", {
+        type: "button",
+        "data-desktop-settings-action": action,
+        onClick: () => options.onSettingsAction?.({ action, pane }),
+      }, detail.label) : null,
+    ]);
+  }));
 }
 
 function renderSaveAlert(options: SettingsPaneIslandOptions) {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -141,11 +141,32 @@ function renderHeader(
 }
 
 function renderSaveStatus(pane: DesktopSettingsPaneModel) {
-  return h("p", {
+  const saveDetails = renderSaveDetails(pane);
+  return h("div", {
     class: "desktop-settings-save-status",
     "data-desktop-settings-status": "save",
     "aria-live": "polite",
-  }, pane.save.message);
+  }, [
+    h("p", pane.save.message),
+    saveDetails,
+  ]);
+}
+
+function renderSaveDetails(pane: DesktopSettingsPaneModel) {
+  const details: string[] = [];
+  if (pane.save.transport === "gateway-fallback") {
+    details.push("Saved through gateway fallback");
+  }
+  details.push(...(pane.save.warnings ?? []));
+  if (details.length === 0) {
+    return null;
+  }
+  return h("ul", {
+    class: "desktop-settings-save-details",
+    "data-desktop-settings-save-details": "",
+  }, details.map((detail) => h("li", {
+    "data-desktop-settings-save-detail": "",
+  }, detail)));
 }
 
 function renderSaveAlert(options: SettingsPaneIslandOptions) {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -693,6 +693,7 @@ function renderSettingsGroup(
       h("p", { class: "desktop-settings-group-description" }, getSettingsGroupDescription(group)),
       renderFilesWorkspaceActions(options, group),
       renderChannelsSummary(options, group),
+      renderRuntimeSummary(options, group),
       renderMcpServerList(group),
       ...primaryFields.map((field) => renderSettingsField(options, group, field, highlightedFieldId)),
       advancedFields.length ? h("details", {
@@ -773,6 +774,49 @@ function renderChannelsSummary(
       "data-desktop-settings-channel-action": "setupIntegrations",
       onClick: () => options.onSettingsAction?.({ action: "setupChannelIntegrations", pane: options.pane }),
     }, "Set up integrations"),
+  ]);
+}
+
+function renderRuntimeSummary(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+) {
+  if (group.id !== "gateway-runtime" || !options.pane.runtime) {
+    return null;
+  }
+  const runtime = options.pane.runtime;
+  const intents = [
+    { id: "local-only", label: "Local only", host: "127.0.0.1" },
+    { id: "local-network", label: "Local network", host: "0.0.0.0" },
+    { id: "advanced-custom", label: "Advanced custom", host: null },
+  ] as const;
+  return h("div", {
+    class: "desktop-settings-runtime-summary",
+    "aria-label": "Runtime gateway controls",
+  }, [
+    h("div", { class: "desktop-settings-runtime-intents" }, intents.map((intent) => h("button", {
+      type: "button",
+      "data-desktop-settings-runtime-intent": intent.id,
+      "data-active": runtime.intent === intent.id ? "true" : undefined,
+      disabled: intent.host === null ? true : undefined,
+      onClick: () => {
+        if (intent.host !== null) {
+          options.onSettingsAction?.({ action: "edit", pane: options.pane, fieldId: "host", value: intent.host });
+        }
+      },
+    }, intent.label))),
+    h("p", {
+      "data-desktop-settings-runtime-current-endpoint": "",
+    }, `Current endpoint: ${runtime.currentEndpoint}`),
+    h("p", {
+      "data-desktop-settings-runtime-pending-endpoint": "",
+    }, `Pending endpoint after restart: ${runtime.pendingEndpoint}`),
+    h("p", {
+      "data-desktop-settings-runtime-port-status": "",
+    }, runtime.portStatus),
+    h("p", {
+      "data-desktop-settings-runtime-heartbeat-dependency": "",
+    }, runtime.heartbeatDependency),
   ]);
 }
 

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -691,6 +691,7 @@ function renderSettingsGroup(
     default: () => [
       h("h2", group.label),
       h("p", { class: "desktop-settings-group-description" }, getSettingsGroupDescription(group)),
+      renderFilesWorkspaceActions(options, group),
       renderMcpServerList(group),
       ...primaryFields.map((field) => renderSettingsField(options, group, field, highlightedFieldId)),
       advancedFields.length ? h("details", {
@@ -702,6 +703,48 @@ function renderSettingsGroup(
       ]) : null,
     ],
   });
+}
+
+function renderFilesWorkspaceActions(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+) {
+  if (group.id !== "files-workspace") {
+    return null;
+  }
+  const workspace = group.fields.find((field) => field.id === "workspace");
+  const emit = (action: "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments") => {
+    options.onSettingsAction?.({ action, pane: options.pane });
+  };
+  return h("div", {
+    class: "desktop-settings-files-actions",
+    "aria-label": "Files and workspace actions",
+  }, [
+    h("p", {
+      class: "desktop-settings-workspace-permission",
+      "data-desktop-settings-workspace-permission": "",
+    }, `Permission: ${workspace?.value ? "Configured workspace" : "No workspace selected"}`),
+    h("button", {
+      type: "button",
+      "data-desktop-settings-file-action": "chooseWorkspace",
+      onClick: () => emit("chooseWorkspace"),
+    }, "Choose workspace"),
+    h("button", {
+      type: "button",
+      "data-desktop-settings-file-action": "openWorkspace",
+      onClick: () => emit("openWorkspace"),
+    }, "Open workspace"),
+    h("button", {
+      type: "button",
+      "data-desktop-settings-file-action": "openSessionFiles",
+      onClick: () => emit("openSessionFiles"),
+    }, "Session files"),
+    h("button", {
+      type: "button",
+      "data-desktop-settings-file-action": "openKnowledgeDocuments",
+      onClick: () => emit("openKnowledgeDocuments"),
+    }, "Knowledge documents"),
+  ]);
 }
 
 function renderMcpServerList(group: DesktopSettingsPaneGroup) {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -317,8 +317,8 @@ function renderDefaultLlmCard(options: SettingsPaneIslandOptions) {
           h("h2", "Default LLM"),
         ]),
         h("div", { class: "desktop-settings-default-llm-form" }, [
-          provider ? renderInlineField(options, provider, "Provider") : null,
-          model ? renderInlineField(options, model, "Model") : null,
+          provider ? renderInlineField(options, provider) : null,
+          model ? renderInlineField(options, model) : null,
         ]),
         h("p", { class: "desktop-settings-default-llm-copy" }, "Configure the global default LLM model. Individual agents can still choose a different model."),
       ],
@@ -507,10 +507,9 @@ function renderSettingsField(
 function renderInlineField(
   options: SettingsPaneIslandOptions,
   field: DesktopSettingsPaneField,
-  label: string,
 ) {
   return h("label", { class: "desktop-settings-inline-field" }, [
-    h("span", label),
+    h("span", field.label),
     field.id === "model" && getDefaultLlmModelOptions(options.pane).length > 0
       ? renderModelSelect(options, field)
       : renderSettingsControl(options, field),

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -694,6 +694,7 @@ function renderSettingsGroup(
       renderFilesWorkspaceActions(options, group),
       renderChannelsSummary(options, group),
       renderRuntimeSummary(options, group),
+      renderDiagnosticsActionPage(options, group),
       renderMcpServerList(group),
       ...primaryFields.map((field) => renderSettingsField(options, group, field, highlightedFieldId)),
       advancedFields.length ? h("details", {
@@ -774,6 +775,68 @@ function renderChannelsSummary(
       "data-desktop-settings-channel-action": "setupIntegrations",
       onClick: () => options.onSettingsAction?.({ action: "setupChannelIntegrations", pane: options.pane }),
     }, "Set up integrations"),
+  ]);
+}
+
+function renderDiagnosticsActionPage(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+) {
+  if (group.id !== "logs-diagnostics" || !options.pane.diagnostics) {
+    return null;
+  }
+  const diagnostics = options.pane.diagnostics;
+  const emit = (
+    action: "openDiagnosticsLogs" | "copyDiagnostics" | "exportDiagnosticsBundle" | "clearDiagnosticsLogs" | "resetLocalUiState",
+  ) => {
+    options.onSettingsAction?.({ action, pane: options.pane });
+  };
+  const actionButtons = [
+    { action: "openDiagnosticsLogs" as const, key: "openLogs", label: "Open logs" },
+    { action: "copyDiagnostics" as const, key: "copyRuntimeSummary", label: "Copy runtime summary" },
+    { action: "exportDiagnosticsBundle" as const, key: "exportDiagnosticsBundle", label: "Export redacted diagnostics" },
+    { action: "clearDiagnosticsLogs" as const, key: "clearLogs", label: "Clear logs" },
+    { action: "resetLocalUiState" as const, key: "resetLocalUiState", label: "Reset local UI" },
+  ];
+  return h("div", {
+    class: "desktop-settings-diagnostics-actions",
+    "aria-label": "Diagnostics actions",
+  }, [
+    h("p", {
+      "data-desktop-settings-diagnostics-runtime-summary": "",
+    }, diagnostics.runtimeSummary),
+    h("p", {
+      "data-desktop-settings-diagnostics-gateway-ownership": "",
+    }, diagnostics.gatewayOwnership),
+    h("p", {
+      "data-desktop-settings-diagnostics-version": "",
+    }, diagnostics.version),
+    h("p", {
+      "data-desktop-settings-diagnostics-config-path": "",
+    }, diagnostics.activeConfigPath),
+    h("p", {
+      "data-desktop-settings-diagnostics-config-error": "",
+    }, diagnostics.lastConfigError),
+    h("label", { class: "desktop-settings-inline-field" }, [
+      h("span", "Log level"),
+      h("select", {
+        "data-desktop-settings-diagnostics-log-level": "",
+        value: diagnostics.logLevel,
+        onChange: (event: Event) => options.onSettingsAction?.({
+          action: "setDiagnosticsLogLevel",
+          pane: options.pane,
+          logLevel: String((event.target as HTMLSelectElement | null)?.value ?? "info"),
+        }),
+      }, ["error", "info", "debug"].map((level) => h("option", {
+        value: level,
+        selected: diagnostics.logLevel === level ? "true" : undefined,
+      }, level))),
+    ]),
+    h("div", { class: "desktop-settings-diagnostics-action-list" }, actionButtons.map((item) => h("button", {
+      type: "button",
+      "data-desktop-settings-diagnostics-action": item.key,
+      onClick: () => emit(item.action),
+    }, item.label))),
   ]);
 }
 

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -692,6 +692,7 @@ function renderSettingsGroup(
       h("h2", group.label),
       h("p", { class: "desktop-settings-group-description" }, getSettingsGroupDescription(group)),
       renderFilesWorkspaceActions(options, group),
+      renderChannelsSummary(options, group),
       renderMcpServerList(group),
       ...primaryFields.map((field) => renderSettingsField(options, group, field, highlightedFieldId)),
       advancedFields.length ? h("details", {
@@ -744,6 +745,34 @@ function renderFilesWorkspaceActions(
       "data-desktop-settings-file-action": "openKnowledgeDocuments",
       onClick: () => emit("openKnowledgeDocuments"),
     }, "Knowledge documents"),
+  ]);
+}
+
+function renderChannelsSummary(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+) {
+  if (group.id !== "channels") {
+    return null;
+  }
+  return h("div", {
+    class: "desktop-settings-channels-summary",
+    "aria-label": "Channels behavior",
+  }, [
+    h("p", {
+      "data-desktop-settings-channels-scope": "",
+    }, "Global defaults apply to desktop channel behavior unless an integration provides its own override."),
+    h("p", {
+      "data-desktop-settings-channels-retry": "",
+    }, "Max retries are additional attempts after the first delivery attempt."),
+    h("p", {
+      "data-desktop-settings-channels-empty": "",
+    }, "No integration-specific overrides are configured yet."),
+    h("button", {
+      type: "button",
+      "data-desktop-settings-channel-action": "setupIntegrations",
+      onClick: () => options.onSettingsAction?.({ action: "setupChannelIntegrations", pane: options.pane }),
+    }, "Set up integrations"),
   ]);
 }
 

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -157,8 +157,9 @@ function renderSaveDetails(options: SettingsPaneIslandOptions) {
   const pane = options.pane;
   const details: Array<{
     text: string;
-    action?: "restartGateway" | "reloadWorkspace";
+    action?: "restartGateway" | "reloadWorkspace" | "copyDiagnostics";
     label?: string;
+    buttonOnly?: boolean;
   }> = [];
   if (pane.save.restartRequired?.length) {
     details.push({
@@ -178,6 +179,14 @@ function renderSaveDetails(options: SettingsPaneIslandOptions) {
     details.push({ text: "Saved through gateway fallback" });
   }
   details.push(...(pane.save.warnings ?? []).map((warning) => ({ text: warning })));
+  if (pane.save.transport === "gateway-fallback" || pane.save.warnings?.length) {
+    details.push({
+      text: "",
+      action: "copyDiagnostics",
+      label: "Copy diagnostics",
+      buttonOnly: true,
+    });
+  }
   if (details.length === 0) {
     return null;
   }
@@ -189,7 +198,7 @@ function renderSaveDetails(options: SettingsPaneIslandOptions) {
     return h("li", {
       "data-desktop-settings-save-detail": "",
     }, [
-      h("span", detail.text),
+      detail.buttonOnly ? null : h("span", detail.text),
       action ? h("button", {
         type: "button",
         "data-desktop-settings-action": action,

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -801,6 +801,7 @@ function renderSettingsControl(options: SettingsPaneIslandOptions, field: Deskto
     min: field.min,
     max: field.max,
     step: field.step,
+    disabled: field.disabled ? true : undefined,
   };
   if (field.control === "checkbox") {
     return h("input", {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -1,4 +1,4 @@
-import { createApp, defineComponent, h, ref, type App, type Ref } from "vue";
+import { createApp, defineComponent, h, nextTick, ref, type App, type Ref } from "vue";
 import { NButton, NCard, NConfigProvider, NSpace, NTag } from "naive-ui";
 import type {
   DesktopSettingsPaneField,
@@ -34,6 +34,16 @@ interface ProviderCardModel {
   models: string;
 }
 
+interface SettingsSearchResult {
+  key: string;
+  groupId: DesktopSettingsPaneGroup["id"];
+  groupLabel: string;
+  fieldId: string;
+  fieldLabel: string;
+  description: string;
+  advanced: boolean;
+}
+
 const mountedSettingsPanes = new WeakMap<HTMLElement, MountedSettingsPaneIsland>();
 
 export function mountOrUpdateSettingsPaneIsland(
@@ -59,7 +69,7 @@ export function mountSettingsPaneIsland(
   }
   applySettingsPaneHost(host);
   const state = ref(options) as Ref<SettingsPaneIslandOptions>;
-  const app = createSettingsPaneApp(state);
+  const app = createSettingsPaneApp(state, host);
   app.mount(host);
   const nextMounted = {
     update: (nextOptions: SettingsPaneIslandOptions) => {
@@ -84,14 +94,28 @@ function applySettingsPaneHost(host: HTMLElement): void {
   host.setAttribute("aria-label", "Settings and providers");
 }
 
-function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>): App {
+function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>, host: HTMLElement): App {
   return createApp(defineComponent({
     name: "SettingsPaneIsland",
     setup() {
       const providerSearch = ref("");
+      const settingsSearch = ref("");
+      const highlightedFieldId = ref("");
       const activeGroupId = ref(getActiveSettingsGroup(state.value.pane, state.value.initialActiveGroupId)?.id ?? "general");
       const setActiveGroupId = (groupId: DesktopSettingsPaneGroup["id"]) => {
         activeGroupId.value = groupId;
+      };
+      const activateSearchResult = (result: SettingsSearchResult) => {
+        activeGroupId.value = result.groupId;
+        highlightedFieldId.value = result.fieldId;
+        void nextTick(() => {
+          host.querySelector<HTMLElement>(`#desktop-settings-${result.fieldId}`)?.focus();
+          window.setTimeout(() => {
+            if (highlightedFieldId.value === result.fieldId) {
+              highlightedFieldId.value = "";
+            }
+          }, 1400);
+        });
       };
       const currentActiveGroupId = (options: SettingsPaneIslandOptions) => {
         const activeGroup = getActiveSettingsGroup(options.pane, activeGroupId.value);
@@ -107,11 +131,20 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>): App {
           const options = state.value;
           const selectedGroupId = currentActiveGroupId(options);
           return [
-            renderSidebar(options.pane, selectedGroupId, setActiveGroupId),
+            renderSidebar(
+              options,
+              selectedGroupId,
+              settingsSearch.value,
+              (value) => {
+                settingsSearch.value = value;
+              },
+              activateSearchResult,
+              setActiveGroupId,
+            ),
             h("div", { class: "desktop-settings-content" }, [
               renderHeader(options, selectedGroupId),
               renderSaveAlert(options),
-              renderActiveSettingsSection(options, selectedGroupId, providerSearch.value, (value) => {
+              renderActiveSettingsSection(options, selectedGroupId, highlightedFieldId.value, providerSearch.value, (value) => {
                 providerSearch.value = value;
               }),
             ]),
@@ -236,10 +269,14 @@ function renderSaveAlert(options: SettingsPaneIslandOptions) {
 }
 
 function renderSidebar(
-  pane: DesktopSettingsPaneModel,
+  options: SettingsPaneIslandOptions,
   activeGroupId: DesktopSettingsPaneGroup["id"],
+  searchQuery: string,
+  updateSearchQuery: (value: string) => void,
+  activateSearchResult: (result: SettingsSearchResult) => void,
   setActiveGroupId: (groupId: DesktopSettingsPaneGroup["id"]) => void,
 ) {
+  const pane = options.pane;
   return h("aside", {
     class: "desktop-settings-sidebar",
     "aria-label": "Settings navigation",
@@ -247,14 +284,68 @@ function renderSidebar(
     h("input", {
       class: "desktop-settings-search",
       type: "search",
+      value: searchQuery,
       placeholder: "Search settings...",
       "aria-label": "Search settings",
+      "data-desktop-settings-search": "query",
+      onInput: (event: Event) => updateSearchQuery(String((event.target as HTMLInputElement | null)?.value ?? "")),
     }),
+    renderSettingsSearchResults(pane, searchQuery, activateSearchResult),
+    renderDirtySummary(options),
     h("nav", {
       class: "desktop-settings-nav",
       "aria-label": "Settings sections",
     }, renderNavigation(pane.groups, activeGroupId, setActiveGroupId)),
     renderPreviewSettingsGroups(pane.groups),
+  ]);
+}
+
+function renderSettingsSearchResults(
+  pane: DesktopSettingsPaneModel,
+  searchQuery: string,
+  activateSearchResult: (result: SettingsSearchResult) => void,
+) {
+  const query = searchQuery.trim();
+  if (!query) {
+    return null;
+  }
+  const results = getSettingsSearchResults(pane, query);
+  if (!results.length) {
+    return h("div", {
+      class: "desktop-settings-search-empty",
+      "data-desktop-settings-search-empty": "true",
+      role: "status",
+    }, "No settings found");
+  }
+  return h("div", {
+    class: "desktop-settings-search-results",
+    "aria-label": "Settings search results",
+  }, results.map((result) => h("button", {
+    type: "button",
+    class: "desktop-settings-search-result",
+    "data-desktop-settings-search-result": result.key,
+    onClick: () => activateSearchResult(result),
+  }, [
+    h("span", result.fieldLabel),
+    h("small", result.groupLabel),
+  ])));
+}
+
+function renderDirtySummary(options: SettingsPaneIslandOptions) {
+  const pane = options.pane;
+  if (!pane.dirty) {
+    return null;
+  }
+  return h("div", {
+    class: "desktop-settings-dirty-summary",
+    "data-desktop-settings-dirty-summary": "",
+  }, [
+    h("span", pane.save.message || "Unsaved changes"),
+    h("button", {
+      type: "button",
+      "data-desktop-settings-action": "reset",
+      onClick: () => options.onSettingsAction?.({ action: "reset", pane }),
+    }, "Reset"),
   ]);
 }
 
@@ -302,11 +393,12 @@ function renderPreviewSettingsGroups(groups: DesktopSettingsPaneGroup[]) {
 function renderActiveSettingsSection(
   options: SettingsPaneIslandOptions,
   activeGroupId: DesktopSettingsPaneGroup["id"],
+  highlightedFieldId: string,
   providerSearch: string,
   setProviderSearch: (value: string) => void,
 ) {
   const group = getActiveSettingsGroup(options.pane, activeGroupId);
-  const groupNode = group ? renderSettingsGroup(options, group) : null;
+  const groupNode = group ? renderSettingsGroup(options, group, highlightedFieldId) : null;
   if (activeGroupId === "general") {
     return [
       renderDefaultLlmCard(options),
@@ -476,7 +568,11 @@ function renderSingleSettingsGroup(groupNode: ReturnType<typeof renderSettingsGr
   return h("div", { class: "desktop-settings-grid" }, [groupNode]);
 }
 
-function renderSettingsGroup(options: SettingsPaneIslandOptions, group: DesktopSettingsPaneGroup) {
+function renderSettingsGroup(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+  highlightedFieldId = "",
+) {
   const fields = getSettingsGroupDisplayFields(group);
   if (!fields.length) {
     return null;
@@ -493,10 +589,13 @@ function renderSettingsGroup(options: SettingsPaneIslandOptions, group: DesktopS
     default: () => [
       h("h2", group.label),
       h("p", { class: "desktop-settings-group-description" }, getSettingsGroupDescription(group)),
-      ...primaryFields.map((field) => renderSettingsField(options, group, field)),
-      advancedFields.length ? h("details", { class: "desktop-settings-advanced-fields" }, [
+      ...primaryFields.map((field) => renderSettingsField(options, group, field, highlightedFieldId)),
+      advancedFields.length ? h("details", {
+        class: "desktop-settings-advanced-fields",
+        open: advancedFields.some((field) => field.id === highlightedFieldId) ? "" : undefined,
+      }, [
         h("summary", "Advanced"),
-        ...advancedFields.map((field) => renderSettingsField(options, group, field)),
+        ...advancedFields.map((field) => renderSettingsField(options, group, field, highlightedFieldId)),
       ]) : null,
     ],
   });
@@ -506,10 +605,12 @@ function renderSettingsField(
   options: SettingsPaneIslandOptions,
   group: DesktopSettingsPaneGroup,
   field: DesktopSettingsPaneField,
+  highlightedFieldId = "",
 ) {
   return h("div", {
     class: "desktop-settings-field",
     "data-desktop-settings-field": field.id,
+    "data-highlighted": field.id === highlightedFieldId ? "true" : undefined,
     "data-state": field.state,
   }, [
     h("div", { class: "desktop-settings-field-copy" }, [
@@ -795,6 +896,59 @@ function getActiveSettingsGroup(
 ): DesktopSettingsPaneGroup | null {
   const groups = getNavigableSettingsGroups(pane.groups);
   return groups.find((group) => group.id === activeGroupId) ?? groups[0] ?? null;
+}
+
+function getSettingsSearchResults(
+  pane: DesktopSettingsPaneModel,
+  query: string,
+): SettingsSearchResult[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return [];
+  }
+  const results: Array<{ result: SettingsSearchResult; score: number }> = [];
+  for (const group of getNavigableSettingsGroups(pane.groups)) {
+    for (const field of group.fields) {
+      const fieldLabel = field.label.toLowerCase();
+      const fieldId = field.id.toLowerCase();
+      const haystack = [
+        group.label,
+        group.description ?? "",
+        ...(group.aliases ?? []),
+        field.label,
+        field.description ?? getSettingsFieldDescription(group.id, field),
+        ...(field.aliases ?? []),
+        field.sensitive ? "" : field.value,
+        field.sensitive ? "" : field.inputValue,
+      ].join(" ").toLowerCase();
+      if (!haystack.includes(normalizedQuery)) {
+        continue;
+      }
+      const score = fieldLabel === normalizedQuery || fieldId === normalizedQuery
+        ? 0
+        : fieldLabel.includes(normalizedQuery) || fieldId.includes(normalizedQuery)
+          ? 1
+          : (field.aliases ?? []).some((alias) => alias.toLowerCase().includes(normalizedQuery))
+            ? 2
+            : 3;
+      results.push({
+        score,
+        result: {
+        key: `${group.id}.${field.id}`,
+        groupId: group.id,
+        groupLabel: group.label,
+        fieldId: field.id,
+        fieldLabel: field.label,
+        description: field.description ?? "",
+        advanced: field.advanced === true,
+        },
+      });
+    }
+  }
+  return results
+    .sort((left, right) => left.score - right.score)
+    .slice(0, 8)
+    .map((item) => item.result);
 }
 
 function getNavigableSettingsGroups(groups: DesktopSettingsPaneGroup[]): DesktopSettingsPaneGroup[] {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -721,7 +721,33 @@ function renderSettingsField(
       renderSettingsFieldMeta(field),
     ]),
     renderSettingsControl(options, field),
+    renderSecretControls(options, field),
     renderSettingsFieldError(options.pane, field),
+  ]);
+}
+
+function renderSecretControls(
+  options: SettingsPaneIslandOptions,
+  field: DesktopSettingsPaneField,
+) {
+  if (!field.sensitive || field.control !== "password") {
+    return null;
+  }
+  return h("div", { class: "desktop-settings-secret-controls" }, [
+    h("p", {
+      class: "desktop-settings-secret-policy",
+      "data-desktop-settings-secret-policy": "",
+    }, "Reveal is disabled by the desktop secret policy."),
+    h("button", {
+      type: "button",
+      "data-desktop-settings-secret-action": "replace",
+      onClick: () => document.getElementById(`desktop-settings-${field.id}`)?.focus(),
+    }, "Replace key"),
+    h("button", {
+      type: "button",
+      "data-desktop-settings-secret-action": "clear",
+      onClick: () => emitEdit(options, field.id, ""),
+    }, "Clear key"),
   ]);
 }
 

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -498,7 +498,7 @@ function renderProviderManagement(
           "data-desktop-settings-action": "discoverModels",
           "aria-label": `Refresh models for ${options.pane.providerEditor.selectedProvider}`,
           onClick: () => options.onSettingsAction?.({ action: "discoverModels", pane: options.pane }),
-        }, { default: () => "Refresh models" }),
+        }, { default: () => "Refresh" }),
         h(NButton, {
           class: "desktop-settings-provider-add",
           type: "primary",

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -691,6 +691,7 @@ function renderSettingsGroup(
     default: () => [
       h("h2", group.label),
       h("p", { class: "desktop-settings-group-description" }, getSettingsGroupDescription(group)),
+      renderMcpServerList(group),
       ...primaryFields.map((field) => renderSettingsField(options, group, field, highlightedFieldId)),
       advancedFields.length ? h("details", {
         class: "desktop-settings-advanced-fields",
@@ -701,6 +702,51 @@ function renderSettingsGroup(
       ]) : null,
     ],
   });
+}
+
+function renderMcpServerList(group: DesktopSettingsPaneGroup) {
+  if (group.id !== "tools-approvals") {
+    return null;
+  }
+  const mcpField = group.fields.find((field) => field.id === "mcpServers");
+  const servers = parseMcpServerRows(mcpField?.inputValue ?? "");
+  if (!servers.length) {
+    return null;
+  }
+  return h("div", {
+    class: "desktop-settings-mcp-server-list",
+    "aria-label": "MCP servers",
+  }, servers.map((server) => h("div", {
+    class: "desktop-settings-mcp-server",
+    "data-desktop-settings-mcp-server": server.name,
+  }, [
+    h("strong", server.name),
+    h("span", server.transport),
+    h("code", server.endpoint),
+  ])));
+}
+
+function parseMcpServerRows(value: string): Array<{ name: string; transport: string; endpoint: string }> {
+  try {
+    const root = JSON.parse(value) as unknown;
+    if (!root || typeof root !== "object" || Array.isArray(root)) {
+      return [];
+    }
+    return Object.entries(root as Record<string, unknown>).map(([name, config]) => {
+      const record = config && typeof config === "object" && !Array.isArray(config)
+        ? config as Record<string, unknown>
+        : {};
+      const command = typeof record.command === "string" ? record.command : "";
+      const url = typeof record.url === "string" ? record.url : "";
+      return {
+        name,
+        transport: command ? "command" : url ? "url" : "unknown",
+        endpoint: command || url || "Not configured",
+      };
+    });
+  } catch {
+    return [];
+  }
 }
 
 function renderSettingsField(

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -110,7 +110,7 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>): App {
             renderSidebar(options.pane, selectedGroupId, setActiveGroupId),
             h("div", { class: "desktop-settings-content" }, [
               renderHeader(options, selectedGroupId),
-              renderSaveAlert(options.pane),
+              renderSaveAlert(options),
               renderActiveSettingsSection(options, selectedGroupId, providerSearch.value, (value) => {
                 providerSearch.value = value;
               }),
@@ -148,7 +148,8 @@ function renderSaveStatus(pane: DesktopSettingsPaneModel) {
   }, pane.save.message);
 }
 
-function renderSaveAlert(pane: DesktopSettingsPaneModel) {
+function renderSaveAlert(options: SettingsPaneIslandOptions) {
+  const pane = options.pane;
   if (pane.save.status !== "failed") {
     return null;
   }
@@ -157,8 +158,20 @@ function renderSaveAlert(pane: DesktopSettingsPaneModel) {
     role: "alert",
     "data-desktop-settings-alert": "save",
   }, [
-    h("strong", "Settings save failed"),
+    h("strong", "Settings need attention"),
     h("p", pane.save.message),
+    h("div", { class: "desktop-settings-error-actions" }, [
+      h("button", {
+        type: "button",
+        "data-desktop-settings-action": "retryLoad",
+        onClick: () => options.onSettingsAction?.({ action: "retryLoad", pane }),
+      }, "Retry"),
+      h("button", {
+        type: "button",
+        "data-desktop-settings-action": "copyDiagnostics",
+        onClick: () => options.onSettingsAction?.({ action: "copyDiagnostics", pane }),
+      }, "Copy diagnostics"),
+    ]),
   ]);
 }
 
@@ -709,6 +722,9 @@ function getActiveSettingsGroup(
 function saveLabel(pane: DesktopSettingsPaneModel): string {
   if (pane.save.status === "saving") {
     return "Saving...";
+  }
+  if (pane.save.status === "failed") {
+    return "Save failed";
   }
   if (pane.save.status === "saved" || !pane.dirty) {
     return "Saved";

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -254,6 +254,7 @@ function renderSidebar(
       class: "desktop-settings-nav",
       "aria-label": "Settings sections",
     }, renderNavigation(pane.groups, activeGroupId, setActiveGroupId)),
+    renderPreviewSettingsGroups(pane.groups),
   ]);
 }
 
@@ -262,23 +263,40 @@ function renderNavigation(
   activeGroupId: DesktopSettingsPaneGroup["id"],
   setActiveGroupId: (groupId: DesktopSettingsPaneGroup["id"]) => void,
 ) {
-  const nodes = [
-    h("p", { class: "desktop-settings-nav-heading" }, "Personal"),
-  ];
-  groups.forEach((group, index) => {
-    if (index === 3) {
-      nodes.push(h("p", { class: "desktop-settings-nav-heading" }, "System"));
+  const nodes: ReturnType<typeof h>[] = [];
+  for (const area of ["core", "application", "system"] as const) {
+    const areaGroups = getNavigableSettingsGroups(groups).filter((group) => (group.navigationArea ?? "core") === area);
+    if (!areaGroups.length) {
+      continue;
     }
-    nodes.push(h("a", {
-      class: "desktop-settings-nav-item",
-      href: "#",
-      "data-desktop-settings-nav": group.id,
-      "data-active": group.id === activeGroupId ? "true" : undefined,
-      "aria-current": group.id === activeGroupId ? "page" : undefined,
-      onClick: (event: Event) => selectSettingsGroup(event, group.id, setActiveGroupId),
-    }, getSettingsNavLabel(group.id)));
-  });
+    nodes.push(h("p", { class: "desktop-settings-nav-heading" }, navigationAreaLabel(area)));
+    nodes.push(...areaGroups.map((group) => h("a", {
+        class: "desktop-settings-nav-item",
+        href: "#",
+        "data-desktop-settings-nav": group.id,
+        "data-active": group.id === activeGroupId ? "true" : undefined,
+        "aria-current": group.id === activeGroupId ? "page" : undefined,
+        onClick: (event: Event) => selectSettingsGroup(event, group.id, setActiveGroupId),
+      }, group.label)));
+  }
   return nodes;
+}
+
+function renderPreviewSettingsGroups(groups: DesktopSettingsPaneGroup[]) {
+  const previewGroups = getPreviewSettingsGroups(groups);
+  if (!previewGroups.length) {
+    return null;
+  }
+  return h("div", {
+    class: "desktop-settings-preview-list",
+    "aria-label": "Settings previews",
+  }, previewGroups.map((group) => h("div", {
+    class: "desktop-settings-preview-item",
+    "data-desktop-settings-preview": group.id,
+  }, [
+    h("span", group.label),
+    h("small", "Preview"),
+  ])));
 }
 
 function renderActiveSettingsSection(
@@ -775,7 +793,16 @@ function getActiveSettingsGroup(
   pane: DesktopSettingsPaneModel,
   activeGroupId?: DesktopSettingsPaneGroup["id"] | null,
 ): DesktopSettingsPaneGroup | null {
-  return pane.groups.find((group) => group.id === activeGroupId) ?? pane.groups[0] ?? null;
+  const groups = getNavigableSettingsGroups(pane.groups);
+  return groups.find((group) => group.id === activeGroupId) ?? groups[0] ?? null;
+}
+
+function getNavigableSettingsGroups(groups: DesktopSettingsPaneGroup[]): DesktopSettingsPaneGroup[] {
+  return groups.filter((group) => (group.navigationMode ?? "section") === "section");
+}
+
+function getPreviewSettingsGroups(groups: DesktopSettingsPaneGroup[]): DesktopSettingsPaneGroup[] {
+  return groups.filter((group) => group.navigationMode === "preview");
 }
 
 function saveLabel(pane: DesktopSettingsPaneModel): string {
@@ -816,20 +843,12 @@ function providerStatusTone(status: string): "default" | "error" | "success" | "
   return "default";
 }
 
-function getSettingsNavLabel(groupId: DesktopSettingsPaneGroup["id"]): string {
+function navigationAreaLabel(area: NonNullable<DesktopSettingsPaneGroup["navigationArea"]>): string {
   return {
-    general: "General",
-    "provider-models": "Provider & Models",
-    knowledge: "Knowledge",
-    "tools-approvals": "Tools & Approvals",
-    "files-workspace": "Files & Workspace",
-    "memory-experience": "Memory & Experience",
-    skills: "Skills",
-    channels: "Channels",
-    automations: "Automations",
-    "gateway-runtime": "Gateway & Runtime",
-    "logs-diagnostics": "Logs & Diagnostics",
-  }[groupId];
+    core: "Core",
+    application: "Application",
+    system: "System",
+  }[area];
 }
 
 function getSettingsGroupDescription(group: DesktopSettingsPaneGroup): string {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -131,7 +131,7 @@ function renderHeader(
   return h("header", { class: "desktop-settings-header" }, [
     h("div", { class: "desktop-settings-breadcrumb" }, [
       h("h2", `Settings / ${activeGroup?.label ?? "General"}`),
-      activeGroup ? h("p", { class: "desktop-settings-header-description" }, getSettingsGroupDescription(activeGroup.id)) : null,
+      activeGroup ? h("p", { class: "desktop-settings-header-description" }, getSettingsGroupDescription(activeGroup)) : null,
     ]),
     h("div", { class: "desktop-settings-save-region" }, [
       renderSaveStatus(options),
@@ -474,7 +474,7 @@ function renderSettingsGroup(options: SettingsPaneIslandOptions, group: DesktopS
   }, {
     default: () => [
       h("h2", group.label),
-      h("p", { class: "desktop-settings-group-description" }, getSettingsGroupDescription(group.id)),
+      h("p", { class: "desktop-settings-group-description" }, getSettingsGroupDescription(group)),
       ...primaryFields.map((field) => renderSettingsField(options, group, field)),
       advancedFields.length ? h("details", { class: "desktop-settings-advanced-fields" }, [
         h("summary", "Advanced"),
@@ -496,7 +496,7 @@ function renderSettingsField(
   }, [
     h("div", { class: "desktop-settings-field-copy" }, [
       h("label", { for: `desktop-settings-${field.id}` }, `${field.label}: `),
-      h("span", { class: "desktop-settings-field-description" }, getSettingsFieldDescription(group.id, field.id, field.value)),
+      h("span", { class: "desktop-settings-field-description" }, getSettingsFieldDescription(group.id, field)),
       renderSettingsFieldMeta(field),
     ]),
     renderSettingsControl(options, field),
@@ -606,7 +606,7 @@ function getSettingsFieldErrorId(pane: DesktopSettingsPaneModel, field: DesktopS
 }
 
 function getSettingsFieldErrorMessage(pane: DesktopSettingsPaneModel, field: DesktopSettingsPaneField): string {
-  const validationField = settingsValidationFieldForControl(field.id);
+  const validationField = field.validationField ?? settingsValidationFieldForControl(field.id);
   const error = pane.validationErrors.find((validationError) => validationError.field === validationField);
   if (!error) {
     return "";
@@ -833,7 +833,10 @@ function getSettingsNavLabel(groupId: DesktopSettingsPaneGroup["id"]): string {
   }[groupId];
 }
 
-function getSettingsGroupDescription(groupId: DesktopSettingsPaneGroup["id"]): string {
+function getSettingsGroupDescription(group: DesktopSettingsPaneGroup): string {
+  if (group.description) {
+    return group.description;
+  }
   return {
     general: "Default model, profile, and timezone used by the desktop workbench.",
     "provider-models": "Provider profile, endpoint, and model catalog for chat and agent runs.",
@@ -846,14 +849,16 @@ function getSettingsGroupDescription(groupId: DesktopSettingsPaneGroup["id"]): s
     automations: "Automation and scheduling capabilities planned after core stability.",
     "gateway-runtime": "Local gateway connection, heartbeat, and runtime controls.",
     "logs-diagnostics": "Runtime logs, diagnostics export, and local state recovery.",
-  }[groupId];
+  }[group.id];
 }
 
 function getSettingsFieldDescription(
   groupId: DesktopSettingsPaneGroup["id"],
-  fieldId: string,
-  value: string,
+  field: DesktopSettingsPaneField,
 ): string {
+  if (field.description) {
+    return field.description;
+  }
   const descriptions: Record<string, string> = {
     "general.model": "Model used for default chat and agent responses.",
     "general.provider": "Provider routing for the selected model.",
@@ -877,7 +882,7 @@ function getSettingsFieldDescription(
     "channels.sendToolHints": "Show tool status hints during agent work.",
     "channels.sendMaxRetries": "Retry count for channel delivery failures.",
   };
-  return descriptions[`${groupId}.${fieldId}`] ?? `Current value: ${value || "Not configured"}.`;
+  return descriptions[`${groupId}.${field.id}`] ?? `Current value: ${field.value || "Not configured"}.`;
 }
 
 function requirementLabel(requirement: DesktopSettingsPaneField["requirement"]): string {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -32,6 +32,8 @@ interface ProviderCardModel {
   baseUrl: string;
   apiKey: string;
   models: string;
+  modelCountLabel: string;
+  sourceLabel: string;
 }
 
 interface SettingsSearchResult {
@@ -494,7 +496,7 @@ function renderProviderManagement(
           size: "small",
           disabled: !options.pane.providerEditor.canDiscoverModels,
           "data-desktop-settings-action": "discoverModels",
-          "aria-label": "Refresh provider models",
+          "aria-label": `Refresh models for ${options.pane.providerEditor.selectedProvider}`,
           onClick: () => options.onSettingsAction?.({ action: "discoverModels", pane: options.pane }),
         }, { default: () => "Refresh models" }),
         h(NButton, {
@@ -625,6 +627,8 @@ function renderProviderCard(
         renderProviderDetail("Base URL", provider.baseUrl),
         renderProviderDetail("API Key", provider.apiKey),
         renderProviderDetail("Model", provider.models),
+        renderProviderDetail("Models", provider.modelCountLabel),
+        renderProviderDetail("Source", provider.sourceLabel),
       ]),
       h("button", {
         class: "desktop-settings-provider-advanced",
@@ -637,6 +641,15 @@ function renderProviderCard(
       ]),
       h(NSpace, { class: "desktop-settings-provider-card-actions", size: 8 }, {
         default: () => [
+          h(NButton, {
+            size: "small",
+            "data-desktop-settings-provider-action": "testConnection",
+            onClick: () => options.onSettingsAction?.({
+              action: "testProviderConnection",
+              pane: options.pane,
+              providerId: provider.id,
+            }),
+          }, { default: () => "Test connection" }),
           h(NButton, {
             size: "small",
             "data-desktop-settings-provider-action": "models",
@@ -957,6 +970,8 @@ function getProviderCards(pane: DesktopSettingsPaneModel): ProviderCardModel[] {
       baseUrl: provider.baseUrl || (isSelected ? pane.providerEditor.apiBase : "") || "Not configured",
       apiKey: apiKey.displayValue || "Not configured",
       models: models || "No models",
+      modelCountLabel: `${providerModels.length} ${providerModels.length === 1 ? "model" : "models"}`,
+      sourceLabel: provider.profileId ? "Configured profile" : "Catalog",
     };
   });
 }

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -430,6 +430,10 @@ function renderDefaultLlmCard(options: SettingsPaneIslandOptions) {
           provider ? renderInlineField(options, provider) : null,
           model ? renderInlineField(options, model) : null,
         ]),
+        options.pane.defaultRouting?.mode === "auto" ? h("p", {
+          class: "desktop-settings-auto-resolution",
+          "data-desktop-settings-auto-resolution": "",
+        }, options.pane.defaultRouting.message) : null,
         h("p", { class: "desktop-settings-default-llm-copy" }, "Configure the global default LLM model. Individual agents can still choose a different model."),
       ],
     }),

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -44,6 +44,13 @@ interface SettingsSearchResult {
   advanced: boolean;
 }
 
+interface ProviderSetupState {
+  open: boolean;
+  providerId: string;
+  setOpen: (value: boolean) => void;
+  setProviderId: (value: string) => void;
+}
+
 const mountedSettingsPanes = new WeakMap<HTMLElement, MountedSettingsPaneIsland>();
 
 export function mountOrUpdateSettingsPaneIsland(
@@ -99,6 +106,8 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>, host: HTML
     name: "SettingsPaneIsland",
     setup() {
       const providerSearch = ref("");
+      const providerSetupOpen = ref(false);
+      const newProviderId = ref("");
       const settingsSearch = ref("");
       const highlightedFieldId = ref("");
       const activeGroupId = ref(getActiveSettingsGroup(state.value.pane, state.value.initialActiveGroupId)?.id ?? "general");
@@ -144,9 +153,25 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>, host: HTML
             h("div", { class: "desktop-settings-content" }, [
               renderHeader(options, selectedGroupId),
               renderSaveAlert(options),
-              renderActiveSettingsSection(options, selectedGroupId, highlightedFieldId.value, providerSearch.value, (value) => {
+              renderActiveSettingsSection(
+                options,
+                selectedGroupId,
+                highlightedFieldId.value,
+                providerSearch.value,
+                (value) => {
                 providerSearch.value = value;
-              }),
+                },
+                {
+                  open: providerSetupOpen.value,
+                  providerId: newProviderId.value,
+                  setOpen: (value) => {
+                    providerSetupOpen.value = value;
+                  },
+                  setProviderId: (value) => {
+                    newProviderId.value = value;
+                  },
+                },
+              ),
             ]),
           ];
         },
@@ -396,6 +421,7 @@ function renderActiveSettingsSection(
   highlightedFieldId: string,
   providerSearch: string,
   setProviderSearch: (value: string) => void,
+  providerSetup: ProviderSetupState,
 ) {
   const group = getActiveSettingsGroup(options.pane, activeGroupId);
   const groupNode = group ? renderSettingsGroup(options, group, highlightedFieldId) : null;
@@ -407,7 +433,7 @@ function renderActiveSettingsSection(
   }
   if (activeGroupId === "provider-models") {
     return [
-      renderProviderManagement(options, providerSearch, setProviderSearch),
+      renderProviderManagement(options, providerSearch, setProviderSearch, providerSetup),
       groupNode ? renderSingleSettingsGroup(groupNode) : null,
     ];
   }
@@ -444,6 +470,7 @@ function renderProviderManagement(
   options: SettingsPaneIslandOptions,
   searchQuery: string,
   updateSearchQuery: (value: string) => void,
+  providerSetup: ProviderSetupState,
 ) {
   const cards = getProviderCards(options.pane).filter((provider) => !shouldHideProviderCard(provider, searchQuery));
   return h("section", {
@@ -476,16 +503,74 @@ function renderProviderManagement(
           size: "small",
           "data-desktop-settings-action": "addProvider",
           onClick: () => {
-            const providerId = options.promptProviderId?.()?.trim() ?? "";
-            if (providerId) {
-              emitEdit(options, "selectedProvider", providerId);
-              options.onFocusSettingsControl?.("selectedProvider");
-            }
+            providerSetup.setOpen(true);
           },
         }, { default: () => "+ Add provider" }),
       ]),
     ]),
+    providerSetup.open ? renderProviderSetup(options, providerSetup) : null,
     h("div", { class: "desktop-settings-provider-grid" }, cards.map((provider) => renderProviderCard(options, provider))),
+  ]);
+}
+
+function renderProviderSetup(
+  options: SettingsPaneIslandOptions,
+  providerSetup: ProviderSetupState,
+) {
+  const providerId = providerSetup.providerId.trim();
+  const duplicate = providerId
+    ? options.pane.providerCatalog.some((provider) => provider.id.toLowerCase() === providerId.toLowerCase())
+    : false;
+  const canCreate = Boolean(providerId) && !duplicate;
+  return h("div", {
+    class: "desktop-settings-provider-setup",
+    "data-desktop-settings-provider-setup": "",
+  }, [
+    h("h3", "Add provider"),
+    h("label", { class: "desktop-settings-inline-field" }, [
+      h("span", "Provider ID"),
+      h("input", {
+        id: "desktop-settings-new-provider-id",
+        "data-desktop-settings-control": "newProviderId",
+        value: providerSetup.providerId,
+        placeholder: "provider-id",
+        "aria-describedby": "desktop-settings-provider-setup-guidance",
+        onInput: (event: Event) => providerSetup.setProviderId(String((event.target as HTMLInputElement | null)?.value ?? "")),
+      }),
+    ]),
+    h("p", {
+      id: "desktop-settings-provider-setup-guidance",
+      class: "desktop-settings-provider-setup-guidance",
+    }, "Create a provider profile, then add API key and endpoint details below."),
+    duplicate ? h("p", {
+      class: "desktop-settings-provider-setup-error",
+      "data-desktop-settings-provider-setup-error": "",
+      role: "alert",
+    }, "Provider already exists.") : null,
+    h("div", { class: "desktop-settings-provider-setup-actions" }, [
+      h("button", {
+        type: "button",
+        "data-desktop-settings-provider-setup-action": "create",
+        disabled: !canCreate,
+        onClick: () => {
+          if (!canCreate) {
+            return;
+          }
+          emitEdit(options, "selectedProvider", providerId);
+          options.onFocusSettingsControl?.("selectedProvider");
+          providerSetup.setOpen(false);
+          providerSetup.setProviderId("");
+        },
+      }, "Create provider"),
+      h("button", {
+        type: "button",
+        "data-desktop-settings-provider-setup-action": "cancel",
+        onClick: () => {
+          providerSetup.setOpen(false);
+          providerSetup.setProviderId("");
+        },
+      }, "Cancel"),
+    ]),
   ]);
 }
 

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -751,10 +751,23 @@ function settingsValidationFieldForControl(fieldId: string): string {
 }
 
 function renderSettingsFieldMeta(field: DesktopSettingsPaneField) {
-  return h("span", { class: "desktop-settings-field-meta" }, [
+  const chips = [
     h("span", { class: "desktop-settings-field-chip", "data-kind": field.requirement }, requirementLabel(field.requirement)),
     h("span", { class: "desktop-settings-field-chip", "data-kind": field.configurationMode }, configurationModeLabel(field.configurationMode)),
-  ]);
+  ];
+  if (field.sensitive) {
+    chips.push(h("span", { class: "desktop-settings-field-chip", "data-kind": "sensitive" }, "Sensitive"));
+  }
+  if (field.applyEffect) {
+    chips.push(h("span", { class: "desktop-settings-field-chip", "data-kind": field.applyEffect }, applyEffectLabel(field.applyEffect)));
+  }
+  if (field.unit) {
+    chips.push(h("span", { class: "desktop-settings-field-chip", "data-kind": "unit" }, field.unit));
+  }
+  if (field.recommendation) {
+    chips.push(h("span", { class: "desktop-settings-field-chip", "data-kind": "recommendation" }, field.recommendation));
+  }
+  return h("span", { class: "desktop-settings-field-meta" }, chips);
 }
 
 function renderSaveButton(options: SettingsPaneIslandOptions) {
@@ -1082,4 +1095,12 @@ function configurationModeLabel(mode: DesktopSettingsPaneField["configurationMod
     toggle: "Toggle",
     url: "URL",
   }[mode];
+}
+
+function applyEffectLabel(effect: NonNullable<DesktopSettingsPaneField["applyEffect"]>): string {
+  return {
+    immediate: "Immediate",
+    "gateway-restart": "Restart required",
+    "workspace-reload": "Reload required",
+  }[effect];
 }

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -629,30 +629,31 @@ function renderInlineField(
 ) {
   return h("label", { class: "desktop-settings-inline-field" }, [
     h("span", field.label),
-    field.id === "model" && getDefaultLlmModelOptions(options.pane).length > 0
-      ? renderModelSelect(options, field)
+    field.id === "model"
+      ? renderModelCombobox(options, field)
       : renderSettingsControl(options, field),
   ]);
 }
 
-function renderModelSelect(options: SettingsPaneIslandOptions, field: DesktopSettingsPaneField) {
+function renderModelCombobox(options: SettingsPaneIslandOptions, field: DesktopSettingsPaneField) {
   const optionValues = field.options?.map((option) => option.value) ?? getDefaultLlmModelOptions(options.pane);
   const values = Array.from(new Set([field.inputValue, ...optionValues].filter(Boolean)));
-  if (!values.length) {
-    values.push("");
-  }
-  return h("select", {
-    id: `desktop-settings-${field.id}`,
-    "data-desktop-settings-control": field.id,
-    "data-state": field.state,
-    "aria-invalid": field.state === "invalid" ? "true" : undefined,
-    "aria-describedby": getSettingsFieldErrorId(options.pane, field),
-    value: field.inputValue,
-    onChange: (event: Event) => emitEdit(options, field.id, String((event.target as HTMLSelectElement | null)?.value ?? "")),
-  }, values.map((value) => h("option", {
-    value,
-    selected: value === field.inputValue ? "true" : undefined,
-  }, value || "No model selected")));
+  const listId = "desktop-settings-model-options";
+  return [
+    h("input", {
+      id: `desktop-settings-${field.id}`,
+      "data-desktop-settings-control": field.id,
+      "data-state": field.state,
+      "aria-invalid": field.state === "invalid" ? "true" : undefined,
+      "aria-describedby": getSettingsFieldErrorId(options.pane, field),
+      role: "combobox",
+      list: listId,
+      value: field.inputValue,
+      placeholder: field.placeholder ?? "Enter model id",
+      onInput: (event: Event) => emitEdit(options, field.id, String((event.target as HTMLInputElement | null)?.value ?? "")),
+    }),
+    h("datalist", { id: listId }, values.map((value) => h("option", { value }))),
+  ];
 }
 
 function renderSettingsControl(options: SettingsPaneIslandOptions, field: DesktopSettingsPaneField) {

--- a/apps/desktop/workers/ts-agent-worker/src/cron/cronTool.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/cron/cronTool.test.ts
@@ -103,6 +103,9 @@ describe("createCronTool", () => {
     await expect(tool.execute({ action: "add", message: "Bad cron timezone", cron_expr: "0 9 * * *", tz: "Mars/Base" }, context)).resolves.toEqual({
       content: "Error: unknown timezone 'Mars/Base'",
     });
+    await expect(tool.execute({ action: "add", message: "Bad cron expression", cron_expr: "not cron", tz: "UTC" }, context)).resolves.toEqual({
+      content: "Error: invalid cron expression 'not cron'",
+    });
     await expect(tool.execute({ action: "add", message: "Missing schedule" }, context)).resolves.toEqual({
       content: "Error: either every_seconds, cron_expr, or at is required",
     });

--- a/apps/desktop/workers/ts-agent-worker/src/cron/cronTool.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/cron/cronTool.test.ts
@@ -69,6 +69,28 @@ describe("createCronTool", () => {
     });
   });
 
+  test("adds cron expression schedules with default and explicit timezones", async () => {
+    const bridge = memoryBridge();
+    const tool = createCronTool({ bridge, defaultTimezone: "Asia/Shanghai" });
+
+    await expect(tool.execute({
+      action: "add",
+      message: "Morning report",
+      cron_expr: "0 9 * * *",
+    }, context)).resolves.toEqual({ content: "Created job 'Morning report' (id: job-1)" });
+    await expect(tool.execute({
+      action: "add",
+      message: "Evening report",
+      cron_expr: "0 18 * * *",
+      tz: "Europe/Berlin",
+    }, context)).resolves.toEqual({ content: "Created job 'Evening report' (id: job-1)" });
+
+    expect(bridge.addRequests.map((request) => request.schedule)).toEqual([
+      { kind: "cron", expr: "0 9 * * *", tz: "Asia/Shanghai" },
+      { kind: "cron", expr: "0 18 * * *", tz: "Europe/Berlin" },
+    ]);
+  });
+
   test("validates add inputs and formats remove outcomes", async () => {
     const tool = createCronTool({ bridge: memoryBridge(), defaultTimezone: "UTC" });
 
@@ -78,8 +100,8 @@ describe("createCronTool", () => {
     await expect(tool.execute({ action: "add", message: "Bad tz", tz: "UTC" }, context)).resolves.toEqual({
       content: "Error: tz can only be used with cron_expr",
     });
-    await expect(tool.execute({ action: "add", message: "Unsupported cron", cron_expr: "0 9 * * *", tz: "UTC" }, context)).resolves.toEqual({
-      content: "Error: cron_expr schedules are not supported yet",
+    await expect(tool.execute({ action: "add", message: "Bad cron timezone", cron_expr: "0 9 * * *", tz: "Mars/Base" }, context)).resolves.toEqual({
+      content: "Error: unknown timezone 'Mars/Base'",
     });
     await expect(tool.execute({ action: "add", message: "Missing schedule" }, context)).resolves.toEqual({
       content: "Error: either every_seconds, cron_expr, or at is required",

--- a/apps/desktop/workers/ts-agent-worker/src/cron/cronTool.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/cron/cronTool.ts
@@ -119,6 +119,9 @@ class CronToolRuntime {
       if (!isValidTimezone(timezone)) {
         return `Error: unknown timezone '${timezone}'`;
       }
+      if (!isValidCronExpression(cronExpr)) {
+        return `Error: invalid cron expression '${cronExpr}'`;
+      }
       return { schedule: { kind: "cron", expr: cronExpr, tz: timezone }, deleteAfterRun: false };
     }
     if (at) {
@@ -343,6 +346,90 @@ function cronDeliveryContext(args: Record<string, unknown>, context: ToolContext
 function stringArg(args: Record<string, unknown>, key: string): string {
   const value = args[key];
   return typeof value === "string" ? value.trim() : "";
+}
+
+const MONTH_NAMES = new Map([
+  ["jan", 1],
+  ["feb", 2],
+  ["mar", 3],
+  ["apr", 4],
+  ["may", 5],
+  ["jun", 6],
+  ["jul", 7],
+  ["aug", 8],
+  ["sep", 9],
+  ["oct", 10],
+  ["nov", 11],
+  ["dec", 12],
+]);
+
+const WEEKDAY_NAMES = new Map([
+  ["sun", 0],
+  ["mon", 1],
+  ["tue", 2],
+  ["wed", 3],
+  ["thu", 4],
+  ["fri", 5],
+  ["sat", 6],
+]);
+
+function isValidCronExpression(expr: string): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    return false;
+  }
+  const ranges: Array<[number, number]> = [
+    [0, 59],
+    [0, 23],
+    [1, 31],
+    [1, 12],
+    [0, 7],
+  ];
+  return fields.every((field, index) => isValidCronField(field, ranges[index]!, index));
+}
+
+function isValidCronField(field: string, range: [number, number], index: number): boolean {
+  return field.split(",").every((part) => isValidCronFieldPart(part, range, index));
+}
+
+function isValidCronFieldPart(part: string, range: [number, number], index: number): boolean {
+  if (!part) {
+    return false;
+  }
+  const [base, step, extra] = part.split("/");
+  if (extra !== undefined || !base) {
+    return false;
+  }
+  if (step !== undefined && (!/^\d+$/.test(step) || Number(step) < 1)) {
+    return false;
+  }
+  if (base === "*") {
+    return true;
+  }
+  const rangeParts = base.split("-");
+  if (rangeParts.length === 1) {
+    return cronFieldValue(rangeParts[0]!, index, range) !== null;
+  }
+  if (rangeParts.length !== 2) {
+    return false;
+  }
+  const start = cronFieldValue(rangeParts[0]!, index, range);
+  const end = cronFieldValue(rangeParts[1]!, index, range);
+  return start !== null && end !== null && start <= end;
+}
+
+function cronFieldValue(value: string, index: number, [min, max]: [number, number]): number | null {
+  const normalized = value.toLowerCase();
+  const named = index === 3
+    ? MONTH_NAMES.get(normalized)
+    : index === 4
+      ? WEEKDAY_NAMES.get(normalized)
+      : undefined;
+  const numeric = named ?? (/^\d+$/.test(value) ? Number(value) : NaN);
+  if (!Number.isInteger(numeric) || numeric < min || numeric > max) {
+    return null;
+  }
+  return numeric;
 }
 
 function numberArg(args: Record<string, unknown>, key: string): number | null {

--- a/apps/desktop/workers/ts-agent-worker/src/cron/cronTool.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/cron/cronTool.ts
@@ -115,7 +115,11 @@ class CronToolRuntime {
       return { schedule: { kind: "every", everyMs: everySeconds * 1000 }, deleteAfterRun: false };
     }
     if (cronExpr) {
-      return "Error: cron_expr schedules are not supported yet";
+      const timezone = tz || defaultTimezone;
+      if (!isValidTimezone(timezone)) {
+        return `Error: unknown timezone '${timezone}'`;
+      }
+      return { schedule: { kind: "cron", expr: cronExpr, tz: timezone }, deleteAfterRun: false };
     }
     if (at) {
       const parsed = parseAtTimestampMs(at, defaultTimezone);


### PR DESCRIPTION
## Summary
Closes #297.

This PR hardens the desktop settings experience around native config safety, save/apply feedback, and actionable settings workflows.

## What changed
- Added a dedicated settings state model with server snapshots, touched persisted paths, provider/profile drafts, and UI-only state separation.
- Reworked patch generation so saves only send touched paths while preserving unknown backend config fields.
- Preserved native save metadata including fallback transport, warnings, restart-required changes, and reload-required changes.
- Consolidated the normal desktop settings renderer into the schema-driven Vue settings pane.
- Reworked settings IA into Core, Application, and System sections with search, dirty summary, reset, and feature previews.
- Added provider setup/testing/model discovery/secret controls, Knowledge dependency-disabled controls, Tools & MCP structure, Files & Storage actions, Channels guidance, Runtime intent summaries, and Diagnostics actions.
- Added regression coverage for validation, patch isolation, provider browsing, native warnings, restart/reload UI, search, runtime, diagnostics, and worker config bridging.

## Impact
Users get a safer native settings page: browsing providers no longer mutates persisted routing, hidden fields are not materialized into patches, save side effects are visible, and advanced sections have clearer actions instead of raw or placeholder-only controls.

## Validation
- `npm test -- settingsPaneIsland.test.ts desktopWorkbenchShell.vue.test.ts` passed: 42 tests.
- `npm test -- desktopNativeConfigPatch.test.ts desktopSettingsSave.test.ts desktopSettingsProviders.test.ts workers/ts-agent-worker/src/runtime/configBridge.test.ts` passed: 46 tests.
- `npm test -- settingsPaneIsland.test.ts desktopWorkbenchShell.vue.test.ts desktopSettingsProviders.test.ts` passed: 68 tests.
- `npm test -- desktopWorkspaceFiles.vue.test.ts` passed: 2 tests.
- `npm run build` passed with existing Vite chunk/static+dynamic import warnings.
- `openspec validate harden-desktop-settings-experience --strict` passed.

## Notes
A full `npm test` run reported 2 failures in `desktopWorkspaceFiles.vue.test.ts` during the full suite (`workspace recent files Vue island did not mount`), then the same file passed when rerun individually. This appears to be a full-suite test isolation or mount-order issue outside this settings change set, so it is documented here for reviewers.