### PR TITLE
Improve native desktop settings UX

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -30,7 +30,21 @@ jobs:
         run: npm ci
 
       - name: Run desktop tests
-        run: npm test
+        shell: bash
+        run: |
+          set +e
+          npm test > test-output.log 2>&1
+          status=$?
+          tail -n 200 test-output.log
+          exit "$status"
+
+      - name: Upload failed desktop test log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-test-output
+          path: apps/desktop/test-output.log
+          retention-days: 3
 
       - name: Build desktop frontend
         run: npm run build

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -1,0 +1,36 @@
+name: Desktop CI
+
+on:
+  pull_request:
+    paths:
+      - "apps/desktop/**"
+      - "webui/**"
+      - ".github/workflows/desktop-ci.yml"
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/desktop
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: apps/desktop/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run desktop tests
+        run: npm test
+
+      - name: Build desktop frontend
+        run: npm run build

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -9,6 +9,7 @@
       content="Tinybot desktop WebUI surface backed by the local gateway."
     />
     <link rel="icon" type="image/svg+xml" href="/assets/logo-mark.svg" />
+    <link rel="stylesheet" href="/assets/styles/components/desktop-settings.css" />
     <style>
       body {
         margin: 0;

--- a/apps/desktop/src/desktopSettingsExperience.test.ts
+++ b/apps/desktop/src/desktopSettingsExperience.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import desktopSettingsCss from "../../../webui/assets/styles/components/desktop-settings.css?raw";
+import mainCss from "../../../webui/assets/styles/main.css?raw";
+
+const nativeSettingsScope = "html[data-desktop-active-workbench-module=\"settings\"] body.desktop-native-workbench";
+
+describe("desktop settings experience stylesheet", () => {
+  test("loads after the shared WebUI theme and stays scoped to the native settings route", () => {
+    expect(mainCss.trimEnd().endsWith("@import './components/desktop-settings.css';")).toBe(true);
+    expect(desktopSettingsCss).toContain(nativeSettingsScope);
+    expect(desktopSettingsCss).not.toMatch(/^body\s*\{/m);
+  });
+
+  test("provides clear search, navigation, save, and keyboard focus states", () => {
+    expect(desktopSettingsCss).toContain(".desktop-settings-search-results");
+    expect(desktopSettingsCss).toContain("max-height: min(336px, 42vh)");
+    expect(desktopSettingsCss).toContain('.desktop-settings-nav-item[data-active="true"]::before');
+    expect(desktopSettingsCss).toContain(".desktop-settings-save-status-button:not(:disabled)");
+    expect(desktopSettingsCss).toContain(":focus-visible");
+    expect(desktopSettingsCss).toContain("@media (prefers-reduced-motion: reduce)");
+  });
+
+  test("adapts the settings layout for compact desktop windows", () => {
+    expect(desktopSettingsCss).toContain("@media (max-width: 1040px)");
+    expect(desktopSettingsCss).toContain("@media (max-width: 760px)");
+    expect(desktopSettingsCss).toContain("@media (max-width: 520px)");
+    expect(desktopSettingsCss).toContain("grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr))");
+    expect(desktopSettingsCss).toContain("grid-template-columns: 1fr");
+  });
+
+  test("uses shared desktop design tokens instead of a light-theme-only palette", () => {
+    for (const token of ["--bg", "--panel", "--border", "--text", "--text-muted", "--accent", "--accent-soft"]) {
+      expect(desktopSettingsCss).toContain(`var(${token})`);
+    }
+  });
+});

--- a/apps/desktop/src/desktopSettingsExperience.test.ts
+++ b/apps/desktop/src/desktopSettingsExperience.test.ts
@@ -1,7 +1,11 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, test } from "vitest";
-import desktopSettingsCss from "../../../webui/assets/styles/components/desktop-settings.css?raw";
-import mainCss from "../../../webui/assets/styles/main.css?raw";
 
+const desktopSettingsCss = readFileSync(
+  new URL("../../../webui/assets/styles/components/desktop-settings.css", import.meta.url),
+  "utf8",
+);
+const mainCss = readFileSync(new URL("../../../webui/assets/styles/main.css", import.meta.url), "utf8");
 const nativeSettingsScope = "html[data-desktop-active-workbench-module=\"settings\"] body.desktop-native-workbench";
 
 describe("desktop settings experience stylesheet", () => {

--- a/apps/desktop/src/desktopSettingsExperience.test.ts
+++ b/apps/desktop/src/desktopSettingsExperience.test.ts
@@ -5,12 +5,14 @@ const desktopSettingsCss = readFileSync(
   new URL("../../../webui/assets/styles/components/desktop-settings.css", import.meta.url),
   "utf8",
 );
+const desktopIndexHtml = readFileSync(new URL("../index.html", import.meta.url), "utf8");
 const mainCss = readFileSync(new URL("../../../webui/assets/styles/main.css", import.meta.url), "utf8");
 const nativeSettingsScope = "html[data-desktop-active-workbench-module=\"settings\"] body.desktop-native-workbench";
 
 describe("desktop settings experience stylesheet", () => {
-  test("loads after the shared WebUI theme and stays scoped to the native settings route", () => {
-    expect(mainCss.trimEnd().endsWith("@import './components/desktop-settings.css';")).toBe(true);
+  test("loads from the native shell and stays out of the browser WebUI bundle", () => {
+    expect(desktopIndexHtml).toContain('href="/assets/styles/components/desktop-settings.css"');
+    expect(mainCss).not.toContain("desktop-settings.css");
     expect(desktopSettingsCss).toContain(nativeSettingsScope);
     expect(desktopSettingsCss).not.toMatch(/^body\s*\{/m);
   });

--- a/apps/desktop/src/viteStaticPlugin.test.ts
+++ b/apps/desktop/src/viteStaticPlugin.test.ts
@@ -19,6 +19,9 @@ describe("desktop WebUI static routing", () => {
     expect(resolveWebuiStaticFile(webuiRoot, "/assets/src/main.js")).toBe(
       path.join(webuiRoot, "assets", "src", "main.js"),
     );
+    expect(resolveWebuiStaticFile(webuiRoot, "/assets/styles/components/desktop-settings.css")).toBe(
+      path.join(webuiRoot, "assets", "styles", "components", "desktop-settings.css"),
+    );
   });
 
   test("leaves non-static and path traversal requests unresolved", () => {
@@ -71,6 +74,7 @@ describe("desktop WebUI static routing", () => {
         "docs/quickstart",
         "docs/quickstart.html",
         "assets/styles.css",
+        "assets/styles/components/desktop-settings.css",
         "assets/docs-styles.css",
         "assets/docs.js",
         "assets/logo-mark.svg",

--- a/apps/desktop/workers/ts-agent-worker/src/config/configPaths.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/config/configPaths.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, test } from "vitest";
 
 import {
@@ -7,6 +8,8 @@ import {
 
 describe("configPaths", () => {
   test("derives runtime paths from the active config path", () => {
+    const homeDir = path.normalize("C:/Users/test");
+    const dataDir = path.join(homeDir, ".tinybot");
     const paths = resolveTinybotRuntimePaths({
       configPath: "C:/Users/test/.tinybot/config.json",
       homeDir: "C:/Users/test",
@@ -14,33 +17,35 @@ describe("configPaths", () => {
     });
 
     expect(paths).toEqual({
-      dataDir: "C:\\Users\\test\\.tinybot",
-      mediaDir: "C:\\Users\\test\\.tinybot\\media",
-      cronDir: "C:\\Users\\test\\.tinybot\\cron",
-      logsDir: "C:\\Users\\test\\.tinybot\\logs",
-      knowledgeDir: "C:\\Users\\test\\.tinybot\\knowledge",
-      workspacePath: "D:\\workspace\\project",
-      cliHistoryPath: "C:\\Users\\test\\.tinybot\\history\\cli_history",
-      bridgeInstallDir: "C:\\Users\\test\\.tinybot\\bridge",
-      legacySessionsDir: "C:\\Users\\test\\.tinybot\\sessions",
+      dataDir,
+      mediaDir: path.join(dataDir, "media"),
+      cronDir: path.join(dataDir, "cron"),
+      logsDir: path.join(dataDir, "logs"),
+      knowledgeDir: path.join(dataDir, "knowledge"),
+      workspacePath: path.normalize("D:/workspace/project"),
+      cliHistoryPath: path.join(homeDir, ".tinybot", "history", "cli_history"),
+      bridgeInstallDir: path.join(homeDir, ".tinybot", "bridge"),
+      legacySessionsDir: path.join(homeDir, ".tinybot", "sessions"),
     });
   });
 
   test("uses Python-compatible defaults when config path and workspace are omitted", () => {
+    const homeDir = path.normalize("C:/Users/test");
     const paths = resolveTinybotRuntimePaths({ homeDir: "C:/Users/test" });
 
-    expect(paths.dataDir).toBe("C:\\Users\\test\\.tinybot");
-    expect(paths.workspacePath).toBe("C:\\Users\\test\\.tinybot\\workspace");
+    expect(paths.dataDir).toBe(path.join(homeDir, ".tinybot"));
+    expect(paths.workspacePath).toBe(path.join(homeDir, ".tinybot", "workspace"));
     expect(isDefaultWorkspacePath(paths.workspacePath, "C:/Users/test")).toBe(true);
   });
 
   test("expands home-relative workspace and detects non-default workspace paths", () => {
+    const homeDir = path.normalize("C:/Users/test");
     const paths = resolveTinybotRuntimePaths({
       homeDir: "C:/Users/test",
       workspace: "~/.tinybot/workspace-alt",
     });
 
-    expect(paths.workspacePath).toBe("C:\\Users\\test\\.tinybot\\workspace-alt");
+    expect(paths.workspacePath).toBe(path.join(homeDir, ".tinybot", "workspace-alt"));
     expect(isDefaultWorkspacePath(paths.workspacePath, "C:/Users/test")).toBe(false);
   });
 });

--- a/webui/assets/styles/components/desktop-settings.css
+++ b/webui/assets/styles/components/desktop-settings.css
@@ -1,0 +1,563 @@
+/* Native desktop settings experience.
+ *
+ * This file is intentionally scoped to the native workbench settings route so
+ * the browser WebUI remains unchanged. The extra route-level specificity also
+ * lets these refinements override the desktop shell's generated baseline CSS.
+ */
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-workbench-main .desktop-utility-surfaces {
+  padding: clamp(16px, 2.5vw, 32px);
+  scroll-padding-top: 88px;
+  scrollbar-gutter: stable;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane {
+  grid-template-columns: minmax(216px, 252px) minmax(0, 1fr);
+  gap: clamp(24px, 3vw, 40px);
+  width: min(100%, 1320px);
+  max-width: 1320px;
+  padding: 4px 0 48px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-sidebar {
+  position: sticky;
+  top: 12px;
+  gap: 12px;
+  max-height: calc(100vh - var(--desktop-window-frame-height, 0px) - 72px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 12px;
+  background: color-mix(in srgb, var(--panel) 92%, var(--surface-soft));
+  box-shadow: var(--shadow-xs);
+  scrollbar-gutter: stable;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-sidebar:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-search {
+  width: 100%;
+  min-width: 0;
+  min-height: 42px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0 12px;
+  background: var(--bg);
+  color: var(--text);
+  font: 500 13px/1.35 var(--font-sans);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background-color var(--transition-fast);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search::placeholder,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-search::placeholder {
+  color: var(--text-subtle);
+  opacity: 1;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search-results {
+  display: grid;
+  gap: 4px;
+  max-height: min(336px, 42vh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 5px;
+  background: var(--bg);
+  box-shadow: var(--shadow-md);
+  scrollbar-gutter: stable;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search-result {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 7px 9px;
+  background: transparent;
+  color: var(--text);
+  font: 600 12px/1.3 var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search-result:hover,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search-result:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border));
+  background: var(--accent-soft);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search-result span,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search-result small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search-result small {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-search-empty {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  background: color-mix(in srgb, var(--surface-soft) 72%, transparent);
+  color: var(--text-muted);
+  font: 500 12px/1.4 var(--font-sans);
+  text-align: center;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-dirty-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
+  border-radius: var(--radius-md);
+  padding: 9px 10px;
+  background: var(--accent-soft);
+  color: var(--text);
+  font: 600 12px/1.35 var(--font-sans);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-dirty-summary button {
+  min-height: 30px;
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border));
+  border-radius: var(--radius-sm);
+  padding: 0 9px;
+  background: var(--bg);
+  color: var(--text);
+  font: 700 11px/1.2 var(--font-sans);
+  cursor: pointer;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav {
+  display: grid;
+  gap: 4px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-heading {
+  margin: 14px 8px 4px;
+  color: var(--text-subtle);
+  font: 700 10px/1.2 var(--font-sans);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-heading:first-child {
+  margin-top: 2px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  min-height: 40px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  padding: 0 11px 0 14px;
+  background: transparent;
+  color: var(--text-muted);
+  font: 600 13px/1.25 var(--font-sans);
+  text-decoration: none;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast), color var(--transition-fast);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-item::before {
+  position: absolute;
+  top: 9px;
+  bottom: 9px;
+  left: 5px;
+  width: 3px;
+  border-radius: var(--radius-full);
+  background: var(--accent);
+  content: "";
+  opacity: 0;
+  transform: scaleY(0.55);
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-item:hover,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-item:focus-visible {
+  border-color: var(--border);
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-item[data-active="true"] {
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border));
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-item[data-active="true"]::before {
+  opacity: 1;
+  transform: scaleY(1);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-preview-list {
+  display: grid;
+  gap: 5px;
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 12px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-preview-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 34px;
+  border-radius: var(--radius-sm);
+  padding: 0 9px;
+  color: var(--text-muted);
+  font: 600 12px/1.25 var(--font-sans);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-preview-item small {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 2px 7px;
+  background: var(--surface-soft);
+  color: var(--text-subtle);
+  font-size: 10px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-content {
+  gap: 20px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-header {
+  position: sticky;
+  top: -1px;
+  z-index: 6;
+  align-items: center;
+  min-height: 72px;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 10px 0 12px;
+  background: color-mix(in srgb, var(--bg) 94%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-breadcrumb h2,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-card-heading h2,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-header h2,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-group h2 {
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-breadcrumb h2 {
+  font-size: clamp(20px, 2vw, 24px);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-header-description,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-llm-copy,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-group-description,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field-description {
+  color: var(--text-muted);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-region {
+  flex: 0 1 440px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-status {
+  flex: 1 1 220px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  color: var(--text-muted);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-details {
+  display: grid;
+  gap: 5px;
+  margin: 7px 0 0;
+  padding: 7px 0 0 18px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-details button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--accent-hover);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-status-button:not(:disabled) {
+  min-height: 40px;
+  border-color: transparent;
+  background: var(--accent);
+  color: var(--on-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-status-button:not(:disabled):hover {
+  background: var(--accent-hover);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-error-banner {
+  display: grid;
+  gap: 8px;
+  border: 1px solid color-mix(in srgb, var(--danger) 42%, var(--border));
+  border-radius: var(--radius-lg);
+  padding: 14px 16px;
+  background: var(--danger-soft);
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-error-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-llm-card,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-group,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-card,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-setup {
+  border-color: var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--panel);
+  box-shadow: var(--shadow-xs);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-llm-card {
+  padding: clamp(20px, 2.5vw, 28px);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-llm-form {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-inline-field,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field label {
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-inline-field select,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-inline-field input,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field input,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field select,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field textarea,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail input {
+  border-color: var(--border);
+  background: var(--bg);
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-header {
+  align-items: end;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-tools {
+  grid-template-columns: minmax(180px, 1fr) auto auto;
+  min-width: min(520px, 100%);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  gap: 14px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-card {
+  min-height: 0;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 22%, var(--border));
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-title h3,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-advanced {
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-switch {
+  background: var(--surface-cream-strong);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-switch[data-state="on"] {
+  background: var(--accent);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-switch::after {
+  background: var(--bg);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-group {
+  overflow: clip;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field {
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 360px);
+  gap: clamp(18px, 2.5vw, 32px);
+  min-height: 72px;
+  border-top-color: var(--border-subtle);
+  padding: 16px 18px;
+  scroll-margin-top: 96px;
+  transition: background-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field[data-highlighted="true"] {
+  background: var(--accent-soft);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field-chip {
+  border-color: var(--border);
+  background: var(--surface-soft);
+  color: var(--text-muted);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-advanced-fields {
+  border-top-color: var(--border-subtle);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-advanced-fields summary {
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-advanced-fields summary:hover {
+  background: var(--surface-soft);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-files-actions,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-channels-summary,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-runtime-summary,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-diagnostics-actions,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-mcp-server-list,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-secret-controls {
+  border-color: var(--border-subtle);
+  background: var(--surface-soft);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane :is(input, select, textarea, button, a, summary):focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 72%, transparent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--accent-glow);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane :is(input, select, textarea):disabled {
+  cursor: not-allowed;
+  opacity: 0.66;
+}
+
+@media (max-width: 1040px) {
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-sidebar {
+    position: static;
+    max-height: none;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 5px;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav-heading {
+    grid-column: 1 / -1;
+    margin-top: 10px;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-preview-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-header {
+    position: static;
+    min-height: 0;
+    background: transparent;
+    backdrop-filter: none;
+  }
+}
+
+@media (max-width: 760px) {
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-workbench-main .desktop-utility-surfaces {
+    padding: 14px;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-header,
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-region,
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-tools {
+    width: 100%;
+    min-width: 0;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-status-button {
+    flex: 1 1 auto;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-llm-form,
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field {
+    grid-template-columns: 1fr;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field {
+    gap: 12px;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-tools {
+    grid-template-columns: 1fr auto auto;
+  }
+}
+
+@media (max-width: 520px) {
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-nav,
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-preview-list,
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-tools {
+    grid-template-columns: 1fr;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-tools button,
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-save-status-button {
+    width: 100%;
+  }
+
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-llm-card {
+    padding: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane *,
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane *::before,
+  html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane *::after {
+    scroll-behavior: auto;
+    transition-duration: 0.01ms;
+  }
+}

--- a/webui/assets/styles/main.css
+++ b/webui/assets/styles/main.css
@@ -14,4 +14,3 @@
 @import './responsive.css';
 @import './utilities.css?v=provider-catalog-2';
 @import './anthropic-theme.css';
-@import './components/desktop-settings.css';

--- a/webui/assets/styles/main.css
+++ b/webui/assets/styles/main.css
@@ -14,3 +14,4 @@
 @import './responsive.css';
 @import './utilities.css?v=provider-catalog-2';
 @import './anthropic-theme.css';
+@import './components/desktop-settings.css';


### PR DESCRIPTION
## Summary
- add a native-settings-only visual layer with stronger information hierarchy and token-based theming
- improve settings search results, active navigation, save/dirty feedback, keyboard focus visibility, and highlighted-field feedback
- make provider cards, form fields, and the settings sidebar adapt cleanly to compact desktop windows
- preserve the browser WebUI by scoping every rule to the native workbench settings route

## Front-end UX changes
- roomier, fluid settings layout with a bounded sticky sidebar
- clearer selected-section indicator and larger navigation/search targets
- scrollable search results and stronger empty, dirty, error, and save states
- sticky desktop save header plus stacked compact-window forms and controls
- responsive provider grids, single-column mobile fields, and reduced-motion support
- shared design tokens for dark-theme compatibility instead of additional light-only colors

## Quality and validation
- add Vitest coverage for stylesheet loading order, native-only scoping, focus/reduced-motion affordances, responsive breakpoints, and design-token usage
- add a path-scoped Desktop CI workflow that runs the complete Vitest suite and production frontend build
- make an existing runtime-path test platform-neutral so desktop CI runs consistently on Linux and Windows
- verified the complete desktop test suite and `npm run build`
- verified repository Python tests, lint, and typecheck

## UX notes
The change deliberately leaves settings data flow and gateway contracts untouched. It builds on the existing searchable section-page architecture and focuses on readability, discoverability, keyboard access, dark-theme compatibility, and smaller desktop window sizes.