### PR TITLE
Redesign native desktop settings pages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2025 nanobot contributors
-Copyright (c) 2026 Zhihao GU
+Copyright (c) 2026 SudoJacky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/desktop/src/desktopSettingsExperience.test.ts
+++ b/apps/desktop/src/desktopSettingsExperience.test.ts
@@ -34,6 +34,24 @@ describe("desktop settings experience stylesheet", () => {
     expect(desktopSettingsCss).toContain("grid-template-columns: 1fr");
   });
 
+  test("styles the redesigned settings task pages and quality layers", () => {
+    expect(desktopSettingsCss).toContain(".desktop-settings-task-page");
+    expect(desktopSettingsCss).toContain(".desktop-settings-provider-page");
+    expect(desktopSettingsCss).toContain(".desktop-settings-provider-detail-panel");
+    expect(desktopSettingsCss).toContain(".desktop-settings-knowledge-stages");
+    expect(desktopSettingsCss).toContain(".desktop-settings-quality-layer-grid");
+    expect(desktopSettingsCss).toContain(".desktop-settings-segmented-control");
+    expect(desktopSettingsCss).toContain(".desktop-settings-quality-preset");
+  });
+
+  test("keeps redesigned settings pages from forcing horizontal scrolling", () => {
+    expect(desktopSettingsCss).toContain("overflow-x: hidden");
+    expect(desktopSettingsCss).toContain(".desktop-settings-task-card .desktop-settings-field");
+    expect(desktopSettingsCss).toContain("grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr))");
+    expect(desktopSettingsCss).toContain("width: 100%");
+    expect(desktopSettingsCss).toContain("min-width: 0");
+  });
+
   test("uses shared desktop design tokens instead of a light-theme-only palette", () => {
     for (const token of ["--bg", "--panel", "--border", "--text", "--text-muted", "--accent", "--accent-soft"]) {
       expect(desktopSettingsCss).toContain(`var(${token})`);

--- a/apps/desktop/src/desktopWorkbenchShell.settingsRenderer.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.settingsRenderer.test.ts
@@ -56,4 +56,57 @@ describe("desktop settings renderer ownership", () => {
       hasImperativeContent: false,
     });
   }, 30000);
+
+  test("renders redesigned settings pages through the fallback shell renderer", async () => {
+    vi.resetModules();
+    const originalHTMLElement = globalThis.HTMLElement;
+    vi.stubGlobal("HTMLElement", undefined);
+    try {
+      const [
+        { buildDesktopSettingsFormState, buildDesktopSettingsPaneModel },
+        { createDefaultWorkbenchLayout },
+        { installDesktopWorkbenchShell },
+      ] = await Promise.all([
+        import("./desktopSettingsProviders"),
+        import("./desktopWorkbenchLayout"),
+        import("./desktopWorkbenchShell"),
+      ]);
+
+      document.body.replaceChildren();
+      document.head.replaceChildren();
+      const state = buildDesktopSettingsFormState({
+        agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "Asia/Shanghai" } },
+        providers: { profiles: { work: { provider: "openai", api_key: "sk-live", models: ["gpt-4.1-mini"] } } },
+        knowledge: { enabled: true, retrieval_mode: "hybrid", max_chunks: 5 },
+      }, [{ id: "openai", displayName: "OpenAI", status: "ready" }]);
+
+      installDesktopWorkbenchShell({
+        targetDocument: document,
+        layout: createDefaultWorkbenchLayout(),
+        gatewayHttp: "http://127.0.0.1:18790",
+        settingsPane: buildDesktopSettingsPaneModel(state, {
+          lastSavedState: state,
+          providerCatalog: [{ id: "openai", displayName: "OpenAI", status: "ready" }],
+        }),
+      });
+
+      const settingsPane = document.querySelector(".desktop-settings-pane");
+      expect(settingsPane?.getAttribute("data-desktop-vue-island")).toBeNull();
+      expect(settingsPane?.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("General");
+      expect(settingsPane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Default AI");
+
+      settingsPane?.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]')?.click();
+      expect(settingsPane?.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Provider & Models");
+      expect(settingsPane?.querySelector(".desktop-settings-provider-detail-panel")?.textContent).toContain("Edit OpenAI");
+
+      settingsPane?.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="knowledge"]')?.click();
+      expect(settingsPane?.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Knowledge");
+      expect(Array.from(
+        settingsPane?.querySelectorAll("[data-desktop-settings-knowledge-stage]") ?? [],
+        (node) => node.getAttribute("data-desktop-settings-knowledge-stage"),
+      )).toEqual(["documents", "chunking", "embeddings", "retrieval", "rerank", "graph"]);
+    } finally {
+      vi.stubGlobal("HTMLElement", originalHTMLElement);
+    }
+  }, 30000);
 });

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -25,6 +25,7 @@ class FakeElement {
   public children: FakeElement[] = [];
   public parentElement: FakeElement | null = null;
   public attributes = new Map<string, string>();
+  public dataset: Record<string, string> = {};
   public value = "";
   public checked = false;
   public disabled = false;
@@ -186,10 +187,12 @@ class FakeHead extends FakeElement {
 class FakeDocument {
   public body: FakeBody;
   public head: FakeHead;
+  public documentElement: FakeElement;
   public activeElement: FakeElement | null = null;
   public listeners = new Map<string, ((event: unknown) => void)[]>();
 
   constructor() {
+    this.documentElement = new FakeElement("html", this);
     this.body = new FakeBody(this);
     this.head = new FakeHead(this);
   }
@@ -2850,16 +2853,16 @@ describe("desktop workbench shell", () => {
       "Logs & Diagnostics",
     ]);
     expect(pane?.querySelector(".desktop-settings-nav-item")?.getAttribute("data-active")).toBe("true");
-    expect(pane?.querySelector(".desktop-settings-content")?.textContent).toContain("Settings / General");
+    expect(pane?.querySelector(".desktop-settings-content")?.textContent).toContain("General");
     expect(pane?.querySelector(".desktop-settings-capability-map")).toBeNull();
-    expect(pane?.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("默认 LLM");
-    expect(pane?.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("提供商");
-    expect(pane?.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("模型");
-    expect(pane?.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("这里设置全局默认的 LLM 模型");
+    expect(pane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Default AI");
+    expect(pane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Provider");
+    expect(pane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Model");
+    expect(pane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Resolved route");
     pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
-    expect(pane?.querySelector(".desktop-settings-provider-section")?.textContent).toContain("提供商");
-    expect(pane?.querySelector(".desktop-settings-provider-search")?.getAttribute("placeholder")).toBe("搜索提供商...");
-    expect(pane?.querySelector('[data-desktop-settings-action="addProvider"]')?.textContent).toBe("+ 添加提供商");
+    expect(pane?.querySelector(".desktop-settings-provider-section")?.textContent).toContain("Connected providers");
+    expect(pane?.querySelector(".desktop-settings-provider-search")?.getAttribute("placeholder")).toBe("Search providers...");
+    expect(pane?.querySelector('[data-desktop-settings-action="addProvider"]')?.textContent).toBe("+ Add provider");
     expect(pane?.querySelector(".desktop-settings-provider-card")?.textContent).toContain("OpenAI");
     expect(pane?.querySelector(".desktop-settings-provider-card")?.textContent).toContain("Base URL: https://api.openai.com/v1");
     expect(pane?.querySelector(".desktop-settings-provider-card")?.textContent).toContain("API Key: ********");
@@ -2877,10 +2880,10 @@ describe("desktop workbench shell", () => {
     expect(settingsActions).toEqual(["save"]);
     settingsActions.length = 0;
     pane?.querySelector('[data-desktop-settings-nav="general"]')?.click();
-    expect(pane?.querySelector('[data-desktop-settings-group="general"]')?.getAttribute("id")).toBe("desktop-settings-group-general");
-    expect(pane?.textContent).toContain("Settings / General");
+    expect(pane?.querySelector('[data-desktop-settings-group="general"]')).toBeNull();
+    expect(pane?.textContent).toContain("General");
     expect(pane?.querySelector('[data-desktop-settings-control="model"]')?.tagName).toBe("select");
-    expect(pane?.querySelector(".desktop-settings-status-card")).toBeNull();
+    expect(pane?.querySelector(".desktop-settings-resolved-route-card")?.textContent).toContain("Resolved route");
     expect(pane?.textContent).not.toContain("Save: HTTP 400");
     expect(pane?.textContent).not.toContain("Catalog: OpenAI (ready)");
     expect(pane?.textContent).not.toContain("Open docs");
@@ -3882,6 +3885,37 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain(
       'body.desktop-native-workbench .desktop-workbench-shell[data-sidebar-visible="false"][data-inspector-visible="false"] {\n      grid-template-columns: 92px 0 minmax(0, 1fr) 0;',
     );
+  });
+
+  test("hides the secondary chat sidebar outside the chat module by default", () => {
+    const chatDocument = new FakeDocument();
+    chatDocument.documentElement.setAttribute("data-desktop-active-workbench-module", "chat");
+
+    installDesktopWorkbenchShell({
+      targetDocument: chatDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+    });
+
+    expect(chatDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("true");
+    expect(chatDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("true");
+
+    const settingsDocument = new FakeDocument();
+    settingsDocument.documentElement.setAttribute("data-desktop-active-workbench-module", "settings");
+    const settingsState = buildDesktopSettingsFormState({
+      agents: { defaults: { provider: "deepseek", model: "deepseek-v4-flash" } },
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: settingsDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      settingsPane: buildDesktopSettingsPaneModel(settingsState, { lastSavedState: settingsState }),
+    });
+
+    expect(settingsDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("false");
+    expect(settingsDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("false");
+    expect(settingsDocument.body.querySelector(".desktop-settings-pane")).not.toBeNull();
   });
 
   test("collapses secondary panes at the minimum desktop width", () => {

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -3900,6 +3900,21 @@ describe("desktop workbench shell", () => {
     expect(chatDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("true");
     expect(chatDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("true");
 
+    const startupDocument = new FakeDocument();
+    const startupSettingsState = buildDesktopSettingsFormState({
+      agents: { defaults: { provider: "deepseek", model: "deepseek-v4-flash" } },
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: startupDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      settingsPane: buildDesktopSettingsPaneModel(startupSettingsState, { lastSavedState: startupSettingsState }),
+    });
+
+    expect(startupDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("true");
+    expect(startupDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("true");
+
     const settingsDocument = new FakeDocument();
     settingsDocument.documentElement.setAttribute("data-desktop-active-workbench-module", "settings");
     const settingsState = buildDesktopSettingsFormState({

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -847,25 +847,55 @@ function createWorkbenchShell(
   const inspectorState = hasInspectorContent(inspectorContent)
     ? layout.inspector
     : { ...layout.inspector, visible: false };
+  const activeModule = getDesktopActiveWorkbenchModule(targetDocument, settingsPane, knowledgePane, toolsSkillsPane, coworkPane);
+  const sidebarState = activeModule === "chat"
+    ? layout.sidebar
+    : { ...layout.sidebar, visible: false };
   const shell = targetDocument.createElement("main");
   shell.id = SHELL_ID;
   shell.className = "desktop-workbench-shell";
-  shell.setAttribute("data-sidebar-visible", String(layout.sidebar.visible));
+  shell.setAttribute("data-sidebar-visible", String(sidebarState.visible));
   shell.setAttribute("data-inspector-visible", String(inspectorState.visible));
   shell.setAttribute("data-bottom-visible", String(layout.bottom.visible));
-  shell.style.setProperty("--desktop-sidebar-size", `${layout.sidebar.size}px`);
+  shell.style.setProperty("--desktop-sidebar-size", `${sidebarState.size}px`);
   shell.style.setProperty("--desktop-inspector-size", `${inspectorState.size}px`);
   shell.style.setProperty("--desktop-bottom-size", `${layout.bottom.size}px`);
 
   shell.append(
     createActivityRail(targetDocument),
-    createPanel(targetDocument, "sidebar", layout.sidebar, createSidebar(targetDocument, chat, chatActions)),
+    createPanel(targetDocument, "sidebar", sidebarState, createSidebar(targetDocument, chat, chatActions)),
     createMainRegion(targetDocument, gatewayHttp, layout, chat, chatActions, agentUiForms, agentUiActions, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, workLens, workLensActions),
     createPanel(targetDocument, "inspector", inspectorState, inspectorContent),
     createPanel(targetDocument, "bottom", layout.bottom, createBottomRegion(targetDocument, runtimeStatus, gatewayHttp, taskCenterItems, taskActions, gatewayActions)),
   );
 
   return shell;
+}
+
+function getDesktopActiveWorkbenchModule(
+  targetDocument: Document,
+  settingsPane: DesktopSettingsPaneModel | null,
+  knowledgePane: DesktopKnowledgePaneModel | null,
+  toolsSkillsPane: DesktopToolsSkillsPaneModel | null,
+  coworkPane: DesktopCoworkPaneModel | null,
+): string {
+  const routeModule = targetDocument.documentElement?.getAttribute("data-desktop-active-workbench-module")?.trim();
+  if (routeModule) {
+    return routeModule;
+  }
+  if (settingsPane) {
+    return "settings";
+  }
+  if (knowledgePane) {
+    return "knowledge";
+  }
+  if (toolsSkillsPane) {
+    return "tools";
+  }
+  if (coworkPane) {
+    return "cowork";
+  }
+  return "chat";
 }
 
 function createActivityRail(targetDocument: Document): HTMLElement {

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -5186,10 +5186,16 @@ function createSettingsActivePage(
   const activeGroup = getDesktopSettingsActiveGroup(pane, activeGroupId);
   const nodes = [createSettingsPageHeader(targetDocument, pane, settingsActions, activeGroup)];
   if (activeGroup?.id === "general") {
-    nodes.push(createDefaultLlmSettingsCard(targetDocument, pane, settingsActions));
+    nodes.push(createGeneralSettingsPage(targetDocument, pane, activeGroup, settingsActions));
+    return nodes;
   }
   if (activeGroup?.id === "provider-models") {
-    nodes.push(createProviderManagementSection(targetDocument, pane, settingsActions));
+    nodes.push(createProviderModelsSettingsPage(targetDocument, pane, activeGroup, settingsActions));
+    return nodes;
+  }
+  if (activeGroup?.id === "knowledge") {
+    nodes.push(createKnowledgeSettingsPage(targetDocument, pane, activeGroup, settingsActions));
+    return nodes;
   }
   if (activeGroup) {
     const grid = targetDocument.createElement("div");
@@ -5213,7 +5219,7 @@ function createSettingsPageHeader(
   header.className = "desktop-settings-header";
   const breadcrumb = targetDocument.createElement("div");
   breadcrumb.className = "desktop-settings-breadcrumb";
-  breadcrumb.append(createText(targetDocument, "h2", `Settings / ${group?.label ?? "General"}`));
+  breadcrumb.append(createText(targetDocument, "h2", group?.label ?? "General"));
   if (group) {
     const description = createText(targetDocument, "p", getSettingsGroupDescription(group.id));
     description.className = "desktop-settings-header-description";
@@ -5309,35 +5315,201 @@ function mountSettingsPaneVueIsland(
   });
 }
 
-function createDefaultLlmSettingsCard(
+function createSettingsSectionHeading(
+  targetDocument: Document,
+  title: string,
+  description: string,
+  badge?: string,
+): HTMLElement {
+  const header = targetDocument.createElement("header");
+  header.className = "desktop-settings-section-heading";
+  const copy = targetDocument.createElement("div");
+  copy.append(createText(targetDocument, "h2", title), createText(targetDocument, "p", description));
+  header.append(copy);
+  if (badge) {
+    const tag = createText(targetDocument, "span", badge);
+    tag.className = "desktop-settings-section-badge";
+    header.append(tag);
+  }
+  return header;
+}
+
+function createGeneralSettingsPage(
   targetDocument: Document,
   pane: DesktopSettingsPaneModel,
+  group: DesktopSettingsPaneGroup,
   settingsActions: DesktopSettingsActionOptions,
 ): HTMLElement {
-  const card = targetDocument.createElement("section");
-  card.className = "desktop-settings-default-llm-card";
-  card.setAttribute("aria-label", "Default LLM settings");
+  const page = targetDocument.createElement("div");
+  page.className = "desktop-settings-task-page desktop-settings-general-page";
+  page.setAttribute("data-desktop-settings-task-page", "general");
 
-  const heading = targetDocument.createElement("div");
-  heading.className = "desktop-settings-card-heading";
-  heading.append(createText(targetDocument, "h2", "默认 LLM"));
-
-  const form = targetDocument.createElement("div");
-  form.className = "desktop-settings-default-llm-form";
+  const defaultAi = targetDocument.createElement("section");
+  defaultAi.className = "desktop-settings-task-card desktop-settings-default-ai-section";
+  defaultAi.setAttribute("data-desktop-settings-page-section", "default-ai");
+  defaultAi.append(createSettingsSectionHeading(targetDocument, "Default AI", "Choose the provider and model used when a task has no explicit override.", "Auto routing"));
+  const defaultLayout = targetDocument.createElement("div");
+  defaultLayout.className = "desktop-settings-default-ai-layout";
+  const fields = targetDocument.createElement("div");
+  fields.className = "desktop-settings-field-pair";
   const provider = findSettingsPaneField(pane, "general", "provider");
   const model = findSettingsPaneField(pane, "general", "model");
-  if (provider) {
-    form.append(createSettingsControlField(targetDocument, pane, provider, "提供商", settingsActions));
+  if (provider) fields.append(createSettingsControlField(targetDocument, pane, provider, provider.label, settingsActions));
+  if (model) fields.append(createSettingsControlField(targetDocument, pane, model, model.label, settingsActions));
+  const resolved = targetDocument.createElement("aside");
+  resolved.className = "desktop-settings-status-card desktop-settings-resolved-route-card";
+  resolved.setAttribute("data-desktop-settings-auto-resolution", "");
+  resolved.append(
+    createText(targetDocument, "span", "Resolved route"),
+    createText(targetDocument, "strong", `${pane.defaultRouting?.providerLabel ?? provider?.inputValue ?? "Auto"} / ${pane.defaultRouting?.model ?? model?.inputValue ?? "Not configured"}`),
+  );
+  defaultLayout.append(fields, resolved);
+  defaultAi.append(defaultLayout, createText(targetDocument, "p", "Agents can still override this default per task."));
+
+  const profileLocale = targetDocument.createElement("section");
+  profileLocale.className = "desktop-settings-task-card desktop-settings-profile-locale-section";
+  profileLocale.setAttribute("data-desktop-settings-page-section", "profile-locale");
+  profileLocale.append(createSettingsSectionHeading(targetDocument, "Profile & locale", "Identity and time settings used throughout the desktop app."));
+  const localeFields = targetDocument.createElement("div");
+  localeFields.className = "desktop-settings-field-pair";
+  for (const id of ["activeProfile", "timezone"]) {
+    const field = findSettingsPaneField(pane, "general", id);
+    if (field) localeFields.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
   }
-  if (model) {
-    form.append(createSettingsControlField(targetDocument, pane, model, "模型", settingsActions));
+  const timezoneStatus = targetDocument.createElement("aside");
+  timezoneStatus.className = "desktop-settings-status-card desktop-settings-timezone-status";
+  timezoneStatus.append(createText(targetDocument, "strong", "Timezone is valid"), createText(targetDocument, "span", "Used for reminders and schedules."));
+  localeFields.append(timezoneStatus);
+  profileLocale.append(localeFields);
+
+  const responseDefaults = targetDocument.createElement("section");
+  responseDefaults.className = "desktop-settings-task-card desktop-settings-response-defaults-section";
+  responseDefaults.setAttribute("data-desktop-settings-page-section", "response-defaults");
+  responseDefaults.append(createSettingsSectionHeading(targetDocument, "Response defaults", "Balanced defaults for quality, speed, and context usage."));
+  const responseGrid = targetDocument.createElement("div");
+  responseGrid.className = "desktop-settings-response-grid";
+  for (const id of ["temperature", "maxTokens", "contextWindowTokens", "reasoningEffort", "maxToolIterations"]) {
+    const field = findSettingsPaneField(pane, "general", id);
+    if (field) responseGrid.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
+  }
+  responseGrid.append(createText(targetDocument, "aside", "Recommended baseline: Good for everyday desktop work."));
+  responseDefaults.append(responseGrid);
+
+  page.append(defaultAi, profileLocale, responseDefaults);
+  return page;
+}
+
+function createProviderModelsSettingsPage(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  group: DesktopSettingsPaneGroup,
+  settingsActions: DesktopSettingsActionOptions,
+): HTMLElement {
+  const page = targetDocument.createElement("div");
+  page.className = "desktop-settings-task-page desktop-settings-provider-page";
+  page.setAttribute("data-desktop-settings-task-page", "provider-models");
+  page.append(createProviderManagementSection(targetDocument, pane, settingsActions));
+
+  const selected = getProviderCards(pane).find((provider) => provider.id === pane.providerEditor.selectedProvider) ?? getProviderCards(pane)[0];
+  const detail = targetDocument.createElement("aside");
+  detail.className = "desktop-settings-task-card desktop-settings-provider-detail-panel";
+  detail.setAttribute("data-desktop-settings-provider-detail", selected?.id ?? "");
+  detail.append(createSettingsSectionHeading(targetDocument, `Edit ${selected?.label ?? pane.providerEditor.selectedProvider}`, "Changes apply to the selected profile.", selected?.statusLabel));
+
+  const connection = targetDocument.createElement("section");
+  connection.className = "desktop-settings-provider-detail-section";
+  connection.setAttribute("data-desktop-settings-provider-detail-section", "connection");
+  connection.append(createText(targetDocument, "h3", "Connection"));
+  for (const id of ["profileId", "apiKey", "apiBase"]) {
+    const field = findSettingsPaneField(pane, "provider-models", id);
+    if (field) connection.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
   }
 
-  const copy = createText(targetDocument, "p", "这里设置全局默认的 LLM 模型。你也可以在聊天页面为具体 Agent 单独选择使用的模型。");
-  copy.className = "desktop-settings-default-llm-copy";
+  const models = targetDocument.createElement("section");
+  models.className = "desktop-settings-provider-detail-section";
+  models.setAttribute("data-desktop-settings-provider-detail-section", "models");
+  models.append(createText(targetDocument, "h3", "Model catalog"));
+  const modelField = findSettingsPaneField(pane, "provider-models", "models");
+  if (modelField) models.append(createDesktopSettingsFieldRow(targetDocument, pane, group, modelField, settingsActions));
+  detail.append(connection, models);
 
-  card.append(heading, form, copy);
-  return card;
+  page.append(detail);
+  return page;
+}
+
+function createKnowledgeSettingsPage(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  group: DesktopSettingsPaneGroup,
+  settingsActions: DesktopSettingsActionOptions,
+): HTMLElement {
+  const page = targetDocument.createElement("div");
+  page.className = "desktop-settings-task-page desktop-settings-knowledge-page";
+  page.setAttribute("data-desktop-settings-task-page", "knowledge");
+
+  const toolbar = targetDocument.createElement("div");
+  toolbar.className = "desktop-settings-knowledge-toolbar";
+  const enabled = findSettingsPaneField(pane, "knowledge", "enabled");
+  const enabledLabel = targetDocument.createElement("label");
+  enabledLabel.className = "desktop-settings-knowledge-enabled";
+  enabledLabel.setAttribute("data-desktop-settings-knowledge-enabled", "");
+  enabledLabel.append(createText(targetDocument, "span", "Knowledge enabled"));
+  if (enabled) enabledLabel.append(createDesktopSettingsControl(targetDocument, pane, enabled, settingsActions));
+  const openDocuments = createText(targetDocument, "button", "Open documents");
+  openDocuments.setAttribute("type", "button");
+  openDocuments.setAttribute("data-desktop-settings-knowledge-action", "openDocuments");
+  openDocuments.addEventListener("click", () => settingsActions.onSettingsAction?.({ action: "openKnowledgeDocuments", pane }));
+  toolbar.append(enabledLabel, openDocuments);
+
+  const pipeline = targetDocument.createElement("section");
+  pipeline.className = "desktop-settings-task-card desktop-settings-knowledge-pipeline";
+  pipeline.setAttribute("data-desktop-settings-page-section", "knowledge-pipeline");
+  pipeline.append(createSettingsSectionHeading(targetDocument, "Knowledge pipeline", "Retrieval is available. Advanced enrichment remains optional.", "Ready"));
+  const stages = targetDocument.createElement("ol");
+  stages.className = "desktop-settings-knowledge-stages";
+  for (const stage of ["documents", "chunking", "embeddings", "retrieval", "rerank", "graph"]) {
+    const item = createText(targetDocument, "li", stage);
+    item.setAttribute("data-desktop-settings-knowledge-stage", stage);
+    stages.append(item);
+  }
+  pipeline.append(stages);
+
+  const retrieval = targetDocument.createElement("section");
+  retrieval.className = "desktop-settings-task-card desktop-settings-retrieval-defaults";
+  retrieval.setAttribute("data-desktop-settings-page-section", "retrieval-defaults");
+  retrieval.append(createSettingsSectionHeading(targetDocument, "Retrieval defaults", "The settings used when a chat requests knowledge."));
+  for (const id of ["autoRetrieve", "retrievalMode", "maxChunks"]) {
+    const field = findSettingsPaneField(pane, "knowledge", id);
+    if (field) retrieval.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
+  }
+
+  const presets = targetDocument.createElement("section");
+  presets.className = "desktop-settings-task-card desktop-settings-quality-presets";
+  presets.setAttribute("data-desktop-settings-page-section", "quality-presets");
+  presets.append(createSettingsSectionHeading(targetDocument, "Quality preset", "A shortcut mapped to existing settings."));
+  for (const preset of ["fast", "balanced", "deep"]) {
+    const button = createText(targetDocument, "button", preset);
+    button.setAttribute("type", "button");
+    button.setAttribute("data-desktop-settings-quality-preset", preset);
+    button.addEventListener("click", () => {
+      const deep = preset === "deep";
+      settingsActions.onSettingsAction?.({ action: "edit", pane, fieldId: "rerankEnabled", value: deep });
+      settingsActions.onSettingsAction?.({ action: "edit", pane, fieldId: "graphExtractionEnabled", value: deep });
+    });
+    presets.append(button);
+  }
+
+  const layers = targetDocument.createElement("section");
+  layers.className = "desktop-settings-task-card desktop-settings-quality-layers";
+  layers.setAttribute("data-desktop-settings-page-section", "quality-layers");
+  layers.append(createSettingsSectionHeading(targetDocument, "Indexing & quality layers", "Tune source preparation and optional quality improvements."));
+  for (const id of ["chunkSize", "chunkOverlap", "rerankEnabled", "rerankTopN", "graphExtractionEnabled", "graphExtractionModel"]) {
+    const field = findSettingsPaneField(pane, "knowledge", id);
+    if (field) layers.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
+  }
+
+  page.append(toolbar, pipeline, retrieval, presets, layers);
+  return page;
 }
 
 function createProviderManagementSection(
@@ -5351,15 +5523,21 @@ function createProviderManagementSection(
 
   const header = targetDocument.createElement("header");
   header.className = "desktop-settings-provider-header";
-  header.append(createText(targetDocument, "h2", "提供商"));
+  const title = targetDocument.createElement("div");
+  title.append(
+    createText(targetDocument, "h2", "Connected providers"),
+    createText(targetDocument, "p", "Select a card to edit its connection and models."),
+  );
+  title.querySelector("p")?.classList.add("desktop-settings-group-description");
 
   const tools = targetDocument.createElement("div");
   tools.className = "desktop-settings-provider-tools";
   const search = targetDocument.createElement("input");
   search.className = "desktop-settings-provider-search";
   search.setAttribute("type", "search");
-  search.setAttribute("placeholder", "搜索提供商...");
+  search.setAttribute("placeholder", "Search providers...");
   search.setAttribute("aria-label", "Search providers");
+  tools.append(search);
 
   const refresh = targetDocument.createElement("button");
   refresh.className = "desktop-settings-provider-icon-button";
@@ -5374,6 +5552,20 @@ function createProviderManagementSection(
     settingsActions.onSettingsAction?.({ action: "discoverModels", pane });
   });
 
+  const allProviders = getProviderCards(pane);
+  const readyCount = allProviders.filter((provider) => provider.connected || /ready|connected/i.test(provider.statusLabel)).length;
+  const modelCount = pane.providerCatalog.reduce((total, provider) => total + (provider.models?.length ?? 0), 0);
+  for (const [summary, label] of [
+    ["total", `${allProviders.length} ${allProviders.length === 1 ? "provider" : "providers"}`],
+    ["ready", `${readyCount} ready`],
+    ["models", `${modelCount} ${modelCount === 1 ? "model" : "models"}`],
+  ] as const) {
+    const chip = createText(targetDocument, "span", label);
+    chip.className = "desktop-settings-provider-summary";
+    chip.setAttribute("data-desktop-settings-provider-summary", summary);
+    tools.append(chip);
+  }
+
   const add = targetDocument.createElement("button");
   add.className = "desktop-settings-provider-add";
   add.setAttribute("type", "button");
@@ -5385,9 +5577,9 @@ function createProviderManagementSection(
       focusDesktopSettingsControl(targetDocument, "selectedProvider");
     }
   });
-  add.textContent = "+ 添加提供商";
-  tools.append(search, refresh, add);
-  header.append(tools);
+  add.textContent = "+ Add provider";
+  tools.append(refresh, add);
+  header.append(title, tools);
 
   const cards = targetDocument.createElement("div");
   cards.className = "desktop-settings-provider-grid";
@@ -5474,6 +5666,9 @@ function createProviderManagementCard(
   const card = targetDocument.createElement("article");
   card.className = "desktop-settings-provider-card";
   card.setAttribute("data-desktop-settings-provider-card", provider.id);
+  if (provider.badge) {
+    card.setAttribute("data-selected", "true");
+  }
 
   const header = targetDocument.createElement("header");
   header.className = "desktop-settings-provider-card-header";

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -847,7 +847,7 @@ function createWorkbenchShell(
   const inspectorState = hasInspectorContent(inspectorContent)
     ? layout.inspector
     : { ...layout.inspector, visible: false };
-  const activeModule = getDesktopActiveWorkbenchModule(targetDocument, settingsPane, knowledgePane, toolsSkillsPane, coworkPane);
+  const activeModule = getDesktopActiveWorkbenchModule(targetDocument);
   const sidebarState = activeModule === "chat"
     ? layout.sidebar
     : { ...layout.sidebar, visible: false };
@@ -872,28 +872,10 @@ function createWorkbenchShell(
   return shell;
 }
 
-function getDesktopActiveWorkbenchModule(
-  targetDocument: Document,
-  settingsPane: DesktopSettingsPaneModel | null,
-  knowledgePane: DesktopKnowledgePaneModel | null,
-  toolsSkillsPane: DesktopToolsSkillsPaneModel | null,
-  coworkPane: DesktopCoworkPaneModel | null,
-): string {
+function getDesktopActiveWorkbenchModule(targetDocument: Document): string {
   const routeModule = targetDocument.documentElement?.getAttribute("data-desktop-active-workbench-module")?.trim();
   if (routeModule) {
     return routeModule;
-  }
-  if (settingsPane) {
-    return "settings";
-  }
-  if (knowledgePane) {
-    return "knowledge";
-  }
-  if (toolsSkillsPane) {
-    return "tools";
-  }
-  if (coworkPane) {
-    return "cowork";
   }
   return "chat";
 }

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -47,6 +47,199 @@ const pane = buildDesktopSettingsPaneModel(draftState, {
 });
 
 describe("settings pane Vue island", () => {
+  test("renders redesigned General, Provider, and Knowledge task pages", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane,
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        if (event.action === "edit") {
+          actions.push(`${event.action}:${event.fieldId}:${String(event.value)}`);
+          return;
+        }
+        actions.push(event.action);
+      },
+    });
+    await nextTick();
+
+    expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("General");
+    expect(host.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Default AI");
+    expect(host.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("OpenAI / gpt-4.1");
+    expect(host.querySelector(".desktop-settings-profile-locale-section")?.textContent).toContain("Profile & locale");
+    expect(host.querySelector(".desktop-settings-profile-locale-section")?.textContent).toContain("Timezone");
+    expect(host.querySelector(".desktop-settings-response-defaults-section")?.textContent).toContain("Response defaults");
+    expect(host.querySelector(".desktop-settings-response-defaults-section")?.textContent).toContain("tokens");
+    expect(host.querySelector('[data-desktop-settings-group="general"]')).toBeNull();
+
+    host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]')?.click();
+    await nextTick();
+
+    expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Provider & Models");
+    expect(host.querySelector("[data-desktop-settings-provider-summary=\"total\"]")?.textContent).toContain("1 provider");
+    expect(host.querySelector("[data-desktop-settings-provider-summary=\"ready\"]")?.textContent).toContain("1 ready");
+    expect(host.querySelector("[data-desktop-settings-provider-summary=\"models\"]")?.textContent).toContain("2 models");
+    expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.getAttribute("data-selected")).toBe("true");
+    expect(host.querySelector(".desktop-settings-provider-detail-panel")?.textContent).toContain("Edit OpenAI");
+    expect(host.querySelector(".desktop-settings-provider-detail-panel")?.textContent).toContain("Connection");
+    expect(host.querySelector(".desktop-settings-provider-detail-panel")?.textContent).toContain("Model catalog");
+    expect(host.querySelector(".desktop-settings-provider-detail-panel [data-desktop-settings-control=\"apiKey\"]")?.getAttribute("type")).toBe("password");
+    expect(host.querySelector('[data-desktop-settings-group="provider-models"]')).toBeNull();
+
+    host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="knowledge"]')?.click();
+    await nextTick();
+
+    expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Knowledge");
+    expect(host.querySelector("[data-desktop-settings-knowledge-enabled]")?.textContent).toContain("Knowledge enabled");
+    expect(host.querySelector("[data-desktop-settings-knowledge-action=\"openDocuments\"]")?.textContent).toContain("Open documents");
+    expect(Array.from(
+      host.querySelectorAll("[data-desktop-settings-knowledge-stage]"),
+      (node) => node.getAttribute("data-desktop-settings-knowledge-stage"),
+    )).toEqual(["documents", "chunking", "embeddings", "retrieval", "rerank", "graph"]);
+    expect(host.querySelector("[data-desktop-settings-retrieval-mode=\"hybrid\"]")?.getAttribute("aria-pressed")).toBe("true");
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-quality-preset="deep"]')?.click();
+    expect(actions).toContain("edit:rerankEnabled:true");
+    expect(actions).toContain("edit:graphExtractionEnabled:true");
+    expect(host.querySelector('[data-desktop-settings-group="knowledge"]')).toBeNull();
+
+    mounted.unmount();
+  });
+
+  test("filters and selects provider cards while preserving selected detail state", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    const multiProviderCatalog = [
+      { id: "openai", displayName: "OpenAI", status: "ready", models: ["gpt-4.1", "gpt-4.1-mini"] },
+      { id: "anthropic", displayName: "Anthropic", status: "not_configured", models: ["claude-3-5-sonnet"] },
+    ];
+    const state = buildDesktopSettingsFormState({
+      agents: { defaults: { provider: "openai", model: "gpt-4.1", active_profile: "work" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-live",
+            api_base: "https://api.openai.com/v1",
+            models: ["gpt-4.1", "gpt-4.1-mini"],
+          },
+        },
+      },
+    }, multiProviderCatalog);
+    const multiPane = buildDesktopSettingsPaneModel(state, {
+      lastSavedState: state,
+      providerCatalog: multiProviderCatalog,
+    });
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: multiPane,
+      initialActiveGroupId: "provider-models",
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        if (event.action === "edit") {
+          actions.push(`${event.fieldId}:${String(event.value)}`);
+        }
+      },
+    });
+    await nextTick();
+
+    expect(host.querySelector("[data-desktop-settings-provider-summary=\"total\"]")?.textContent).toContain("2 providers");
+    expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.getAttribute("data-selected")).toBe("true");
+    expect(host.querySelector(".desktop-settings-provider-detail-panel")?.textContent).toContain("Edit OpenAI");
+
+    const search = host.querySelector<HTMLInputElement>(".desktop-settings-provider-search");
+    search!.value = "Anthropic";
+    search?.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')).toBeNull();
+    expect(host.querySelector('[data-desktop-settings-provider-card="anthropic"]')?.textContent).toContain("Anthropic");
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-provider-card="anthropic"] [data-desktop-settings-provider-action="settings"]')?.click();
+    expect(actions).toContain("selectedProvider:anthropic");
+    expect(host.querySelector(".desktop-settings-provider-detail-panel")?.textContent).toContain("Edit OpenAI");
+
+    mounted.unmount();
+  });
+
+  test("keeps Knowledge disabled fields visible and maps presets before manual overrides", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    const disabledState = buildDesktopSettingsFormState({
+      knowledge: {
+        enabled: false,
+        auto_retrieve: true,
+        retrieval_mode: "dense",
+        max_chunks: 4,
+        rerank_enabled: true,
+        graph_extraction_enabled: true,
+      },
+    }, providerCatalog);
+    const disabledPane = buildDesktopSettingsPaneModel(disabledState, {
+      lastSavedState: disabledState,
+      providerCatalog,
+    });
+
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: disabledPane,
+      initialActiveGroupId: "knowledge",
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        if (event.action === "edit") {
+          actions.push(`${event.fieldId}:${String(event.value)}`);
+        }
+      },
+    });
+    await nextTick();
+
+    expect(host.querySelector(".desktop-settings-knowledge-page")?.getAttribute("data-knowledge-disabled")).toBe("true");
+    expect(host.querySelector("[data-desktop-settings-knowledge-stage=\"retrieval\"]")?.getAttribute("data-state")).toBe("disabled");
+    expect(host.querySelector("[data-desktop-settings-knowledge-stage=\"rerank\"]")?.textContent).toContain("Enabled");
+    expect(host.querySelector<HTMLInputElement>('[data-desktop-settings-control="maxChunks"]')?.disabled).toBe(true);
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-settings-quality-preset="fast"]')?.click();
+    expect(actions).toEqual([
+      "maxChunks:3",
+      "retrievalMode:sparse",
+      "rerankEnabled:false",
+      "graphExtractionEnabled:false",
+    ]);
+
+    mounted.unmount();
+
+    const enabledHost = document.createElement("section");
+    const enabledActions: string[] = [];
+    const enabledState = buildDesktopSettingsFormState({
+      knowledge: {
+        enabled: true,
+        retrieval_mode: "sparse",
+        max_chunks: 3,
+      },
+    }, providerCatalog);
+    const enabledPane = buildDesktopSettingsPaneModel(enabledState, {
+      lastSavedState: enabledState,
+      providerCatalog,
+    });
+    const enabledMounted = mountSettingsPaneIsland(enabledHost, {
+      pane: enabledPane,
+      initialActiveGroupId: "knowledge",
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        if (event.action === "edit") {
+          enabledActions.push(`${event.fieldId}:${String(event.value)}`);
+        }
+      },
+    });
+    await nextTick();
+
+    enabledHost.querySelector<HTMLButtonElement>('[data-desktop-settings-quality-preset="deep"]')?.click();
+    enabledHost.querySelector<HTMLButtonElement>('[data-desktop-settings-retrieval-mode="sparse"]')?.click();
+    expect(enabledActions).toEqual([
+      "maxChunks:8",
+      "retrievalMode:hybrid",
+      "rerankEnabled:true",
+      "graphExtractionEnabled:true",
+      "retrievalMode:sparse",
+    ]);
+
+    enabledMounted.unmount();
+  });
+
   test("renders the provided initial settings section", async () => {
     const host = document.createElement("section");
 
@@ -56,7 +249,7 @@ describe("settings pane Vue island", () => {
     });
     await nextTick();
 
-    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Provider & Models");
+    expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Provider & Models");
     expect(host.querySelector('[data-desktop-settings-nav="provider-models"]')?.getAttribute("data-active")).toBe("true");
     expect(host.querySelector(".desktop-settings-provider-section")).not.toBeNull();
     expect(host.querySelector(".desktop-settings-default-llm-card")).toBeNull();
@@ -93,11 +286,11 @@ describe("settings pane Vue island", () => {
     expect(host.getAttribute("aria-label")).toBe("Settings and providers");
 
     expect(host.querySelector(".desktop-settings-sidebar")?.textContent).toContain("General");
-    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / General");
+    expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("General");
     expect(host.querySelector(".desktop-settings-capability-map")).toBeNull();
-    expect(host.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("Default LLM");
+    expect(host.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Default AI");
     expect(host.querySelector(".desktop-settings-provider-section")).toBeNull();
-    expect(host.querySelector(".desktop-settings-status-card")).toBeNull();
+    expect(host.querySelector(".desktop-settings-resolved-route-card")?.textContent).toContain("Resolved route");
     expect(Array.from(
       host.querySelectorAll(".desktop-settings-nav-heading"),
       (node) => node.textContent,
@@ -125,19 +318,19 @@ describe("settings pane Vue island", () => {
     expect(Array.from(
       host.querySelectorAll("[data-desktop-settings-group]"),
       (node) => node.getAttribute("data-desktop-settings-group"),
-    )).toEqual(["general"]);
+    )).toEqual([]);
     expect(host.querySelector('[data-desktop-settings-group="knowledge"]')).toBeNull();
     expect(host.querySelector('[data-desktop-settings-field="timezone"] .desktop-settings-field-meta')?.textContent).toContain("Required");
     expect(host.querySelector('[data-desktop-settings-field="timezone"] .desktop-settings-field-meta')?.textContent).toContain("Free text");
-    expect(host.querySelector('[data-desktop-settings-group="general"] details.desktop-settings-advanced-fields summary')?.textContent).toContain("Advanced");
-    expect(host.querySelector('[data-desktop-settings-field="temperature"]')?.closest("details")?.className).toContain("desktop-settings-advanced-fields");
+    expect(host.querySelector(".desktop-settings-response-defaults-section")?.textContent).toContain("Response defaults");
+    expect(host.querySelector('[data-desktop-settings-field="temperature"]')?.closest(".desktop-settings-response-defaults-section")).not.toBeNull();
 
     const navProvider = host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]');
     navProvider?.click();
     await nextTick();
-    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Provider & Models");
+    expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Provider & Models");
     expect(host.querySelector(".desktop-settings-default-llm-card")).toBeNull();
-    expect(host.querySelector(".desktop-settings-provider-section")?.textContent).toContain("Providers");
+    expect(host.querySelector(".desktop-settings-provider-section")?.textContent).toContain("Connected providers");
     expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
     expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("2 models");
     expect(host.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("Configured profile");
@@ -153,7 +346,7 @@ describe("settings pane Vue island", () => {
     const navFiles = host.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="files-workspace"]');
     navFiles?.click();
     await nextTick();
-    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Files & Workspace");
+    expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Files & Workspace");
     expect(Array.from(
       host.querySelectorAll("[data-desktop-settings-group]"),
       (node) => node.getAttribute("data-desktop-settings-group"),
@@ -253,8 +446,8 @@ describe("settings pane Vue island", () => {
     });
     await nextTick();
 
-    expect(host.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("Model-owned provider label");
-    expect(host.querySelector(".desktop-settings-default-llm-card")?.textContent).toContain("Model-owned default model label");
+    expect(host.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Model-owned provider label");
+    expect(host.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Model-owned default model label");
     expect(host.querySelector(".desktop-settings-header-description")?.textContent).toContain("Model-owned group description");
     expect(host.querySelector('[data-desktop-settings-field="timezone"] .desktop-settings-field-description')?.textContent).toContain("Model-owned timezone description");
     expect(host.querySelector('[data-desktop-settings-status="save"]')?.textContent).toContain("Model-owned dirty state");
@@ -448,7 +641,7 @@ describe("settings pane Vue island", () => {
     await nextTick();
 
     const workspace = host.querySelector<HTMLInputElement>('[data-desktop-settings-control="workspace"]');
-    expect(host.querySelector(".desktop-settings-breadcrumb")?.textContent).toContain("Settings / Files & Workspace");
+    expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Files & Workspace");
     expect(document.activeElement).toBe(workspace);
     expect(host.querySelector('[data-desktop-settings-field="workspace"]')?.getAttribute("data-highlighted")).toBe("true");
 
@@ -457,7 +650,7 @@ describe("settings pane Vue island", () => {
     await nextTick();
     host.querySelector<HTMLButtonElement>('[data-desktop-settings-search-result="general.temperature"]')?.click();
     await nextTick();
-    expect(host.querySelector('[data-desktop-settings-group="general"] details.desktop-settings-advanced-fields')?.hasAttribute("open")).toBe(true);
+    expect(host.querySelector(".desktop-settings-response-defaults-section")?.textContent).toContain("Temperature");
     expect(document.activeElement).toBe(host.querySelector('[data-desktop-settings-control="temperature"]'));
 
     search!.value = "sk-live";

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -190,7 +190,7 @@ function renderHeader(
   const activeGroup = getActiveSettingsGroup(pane, activeGroupId);
   return h("header", { class: "desktop-settings-header" }, [
     h("div", { class: "desktop-settings-breadcrumb" }, [
-      h("h2", `Settings / ${activeGroup?.label ?? "General"}`),
+      h("h2", activeGroup?.label ?? "General"),
       activeGroup ? h("p", { class: "desktop-settings-header-description" }, getSettingsGroupDescription(activeGroup)) : null,
     ]),
     h("div", { class: "desktop-settings-save-region" }, [
@@ -426,45 +426,339 @@ function renderActiveSettingsSection(
   providerSetup: ProviderSetupState,
 ) {
   const group = getActiveSettingsGroup(options.pane, activeGroupId);
-  const groupNode = group ? renderSettingsGroup(options, group, highlightedFieldId) : null;
   if (activeGroupId === "general") {
-    return [
-      renderDefaultLlmCard(options),
-      groupNode ? renderSingleSettingsGroup(groupNode) : null,
-    ];
+    return group ? renderGeneralSettingsPage(options, group, highlightedFieldId) : null;
   }
   if (activeGroupId === "provider-models") {
-    return [
-      renderProviderManagement(options, providerSearch, setProviderSearch, providerSetup),
-      groupNode ? renderSingleSettingsGroup(groupNode) : null,
-    ];
+    return group ? renderProviderModelsPage(options, group, highlightedFieldId, providerSearch, setProviderSearch, providerSetup) : null;
   }
+  if (activeGroupId === "knowledge") {
+    return group ? renderKnowledgeSettingsPage(options, group, highlightedFieldId) : null;
+  }
+  const groupNode = group ? renderSettingsGroup(options, group, highlightedFieldId) : null;
   return groupNode ? renderSingleSettingsGroup(groupNode) : null;
 }
 
-function renderDefaultLlmCard(options: SettingsPaneIslandOptions) {
-  const provider = findPaneField(options.pane, "general", "provider");
-  const model = findPaneField(options.pane, "general", "model");
-  return h("section", {
-    class: "desktop-settings-default-llm-card",
-    "aria-label": "Default LLM settings",
+function renderGeneralSettingsPage(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+  highlightedFieldId: string,
+) {
+  const field = (fieldId: string) => findPaneField(options.pane, "general", fieldId);
+  const provider = field("provider");
+  const model = field("model");
+  const activeProfile = field("activeProfile");
+  const timezone = field("timezone");
+  const temperature = field("temperature");
+  const maxTokens = field("maxTokens");
+  const contextWindowTokens = field("contextWindowTokens");
+  const reasoningEffort = field("reasoningEffort");
+  const maxToolIterations = field("maxToolIterations");
+  return h("div", {
+    class: "desktop-settings-task-page desktop-settings-general-page",
+    "data-desktop-settings-task-page": "general",
   }, [
-    h(NCard, { size: "small", bordered: false }, {
-      default: () => [
-        h("div", { class: "desktop-settings-card-heading" }, [
-          h("h2", "Default LLM"),
-        ]),
-        h("div", { class: "desktop-settings-default-llm-form" }, [
+    h("section", {
+      class: "desktop-settings-task-card desktop-settings-default-ai-section",
+      "data-desktop-settings-page-section": "default-ai",
+    }, [
+      renderSectionHeading("Default AI", "Choose the provider and model used when a task has no explicit override.", "Auto routing"),
+      h("div", { class: "desktop-settings-default-ai-layout" }, [
+        h("div", { class: "desktop-settings-field-pair" }, [
           provider ? renderInlineField(options, provider) : null,
           model ? renderInlineField(options, model) : null,
         ]),
-        options.pane.defaultRouting?.mode === "auto" ? h("p", {
-          class: "desktop-settings-auto-resolution",
-          "data-desktop-settings-auto-resolution": "",
-        }, options.pane.defaultRouting.message) : null,
-        h("p", { class: "desktop-settings-default-llm-copy" }, "Configure the global default LLM model. Individual agents can still choose a different model."),
-      ],
-    }),
+        renderResolvedRouteCard(options),
+      ]),
+      h("p", { class: "desktop-settings-supporting-copy" }, "Agents can still override this default per task."),
+    ]),
+    h("section", {
+      class: "desktop-settings-task-card desktop-settings-profile-locale-section",
+      "data-desktop-settings-page-section": "profile-locale",
+    }, [
+      renderSectionHeading("Profile & locale", "Identity and time settings used throughout the desktop app."),
+      h("div", { class: "desktop-settings-field-pair" }, [
+        activeProfile ? renderSettingsField(options, group, activeProfile, highlightedFieldId) : null,
+        timezone ? renderSettingsField(options, group, timezone, highlightedFieldId) : null,
+        renderTimezoneStatusCard(timezone),
+      ]),
+    ]),
+    h("section", {
+      class: "desktop-settings-task-card desktop-settings-response-defaults-section",
+      "data-desktop-settings-page-section": "response-defaults",
+    }, [
+      renderSectionHeading("Response defaults", "Balanced defaults for quality, speed, and context usage."),
+      h("div", { class: "desktop-settings-response-grid" }, [
+        temperature ? renderSettingsField(options, group, temperature, highlightedFieldId) : null,
+        maxTokens ? renderSettingsField(options, group, maxTokens, highlightedFieldId) : null,
+        contextWindowTokens ? renderSettingsField(options, group, contextWindowTokens, highlightedFieldId) : null,
+        reasoningEffort ? renderSettingsField(options, group, reasoningEffort, highlightedFieldId) : null,
+        maxToolIterations ? renderSettingsField(options, group, maxToolIterations, highlightedFieldId) : null,
+        h("aside", {
+          class: "desktop-settings-status-card desktop-settings-recommendation-card",
+          "data-desktop-settings-response-baseline": "",
+        }, [
+          h("strong", "Recommended baseline"),
+          h("span", "Good for everyday desktop work."),
+        ]),
+      ]),
+      h("details", { class: "desktop-settings-advanced-fields desktop-settings-response-advanced" }, [
+        h("summary", "Advanced defaults"),
+        h("p", "These values use the same saved settings fields and remain fully editable above."),
+      ]),
+    ]),
+  ]);
+}
+
+function renderResolvedRouteCard(options: SettingsPaneIslandOptions) {
+  const routing = options.pane.defaultRouting;
+  const provider = routing?.providerLabel || findPaneField(options.pane, "general", "provider")?.inputValue || "Auto";
+  const model = routing?.model || findPaneField(options.pane, "general", "model")?.inputValue || "Not configured";
+  const modelCount = getDefaultLlmModelOptions(options.pane).length;
+  return h("aside", {
+    class: "desktop-settings-status-card desktop-settings-resolved-route-card",
+    "data-desktop-settings-auto-resolution": "",
+  }, [
+    h("span", { class: "desktop-settings-eyebrow" }, "Resolved route"),
+    h("strong", `${provider} / ${model}`),
+    h("span", { class: "desktop-settings-status-line" }, routing?.message || `${modelCount} ${modelCount === 1 ? "model" : "models"} available`),
+  ]);
+}
+
+function renderSectionHeading(title: string, description: string, badge?: string) {
+  return h("header", { class: "desktop-settings-section-heading" }, [
+    h("div", [
+      h("h2", title),
+      h("p", description),
+    ]),
+    badge ? h("span", { class: "desktop-settings-section-badge" }, badge) : null,
+  ]);
+}
+
+function renderTimezoneStatusCard(timezone: DesktopSettingsPaneField | null) {
+  if (!timezone) {
+    return null;
+  }
+  const valid = timezone.state !== "invalid";
+  return h("aside", {
+    class: "desktop-settings-status-card desktop-settings-timezone-status",
+    "data-desktop-settings-timezone-status": valid ? "valid" : "invalid",
+  }, [
+    h("strong", valid ? "Timezone is valid" : "Timezone needs attention"),
+    h("span", "Used for reminders, schedules, and time display."),
+  ]);
+}
+
+function renderKnowledgeSettingsPage(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+  highlightedFieldId: string,
+) {
+  const field = (fieldId: string) => findPaneField(options.pane, "knowledge", fieldId);
+  const enabled = field("enabled");
+  const autoRetrieve = field("autoRetrieve");
+  const retrievalMode = field("retrievalMode");
+  const maxChunks = field("maxChunks");
+  const chunkSize = field("chunkSize");
+  const chunkOverlap = field("chunkOverlap");
+  const rerankEnabled = field("rerankEnabled");
+  const rerankTopN = field("rerankTopN");
+  const rerankModel = field("rerankModel");
+  const rerankApiBase = field("rerankApiBase");
+  const graphExtractionEnabled = field("graphExtractionEnabled");
+  const graphExtractionModel = field("graphExtractionModel");
+  const graphExtractionMaxTokens = field("graphExtractionMaxTokens");
+  const graphExtractionMaxJobTokens = field("graphExtractionMaxJobTokens");
+  const graphExtractionConcurrency = field("graphExtractionConcurrency");
+  const disabled = enabled?.checked === false;
+  return h("div", {
+    class: "desktop-settings-task-page desktop-settings-knowledge-page",
+    "data-desktop-settings-task-page": "knowledge",
+    "data-knowledge-disabled": disabled ? "true" : undefined,
+  }, [
+    h("div", { class: "desktop-settings-knowledge-toolbar" }, [
+      h("label", {
+        class: "desktop-settings-knowledge-enabled",
+        "data-desktop-settings-knowledge-enabled": "",
+      }, [
+        h("span", "Knowledge enabled"),
+        enabled ? renderSettingsControl(options, enabled) : null,
+      ]),
+      h(NButton, {
+        size: "small",
+        "data-desktop-settings-knowledge-action": "openDocuments",
+        onClick: () => options.onSettingsAction?.({ action: "openKnowledgeDocuments", pane: options.pane }),
+      }, { default: () => "Open documents" }),
+    ]),
+    h("section", {
+      class: "desktop-settings-task-card desktop-settings-knowledge-pipeline",
+      "data-desktop-settings-page-section": "knowledge-pipeline",
+    }, [
+      renderSectionHeading("Knowledge pipeline", "Retrieval is available. Advanced enrichment remains optional.", disabled ? "Disabled" : "Ready"),
+      h("ol", { class: "desktop-settings-knowledge-stages" }, getKnowledgePipelineStages(group).map((stage) => h("li", {
+        "data-desktop-settings-knowledge-stage": stage.id,
+        "data-state": stage.state,
+      }, [
+        h("span", { class: "desktop-settings-knowledge-stage-marker" }, stage.index),
+        h("strong", stage.label),
+        h("small", stage.detail),
+      ]))),
+    ]),
+    h("div", { class: "desktop-settings-knowledge-core-layout" }, [
+      h("section", {
+        class: "desktop-settings-task-card desktop-settings-retrieval-defaults",
+        "data-desktop-settings-page-section": "retrieval-defaults",
+      }, [
+        renderSectionHeading("Retrieval defaults", "The settings used when a chat requests knowledge."),
+        autoRetrieve ? renderSettingsField(options, group, autoRetrieve, highlightedFieldId) : null,
+        retrievalMode ? renderRetrievalModeControl(options, retrievalMode) : null,
+        maxChunks ? renderSettingsField(options, group, maxChunks, highlightedFieldId) : null,
+        h("p", { class: "desktop-settings-recommendation-note" }, "Hybrid is recommended for mixed docs and exact terms."),
+      ]),
+      h("section", {
+        class: "desktop-settings-task-card desktop-settings-quality-presets",
+        "data-desktop-settings-page-section": "quality-presets",
+      }, [
+        renderSectionHeading("Quality preset", "A shortcut mapped to existing settings."),
+        ...renderKnowledgePresetButtons(options),
+        h("p", { class: "desktop-settings-supporting-copy" }, "Presets only change visible fields; every value remains editable."),
+      ]),
+    ]),
+    h("section", {
+      class: "desktop-settings-task-card desktop-settings-quality-layers",
+      "data-desktop-settings-page-section": "quality-layers",
+    }, [
+      renderSectionHeading("Indexing & quality layers", "Tune source preparation and optional quality improvements."),
+      h("div", { class: "desktop-settings-quality-layer-grid" }, [
+        h("article", { class: "desktop-settings-quality-layer", "data-desktop-settings-quality-layer": "chunking" }, [
+          h("h3", "Chunking"),
+          chunkSize ? renderSettingsField(options, group, chunkSize, highlightedFieldId) : null,
+          chunkOverlap ? renderSettingsField(options, group, chunkOverlap, highlightedFieldId) : null,
+        ]),
+        h("article", { class: "desktop-settings-quality-layer", "data-desktop-settings-quality-layer": "reranking" }, [
+          h("h3", "Reranking"),
+          rerankEnabled ? renderSettingsField(options, group, rerankEnabled, highlightedFieldId) : null,
+          rerankTopN ? renderSettingsField(options, group, rerankTopN, highlightedFieldId) : null,
+          rerankModel ? renderSettingsField(options, group, rerankModel, highlightedFieldId) : null,
+          rerankApiBase ? renderSettingsField(options, group, rerankApiBase, highlightedFieldId) : null,
+        ]),
+        h("article", { class: "desktop-settings-quality-layer", "data-desktop-settings-quality-layer": "graph" }, [
+          h("h3", "Knowledge graph"),
+          graphExtractionEnabled ? renderSettingsField(options, group, graphExtractionEnabled, highlightedFieldId) : null,
+          graphExtractionModel ? renderSettingsField(options, group, graphExtractionModel, highlightedFieldId) : null,
+          graphExtractionMaxTokens ? renderSettingsField(options, group, graphExtractionMaxTokens, highlightedFieldId) : null,
+          graphExtractionMaxJobTokens ? renderSettingsField(options, group, graphExtractionMaxJobTokens, highlightedFieldId) : null,
+          graphExtractionConcurrency ? renderSettingsField(options, group, graphExtractionConcurrency, highlightedFieldId) : null,
+        ]),
+      ]),
+      h("details", { class: "desktop-settings-advanced-fields desktop-settings-knowledge-advanced" }, [
+        h("summary", "Advanced knowledge settings"),
+        h("p", "Advanced graph and reranking fields remain editable in the quality layer cards."),
+      ]),
+    ]),
+  ]);
+}
+
+function renderRetrievalModeControl(
+  options: SettingsPaneIslandOptions,
+  field: DesktopSettingsPaneField,
+) {
+  const modes = [
+    { value: "sparse", label: "Keyword" },
+    { value: "dense", label: "Semantic" },
+    { value: "hybrid", label: "Hybrid" },
+  ];
+  return h("div", {
+    class: "desktop-settings-segmented-control",
+    role: "group",
+    "aria-label": field.label,
+  }, modes.map((mode) => h("button", {
+    type: "button",
+    "data-desktop-settings-retrieval-mode": mode.value,
+    "aria-pressed": field.inputValue === mode.value ? "true" : "false",
+    disabled: field.disabled ? true : undefined,
+    onClick: () => emitEdit(options, field.id, mode.value),
+  }, mode.label)));
+}
+
+function renderKnowledgePresetButtons(options: SettingsPaneIslandOptions) {
+  const presets = [
+    { id: "fast", label: "Fast", detail: "No rerank - no graph" },
+    { id: "balanced", label: "Balanced", detail: "Hybrid - 5 chunks" },
+    { id: "deep", label: "Deep", detail: "Rerank - graph" },
+  ];
+  return presets.map((preset) => h("button", {
+    type: "button",
+    class: "desktop-settings-quality-preset",
+    "data-desktop-settings-quality-preset": preset.id,
+    onClick: () => applyKnowledgePreset(options, preset.id),
+  }, [
+    h("strong", preset.label),
+    h("span", preset.detail),
+  ]));
+}
+
+function applyKnowledgePreset(options: SettingsPaneIslandOptions, presetId: string): void {
+  const patches: Record<string, string | boolean> = presetId === "fast"
+    ? {
+        maxChunks: "3",
+        retrievalMode: "sparse",
+        rerankEnabled: false,
+        graphExtractionEnabled: false,
+      }
+    : presetId === "deep"
+      ? {
+          maxChunks: "8",
+          retrievalMode: "hybrid",
+          rerankEnabled: true,
+          graphExtractionEnabled: true,
+        }
+      : {
+          maxChunks: "5",
+          retrievalMode: "hybrid",
+          rerankEnabled: false,
+          graphExtractionEnabled: false,
+        };
+  for (const [fieldId, value] of Object.entries(patches)) {
+    emitEdit(options, fieldId, value);
+  }
+}
+
+function getKnowledgePipelineStages(group: DesktopSettingsPaneGroup): Array<{
+  id: string;
+  label: string;
+  detail: string;
+  state: "ready" | "optional" | "disabled";
+  index: string;
+}> {
+  const field = (fieldId: string) => group.fields.find((candidate) => candidate.id === fieldId);
+  const enabled = field("enabled")?.checked !== false;
+  const rerank = field("rerankEnabled")?.checked === true;
+  const graph = field("graphExtractionEnabled")?.checked === true;
+  return [
+    { id: "documents", label: "Documents", detail: "Available", state: enabled ? "ready" : "disabled", index: "1" },
+    { id: "chunking", label: "Chunking", detail: "Configured", state: enabled ? "ready" : "disabled", index: "2" },
+    { id: "embeddings", label: "Embeddings", detail: "Configured", state: enabled ? "ready" : "disabled", index: "3" },
+    { id: "retrieval", label: "Retrieval", detail: "Available", state: enabled ? "ready" : "disabled", index: "4" },
+    { id: "rerank", label: "Rerank", detail: rerank ? "Enabled" : "Optional", state: !enabled ? "disabled" : rerank ? "ready" : "optional", index: "5" },
+    { id: "graph", label: "Graph", detail: graph ? "Enabled" : "Optional", state: !enabled ? "disabled" : graph ? "ready" : "optional", index: "6" },
+  ];
+}
+
+function renderProviderModelsPage(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+  highlightedFieldId: string,
+  searchQuery: string,
+  updateSearchQuery: (value: string) => void,
+  providerSetup: ProviderSetupState,
+) {
+  return h("div", {
+    class: "desktop-settings-task-page desktop-settings-provider-page",
+    "data-desktop-settings-task-page": "provider-models",
+  }, [
+    renderProviderManagement(options, searchQuery, updateSearchQuery, providerSetup),
+    renderProviderDetailPanel(options, group, highlightedFieldId),
   ]);
 }
 
@@ -475,12 +769,18 @@ function renderProviderManagement(
   providerSetup: ProviderSetupState,
 ) {
   const cards = getProviderCards(options.pane).filter((provider) => !shouldHideProviderCard(provider, searchQuery));
+  const allCards = getProviderCards(options.pane);
+  const readyCount = allCards.filter((provider) => provider.connected || /ready|connected/i.test(provider.statusLabel)).length;
+  const modelCount = options.pane.providerCatalog.reduce((total, provider) => total + (provider.models?.length ?? 0), 0);
   return h("section", {
     class: "desktop-settings-provider-section",
     "aria-label": "Provider management",
   }, [
     h("header", { class: "desktop-settings-provider-header" }, [
-      h("h2", "Providers"),
+      h("div", [
+        h("h2", "Connected providers"),
+        h("p", { class: "desktop-settings-group-description" }, "Select a card to edit its connection and models."),
+      ]),
       h("div", { class: "desktop-settings-provider-tools" }, [
         h("input", {
           class: "desktop-settings-provider-search",
@@ -490,6 +790,18 @@ function renderProviderManagement(
           "aria-label": "Search providers",
           onInput: (event: Event) => updateSearchQuery(String((event.target as HTMLInputElement | null)?.value ?? "")),
         }),
+        h("span", {
+          class: "desktop-settings-provider-summary",
+          "data-desktop-settings-provider-summary": "total",
+        }, `${allCards.length} ${allCards.length === 1 ? "provider" : "providers"}`),
+        h("span", {
+          class: "desktop-settings-provider-summary",
+          "data-desktop-settings-provider-summary": "ready",
+        }, `${readyCount} ready`),
+        h("span", {
+          class: "desktop-settings-provider-summary",
+          "data-desktop-settings-provider-summary": "models",
+        }, `${modelCount} ${modelCount === 1 ? "model" : "models"}`),
         h(NButton, {
           class: "desktop-settings-provider-icon-button",
           type: "default",
@@ -512,6 +824,63 @@ function renderProviderManagement(
     ]),
     providerSetup.open ? renderProviderSetup(options, providerSetup) : null,
     h("div", { class: "desktop-settings-provider-grid" }, cards.map((provider) => renderProviderCard(options, provider))),
+  ]);
+}
+
+function renderProviderDetailPanel(
+  options: SettingsPaneIslandOptions,
+  group: DesktopSettingsPaneGroup,
+  highlightedFieldId: string,
+) {
+  const selected = getProviderCards(options.pane).find((provider) => provider.id === options.pane.providerEditor.selectedProvider)
+    ?? getProviderCards(options.pane)[0];
+  const profileId = findPaneField(options.pane, "provider-models", "profileId");
+  const apiKey = findPaneField(options.pane, "provider-models", "apiKey");
+  const apiBase = findPaneField(options.pane, "provider-models", "apiBase");
+  const models = findPaneField(options.pane, "provider-models", "models");
+  return h("aside", {
+    class: "desktop-settings-task-card desktop-settings-provider-detail-panel",
+    "data-desktop-settings-provider-detail": selected?.id ?? "",
+  }, [
+    h("header", { class: "desktop-settings-provider-detail-header" }, [
+      h("div", [
+        h("h2", `Edit ${selected?.label ?? options.pane.providerEditor.selectedProvider}`),
+        h("p", { class: "desktop-settings-group-description" }, "Changes apply to the selected profile."),
+      ]),
+      h(NTag, { size: "small", round: true, type: selected?.statusTone ?? "default" }, { default: () => selected?.statusLabel ?? "Unknown" }),
+    ]),
+    h("section", {
+      class: "desktop-settings-provider-detail-section",
+      "data-desktop-settings-provider-detail-section": "connection",
+    }, [
+      h("h3", "Connection"),
+      profileId ? renderSettingsField(options, group, profileId, highlightedFieldId) : null,
+      apiKey ? renderSettingsField(options, group, apiKey, highlightedFieldId) : null,
+      apiBase ? renderSettingsField(options, group, apiBase, highlightedFieldId) : null,
+      h("div", { class: "desktop-settings-status-card" }, [
+        h("strong", selected?.connected ? "Connection healthy" : "Connection needs attention"),
+        h("span", selected?.baseUrl ?? "No endpoint configured"),
+      ]),
+    ]),
+    h("section", {
+      class: "desktop-settings-provider-detail-section",
+      "data-desktop-settings-provider-detail-section": "models",
+    }, [
+      h("h3", "Model catalog"),
+      models ? renderSettingsField(options, group, models, highlightedFieldId) : null,
+      h("div", { class: "desktop-settings-provider-model-list" }, options.pane.providerEditor.models.map((model) => h("span", {
+        "data-desktop-settings-provider-model": model,
+      }, model))),
+      h(NButton, {
+        size: "small",
+        "data-desktop-settings-provider-action": "testConnection",
+        onClick: () => options.onSettingsAction?.({
+          action: "testProviderConnection",
+          pane: options.pane,
+          providerId: options.pane.providerEditor.selectedProvider,
+        }),
+      }, { default: () => "Test connection" }),
+    ]),
   ]);
 }
 
@@ -583,6 +952,7 @@ function renderProviderCard(
   return h(NCard, {
     class: "desktop-settings-provider-card",
     "data-desktop-settings-provider-card": provider.id,
+    "data-selected": provider.badge ? "true" : undefined,
     size: "small",
     bordered: false,
   }, {

--- a/webui/assets/styles/components/desktop-settings.css
+++ b/webui/assets/styles/components/desktop-settings.css
@@ -7,6 +7,7 @@
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-workbench-main .desktop-utility-surfaces {
   padding: clamp(16px, 2.5vw, 32px);
+  overflow-x: hidden;
   scroll-padding-top: 88px;
   scrollbar-gutter: stable;
 }
@@ -14,8 +15,9 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane {
   grid-template-columns: minmax(216px, 252px) minmax(0, 1fr);
   gap: clamp(24px, 3vw, 40px);
-  width: min(100%, 1320px);
-  max-width: 1320px;
+  width: 100%;
+  max-width: min(100%, 1320px);
+  min-width: 0;
   padding: 4px 0 48px;
 }
 
@@ -240,6 +242,7 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-content {
   gap: 20px;
+  min-width: 0;
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-header {
@@ -333,6 +336,7 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-llm-card,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-task-card,
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-group,
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-card,
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-setup {
@@ -346,6 +350,93 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
   padding: clamp(20px, 2.5vw, 28px);
 }
 
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-task-page {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-task-card {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+  overflow: hidden;
+  padding: clamp(18px, 2.2vw, 26px);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-section-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-section-heading h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 18px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-section-heading p,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-supporting-copy,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-recommendation-note {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-section-badge,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-summary {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
+  border-radius: var(--radius-full);
+  padding: 0 10px;
+  background: var(--accent-soft);
+  color: var(--text);
+  font: 700 11px/1.2 var(--font-sans);
+  white-space: nowrap;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-ai-layout,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-response-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 0.48fr);
+  gap: 16px;
+  align-items: stretch;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field-pair {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 16px;
+  align-items: stretch;
+  min-width: 0;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-ai-layout > .desktop-settings-field-pair {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 180px), 1fr));
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-response-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-status-card {
+  display: grid;
+  align-content: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-status-card span {
+  color: var(--text-muted);
+}
+
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-default-llm-form {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
@@ -356,12 +447,21 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
   color: var(--text);
 }
 
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-inline-field {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  min-width: 0;
+}
+
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-inline-field select,
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-inline-field input,
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field input,
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field select,
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field textarea,
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail input {
+  width: 100%;
+  min-width: 0;
   border-color: var(--border);
   background: var(--bg);
   color: var(--text);
@@ -372,8 +472,13 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-tools {
-  grid-template-columns: minmax(180px, 1fr) auto auto;
+  grid-template-columns: minmax(180px, 1fr) auto auto auto auto auto;
   min-width: min(520px, 100%);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-page {
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.44fr);
+  align-items: start;
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-grid {
@@ -384,6 +489,11 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-card {
   min-height: 0;
   transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-card[data-selected="true"] {
+  border-color: color-mix(in srgb, var(--accent) 54%, var(--border));
+  box-shadow: inset 4px 0 0 var(--accent), var(--shadow-sm);
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-card:hover {
@@ -410,6 +520,140 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
   background: var(--bg);
 }
 
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail-panel {
+  position: sticky;
+  top: 88px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail-header,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-knowledge-toolbar,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-knowledge-enabled {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail-section {
+  display: grid;
+  gap: 10px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-model-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-model-list span {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 3px 8px;
+  background: var(--surface-soft);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-knowledge-core-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.36fr);
+  gap: 16px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-knowledge-stages {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-knowledge-stages li {
+  display: grid;
+  gap: 5px;
+  justify-items: center;
+  min-width: 0;
+  border-top: 3px solid var(--border);
+  padding-top: 10px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-knowledge-stages li[data-state="ready"] {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-knowledge-stage-marker {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-full);
+  background: var(--surface-soft);
+  color: var(--text);
+  font-weight: 800;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-segmented-control {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 3px;
+  background: var(--surface-soft);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-segmented-control button,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-quality-preset {
+  min-height: 40px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-segmented-control button[aria-pressed="true"],
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-quality-preset:hover,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-quality-preset:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
+  background: var(--bg);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-quality-preset {
+  display: grid;
+  justify-items: start;
+  width: 100%;
+  border-color: var(--border);
+  padding: 10px 12px;
+  background: var(--surface-soft);
+  text-align: left;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-quality-preset span {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-quality-layer-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-quality-layer {
+  display: grid;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 14px;
+  background: var(--surface-soft);
+}
+
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-group {
   overflow: clip;
 }
@@ -417,11 +661,36 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field {
   grid-template-columns: minmax(0, 1fr) minmax(240px, 360px);
   gap: clamp(18px, 2.5vw, 32px);
+  min-width: 0;
   min-height: 72px;
   border-top-color: var(--border-subtle);
   padding: 16px 18px;
   scroll-margin-top: 96px;
   transition: background-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-task-card .desktop-settings-field,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-quality-layer .desktop-settings-field,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail-panel .desktop-settings-field {
+  grid-template-columns: 1fr;
+  gap: 10px;
+  border-top: 1px solid var(--border-subtle);
+  padding: 12px 0;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field-copy {
+  min-width: 0;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-task-card .desktop-settings-field-description,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail-panel .desktop-settings-field-description {
+  display: block;
+  margin-top: 4px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-secret-controls,
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field-error {
+  grid-column: 1 / -1;
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-field[data-highlighted="true"] {


### PR DESCRIPTION
## Summary
- redesign native desktop settings pages for the new section-based settings experience
- hide the secondary chat sidebar by default outside Chat pages
- update the LICENSE copyright holder to SudoJacky

## Verification
- npm test -- src/desktopWorkbenchShell.test.ts src/desktopWorkbenchShell.settingsRenderer.test.ts src/native-vue/settingsPaneIsland.test.ts src/desktopSettingsExperience.test.ts
- npm run build