### PR TITLE
Fix desktop settings provider model UX

### DIFF
--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -85,6 +85,7 @@ import {
 } from "./desktopToolsSkills";
 import {
   installDesktopWorkbenchShell,
+  syncDesktopWorkbenchRouteSidebar,
   updateDesktopGatewayRuntimeStatus,
   updateDesktopAgentUiForms,
   updateDesktopCoworkPane,
@@ -1085,7 +1086,17 @@ function installNativeChatRuntimeActions(): void {
     logDesktopNativeDebug("route.request", {
       path,
     });
-    applyDesktopWorkbenchRouteState(document, path);
+    const activeModule = applyDesktopWorkbenchRouteState(document, path);
+    syncDesktopWorkbenchRouteSidebar(document, activeModule, {
+      chat: nativeWorkbenchRuntime?.chat ?? null,
+      chatActions: nativeChatActions(),
+      settingsPane: currentNativeSettingsPane(),
+      settingsActions: {
+        onSettingsAction: (nextEvent) => {
+          void handleNativeSettingsAction(nextEvent);
+        },
+      },
+    });
     if (path === "/chat/new") {
       nativeChatActions().onNewChat();
       return;
@@ -2166,7 +2177,9 @@ async function handleNativeSettingsAction(event: DesktopSettingsActionEvent): Pr
     await saveNativeSettingsPane();
     return;
   }
-  await refreshNativeProviderModels();
+  if (event.action === "discoverModels") {
+    await refreshNativeProviderModels(event.providerId);
+  }
 }
 
 async function retryLoadNativeSettingsPane(): Promise<void> {
@@ -2244,10 +2257,16 @@ async function saveNativeSettingsPane(): Promise<void> {
   }
 }
 
-async function refreshNativeProviderModels(): Promise<void> {
+async function refreshNativeProviderModels(providerId?: string): Promise<void> {
   if (!nativeSettingsState) {
     logDesktopNativeDebug("settings.providerModels.skipped", { reason: "state unavailable" });
     return;
+  }
+  const nextProviderId = providerId?.trim();
+  if (nextProviderId && nextProviderId !== nativeSettingsState.providerEditor.selectedProvider) {
+    saveDesktopSettingsLocalPreferences({ providerEditorSelectedProvider: nextProviderId });
+    nativeSettingsState = applyDesktopSettingsFieldEdit(nativeSettingsState, "selectedProvider", nextProviderId);
+    updateNativeSettingsPane("idle");
   }
   const request = buildDesktopProviderModelRequest(nativeSettingsState);
   logDesktopNativeDebug("settings.providerModels.start", {
@@ -2319,6 +2338,17 @@ function updateNativeSettingsPane(
     },
   });
   syncNativeRuntimeMetadata();
+}
+
+function currentNativeSettingsPane(): DesktopSettingsPaneModel | null {
+  if (!nativeSettingsState) {
+    return null;
+  }
+  return buildDesktopSettingsPaneModel(nativeSettingsState, {
+    lastSavedState: nativeSettingsLastSavedState,
+    providerCatalog: nativeSettingsProviderCatalog,
+    saveStatus: "idle",
+  });
 }
 
 function buildNativeSettingsPaneSaveDetails(saveResult: DesktopSettingsSaveResult): DesktopSettingsPaneSaveDetails {

--- a/apps/desktop/src/desktopSettingsExperience.test.ts
+++ b/apps/desktop/src/desktopSettingsExperience.test.ts
@@ -27,17 +27,32 @@ describe("desktop settings experience stylesheet", () => {
   });
 
   test("adapts the settings layout for compact desktop windows", () => {
+    const workbenchSettingsSidebarRule = desktopSettingsCss.match(
+      /\.desktop-workbench-sidebar \.desktop-settings-sidebar \{[\s\S]*?\}/,
+    )?.[0] ?? "";
+
     expect(desktopSettingsCss).toContain("@media (max-width: 1040px)");
     expect(desktopSettingsCss).toContain("@media (max-width: 760px)");
     expect(desktopSettingsCss).toContain("@media (max-width: 520px)");
+    expect(desktopSettingsCss).toContain(".desktop-settings-pane {\n  grid-template-columns: minmax(0, 1fr);");
+    expect(desktopSettingsCss).not.toContain("grid-template-columns: minmax(216px, 252px) minmax(0, 1fr)");
+    expect(desktopSettingsCss).toContain(".desktop-workbench-sidebar .desktop-settings-sidebar");
+    expect(workbenchSettingsSidebarRule).toContain("min-height: 100%");
+    expect(workbenchSettingsSidebarRule).toContain("overflow: visible");
     expect(desktopSettingsCss).toContain("grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr))");
     expect(desktopSettingsCss).toContain("grid-template-columns: 1fr");
   });
 
   test("styles the redesigned settings task pages and quality layers", () => {
+    const providerDetailPanelRule = desktopSettingsCss.match(
+      /\.desktop-settings-provider-detail-panel \{[\s\S]*?\}/,
+    )?.[0] ?? "";
+
     expect(desktopSettingsCss).toContain(".desktop-settings-task-page");
     expect(desktopSettingsCss).toContain(".desktop-settings-provider-page");
     expect(desktopSettingsCss).toContain(".desktop-settings-provider-detail-panel");
+    expect(providerDetailPanelRule).toContain("max-height:");
+    expect(providerDetailPanelRule).toContain("overflow-y: auto");
     expect(desktopSettingsCss).toContain(".desktop-settings-knowledge-stages");
     expect(desktopSettingsCss).toContain(".desktop-settings-quality-layer-grid");
     expect(desktopSettingsCss).toContain(".desktop-settings-segmented-control");

--- a/apps/desktop/src/desktopSettingsProviders.test.ts
+++ b/apps/desktop/src/desktopSettingsProviders.test.ts
@@ -189,8 +189,8 @@ describe("desktop settings and provider helpers", () => {
     ]);
   });
 
-  test("accepts UTC, GMT, and IANA timezone defaults while rejecting invalid timezone values", () => {
-    for (const timezone of ["UTC", "GMT", "Asia/Shanghai"]) {
+  test("accepts UTC, GMT, offset aliases, and IANA timezone defaults while rejecting invalid timezone values", () => {
+    for (const timezone of ["UTC", "GMT", "UTC+8", "UTC-05:30", "Asia/Shanghai"]) {
       const state = buildDesktopSettingsFormState({
         agents: { defaults: { model: "gpt-4.1", timezone } },
       });

--- a/apps/desktop/src/desktopSettingsProviders.ts
+++ b/apps/desktop/src/desktopSettingsProviders.ts
@@ -1605,6 +1605,9 @@ export function validateDesktopTimezone(value: string): boolean {
   if (!timezone) {
     return false;
   }
+  if (/^(?:UTC|GMT)[+-](?:[0-9]|0[0-9]|1[0-4])(?::[0-5][0-9])?$/i.test(timezone)) {
+    return true;
+  }
   if (["UTC", "GMT"].includes(timezone)) {
     return true;
   }

--- a/apps/desktop/src/desktopWorkbenchShell.settingsRenderer.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.settingsRenderer.test.ts
@@ -74,6 +74,7 @@ describe("desktop settings renderer ownership", () => {
 
       document.body.replaceChildren();
       document.head.replaceChildren();
+      document.documentElement.setAttribute("data-desktop-active-workbench-module", "settings");
       const state = buildDesktopSettingsFormState({
         agents: { defaults: { model: "gpt-4.1-mini", provider: "openai", active_profile: "work", timezone: "Asia/Shanghai" } },
         providers: { profiles: { work: { provider: "openai", api_key: "sk-live", models: ["gpt-4.1-mini"] } } },
@@ -91,15 +92,19 @@ describe("desktop settings renderer ownership", () => {
       });
 
       const settingsPane = document.querySelector(".desktop-settings-pane");
+      const settingsSidebar = document.querySelector(".desktop-workbench-sidebar .desktop-settings-sidebar");
       expect(settingsPane?.getAttribute("data-desktop-vue-island")).toBeNull();
+      expect(settingsPane?.querySelector(".desktop-settings-sidebar")).toBeNull();
+      expect(settingsSidebar?.querySelector('[data-desktop-settings-nav="general"]')?.getAttribute("data-active")).toBe("true");
       expect(settingsPane?.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("General");
       expect(settingsPane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Default AI");
 
-      settingsPane?.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]')?.click();
+      settingsSidebar?.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]')?.click();
       expect(settingsPane?.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Provider & Models");
+      expect(settingsSidebar?.querySelector('[data-desktop-settings-nav="provider-models"]')?.getAttribute("data-active")).toBe("true");
       expect(settingsPane?.querySelector(".desktop-settings-provider-detail-panel")?.textContent).toContain("Edit OpenAI");
 
-      settingsPane?.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="knowledge"]')?.click();
+      settingsSidebar?.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="knowledge"]')?.click();
       expect(settingsPane?.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Knowledge");
       expect(Array.from(
         settingsPane?.querySelectorAll("[data-desktop-settings-knowledge-stage]") ?? [],

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -9,6 +9,7 @@ import { buildDesktopWorkLensProjection } from "./desktopWorkLens";
 import { createDefaultWorkbenchLayout } from "./desktopWorkbenchLayout";
 import {
   installDesktopWorkbenchShell,
+  syncDesktopWorkbenchRouteSidebar,
   updateDesktopGatewayRuntimeStatus,
   updateDesktopKnowledgePane,
   updateDesktopNativeChat,
@@ -993,6 +994,11 @@ describe("desktop workbench shell", () => {
     expect(sidebarStyle).toContain("overflow-y: auto;");
     expect(sidebarStyle).toContain(".desktop-sidebar-list-section-recent");
     expect(sidebarStyle).toContain("max-height: min(42vh, 360px)");
+    const workbenchSettingsSidebarRule = sidebarStyle.match(
+      /body\.desktop-native-workbench \.desktop-workbench-sidebar \.desktop-settings-sidebar \{[\s\S]*?\}/,
+    )?.[0] ?? "";
+    expect(workbenchSettingsSidebarRule).toContain("min-height: 100%;");
+    expect(workbenchSettingsSidebarRule).toContain("overflow: visible;");
 
     const chatHeader = targetDocument.body.querySelector(".desktop-chat-header");
     const conversationThread = targetDocument.body.querySelector(".desktop-conversation-thread");
@@ -2687,6 +2693,7 @@ describe("desktop workbench shell", () => {
 
   test("renders grouped settings and providers pane state in the desktop workbench", () => {
     const targetDocument = new FakeDocument();
+    targetDocument.documentElement.setAttribute("data-desktop-active-workbench-module", "settings");
     const settingsActions: string[] = [];
     (targetDocument as unknown as { defaultView: { prompt: () => string } }).defaultView = {
       prompt: () => "custom-openai",
@@ -2834,16 +2841,25 @@ describe("desktop workbench shell", () => {
             settingsActions.push(`${event.action}:${event.fieldId}:${String(event.value)}`);
             return;
           }
+          if (event.action === "discoverModels") {
+            settingsActions.push(`${event.action}:${event.providerId ?? ""}`);
+            return;
+          }
           settingsActions.push(event.action);
         },
       },
     });
 
     const pane = targetDocument.body.querySelector(".desktop-settings-pane");
+    const settingsSidebar = targetDocument.body.querySelector(".desktop-settings-sidebar");
+    const clickSettingsNav = (groupId: string) => {
+      targetDocument.body.querySelector(`[data-desktop-settings-nav="${groupId}"]`)?.click();
+    };
     expect(pane?.getAttribute("aria-label")).toBe("Settings and providers");
     expect(pane?.getAttribute("data-settings-layout")).toBe("section-pages");
-    expect(pane?.querySelector(".desktop-settings-search")?.getAttribute("placeholder")).toBe("Search settings...");
-    expect(pane?.querySelectorAll(".desktop-settings-nav-item").map((item) => item.textContent)).toEqual([
+    expect(pane?.querySelector(".desktop-settings-sidebar")).toBeNull();
+    expect(settingsSidebar?.querySelector(".desktop-settings-search")?.getAttribute("placeholder")).toBe("Search settings...");
+    expect(settingsSidebar?.querySelectorAll(".desktop-settings-nav-item").map((item) => item.textContent)).toEqual([
       "General",
       "Provider & Models",
       "Knowledge",
@@ -2856,14 +2872,14 @@ describe("desktop workbench shell", () => {
       "Gateway & Runtime",
       "Logs & Diagnostics",
     ]);
-    expect(pane?.querySelector(".desktop-settings-nav-item")?.getAttribute("data-active")).toBe("true");
+    expect(settingsSidebar?.querySelector(".desktop-settings-nav-item")?.getAttribute("data-active")).toBe("true");
     expect(pane?.querySelector(".desktop-settings-content")?.textContent).toContain("General");
     expect(pane?.querySelector(".desktop-settings-capability-map")).toBeNull();
     expect(pane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Default AI");
     expect(pane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Provider");
     expect(pane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Model");
     expect(pane?.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Resolved route");
-    pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
+    clickSettingsNav("provider-models");
     expect(pane?.querySelector(".desktop-settings-provider-section")?.textContent).toContain("Connected providers");
     expect(pane?.querySelector(".desktop-settings-provider-search")?.getAttribute("placeholder")).toBe("Search providers...");
     expect(pane?.querySelector('[data-desktop-settings-action="addProvider"]')?.textContent).toBe("+ Add provider");
@@ -2873,6 +2889,7 @@ describe("desktop workbench shell", () => {
     expect(pane?.querySelector(".desktop-settings-provider-card")?.textContent).toContain("Model: gpt-4.1, gpt-4.1-mini");
     expect(pane?.querySelector('[data-desktop-settings-provider-card="deepseek"]')?.textContent).toContain("Base URL: https://api.deepseek.com");
     expect(pane?.querySelector('[data-desktop-settings-provider-card="deepseek"]')?.textContent).toContain("Model: deepseek-chat");
+    expect(pane?.querySelector('[data-desktop-settings-provider-action="autoFetchModels"]')?.textContent).toContain("Auto fetch models");
     expect(pane?.querySelectorAll(".desktop-settings-provider-card").map((card) => card.getAttribute("data-desktop-settings-provider-card"))).toEqual([
       "openai",
       "deepseek",
@@ -2883,11 +2900,14 @@ describe("desktop workbench shell", () => {
     providerSave?.click();
     expect(settingsActions).toEqual(["save"]);
     settingsActions.length = 0;
-    pane?.querySelector('[data-desktop-settings-nav="general"]')?.click();
+    clickSettingsNav("general");
     expect(pane?.querySelector('[data-desktop-settings-group="general"]')).toBeNull();
     expect(pane?.textContent).toContain("General");
     expect(pane?.querySelector('[data-desktop-settings-control="model"]')?.tagName).toBe("select");
     expect(pane?.querySelector(".desktop-settings-resolved-route-card")?.textContent).toContain("Resolved route");
+    expect(pane?.querySelector(".desktop-settings-profile-locale-section")?.textContent).toContain("Locale");
+    expect(pane?.querySelector(".desktop-settings-profile-locale-section [data-desktop-settings-field=\"activeProfile\"]")).toBeNull();
+    expect(pane?.querySelector(".desktop-settings-profile-locale-section .desktop-settings-timezone-status")).toBeNull();
     expect(pane?.textContent).not.toContain("Save: HTTP 400");
     expect(pane?.textContent).not.toContain("Catalog: OpenAI (ready)");
     expect(pane?.textContent).not.toContain("Open docs");
@@ -2901,29 +2921,29 @@ describe("desktop workbench shell", () => {
     modelInput!.value = "gpt-4.1";
     modelInput?.dispatchEvent({ type: "change", target: modelInput });
 
-    pane?.querySelector('[data-desktop-settings-nav="knowledge"]')?.click();
+    clickSettingsNav("knowledge");
     expect(pane?.querySelector('[data-desktop-settings-control="enabled"]')?.checked).toBe(true);
     const knowledgeToggle = pane?.querySelector('[data-desktop-settings-control="enabled"]');
     knowledgeToggle!.checked = false;
     knowledgeToggle?.dispatchEvent({ type: "change", target: knowledgeToggle });
 
-    pane?.querySelector('[data-desktop-settings-nav="tools-approvals"]')?.click();
+    clickSettingsNav("tools-approvals");
     expect(pane?.querySelector('[data-desktop-settings-control="mcpServers"]')?.tagName).toBe("textarea");
 
-    pane?.querySelector('[data-desktop-settings-nav="general"]')?.click();
+    clickSettingsNav("general");
     pane?.querySelector('[data-desktop-settings-action="save"]')?.click();
-    pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
+    clickSettingsNav("provider-models");
     expect(pane?.querySelector('[data-desktop-settings-action="discoverModels"]')?.textContent).toBe("Refresh models");
     pane?.querySelector('[data-desktop-settings-action="discoverModels"]')?.click();
-    expect(settingsActions).toEqual(["edit:model:gpt-4.1", "edit:enabled:false", "save", "discoverModels"]);
+    expect(settingsActions).toEqual(["edit:model:gpt-4.1", "edit:enabled:false", "save", "discoverModels:openai"]);
 
-    pane?.querySelector('[data-desktop-settings-nav="general"]')?.click();
+    clickSettingsNav("general");
     const defaultProviderSelect = pane?.querySelector('[data-desktop-settings-control="provider"]');
     defaultProviderSelect!.value = "deepseek";
     defaultProviderSelect?.dispatchEvent({ type: "change", target: defaultProviderSelect });
     expect(settingsActions[settingsActions.length - 1]).toBe("edit:provider:deepseek");
 
-    pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
+    clickSettingsNav("provider-models");
     const providerSearch = pane?.querySelector(".desktop-settings-provider-search");
     providerSearch!.value = "deep";
     providerSearch?.dispatchEvent({ type: "input", target: providerSearch });
@@ -2995,6 +3015,7 @@ describe("desktop workbench shell", () => {
 
   test("updates the installed settings pane without rebuilding the workbench", () => {
     const targetDocument = new FakeDocument();
+    targetDocument.documentElement.setAttribute("data-desktop-active-workbench-module", "settings");
     const firstPane = buildDesktopSettingsPaneModel(buildDesktopSettingsFormState({}), {
       saveStatus: "idle",
     });
@@ -3018,10 +3039,68 @@ describe("desktop workbench shell", () => {
     updateDesktopSettingsPane(targetDocument as unknown as Document, nextPane);
 
     const pane = targetDocument.body.querySelector(".desktop-settings-pane");
+    const settingsSidebar = targetDocument.body.querySelector(".desktop-settings-sidebar");
     expect(pane?.querySelector(".desktop-settings-status-card")).toBeNull();
-    expect(pane?.querySelector('[data-desktop-settings-nav="provider-models"]')?.getAttribute("data-active")).toBe("true");
+    expect(settingsSidebar?.querySelector('[data-desktop-settings-nav="provider-models"]')?.getAttribute("data-active")).toBe("true");
     expect(pane?.querySelector(".desktop-settings-default-llm-card")).toBeNull();
     expect(pane?.querySelector('[data-desktop-settings-provider-card="openai"]')?.textContent).toContain("OpenAI");
+  });
+
+  test("fetches models for the provider selected from a fallback provider card", () => {
+    const targetDocument = new FakeDocument();
+    targetDocument.documentElement.setAttribute("data-desktop-active-workbench-module", "settings");
+    const settingsActions: string[] = [];
+    const providerCatalog = [
+      { id: "openai", displayName: "OpenAI", status: "ready" },
+      { id: "deepseek", displayName: "DeepSeek", status: "needs_key" },
+    ];
+    const settingsPane = buildDesktopSettingsPaneModel(buildDesktopSettingsFormState({
+      agents: { defaults: { provider: "openai", active_profile: "work" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-openai",
+            api_base: "https://api.openai.com/v1",
+            models: ["gpt-4.1"],
+          },
+          deepseek: {
+            provider: "deepseek",
+            api_key: "sk-deepseek",
+            api_base: "https://api.deepseek.com/v1",
+            models: [],
+          },
+        },
+      },
+    }, providerCatalog), {
+      lastSavedState: buildDesktopSettingsFormState({}),
+      providerCatalog,
+    });
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      settingsPane,
+      settingsActions: {
+        onSettingsAction: (event) => {
+          if (event.action === "edit") {
+            settingsActions.push(`${event.action}:${event.fieldId}:${String(event.value)}`);
+            return;
+          }
+          if (event.action === "discoverModels") {
+            settingsActions.push(`${event.action}:${event.providerId ?? ""}`);
+          }
+        },
+      },
+    });
+
+    targetDocument.body.querySelector('[data-desktop-settings-nav="provider-models"]')?.click();
+    targetDocument.body.querySelector('[data-desktop-settings-provider-card="deepseek"]')
+      ?.querySelector('[data-desktop-settings-provider-action="models"]')
+      ?.click();
+
+    expect(settingsActions).toEqual(["edit:selectedProvider:deepseek", "discoverModels:deepseek"]);
   });
 
   test("renders tools and skills list-detail pane in the desktop workbench", () => {
@@ -3891,7 +3970,7 @@ describe("desktop workbench shell", () => {
     );
   });
 
-  test("hides the secondary chat sidebar outside the chat module by default", () => {
+  test("switches the secondary sidebar content by active module", () => {
     const chatDocument = new FakeDocument();
     chatDocument.documentElement.setAttribute("data-desktop-active-workbench-module", "chat");
 
@@ -3932,9 +4011,51 @@ describe("desktop workbench shell", () => {
       settingsPane: buildDesktopSettingsPaneModel(settingsState, { lastSavedState: settingsState }),
     });
 
-    expect(settingsDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("false");
-    expect(settingsDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("false");
+    expect(settingsDocument.getElementById("desktop-workbench-shell")?.getAttribute("data-sidebar-visible")).toBe("true");
+    expect(settingsDocument.body.querySelector('[data-workbench-region="sidebar"]')?.getAttribute("data-visible")).toBe("true");
+    expect(settingsDocument.body.querySelector(".desktop-settings-sidebar")).not.toBeNull();
+    expect(settingsDocument.body.querySelector(".desktop-recent-chat-list")).toBeNull();
     expect(settingsDocument.body.querySelector(".desktop-settings-pane")).not.toBeNull();
+  });
+
+  test("syncs the existing secondary sidebar when route changes between chat and settings", () => {
+    const targetDocument = new FakeDocument();
+    targetDocument.documentElement.setAttribute("data-desktop-active-workbench-module", "chat");
+    const settingsState = buildDesktopSettingsFormState({
+      agents: { defaults: { provider: "deepseek", model: "deepseek-v4-flash" } },
+    });
+    const settingsPane = buildDesktopSettingsPaneModel(settingsState, { lastSavedState: settingsState });
+    const chat = {
+      sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+      activeSessionKey: "WebSocket:chat-live",
+      activeChatId: "chat-live",
+      messages: [],
+    };
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat,
+      settingsPane,
+    });
+
+    expect(targetDocument.body.querySelector(".desktop-recent-chat-list")?.textContent).toContain("Live session");
+    expect(targetDocument.body.querySelector(".desktop-settings-sidebar")).toBeNull();
+
+    syncDesktopWorkbenchRouteSidebar(targetDocument as unknown as Document, "settings", {
+      settingsPane,
+    });
+
+    expect(targetDocument.body.querySelector(".desktop-recent-chat-list")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-settings-sidebar")?.textContent).toContain("Provider & Models");
+
+    syncDesktopWorkbenchRouteSidebar(targetDocument as unknown as Document, "chat", {
+      chat,
+    });
+
+    expect(targetDocument.body.querySelector(".desktop-settings-sidebar")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-recent-chat-list")?.textContent).toContain("Live session");
   });
 
   test("collapses secondary panes at the minimum desktop width", () => {
@@ -4046,10 +4167,13 @@ describe("desktop workbench shell", () => {
 
     const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
     expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-task-card {\n      display: grid;");
-    expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-task-card .desktop-settings-field {\n      grid-template-columns: minmax(0, 1fr);");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-task-card .desktop-settings-field {\n      grid-template-columns: minmax(0, 1fr);\n      border: 0;\n      border-radius: 0;\n      padding: 0;\n      background: transparent;");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-field input,\n    body.desktop-native-workbench .desktop-settings-field select,\n    body.desktop-native-workbench .desktop-settings-field textarea {\n      width: 100%;\n      min-width: 0;\n      min-height: 40px;\n      padding: 10px 12px;");
     expect(styleText).toContain("background: var(--panel, #faf9f5);");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-breadcrumb h2 {\n      margin: 0;\n      color: var(--text, #141413);\n      font: 400 28px/1.2 var(--font-display);");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-provider-add {\n      border-color: var(--accent, #cc785c);");
+    expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-provider-detail-panel {\n      position: sticky;");
+    expect(styleText).toContain("overflow-y: auto;");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-provider-mark {\n      display: grid;");
     expect(styleText).toContain("background: var(--surface-dark, #181715);");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-settings-provider-switch[data-state=\"on\"] {\n      background: var(--accent, #cc785c);");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -230,6 +230,7 @@ export type DesktopSettingsActionEvent =
   | {
       action: "save" | "discoverModels" | "retryLoad" | "copyDiagnostics" | "restartGateway" | "reloadWorkspace" | "reset" | "chooseWorkspace" | "openWorkspace" | "openSessionFiles" | "openKnowledgeDocuments" | "setupChannelIntegrations" | "openDiagnosticsLogs" | "exportDiagnosticsBundle" | "clearDiagnosticsLogs" | "resetLocalUiState";
       pane: DesktopSettingsPaneModel;
+      providerId?: string;
     }
   | {
       action: "setDiagnosticsLogLevel";
@@ -546,14 +547,79 @@ export function updateDesktopSettingsPane(
     mountOrUpdateSettingsPaneIsland(pane, {
       pane: settingsPane,
       initialActiveGroupId: activeGroupId,
+      mode: "content",
+      onSettingsAction: settingsActions.onSettingsAction,
+      promptProviderId: () => promptForSettingsProviderId(targetDocument),
+      onFocusSettingsControl: (fieldId) => focusDesktopSettingsControl(targetDocument, fieldId),
+    });
+    updateDesktopSettingsSidebar(targetDocument, settingsPane, settingsActions, activeGroupId);
+    return;
+  }
+  const next = createSettingsProvidersPane(targetDocument, settingsPane, settingsActions, activeGroupId);
+  pane.replaceChildren(...Array.from(next.children));
+  updateDesktopSettingsSidebar(targetDocument, settingsPane, settingsActions, activeGroupId);
+}
+
+export function syncDesktopWorkbenchRouteSidebar(
+  targetDocument: Document = document,
+  activeModule: string = getDesktopActiveWorkbenchModule(targetDocument),
+  options: {
+    chat?: DesktopNativeChatModel | null;
+    chatActions?: DesktopNativeChatActionOptions;
+    settingsPane?: DesktopSettingsPaneModel | null;
+    settingsActions?: DesktopSettingsActionOptions;
+  } = {},
+): void {
+  if (activeModule !== "chat" && activeModule !== "settings") {
+    return;
+  }
+  const sidebarPanel = targetDocument.querySelector<HTMLElement>('[data-workbench-region="sidebar"]');
+  if (!sidebarPanel) {
+    return;
+  }
+  const nextContent = activeModule === "settings" && options.settingsPane
+    ? createSettingsWorkbenchSidebar(targetDocument, options.settingsPane, options.settingsActions ?? {})
+    : createSidebar(targetDocument, options.chat ?? null, options.chatActions ?? {});
+  replaceDesktopWorkbenchSidebarContent(sidebarPanel, nextContent);
+}
+
+function replaceDesktopWorkbenchSidebarContent(sidebarPanel: HTMLElement, content: HTMLElement): void {
+  const contentHost = sidebarPanel.querySelector<HTMLElement>(".desktop-workbench-panel-content");
+  if (contentHost) {
+    contentHost.replaceChildren(content);
+    return;
+  }
+  const resizer = sidebarPanel.querySelector<HTMLElement>("[data-desktop-sidebar-resizer]");
+  if (resizer) {
+    sidebarPanel.replaceChildren(content, resizer);
+    return;
+  }
+  sidebarPanel.replaceChildren(content);
+}
+
+function updateDesktopSettingsSidebar(
+  targetDocument: Document,
+  settingsPane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions,
+  activeGroupId: DesktopSettingsPaneGroup["id"],
+): void {
+  const sidebar = targetDocument.querySelector<HTMLElement>(".desktop-settings-sidebar");
+  if (!sidebar) {
+    return;
+  }
+  if (canMountVueIsland(sidebar) && sidebar.getAttribute("data-desktop-vue-island") === "settings-sidebar") {
+    mountOrUpdateSettingsPaneIsland(sidebar, {
+      pane: settingsPane,
+      initialActiveGroupId: activeGroupId,
+      mode: "sidebar",
       onSettingsAction: settingsActions.onSettingsAction,
       promptProviderId: () => promptForSettingsProviderId(targetDocument),
       onFocusSettingsControl: (fieldId) => focusDesktopSettingsControl(targetDocument, fieldId),
     });
     return;
   }
-  const next = createSettingsProvidersPane(targetDocument, settingsPane, settingsActions, activeGroupId);
-  pane.replaceChildren(...Array.from(next.children));
+  const next = createSettingsWorkbenchSidebar(targetDocument, settingsPane, settingsActions, activeGroupId);
+  sidebar.replaceChildren(...Array.from(next.children));
 }
 
 export function updateDesktopKnowledgePane(
@@ -848,9 +914,13 @@ function createWorkbenchShell(
     ? layout.inspector
     : { ...layout.inspector, visible: false };
   const activeModule = getDesktopActiveWorkbenchModule(targetDocument);
-  const sidebarState = activeModule === "chat"
+  const shouldShowSidebar = activeModule === "chat" || (activeModule === "settings" && settingsPane !== null);
+  const sidebarState = shouldShowSidebar
     ? layout.sidebar
     : { ...layout.sidebar, visible: false };
+  const sidebarContent = activeModule === "settings" && settingsPane !== null
+    ? createSettingsWorkbenchSidebar(targetDocument, settingsPane, settingsActions)
+    : createSidebar(targetDocument, chat, chatActions);
   const shell = targetDocument.createElement("main");
   shell.id = SHELL_ID;
   shell.className = "desktop-workbench-shell";
@@ -863,7 +933,7 @@ function createWorkbenchShell(
 
   shell.append(
     createActivityRail(targetDocument),
-    createPanel(targetDocument, "sidebar", sidebarState, createSidebar(targetDocument, chat, chatActions)),
+    createPanel(targetDocument, "sidebar", sidebarState, sidebarContent),
     createMainRegion(targetDocument, gatewayHttp, layout, chat, chatActions, agentUiForms, agentUiActions, taskCenterItems, settingsPane, settingsActions, knowledgePane, knowledgeActions, toolsSkillsPane, toolsSkillsActions, coworkPane, coworkActions, workLens, workLensActions),
     createPanel(targetDocument, "inspector", inspectorState, inspectorContent),
     createPanel(targetDocument, "bottom", layout.bottom, createBottomRegion(targetDocument, runtimeStatus, gatewayHttp, taskCenterItems, taskActions, gatewayActions)),
@@ -890,6 +960,7 @@ function createActivityRail(targetDocument: Document): HTMLElement {
   rail.className = "desktop-activity-rail";
   rail.setAttribute("data-workbench-region", "activity");
   rail.setAttribute("aria-label", "Desktop workbench modules");
+  const activeModule = getDesktopActiveWorkbenchModule(targetDocument);
 
   const primary = targetDocument.createElement("div");
   primary.className = "desktop-activity-primary";
@@ -908,7 +979,7 @@ function createActivityRail(targetDocument: Document): HTMLElement {
     item.setAttribute("aria-label", label);
     item.setAttribute("title", label);
     item.setAttribute("data-desktop-module-target", module);
-    if (module === "chat") {
+    if (module === activeModule) {
       item.setAttribute("data-active", "true");
       item.setAttribute("aria-current", "page");
     }
@@ -928,6 +999,10 @@ function createActivityRail(targetDocument: Document): HTMLElement {
     item.setAttribute("aria-label", label);
     item.setAttribute("title", label);
     item.setAttribute("data-desktop-module-target", module);
+    if (module === activeModule) {
+      item.setAttribute("data-active", "true");
+      item.setAttribute("aria-current", "page");
+    }
     secondary.append(item);
   }
 
@@ -950,6 +1025,28 @@ function createSidebar(
     mountSidebarContentVueIsland(sidebar, targetDocument, chat);
   }
   return sidebar;
+}
+
+function createSettingsWorkbenchSidebar(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions = {},
+  initialActiveGroupId?: DesktopSettingsPaneGroup["id"],
+): HTMLElement {
+  const activeGroupId = getDesktopSettingsActiveGroup(pane, initialActiveGroupId)?.id ?? "general";
+  const sidebar = targetDocument.createElement("aside");
+  sidebar.className = "desktop-settings-sidebar";
+  sidebar.setAttribute("aria-label", "Settings navigation");
+  if (canMountVueIsland(sidebar)) {
+    mountSettingsPaneVueIsland(sidebar, targetDocument, pane, settingsActions, activeGroupId, "sidebar");
+    return sidebar;
+  }
+  return createSettingsSidebar(
+    targetDocument,
+    pane,
+    (groupId) => renderFallbackSettingsContent(targetDocument, pane, settingsActions, groupId),
+    activeGroupId,
+  );
 }
 
 function mountSidebarContentVueIsland(
@@ -5170,7 +5267,7 @@ function createSettingsProvidersPane(
   section.setAttribute("aria-label", "Settings and providers");
   const activeGroupId = getDesktopSettingsActiveGroup(pane, initialActiveGroupId)?.id ?? "general";
   if (canMountVueIsland(section)) {
-    mountSettingsPaneVueIsland(section, targetDocument, pane, settingsActions, activeGroupId);
+    mountSettingsPaneVueIsland(section, targetDocument, pane, settingsActions, activeGroupId, "content");
     return section;
   }
 
@@ -5182,11 +5279,23 @@ function createSettingsProvidersPane(
     content.replaceChildren(...createSettingsActivePage(targetDocument, pane, settingsActions, groupId));
   };
 
-  section.append(createSettingsSidebar(targetDocument, pane, renderActiveGroup, activeGroupId));
   renderActiveGroup(activeGroupId);
   section.append(content);
-  mountSettingsPaneVueIsland(section, targetDocument, pane, settingsActions, activeGroupId);
   return section;
+}
+
+function renderFallbackSettingsContent(
+  targetDocument: Document,
+  pane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions,
+  activeGroupId: DesktopSettingsPaneGroup["id"],
+): void {
+  const content = targetDocument.querySelector<HTMLElement>(".desktop-settings-content");
+  if (!content) {
+    return;
+  }
+  setDesktopSettingsActiveNav(targetDocument, activeGroupId);
+  content.replaceChildren(...createSettingsActivePage(targetDocument, pane, settingsActions, activeGroupId));
 }
 
 function createSettingsActivePage(
@@ -5314,6 +5423,7 @@ function mountSettingsPaneVueIsland(
   pane: DesktopSettingsPaneModel,
   settingsActions: DesktopSettingsActionOptions,
   initialActiveGroupId: DesktopSettingsPaneGroup["id"],
+  mode: "full" | "content" | "sidebar" = "full",
 ): void {
   if (!canMountVueIsland(section)) {
     return;
@@ -5321,6 +5431,7 @@ function mountSettingsPaneVueIsland(
   mountSettingsPaneIsland(section, {
     pane,
     initialActiveGroupId,
+    mode,
     onSettingsAction: settingsActions.onSettingsAction,
     promptProviderId: () => promptForSettingsProviderId(targetDocument),
     onFocusSettingsControl: (fieldId) => focusDesktopSettingsControl(targetDocument, fieldId),
@@ -5381,17 +5492,13 @@ function createGeneralSettingsPage(
   const profileLocale = targetDocument.createElement("section");
   profileLocale.className = "desktop-settings-task-card desktop-settings-profile-locale-section";
   profileLocale.setAttribute("data-desktop-settings-page-section", "profile-locale");
-  profileLocale.append(createSettingsSectionHeading(targetDocument, "Profile & locale", "Identity and time settings used throughout the desktop app."));
+  profileLocale.append(createSettingsSectionHeading(targetDocument, "Locale", "Time settings used throughout the desktop app."));
   const localeFields = targetDocument.createElement("div");
   localeFields.className = "desktop-settings-field-pair";
-  for (const id of ["activeProfile", "timezone"]) {
+  for (const id of ["timezone"]) {
     const field = findSettingsPaneField(pane, "general", id);
     if (field) localeFields.append(createDesktopSettingsFieldRow(targetDocument, pane, group, field, settingsActions));
   }
-  const timezoneStatus = targetDocument.createElement("aside");
-  timezoneStatus.className = "desktop-settings-status-card desktop-settings-timezone-status";
-  timezoneStatus.append(createText(targetDocument, "strong", "Timezone is valid"), createText(targetDocument, "span", "Used for reminders and schedules."));
-  localeFields.append(timezoneStatus);
   profileLocale.append(localeFields);
 
   const responseDefaults = targetDocument.createElement("section");
@@ -5443,6 +5550,21 @@ function createProviderModelsSettingsPage(
   models.append(createText(targetDocument, "h3", "Model catalog"));
   const modelField = findSettingsPaneField(pane, "provider-models", "models");
   if (modelField) models.append(createDesktopSettingsFieldRow(targetDocument, pane, group, modelField, settingsActions));
+  const modelActions = targetDocument.createElement("div");
+  modelActions.className = "desktop-settings-provider-model-actions";
+  const autoFetch = createText(targetDocument, "button", "Auto fetch models");
+  autoFetch.setAttribute("type", "button");
+  autoFetch.setAttribute("data-desktop-settings-action", "discoverModels");
+  autoFetch.setAttribute("data-desktop-settings-provider-action", "autoFetchModels");
+  autoFetch.setAttribute("aria-label", `Auto fetch models for ${selected?.id ?? pane.providerEditor.selectedProvider}`);
+  if (!pane.providerEditor.canDiscoverModels) {
+    autoFetch.setAttribute("disabled", "true");
+  }
+  autoFetch.addEventListener("click", () => {
+    requestSettingsProviderModels(pane, settingsActions, selected?.id ?? pane.providerEditor.selectedProvider);
+  });
+  modelActions.append(autoFetch);
+  models.append(modelActions);
   detail.append(connection, models);
 
   page.append(detail);
@@ -5561,7 +5683,7 @@ function createProviderManagementSection(
   }
   refresh.textContent = "Refresh models";
   refresh.addEventListener("click", () => {
-    settingsActions.onSettingsAction?.({ action: "discoverModels", pane });
+    requestSettingsProviderModels(pane, settingsActions, pane.providerEditor.selectedProvider);
   });
 
   const allProviders = getProviderCards(pane);
@@ -5742,7 +5864,7 @@ function createProviderManagementCard(
 
   const actions = targetDocument.createElement("div");
   actions.className = "desktop-settings-provider-card-actions";
-  const modelAction = createText(targetDocument, "button", "\u6a21\u578b");
+  const modelAction = createText(targetDocument, "button", "Models");
   modelAction.setAttribute("type", "button");
   modelAction.setAttribute("data-desktop-settings-provider-action", "models");
   modelAction.addEventListener("click", () => {
@@ -5798,9 +5920,15 @@ function handleSettingsProviderCardAction(
   if (providerId !== pane.providerEditor.selectedProvider) {
     selectSettingsProvider(pane, settingsActions, providerId);
     focusDesktopSettingsControl(targetDocument, target === "models" ? "models" : "apiBase");
+    if (target === "models") {
+      requestSettingsProviderModels(pane, settingsActions, providerId);
+    }
     return;
   }
   focusDesktopSettingsControl(targetDocument, target === "models" ? "models" : "apiBase");
+  if (target === "models") {
+    requestSettingsProviderModels(pane, settingsActions, providerId);
+  }
 }
 
 function selectSettingsProvider(
@@ -5813,6 +5941,18 @@ function selectSettingsProvider(
     pane,
     fieldId: "selectedProvider",
     value: providerId,
+  });
+}
+
+function requestSettingsProviderModels(
+  pane: DesktopSettingsPaneModel,
+  settingsActions: DesktopSettingsActionOptions,
+  providerId: string,
+): void {
+  settingsActions.onSettingsAction?.({
+    action: "discoverModels",
+    pane,
+    providerId,
   });
 }
 
@@ -5995,7 +6135,7 @@ function getCurrentDesktopSettingsActiveGroupId(
   pane: HTMLElement,
   nextSettingsPane: DesktopSettingsPaneModel,
 ): DesktopSettingsPaneGroup["id"] {
-  const activeGroupId = Array.from(pane.querySelectorAll<HTMLElement>("[data-desktop-settings-nav]"))
+  const activeGroupId = Array.from(pane.ownerDocument.querySelectorAll<HTMLElement>("[data-desktop-settings-nav]"))
     .find((item) => item.getAttribute("data-active") === "true")
     ?.getAttribute("data-desktop-settings-nav");
   return getDesktopSettingsActiveGroup(nextSettingsPane, activeGroupId)?.id ?? nextSettingsPane.groups[0]?.id ?? "general";
@@ -7527,7 +7667,7 @@ function createSidebarResizer(targetDocument: Document, initialSize: number): HT
   handle.className = "desktop-workbench-sidebar-resizer";
   handle.setAttribute("data-desktop-sidebar-resizer", "");
   handle.setAttribute("role", "separator");
-  handle.setAttribute("aria-label", "Resize session list");
+  handle.setAttribute("aria-label", "Resize sidebar");
   handle.setAttribute("aria-orientation", "vertical");
   handle.setAttribute("aria-valuemin", String(DESKTOP_SIDEBAR_MIN_SIZE));
   handle.setAttribute("aria-valuemax", String(DESKTOP_SIDEBAR_MAX_SIZE));
@@ -12606,10 +12746,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-settings-pane {
-      grid-template-columns: minmax(190px, 230px) minmax(0, 1fr);
+      grid-template-columns: minmax(0, 1fr);
       justify-content: stretch;
       align-items: start;
-      gap: 28px;
+      gap: 0;
       min-width: 0;
       width: 100%;
       max-width: 1220px;
@@ -12631,6 +12771,20 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       border-radius: var(--radius-lg, 12px);
       padding: 14px;
       background: var(--surface-soft, #f5f0e8);
+    }
+
+    body.desktop-native-workbench .desktop-workbench-sidebar .desktop-settings-sidebar {
+      position: static;
+      min-height: 100%;
+      height: auto;
+      max-height: none;
+      border: 0;
+      border-radius: 0;
+      padding: 14px 16px;
+      background: transparent;
+      overflow: visible;
+      overscroll-behavior: auto;
+      scrollbar-gutter: auto;
     }
 
     body.desktop-native-workbench .desktop-settings-search {
@@ -13041,6 +13195,29 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-settings-provider-section {
       display: grid;
       gap: 18px;
+    }
+
+    body.desktop-native-workbench .desktop-settings-provider-detail-panel {
+      position: sticky;
+      top: 88px;
+      align-self: start;
+      max-height: min(720px, calc(100dvh - var(--desktop-window-frame-height, 0px) - 112px));
+      overflow-x: hidden;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      scrollbar-gutter: stable;
+    }
+
+    body.desktop-native-workbench .desktop-settings-provider-detail-section {
+      display: grid;
+      gap: 10px;
+    }
+
+    body.desktop-native-workbench .desktop-settings-provider-model-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      min-width: 0;
     }
 
     body.desktop-native-workbench .desktop-settings-provider-header {
@@ -13558,10 +13735,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-settings-task-card .desktop-settings-field {
       grid-template-columns: minmax(0, 1fr);
-      border: 1px solid var(--border-subtle, #ebe6df);
-      border-radius: var(--radius-md, 8px);
-      padding: 12px;
-      background: var(--surface-soft, #f5f0e8);
+      border: 0;
+      border-radius: 0;
+      padding: 0;
+      background: transparent;
     }
 
     body.desktop-native-workbench .desktop-settings-task-card .desktop-settings-readonly-value {
@@ -13641,8 +13818,8 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-settings-field textarea {
       width: 100%;
       min-width: 0;
-      min-height: 34px;
-      padding: 7px 9px;
+      min-height: 40px;
+      padding: 10px 12px;
     }
 
     body.desktop-native-workbench .desktop-settings-readonly-value {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.test.ts
@@ -66,8 +66,10 @@ describe("settings pane Vue island", () => {
     expect(host.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("General");
     expect(host.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("Default AI");
     expect(host.querySelector(".desktop-settings-default-ai-section")?.textContent).toContain("OpenAI / gpt-4.1");
-    expect(host.querySelector(".desktop-settings-profile-locale-section")?.textContent).toContain("Profile & locale");
+    expect(host.querySelector(".desktop-settings-profile-locale-section")?.textContent).toContain("Locale");
     expect(host.querySelector(".desktop-settings-profile-locale-section")?.textContent).toContain("Timezone");
+    expect(host.querySelector(".desktop-settings-profile-locale-section [data-desktop-settings-field=\"activeProfile\"]")).toBeNull();
+    expect(host.querySelector(".desktop-settings-profile-locale-section .desktop-settings-timezone-status")).toBeNull();
     expect(host.querySelector(".desktop-settings-response-defaults-section")?.textContent).toContain("Response defaults");
     expect(host.querySelector(".desktop-settings-response-defaults-section")?.textContent).toContain("tokens");
     expect(host.querySelector('[data-desktop-settings-group="general"]')).toBeNull();
@@ -274,6 +276,10 @@ describe("settings pane Vue island", () => {
           actions.push(`${event.action}:${event.providerId}`);
           return;
         }
+        if (event.action === "discoverModels") {
+          actions.push(`${event.action}:${event.providerId ?? ""}`);
+          return;
+        }
         actions.push(event.action);
       },
       promptProviderId: () => "openai",
@@ -326,6 +332,8 @@ describe("settings pane Vue island", () => {
     expect(host.querySelector('[data-desktop-settings-field="timezone"]')?.getAttribute("data-source-kind")).toBe("config");
     expect(host.querySelector('[data-desktop-settings-field="timezone"]')?.getAttribute("data-value-origin")).toBe("explicit");
     expect(host.querySelector('[data-desktop-settings-field="timezone"] .desktop-settings-field-meta')?.textContent).toContain("Explicit value");
+    expect(host.querySelector(".desktop-settings-profile-locale-section [data-desktop-settings-field=\"activeProfile\"]")).toBeNull();
+    expect(host.querySelector(".desktop-settings-profile-locale-section .desktop-settings-timezone-status")).toBeNull();
     expect(host.querySelector(".desktop-settings-response-defaults-section")?.textContent).toContain("Response defaults");
     expect(host.querySelector('[data-desktop-settings-field="temperature"]')?.closest(".desktop-settings-response-defaults-section")).not.toBeNull();
 
@@ -342,6 +350,7 @@ describe("settings pane Vue island", () => {
     expect(host.querySelector<HTMLInputElement>('[data-desktop-settings-control="apiKey"]')?.value).toBe("********");
     expect(host.querySelector('[data-desktop-settings-field="apiKey"] .desktop-settings-field-meta')?.textContent).toContain("Sensitive");
     expect(host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="discoverModels"]')?.getAttribute("aria-label")).toBe("Refresh models for openai");
+    expect(host.querySelector('[data-desktop-settings-provider-action="autoFetchModels"]')?.textContent).toContain("Auto fetch models");
     host.querySelector<HTMLButtonElement>('[data-desktop-settings-provider-action="testConnection"]')?.click();
     const providerSave = host.querySelector<HTMLButtonElement>('[data-desktop-settings-action="save"]');
     expect(providerSave).not.toBeNull();
@@ -396,13 +405,102 @@ describe("settings pane Vue island", () => {
       "save",
       "edit:model:custom-model-id",
       "save",
-      "discoverModels",
+      "discoverModels:openai",
       "edit:apiKey:sk-replacement",
     ]);
     expect(focused).toEqual(["apiBase"]);
 
     mounted.unmount();
     expect(host.textContent).toBe("");
+  });
+
+  test("fetches models for the provider selected from a provider card", async () => {
+    const host = document.createElement("section");
+    const actions: string[] = [];
+    const focused: string[] = [];
+    const discoveryPane = buildDesktopSettingsPaneModel(buildDesktopSettingsFormState({
+      agents: { defaults: { provider: "openai", active_profile: "work" } },
+      providers: {
+        profiles: {
+          work: {
+            provider: "openai",
+            api_key: "sk-openai",
+            api_base: "https://api.openai.com/v1",
+            models: ["gpt-4.1"],
+          },
+          deepseek: {
+            provider: "deepseek",
+            api_key: "sk-deepseek",
+            api_base: "https://api.deepseek.com/v1",
+            models: [],
+          },
+        },
+      },
+    }, [
+      { id: "openai", displayName: "OpenAI", status: "ready" },
+      { id: "deepseek", displayName: "DeepSeek", status: "needs_key" },
+    ]), {
+      providerCatalog: [
+        { id: "openai", displayName: "OpenAI", status: "ready" },
+        { id: "deepseek", displayName: "DeepSeek", status: "needs_key" },
+      ],
+    });
+    const mounted = mountSettingsPaneIsland(host, {
+      pane: discoveryPane,
+      initialActiveGroupId: "provider-models",
+      onFocusSettingsControl: (fieldId) => focused.push(fieldId),
+      onSettingsAction: (event: DesktopSettingsActionEvent) => {
+        if (event.action === "edit") {
+          actions.push(`${event.action}:${event.fieldId}:${String(event.value)}`);
+          return;
+        }
+        if (event.action === "discoverModels") {
+          actions.push(`${event.action}:${event.providerId ?? ""}`);
+        }
+      },
+    });
+    await nextTick();
+
+    host.querySelector<HTMLElement>('[data-desktop-settings-provider-card="deepseek"]')
+      ?.querySelector<HTMLButtonElement>('[data-desktop-settings-provider-action="models"]')
+      ?.click();
+
+    expect(actions).toEqual(["edit:selectedProvider:deepseek", "discoverModels:deepseek"]);
+    expect(focused).toEqual(["models"]);
+
+    mounted.unmount();
+  });
+
+  test("can split settings navigation into a separate sidebar host", async () => {
+    const contentHost = document.createElement("section");
+    const sidebarHost = document.createElement("aside");
+
+    const contentMounted = mountSettingsPaneIsland(contentHost, {
+      pane,
+      mode: "content",
+    });
+    const sidebarMounted = mountSettingsPaneIsland(sidebarHost, {
+      pane,
+      mode: "sidebar",
+    });
+    await nextTick();
+
+    expect(contentHost.className).toBe("desktop-workbench-section desktop-settings-pane");
+    expect(contentHost.querySelector(".desktop-settings-sidebar")).toBeNull();
+    expect(contentHost.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("General");
+    expect(sidebarHost.className).toContain("desktop-settings-sidebar");
+    expect(sidebarHost.querySelector(".desktop-settings-content")).toBeNull();
+    expect(sidebarHost.querySelector('[data-desktop-settings-nav="general"]')?.getAttribute("data-active")).toBe("true");
+
+    sidebarHost.querySelector<HTMLAnchorElement>('[data-desktop-settings-nav="provider-models"]')?.click();
+    await nextTick();
+
+    expect(contentHost.querySelector(".desktop-settings-breadcrumb h2")?.textContent).toBe("Provider & Models");
+    expect(sidebarHost.querySelector('[data-desktop-settings-nav="general"]')?.getAttribute("data-active")).toBeNull();
+    expect(sidebarHost.querySelector('[data-desktop-settings-nav="provider-models"]')?.getAttribute("data-active")).toBe("true");
+
+    sidebarMounted.unmount();
+    contentMounted.unmount();
   });
 
   test("renders labels, descriptions, validation, dirty state, and save actions from the pane model", async () => {

--- a/apps/desktop/src/native-vue/settingsPaneIsland.ts
+++ b/apps/desktop/src/native-vue/settingsPaneIsland.ts
@@ -1,4 +1,4 @@
-import { createApp, defineComponent, h, nextTick, ref, type App, type Ref } from "vue";
+import { createApp, defineComponent, h, nextTick, onBeforeUnmount, onMounted, ref, type App, type Ref } from "vue";
 import { NButton, NCard, NConfigProvider, NSpace, NTag } from "naive-ui";
 import type {
   DesktopSettingsPaneField,
@@ -11,6 +11,7 @@ import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 export interface SettingsPaneIslandOptions {
   pane: DesktopSettingsPaneModel;
   initialActiveGroupId?: DesktopSettingsPaneGroup["id"];
+  mode?: "full" | "content" | "sidebar";
   onSettingsAction?: (event: DesktopSettingsActionEvent) => void;
   promptProviderId?: () => string | null;
   onFocusSettingsControl?: (fieldId: string) => void;
@@ -54,6 +55,7 @@ interface ProviderSetupState {
 }
 
 const mountedSettingsPanes = new WeakMap<HTMLElement, MountedSettingsPaneIsland>();
+const SETTINGS_GROUP_SELECT_EVENT = "desktop-settings-select-group";
 
 export function mountOrUpdateSettingsPaneIsland(
   host: HTMLElement,
@@ -76,13 +78,13 @@ export function mountSettingsPaneIsland(
     mounted.update(options);
     return mounted;
   }
-  applySettingsPaneHost(host);
+  applySettingsPaneHost(host, options.mode);
   const state = ref(options) as Ref<SettingsPaneIslandOptions>;
   const app = createSettingsPaneApp(state, host);
   app.mount(host);
   const nextMounted = {
     update: (nextOptions: SettingsPaneIslandOptions) => {
-      applySettingsPaneHost(host);
+      applySettingsPaneHost(host, nextOptions.mode);
       state.value = nextOptions;
     },
     unmount: () => {
@@ -95,7 +97,15 @@ export function mountSettingsPaneIsland(
   return nextMounted;
 }
 
-function applySettingsPaneHost(host: HTMLElement): void {
+function applySettingsPaneHost(host: HTMLElement, mode: SettingsPaneIslandOptions["mode"] = "full"): void {
+  if (mode === "sidebar") {
+    host.setAttribute("data-desktop-vue-island", "settings-sidebar");
+    host.className = "desktop-settings-sidebar";
+    host.removeAttribute("data-desktop-module-surface");
+    host.removeAttribute("data-settings-layout");
+    host.setAttribute("aria-label", "Settings navigation");
+    return;
+  }
   host.setAttribute("data-desktop-vue-island", "settings-pane");
   host.className = "desktop-workbench-section desktop-settings-pane";
   host.setAttribute("data-desktop-module-surface", "settings");
@@ -113,12 +123,20 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>, host: HTML
       const settingsSearch = ref("");
       const highlightedFieldId = ref("");
       const activeGroupId = ref(getActiveSettingsGroup(state.value.pane, state.value.initialActiveGroupId)?.id ?? "general");
+      const dispatchActiveGroupId = (groupId: DesktopSettingsPaneGroup["id"], fieldId = "") => {
+        const EventCtor = host.ownerDocument.defaultView?.CustomEvent ?? CustomEvent;
+        host.ownerDocument.dispatchEvent(new EventCtor(SETTINGS_GROUP_SELECT_EVENT, {
+          detail: { groupId, fieldId },
+        }));
+      };
       const setActiveGroupId = (groupId: DesktopSettingsPaneGroup["id"]) => {
         activeGroupId.value = groupId;
+        dispatchActiveGroupId(groupId);
       };
       const activateSearchResult = (result: SettingsSearchResult) => {
         activeGroupId.value = result.groupId;
         highlightedFieldId.value = result.fieldId;
+        dispatchActiveGroupId(result.groupId, result.fieldId);
         void nextTick(() => {
           host.querySelector<HTMLElement>(`#desktop-settings-${result.fieldId}`)?.focus();
           window.setTimeout(() => {
@@ -137,12 +155,32 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>, host: HTML
         activeGroupId.value = "general";
         return activeGroupId.value;
       };
+      const onExternalGroupSelected = (event: Event) => {
+        const detail = (event as CustomEvent<{ groupId?: DesktopSettingsPaneGroup["id"]; fieldId?: string }>).detail;
+        const groupId = detail?.groupId;
+        if (!groupId || !getActiveSettingsGroup(state.value.pane, groupId)) {
+          return;
+        }
+        activeGroupId.value = groupId;
+        if (detail.fieldId) {
+          highlightedFieldId.value = detail.fieldId;
+          void nextTick(() => {
+            host.ownerDocument.querySelector<HTMLElement>(`#desktop-settings-${detail.fieldId}`)?.focus();
+          });
+        }
+      };
+      onMounted(() => {
+        host.ownerDocument.addEventListener(SETTINGS_GROUP_SELECT_EVENT, onExternalGroupSelected);
+      });
+      onBeforeUnmount(() => {
+        host.ownerDocument.removeEventListener(SETTINGS_GROUP_SELECT_EVENT, onExternalGroupSelected);
+      });
       return () => h(NConfigProvider, { themeOverrides: desktopNaiveThemeOverrides }, {
         default: () => {
           const options = state.value;
+          const mode = options.mode ?? "full";
           const selectedGroupId = currentActiveGroupId(options);
-          return [
-            renderSidebar(
+          const sidebar = renderSidebar(
               options,
               selectedGroupId,
               settingsSearch.value,
@@ -151,8 +189,8 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>, host: HTML
               },
               activateSearchResult,
               setActiveGroupId,
-            ),
-            h("div", { class: "desktop-settings-content" }, [
+            );
+          const content = h("div", { class: "desktop-settings-content" }, [
               renderHeader(options, selectedGroupId),
               renderSaveAlert(options),
               renderActiveSettingsSection(
@@ -174,8 +212,14 @@ function createSettingsPaneApp(state: Ref<SettingsPaneIslandOptions>, host: HTML
                   },
                 },
               ),
-            ]),
-          ];
+            ]);
+          if (mode === "sidebar") {
+            return sidebar;
+          }
+          if (mode === "content") {
+            return content;
+          }
+          return [sidebar, content];
         },
       });
     },
@@ -447,7 +491,6 @@ function renderGeneralSettingsPage(
   const field = (fieldId: string) => findPaneField(options.pane, "general", fieldId);
   const provider = field("provider");
   const model = field("model");
-  const activeProfile = field("activeProfile");
   const timezone = field("timezone");
   const temperature = field("temperature");
   const maxTokens = field("maxTokens");
@@ -476,11 +519,9 @@ function renderGeneralSettingsPage(
       class: "desktop-settings-task-card desktop-settings-profile-locale-section",
       "data-desktop-settings-page-section": "profile-locale",
     }, [
-      renderSectionHeading("Profile & locale", "Identity and time settings used throughout the desktop app."),
+      renderSectionHeading("Locale", "Time settings used throughout the desktop app."),
       h("div", { class: "desktop-settings-field-pair" }, [
-        activeProfile ? renderSettingsField(options, group, activeProfile, highlightedFieldId) : null,
         timezone ? renderSettingsField(options, group, timezone, highlightedFieldId) : null,
-        renderTimezoneStatusCard(timezone),
       ]),
     ]),
     h("section", {
@@ -532,20 +573,6 @@ function renderSectionHeading(title: string, description: string, badge?: string
       h("p", description),
     ]),
     badge ? h("span", { class: "desktop-settings-section-badge" }, badge) : null,
-  ]);
-}
-
-function renderTimezoneStatusCard(timezone: DesktopSettingsPaneField | null) {
-  if (!timezone) {
-    return null;
-  }
-  const valid = timezone.state !== "invalid";
-  return h("aside", {
-    class: "desktop-settings-status-card desktop-settings-timezone-status",
-    "data-desktop-settings-timezone-status": valid ? "valid" : "invalid",
-  }, [
-    h("strong", valid ? "Timezone is valid" : "Timezone needs attention"),
-    h("span", "Used for reminders, schedules, and time display."),
   ]);
 }
 
@@ -809,7 +836,7 @@ function renderProviderManagement(
           disabled: !options.pane.providerEditor.canDiscoverModels,
           "data-desktop-settings-action": "discoverModels",
           "aria-label": `Refresh models for ${options.pane.providerEditor.selectedProvider}`,
-          onClick: () => options.onSettingsAction?.({ action: "discoverModels", pane: options.pane }),
+          onClick: () => requestProviderModelDiscovery(options, options.pane.providerEditor.selectedProvider),
         }, { default: () => "Refresh" }),
         h(NButton, {
           class: "desktop-settings-provider-add",
@@ -868,6 +895,16 @@ function renderProviderDetailPanel(
     }, [
       h("h3", "Model catalog"),
       models ? renderSettingsField(options, group, models, highlightedFieldId) : null,
+      h("div", { class: "desktop-settings-provider-model-actions" }, [
+        h(NButton, {
+          size: "small",
+          disabled: !options.pane.providerEditor.canDiscoverModels,
+          "data-desktop-settings-action": "discoverModels",
+          "data-desktop-settings-provider-action": "autoFetchModels",
+          "aria-label": `Auto fetch models for ${selected?.id ?? options.pane.providerEditor.selectedProvider}`,
+          onClick: () => requestProviderModelDiscovery(options, selected?.id ?? options.pane.providerEditor.selectedProvider),
+        }, { default: () => "Auto fetch models" }),
+      ]),
       h("div", { class: "desktop-settings-provider-model-list" }, options.pane.providerEditor.models.map((model) => h("span", {
         "data-desktop-settings-provider-model": model,
       }, model))),
@@ -1539,9 +1576,23 @@ function handleProviderCardAction(
   if (providerId !== options.pane.providerEditor.selectedProvider) {
     emitEdit(options, "selectedProvider", providerId);
     options.onFocusSettingsControl?.(target === "models" ? "models" : "apiBase");
+    if (target === "models") {
+      requestProviderModelDiscovery(options, providerId);
+    }
     return;
   }
   options.onFocusSettingsControl?.(target === "models" ? "models" : "apiBase");
+  if (target === "models") {
+    requestProviderModelDiscovery(options, providerId);
+  }
+}
+
+function requestProviderModelDiscovery(options: SettingsPaneIslandOptions, providerId: string): void {
+  options.onSettingsAction?.({
+    action: "discoverModels",
+    pane: options.pane,
+    providerId,
+  });
 }
 
 function emitEdit(options: SettingsPaneIslandOptions, fieldId: string, value: string | boolean): void {

--- a/apps/desktop/src/native-vue/settingsProviderManagementIsland.ts
+++ b/apps/desktop/src/native-vue/settingsProviderManagementIsland.ts
@@ -84,7 +84,7 @@ function renderProviderManagement(
           disabled: !options.pane.providerEditor.canDiscoverModels,
           "data-desktop-settings-action": "discoverModels",
           "aria-label": "Refresh provider models",
-          onClick: () => options.onSettingsAction?.({ action: "discoverModels", pane: options.pane }),
+          onClick: () => requestProviderModelDiscovery(options, options.pane.providerEditor.selectedProvider),
         }, { default: () => "Refresh models" }),
         h(NButton, {
           class: "desktop-settings-provider-add",
@@ -213,9 +213,15 @@ function handleProviderCardAction(
   if (providerId !== options.pane.providerEditor.selectedProvider) {
     selectProvider(options, providerId);
     options.onFocusSettingsControl?.(target === "models" ? "models" : "apiBase");
+    if (target === "models") {
+      requestProviderModelDiscovery(options, providerId);
+    }
     return;
   }
   options.onFocusSettingsControl?.(target === "models" ? "models" : "apiBase");
+  if (target === "models") {
+    requestProviderModelDiscovery(options, providerId);
+  }
 }
 
 function selectProvider(options: SettingsProviderManagementIslandOptions, providerId: string): void {
@@ -224,6 +230,14 @@ function selectProvider(options: SettingsProviderManagementIslandOptions, provid
     pane: options.pane,
     fieldId: "selectedProvider",
     value: providerId,
+  });
+}
+
+function requestProviderModelDiscovery(options: SettingsProviderManagementIslandOptions, providerId: string): void {
+  options.onSettingsAction?.({
+    action: "discoverModels",
+    pane: options.pane,
+    providerId,
   });
 }
 

--- a/webui/assets/styles/components/desktop-settings.css
+++ b/webui/assets/styles/components/desktop-settings.css
@@ -13,8 +13,8 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-pane {
-  grid-template-columns: minmax(216px, 252px) minmax(0, 1fr);
-  gap: clamp(24px, 3vw, 40px);
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
   width: 100%;
   max-width: min(100%, 1320px);
   min-width: 0;
@@ -35,6 +35,22 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
   background: color-mix(in srgb, var(--panel) 92%, var(--surface-soft));
   box-shadow: var(--shadow-xs);
   scrollbar-gutter: stable;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-workbench-sidebar .desktop-settings-sidebar {
+  position: static;
+  top: auto;
+  min-height: 100%;
+  height: auto;
+  max-height: none;
+  overflow: visible;
+  overscroll-behavior: auto;
+  border: 0;
+  border-radius: 0;
+  padding: 14px 16px;
+  background: transparent;
+  box-shadow: none;
+  scrollbar-gutter: auto;
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-sidebar:focus-within {
@@ -523,6 +539,12 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail-panel {
   position: sticky;
   top: 88px;
+  align-self: start;
+  max-height: min(720px, calc(100dvh - var(--desktop-window-frame-height, 0px) - 112px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-detail-header,
@@ -543,6 +565,13 @@ html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbe
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-model-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
 }
 
 html[data-desktop-active-workbench-module="settings"] body.desktop-native-workbench .desktop-settings-provider-model-list span {


### PR DESCRIPTION
## Summary
- move the settings navigation into the workbench sidebar without nested scrolling
- make provider detail panels independently scroll within the viewport
- add provider-specific model discovery actions from refresh, model buttons, and detail panel auto-fetch
- accept UTC offset timezone aliases in desktop settings validation

## Verification
- npm test -- src/desktopSettingsExperience.test.ts src/desktopWorkbenchShell.test.ts src/desktopSettingsProviders.test.ts src/native-vue/settingsPaneIsland.test.ts src/native-vue/settingsProviderManagementIsland.test.ts src/desktopWorkbenchShell.settingsRenderer.test.ts
- npm run build