### PR TITLE
Improve desktop chat timeline: collapse run-chain tool and reasoning messages

### DIFF
--- a/apps/desktop/src/desktopChatWorkbenchProjection.ts
+++ b/apps/desktop/src/desktopChatWorkbenchProjection.ts
@@ -201,19 +201,66 @@ function buildTimeline(input: DesktopChatWorkbenchProjectionInput): DesktopChatW
   const start = clampWindowStart(input.virtualWindow?.start ?? 0, total, size);
   const end = Math.min(total, start + size);
   const pendingFormIds = input.pendingFormIds ?? [];
-
+  const items: DesktopChatWorkbenchTimelineItem[] = [];
+  let pendingAttached = false;
+  const messages = input.messages;
+  let localIndex = 0;
+  for (let idx = start; idx < end;) {
+    const message = messages[idx];
+    // Non-assistant messages or final assistant messages are added directly
+    if (message.role !== 'assistant' || isFinalAssistantMessage(message)) {
+      items.push({
+        id: message.messageId || `message-${start + localIndex + 1}`,
+        role: message.role,
+        content: message.content,
+        reasoningVisible: Boolean(message.reasoningContent),
+        referenceCount: message.references?.length ?? 0,
+        toolCards: (message.toolActivities ?? []).map(toolCard),
+        formCards: pendingAttached ? [] : pendingFormIds.map((id) => ({ id, state: "pending" as const })),
+      });
+      pendingAttached = true;
+      idx++;
+      localIndex++;
+      continue;
+    }
+    // Collect run-chain messages until a final assistant message is reached
+    const chainMessages: NativeChatMessage[] = [];
+    while (idx < end && !isFinalAssistantMessage(messages[idx])) {
+      chainMessages.push(messages[idx]);
+      idx++;
+    }
+    const aggregatedActivities = chainMessages.flatMap((msg) => msg.toolActivities ?? []);
+    const chainId = chainMessages[0]?.messageId || `chain-${start + items.length + 1}`;
+    items.push({
+      id: chainId,
+      role: 'assistant',
+      content: '',
+      reasoningVisible: false,
+      referenceCount: 0,
+      toolCards: aggregatedActivities.map(toolCard),
+      formCards: pendingAttached ? [] : pendingFormIds.map((id) => ({ id, state: "pending" as const })),
+    });
+    pendingAttached = true;
+    // After collapsing the chain, add the final assistant message if present
+    if (idx < end && isFinalAssistantMessage(messages[idx])) {
+      const finalMessage = messages[idx];
+      items.push({
+        id: finalMessage.messageId || `message-${start + items.length + 1}`,
+        role: finalMessage.role,
+        content: finalMessage.content,
+        reasoningVisible: Boolean(finalMessage.reasoningContent),
+        referenceCount: finalMessage.references?.length ?? 0,
+        toolCards: (finalMessage.toolActivities ?? []).map(toolCard),
+        formCards: [],
+      });
+      idx++;
+    }
+    localIndex = items.length;
+  }
   return {
     total,
     window: { start, end, size },
-    items: input.messages.slice(start, end).map((message, index) => ({
-      id: message.messageId || `message-${start + index + 1}`,
-      role: message.role,
-      content: message.content,
-      reasoningVisible: Boolean(message.reasoningContent),
-      referenceCount: message.references?.length ?? 0,
-      toolCards: (message.toolActivities ?? []).map(toolCard),
-      formCards: index === 0 ? pendingFormIds.map((id) => ({ id, state: "pending" as const })) : [],
-    })),
+    items,
   };
 }
 
@@ -285,4 +332,12 @@ function clampWindowStart(start: number, total: number, size: number): number {
     return 0;
   }
   return Math.max(0, Math.min(Math.floor(start), Math.max(0, total - size)));
+}
+
+function hasToolActivities(message: NativeChatMessage): boolean {
+  return Boolean(message.toolActivities && message.toolActivities.length > 0);
+}
+
+function isFinalAssistantMessage(message: NativeChatMessage): boolean {
+  return message.role === 'assistant' && !hasToolActivities(message);
 }


### PR DESCRIPTION
This PR enhances the desktop chat timeline to better reflect the AI agent workflow and provide a cleaner conversation flow for users.

### Key changes

- **Collapsed run-chain items**: The `buildTimeline` function now scans through incoming messages and groups sequences of assistant tool calls and reasoning messages into a single collapsed run-chain item. When the final assistant response arrives, the intermediate messages are replaced with a summary that aggregates all tool activities.
- **Improved pending form handling**: Pending form cards now attach only to the first visible timeline item, ensuring they remain visible even when earlier messages are collapsed.
- **Helper functions**: Added `hasToolActivities` and `isFinalAssistantMessage` helper functions to detect run-chain boundaries and final assistant content.
- **Normal message handling preserved**: User messages and standalone assistant messages (with no tool activities) are still displayed individually, so the overall conversation flow remains intuitive.

This update aims to provide a more interactive and readable desktop chat experience by collapsing intermediate tool invocations and reasoning steps while keeping the final results prominent. Further UI/animation enhancements can build upon this improved projection logic.
