### PR TITLE
Fix native approval resume flow

### DIFF
--- a/apps/desktop/src-tauri/src/worker_rpc/approval.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc/approval.rs
@@ -98,7 +98,7 @@ impl WorkerApprovalRpc {
         let Some(record) = self.pending.get(&params.approval_id).cloned() else {
             return Err(invalid_approval_request("pending approval not found"));
         };
-        if record.session_id.as_deref() != Some(params.session_id.as_str()) {
+        if !same_session_id(record.session_id.as_deref(), &params.session_id) {
             return Err(invalid_approval_request("pending approval not found"));
         }
         self.pending.remove(&params.approval_id);
@@ -142,7 +142,7 @@ impl WorkerApprovalRpc {
         let mut approvals: Vec<Value> = self
             .pending
             .values()
-            .filter(|record| record.session_id.as_deref() == Some(session_id))
+            .filter(|record| same_session_id(record.session_id.as_deref(), session_id))
             .map(ApprovalRecord::to_pending_json)
             .collect();
         approvals.sort_by(|left, right| {
@@ -414,7 +414,7 @@ impl ApprovalRunGrant {
     fn from_record(record: &ApprovalRecord) -> Self {
         Self {
             run_id: record.run_id.clone(),
-            session_id: record.session_id.clone(),
+            session_id: canonical_session_id_option(record.session_id.as_deref()),
             fingerprint: record.fingerprint.clone(),
         }
     }
@@ -423,16 +423,35 @@ impl ApprovalRunGrant {
 impl ApprovalGrant {
     fn once(record: &ApprovalRecord) -> Self {
         Self {
-            session_id: record.session_id.clone(),
+            session_id: canonical_session_id_option(record.session_id.as_deref()),
             fingerprint: record.fingerprint.clone(),
         }
     }
 
     fn session(record: &ApprovalRecord) -> Self {
         Self {
-            session_id: record.session_id.clone(),
+            session_id: canonical_session_id_option(record.session_id.as_deref()),
             fingerprint: record.session_fingerprint.clone(),
         }
+    }
+}
+
+fn same_session_id(left: Option<&str>, right: &str) -> bool {
+    left.map(canonical_session_id).as_deref() == Some(canonical_session_id(right).as_str())
+}
+
+fn canonical_session_id_option(value: Option<&str>) -> Option<String> {
+    value.map(canonical_session_id)
+}
+
+fn canonical_session_id(value: &str) -> String {
+    let Some((channel, id)) = value.split_once(':') else {
+        return value.to_string();
+    };
+    if channel.eq_ignore_ascii_case("websocket") {
+        format!("websocket:{id}")
+    } else {
+        value.to_string()
     }
 }
 
@@ -729,6 +748,124 @@ mod tests {
                 "sessionFingerprint": "write_file:notes/today.md"
             })
         );
+    }
+
+    #[test]
+    fn approval_resolve_matches_websocket_session_key_case_insensitively() {
+        let operation = json!({
+            "toolName": "write_file",
+            "arguments": { "path": "notes/today.md", "contents": "hello" },
+            "toolCallId": "call-1"
+        });
+        let mut approval = approval_rpc();
+        let request_response = approval
+            .request_from_request(&approval_request(
+                "req-request",
+                "run-1",
+                "WebSocket:chat-1",
+                operation,
+                "write_file:notes/today.md",
+                "write_file:notes/today.md",
+            ))
+            .unwrap();
+        let approval_id = request_response["approvalId"].as_str().unwrap().to_string();
+
+        let response = approval
+            .resolve_from_request(&WorkerRequest::new(
+                "req-resolve",
+                "trace-1",
+                "approval.resolve",
+                json!({
+                    "session_id": "websocket:chat-1",
+                    "approval_id": approval_id,
+                    "approved": true,
+                    "scope": "once"
+                }),
+            ))
+            .unwrap();
+
+        assert_eq!(response["status"], "approved");
+        assert_eq!(response["sessionId"], "websocket:chat-1");
+    }
+
+    #[test]
+    fn approval_list_pending_matches_websocket_session_key_case_insensitively() {
+        let operation = json!({
+            "toolName": "write_file",
+            "arguments": { "path": "notes/today.md", "contents": "hello" },
+            "toolCallId": "call-1"
+        });
+        let mut approval = approval_rpc();
+        let request_response = approval
+            .request_from_request(&approval_request(
+                "req-request",
+                "run-1",
+                "WebSocket:chat-1",
+                operation,
+                "write_file:notes/today.md",
+                "write_file:notes/today.md",
+            ))
+            .unwrap();
+        let approval_id = request_response["approvalId"].as_str().unwrap().to_string();
+
+        let response = approval
+            .list_pending_from_request(&WorkerRequest::new(
+                "req-list",
+                "trace-1",
+                "approval.list_pending",
+                json!({ "session_id": "websocket:chat-1" }),
+            ))
+            .unwrap();
+
+        assert_eq!(response["approvals"][0]["id"], approval_id);
+    }
+
+    #[test]
+    fn approval_session_scope_matches_websocket_session_key_case_insensitively() {
+        let operation = json!({
+            "toolName": "write_file",
+            "arguments": { "path": "notes/today.md", "contents": "hello" },
+            "toolCallId": "call-1"
+        });
+        let mut approval = approval_rpc();
+        let request_response = approval
+            .request_from_request(&approval_request(
+                "req-request",
+                "run-1",
+                "WebSocket:chat-1",
+                operation.clone(),
+                "write_file:notes/today.md",
+                "write_file:notes/today.md",
+            ))
+            .unwrap();
+        let approval_id = request_response["approvalId"].as_str().unwrap().to_string();
+        approval
+            .resolve_from_request(&WorkerRequest::new(
+                "req-resolve",
+                "trace-1",
+                "approval.resolve",
+                json!({
+                    "session_id": "websocket:chat-1",
+                    "approval_id": approval_id,
+                    "approved": true,
+                    "scope": "session"
+                }),
+            ))
+            .unwrap();
+
+        let response = approval
+            .request_from_request(&approval_request(
+                "req-request-again",
+                "run-2",
+                "websocket:chat-1",
+                operation,
+                "write_file:notes/today.md",
+                "write_file:notes/today.md",
+            ))
+            .unwrap();
+
+        assert_eq!(response["status"], "approved");
+        assert_eq!(response["scope"], "session");
     }
 
     #[test]

--- a/apps/desktop/src/chatRunModel.test.ts
+++ b/apps/desktop/src/chatRunModel.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "vitest";
+import {
+  createChatRunState,
+  legacyMessagesToTurns,
+  reduceAgentEvent,
+  redactedPreview,
+  safeArtifactPreview,
+  turnsToConversationMessages,
+} from "./chatRunModel";
+import type { NativeChatMessage } from "./nativeChat";
+
+describe("chat run model", () => {
+  test("converts legacy messages into turns with separate process steps and final answer", () => {
+    const messages: NativeChatMessage[] = [
+      {
+        role: "user",
+        content: "List the workspace",
+        reasoningContent: "",
+        timestamp: "2026-06-27T04:00:00.000Z",
+        messageId: "user-1",
+      },
+      {
+        role: "assistant",
+        content: "",
+        reasoningContent: "I should inspect the workspace.",
+        toolActivities: [{
+          argsText: "{\"path\":\".\"}",
+          id: "call-list",
+          kind: "call",
+          name: "list_dir",
+          responseText: "",
+          status: "running",
+        }],
+        timestamp: "2026-06-27T04:00:01.000Z",
+        messageId: "assistant-tools",
+      },
+      {
+        role: "assistant",
+        content: "The workspace contains apps and tests.",
+        reasoningContent: "I have enough context.",
+        references: [{ detail: "workspace", kind: "reference", title: "." }],
+        timestamp: "2026-06-27T04:00:02.000Z",
+        messageId: "assistant-final",
+      },
+    ];
+
+    const turns = legacyMessagesToTurns("WebSocket:chat-1", messages);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({
+      id: "turn:WebSocket:chat-1:user-1",
+      sessionKey: "WebSocket:chat-1",
+      userMessageId: "user-1",
+      status: "completed",
+      finalMessage: {
+        id: "assistant-final",
+        text: "The workspace contains apps and tests.",
+      },
+    });
+    expect(turns[0].steps.map((step) => [step.kind, step.title, step.status])).toEqual([
+      ["reasoning", "Thinking", "completed"],
+      ["tool_call", "list_dir", "running"],
+      ["reasoning", "Thinking complete", "completed"],
+    ]);
+    expect(turns[0].steps[1].toolCall).toMatchObject({
+      id: "call-list",
+      argsPreview: "{\"path\":\".\"}",
+      name: "list_dir",
+    });
+  });
+
+  test("replays structured events with deduplication, delegated workflows, and artifacts", () => {
+    const state = createChatRunState();
+    const started = {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-turn-start",
+      event_type: "agent.turn.started",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-1",
+      sequence: 1,
+      created_at: "2026-06-27T04:00:00.000Z",
+      payload: {
+        user_message: { id: "user-1", role: "user", text: "Run tests" },
+        user_message_id: "user-1",
+        title: "Run tests",
+      },
+    } as const;
+
+    reduceAgentEvent(state, started);
+    reduceAgentEvent(state, started);
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-tool-start",
+      event_type: "tool.call.started",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-1",
+      step_id: "step-tool",
+      sequence: 2,
+      created_at: "2026-06-27T04:00:01.000Z",
+      payload: {
+        args_json: { command: "npm test", token: "secret-token" },
+        name: "shell",
+        status: "running",
+        tool_call_id: "call-shell",
+      },
+    });
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-delegate",
+      event_type: "agent.delegate.started",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-1",
+      step_id: "step-delegate",
+      sequence: 3,
+      created_at: "2026-06-27T04:00:02.000Z",
+      payload: {
+        agent_context: { id: "cowork-1", title: "Cowork", type: "cowork" },
+        delegate_id: "cowork-1",
+        delegate_type: "cowork",
+        task: "Review implementation",
+        title: "Review implementation",
+      },
+    });
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-artifact",
+      event_type: "artifact.created",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-1",
+      step_id: "step-tool",
+      sequence: 4,
+      created_at: "2026-06-27T04:00:03.000Z",
+      payload: {
+        artifact: {
+          id: "artifact-output",
+          kind: "terminal_output",
+          mimeType: "text/plain",
+          preview: "npm test output",
+          sizeBytes: 1200,
+          title: "npm test",
+        },
+      },
+    });
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-final",
+      event_type: "message.completed",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-1",
+      step_id: "step-final",
+      sequence: 5,
+      created_at: "2026-06-27T04:00:04.000Z",
+      payload: {
+        message_id: "assistant-final",
+        role: "assistant",
+        text: "Tests passed.",
+      },
+    });
+
+    const turns = state.turnsBySession.get("WebSocket:chat-1") ?? [];
+    expect(turns).toHaveLength(1);
+    expect(state.appliedEventIds.size).toBe(5);
+    expect(turns[0].steps.map((step) => [step.id, step.kind, step.title])).toEqual([
+      ["step-tool", "tool_call", "shell"],
+      ["step-delegate", "delegate", "Review implementation"],
+      ["step-final", "message", "Final answer"],
+    ]);
+    expect(turns[0].steps[0].toolCall?.argsJson).toEqual({ command: "npm test", token: "[redacted]" });
+    expect(turns[0].steps[0].artifacts).toEqual([{
+      id: "artifact-output",
+      kind: "terminal_output",
+      mimeType: "text/plain",
+      preview: "npm test output",
+      sizeBytes: 1200,
+      status: "available",
+      title: "npm test",
+    }]);
+    expect(turns[0].steps[1].delegate).toMatchObject({
+      id: "cowork-1",
+      type: "cowork",
+      task: "Review implementation",
+    });
+    expect(turns[0].finalMessage?.text).toBe("Tests passed.");
+  });
+
+  test("builds legacy conversation messages and keeps final answer copy separate", () => {
+    const turns = legacyMessagesToTurns("WebSocket:chat-1", [
+      {
+        role: "user",
+        content: "Summarize",
+        reasoningContent: "",
+        timestamp: "2026-06-27T04:00:00.000Z",
+        messageId: "user-1",
+      },
+      {
+        role: "assistant",
+        content: "",
+        reasoningContent: "hidden raw chain",
+        timestamp: "2026-06-27T04:00:01.000Z",
+        messageId: "reasoning-1",
+      },
+      {
+        role: "assistant",
+        content: "Final only",
+        reasoningContent: "do not copy",
+        timestamp: "2026-06-27T04:00:02.000Z",
+        messageId: "final-1",
+      },
+    ]);
+
+    const view = turnsToConversationMessages(turns);
+
+    expect(view).toEqual([
+      expect.objectContaining({ body: ["Summarize"], tone: "user" }),
+      expect.objectContaining({ body: [], reasoningContent: "hidden raw chain", tone: "assistant" }),
+      expect.objectContaining({ body: [], reasoningContent: "do not copy", tone: "assistant" }),
+      expect.objectContaining({ body: ["Final only"], copyable: true, reasoningContent: "", tone: "assistant" }),
+    ]);
+  });
+
+  test("redacts sensitive fields and renders unsafe artifact payloads inertly", () => {
+    expect(redactedPreview({
+      authorization: "Bearer abc",
+      nested: { private_key: "key", safe: "value" },
+      token: "secret",
+    })).toBe("{\"authorization\":\"[redacted]\",\"nested\":{\"private_key\":\"[redacted]\",\"safe\":\"value\"},\"token\":\"[redacted]\"}");
+
+    expect(safeArtifactPreview({
+      html: "<button onclick=\"steal()\">Run</button>",
+      onClick: "steal()",
+      script: "alert(1)",
+      text: "Visible",
+    })).toBe("{\"html\":\"[unsafe omitted]\",\"onClick\":\"[unsafe omitted]\",\"script\":\"[unsafe omitted]\",\"text\":\"Visible\"}");
+  });
+});

--- a/apps/desktop/src/chatRunModel.test.ts
+++ b/apps/desktop/src/chatRunModel.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "vitest";
 import {
   createChatRunState,
+  getArtifactRef,
   legacyMessagesToTurns,
   reduceAgentEvent,
   redactedPreview,
+  resolveChatInspectorPanel,
   safeArtifactPreview,
+  selectChatInspector,
   turnsToConversationMessages,
 } from "./chatRunModel";
 import type { NativeChatMessage } from "./nativeChat";
@@ -236,5 +239,190 @@ describe("chat run model", () => {
       script: "alert(1)",
       text: "Visible",
     })).toBe("{\"html\":\"[unsafe omitted]\",\"onClick\":\"[unsafe omitted]\",\"script\":\"[unsafe omitted]\",\"text\":\"Visible\"}");
+  });
+
+  test("stores artifact refs lazily and resolves inspector registry panels", () => {
+    const state = createChatRunState();
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-tool",
+      event_type: "tool.call.completed",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-1",
+      step_id: "step-tool",
+      sequence: 1,
+      created_at: "2026-06-27T04:00:01.000Z",
+      payload: {
+        name: "shell",
+        result_preview: "ok",
+        status: "completed",
+        tool_call_id: "call-shell",
+      },
+    });
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-artifact",
+      event_type: "artifact.created",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-1",
+      step_id: "step-tool",
+      sequence: 2,
+      created_at: "2026-06-27T04:00:02.000Z",
+      payload: {
+        artifact: {
+          fetch_path: "/api/sessions/WebSocket:chat-1/artifacts/artifact-log",
+          id: "artifact-log",
+          kind: "terminal_output",
+          mime_type: "text/plain",
+          preview: "npm test summary",
+          size_bytes: 4096,
+          title: "npm test",
+        },
+      },
+    });
+
+    expect(getArtifactRef(state, "WebSocket:chat-1", "artifact-log")).toMatchObject({
+      fetchPath: "/api/sessions/WebSocket:chat-1/artifacts/artifact-log",
+      preview: "npm test summary",
+      sizeBytes: 4096,
+    });
+    selectChatInspector(state, { kind: "artifact", sessionKey: "WebSocket:chat-1", artifactId: "artifact-log" });
+    expect(resolveChatInspectorPanel(state)).toMatchObject({
+      kind: "artifact",
+      subtitle: "terminal_output / text/plain / 4096 bytes",
+      title: "npm test",
+    });
+    expect(resolveChatInspectorPanel(state)?.body).toBe("npm test summary");
+
+    selectChatInspector(state, { kind: "tool_call", sessionKey: "WebSocket:chat-1", turnId: "turn-1", stepId: "step-tool", toolCallId: "call-shell" });
+    expect(resolveChatInspectorPanel(state)).toMatchObject({
+      kind: "tool_call",
+      status: "completed",
+      title: "shell",
+    });
+
+    selectChatInspector(state, { kind: "delegate", sessionKey: "WebSocket:chat-1", turnId: "turn-1", stepId: "missing", delegateId: "missing" });
+    expect(resolveChatInspectorPanel(state)).toMatchObject({
+      kind: "delegate",
+      status: "unavailable",
+      title: "Unavailable",
+    });
+  });
+
+  test("replays approval, failure, interruption, form, browser, file diff, and delegate variants", () => {
+    const state = createChatRunState();
+    const base = {
+      schema_version: "tinybot.agent_event.v1" as const,
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-rich",
+      created_at: "2026-06-27T04:00:00.000Z",
+    };
+    reduceAgentEvent(state, {
+      ...base,
+      event_id: "turn-updated",
+      event_type: "agent.turn.updated",
+      sequence: 1,
+      payload: { status: "awaiting_form" },
+    });
+    reduceAgentEvent(state, {
+      ...base,
+      event_id: "approval-requested",
+      event_type: "approval.requested",
+      step_id: "step-approval",
+      sequence: 2,
+      payload: {
+        actions: ["approveOnce", "deny"],
+        approval_id: "approval-1",
+        risk_level: "medium",
+        title: "Run shell",
+        tool_call_id: "call-shell",
+      },
+    });
+    reduceAgentEvent(state, {
+      ...base,
+      event_id: "form-requested",
+      event_type: "ui.form.requested",
+      step_id: "step-form",
+      sequence: 3,
+      payload: { form: { title: "Travel preferences" } },
+    });
+    for (const [index, delegateType] of ["spawn", "subagent", "cowork", "team"].entries()) {
+      reduceAgentEvent(state, {
+        ...base,
+        event_id: `delegate-${delegateType}`,
+        event_type: index === 3 ? "agent.delegate.completed" : "agent.delegate.started",
+        step_id: `step-${delegateType}`,
+        sequence: 4 + index,
+        payload: {
+          agent_count: index + 1,
+          artifacts: [{ id: `artifact-${delegateType}`, kind: "markdown", preview: `${delegateType} notes`, title: `${delegateType} notes` }],
+          delegate_id: delegateType,
+          delegate_type: delegateType,
+          final_output: index === 3 ? "Team finished" : "",
+          latest_activity: `${delegateType} active`,
+          status: index === 3 ? "completed" : "running",
+          task: `${delegateType} task`,
+          workflow: "review",
+        },
+      });
+    }
+    reduceAgentEvent(state, {
+      ...base,
+      event_id: "browser-artifact",
+      event_type: "artifact.created",
+      step_id: "step-browser",
+      sequence: 9,
+      payload: { artifact: { id: "browser-1", kind: "browser_snapshot", preview: "data:image/png;base64,x", title: "Browser snapshot" } },
+    });
+    reduceAgentEvent(state, {
+      ...base,
+      event_id: "diff-artifact",
+      event_type: "artifact.created",
+      step_id: "step-diff",
+      sequence: 10,
+      payload: { artifact: { id: "diff-1", kind: "file_diff", preview: "-old\n+new", title: "Patch" } },
+    });
+    reduceAgentEvent(state, {
+      ...base,
+      event_id: "turn-failed",
+      event_type: "agent.turn.failed",
+      step_id: "step-error",
+      sequence: 11,
+      payload: { error: { message: "boom" } },
+    });
+    reduceAgentEvent(state, {
+      ...base,
+      event_id: "turn-interrupted",
+      event_type: "agent.turn.interrupted",
+      sequence: 12,
+      payload: {},
+    });
+
+    const turn = state.turnsBySession.get("WebSocket:chat-1")?.[0];
+    expect(turn?.status).toBe("interrupted");
+    expect(turn?.steps.map((step) => step.kind)).toEqual([
+      "approval",
+      "form",
+      "delegate",
+      "delegate",
+      "delegate",
+      "delegate",
+      "artifact",
+      "artifact",
+      "error",
+    ]);
+    expect(turn?.steps.filter((step) => step.kind === "delegate").map((step) => step.delegate?.type)).toEqual(["spawn", "subagent", "cowork", "team"]);
+    expect(getArtifactRef(state, "WebSocket:chat-1", "artifact-team")).toMatchObject({ kind: "markdown", preview: "team notes" });
+    expect(getArtifactRef(state, "WebSocket:chat-1", "browser-1")).toMatchObject({ kind: "browser_snapshot" });
+    expect(getArtifactRef(state, "WebSocket:chat-1", "diff-1")).toMatchObject({ kind: "file_diff" });
+    selectChatInspector(state, { kind: "approval", sessionKey: "WebSocket:chat-1", turnId: "turn-rich", stepId: "step-approval", approvalId: "approval-1" });
+    expect(resolveChatInspectorPanel(state)).toMatchObject({
+      kind: "approval",
+      subtitle: "approval-1",
+      title: "Run shell",
+    });
   });
 });

--- a/apps/desktop/src/chatRunModel.ts
+++ b/apps/desktop/src/chatRunModel.ts
@@ -372,8 +372,39 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
   }
 
   if (event.event_type === "approval.requested" || event.event_type === "approval.resolved") {
+    const approval = approvalFromPayload(event.payload);
+    if (event.event_type === "approval.requested" && approval.toolCallId) {
+      const existingToolStep = turn.steps.find((step) => step.toolCall?.id === approval.toolCallId);
+      const existingToolCall = existingToolStep?.toolCall;
+      const toolCall: ToolCallState = {
+        ...(existingToolCall ?? {
+          id: approval.toolCallId,
+          name: stringValue(event.payload.name) || "tool",
+        }),
+        approvalId: approval.approvalId,
+        approvalStatus: stringValue(event.payload.approval_status) || "approval_required",
+        argsPreview: existingToolCall?.argsPreview || safeArtifactText(stringValue(event.payload.args_preview)),
+      };
+      if (existingToolStep) {
+        Object.assign(existingToolStep, {
+          completedAt: existingToolStep.completedAt,
+          status: "blocked",
+          title: existingToolStep.title || toolCall.name,
+          toolCall,
+          updatedAt: event.created_at,
+        });
+        return state;
+      }
+      upsertStep(turn, event, {
+        kind: "tool_call",
+        status: "blocked",
+        title: toolCall.name,
+        toolCall,
+      });
+      return state;
+    }
     upsertStep(turn, event, {
-      approval: approvalFromPayload(event.payload),
+      approval,
       kind: "approval",
       status: event.event_type === "approval.resolved" ? "completed" : "blocked",
       title: stringValue(event.payload.title) || "Approval",

--- a/apps/desktop/src/chatRunModel.ts
+++ b/apps/desktop/src/chatRunModel.ts
@@ -1,0 +1,790 @@
+import type { NativeChatMessage, NativeChatReference } from "./nativeChat";
+import type { ConversationMessageIslandOptions } from "./native-vue/conversationMessageIsland";
+
+export type ChatTurnStatus = "pending" | "running" | "awaiting_approval" | "awaiting_user" | "completed" | "failed" | "interrupted";
+export type ChatStepStatus = "pending" | "running" | "blocked" | "completed" | "failed" | "cancelled";
+export type AgentContextType = "main" | "spawn" | "subagent" | "cowork" | "team";
+export type ArtifactKind =
+  | "terminal_output"
+  | "file_diff"
+  | "browser_snapshot"
+  | "image"
+  | "markdown"
+  | "json"
+  | "generated_file"
+  | "text";
+
+export type AgentContext = {
+  id: string;
+  title: string;
+  type: AgentContextType;
+};
+
+export type ArtifactRef = {
+  id: string;
+  kind: ArtifactKind | string;
+  mimeType?: string;
+  preview?: string;
+  sizeBytes?: number;
+  status?: string;
+  title: string;
+};
+
+export type TokenUsage = {
+  cachedTokens?: number;
+  completionTokens?: number;
+  promptTokens?: number;
+  totalTokens?: number;
+};
+
+export type ToolCallState = {
+  approvalId?: string;
+  approvalStatus?: string;
+  argsJson?: unknown;
+  argsPreview?: string;
+  durationMs?: number;
+  id: string;
+  name: string;
+  resultJson?: unknown;
+  resultPreview?: string;
+  resultRef?: string;
+  stderrPreview?: string;
+};
+
+export type DelegatedAgentState = {
+  agentCount?: number;
+  artifacts?: ArtifactRef[];
+  finalOutput?: string;
+  id: string;
+  latestActivity?: string;
+  status: ChatStepStatus;
+  task?: string;
+  title: string;
+  type: AgentContextType;
+  workflow?: string;
+};
+
+export type ApprovalState = {
+  actions?: string[];
+  approvalId: string;
+  decision?: string;
+  riskLevel?: string;
+  title?: string;
+  toolCallId?: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  references?: NativeChatReference[];
+  role: "user" | "assistant";
+  text: string;
+  timestamp: string;
+};
+
+export type ChatStepKind =
+  | "reasoning"
+  | "message"
+  | "tool_call"
+  | "tool_result"
+  | "approval"
+  | "delegate"
+  | "artifact"
+  | "browser"
+  | "memory"
+  | "error";
+
+export type ChatStep = {
+  agentContext: AgentContext;
+  approval?: ApprovalState;
+  artifacts?: ArtifactRef[];
+  completedAt?: string;
+  delegate?: DelegatedAgentState;
+  error?: unknown;
+  id: string;
+  kind: ChatStepKind;
+  parentStepId?: string;
+  references?: NativeChatReference[];
+  sequence: number;
+  startedAt?: string;
+  status: ChatStepStatus;
+  summary?: string;
+  title: string;
+  toolCall?: ToolCallState;
+};
+
+export type ChatTurn = {
+  completedAt?: string;
+  finalMessage?: ChatMessage;
+  id: string;
+  sessionKey: string;
+  startedAt: string;
+  status: ChatTurnStatus;
+  steps: ChatStep[];
+  updatedAt: string;
+  usage?: TokenUsage;
+  userMessage: ChatMessage;
+  userMessageId: string;
+};
+
+export type ChatInspectorSelection =
+  | { kind: "tool_call"; sessionKey: string; turnId: string; stepId: string; toolCallId: string }
+  | { kind: "delegate"; sessionKey: string; turnId: string; stepId: string; delegateId: string }
+  | { kind: "approval"; sessionKey: string; turnId: string; stepId: string; approvalId: string }
+  | { kind: "artifact"; sessionKey: string; artifactId: string }
+  | { kind: "reference"; sessionKey: string; referenceId: string }
+  | { kind: "error"; sessionKey: string; turnId: string; stepId: string };
+
+export type ChatRunState = {
+  appliedEventIds: Set<string>;
+  legacyMessagesBySession: Map<string, NativeChatMessage[]>;
+  selectedInspector: ChatInspectorSelection | null;
+  turnsBySession: Map<string, ChatTurn[]>;
+};
+
+export type AgentEventEnvelope = {
+  chat_id: string;
+  created_at: string;
+  event_id: string;
+  event_type: string;
+  parent_step_id?: string;
+  payload: Record<string, unknown>;
+  schema_version: "tinybot.agent_event.v1";
+  sequence: number;
+  session_key: string;
+  step_id?: string;
+  turn_id: string;
+};
+
+const SENSITIVE_KEYS = new Set(["api_key", "token", "secret", "password", "authorization", "cookie", "credential", "private_key"]);
+const UNSAFE_KEYS = new Set(["html", "script", "style", "component", "handler", "renderer", "template", "onClick", "onSubmit"]);
+
+export function createChatRunState(): ChatRunState {
+  return {
+    appliedEventIds: new Set(),
+    legacyMessagesBySession: new Map(),
+    selectedInspector: null,
+    turnsBySession: new Map(),
+  };
+}
+
+export function legacyMessagesToTurns(sessionKey: string, messages: NativeChatMessage[]): ChatTurn[] {
+  const turns: ChatTurn[] = [];
+  let current: ChatTurn | null = null;
+  let sequence = 0;
+  for (const message of messages) {
+    if (message.role === "user") {
+      current = {
+        id: stableId("turn", sessionKey, message.messageId || String(turns.length + 1)),
+        sessionKey,
+        userMessageId: message.messageId || stableId("user", sessionKey, String(turns.length + 1)),
+        userMessage: {
+          id: message.messageId || stableId("user", sessionKey, String(turns.length + 1)),
+          role: "user",
+          text: message.content,
+          timestamp: message.timestamp,
+        },
+        status: "running",
+        steps: [],
+        startedAt: message.timestamp,
+        updatedAt: message.timestamp,
+      };
+      turns.push(current);
+      sequence = 0;
+      continue;
+    }
+
+    if (!current) {
+      current = syntheticTurn(sessionKey, turns.length + 1, message.timestamp);
+      turns.push(current);
+      sequence = 0;
+    }
+
+    const isFinal = Boolean(message.content.trim());
+    const processSteps = stepsFromLegacyMessage(message, current, sequence);
+    sequence += processSteps.length;
+    current.steps.push(...processSteps);
+    current.updatedAt = message.timestamp || current.updatedAt;
+    if (isFinal) {
+      current.finalMessage = {
+        id: message.messageId || stableId("message", current.id, "final"),
+        references: message.references,
+        role: "assistant",
+        text: message.content,
+        timestamp: message.timestamp,
+      };
+      current.status = "completed";
+      current.completedAt = message.timestamp;
+      for (const step of current.steps) {
+        if (step.status === "pending") {
+          step.status = "completed";
+        }
+      }
+    }
+  }
+  return turns;
+}
+
+export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope): ChatRunState {
+  if (state.appliedEventIds.has(event.event_id)) {
+    return state;
+  }
+  state.appliedEventIds.add(event.event_id);
+  const turn = ensureTurn(state, event);
+  turn.updatedAt = event.created_at || turn.updatedAt;
+
+  if (event.event_type === "agent.turn.started") {
+    const payloadMessage = recordValue(event.payload.user_message);
+    turn.userMessage = {
+      id: stringValue(event.payload.user_message_id) || stringValue(payloadMessage.id) || turn.userMessage.id,
+      role: "user",
+      text: stringValue(payloadMessage.text ?? payloadMessage.content) || turn.userMessage.text,
+      timestamp: event.created_at,
+    };
+    turn.userMessageId = turn.userMessage.id;
+    turn.status = "running";
+    return state;
+  }
+
+  if (event.event_type === "agent.turn.completed") {
+    turn.status = "completed";
+    turn.completedAt = event.created_at;
+    turn.usage = normalizeUsage(event.payload.usage);
+    return state;
+  }
+
+  if (event.event_type === "agent.turn.failed") {
+    turn.status = "failed";
+    upsertStep(turn, event, {
+      error: event.payload.error,
+      kind: "error",
+      status: "failed",
+      title: "Error",
+    });
+    return state;
+  }
+
+  if (event.event_type === "agent.turn.interrupted") {
+    turn.status = "interrupted";
+    return state;
+  }
+
+  if (event.event_type === "reasoning.started" || event.event_type === "reasoning.delta" || event.event_type === "reasoning.completed") {
+    const visibility = stringValue(event.payload.visibility) || "hidden";
+    upsertStep(turn, event, {
+      kind: "reasoning",
+      status: event.event_type === "reasoning.completed" ? "completed" : "running",
+      summary: visibility === "hidden" ? stringValue(event.payload.summary) : stringValue(event.payload.text ?? event.payload.summary),
+      title: event.event_type === "reasoning.completed" ? "Thinking complete" : "Thinking",
+    });
+    return state;
+  }
+
+  if (event.event_type === "message.delta" || event.event_type === "message.completed") {
+    const text = stringValue(event.payload.text);
+    const messageId = stringValue(event.payload.message_id) || stableId("message", turn.id, event.sequence);
+    if (event.event_type === "message.completed") {
+      turn.finalMessage = {
+        id: messageId,
+        references: normalizeReferences(event.payload.references),
+        role: "assistant",
+        text,
+        timestamp: event.created_at,
+      };
+      turn.status = "completed";
+      turn.completedAt = event.created_at;
+    }
+    upsertStep(turn, event, {
+      kind: "message",
+      status: event.event_type === "message.completed" ? "completed" : "running",
+      summary: text,
+      title: event.event_type === "message.completed" ? "Final answer" : "Assistant message",
+    });
+    return state;
+  }
+
+  if (event.event_type === "tool.call.started" || event.event_type === "tool.call.arguments.delta") {
+    const toolCall = toolCallFromPayload(event.payload);
+    upsertStep(turn, event, {
+      kind: "tool_call",
+      status: statusValue(event.payload.status) || "running",
+      title: toolCall.name,
+      toolCall,
+    });
+    return state;
+  }
+
+  if (event.event_type === "tool.call.completed" || event.event_type === "tool.call.failed") {
+    const toolCall = toolCallFromPayload(event.payload);
+    upsertStep(turn, event, {
+      kind: "tool_call",
+      status: event.event_type === "tool.call.failed" ? "failed" : statusValue(event.payload.status) || "completed",
+      title: toolCall.name,
+      toolCall,
+    });
+    return state;
+  }
+
+  if (event.event_type === "approval.requested" || event.event_type === "approval.resolved") {
+    upsertStep(turn, event, {
+      approval: approvalFromPayload(event.payload),
+      kind: "approval",
+      status: event.event_type === "approval.resolved" ? "completed" : "blocked",
+      title: stringValue(event.payload.title) || "Approval",
+    });
+    return state;
+  }
+
+  if (event.event_type === "agent.delegate.started" || event.event_type === "agent.delegate.updated" || event.event_type === "agent.delegate.completed") {
+    const delegate = delegateFromPayload(event.payload);
+    upsertStep(turn, event, {
+      delegate,
+      kind: "delegate",
+      status: delegate.status,
+      title: delegate.title,
+    });
+    return state;
+  }
+
+  if (event.event_type === "artifact.created" || event.event_type === "artifact.updated") {
+    const artifact = artifactFromPayload(event.payload.artifact ?? event.payload);
+    const targetStep = event.step_id ? turn.steps.find((step) => step.id === event.step_id) : undefined;
+    if (targetStep) {
+      targetStep.artifacts = upsertArtifact(targetStep.artifacts ?? [], artifact);
+    } else {
+      upsertStep(turn, event, {
+        artifacts: [artifact],
+        kind: "artifact",
+        status: "completed",
+        title: artifact.title,
+      });
+    }
+    return state;
+  }
+
+  return state;
+}
+
+export function turnsToConversationMessages(turns: ChatTurn[]): ConversationMessageIslandOptions[] {
+  return turns.flatMap((turn) => {
+    const messages: ConversationMessageIslandOptions[] = [{
+      author: "You",
+      body: [turn.userMessage.text],
+      references: [],
+      time: turn.userMessage.timestamp,
+      tone: "user",
+      toolActivities: [],
+    }];
+    for (const step of turn.steps) {
+      messages.push(stepToConversationMessage(step));
+    }
+    if (turn.finalMessage) {
+      messages.push({
+        author: "Tinybot",
+        body: [turn.finalMessage.text],
+        copyable: true,
+        references: conversationReferences(turn.finalMessage.references),
+        reasoningContent: "",
+        time: turn.finalMessage.timestamp,
+        tone: "assistant",
+        toolActivities: [],
+      });
+    }
+    return messages;
+  });
+}
+
+export function redactedPreview(value: unknown): string {
+  return serialize(redactSensitive(value));
+}
+
+export function safeArtifactPreview(value: unknown): string {
+  return serialize(omitUnsafe(redactSensitive(value)));
+}
+
+export function redactSensitive(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactSensitive);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [
+    key,
+    SENSITIVE_KEYS.has(key.toLowerCase()) ? "[redacted]" : redactSensitive(item),
+  ]));
+}
+
+export function sanitizeTextPreview(value: string): string {
+  return value
+    .replace(/<\s*script\b[^>]*>[\s\S]*?<\s*\/\s*script\s*>/gi, "[unsafe omitted]")
+    .replace(/<[^>]+>/g, "[unsafe omitted]")
+    .replace(/\b(api_key|token|secret|password|authorization|cookie|credential|private_key)\s*[:=]\s*([^\s,;]+)/gi, "$1=[redacted]");
+}
+
+function stepToConversationMessage(step: ChatStep): ConversationMessageIslandOptions {
+  return {
+    author: "Tinybot",
+    body: step.kind === "message" && step.summary ? [step.summary] : [],
+    references: conversationReferences(step.references),
+    reasoningContent: step.kind === "reasoning" ? step.summary : "",
+    reasoningLabel: step.title,
+    time: step.startedAt || step.completedAt || "",
+    tone: "assistant",
+    toolActivities: stepToToolActivities(step),
+  };
+}
+
+function stepToToolActivities(step: ChatStep): ConversationMessageIslandOptions["toolActivities"] {
+  if (step.toolCall) {
+    return [{
+      approvalId: step.toolCall.approvalId,
+      approvalStatus: step.toolCall.approvalStatus ?? "",
+      argsText: step.toolCall.argsPreview ?? serialize(step.toolCall.argsJson ?? ""),
+      id: step.toolCall.id,
+      kind: step.status === "completed" || step.status === "failed" ? "result" : "call",
+      name: step.toolCall.name,
+      responseText: step.toolCall.resultPreview ?? serialize(step.toolCall.resultJson ?? ""),
+      status: step.status,
+    }];
+  }
+  if (step.delegate) {
+    return [{
+      argsText: step.delegate.task ?? "",
+      id: step.delegate.id,
+      kind: "call",
+      name: `${capitalize(step.delegate.type)}: ${step.delegate.title}`,
+      responseText: step.delegate.latestActivity ?? step.delegate.finalOutput ?? "",
+      approvalStatus: "",
+      status: step.status,
+    }];
+  }
+  if (step.artifacts?.length) {
+    return step.artifacts.map((artifact) => ({
+      argsText: "",
+      id: artifact.id,
+      kind: "result" as const,
+      name: `Artifact: ${artifact.title}`,
+      responseText: safeArtifactText(artifact.preview ?? ""),
+      approvalStatus: "",
+      status: artifact.status ?? "completed",
+    }));
+  }
+  return [];
+}
+
+function stepsFromLegacyMessage(message: NativeChatMessage, turn: ChatTurn, startSequence: number): ChatStep[] {
+  const steps: ChatStep[] = [];
+  let sequence = startSequence;
+  const baseTime = message.timestamp || turn.updatedAt;
+  const isFinal = Boolean(message.content.trim());
+  if (message.reasoningContent?.trim()) {
+    steps.push({
+      agentContext: mainContext(),
+      id: stableId("step", turn.id, message.messageId || sequence, "reasoning"),
+      kind: "reasoning",
+      sequence: ++sequence,
+      startedAt: baseTime,
+      status: "completed",
+      summary: isFinal ? message.reasoningContent : message.reasoningContent,
+      title: isFinal ? "Thinking complete" : "Thinking",
+    });
+  }
+  for (const activity of message.toolActivities ?? []) {
+    steps.push({
+      agentContext: mainContext(),
+      id: stableId("step", turn.id, activity.id),
+      kind: "tool_call",
+      sequence: ++sequence,
+      startedAt: baseTime,
+      status: statusValue(activity.status) || (activity.kind === "result" ? "completed" : "running"),
+      title: activity.name || "tool",
+      toolCall: {
+        approvalId: activity.approvalId,
+        approvalStatus: activity.approvalStatus,
+        argsPreview: activity.argsText,
+        id: activity.id,
+        name: activity.name || "tool",
+        resultPreview: activity.responseText,
+      },
+    });
+  }
+  return steps;
+}
+
+function ensureTurn(state: ChatRunState, event: AgentEventEnvelope): ChatTurn {
+  const turns = state.turnsBySession.get(event.session_key) ?? [];
+  state.turnsBySession.set(event.session_key, turns);
+  let turn = turns.find((item) => item.id === event.turn_id);
+  if (!turn) {
+    turn = {
+      id: event.turn_id,
+      sessionKey: event.session_key,
+      userMessage: {
+        id: stringValue(event.payload.user_message_id) || stableId("user", event.turn_id),
+        role: "user",
+        text: "",
+        timestamp: event.created_at,
+      },
+      userMessageId: stringValue(event.payload.user_message_id) || stableId("user", event.turn_id),
+      status: "pending",
+      steps: [],
+      startedAt: event.created_at,
+      updatedAt: event.created_at,
+    };
+    turns.push(turn);
+  }
+  return turn;
+}
+
+function upsertStep(turn: ChatTurn, event: AgentEventEnvelope, patch: Partial<ChatStep> & Pick<ChatStep, "kind" | "status" | "title">): ChatStep {
+  const stepId = event.step_id || stableId("step", event.turn_id, event.sequence);
+  let step = turn.steps.find((item) => item.id === stepId);
+  if (!step) {
+    step = {
+      agentContext: agentContextFromPayload(event.payload.agent_context),
+      id: stepId,
+      kind: patch.kind,
+      parentStepId: event.parent_step_id,
+      sequence: event.sequence,
+      startedAt: event.created_at,
+      status: patch.status,
+      title: patch.title,
+    };
+    turn.steps.push(step);
+    turn.steps.sort((a, b) => a.sequence - b.sequence);
+  }
+  Object.assign(step, patch, {
+    agentContext: patch.agentContext ?? step.agentContext,
+    completedAt: patch.status === "completed" || patch.status === "failed" || patch.status === "cancelled" ? event.created_at : step.completedAt,
+    startedAt: step.startedAt || event.created_at,
+  });
+  return step;
+}
+
+function syntheticTurn(sessionKey: string, index: number, timestamp: string): ChatTurn {
+  const userId = stableId("synthetic-user", sessionKey, index);
+  return {
+    id: stableId("turn", sessionKey, `synthetic-${index}`),
+    sessionKey,
+    userMessage: { id: userId, role: "user", text: "", timestamp },
+    userMessageId: userId,
+    status: "running",
+    steps: [],
+    startedAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+function toolCallFromPayload(payload: Record<string, unknown>): ToolCallState {
+  return {
+    approvalId: stringValue(payload.approval_id),
+    approvalStatus: stringValue(payload.approval_status),
+    argsJson: payload.args_json === undefined ? undefined : redactSensitive(payload.args_json),
+    argsPreview: safeArtifactText(stringValue(payload.args_preview)),
+    durationMs: numberValue(payload.duration_ms),
+    id: stringValue(payload.tool_call_id) || stringValue(payload.id) || "tool-call",
+    name: stringValue(payload.name) || "tool",
+    resultJson: payload.result_json === undefined ? undefined : redactSensitive(payload.result_json),
+    resultPreview: safeArtifactText(stringValue(payload.result_preview)),
+    resultRef: stringValue(payload.result_ref),
+    stderrPreview: safeArtifactText(stringValue(payload.stderr_preview)),
+  };
+}
+
+function approvalFromPayload(payload: Record<string, unknown>): ApprovalState {
+  return {
+    actions: Array.isArray(payload.actions) ? payload.actions.map(String) : undefined,
+    approvalId: stringValue(payload.approval_id) || "approval",
+    decision: stringValue(payload.decision),
+    riskLevel: stringValue(payload.risk_level),
+    title: stringValue(payload.title),
+    toolCallId: stringValue(payload.tool_call_id),
+  };
+}
+
+function delegateFromPayload(payload: Record<string, unknown>): DelegatedAgentState {
+  const type = agentContextType(stringValue(payload.delegate_type));
+  return {
+    agentCount: Array.isArray(payload.agents) ? payload.agents.length : numberValue(payload.agent_count),
+    artifacts: artifactArray(payload.artifacts),
+    finalOutput: stringValue(payload.final_output),
+    id: stringValue(payload.delegate_id) || "delegate",
+    latestActivity: stringValue(payload.summary ?? payload.latest_activity),
+    status: statusValue(payload.status) || "running",
+    task: stringValue(payload.task),
+    title: stringValue(payload.title) || stringValue(payload.task) || "Delegated work",
+    type,
+    workflow: stringValue(payload.workflow),
+  };
+}
+
+function artifactFromPayload(value: unknown): ArtifactRef {
+  const payload = recordValue(value);
+  return {
+    id: stringValue(payload.id ?? payload.artifact_id) || "artifact",
+    kind: stringValue(payload.kind) || "text",
+    mimeType: stringValue(payload.mime_type ?? payload.mimeType),
+    preview: safeArtifactText(stringValue(payload.preview)),
+    sizeBytes: numberValue(payload.size_bytes ?? payload.sizeBytes),
+    status: stringValue(payload.status) || "available",
+    title: stringValue(payload.title) || stringValue(payload.id ?? payload.artifact_id) || "Artifact",
+  };
+}
+
+function artifactArray(value: unknown): ArtifactRef[] | undefined {
+  return Array.isArray(value) ? value.map(artifactFromPayload) : undefined;
+}
+
+function upsertArtifact(artifacts: ArtifactRef[], artifact: ArtifactRef): ArtifactRef[] {
+  const index = artifacts.findIndex((item) => item.id === artifact.id);
+  if (index === -1) {
+    return [...artifacts, artifact];
+  }
+  return artifacts.map((item, itemIndex) => itemIndex === index ? { ...item, ...artifact } : item);
+}
+
+function normalizeUsage(value: unknown): TokenUsage | undefined {
+  const payload = recordValue(value);
+  if (!Object.keys(payload).length) {
+    return undefined;
+  }
+  return {
+    cachedTokens: numberValue(payload.cached_tokens ?? payload.cachedTokens),
+    completionTokens: numberValue(payload.completion_tokens ?? payload.completionTokens),
+    promptTokens: numberValue(payload.prompt_tokens ?? payload.promptTokens),
+    totalTokens: numberValue(payload.total_tokens ?? payload.totalTokens),
+  };
+}
+
+function normalizeReferences(value: unknown): NativeChatReference[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.map((item) => {
+    const row = recordValue(item);
+    return {
+      detail: stringValue(row.detail ?? row.content ?? row.summary ?? row.url),
+      kind: "reference",
+      title: stringValue(row.title ?? row.name ?? row.id) || "Reference",
+    };
+  });
+}
+
+function conversationReferences(references?: NativeChatReference[]): ConversationMessageIslandOptions["references"] {
+  return (references ?? []).map((reference) => ({
+    detail: reference.detail,
+    evidenceId: reference.evidenceId,
+    kind: reference.kind,
+    noteId: reference.noteId,
+    rawLine: reference.rawLine,
+    rawPath: reference.rawPath,
+    scope: reference.scope,
+    sourceLine: reference.sourceLine,
+    sourcePath: reference.sourcePath,
+    sourceText: reference.sourceText,
+    title: reference.title,
+    type: reference.type,
+  }));
+}
+
+function agentContextFromPayload(value: unknown): AgentContext {
+  const payload = recordValue(value);
+  return {
+    id: stringValue(payload.id) || "main",
+    title: stringValue(payload.title) || "Tinybot",
+    type: agentContextType(stringValue(payload.type)),
+  };
+}
+
+function mainContext(): AgentContext {
+  return { id: "main", title: "Tinybot", type: "main" };
+}
+
+function agentContextType(value: string): AgentContextType {
+  return ["spawn", "subagent", "cowork", "team"].includes(value) ? value as AgentContextType : "main";
+}
+
+function statusValue(value: unknown): ChatStepStatus | "" {
+  const normalized = stringValue(value).toLowerCase().replace(/[\s-]+/g, "_");
+  if (["pending", "running", "blocked", "completed", "failed", "cancelled"].includes(normalized)) {
+    return normalized as ChatStepStatus;
+  }
+  if (["complete", "success", "succeeded", "done"].includes(normalized)) {
+    return "completed";
+  }
+  if (["error", "errored", "failure"].includes(normalized)) {
+    return "failed";
+  }
+  if (["canceled", "interrupted", "stopped"].includes(normalized)) {
+    return "cancelled";
+  }
+  return "";
+}
+
+function omitUnsafe(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(omitUnsafe);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [
+    key,
+    UNSAFE_KEYS.has(key) ? "[unsafe omitted]" : omitUnsafe(item),
+  ]));
+}
+
+function safeArtifactText(value: string): string {
+  return sanitizeTextPreview(value);
+}
+
+function stableId(...parts: Array<string | number | undefined>): string {
+  return parts.filter((part) => part !== undefined && String(part).length > 0).map((part) => String(part).replace(/\s+/g, "-")).join(":");
+}
+
+function serialize(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function capitalize(value: string): string {
+  return value ? `${value.slice(0, 1).toUpperCase()}${value.slice(1)}` : value;
+}

--- a/apps/desktop/src/chatRunModel.ts
+++ b/apps/desktop/src/chatRunModel.ts
@@ -21,6 +21,7 @@ export type AgentContext = {
 };
 
 export type ArtifactRef = {
+  fetchPath?: string;
   id: string;
   kind: ArtifactKind | string;
   mimeType?: string;
@@ -90,6 +91,7 @@ export type ChatStepKind =
   | "delegate"
   | "artifact"
   | "browser"
+  | "form"
   | "memory"
   | "error";
 
@@ -136,6 +138,7 @@ export type ChatInspectorSelection =
 
 export type ChatRunState = {
   appliedEventIds: Set<string>;
+  artifactsBySession: Map<string, Map<string, ArtifactRef>>;
   legacyMessagesBySession: Map<string, NativeChatMessage[]>;
   selectedInspector: ChatInspectorSelection | null;
   turnsBySession: Map<string, ChatTurn[]>;
@@ -155,16 +158,54 @@ export type AgentEventEnvelope = {
   turn_id: string;
 };
 
+export type ChatInspectorPanel = {
+  body: string;
+  kind: ChatInspectorSelection["kind"];
+  status?: string;
+  subtitle?: string;
+  title: string;
+};
+
+export type ChatInspectorRegistry = Record<ChatInspectorSelection["kind"], (state: ChatRunState, selection: ChatInspectorSelection) => ChatInspectorPanel>;
+
 const SENSITIVE_KEYS = new Set(["api_key", "token", "secret", "password", "authorization", "cookie", "credential", "private_key"]);
 const UNSAFE_KEYS = new Set(["html", "script", "style", "component", "handler", "renderer", "template", "onClick", "onSubmit"]);
 
 export function createChatRunState(): ChatRunState {
   return {
     appliedEventIds: new Set(),
+    artifactsBySession: new Map(),
     legacyMessagesBySession: new Map(),
     selectedInspector: null,
     turnsBySession: new Map(),
   };
+}
+
+export function createChatInspectorRegistry(): ChatInspectorRegistry {
+  return {
+    approval: resolveApprovalInspectorPanel,
+    artifact: resolveArtifactInspectorPanel,
+    delegate: resolveDelegateInspectorPanel,
+    error: resolveErrorInspectorPanel,
+    reference: resolveReferenceInspectorPanel,
+    tool_call: resolveToolCallInspectorPanel,
+  };
+}
+
+export function selectChatInspector(state: ChatRunState, selection: ChatInspectorSelection | null): ChatRunState {
+  state.selectedInspector = selection;
+  return state;
+}
+
+export function resolveChatInspectorPanel(state: ChatRunState, selection = state.selectedInspector): ChatInspectorPanel | null {
+  if (!selection) {
+    return null;
+  }
+  return createChatInspectorRegistry()[selection.kind](state, selection);
+}
+
+export function getArtifactRef(state: ChatRunState, sessionKey: string, artifactId: string): ArtifactRef | null {
+  return state.artifactsBySession.get(sessionKey)?.get(artifactId) ?? null;
 }
 
 export function legacyMessagesToTurns(sessionKey: string, messages: NativeChatMessage[]): ChatTurn[] {
@@ -252,6 +293,12 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
     return state;
   }
 
+  if (event.event_type === "agent.turn.updated") {
+    turn.status = turnStatusValue(event.payload.status) || turn.status;
+    turn.usage = normalizeUsage(event.payload.usage) ?? turn.usage;
+    return state;
+  }
+
   if (event.event_type === "agent.turn.failed") {
     turn.status = "failed";
     upsertStep(turn, event, {
@@ -334,8 +381,21 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
     return state;
   }
 
+  if (event.event_type === "agent.form.requested" || event.event_type === "ui.form.requested") {
+    upsertStep(turn, event, {
+      kind: "form",
+      status: "blocked",
+      summary: stringValue(event.payload.title) || stringValue(recordValue(event.payload.form).title),
+      title: stringValue(event.payload.title) || stringValue(recordValue(event.payload.form).title) || "Form requested",
+    });
+    return state;
+  }
+
   if (event.event_type === "agent.delegate.started" || event.event_type === "agent.delegate.updated" || event.event_type === "agent.delegate.completed") {
     const delegate = delegateFromPayload(event.payload);
+    for (const artifact of delegate.artifacts ?? []) {
+      storeArtifact(state, event.session_key, artifact);
+    }
     upsertStep(turn, event, {
       delegate,
       kind: "delegate",
@@ -347,6 +407,7 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
 
   if (event.event_type === "artifact.created" || event.event_type === "artifact.updated") {
     const artifact = artifactFromPayload(event.payload.artifact ?? event.payload);
+    storeArtifact(state, event.session_key, artifact);
     const targetStep = event.step_id ? turn.steps.find((step) => step.id === event.step_id) : undefined;
     if (targetStep) {
       targetStep.artifacts = upsertArtifact(targetStep.artifacts ?? [], artifact);
@@ -620,7 +681,9 @@ function delegateFromPayload(payload: Record<string, unknown>): DelegatedAgentSt
 
 function artifactFromPayload(value: unknown): ArtifactRef {
   const payload = recordValue(value);
+  const fetchPath = stringValue(payload.fetch_path ?? payload.fetchPath);
   return {
+    ...(fetchPath ? { fetchPath } : {}),
     id: stringValue(payload.id ?? payload.artifact_id) || "artifact",
     kind: stringValue(payload.kind) || "text",
     mimeType: stringValue(payload.mime_type ?? payload.mimeType),
@@ -641,6 +704,122 @@ function upsertArtifact(artifacts: ArtifactRef[], artifact: ArtifactRef): Artifa
     return [...artifacts, artifact];
   }
   return artifacts.map((item, itemIndex) => itemIndex === index ? { ...item, ...artifact } : item);
+}
+
+function storeArtifact(state: ChatRunState, sessionKey: string, artifact: ArtifactRef): void {
+  const bucket = state.artifactsBySession.get(sessionKey) ?? new Map<string, ArtifactRef>();
+  state.artifactsBySession.set(sessionKey, bucket);
+  bucket.set(artifact.id, { ...(bucket.get(artifact.id) ?? {}), ...artifact });
+}
+
+function resolveToolCallInspectorPanel(state: ChatRunState, selection: ChatInspectorSelection): ChatInspectorPanel {
+  if (selection.kind !== "tool_call") {
+    return unavailablePanel(selection.kind);
+  }
+  const step = findStep(state, selection.sessionKey, selection.turnId, selection.stepId);
+  const tool = step?.toolCall;
+  if (!tool) {
+    return unavailablePanel("tool_call");
+  }
+  return {
+    body: [
+      tool.argsPreview || serialize(tool.argsJson ?? ""),
+      tool.resultPreview || serialize(tool.resultJson ?? ""),
+      tool.stderrPreview || "",
+    ].filter(Boolean).join("\n\n"),
+    kind: "tool_call",
+    status: step?.status,
+    subtitle: tool.id,
+    title: tool.name,
+  };
+}
+
+function resolveDelegateInspectorPanel(state: ChatRunState, selection: ChatInspectorSelection): ChatInspectorPanel {
+  if (selection.kind !== "delegate") {
+    return unavailablePanel(selection.kind);
+  }
+  const step = findStep(state, selection.sessionKey, selection.turnId, selection.stepId);
+  const delegate = step?.delegate;
+  if (!delegate) {
+    return unavailablePanel("delegate");
+  }
+  return {
+    body: [
+      delegate.task,
+      delegate.latestActivity,
+      delegate.finalOutput,
+      delegate.artifacts?.map((artifact) => `${artifact.kind}: ${artifact.title}`).join("\n"),
+    ].filter(Boolean).join("\n\n"),
+    kind: "delegate",
+    status: delegate.status,
+    subtitle: [delegate.type, delegate.workflow, delegate.agentCount ? `${delegate.agentCount} agents` : ""].filter(Boolean).join(" / "),
+    title: delegate.title,
+  };
+}
+
+function resolveApprovalInspectorPanel(state: ChatRunState, selection: ChatInspectorSelection): ChatInspectorPanel {
+  if (selection.kind !== "approval") {
+    return unavailablePanel(selection.kind);
+  }
+  const step = findStep(state, selection.sessionKey, selection.turnId, selection.stepId);
+  const approval = step?.approval;
+  if (!approval) {
+    return unavailablePanel("approval");
+  }
+  return {
+    body: [approval.riskLevel, approval.actions?.join(", "), approval.decision].filter(Boolean).join("\n"),
+    kind: "approval",
+    status: step?.status,
+    subtitle: approval.approvalId,
+    title: approval.title || "Approval",
+  };
+}
+
+function resolveArtifactInspectorPanel(state: ChatRunState, selection: ChatInspectorSelection): ChatInspectorPanel {
+  if (selection.kind !== "artifact") {
+    return unavailablePanel(selection.kind);
+  }
+  const artifact = getArtifactRef(state, selection.sessionKey, selection.artifactId);
+  if (!artifact) {
+    return unavailablePanel("artifact");
+  }
+  return {
+    body: artifact.preview || "Artifact preview unavailable. Full content is fetched only when requested.",
+    kind: "artifact",
+    status: artifact.status,
+    subtitle: [artifact.kind, artifact.mimeType, artifact.sizeBytes ? `${artifact.sizeBytes} bytes` : ""].filter(Boolean).join(" / "),
+    title: artifact.title,
+  };
+}
+
+function resolveReferenceInspectorPanel(): ChatInspectorPanel {
+  return unavailablePanel("reference");
+}
+
+function resolveErrorInspectorPanel(state: ChatRunState, selection: ChatInspectorSelection): ChatInspectorPanel {
+  if (selection.kind !== "error") {
+    return unavailablePanel(selection.kind);
+  }
+  const step = findStep(state, selection.sessionKey, selection.turnId, selection.stepId);
+  return {
+    body: serialize(step?.error ?? "Error details unavailable."),
+    kind: "error",
+    status: step?.status,
+    title: step?.title || "Error",
+  };
+}
+
+function findStep(state: ChatRunState, sessionKey: string, turnId: string, stepId: string): ChatStep | null {
+  return state.turnsBySession.get(sessionKey)?.find((turn) => turn.id === turnId)?.steps.find((step) => step.id === stepId) ?? null;
+}
+
+function unavailablePanel(kind: ChatInspectorSelection["kind"]): ChatInspectorPanel {
+  return {
+    body: "Details are unavailable for this selection.",
+    kind,
+    status: "unavailable",
+    title: "Unavailable",
+  };
 }
 
 function normalizeUsage(value: unknown): TokenUsage | undefined {
@@ -717,6 +896,17 @@ function statusValue(value: unknown): ChatStepStatus | "" {
   }
   if (["canceled", "interrupted", "stopped"].includes(normalized)) {
     return "cancelled";
+  }
+  return "";
+}
+
+function turnStatusValue(value: unknown): ChatTurnStatus | "" {
+  const normalized = stringValue(value).toLowerCase().replace(/[\s-]+/g, "_");
+  if (["pending", "running", "awaiting_approval", "awaiting_user", "completed", "failed", "interrupted"].includes(normalized)) {
+    return normalized as ChatTurnStatus;
+  }
+  if (normalized === "awaiting_form" || normalized === "blocked") {
+    return "awaiting_user";
   }
   return "";
 }

--- a/apps/desktop/src/desktopApprovalActions.test.ts
+++ b/apps/desktop/src/desktopApprovalActions.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  nativeApprovalRefreshOptions,
+  submitDesktopApprovalAction,
+  summarizeDesktopApprovalResumeResult,
+} from "./desktopApprovalActions";
+
+describe("desktop approval actions", () => {
+  test("resumes native worker approvals before using WebUI approval routes", async () => {
+    const resumeResult = { sessionId: "WebSocket:chat-1", approval: { id: "approval-1" }, result: { finalOutput: "你好" } };
+    const invoke = vi.fn(async () => resumeResult);
+    const gatewayTools = {
+      approveApproval: vi.fn(async () => ({})),
+      denyApproval: vi.fn(async () => ({})),
+    };
+
+    const result = await submitDesktopApprovalAction({
+      action: "approveOnce",
+      approvalId: "approval-1",
+      gatewayTools,
+      invoke,
+      preferNativeWorkerResume: true,
+      sessionKey: "WebSocket:chat-1",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("worker_resume_agent_approval", {
+      input: {
+        approvalId: "approval-1",
+        approved: true,
+        scope: "once",
+        sessionId: "WebSocket:chat-1",
+      },
+    });
+    expect(gatewayTools.approveApproval).not.toHaveBeenCalled();
+    expect(gatewayTools.denyApproval).not.toHaveBeenCalled();
+    expect(result).toBe(resumeResult);
+  });
+
+  test("reports native resume attempts and gateway fallback", async () => {
+    const error = new Error("native command unavailable");
+    const invoke = vi.fn(async () => {
+      throw error;
+    });
+    const gatewayTools = {
+      approveApproval: vi.fn(async () => ({})),
+      denyApproval: vi.fn(async () => ({})),
+    };
+    const onNativeResumeAttempt = vi.fn();
+    const onNativeResumeFailed = vi.fn();
+    const onGatewayFallback = vi.fn();
+
+    await submitDesktopApprovalAction({
+      action: "deny",
+      approvalId: "approval-1",
+      gatewayTools,
+      invoke,
+      onGatewayFallback,
+      onNativeResumeAttempt,
+      onNativeResumeFailed,
+      preferNativeWorkerResume: true,
+      sessionKey: "WebSocket:chat-1",
+    });
+
+    expect(onNativeResumeAttempt).toHaveBeenCalledWith({
+      action: "deny",
+      approvalId: "approval-1",
+      approved: false,
+      scope: "once",
+      sessionKey: "WebSocket:chat-1",
+    });
+    expect(onNativeResumeFailed).toHaveBeenCalledWith(error);
+    expect(onGatewayFallback).toHaveBeenCalledWith({
+      action: "deny",
+      approvalId: "approval-1",
+      approved: false,
+      scope: "once",
+      sessionKey: "WebSocket:chat-1",
+    });
+    expect(gatewayTools.denyApproval).toHaveBeenCalledWith("approval-1", {
+      session_key: "WebSocket:chat-1",
+      auto_retry: true,
+    });
+  });
+
+  test("builds native approval refresh options from active chat context", () => {
+    expect(nativeApprovalRefreshOptions({
+      activeChatId: "chat-1",
+      activeSessionKey: "WebSocket:chat-1",
+    })).toEqual({ sessionKey: "WebSocket:chat-1" });
+    expect(nativeApprovalRefreshOptions({
+      activeChatId: "chat-1",
+      activeSessionKey: "",
+    })).toEqual({ chatId: "chat-1", channel: "websocket" });
+    expect(nativeApprovalRefreshOptions({
+      activeChatId: "",
+      activeSessionKey: "",
+    })).toBeUndefined();
+  });
+
+  test("summarizes native resume results for diagnostics", () => {
+    expect(summarizeDesktopApprovalResumeResult({
+      sessionId: "WebSocket:chat-1",
+      approval: { id: "approval-1" },
+      checkpoint: { checkpointId: "checkpoint-1" },
+      result: {
+        finalOutput: "Subagent said hello",
+        stopReason: "stop",
+      },
+    })).toEqual({
+      hasApproval: true,
+      hasCheckpoint: true,
+      hasResult: true,
+      resultPreview: "Subagent said hello",
+      resultStopReason: "stop",
+      sessionId: "WebSocket:chat-1",
+    });
+  });
+});

--- a/apps/desktop/src/desktopApprovalActions.ts
+++ b/apps/desktop/src/desktopApprovalActions.ts
@@ -1,0 +1,152 @@
+export type DesktopApprovalAction = "approveOnce" | "approveSession" | "deny";
+
+export type DesktopApprovalGatewayTools = {
+  approveApproval(approvalId: string, body: unknown): Promise<unknown> | unknown;
+  denyApproval(approvalId: string, body: unknown): Promise<unknown> | unknown;
+};
+
+export type SubmitDesktopApprovalActionOptions = {
+  action: DesktopApprovalAction;
+  approvalId: string;
+  gatewayTools: DesktopApprovalGatewayTools;
+  invoke?: (command: string, args?: DesktopApprovalResumeArgs) => Promise<unknown> | unknown;
+  onGatewayFallback?: (context: DesktopApprovalActionContext) => void;
+  onNativeResumeAttempt?: (context: DesktopApprovalActionContext) => void;
+  onNativeResumeFailed?: (error: unknown) => void;
+  onNativeResumeSucceeded?: (context: DesktopApprovalActionContext, result: unknown) => void;
+  preferNativeWorkerResume?: boolean;
+  sessionKey: string;
+};
+
+export type DesktopApprovalActionContext = {
+  action: DesktopApprovalAction;
+  approvalId: string;
+  approved: boolean;
+  scope: "once" | "session";
+  sessionKey: string;
+};
+
+export type DesktopApprovalRefreshOptions = {
+  channel?: string;
+  chatId?: string;
+  sessionKey?: string;
+};
+
+export type DesktopApprovalRefreshContext = {
+  activeChatId?: string;
+  activeSessionKey?: string;
+};
+
+type DesktopApprovalResumeArgs = {
+  input: {
+    approvalId: string;
+    approved: boolean;
+    scope: "once" | "session";
+    sessionId: string;
+  };
+};
+
+export function nativeApprovalRefreshOptions(context: DesktopApprovalRefreshContext): DesktopApprovalRefreshOptions | undefined {
+  if (context.activeSessionKey) {
+    return { sessionKey: context.activeSessionKey };
+  }
+  if (context.activeChatId) {
+    return { chatId: context.activeChatId, channel: "websocket" };
+  }
+  return undefined;
+}
+
+export type DesktopApprovalResumeResultSummary = {
+  hasApproval: boolean;
+  hasCheckpoint: boolean;
+  hasResult: boolean;
+  resultPreview: string;
+  resultStopReason: string;
+  sessionId: string;
+};
+
+export function summarizeDesktopApprovalResumeResult(result: unknown): DesktopApprovalResumeResultSummary {
+  const record = isRecord(result) ? result : {};
+  const nestedResult = record.result;
+  const nestedRecord = isRecord(nestedResult) ? nestedResult : {};
+  return {
+    hasApproval: Boolean(record.approval),
+    hasCheckpoint: Boolean(record.checkpoint),
+    hasResult: nestedResult !== undefined && nestedResult !== null,
+    resultPreview: summarizeResumeText(resultPreviewValue(nestedResult)),
+    resultStopReason: stringValue(nestedRecord.stopReason ?? nestedRecord.stop_reason ?? nestedRecord.status),
+    sessionId: stringValue(record.sessionId ?? record.session_id),
+  };
+}
+
+export async function submitDesktopApprovalAction(options: SubmitDesktopApprovalActionOptions): Promise<unknown> {
+  const approved = options.action !== "deny";
+  const scope = options.action === "approveSession" ? "session" : "once";
+  const context: DesktopApprovalActionContext = {
+    action: options.action,
+    approvalId: options.approvalId,
+    approved,
+    scope,
+    sessionKey: options.sessionKey,
+  };
+  if (options.preferNativeWorkerResume && options.invoke) {
+    try {
+      options.onNativeResumeAttempt?.(context);
+      const result = await options.invoke("worker_resume_agent_approval", {
+        input: {
+          sessionId: options.sessionKey,
+          approvalId: options.approvalId,
+          approved,
+          scope,
+        },
+      });
+      options.onNativeResumeSucceeded?.(context, result);
+      return result;
+    } catch (error) {
+      options.onNativeResumeFailed?.(error);
+      // Fall through to WebUI/gateway approval routes for non-native approvals.
+    }
+  }
+  options.onGatewayFallback?.(context);
+  if (!approved) {
+    await options.gatewayTools.denyApproval(options.approvalId, {
+      session_key: options.sessionKey,
+      auto_retry: true,
+    });
+    return undefined;
+  }
+  return await options.gatewayTools.approveApproval(options.approvalId, {
+    session_key: options.sessionKey,
+    scope,
+    auto_retry: true,
+  });
+}
+
+function resultPreviewValue(result: unknown): unknown {
+  if (typeof result === "string") {
+    return result;
+  }
+  if (!isRecord(result)) {
+    return "";
+  }
+  return result.finalOutput
+    ?? result.final_output
+    ?? result.content
+    ?? result.message
+    ?? result.output
+    ?? result.text
+    ?? "";
+}
+
+function summarizeResumeText(value: unknown): string {
+  const text = stringValue(value).trim().replace(/\s+/g, " ");
+  return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -47,6 +47,11 @@ import {
 } from "./desktopSettingsLocalPreferences";
 import { saveDesktopSettingsConfig, type DesktopSettingsSaveResult } from "./desktopSettingsSave";
 import { buildDesktopTsAgentFormSubmissionInput } from "./desktopTsAgentFormActions";
+import {
+  nativeApprovalRefreshOptions,
+  submitDesktopApprovalAction,
+  summarizeDesktopApprovalResumeResult,
+} from "./desktopApprovalActions";
 import { installDesktopNavigation } from "./desktopNavigation";
 import { applyDesktopWorkbenchRouteState } from "./desktopEntityFocus";
 import {
@@ -1161,11 +1166,23 @@ async function handleNativeInlineApprovalAction(detail: unknown): Promise<void> 
     return;
   }
   try {
-    await submitNativeApprovalAction(approvalId, sessionKey, action);
+    const resumeResult = await submitNativeApprovalAction(approvalId, sessionKey, action);
+    const resumeSummary = summarizeDesktopApprovalResumeResult(resumeResult);
+    const decision = action === "deny" ? "denied" : "approved";
+    const resolvedLocally = nativeWorkbenchRuntime?.resolveApproval(approvalId, decision, sessionKey) ?? false;
+    if (nativeWorkbenchRuntime && resolvedLocally) {
+      updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
+    }
     nativeApprovalTaskOperations.delete(taskId);
     publishNativeTaskCenterItems();
     await refreshNativeApprovalTasks();
-    logDesktopNativeDebug("inlineApproval.complete", { action, approvalId, toolName });
+    logDesktopNativeDebug("inlineApproval.complete", {
+      action,
+      approvalId,
+      resolvedLocally,
+      resume: resumeSummary,
+      toolName,
+    });
   } catch (error) {
     nativeApprovalTaskOperations.set(taskId, {
       id: taskId,
@@ -1192,31 +1209,53 @@ async function submitNativeApprovalAction(
   approvalId: string,
   sessionKey: string,
   action: string,
-): Promise<void> {
-  const approved = action !== "deny";
-  const scope = action === "approveSession" ? "session" : "once";
-  if (nativeAgentRoute === "ts-agent") {
-    await invoke("worker_resume_agent_approval", {
-      input: {
-        sessionId: sessionKey,
+): Promise<unknown> {
+  if (!["approveOnce", "approveSession", "deny"].includes(action)) {
+    return undefined;
+  }
+  const preferNativeWorkerResume = true;
+  logDesktopNativeDebug("approvalAction.route", {
+    action,
+    approvalId,
+    hasSessionKey: Boolean(sessionKey),
+    hasTauriRuntime: hasTauriRuntime(),
+    nativeAgentRoute,
+    preferNativeWorkerResume,
+    sessionKeyPrefix: sessionKey.split(":")[0] || "",
+  });
+  return await submitDesktopApprovalAction({
+    action: action as "approveOnce" | "approveSession" | "deny",
+    approvalId,
+    gatewayTools: gatewayApi.tools,
+    invoke,
+    onGatewayFallback: () => {
+      logDesktopNativeDebug("approvalAction.gatewayFallback", {
+        action,
         approvalId,
-        approved,
-        scope,
-      },
-    });
-    return;
-  }
-  if (!approved) {
-    await gatewayApi.tools.denyApproval(approvalId, {
-      session_key: sessionKey,
-      auto_retry: true,
-    });
-    return;
-  }
-  await gatewayApi.tools.approveApproval(approvalId, {
-    session_key: sessionKey,
-    scope,
-    auto_retry: true,
+      });
+    },
+    onNativeResumeAttempt: () => {
+      logDesktopNativeDebug("approvalAction.nativeResume.start", {
+        action,
+        approvalId,
+      });
+    },
+    onNativeResumeFailed: (error) => {
+      logDesktopNativeDebug("approvalAction.nativeResume.failed", {
+        action,
+        approvalId,
+        error: stringifyError(error),
+      });
+    },
+    onNativeResumeSucceeded: (_context, result) => {
+      logDesktopNativeDebug("approvalAction.nativeResume.complete", {
+        action,
+        approvalId,
+        resume: summarizeDesktopApprovalResumeResult(result),
+      });
+    },
+    preferNativeWorkerResume,
+    sessionKey,
   });
 }
 
@@ -2780,9 +2819,23 @@ function failedGatewayRuntimeStatus(
 }
 
 async function refreshNativeApprovalTasks(): Promise<void> {
-  logDesktopNativeDebug("approvals.refresh.start");
+  const approvalOptions = nativeApprovalRefreshOptions({
+    activeChatId: nativeWorkbenchRuntime?.chat.activeChatId,
+    activeSessionKey: nativeWorkbenchRuntime?.chat.activeSessionKey,
+  });
+  logDesktopNativeDebug("approvals.refresh.start", {
+    activeChatId: nativeWorkbenchRuntime?.chat.activeChatId ?? "",
+    hasSessionKey: Boolean(nativeWorkbenchRuntime?.chat.activeSessionKey),
+    mode: approvalOptions ? "session" : "skipped",
+  });
+  if (!approvalOptions) {
+    logDesktopNativeDebug("approvals.refresh.skipped", {
+      reason: "missing active chat context",
+    });
+    return;
+  }
   try {
-    const payload = await gatewayApi.tools.approvals();
+    const payload = await gatewayApi.tools.approvals(approvalOptions);
     nativeApprovalTaskOperations.clear();
     for (const operation of buildDesktopApprovalTaskOperations(payload)) {
       nativeApprovalTaskOperations.set(operation.id, operation);

--- a/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
@@ -579,6 +579,35 @@ describe("desktop native WebSocket bridge", () => {
       _tool_name: "read_file",
       _tool_result: true,
     });
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      schema_version: "tinybot.agent_event.v1",
+      event_type: "tool.call.started",
+      chat_id: "chat-native",
+      session_key: "websocket:chat-native",
+      turn_id: "run-2",
+      step_id: "run-2:call-read",
+      payload: expect.objectContaining({
+        name: "read_file",
+        status: "running",
+        tool_call_id: "call-read",
+      }),
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      schema_version: "tinybot.agent_event.v1",
+      event_type: "tool.call.completed",
+      chat_id: "chat-native",
+      session_key: "websocket:chat-native",
+      turn_id: "run-2",
+      step_id: "run-2:call-read",
+      payload: expect.objectContaining({
+        name: "read_file",
+        result_preview: "file contents",
+        status: "completed",
+        tool_call_id: "call-read",
+      }),
+    }));
   });
 
   test("projects TS worker awaiting interaction events into legacy WebUI frames", async () => {

--- a/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
@@ -88,6 +88,26 @@ describe("desktop native WebSocket bridge", () => {
       _memory_references: [{ note_id: "note-1" }],
       _recent_context_references: [{ evidence_id: "ev-1" }],
     });
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "message.delta",
+      turn_id: "run-1",
+      payload: expect.objectContaining({
+        message_id: "message-1",
+        text: "hello",
+        visibility: "visible",
+      }),
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "reasoning.delta",
+      turn_id: "run-1",
+      payload: expect.objectContaining({
+        message_id: "message-1",
+        text: "thinking",
+        visibility: "hidden",
+      }),
+    }));
     expect(events).not.toContainEqual(expect.objectContaining({
       event: "message",
       chat_id: "chat-native",
@@ -664,9 +684,13 @@ describe("desktop native WebSocket bridge", () => {
       stopReason: "awaiting_form",
     });
     handlers.get(toDesktopNativeTauriEventName("agent.awaiting_approval"))?.({
+      actions: ["approveOnce", "deny"],
       runId: "run-3",
+      argsPreview: "shell command",
       approvalId: "approval-1",
+      riskLevel: "medium",
       stopReason: "awaiting_approval",
+      toolCallId: "call-shell",
     });
 
     expect(events).toContainEqual({
@@ -694,6 +718,76 @@ describe("desktop native WebSocket bridge", () => {
       chat_id: "chat-native",
       approval_id: "approval-1",
     });
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "approval.requested",
+      chat_id: "chat-native",
+      turn_id: "run-3",
+      payload: expect.objectContaining({
+        actions: ["approveOnce", "deny"],
+        approval_id: "approval-1",
+        args_preview: "shell command",
+        risk_level: "medium",
+        tool_call_id: "call-shell",
+      }),
+    }));
+  });
+
+  test("emits approval resolved structured events while forwarding legacy approval frames", async () => {
+    const nativeTransport: NativeTransportApi = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async () => ({
+        transport: {
+          kind: "message",
+          chatId: "chat-native",
+          sessionId: "websocket:chat-native",
+          frames: [],
+        },
+      })),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const socket = createDesktopNativeWebSocket({
+      url: "/ws",
+      nativeTransport,
+    });
+    const events: Array<Record<string, unknown>> = [];
+    socket.addEventListener("message", (event) => {
+      events.push(JSON.parse(String((event as MessageEvent).data)) as Record<string, unknown>);
+    });
+
+    await flushMicrotasks();
+    socket.send(JSON.stringify({ type: "message", chat_id: "chat-native", content: "needs approval" }));
+    await flushMicrotasks();
+    const request = vi.mocked(nativeTransport.dispatchWebsocketMessage).mock.calls[0]?.[0] as { runId?: string };
+    expect(request.runId).toBeTruthy();
+
+    socket.send(JSON.stringify({
+      type: "approval",
+      chat_id: "chat-native",
+      run_id: request.runId,
+      approval_id: "approval-1",
+      action: "deny",
+      tool_call_id: "call-shell",
+    }));
+    await flushMicrotasks();
+
+    expect(nativeTransport.dispatchWebsocketMessage).toHaveBeenCalledTimes(2);
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "approval.resolved",
+      chat_id: "chat-native",
+      turn_id: request.runId,
+      step_id: `${request.runId}:approval:approval-1`,
+      payload: expect.objectContaining({
+        approval_id: "approval-1",
+        decision: "denied",
+        tool_call_id: "call-shell",
+      }),
+    }));
   });
 
   test("projects TS worker memory references and task progress into legacy WebUI message frames", async () => {

--- a/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.test.ts
@@ -630,6 +630,152 @@ describe("desktop native WebSocket bridge", () => {
     }));
   });
 
+  test("projects tool results awaiting approval as pending approval tool frames", async () => {
+    const handlers = new Map<string, (payload: unknown) => void>();
+    const nativeTransport: NativeTransportApi = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async () => ({
+        transport: {
+          kind: "message",
+          chatId: "chat-native",
+          sessionId: "websocket:chat-native",
+          frames: [],
+        },
+        agent: {
+          runId: "run-approval",
+          stopReason: "awaiting_approval",
+        },
+      })),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const socket = createDesktopNativeWebSocket({
+      url: "/ws",
+      nativeTransport,
+      listenToAgentEvent: (eventName, handler) => {
+        handlers.set(eventName, handler);
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+    socket.addEventListener("message", (event) => {
+      events.push(JSON.parse(String((event as MessageEvent).data)) as Record<string, unknown>);
+    });
+
+    await flushMicrotasks();
+    socket.send(JSON.stringify({ type: "message", chat_id: "chat-native", content: "hello" }));
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    handlers.get(toDesktopNativeTauriEventName("agent.tool.result"))?.({
+      runId: "run-approval",
+      toolCallId: "call-spawn",
+      toolName: "spawn",
+      content: "Waiting for approval.",
+      metadata: {
+        awaitingUserInput: true,
+        stopReason: "awaiting_approval",
+        approvalId: "approval-1",
+        operation: {
+          toolName: "spawn",
+          arguments: { task: "说一句你好" },
+        },
+      },
+    });
+
+    expect(events).not.toContainEqual(expect.objectContaining({
+      event: "message",
+      message_id: "run-approval:call-spawn:result",
+      _tool_result: true,
+    }));
+    expect(events).toContainEqual({
+      event: "approval_pending",
+      chat_id: "chat-native",
+      approval_id: "approval-1",
+    });
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "approval.requested",
+      chat_id: "chat-native",
+      turn_id: "run-approval",
+      step_id: "run-approval:approval:approval-1",
+      payload: expect.objectContaining({
+        approval_id: "approval-1",
+        status: "approval_required",
+        tool_call_id: "call-spawn",
+      }),
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "tool.call.completed",
+      payload: expect.objectContaining({
+        tool_call_id: "call-spawn",
+      }),
+    }));
+  });
+
+  test("projects later awaiting approval events back onto pending tool result frames", async () => {
+    const handlers = new Map<string, (payload: unknown) => void>();
+    const nativeTransport: NativeTransportApi = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async () => ({
+        transport: {
+          kind: "message",
+          chatId: "chat-native",
+          sessionId: "websocket:chat-native",
+          frames: [],
+        },
+        agent: {
+          runId: "run-approval",
+          stopReason: "awaiting_approval",
+        },
+      })),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const socket = createDesktopNativeWebSocket({
+      url: "/ws",
+      nativeTransport,
+      listenToAgentEvent: (eventName, handler) => {
+        handlers.set(eventName, handler);
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+    socket.addEventListener("message", (event) => {
+      events.push(JSON.parse(String((event as MessageEvent).data)) as Record<string, unknown>);
+    });
+
+    await flushMicrotasks();
+    socket.send(JSON.stringify({ type: "message", chat_id: "chat-native", content: "hello" }));
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    handlers.get(toDesktopNativeTauriEventName("agent.tool.result"))?.({
+      runId: "run-approval",
+      toolCallId: "call-spawn",
+      toolName: "spawn",
+      content: "Waiting for approval.",
+    });
+    handlers.get(toDesktopNativeTauriEventName("agent.awaiting_approval"))?.({
+      runId: "run-approval",
+      approvalId: "approval-1",
+      argsPreview: "spawn({\"task\":\"说一句你好\"})",
+      toolCallId: "call-spawn",
+      toolName: "spawn",
+    });
+
+    expect(events).not.toContainEqual(expect.objectContaining({
+      event: "message",
+      message_id: "run-approval:call-spawn:result",
+      _tool_result: true,
+    }));
+  });
+
   test("projects TS worker awaiting interaction events into legacy WebUI frames", async () => {
     const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {

--- a/apps/desktop/src/desktopNativeWebSocketBridge.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.ts
@@ -446,7 +446,30 @@ class DesktopNativeWebSocket extends EventTarget {
       const toolCallId = stringValue(payload.toolCallId) || stringValue(payload.tool_call_id) || `${runId}:tool`;
       const toolName = stringValue(payload.toolName) || stringValue(payload.tool_name) || "tool";
       const text = stringValue(payload.content) || stringValue(payload.result) || stringValue(payload.output);
+      const metadata = isRecord(payload.metadata) ? payload.metadata : {};
+      const approvalId = approvalIdFromPayload(payload, metadata);
+      const awaitingApproval = isAwaitingApprovalToolResult(payload, metadata, text);
       const failed = ["failed", "error", "errored"].includes(stringValue(payload.status).toLowerCase());
+      if (awaitingApproval) {
+        if (approvalId) {
+          this.emitJson({
+            event: "approval_pending",
+            chat_id: run.chatId,
+            approval_id: approvalId,
+          });
+        }
+        this.emitAgentEventFrame(run, runId, "approval.requested", {
+          actions: arrayValue(payload.actions ?? metadata.actions),
+          ...(approvalId ? { approval_id: approvalId } : {}),
+          args_preview: approvalArgsPreview(payload, metadata),
+          risk_level: stringValue(payload.riskLevel) || stringValue(payload.risk_level) || stringValue(metadata.riskLevel) || stringValue(metadata.risk_level),
+          status: "approval_required",
+          title: approvalTitle(payload, metadata, toolName),
+          tool_call_id: toolCallId,
+        }, approvalId ? `${runId}:approval:${approvalId}` : `${runId}:approval`);
+        this.deleteToolCallDelta(runId, toolCallId);
+        return;
+      }
       this.emitToolProgressFrame(run.chatId, `${runId}:${toolCallId}:result`, toolName, toolCallId, text, {
         result: true,
       });
@@ -474,6 +497,13 @@ class DesktopNativeWebSocket extends EventTarget {
     }
     if (eventName === "agent.awaiting_approval") {
       const approvalId = stringValue(payload.approvalId) || stringValue(payload.approval_id);
+      const toolCallId = stringValue(payload.toolCallId) || stringValue(payload.tool_call_id) || approvalId;
+      const operation = isRecord(payload.operation) ? payload.operation : {};
+      const toolName = stringValue(payload.toolName)
+        || stringValue(payload.tool_name)
+        || stringValue(operation.toolName)
+        || stringValue(operation.tool_name)
+        || "tool";
       this.emitJson({
         event: "approval_pending",
         chat_id: run.chatId,
@@ -484,8 +514,8 @@ class DesktopNativeWebSocket extends EventTarget {
         approval_id: approvalId,
         args_preview: stringValue(payload.argsPreview) || stringValue(payload.args_preview),
         risk_level: stringValue(payload.riskLevel) || stringValue(payload.risk_level),
-        title: stringValue(payload.title) || stringValue(payload.message) || "Approval required",
-        tool_call_id: stringValue(payload.toolCallId) || stringValue(payload.tool_call_id),
+        title: stringValue(payload.title) || stringValue(payload.message) || `Approval required for ${toolName}`,
+        tool_call_id: toolCallId,
       }, approvalId ? `${runId}:approval:${approvalId}` : `${runId}:approval`);
       return;
     }
@@ -642,6 +672,7 @@ class DesktopNativeWebSocket extends EventTarget {
     toolCallId: string,
     text: string,
     flags: { detail?: boolean; hint?: boolean; result?: boolean },
+    extra: Record<string, unknown> = {},
   ): void {
     this.emitJson({
       event: "message",
@@ -654,6 +685,7 @@ class DesktopNativeWebSocket extends EventTarget {
       ...(flags.hint ? { _tool_hint: true } : {}),
       ...(flags.result ? { _tool_result: true } : {}),
       _tool_name: toolName,
+      ...extra,
     });
   }
 
@@ -781,6 +813,74 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function arrayValue(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
+}
+
+function approvalIdFromPayload(payload: Record<string, unknown>, metadata: Record<string, unknown>): string {
+  return stringValue(payload.approvalId)
+    || stringValue(payload.approval_id)
+    || stringValue(metadata.approvalId)
+    || stringValue(metadata.approval_id)
+    || stringValue(payload.id)
+    || stringValue(metadata.id);
+}
+
+function isAwaitingApprovalToolResult(
+  payload: Record<string, unknown>,
+  metadata: Record<string, unknown>,
+  text: string,
+): boolean {
+  const status = normalizeStatusValue(
+    stringValue(payload.status)
+      || stringValue(payload.stopReason)
+      || stringValue(payload.stop_reason)
+      || stringValue(metadata.status)
+      || stringValue(metadata.stopReason)
+      || stringValue(metadata.stop_reason),
+  );
+  if (["awaiting_approval", "approval_required", "pending_approval", "waiting_approval"].includes(status)) {
+    return true;
+  }
+  return (
+    metadata.awaitingUserInput === true
+    && normalizeStatusValue(stringValue(metadata.stopReason) || stringValue(metadata.stop_reason)) === "awaiting_approval"
+  ) || text.trim().toLowerCase() === "waiting for approval.";
+}
+
+function approvalArgsPreview(payload: Record<string, unknown>, metadata: Record<string, unknown>): string {
+  const explicit = stringValue(payload.argsPreview)
+    || stringValue(payload.args_preview)
+    || stringValue(metadata.argsPreview)
+    || stringValue(metadata.args_preview);
+  if (explicit) {
+    return explicit;
+  }
+  const operation = isRecord(payload.operation) ? payload.operation : isRecord(metadata.operation) ? metadata.operation : {};
+  const args = operation.arguments ?? operation.args;
+  if (args === undefined) {
+    return "";
+  }
+  if (typeof args === "string") {
+    return args;
+  }
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return "";
+  }
+}
+
+function approvalTitle(payload: Record<string, unknown>, metadata: Record<string, unknown>, fallbackToolName: string): string {
+  const operation = isRecord(payload.operation) ? payload.operation : isRecord(metadata.operation) ? metadata.operation : {};
+  const toolName = stringValue(operation.toolName) || stringValue(operation.tool_name) || fallbackToolName;
+  return stringValue(payload.title)
+    || stringValue(payload.message)
+    || stringValue(metadata.title)
+    || stringValue(metadata.message)
+    || `Approval required for ${toolName}`;
+}
+
+function normalizeStatusValue(value: string): string {
+  return value.trim().toLowerCase().replace(/[\s-]+/g, "_");
 }
 
 function isCoworkEventName(eventName: DesktopNativeWebSocketAgentEventName): boolean {

--- a/apps/desktop/src/desktopNativeWebSocketBridge.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.ts
@@ -104,6 +104,8 @@ class DesktopNativeWebSocket extends EventTarget {
   private readonly activeToolCallDeltas = new Map<string, ActiveToolCallDelta>();
   private readonly completedStreamedRunIds = new Set<string>();
   private readonly completedStreamedRunIdsByChat = new Map<string, string>();
+  private readonly startedAgentRunIds = new Set<string>();
+  private readonly lastUserMessageByChat = new Map<string, string>();
   private agentEventSequence = 0;
   private attachedChatId?: string;
 
@@ -152,6 +154,7 @@ class DesktopNativeWebSocket extends EventTarget {
     const sessionExists = await this.resolveAttachSessionExists(frame);
     const model = stringValue(frame.model);
     const run = optimisticRunForFrame(frame);
+    this.maybeEmitApprovalResolvedFrame(frame);
     logDesktopNativeDebug("nativeWebSocket.dispatchFrame", {
       chatId: stringValue(frame.chat_id),
       hasRun: Boolean(run),
@@ -168,7 +171,9 @@ class DesktopNativeWebSocket extends EventTarget {
       ...(run ? { runId: run.runId } : {}),
     };
     if (run) {
+      this.lastUserMessageByChat.set(run.chatId, stringValue(frame.content));
       this.registerRun(run.runId, run);
+      this.emitTurnStartedFrame(run, run.runId, frame);
     }
     try {
       this.applyDispatchResult(await this.nativeTransport.dispatchWebsocketMessage(request));
@@ -223,6 +228,12 @@ class DesktopNativeWebSocket extends EventTarget {
         messageId: stringValue(agent?.messageId) || stringValue(agent?.message_id) || runId,
         streamed: false,
       });
+      const registeredRun = this.activeRuns.get(runId);
+      if (registeredRun) {
+        this.emitTurnStartedFrame(registeredRun, runId, {
+          content: this.lastUserMessageByChat.get(chatId) ?? "",
+        });
+      }
     }
     const finalContent = stringValue(agent?.finalContent);
     const run = runId ? this.activeRuns.get(runId) : undefined;
@@ -240,6 +251,17 @@ class DesktopNativeWebSocket extends EventTarget {
         message_id: runId || `native:${chatId}`,
         reason: stringValue(agent?.stopReason) || "stop",
       });
+      if (run && runId) {
+        this.emitAgentEventFrame(run, runId, "message.completed", {
+          message_id: run.messageId,
+          text: finalContent,
+        }, `${runId}:final`);
+        this.emitAgentEventFrame(run, runId, "agent.turn.completed", {
+          message_id: run.messageId,
+          reason: stringValue(agent?.stopReason) || "stop",
+          usage: isRecord(agent?.usage) ? agent?.usage : undefined,
+        });
+      }
     }
   }
 
@@ -297,6 +319,8 @@ class DesktopNativeWebSocket extends EventTarget {
     this.activeToolCallDeltas.clear();
     this.completedStreamedRunIds.clear();
     this.completedStreamedRunIdsByChat.clear();
+    this.startedAgentRunIds.clear();
+    this.lastUserMessageByChat.clear();
   }
 
   private registerRun(runId: string, run: ActiveRun): void {
@@ -381,6 +405,7 @@ class DesktopNativeWebSocket extends EventTarget {
         is_reasoning: eventName === "agent.reasoning_delta",
       });
       this.emitAgentEventFrame(run, runId, eventName === "agent.reasoning_delta" ? "reasoning.delta" : "message.delta", {
+        message_id: run.messageId,
         text,
         visibility: eventName === "agent.reasoning_delta" ? "hidden" : "visible",
       });
@@ -421,13 +446,15 @@ class DesktopNativeWebSocket extends EventTarget {
       const toolCallId = stringValue(payload.toolCallId) || stringValue(payload.tool_call_id) || `${runId}:tool`;
       const toolName = stringValue(payload.toolName) || stringValue(payload.tool_name) || "tool";
       const text = stringValue(payload.content) || stringValue(payload.result) || stringValue(payload.output);
+      const failed = ["failed", "error", "errored"].includes(stringValue(payload.status).toLowerCase());
       this.emitToolProgressFrame(run.chatId, `${runId}:${toolCallId}:result`, toolName, toolCallId, text, {
         result: true,
       });
-      this.emitAgentEventFrame(run, runId, "tool.call.completed", {
+      this.emitAgentEventFrame(run, runId, failed ? "tool.call.failed" : "tool.call.completed", {
+        error: failed ? { message: text || "tool failed" } : undefined,
         name: toolName,
         result_preview: text,
-        status: "completed",
+        status: failed ? "failed" : "completed",
         tool_call_id: toolCallId,
       }, `${runId}:${toolCallId}`);
       this.deleteToolCallDelta(runId, toolCallId);
@@ -453,7 +480,10 @@ class DesktopNativeWebSocket extends EventTarget {
         ...(approvalId ? { approval_id: approvalId } : {}),
       });
       this.emitAgentEventFrame(run, runId, "approval.requested", {
+        actions: arrayValue(payload.actions),
         approval_id: approvalId,
+        args_preview: stringValue(payload.argsPreview) || stringValue(payload.args_preview),
+        risk_level: stringValue(payload.riskLevel) || stringValue(payload.risk_level),
         title: stringValue(payload.title) || stringValue(payload.message) || "Approval required",
         tool_call_id: stringValue(payload.toolCallId) || stringValue(payload.tool_call_id),
       }, approvalId ? `${runId}:approval:${approvalId}` : `${runId}:approval`);
@@ -540,6 +570,7 @@ class DesktopNativeWebSocket extends EventTarget {
         ...referenceMetadata(payload),
       });
       this.emitAgentEventFrame(run, runId, "agent.turn.completed", {
+        message_id: run.messageId,
         reason: stringValue(payload.stopReason) || stringValue(payload.stop_reason) || "stop",
         usage: isRecord(payload.usage) ? payload.usage : undefined,
       });
@@ -624,6 +655,41 @@ class DesktopNativeWebSocket extends EventTarget {
       ...(flags.result ? { _tool_result: true } : {}),
       _tool_name: toolName,
     });
+  }
+
+  private emitTurnStartedFrame(run: ActiveRun, runId: string, frame: Record<string, unknown>): void {
+    if (this.startedAgentRunIds.has(runId)) {
+      return;
+    }
+    this.startedAgentRunIds.add(runId);
+    this.emitAgentEventFrame(run, runId, "agent.turn.started", {
+      user_message: {
+        id: `${runId}:user`,
+        role: "user",
+        text: stringValue(frame.content),
+      },
+      user_message_id: `${runId}:user`,
+    });
+  }
+
+  private maybeEmitApprovalResolvedFrame(frame: Record<string, unknown>): void {
+    const approvalId = stringValue(frame.approval_id) || stringValue(frame.approvalId);
+    const decision = stringValue(frame.decision) || stringValue(frame.action) || stringValue(frame.approval_action);
+    const normalizedDecision = decision.toLowerCase();
+    if (!approvalId || !["approve", "approved", "approve_once", "approve_session", "deny", "denied", "reject", "rejected"].includes(normalizedDecision)) {
+      return;
+    }
+    const chatId = stringValue(frame.chat_id) || stringValue(frame.chatId) || this.attachedChatId || "";
+    const runId = stringValue(frame.run_id) || stringValue(frame.runId) || this.activeRunIdForChat(chatId);
+    const run = runId ? this.activeRuns.get(runId) : undefined;
+    if (!run) {
+      return;
+    }
+    this.emitAgentEventFrame(run, runId, "approval.resolved", {
+      approval_id: approvalId,
+      decision: normalizedDecision.startsWith("deny") || normalizedDecision.startsWith("reject") ? "denied" : "approved",
+      tool_call_id: stringValue(frame.tool_call_id) || stringValue(frame.toolCallId),
+    }, `${runId}:approval:${approvalId}`);
   }
 
   private emitAgentEventFrame(

--- a/apps/desktop/src/desktopNativeWebSocketBridge.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.ts
@@ -104,6 +104,7 @@ class DesktopNativeWebSocket extends EventTarget {
   private readonly activeToolCallDeltas = new Map<string, ActiveToolCallDelta>();
   private readonly completedStreamedRunIds = new Set<string>();
   private readonly completedStreamedRunIdsByChat = new Map<string, string>();
+  private agentEventSequence = 0;
   private attachedChatId?: string;
 
   constructor(options: DesktopNativeWebSocketOptions) {
@@ -379,6 +380,10 @@ class DesktopNativeWebSocket extends EventTarget {
         text,
         is_reasoning: eventName === "agent.reasoning_delta",
       });
+      this.emitAgentEventFrame(run, runId, eventName === "agent.reasoning_delta" ? "reasoning.delta" : "message.delta", {
+        text,
+        visibility: eventName === "agent.reasoning_delta" ? "hidden" : "visible",
+      });
       return;
     }
     if (eventName === "agent.tool_call.delta") {
@@ -404,6 +409,12 @@ class DesktopNativeWebSocket extends EventTarget {
         detail: true,
         hint: true,
       });
+      this.emitAgentEventFrame(run, runId, "tool.call.started", {
+        args_preview: cachedToolCall?.argumentsText ?? "",
+        name: toolName,
+        status: "running",
+        tool_call_id: toolCallId,
+      }, `${runId}:${toolCallId}`);
       return;
     }
     if (eventName === "agent.tool.result") {
@@ -413,6 +424,12 @@ class DesktopNativeWebSocket extends EventTarget {
       this.emitToolProgressFrame(run.chatId, `${runId}:${toolCallId}:result`, toolName, toolCallId, text, {
         result: true,
       });
+      this.emitAgentEventFrame(run, runId, "tool.call.completed", {
+        name: toolName,
+        result_preview: text,
+        status: "completed",
+        tool_call_id: toolCallId,
+      }, `${runId}:${toolCallId}`);
       this.deleteToolCallDelta(runId, toolCallId);
       return;
     }
@@ -435,6 +452,11 @@ class DesktopNativeWebSocket extends EventTarget {
         chat_id: run.chatId,
         ...(approvalId ? { approval_id: approvalId } : {}),
       });
+      this.emitAgentEventFrame(run, runId, "approval.requested", {
+        approval_id: approvalId,
+        title: stringValue(payload.title) || stringValue(payload.message) || "Approval required",
+        tool_call_id: stringValue(payload.toolCallId) || stringValue(payload.tool_call_id),
+      }, approvalId ? `${runId}:approval:${approvalId}` : `${runId}:approval`);
       return;
     }
     if (eventName === "agent.memory_reference") {
@@ -467,6 +489,14 @@ class DesktopNativeWebSocket extends EventTarget {
         source_command: stringValue(payload.sourceCommand) || stringValue(payload.source_command),
         captured_at: payload.capturedAt ?? payload.captured_at ?? null,
       });
+      this.emitAgentEventFrame(run, runId, "artifact.created", {
+        artifact: {
+          id: stringValue(payload.artifactId) || stringValue(payload.artifact_id) || `${runId}:browser-frame`,
+          kind: "browser_snapshot",
+          preview: stringValue(payload.imageUrl) || stringValue(payload.image_url),
+          title: stringValue(payload.sourceCommand) || stringValue(payload.source_command) || "Browser snapshot",
+        },
+      }, `${runId}:browser-frame`);
       return;
     }
     if (eventName === "agent.cancelled") {
@@ -474,6 +504,9 @@ class DesktopNativeWebSocket extends EventTarget {
       this.emitJson({
         event: "interrupted",
         chat_id: run.chatId,
+        cancelled: payload.cancelled !== false,
+      });
+      this.emitAgentEventFrame(run, runId, "agent.turn.interrupted", {
         cancelled: payload.cancelled !== false,
       });
       this.activeRuns.delete(runId);
@@ -490,6 +523,11 @@ class DesktopNativeWebSocket extends EventTarget {
         message_id: run.messageId,
         message: stringValue(payload.message) || stringValue(payload.error) || "agent error",
       });
+      this.emitAgentEventFrame(run, runId, "agent.turn.failed", {
+        error: {
+          message: stringValue(payload.message) || stringValue(payload.error) || "agent error",
+        },
+      });
       return;
     }
     if (eventName === "agent.done") {
@@ -500,6 +538,10 @@ class DesktopNativeWebSocket extends EventTarget {
         message_id: run.messageId,
         reason: stringValue(payload.stopReason) || stringValue(payload.stop_reason) || "stop",
         ...referenceMetadata(payload),
+      });
+      this.emitAgentEventFrame(run, runId, "agent.turn.completed", {
+        reason: stringValue(payload.stopReason) || stringValue(payload.stop_reason) || "stop",
+        usage: isRecord(payload.usage) ? payload.usage : undefined,
       });
       this.activeRuns.delete(runId);
       this.completedStreamedRunIds.add(runId);
@@ -581,6 +623,29 @@ class DesktopNativeWebSocket extends EventTarget {
       ...(flags.hint ? { _tool_hint: true } : {}),
       ...(flags.result ? { _tool_result: true } : {}),
       _tool_name: toolName,
+    });
+  }
+
+  private emitAgentEventFrame(
+    run: ActiveRun,
+    runId: string,
+    eventType: string,
+    payload: Record<string, unknown>,
+    stepId?: string,
+  ): void {
+    const sequence = ++this.agentEventSequence;
+    this.emitJson({
+      event: "agent_event",
+      schema_version: "tinybot.agent_event.v1",
+      event_id: `${runId}:${eventType}:${sequence}`,
+      event_type: eventType,
+      chat_id: run.chatId,
+      session_key: run.sessionId || `websocket:${run.chatId}`,
+      turn_id: runId,
+      ...(stepId ? { step_id: stepId } : {}),
+      sequence,
+      created_at: new Date().toISOString(),
+      payload,
     });
   }
 

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
@@ -18,6 +18,7 @@ import type { NormalizedGatewayEvent } from "./gatewayWebSocketClient";
 import {
   appendUserMessage,
   applyChatEvent,
+  resolveNativeChatApproval,
   sessionKeyForChatState,
   type NativeChatMessage,
   type NativeChatReference,
@@ -113,6 +114,7 @@ export interface DesktopNativeWorkbenchRuntime {
   setPersistentRag(enabled: boolean): void;
   submitComposerMessage(content: string, usePersistentRag?: boolean): ChatSubmitResult;
   interruptActiveChat(): boolean;
+  resolveApproval(approvalId: string, decision: "approved" | "denied", sessionKey?: string): boolean;
   handleGatewayEvent(event: NormalizedGatewayEvent): Promise<void>;
   handleTsAgentWorkerEvent(eventName: DesktopTsAgentWorkerEventName, payload: unknown): void;
 }
@@ -847,6 +849,9 @@ export function createDesktopNativeWorkbenchRuntime({
     setPersistentRag,
     submitComposerMessage,
     interruptActiveChat,
+    resolveApproval(approvalId: string, decision: "approved" | "denied", sessionKey = chatController.state.activeSessionKey) {
+      return resolveNativeChatApproval(chatController.state, { approvalId, decision, sessionKey });
+    },
     handleGatewayEvent,
     handleTsAgentWorkerEvent,
   };

--- a/apps/desktop/src/gateway.test.ts
+++ b/apps/desktop/src/gateway.test.ts
@@ -2877,6 +2877,20 @@ describe("gateway WebSocket client", () => {
     });
     expect(
       normalizeGatewayFrame({
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-tool",
+        event_type: "tool.call.started",
+        chat_id: "chat-1",
+        turn_id: "turn-1",
+        payload: { name: "read_file" },
+      }),
+    ).toMatchObject({
+      kind: "agent.event",
+      chatId: "chat-1",
+    });
+    expect(
+      normalizeGatewayFrame({
         event: "agent_ui_event",
         agent_ui_event: { event_type: "ui.form.requested", payload: { form_id: "form-1" } },
       }),

--- a/apps/desktop/src/gateway.test.ts
+++ b/apps/desktop/src/gateway.test.ts
@@ -619,6 +619,43 @@ describe("gateway HTTP client", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
+  test("normalizes desktop WebSocket session keys for native WebUI approval resolution", async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
+    const nativeWebui = {
+      route: vi.fn(async (request: { method: string; path: string; body?: unknown }) => ({
+        ok: true,
+        request,
+      })),
+    };
+    const client = createGatewayApiClient({
+      config: DEFAULT_GATEWAY_CONFIG,
+      fetchFn,
+      nativeWebui,
+    });
+
+    await client.tools.approveApproval("approval-1", {
+      session_key: "WebSocket:chat-1",
+      scope: "once",
+      auto_retry: true,
+    });
+    await client.tools.denyApproval("approval-1", {
+      session_key: "WebSocket:chat-1",
+      auto_retry: true,
+    });
+
+    expect(nativeWebui.route).toHaveBeenCalledWith({
+      method: "POST",
+      path: "/api/approvals/approval-1/approve",
+      body: { session_key: "websocket:chat-1", scope: "once", auto_retry: true },
+    });
+    expect(nativeWebui.route).toHaveBeenCalledWith({
+      method: "POST",
+      path: "/api/approvals/approval-1/deny",
+      body: { session_key: "websocket:chat-1", auto_retry: true },
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
   test("prefers native WebUI session list route when available", async () => {
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {

--- a/apps/desktop/src/gatewayHttpClient.ts
+++ b/apps/desktop/src/gatewayHttpClient.ts
@@ -445,7 +445,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
       approveApproval: (approvalId: string, body: unknown) => {
         const path = `/api/approvals/${encodePathSegment(approvalId)}/approve`;
         return nativeOrGateway(
-          () => options.nativeWebui?.route({ method: "POST", path, body }),
+          () => options.nativeWebui?.route({ method: "POST", path, body: nativeWebuiApprovalBody(body) }),
           () => request(path, jsonRequest("POST", body)),
           "webui.approvals.approve",
         );
@@ -453,7 +453,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
       denyApproval: (approvalId: string, body: unknown) => {
         const path = `/api/approvals/${encodePathSegment(approvalId)}/deny`;
         return nativeOrGateway(
-          () => options.nativeWebui?.route({ method: "POST", path, body }),
+          () => options.nativeWebui?.route({ method: "POST", path, body: nativeWebuiApprovalBody(body) }),
           () => request(path, jsonRequest("POST", body)),
           "webui.approvals.deny",
         );
@@ -1567,6 +1567,10 @@ function encodePathSegment(value: string): string {
   return encodeURIComponent(value);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function approvalsListPath(options: WebuiApprovalsListOptions | undefined): string {
   const params = new URLSearchParams();
   if (options?.sessionKey) {
@@ -1580,6 +1584,22 @@ function approvalsListPath(options: WebuiApprovalsListOptions | undefined): stri
   }
   const query = params.toString();
   return query ? `/api/approvals?${query}` : "/api/approvals";
+}
+
+function nativeWebuiApprovalBody(body: unknown): unknown {
+  if (!isRecord(body) || typeof body.session_key !== "string") {
+    return body;
+  }
+  return {
+    ...body,
+    session_key: normalizeNativeWebuiSessionKey(body.session_key),
+  };
+}
+
+function normalizeNativeWebuiSessionKey(sessionKey: string): string {
+  return sessionKey.startsWith("WebSocket:")
+    ? `websocket:${sessionKey.slice("WebSocket:".length)}`
+    : sessionKey;
 }
 
 function knowledgeDocumentsPath(options: KnowledgeDocumentsOptions): string {

--- a/apps/desktop/src/gatewayWebSocketClient.ts
+++ b/apps/desktop/src/gatewayWebSocketClient.ts
@@ -16,6 +16,7 @@ export const createGatewaySocketMessage = {
 export type NormalizedGatewayEvent =
   | { kind: "attached"; chatId: string; raw: Record<string, unknown> }
   | { kind: "chat.created"; chatId: string; raw: Record<string, unknown> }
+  | { kind: "agent.event"; chatId?: string; raw: Record<string, unknown> }
   | { kind: "message.delta"; chatId?: string; messageId?: string; text: string; reasoning: boolean; raw: Record<string, unknown> }
   | { kind: "message.completed"; chatId?: string; messageId?: string; text: string; raw: Record<string, unknown> }
   | { kind: "message.stream.completed"; chatId?: string; messageId?: string; raw: Record<string, unknown> }
@@ -36,6 +37,8 @@ export function normalizeGatewayFrame(frame: unknown): NormalizedGatewayEvent {
       return { kind: "attached", chatId: stringValue(raw.chat_id), raw };
     case "chat_created":
       return { kind: "chat.created", chatId: stringValue(raw.chat_id), raw };
+    case "agent_event":
+      return { kind: "agent.event", chatId: optionalString(raw.chat_id), raw };
     case "delta":
     case "message_delta":
       return {

--- a/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { readFileSync } from "node:fs";
 import { describe, expect, test, vi } from "vitest";
 import { nextTick } from "vue";
 import { mountConversationThreadIsland } from "./conversationThreadIsland";
@@ -792,10 +793,99 @@ describe("conversation thread Vue island", () => {
     await flushDetailPanelOpeningMotion();
 
     const panel = host.querySelector<HTMLElement>(".desktop-tool-detail-panel");
+    expect(panel?.getAttribute("aria-label")).toBe("Artifact details");
+    expect(panel?.getAttribute("data-inspector-kind")).toBe("artifact");
     expect(panel?.textContent).toContain("Artifact: npm test");
     expect(panel?.textContent).not.toContain("<script>");
     expect(panel?.textContent).not.toContain("api_key=secret");
     expect(panel?.textContent).toContain("[unsafe omitted]");
     expect(panel?.textContent).toContain("[redacted]");
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-tool-activity-id="delegate-cowork"] .desktop-tool-activity-row')?.click();
+    await nextTick();
+    await flushDetailPanelOpeningMotion();
+
+    const delegatePanel = host.querySelector<HTMLElement>(".desktop-tool-detail-panel");
+    expect(delegatePanel?.getAttribute("aria-label")).toBe("Delegated agent details");
+    expect(delegatePanel?.getAttribute("data-inspector-kind")).toBe("delegate");
+    expect(delegatePanel?.textContent).toContain("Review implementation");
+    expect(delegatePanel?.textContent).toContain("2 agents active");
+  });
+
+  test("windows very large timelines and keeps the latest visible nodes", async () => {
+    const host = document.createElement("section");
+    const messages = Array.from({ length: 340 }, (_, index) => ({
+      author: index % 2 === 0 ? "You" : "Tinybot",
+      body: [`Message ${index}`],
+      references: [],
+      time: "10:31 AM",
+      tone: index % 2 === 0 ? "user" as const : "assistant" as const,
+      toolActivities: [],
+    }));
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages,
+    });
+    await nextTick();
+    await nextTick();
+
+    const timeline = host.querySelector<HTMLElement>(".desktop-conversation-timeline");
+    expect(host.querySelector(".desktop-conversation-layout")?.getAttribute("data-large-timeline-windowed")).toBe("true");
+    expect(timeline?.getAttribute("data-total-node-count")).toBe("340");
+    expect(timeline?.getAttribute("data-rendered-node-count")).toBe("301");
+    expect(host.querySelector(".desktop-conversation-large-window-placeholder")?.getAttribute("data-omitted-node-count")).toBe("40");
+    expect(host.textContent).not.toContain("Message 0");
+    expect(host.textContent).toContain("Message 339");
+  });
+
+  test("respects reduced motion for inspector transitions", async () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+    const host = document.createElement("section");
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [{
+        author: "Tinybot",
+        body: [],
+        references: [],
+        time: "10:31 AM",
+        tone: "assistant",
+        toolActivities: [{
+          argsText: "npm test",
+          approvalStatus: "",
+          id: "tool-shell",
+          kind: "call",
+          name: "shell",
+          responseText: "",
+          runChainItemKey: "turn-1:tool-shell",
+          status: "running",
+        }],
+      }],
+    });
+    await nextTick();
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-tool-activity-id="tool-shell"] .desktop-tool-activity-row')?.click();
+    await nextTick();
+
+    expect(host.querySelector(".desktop-conversation-layout")?.getAttribute("data-reduced-motion")).toBe("true");
+    expect(host.querySelector(".desktop-tool-detail-panel")?.getAttribute("data-tool-detail-motion")).toBe("open");
+
+    const css = readFileSync("src/styles.css", "utf8");
+    expect(css).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(css).toContain("animation: none !important");
+    expect(css).toContain("transition: none !important");
+
+    window.matchMedia = originalMatchMedia;
   });
 });

--- a/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
@@ -748,4 +748,54 @@ describe("conversation thread Vue island", () => {
     expect(host.querySelector(".desktop-conversation-layout")?.getAttribute("data-tool-detail-visible")).toBe("false");
     expect(host.querySelector<HTMLElement>(".desktop-conversation-layout")?.style.getPropertyValue("--desktop-tool-detail-width")).toBe("");
   });
+
+  test("renders delegated workflow and artifact inspector rows with safe previews", async () => {
+    const host = document.createElement("section");
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [{
+        author: "Tinybot",
+        body: ["I coordinated extra work."],
+        references: [],
+        time: "10:31 AM",
+        tone: "assistant",
+        toolActivities: [{
+          argsText: "Review implementation",
+          approvalStatus: "",
+          id: "delegate-cowork",
+          kind: "call",
+          name: "Cowork: Review implementation",
+          responseText: "2 agents active",
+          runChainItemKey: "turn-1:delegate-cowork",
+          status: "running",
+        }, {
+          argsText: "",
+          approvalStatus: "",
+          id: "artifact-output",
+          kind: "result",
+          name: "Artifact: npm test",
+          responseText: "<script>alert(1)</script> api_key=secret",
+          runChainItemKey: "turn-1:artifact-output",
+          status: "completed",
+        }],
+      }],
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(host.textContent).toContain("Cowork: Review implementation");
+    expect(host.textContent).toContain("Artifact: npm test");
+
+    host.querySelector<HTMLButtonElement>('[data-desktop-tool-activity-id="artifact-output"] .desktop-tool-activity-row')?.click();
+    await nextTick();
+    await flushDetailPanelOpeningMotion();
+
+    const panel = host.querySelector<HTMLElement>(".desktop-tool-detail-panel");
+    expect(panel?.textContent).toContain("Artifact: npm test");
+    expect(panel?.textContent).not.toContain("<script>");
+    expect(panel?.textContent).not.toContain("api_key=secret");
+    expect(panel?.textContent).toContain("[unsafe omitted]");
+    expect(panel?.textContent).toContain("[redacted]");
+  });
 });

--- a/apps/desktop/src/native-vue/conversationThreadIsland.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.ts
@@ -2,6 +2,7 @@ import { computed, createApp, defineComponent, h, nextTick, onBeforeUnmount, ref
 import { NConfigProvider, NEmpty } from "naive-ui";
 import type { AgentUiForm } from "../agentUiEvents";
 import { logDesktopNativeChatDebug, logDesktopNativeDebug, summarizeDebugText } from "../desktopNativeChatDebug";
+import { sanitizeTextPreview } from "../chatRunModel";
 import { desktopNaiveThemeOverrides } from "./desktopNaiveTheme";
 import { renderAgentUiFormCardChildren } from "./agentUiFormCardIsland";
 import { renderConversationMessageChildren, type ConversationMessageIslandOptions } from "./conversationMessageIsland";
@@ -903,7 +904,7 @@ function renderToolDetailMeta(activity: ToolActivityIslandOptions) {
 }
 
 function renderToolDetailText(label: string, value: string, emptyLabel: string) {
-  const formatted = formatMaybeJson(value);
+  const formatted = formatMaybeJson(sanitizeTextPreview(value));
   return h("section", { class: "desktop-tool-detail-section" }, [
     h("h4", label),
     h("pre", { class: "desktop-tool-detail-pre" }, formatted || emptyLabel),

--- a/apps/desktop/src/native-vue/conversationThreadIsland.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.ts
@@ -67,7 +67,9 @@ interface ConversationTimelineScrollState {
 
 const mountedConversationThreads = new WeakMap<HTMLElement, MountedConversationThreadIsland>();
 const DETAIL_PANEL_MOTION_MS = 560;
+const TIMELINE_EAGER_NODE_LIMIT = 300;
 type DetailPanelState = "closed" | "opening" | "open" | "closing";
+type ActivityInspectorKind = "approval" | "artifact" | "delegate" | "tool_call";
 
 export function mountOrUpdateConversationThreadIsland(
   host: HTMLElement,
@@ -130,6 +132,7 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
       const detailPanelState = ref<DetailPanelState>("closed");
       const panelWidth = ref(50);
       const overlayMode = ref(isToolDetailOverlayMode());
+      const reducedMotion = ref(prefersReducedMotion());
       let closePanelTimer: number | null = null;
       let openPanelFrame: number | null = null;
       const selectedTool = computed(() => selectedToolKey.value ? findToolActivity(state.value.messages, selectedToolKey.value) : null);
@@ -164,7 +167,7 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
         detailPanelState.value = "closing";
         clearOpenPanelFrame();
         clearClosePanelTimer();
-        if (typeof window === "undefined") {
+        if (typeof window === "undefined" || reducedMotion.value) {
           clearPanelSelection();
           return;
         }
@@ -177,7 +180,7 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
         }
         clearOpenPanelFrame();
         detailPanelState.value = "opening";
-        if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+        if (typeof window === "undefined" || reducedMotion.value || typeof window.requestAnimationFrame !== "function") {
           detailPanelState.value = "open";
           return;
         }
@@ -229,6 +232,7 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
       };
       const updateOverlayMode = () => {
         overlayMode.value = isToolDetailOverlayMode();
+        reducedMotion.value = prefersReducedMotion();
       };
       if (typeof window !== "undefined") {
         window.addEventListener("resize", updateOverlayMode);
@@ -249,9 +253,10 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
             ...(state.value.coworkRuns ?? []).map((run) => renderChatCoworkRun(run, openCoworkAgentDetail)),
             ...(state.value.inlineForms ?? []).map((form) => renderInlineAgentUiForm(state.value, form)),
           ];
+          const timelineNodes = windowTimelineNodes(nodes);
           const hasPanelSelection = hasDetailPanelSelection();
           const detailPanel = selectedTool.value
-            ? renderToolDetailPanel({
+            ? renderActivityInspectorPanel({
               activity: selectedTool.value,
               mode: overlayMode.value ? "overlay" : "push",
               motionState: detailPanelState.value,
@@ -291,7 +296,9 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
               "data-cowork-agent-detail-visible": String(Boolean(selectedCoworkAgent.value) && detailPanelState.value === "open"),
               "data-detail-panel-mode": overlayMode.value ? "overlay" : "push",
               "data-detail-panel-state": hasPanelSelection ? detailPanelState.value : "closed",
+              "data-large-timeline-windowed": String(nodes.length > TIMELINE_EAGER_NODE_LIMIT),
               "data-reference-detail-visible": String(Boolean(selectedReference.value) && detailPanelState.value === "open"),
+              "data-reduced-motion": String(reducedMotion.value),
               "data-tool-detail-visible": String(Boolean(selectedTool.value) && detailPanelState.value === "open"),
               onClick: handleLayoutClick,
               onDesktopToolDetailOpen: openToolDetail,
@@ -305,13 +312,19 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
                 class: "desktop-conversation-layout",
                 "data-cowork-agent-detail-visible": String(Boolean(selectedCoworkAgent.value) && detailPanelState.value === "open"),
                 "data-detail-panel-state": hasPanelSelection ? detailPanelState.value : "closed",
+                "data-large-timeline-windowed": String(nodes.length > TIMELINE_EAGER_NODE_LIMIT),
                 "data-reference-detail-visible": String(Boolean(selectedReference.value) && detailPanelState.value === "open"),
+                "data-reduced-motion": String(reducedMotion.value),
                 "data-tool-detail-visible": String(Boolean(selectedTool.value) && detailPanelState.value === "open"),
                 style: hasPanelSelection
                   ? { "--desktop-tool-detail-width": `${panelWidth.value}%` }
                   : undefined,
               }, [
-                h("div", { class: "desktop-conversation-timeline" }, nodes),
+                h("div", {
+                  class: "desktop-conversation-timeline",
+                  "data-rendered-node-count": String(timelineNodes.length),
+                  "data-total-node-count": String(nodes.length),
+                }, timelineNodes),
               ]),
               detailPanel
                 ? h("div", {
@@ -325,6 +338,21 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
       });
     },
   }));
+}
+
+function windowTimelineNodes(nodes: VNode[]): VNode[] {
+  if (nodes.length <= TIMELINE_EAGER_NODE_LIMIT) {
+    return nodes;
+  }
+  const omitted = nodes.length - TIMELINE_EAGER_NODE_LIMIT;
+  return [
+    h("div", {
+      key: "timeline-window-placeholder",
+      class: "desktop-conversation-large-window-placeholder",
+      "data-omitted-node-count": String(omitted),
+    }, `${omitted} earlier timeline item${omitted === 1 ? "" : "s"} deferred`),
+    ...nodes.slice(-TIMELINE_EAGER_NODE_LIMIT),
+  ];
 }
 
 interface AssistantMessageRunItem {
@@ -642,7 +670,7 @@ function renderInlineAgentUiForm(options: ConversationThreadIslandOptions, form:
   }));
 }
 
-function renderToolDetailPanel(options: {
+function renderActivityInspectorPanel(options: {
   activity: ToolActivityIslandOptions;
   mode: "overlay" | "push";
   motionState: DetailPanelState;
@@ -650,12 +678,14 @@ function renderToolDetailPanel(options: {
   onResize: (nextWidth: number) => void;
 }) {
   const { activity } = options;
+  const inspectorKind = activityInspectorKind(activity);
   const status = normalizeToolStatus(activity);
   const label = getToolStatusLabel(status);
   const tone = getToolStatusTone(status);
   return h("aside", {
-    "aria-label": "Tool call details",
-    class: "desktop-tool-detail-panel",
+    "aria-label": inspectorAriaLabel(inspectorKind),
+    class: ["desktop-tool-detail-panel", `desktop-${inspectorKind}-detail-panel`].join(" "),
+    "data-inspector-kind": inspectorKind,
     "data-tool-detail-mode": options.mode,
     "data-tool-detail-motion": options.motionState,
   }, [
@@ -670,7 +700,7 @@ function renderToolDetailPanel(options: {
       : null,
     h("header", { class: "desktop-tool-detail-header" }, [
       h("div", { class: "desktop-tool-detail-title-group" }, [
-        h("span", { class: "desktop-tool-detail-eyebrow" }, "Tool"),
+        h("span", { class: "desktop-tool-detail-eyebrow" }, inspectorEyebrow(inspectorKind)),
         h("h3", { class: "desktop-tool-detail-title" }, activity.name || "unknown"),
       ]),
       h("button", {
@@ -684,21 +714,96 @@ function renderToolDetailPanel(options: {
       h("span", { class: "desktop-tool-activity-status-dot", "data-tool-status-tone": tone }),
       h("span", label),
     ]),
-    isPendingToolApproval(activity)
+    inspectorKind === "approval"
       ? h("section", { class: "desktop-tool-detail-approval-actions", "aria-label": "Tool approval actions" }, [
         renderDetailApprovalButton(activity, "approveOnce", "Approve once"),
         renderDetailApprovalButton(activity, "approveSession", "Allow session"),
         renderDetailApprovalButton(activity, "deny", "Deny"),
       ])
       : null,
-    h("div", { class: "desktop-tool-detail-body" }, [
-      renderToolDetailMeta(activity),
-      renderToolDetailText("Arguments", activity.argsText, "No arguments available"),
-      renderToolDetailText("Response", activity.responseText, "No response available"),
-      renderToolDetailText("stderr", "", "No stderr available"),
-      renderToolDetailText("Duration", "", "Duration unavailable"),
-    ]),
+    h("div", { class: "desktop-tool-detail-body" }, renderActivityInspectorBody(activity, inspectorKind)),
   ]);
+}
+
+function renderActivityInspectorBody(activity: ToolActivityIslandOptions, inspectorKind: ActivityInspectorKind): Array<VNode | null> {
+  if (inspectorKind === "artifact") {
+    return [
+      renderToolDetailMeta(activity),
+      renderToolDetailText("Preview", activity.responseText || activity.argsText, "Preview unavailable"),
+      renderToolDetailText("Fetch", activity.runChainItemKey || activity.id, "Artifact fetch reference unavailable"),
+      renderToolDetailText("Renderer", artifactRendererLabel(activity.name), "Renderer unavailable"),
+    ];
+  }
+  if (inspectorKind === "delegate") {
+    return [
+      renderToolDetailMeta(activity),
+      renderToolDetailText("Task", activity.argsText, "No delegated task available"),
+      renderToolDetailText("Latest activity", activity.responseText, "No delegated activity available"),
+      renderToolDetailText("Related link", activity.runChainItemKey || activity.id, "Related link unavailable"),
+    ];
+  }
+  return [
+    renderToolDetailMeta(activity),
+    renderToolDetailText("Arguments", activity.argsText, "No arguments available"),
+    renderToolDetailText("Response", activity.responseText, "No response available"),
+    renderToolDetailText("stderr", "", "No stderr available"),
+    renderToolDetailText("Duration", "", "Duration unavailable"),
+  ];
+}
+
+function activityInspectorKind(activity: ToolActivityIslandOptions): ActivityInspectorKind {
+  const normalized = `${activity.name} ${activity.id}`.toLowerCase();
+  if (normalized.includes("artifact:") || normalized.includes("artifact")) {
+    return "artifact";
+  }
+  if (normalized.includes("cowork:") || normalized.includes("spawn:") || normalized.includes("subagent:") || normalized.includes("team:")) {
+    return "delegate";
+  }
+  if (isPendingToolApproval(activity)) {
+    return "approval";
+  }
+  return "tool_call";
+}
+
+function inspectorAriaLabel(kind: ActivityInspectorKind): string {
+  return {
+    approval: "Tool call details",
+    artifact: "Artifact details",
+    delegate: "Delegated agent details",
+    tool_call: "Tool call details",
+  }[kind];
+}
+
+function inspectorEyebrow(kind: ActivityInspectorKind): string {
+  return {
+    approval: "Approval",
+    artifact: "Artifact",
+    delegate: "Delegated work",
+    tool_call: "Tool",
+  }[kind];
+}
+
+function artifactRendererLabel(name: string): string {
+  const normalized = name.toLowerCase();
+  if (normalized.includes("json")) {
+    return "Structured JSON";
+  }
+  if (normalized.includes("diff")) {
+    return "File diff";
+  }
+  if (normalized.includes("snapshot") || normalized.includes("browser")) {
+    return "Browser snapshot";
+  }
+  if (normalized.includes("image")) {
+    return "Image";
+  }
+  if (normalized.includes("markdown")) {
+    return "Markdown";
+  }
+  if (normalized.includes("terminal") || normalized.includes("npm") || normalized.includes("shell")) {
+    return "Terminal output";
+  }
+  return "Inert text";
 }
 
 function renderReferenceDetailPanel(options: {
@@ -963,6 +1068,12 @@ function summarizeToolActivity(activity: ToolActivityIslandOptions | null): Reco
 
 function isToolDetailOverlayMode(): boolean {
   return typeof window !== "undefined" ? window.innerWidth < 900 : false;
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
 function clampToolPanelWidth(value: number): number {

--- a/apps/desktop/src/nativeChat.test.ts
+++ b/apps/desktop/src/nativeChat.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "vitest";
 import {
+  activateChat,
   applyChatEvent,
   appendUserMessage,
   createNativeChatState,
   normalizeMessagesPayload,
   normalizeSessionsPayload,
+  resolveNativeChatApproval,
   sessionKeyForChat,
 } from "./nativeChat";
 
@@ -729,5 +731,136 @@ describe("native chat state", () => {
         status: "failed",
       },
     ]);
+  });
+
+  test("merges approval requests into the matching tool activity", () => {
+    const state = createNativeChatState();
+    activateChat(state, "chat-1");
+    appendUserMessage(state, "Use subagent");
+
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-tool-start",
+        event_type: "tool.call.started",
+        chat_id: "chat-1",
+        session_key: "WebSocket:chat-1",
+        turn_id: "turn-1",
+        step_id: "turn-1:call-spawn",
+        sequence: 2,
+        created_at: "2026-06-27T04:00:01.000Z",
+        payload: {
+          args_preview: "spawn({\"task\":\"say hi\"})",
+          name: "spawn",
+          status: "running",
+          tool_call_id: "call-spawn",
+        },
+      },
+    });
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-approval",
+        event_type: "approval.requested",
+        chat_id: "chat-1",
+        session_key: "WebSocket:chat-1",
+        turn_id: "turn-1",
+        step_id: "turn-1:approval:approval-1",
+        sequence: 3,
+        created_at: "2026-06-27T04:00:02.000Z",
+        payload: {
+          approval_id: "approval-1",
+          approval_status: "approval_required",
+          args_preview: "spawn({\"task\":\"say hi\"})",
+          title: "Approval required",
+          tool_call_id: "call-spawn",
+        },
+      },
+    });
+
+    const assistantMessages = state.messages.get(sessionKeyForChat("chat-1"))?.filter((message) => message.role === "assistant") ?? [];
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0].toolActivities).toEqual([{
+      id: "call-spawn",
+      name: "spawn",
+      argsText: "spawn({\"task\":\"say hi\"})",
+      responseText: "",
+      kind: "call",
+      approvalId: "approval-1",
+      approvalStatus: "approval_required",
+      status: "blocked",
+    }]);
+  });
+
+  test("marks pending approval tool activities as resolved locally", () => {
+    const state = createNativeChatState();
+    activateChat(state, "chat-1");
+    appendUserMessage(state, "Use subagent");
+
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-tool-start",
+        event_type: "tool.call.started",
+        chat_id: "chat-1",
+        session_key: "WebSocket:chat-1",
+        turn_id: "turn-1",
+        step_id: "turn-1:call-spawn",
+        sequence: 2,
+        created_at: "2026-06-27T04:00:01.000Z",
+        payload: {
+          args_preview: "spawn({\"task\":\"say hi\"})",
+          name: "spawn",
+          status: "running",
+          tool_call_id: "call-spawn",
+        },
+      },
+    });
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-approval",
+        event_type: "approval.requested",
+        chat_id: "chat-1",
+        session_key: "WebSocket:chat-1",
+        turn_id: "turn-1",
+        step_id: "turn-1:approval:approval-1",
+        sequence: 3,
+        created_at: "2026-06-27T04:00:02.000Z",
+        payload: {
+          approval_id: "approval-1",
+          approval_status: "approval_required",
+          title: "Approval required",
+          tool_call_id: "call-spawn",
+        },
+      },
+    });
+
+    expect(resolveNativeChatApproval(state, {
+      approvalId: "approval-1",
+      decision: "approved",
+      sessionKey: "WebSocket:chat-1",
+    })).toBe(true);
+
+    const assistantMessages = state.messages.get(sessionKeyForChat("chat-1"))?.filter((message) => message.role === "assistant") ?? [];
+    expect(assistantMessages[0].toolActivities).toEqual([expect.objectContaining({
+      approvalId: "approval-1",
+      approvalStatus: "approved",
+      id: "call-spawn",
+      responseText: "Approved.",
+      status: "completed",
+    })]);
   });
 });

--- a/apps/desktop/src/nativeChat.test.ts
+++ b/apps/desktop/src/nativeChat.test.ts
@@ -612,6 +612,71 @@ describe("native chat state", () => {
     ]);
   });
 
+  test("projects structured agent events through the native chat message timeline", () => {
+    const state = createNativeChatState();
+    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
+    appendUserMessage(state, "Inspect files", "2026-06-27T04:00:00.000Z");
+
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-tool-start",
+        event_type: "tool.call.started",
+        chat_id: "chat-1",
+        session_key: "WebSocket:chat-1",
+        turn_id: "turn-1",
+        step_id: "step-tool",
+        sequence: 2,
+        created_at: "2026-06-27T04:00:01.000Z",
+        payload: {
+          args_preview: "{\"path\":\".\"}",
+          name: "list_dir",
+          status: "running",
+          tool_call_id: "call-list",
+        },
+      },
+    });
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-final",
+        event_type: "message.completed",
+        chat_id: "chat-1",
+        session_key: "WebSocket:chat-1",
+        turn_id: "turn-1",
+        step_id: "step-final",
+        sequence: 3,
+        created_at: "2026-06-27T04:00:02.000Z",
+        payload: {
+          message_id: "assistant-final",
+          text: "Files inspected.",
+        },
+      },
+    });
+
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
+      { role: "user", content: "Inspect files" },
+      {
+        role: "assistant",
+        content: "",
+        toolActivities: [{
+          id: "call-list",
+          name: "list_dir",
+          argsText: "{\"path\":\".\"}",
+          status: "running",
+        }],
+      },
+      { role: "assistant", content: "Files inspected." },
+    ]);
+    expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(false);
+  });
+
   test("normalizes tool activity execution status for timeline rendering", () => {
     expect(
       normalizeMessagesPayload({

--- a/apps/desktop/src/nativeChat.ts
+++ b/apps/desktop/src/nativeChat.ts
@@ -141,6 +141,60 @@ export function setMessages(state: NativeChatState, sessionKey: string, messages
   state.chatRuns.legacyMessagesBySession.set(sessionKey, messages);
 }
 
+export function resolveNativeChatApproval(
+  state: NativeChatState,
+  options: { approvalId: string; decision: "approved" | "denied"; sessionKey: string },
+): boolean {
+  const status = options.decision === "approved" ? "completed" : "failed";
+  const resolutionText = options.decision === "approved" ? "Approved." : "Denied.";
+  let changed = false;
+  const messages = state.messages.get(options.sessionKey) ?? [];
+  for (const message of messages) {
+    if (!message.toolActivities?.length) {
+      continue;
+    }
+    message.toolActivities = message.toolActivities.map((activity) => {
+      if (activity.approvalId !== options.approvalId) {
+        return activity;
+      }
+      changed = true;
+      return {
+        ...activity,
+        approvalStatus: options.decision,
+        responseText: shouldReplaceApprovalPlaceholder(activity.responseText) ? resolutionText : activity.responseText,
+        status,
+      };
+    });
+  }
+  const turns = state.chatRuns.turnsBySession.get(options.sessionKey) ?? [];
+  for (const turn of turns) {
+    for (const step of turn.steps) {
+      if (step.toolCall?.approvalId === options.approvalId) {
+        step.status = status;
+        step.toolCall.approvalStatus = options.decision;
+        if (shouldReplaceApprovalPlaceholder(step.toolCall.resultPreview)) {
+          step.toolCall.resultPreview = resolutionText;
+        }
+        changed = true;
+      }
+      if (step.approval?.approvalId === options.approvalId) {
+        step.status = "completed";
+        step.approval.decision = options.decision;
+        changed = true;
+      }
+    }
+  }
+  if (turns.length && changed) {
+    state.messages.set(options.sessionKey, conversationMessagesToNativeMessages(turnsToConversationMessages(turns)));
+  }
+  return changed;
+}
+
+function shouldReplaceApprovalPlaceholder(value: unknown): boolean {
+  const text = typeof value === "string" ? value.trim() : "";
+  return !text || text === "Waiting for approval.";
+}
+
 export function activateChat(state: NativeChatState, chatId: string) {
   const existing = state.sessions.find((session) => session.chatId === chatId);
   activateSession(state, existing?.key || sessionKeyForChat(chatId), chatId);

--- a/apps/desktop/src/nativeChat.ts
+++ b/apps/desktop/src/nativeChat.ts
@@ -1,5 +1,13 @@
 import type { NormalizedGatewayEvent } from "./gatewayWebSocketClient";
 import { logDesktopNativeChatDebug, summarizeDebugText } from "./desktopNativeChatDebug";
+import {
+  createChatRunState,
+  legacyMessagesToTurns,
+  reduceAgentEvent,
+  turnsToConversationMessages,
+  type AgentEventEnvelope,
+  type ChatRunState,
+} from "./chatRunModel";
 
 export type NativeChatSession = {
   key: string;
@@ -49,6 +57,7 @@ export type NativeChatReference = {
 export type NativeChatState = {
   sessions: NativeChatSession[];
   messages: Map<string, NativeChatMessage[]>;
+  chatRuns: ChatRunState;
   activeSessionKey: string;
   activeChatId: string;
   respondingSessionKeys: Set<string>;
@@ -60,6 +69,7 @@ export function createNativeChatState(): NativeChatState {
   return {
     sessions: [],
     messages: new Map(),
+    chatRuns: createChatRunState(),
     activeSessionKey: "",
     activeChatId: "",
     respondingSessionKeys: new Set(),
@@ -128,6 +138,7 @@ export function setSessions(state: NativeChatState, sessions: NativeChatSession[
 
 export function setMessages(state: NativeChatState, sessionKey: string, messages: NativeChatMessage[]) {
   state.messages.set(sessionKey, messages);
+  state.chatRuns.legacyMessagesBySession.set(sessionKey, messages);
 }
 
 export function activateChat(state: NativeChatState, chatId: string) {
@@ -206,6 +217,42 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
       state: summarizeNativeChatState(state),
       targetSessionKey: sessionKey,
     });
+    return;
+  }
+
+  if (event.kind === "agent.event") {
+    const envelope = agentEventEnvelopeFromRaw(event.raw);
+    if (!envelope) {
+      return;
+    }
+    const sessionKey = envelope.session_key || sessionKeyForChatState(state, envelope.chat_id || state.activeChatId);
+    if (!sessionKey) {
+      return;
+    }
+    if (!state.chatRuns.turnsBySession.has(sessionKey)) {
+      const legacyMessages = state.messages.get(sessionKey) ?? [];
+      state.chatRuns.turnsBySession.set(sessionKey, legacyMessagesToTurns(sessionKey, legacyMessages));
+    }
+    const seededTurns = state.chatRuns.turnsBySession.get(sessionKey) ?? [];
+    if (!seededTurns.some((turn) => turn.id === envelope.turn_id)) {
+      const pendingTurn = seededTurns[seededTurns.length - 1];
+      if (pendingTurn && !pendingTurn.finalMessage) {
+        pendingTurn.id = envelope.turn_id;
+      }
+    }
+    reduceAgentEvent(state.chatRuns, { ...envelope, session_key: sessionKey });
+    const turns = state.chatRuns.turnsBySession.get(sessionKey) ?? [];
+    state.messages.set(sessionKey, conversationMessagesToNativeMessages(turnsToConversationMessages(turns)));
+    if (
+      envelope.event_type === "agent.turn.completed"
+      || envelope.event_type === "agent.turn.failed"
+      || envelope.event_type === "agent.turn.interrupted"
+      || envelope.event_type === "message.completed"
+    ) {
+      state.respondingSessionKeys.delete(sessionKey);
+    } else {
+      state.respondingSessionKeys.add(sessionKey);
+    }
     return;
   }
 
@@ -463,6 +510,87 @@ function summarizeChatEvent(event: NormalizedGatewayEvent): Record<string, unkno
     messageId: "messageId" in event ? event.messageId : "",
     text: "text" in event ? summarizeDebugText(event.text) : undefined,
   };
+}
+
+function agentEventEnvelopeFromRaw(raw: Record<string, unknown>): AgentEventEnvelope | null {
+  if (raw.schema_version !== "tinybot.agent_event.v1") {
+    return null;
+  }
+  const eventId = stringValue(raw.event_id);
+  const eventType = stringValue(raw.event_type);
+  const chatId = stringValue(raw.chat_id);
+  const sessionKey = stringValue(raw.session_key);
+  const turnId = stringValue(raw.turn_id);
+  if (!eventId || !eventType || !turnId) {
+    return null;
+  }
+  return {
+    chat_id: chatId,
+    created_at: stringValue(raw.created_at) || new Date().toISOString(),
+    event_id: eventId,
+    event_type: eventType,
+    ...(stringValue(raw.parent_step_id) ? { parent_step_id: stringValue(raw.parent_step_id) } : {}),
+    payload: isRecord(raw.payload) ? raw.payload : {},
+    schema_version: "tinybot.agent_event.v1",
+    sequence: numberValue(raw.sequence) ?? 0,
+    session_key: sessionKey || sessionKeyForChat(chatId),
+    ...(stringValue(raw.step_id) ? { step_id: stringValue(raw.step_id) } : {}),
+    turn_id: turnId,
+  };
+}
+
+function conversationMessagesToNativeMessages(messages: ReturnType<typeof turnsToConversationMessages>): NativeChatMessage[] {
+  return messages.filter((message, index) => {
+    const next = messages[index + 1];
+    return !(
+      message.tone === "assistant"
+      && message.copyable !== true
+      && next?.tone === "assistant"
+      && next.copyable === true
+      && message.body.join("\n") === next.body.join("\n")
+    );
+  }).map((message, index) => ({
+    role: message.tone,
+    content: message.body.join("\n"),
+    reasoningContent: message.reasoningContent ?? "",
+    ...(message.toolActivities?.length ? {
+      toolActivities: message.toolActivities.map((activity) => ({
+        approvalId: activity.approvalId,
+        approvalStatus: activity.approvalStatus,
+        argsText: activity.argsText,
+        id: activity.id,
+        kind: activity.kind,
+        name: activity.name,
+        responseText: activity.responseText,
+        sessionKey: activity.sessionKey,
+        status: activity.status,
+      })),
+    } : {}),
+    ...(message.references.length ? {
+      references: message.references.map((reference) => ({
+        detail: reference.detail,
+        evidenceId: reference.evidenceId,
+        kind: nativeReferenceKind(reference.kind),
+        noteId: reference.noteId,
+        rawLine: reference.rawLine,
+        rawPath: reference.rawPath,
+        scope: reference.scope,
+        sourceLine: reference.sourceLine,
+        sourcePath: reference.sourcePath,
+        sourceText: reference.sourceText,
+        title: reference.title,
+        type: reference.type,
+      })),
+    } : {}),
+    timestamp: message.time,
+    messageId: `agent-run:${index}`,
+  }));
+}
+
+function nativeReferenceKind(value: string): NativeChatReference["kind"] {
+  return value === "browser" || value === "memory" || value === "recent" || value === "reference"
+    ? value
+    : "reference";
 }
 
 function normalizeMessageReferences(message: Record<string, unknown>): NativeChatReference[] {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -741,6 +741,63 @@ pre {
   line-height: 1.45;
 }
 
+.desktop-conversation-message,
+.desktop-assistant-step-group,
+.desktop-tool-detail-panel {
+  animation: desktop-agent-workbench-enter 160ms ease-out;
+}
+
+.desktop-tool-detail-panel[data-tool-detail-motion="opening"],
+.desktop-tool-detail-panel[data-tool-detail-motion="closing"] {
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.desktop-tool-activity-status-dot[data-tool-status-tone="running"] {
+  animation: desktop-agent-running-pulse 1100ms ease-in-out infinite;
+}
+
+.desktop-conversation-large-window-placeholder {
+  border: 1px dashed var(--color-hairline);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--color-muted);
+  background: var(--color-surface-soft);
+  font-size: 13px;
+}
+
+@keyframes desktop-agent-workbench-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes desktop-agent-running-pulse {
+  0%,
+  100% {
+    opacity: 0.65;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .desktop-conversation-message,
+  .desktop-assistant-step-group,
+  .desktop-tool-detail-panel,
+  .desktop-tool-activity-status-dot {
+    animation: none !important;
+    scroll-behavior: auto !important;
+    transition: none !important;
+    transform: none !important;
+  }
+}
+
 @media (max-width: 900px) {
   body {
     min-width: 0;

--- a/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.test.ts
@@ -1081,6 +1081,53 @@ describe("AgentRunner", () => {
     });
   });
 
+  test("includes awaiting approval metadata in tool result events", async () => {
+    const provider = new QueueProvider([
+      {
+        content: "",
+        toolCalls: [{ id: "call-1", name: "request_approval", argumentsJson: "{}" }],
+        stopReason: "tool_calls",
+      },
+    ]);
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "request_approval",
+      description: "Request approval",
+      parameters: { type: "object" },
+      execute: async () => ({
+        content: "Waiting for approval.",
+        metadata: {
+          awaitingUserInput: true,
+          stopReason: "awaiting_approval",
+          approvalId: "approval-1",
+        },
+      }),
+    });
+    const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+    const runner = new AgentRunner({
+      provider,
+      tools,
+      emitEvent: (event) => events.push(event),
+    });
+
+    await runner.run(spec());
+
+    expect(events).toContainEqual({
+      type: "tool_result",
+      payload: {
+        runId: "run-1",
+        toolCallId: "call-1",
+        toolName: "request_approval",
+        content: "Waiting for approval.",
+        metadata: {
+          awaitingUserInput: true,
+          stopReason: "awaiting_approval",
+          approvalId: "approval-1",
+        },
+      },
+    });
+  });
+
   test("forwards provider streaming deltas as runner events", async () => {
     const provider = new QueueProvider([{ content: "done", toolCalls: [], stopReason: "stop" }]);
     const events: Array<{ type: string; payload: Record<string, unknown> }> = [];

--- a/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.ts
@@ -175,6 +175,7 @@ export class AgentRunner {
               toolCallId: toolCall.id,
               toolName: toolCall.name,
               content: result.content,
+              ...(result.metadata ? { metadata: result.metadata } : {}),
             },
           });
           const memoryReferences = memoryReferencesFromMetadata(result.metadata);

--- a/tests/api/test_webui.py
+++ b/tests/api/test_webui.py
@@ -13,6 +13,7 @@ from tinybot.api.webui import (
     WebUIControlPaths,
     WebUIControlRuntime,
     _attach_cowork_listener,
+    _serialize_message,
     desktop_cors_middleware,
     register_webui_control_routes,
 )
@@ -42,6 +43,34 @@ def api_workspace():
 def _authorized_headers(token_manager: WebTokenManager) -> dict[str, str]:
     token = token_manager.issue()
     return {"Authorization": f"Bearer {token}"}
+
+
+def test_webui_serialize_message_preserves_agent_turn_event_metadata():
+    payload = _serialize_message(
+        {
+            "role": "assistant",
+            "content": "",
+            "turn_id": "turn-1",
+            "step_id": "step-tool",
+            "parent_step_id": "step-parent",
+            "sequence": 4,
+            "agent_context": {"type": "main", "id": "main", "title": "Tinybot"},
+            "status": "completed",
+            "tool_call": {"id": "call-1", "name": "read_file"},
+            "tool_result": {"status": "completed", "result_preview": "ok"},
+            "approval": {"approval_id": "approval-1", "decision": "approved_once"},
+            "duration_ms": 12,
+            "error": {"message": "boom"},
+            "artifacts": [{"id": "artifact-1", "kind": "terminal_output"}],
+            "trace_ref": "trace-1",
+        }
+    )
+
+    assert payload["turn_id"] == "turn-1"
+    assert payload["step_id"] == "step-tool"
+    assert payload["sequence"] == 4
+    assert payload["tool_call"]["name"] == "read_file"
+    assert payload["artifacts"][0]["id"] == "artifact-1"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_webui.py
+++ b/tests/api/test_webui.py
@@ -1212,6 +1212,60 @@ async def test_webui_control_messages_restore_agent_ui_form_display_metadata(api
 
 
 @pytest.mark.asyncio
+async def test_webui_control_artifact_refs_are_lightweight_and_fetch_details_safely(api_workspace):
+    token_manager = WebTokenManager(ttl_s=300)
+    session_manager = SessionManager(api_workspace)
+    session = session_manager.get_or_create("websocket:chat-1")
+    session.add_message(
+        "assistant",
+        "",
+        message_id="msg-artifact-1",
+        artifacts=[
+            {
+                "id": "artifact-log",
+                "kind": "terminal_output",
+                "title": "npm test",
+                "mime_type": "text/plain",
+                "size_bytes": 4096,
+                "status": "available",
+                "preview": "npm test api_key=secret",
+                "content": "<script>alert(1)</script> api_key=secret",
+                "renderer": {"component": "DangerousPanel"},
+            }
+        ],
+    )
+    session_manager.save(session)
+    app = web.Application()
+    register_webui_control_routes(
+        app,
+        WebUIControlRuntime(token_manager=token_manager, session_manager=session_manager),
+    )
+    client = await _client(app)
+    try:
+        headers = _authorized_headers(token_manager)
+        response = await client.get("/api/sessions/websocket:chat-1/messages", headers=headers)
+        assert response.status == 200
+        payload = await response.json()
+        artifact_ref = payload["messages"][0]["artifacts"][0]
+        assert artifact_ref["id"] == "artifact-log"
+        assert artifact_ref["preview"] == "npm test api_key=[redacted]"
+        assert "content" not in artifact_ref
+        assert "renderer" not in artifact_ref
+
+        response = await client.get("/api/sessions/websocket:chat-1/artifacts/artifact-log", headers=headers)
+        assert response.status == 200
+        artifact = (await response.json())["artifact"]
+        assert artifact["content"] == "[unsafe omitted] api_key=[redacted]"
+        assert artifact["renderer"] == "[unsafe omitted]"
+
+        response = await client.get("/api/sessions/websocket:chat-1/artifacts/missing", headers=headers)
+        assert response.status == 404
+        assert (await response.json())["artifact"]["status"] == "unavailable"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_webui_control_messages_hide_internal_agent_ui_tool_results(api_workspace):
     token_manager = WebTokenManager(ttl_s=300)
     session_manager = SessionManager(api_workspace)

--- a/tests/channels/test_websocket.py
+++ b/tests/channels/test_websocket.py
@@ -173,6 +173,34 @@ def test_serialize_message_preserves_agent_ui_form_display_metadata():
     assert payload["_agent_ui_form_display"]["schema"]["title"] == "Travel preferences"
 
 
+def test_serialize_message_preserves_agent_turn_event_metadata():
+    payload = _serialize_message(
+        {
+            "role": "assistant",
+            "content": "",
+            "turn_id": "turn-1",
+            "step_id": "step-tool",
+            "parent_step_id": "step-parent",
+            "sequence": 4,
+            "agent_context": {"type": "main", "id": "main", "title": "Tinybot"},
+            "status": "completed",
+            "tool_call": {"id": "call-1", "name": "read_file"},
+            "tool_result": {"status": "completed", "result_preview": "ok"},
+            "approval": {"approval_id": "approval-1", "decision": "approved_once"},
+            "duration_ms": 12,
+            "error": {"message": "boom"},
+            "artifacts": [{"id": "artifact-1", "kind": "terminal_output"}],
+            "trace_ref": "trace-1",
+        }
+    )
+
+    assert payload["turn_id"] == "turn-1"
+    assert payload["step_id"] == "step-tool"
+    assert payload["sequence"] == 4
+    assert payload["tool_call"]["name"] == "read_file"
+    assert payload["artifacts"][0]["id"] == "artifact-1"
+
+
 @pytest.mark.asyncio
 async def test_websocket_chat_flow(web_channel, web_client):
     channel, bus, _ = web_channel

--- a/tests/channels/test_websocket.py
+++ b/tests/channels/test_websocket.py
@@ -201,6 +201,31 @@ def test_serialize_message_preserves_agent_turn_event_metadata():
     assert payload["artifacts"][0]["id"] == "artifact-1"
 
 
+def test_serialize_message_returns_lightweight_safe_artifact_refs():
+    payload = _serialize_message(
+        {
+            "role": "assistant",
+            "content": "",
+            "artifacts": [
+                {
+                    "id": "artifact-log",
+                    "kind": "terminal_output",
+                    "preview": "<script>alert(1)</script> token=secret",
+                    "content": "large body",
+                    "renderer": {"component": "DangerousPanel"},
+                }
+            ],
+        }
+    )
+
+    artifact = payload["artifacts"][0]
+    assert artifact == {
+        "id": "artifact-log",
+        "kind": "terminal_output",
+        "preview": "[unsafe omitted] token=[redacted]",
+    }
+
+
 @pytest.mark.asyncio
 async def test_websocket_chat_flow(web_channel, web_client):
     channel, bus, _ = web_channel

--- a/tinybot/api/webui.py
+++ b/tinybot/api/webui.py
@@ -257,8 +257,80 @@ def _serialize_message(message: dict[str, Any]) -> dict[str, Any]:
         "trace_ref",
     ):
         if key in message:
-            payload[key] = message[key]
+            payload[key] = _serialize_artifact_refs(message[key]) if key == "artifacts" else message[key]
     return payload
+
+
+_SENSITIVE_ARTIFACT_KEYS = {
+    "api_key",
+    "authorization",
+    "cookie",
+    "credential",
+    "password",
+    "private_key",
+    "secret",
+    "token",
+}
+_UNSAFE_ARTIFACT_KEYS = {
+    "component",
+    "handler",
+    "html",
+    "onclick",
+    "onsubmit",
+    "renderer",
+    "script",
+    "style",
+    "template",
+}
+
+
+def _serialize_artifact_refs(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    refs: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            continue
+        artifact_id = str(item.get("id") or item.get("artifact_id") or f"artifact-{index}")
+        refs.append(
+            {
+                key: _safe_artifact_preview(item.get(key))
+                for key in ("kind", "title", "mime_type", "mimeType", "size_bytes", "sizeBytes", "status", "preview")
+                if key in item
+            }
+            | {"id": artifact_id}
+        )
+    return refs
+
+
+def _safe_artifact_detail(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_safe_artifact_detail(item) for item in value]
+    if isinstance(value, dict):
+        cleaned: dict[str, Any] = {}
+        for key, item in value.items():
+            normalized = str(key).lower()
+            if normalized in _UNSAFE_ARTIFACT_KEYS or normalized.startswith("on"):
+                cleaned[key] = "[unsafe omitted]"
+            elif normalized in _SENSITIVE_ARTIFACT_KEYS:
+                cleaned[key] = "[redacted]"
+            else:
+                cleaned[key] = _safe_artifact_detail(item)
+        return cleaned
+    return _safe_artifact_preview(value)
+
+
+def _safe_artifact_preview(value: Any) -> Any:
+    if isinstance(value, str):
+        text = re.sub(r"<\s*script\b[^>]*>[\s\S]*?<\s*/\s*script\s*>", "[unsafe omitted]", value, flags=re.IGNORECASE)
+        text = re.sub(r"<[^>]+>", "[unsafe omitted]", text)
+        return re.sub(
+            r"\b(api_key|token|secret|password|authorization|cookie|credential|private_key)\s*[:=]\s*([^\s,;]+)",
+            r"\1=[redacted]",
+            text,
+            flags=re.IGNORECASE,
+        )
+    return value
 
 
 def _task_progress_message_from_plan(runtime: WebUIControlRuntime, plan_id: str) -> dict[str, Any] | None:
@@ -468,6 +540,47 @@ def _get_messages_handler(runtime: WebUIControlRuntime, paths: WebUIControlPaths
         )
 
     return handler
+
+
+def _get_session_artifact_handler(runtime: WebUIControlRuntime, paths: WebUIControlPaths) -> Handler:
+    async def handler(request: web.Request) -> web.Response:
+        if runtime.session_manager is None:
+            return _session_manager_unavailable()
+
+        key = request.match_info["key"]
+        artifact_id = request.match_info["artifact_id"]
+        session = runtime.session_manager.get(key)
+        if session is None:
+            return web.json_response({"error": "session not found"}, status=404)
+        artifact = _find_session_artifact(session.messages, artifact_id)
+        if artifact is None:
+            return web.json_response(
+                {
+                    "artifact": {
+                        "id": artifact_id,
+                        "status": "unavailable",
+                        "preview": "Artifact is unavailable or expired.",
+                    }
+                },
+                status=404,
+            )
+        return web.json_response({"artifact": _safe_artifact_detail(artifact)})
+
+    return handler
+
+
+def _find_session_artifact(messages: list[dict[str, Any]], artifact_id: str) -> dict[str, Any] | None:
+    for message in messages:
+        artifacts = message.get("artifacts")
+        if not isinstance(artifacts, list):
+            continue
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            candidate_id = str(artifact.get("id") or artifact.get("artifact_id") or "")
+            if candidate_id == artifact_id:
+                return artifact
+    return None
 
 
 def _delete_session_handler(runtime: WebUIControlRuntime, paths: WebUIControlPaths) -> Handler:
@@ -2029,6 +2142,7 @@ def _default_handler(route_key: str, runtime: WebUIControlRuntime, paths: WebUIC
         "refresh_token": _refresh_token_handler,
         "list_sessions": _list_sessions_handler,
         "get_messages": _get_messages_handler,
+        "get_session_artifact": _get_session_artifact_handler,
         "delete_session": _delete_session_handler,
         "patch_session": _patch_session_handler,
         "clear_session": _clear_session_handler,
@@ -2069,6 +2183,7 @@ def _route_specs(paths: WebUIControlPaths) -> tuple[_RouteSpec, ...]:
         _RouteSpec("refresh_token", "POST", "/webui/refresh-token", public=True),
         _RouteSpec("list_sessions", "GET", sessions_path),
         _RouteSpec("get_messages", "GET", f"{sessions_path}/{{key}}/messages"),
+        _RouteSpec("get_session_artifact", "GET", f"{sessions_path}/{{key}}/artifacts/{{artifact_id}}"),
         _RouteSpec("delete_session", "DELETE", f"{sessions_path}/{{key}}"),
         _RouteSpec("patch_session", "PATCH", f"{sessions_path}/{{key}}"),
         _RouteSpec("clear_session", "POST", f"{sessions_path}/{{key}}/clear"),

--- a/tinybot/api/webui.py
+++ b/tinybot/api/webui.py
@@ -242,6 +242,19 @@ def _serialize_message(message: dict[str, Any]) -> dict[str, Any]:
         "_agent_ui_form_status",
         "_agent_ui_form_display",
         "_agent_ui_form_response",
+        "turn_id",
+        "step_id",
+        "parent_step_id",
+        "sequence",
+        "agent_context",
+        "status",
+        "tool_call",
+        "tool_result",
+        "approval",
+        "duration_ms",
+        "error",
+        "artifacts",
+        "trace_ref",
     ):
         if key in message:
             payload[key] = message[key]

--- a/tinybot/channels/websocket.py
+++ b/tinybot/channels/websocket.py
@@ -58,6 +58,19 @@ def _serialize_message(message: dict[str, Any]) -> dict[str, Any]:
         "_agent_ui_form_status",
         "_agent_ui_form_display",
         "_agent_ui_form_response",
+        "turn_id",
+        "step_id",
+        "parent_step_id",
+        "sequence",
+        "agent_context",
+        "status",
+        "tool_call",
+        "tool_result",
+        "approval",
+        "duration_ms",
+        "error",
+        "artifacts",
+        "trace_ref",
     ):
         if key in message:
             payload[key] = message[key]

--- a/tinybot/channels/websocket.py
+++ b/tinybot/channels/websocket.py
@@ -15,7 +15,13 @@ from typing import Any
 from loguru import logger
 
 from tinybot.agent.forms import AgentUiFormRegistry
-from tinybot.api.webui import WebUIControlPaths, WebUIControlRuntime, desktop_cors_middleware, register_webui_control_routes
+from tinybot.api.webui import (
+    WebUIControlPaths,
+    WebUIControlRuntime,
+    _serialize_artifact_refs,
+    desktop_cors_middleware,
+    register_webui_control_routes,
+)
 from tinybot.bus.events import OutboundMessage
 from tinybot.bus.queue import MessageBus
 from tinybot.channels.base import BaseChannel
@@ -73,7 +79,7 @@ def _serialize_message(message: dict[str, Any]) -> dict[str, Any]:
         "trace_ref",
     ):
         if key in message:
-            payload[key] = message[key]
+            payload[key] = _serialize_artifact_refs(message[key]) if key == "artifacts" else message[key]
     return payload
 
 


### PR DESCRIPTION
## Summary
- preserve approval metadata through the TS agent and native WebSocket bridge so pending approvals render correctly
- route inline approval actions through native worker resume before WebUI/gateway fallbacks
- normalize WebSocket session keys for approval matching and refresh session-scoped approvals
- resolve approved/denied approval cards locally and add resume result diagnostics

## Validation
- npm test -- nativeChat.test.ts desktopApprovalActions.test.ts desktopNativeWebSocketBridge.test.ts desktopNativeWorkbenchRuntime.test.ts native-vue/toolActivityIsland.test.ts native-vue/toolActivityStatus.test.ts gateway.test.ts native-vue/conversationThreadIsland.test.ts
- npm run build
- cargo test worker_rpc::approval::tests::approval_ -- --nocapture