### PR TITLE
Fix desktop inline approval routing

### DIFF
--- a/apps/desktop/src/desktopApprovalActions.test.ts
+++ b/apps/desktop/src/desktopApprovalActions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import {
+  gatewayCompatibleApprovalSessionKey,
   nativeApprovalRefreshOptions,
   submitDesktopApprovalAction,
   summarizeDesktopApprovalResumeResult,
@@ -74,10 +75,33 @@ describe("desktop approval actions", () => {
       approvalId: "approval-1",
       approved: false,
       scope: "once",
-      sessionKey: "WebSocket:chat-1",
+      sessionKey: "websocket:chat-1",
     });
     expect(gatewayTools.denyApproval).toHaveBeenCalledWith("approval-1", {
-      session_key: "WebSocket:chat-1",
+      session_key: "websocket:chat-1",
+      auto_retry: true,
+    });
+  });
+
+  test("normalizes synthetic WebSocket approval session keys for gateway-compatible routes", async () => {
+    const gatewayTools = {
+      approveApproval: vi.fn(async () => ({ approved: true })),
+      denyApproval: vi.fn(async () => ({})),
+    };
+
+    await submitDesktopApprovalAction({
+      action: "approveSession",
+      approvalId: "approval-1",
+      gatewayTools,
+      preferNativeWorkerResume: false,
+      sessionKey: "WebSocket:chat-1",
+    });
+
+    expect(gatewayCompatibleApprovalSessionKey("WebSocket:chat-1")).toBe("websocket:chat-1");
+    expect(gatewayCompatibleApprovalSessionKey("ts-agent:chat-1")).toBe("ts-agent:chat-1");
+    expect(gatewayTools.approveApproval).toHaveBeenCalledWith("approval-1", {
+      session_key: "websocket:chat-1",
+      scope: "session",
       auto_retry: true,
     });
   });
@@ -86,7 +110,7 @@ describe("desktop approval actions", () => {
     expect(nativeApprovalRefreshOptions({
       activeChatId: "chat-1",
       activeSessionKey: "WebSocket:chat-1",
-    })).toEqual({ sessionKey: "WebSocket:chat-1" });
+    })).toEqual({ sessionKey: "websocket:chat-1" });
     expect(nativeApprovalRefreshOptions({
       activeChatId: "chat-1",
       activeSessionKey: "",

--- a/apps/desktop/src/desktopApprovalActions.ts
+++ b/apps/desktop/src/desktopApprovalActions.ts
@@ -48,7 +48,7 @@ type DesktopApprovalResumeArgs = {
 
 export function nativeApprovalRefreshOptions(context: DesktopApprovalRefreshContext): DesktopApprovalRefreshOptions | undefined {
   if (context.activeSessionKey) {
-    return { sessionKey: context.activeSessionKey };
+    return { sessionKey: gatewayCompatibleApprovalSessionKey(context.activeSessionKey) };
   }
   if (context.activeChatId) {
     return { chatId: context.activeChatId, channel: "websocket" };
@@ -107,19 +107,29 @@ export async function submitDesktopApprovalAction(options: SubmitDesktopApproval
       // Fall through to WebUI/gateway approval routes for non-native approvals.
     }
   }
-  options.onGatewayFallback?.(context);
+  const gatewaySessionKey = gatewayCompatibleApprovalSessionKey(options.sessionKey);
+  const gatewayContext = gatewaySessionKey === options.sessionKey
+    ? context
+    : { ...context, sessionKey: gatewaySessionKey };
+  options.onGatewayFallback?.(gatewayContext);
   if (!approved) {
     await options.gatewayTools.denyApproval(options.approvalId, {
-      session_key: options.sessionKey,
+      session_key: gatewaySessionKey,
       auto_retry: true,
     });
     return undefined;
   }
   return await options.gatewayTools.approveApproval(options.approvalId, {
-    session_key: options.sessionKey,
+    session_key: gatewaySessionKey,
     scope,
     auto_retry: true,
   });
+}
+
+export function gatewayCompatibleApprovalSessionKey(sessionKey: string): string {
+  return sessionKey.startsWith("WebSocket:")
+    ? `websocket:${sessionKey.slice("WebSocket:".length)}`
+    : sessionKey;
 }
 
 function resultPreviewValue(result: unknown): unknown {


### PR DESCRIPTION
## Summary

- Normalize synthetic `WebSocket:<chatId>` session keys to the gateway-compatible `websocket:<chatId>` form when desktop approval actions fall back to WebUI/gateway approval routes.
- Apply the same normalization to approval refresh/list options so pending approval queries look at the persisted gateway session instead of creating an empty synthetic session.
- Add tests covering gateway fallback and approval-session normalization.

## Why

Inline approval currently attempts the native worker resume path first. When that path cannot handle a gateway/WebSocket approval, the fallback approval route was called with the raw synthetic `WebSocket:` key. The Python WebUI approval route uses the provided `session_key` directly, so it can look in a different session than the one that actually owns the pending approval.

## Notes

I did not run the desktop test suite from this environment; CI should verify the Vitest coverage.