### PR TITLE
Add subagent observability surface

### DIFF
--- a/apps/desktop/src-tauri/src/config_store.rs
+++ b/apps/desktop/src-tauri/src/config_store.rs
@@ -1192,10 +1192,7 @@ mod tests {
             snapshot.effective_public_config["agents"]["defaults"]["model"],
             "deepseek-reasoner"
         );
-        assert_eq!(
-            snapshot.origins["agents.defaults.model"],
-            "default"
-        );
+        assert_eq!(snapshot.origins["agents.defaults.model"], "default");
     }
 
     #[test]
@@ -1412,7 +1409,10 @@ mod tests {
         let store = ConfigStore::load(path, default_snapshot())
             .expect("conflicting aliases should still load for diagnostics");
 
-        assert_eq!(store.diagnostics()[0].code, ConfigDiagnosticCode::AliasConflict);
+        assert_eq!(
+            store.diagnostics()[0].code,
+            ConfigDiagnosticCode::AliasConflict
+        );
         assert!(store.diagnostics()[0]
             .message
             .contains("agents.defaults.maxTokens"));
@@ -1486,17 +1486,16 @@ mod tests {
         let path = fixture.write("config.json", r#"{"gateway":{"port":18790}}"#);
         let blocking_temp_path = path.with_extension("json.tmp");
         fs::create_dir_all(&blocking_temp_path).expect("blocking temp directory should create");
-        let mut store = ConfigStore::from_snapshot(
-            path.clone(),
-            json!({"gateway":{"port":18888}}),
-        );
+        let mut store = ConfigStore::from_snapshot(path.clone(), json!({"gateway":{"port":18888}}));
 
         let error = store
             .save_snapshot()
             .expect_err("temp-file creation failure should be reported");
 
         match error {
-            ConfigStoreError::Io { path: error_path, .. } => assert_eq!(error_path, path),
+            ConfigStoreError::Io {
+                path: error_path, ..
+            } => assert_eq!(error_path, path),
             other => panic!("expected IO error, got {other:?}"),
         }
         let saved = serde_json::from_str::<serde_json::Value>(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -266,6 +266,27 @@ struct WorkerRestoreAgentCheckpointInput {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct WorkerBackgroundTraceListInput {
+    #[serde(default)]
+    filter: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkerBackgroundTraceGetDelegateTraceInput {
+    #[serde(default)]
+    filter: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkerBackgroundTraceGetArtifactInput {
+    #[serde(default)]
+    filter: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct WorkerSubmitAgentFormInput {
     session_id: String,
     form_id: String,
@@ -575,6 +596,48 @@ fn worker_restore_agent_checkpoint(
     worker_restore_agent_checkpoint_with_options(
         state.inner(),
         input.session_id,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_background_trace_list(
+    input: WorkerBackgroundTraceListInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_background_trace_list_with_options(
+        state.inner(),
+        input,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_background_trace_get_delegate_trace(
+    input: WorkerBackgroundTraceGetDelegateTraceInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_background_trace_get_delegate_trace_with_options(
+        state.inner(),
+        input,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_background_trace_get_artifact(
+    input: WorkerBackgroundTraceGetArtifactInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_background_trace_get_artifact_with_options(
+        state.inner(),
+        input,
         ts_agent_worker_workspace_root(),
         experimental_worker_config_snapshot(),
         Duration::from_secs(10),
@@ -1440,6 +1503,91 @@ fn build_worker_restore_agent_checkpoint_request(
     )
 }
 
+fn worker_background_trace_list_with_options(
+    shared: &SharedGateway,
+    input: WorkerBackgroundTraceListInput,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let client = WorkerClient::experimental(shared);
+    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
+
+    let request =
+        build_worker_background_trace_list_request(next_worker_request_correlation(), input);
+    client.call(&request, timeout, "worker background trace list")
+}
+
+fn build_worker_background_trace_list_request(
+    request_id: WorkerRequestCorrelation,
+    input: WorkerBackgroundTraceListInput,
+) -> WorkerRequest {
+    WorkerRequest::new(
+        request_id.id("background-trace-list"),
+        request_id.trace_id("background-trace-list"),
+        "background.trace.list",
+        serde_json::json!({ "filter": input.filter }),
+    )
+}
+
+fn worker_background_trace_get_delegate_trace_with_options(
+    shared: &SharedGateway,
+    input: WorkerBackgroundTraceGetDelegateTraceInput,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let client = WorkerClient::experimental(shared);
+    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
+
+    let request = build_worker_background_trace_get_delegate_trace_request(
+        next_worker_request_correlation(),
+        input,
+    );
+    client.call(&request, timeout, "worker background delegate trace get")
+}
+
+fn build_worker_background_trace_get_delegate_trace_request(
+    request_id: WorkerRequestCorrelation,
+    input: WorkerBackgroundTraceGetDelegateTraceInput,
+) -> WorkerRequest {
+    WorkerRequest::new(
+        request_id.id("background-trace-get-delegate-trace"),
+        request_id.trace_id("background-trace-get-delegate-trace"),
+        "background.trace.get_delegate_trace",
+        serde_json::json!({ "filter": input.filter }),
+    )
+}
+
+fn worker_background_trace_get_artifact_with_options(
+    shared: &SharedGateway,
+    input: WorkerBackgroundTraceGetArtifactInput,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let client = WorkerClient::experimental(shared);
+    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
+
+    let request = build_worker_background_trace_get_artifact_request(
+        next_worker_request_correlation(),
+        input,
+    );
+    client.call(&request, timeout, "worker background trace artifact get")
+}
+
+fn build_worker_background_trace_get_artifact_request(
+    request_id: WorkerRequestCorrelation,
+    input: WorkerBackgroundTraceGetArtifactInput,
+) -> WorkerRequest {
+    WorkerRequest::new(
+        request_id.id("background-trace-get-artifact"),
+        request_id.trace_id("background-trace-get-artifact"),
+        "background.trace.get_artifact",
+        serde_json::json!({ "filter": input.filter }),
+    )
+}
+
 fn worker_submit_agent_form_with_options(
     shared: &SharedGateway,
     session_id: String,
@@ -1889,6 +2037,9 @@ pub fn run() {
             worker_channel_login,
             worker_cancel_agent,
             worker_restore_agent_checkpoint,
+            worker_background_trace_list,
+            worker_background_trace_get_delegate_trace,
+            worker_background_trace_get_artifact,
             worker_submit_agent_form,
             worker_resume_agent_approval,
             worker_cron_dispatch_due,
@@ -3026,6 +3177,81 @@ mod tests {
     }
 
     #[test]
+    fn worker_background_trace_list_request_wraps_filter_for_ts_worker() {
+        let request = build_worker_background_trace_list_request(
+            test_request_correlation("42"),
+            WorkerBackgroundTraceListInput {
+                filter: serde_json::json!({ "sessionKey": "WebSocket:chat-1" }),
+            },
+        );
+
+        assert_eq!(request.id, "background-trace-list-42");
+        assert_eq!(request.trace_id, "trace-background-trace-list-42");
+        assert_eq!(request.method, "background.trace.list");
+        assert_eq!(
+            request.params,
+            serde_json::json!({ "filter": { "sessionKey": "WebSocket:chat-1" } })
+        );
+    }
+
+    #[test]
+    fn worker_background_trace_get_delegate_trace_request_wraps_filter_for_ts_worker() {
+        let request = build_worker_background_trace_get_delegate_trace_request(
+            test_request_correlation("42"),
+            WorkerBackgroundTraceGetDelegateTraceInput {
+                filter: serde_json::json!({
+                    "sessionKey": "WebSocket:chat-1",
+                    "delegateId": "delegate-1"
+                }),
+            },
+        );
+
+        assert_eq!(request.id, "background-trace-get-delegate-trace-42");
+        assert_eq!(
+            request.trace_id,
+            "trace-background-trace-get-delegate-trace-42"
+        );
+        assert_eq!(request.method, "background.trace.get_delegate_trace");
+        assert_eq!(
+            request.params,
+            serde_json::json!({
+                "filter": {
+                    "sessionKey": "WebSocket:chat-1",
+                    "delegateId": "delegate-1"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn worker_background_trace_get_artifact_request_wraps_filter_for_ts_worker() {
+        let request = build_worker_background_trace_get_artifact_request(
+            test_request_correlation("42"),
+            WorkerBackgroundTraceGetArtifactInput {
+                filter: serde_json::json!({
+                    "sessionKey": "WebSocket:chat-1",
+                    "delegateId": "delegate-1",
+                    "artifactId": "artifact-1"
+                }),
+            },
+        );
+
+        assert_eq!(request.id, "background-trace-get-artifact-42");
+        assert_eq!(request.trace_id, "trace-background-trace-get-artifact-42");
+        assert_eq!(request.method, "background.trace.get_artifact");
+        assert_eq!(
+            request.params,
+            serde_json::json!({
+                "filter": {
+                    "sessionKey": "WebSocket:chat-1",
+                    "delegateId": "delegate-1",
+                    "artifactId": "artifact-1"
+                }
+            })
+        );
+    }
+
+    #[test]
     fn worker_submit_agent_form_request_wraps_form_submission_for_ts_worker() {
         let request = build_worker_submit_agent_form_request(
             test_request_correlation("42"),
@@ -3316,16 +3542,11 @@ mod tests {
                 .expect("config path should have parent"),
         )
         .expect("config directory should create");
-        std::fs::write(
-            &config_path,
-            r#"{"agents":{"defaults":{"model":"gpt-5"}}}"#,
-        )
-        .expect("fixture config should write");
-        let store = crate::config_store::ConfigStore::load(
-            config_path.clone(),
-            serde_json::json!({}),
-        )
-        .expect("custom config should load");
+        std::fs::write(&config_path, r#"{"agents":{"defaults":{"model":"gpt-5"}}}"#)
+            .expect("fixture config should write");
+        let store =
+            crate::config_store::ConfigStore::load(config_path.clone(), serde_json::json!({}))
+                .expect("custom config should load");
 
         let result = apply_config_operations_to_path(
             &config_path,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1504,18 +1504,20 @@ fn build_worker_restore_agent_checkpoint_request(
 }
 
 fn worker_background_trace_list_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     input: WorkerBackgroundTraceListInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    let client = WorkerClient::experimental(shared);
-    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
-
     let request =
         build_worker_background_trace_list_request(next_worker_request_correlation(), input);
-    client.call(&request, timeout, "worker background trace list")
+    dispatch_worker_background_trace_request(
+        workspace_root,
+        config_snapshot,
+        request,
+        "worker background trace list",
+    )
 }
 
 fn build_worker_background_trace_list_request(
@@ -1531,20 +1533,22 @@ fn build_worker_background_trace_list_request(
 }
 
 fn worker_background_trace_get_delegate_trace_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     input: WorkerBackgroundTraceGetDelegateTraceInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    let client = WorkerClient::experimental(shared);
-    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
-
     let request = build_worker_background_trace_get_delegate_trace_request(
         next_worker_request_correlation(),
         input,
     );
-    client.call(&request, timeout, "worker background delegate trace get")
+    dispatch_worker_background_trace_request(
+        workspace_root,
+        config_snapshot,
+        request,
+        "worker background delegate trace get",
+    )
 }
 
 fn build_worker_background_trace_get_delegate_trace_request(
@@ -1560,20 +1564,22 @@ fn build_worker_background_trace_get_delegate_trace_request(
 }
 
 fn worker_background_trace_get_artifact_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     input: WorkerBackgroundTraceGetArtifactInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    let client = WorkerClient::experimental(shared);
-    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
-
     let request = build_worker_background_trace_get_artifact_request(
         next_worker_request_correlation(),
         input,
     );
-    client.call(&request, timeout, "worker background trace artifact get")
+    dispatch_worker_background_trace_request(
+        workspace_root,
+        config_snapshot,
+        request,
+        "worker background trace artifact get",
+    )
 }
 
 fn build_worker_background_trace_get_artifact_request(
@@ -1586,6 +1592,22 @@ fn build_worker_background_trace_get_artifact_request(
         "background.trace.get_artifact",
         serde_json::json!({ "filter": input.filter }),
     )
+}
+
+fn dispatch_worker_background_trace_request(
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    request: WorkerRequest,
+    context: &str,
+) -> Result<serde_json::Value, String> {
+    let mut router = experimental_worker_router(workspace_root, config_snapshot);
+    let response = router.dispatch(&request);
+    if let Some(error) = response.error {
+        return Err(format!("{context} returned error: {}", error.message));
+    }
+    response
+        .result
+        .ok_or_else(|| format!("{context} response missing result"))
 }
 
 fn worker_submit_agent_form_with_options(
@@ -3177,7 +3199,7 @@ mod tests {
     }
 
     #[test]
-    fn worker_background_trace_list_request_wraps_filter_for_ts_worker() {
+    fn worker_background_trace_list_request_wraps_filter_for_background_rpc() {
         let request = build_worker_background_trace_list_request(
             test_request_correlation("42"),
             WorkerBackgroundTraceListInput {
@@ -3195,7 +3217,52 @@ mod tests {
     }
 
     #[test]
-    fn worker_background_trace_get_delegate_trace_request_wraps_filter_for_ts_worker() {
+    fn worker_background_trace_list_reads_rust_registry_without_ts_worker() {
+        let fixture = WorkspaceFixture::new();
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let mut router = experimental_worker_router(fixture.root.clone(), serde_json::json!({}));
+        let append_response = router.dispatch(&WorkerRequest::new(
+            "req-background-trace-append",
+            "trace-1",
+            "background.trace.append",
+            serde_json::json!({
+                "event": {
+                    "eventId": "event-1",
+                    "eventType": "agent.delegate.started",
+                    "sessionKey": "WebSocket:chat-1",
+                    "turnId": "turn-1",
+                    "delegateId": "delegate-1",
+                    "childRunId": "delegate-1",
+                    "traceRef": "trace-ref-1",
+                    "sequence": 1,
+                    "createdAt": "2026-06-29T02:25:30.000Z",
+                    "payload": { "status": "running" }
+                }
+            }),
+        ));
+        assert_eq!(append_response.error, None);
+
+        let result = worker_background_trace_list_with_options(
+            &shared,
+            WorkerBackgroundTraceListInput {
+                filter: serde_json::json!({ "sessionKey": "WebSocket:chat-1" }),
+            },
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("trace list should read the Rust background registry without starting TS worker");
+
+        assert_eq!(result["events"][0]["eventId"], "event-1");
+        assert_eq!(result["events"][0]["delegateId"], "delegate-1");
+        assert_eq!(
+            lock_runtime(&shared).experimental_worker.status().state,
+            WorkerManagerState::Stopped
+        );
+    }
+
+    #[test]
+    fn worker_background_trace_get_delegate_trace_request_wraps_filter_for_background_rpc() {
         let request = build_worker_background_trace_get_delegate_trace_request(
             test_request_correlation("42"),
             WorkerBackgroundTraceGetDelegateTraceInput {
@@ -3224,7 +3291,7 @@ mod tests {
     }
 
     #[test]
-    fn worker_background_trace_get_artifact_request_wraps_filter_for_ts_worker() {
+    fn worker_background_trace_get_artifact_request_wraps_filter_for_background_rpc() {
         let request = build_worker_background_trace_get_artifact_request(
             test_request_correlation("42"),
             WorkerBackgroundTraceGetArtifactInput {

--- a/apps/desktop/src-tauri/src/worker_background.rs
+++ b/apps/desktop/src-tauri/src/worker_background.rs
@@ -69,6 +69,171 @@ impl WorkerBackgroundRpc {
         Ok(BackgroundRunResult { run: result })
     }
 
+    pub fn append_trace_event(
+        &self,
+        params: BackgroundTraceAppendParams,
+    ) -> Result<BackgroundTraceEventResult, WorkerProtocolError> {
+        self.require(WorkerCapability::BackgroundWrite)?;
+        validate_trace_event(&params.event)?;
+        let mut store = self.read_store()?;
+        match store
+            .trace_events
+            .iter()
+            .position(|event| event.event_id == params.event.event_id)
+        {
+            Some(index) => store.trace_events[index] = params.event.clone(),
+            None => store.trace_events.push(params.event.clone()),
+        }
+        store.trace_events.sort_by(|left, right| {
+            left.sequence
+                .cmp(&right.sequence)
+                .then(left.event_id.cmp(&right.event_id))
+        });
+        self.write_store(&store)?;
+        Ok(BackgroundTraceEventResult {
+            event: params.event,
+        })
+    }
+
+    pub fn list_trace_events(
+        &self,
+        params: BackgroundTraceListParams,
+    ) -> Result<BackgroundTraceEventListResult, WorkerProtocolError> {
+        self.require(WorkerCapability::BackgroundRead)?;
+        let filter = params.filter.unwrap_or_default();
+        let events = self
+            .read_store()?
+            .trace_events
+            .into_iter()
+            .filter(|event| {
+                filter
+                    .session_key
+                    .as_ref()
+                    .map_or(true, |session_key| event.session_key == *session_key)
+            })
+            .filter(|event| {
+                filter.delegate_id.as_ref().map_or(true, |delegate_id| {
+                    event.delegate_id.as_ref() == Some(delegate_id)
+                })
+            })
+            .filter(|event| {
+                filter.trace_ref.as_ref().map_or(true, |trace_ref| {
+                    event.trace_ref.as_ref() == Some(trace_ref)
+                })
+            })
+            .filter(|event| {
+                filter
+                    .event_type
+                    .as_ref()
+                    .map_or(true, |event_type| event.event_type == *event_type)
+            })
+            .filter(|event| {
+                filter.artifact_id.as_ref().map_or(true, |artifact_id| {
+                    trace_event_artifact_id(event).as_deref() == Some(artifact_id)
+                })
+            })
+            .collect();
+        Ok(BackgroundTraceEventListResult { events })
+    }
+
+    pub fn get_delegate_trace(
+        &self,
+        params: BackgroundTraceGetDelegateTraceParams,
+    ) -> Result<BackgroundDelegateTraceResult, WorkerProtocolError> {
+        self.require(WorkerCapability::BackgroundRead)?;
+        let events = self
+            .list_trace_events(BackgroundTraceListParams {
+                filter: Some(params.filter),
+            })?
+            .events;
+        let Some(first) = events.first() else {
+            return Ok(BackgroundDelegateTraceResult {
+                trace: BackgroundDelegateTrace {
+                    session_key: String::new(),
+                    delegate_id: None,
+                    child_run_id: None,
+                    trace_ref: None,
+                    status: None,
+                    final_output: None,
+                    events,
+                    approvals: Vec::new(),
+                    artifacts: Vec::new(),
+                },
+            });
+        };
+        let mut status = None;
+        let mut final_output = None;
+        let mut approvals = Vec::new();
+        let mut artifacts = Vec::new();
+        for event in &events {
+            if let Some(value) = json_string(&event.payload, "status") {
+                status = Some(value);
+            } else if event.event_type.ends_with(".completed") {
+                status = Some("completed".to_string());
+            } else if event.event_type.ends_with(".failed") {
+                status = Some("failed".to_string());
+            } else if event.event_type.ends_with(".requested")
+                || event.event_type.ends_with(".awaiting_approval")
+            {
+                status = Some("awaiting_approval".to_string());
+            }
+            if let Some(value) = json_string(&event.payload, "finalOutput")
+                .or_else(|| json_string(&event.payload, "final_output"))
+                .or_else(|| json_string(&event.payload, "resultPreview"))
+                .or_else(|| json_string(&event.payload, "result_preview"))
+            {
+                final_output = Some(value);
+            }
+            if event.event_type.starts_with("child.approval.")
+                || event.payload.get("approvalId").is_some()
+                || event.payload.get("approval_id").is_some()
+            {
+                approvals.push(event.payload.clone());
+            }
+            if event.event_type.starts_with("child.artifact.")
+                || event.payload.get("artifactId").is_some()
+                || event.payload.get("artifact_id").is_some()
+            {
+                artifacts.push(event.payload.clone());
+            }
+        }
+
+        Ok(BackgroundDelegateTraceResult {
+            trace: BackgroundDelegateTrace {
+                session_key: first.session_key.clone(),
+                delegate_id: events.iter().find_map(|event| event.delegate_id.clone()),
+                child_run_id: events.iter().find_map(|event| event.child_run_id.clone()),
+                trace_ref: events.iter().find_map(|event| event.trace_ref.clone()),
+                status,
+                final_output,
+                events,
+                approvals,
+                artifacts,
+            },
+        })
+    }
+
+    pub fn get_artifact(
+        &self,
+        params: BackgroundTraceGetArtifactParams,
+    ) -> Result<BackgroundTraceArtifactResult, WorkerProtocolError> {
+        self.require(WorkerCapability::BackgroundRead)?;
+        let events = self
+            .list_trace_events(BackgroundTraceListParams {
+                filter: Some(params.filter),
+            })?
+            .events;
+        let artifact = events
+            .iter()
+            .filter(|event| {
+                event.event_type.starts_with("child.artifact.")
+                    || trace_event_artifact_id(event).is_some()
+            })
+            .find_map(trace_event_artifact_payload)
+            .unwrap_or(Value::Null);
+        Ok(BackgroundTraceArtifactResult { artifact })
+    }
+
     fn require(&self, capability: WorkerCapability) -> Result<(), WorkerProtocolError> {
         if self.policy.allows(&capability) {
             return Ok(());
@@ -141,6 +306,8 @@ pub struct BackgroundRunCompleteParams {
 pub struct BackgroundRegistryStore {
     pub version: usize,
     pub runs: Vec<BackgroundRun>,
+    #[serde(default, rename = "traceEvents")]
+    pub trace_events: Vec<BackgroundTraceEvent>,
 }
 
 impl Default for BackgroundRegistryStore {
@@ -148,6 +315,7 @@ impl Default for BackgroundRegistryStore {
         Self {
             version: 1,
             runs: Vec::new(),
+            trace_events: Vec::new(),
         }
     }
 }
@@ -198,6 +366,7 @@ pub enum BackgroundRunSource {
 pub enum BackgroundRunStatus {
     Queued,
     Running,
+    AwaitingApproval,
     Completed,
     Failed,
     Cancelled,
@@ -213,6 +382,88 @@ pub struct BackgroundRunResult {
     pub run: BackgroundRun,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+pub struct BackgroundTraceAppendParams {
+    pub event: BackgroundTraceEvent,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackgroundTraceListFilter {
+    pub session_key: Option<String>,
+    pub delegate_id: Option<String>,
+    pub trace_ref: Option<String>,
+    pub event_type: Option<String>,
+    pub artifact_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct BackgroundTraceListParams {
+    pub filter: Option<BackgroundTraceListFilter>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct BackgroundTraceGetDelegateTraceParams {
+    pub filter: BackgroundTraceListFilter,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct BackgroundTraceGetArtifactParams {
+    pub filter: BackgroundTraceListFilter,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackgroundTraceEvent {
+    pub event_id: String,
+    pub event_type: String,
+    pub session_key: String,
+    pub turn_id: String,
+    pub parent_step_id: Option<String>,
+    pub delegate_id: Option<String>,
+    pub child_run_id: Option<String>,
+    pub child_step_id: Option<String>,
+    pub trace_ref: Option<String>,
+    pub sequence: i64,
+    pub created_at: String,
+    #[serde(default)]
+    pub payload: Value,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BackgroundTraceEventResult {
+    pub event: BackgroundTraceEvent,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BackgroundTraceEventListResult {
+    pub events: Vec<BackgroundTraceEvent>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackgroundDelegateTrace {
+    pub session_key: String,
+    pub delegate_id: Option<String>,
+    pub child_run_id: Option<String>,
+    pub trace_ref: Option<String>,
+    pub status: Option<String>,
+    pub final_output: Option<String>,
+    pub events: Vec<BackgroundTraceEvent>,
+    pub approvals: Vec<Value>,
+    pub artifacts: Vec<Value>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BackgroundDelegateTraceResult {
+    pub trace: BackgroundDelegateTrace,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BackgroundTraceArtifactResult {
+    pub artifact: Value,
+}
+
 fn validate_run(run: &BackgroundRun) -> Result<(), WorkerProtocolError> {
     if run.id.trim().is_empty() {
         return Err(invalid_background_request("run.id is required"));
@@ -226,6 +477,62 @@ fn validate_run(run: &BackgroundRun) -> Result<(), WorkerProtocolError> {
         return Err(invalid_background_request(
             "run.updatedAtMs must be positive",
         ));
+    }
+    Ok(())
+}
+
+fn json_string(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|item| !item.is_empty())
+}
+
+fn trace_event_artifact_id(event: &BackgroundTraceEvent) -> Option<String> {
+    event
+        .child_step_id
+        .clone()
+        .filter(|value| value.starts_with("artifact"))
+        .or_else(|| json_string(&trace_event_artifact_payload(event)?, "artifactId"))
+        .or_else(|| json_string(&trace_event_artifact_payload(event)?, "artifact_id"))
+        .or_else(|| json_string(&trace_event_artifact_payload(event)?, "id"))
+}
+
+fn trace_event_artifact_payload(event: &BackgroundTraceEvent) -> Option<Value> {
+    if let Some(artifact) = event.payload.get("artifact") {
+        return Some(artifact.clone());
+    }
+    if event.event_type.starts_with("child.artifact.")
+        || event.payload.get("artifactId").is_some()
+        || event.payload.get("artifact_id").is_some()
+        || event.payload.get("id").is_some()
+    {
+        return Some(event.payload.clone());
+    }
+    None
+}
+
+fn validate_trace_event(event: &BackgroundTraceEvent) -> Result<(), WorkerProtocolError> {
+    if event.event_id.trim().is_empty() {
+        return Err(invalid_background_request("event.eventId is required"));
+    }
+    if event.event_type.trim().is_empty() {
+        return Err(invalid_background_request("event.eventType is required"));
+    }
+    if event.session_key.trim().is_empty() {
+        return Err(invalid_background_request("event.sessionKey is required"));
+    }
+    if event.turn_id.trim().is_empty() {
+        return Err(invalid_background_request("event.turnId is required"));
+    }
+    if event.sequence <= 0 {
+        return Err(invalid_background_request(
+            "event.sequence must be positive",
+        ));
+    }
+    if event.created_at.trim().is_empty() {
+        return Err(invalid_background_request("event.createdAt is required"));
     }
     Ok(())
 }
@@ -306,6 +613,253 @@ mod tests {
         assert_eq!(run.id, "run-existing");
         assert_eq!(run.status, BackgroundRunStatus::Running);
         assert_eq!(run.metadata["source"], "pre-storage-refactor");
+    }
+
+    #[test]
+    fn upsert_accepts_awaiting_approval_runs() {
+        let root = temp_workspace_root("awaiting-approval-store");
+        let _cleanup = TempWorkspaceCleanup(root.clone());
+        let rpc = WorkerBackgroundRpc::new(
+            root,
+            CapabilityPolicy::new([WorkerCapability::BackgroundWrite]),
+        );
+
+        let result = rpc
+            .upsert_run(BackgroundRunUpsertParams {
+                run: BackgroundRun {
+                    id: "run-awaiting".to_string(),
+                    kind: BackgroundRunKind::Subagent,
+                    source: BackgroundRunSource::Subagent,
+                    status: BackgroundRunStatus::AwaitingApproval,
+                    label: Some("Writer".to_string()),
+                    session_key: Some("desktop:session-1".to_string()),
+                    plan_id: None,
+                    subtask_id: None,
+                    cron_job_id: None,
+                    started_at_ms: 1710000000000,
+                    updated_at_ms: 1710000005000,
+                    completed_at_ms: None,
+                    result: Some("Waiting for approval.".to_string()),
+                    error: None,
+                    metadata: json!({ "stopReason": "awaiting_approval" }),
+                },
+            })
+            .expect("awaiting approval should be a valid non-final background status");
+
+        assert_eq!(result.run.status, BackgroundRunStatus::AwaitingApproval);
+        assert_eq!(result.run.metadata["stopReason"], "awaiting_approval");
+    }
+
+    #[test]
+    fn appends_and_filters_trace_events() {
+        let root = temp_workspace_root("trace-event-store");
+        let _cleanup = TempWorkspaceCleanup(root.clone());
+        let rpc = WorkerBackgroundRpc::new(
+            root.clone(),
+            CapabilityPolicy::new([
+                WorkerCapability::BackgroundRead,
+                WorkerCapability::BackgroundWrite,
+            ]),
+        );
+
+        rpc.append_trace_event(BackgroundTraceAppendParams {
+            event: BackgroundTraceEvent {
+                event_id: "event-1".to_string(),
+                event_type: "agent.delegate.started".to_string(),
+                session_key: "WebSocket:chat-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                parent_step_id: None,
+                delegate_id: Some("delegate-1".to_string()),
+                child_run_id: Some("delegate-1".to_string()),
+                child_step_id: None,
+                trace_ref: Some("trace-delegate-1".to_string()),
+                sequence: 1,
+                created_at: "2026-06-28T00:00:00.000Z".to_string(),
+                payload: json!({ "status": "running" }),
+            },
+        })
+        .expect("trace event append should succeed");
+        rpc.append_trace_event(BackgroundTraceAppendParams {
+            event: BackgroundTraceEvent {
+                event_id: "event-2".to_string(),
+                event_type: "agent.delegate.completed".to_string(),
+                session_key: "WebSocket:chat-2".to_string(),
+                turn_id: "turn-2".to_string(),
+                parent_step_id: None,
+                delegate_id: Some("delegate-2".to_string()),
+                child_run_id: Some("delegate-2".to_string()),
+                child_step_id: None,
+                trace_ref: Some("trace-delegate-2".to_string()),
+                sequence: 2,
+                created_at: "2026-06-28T00:00:01.000Z".to_string(),
+                payload: json!({ "status": "completed" }),
+            },
+        })
+        .expect("second trace event append should succeed");
+
+        let result = rpc
+            .list_trace_events(BackgroundTraceListParams {
+                filter: Some(BackgroundTraceListFilter {
+                    session_key: Some("WebSocket:chat-1".to_string()),
+                    delegate_id: Some("delegate-1".to_string()),
+                    trace_ref: None,
+                    event_type: None,
+                    artifact_id: None,
+                }),
+            })
+            .expect("trace events should list");
+
+        assert_eq!(result.events.len(), 1);
+        assert_eq!(result.events[0].event_id, "event-1");
+        assert_eq!(result.events[0].payload["status"], "running");
+        assert!(
+            std::fs::read_to_string(root.join("background").join("registry.json"))
+                .unwrap()
+                .contains("traceEvents")
+        );
+    }
+
+    #[test]
+    fn reconstructs_delegate_trace_from_journal_events() {
+        let root = temp_workspace_root("delegate-trace-store");
+        let _cleanup = TempWorkspaceCleanup(root.clone());
+        let rpc = WorkerBackgroundRpc::new(
+            root,
+            CapabilityPolicy::new([
+                WorkerCapability::BackgroundRead,
+                WorkerCapability::BackgroundWrite,
+            ]),
+        );
+
+        rpc.append_trace_event(BackgroundTraceAppendParams {
+            event: BackgroundTraceEvent {
+                event_id: "event-1".to_string(),
+                event_type: "agent.delegate.started".to_string(),
+                session_key: "WebSocket:chat-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                parent_step_id: None,
+                delegate_id: Some("delegate-1".to_string()),
+                child_run_id: Some("child-1".to_string()),
+                child_step_id: None,
+                trace_ref: Some("trace-delegate-1".to_string()),
+                sequence: 1,
+                created_at: "2026-06-28T00:00:00.000Z".to_string(),
+                payload: json!({ "status": "running" }),
+            },
+        })
+        .expect("start event should append");
+        rpc.append_trace_event(BackgroundTraceAppendParams {
+            event: BackgroundTraceEvent {
+                event_id: "event-2".to_string(),
+                event_type: "child.approval.resolved".to_string(),
+                session_key: "WebSocket:chat-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                parent_step_id: None,
+                delegate_id: Some("delegate-1".to_string()),
+                child_run_id: Some("child-1".to_string()),
+                child_step_id: Some("approval-1".to_string()),
+                trace_ref: Some("trace-delegate-1".to_string()),
+                sequence: 2,
+                created_at: "2026-06-28T00:00:01.000Z".to_string(),
+                payload: json!({
+                    "approvalId": "approval-1",
+                    "status": "approved",
+                    "toolName": "write_file"
+                }),
+            },
+        })
+        .expect("approval event should append");
+        rpc.append_trace_event(BackgroundTraceAppendParams {
+            event: BackgroundTraceEvent {
+                event_id: "event-3".to_string(),
+                event_type: "agent.delegate.completed".to_string(),
+                session_key: "WebSocket:chat-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                parent_step_id: None,
+                delegate_id: Some("delegate-1".to_string()),
+                child_run_id: Some("child-1".to_string()),
+                child_step_id: None,
+                trace_ref: Some("trace-delegate-1".to_string()),
+                sequence: 3,
+                created_at: "2026-06-28T00:00:02.000Z".to_string(),
+                payload: json!({ "status": "completed", "finalOutput": "Done" }),
+            },
+        })
+        .expect("completed event should append");
+
+        let result = rpc
+            .get_delegate_trace(BackgroundTraceGetDelegateTraceParams {
+                filter: BackgroundTraceListFilter {
+                    session_key: Some("WebSocket:chat-1".to_string()),
+                    delegate_id: Some("delegate-1".to_string()),
+                    trace_ref: None,
+                    event_type: None,
+                    artifact_id: None,
+                },
+            })
+            .expect("delegate trace should reconstruct");
+
+        assert_eq!(result.trace.session_key, "WebSocket:chat-1");
+        assert_eq!(result.trace.delegate_id.as_deref(), Some("delegate-1"));
+        assert_eq!(result.trace.child_run_id.as_deref(), Some("child-1"));
+        assert_eq!(result.trace.trace_ref.as_deref(), Some("trace-delegate-1"));
+        assert_eq!(result.trace.status.as_deref(), Some("completed"));
+        assert_eq!(result.trace.final_output.as_deref(), Some("Done"));
+        assert_eq!(result.trace.events.len(), 3);
+        assert_eq!(result.trace.approvals.len(), 1);
+        assert_eq!(result.trace.approvals[0]["approvalId"], "approval-1");
+    }
+
+    #[test]
+    fn retrieves_artifact_from_trace_journal_events() {
+        let root = temp_workspace_root("trace-artifact-store");
+        let _cleanup = TempWorkspaceCleanup(root.clone());
+        let rpc = WorkerBackgroundRpc::new(
+            root,
+            CapabilityPolicy::new([
+                WorkerCapability::BackgroundRead,
+                WorkerCapability::BackgroundWrite,
+            ]),
+        );
+
+        rpc.append_trace_event(BackgroundTraceAppendParams {
+            event: BackgroundTraceEvent {
+                event_id: "event-artifact".to_string(),
+                event_type: "child.artifact.created".to_string(),
+                session_key: "WebSocket:chat-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                parent_step_id: None,
+                delegate_id: Some("delegate-1".to_string()),
+                child_run_id: Some("child-1".to_string()),
+                child_step_id: Some("artifact-1".to_string()),
+                trace_ref: Some("trace-delegate-1".to_string()),
+                sequence: 1,
+                created_at: "2026-06-28T00:00:00.000Z".to_string(),
+                payload: json!({
+                    "artifactId": "artifact-1",
+                    "kind": "diff",
+                    "title": "Patch",
+                    "content": "--- a/file\n+++ b/file"
+                }),
+            },
+        })
+        .expect("artifact event should append");
+
+        let result = rpc
+            .get_artifact(BackgroundTraceGetArtifactParams {
+                filter: BackgroundTraceListFilter {
+                    session_key: Some("WebSocket:chat-1".to_string()),
+                    delegate_id: Some("delegate-1".to_string()),
+                    trace_ref: None,
+                    event_type: None,
+                    artifact_id: Some("artifact-1".to_string()),
+                },
+            })
+            .expect("artifact should load");
+
+        assert_eq!(result.artifact["artifactId"], "artifact-1");
+        assert_eq!(result.artifact["kind"], "diff");
+        assert_eq!(result.artifact["title"], "Patch");
     }
 
     fn temp_workspace_root(name: &str) -> PathBuf {

--- a/apps/desktop/src-tauri/src/worker_rpc.rs
+++ b/apps/desktop/src-tauri/src/worker_rpc.rs
@@ -1,6 +1,8 @@
 use crate::config_store::{ConfigPatchBridgeResult, ConfigStore};
 use crate::worker_background::{
-    BackgroundRunCompleteParams, BackgroundRunUpsertParams, WorkerBackgroundRpc,
+    BackgroundRunCompleteParams, BackgroundRunUpsertParams, BackgroundTraceAppendParams,
+    BackgroundTraceGetArtifactParams, BackgroundTraceGetDelegateTraceParams,
+    BackgroundTraceListParams, WorkerBackgroundRpc,
 };
 use crate::worker_capability::CapabilityPolicy;
 use crate::worker_config::WorkerConfigRpc;
@@ -610,6 +612,26 @@ impl WorkerRpcRouter {
             "background.run.complete" => {
                 let params: BackgroundRunCompleteParams = parse_params(request)?;
                 serde_json::to_value(self.background.complete_run(params)?)
+                    .map_err(serialization_error)
+            }
+            "background.trace.append" => {
+                let params: BackgroundTraceAppendParams = parse_params(request)?;
+                serde_json::to_value(self.background.append_trace_event(params)?)
+                    .map_err(serialization_error)
+            }
+            "background.trace.list" => {
+                let params: BackgroundTraceListParams = parse_params(request)?;
+                serde_json::to_value(self.background.list_trace_events(params)?)
+                    .map_err(serialization_error)
+            }
+            "background.trace.get_delegate_trace" => {
+                let params: BackgroundTraceGetDelegateTraceParams = parse_params(request)?;
+                serde_json::to_value(self.background.get_delegate_trace(params)?)
+                    .map_err(serialization_error)
+            }
+            "background.trace.get_artifact" => {
+                let params: BackgroundTraceGetArtifactParams = parse_params(request)?;
+                serde_json::to_value(self.background.get_artifact(params)?)
                     .map_err(serialization_error)
             }
             "mcp.call_tool" => self.mcp.call_tool_from_request(request),
@@ -2810,6 +2832,112 @@ mod tests {
         assert_eq!(
             complete_response.result.as_ref().unwrap()["run"]["completedAtMs"],
             2000
+        );
+
+        let append_trace_response = router.dispatch(&WorkerRequest::new(
+            "req-background-trace-append",
+            "trace-1",
+            "background.trace.append",
+            json!({
+                "event": {
+                    "eventId": "event-1",
+                    "eventType": "agent.delegate.started",
+                    "sessionKey": "desktop:chat-1",
+                    "turnId": "turn-1",
+                    "delegateId": "subagent-1",
+                    "childRunId": "subagent-1",
+                    "traceRef": "trace-1",
+                    "sequence": 1,
+                    "createdAt": "2026-06-28T00:00:00.000Z",
+                    "payload": { "status": "running" }
+                }
+            }),
+        ));
+        assert_eq!(append_trace_response.error, None);
+        assert_eq!(
+            append_trace_response.result.as_ref().unwrap()["event"]["eventId"],
+            "event-1"
+        );
+
+        let list_trace_response = router.dispatch(&WorkerRequest::new(
+            "req-background-trace-list",
+            "trace-1",
+            "background.trace.list",
+            json!({
+                "filter": {
+                    "sessionKey": "desktop:chat-1",
+                    "delegateId": "subagent-1"
+                }
+            }),
+        ));
+        assert_eq!(list_trace_response.error, None);
+        assert_eq!(
+            list_trace_response.result.as_ref().unwrap()["events"][0]["eventType"],
+            "agent.delegate.started"
+        );
+
+        let get_trace_response = router.dispatch(&WorkerRequest::new(
+            "req-background-trace-get",
+            "trace-1",
+            "background.trace.get_delegate_trace",
+            json!({
+                "filter": {
+                    "sessionKey": "desktop:chat-1",
+                    "delegateId": "subagent-1"
+                }
+            }),
+        ));
+        assert_eq!(get_trace_response.error, None);
+        assert_eq!(
+            get_trace_response.result.as_ref().unwrap()["trace"]["status"],
+            "running"
+        );
+        assert_eq!(
+            get_trace_response.result.as_ref().unwrap()["trace"]["events"][0]["eventType"],
+            "agent.delegate.started"
+        );
+
+        let append_artifact_response = router.dispatch(&WorkerRequest::new(
+            "req-background-trace-artifact-append",
+            "trace-1",
+            "background.trace.append",
+            json!({
+                "event": {
+                    "eventId": "event-artifact-1",
+                    "eventType": "child.artifact.created",
+                    "sessionKey": "desktop:chat-1",
+                    "turnId": "turn-1",
+                    "delegateId": "subagent-1",
+                    "childRunId": "subagent-1",
+                    "childStepId": "artifact-1",
+                    "traceRef": "trace-1",
+                    "sequence": 2,
+                    "createdAt": "2026-06-28T00:00:01.000Z",
+                    "payload": {
+                        "artifactId": "artifact-1",
+                        "kind": "diff",
+                        "title": "Patch"
+                    }
+                }
+            }),
+        ));
+        assert_eq!(append_artifact_response.error, None);
+        let get_artifact_response = router.dispatch(&WorkerRequest::new(
+            "req-background-trace-get-artifact",
+            "trace-1",
+            "background.trace.get_artifact",
+            json!({
+                "filter": {
+                    "sessionKey": "desktop:chat-1",
+                    "delegateId": "subagent-1",
+                    "artifactId": "artifact-1"
+                }
+            }),
+        ));
+        assert_eq!(get_artifact_response.error, None);
+        assert_eq!(
+            get_artifact_response.result.as_ref().unwrap()["artifact"]["artifactId"],
+            "artifact-1"
         );
     }
 

--- a/apps/desktop/src/chatRunModel.test.ts
+++ b/apps/desktop/src/chatRunModel.test.ts
@@ -504,6 +504,40 @@ describe("chat run model", () => {
     });
   });
 
+  test("replays interrupted delegated runs as cancelled steps", () => {
+    const state = createChatRunState();
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "delegate-interrupted",
+      event_type: "agent.delegate.interrupted",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-spawn",
+      step_id: "turn-spawn:delegate:delegate-1",
+      sequence: 1,
+      created_at: "2026-06-27T04:10:02.000Z",
+      payload: {
+        delegate_id: "delegate-1",
+        delegate_type: "spawn",
+        latest_activity: "Delegated run interrupted.",
+        status: "cancelled",
+        task: "long review",
+        title: "Long review",
+        trace_ref: "trace-1",
+      },
+    });
+
+    const turns = state.turnsBySession.get("WebSocket:chat-1") ?? [];
+    expect(turns[0]?.steps[0]).toMatchObject({
+      kind: "delegate",
+      status: "cancelled",
+      delegate: {
+        id: "delegate-1",
+        status: "cancelled",
+      },
+    });
+  });
+
   test("replays approval, failure, interruption, form, browser, file diff, and delegate variants", () => {
     const state = createChatRunState();
     const base = {

--- a/apps/desktop/src/chatRunModel.ts
+++ b/apps/desktop/src/chatRunModel.ts
@@ -517,6 +517,7 @@ function isDelegatedRunEventType(eventType: string): boolean {
     || eventType === "agent.delegate.updated"
     || eventType === "agent.delegate.completed"
     || eventType === "agent.delegate.failed"
+    || eventType === "agent.delegate.interrupted"
     || eventType === "agent.delegate.closed";
 }
 
@@ -608,11 +609,19 @@ function stepToToolActivities(step: ChatStep): ConversationMessageIslandOptions[
       approvalId: step.delegate.approvalId,
       approvalStatus: step.delegate.approvalStatus ?? "",
       argsText: delegatedActivityArgsText(step.delegate),
+      delegatedTrace: step.delegate.trace as Record<string, unknown> | undefined,
+      delegateId: step.delegate.id,
+      delegateTask: step.delegate.task,
+      delegateTitle: step.delegate.title,
+      delegateType: step.delegate.type,
+      finalOutput: step.delegate.finalOutput,
       id: step.delegate.parentToolCallId || step.delegate.id,
       kind: step.status === "completed" || step.status === "failed" ? "result" : "call",
       name: step.delegate.toolName || step.delegate.type || "delegate",
+      parentRunId: step.delegate.trace?.parentRunId,
       responseText: step.delegate.latestActivity ?? step.delegate.finalOutput ?? "",
       status: step.status,
+      traceRef: step.delegate.traceRef,
     }];
   }
   if (step.artifacts?.length) {

--- a/apps/desktop/src/desktopBootstrap.ts
+++ b/apps/desktop/src/desktopBootstrap.ts
@@ -642,6 +642,15 @@ async function loadNativeChatRuntime(): Promise<DesktopNativeWorkbenchRuntime> {
     api: {
       listSessions: () => gatewayApi.sessions.list(),
       loadMessages: (sessionKey) => gatewayApi.sessions.messages(sessionKey),
+      listTraceEvents: agentRoute === "ts-agent"
+        ? (filter) => invoke("worker_background_trace_list", { input: { filter } })
+        : undefined,
+      getDelegateTrace: agentRoute === "ts-agent"
+        ? (filter) => invoke("worker_background_trace_get_delegate_trace", { input: { filter } })
+        : undefined,
+      getArtifact: agentRoute === "ts-agent"
+        ? (filter) => invoke("worker_background_trace_get_artifact", { input: { filter } })
+        : undefined,
       deleteSession: (sessionKey) => gatewayApi.sessions.delete(sessionKey),
     },
     sendSocketMessage: (message) => sendNativeChatSocketMessage(message),
@@ -707,6 +716,7 @@ function installNativeTsAgentEventListeners(): void {
     "agent.delegate.trace.updated",
     "agent.delegate.completed",
     "agent.delegate.failed",
+    "agent.delegate.interrupted",
     "agent.delegate.closed",
     "heartbeat.delivery",
     "agent.cancelled",
@@ -835,6 +845,18 @@ function nativeChatActions() {
     },
     onAttachSessionFile: () => {
       document.getElementById("desktop-session-file-upload")?.click();
+    },
+    onArtifactLoad: (selection: { sessionKey: string; delegateId?: string; traceRef?: string; artifactId: string }) => {
+      if (!nativeWorkbenchRuntime) {
+        return Promise.resolve(null);
+      }
+      return nativeWorkbenchRuntime.loadArtifact(selection);
+    },
+    onDelegateTraceLoad: (selection: { sessionKey: string; delegateId?: string; traceRef?: string }) => {
+      if (!nativeWorkbenchRuntime) {
+        return Promise.resolve(null);
+      }
+      return nativeWorkbenchRuntime.loadDelegateTrace(selection);
     },
     onSelectModel: (model: string) => {
       void selectNativeComposerModel(model);

--- a/apps/desktop/src/desktopChatSessionController.test.ts
+++ b/apps/desktop/src/desktopChatSessionController.test.ts
@@ -24,6 +24,116 @@ describe("desktop chat session controller", () => {
     expect(sent).toEqual([{ type: "attach", chat_id: "chat-1" }]);
   });
 
+  test("replays delegated trace events when selecting a persisted native session", async () => {
+    const sent: unknown[] = [];
+    const listTraceEvents = vi.fn(async () => ({
+      events: [{
+        eventId: "trace-event-1",
+        eventType: "agent.delegate.trace.updated",
+        sessionKey: "WebSocket:chat-1",
+        turnId: "turn-restored",
+        stepId: "step-delegate-1",
+        sequence: 1,
+        createdAt: "2026-06-28T04:00:01Z",
+        payload: {
+          delegate_id: "delegate-1",
+          delegate_type: "spawn",
+          final_output: "hello",
+          parent_tool_call_id: "call-spawn",
+          status: "completed",
+          task: "Say hello",
+          title: "Greeter",
+          tool_name: "spawn_agent",
+          trace_ref: "trace-delegate-1",
+          trace: {
+            delegateId: "delegate-1",
+            parentRunId: "run-parent",
+            parentSessionKey: "WebSocket:chat-1",
+            status: "completed",
+            steps: [{
+              id: "message:delegate-1",
+              kind: "message",
+              status: "completed",
+              title: "Assistant message",
+              summary: "hello",
+            }],
+          },
+        },
+      }],
+    }));
+    const controller = createDesktopChatSessionController({
+      api: {
+        listSessions: vi.fn(async () => ({
+          items: [{ key: "WebSocket:chat-1", chat_id: "chat-1", title: "Spawn", updated_at: "2026-06-28T04:00:00Z" }],
+        })),
+        loadMessages: vi.fn(async () => ({
+          messages: [{ role: "user", content: "spawn a subagent", message_id: "m-user" }],
+        })),
+        listTraceEvents,
+      },
+      sendSocketMessage: (message) => sent.push(message),
+    });
+
+    await controller.loadSessions();
+
+    expect(listTraceEvents).toHaveBeenCalledWith({ sessionKey: "WebSocket:chat-1" });
+    const toolActivities = [...(controller.state.messages.get("WebSocket:chat-1") ?? [])]
+      .flatMap((message) => message.toolActivities ?? []);
+    expect(toolActivities).toEqual([
+      expect.objectContaining({
+        delegatedTrace: expect.objectContaining({
+          delegateId: "delegate-1",
+          steps: [expect.objectContaining({ summary: "hello" })],
+        }),
+        delegateId: "delegate-1",
+        delegateTask: "Say hello",
+        delegateTitle: "Greeter",
+        finalOutput: "hello",
+        id: "call-spawn",
+        name: "spawn_agent",
+        status: "completed",
+        traceRef: "trace-delegate-1",
+      }),
+    ]);
+    expect(sent).toEqual([{ type: "attach", chat_id: "chat-1" }]);
+  });
+
+  test("loads a delegated artifact through the trace API", async () => {
+    const getArtifact = vi.fn(async () => ({
+      artifact: {
+        artifactId: "artifact-1",
+        content: "artifact body",
+      },
+    }));
+    const controller = createDesktopChatSessionController({
+      api: {
+        getArtifact,
+        listSessions: vi.fn(async () => ({ items: [] })),
+        loadMessages: vi.fn(async () => ({ messages: [] })),
+      },
+      sendSocketMessage: vi.fn(),
+    });
+
+    await expect(controller.loadArtifact({
+      artifactId: "artifact-1",
+      delegateId: "delegate-1",
+      sessionKey: "WebSocket:chat-1",
+      traceRef: "trace-1",
+    })).resolves.toEqual({
+      artifact: {
+        artifactId: "artifact-1",
+        content: "artifact body",
+      },
+    });
+
+    expect(getArtifact).toHaveBeenCalledWith({
+      artifactId: "artifact-1",
+      delegateId: "delegate-1",
+      sessionKey: "WebSocket:chat-1",
+      traceRef: "trace-1",
+    });
+  });
+
   test("preserves gateway session keys when selecting recent chats with non-WebSocket keys", async () => {
     const sent: unknown[] = [];
     const controller = createDesktopChatSessionController({

--- a/apps/desktop/src/desktopChatSessionController.ts
+++ b/apps/desktop/src/desktopChatSessionController.ts
@@ -3,11 +3,13 @@ import {
   applyChatEvent,
   createNativeChatState,
   activateSession,
+  hydrateDelegatedRunsFromTraceEvents,
   normalizeMessagesPayload,
   normalizeSessionsPayload,
   setMessages,
   setSessions,
   sessionKeyForChat,
+  type NativeBackgroundTraceEvent,
   type NativeChatState,
 } from "./nativeChat";
 import { createGatewaySocketMessage, type NormalizedGatewayEvent } from "./gatewayWebSocketClient";
@@ -16,6 +18,9 @@ import { logDesktopNativeDebug, summarizeDebugText } from "./desktopNativeChatDe
 export interface DesktopChatSessionControllerApi {
   listSessions(): Promise<unknown>;
   loadMessages(sessionKey: string): Promise<unknown>;
+  listTraceEvents?: (filter: { sessionKey: string }) => Promise<unknown>;
+  getDelegateTrace?: (filter: { sessionKey: string; delegateId?: string; traceRef?: string }) => Promise<unknown>;
+  getArtifact?: (filter: { sessionKey: string; delegateId?: string; traceRef?: string; artifactId: string }) => Promise<unknown>;
   deleteSession?: (sessionKey: string) => Promise<unknown>;
 }
 
@@ -51,6 +56,8 @@ export interface DesktopChatSessionController {
   interruptActiveChat(): boolean;
   handleGatewayEvent(event: NormalizedGatewayEvent): Promise<ChatGatewayEventResult>;
   loadMessagesForChat(chatId: string): Promise<boolean>;
+  loadDelegateTrace(selection: { sessionKey: string; delegateId?: string; traceRef?: string }): Promise<unknown>;
+  loadArtifact(selection: { sessionKey: string; delegateId?: string; traceRef?: string; artifactId: string }): Promise<unknown>;
 }
 
 export function createDesktopChatSessionController({
@@ -86,6 +93,7 @@ export function createDesktopChatSessionController({
       const payload = await api.loadMessages(sessionKey);
       const messages = normalizeMessagesPayload(payload);
       setMessages(state, sessionKey, messages);
+      await loadTraceEventsForSession(sessionKey);
       state.error = "";
     } catch (error) {
       state.error = error instanceof Error ? error.message : String(error);
@@ -102,6 +110,32 @@ export function createDesktopChatSessionController({
       messageCount: state.messages.get(sessionKey)?.length ?? 0,
       sessionKey,
     });
+  }
+
+  async function loadTraceEventsForSession(sessionKey: string): Promise<void> {
+    if (!api.listTraceEvents) {
+      return;
+    }
+    logDesktopNativeDebug("session.trace.load.start", {
+      ...summarizeSessionState(),
+      sessionKey,
+    });
+    try {
+      const payload = await api.listTraceEvents({ sessionKey });
+      const events = normalizeTraceEventsPayload(payload);
+      hydrateDelegatedRunsFromTraceEvents(state, sessionKey, events);
+      logDesktopNativeDebug("session.trace.load.complete", {
+        ...summarizeSessionState(),
+        eventCount: events.length,
+        sessionKey,
+      });
+    } catch (error) {
+      logDesktopNativeDebug("session.trace.load.failed", {
+        ...summarizeSessionState(),
+        error: error instanceof Error ? error.message : String(error),
+        sessionKey,
+      });
+    }
   }
 
   function startNewChat(): void {
@@ -271,12 +305,53 @@ export function createDesktopChatSessionController({
     const payload = await api.loadMessages(sessionKey);
     const messages = normalizeMessagesPayload(payload);
     setMessages(state, sessionKey, messages);
+    await loadTraceEventsForSession(sessionKey);
     logDesktopNativeDebug("session.messages.loaded", {
       chatId,
       messageCount: messages.length,
       sessionKey,
     });
     return true;
+  }
+
+  async function loadDelegateTrace(selection: { sessionKey: string; delegateId?: string; traceRef?: string }): Promise<unknown> {
+    if (!api.getDelegateTrace) {
+      throw new Error("Delegate trace API is unavailable.");
+    }
+    logDesktopNativeDebug("session.delegateTrace.load.start", {
+      delegateId: selection.delegateId ?? "",
+      sessionKey: selection.sessionKey,
+      traceRef: selection.traceRef ?? "",
+    });
+    const trace = await api.getDelegateTrace(selection);
+    logDesktopNativeDebug("session.delegateTrace.load.complete", {
+      delegateId: selection.delegateId ?? "",
+      hasTrace: Boolean(trace),
+      sessionKey: selection.sessionKey,
+      traceRef: selection.traceRef ?? "",
+    });
+    return trace;
+  }
+
+  async function loadArtifact(selection: { sessionKey: string; delegateId?: string; traceRef?: string; artifactId: string }): Promise<unknown> {
+    if (!api.getArtifact) {
+      throw new Error("Artifact API is unavailable.");
+    }
+    logDesktopNativeDebug("session.artifact.load.start", {
+      artifactId: selection.artifactId,
+      delegateId: selection.delegateId ?? "",
+      sessionKey: selection.sessionKey,
+      traceRef: selection.traceRef ?? "",
+    });
+    const artifact = await api.getArtifact(selection);
+    logDesktopNativeDebug("session.artifact.load.complete", {
+      artifactId: selection.artifactId,
+      delegateId: selection.delegateId ?? "",
+      hasArtifact: Boolean(artifact),
+      sessionKey: selection.sessionKey,
+      traceRef: selection.traceRef ?? "",
+    });
+    return artifact;
   }
 
   function sendActiveChatMessage(content: string, usePersistentRag = true): void {
@@ -294,6 +369,8 @@ export function createDesktopChatSessionController({
     interruptActiveChat,
     handleGatewayEvent,
     loadMessagesForChat,
+    loadDelegateTrace,
+    loadArtifact,
   };
 
   function summarizeSessionState(): Record<string, unknown> {
@@ -304,4 +381,18 @@ export function createDesktopChatSessionController({
       sessionCount: state.sessions.length,
     };
   }
+}
+
+function normalizeTraceEventsPayload(payload: unknown): NativeBackgroundTraceEvent[] {
+  if (Array.isArray(payload)) {
+    return payload.filter(isRecord) as NativeBackgroundTraceEvent[];
+  }
+  if (isRecord(payload) && Array.isArray(payload.events)) {
+    return payload.events.filter(isRecord) as NativeBackgroundTraceEvent[];
+  }
+  return [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/desktop/src/desktopNativeWebSocketBridge.ts
+++ b/apps/desktop/src/desktopNativeWebSocketBridge.ts
@@ -33,6 +33,7 @@ export type DesktopNativeWebSocketAgentEventName =
   | "agent.delegate.trace.updated"
   | "agent.delegate.completed"
   | "agent.delegate.failed"
+  | "agent.delegate.interrupted"
   | "agent.delegate.closed"
   | "agent.browser_frame"
   | "cowork_updated"
@@ -68,6 +69,7 @@ const AGENT_EVENT_NAMES: DesktopNativeWebSocketAgentEventName[] = [
   "agent.delegate.trace.updated",
   "agent.delegate.completed",
   "agent.delegate.failed",
+  "agent.delegate.interrupted",
   "agent.delegate.closed",
   "agent.browser_frame",
   "cowork_updated",
@@ -912,7 +914,10 @@ function delegatedEventTypeFromStatus(status: string): string {
   if (status === "failed") {
     return "agent.delegate.failed";
   }
-  if (status === "closed" || status === "cancelled") {
+  if (status === "cancelled") {
+    return "agent.delegate.interrupted";
+  }
+  if (status === "closed") {
     return "agent.delegate.closed";
   }
   if (status === "awaiting_approval" || status === "blocked") {

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.test.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { createDesktopNativeWorkbenchRuntime } from "./desktopNativeWorkbenchRuntime";
 
 describe("desktop native workbench runtime", () => {
@@ -40,6 +40,41 @@ describe("desktop native workbench runtime", () => {
     expect(runtime.chat.status).toBe("Loaded 1 session from gateway.");
     expect(runtime.chat.responding).toBe(false);
     expect(sentSocketMessages).toContainEqual({ type: "attach", chat_id: "chat-live" });
+  });
+
+  test("loads delegated artifacts through the native chat runtime", async () => {
+    const getArtifact = vi.fn(async () => ({
+      artifact: {
+        artifactId: "artifact-1",
+        content: "artifact body",
+      },
+    }));
+    const runtime = createDesktopNativeWorkbenchRuntime({
+      api: {
+        getArtifact,
+        listSessions: async () => ({ items: [] }),
+        loadMessages: async () => ({ messages: [] }),
+      },
+      sendSocketMessage: vi.fn(),
+    });
+
+    await expect(runtime.loadArtifact({
+      artifactId: "artifact-1",
+      delegateId: "delegate-1",
+      sessionKey: "WebSocket:chat-1",
+      traceRef: "trace-1",
+    })).resolves.toEqual({
+      artifact: {
+        artifactId: "artifact-1",
+        content: "artifact body",
+      },
+    });
+    expect(getArtifact).toHaveBeenCalledWith({
+      artifactId: "artifact-1",
+      delegateId: "delegate-1",
+      sessionKey: "WebSocket:chat-1",
+      traceRef: "trace-1",
+    });
   });
 
   test("selects a native chat session, reloads messages, and reattaches the gateway socket", async () => {

--- a/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
+++ b/apps/desktop/src/desktopNativeWorkbenchRuntime.ts
@@ -105,6 +105,7 @@ export type DesktopTsAgentWorkerEventName =
   | "agent.delegate.trace.updated"
   | "agent.delegate.completed"
   | "agent.delegate.failed"
+  | "agent.delegate.interrupted"
   | "agent.delegate.closed"
   | "heartbeat.delivery"
   | "agent.cancelled"
@@ -124,6 +125,8 @@ export interface DesktopNativeWorkbenchRuntime {
   setPersistentRag(enabled: boolean): void;
   submitComposerMessage(content: string, usePersistentRag?: boolean): ChatSubmitResult;
   interruptActiveChat(): boolean;
+  loadDelegateTrace(selection: { sessionKey: string; delegateId?: string; traceRef?: string }): Promise<unknown>;
+  loadArtifact(selection: { sessionKey: string; delegateId?: string; traceRef?: string; artifactId: string }): Promise<unknown>;
   resolveApproval(approvalId: string, decision: "approved" | "denied", sessionKey?: string): boolean;
   handleGatewayEvent(event: NormalizedGatewayEvent): Promise<void>;
   handleTsAgentWorkerEvent(eventName: DesktopTsAgentWorkerEventName, payload: unknown): void;
@@ -775,7 +778,10 @@ export function createDesktopNativeWorkbenchRuntime({
     if (status === "failed") {
       return "agent.delegate.failed";
     }
-    if (status === "closed" || status === "cancelled") {
+    if (status === "cancelled") {
+      return "agent.delegate.interrupted";
+    }
+    if (status === "closed") {
       return "agent.delegate.closed";
     }
     if (status === "blocked") {
@@ -926,6 +932,14 @@ export function createDesktopNativeWorkbenchRuntime({
     return interrupted;
   }
 
+  async function loadDelegateTrace(selection: { sessionKey: string; delegateId?: string; traceRef?: string }): Promise<unknown> {
+    return chatController.loadDelegateTrace(selection);
+  }
+
+  async function loadArtifact(selection: { sessionKey: string; delegateId?: string; traceRef?: string; artifactId: string }): Promise<unknown> {
+    return chatController.loadArtifact(selection);
+  }
+
   async function handleGatewayEvent(event: NormalizedGatewayEvent): Promise<void> {
     logDesktopNativeDebug("runtime.gatewayEvent.start", summarizeGatewayEvent(event));
     if (event.kind === "usage") {
@@ -1023,6 +1037,8 @@ export function createDesktopNativeWorkbenchRuntime({
     setPersistentRag,
     submitComposerMessage,
     interruptActiveChat,
+    loadDelegateTrace,
+    loadArtifact,
     resolveApproval(approvalId: string, decision: "approved" | "denied", sessionKey = chatController.state.activeSessionKey) {
       return resolveNativeChatApproval(chatController.state, { approvalId, decision, sessionKey });
     },

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -4349,6 +4349,13 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-layout {");
     expect(styleText).toContain("display: grid;\n      align-content: start;");
     expect(styleText).toContain("grid-column: 1;\n      grid-row: 2;");
+    const conversationLayoutRule = styleText.match(/body\.desktop-native-workbench \.desktop-conversation-layout \{([\s\S]*?)\n    \}/)?.[1] ?? "";
+    expect(conversationLayoutRule).toContain("height: auto;");
+    expect(conversationLayoutRule).toContain("max-height: none;");
+    expect(conversationLayoutRule).toContain("min-height: 0;");
+    expect(conversationLayoutRule).toContain("overflow: visible;");
+    expect(conversationLayoutRule).not.toContain("height: 100%;");
+    expect(conversationLayoutRule).not.toContain("overflow: hidden;");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-detail-panel-slot {");
     expect(styleText).toContain("position: relative;\n      align-self: stretch;");
     expect(styleText).toContain("box-sizing: border-box;");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -76,6 +76,8 @@ import { mountConversationReferenceIsland } from "./native-vue/conversationRefer
 import {
   mountOrUpdateConversationThreadIsland,
   type ConversationCoworkRunOptions,
+  type DelegateArtifactLoadSelection,
+  type DelegateTraceLoadSelection,
 } from "./native-vue/conversationThreadIsland";
 import { mountCoworkActionsIsland } from "./native-vue/coworkActionsIsland";
 import { mountCoworkDataRowIsland } from "./native-vue/coworkDataRowIsland";
@@ -206,6 +208,8 @@ interface DesktopNativeChatActionOptions {
   onComposerSubmit?: (event: DesktopNativeChatComposerSubmitEvent) => void;
   onInterrupt?: () => void;
   onAttachSessionFile?: () => void;
+  onArtifactLoad?: (selection: DelegateArtifactLoadSelection) => Promise<unknown>;
+  onDelegateTraceLoad?: (selection: DelegateTraceLoadSelection) => Promise<unknown>;
   onNewChat?: () => void;
   onDeleteSession?: (event: DesktopNativeChatDeleteSessionEvent) => unknown | Promise<unknown>;
   onPinSession?: (event: DesktopNativeChatPinSessionEvent) => void;
@@ -432,6 +436,7 @@ const desktopPanelFrameEventDocuments = new WeakSet<Document>();
 const desktopChatTimelineContexts = new WeakMap<Document, {
   agentUiActions: DesktopAgentUiFormActionOptions;
   agentUiForms: AgentUiForm[];
+  chatActions: DesktopNativeChatActionOptions;
   coworkActions: DesktopCoworkActionOptions;
   coworkPane: DesktopCoworkPaneModel | null;
 }>();
@@ -469,6 +474,7 @@ export function installDesktopWorkbenchShell({
   desktopChatTimelineContexts.set(targetDocument, {
     agentUiActions,
     agentUiForms,
+    chatActions,
     coworkActions,
     coworkPane,
   });
@@ -708,6 +714,7 @@ function updateDesktopChatTimelineContext(
   patch: Partial<{
     agentUiActions: DesktopAgentUiFormActionOptions;
     agentUiForms: AgentUiForm[];
+    chatActions: DesktopNativeChatActionOptions;
     coworkActions: DesktopCoworkActionOptions;
     coworkPane: DesktopCoworkPaneModel | null;
   }>,
@@ -715,6 +722,7 @@ function updateDesktopChatTimelineContext(
   const current = desktopChatTimelineContexts.get(targetDocument) ?? {
     agentUiActions: {},
     agentUiForms: [],
+    chatActions: {},
     coworkActions: {},
     coworkPane: null,
   };
@@ -728,6 +736,7 @@ export function updateDesktopNativeChat(
   chatActions: DesktopNativeChatActionOptions = {},
 ): void {
   desktopNativeChatModels.set(targetDocument, chat);
+  updateDesktopChatTimelineContext(targetDocument, { chatActions });
   logDesktopNativeChatDebug("shell.update", {
     chat: summarizeDesktopNativeChatForDebug(chat),
     dom: summarizeNativeChatDomForDebug(targetDocument),
@@ -743,7 +752,7 @@ export function updateDesktopNativeChat(
   if (thread) {
     const scrollState = captureConversationThreadScroll(thread);
     if (canMountVueIsland(thread)) {
-      mountConversationThreadVueIsland(thread, conversationThreadOptions(targetDocument, chat));
+      mountConversationThreadVueIsland(thread, conversationThreadMountOptions(targetDocument, conversationThreadOptions(targetDocument, chat)));
     } else {
       const next = createConversationThread(targetDocument, chat);
       thread.replaceChildren(...Array.from(next.children));
@@ -2158,6 +2167,7 @@ function conversationThreadMountOptions(
   const context = desktopChatTimelineContexts.get(targetDocument) ?? {
     agentUiActions: {},
     agentUiForms: [],
+    chatActions: {},
     coworkActions: {},
     coworkPane: null,
   };
@@ -2173,6 +2183,8 @@ function conversationThreadMountOptions(
     onInlineFormSubmit: (form, values) => {
       context.agentUiActions.onAgentUiFormAction?.({ action: "submit", form, values });
     },
+    onArtifactLoad: context.chatActions.onArtifactLoad,
+    onDelegateTraceLoad: context.chatActions.onDelegateTraceLoad,
     onReferenceInspect: (reference) => {
       setRouteStatus(targetDocument, `Inspecting ${reference.kind} reference ${reference.title}`);
     },
@@ -2218,13 +2230,22 @@ function conversationThreadOptions(targetDocument: Document, chat: DesktopNative
       approvalId?: string;
       argsText: string;
       approvalStatus: string;
+      delegatedTrace?: Record<string, unknown>;
+      delegateId?: string;
+      delegateTask?: string;
+      delegateTitle?: string;
+      delegateType?: string;
+      finalOutput?: string;
       id: string;
       kind: "call" | "result";
       name: string;
+      parentRunId?: string;
+      parentTurnId?: string;
       responseText: string;
       runChainItemKey?: string;
       sessionKey?: string;
       status?: string;
+      traceRef?: string;
     }>;
   }>;
 } {
@@ -2244,13 +2265,22 @@ function conversationThreadOptions(targetDocument: Document, chat: DesktopNative
         approvalId: activity.approvalId,
         argsText: activity.argsText || "",
         approvalStatus: activity.approvalStatus || "",
+        delegatedTrace: activity.delegatedTrace,
+        delegateId: activity.delegateId,
+        delegateTask: activity.delegateTask,
+        delegateTitle: activity.delegateTitle,
+        delegateType: activity.delegateType,
+        finalOutput: activity.finalOutput,
         id: activity.id || "",
         kind: activity.kind,
         name: activity.name || "",
+        parentRunId: activity.parentRunId,
+        parentTurnId: activity.parentTurnId,
         responseText: activity.responseText || "",
         runChainItemKey: conversationToolActivityRunChainKey(message, activity),
         sessionKey: activity.sessionKey || chat.activeSessionKey,
         status: activity.status,
+        traceRef: activity.traceRef,
       })),
       references: (message.references ?? []).map((reference) => ({
         detail: reference.detail ?? "",
@@ -2301,16 +2331,27 @@ function mountConversationThreadVueIsland(
         approvalId?: string;
         argsText: string;
         approvalStatus: string;
+        delegatedTrace?: Record<string, unknown>;
+        delegateId?: string;
+        delegateTask?: string;
+        delegateTitle?: string;
+        delegateType?: string;
+        finalOutput?: string;
         id: string;
         kind: "call" | "result";
         name: string;
+        parentRunId?: string;
+        parentTurnId?: string;
         responseText: string;
         runChainItemKey?: string;
         sessionKey?: string;
         status?: string;
+        traceRef?: string;
       }>;
     }>;
     onCoworkAgentInspect?: (selection: { agentId: string; sessionId: string }) => void;
+    onArtifactLoad?: (selection: DelegateArtifactLoadSelection) => Promise<unknown>;
+    onDelegateTraceLoad?: (selection: DelegateTraceLoadSelection) => Promise<unknown>;
     onInlineFormCancel?: (form: AgentUiForm) => void;
     onInlineFormSubmit?: (form: AgentUiForm, values: Record<string, unknown>) => void;
     onReferenceInspect?: (reference: {
@@ -11622,9 +11663,10 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       min-width: 0;
       min-height: 0;
       width: min(var(--desktop-chat-column-width), 100%);
-      height: 100%;
+      height: auto;
+      max-height: none;
       padding: 18px 0 var(--desktop-composer-reserve);
-      overflow: hidden;
+      overflow: visible;
     }
 
     body.desktop-native-workbench .desktop-conversation-timeline {

--- a/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
@@ -237,8 +237,21 @@ describe("conversation thread Vue island", () => {
 
     const shelf = host.querySelector(".desktop-subagent-shelf");
     expect(shelf?.getAttribute("data-subagent-count")).toBe("1");
+    expect(shelf?.getAttribute("data-subagent-shelf-layout")).toBe("stacked-status");
     expect(shelf?.textContent).toContain("spawn");
     expect(shelf?.textContent).toContain("Completed");
+    expect(shelf?.querySelector("[data-subagent-shelf-row]")).toBeTruthy();
+
+    const cssText = document.getElementById("desktop-conversation-agent-flow-styles")?.textContent ?? "";
+    const shelfListRule = cssText.match(/\.desktop-subagent-shelf-list \{([\s\S]*?)\}/)?.[1] ?? "";
+    const shelfItemRule = cssText.match(/\.desktop-subagent-shelf-item \{([\s\S]*?)\}/)?.[1] ?? "";
+    const shelfActivityRule = cssText.match(/\.desktop-subagent-shelf-activity \{([\s\S]*?)\}/)?.[1] ?? "";
+    expect(shelfListRule).toContain("display: grid;");
+    expect(shelfListRule).toContain("overflow-y: auto;");
+    expect(shelfListRule).toContain("overflow-x: hidden;");
+    expect(shelfItemRule).toContain("grid-template-columns: auto minmax(92px, .8fr) max-content minmax(0, 1.2fr);");
+    expect(shelfItemRule).toContain("width: 100%;");
+    expect(shelfActivityRule).not.toContain("grid-column:");
 
     shelf?.querySelector<HTMLButtonElement>("[data-subagent-shelf-item]")?.click();
     await nextTick();
@@ -249,6 +262,425 @@ describe("conversation thread Vue island", () => {
     expect(inspector?.textContent).toContain("Subagent timeline");
     expect(inspector?.textContent).toContain("say");
     expect(inspector?.textContent).toContain("你好");
+  });
+
+  test("groups delegated trace details into transcript tools approvals and context", async () => {
+    const host = document.createElement("section");
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [{
+        author: "Tinybot",
+        body: ["I observed a child agent."],
+        references: [],
+        time: "10:30 AM",
+        tone: "assistant",
+        toolActivities: [{
+          argsText: "Spawn greeter",
+          approvalStatus: "",
+          delegatedTrace: {
+            childRunId: "child-run-1",
+            steps: [
+              {
+                id: "reasoning-1",
+                kind: "reasoning",
+                status: "completed",
+                summary: "The child agent planned a short greeting.",
+                title: "Thinking",
+              },
+              {
+                argsPreview: "{\"text\":\"hello\"}",
+                id: "tool-1",
+                kind: "tool_call",
+                resultPreview: "hello",
+                status: "completed",
+                summary: "Child tool say completed.",
+                title: "say",
+              },
+              {
+                approvalId: "approval-child-1",
+                approvalStatus: "approved",
+                id: "approval-1",
+                kind: "approval",
+                status: "approved",
+                summary: "Child approval was granted.",
+                title: "Approval checkpoint",
+              },
+              {
+                id: "final-1",
+                kind: "message",
+                resultPreview: "hello",
+                status: "completed",
+                title: "Final response",
+              },
+              {
+                id: "artifact-1",
+                kind: "artifact",
+                resultPreview: "notes/hello.md",
+                status: "completed",
+                summary: "Created notes/hello.md",
+                title: "hello.md",
+              },
+            ],
+            artifacts: [{
+              id: "artifact-1",
+              kind: "file",
+              path: "notes/hello.md",
+              summary: "Greeting note",
+            }],
+          },
+          delegateId: "delegate-1",
+          delegateTask: "Say hello",
+          finalOutput: "hello",
+          id: "delegate-1",
+          kind: "result",
+          name: "spawn_agent",
+          responseText: "hello",
+          status: "completed",
+          traceRef: "child-run-1",
+        }],
+      }],
+    });
+    await nextTick();
+    await nextTick();
+
+    host.querySelector<HTMLButtonElement>("[data-subagent-shelf-item]")?.click();
+    await nextTick();
+    await flushDetailPanelOpeningMotion();
+
+    const inspector = host.querySelector(".desktop-delegate-detail-panel");
+    expect(inspector?.textContent).toContain("Subagent timeline");
+    expect(inspector?.textContent).toContain("Transcript");
+    expect(inspector?.textContent).toContain("Tools");
+    expect(inspector?.textContent).toContain("Approvals");
+    expect(inspector?.textContent).toContain("Artifacts");
+    expect(inspector?.textContent).toContain("Raw context");
+    expect(inspector?.textContent).toContain("child-run-1");
+    expect(inspector?.textContent).toContain("hello");
+
+    inspector?.querySelector<HTMLButtonElement>('[data-subagent-observability-tab="transcript"]')?.click();
+    await nextTick();
+    expect(inspector?.querySelector('[data-subagent-observability-tab-panel="transcript"]')?.textContent)
+      .toContain("The child agent planned a short greeting.");
+
+    inspector?.querySelector<HTMLButtonElement>('[data-subagent-observability-tab="approvals"]')?.click();
+    await nextTick();
+    expect(inspector?.querySelector('[data-subagent-observability-tab-panel="approvals"]')?.textContent)
+      .toContain("Child approval was granted.");
+
+    inspector?.querySelector<HTMLButtonElement>('[data-subagent-observability-tab="artifacts"]')?.click();
+    await nextTick();
+    const artifactPanel = inspector?.querySelector('[data-subagent-observability-tab-panel="artifacts"]');
+    expect(artifactPanel?.textContent).toContain("Greeting note");
+    expect(artifactPanel?.textContent).toContain("notes/hello.md");
+  });
+
+  test("lazy loads persisted delegated trace when opening a subagent inspector", async () => {
+    const host = document.createElement("section");
+    const onDelegateTraceLoad = vi.fn(async () => ({
+      delegateId: "delegate-1",
+      traceRef: "child-run-1",
+      events: [{
+        event_id: "child-message-1",
+        event_type: "agent.message",
+        payload: {
+          content: "child said hello",
+        },
+        status: "completed",
+      }],
+    }));
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [{
+        author: "Tinybot",
+        body: ["I spawned a greeter."],
+        references: [],
+        time: "10:30 AM",
+        tone: "assistant",
+        toolActivities: [{
+          argsText: "Say hello",
+          approvalStatus: "",
+          delegateId: "delegate-1",
+          delegateTask: "Say hello",
+          id: "delegate-1",
+          kind: "result",
+          name: "spawn_agent",
+          responseText: "done",
+          sessionKey: "WebSocket:chat-1",
+          status: "completed",
+          traceRef: "child-run-1",
+        }],
+      }],
+      onDelegateTraceLoad,
+    });
+    await nextTick();
+
+    host.querySelector<HTMLButtonElement>("[data-subagent-shelf-item]")?.click();
+    await nextTick();
+    await flushDetailPanelOpeningMotion();
+    await nextTick();
+
+    expect(onDelegateTraceLoad).toHaveBeenCalledWith({
+      activityId: "delegate-1",
+      delegateId: "delegate-1",
+      sessionKey: "WebSocket:chat-1",
+      traceRef: "child-run-1",
+    });
+    const inspector = host.querySelector(".desktop-delegate-detail-panel");
+    expect(inspector?.textContent).toContain("Subagent timeline");
+    inspector?.querySelector<HTMLButtonElement>('[data-subagent-observability-tab="transcript"]')?.click();
+    await nextTick();
+    expect(inspector?.querySelector('[data-subagent-observability-tab-panel="transcript"]')?.textContent)
+      .toContain("child said hello");
+  });
+
+  test("renders subagent observability as switchable inspector tabs", async () => {
+    const host = document.createElement("section");
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [{
+        author: "Tinybot",
+        body: ["I observed a child agent."],
+        references: [],
+        time: "10:30 AM",
+        tone: "assistant",
+        toolActivities: [{
+          argsText: "Spawn greeter",
+          approvalStatus: "approved",
+          delegatedTrace: {
+            childRunId: "child-run-1",
+            steps: [
+              {
+                id: "message-1",
+                kind: "message",
+                resultPreview: "child transcript output",
+                status: "completed",
+                title: "Assistant response",
+              },
+              {
+                argsPreview: "{\"text\":\"hello\"}",
+                id: "tool-1",
+                kind: "tool_call",
+                resultPreview: "tool result output",
+                status: "completed",
+                title: "say",
+              },
+              {
+                approvalId: "approval-child-1",
+                approvalStatus: "approved",
+                id: "approval-1",
+                kind: "approval",
+                status: "approved",
+                title: "Approval checkpoint",
+              },
+            ],
+          },
+          delegateId: "delegate-1",
+          delegateTask: "Say hello",
+          finalOutput: "child transcript output",
+          id: "delegate-1",
+          kind: "result",
+          name: "spawn_agent",
+          responseText: "done",
+          status: "completed",
+          traceRef: "child-run-1",
+        }],
+      }],
+    });
+    await nextTick();
+
+    host.querySelector<HTMLButtonElement>("[data-subagent-shelf-item]")?.click();
+    await nextTick();
+    await flushDetailPanelOpeningMotion();
+
+    const inspector = host.querySelector(".desktop-delegate-detail-panel");
+    const tabs = inspector?.querySelector('[role="tablist"][aria-label="Subagent observability"]');
+    expect(tabs?.textContent).toContain("Overview");
+    expect(tabs?.textContent).toContain("Transcript");
+    expect(tabs?.textContent).toContain("Tools");
+    expect(inspector?.querySelector('[data-subagent-observability-tab-panel="overview"]')?.textContent).toContain("child-run-1");
+
+    inspector?.querySelector<HTMLButtonElement>('[data-subagent-observability-tab="transcript"]')?.click();
+    await nextTick();
+
+    const transcriptPanel = inspector?.querySelector('[data-subagent-observability-tab-panel="transcript"]');
+    expect(transcriptPanel?.textContent).toContain("child transcript output");
+    expect(transcriptPanel?.textContent).not.toContain("tool result output");
+    expect(inspector?.querySelector('[data-subagent-observability-tab-panel="tools"]')).toBeNull();
+  });
+
+  test("lazy loads subagent artifacts from the inspector artifact tab", async () => {
+    const host = document.createElement("section");
+    const onArtifactLoad = vi.fn(async () => ({
+      artifactId: "artifact-1",
+      content: "# Artifact body\n\nchild artifact details",
+      kind: "markdown",
+      title: "hello.md",
+    }));
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [{
+        author: "Tinybot",
+        body: ["I observed a child artifact."],
+        references: [],
+        time: "10:30 AM",
+        tone: "assistant",
+        toolActivities: [{
+          argsText: "Spawn greeter",
+          approvalStatus: "",
+          delegatedTrace: {
+            artifacts: [{
+              id: "artifact-1",
+              kind: "markdown",
+              path: "notes/hello.md",
+              summary: "Greeting note",
+              title: "hello.md",
+            }],
+            childRunId: "child-run-1",
+            steps: [],
+          },
+          delegateId: "delegate-1",
+          delegateTask: "Say hello",
+          id: "delegate-1",
+          kind: "result",
+          name: "spawn_agent",
+          responseText: "done",
+          sessionKey: "WebSocket:chat-1",
+          status: "completed",
+          traceRef: "child-run-1",
+        }],
+      }],
+      onArtifactLoad,
+    });
+    await nextTick();
+
+    host.querySelector<HTMLButtonElement>("[data-subagent-shelf-item]")?.click();
+    await nextTick();
+    await flushDetailPanelOpeningMotion();
+
+    const inspector = host.querySelector(".desktop-delegate-detail-panel");
+    inspector?.querySelector<HTMLButtonElement>('[data-subagent-observability-tab="artifacts"]')?.click();
+    await nextTick();
+
+    inspector?.querySelector<HTMLButtonElement>('[data-subagent-artifact-id="artifact-1"]')?.click();
+    await nextTick();
+    await nextTick();
+
+    expect(onArtifactLoad).toHaveBeenCalledWith({
+      activityId: "delegate-1",
+      artifactId: "artifact-1",
+      delegateId: "delegate-1",
+      sessionKey: "WebSocket:chat-1",
+      traceRef: "child-run-1",
+    });
+    const artifactPanel = inspector?.querySelector('[data-subagent-observability-tab-panel="artifacts"]');
+    expect(artifactPanel?.textContent).toContain("hello.md");
+    expect(artifactPanel?.textContent).toContain("child artifact details");
+  });
+
+  test("keeps expanded agent flow groups from clipping step content", async () => {
+    const host = document.createElement("section");
+
+    mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [
+        {
+          author: "You",
+          body: ["Use a subagent"],
+          references: [],
+          time: "10:29 AM",
+          tone: "user",
+          toolActivities: [],
+        },
+        {
+          author: "Tinybot",
+          body: [],
+          reasoningContent: "I should create a child agent.",
+          references: [],
+          time: "10:30 AM",
+          tone: "assistant",
+          toolActivities: [],
+        },
+        {
+          author: "Tinybot",
+          body: [],
+          references: [],
+          time: "10:31 AM",
+          tone: "assistant",
+          toolActivities: [{
+            approvalStatus: "",
+            argsText: "{\"task\":\"Say hello\"}",
+            id: "delegate-1",
+            kind: "call",
+            name: "spawn_agent",
+            responseText: "",
+            status: "running",
+          }],
+        },
+        {
+          author: "Tinybot",
+          body: [],
+          references: [],
+          time: "10:32 AM",
+          tone: "assistant",
+          toolActivities: [{
+            approvalStatus: "",
+            argsText: "{\"target\":\"delegate-1\"}",
+            id: "wait-1",
+            kind: "result",
+            name: "wait_agent",
+            responseText: "The child agent returned a detailed result that should remain visible.",
+            status: "completed",
+          }],
+        },
+        {
+          author: "Tinybot",
+          body: ["Done"],
+          references: [],
+          time: "10:33 AM",
+          tone: "assistant",
+          toolActivities: [],
+        },
+      ],
+    });
+    await nextTick();
+    await nextTick();
+
+    const group = host.querySelector<HTMLDetailsElement>(".desktop-agent-flow-group");
+    group!.open = true;
+    group!.dispatchEvent(new Event("toggle"));
+    await nextTick();
+
+    const cssText = document.getElementById("desktop-conversation-agent-flow-styles")?.textContent ?? "";
+    const groupRule = cssText.match(/\.desktop-assistant-step-group\.desktop-agent-flow-group,[\s\S]*?body\.desktop-native-workbench \.desktop-assistant-step-group\.desktop-agent-flow-group \{([\s\S]*?)\}/)?.[1] ?? "";
+    const stepListRule = cssText.match(/\.desktop-agent-flow-step-list,[\s\S]*?body\.desktop-native-workbench \.desktop-agent-flow-step-list\.desktop-assistant-step-list \{([\s\S]*?)\}/)?.[1] ?? "";
+    const firstStep = host.querySelector<HTMLElement>(".desktop-agent-flow-step");
+    const stepList = host.querySelector<HTMLElement>(".desktop-agent-flow-step-list");
+    Object.defineProperty(stepList, "scrollHeight", { configurable: true, value: 480 });
+    group!.dispatchEvent(new Event("toggle"));
+    await nextTick();
+
+    expect(group!.style.getPropertyValue("--desktop-agent-flow-content-height")).toBe("480px");
+    expect(firstStep?.getAttribute("style")).toContain("--desktop-agent-flow-step-index: 0");
+    expect(groupRule).toContain("display: block;");
+    expect(groupRule).toContain("align-self: start;");
+    expect(groupRule).not.toContain("display: grid;");
+    expect(groupRule).not.toContain("grid-template-rows:");
+    expect(groupRule).toContain("overflow: visible;");
+    expect(groupRule).not.toContain("overflow: hidden;");
+    expect(stepListRule).toContain("position: static;");
+    expect(stepListRule).toContain("contain: none;");
+    expect(stepListRule).toContain("transition:");
+    expect(stepListRule).toContain("max-height 300ms");
+    expect(stepListRule).toContain("opacity 220ms");
+    expect(stepListRule).toContain("transform 300ms");
+    expect(cssText).toMatch(/\.desktop-agent-flow-group\[open\] \.desktop-agent-flow-step-list[\s\S]*max-height:\s*var\(--desktop-agent-flow-content-height, 1200px\);/);
+    expect(cssText).toMatch(/\.desktop-agent-flow-group\[open\] \.desktop-agent-flow-step,[\s\S]*body\.desktop-native-workbench \.desktop-agent-flow-group\[open\] \.desktop-agent-flow-step[\s\S]*animation-delay:\s*calc\(var\(--desktop-agent-flow-step-index, 0\) \* 55ms\);/);
+    expect(cssText).toMatch(/\.desktop-agent-flow-step[\s\S]*overflow:\s*visible;/);
+    expect(cssText).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.desktop-agent-flow-step-list/);
   });
 
   test("dispatches memory reference inspection from reference cards", async () => {
@@ -587,6 +1019,10 @@ describe("conversation thread Vue island", () => {
     ]);
     const finalAnswer = Array.from(host.querySelectorAll<HTMLElement>(".desktop-conversation-message"))
       .find((message) => message.textContent?.includes("The workspace contains"));
+    const assistantRunGroup = host.querySelector<HTMLElement>(".desktop-assistant-run-group");
+    expect(assistantRunGroup).toBeTruthy();
+    expect(details?.closest(".desktop-assistant-run-group")).toBe(assistantRunGroup);
+    expect(finalAnswer?.closest(".desktop-assistant-run-group")).toBe(assistantRunGroup);
     expect(details && finalAnswer ? details.compareDocumentPosition(finalAnswer) & Node.DOCUMENT_POSITION_FOLLOWING : 0).not.toBe(0);
     expect(finalAnswer?.querySelector(".desktop-message-reasoning-toggle")).toBeNull();
     expect(host.querySelectorAll(".desktop-message-copy-button")).toHaveLength(1);
@@ -639,9 +1075,16 @@ describe("conversation thread Vue island", () => {
     expect(details?.textContent).toContain("The subagent needs approval");
     expect(details?.querySelectorAll(".desktop-tool-activity")).toHaveLength(1);
     const injectedStyles = document.getElementById("desktop-conversation-agent-flow-styles")?.textContent ?? "";
+    expect(injectedStyles).toContain("body.desktop-native-workbench .desktop-conversation-layout");
+    expect(injectedStyles).toContain("height: auto");
     expect(injectedStyles).toContain("max-height: none");
-    expect(injectedStyles).toContain("overflow-y: visible");
+    expect(injectedStyles).toContain("overflow: hidden");
     expect(injectedStyles).toContain("minmax(0, auto)");
+    expect(injectedStyles).toContain("display: flex");
+    expect(injectedStyles).toContain("flex-direction: column");
+    expect(injectedStyles).toContain("flex: 0 0 auto");
+    expect(injectedStyles).toContain("body.desktop-native-workbench .desktop-assistant-step-group.desktop-agent-flow-group");
+    expect(injectedStyles).toContain("body.desktop-native-workbench .desktop-agent-flow-step-card");
     const finalAnswer = Array.from(host.querySelectorAll<HTMLElement>(".desktop-conversation-message"))
       .find((message) => message.textContent?.includes("我会等待审批后继续。"));
     expect(finalAnswer?.querySelector(".desktop-message-reasoning-toggle")).toBeNull();

--- a/apps/desktop/src/native-vue/conversationThreadIsland.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.ts
@@ -22,9 +22,22 @@ export interface ConversationThreadIslandOptions {
   inlineForms?: AgentUiForm[];
   messages: ConversationMessageIslandOptions[];
   onCoworkAgentInspect?: (selection: { agentId: string; sessionId: string }) => void;
+  onArtifactLoad?: (selection: DelegateArtifactLoadSelection) => Promise<unknown>;
+  onDelegateTraceLoad?: (selection: DelegateTraceLoadSelection) => Promise<unknown>;
   onInlineFormCancel?: (form: AgentUiForm) => void;
   onInlineFormSubmit?: (form: AgentUiForm, values: Record<string, unknown>) => void;
   onReferenceInspect?: (reference: ConversationReferenceIslandOptions) => void;
+}
+
+export interface DelegateTraceLoadSelection {
+  activityId: string;
+  delegateId?: string;
+  sessionKey: string;
+  traceRef?: string;
+}
+
+export interface DelegateArtifactLoadSelection extends DelegateTraceLoadSelection {
+  artifactId: string;
 }
 
 export interface ConversationCoworkRunOptions {
@@ -68,6 +81,7 @@ interface ConversationTimelineScrollState {
 type DetailPanelState = "closed" | "opening" | "open" | "closing";
 type AgentToolKind = "tool" | "spawn" | "subagent" | "cowork" | "team";
 type AgentFlowStepKind = "thinking" | "tool" | "spawn" | "subagent" | "cowork" | "team" | "response";
+type SubagentObservabilityTab = "overview" | "timeline" | "transcript" | "tools" | "approvals" | "artifacts" | "raw";
 
 interface AssistantMessageRunItem {
   index: number;
@@ -89,6 +103,14 @@ interface AgentWorkflowStep {
   title: string;
 }
 
+interface SubagentTraceStep {
+  id: string;
+  kind: string;
+  raw: Record<string, unknown>;
+  status: string;
+  title: string;
+}
+
 interface SubagentShelfItem {
   activity: ToolActivityIslandOptions;
   key: string;
@@ -102,6 +124,18 @@ interface AgentFlowStepProfile {
   kind: AgentFlowStepKind;
   label: string;
   title: string;
+}
+
+interface DelegateTraceLoadState {
+  error: string;
+  loading: boolean;
+  trace: Record<string, unknown> | null;
+}
+
+interface DelegateArtifactLoadState {
+  artifact: Record<string, unknown> | null;
+  error: string;
+  loading: boolean;
 }
 
 const mountedConversationThreads = new WeakMap<HTMLElement, MountedConversationThreadIsland>();
@@ -171,13 +205,29 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
       const selectedToolKey = ref("");
       const selectedReference = ref<ConversationReferenceIslandOptions | null>(null);
       const selectedCoworkAgent = ref<SelectedCoworkAgent | null>(null);
+      const selectedSubagentTraceTab = ref<SubagentObservabilityTab>("overview");
       const detailPanelState = ref<DetailPanelState>("closed");
+      const delegateArtifactLoads = ref(new Map<string, DelegateArtifactLoadState>());
+      const delegateTraceLoads = ref(new Map<string, DelegateTraceLoadState>());
       const panelWidth = ref(50);
       const overlayMode = ref(isToolDetailOverlayMode());
       const reducedMotion = ref(prefersReducedMotion());
       let closePanelTimer: number | null = null;
       let openPanelFrame: number | null = null;
-      const selectedTool = computed(() => selectedToolKey.value ? findToolActivity(state.value.messages, selectedToolKey.value) : null);
+      const selectedTool = computed(() => {
+        const activity = selectedToolKey.value ? findToolActivity(state.value.messages, selectedToolKey.value) : null;
+        if (!activity) {
+          return null;
+        }
+        const loaded = delegateTraceLoads.value.get(delegateTraceLoadKey(activity));
+        if (!loaded?.trace) {
+          return activity;
+        }
+        return {
+          ...activity,
+          delegatedTrace: loaded.trace,
+        };
+      });
       const subagentShelfItems = computed(() => collectSubagentShelfItems(state.value.messages));
       const hasDetailPanelSelection = () => Boolean(selectedTool.value || selectedReference.value || selectedCoworkAgent.value);
       const clearClosePanelTimer = () => {
@@ -265,6 +315,8 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
         selectedReference.value = null;
         selectedCoworkAgent.value = null;
         selectedToolKey.value = toolActivitySelectionKey(activity);
+        selectedSubagentTraceTab.value = "overview";
+        requestDelegateTraceLoad(activity);
         openPanel();
         logDesktopNativeDebug("toolDetail.open", summarizeToolActivity(activity));
       };
@@ -272,8 +324,121 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
         selectedReference.value = null;
         selectedCoworkAgent.value = null;
         selectedToolKey.value = item.key;
+        selectedSubagentTraceTab.value = "overview";
+        requestDelegateTraceLoad(item.activity);
         openPanel();
         logDesktopNativeDebug("subagentDetail.open", summarizeToolActivity(item.activity));
+      };
+      const requestDelegateTraceLoad = (activity: ToolActivityIslandOptions) => {
+        if (!state.value.onDelegateTraceLoad || activityInspectorKind(activity) !== "delegate") {
+          return;
+        }
+        const selection = delegateTraceLoadSelection(activity);
+        if (!selection) {
+          return;
+        }
+        const key = delegateTraceLoadKey(activity);
+        const current = delegateTraceLoads.value.get(key);
+        if (current?.loading || current?.trace) {
+          return;
+        }
+        delegateTraceLoads.value = new Map(delegateTraceLoads.value).set(key, {
+          error: "",
+          loading: true,
+          trace: null,
+        });
+        logDesktopNativeDebug("subagentTrace.load.start", {
+          activityId: selection.activityId,
+          delegateId: selection.delegateId ?? "",
+          sessionKey: selection.sessionKey,
+          traceRef: selection.traceRef ?? "",
+        });
+        state.value.onDelegateTraceLoad(selection).then((payload) => {
+          const trace = normalizeLoadedDelegateTrace(payload);
+          delegateTraceLoads.value = new Map(delegateTraceLoads.value).set(key, {
+            error: "",
+            loading: false,
+            trace,
+          });
+          logDesktopNativeDebug("subagentTrace.load.complete", {
+            activityId: selection.activityId,
+            delegateId: selection.delegateId ?? "",
+            hasTrace: Boolean(trace),
+            sessionKey: selection.sessionKey,
+            traceRef: selection.traceRef ?? "",
+          });
+        }).catch((error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          delegateTraceLoads.value = new Map(delegateTraceLoads.value).set(key, {
+            error: message,
+            loading: false,
+            trace: null,
+          });
+          logDesktopNativeDebug("subagentTrace.load.failed", {
+            activityId: selection.activityId,
+            delegateId: selection.delegateId ?? "",
+            error: message,
+            sessionKey: selection.sessionKey,
+            traceRef: selection.traceRef ?? "",
+          });
+        });
+      };
+      const requestDelegateArtifactLoad = (activity: ToolActivityIslandOptions, artifactId: string) => {
+        if (!state.value.onArtifactLoad || activityInspectorKind(activity) !== "delegate") {
+          return;
+        }
+        const selection = delegateArtifactLoadSelection(activity, artifactId);
+        if (!selection) {
+          return;
+        }
+        const key = delegateArtifactLoadKey(activity, artifactId);
+        const current = delegateArtifactLoads.value.get(key);
+        if (current?.loading || current?.artifact) {
+          return;
+        }
+        delegateArtifactLoads.value = new Map(delegateArtifactLoads.value).set(key, {
+          artifact: null,
+          error: "",
+          loading: true,
+        });
+        logDesktopNativeDebug("subagentArtifact.load.start", {
+          activityId: selection.activityId,
+          artifactId: selection.artifactId,
+          delegateId: selection.delegateId ?? "",
+          sessionKey: selection.sessionKey,
+          traceRef: selection.traceRef ?? "",
+        });
+        state.value.onArtifactLoad(selection).then((payload) => {
+          const artifact = normalizeLoadedArtifact(payload);
+          delegateArtifactLoads.value = new Map(delegateArtifactLoads.value).set(key, {
+            artifact,
+            error: "",
+            loading: false,
+          });
+          logDesktopNativeDebug("subagentArtifact.load.complete", {
+            activityId: selection.activityId,
+            artifactId: selection.artifactId,
+            delegateId: selection.delegateId ?? "",
+            hasArtifact: Boolean(artifact),
+            sessionKey: selection.sessionKey,
+            traceRef: selection.traceRef ?? "",
+          });
+        }).catch((error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          delegateArtifactLoads.value = new Map(delegateArtifactLoads.value).set(key, {
+            artifact: null,
+            error: message,
+            loading: false,
+          });
+          logDesktopNativeDebug("subagentArtifact.load.failed", {
+            activityId: selection.activityId,
+            artifactId: selection.artifactId,
+            delegateId: selection.delegateId ?? "",
+            error: message,
+            sessionKey: selection.sessionKey,
+            traceRef: selection.traceRef ?? "",
+          });
+        });
       };
       const handleKeydown = (event: KeyboardEvent) => {
         if (event.key === "Escape" && hasDetailPanelSelection()) {
@@ -308,6 +473,7 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
           const detailPanel = selectedTool.value
             ? renderActivityInspectorPanel({
               activity: selectedTool.value,
+              artifactLoads: delegateArtifactLoads.value,
               mode: overlayMode.value ? "overlay" : "push",
               motionState: detailPanelState.value,
               onClose: closePanel,
@@ -318,6 +484,15 @@ function createConversationThreadApp(state: Ref<ConversationThreadIslandOptions>
                   widthPercent: panelWidth.value,
                 });
               },
+              onSubagentTraceTabChange: (tab) => {
+                selectedSubagentTraceTab.value = tab;
+              },
+              onSubagentArtifactLoad: (artifactId) => {
+                if (selectedTool.value) {
+                  requestDelegateArtifactLoad(selectedTool.value, artifactId);
+                }
+              },
+              subagentTraceTab: selectedSubagentTraceTab.value,
             })
             : selectedReference.value
               ? renderReferenceDetailPanel({
@@ -466,7 +641,11 @@ function renderAssistantRun(
     nodes.push(renderAssistantStepGroup(processSteps, selectedToolKey, onReferenceInspect));
   }
   nodes.push(renderThreadMessage(assistantFinalAnswerMessage(final.message), final.index, selectedToolKey, true, onReferenceInspect));
-  return nodes;
+  return [h("div", {
+    key: `assistant-run:${run[0]?.index ?? final.index}`,
+    class: "desktop-assistant-run-group",
+    "data-desktop-chat-region": "assistant-run",
+  }, nodes)];
 }
 
 function collectSubagentShelfItems(messages: ConversationMessageIslandOptions[]): SubagentShelfItem[] {
@@ -517,6 +696,7 @@ function renderSubagentShelf(
   return h("section", {
     class: "desktop-subagent-shelf",
     "data-subagent-count": String(items.length),
+    "data-subagent-shelf-layout": "stacked-status",
     "data-visible-limit": "5",
     "aria-label": "Subagents",
   }, [
@@ -524,6 +704,7 @@ function renderSubagentShelf(
       key: item.key,
       class: "desktop-subagent-shelf-item",
       "data-subagent-shelf-item": item.key,
+      "data-subagent-shelf-row": "status",
       "aria-selected": String(selectedKey === item.key),
       onClick: () => onSelect(item),
       type: "button",
@@ -612,6 +793,7 @@ function renderAssistantStepGroup(
     "data-agent-flow-tool-count": String(flowSummary.toolCount),
     "data-agent-flow-delegated-count": String(flowSummary.delegatedCount),
     "data-desktop-chat-region": "assistant-intermediate-steps",
+    onToggle: syncAgentFlowExpansionHeight,
   }, [
     h("summary", { class: "desktop-assistant-step-summary desktop-agent-flow-summary" }, [
       h("span", { class: "desktop-assistant-step-summary-label" }, "Processed"),
@@ -629,6 +811,18 @@ function renderAssistantStepGroup(
       onReferenceInspect,
     ))),
   ]);
+}
+
+function syncAgentFlowExpansionHeight(event: Event): void {
+  const group = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+  if (!group) {
+    return;
+  }
+  const stepList = group.querySelector<HTMLElement>(".desktop-agent-flow-step-list");
+  if (!stepList) {
+    return;
+  }
+  group.style.setProperty("--desktop-agent-flow-content-height", `${Math.max(0, stepList.scrollHeight)}px`);
 }
 
 function summarizeAssistantAgentFlow(items: AssistantMessageRunItem[]): { delegatedCount: number; label: string; toolCount: number } {
@@ -665,6 +859,7 @@ function renderAgentFlowStep(
     class: "desktop-agent-flow-step",
     "data-agent-flow-step-kind": profile.kind,
     "data-agent-flow-step-index": String(position + 1),
+    style: { "--desktop-agent-flow-step-index": String(position) },
   }, [
     h("div", { class: "desktop-agent-flow-step-rail", "aria-hidden": "true" }, [
       h("span", { class: "desktop-agent-flow-step-node" }, String(position + 1)),
@@ -829,10 +1024,14 @@ function renderInlineAgentUiForm(options: ConversationThreadIslandOptions, form:
 
 function renderActivityInspectorPanel(options: {
   activity: ToolActivityIslandOptions;
+  artifactLoads: Map<string, DelegateArtifactLoadState>;
   mode: "overlay" | "push";
   motionState: DetailPanelState;
   onClose: () => void;
   onResize: (nextWidth: number) => void;
+  onSubagentArtifactLoad: (artifactId: string) => void;
+  onSubagentTraceTabChange: (tab: SubagentObservabilityTab) => void;
+  subagentTraceTab: SubagentObservabilityTab;
 }) {
   const { activity } = options;
   const inspectorKind = activityInspectorKind(activity);
@@ -895,13 +1094,24 @@ function renderActivityInspectorPanel(options: {
         renderDetailApprovalButton(activity, "deny", "Deny"),
       ])
       : null,
-    h("div", { class: "desktop-tool-detail-body" }, renderActivityInspectorBody(activity, inspectorKind)),
+    h("div", { class: "desktop-tool-detail-body" }, renderActivityInspectorBody(
+      activity,
+      options.artifactLoads,
+      inspectorKind,
+      options.onSubagentArtifactLoad,
+      options.subagentTraceTab,
+      options.onSubagentTraceTabChange,
+    )),
   ]);
 }
 
 function renderActivityInspectorBody(
   activity: ToolActivityIslandOptions,
+  artifactLoads: Map<string, DelegateArtifactLoadState>,
   inspectorKind: ActivityInspectorKind,
+  onSubagentArtifactLoad: (artifactId: string) => void,
+  subagentTraceTab: SubagentObservabilityTab,
+  onSubagentTraceTabChange: (tab: SubagentObservabilityTab) => void,
 ): Array<VNode | null> {
   const agentProfile = resolveAgentToolProfile(activity);
   if (inspectorKind === "artifact") {
@@ -915,7 +1125,7 @@ function renderActivityInspectorBody(
   if (inspectorKind === "delegate") {
     return [
       renderAgentToolWorkflowPanel(activity, agentProfile),
-      renderSubagentTracePanel(activity),
+      renderSubagentTracePanel(activity, artifactLoads, subagentTraceTab, onSubagentTraceTabChange, onSubagentArtifactLoad),
       renderToolDetailMeta(activity),
       renderToolDetailText("Task", activity.argsText, "No delegated task available"),
       renderToolDetailText("Latest activity", activity.responseText, "No delegated activity available"),
@@ -931,29 +1141,567 @@ function renderActivityInspectorBody(
   ];
 }
 
-function renderSubagentTracePanel(activity: ToolActivityIslandOptions): VNode | null {
+const SUBAGENT_OBSERVABILITY_TABS: Array<{ id: SubagentObservabilityTab; label: string }> = [
+  { id: "overview", label: "Overview" },
+  { id: "timeline", label: "Timeline" },
+  { id: "transcript", label: "Transcript" },
+  { id: "tools", label: "Tools" },
+  { id: "approvals", label: "Approvals" },
+  { id: "artifacts", label: "Artifacts" },
+  { id: "raw", label: "Raw" },
+];
+
+function renderSubagentTracePanel(
+  activity: ToolActivityIslandOptions,
+  artifactLoads: Map<string, DelegateArtifactLoadState>,
+  selectedTab: SubagentObservabilityTab,
+  onTabChange: (tab: SubagentObservabilityTab) => void,
+  onArtifactLoad: (artifactId: string) => void,
+): VNode | null {
   const payload = mergedActivityPayload(activity);
-  const trace = isRecord(payload.trace) ? payload.trace : null;
-  const steps = Array.isArray(trace?.steps) ? trace.steps.map((step) => isRecord(step) ? step : null).filter((step): step is Record<string, unknown> => Boolean(step)) : [];
-  if (!steps.length) {
+  const trace = delegatedTraceRecord(activity, payload);
+  const steps = subagentTraceSteps(trace);
+  const artifactSteps = subagentArtifactTraceSteps(trace, steps);
+  if (!steps.length && !artifactSteps.length) {
     return null;
   }
-  return h("section", { class: "desktop-subagent-trace-panel" }, [
+  const transcriptSteps = steps.filter(isTranscriptTraceStep);
+  const toolSteps = steps.filter(isToolTraceStep);
+  const approvalSteps = [
+    ...steps.filter(isApprovalTraceStep),
+    ...syntheticApprovalTraceSteps(activity, payload, steps),
+  ];
+  const tabContent = renderSubagentTraceTabPanel({
+    activity,
+    approvalSteps,
+    artifactSteps,
+    artifactLoads,
+    onArtifactLoad,
+    payload,
+    selectedTab,
+    steps,
+    toolSteps,
+    trace,
+    transcriptSteps,
+  });
+  return h("section", { class: "desktop-subagent-trace-panel desktop-subagent-observability-panel" }, [
     h("h4", "Subagent timeline"),
-    h("ol", { class: "desktop-subagent-trace-list" }, steps.map((step, index) => h("li", {
-      class: "desktop-subagent-trace-step",
-      "data-subagent-trace-step-kind": fieldString(step, ["kind"]),
-      key: fieldString(step, ["id"]) || String(index),
-    }, [
-      h("strong", fieldString(step, ["title"]) || fieldString(step, ["kind"]) || "Step"),
-      h("span", { class: "desktop-subagent-trace-status" }, fieldString(step, ["status"])),
-      h("p", [
-        fieldString(step, ["summary"]),
-        fieldString(step, ["resultPreview", "result_preview"]),
-        fieldString(step, ["error"]),
-      ].filter(Boolean).join(" ")),
-    ]))),
+    h("div", {
+      "aria-label": "Subagent observability",
+      class: "desktop-subagent-observability-tabs",
+      role: "tablist",
+    }, SUBAGENT_OBSERVABILITY_TABS.map((tab) => h("button", {
+      "aria-selected": String(selectedTab === tab.id),
+      class: "desktop-subagent-observability-tab",
+      "data-subagent-observability-tab": tab.id,
+      onClick: () => onTabChange(tab.id),
+      role: "tab",
+      type: "button",
+    }, tab.label))),
+    tabContent,
   ]);
+}
+
+function renderSubagentTraceTabPanel(options: {
+  activity: ToolActivityIslandOptions;
+  approvalSteps: SubagentTraceStep[];
+  artifactSteps: SubagentTraceStep[];
+  artifactLoads: Map<string, DelegateArtifactLoadState>;
+  onArtifactLoad: (artifactId: string) => void;
+  payload: Record<string, unknown>;
+  selectedTab: SubagentObservabilityTab;
+  steps: SubagentTraceStep[];
+  toolSteps: SubagentTraceStep[];
+  trace: Record<string, unknown> | null;
+  transcriptSteps: SubagentTraceStep[];
+}): VNode {
+  const { activity, approvalSteps, artifactSteps, artifactLoads, onArtifactLoad, payload, selectedTab, steps, toolSteps, trace, transcriptSteps } = options;
+  const content = {
+    approvals: renderSubagentTraceSection("Approvals", "Approval checkpoints seen inside the child run.", "approvals", approvalSteps),
+    artifacts: renderSubagentArtifactSection(activity, artifactSteps, artifactLoads, onArtifactLoad),
+    overview: renderSubagentTraceOverview(activity, payload, trace, {
+      approvals: approvalSteps.length,
+      artifacts: artifactSteps.length,
+      timeline: steps.length,
+      tools: toolSteps.length,
+      transcript: transcriptSteps.length,
+    }),
+    raw: renderSubagentTraceRaw(payload, trace),
+    timeline: renderSubagentTraceSection("Timeline", "Ordered child-agent events.", "timeline", steps),
+    tools: renderSubagentTraceSection("Tools", "Child tool calls and returned observations.", "tools", toolSteps),
+    transcript: renderSubagentTraceSection("Transcript", "Reasoning summaries and assistant output.", "transcript", transcriptSteps),
+  } satisfies Record<SubagentObservabilityTab, VNode>;
+  return h("div", {
+    class: "desktop-subagent-observability-tab-panel",
+    "data-subagent-observability-tab-panel": selectedTab,
+    role: "tabpanel",
+  }, [content[selectedTab]]);
+}
+
+function renderSubagentTraceOverview(
+  activity: ToolActivityIslandOptions,
+  payload: Record<string, unknown>,
+  trace: Record<string, unknown> | null,
+  counts: Record<"approvals" | "artifacts" | "timeline" | "tools" | "transcript", number>,
+): VNode {
+  return h("section", {
+    class: "desktop-subagent-trace-section desktop-subagent-trace-overview-section",
+    "data-subagent-observability-section": "overview",
+  }, [
+    h("header", { class: "desktop-subagent-trace-section-header" }, [
+      h("strong", "Overview"),
+      h("span", "Child run identifiers, result, and recorded trace counts."),
+    ]),
+    h("dl", { class: "desktop-subagent-trace-overview-metrics" }, [
+      ["Timeline", counts.timeline],
+      ["Transcript", counts.transcript],
+      ["Tools", counts.tools],
+      ["Approvals", counts.approvals],
+      ["Artifacts", counts.artifacts],
+    ].flatMap(([label, value]) => [
+      h("dt", String(label)),
+      h("dd", String(value)),
+    ])),
+    renderSubagentTraceContext(activity, payload, trace),
+  ]);
+}
+
+function renderSubagentTraceRaw(payload: Record<string, unknown>, trace: Record<string, unknown> | null): VNode {
+  return h("section", {
+    class: "desktop-subagent-trace-section desktop-subagent-trace-raw-section",
+    "data-subagent-observability-section": "raw",
+  }, [
+    h("header", { class: "desktop-subagent-trace-section-header" }, [
+      h("strong", "Raw"),
+      h("span", "Normalized trace payload for debugging."),
+    ]),
+    h("pre", { class: "desktop-subagent-trace-raw" }, formatMaybeJson(JSON.stringify({
+      payload,
+      trace,
+    }))),
+  ]);
+}
+
+function delegatedTraceRecord(activity: ToolActivityIslandOptions, payload: Record<string, unknown>): Record<string, unknown> | null {
+  if (isRecord(activity.delegatedTrace)) {
+    return activity.delegatedTrace;
+  }
+  for (const key of ["_delegate_trace", "delegateTrace", "trace"]) {
+    const value = payload[key];
+    if (isRecord(value)) {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return { steps: value };
+    }
+  }
+  return null;
+}
+
+function delegateTraceLoadSelection(activity: ToolActivityIslandOptions): DelegateTraceLoadSelection | null {
+  if (!activity.sessionKey?.trim()) {
+    return null;
+  }
+  const payload = mergedActivityPayload(activity);
+  const delegateId = activity.delegateId || fieldString(payload, ["delegate_id", "delegateId", "task_name", "taskName"]);
+  const traceRef = activity.traceRef || fieldString(payload, ["trace_ref", "traceRef", "child_run_id", "childRunId"]);
+  return {
+    activityId: activity.id,
+    delegateId: delegateId || undefined,
+    sessionKey: activity.sessionKey,
+    traceRef: traceRef || undefined,
+  };
+}
+
+function delegateTraceLoadKey(activity: ToolActivityIslandOptions): string {
+  const selection = delegateTraceLoadSelection(activity);
+  if (!selection) {
+    return toolActivitySelectionKey(activity);
+  }
+  return [
+    selection.sessionKey,
+    selection.delegateId || "",
+    selection.traceRef || "",
+    selection.activityId,
+  ].join(":");
+}
+
+function delegateArtifactLoadSelection(activity: ToolActivityIslandOptions, artifactId: string): DelegateArtifactLoadSelection | null {
+  const base = delegateTraceLoadSelection(activity);
+  if (!base || !artifactId.trim()) {
+    return null;
+  }
+  return {
+    ...base,
+    artifactId,
+  };
+}
+
+function delegateArtifactLoadKey(activity: ToolActivityIslandOptions, artifactId: string): string {
+  return `${delegateTraceLoadKey(activity)}:${artifactId}`;
+}
+
+function normalizeLoadedDelegateTrace(payload: unknown): Record<string, unknown> | null {
+  const trace = isRecord(payload) && isRecord(payload.trace) ? payload.trace : payload;
+  if (!isRecord(trace)) {
+    return null;
+  }
+  const steps = Array.isArray(trace.steps)
+    ? trace.steps
+    : Array.isArray(trace.events)
+      ? trace.events.map(delegateTraceEventToStep)
+      : [];
+  return { ...trace, steps };
+}
+
+function normalizeLoadedArtifact(payload: unknown): Record<string, unknown> | null {
+  const artifact = isRecord(payload) && isRecord(payload.artifact) ? payload.artifact : payload;
+  return isRecord(artifact) ? artifact : null;
+}
+
+function delegateTraceEventToStep(event: unknown, index: number): unknown {
+  if (!isRecord(event)) {
+    return event;
+  }
+  const payload = isRecord(event.payload) ? event.payload : {};
+  return {
+    ...event,
+    argsPreview: previewFromKeys(payload, ["arguments", "args", "input", "operation", "task"]),
+    id: fieldString(event, ["event_id", "eventId", "id"]) || `event-${index + 1}`,
+    kind: fieldString(event, ["event_type", "eventType", "kind", "type"]) || "event",
+    resultPreview: previewFromKeys(payload, ["result", "output", "content", "text", "final_output", "finalOutput"]),
+    status: fieldString(event, ["status", "state", "phase"]),
+    summary: previewFromKeys(payload, ["summary", "content", "text", "message", "output", "result"]),
+    title: fieldString(event, ["title", "name", "tool_name", "toolName", "label"])
+      || fieldString(event, ["event_type", "eventType", "kind", "type"])
+      || `Event ${index + 1}`,
+  };
+}
+
+function subagentTraceSteps(trace: Record<string, unknown> | null): SubagentTraceStep[] {
+  const rawSteps = Array.isArray(trace?.steps) ? trace?.steps : [];
+  return rawSteps
+    .map((step, index) => subagentTraceStepFromUnknown(step, index))
+    .filter((step): step is SubagentTraceStep => Boolean(step));
+}
+
+function subagentTraceStepFromUnknown(value: unknown, index: number): SubagentTraceStep | null {
+  if (typeof value === "string") {
+    return {
+      id: `trace-step-${index}`,
+      kind: "message",
+      raw: { summary: value },
+      status: "",
+      title: `Step ${index + 1}`,
+    };
+  }
+  if (!isRecord(value)) {
+    return null;
+  }
+  const kind = fieldString(value, ["kind", "type", "event"]) || "event";
+  return {
+    id: fieldString(value, ["id", "step_id", "stepId"]) || `trace-step-${index}`,
+    kind,
+    raw: value,
+    status: fieldString(value, ["status", "state", "phase"]),
+    title: fieldString(value, ["title", "name", "toolName", "tool_name", "label"]) || kind || `Step ${index + 1}`,
+  };
+}
+
+function renderSubagentTraceSection(
+  title: string,
+  description: string,
+  section: "timeline" | "transcript" | "tools" | "approvals" | "artifacts",
+  steps: SubagentTraceStep[],
+): VNode {
+  return h("section", {
+    class: "desktop-subagent-trace-section",
+    "data-subagent-observability-section": section,
+  }, [
+    h("header", { class: "desktop-subagent-trace-section-header" }, [
+      h("strong", title),
+      h("span", description),
+    ]),
+    steps.length
+      ? h("ol", { class: "desktop-subagent-trace-list" }, steps.map((step, index) => renderSubagentTraceStep(step, index)))
+      : h("p", { class: "desktop-subagent-trace-empty" }, emptySubagentTraceSectionLabel(section)),
+  ]);
+}
+
+function renderSubagentArtifactSection(
+  activity: ToolActivityIslandOptions,
+  steps: SubagentTraceStep[],
+  artifactLoads: Map<string, DelegateArtifactLoadState>,
+  onArtifactLoad: (artifactId: string) => void,
+): VNode {
+  return h("section", {
+    class: "desktop-subagent-trace-section desktop-subagent-artifact-section",
+    "data-subagent-observability-section": "artifacts",
+  }, [
+    h("header", { class: "desktop-subagent-trace-section-header" }, [
+      h("strong", "Artifacts"),
+      h("span", "Files and outputs produced by the child run."),
+    ]),
+    steps.length
+      ? h("ol", { class: "desktop-subagent-trace-list" }, steps.map((step, index) => renderSubagentArtifactStep(
+        activity,
+        step,
+        index,
+        artifactLoads,
+        onArtifactLoad,
+      )))
+      : h("p", { class: "desktop-subagent-trace-empty" }, emptySubagentTraceSectionLabel("artifacts")),
+  ]);
+}
+
+function renderSubagentArtifactStep(
+  activity: ToolActivityIslandOptions,
+  step: SubagentTraceStep,
+  index: number,
+  artifactLoads: Map<string, DelegateArtifactLoadState>,
+  onArtifactLoad: (artifactId: string) => void,
+): VNode {
+  const artifactId = subagentArtifactId(step) || step.id || `artifact-${index + 1}`;
+  const loadState = artifactLoads.get(delegateArtifactLoadKey(activity, artifactId));
+  return h("li", {
+    class: "desktop-subagent-trace-step desktop-subagent-artifact-step",
+    "data-subagent-trace-step-kind": step.kind,
+    key: step.id || String(index),
+  }, [
+    h("div", { class: "desktop-subagent-artifact-heading" }, [
+      h("div", { class: "desktop-subagent-trace-step-heading" }, [
+        h("strong", step.title || artifactId || "Artifact"),
+        step.kind ? h("span", { class: "desktop-subagent-trace-kind" }, step.kind) : null,
+        step.status ? h("span", { class: "desktop-subagent-trace-status" }, step.status) : null,
+      ]),
+      h("button", {
+        class: "desktop-subagent-artifact-load",
+        "data-subagent-artifact-id": artifactId,
+        disabled: loadState?.loading === true,
+        onClick: () => onArtifactLoad(artifactId),
+        type: "button",
+      }, loadState?.artifact ? "Refresh" : loadState?.loading ? "Loading" : "Open"),
+    ]),
+    h("p", subagentTraceStepPreview(step)),
+    renderSubagentTraceStepMeta(step),
+    renderSubagentArtifactLoadState(loadState),
+  ]);
+}
+
+function renderSubagentArtifactLoadState(loadState: DelegateArtifactLoadState | undefined): VNode | null {
+  if (!loadState) {
+    return null;
+  }
+  if (loadState.loading) {
+    return h("p", { class: "desktop-subagent-artifact-loading" }, "Loading artifact...");
+  }
+  if (loadState.error) {
+    return h("p", { class: "desktop-subagent-artifact-error" }, loadState.error);
+  }
+  if (!loadState.artifact) {
+    return null;
+  }
+  return h("pre", { class: "desktop-subagent-artifact-preview" }, artifactPreview(loadState.artifact));
+}
+
+function artifactPreview(artifact: Record<string, unknown>): string {
+  return previewFromKeys(artifact, ["content", "text", "body", "preview", "result", "output"])
+    || formatMaybeJson(JSON.stringify(artifact));
+}
+
+function subagentArtifactId(step: SubagentTraceStep): string {
+  return fieldString(step.raw, ["artifactId", "artifact_id", "id", "path", "uri", "file", "filename"]);
+}
+
+function renderSubagentTraceStep(step: SubagentTraceStep, index: number): VNode {
+  return h("li", {
+    class: "desktop-subagent-trace-step",
+    "data-subagent-trace-step-kind": step.kind,
+    key: step.id || String(index),
+  }, [
+    h("div", { class: "desktop-subagent-trace-step-heading" }, [
+      h("strong", step.title || "Step"),
+      step.kind ? h("span", { class: "desktop-subagent-trace-kind" }, step.kind) : null,
+      step.status ? h("span", { class: "desktop-subagent-trace-status" }, step.status) : null,
+    ]),
+    h("p", subagentTraceStepPreview(step)),
+    renderSubagentTraceStepMeta(step),
+  ]);
+}
+
+function renderSubagentTraceStepMeta(step: SubagentTraceStep): VNode | null {
+  const rows: Array<[string, string]> = [
+    ["Args", previewFromKeys(step.raw, ["argsPreview", "args_preview", "arguments", "args", "input"])],
+    ["Result", previewFromKeys(step.raw, ["resultPreview", "result_preview", "result", "output", "observation", "final_output", "finalOutput"])],
+    ["Error", previewFromKeys(step.raw, ["error", "errorMessage", "error_message"])],
+    ["Approval", previewFromKeys(step.raw, ["approvalId", "approval_id", "approvalStatus", "approval_status"])],
+  ].filter((entry): entry is [string, string] => Boolean(entry[1]));
+  if (!rows.length) {
+    return null;
+  }
+  return h("dl", { class: "desktop-subagent-trace-step-meta" }, rows.flatMap(([label, value]) => [
+    h("dt", label),
+    h("dd", value),
+  ]));
+}
+
+function renderSubagentTraceContext(
+  activity: ToolActivityIslandOptions,
+  payload: Record<string, unknown>,
+  trace: Record<string, unknown> | null,
+): VNode {
+  const rows: Array<[string, string]> = [
+    ["Delegate", activity.delegateTitle || activity.delegateId || fieldString(payload, ["delegate_id", "delegateId", "task_name", "taskName"])],
+    ["Task", activity.delegateTask || fieldString(payload, ["task", "message", "prompt", "goal"])],
+    ["Trace", activity.traceRef || fieldString(trace ?? {}, ["trace_ref", "traceRef", "child_run_id", "childRunId", "run_id", "runId"])],
+    ["Final output", activity.finalOutput || fieldString(payload, ["final_output", "finalOutput"]) || activity.responseText],
+  ].filter((entry): entry is [string, string] => Boolean(entry[1]?.trim()));
+  return h("section", {
+    class: "desktop-subagent-trace-section desktop-subagent-trace-context-section",
+    "data-subagent-observability-section": "context",
+  }, [
+    h("header", { class: "desktop-subagent-trace-section-header" }, [
+      h("strong", "Raw context"),
+      h("span", "Stable identifiers and final values for debugging."),
+    ]),
+    rows.length
+      ? h("dl", { class: "desktop-subagent-trace-context" }, rows.flatMap(([label, value]) => [
+        h("dt", label),
+        h("dd", summarizeWorkflowText(sanitizeTextPreview(value))),
+      ]))
+      : h("p", { class: "desktop-subagent-trace-empty" }, "No delegated context was returned."),
+  ]);
+}
+
+function subagentTraceStepPreview(step: SubagentTraceStep): string {
+  return [
+    previewFromKeys(step.raw, ["summary", "message", "content", "text", "detail"]),
+    previewFromKeys(step.raw, ["resultPreview", "result_preview", "result", "output", "observation", "final_output", "finalOutput"]),
+    previewFromKeys(step.raw, ["error", "errorMessage", "error_message"]),
+  ].filter(Boolean).filter((value, index, values) => values.indexOf(value) === index).join(" ");
+}
+
+function previewFromKeys(payload: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = valuePreview(payload[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return "";
+}
+
+function valuePreview(value: unknown): string {
+  if (typeof value === "string") {
+    return summarizeWorkflowText(sanitizeTextPreview(value));
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value) || isRecord(value)) {
+    try {
+      return summarizeWorkflowText(sanitizeTextPreview(JSON.stringify(value)));
+    } catch (error) {
+      return "";
+    }
+  }
+  return "";
+}
+
+function isTranscriptTraceStep(step: SubagentTraceStep): boolean {
+  const kind = step.kind.toLowerCase();
+  return ["reasoning", "message", "assistant_message", "assistant", "content", "final"].some((value) => kind.includes(value));
+}
+
+function isToolTraceStep(step: SubagentTraceStep): boolean {
+  const kind = step.kind.toLowerCase();
+  return kind.includes("tool") || Boolean(previewFromKeys(step.raw, ["toolName", "tool_name", "args", "arguments"]));
+}
+
+function isApprovalTraceStep(step: SubagentTraceStep): boolean {
+  const kind = step.kind.toLowerCase();
+  return kind.includes("approval")
+    || Boolean(previewFromKeys(step.raw, ["approvalId", "approval_id", "approvalStatus", "approval_status"]))
+    || step.status === "approval_required";
+}
+
+function isArtifactTraceStep(step: SubagentTraceStep): boolean {
+  const kind = step.kind.toLowerCase();
+  return kind.includes("artifact")
+    || Boolean(previewFromKeys(step.raw, ["artifactId", "artifact_id", "path", "uri", "file", "filename"]));
+}
+
+function subagentArtifactTraceSteps(
+  trace: Record<string, unknown> | null,
+  steps: SubagentTraceStep[],
+): SubagentTraceStep[] {
+  const artifactSteps = steps.filter(isArtifactTraceStep);
+  const artifacts = Array.isArray(trace?.artifacts) ? trace.artifacts.filter(isRecord) : [];
+  if (!artifacts.length) {
+    return artifactSteps;
+  }
+  const byId = new Map(artifactSteps.map((step) => [step.id, step]));
+  for (const artifact of artifacts) {
+    const id = fieldString(artifact, ["id", "artifactId", "artifact_id", "path", "uri", "file", "filename"]);
+    if (!id) {
+      continue;
+    }
+    const existing = byId.get(id);
+    byId.set(id, artifactTraceStepFromRecord(artifact, existing));
+  }
+  return [...byId.values()];
+}
+
+function artifactTraceStepFromRecord(
+  artifact: Record<string, unknown>,
+  existing: SubagentTraceStep | undefined,
+): SubagentTraceStep {
+  const path = fieldString(artifact, ["path", "uri", "file", "filename"]);
+  const summary = fieldString(artifact, ["summary", "title", "name", "description", "kind"]) || path;
+  return {
+    id: fieldString(artifact, ["id", "artifactId", "artifact_id"]) || existing?.id || path || "artifact",
+    kind: fieldString(artifact, ["kind", "type"]) || existing?.kind || "artifact",
+    raw: {
+      ...(existing?.raw ?? {}),
+      ...artifact,
+      ...(path ? { resultPreview: path } : {}),
+      ...(summary ? { summary } : {}),
+    },
+    status: fieldString(artifact, ["status", "state", "phase"]) || existing?.status || "",
+    title: fieldString(artifact, ["title", "name"]) || existing?.title || path || summary || "Artifact",
+  };
+}
+
+function syntheticApprovalTraceSteps(
+  activity: ToolActivityIslandOptions,
+  payload: Record<string, unknown>,
+  existingSteps: SubagentTraceStep[],
+): SubagentTraceStep[] {
+  const approvalId = activity.approvalId || fieldString(payload, ["approvalId", "approval_id"]);
+  if (!approvalId || existingSteps.some((step) => previewFromKeys(step.raw, ["approvalId", "approval_id"]) === approvalId)) {
+    return [];
+  }
+  return [{
+    id: approvalId,
+    kind: "approval",
+    raw: {
+      approvalId,
+      approvalStatus: activity.approvalStatus || fieldString(payload, ["approvalStatus", "approval_status"]),
+      summary: activity.responseText || "Waiting for approval.",
+    },
+    status: activity.approvalStatus || activity.status || "approval_required",
+    title: "Approval checkpoint",
+  }];
+}
+
+function emptySubagentTraceSectionLabel(section: "timeline" | "transcript" | "tools" | "approvals" | "artifacts"): string {
+  return {
+    approvals: "No child approval checkpoint has been recorded.",
+    artifacts: "No child artifacts have been recorded.",
+    timeline: "No child timeline events have been recorded.",
+    tools: "No child tool calls have been recorded.",
+    transcript: "No child transcript messages have been recorded.",
+  }[section];
 }
 
 function activityInspectorKind(activity: ToolActivityIslandOptions): ActivityInspectorKind {
@@ -1730,18 +2478,20 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
       gap: 0;
     }
 
-    .desktop-conversation-layout {
+    .desktop-conversation-layout,
+    body.desktop-native-workbench .desktop-conversation-layout {
       display: grid;
-      grid-template-rows: minmax(0, 1fr) auto;
-      height: 100%;
-      max-height: 100%;
+      grid-template-rows: minmax(0, auto) auto;
+      height: auto;
+      max-height: none;
       min-height: 0;
       min-width: 0;
-      overflow: hidden;
+      overflow: visible;
       transition: transform 320ms cubic-bezier(.2,.8,.2,1), filter 320ms ease;
     }
 
-    .desktop-conversation-timeline {
+    .desktop-conversation-timeline,
+    body.desktop-native-workbench .desktop-conversation-timeline {
       min-height: 0;
       overflow: auto;
       scroll-behavior: smooth;
@@ -1754,10 +2504,12 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
     }
 
     .desktop-subagent-shelf-list {
-      display: flex;
-      gap: 8px;
-      overflow-x: auto;
-      padding-bottom: 2px;
+      display: grid;
+      gap: 6px;
+      max-height: 178px;
+      overflow-x: hidden;
+      overflow-y: auto;
+      padding: 0 2px 0 0;
     }
 
     .desktop-subagent-shelf-item {
@@ -1768,12 +2520,12 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
       color: var(--text, #1e1d1b);
       cursor: pointer;
       display: grid;
-      flex: 0 0 min(220px, 52vw);
-      gap: 2px 8px;
-      grid-template-columns: auto minmax(0, 1fr) auto;
-      min-height: 46px;
-      padding: 7px 10px;
+      gap: 8px;
+      grid-template-columns: auto minmax(92px, .8fr) max-content minmax(0, 1.2fr);
+      min-height: 38px;
+      padding: 7px 9px;
       text-align: left;
+      width: 100%;
     }
 
     .desktop-subagent-shelf-item[aria-selected="true"] {
@@ -1802,7 +2554,6 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
     .desktop-subagent-shelf-activity {
       color: var(--text-muted, #716b63);
       font-size: 12px;
-      grid-column: 2 / 4;
     }
 
     .desktop-subagent-trace-panel {
@@ -1819,6 +2570,70 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
       color: var(--text-muted, #716b63);
     }
 
+    .desktop-subagent-observability-panel {
+      display: grid;
+      gap: 12px;
+    }
+
+    .desktop-subagent-observability-tabs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    .desktop-subagent-observability-tab {
+      background: var(--panel-strong, #fffaf7);
+      border: 1px solid var(--desktop-flow-muted-border);
+      border-radius: 999px;
+      color: var(--text-muted, #716b63);
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1.2;
+      padding: 5px 9px;
+    }
+
+    .desktop-subagent-observability-tab[aria-selected="true"] {
+      background: color-mix(in srgb, var(--accent, #cc785c) 13%, var(--panel-strong, #fffaf7));
+      border-color: color-mix(in srgb, var(--accent, #cc785c) 45%, var(--desktop-flow-muted-border));
+      color: var(--text, #1e1d1b);
+    }
+
+    .desktop-subagent-observability-tab-panel {
+      min-width: 0;
+    }
+
+    .desktop-subagent-trace-section {
+      display: grid;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .desktop-subagent-trace-section + .desktop-subagent-trace-section {
+      border-top: 1px solid color-mix(in srgb, var(--desktop-flow-muted-border) 72%, transparent);
+      padding-top: 10px;
+    }
+
+    .desktop-subagent-trace-section-header {
+      display: grid;
+      gap: 2px;
+    }
+
+    .desktop-subagent-trace-section-header strong {
+      font-size: 13px;
+    }
+
+    .desktop-subagent-trace-section-header span,
+    .desktop-subagent-trace-empty {
+      color: var(--text-muted, #716b63);
+      font-size: 12px;
+    }
+
+    .desktop-subagent-trace-empty {
+      margin: 0;
+    }
+
     .desktop-subagent-trace-list {
       display: grid;
       gap: 8px;
@@ -1830,26 +2645,97 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
     .desktop-subagent-trace-step {
       border-left: 3px solid color-mix(in srgb, var(--accent, #cc785c) 65%, transparent);
       padding-left: 10px;
+      min-width: 0;
+    }
+
+    .desktop-subagent-trace-step-heading {
+      align-items: baseline;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-width: 0;
     }
 
     .desktop-subagent-trace-step strong {
-      display: block;
       font-size: 14px;
+      min-width: 0;
+      overflow-wrap: anywhere;
     }
 
+    .desktop-subagent-trace-kind,
     .desktop-subagent-trace-status {
       color: var(--text-muted, #716b63);
       font-size: 12px;
       text-transform: capitalize;
     }
 
+    .desktop-subagent-trace-kind {
+      border: 1px solid var(--desktop-flow-muted-border);
+      border-radius: 999px;
+      padding: 1px 6px;
+    }
+
     .desktop-subagent-trace-step p {
       margin: 4px 0 0;
+      overflow-wrap: anywhere;
       white-space: pre-wrap;
     }
 
-    .desktop-assistant-step-group.desktop-agent-flow-group {
-      overflow: hidden;
+    .desktop-subagent-trace-step-meta,
+    .desktop-subagent-trace-context,
+    .desktop-subagent-trace-overview-metrics {
+      display: grid;
+      gap: 4px 8px;
+      grid-template-columns: max-content minmax(0, 1fr);
+      margin: 8px 0 0;
+    }
+
+    .desktop-subagent-trace-step-meta dt,
+    .desktop-subagent-trace-context dt,
+    .desktop-subagent-trace-overview-metrics dt {
+      color: var(--text-muted, #716b63);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .desktop-subagent-trace-step-meta dd,
+    .desktop-subagent-trace-context dd,
+    .desktop-subagent-trace-overview-metrics dd {
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      white-space: pre-wrap;
+    }
+
+    .desktop-subagent-trace-raw {
+      background: #1f1d1a;
+      border-radius: 8px;
+      color: #f8f2e8;
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12px;
+      margin: 0;
+      max-height: 320px;
+      overflow: auto;
+      padding: 10px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .desktop-assistant-run-group,
+    body.desktop-native-workbench .desktop-assistant-run-group {
+      display: grid;
+      gap: 12px;
+      min-width: 0;
+    }
+
+    .desktop-assistant-step-group.desktop-agent-flow-group,
+    body.desktop-native-workbench .desktop-assistant-step-group.desktop-agent-flow-group {
+      align-self: start;
+      display: block;
+      box-sizing: border-box;
+      height: auto;
+      max-height: none;
+      overflow: visible;
       border: 1px solid var(--desktop-flow-muted-border);
       border-radius: 14px;
       background: var(--desktop-flow-card-bg);
@@ -1918,21 +2804,51 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
 
     .desktop-agent-flow-step-list,
     body.desktop-native-workbench .desktop-agent-flow-step-list.desktop-assistant-step-list {
-      display: grid;
+      display: flex;
+      flex-direction: column;
       gap: 0;
+      height: auto;
       margin: 0;
-      max-height: none;
+      max-height: 0;
       min-height: 0;
-      overflow-y: visible;
+      opacity: 0;
+      overflow: hidden;
       padding: 4px 12px 14px;
       padding-right: 8px;
+      position: static;
+      contain: none;
+      transform: translateY(-8px);
+      transition:
+        max-height 300ms cubic-bezier(.2, .8, .2, 1),
+        opacity 220ms ease,
+        transform 300ms cubic-bezier(.2, .8, .2, 1);
+      will-change: max-height, opacity, transform;
     }
 
-    .desktop-agent-flow-step {
+    .desktop-agent-flow-group[open] .desktop-agent-flow-step-list,
+    body.desktop-native-workbench .desktop-agent-flow-group[open] .desktop-agent-flow-step-list.desktop-assistant-step-list {
+      max-height: var(--desktop-agent-flow-content-height, 1200px);
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .desktop-agent-flow-step,
+    body.desktop-native-workbench .desktop-agent-flow-step {
       display: grid;
+      flex: 0 0 auto;
       grid-template-columns: 30px minmax(0, 1fr);
+      height: auto;
+      max-height: none;
       min-width: 0;
+      opacity: 0;
+      overflow: visible;
+      transform: translateY(-8px);
+    }
+
+    .desktop-agent-flow-group[open] .desktop-agent-flow-step,
+    body.desktop-native-workbench .desktop-agent-flow-group[open] .desktop-agent-flow-step {
       animation: desktopAgentFlowStepIn 260ms ease both;
+      animation-delay: calc(var(--desktop-agent-flow-step-index, 0) * 55ms);
     }
 
     .desktop-agent-flow-step-rail {
@@ -1963,8 +2879,12 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
       background: linear-gradient(var(--desktop-flow-muted-border), transparent);
     }
 
-    .desktop-agent-flow-step-card {
+    .desktop-agent-flow-step-card,
+    body.desktop-native-workbench .desktop-agent-flow-step-card {
+      height: auto;
+      max-height: none;
       min-width: 0;
+      overflow: visible;
       padding: 8px 0 10px;
     }
 
@@ -2161,8 +3081,8 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
     }
 
     @keyframes desktopAgentFlowStepIn {
-      from { opacity: 0; transform: translateX(-6px); }
-      to { opacity: 1; transform: translateX(0); }
+      from { opacity: 0; transform: translateY(-8px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
     @keyframes desktopToolDetailSlideIn {
@@ -2178,11 +3098,19 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
     @media (prefers-reduced-motion: reduce) {
       .desktop-conversation-layout,
       .desktop-agent-flow-summary::before,
+      .desktop-agent-flow-step-list,
       .desktop-agent-flow-step,
       .desktop-tool-detail-panel[data-tool-detail-motion] {
         animation: none !important;
         scroll-behavior: auto !important;
         transition: none !important;
+      }
+
+      .desktop-agent-flow-group[open] .desktop-agent-flow-step-list,
+      .desktop-agent-flow-group[open] .desktop-agent-flow-step {
+        max-height: none !important;
+        opacity: 1 !important;
+        transform: none !important;
       }
     }
   `;

--- a/apps/desktop/src/native-vue/toolActivityIsland.ts
+++ b/apps/desktop/src/native-vue/toolActivityIsland.ts
@@ -13,14 +13,23 @@ export interface ToolActivityIslandOptions {
   approvalId?: string;
   argsText: string;
   approvalStatus: string;
+  delegatedTrace?: Record<string, unknown>;
+  delegateId?: string;
+  delegateTask?: string;
+  delegateTitle?: string;
+  delegateType?: string;
+  finalOutput?: string;
   id: string;
   kind: "call" | "result";
   name: string;
+  parentRunId?: string;
+  parentTurnId?: string;
   responseText: string;
   runChainItemKey?: string;
   selected?: boolean;
   sessionKey?: string;
   status?: string;
+  traceRef?: string;
 }
 
 export interface MountedToolActivityIsland {
@@ -200,13 +209,22 @@ function openToolDetails(
         approvalId: options.approvalId,
         approvalStatus: options.approvalStatus,
         argsText: options.argsText,
+        delegatedTrace: options.delegatedTrace,
+        delegateId: options.delegateId,
+        delegateTask: options.delegateTask,
+        delegateTitle: options.delegateTitle,
+        delegateType: options.delegateType,
+        finalOutput: options.finalOutput,
         id: options.id,
         kind: options.kind,
         name: options.name,
+        parentRunId: options.parentRunId,
+        parentTurnId: options.parentTurnId,
         responseText: options.responseText,
         runChainItemKey: options.runChainItemKey,
         sessionKey: options.sessionKey,
         status: options.status,
+        traceRef: options.traceRef,
       },
       normalizedStatus: status,
     },

--- a/apps/desktop/src/nativeChat.test.ts
+++ b/apps/desktop/src/nativeChat.test.ts
@@ -4,9 +4,11 @@ import {
   applyChatEvent,
   appendUserMessage,
   createNativeChatState,
+  hydrateDelegatedRunsFromTraceEvents,
   normalizeMessagesPayload,
   normalizeSessionsPayload,
   resolveNativeChatApproval,
+  setMessages,
   sessionKeyForChat,
 } from "./nativeChat";
 
@@ -835,6 +837,158 @@ describe("native chat state", () => {
     expect(messages[0].toolActivities?.[0]?.argsText).toContain("请用中文说一句");
     expect(messages[0].toolActivities?.[0]?.argsText).toContain("Spawned agent workflow");
     expect(messages[0].toolActivities?.[0]?.argsText).toContain("tool:call-1:completed");
+  });
+
+  test("hydrates delegated trace snapshots into chat run state when messages reload", () => {
+    const state = createNativeChatState();
+    const messages = normalizeMessagesPayload({
+      messages: [
+        {
+          role: "user",
+          content: "Spawn a subagent",
+          timestamp: "2026-06-27T04:00:00Z",
+          message_id: "user-1",
+        },
+        {
+          role: "tool",
+          content: "child final result",
+          tool_call_id: "call-spawn",
+          name: "spawn",
+          _delegate_event: true,
+          _delegate_id: "delegate-1",
+          _delegate_label: "Greeter",
+          _delegate_status: "completed",
+          _delegate_task: "Say hello",
+          _delegate_trace_ref: "trace-delegate-1",
+          _delegate_result: { summary: "hello", status: "completed" },
+          _delegate_trace: {
+            delegateId: "delegate-1",
+            childRunId: "delegate-1",
+            parentRunId: "run-1",
+            parentSessionKey: "WebSocket:chat-1",
+            status: "completed",
+            steps: [{
+              id: "message:delegate-1",
+              kind: "message",
+              status: "completed",
+              title: "Assistant message",
+              summary: "hello",
+              createdAt: "2026-06-27T04:00:01Z",
+              updatedAt: "2026-06-27T04:00:01Z",
+            }],
+            approvals: [],
+            artifacts: [],
+            updatedAt: "2026-06-27T04:00:01Z",
+          },
+          timestamp: "2026-06-27T04:00:02Z",
+          message_id: "tool-delegate",
+        },
+      ],
+    });
+
+    setMessages(state, "WebSocket:chat-1", messages);
+
+    const delegate = state.chatRuns.delegatedRunsBySession.get("WebSocket:chat-1")?.get("delegate-1");
+    expect(delegate).toMatchObject({
+      id: "delegate-1",
+      title: "Greeter",
+      task: "Say hello",
+      status: "completed",
+      traceRef: "trace-delegate-1",
+      trace: {
+        steps: [expect.objectContaining({
+          id: "message:delegate-1",
+          summary: "hello",
+        })],
+      },
+    });
+  });
+
+  test("hydrates child trace journal events into delegated run traces", () => {
+    const state = createNativeChatState();
+    const sessionKey = "WebSocket:chat-1";
+    setMessages(state, sessionKey, normalizeMessagesPayload({
+      messages: [
+        {
+          role: "user",
+          content: "Use a subagent",
+          timestamp: "2026-06-27T04:00:00Z",
+          message_id: "user-1",
+        },
+      ],
+    }));
+
+    hydrateDelegatedRunsFromTraceEvents(state, sessionKey, [
+      {
+        eventId: "delegate-1:1:agent.delegate.started",
+        eventType: "agent.delegate.started",
+        sessionKey,
+        turnId: "turn-1",
+        stepId: "delegate-1",
+        traceRef: "trace-delegate-1",
+        sequence: 1,
+        createdAt: "2026-06-27T04:00:01Z",
+        payload: {
+          child_run_id: "delegate-1",
+          delegate_id: "delegate-1",
+          status: "running",
+          task: "Say hello",
+          title: "Greeter",
+          trace_ref: "trace-delegate-1",
+        },
+      },
+      {
+        eventId: "delegate-1:2:child.message.completed:final:delegate-1",
+        eventType: "child.message.completed",
+        sessionKey,
+        turnId: "turn-1",
+        stepId: "delegate-1",
+        traceRef: "trace-delegate-1",
+        sequence: 2,
+        createdAt: "2026-06-27T04:00:02Z",
+        payload: {
+          child_run_id: "delegate-1",
+          child_step_id: "final:delegate-1",
+          delegate_id: "delegate-1",
+          status: "completed",
+          summary: "hello from child",
+          trace_ref: "trace-delegate-1",
+          step: {
+            id: "final:delegate-1",
+            kind: "message",
+            status: "completed",
+            title: "Final answer",
+            summary: "hello from child",
+            resultPreview: "hello from child",
+            createdAt: "2026-06-27T04:00:02Z",
+            updatedAt: "2026-06-27T04:00:02Z",
+          },
+        },
+      },
+    ]);
+
+    const delegate = state.chatRuns.delegatedRunsBySession.get(sessionKey)?.get("delegate-1");
+    expect(delegate).toMatchObject({
+      id: "delegate-1",
+      trace: {
+        steps: [expect.objectContaining({
+          id: "final:delegate-1",
+          kind: "message",
+          status: "completed",
+          summary: "hello from child",
+        })],
+      },
+    });
+    const toolActivities = (state.messages.get(sessionKey) ?? []).flatMap((message) => message.toolActivities ?? []);
+    expect(toolActivities).toContainEqual(expect.objectContaining({
+      delegateId: "delegate-1",
+      delegatedTrace: expect.objectContaining({
+        steps: [expect.objectContaining({
+          id: "final:delegate-1",
+          summary: "hello from child",
+        })],
+      }),
+    }));
   });
 
   test("merges pending approval tool result messages into the latest running tool by name", () => {

--- a/apps/desktop/src/nativeChat.ts
+++ b/apps/desktop/src/nativeChat.ts
@@ -29,12 +29,21 @@ export type NativeChatMessage = {
 
 export type NativeChatToolActivity = {
   approvalId?: string;
+  delegatedTrace?: Record<string, unknown>;
+  delegateId?: string;
+  delegateTitle?: string;
+  delegateTask?: string;
+  delegateType?: string;
+  finalOutput?: string;
   id: string;
   name: string;
   argsText: string;
   responseText: string;
   kind: "call" | "result";
   approvalStatus?: string;
+  parentRunId?: string;
+  parentTurnId?: string;
+  traceRef?: string;
   sessionKey?: string;
   status?: string;
 };
@@ -52,6 +61,25 @@ export type NativeChatReference = {
   evidenceId?: string;
   scope?: string;
   type?: string;
+};
+
+export type NativeBackgroundTraceEvent = {
+  eventId?: string;
+  event_id?: string;
+  eventType?: string;
+  event_type?: string;
+  sessionKey?: string;
+  session_key?: string;
+  turnId?: string;
+  turn_id?: string;
+  stepId?: string;
+  step_id?: string;
+  traceRef?: string;
+  trace_ref?: string;
+  sequence?: number;
+  createdAt?: string;
+  created_at?: string;
+  payload?: Record<string, unknown>;
 };
 
 export type NativeChatState = {
@@ -151,6 +179,231 @@ export function setSessions(state: NativeChatState, sessions: NativeChatSession[
 export function setMessages(state: NativeChatState, sessionKey: string, messages: NativeChatMessage[]) {
   state.messages.set(sessionKey, messages);
   state.chatRuns.legacyMessagesBySession.set(sessionKey, messages);
+  state.chatRuns.turnsBySession.set(sessionKey, legacyMessagesToTurns(sessionKey, messages));
+  hydrateDelegatedRunsFromMessages(state, sessionKey, messages);
+}
+
+export function hydrateDelegatedRunsFromTraceEvents(
+  state: NativeChatState,
+  sessionKey: string,
+  events: NativeBackgroundTraceEvent[],
+): void {
+  if (!events.length) {
+    return;
+  }
+  if (!state.chatRuns.turnsBySession.has(sessionKey)) {
+    const legacyMessages = state.messages.get(sessionKey) ?? [];
+    state.chatRuns.legacyMessagesBySession.set(sessionKey, legacyMessages);
+    state.chatRuns.turnsBySession.set(sessionKey, legacyMessagesToTurns(sessionKey, legacyMessages));
+  }
+  const sortedEvents = [...events].sort((left, right) => (numberValue(left.sequence) ?? 0) - (numberValue(right.sequence) ?? 0));
+  for (const raw of sortedEvents) {
+    const payload = isRecord(raw.payload) ? raw.payload : {};
+    const eventType = stringValue(raw.eventType ?? raw.event_type);
+    const eventSessionKey = stringValue(raw.sessionKey ?? raw.session_key) || sessionKey;
+    if (eventSessionKey !== sessionKey) {
+      continue;
+    }
+    const childTracePayload = eventType.startsWith("child.")
+      ? childTracePayloadFromJournalEvent(raw, payload, eventType, sessionKey)
+      : undefined;
+    const replayEventType = childTracePayload ? "agent.delegate.trace.updated" : eventType;
+    const replayPayload = childTracePayload ?? payload;
+    if (!replayEventType.startsWith("agent.delegate.")) {
+      continue;
+    }
+    reduceAgentEvent(state.chatRuns, {
+      chat_id: state.activeChatId,
+      created_at: stringValue(raw.createdAt ?? raw.created_at) || new Date().toISOString(),
+      event_id: childTracePayload
+        ? `restore:child-trace:${stringValue(raw.eventId ?? raw.event_id) || `${sessionKey}:${eventType}:${numberValue(raw.sequence) ?? 0}`}`
+        : stringValue(raw.eventId ?? raw.event_id) || `restore:trace-event:${sessionKey}:${eventType}:${numberValue(raw.sequence) ?? 0}`,
+      event_type: replayEventType,
+      payload: replayPayload,
+      schema_version: "tinybot.agent_event.v1",
+      sequence: numberValue(raw.sequence) ?? 0,
+      session_key: sessionKey,
+      step_id: stringValue(raw.stepId ?? raw.step_id) || stringValue(replayPayload.step_id ?? replayPayload.stepId) || `trace:${stringValue(raw.traceRef ?? raw.trace_ref) || replayEventType}`,
+      turn_id: stringValue(raw.turnId ?? raw.turn_id) || stringValue(replayPayload.parent_turn_id ?? replayPayload.parentTurnId) || `restore:${sessionKey}`,
+    });
+  }
+  const turns = state.chatRuns.turnsBySession.get(sessionKey) ?? [];
+  state.messages.set(sessionKey, coalesceToolActivityMessages(conversationMessagesToNativeMessages(turnsToConversationMessages(turns))));
+}
+
+function childTracePayloadFromJournalEvent(
+  raw: NativeBackgroundTraceEvent,
+  payload: Record<string, unknown>,
+  eventType: string,
+  sessionKey: string,
+): Record<string, unknown> | undefined {
+  const step = childTraceStepFromJournalPayload(payload, eventType);
+  const delegateId = stringValue(payload.delegate_id ?? payload.delegateId);
+  if (!delegateId || !step) {
+    return undefined;
+  }
+  const childRunId = stringValue(payload.child_run_id ?? payload.childRunId) || delegateId;
+  const traceRef = stringValue(raw.traceRef ?? raw.trace_ref ?? payload.trace_ref ?? payload.traceRef);
+  const runStatus = stringValue(payload.delegate_status ?? payload.delegateStatus ?? payload.status) || "running";
+  const approval = step.kind === "approval"
+    ? {
+      approvalId: step.approvalId,
+      childRunId,
+      childToolCallId: step.toolCallId,
+      delegateId,
+      status: step.resultPreview === "Denied." ? "denied" : step.status === "completed" ? "approved" : "approval_required",
+      toolName: step.toolName,
+    }
+    : undefined;
+  return {
+    ...payload,
+    child_run_id: childRunId,
+    delegate_id: delegateId,
+    parent_session_key: sessionKey,
+    status: runStatus,
+    trace: {
+      approvals: approval?.approvalId ? [approval] : [],
+      artifacts: [],
+      childRunId,
+      delegateId,
+      parentSessionKey: sessionKey,
+      status: runStatus,
+      steps: [step],
+      updatedAt: step.updatedAt || step.createdAt || stringValue(raw.createdAt ?? raw.created_at),
+    },
+    trace_ref: traceRef,
+  };
+}
+
+function childTraceStepFromJournalPayload(
+  payload: Record<string, unknown>,
+  eventType: string,
+): Record<string, unknown> | undefined {
+  const provided = isRecord(payload.step) ? payload.step : undefined;
+  if (provided) {
+    return provided;
+  }
+  const kind = childTraceKind(eventType);
+  if (!kind) {
+    return undefined;
+  }
+  const status = childTraceStatus(eventType, stringValue(payload.step_status ?? payload.stepStatus ?? payload.status));
+  const title = stringValue(payload.title)
+    || stringValue(payload.tool_name ?? payload.toolName)
+    || childTraceTitle(kind, status);
+  const id = stringValue(payload.child_step_id ?? payload.childStepId)
+    || stringValue(payload.tool_call_id ?? payload.toolCallId)
+    || stringValue(payload.approval_id ?? payload.approvalId)
+    || `${kind}:${stringValue(payload.delegate_id ?? payload.delegateId) || "delegate"}`;
+  return {
+    approvalId: stringValue(payload.approval_id ?? payload.approvalId),
+    argsPreview: summarizeDebugText(textValue(payload.args_preview ?? payload.argsPreview)),
+    createdAt: stringValue(payload.created_at ?? payload.createdAt),
+    error: summarizeDebugText(textValue(payload.error)),
+    id,
+    kind,
+    resultPreview: summarizeDebugText(textValue(payload.result_preview ?? payload.resultPreview)),
+    status,
+    summary: summarizeDebugText(textValue(payload.summary)),
+    title,
+    toolCallId: stringValue(payload.tool_call_id ?? payload.toolCallId),
+    toolName: stringValue(payload.tool_name ?? payload.toolName),
+    updatedAt: stringValue(payload.updated_at ?? payload.updatedAt),
+  };
+}
+
+function childTraceKind(eventType: string): string {
+  if (eventType.startsWith("child.reasoning.")) {
+    return "reasoning";
+  }
+  if (eventType.startsWith("child.message.")) {
+    return "message";
+  }
+  if (eventType.startsWith("child.tool.")) {
+    return "tool_call";
+  }
+  if (eventType.startsWith("child.approval.")) {
+    return "approval";
+  }
+  if (eventType.startsWith("child.artifact.")) {
+    return "artifact";
+  }
+  return "";
+}
+
+function childTraceStatus(eventType: string, fallback: string): string {
+  if (eventType.endsWith(".completed") || eventType.endsWith(".resolved") || eventType.endsWith(".created")) {
+    return "completed";
+  }
+  if (eventType.endsWith(".failed")) {
+    return "failed";
+  }
+  if (eventType.endsWith(".requested")) {
+    return "blocked";
+  }
+  return fallback || "running";
+}
+
+function childTraceTitle(kind: string, status: string): string {
+  if (kind === "reasoning") {
+    return status === "completed" ? "Thinking complete" : "Thinking";
+  }
+  if (kind === "message") {
+    return status === "completed" ? "Final answer" : "Assistant message";
+  }
+  if (kind === "tool_call") {
+    return "Tool call";
+  }
+  if (kind === "approval") {
+    return "Approval";
+  }
+  if (kind === "artifact") {
+    return "Artifact";
+  }
+  return "Trace step";
+}
+
+function hydrateDelegatedRunsFromMessages(
+  state: NativeChatState,
+  sessionKey: string,
+  messages: NativeChatMessage[],
+) {
+  let sequence = 0;
+  const turns = state.chatRuns.turnsBySession.get(sessionKey) ?? [];
+  const turnId = turns[turns.length - 1]?.id || `restore:${sessionKey}`;
+  for (const message of messages) {
+    for (const activity of message.toolActivities ?? []) {
+      if (!activity.delegatedTrace) {
+        continue;
+      }
+      const delegateId = activity.delegateId || activity.id;
+      const event: AgentEventEnvelope = {
+        chat_id: "",
+        created_at: message.timestamp || new Date().toISOString(),
+        event_id: `restore:delegate-trace:${sessionKey}:${message.messageId}:${delegateId}:${sequence}`,
+        event_type: "agent.delegate.trace.updated",
+        payload: {
+          delegate_id: delegateId,
+          delegate_type: activity.delegateType || "spawn",
+          final_output: activity.finalOutput,
+          parent_run_id: activity.parentRunId,
+          parent_turn_id: activity.parentTurnId,
+          status: activity.status || "completed",
+          task: activity.delegateTask,
+          title: activity.delegateTitle || activity.name,
+          trace: activity.delegatedTrace,
+          trace_ref: activity.traceRef,
+          workflow: "Spawned agent workflow",
+        },
+        schema_version: "tinybot.agent_event.v1",
+        sequence: sequence += 1,
+        session_key: sessionKey,
+        step_id: `restore:delegate:${delegateId}`,
+        turn_id: turnId,
+      };
+      reduceAgentEvent(state.chatRuns, event);
+    }
+  }
 }
 
 export function resolveNativeChatApproval(
@@ -745,12 +998,21 @@ function conversationMessagesToNativeMessages(messages: ReturnType<typeof turnsT
         approvalId: activity.approvalId,
         approvalStatus: activity.approvalStatus,
         argsText: activity.argsText,
+        delegatedTrace: activity.delegatedTrace,
+        delegateId: activity.delegateId,
+        delegateTask: activity.delegateTask,
+        delegateTitle: activity.delegateTitle,
+        delegateType: activity.delegateType,
+        finalOutput: activity.finalOutput,
         id: activity.id,
         kind: activity.kind,
         name: activity.name,
+        parentRunId: activity.parentRunId,
+        parentTurnId: activity.parentTurnId,
         responseText: activity.responseText,
         sessionKey: activity.sessionKey,
         status: activity.status,
+        traceRef: activity.traceRef,
       })),
     } : {}),
     ...(message.references.length ? {
@@ -942,6 +1204,11 @@ function isDelegatedToolMessage(message: Record<string, unknown>): boolean {
 
 function delegatedToolActivityFromMessage(message: Record<string, unknown>, responseText: string): NativeChatToolActivity {
   const metadata = messageMetadata(message);
+  const delegatedTrace = isRecord(message._delegate_trace)
+    ? message._delegate_trace
+    : isRecord(metadata._delegate_trace)
+      ? metadata._delegate_trace
+      : undefined;
   const result = isRecord(message._delegate_result)
     ? message._delegate_result
     : isRecord(metadata._delegate_result)
@@ -965,6 +1232,15 @@ function delegatedToolActivityFromMessage(message: Record<string, unknown>, resp
     kind: "result",
     ...(approvalId ? { approvalId } : {}),
     ...(approvalStatus ? { approvalStatus } : {}),
+    ...(delegatedTrace ? { delegatedTrace } : {}),
+    delegateId: stringValue(message._delegate_id ?? metadata._delegate_id),
+    delegateTitle: stringValue(message._delegate_label ?? metadata._delegate_label ?? message.title),
+    delegateTask: stringValue(message._delegate_task ?? metadata._delegate_task),
+    delegateType: "spawn",
+    finalOutput: stringValue(message.final_output ?? metadata.final_output),
+    parentRunId: stringValue(message._delegate_parent_run_id ?? metadata._delegate_parent_run_id),
+    parentTurnId: stringValue(message._delegate_parent_turn_id ?? metadata._delegate_parent_turn_id),
+    traceRef: stringValue(message._delegate_trace_ref ?? metadata._delegate_trace_ref),
     status,
   };
 }

--- a/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.test.ts
@@ -1081,6 +1081,73 @@ describe("AgentRunner", () => {
     });
   });
 
+  test("executes the original tool when approval is already allowed", async () => {
+    const provider = new QueueProvider([
+      {
+        content: "",
+        toolCalls: [
+          {
+            id: "call-1",
+            name: "write_file",
+            argumentsJson: "{\"path\":\"notes/today.md\",\"content\":\"hello\"}",
+          },
+        ],
+        stopReason: "tool_calls",
+      },
+      {
+        content: "done",
+        toolCalls: [],
+        stopReason: "stop",
+      },
+    ]);
+    const tools = new ToolRegistry();
+    const executedWrites: Record<string, unknown>[] = [];
+    const approvalRequests: Record<string, unknown>[] = [];
+    tools.register({
+      name: "write_file",
+      description: "Write a file",
+      parameters: { type: "object" },
+      capabilities: ["fs.workspace.write"],
+      requiresApproval: true,
+      execute: async (args) => {
+        executedWrites.push(args);
+        return { content: "written" };
+      },
+    });
+    tools.register({
+      name: "request_approval",
+      description: "Request approval",
+      parameters: { type: "object" },
+      execute: async (args) => {
+        approvalRequests.push(args);
+        return {
+          content: "Allowed.",
+          metadata: {
+            decision: "allow",
+            status: "approved",
+            scope: "session",
+            operation: args.operation,
+          },
+        };
+      },
+    });
+    const runner = new AgentRunner({ provider, tools });
+
+    const result = await runner.run(spec());
+
+    expect(executedWrites).toEqual([{ path: "notes/today.md", content: "hello" }]);
+    expect(approvalRequests).toHaveLength(1);
+    expect(result.stopReason).toBe("final_response");
+    expect(result.finalContent).toBe("done");
+    expect(result.messages).toContainEqual({
+      role: "tool",
+      content: "written",
+      toolCallId: "call-1",
+      name: "write_file",
+      metadata: undefined,
+    });
+  });
+
   test("includes awaiting approval metadata in tool result events", async () => {
     const provider = new QueueProvider([
       {

--- a/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/agent/agentRunner.ts
@@ -130,10 +130,16 @@ export class AgentRunner {
                   runId: spec.runId,
                   traceId: spec.traceId,
                   sessionId: spec.sessionId,
+                  parentMessages: messages.map(cloneMessage),
                 };
-                result = prepared.tool.requiresApproval
-                  ? await this.requestToolApproval(prepared.tool, prepared.args, context)
-                  : await prepared.tool.execute(prepared.args, context);
+                if (prepared.tool.requiresApproval) {
+                  const approvalResult = await this.requestToolApproval(prepared.tool, prepared.args, context);
+                  result = approvalAllowsToolExecution(approvalResult)
+                    ? await prepared.tool.execute(prepared.args, context)
+                    : approvalResult;
+                } else {
+                  result = await prepared.tool.execute(prepared.args, context);
+                }
               } catch (error) {
                 if (spec.failOnToolError) {
                   const finalContent = `Error: ${errorName(error)}: ${errorMessage(error)}`;
@@ -541,6 +547,17 @@ function normalizeAwaitingStopReason(value: unknown): "awaiting_user_input" | "a
     return value;
   }
   return "awaiting_user_input";
+}
+
+function approvalAllowsToolExecution(result: ToolResult): boolean {
+  const metadata = result.metadata;
+  if (!metadata) {
+    return false;
+  }
+  return metadata.decision === "allow"
+    || metadata.status === "approved"
+    || metadata.approvalStatus === "approved"
+    || metadata.approved === true;
 }
 
 function snipHistory(spec: AgentRunSpec, messages: AgentMessage[]): AgentMessage[] {

--- a/apps/desktop/workers/ts-agent-worker/src/background/backgroundRegistryBridge.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/background/backgroundRegistryBridge.test.ts
@@ -4,10 +4,11 @@ import { NativeBackgroundRegistryBridge } from "./backgroundRegistryBridge";
 
 class FakeRpc {
   readonly requests: Array<{ traceId: string; method: string; params: Record<string, unknown> }> = [];
+  response: unknown = {};
 
   async request(traceId: string, method: string, params: Record<string, unknown>): Promise<unknown> {
     this.requests.push({ traceId, method, params });
-    return {};
+    return this.response;
   }
 }
 
@@ -28,6 +29,18 @@ describe("NativeBackgroundRegistryBridge", () => {
       startedAtMs: 1000,
       updatedAtMs: 1000,
       metadata: { traceId: "trace-1" },
+    }, "trace-1");
+    await bridge.upsertRun({
+      id: "subagent-1",
+      kind: "subagent",
+      source: "task",
+      status: "awaiting_approval",
+      label: "Inspect",
+      sessionKey: "desktop:chat-1",
+      startedAtMs: 1000,
+      updatedAtMs: 1500,
+      result: "Waiting for approval.",
+      metadata: { traceId: "trace-1", stopReason: "awaiting_approval" },
     }, "trace-1");
     await bridge.completeRun({
       runId: "subagent-1",
@@ -59,6 +72,24 @@ describe("NativeBackgroundRegistryBridge", () => {
       },
       {
         traceId: "trace-1",
+        method: "background.run.upsert",
+        params: {
+          run: {
+            id: "subagent-1",
+            kind: "subagent",
+            source: "task",
+            status: "awaiting_approval",
+            label: "Inspect",
+            sessionKey: "desktop:chat-1",
+            startedAtMs: 1000,
+            updatedAtMs: 1500,
+            result: "Waiting for approval.",
+            metadata: { traceId: "trace-1", stopReason: "awaiting_approval" },
+          },
+        },
+      },
+      {
+        traceId: "trace-1",
         method: "background.run.complete",
         params: {
           run_id: "subagent-1",
@@ -69,5 +100,199 @@ describe("NativeBackgroundRegistryBridge", () => {
         },
       },
     ]);
+  });
+
+  test("lists persisted native background runs", async () => {
+    const rpc = new FakeRpc();
+    rpc.response = {
+      runs: [{
+        id: "delegate-restored",
+        kind: "subagent",
+        source: "subagent",
+        status: "completed",
+        label: "Say hello",
+        sessionKey: "WebSocket:chat-1",
+        startedAtMs: 1000,
+        updatedAtMs: 2000,
+        completedAtMs: 2000,
+        result: "你好",
+        error: null,
+        metadata: {
+          parentRunId: "parent-run",
+          taskName: "say_hello",
+          traceId: "trace-restored",
+        },
+      }],
+    };
+    const bridge = new NativeBackgroundRegistryBridge(rpc);
+
+    await expect(bridge.listRuns("trace-list-runs")).resolves.toEqual([{
+      id: "delegate-restored",
+      kind: "subagent",
+      source: "subagent",
+      status: "completed",
+      label: "Say hello",
+      sessionKey: "WebSocket:chat-1",
+      startedAtMs: 1000,
+      updatedAtMs: 2000,
+      completedAtMs: 2000,
+      result: "你好",
+      error: null,
+      metadata: {
+        parentRunId: "parent-run",
+        taskName: "say_hello",
+        traceId: "trace-restored",
+      },
+    }]);
+    expect(rpc.requests.at(-1)).toEqual({
+      traceId: "trace-list-runs",
+      method: "background.run.list",
+      params: {},
+    });
+  });
+
+  test("maps trace journal append and list to native background RPC methods", async () => {
+    const rpc = new FakeRpc();
+    const bridge = new NativeBackgroundRegistryBridge(rpc);
+
+    await bridge.appendTraceEvent({
+      eventId: "evt-1",
+      eventType: "agent.delegate.started",
+      sessionKey: "WebSocket:chat-1",
+      turnId: "turn-1",
+      delegateId: "delegate-1",
+      childRunId: "delegate-1",
+      traceRef: "trace-delegate-1",
+      sequence: 1,
+      createdAt: "2026-06-28T00:00:00.000Z",
+      payload: { status: "running" },
+    }, "trace-delegate-1");
+    await bridge.listTraceEvents({ sessionKey: "WebSocket:chat-1", delegateId: "delegate-1" }, "trace-delegate-1");
+
+    expect(rpc.requests.slice(-2)).toEqual([
+      {
+        traceId: "trace-delegate-1",
+        method: "background.trace.append",
+        params: {
+          event: {
+            eventId: "evt-1",
+            eventType: "agent.delegate.started",
+            sessionKey: "WebSocket:chat-1",
+            turnId: "turn-1",
+            delegateId: "delegate-1",
+            childRunId: "delegate-1",
+            traceRef: "trace-delegate-1",
+            sequence: 1,
+            createdAt: "2026-06-28T00:00:00.000Z",
+            payload: { status: "running" },
+          },
+        },
+      },
+      {
+        traceId: "trace-delegate-1",
+        method: "background.trace.list",
+        params: {
+          filter: {
+            sessionKey: "WebSocket:chat-1",
+            delegateId: "delegate-1",
+          },
+        },
+      },
+    ]);
+  });
+
+  test("maps delegate trace reconstruction to native background RPC method", async () => {
+    const rpc = new FakeRpc();
+    rpc.response = {
+      trace: {
+        sessionKey: "WebSocket:chat-1",
+        delegateId: "delegate-1",
+        childRunId: "child-1",
+        traceRef: "trace-delegate-1",
+        status: "completed",
+        finalOutput: "Done",
+        events: [
+          {
+            eventId: "event-1",
+            eventType: "child.message.completed",
+            sessionKey: "WebSocket:chat-1",
+            turnId: "turn-1",
+            delegateId: "delegate-1",
+            childRunId: "child-1",
+            traceRef: "trace-delegate-1",
+            sequence: 1,
+            createdAt: "2026-06-28T00:00:00.000Z",
+            payload: { resultPreview: "Done" },
+          },
+        ],
+        approvals: [{ approvalId: "approval-1", status: "approved" }],
+        artifacts: [{ artifactId: "artifact-1", kind: "diff" }],
+      },
+    };
+    const bridge = new NativeBackgroundRegistryBridge(rpc);
+
+    const trace = await bridge.getDelegateTrace({
+      sessionKey: "WebSocket:chat-1",
+      delegateId: "delegate-1",
+    }, "trace-delegate-1");
+
+    expect(trace).toMatchObject({
+      sessionKey: "WebSocket:chat-1",
+      delegateId: "delegate-1",
+      childRunId: "child-1",
+      traceRef: "trace-delegate-1",
+      status: "completed",
+      finalOutput: "Done",
+      approvals: [{ approvalId: "approval-1", status: "approved" }],
+      artifacts: [{ artifactId: "artifact-1", kind: "diff" }],
+    });
+    expect(trace?.events).toHaveLength(1);
+    expect(rpc.requests.at(-1)).toEqual({
+      traceId: "trace-delegate-1",
+      method: "background.trace.get_delegate_trace",
+      params: {
+        filter: {
+          sessionKey: "WebSocket:chat-1",
+          delegateId: "delegate-1",
+        },
+      },
+    });
+  });
+
+  test("maps artifact retrieval to native background RPC method", async () => {
+    const rpc = new FakeRpc();
+    rpc.response = {
+      artifact: {
+        artifactId: "artifact-1",
+        kind: "diff",
+        title: "Patch",
+        content: "--- a/file\n+++ b/file",
+      },
+    };
+    const bridge = new NativeBackgroundRegistryBridge(rpc);
+
+    const artifact = await bridge.getArtifact({
+      sessionKey: "WebSocket:chat-1",
+      delegateId: "delegate-1",
+      artifactId: "artifact-1",
+    }, "trace-delegate-1");
+
+    expect(artifact).toEqual({
+      artifactId: "artifact-1",
+      kind: "diff",
+      title: "Patch",
+      content: "--- a/file\n+++ b/file",
+    });
+    expect(rpc.requests.at(-1)).toEqual({
+      traceId: "trace-delegate-1",
+      method: "background.trace.get_artifact",
+      params: {
+        filter: {
+          sessionKey: "WebSocket:chat-1",
+          delegateId: "delegate-1",
+          artifactId: "artifact-1",
+        },
+      },
+    });
   });
 });

--- a/apps/desktop/workers/ts-agent-worker/src/background/backgroundRegistryBridge.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/background/backgroundRegistryBridge.ts
@@ -1,7 +1,7 @@
 import type { JsonObject } from "../protocol/messages.ts";
 import type { NativeRpcClient } from "../tools/nativeToolProxy.ts";
 
-export type BackgroundRunStatus = "queued" | "running" | "completed" | "failed" | "cancelled";
+export type BackgroundRunStatus = "queued" | "running" | "awaiting_approval" | "completed" | "failed" | "cancelled";
 
 export interface BackgroundRunRecord {
   id: string;
@@ -29,12 +29,58 @@ export interface BackgroundRunCompletion {
   error?: string | null;
 }
 
+export interface BackgroundTraceEvent {
+  eventId: string;
+  eventType: string;
+  sessionKey: string;
+  turnId: string;
+  parentStepId?: string;
+  delegateId?: string;
+  childRunId?: string;
+  childStepId?: string;
+  traceRef?: string;
+  sequence: number;
+  createdAt: string;
+  payload: Record<string, unknown>;
+}
+
+export interface BackgroundTraceListFilter {
+  sessionKey?: string;
+  delegateId?: string;
+  traceRef?: string;
+  eventType?: string;
+  artifactId?: string;
+}
+
+export interface BackgroundDelegateTrace {
+  sessionKey: string;
+  delegateId?: string;
+  childRunId?: string;
+  traceRef?: string;
+  status?: string;
+  finalOutput?: string;
+  events: BackgroundTraceEvent[];
+  approvals: Record<string, unknown>[];
+  artifacts: Record<string, unknown>[];
+}
+
 export interface BackgroundRunRegistry {
   upsertRun(run: BackgroundRunRecord, traceId: string): Promise<void>;
   completeRun(completion: BackgroundRunCompletion, traceId: string): Promise<void>;
 }
 
-export class NativeBackgroundRegistryBridge implements BackgroundRunRegistry {
+export interface BackgroundRunReader {
+  listRuns(traceId?: string): Promise<BackgroundRunRecord[]>;
+}
+
+export interface BackgroundTraceJournal {
+  appendTraceEvent(event: BackgroundTraceEvent, traceId: string): Promise<void>;
+  listTraceEvents(filter: BackgroundTraceListFilter, traceId: string): Promise<BackgroundTraceEvent[]>;
+  getDelegateTrace(filter: BackgroundTraceListFilter, traceId: string): Promise<BackgroundDelegateTrace | null>;
+  getArtifact(filter: BackgroundTraceListFilter, traceId: string): Promise<Record<string, unknown> | null>;
+}
+
+export class NativeBackgroundRegistryBridge implements BackgroundRunRegistry, BackgroundRunReader, BackgroundTraceJournal {
   private readonly rpcClient: NativeRpcClient;
 
   constructor(rpcClient: NativeRpcClient) {
@@ -54,4 +100,68 @@ export class NativeBackgroundRegistryBridge implements BackgroundRunRegistry {
       error: completion.error ?? null,
     });
   }
+
+  async listRuns(traceId = "trace-background-run-list"): Promise<BackgroundRunRecord[]> {
+    const result = await this.rpcClient.request(traceId, "background.run.list", {});
+    if (!isRecord(result) || !Array.isArray(result.runs)) {
+      return [];
+    }
+    return result.runs.filter(isRecord).map((run) => run as unknown as BackgroundRunRecord);
+  }
+
+  async appendTraceEvent(event: BackgroundTraceEvent, traceId: string): Promise<void> {
+    await this.rpcClient.request(traceId, "background.trace.append", { event: event as unknown as JsonObject });
+  }
+
+  async listTraceEvents(filter: BackgroundTraceListFilter, traceId: string): Promise<BackgroundTraceEvent[]> {
+    const result = await this.rpcClient.request(traceId, "background.trace.list", { filter: filter as unknown as JsonObject });
+    if (!isRecord(result) || !Array.isArray(result.events)) {
+      return [];
+    }
+    return result.events.filter(isRecord).map((event) => event as unknown as BackgroundTraceEvent);
+  }
+
+  async getDelegateTrace(filter: BackgroundTraceListFilter, traceId: string): Promise<BackgroundDelegateTrace | null> {
+    const result = await this.rpcClient.request(traceId, "background.trace.get_delegate_trace", { filter: filter as unknown as JsonObject });
+    if (!isRecord(result) || !isRecord(result.trace)) {
+      return null;
+    }
+    const trace = result.trace;
+    const events = Array.isArray(trace.events)
+      ? trace.events.filter(isRecord).map((event) => event as unknown as BackgroundTraceEvent)
+      : [];
+    const approvals = Array.isArray(trace.approvals)
+      ? trace.approvals.filter(isRecord)
+      : [];
+    const artifacts = Array.isArray(trace.artifacts)
+      ? trace.artifacts.filter(isRecord)
+      : [];
+    return {
+      sessionKey: String(trace.sessionKey ?? trace.session_key ?? ""),
+      delegateId: optionalString(trace.delegateId ?? trace.delegate_id),
+      childRunId: optionalString(trace.childRunId ?? trace.child_run_id),
+      traceRef: optionalString(trace.traceRef ?? trace.trace_ref),
+      status: optionalString(trace.status),
+      finalOutput: optionalString(trace.finalOutput ?? trace.final_output),
+      events,
+      approvals,
+      artifacts,
+    };
+  }
+
+  async getArtifact(filter: BackgroundTraceListFilter, traceId: string): Promise<Record<string, unknown> | null> {
+    const result = await this.rpcClient.request(traceId, "background.trace.get_artifact", { filter: filter as unknown as JsonObject });
+    if (!isRecord(result) || !isRecord(result.artifact)) {
+      return null;
+    }
+    return result.artifact;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
 }

--- a/apps/desktop/workers/ts-agent-worker/src/background/delegatedRun.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/background/delegatedRun.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 
+import type { BackgroundTraceEvent } from "./backgroundRegistryBridge";
 import { DelegatedRunManager, DelegatedRunRegistry } from "./delegatedRun";
 import { SubagentRuntime, type SubagentRunRequest } from "./subagentRuntime";
 
@@ -15,6 +16,7 @@ describe("DelegatedRunManager", () => {
   test("spawns a delegated run with parent linkage and conservative defaults", async () => {
     const started: SubagentRunRequest[] = [];
     const events: string[] = [];
+    const traceEvents: BackgroundTraceEvent[] = [];
     const gate = deferred<string>();
     const runtime = new SubagentRuntime({
       timeoutMs: 1000,
@@ -26,6 +28,12 @@ describe("DelegatedRunManager", () => {
     });
     const manager = new DelegatedRunManager({
       runtime,
+      traceJournal: {
+        appendTraceEvent: async (event) => {
+          traceEvents.push(event);
+        },
+        listTraceEvents: async () => traceEvents,
+      },
       emitEvent: (event) => events.push(event.eventName),
       now: () => "2026-06-27T12:00:00.000Z",
     });
@@ -97,6 +105,7 @@ describe("DelegatedRunManager", () => {
     gate.resolve("approval review complete");
     await expect(waitPromise).resolves.toMatchObject({
       active: [],
+      awaitingApproval: [],
       timedOut: [],
       runs: [{
         delegateId: "delegate-1",
@@ -120,6 +129,61 @@ describe("DelegatedRunManager", () => {
       "agent.delegate.running",
       "agent.delegate.trace.updated",
       "agent.delegate.completed",
+    ]);
+    await waitFor(() => traceEvents.length === events.length + 1);
+    const agentTraceEvents = traceEvents.filter((event) => event.eventType.startsWith("agent.delegate."));
+    const childTraceEvents = traceEvents.filter((event) => event.eventType.startsWith("child."));
+    expect(agentTraceEvents.map((event) => event.eventType)).toEqual(events);
+    expect(agentTraceEvents).toEqual([
+      expect.objectContaining({
+        eventId: "delegate-1:1:agent.delegate.started",
+        sessionKey: "WebSocket:chat-1",
+        turnId: "turn-1",
+        delegateId: "delegate-1",
+        childRunId: "delegate-1",
+        traceRef: "trace-parent",
+        sequence: 1,
+        payload: expect.objectContaining({
+          task_name: "review_desktop_approval",
+          status: "running",
+        }),
+      }),
+      expect.objectContaining({
+        eventId: "delegate-1:2:agent.delegate.running",
+        sequence: 2,
+      }),
+      expect.objectContaining({
+        eventId: "delegate-1:3:agent.delegate.trace.updated",
+        sequence: 3,
+        payload: expect.objectContaining({
+          trace: expect.objectContaining({
+            status: "completed",
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        eventId: "delegate-1:5:agent.delegate.completed",
+        sequence: 5,
+        payload: expect.objectContaining({
+          final_output: "approval review complete",
+        }),
+      }),
+    ]);
+    expect(childTraceEvents).toEqual([
+      expect.objectContaining({
+        childRunId: "delegate-1",
+        childStepId: "final:delegate-1",
+        delegateId: "delegate-1",
+        eventId: "delegate-1:4:child.message.completed:final:delegate-1",
+        eventType: "child.message.completed",
+        sequence: 4,
+        payload: expect.objectContaining({
+          child_step_id: "final:delegate-1",
+          step_kind: "message",
+          step_status: "completed",
+          summary: "approval review complete",
+        }),
+      }),
     ]);
   });
 
@@ -148,8 +212,429 @@ describe("DelegatedRunManager", () => {
     expect(second).toMatchObject({ delegateId: "delegate-2", status: "queued", queued: true });
     await expect(manager.waitAgent(["delegate-1", "delegate-2"], { timeoutMs: 0 })).resolves.toMatchObject({
       active: ["delegate-1", "delegate-2"],
+      awaitingApproval: [],
       timedOut: ["delegate-1", "delegate-2"],
     });
+  });
+
+  test("followup_task triggers a new child turn on the same delegated run", async () => {
+    const started: SubagentRunRequest[] = [];
+    const completions = ["initial complete", "follow-up complete"];
+    const events: string[] = [];
+    const traceEvents: BackgroundTraceEvent[] = [];
+    const runtime = new SubagentRuntime({
+      timeoutMs: 1000,
+      idGenerator: () => "delegate-followup",
+      runner: async (request) => {
+        started.push(request);
+        return { status: "completed", result: completions.shift() ?? "unexpected" };
+      },
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      traceJournal: {
+        appendTraceEvent: async (event) => {
+          traceEvents.push(event);
+        },
+        listTraceEvents: async () => traceEvents,
+      },
+      emitEvent: (event) => events.push(event.eventName),
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+
+    await manager.spawnAgent(
+      { taskName: "Investigate", message: "Initial task", forkTurns: "1" },
+      {
+        runId: "parent-run",
+        sessionKey: "WebSocket:chat-1",
+        traceId: "trace-parent",
+        parentMessages: [
+          { role: "user", content: "Parent request" },
+          { role: "assistant", content: "Parent final answer" },
+        ],
+      },
+    );
+    await manager.waitAgent(["delegate-followup"], { timeoutMs: 1000 });
+
+    const followup = await manager.followupTask("delegate-followup", "Check one more file");
+    expect(followup).toMatchObject({
+      delegateId: "delegate-followup",
+      status: "running",
+      messages: [expect.objectContaining({
+        message: "Check one more file",
+        triggerFollowup: true,
+      })],
+    });
+    await expect(manager.waitAgent(["delegate-followup"], { timeoutMs: 1000 })).resolves.toMatchObject({
+      active: [],
+      timedOut: [],
+      runs: [{
+        delegateId: "delegate-followup",
+        status: "completed",
+        result: {
+          status: "completed",
+          summary: "follow-up complete",
+        },
+      }],
+    });
+    expect(started.map((request) => ({ id: request.id, task: request.task, origin: request.metadata?.origin }))).toEqual([
+      { id: "delegate-followup", task: "Initial task", origin: "delegated_run" },
+      { id: "delegate-followup", task: "Check one more file", origin: "delegated_followup" },
+    ]);
+    expect(started[1]?.metadata?.delegatedContextPack).toMatchObject({
+      message: "Check one more file",
+      forkTurns: "1",
+      forkedMessages: [
+        { role: "user", content: "Parent request" },
+        { role: "assistant", content: "Parent final answer" },
+      ],
+    });
+    expect(events).toEqual([
+      "agent.delegate.started",
+      "agent.delegate.running",
+      "agent.delegate.trace.updated",
+      "agent.delegate.completed",
+      "agent.delegate.message_queued",
+      "agent.delegate.running",
+      "agent.delegate.trace.updated",
+      "agent.delegate.completed",
+    ]);
+    await waitFor(() => traceEvents.filter((event) => event.eventType === "child.message.completed").length === 2);
+    expect(traceEvents.filter((event) => event.eventType === "child.message.completed")).toEqual([
+      expect.objectContaining({
+        childStepId: "final:delegate-followup",
+        payload: expect.objectContaining({
+          summary: "initial complete",
+        }),
+      }),
+      expect.objectContaining({
+        childStepId: "final:delegate-followup",
+        payload: expect.objectContaining({
+          summary: "follow-up complete",
+        }),
+      }),
+    ]);
+  });
+
+  test("interrupts an active delegated run without letting abort completion overwrite cancellation", async () => {
+    const events: Array<{ eventName: string; payload: Record<string, unknown> }> = [];
+    const runtime = new SubagentRuntime({
+      timeoutMs: 1000,
+      idGenerator: () => "delegate-interrupt",
+      runner: async (request) => new Promise((resolve) => {
+        request.signal.addEventListener("abort", () => resolve({
+          status: "failed",
+          result: "Subagent cancelled.",
+          error: "Subagent cancelled.",
+        }), { once: true });
+      }),
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      emitEvent: (event) => events.push({ eventName: event.eventName, payload: event.payload }),
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+
+    await manager.spawnAgent(
+      { taskName: "Long review", message: "Keep reviewing" },
+      { runId: "parent-run", sessionKey: "WebSocket:chat-1" },
+    );
+
+    const interrupted = await manager.interruptAgent("delegate-interrupt");
+    expect(interrupted).toMatchObject({
+      delegateId: "delegate-interrupt",
+      status: "cancelled",
+      result: {
+        status: "cancelled",
+        summary: "Delegated run interrupted.",
+      },
+      trace: {
+        steps: [expect.objectContaining({
+          kind: "error",
+          status: "cancelled",
+          title: "Interrupted",
+        })],
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(manager.waitAgent(["delegate-interrupt"], { timeoutMs: 1000 })).resolves.toMatchObject({
+      active: [],
+      timedOut: [],
+      runs: [{
+        delegateId: "delegate-interrupt",
+        status: "cancelled",
+        result: {
+          status: "cancelled",
+          summary: "Delegated run interrupted.",
+        },
+      }],
+    });
+    expect(events.map((event) => event.eventName)).toEqual([
+      "agent.delegate.started",
+      "agent.delegate.running",
+      "agent.delegate.trace.updated",
+      "agent.delegate.interrupted",
+    ]);
+    expect(events.at(-1)?.payload).toMatchObject({
+      delegateId: "delegate-interrupt",
+      status: "cancelled",
+      latest_activity: "Delegated run interrupted.",
+    });
+  });
+
+  test("keeps awaiting approval delegated runs out of failed completions", async () => {
+    const events: Array<{ eventName: string; payload: Record<string, unknown> }> = [];
+    const runtime = new SubagentRuntime({
+      timeoutMs: 1000,
+      idGenerator: () => "delegate-approval",
+      runner: async () => ({
+        status: "awaiting_approval",
+        result: "Waiting for approval.",
+        metadata: {
+          awaitingUserInput: true,
+          stopReason: "awaiting_approval",
+          approvalId: "approval-1",
+          _delegate_child_run_id: "delegate-approval",
+          _delegate_child_tool_call_id: "call-write",
+          _delegate_child_tool_name: "write_file",
+          _delegate_operation_preview: "write_file path=\"notes.md\"",
+        },
+      }),
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      emitEvent: (event) => events.push({ eventName: event.eventName, payload: event.payload }),
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+
+    await manager.spawnAgent(
+      { taskName: "Write notes", message: "Write notes", permissionProfile: "workspace_write" },
+      { runId: "parent-run", sessionKey: "WebSocket:chat-1", permissionProfile: "workspace_write" },
+    );
+    const wait = await manager.waitAgent(["delegate-approval"], { timeoutMs: 1000 });
+
+    expect(wait).toMatchObject({
+      active: [],
+      awaitingApproval: ["delegate-approval"],
+      timedOut: [],
+      runs: [{
+        delegateId: "delegate-approval",
+        status: "awaiting_approval",
+        approvalState: {
+          approvalId: "approval-1",
+          childToolCallId: "call-write",
+          toolName: "write_file",
+          operationPreview: "write_file path=\"notes.md\"",
+        },
+      }],
+    });
+    expect(events.map((event) => event.eventName)).toEqual([
+      "agent.delegate.started",
+      "agent.delegate.running",
+      "agent.delegate.awaiting_approval",
+    ]);
+    expect(events.at(-1)?.payload).toMatchObject({
+      approvalId: "approval-1",
+      status: "blocked",
+      toolName: "write_file",
+    });
+  });
+
+  test("records a resolved child approval before completing an awaiting delegated run", async () => {
+    let complete!: NonNullable<SubagentRunRequest["onComplete"]>;
+    const events: Array<{ eventName: string; payload: Record<string, unknown> }> = [];
+    const traceEvents: BackgroundTraceEvent[] = [];
+    const manager = new DelegatedRunManager({
+      runtime: {
+        spawn: async (request) => {
+          complete = request.onComplete!;
+          return {
+            id: "delegate-resume",
+            label: request.label,
+            message: "started",
+            queued: false,
+            queuedCount: 0,
+            runningCount: 1,
+          };
+        },
+        runExisting: async () => {
+          throw new Error("not used");
+        },
+      },
+      traceJournal: {
+        appendTraceEvent: async (event) => {
+          traceEvents.push(event);
+        },
+        listTraceEvents: async () => traceEvents,
+      },
+      emitEvent: (event) => events.push({ eventName: event.eventName, payload: event.payload }),
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+
+    await manager.spawnAgent(
+      { taskName: "Write notes", message: "Write notes", permissionProfile: "workspace_write" },
+      { runId: "parent-run", turnId: "turn-1", sessionKey: "WebSocket:chat-1", traceId: "trace-parent", permissionProfile: "workspace_write" },
+    );
+    await complete({
+      id: "delegate-resume",
+      status: "awaiting_approval",
+      result: "Waiting for approval.",
+      metadata: {
+        awaitingUserInput: true,
+        stopReason: "awaiting_approval",
+        approvalId: "approval-1",
+        _delegate_child_run_id: "delegate-resume",
+        _delegate_child_tool_call_id: "call-write",
+        _delegate_child_tool_name: "write_file",
+      },
+    });
+    await complete({
+      id: "delegate-resume",
+      status: "completed",
+      result: "child completed after approval",
+    });
+
+    const wait = await manager.waitAgent(["delegate-resume"], { timeoutMs: 1000 });
+    expect(wait.runs[0]).toMatchObject({
+      status: "completed",
+      approvalState: {
+        approvalId: "approval-1",
+        status: "approved",
+      },
+      trace: {
+        approvals: [expect.objectContaining({
+          approvalId: "approval-1",
+          status: "approved",
+        })],
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            approvalId: "approval-1",
+            kind: "approval",
+            status: "completed",
+            title: "write_file approval resolved",
+          }),
+          expect.objectContaining({
+            kind: "message",
+            status: "completed",
+            summary: "child completed after approval",
+          }),
+        ]),
+      },
+    });
+    expect(events.map((event) => event.eventName)).toEqual([
+      "agent.delegate.started",
+      "agent.delegate.running",
+      "agent.delegate.awaiting_approval",
+      "agent.delegate.trace.updated",
+      "agent.delegate.trace.updated",
+      "agent.delegate.completed",
+    ]);
+    await waitFor(() => traceEvents.some((event) => event.eventType === "child.approval.resolved"));
+    expect(traceEvents).toContainEqual(expect.objectContaining({
+      childStepId: "approval:approval-1",
+      eventType: "child.approval.resolved",
+      payload: expect.objectContaining({
+        approval_id: "approval-1",
+        step_kind: "approval",
+        step_status: "completed",
+      }),
+    }));
+  });
+
+  test("records a denied child approval before completing an awaiting delegated run", async () => {
+    let complete!: NonNullable<SubagentRunRequest["onComplete"]>;
+    const traceEvents: BackgroundTraceEvent[] = [];
+    const manager = new DelegatedRunManager({
+      runtime: {
+        spawn: async (request) => {
+          complete = request.onComplete!;
+          return {
+            id: "delegate-denied",
+            label: request.label,
+            message: "started",
+            queued: false,
+            queuedCount: 0,
+            runningCount: 1,
+          };
+        },
+        runExisting: async () => {
+          throw new Error("not used");
+        },
+      },
+      traceJournal: {
+        appendTraceEvent: async (event) => {
+          traceEvents.push(event);
+        },
+        listTraceEvents: async () => traceEvents,
+      },
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+
+    await manager.spawnAgent(
+      { taskName: "Write notes", message: "Write notes", permissionProfile: "workspace_write" },
+      { runId: "parent-run", turnId: "turn-1", sessionKey: "WebSocket:chat-1", traceId: "trace-parent", permissionProfile: "workspace_write" },
+    );
+    await complete({
+      id: "delegate-denied",
+      status: "awaiting_approval",
+      result: "Waiting for approval.",
+      metadata: {
+        awaitingUserInput: true,
+        stopReason: "awaiting_approval",
+        approvalId: "approval-1",
+        _delegate_child_run_id: "delegate-denied",
+        _delegate_child_tool_call_id: "call-write",
+        _delegate_child_tool_name: "write_file",
+      },
+    });
+    await complete({
+      id: "delegate-denied",
+      status: "completed",
+      result: "child handled denied approval",
+      metadata: {
+        approvalId: "approval-1",
+        approvalStatus: "denied",
+        approved: false,
+      },
+    });
+
+    const wait = await manager.waitAgent(["delegate-denied"], { timeoutMs: 1000 });
+    expect(wait.runs[0]).toMatchObject({
+      status: "completed",
+      approvalState: {
+        approvalId: "approval-1",
+        status: "denied",
+      },
+      trace: {
+        approvals: [expect.objectContaining({
+          approvalId: "approval-1",
+          status: "denied",
+        })],
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            approvalId: "approval-1",
+            kind: "approval",
+            status: "completed",
+            summary: "Denied: approval-1",
+            resultPreview: "Denied.",
+          }),
+        ]),
+      },
+    });
+    await waitFor(() => traceEvents.some((event) => event.eventType === "child.approval.resolved"));
+    expect(traceEvents).toContainEqual(expect.objectContaining({
+      childStepId: "approval:approval-1",
+      eventType: "child.approval.resolved",
+      payload: expect.objectContaining({
+        approval_id: "approval-1",
+        step: expect.objectContaining({
+          approvalId: "approval-1",
+          resultPreview: "Denied.",
+          summary: "Denied: approval-1",
+        }),
+      }),
+    }));
   });
 
   test("limits active delegated runs per parent run", async () => {
@@ -197,7 +682,7 @@ describe("DelegatedRunManager", () => {
       await manager.waitAgent([`delegate-${index + 1}`], { timeoutMs: 1000 });
     }
 
-    expect(manager.listAgents({ parentRunId: "parent-run" }).filter((run) => run.status === "completed")).toHaveLength(9);
+    expect((await manager.listAgents({ parentRunId: "parent-run" })).filter((run) => run.status === "completed")).toHaveLength(9);
   });
 
   test("lists, records messages, and closes delegated runs", async () => {
@@ -224,8 +709,8 @@ describe("DelegatedRunManager", () => {
       },
     );
 
-    expect(manager.listAgents({ parentSessionKey: "WebSocket:chat-1" })).toHaveLength(1);
-    expect(manager.sendMessage("delegate-1", "Please focus on tests", { triggerFollowup: true })).toMatchObject({
+    await expect(manager.listAgents({ parentSessionKey: "WebSocket:chat-1" })).resolves.toHaveLength(1);
+    await expect(manager.sendMessage("delegate-1", "Please focus on tests", { triggerFollowup: true })).resolves.toMatchObject({
       messages: [{
         id: "msg-1",
         message: "Please focus on tests",
@@ -233,7 +718,7 @@ describe("DelegatedRunManager", () => {
         createdAt: "2026-06-27T12:00:00.000Z",
       }],
     });
-    expect(manager.closeAgent("delegate-1")).toMatchObject({
+    await expect(manager.closeAgent("delegate-1")).resolves.toMatchObject({
       delegateId: "delegate-1",
       status: "closed",
       result: {
@@ -304,6 +789,62 @@ describe("DelegatedRunManager", () => {
     });
   });
 
+  test("persists child tool argument deltas separately from tool lifecycle events", async () => {
+    const traceEvents: BackgroundTraceEvent[] = [];
+    const runtime = new SubagentRuntime({
+      timeoutMs: 1000,
+      idGenerator: () => "delegate-args",
+      runner: async () => new Promise(() => {}),
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      traceJournal: {
+        appendTraceEvent: async (event) => {
+          traceEvents.push(event);
+        },
+        listTraceEvents: async () => traceEvents,
+      },
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+
+    await manager.spawnAgent(
+      { taskName: "Inspect args", message: "Inspect arguments" },
+      { runId: "parent-run", turnId: "turn-1", sessionKey: "WebSocket:chat-1", traceId: "trace-parent" },
+    );
+
+    manager.appendTraceStep("delegate-args", {
+      argsPreview: "{\"path\":\"README.md\"}",
+      createdAt: "2026-06-27T12:00:01.000Z",
+      id: "tool-read-1",
+      kind: "tool_call",
+      status: "running",
+      summary: "Reading README.md",
+      title: "read_file",
+      toolCallId: "call-read-1",
+      toolName: "read_file",
+      updatedAt: "2026-06-27T12:00:01.000Z",
+    });
+
+    await waitFor(() => traceEvents.some((event) => event.eventType === "child.tool.arguments.delta"));
+
+    expect(traceEvents.map((event) => event.eventType)).toEqual([
+      "agent.delegate.started",
+      "agent.delegate.running",
+      "agent.delegate.trace.updated",
+      "child.tool.started",
+      "child.tool.arguments.delta",
+    ]);
+    expect(traceEvents.at(-1)).toMatchObject({
+      childStepId: "tool-read-1",
+      eventType: "child.tool.arguments.delta",
+      payload: expect.objectContaining({
+        args_preview: "{\"path\":\"README.md\"}",
+        tool_call_id: "call-read-1",
+        tool_name: "read_file",
+      }),
+    });
+  });
+
   test("rejects silent permission expansion and invalid fork policies", async () => {
     const runtime = new SubagentRuntime({
       timeoutMs: 1000,
@@ -347,6 +888,59 @@ describe("DelegatedRunManager", () => {
         message: "Use all available context",
       },
     });
+  });
+
+  test("forks only sanitized recent parent turns into the delegated context pack", async () => {
+    const started: SubagentRunRequest[] = [];
+    const runtime = new SubagentRuntime({
+      timeoutMs: 1000,
+      idGenerator: () => "delegate-forked",
+      runner: async (request) => {
+        started.push(request);
+        return new Promise(() => {});
+      },
+    });
+    const manager = new DelegatedRunManager({ runtime });
+
+    await manager.spawnAgent(
+      { taskName: "Recent context", message: "Use recent parent context", forkTurns: "2" },
+      {
+        runId: "parent-run",
+        sessionKey: "WebSocket:chat-1",
+        parentMessages: [
+          { role: "system", content: "System rules" },
+          { role: "user", content: "Old user request" },
+          { role: "assistant", content: "Old final answer" },
+          { role: "tool", name: "read_file", toolCallId: "tool-old", content: "Old tool output" },
+          { role: "user", content: "Recent user request" },
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{ id: "call-1", name: "read_file", argumentsJson: "{}" }],
+          },
+          { role: "tool", name: "read_file", toolCallId: "call-1", content: "Recent tool output" },
+          { role: "assistant", content: "Recent final answer", reasoningContent: "hidden reasoning" },
+          { role: "user", content: "Current user request" },
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{ id: "call-spawn", name: "spawn_agent", argumentsJson: "{}" }],
+          },
+        ],
+      },
+    );
+    await waitFor(() => started.length === 1);
+
+    const delegatedContextPack = started[0]?.metadata?.delegatedContextPack as {
+      forkedMessages?: Array<{ role: string; content: string; reasoningContent?: string; toolCalls?: unknown[] }>;
+    } | undefined;
+    expect(delegatedContextPack?.forkedMessages).toEqual([
+      { role: "user", content: "Recent user request" },
+      { role: "assistant", content: "Recent final answer" },
+      { role: "user", content: "Current user request" },
+    ]);
+    expect(JSON.stringify(delegatedContextPack?.forkedMessages)).not.toContain("tool");
+    expect(JSON.stringify(delegatedContextPack?.forkedMessages)).not.toContain("hidden reasoning");
   });
 });
 

--- a/apps/desktop/workers/ts-agent-worker/src/background/delegatedRun.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/background/delegatedRun.ts
@@ -1,4 +1,6 @@
-import type { SubagentRuntime, SubagentSpawnRequest } from "./subagentRuntime.ts";
+import type { AgentMessage } from "../agent/agentRunSpec.ts";
+import type { BackgroundRunReader, BackgroundRunRecord, BackgroundTraceJournal } from "./backgroundRegistryBridge.ts";
+import type { SubagentCompletion, SubagentRuntime, SubagentSpawnRequest } from "./subagentRuntime.ts";
 
 export type DelegatedRunStatus =
   | "created"
@@ -116,6 +118,7 @@ export interface DelegatedRun {
   runningCount: number;
   queuedCount: number;
   startMessage: string;
+  contextPack?: DelegatedContextPack;
   result?: DelegatedRunResult;
   approvalState?: DelegatedApprovalState;
   messages: DelegatedRunMessage[];
@@ -142,6 +145,7 @@ export interface DelegatedParentContext {
   turnId?: string;
   sessionKey?: string;
   traceId?: string;
+  parentMessages?: AgentMessage[];
   model?: string;
   permissionProfile?: DelegatedPermissionProfile;
   approvalPolicy?: string;
@@ -159,6 +163,7 @@ export interface DelegatedContextPack {
   parentTurnId: string;
   parentSessionKey: string;
   forkTurns: "none" | "all" | `${number}`;
+  forkedMessages: AgentMessage[];
   runtimePolicy: {
     model?: string;
     permissionProfile: DelegatedPermissionProfile;
@@ -181,6 +186,7 @@ export type DelegatedRunEventName =
   | "agent.delegate.trace.updated"
   | "agent.delegate.completed"
   | "agent.delegate.failed"
+  | "agent.delegate.interrupted"
   | "agent.delegate.closed";
 
 export interface DelegatedRunEvent {
@@ -194,9 +200,11 @@ export interface WaitAgentResult {
   runs: DelegatedRun[];
   timedOut: string[];
   active: string[];
+  awaitingApproval: string[];
 }
 
 export interface DelegatedRunRegistryListFilter {
+  pathPrefix?: string;
   parentSessionKey?: string;
   parentRunId?: string;
   status?: DelegatedRunStatus;
@@ -242,6 +250,7 @@ export class DelegatedRunRegistry {
     return [...this.runs.values()]
       .filter((run) => !filter.parentSessionKey || run.parentSessionKey === filter.parentSessionKey)
       .filter((run) => !filter.parentRunId || run.parentRunId === filter.parentRunId)
+      .filter((run) => !filter.pathPrefix || run.agentPath.startsWith(filter.pathPrefix))
       .filter((run) => !filter.status || run.status === filter.status)
       .map(cloneRun);
   }
@@ -303,8 +312,10 @@ export class DelegatedRunRegistry {
 }
 
 export interface DelegatedRunManagerOptions {
-  runtime: Pick<SubagentRuntime, "spawn">;
+  runtime: Pick<SubagentRuntime, "spawn" | "runExisting" | "cancel">;
   registry?: DelegatedRunRegistry;
+  runStore?: BackgroundRunReader;
+  traceJournal?: BackgroundTraceJournal;
   emitEvent?: (event: DelegatedRunEvent) => void;
   now?: () => string;
 }
@@ -312,14 +323,19 @@ export interface DelegatedRunManagerOptions {
 const MAX_ACTIVE_DELEGATED_RUNS_PER_PARENT = 8;
 
 export class DelegatedRunManager {
-  private readonly runtime: Pick<SubagentRuntime, "spawn">;
+  private readonly runtime: Pick<SubagentRuntime, "spawn" | "runExisting" | "cancel">;
   private readonly registry: DelegatedRunRegistry;
+  private readonly runStore?: BackgroundRunReader;
+  private readonly traceJournal?: BackgroundTraceJournal;
   private readonly emitEvent: (event: DelegatedRunEvent) => void;
   private readonly now: () => string;
+  private readonly traceSequences = new Map<string, number>();
 
   constructor(options: DelegatedRunManagerOptions) {
     this.runtime = options.runtime;
     this.registry = options.registry ?? new DelegatedRunRegistry();
+    this.runStore = options.runStore;
+    this.traceJournal = options.traceJournal;
     this.emitEvent = options.emitEvent ?? (() => undefined);
     this.now = options.now ?? (() => new Date().toISOString());
   }
@@ -328,6 +344,7 @@ export class DelegatedRunManager {
     const taskName = normalizeTaskName(request.taskName);
     const parentTurnId = parent.turnId ?? parent.runId;
     const parentSessionKey = parent.sessionKey ?? "";
+    await this.restoreRunsFromStore({ parentRunId: parent.runId, parentSessionKey });
     const activeForParent = this.registry.list({ parentRunId: parent.runId })
       .filter((run) => !isFinalDelegatedStatus(run.status)).length;
     if (activeForParent >= MAX_ACTIVE_DELEGATED_RUNS_PER_PARENT) {
@@ -349,6 +366,7 @@ export class DelegatedRunManager {
       parentTurnId,
       parentSessionKey,
       forkTurns,
+      forkedMessages: buildForkedParentMessages(parent.parentMessages ?? [], forkTurns),
       runtimePolicy: {
         model,
         permissionProfile,
@@ -373,55 +391,7 @@ export class DelegatedRunManager {
       label: request.label ?? taskName,
       sessionKey: parent.sessionKey,
       metadata,
-      onComplete: async (completion) => {
-        const approvalState = delegatedApprovalStateFromMetadata(completion.id, completion.metadata);
-        if (approvalState) {
-          const awaiting = this.registry.update(completion.id, {
-            status: "awaiting_approval",
-            approvalState,
-          });
-          this.emitDelegatedEvent("agent.delegate.awaiting_approval", awaiting, {
-            approvalId: approvalState.approvalId,
-            approval_id: approvalState.approvalId,
-            childToolCallId: approvalState.childToolCallId,
-            child_tool_call_id: approvalState.childToolCallId,
-            toolName: approvalState.toolName,
-            tool_name: approvalState.toolName,
-            latest_activity: "Waiting for approval.",
-            operation_preview: approvalState.operationPreview,
-            reason: approvalState.reason,
-            status: "blocked",
-          });
-          return;
-        }
-        const status = completion.status === "completed" ? "completed" : "failed";
-        let completed = this.registry.update(completion.id, {
-          status,
-          result: {
-            status,
-            summary: completion.result,
-            ...(completion.error ? { error: completion.error } : {}),
-          },
-        });
-        completed = this.registry.appendTraceStep(completion.id, {
-          id: `final:${completion.id}`,
-          kind: completion.error ? "error" : "message",
-          status: completion.error ? "failed" : "completed",
-          title: completion.error ? "Error" : "Final answer",
-          summary: completion.error ?? completion.result,
-          error: completion.error,
-          createdAt: this.now(),
-          updatedAt: this.now(),
-        });
-        this.emitDelegatedEvent("agent.delegate.trace.updated", completed, {
-          latest_activity: completion.error ?? completion.result,
-          trace: completed.trace,
-        });
-        this.emitDelegatedEvent(status === "completed" ? "agent.delegate.completed" : "agent.delegate.failed", completed, {
-          final_output: completion.result,
-          latest_activity: completion.error ?? completion.result,
-        });
-      },
+      onComplete: (completion) => this.handleRuntimeCompletion(completion),
     } satisfies SubagentSpawnRequest);
     const createdAt = this.now();
     const run = this.registry.create({
@@ -450,6 +420,7 @@ export class DelegatedRunManager {
       runningCount: spawned.runningCount,
       queuedCount: spawned.queuedCount,
       startMessage: spawned.message,
+      contextPack,
       messages: [],
     });
     this.emitDelegatedEvent("agent.delegate.started", run, { latest_activity: spawned.message });
@@ -460,6 +431,7 @@ export class DelegatedRunManager {
   }
 
   async waitAgent(delegateIds: string[], options: { timeoutMs?: number } = {}): Promise<WaitAgentResult> {
+    await this.restoreRunsFromStore({}, new Set(delegateIds));
     const deadline = options.timeoutMs === undefined ? null : Date.now() + Math.max(0, options.timeoutMs);
     while (true) {
       const runs = delegateIds.map((id) => this.registry.require(id));
@@ -467,23 +439,39 @@ export class DelegatedRunManager {
         .filter((run) => !isFinalDelegatedStatus(run.status) && run.status !== "awaiting_approval")
         .map((run) => run.delegateId);
       if (active.length === 0) {
-        return { runs, active: [], timedOut: [] };
+        return {
+          runs,
+          active: [],
+          timedOut: [],
+          awaitingApproval: runs
+            .filter((run) => run.status === "awaiting_approval")
+            .map((run) => run.delegateId),
+        };
       }
       if (deadline !== null && Date.now() >= deadline) {
-        return { runs, active, timedOut: active };
+        return {
+          runs,
+          active,
+          timedOut: active,
+          awaitingApproval: runs
+            .filter((run) => run.status === "awaiting_approval")
+            .map((run) => run.delegateId),
+        };
       }
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
   }
 
-  listAgents(filter: DelegatedRunRegistryListFilter = {}): DelegatedRun[] {
+  async listAgents(filter: DelegatedRunRegistryListFilter = {}): Promise<DelegatedRun[]> {
+    await this.restoreRunsFromStore(filter);
     return this.registry.list(filter);
   }
 
-  sendMessage(delegateId: string, message: string, options: { triggerFollowup?: boolean } = {}): DelegatedRun {
+  async sendMessage(delegateId: string, message: string, options: { triggerFollowup?: boolean } = {}): Promise<DelegatedRun> {
     if (!message.trim()) {
       throw new Error("delegated message must be non-empty");
     }
+    await this.restoreRunsFromStore({}, new Set([delegateId]));
     const run = this.registry.appendMessage(delegateId, {
       message,
       triggerFollowup: options.triggerFollowup ?? false,
@@ -497,10 +485,133 @@ export class DelegatedRunManager {
     return run;
   }
 
-  closeAgent(delegateId: string): DelegatedRun {
+  async followupTask(delegateId: string, message: string): Promise<DelegatedRun> {
+    if (!message.trim()) {
+      throw new Error("delegated follow-up message must be non-empty");
+    }
+    await this.restoreRunsFromStore({}, new Set([delegateId]));
+    const current = this.registry.require(delegateId);
+    if (current.status === "closed") {
+      throw new Error(`delegated run is closed: ${delegateId}`);
+    }
+    if (!isFinalDelegatedStatus(current.status)) {
+      throw new Error(`delegated run is already active: ${delegateId}`);
+    }
+    const queuedMessage = await this.sendMessage(delegateId, message, { triggerFollowup: true });
+    const contextPack = createDelegatedContextPack({
+      taskName: queuedMessage.taskName,
+      message,
+      parentRunId: queuedMessage.parentRunId,
+      parentTurnId: queuedMessage.parentTurnId,
+      parentSessionKey: queuedMessage.parentSessionKey,
+      forkTurns: queuedMessage.forkTurns,
+      forkedMessages: queuedMessage.contextPack?.forkedMessages.map(cloneAgentMessage) ?? [],
+      runtimePolicy: {
+        model: queuedMessage.model,
+        permissionProfile: queuedMessage.permissionProfile,
+        approvalPolicy: queuedMessage.approvalPolicy,
+        approvalReviewer: queuedMessage.approvalReviewer,
+        cwd: queuedMessage.cwd,
+        workspace: queuedMessage.workspace,
+        toolLimits: queuedMessage.toolLimits,
+      },
+    });
+    const spawned = await this.runtime.runExisting(delegateId, {
+      task: message,
+      label: queuedMessage.label,
+      sessionKey: queuedMessage.parentSessionKey,
+      metadata: {
+        traceId: queuedMessage.traceRef,
+        parentRunId: queuedMessage.parentRunId,
+        parentTurnId: queuedMessage.parentTurnId,
+        origin: "delegated_followup",
+        taskName: queuedMessage.taskName,
+        delegatedContextPack: contextPack,
+      },
+      onComplete: (completion) => this.handleRuntimeCompletion(completion),
+    } satisfies SubagentSpawnRequest);
+    const running = this.registry.update(delegateId, {
+      status: spawned.queued ? "queued" : "running",
+      result: undefined,
+      approvalState: undefined,
+      queued: spawned.queued,
+      runningCount: spawned.runningCount,
+      queuedCount: spawned.queuedCount,
+      startMessage: spawned.message,
+    });
+    this.emitDelegatedEvent("agent.delegate.running", running, {
+      latest_activity: spawned.message,
+      followup: true,
+    });
+    return running;
+  }
+
+  async closeAgent(delegateId: string): Promise<DelegatedRun> {
+    await this.restoreRunsFromStore({}, new Set([delegateId]));
     const run = this.registry.close(delegateId);
     this.emitDelegatedEvent("agent.delegate.closed", run, { latest_activity: run.result?.summary ?? "Delegated run closed." });
     return run;
+  }
+
+  async interruptAgent(delegateId: string): Promise<DelegatedRun> {
+    await this.restoreRunsFromStore({}, new Set([delegateId]));
+    const current = this.registry.require(delegateId);
+    if (isFinalDelegatedStatus(current.status)) {
+      return current;
+    }
+    this.runtime.cancel(delegateId);
+    let interrupted = this.registry.update(delegateId, {
+      status: "cancelled",
+      result: {
+        status: "cancelled",
+        summary: "Delegated run interrupted.",
+      },
+    });
+    interrupted = this.registry.appendTraceStep(delegateId, {
+      id: `interrupted:${delegateId}`,
+      kind: "error",
+      status: "cancelled",
+      title: "Interrupted",
+      summary: "Delegated run interrupted.",
+      createdAt: this.now(),
+      updatedAt: this.now(),
+    });
+    this.emitDelegatedEvent("agent.delegate.trace.updated", interrupted, {
+      latest_activity: "Delegated run interrupted.",
+      trace: interrupted.trace,
+    });
+    this.emitDelegatedEvent("agent.delegate.interrupted", interrupted, {
+      latest_activity: "Delegated run interrupted.",
+    });
+    return interrupted;
+  }
+
+  private async restoreRunsFromStore(
+    filter: DelegatedRunRegistryListFilter = {},
+    delegateIds?: Set<string>,
+  ): Promise<void> {
+    if (!this.runStore) {
+      return;
+    }
+    const records = await this.runStore.listRuns("trace-delegated-run-restore").catch(() => []);
+    for (const record of records) {
+      if (delegateIds && !delegateIds.has(record.id)) {
+        continue;
+      }
+      const current = this.registry.get(record.id);
+      const restored = delegatedRunFromBackgroundRunRecord(record, { orphanedActive: !current });
+      if (!restored || !matchesDelegatedRunFilter(restored, filter)) {
+        continue;
+      }
+      if (current) {
+        this.registry.update(restored.delegateId, {
+          ...restored,
+          messages: current.messages.length ? current.messages : restored.messages,
+        });
+      } else {
+        this.registry.create(restored);
+      }
+    }
   }
 
   appendTraceStep(delegateId: string, step: DelegatedTraceStep): DelegatedRun {
@@ -512,16 +623,202 @@ export class DelegatedRunManager {
     return run;
   }
 
+  private async handleRuntimeCompletion(completion: SubagentCompletion): Promise<void> {
+    const existing = this.registry.get(completion.id);
+    if (existing?.status === "cancelled" || existing?.status === "closed") {
+      return;
+    }
+    const metadataTrace = delegatedTraceFromMetadata(completion.metadata);
+    if (metadataTrace) {
+      this.registry.update(completion.id, { trace: metadataTrace });
+    }
+    const approvalState = delegatedApprovalStateFromMetadata(completion.id, completion.metadata);
+    if (completion.status === "awaiting_approval" || approvalState) {
+      const nextApprovalState = approvalState ?? {
+        approvalId: "",
+        delegateId: completion.id,
+        childRunId: completion.id,
+        childToolCallId: "",
+        toolName: "tool",
+        status: "approval_required",
+      } satisfies DelegatedApprovalState;
+      const awaiting = this.registry.update(completion.id, {
+        status: "awaiting_approval",
+        approvalState: nextApprovalState,
+      });
+      this.emitDelegatedEvent("agent.delegate.awaiting_approval", awaiting, {
+        approvalId: nextApprovalState.approvalId,
+        approval_id: nextApprovalState.approvalId,
+        childToolCallId: nextApprovalState.childToolCallId,
+        child_tool_call_id: nextApprovalState.childToolCallId,
+        toolName: nextApprovalState.toolName,
+        tool_name: nextApprovalState.toolName,
+        latest_activity: "Waiting for approval.",
+        operation_preview: nextApprovalState.operationPreview,
+        reason: nextApprovalState.reason,
+        status: "blocked",
+      });
+      return;
+    }
+    const status = completion.status === "completed" ? "completed" : "failed";
+    const current = this.registry.get(completion.id);
+    if (current?.approvalState?.status === "approval_required") {
+      const resolution = delegatedApprovalResolutionFromMetadata(completion.metadata) ?? "approved";
+      const resolutionLabel = resolution === "denied" ? "Denied" : "Approved";
+      const resolvedApproval: DelegatedApprovalState = {
+        ...current.approvalState,
+        status: resolution,
+      };
+      this.registry.update(completion.id, { approvalState: resolvedApproval });
+      const resolved = this.registry.appendTraceStep(completion.id, {
+        id: `approval:${resolvedApproval.approvalId}`,
+        kind: "approval",
+        status: "completed",
+        title: `${resolvedApproval.toolName || "tool"} approval resolved`,
+        summary: `${resolutionLabel}: ${resolvedApproval.approvalId}`,
+        approvalId: resolvedApproval.approvalId,
+        toolName: resolvedApproval.toolName,
+        toolCallId: resolvedApproval.childToolCallId,
+        resultPreview: `${resolutionLabel}.`,
+        createdAt: this.now(),
+        updatedAt: this.now(),
+      });
+      this.emitDelegatedEvent("agent.delegate.trace.updated", resolved, {
+        latest_activity: `${resolutionLabel}: ${resolvedApproval.approvalId}`,
+        trace: resolved.trace,
+      });
+    }
+    let completed = this.registry.update(completion.id, {
+      status,
+      result: {
+        status,
+        summary: completion.result,
+        ...(completion.error ? { error: completion.error } : {}),
+      },
+    });
+    completed = this.registry.appendTraceStep(completion.id, {
+      id: `final:${completion.id}`,
+      kind: completion.error ? "error" : "message",
+      status: completion.error ? "failed" : "completed",
+      title: completion.error ? "Error" : "Final answer",
+      summary: completion.error ?? completion.result,
+      error: completion.error,
+      createdAt: this.now(),
+      updatedAt: this.now(),
+    });
+    this.emitDelegatedEvent("agent.delegate.trace.updated", completed, {
+      latest_activity: completion.error ?? completion.result,
+      trace: completed.trace,
+    });
+    this.emitDelegatedEvent(status === "completed" ? "agent.delegate.completed" : "agent.delegate.failed", completed, {
+      final_output: completion.result,
+      latest_activity: completion.error ?? completion.result,
+    });
+  }
+
   private emitDelegatedEvent(eventName: DelegatedRunEventName, run: DelegatedRun, extra: Record<string, unknown> = {}): void {
+    const payload = {
+      ...delegatedRunEventPayload(run),
+      ...extra,
+    };
     this.emitEvent({
       eventName,
-      payload: {
-        ...delegatedRunEventPayload(run),
-        ...extra,
-      },
+      payload,
       run,
       traceId: run.traceRef,
     });
+    this.appendTraceJournalEvent(eventName, run, payload);
+  }
+
+  private appendTraceJournalEvent(
+    eventName: DelegatedRunEventName,
+    run: DelegatedRun,
+    payload: Record<string, unknown>,
+  ): void {
+    if (!this.traceJournal) {
+      return;
+    }
+    const sequence = this.nextTraceSequence(run.traceRef || run.delegateId);
+    void this.traceJournal.appendTraceEvent({
+      eventId: `${run.delegateId}:${sequence}:${eventName}`,
+      eventType: eventName,
+      sessionKey: run.parentSessionKey,
+      turnId: run.parentTurnId,
+      delegateId: run.delegateId,
+      childRunId: run.childRunId,
+      traceRef: run.traceRef,
+      sequence,
+      createdAt: this.now(),
+      payload,
+    }, run.traceRef).catch(() => {});
+    this.appendChildTraceJournalEvents(eventName, run, payload);
+  }
+
+  private nextTraceSequence(traceRef: string): number {
+    const next = (this.traceSequences.get(traceRef) ?? 0) + 1;
+    this.traceSequences.set(traceRef, next);
+    return next;
+  }
+
+  private appendChildTraceJournalEvents(
+    eventName: DelegatedRunEventName,
+    run: DelegatedRun,
+    payload: Record<string, unknown>,
+  ): void {
+    if (!this.traceJournal || eventName !== "agent.delegate.trace.updated") {
+      return;
+    }
+    const trace = recordValue(payload.trace);
+    const steps = Array.isArray(trace?.steps)
+      ? trace.steps.filter(isDelegatedTraceStep)
+      : [];
+    for (const step of steps) {
+      const childEventType = childTraceEventType(step);
+      if (childEventType) {
+        this.appendChildTraceJournalEvent(run, step, childEventType);
+      }
+      if (step.kind === "tool_call" && step.argsPreview) {
+        this.appendChildTraceJournalEvent(run, step, "child.tool.arguments.delta");
+      }
+    }
+  }
+
+  private appendChildTraceJournalEvent(
+    run: DelegatedRun,
+    step: DelegatedTraceStep,
+    eventType: string,
+  ): void {
+    if (!this.traceJournal) {
+      return;
+    }
+    const sequence = this.nextTraceSequence(run.traceRef || run.delegateId);
+    void this.traceJournal.appendTraceEvent({
+      eventId: `${run.delegateId}:${sequence}:${eventType}:${step.id}`,
+      eventType,
+      sessionKey: run.parentSessionKey,
+      turnId: run.parentTurnId,
+      delegateId: run.delegateId,
+      childRunId: run.childRunId,
+      childStepId: step.id,
+      traceRef: run.traceRef,
+      sequence,
+      createdAt: step.updatedAt || step.createdAt || this.now(),
+      payload: {
+        ...delegatedRunEventPayload(run),
+        child_step_id: step.id,
+        childStepId: step.id,
+        step,
+        step_kind: step.kind,
+        step_status: step.status,
+        summary: step.summary,
+        tool_call_id: step.toolCallId,
+        tool_name: step.toolName,
+        approval_id: step.approvalId,
+        args_preview: step.argsPreview,
+        result_preview: step.resultPreview,
+        error: step.error,
+      },
+    }, run.traceRef).catch(() => {});
   }
 }
 
@@ -605,13 +902,196 @@ function delegatedApprovalStateFromMetadata(
   };
 }
 
+function delegatedApprovalResolutionFromMetadata(
+  metadata: Record<string, unknown> | undefined,
+): "approved" | "denied" | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const status = stringMetadata(metadata, "approvalStatus")
+    ?? stringMetadata(metadata, "approval_status")
+    ?? stringMetadata(metadata, "_delegate_approval_status")
+    ?? stringMetadata(metadata, "status");
+  if (status === "approved" || status === "denied") {
+    return status;
+  }
+  if (metadata.approved === true) {
+    return "approved";
+  }
+  if (metadata.approved === false) {
+    return "denied";
+  }
+  return undefined;
+}
+
+function delegatedRunFromBackgroundRunRecord(
+  record: BackgroundRunRecord,
+  options: { orphanedActive?: boolean } = {},
+): DelegatedRun | undefined {
+  if (record.kind !== "subagent") {
+    return undefined;
+  }
+  const metadata = recordValue(record.metadata) ?? {};
+  const contextPack = delegatedContextPackFromMetadata(metadata);
+  const taskName = normalizeTaskName(
+    stringMetadata(metadata, "taskName")
+      ?? contextPack?.taskName
+      ?? record.label
+      ?? record.id,
+  );
+  const storedStatus = isDelegatedRunStatus(record.status) ? record.status : "running";
+  const status = options.orphanedActive && (storedStatus === "running" || storedStatus === "queued")
+    ? "failed"
+    : storedStatus;
+  const parentRunId = stringMetadata(metadata, "parentRunId") ?? contextPack?.parentRunId ?? "";
+  const parentTurnId = stringMetadata(metadata, "parentTurnId") ?? contextPack?.parentTurnId ?? parentRunId;
+  const parentSessionKey = contextPack?.parentSessionKey ?? record.sessionKey ?? "";
+  const traceRef = stringMetadata(metadata, "traceId") ?? stringMetadata(metadata, "traceRef") ?? `trace-delegate-${record.id}`;
+  const approvalState = delegatedApprovalStateFromMetadata(record.id, metadata) ?? undefined;
+  const trace = delegatedTraceFromMetadata(metadata);
+  return {
+    delegateId: record.id,
+    childRunId: stringMetadata(metadata, "childRunId") ?? stringMetadata(metadata, "_delegate_child_run_id") ?? record.id,
+    taskName,
+    agentPath: `/${taskName}`,
+    parentRunId,
+    parentTurnId,
+    parentSessionKey,
+    label: record.label ?? taskName,
+    task: contextPack?.message ?? stringMetadata(metadata, "task") ?? record.label ?? taskName,
+    status,
+    model: contextPack?.runtimePolicy.model ?? stringMetadata(metadata, "model"),
+    permissionProfile: contextPack?.runtimePolicy.permissionProfile ?? "read_only",
+    approvalPolicy: contextPack?.runtimePolicy.approvalPolicy ?? "ask_on_sensitive_action",
+    approvalReviewer: contextPack?.runtimePolicy.approvalReviewer,
+    cwd: contextPack?.runtimePolicy.cwd,
+    workspace: contextPack?.runtimePolicy.workspace,
+    toolLimits: contextPack?.runtimePolicy.toolLimits,
+    forkTurns: contextPack?.forkTurns ?? "none",
+    traceRef,
+    createdAt: new Date(record.startedAtMs).toISOString(),
+    updatedAt: new Date(record.updatedAtMs).toISOString(),
+    queued: status === "queued",
+    runningCount: 0,
+    queuedCount: 0,
+    startMessage: record.result ?? record.label ?? `Delegated run [${taskName}] restored.`,
+    contextPack,
+    result: finalResultFromBackgroundRunRecord(record, status),
+    approvalState,
+    messages: [],
+    trace,
+  };
+}
+
+function finalResultFromBackgroundRunRecord(
+  record: BackgroundRunRecord,
+  status: DelegatedRunStatus,
+): DelegatedRunResult | undefined {
+  if (status !== "completed" && status !== "failed" && status !== "cancelled") {
+    return undefined;
+  }
+  const orphanedActiveSummary = (
+    status === "failed"
+    && (record.status === "running" || record.status === "queued")
+  )
+    ? `Delegated run ${record.id} was restored from a persisted ${record.status} state, but no live delegated runtime owns it.`
+    : undefined;
+  const summary = orphanedActiveSummary ?? record.result ?? record.error ?? "";
+  return {
+    status,
+    summary,
+    ...(record.error || orphanedActiveSummary ? { error: record.error ?? orphanedActiveSummary } : {}),
+  };
+}
+
+function delegatedContextPackFromMetadata(metadata: Record<string, unknown>): DelegatedContextPack | undefined {
+  const raw = recordValue(metadata.delegatedContextPack);
+  if (!raw || raw.kind !== "delegated_context_pack") {
+    return undefined;
+  }
+  const taskName = stringMetadata(raw, "taskName");
+  const message = stringMetadata(raw, "message");
+  const parentRunId = stringMetadata(raw, "parentRunId");
+  const parentTurnId = stringMetadata(raw, "parentTurnId");
+  const parentSessionKey = stringMetadata(raw, "parentSessionKey");
+  const runtimePolicy = recordValue(raw.runtimePolicy);
+  if (!taskName || !message || !parentRunId || !parentTurnId || !parentSessionKey || !runtimePolicy) {
+    return undefined;
+  }
+  const forkTurns = isForkTurnsValue(raw.forkTurns) ? normalizeForkTurns(raw.forkTurns) : "none";
+  return {
+    kind: "delegated_context_pack",
+    taskName,
+    message,
+    parentRunId,
+    parentTurnId,
+    parentSessionKey,
+    forkTurns,
+    forkedMessages: Array.isArray(raw.forkedMessages)
+      ? raw.forkedMessages.filter(isAgentMessage).map(cloneAgentMessage)
+      : [],
+    runtimePolicy: {
+      model: stringMetadata(runtimePolicy, "model"),
+      permissionProfile: stringMetadata(runtimePolicy, "permissionProfile") ?? "read_only",
+      approvalPolicy: stringMetadata(runtimePolicy, "approvalPolicy") ?? "ask_on_sensitive_action",
+      approvalReviewer: stringMetadata(runtimePolicy, "approvalReviewer"),
+      cwd: stringMetadata(runtimePolicy, "cwd"),
+      workspace: stringMetadata(runtimePolicy, "workspace"),
+      toolLimits: recordValue(runtimePolicy.toolLimits),
+    },
+    outputContract: stringMetadata(raw, "outputContract")
+      ?? "Return only a concise result summary suitable for the parent agent; keep raw trace details behind the trace reference.",
+  };
+}
+
+function isAgentMessage(value: unknown): value is AgentMessage {
+  const message = recordValue(value);
+  return Boolean(
+    message
+    && (message.role === "system" || message.role === "user" || message.role === "assistant" || message.role === "tool")
+    && typeof message.content === "string",
+  );
+}
+
+function matchesDelegatedRunFilter(run: DelegatedRun, filter: DelegatedRunRegistryListFilter): boolean {
+  return (!filter.parentSessionKey || run.parentSessionKey === filter.parentSessionKey)
+    && (!filter.parentRunId || run.parentRunId === filter.parentRunId)
+    && (!filter.pathPrefix || run.agentPath.startsWith(filter.pathPrefix))
+    && (!filter.status || run.status === filter.status);
+}
+
+function isForkTurnsValue(value: unknown): value is "none" | "all" | `${number}` {
+  return value === "none" || value === "all" || (typeof value === "string" && /^[1-9][0-9]*$/.test(value));
+}
+
 function cloneRun(run: DelegatedRun): DelegatedRun {
   return {
     ...run,
     result: run.result ? { ...run.result, artifacts: run.result.artifacts ? [...run.result.artifacts] : undefined } : undefined,
     approvalState: run.approvalState ? { ...run.approvalState } : undefined,
+    contextPack: run.contextPack ? cloneContextPack(run.contextPack) : undefined,
     messages: run.messages.map((message) => ({ ...message })),
     trace: run.trace ? cloneTrace(run.trace) : undefined,
+  };
+}
+
+function cloneContextPack(pack: DelegatedContextPack): DelegatedContextPack {
+  return {
+    ...pack,
+    forkedMessages: pack.forkedMessages.map(cloneAgentMessage),
+    runtimePolicy: {
+      ...pack.runtimePolicy,
+      toolLimits: pack.runtimePolicy.toolLimits ? { ...pack.runtimePolicy.toolLimits } : undefined,
+    },
+  };
+}
+
+function cloneAgentMessage(message: AgentMessage): AgentMessage {
+  return {
+    ...message,
+    toolCalls: message.toolCalls?.map((toolCall) => ({ ...toolCall })),
+    thinkingBlocks: message.thinkingBlocks?.map((block) => ({ ...block })),
+    metadata: message.metadata ? { ...message.metadata } : undefined,
   };
 }
 
@@ -657,6 +1137,137 @@ function createDelegatedContextPack(
     ...input,
     outputContract: "Return only a concise result summary suitable for the parent agent; keep raw trace details behind the trace reference.",
   };
+}
+
+function delegatedTraceFromMetadata(metadata: Record<string, unknown> | undefined): DelegatedRunTrace | undefined {
+  const trace = recordValue(metadata?._delegate_trace);
+  if (!trace) {
+    return undefined;
+  }
+  const steps = Array.isArray(trace.steps)
+    ? trace.steps.filter(isDelegatedTraceStep)
+    : [];
+  return {
+    delegateId: stringMetadata(trace, "delegateId") || stringMetadata(trace, "delegate_id") || "",
+    childRunId: stringMetadata(trace, "childRunId") || stringMetadata(trace, "child_run_id") || "",
+    parentRunId: stringMetadata(trace, "parentRunId") || stringMetadata(trace, "parent_run_id") || "",
+    parentSessionKey: stringMetadata(trace, "parentSessionKey") || stringMetadata(trace, "parent_session_key") || "",
+    status: isDelegatedRunStatus(trace.status) ? trace.status : "running",
+    steps,
+    approvals: Array.isArray(trace.approvals)
+      ? trace.approvals.filter(isDelegatedApprovalState)
+      : [],
+    artifacts: Array.isArray(trace.artifacts) ? trace.artifacts.filter(isRecord) : [],
+    updatedAt: stringMetadata(trace, "updatedAt") || stringMetadata(trace, "updated_at") || new Date().toISOString(),
+  };
+}
+
+function isDelegatedRunStatus(value: unknown): value is DelegatedRunStatus {
+  return value === "created"
+    || value === "queued"
+    || value === "running"
+    || value === "awaiting_approval"
+    || value === "completed"
+    || value === "failed"
+    || value === "cancelled"
+    || value === "closed";
+}
+
+function isDelegatedTraceStep(value: unknown): value is DelegatedTraceStep {
+  const step = recordValue(value);
+  return Boolean(
+    step
+    && typeof step.id === "string"
+    && typeof step.kind === "string"
+    && typeof step.status === "string"
+    && typeof step.title === "string"
+  );
+}
+
+function childTraceEventType(step: DelegatedTraceStep): string | null {
+  if (step.kind === "reasoning") {
+    return step.status === "completed" ? "child.reasoning.completed" : "child.reasoning.delta";
+  }
+  if (step.kind === "message") {
+    return step.status === "completed" ? "child.message.completed" : "child.message.delta";
+  }
+  if (step.kind === "tool_call") {
+    if (step.status === "completed") {
+      return "child.tool.completed";
+    }
+    if (step.status === "failed") {
+      return "child.tool.failed";
+    }
+    return "child.tool.started";
+  }
+  if (step.kind === "approval") {
+    return step.status === "completed" ? "child.approval.resolved" : "child.approval.requested";
+  }
+  if (step.kind === "artifact") {
+    return "child.artifact.created";
+  }
+  return null;
+}
+
+function isDelegatedApprovalState(value: unknown): value is DelegatedApprovalState {
+  const approval = recordValue(value);
+  return Boolean(
+    approval
+    && typeof approval.approvalId === "string"
+    && typeof approval.delegateId === "string"
+    && typeof approval.childRunId === "string"
+    && typeof approval.childToolCallId === "string"
+    && typeof approval.toolName === "string"
+    && typeof approval.status === "string"
+  );
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function buildForkedParentMessages(
+  parentMessages: AgentMessage[],
+  forkTurns: "none" | "all" | `${number}`,
+): AgentMessage[] {
+  if (forkTurns === "none") {
+    return [];
+  }
+  const sanitized = parentMessages
+    .map(sanitizeForkedParentMessage)
+    .filter((message): message is AgentMessage => message !== undefined);
+  if (forkTurns === "all") {
+    return sanitized;
+  }
+  const turnCount = Number.parseInt(forkTurns, 10);
+  if (!Number.isFinite(turnCount) || turnCount <= 0) {
+    return [];
+  }
+  const userTurnIndexes = sanitized
+    .map((message, index) => message.role === "user" ? index : -1)
+    .filter((index) => index >= 0);
+  const keepIndex = userTurnIndexes.length > turnCount
+    ? userTurnIndexes[userTurnIndexes.length - turnCount]
+    : 0;
+  return sanitized.slice(keepIndex);
+}
+
+function sanitizeForkedParentMessage(message: AgentMessage): AgentMessage | undefined {
+  const content = message.content.trim();
+  if (!content) {
+    return undefined;
+  }
+  if (message.role === "system" || message.role === "user") {
+    return { role: message.role, content };
+  }
+  if (message.role === "assistant" && !message.toolCalls?.length && !message.toolCallId && !message.name) {
+    return { role: "assistant", content };
+  }
+  return undefined;
 }
 
 function normalizeForkTurns(value: "none" | "all" | `${number}`): "none" | "all" | `${number}` {

--- a/apps/desktop/workers/ts-agent-worker/src/background/spawnTool.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/background/spawnTool.test.ts
@@ -92,6 +92,8 @@ describe("createDelegatedAgentTools", () => {
       "wait_agent",
       "list_agents",
       "send_message",
+      "followup_task",
+      "interrupt_agent",
       "close_agent",
     ]);
     expect(tools.spawn_agent.parameters).toMatchObject({
@@ -99,6 +101,7 @@ describe("createDelegatedAgentTools", () => {
       properties: {
         task_name: { type: "string" },
         message: { type: "string" },
+        fork_context: { type: "boolean" },
         fork_turns: { type: "string" },
         permission_profile: { type: "string" },
       },
@@ -110,6 +113,13 @@ describe("createDelegatedAgentTools", () => {
         timeout_ms: { type: "integer" },
       },
     });
+    expect(tools.list_agents.parameters).toMatchObject({
+      properties: {
+        path_prefix: { type: "string" },
+        status: { type: "string" },
+      },
+    });
+    expect(tools.send_message.parameters.properties).not.toHaveProperty("trigger_followup");
 
     const spawn = await tools.spawn_agent.execute(
       {
@@ -140,6 +150,7 @@ describe("createDelegatedAgentTools", () => {
     expect(wait.metadata).toMatchObject({
       _delegated_wait: true,
       _delegated_active: [],
+      _delegated_awaiting_approval: [],
       _delegated_timed_out: [],
     });
 
@@ -151,11 +162,284 @@ describe("createDelegatedAgentTools", () => {
       { runId: "run-1" },
     );
     expect(message.content).toContain("\"message\": \"Please include tests\"");
+    expect(message.content).toContain("\"triggerFollowup\": false");
+
+    const followup = await tools.followup_task.execute(
+      { target: "delegate-1", message: "Now summarize the tests" },
+      { runId: "run-1" },
+    );
+    expect(followup.metadata).toMatchObject({
+      _delegate_id: "delegate-1",
+      _delegate_status: "running",
+    });
+    const followupWait = await tools.wait_agent.execute(
+      { target: "delegate-1", timeout_ms: 1000 },
+      { runId: "run-1" },
+    );
+    expect(followupWait.content).toContain("\"summary\": \"review complete\"");
 
     const close = await tools.close_agent.execute({ target: "delegate-1" }, { runId: "run-1" });
     expect(close.metadata).toMatchObject({
       _delegate_id: "delegate-1",
       _delegate_status: "closed",
+    });
+  });
+
+  test("interrupt_agent cancels an active delegated run", async () => {
+    const runtime = new SubagentRuntime({
+      idGenerator: () => "delegate-interrupt",
+      runner: async (request) => new Promise((resolve) => {
+        request.signal.addEventListener("abort", () => resolve({
+          status: "failed",
+          result: "Subagent cancelled.",
+          error: "Subagent cancelled.",
+        }), { once: true });
+      }),
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+    const tools = Object.fromEntries(createDelegatedAgentTools({ manager }).map((tool) => [tool.name, tool]));
+
+    await tools.spawn_agent.execute(
+      { task_name: "Long task", message: "Keep running" },
+      { runId: "run-1", traceId: "trace-1", sessionId: "desktop:chat-1" },
+    );
+    const interrupt = await tools.interrupt_agent.execute(
+      { target: "delegate-interrupt" },
+      { runId: "run-1" },
+    );
+
+    expect(interrupt.content).toContain("\"status\": \"cancelled\"");
+    expect(interrupt.metadata).toMatchObject({
+      _delegate_id: "delegate-interrupt",
+      _delegate_status: "cancelled",
+    });
+  });
+
+  test("requires a stable task_name for Codex-style spawn_agent arguments", async () => {
+    const requests: SubagentRunRequest[] = [];
+    const runtime = new SubagentRuntime({
+      idGenerator: () => "delegate-codex",
+      runner: async (request) => {
+        requests.push(request);
+        return { status: "completed", result: "child final output" };
+      },
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+    const tools = Object.fromEntries(createDelegatedAgentTools({ manager }).map((tool) => [tool.name, tool]));
+
+    await expect(tools.spawn_agent.execute(
+      {
+        message: "Review the approval flow and summarize risks",
+        fork_context: true,
+        model: "test-model",
+      },
+      { runId: "run-1", traceId: "trace-1", sessionId: "desktop:chat-1" },
+    )).rejects.toThrow("task_name is required for spawn_agent");
+    expect(requests).toEqual([]);
+  });
+
+  test("filters listed delegated agents by path prefix", async () => {
+    const runtime = new SubagentRuntime({
+      idGenerator: (() => {
+        let index = 0;
+        return () => `delegate-${index += 1}`;
+      })(),
+      runner: async () => new Promise(() => {}),
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+    const tools = Object.fromEntries(createDelegatedAgentTools({ manager }).map((tool) => [tool.name, tool]));
+
+    await tools.spawn_agent.execute(
+      { task_name: "Research API", message: "Research API docs" },
+      { runId: "run-1", sessionId: "desktop:chat-1" },
+    );
+    await tools.spawn_agent.execute(
+      { task_name: "Write Summary", message: "Write a summary" },
+      { runId: "run-1", sessionId: "desktop:chat-1" },
+    );
+
+    const result = await tools.list_agents.execute(
+      { path_prefix: "/research" },
+      { runId: "run-1", sessionId: "desktop:chat-1" },
+    );
+
+    expect(result.content).toContain("\"taskName\": \"research_api\"");
+    expect(result.content).not.toContain("\"taskName\": \"write_summary\"");
+    expect(result.metadata?._delegated_runs).toEqual([
+      expect.objectContaining({ _delegate_task_name: "research_api" }),
+    ]);
+  });
+
+  test("restores persisted delegated runs before listing and waiting", async () => {
+    const runtime = new SubagentRuntime({
+      runner: async () => {
+        throw new Error("restored completed run should not start a child turn");
+      },
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      runStore: {
+        listRuns: async () => [{
+          id: "delegate-restored",
+          kind: "subagent",
+          source: "subagent",
+          status: "completed",
+          label: "Say hello",
+          sessionKey: "WebSocket:chat-1",
+          startedAtMs: 1000,
+          updatedAtMs: 2000,
+          completedAtMs: 2000,
+          result: "你好",
+          error: null,
+          metadata: {
+            parentRunId: "parent-run",
+            parentTurnId: "turn-1",
+            taskName: "say_hello",
+            traceId: "trace-restored",
+            delegatedContextPack: {
+              kind: "delegated_context_pack",
+              taskName: "say_hello",
+              message: "Say hello",
+              parentRunId: "parent-run",
+              parentTurnId: "turn-1",
+              parentSessionKey: "WebSocket:chat-1",
+              forkTurns: "none",
+              forkedMessages: [],
+              runtimePolicy: {
+                permissionProfile: "read_only",
+                approvalPolicy: "ask_on_sensitive_action",
+              },
+              outputContract: "Return a compact result.",
+            },
+          },
+        }],
+      },
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+    const tools = Object.fromEntries(createDelegatedAgentTools({ manager }).map((tool) => [tool.name, tool]));
+
+    const list = await tools.list_agents.execute({}, { runId: "run-live", sessionId: "WebSocket:chat-1" });
+    expect(list.content).toContain("\"delegateId\": \"delegate-restored\"");
+    expect(list.content).toContain("\"status\": \"completed\"");
+    expect(list.content).toContain("\"traceRef\": \"trace-restored\"");
+
+    const wait = await tools.wait_agent.execute(
+      { target: "delegate-restored", timeout_ms: 0 },
+      { runId: "run-live", sessionId: "WebSocket:chat-1" },
+    );
+    expect(wait.content).toContain("\"completed\": [");
+    expect(wait.content).toContain("\"delegate-restored\"");
+    expect(wait.content).toContain("\"summary\": \"你好\"");
+  });
+
+  test("marks persisted active delegated runs as failed when no live runtime owns them", async () => {
+    const runtime = new SubagentRuntime({
+      runner: async () => {
+        throw new Error("orphaned persisted run should not restart implicitly");
+      },
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      runStore: {
+        listRuns: async () => [{
+          id: "delegate-orphaned",
+          kind: "subagent",
+          source: "subagent",
+          status: "running",
+          label: "Long review",
+          sessionKey: "WebSocket:chat-1",
+          startedAtMs: 1000,
+          updatedAtMs: 2000,
+          result: "Subagent [Long review] started",
+          error: null,
+          metadata: {
+            parentRunId: "parent-run",
+            parentTurnId: "turn-1",
+            taskName: "long_review",
+            traceId: "trace-orphaned",
+            delegatedContextPack: {
+              kind: "delegated_context_pack",
+              taskName: "long_review",
+              message: "Review for a long time",
+              parentRunId: "parent-run",
+              parentTurnId: "turn-1",
+              parentSessionKey: "WebSocket:chat-1",
+              forkTurns: "none",
+              forkedMessages: [],
+              runtimePolicy: {
+                permissionProfile: "read_only",
+                approvalPolicy: "ask_on_sensitive_action",
+              },
+              outputContract: "Return a compact result.",
+            },
+          },
+        }],
+      },
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+    const tools = Object.fromEntries(createDelegatedAgentTools({ manager }).map((tool) => [tool.name, tool]));
+
+    const wait = await tools.wait_agent.execute(
+      { target: "delegate-orphaned", timeout_ms: 0 },
+      { runId: "run-live", sessionId: "WebSocket:chat-1" },
+    );
+
+    expect(wait.content).toContain("\"failed\": [");
+    expect(wait.content).toContain("\"delegate-orphaned\"");
+    expect(wait.content).toContain("no live delegated runtime owns it");
+    expect(wait.metadata).toMatchObject({
+      _delegated_active: [],
+      _delegated_failed: ["delegate-orphaned"],
+      _delegated_timed_out: [],
+    });
+  });
+
+  test("buckets wait_agent results by final delegated status", async () => {
+    const runtime = new SubagentRuntime({
+      idGenerator: (() => {
+        let index = 0;
+        return () => `delegate-${index += 1}`;
+      })(),
+      runner: async (request) => request.id === "delegate-2"
+        ? { status: "failed", result: "failed summary", error: "failed summary" }
+        : { status: "completed", result: "completed summary" },
+    });
+    const manager = new DelegatedRunManager({
+      runtime,
+      now: () => "2026-06-27T12:00:00.000Z",
+    });
+    const tools = Object.fromEntries(createDelegatedAgentTools({ manager }).map((tool) => [tool.name, tool]));
+
+    await tools.spawn_agent.execute(
+      { task_name: "Done Task", message: "Complete this task" },
+      { runId: "run-1", sessionId: "desktop:chat-1" },
+    );
+    await tools.spawn_agent.execute(
+      { task_name: "Fail Task", message: "Fail this task" },
+      { runId: "run-1", sessionId: "desktop:chat-1" },
+    );
+
+    const result = await tools.wait_agent.execute(
+      { targets: ["delegate-1", "delegate-2"], timeout_ms: 1000 },
+      { runId: "run-1", sessionId: "desktop:chat-1" },
+    );
+
+    expect(result.content).toContain("\"completed\": [");
+    expect(result.content).toContain("\"delegate-1\"");
+    expect(result.content).toContain("\"failed\": [");
+    expect(result.content).toContain("\"delegate-2\"");
+    expect(result.metadata).toMatchObject({
+      _delegated_completed: ["delegate-1"],
+      _delegated_failed: ["delegate-2"],
     });
   });
 });

--- a/apps/desktop/workers/ts-agent-worker/src/background/spawnTool.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/background/spawnTool.ts
@@ -1,4 +1,5 @@
 import type { Tool } from "../tools/tool.ts";
+import type { AgentMessage } from "../agent/agentRunSpec.ts";
 import type {
   DelegatedPermissionProfile,
   DelegatedParentContext,
@@ -12,7 +13,7 @@ import type {
 
 export type DelegatedAgentToolManager = Pick<
   DelegatedRunManager,
-  "spawnAgent" | "waitAgent" | "listAgents" | "sendMessage" | "closeAgent"
+  "spawnAgent" | "waitAgent" | "listAgents" | "sendMessage" | "followupTask" | "interruptAgent" | "closeAgent"
 >;
 
 export function createSpawnTool(options: { manager: DelegatedAgentToolManager }): Tool {
@@ -70,6 +71,8 @@ export function createDelegatedAgentTools(options: { manager: DelegatedAgentTool
     createWaitAgentTool(options.manager),
     createListAgentsTool(options.manager),
     createSendMessageTool(options.manager),
+    createFollowupTaskTool(options.manager),
+    createInterruptAgentTool(options.manager),
     createCloseAgentTool(options.manager),
   ];
 }
@@ -87,6 +90,13 @@ function createSpawnAgentTool(manager: DelegatedAgentToolManager): Tool {
         task_name: { type: "string", description: "Short stable task name for identifying the delegated run" },
         message: { type: "string", description: "The task contract/instructions for the delegated agent" },
         label: { type: "string", description: "Optional display label for the delegated run" },
+        agent_type: { type: "string", description: "Optional Codex-compatible agent role hint used as a fallback task name" },
+        model: { type: "string", description: "Optional model override for the delegated run" },
+        reasoning_effort: { type: "string", description: "Optional Codex-compatible reasoning hint recorded in metadata" },
+        fork_context: {
+          type: "boolean",
+          description: "Codex-compatible full-context fork flag. Ignored when fork_turns is provided.",
+        },
         fork_turns: {
           type: "string",
           description: "Parent context fork policy: none, all, or a positive integer string",
@@ -104,16 +114,24 @@ function createSpawnAgentTool(manager: DelegatedAgentToolManager): Tool {
     approvalRisk: "high",
     concurrencySafe: true,
     execute: async (args, context) => {
+      const message = nonEmptyStringArg(args, "message");
+      const label = cleanOptionalString(args.label);
+      const agentType = cleanOptionalString(args.agent_type);
+      const reasoningEffort = cleanOptionalString(args.reasoning_effort);
       const request: SpawnAgentRequest = {
-        taskName: nonEmptyStringArg(args, "task_name"),
-        message: nonEmptyStringArg(args, "message"),
-        label: cleanOptionalString(args.label),
-        forkTurns: forkTurnsArg(args.fork_turns),
+        taskName: requiredSpawnAgentTaskName(args),
+        message,
+        label,
+        forkTurns: forkTurnsArg(args.fork_turns) ?? forkTurnsFromForkContext(args.fork_context),
         permissionProfile: delegatedPermissionProfileArg(args.permission_profile) ?? "read_only",
+        model: cleanOptionalString(args.model),
         metadata: {
           ...(context.traceId ? { traceId: context.traceId } : {}),
           runId: context.runId,
           origin: "spawn_agent_tool",
+          ...(agentType ? { agentType } : {}),
+          ...(reasoningEffort ? { reasoningEffort } : {}),
+          ...(args.fork_context === true ? { forkContext: true } : {}),
         },
       };
       const run = await manager.spawnAgent(request, parentContext(context));
@@ -152,6 +170,9 @@ function createWaitAgentTool(manager: DelegatedAgentToolManager): Tool {
           _delegated_wait: true,
           _delegated_runs: result.runs.map(delegatedRunMetadata),
           _delegated_active: result.active,
+          _delegated_awaiting_approval: result.awaitingApproval,
+          _delegated_completed: delegatedRunIdsByStatus(result, "completed"),
+          _delegated_failed: delegatedRunIdsByStatus(result, "failed"),
           _delegated_timed_out: result.timedOut,
         },
       };
@@ -166,6 +187,7 @@ function createListAgentsTool(manager: DelegatedAgentToolManager): Tool {
     parameters: {
       type: "object",
       properties: {
+        path_prefix: { type: "string", description: "Optional agent path prefix, such as /review" },
         status: { type: "string", description: "Optional delegated run status filter" },
       },
     },
@@ -174,11 +196,13 @@ function createListAgentsTool(manager: DelegatedAgentToolManager): Tool {
     capabilities: ["background.read"],
     execute: async (args, context) => {
       const status = delegatedStatusArg(args.status);
+      const pathPrefix = pathPrefixArg(args.path_prefix);
       const filter: DelegatedRunRegistryListFilter = {
         ...(context.sessionId ? { parentSessionKey: context.sessionId } : {}),
+        ...(pathPrefix ? { pathPrefix } : {}),
         ...(status ? { status } : {}),
       };
-      const runs = manager.listAgents(filter);
+      const runs = await manager.listAgents(filter);
       return {
         content: jsonContent({ delegatedRuns: runs.map(delegatedRunHandle) }),
         metadata: {
@@ -199,18 +223,71 @@ function createSendMessageTool(manager: DelegatedAgentToolManager): Tool {
       properties: {
         target: { type: "string", description: "Delegated run id" },
         message: { type: "string", description: "Message to queue for the delegated agent" },
-        trigger_followup: { type: "boolean", description: "Whether the child should treat the message as follow-up input" },
       },
       required: ["target", "message"],
     },
     capabilities: ["background.write"],
     concurrencySafe: true,
     execute: async (args) => {
-      const run = manager.sendMessage(nonEmptyStringArg(args, "target"), nonEmptyStringArg(args, "message"), {
-        triggerFollowup: optionalBooleanArg(args, "trigger_followup") ?? false,
-      });
+      const run = await manager.sendMessage(
+        nonEmptyStringArg(args, "target"),
+        nonEmptyStringArg(args, "message"),
+      );
       return {
         content: jsonContent({ delegatedRun: delegatedRunHandle(run), queuedMessages: run.messages }),
+        metadata: delegatedRunMetadata(run),
+      };
+    },
+  };
+}
+
+function createFollowupTaskTool(manager: DelegatedAgentToolManager): Tool {
+  return {
+    name: "followup_task",
+    description: [
+      "Send a follow-up instruction to an existing delegated agent and trigger a new child turn.",
+      "Use send_message when you only want to queue a note without running the child.",
+    ].join(" "),
+    parameters: {
+      type: "object",
+      properties: {
+        target: { type: "string", description: "Delegated run id" },
+        message: { type: "string", description: "Follow-up instruction for the delegated agent" },
+      },
+      required: ["target", "message"],
+    },
+    capabilities: ["background.write"],
+    concurrencySafe: true,
+    execute: async (args) => {
+      const run = await manager.followupTask(
+        nonEmptyStringArg(args, "target"),
+        nonEmptyStringArg(args, "message"),
+      );
+      return {
+        content: jsonContent({ delegatedRun: delegatedRunHandle(run), queuedMessages: run.messages }),
+        metadata: delegatedRunMetadata(run),
+      };
+    },
+  };
+}
+
+function createInterruptAgentTool(manager: DelegatedAgentToolManager): Tool {
+  return {
+    name: "interrupt_agent",
+    description: "Interrupt an active delegated agent run without closing its history.",
+    parameters: {
+      type: "object",
+      properties: {
+        target: { type: "string", description: "Delegated run id" },
+      },
+      required: ["target"],
+    },
+    capabilities: ["background.write"],
+    concurrencySafe: true,
+    execute: async (args) => {
+      const run = await manager.interruptAgent(nonEmptyStringArg(args, "target"));
+      return {
+        content: jsonContent({ delegatedRun: delegatedRunHandle(run) }),
         metadata: delegatedRunMetadata(run),
       };
     },
@@ -231,7 +308,7 @@ function createCloseAgentTool(manager: DelegatedAgentToolManager): Tool {
     capabilities: ["background.write"],
     concurrencySafe: true,
     execute: async (args) => {
-      const run = manager.closeAgent(nonEmptyStringArg(args, "target"));
+      const run = await manager.closeAgent(nonEmptyStringArg(args, "target"));
       return {
         content: jsonContent({ delegatedRun: delegatedRunHandle(run) }),
         metadata: delegatedRunMetadata(run),
@@ -280,12 +357,13 @@ function spawnToolResult(run: DelegatedRun) {
   };
 }
 
-function parentContext(context: { runId: string; traceId?: string; sessionId?: string }): DelegatedParentContext {
+function parentContext(context: { runId: string; traceId?: string; sessionId?: string; parentMessages?: AgentMessage[] }): DelegatedParentContext {
   return {
     runId: context.runId,
     turnId: context.runId,
     sessionKey: context.sessionId,
     traceId: context.traceId,
+    parentMessages: context.parentMessages,
     permissionProfile: "full_access",
   };
 }
@@ -305,9 +383,18 @@ function delegatedRunHandle(run: DelegatedRun): Record<string, unknown> {
 function formatWaitAgentResult(result: WaitAgentResult): Record<string, unknown> {
   return {
     delegatedRuns: result.runs.map(delegatedRunHandle),
+    completed: delegatedRunIdsByStatus(result, "completed"),
+    failed: delegatedRunIdsByStatus(result, "failed"),
     active: result.active,
+    awaitingApproval: result.awaitingApproval,
     timedOut: result.timedOut,
   };
+}
+
+function delegatedRunIdsByStatus(result: WaitAgentResult, status: DelegatedRunStatus): string[] {
+  return result.runs
+    .filter((run) => run.status === status)
+    .map((run) => run.delegateId);
 }
 
 function delegatedRunMetadata(run: DelegatedRun): Record<string, unknown> {
@@ -343,6 +430,14 @@ function targetArgs(args: Record<string, unknown>): string[] {
   return allTargets;
 }
 
+function requiredSpawnAgentTaskName(args: Record<string, unknown>): string {
+  const taskName = cleanOptionalString(args.task_name);
+  if (!taskName) {
+    throw new Error("task_name is required for spawn_agent");
+  }
+  return taskName;
+}
+
 function forkTurnsArg(value: unknown): "none" | "all" | `${number}` | undefined {
   const cleaned = cleanOptionalString(value);
   if (!cleaned) {
@@ -355,6 +450,16 @@ function forkTurnsArg(value: unknown): "none" | "all" | `${number}` | undefined 
     return cleaned as `${number}`;
   }
   throw new Error("fork_turns must be none, all, or a positive integer string");
+}
+
+function forkTurnsFromForkContext(value: unknown): "all" | undefined {
+  if (value === undefined || value === false) {
+    return undefined;
+  }
+  if (value === true) {
+    return "all";
+  }
+  throw new Error("fork_context must be a boolean when provided");
 }
 
 function delegatedPermissionProfileArg(value: unknown): DelegatedPermissionProfile | undefined {
@@ -379,6 +484,14 @@ function delegatedStatusArg(value: unknown): DelegatedRunStatus | undefined {
     return cleaned as DelegatedRunStatus;
   }
   throw new Error("status must be a delegated run status");
+}
+
+function pathPrefixArg(value: unknown): string | undefined {
+  const cleaned = cleanOptionalString(value);
+  if (!cleaned) {
+    return undefined;
+  }
+  return cleaned.startsWith("/") ? cleaned : `/${cleaned}`;
 }
 
 function nonEmptyStringArg(args: Record<string, unknown>, key: string): string {

--- a/apps/desktop/workers/ts-agent-worker/src/background/subagentRuntime.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/background/subagentRuntime.test.ts
@@ -365,6 +365,65 @@ describe("SubagentRuntime", () => {
       { id: "subagent-2", status: "completed", result: "implementation complete" },
     ]);
   });
+
+  test("records awaiting approval subagents without completing them as failed", async () => {
+    const upserts: Array<{ id: string; status: string; result?: string | null; stopReason?: unknown }> = [];
+    const completes: Array<{ id: string; status: string; result: string }> = [];
+    const runtime = new SubagentRuntime({
+      idGenerator: () => "subagent-approval",
+      nowMs: (() => {
+        let now = 2000;
+        return () => {
+          now += 1;
+          return now;
+        };
+      })(),
+      registry: {
+        upsertRun: async (run) => {
+          upserts.push({
+            id: run.id,
+            status: run.status,
+            result: run.result,
+            stopReason: run.metadata?.stopReason,
+          });
+        },
+        completeRun: async (completion) => {
+          completes.push({
+            id: completion.runId,
+            status: completion.status,
+            result: completion.result ?? "",
+          });
+        },
+      },
+      runner: async () => ({
+        status: "awaiting_approval",
+        result: "Waiting for approval.",
+        metadata: {
+          awaitingUserInput: true,
+          stopReason: "awaiting_approval",
+          approvalId: "approval-1",
+        },
+      }),
+    });
+
+    await runtime.spawn({
+      task: "Write notes",
+      label: "Writer",
+      sessionKey: "desktop:chat-approval",
+    });
+    await waitFor(() => upserts.some((run) => run.status === "awaiting_approval"));
+
+    expect(upserts).toEqual([
+      { id: "subagent-approval", status: "running", result: undefined, stopReason: undefined },
+      {
+        id: "subagent-approval",
+        status: "awaiting_approval",
+        result: "Waiting for approval.",
+        stopReason: "awaiting_approval",
+      },
+    ]);
+    expect(completes).toEqual([]);
+  });
 });
 
 async function waitFor(condition: () => boolean, attempts = 20): Promise<void> {

--- a/apps/desktop/workers/ts-agent-worker/src/background/subagentRuntime.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/background/subagentRuntime.ts
@@ -5,7 +5,7 @@ import type {
   BackgroundRunStatus,
 } from "./backgroundRegistryBridge.ts";
 
-export type SubagentStatus = "completed" | "failed";
+export type SubagentStatus = "completed" | "failed" | "awaiting_approval";
 
 export interface SubagentSpawnRequest {
   task: string;
@@ -93,6 +93,14 @@ export class SubagentRuntime {
 
   async spawn(request: SubagentSpawnRequest): Promise<SubagentSpawnResult> {
     const id = this.idGenerator();
+    return this.startRequest(id, request);
+  }
+
+  async runExisting(id: string, request: SubagentSpawnRequest): Promise<SubagentSpawnResult> {
+    return this.startRequest(id, request);
+  }
+
+  private startRequest(id: string, request: SubagentSpawnRequest): SubagentSpawnResult {
     const label = request.label || shortLabel(request.task);
     const queued: QueuedSubagent = { request, id, label, controller: new AbortController() };
     this.trackSession(request.sessionKey, id);
@@ -138,6 +146,7 @@ export class SubagentRuntime {
       status: completion.status,
       result: completion.result,
       ...(completion.error ? { error: completion.error } : {}),
+      ...(completion.metadata ? { metadata: completion.metadata } : {}),
     };
   }
 
@@ -159,6 +168,10 @@ export class SubagentRuntime {
 
   cancelPlan(planId: string): number {
     return this.cancelWhere((entry) => entry.request.metadata?.planId === planId);
+  }
+
+  cancel(id: string): boolean {
+    return this.cancelWhere((entry) => entry.id === id) > 0;
   }
 
   private start(entry: QueuedSubagent): void {
@@ -283,6 +296,10 @@ export class SubagentRuntime {
   }
 
   private recordCompletion(entry: QueuedSubagent, result: SubagentRunResult): void {
+    if (result.status === "awaiting_approval") {
+      this.recordAwaitingApproval(entry, result);
+      return;
+    }
     const completion: BackgroundRunCompletion = {
       runId: entry.id,
       status: completionStatus(entry, result),
@@ -291,6 +308,28 @@ export class SubagentRuntime {
       error: result.error ?? null,
     };
     void this.registry?.completeRun(completion, traceIdFor(entry)).catch(() => {});
+  }
+
+  private recordAwaitingApproval(entry: QueuedSubagent, result: SubagentRunResult): void {
+    const now = this.nowMs();
+    void this.registry?.upsertRun({
+      id: entry.id,
+      kind: "subagent",
+      source: this.source,
+      status: "awaiting_approval",
+      label: entry.label,
+      sessionKey: entry.request.sessionKey,
+      planId: stringMetadata(entry.request.metadata, "planId"),
+      subtaskId: stringMetadata(entry.request.metadata, "subtaskId"),
+      startedAtMs: now,
+      updatedAtMs: now,
+      result: result.result,
+      error: result.error ?? null,
+      metadata: {
+        ...(entry.request.metadata ?? {}),
+        ...(result.metadata ?? {}),
+      },
+    }, traceIdFor(entry)).catch(() => {});
   }
 }
 
@@ -309,6 +348,9 @@ function completionStatus(
 ): Extract<BackgroundRunStatus, "completed" | "failed" | "cancelled"> {
   if (entry.controller.signal.aborted) {
     return "cancelled";
+  }
+  if (result.status === "awaiting_approval") {
+    return "failed";
   }
   return result.status;
 }

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.test.ts
@@ -9579,6 +9579,351 @@ describe("AgentWorker", () => {
     expect(clearedSessions).toEqual(["session-1"]);
   });
 
+  test("resumes delegated child checkpoint before continuing the parent approval", async () => {
+    const writtenFiles: Array<Record<string, unknown>> = [];
+    const appendedMessages: AgentMessage[][] = [];
+    const clearedSessions: string[] = [];
+    const events: WorkerEvent[] = [];
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "write_file",
+      description: "Write a file",
+      parameters: { type: "object" },
+      execute: async (args) => {
+        writtenFiles.push(args);
+        return { content: `wrote ${String(args.path)}` };
+      },
+    });
+    const provider = new QueueProvider([
+      { content: "child completed after write", toolCalls: [], stopReason: "stop" },
+      { content: "parent received child result", toolCalls: [], stopReason: "stop" },
+    ]);
+    const childCheckpoint = {
+      runId: "delegate-1",
+      phase: "tools_completed",
+      model: "test-model",
+      maxIterations: 2,
+      stream: false,
+      messages: [
+        { role: "user", content: "write child file" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "child-approval-call", name: "request_approval", argumentsJson: "{}" }],
+        },
+        {
+          role: "tool",
+          content: "Waiting for approval.",
+          toolCallId: "child-approval-call",
+          name: "request_approval",
+          metadata: {
+            awaitingUserInput: true,
+            stopReason: "awaiting_approval",
+            approvalId: "approval-1",
+            operation: {
+              toolName: "write_file",
+              arguments: { path: "child.md", content: "hello" },
+            },
+          },
+        },
+      ],
+    };
+    const worker = new AgentWorker({
+      provider,
+      tools,
+      emitEvent: (event) => events.push(event),
+      approvalBridge: {
+        requestApproval: async () => ({}),
+        listPendingApprovals: async () => ({ approvals: [] }),
+        resolveApproval: async (params) => ({
+          approvalId: params.approvalId,
+          approved: params.approved,
+          scope: params.scope,
+          summary: "write_file path=\"child.md\"",
+          status: "approved",
+        }),
+      },
+      sessionBridge: {
+        setCheckpoint: async () => undefined,
+        clearCheckpoint: async (sessionId) => {
+          clearedSessions.push(sessionId);
+        },
+        appendMessages: async (_sessionId, messages) => {
+          appendedMessages.push(messages);
+        },
+        getCheckpoint: async (sessionId) => ({
+          sessionId,
+          runId: "parent-run",
+          phase: "tools_completed",
+          model: "test-model",
+          maxIterations: 2,
+          stream: false,
+          messages: [
+            { role: "user", content: "spawn writer" },
+            {
+              role: "assistant",
+              content: "",
+              toolCalls: [{ id: "parent-approval-call", name: "request_approval", argumentsJson: "{}" }],
+            },
+            {
+              role: "tool",
+              content: "Waiting for approval.",
+              toolCallId: "parent-approval-call",
+              name: "request_approval",
+              metadata: {
+                awaitingUserInput: true,
+                stopReason: "awaiting_approval",
+                approvalId: "approval-1",
+                _delegate_id: "delegate-1",
+                _delegate_child_run_id: "delegate-1",
+                _delegate_child_tool_call_id: "child-approval-call",
+                _delegate_child_tool_name: "write_file",
+                _delegate_child_checkpoint: childCheckpoint,
+              },
+            },
+          ],
+        }),
+      },
+    });
+
+    const response = await worker.handleRequest(
+      resumeApprovalRequest({
+        sessionId: "session-1",
+        approvalId: "approval-1",
+        approved: true,
+        scope: "once",
+      }),
+    );
+
+    expect(writtenFiles).toEqual([{ path: "child.md", content: "hello" }]);
+    expect(provider.messages[0]).toContainEqual({
+      role: "tool",
+      content: "wrote child.md",
+      toolCallId: "child-approval-call",
+      name: "request_approval",
+    });
+    expect(provider.messages[1]).toContainEqual(expect.objectContaining({
+      role: "tool",
+      content: "child completed after write",
+      toolCallId: "parent-approval-call",
+      name: "request_approval",
+      metadata: expect.objectContaining({
+        _delegate_id: "delegate-1",
+        _delegate_status: "completed",
+        _delegate_result: {
+          status: "completed",
+          summary: "child completed after write",
+        },
+      }),
+    }));
+    expect(response.result).toMatchObject({
+      approval: { approvalId: "approval-1", approved: true, scope: "once", status: "approved" },
+      result: {
+        finalContent: "parent received child result",
+        stopReason: "final_response",
+      },
+    });
+    expect(appendedMessages.at(-1)).toContainEqual(expect.objectContaining({
+      content: "child completed after write",
+      toolCallId: "parent-approval-call",
+      name: "request_approval",
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent.delegate.trace.updated",
+      payload: expect.objectContaining({
+        delegateId: "delegate-1",
+        childRunId: "delegate-1",
+        status: "completed",
+        final_output: "child completed after write",
+        approvalId: "approval-1",
+        approvalStatus: "approved",
+        trace: expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({
+              id: "approval:approval-1",
+              kind: "approval",
+              status: "completed",
+              resultPreview: "Approved.",
+            }),
+            expect.objectContaining({
+              id: "final:delegate-1",
+              kind: "message",
+              status: "completed",
+              summary: "child completed after write",
+            }),
+          ]),
+        }),
+      }),
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent.delegate.completed",
+      payload: expect.objectContaining({
+        delegateId: "delegate-1",
+        status: "completed",
+        final_output: "child completed after write",
+      }),
+    }));
+    expect(clearedSessions).toEqual(["session-1"]);
+  });
+
+  test("resumes delegated child checkpoint with denied approval metadata", async () => {
+    const writtenFiles: Array<Record<string, unknown>> = [];
+    const appendedMessages: AgentMessage[][] = [];
+    const clearedSessions: string[] = [];
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "write_file",
+      description: "Write a file",
+      parameters: { type: "object" },
+      execute: async (args) => {
+        writtenFiles.push(args);
+        return { content: `wrote ${String(args.path)}` };
+      },
+    });
+    const provider = new QueueProvider([
+      { content: "child handled denied approval", toolCalls: [], stopReason: "stop" },
+      { content: "parent received denied child result", toolCalls: [], stopReason: "stop" },
+    ]);
+    const childCheckpoint = {
+      runId: "delegate-1",
+      phase: "tools_completed",
+      model: "test-model",
+      maxIterations: 2,
+      stream: false,
+      messages: [
+        { role: "user", content: "write child file" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "child-approval-call", name: "request_approval", argumentsJson: "{}" }],
+        },
+        {
+          role: "tool",
+          content: "Waiting for approval.",
+          toolCallId: "child-approval-call",
+          name: "request_approval",
+          metadata: {
+            awaitingUserInput: true,
+            stopReason: "awaiting_approval",
+            approvalId: "approval-1",
+            operation: {
+              toolName: "write_file",
+              arguments: { path: "child.md", content: "hello" },
+            },
+          },
+        },
+      ],
+    };
+    const worker = new AgentWorker({
+      provider,
+      tools,
+      emitEvent: () => undefined,
+      approvalBridge: {
+        requestApproval: async () => ({}),
+        listPendingApprovals: async () => ({ approvals: [] }),
+        resolveApproval: async (params) => ({
+          approvalId: params.approvalId,
+          approved: params.approved,
+          scope: params.scope,
+          status: "denied",
+        }),
+      },
+      sessionBridge: {
+        setCheckpoint: async () => undefined,
+        clearCheckpoint: async (sessionId) => {
+          clearedSessions.push(sessionId);
+        },
+        appendMessages: async (_sessionId, messages) => {
+          appendedMessages.push(messages);
+        },
+        getCheckpoint: async (sessionId) => ({
+          sessionId,
+          runId: "parent-run",
+          phase: "tools_completed",
+          model: "test-model",
+          maxIterations: 2,
+          stream: false,
+          messages: [
+            { role: "user", content: "spawn writer" },
+            {
+              role: "assistant",
+              content: "",
+              toolCalls: [{ id: "parent-approval-call", name: "request_approval", argumentsJson: "{}" }],
+            },
+            {
+              role: "tool",
+              content: "Waiting for approval.",
+              toolCallId: "parent-approval-call",
+              name: "request_approval",
+              metadata: {
+                awaitingUserInput: true,
+                stopReason: "awaiting_approval",
+                approvalId: "approval-1",
+                _delegate_id: "delegate-1",
+                _delegate_child_run_id: "delegate-1",
+                _delegate_child_tool_call_id: "child-approval-call",
+                _delegate_child_tool_name: "write_file",
+                _delegate_child_checkpoint: childCheckpoint,
+              },
+            },
+          ],
+        }),
+      },
+    });
+
+    const response = await worker.handleRequest(
+      resumeApprovalRequest({
+        sessionId: "session-1",
+        approvalId: "approval-1",
+        approved: false,
+        scope: "once",
+      }),
+    );
+
+    expect(writtenFiles).toEqual([]);
+    expect(provider.messages[0]).toContainEqual({
+      role: "tool",
+      content: "Approval denied: approval-1",
+      toolCallId: "child-approval-call",
+      name: "request_approval",
+      metadata: {
+        approvalId: "approval-1",
+        approved: false,
+        status: "denied",
+      },
+    });
+    expect(provider.messages[1]).toContainEqual(expect.objectContaining({
+      role: "tool",
+      content: "child handled denied approval",
+      toolCallId: "parent-approval-call",
+      name: "request_approval",
+      metadata: expect.objectContaining({
+        approvalId: "approval-1",
+        approvalStatus: "denied",
+        approved: false,
+        _delegate_id: "delegate-1",
+        _delegate_status: "completed",
+      }),
+    }));
+    expect(response.result).toMatchObject({
+      approval: { approvalId: "approval-1", approved: false, scope: "once", status: "denied" },
+      result: {
+        finalContent: "parent received denied child result",
+        stopReason: "final_response",
+      },
+    });
+    expect(appendedMessages.at(-1)).toContainEqual(expect.objectContaining({
+      content: "child handled denied approval",
+      toolCallId: "parent-approval-call",
+      name: "request_approval",
+      metadata: expect.objectContaining({
+        approvalStatus: "denied",
+        approved: false,
+      }),
+    }));
+    expect(clearedSessions).toEqual(["session-1"]);
+  });
+
   test("handles backend slash deny by resolving a pending approval", async () => {
     let providerCalls = 0;
     const resolveCalls: Array<{ sessionId: string; approvalId: string; approved: boolean; scope?: string; traceId: string }> = [];

--- a/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/runtime/agentWorker.ts
@@ -3912,6 +3912,7 @@ export class AgentWorker {
     const delegatedApproval = delegatedApprovalFromCheckpoint(checkpoint, approval.approvalId);
     if (delegatedApproval) {
       const delegatedResult = await this.resumeApprovedDelegatedChildCheckpoint(traceId, approval, delegatedApproval.childCheckpoint);
+      this.emitDelegatedChildResumeEvents(traceId, delegatedResult.content, delegatedResult.metadata);
       return this.runResumedSpec(traceId, resumedSpecFromApprovedToolResult(checkpoint, {
         sessionId: approval.sessionId,
         approvalId: approval.approvalId,
@@ -3951,7 +3952,16 @@ export class AgentWorker {
       ...(approvedToolResult.metadata ? { metadata: approvedToolResult.metadata } : {}),
     });
     const result = await this.runDelegatedChildSpec(traceId, childSpec);
-    return delegatedParentToolResultFromChildResult(childSpec, result);
+    const delegatedResult = delegatedParentToolResultFromChildResult(childSpec, result);
+    return {
+      ...delegatedResult,
+      metadata: {
+        ...delegatedResult.metadata,
+        approvalId: approval.approvalId,
+        approvalStatus: "approved",
+        approved: true,
+      },
+    };
   }
 
   private async resumeSubmittedFormCheckpoint(
@@ -3967,7 +3977,88 @@ export class AgentWorker {
     approval: ApprovalResolutionRequest,
     checkpoint: Record<string, unknown>,
   ): Promise<AgentRunResult> {
+    const delegatedApproval = delegatedApprovalFromCheckpoint(checkpoint, approval.approvalId);
+    if (delegatedApproval) {
+      const delegatedResult = await this.resumeDeniedDelegatedChildCheckpoint(traceId, approval, delegatedApproval.childCheckpoint);
+      this.emitDelegatedChildResumeEvents(traceId, delegatedResult.content, delegatedResult.metadata);
+      return this.runResumedSpec(traceId, resumedSpecFromApprovedToolResult(checkpoint, {
+        sessionId: approval.sessionId,
+        approvalId: approval.approvalId,
+        content: delegatedResult.content,
+        metadata: delegatedResult.metadata,
+      }));
+    }
     return this.runResumedSpec(traceId, resumedSpecFromDeniedApproval(checkpoint, approval));
+  }
+
+  private async resumeDeniedDelegatedChildCheckpoint(
+    traceId: string,
+    approval: ApprovalResolutionRequest,
+    childCheckpoint: Record<string, unknown>,
+  ): Promise<{ content: string; metadata: Record<string, unknown> }> {
+    const childSpec = resumedSpecFromDeniedApproval(childCheckpoint, approval);
+    const result = await this.runDelegatedChildSpec(traceId, childSpec);
+    const delegatedResult = delegatedParentToolResultFromChildResult(childSpec, result);
+    return {
+      ...delegatedResult,
+      metadata: {
+        ...delegatedResult.metadata,
+        approvalId: approval.approvalId,
+        approvalStatus: "denied",
+        approved: false,
+      },
+    };
+  }
+
+  private emitDelegatedChildResumeEvents(
+    traceId: string,
+    content: string,
+    metadata: Record<string, unknown>,
+  ): void {
+    const delegateId = localStringValue(metadata._delegate_id);
+    if (metadata._delegate_event !== true || !delegateId) {
+      return;
+    }
+    const status = localStringValue(metadata._delegate_status) || "completed";
+    const childRunId = localStringValue(metadata._delegate_child_run_id) || delegateId;
+    const approvalId = localStringValue(metadata.approvalId ?? metadata.approval_id);
+    const approvalStatus = localStringValue(metadata.approvalStatus ?? metadata.approval_status);
+    const finalOutput = delegatedResultSummary(metadata, content);
+    const payload = {
+      delegateId,
+      delegate_id: delegateId,
+      childRunId,
+      child_run_id: childRunId,
+      status,
+      finalOutput,
+      final_output: finalOutput,
+      latestActivity: finalOutput,
+      latest_activity: finalOutput,
+      ...(approvalId ? { approvalId, approval_id: approvalId } : {}),
+      ...(approvalStatus ? { approvalStatus, approval_status: approvalStatus } : {}),
+      ...(typeof metadata.approved === "boolean" ? { approved: metadata.approved } : {}),
+      trace: delegatedResumeTracePayload({
+        delegateId,
+        childRunId,
+        status,
+        finalOutput,
+        approvalId,
+        approvalStatus,
+        approved: typeof metadata.approved === "boolean" ? metadata.approved : undefined,
+      }),
+    };
+    this.emitEvent({
+      protocol_version: WORKER_PROTOCOL_VERSION,
+      trace_id: traceId,
+      event: "agent.delegate.trace.updated",
+      payload: withNativePayloadAliases(payload),
+    });
+    this.emitEvent({
+      protocol_version: WORKER_PROTOCOL_VERSION,
+      trace_id: traceId,
+      event: delegatedResumeTerminalEvent(status),
+      payload: withNativePayloadAliases(payload),
+    });
   }
 
   private async runResumedSpec(traceId: string, spec: AgentRunSpec): Promise<AgentRunResult> {
@@ -4051,6 +4142,8 @@ function delegatedParentToolResultFromChildResult(
   }
   const status = result.stopReason === "final_response" ? "completed" : result.error ? "failed" : "completed";
   const content = result.finalContent || result.error || "Task completed but no final response was generated.";
+  const approvalResolution = latestApprovalResolutionFromMessages(result.messages)
+    ?? latestApprovalResolutionFromMessages(childSpec.messages);
   return {
     content,
     metadata: {
@@ -4058,6 +4151,13 @@ function delegatedParentToolResultFromChildResult(
       _delegate_id: delegateId,
       _delegate_child_run_id: delegateId,
       _delegate_status: status,
+      ...(approvalResolution
+        ? {
+          approvalId: approvalResolution.approvalId,
+          approvalStatus: approvalResolution.status,
+          approved: approvalResolution.approved,
+        }
+        : {}),
       _delegate_result: {
         status,
         summary: content,
@@ -4067,8 +4167,116 @@ function delegatedParentToolResultFromChildResult(
   };
 }
 
+function delegatedResultSummary(metadata: Record<string, unknown>, fallback: string): string {
+  const result = isJsonObject(metadata._delegate_result) ? metadata._delegate_result : undefined;
+  return localStringValue(result?.summary)
+    || localStringValue(result?.error)
+    || fallback;
+}
+
+function delegatedResumeTerminalEvent(status: string): string {
+  if (status === "awaiting_approval") {
+    return "agent.delegate.awaiting_approval";
+  }
+  if (status === "failed") {
+    return "agent.delegate.failed";
+  }
+  return "agent.delegate.completed";
+}
+
+function delegatedResumeTracePayload(input: {
+  delegateId: string;
+  childRunId: string;
+  status: string;
+  finalOutput: string;
+  approvalId?: string;
+  approvalStatus?: string;
+  approved?: boolean;
+}): Record<string, unknown> {
+  const now = new Date().toISOString();
+  const steps: Array<Record<string, unknown>> = [];
+  if (input.approvalId) {
+    steps.push({
+      id: `approval:${input.approvalId}`,
+      kind: "approval",
+      status: "completed",
+      title: "Approval resolved",
+      summary: `${approvalResolutionLabel(input.approvalStatus, input.approved)}: ${input.approvalId}`,
+      approvalId: input.approvalId,
+      approval_id: input.approvalId,
+      resultPreview: `${approvalResolutionLabel(input.approvalStatus, input.approved)}.`,
+      result_preview: `${approvalResolutionLabel(input.approvalStatus, input.approved)}.`,
+      createdAt: now,
+      created_at: now,
+      updatedAt: now,
+      updated_at: now,
+    });
+  }
+  if (input.status !== "awaiting_approval") {
+    steps.push({
+      id: `final:${input.delegateId}`,
+      kind: input.status === "failed" ? "error" : "message",
+      status: input.status === "failed" ? "failed" : "completed",
+      title: input.status === "failed" ? "Error" : "Final answer",
+      summary: input.finalOutput,
+      createdAt: now,
+      created_at: now,
+      updatedAt: now,
+      updated_at: now,
+    });
+  }
+  return {
+    delegateId: input.delegateId,
+    delegate_id: input.delegateId,
+    childRunId: input.childRunId,
+    child_run_id: input.childRunId,
+    status: input.status,
+    steps,
+    approvals: steps.filter((step) => step.kind === "approval"),
+    artifacts: [],
+    updatedAt: now,
+    updated_at: now,
+  };
+}
+
+function approvalResolutionLabel(status: string | undefined, approved: boolean | undefined): "Approved" | "Denied" {
+  if (status === "denied" || approved === false) {
+    return "Denied";
+  }
+  return "Approved";
+}
+
 function localStringValue(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function latestApprovalResolutionFromMessages(
+  messages: AgentMessage[],
+): { approvalId: string; status: "approved" | "denied"; approved: boolean } | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    const metadata = isJsonObject(message.metadata) ? message.metadata : undefined;
+    if (!metadata) {
+      continue;
+    }
+    const status = localStringValue(metadata.status);
+    if (status !== "approved" && status !== "denied") {
+      continue;
+    }
+    if (typeof metadata.approved !== "boolean") {
+      continue;
+    }
+    const approvalId = localStringValue(metadata.approvalId ?? metadata.approval_id);
+    if (!approvalId) {
+      continue;
+    }
+    return {
+      approvalId,
+      status,
+      approved: metadata.approved,
+    };
+  }
+  return undefined;
 }
 
 function findAwaitingFormMetadata(checkpoint: Record<string, unknown>, formId: string): Record<string, unknown> | undefined {

--- a/apps/desktop/workers/ts-agent-worker/src/tools/nativeToolProxy.test.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/nativeToolProxy.test.ts
@@ -333,6 +333,50 @@ describe("createNativeApprovalTools", () => {
       },
     ]);
   });
+
+  test("preserves allowed approval responses without marking them as awaiting input", async () => {
+    const operation = {
+      toolName: "write_file",
+      arguments: { path: "notes/today.md", contents: "hello" },
+    };
+    const classification = {
+      action: "require_approval",
+      category: "filesystem_write",
+      risk: "medium",
+      reason: "File write/edit/delete tools can modify workspace state.",
+    };
+    const rpc = new FakeRpcClient([
+      {
+        content: "Allowed.",
+        decision: "allow",
+        status: "approved",
+        scope: "session",
+        operation,
+      },
+    ]);
+    const [requestApproval] = createNativeApprovalTools(rpc);
+
+    const result = await requestApproval.execute(
+      {
+        operation,
+        classification,
+        fingerprint: "write_file:notes/today.md",
+        sessionFingerprint: "write_file:notes/today.md",
+        summary: "write_file path=\"notes/today.md\"",
+      },
+      { runId: "run-1", traceId: "trace-1", sessionId: "session-1" },
+    );
+
+    expect(result).toEqual({
+      content: "Allowed.",
+      metadata: {
+        decision: "allow",
+        status: "approved",
+        scope: "session",
+        operation,
+      },
+    });
+  });
 });
 
 describe("createNativeMemoryTools", () => {
@@ -581,8 +625,9 @@ describe("createNativeTaskTools", () => {
     );
     await waitFor(() => rpc.requests.filter((request) => request.method === "task.plan.save").length === 2);
 
-    expect(result.content).toBe("任务已后台启动，SubAgent自动执行中。完成后会通知你。无需主动干预。（plan_id: plan-1，启动 1 个子任务）");
+    expect(result.content).toContain("plan_id: plan-1");
     expect(provider.requests[0]?.options?.tools?.map((tool) => tool.name)).toEqual([
+      "request_approval",
       "read_file",
       "list_dir",
     ]);
@@ -628,6 +673,8 @@ describe("createNativeSpawnTools", () => {
       "wait_agent",
       "list_agents",
       "send_message",
+      "followup_task",
+      "interrupt_agent",
       "close_agent",
     ]);
     const result = await spawnTool.execute(
@@ -643,6 +690,7 @@ describe("createNativeSpawnTools", () => {
       _background_message: "Subagent [Inspect] started (id: spawn-1). Running: 1/5",
     });
     expect(provider.requests[0]?.options?.tools?.map((tool) => tool.name)).toEqual([
+      "request_approval",
       "read_file",
       "list_dir",
     ]);
@@ -700,12 +748,31 @@ describe("createNativeSpawnTools", () => {
 
     await spawnAgent?.execute(
       { task_name: "Recent Context", message: "Use recent context", fork_turns: "3" },
-      { runId: "run-3", traceId: "trace-3", sessionId: "desktop:chat-3" },
+      {
+        runId: "run-3",
+        traceId: "trace-3",
+        sessionId: "desktop:chat-3",
+        parentMessages: [
+          { role: "user", content: "Parent request" },
+          { role: "assistant", content: "Parent final answer" },
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{ id: "call-parent", name: "spawn_agent", argumentsJson: "{}" }],
+          },
+          { role: "tool", name: "spawn_agent", toolCallId: "call-parent", content: "Parent tool output" },
+        ],
+      },
     );
     await waitFor(() => provider.requests.length === 1);
 
     expect(provider.requests[0]?.messages[0]?.content).toContain("Fork policy: recent 3 parent turn(s) requested");
     expect(provider.requests[0]?.messages[0]?.content).toContain("Parent run: run-3");
+    expect(provider.requests[0]?.messages.slice(1, -1)).toEqual([
+      { role: "user", content: "Parent request" },
+      { role: "assistant", content: "Parent final answer" },
+    ]);
+    expect(JSON.stringify(provider.requests[0]?.messages)).not.toContain("Parent tool output");
     expect(provider.requests[0]?.messages.at(-1)?.content).toContain("Task name: recent_context");
     expect(provider.requests[0]?.messages.at(-1)?.content).toContain("Use recent context");
   });
@@ -714,9 +781,11 @@ describe("createNativeSpawnTools", () => {
     const rpc = new FakeRpcClient([]);
     const provider: ModelProvider = {
       async complete(_messages, options) {
-        options?.onReasoningDelta?.("thinking about greeting");
-        options?.onContentDelta?.("你好");
-        return { content: "你好", toolCalls: [], stopReason: "stop" };
+        options?.onReasoningDelta?.("thinking ");
+        options?.onReasoningDelta?.("about greeting");
+        options?.onContentDelta?.("Hel");
+        options?.onContentDelta?.("lo");
+        return { content: "Hello", toolCalls: [], stopReason: "stop" };
       },
     };
     const delegatedEvents: Array<{ eventName: string; payload: Record<string, unknown> }> = [];
@@ -727,7 +796,7 @@ describe("createNativeSpawnTools", () => {
       emitDelegatedEvent: (eventName, payload) => delegatedEvents.push({ eventName, payload }),
     });
 
-    await spawnTool.execute(
+    const result = await spawnTool.execute(
       { task: "Say hello", label: "Greeter" },
       { runId: "run-stream", traceId: "trace-stream", sessionId: "desktop:chat-stream" },
     );
@@ -745,16 +814,36 @@ describe("createNativeSpawnTools", () => {
       }),
       expect.objectContaining({
         kind: "message",
-        summary: "你好",
+        summary: "Hello",
+      }),
+    ]));
+    const persistedTrace = result.metadata?._delegate_trace as { steps?: unknown[] } | undefined;
+    expect(persistedTrace?.steps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: "reasoning",
+        summary: "thinking about greeting",
+      }),
+      expect.objectContaining({
+        kind: "message",
+      }),
+      expect.objectContaining({
+        id: "final:delegate-stream",
+        status: "completed",
       }),
     ]));
   });
 
-  test("runs delegated workspace write tools without repeated child approvals", async () => {
+  test("routes delegated workspace write tools through child approval", async () => {
     const rpc = new FakeRpcClient([
       {
-        path: "notes.md",
-        bytes_written: 5,
+        content: "Waiting for approval.",
+        awaitingUserInput: true,
+        stopReason: "awaiting_approval",
+        approvalId: "approval-child-write",
+        operation: {
+          toolName: "write_file",
+          arguments: { path: "notes.md", content: "hello" },
+        },
       },
     ]);
     const provider = new QueueProvider([
@@ -787,18 +876,29 @@ describe("createNativeSpawnTools", () => {
     );
 
     expect(result?.content).toContain("\"delegateId\": \"delegate-write\"");
-    await waitFor(() => delegatedEvents.some((event) => event.eventName === "agent.delegate.completed"));
+    await waitFor(() => delegatedEvents.some((event) => event.eventName === "agent.delegate.awaiting_approval"));
     expect(provider.requests[0]?.options?.tools?.map((tool) => tool.name)).toEqual([
+      "request_approval",
       "read_file",
       "list_dir",
       "write_file",
       "edit_file",
       "delete_file",
     ]);
-    expect(rpc.requests.map((request) => request.method)).toEqual(["workspace.write_file"]);
-    expect(delegatedEvents.map((event) => event.eventName)).not.toContain("agent.delegate.tool.approval_required");
-    expect(delegatedEvents.map((event) => event.eventName)).not.toContain("agent.delegate.awaiting_approval");
+    expect(rpc.requests.map((request) => request.method)).toEqual(["approval.request"]);
+    expect(rpc.requests[0]?.params).toMatchObject({
+      operation: {
+        toolName: "write_file",
+        arguments: { path: "notes.md", content: "hello" },
+      },
+      summary: "write_file path=\"notes.md\"",
+    });
     expect(delegatedEvents.map((event) => event.eventName)).toContain("agent.delegate.trace.updated");
+    expect(delegatedEvents.find((event) => event.eventName === "agent.delegate.awaiting_approval")?.payload).toMatchObject({
+      approvalId: "approval-child-write",
+      status: "blocked",
+      toolName: "write_file",
+    });
     expect(delegatedEvents.find((event) => event.eventName === "agent.delegate.trace.updated")?.payload).toMatchObject({
       delegateId: "delegate-write",
       childRunId: "delegate-write",
@@ -841,6 +941,7 @@ describe("createNativeSpawnTools", () => {
 
     expect(result.content).toContain("Tool 'write_file' not found");
     expect(provider.requests[0]?.options?.tools?.map((tool) => tool.name)).toEqual([
+      "request_approval",
       "read_file",
       "list_dir",
     ]);

--- a/apps/desktop/workers/ts-agent-worker/src/tools/nativeToolProxy.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/nativeToolProxy.ts
@@ -1,7 +1,7 @@
 import type { JsonObject } from "../protocol/messages.ts";
 import { AgentRunner } from "../agent/agentRunner.ts";
 import type { AgentMessage } from "../agent/agentRunSpec.ts";
-import type { BackgroundRunRegistry } from "../background/backgroundRegistryBridge.ts";
+import type { BackgroundRunReader, BackgroundRunRegistry, BackgroundTraceJournal } from "../background/backgroundRegistryBridge.ts";
 import {
   DelegatedRunManager,
   type DelegatedContextPack,
@@ -112,6 +112,8 @@ export function createNativeSpawnTools(
   });
   const manager = new DelegatedRunManager({
     runtime,
+    runStore: isBackgroundRunReader(options.backgroundRegistry) ? options.backgroundRegistry : undefined,
+    traceJournal: isBackgroundTraceJournal(options.backgroundRegistry) ? options.backgroundRegistry : undefined,
     emitEvent: (event) => options.emitDelegatedEvent?.(event.eventName, event.payload, event.traceId),
   });
   return [createSpawnTool({ manager }), ...createDelegatedAgentTools({ manager })];
@@ -167,6 +169,7 @@ async function runSpawnedSubagent(
 ) {
   let childSpec: Parameters<AgentRunner["run"]>[0] | undefined;
   let childCheckpoint: Record<string, unknown> | undefined;
+  const childTraceSteps: Array<Record<string, unknown>> = [];
   const contextPack = delegatedContextPackFromMetadata(request.metadata);
   const tools = createNativeSubagentToolRegistry(
     options.rpcClient,
@@ -175,7 +178,7 @@ async function runSpawnedSubagent(
   const runner = new AgentRunner({
     provider: options.provider,
     tools,
-    emitEvent: (event) => emitDelegatedChildEvent(request, event, options.emitDelegatedEvent),
+    emitEvent: (event) => emitDelegatedChildEvent(request, event, options.emitDelegatedEvent, childTraceSteps),
     checkpoint: (checkpoint) => {
       if (childSpec) {
         childCheckpoint = sessionCheckpointFromRunner(childSpec, checkpoint);
@@ -197,25 +200,52 @@ async function runSpawnedSubagent(
   const result = await runner.run(childSpec);
   if (result.stopReason === "awaiting_approval") {
     return {
-      status: "failed",
+      status: "awaiting_approval",
       result: "Waiting for approval.",
-      metadata: delegatedAwaitingApprovalMetadata(request, result, childCheckpoint),
+      metadata: delegatedAwaitingApprovalMetadata(
+        request,
+        result,
+        childCheckpoint,
+        delegatedTracePayload(delegatedTraceBase(request), "awaiting_approval", childTraceSteps),
+      ),
     } as const;
   }
   if (result.stopReason === "tool_error" || result.stopReason === "error") {
     const error = result.error || result.finalContent || "Error: subagent execution failed.";
-    return { status: "failed", result: error, error } as const;
+    upsertDelegatedTraceStep(childTraceSteps, delegatedFinalTraceStep(request, "failed", error));
+    return {
+      status: "failed",
+      result: error,
+      error,
+      metadata: {
+        _delegate_trace: delegatedTracePayload(delegatedTraceBase(request), "failed", childTraceSteps),
+      },
+    } as const;
   }
+  const finalResult = result.finalContent || "Task completed but no final response was generated.";
+  upsertDelegatedTraceStep(childTraceSteps, delegatedFinalTraceStep(request, "completed", finalResult));
   return {
     status: "completed",
-    result: result.finalContent || "Task completed but no final response was generated.",
+    result: finalResult,
+    metadata: {
+      _delegate_trace: delegatedTracePayload(delegatedTraceBase(request), "completed", childTraceSteps),
+    },
   } as const;
+}
+
+function isBackgroundRunReader(value: BackgroundRunRegistry | undefined): value is BackgroundRunRegistry & BackgroundRunReader {
+  return Boolean(value && "listRuns" in value && typeof value.listRuns === "function");
+}
+
+function isBackgroundTraceJournal(value: BackgroundRunRegistry | undefined): value is BackgroundRunRegistry & BackgroundTraceJournal {
+  return Boolean(value && "appendTraceEvent" in value && typeof value.appendTraceEvent === "function");
 }
 
 function delegatedAwaitingApprovalMetadata(
   request: SubagentRunRequest,
   result: Awaited<ReturnType<AgentRunner["run"]>>,
   childCheckpoint: Record<string, unknown> | undefined,
+  trace: Record<string, unknown>,
 ): Record<string, unknown> {
   const awaiting = result.awaitingInput ?? {};
   const approvalId = stringValue(awaiting.approvalId ?? awaiting.approval_id);
@@ -233,6 +263,7 @@ function delegatedAwaitingApprovalMetadata(
     _delegate_child_tool_name: stringValue(operation.toolName ?? operation.tool_name) || stringValue(awaiting.toolName ?? awaiting.tool_name) || checkpointTool.toolName,
     _delegate_child_checkpoint: childCheckpoint,
     _delegate_operation_preview: approvalArgsPreview(awaiting),
+    _delegate_trace: trace,
   };
 }
 
@@ -263,6 +294,7 @@ function emitDelegatedChildEvent(
   request: SubagentRunRequest,
   event: { type: string; payload: Record<string, unknown> },
   emitDelegatedEvent: ((eventName: DelegatedRunEventName, payload: Record<string, unknown>, traceId?: string) => void) | undefined,
+  traceSteps?: Array<Record<string, unknown>>,
 ): void {
   if (!emitDelegatedEvent) {
     return;
@@ -298,11 +330,12 @@ function emitDelegatedChildEvent(
   };
   if (event.type === "reasoning_delta" || event.type === "content_delta" || event.type === "tool_call_delta") {
     const step = delegatedStreamTraceStep(request, event);
+    upsertDelegatedTraceStep(traceSteps, step);
     emitDelegatedEvent("agent.delegate.trace.updated", {
       ...base,
       status: "running",
       latest_activity: step.summary,
-      trace: delegatedTracePayload(base, "running", [step]),
+      trace: delegatedTracePayload(base, "running", traceSteps ?? [step]),
     }, stringMetadata(metadata, "traceId"));
     return;
   }
@@ -316,6 +349,7 @@ function emitDelegatedChildEvent(
       title: base.toolName || "tool",
       argsPreview: safeJsonStringify(event.payload.args ?? {}),
     });
+    upsertDelegatedTraceStep(traceSteps, step);
     emitDelegatedEvent("agent.delegate.running", {
       ...base,
       status: "running",
@@ -343,18 +377,20 @@ function emitDelegatedChildEvent(
       operation_preview: approvalArgsPreview(resultMetadata),
       reason: stringValue(resultMetadata.reason),
     };
+    const step = delegatedToolTraceStep(base, {
+      kind: "approval",
+      status: "blocked",
+      title: `${base.toolName || "tool"} approval required`,
+      approvalId,
+      argsPreview: approvalArgsPreview(resultMetadata),
+      resultPreview: content || "Waiting for approval.",
+    });
+    upsertDelegatedTraceStep(traceSteps, step);
     emitDelegatedEvent("agent.delegate.tool.approval_required", payload, stringMetadata(metadata, "traceId"));
     emitDelegatedEvent("agent.delegate.awaiting_approval", payload, stringMetadata(metadata, "traceId"));
     emitDelegatedEvent("agent.delegate.trace.updated", {
       ...payload,
-      trace: delegatedTracePayload(base, "awaiting_approval", [delegatedToolTraceStep(base, {
-        kind: "approval",
-        status: "blocked",
-        title: `${base.toolName || "tool"} approval required`,
-        approvalId,
-        argsPreview: approvalArgsPreview(resultMetadata),
-        resultPreview: content || "Waiting for approval.",
-      })]),
+      trace: delegatedTracePayload(base, "awaiting_approval", [step]),
     }, stringMetadata(metadata, "traceId"));
     return;
   }
@@ -364,6 +400,7 @@ function emitDelegatedChildEvent(
     title: base.toolName || "tool",
     resultPreview: content,
   });
+  upsertDelegatedTraceStep(traceSteps, step);
   emitDelegatedEvent("agent.delegate.tool.completed", {
     ...base,
     status: "running",
@@ -444,6 +481,75 @@ function delegatedTracePayload(
   };
 }
 
+function delegatedTraceBase(request: SubagentRunRequest): Record<string, string> {
+  const metadata = request.metadata ?? {};
+  const parentRunId = stringMetadata(metadata, "parentRunId") || "";
+  return {
+    delegateId: request.id,
+    childRunId: request.id,
+    parentRunId,
+    parentSessionKey: request.sessionKey ?? "",
+  };
+}
+
+function upsertDelegatedTraceStep(
+  steps: Array<Record<string, unknown>> | undefined,
+  step: Record<string, unknown>,
+): void {
+  if (!steps) {
+    return;
+  }
+  const id = stringValue(step.id);
+  const index = id ? steps.findIndex((item) => stringValue(item.id) === id) : -1;
+  if (index >= 0) {
+    steps[index] = mergeDelegatedTraceStep(steps[index], step);
+  } else {
+    steps.push(step);
+  }
+}
+
+function mergeDelegatedTraceStep(
+  current: Record<string, unknown>,
+  next: Record<string, unknown>,
+): Record<string, unknown> {
+  const kind = stringValue(next.kind);
+  const currentStatus = stringValue(current.status);
+  const nextStatus = stringValue(next.status);
+  const currentSummary = stringValue(current.summary);
+  const nextSummary = stringValue(next.summary);
+  const shouldAppendStreamingSummary = Boolean(
+    nextSummary
+    && currentStatus === "running"
+    && nextStatus === "running"
+    && (kind === "reasoning" || kind === "message" || kind === "tool_call")
+  );
+  return {
+    ...current,
+    ...next,
+    ...(shouldAppendStreamingSummary
+      ? { summary: `${currentSummary}${nextSummary}` }
+      : {}),
+  };
+}
+
+function delegatedFinalTraceStep(
+  request: SubagentRunRequest,
+  status: "completed" | "failed",
+  summary: string,
+): Record<string, unknown> {
+  const now = new Date().toISOString();
+  return {
+    id: `final:${request.id}`,
+    kind: status === "failed" ? "error" : "message",
+    status,
+    title: status === "failed" ? "Error" : "Final answer",
+    summary,
+    error: status === "failed" ? summary : undefined,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 function delegatedToolTraceStep(
   base: Record<string, string>,
   input: {
@@ -515,6 +621,7 @@ function safeJsonStringify(value: unknown): string {
 function spawnedSubagentMessages(request: Pick<SubagentRunRequest, "task" | "metadata">): AgentMessage[] {
   const contextPack = delegatedContextPackFromMetadata(request.metadata);
   if (contextPack) {
+    const forkedMessages = Array.isArray(contextPack.forkedMessages) ? contextPack.forkedMessages : [];
     return [
       {
         role: "system",
@@ -532,6 +639,7 @@ function spawnedSubagentMessages(request: Pick<SubagentRunRequest, "task" | "met
           contextPack.outputContract,
         ].filter((line): line is string => line !== null).join("\n"),
       },
+      ...forkedMessages.map(cloneAgentMessage),
       {
         role: "user",
         content: [
@@ -552,6 +660,15 @@ function spawnedSubagentMessages(request: Pick<SubagentRunRequest, "task" | "met
     },
     { role: "user", content: request.task },
   ];
+}
+
+function cloneAgentMessage(message: AgentMessage): AgentMessage {
+  return {
+    ...message,
+    toolCalls: message.toolCalls?.map((toolCall) => ({ ...toolCall })),
+    thinkingBlocks: message.thinkingBlocks?.map((block) => ({ ...block })),
+    metadata: message.metadata ? { ...message.metadata } : undefined,
+  };
 }
 
 function delegatedContextPackFromMetadata(metadata: Record<string, unknown> | undefined): DelegatedContextPack | null {
@@ -592,8 +709,11 @@ function createNativeSubagentToolRegistry(
   permissionProfile: DelegatedPermissionProfile = "read_only",
 ): ToolRegistry {
   const registry = new ToolRegistry();
+  for (const tool of createNativeApprovalTools(rpcClient)) {
+    registry.register(tool);
+  }
   for (const tool of delegatedChildToolsForProfile(rpcClient, permissionProfile)) {
-    registry.register(stripDelegatedChildApproval(tool));
+    registry.register(tool);
   }
   return registry;
 }
@@ -611,11 +731,6 @@ function delegatedChildToolsForProfile(rpcClient: NativeRpcClient, permissionPro
     return [...readOnlyTools, ...createNativeWriteTools(rpcClient), ...createNativeShellTools(rpcClient)];
   }
   return readOnlyTools;
-}
-
-function stripDelegatedChildApproval(tool: Tool): Tool {
-  const { requiresApproval: _requiresApproval, approvalCategory: _approvalCategory, approvalRisk: _approvalRisk, ...rest } = tool;
-  return rest;
 }
 
 function nativeApprovalContextParams(context: ToolContext): JsonObject {
@@ -952,18 +1067,30 @@ function createRequestApprovalTool(rpcClient: NativeRpcClient): Tool {
       }
       const result = asObject(await rpcClient.request(requireTraceId(context.traceId), "approval.request", params)) ?? {};
       const { content: rawContent, ...rawMetadata } = result;
-      const metadata = {
-        awaitingUserInput: true,
-        stopReason: "awaiting_approval",
-        operation: asObject(rawMetadata.operation) ?? operation,
-        ...rawMetadata,
-      };
+      const metadata = approvalRequestAlreadyAllowed(rawMetadata)
+        ? {
+          operation: asObject(rawMetadata.operation) ?? operation,
+          ...rawMetadata,
+        }
+        : {
+          awaitingUserInput: true,
+          stopReason: "awaiting_approval",
+          operation: asObject(rawMetadata.operation) ?? operation,
+          ...rawMetadata,
+        };
       return {
         content: asString(rawContent) ?? "Waiting for approval.",
         metadata,
       };
     },
   };
+}
+
+function approvalRequestAlreadyAllowed(metadata: Record<string, unknown>): boolean {
+  return metadata.decision === "allow"
+    || metadata.status === "approved"
+    || metadata.approvalStatus === "approved"
+    || metadata.approved === true;
 }
 
 function createSearchMemoryNotesTool(rpcClient: NativeRpcClient): Tool {

--- a/apps/desktop/workers/ts-agent-worker/src/tools/tool.ts
+++ b/apps/desktop/workers/ts-agent-worker/src/tools/tool.ts
@@ -2,10 +2,13 @@ import type { ApprovalCategory, ApprovalRisk } from "../security/approvalTypes.t
 
 export type JsonSchema = Record<string, unknown>;
 
+import type { AgentMessage } from "../agent/agentRunSpec.ts";
+
 export type ToolContext = {
   runId: string;
   traceId?: string;
   sessionId?: string;
+  parentMessages?: AgentMessage[];
 };
 
 export type ToolResult = {


### PR DESCRIPTION
﻿## Summary
- add delegated subagent runtime tracking, restoration, trace/artifact access, and approval-aware state propagation across the native desktop worker path
- add spawn_agent/wait_agent-style delegated agent tooling semantics and richer tool result metadata for parent-agent consumption
- add native desktop subagent observability UI: trace inspector tabs, stacked status rows, processed-chain rendering fixes, and approval/reload state handling

## Validation
- npm test
- npm test -- conversationThreadIsland.test.ts desktopWorkbenchShell.test.ts
- npm run build
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
- git diff --cached --check

## Notes
- The first Rust full-test pass hit a transient timeout in worker_shell::tests::execute_drains_large_output_while_command_is_running; the exact test passed on rerun and the full Rust suite passed on the second run.
- Local .gitignore and docs/spec scratch files are intentionally left out of this PR.
