### PR TITLE
Fix desktop new chat header placement

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -4341,6 +4341,10 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain("width: min(var(--desktop-chat-column-width), calc(100% - var(--desktop-chat-composer-gutter)));");
     expect(styleText).toContain("grid-template-columns: minmax(0, 1fr) 0;");
     expect(styleText).toContain("grid-template-rows: auto minmax(0, 1fr) auto;");
+    const emptyChromeRule = styleText.match(/body\.desktop-native-workbench \.desktop-chat-workbench-chrome \{([\s\S]*?)\n    \}/)?.[1] ?? "";
+    expect(emptyChromeRule).toContain("grid-column: 1;");
+    expect(emptyChromeRule).toContain("grid-row: 2;");
+    expect(emptyChromeRule).toContain("justify-self: center;");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-chat-workbench:has(.desktop-conversation-body-layout[data-detail-panel-mode=\"push\"][data-detail-panel-state=\"open\"])");
     expect(styleText).toContain("grid-template-columns 520ms cubic-bezier(0.16, 1, 0.3, 1);");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-thread {\n      display: contents;");

--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -4340,11 +4340,15 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain("width: min(var(--desktop-chat-column-width), 100%);");
     expect(styleText).toContain("width: min(var(--desktop-chat-column-width), calc(100% - var(--desktop-chat-composer-gutter)));");
     expect(styleText).toContain("grid-template-columns: minmax(0, 1fr) 0;");
-    expect(styleText).toContain("grid-template-rows: auto minmax(0, 1fr) auto;");
+    expect(styleText).toContain("grid-template-rows: auto minmax(0, 1fr) auto auto;");
     const emptyChromeRule = styleText.match(/body\.desktop-native-workbench \.desktop-chat-workbench-chrome \{([\s\S]*?)\n    \}/)?.[1] ?? "";
     expect(emptyChromeRule).toContain("grid-column: 1;");
     expect(emptyChromeRule).toContain("grid-row: 2;");
     expect(emptyChromeRule).toContain("justify-self: center;");
+    const inlineWorkLensRule = styleText.match(/body\.desktop-native-workbench \.desktop-work-lens-inline \{([\s\S]*?)\n    \}/)?.[1] ?? "";
+    expect(inlineWorkLensRule).toContain("grid-column: 1;");
+    expect(inlineWorkLensRule).toContain("grid-row: 3;");
+    expect(inlineWorkLensRule).toContain("justify-self: center;");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-chat-workbench:has(.desktop-conversation-body-layout[data-detail-panel-mode=\"push\"][data-detail-panel-state=\"open\"])");
     expect(styleText).toContain("grid-template-columns 520ms cubic-bezier(0.16, 1, 0.3, 1);");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-conversation-thread {\n      display: contents;");
@@ -4364,8 +4368,8 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain("position: relative;\n      align-self: stretch;");
     expect(styleText).toContain("box-sizing: border-box;");
     expect(styleText).toContain("padding-bottom: var(--desktop-chat-composer-bottom-offset);");
-    expect(styleText).toContain("grid-column: 2;\n      grid-row: 2 / 4;");
-    expect(styleText).toContain("grid-column: 1;\n      grid-row: 3;\n      justify-self: center;");
+    expect(styleText).toContain("grid-column: 2;\n      grid-row: 2 / 5;");
+    expect(styleText).toContain("grid-column: 1;\n      grid-row: 4;\n      justify-self: center;");
     expect(styleText).toContain("margin: 0 auto var(--desktop-chat-composer-bottom-offset);");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-detail-panel-slot[data-detail-panel-state=\"closing\"] {");
     expect(styleText).toContain("body.desktop-native-workbench .desktop-tool-detail-panel {\n      position: relative;");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -11112,6 +11112,9 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-chat-workbench-chrome {
+      grid-column: 1;
+      grid-row: 2;
+      justify-self: center;
       display: grid;
       gap: 12px;
       width: min(var(--desktop-chat-column-width), 100%);

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -8897,10 +8897,13 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     body.desktop-native-workbench .desktop-work-lens-inline {
+      grid-column: 1;
+      grid-row: 3;
+      justify-self: center;
       display: grid;
       gap: 8px;
       min-width: 0;
-      width: 100%;
+      width: min(var(--desktop-chat-column-width), 100%);
     }
 
     body.desktop-native-workbench .desktop-work-lens[data-desktop-work-lens-placement="inline"] {
@@ -11077,7 +11080,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-self: stretch;
       display: grid;
       grid-template-columns: minmax(0, 1fr) 0;
-      grid-template-rows: auto minmax(0, 1fr) auto;
+      grid-template-rows: auto minmax(0, 1fr) auto auto;
       column-gap: 0;
       row-gap: 0;
       justify-items: stretch;
@@ -11685,7 +11688,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
     body.desktop-native-workbench .desktop-detail-panel-slot {
       grid-column: 2;
-      grid-row: 2 / 4;
+      grid-row: 2 / 5;
       position: relative;
       align-self: stretch;
       box-sizing: border-box;
@@ -12702,7 +12705,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-native-composer {
       position: relative;
       grid-column: 1;
-      grid-row: 3;
+      grid-row: 4;
       justify-self: center;
       width: min(var(--desktop-chat-column-width), calc(100% - var(--desktop-chat-composer-gutter)));
       min-height: 0;


### PR DESCRIPTION
## Summary
- keep the desktop empty-session support copy in the chat workbench content column
- explicitly place the empty-session chrome below the New chat header instead of relying on CSS grid auto-placement
- add a layout regression assertion for the empty-session grid placement

## Validation
- npm test -- desktopWorkbenchShell.test.ts
- npm test -- desktopWorkbenchShell.vue.test.ts
- npm run build

Fixes #313