### PR TITLE
Fix desktop chat model selector menu

### DIFF
--- a/apps/desktop/src/desktopWorkbenchShell.test.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.test.ts
@@ -532,6 +532,32 @@ describe("desktop workbench shell", () => {
     expect(selections).toEqual(["deepseek-chat"]);
   });
 
+  test("keeps the native composer model menu outside clipped runtime overflow", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [],
+        activeSessionKey: "",
+        activeChatId: "",
+        messages: [],
+        runtime: { model: "deepseek-v4-flash", modelOptions: ["deepseek-v4-pro", "deepseek-v4-flash"] },
+      },
+    });
+
+    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
+    const runtimeRules = Array.from(
+      styleText.matchAll(/body\.desktop-native-workbench \.desktop-native-composer-runtime \{(?<rule>[\s\S]*?)\n    \}/g),
+    ).map((match) => match.groups?.rule ?? "");
+
+    expect(runtimeRules.length).toBeGreaterThan(0);
+    expect(runtimeRules.some((rule) => /overflow(?:-[xy])?:\s*(?:auto|hidden);/.test(rule))).toBe(false);
+    expect(runtimeRules.some((rule) => rule.includes("overflow: visible;"))).toBe(true);
+  });
+
   test("overlays recent chat timestamps and delete actions in the same right slot", () => {
     const targetDocument = new FakeDocument();
 
@@ -884,7 +910,7 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain("width: 36px;\n      min-width: 36px;\n      height: 36px;\n      min-height: 36px;");
     expect(styleText).toContain(".desktop-native-token-orb {\n      width: 36px;\n      height: 36px;");
     expect(styleText).toContain("min-height: 38px;\n      max-height: none;");
-    expect(styleText).toContain("overflow-y: visible;");
+    expect(styleText).toContain("overflow: visible;");
     expect(styleText).toContain("gap: 10px 18px;");
     expect(styleText).toContain("gap: 16px;");
     expect(styleText).toContain("border-radius: 999px;");

--- a/apps/desktop/src/desktopWorkbenchShell.ts
+++ b/apps/desktop/src/desktopWorkbenchShell.ts
@@ -10621,7 +10621,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       align-items: center;
       justify-content: flex-end;
       min-width: 0;
-      overflow: hidden;
+      overflow: visible;
     }
 
     body.desktop-native-workbench .desktop-native-token-orb {
@@ -12758,8 +12758,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       justify-content: flex-end;
       min-height: 38px;
       max-height: none;
-      overflow-x: auto;
-      overflow-y: visible;
+      overflow: visible;
       gap: 10px;
       flex-wrap: nowrap;
       min-width: 0;
@@ -12770,6 +12769,7 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       display: inline-flex;
       align-items: center;
       justify-content: center;
+      max-width: min(220px, 100%);
       min-height: 34px;
       border: 0;
       border-radius: 999px;
@@ -12779,6 +12779,14 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       font: 600 12px/1.2 var(--font-sans);
       box-shadow: none;
       cursor: pointer;
+      white-space: nowrap;
+    }
+
+    body.desktop-native-workbench .desktop-native-composer-model-label {
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
       white-space: nowrap;
     }
 


### PR DESCRIPTION
Fixes #315.

## Summary
- Let the native composer runtime row use visible overflow so the absolute-positioned model selector menu is not clipped.
- Constrain the current model label with ellipsis so long model IDs do not stretch the composer.
- Add a regression test that prevents clipped runtime overflow from hiding the model menu.

## Root cause
The native composer runtime row combined clipped or scrollable overflow with an absolutely positioned model menu. Browser overflow-axis behavior can turn the intended vertical visibility into clipping, so clicking the current model could render no usable model options even when Settings had persisted provider models.

## Validation
- npm test -- desktopWorkbenchShell.test.ts
- npm test -- desktopSettingsProviders.test.ts native-vue/composerRuntimeIsland.test.ts native-vue/composerSurfaceIsland.test.ts native-vue/composerModelControlIsland.test.ts
- git diff --check -- apps/desktop/src/desktopWorkbenchShell.ts apps/desktop/src/desktopWorkbenchShell.test.ts
- npm run build