### PR TITLE
Fix desktop chat stream scroll stability

### DIFF
--- a/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.test.ts
@@ -903,6 +903,68 @@ describe("conversation thread Vue island", () => {
     expect(host.querySelector<HTMLElement>(".desktop-conversation-timeline")?.scrollTop).toBe(420);
   });
 
+  test("does not override user scrolling after a streamed update queues restoration", async () => {
+    const host = document.createElement("section");
+
+    const mounted = mountConversationThreadIsland(host, {
+      emptyMessage: "",
+      messages: [
+        {
+          author: "You",
+          body: ["Stream this"],
+          references: [],
+          time: "10:30 AM",
+          tone: "user",
+          toolActivities: [],
+        },
+        {
+          author: "Tinybot",
+          body: ["first chunk"],
+          references: [],
+          time: "10:30 AM",
+          tone: "assistant",
+          toolActivities: [],
+        },
+      ],
+    });
+    await nextTick();
+    await nextTick();
+
+    const timeline = host.querySelector<HTMLElement>(".desktop-conversation-timeline");
+    expect(timeline).not.toBeNull();
+    Object.defineProperty(timeline, "scrollHeight", { configurable: true, value: 1200 });
+    Object.defineProperty(timeline, "clientHeight", { configurable: true, value: 500 });
+    timeline!.scrollTop = 420;
+
+    mounted.update({
+      emptyMessage: "",
+      messages: [
+        {
+          author: "You",
+          body: ["Stream this"],
+          references: [],
+          time: "10:30 AM",
+          tone: "user",
+          toolActivities: [],
+        },
+        {
+          author: "Tinybot",
+          body: ["first chunk second chunk"],
+          references: [],
+          time: "10:30 AM",
+          tone: "assistant",
+          toolActivities: [],
+        },
+      ],
+    });
+    timeline!.scrollTop = 120;
+    timeline!.dispatchEvent(new Event("scroll"));
+    await nextTick();
+    await nextTick();
+
+    expect(host.querySelector<HTMLElement>(".desktop-conversation-timeline")?.scrollTop).toBe(120);
+  });
+
   test("collapses completed assistant process steps in event order before the final answer", async () => {
     const host = document.createElement("section");
 
@@ -1083,6 +1145,7 @@ describe("conversation thread Vue island", () => {
     expect(injectedStyles).toContain("display: flex");
     expect(injectedStyles).toContain("flex-direction: column");
     expect(injectedStyles).toContain("flex: 0 0 auto");
+    expect(injectedStyles).not.toContain("animation: desktopAgentFlowEnter");
     expect(injectedStyles).toContain("body.desktop-native-workbench .desktop-assistant-step-group.desktop-agent-flow-group");
     expect(injectedStyles).toContain("body.desktop-native-workbench .desktop-agent-flow-step-card");
     const finalAnswer = Array.from(host.querySelectorAll<HTMLElement>(".desktop-conversation-message"))

--- a/apps/desktop/src/native-vue/conversationThreadIsland.ts
+++ b/apps/desktop/src/native-vue/conversationThreadIsland.ts
@@ -74,6 +74,7 @@ export interface MountedConversationThreadIsland {
 
 interface ConversationTimelineScrollState {
   bottomOffset: number;
+  scrollVersion: number;
   scrollTop: number;
   wasNearBottom: boolean;
 }
@@ -143,6 +144,8 @@ const DETAIL_PANEL_MOTION_MS = 560;
 const TIMELINE_EAGER_NODE_LIMIT = 300;
 type ActivityInspectorKind = "approval" | "artifact" | "delegate" | "tool_call";
 const CONVERSATION_AGENT_FLOW_STYLE_ID = "desktop-conversation-agent-flow-styles";
+const CONVERSATION_TIMELINE_SCROLL_VERSION_ATTR = "data-desktop-user-scroll-version";
+const CONVERSATION_TIMELINE_SCROLL_TRACKING_ATTR = "data-desktop-scroll-tracking";
 const AGENT_WORKFLOW_STEP_LIMIT = 8;
 
 export function mountOrUpdateConversationThreadIsland(
@@ -2357,10 +2360,12 @@ function captureConversationTimelineScroll(host: HTMLElement): ConversationTimel
   if (!timeline) {
     return null;
   }
+  ensureConversationTimelineScrollTracking(timeline);
   const scrollTop = Number(timeline.scrollTop || 0);
   const bottomOffset = Math.max(0, Number(timeline.scrollHeight || 0) - scrollTop - Number(timeline.clientHeight || 0));
   return {
     bottomOffset,
+    scrollVersion: conversationTimelineScrollVersion(timeline),
     scrollTop,
     wasNearBottom: bottomOffset < 24,
   };
@@ -2395,6 +2400,10 @@ function restoreConversationTimelineScroll(
   if (!timeline) {
     return;
   }
+  ensureConversationTimelineScrollTracking(timeline);
+  if (conversationTimelineScrollVersion(timeline) !== scrollState.scrollVersion) {
+    return;
+  }
   if (scrollState.wasNearBottom) {
     timeline.scrollTop = boundedConversationTimelineScrollTop(
       timeline,
@@ -2403,6 +2412,27 @@ function restoreConversationTimelineScroll(
     return;
   }
   timeline.scrollTop = boundedConversationTimelineScrollTop(timeline, scrollState.scrollTop);
+}
+
+function ensureConversationTimelineScrollTracking(timeline: HTMLElement): void {
+  if (!timeline.hasAttribute(CONVERSATION_TIMELINE_SCROLL_VERSION_ATTR)) {
+    timeline.setAttribute(CONVERSATION_TIMELINE_SCROLL_VERSION_ATTR, "0");
+  }
+  if (timeline.getAttribute(CONVERSATION_TIMELINE_SCROLL_TRACKING_ATTR) === "true") {
+    return;
+  }
+  timeline.setAttribute(CONVERSATION_TIMELINE_SCROLL_TRACKING_ATTR, "true");
+  timeline.addEventListener("scroll", () => {
+    timeline.setAttribute(
+      CONVERSATION_TIMELINE_SCROLL_VERSION_ATTR,
+      String(conversationTimelineScrollVersion(timeline) + 1),
+    );
+  });
+}
+
+function conversationTimelineScrollVersion(timeline: HTMLElement): number {
+  const version = Number(timeline.getAttribute(CONVERSATION_TIMELINE_SCROLL_VERSION_ATTR) || "0");
+  return Number.isFinite(version) ? version : 0;
 }
 
 function conversationTimelineScrollElement(host: HTMLElement): HTMLElement | null {
@@ -2743,7 +2773,6 @@ function installConversationAgentFlowStyles(targetDocument: Document): void {
       flex: 0 0 auto;
       min-height: 0;
       min-width: 0;
-      animation: desktopAgentFlowEnter 240ms ease-out both;
     }
 
     .desktop-agent-flow-summary,


### PR DESCRIPTION
Fixes #317.

## Summary
- Track user scroll events on the native conversation timeline and skip queued stream scroll restoration after the user manually scrolls.
- Preserve the existing DOM-reset restoration behavior when no user scroll event occurred.
- Remove the processed assistant flow group's overall enter animation so streamed updates do not make processed blocks flash repeatedly.

## Root cause
The conversation thread queued scroll restoration after streamed updates and applied it even if the user had already scrolled the timeline. The processed assistant flow container also had an overall enter animation, making any remount during frequent stream updates visually flash.

## Validation
- npm test -- native-vue/conversationThreadIsland.test.ts
- npm test -- desktopWorkbenchShell.test.ts native-vue/conversationMessageIsland.test.ts native-vue/conversationBodyIsland.test.ts native-vue/conversationReasoningIsland.test.ts
- git diff --check -- apps/desktop/src/native-vue/conversationThreadIsland.ts apps/desktop/src/native-vue/conversationThreadIsland.test.ts
- npm run build