### PR TITLE
Move native backend state services toward Rust

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+[source.crates-io]
+replace-with = "rsproxy-sparse"
+
+[source.rsproxy-sparse]
+registry = "sparse+https://rsproxy.cn/index/"
+
+[source.rsproxy]
+registry = "https://rsproxy.cn/crates.io-index"
+
+[registries.rsproxy]
+index = "https://rsproxy.cn/crates.io-index"
+
+[net]
+git-fetch-with-cli = true

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -159,6 +159,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-openai"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3007014661d5b98168b7b6f1014147bce8b1362a194783543eeb9f6117a20be9"
+dependencies = [
+ "async-openai-macros",
+ "base64 0.22.1",
+ "bytes",
+ "derive_builder",
+ "eventsource-stream",
+ "futures",
+ "getrandom 0.3.4",
+ "rand",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "async-openai-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492a944774207eed3acf425214eadbd6ce84a2b89331164ff1c11bae92b26302"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,7 +602,7 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -662,12 +701,36 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -685,11 +748,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -713,6 +787,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -990,6 +1095,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,12 +1166,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1068,6 +1193,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1085,12 +1216,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1158,6 +1305,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1295,9 +1443,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1573,6 +1723,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2058,6 +2224,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2282,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2327,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "notify-rust"
@@ -2392,6 +2601,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2870,15 +3122,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2943,10 +3201,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2955,6 +3228,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3019,6 +3301,39 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3145,6 +3460,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,7 +3497,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3854,6 +4181,7 @@ dependencies = [
 name = "tinybot-desktop"
 version = "0.1.0"
 dependencies = [
+ "async-openai",
  "rfd",
  "serde",
  "serde_json",
@@ -3899,7 +4227,40 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4046,8 +4407,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4204,6 +4567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4275,6 +4644,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5289,6 +5664,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+async-openai = { version = "0.41.1", default-features = false, features = ["native-tls", "chat-completion", "responses"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 rfd = "0.15"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,6 +160,19 @@ struct WorkerSkillUpdateInput {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct WorkerWorkspaceFileInput {
+    path: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkerWorkspacePutFileInput {
+    path: String,
+    body: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct WorkerCoworkRouteInput {
     method: String,
     path: String,
@@ -436,6 +449,45 @@ fn worker_skills_validate(
     worker_skills_validate_with_options(
         state.inner(),
         input.name,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_workspace_files(state: State<'_, SharedGateway>) -> Result<serde_json::Value, String> {
+    worker_workspace_files_with_options(
+        state.inner(),
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_workspace_file(
+    input: WorkerWorkspaceFileInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_workspace_file_with_options(
+        state.inner(),
+        input.path,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_workspace_put_file(
+    input: WorkerWorkspacePutFileInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_workspace_put_file_with_options(
+        state.inner(),
+        input.path,
+        input.body,
         ts_agent_worker_workspace_root(),
         experimental_worker_config_snapshot(),
         Duration::from_secs(10),
@@ -986,6 +1038,84 @@ fn build_worker_skills_validate_request(
         request_id.trace_id("skills-validate"),
         "skills.webui_validate",
         serde_json::json!({ "name": name }),
+    )
+}
+
+fn worker_workspace_files_with_options(
+    _shared: &SharedGateway,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    let items = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("workspace-files"),
+            request_id.trace_id("workspace-files"),
+            "workspace.list_files",
+            serde_json::json!({}),
+        ),
+        "worker workspace files",
+    )?;
+    Ok(serde_json::json!({ "items": items }))
+}
+
+fn worker_workspace_file_with_options(
+    _shared: &SharedGateway,
+    path: String,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("workspace-file"),
+            request_id.trace_id("workspace-file"),
+            "workspace.read_file",
+            serde_json::json!({ "path": path, "format": "raw" }),
+        ),
+        "worker workspace file",
+    )
+}
+
+fn worker_workspace_put_file_with_options(
+    _shared: &SharedGateway,
+    path: String,
+    body: serde_json::Value,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let contents = body
+        .get("content")
+        .or_else(|| body.get("contents"))
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| "worker workspace put file failed: content is required".to_string())?;
+    let expected_updated_at = body
+        .get("expectedUpdatedAt")
+        .or_else(|| body.get("expected_updated_at"))
+        .and_then(|value| value.as_str());
+    let request_id = next_worker_request_correlation();
+    call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("workspace-put-file"),
+            request_id.trace_id("workspace-put-file"),
+            "workspace.write_file",
+            serde_json::json!({
+                "path": path,
+                "contents": contents,
+                "expected_updated_at": expected_updated_at,
+                "internal_operation": true,
+            }),
+        ),
+        "worker workspace put file",
     )
 }
 
@@ -2037,6 +2167,9 @@ pub fn run() {
             worker_skills_update,
             worker_skills_delete,
             worker_skills_validate,
+            worker_workspace_files,
+            worker_workspace_file,
+            worker_workspace_put_file,
             worker_cowork_route,
             worker_webui_route,
             worker_transport_gateway_frame,
@@ -2859,6 +2992,52 @@ mod tests {
         assert_eq!(result["skills"][0]["name"], "planner");
         assert_eq!(result["skills"][0]["description"], "Plan work");
         assert_eq!(result["skills"][0]["enabled"], true);
+        assert_eq!(
+            lock_runtime(&shared).experimental_worker.status().state,
+            WorkerManagerState::Stopped
+        );
+    }
+
+    #[test]
+    fn worker_workspace_file_commands_use_rust_workspace_without_ts_worker() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write("docs/readme.md", "old readme");
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+
+        let files = worker_workspace_files_with_options(
+            &shared,
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("workspace files should be served by Rust workspace state");
+        let file = worker_workspace_file_with_options(
+            &shared,
+            "docs/readme.md".to_string(),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("workspace file should be served by Rust workspace state");
+        let write = worker_workspace_put_file_with_options(
+            &shared,
+            "docs/readme.md".to_string(),
+            serde_json::json!({ "content": "new readme", "expected_updated_at": null }),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("workspace write should be served by Rust workspace state");
+
+        assert_eq!(files["items"][0]["path"], "docs/readme.md");
+        assert_eq!(file["path"], "docs/readme.md");
+        assert_eq!(file["content"], "old readme");
+        assert_eq!(write["path"], "docs/readme.md");
+        assert_eq!(
+            std::fs::read_to_string(fixture.root.join("docs").join("readme.md"))
+                .expect("written file should read"),
+            "new readme"
+        );
         assert_eq!(
             lock_runtime(&shared).experimental_worker.status().state,
             WorkerManagerState::Stopped

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,6 +179,20 @@ struct WorkerSessionInput {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct WorkerSessionPatchInput {
+    key: String,
+    body: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkerSessionTemporaryFileUploadInput {
+    key: String,
+    body: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct WorkerCoworkRouteInput {
     method: String,
     path: String,
@@ -516,6 +530,92 @@ fn worker_session_messages(
     state: State<'_, SharedGateway>,
 ) -> Result<serde_json::Value, String> {
     worker_session_messages_with_options(
+        state.inner(),
+        input.key,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_session_temporary_files(
+    input: WorkerSessionInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_session_temporary_files_with_options(
+        state.inner(),
+        input.key,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_session_upload_temporary_file(
+    input: WorkerSessionTemporaryFileUploadInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_session_upload_temporary_file_with_options(
+        state.inner(),
+        input.key,
+        input.body,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_session_clear_temporary_files(
+    input: WorkerSessionInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_session_clear_temporary_files_with_options(
+        state.inner(),
+        input.key,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_session_delete(
+    input: WorkerSessionInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_session_delete_with_options(
+        state.inner(),
+        input.key,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_session_patch(
+    input: WorkerSessionPatchInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_session_patch_with_options(
+        state.inner(),
+        input.key,
+        input.body,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_session_clear(
+    input: WorkerSessionInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_session_clear_with_options(
         state.inner(),
         input.key,
         ts_agent_worker_workspace_root(),
@@ -1214,6 +1314,159 @@ fn worker_session_messages_with_options(
     Ok(history)
 }
 
+fn worker_session_temporary_files_with_options(
+    _shared: &SharedGateway,
+    key: String,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    let mut result = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("session-temporary-files"),
+            request_id.trace_id("session-temporary-files"),
+            "knowledge.session_list",
+            serde_json::json!({ "session_id": key }),
+        ),
+        "worker session temporary files",
+    )?;
+    add_session_key_fields(&mut result)?;
+    Ok(result)
+}
+
+fn worker_session_upload_temporary_file_with_options(
+    _shared: &SharedGateway,
+    key: String,
+    body: serde_json::Value,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("session-upload-temporary-file"),
+            request_id.trace_id("session-upload-temporary-file"),
+            "session.temporary_file.upload",
+            serde_json::json!({
+                "session_id": key,
+                "name": body.get("name").and_then(serde_json::Value::as_str).unwrap_or_default(),
+                "file_type": body.get("file_type")
+                    .or_else(|| body.get("fileType"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default(),
+                "content": body.get("content").and_then(serde_json::Value::as_str).unwrap_or_default(),
+                "size_bytes": body.get("size_bytes")
+                    .or_else(|| body.get("sizeBytes"))
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or_default(),
+            }),
+        ),
+        "worker session temporary file upload",
+    )
+}
+
+fn worker_session_clear_temporary_files_with_options(
+    _shared: &SharedGateway,
+    key: String,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    let mut result = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("session-clear-temporary-files"),
+            request_id.trace_id("session-clear-temporary-files"),
+            "knowledge.session_clear",
+            serde_json::json!({ "session_id": key }),
+        ),
+        "worker session temporary files clear",
+    )?;
+    add_session_key_fields(&mut result)?;
+    Ok(result)
+}
+
+fn worker_session_delete_with_options(
+    _shared: &SharedGateway,
+    key: String,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    let mut result = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("session-delete"),
+            request_id.trace_id("session-delete"),
+            "session.delete",
+            serde_json::json!({ "session_id": key }),
+        ),
+        "worker session delete",
+    )?;
+    add_session_key_fields(&mut result)?;
+    Ok(result)
+}
+
+fn worker_session_patch_with_options(
+    _shared: &SharedGateway,
+    key: String,
+    body: serde_json::Value,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let metadata = body
+        .get("metadata")
+        .cloned()
+        .unwrap_or_else(|| body.clone());
+    let request_id = next_worker_request_correlation();
+    let session = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("session-patch"),
+            request_id.trace_id("session-patch"),
+            "session.patch_metadata",
+            serde_json::json!({ "session_id": key, "metadata": metadata }),
+        ),
+        "worker session patch",
+    )?;
+    webui_session_item(&session)
+}
+
+fn worker_session_clear_with_options(
+    _shared: &SharedGateway,
+    key: String,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    let mut result = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("session-clear"),
+            request_id.trace_id("session-clear"),
+            "session.clear",
+            serde_json::json!({ "session_id": key }),
+        ),
+        "worker session clear",
+    )?;
+    add_session_key_fields(&mut result)?;
+    Ok(result)
+}
+
 fn webui_session_item(session: &serde_json::Value) -> Result<serde_json::Value, String> {
     let mut item = session
         .as_object()
@@ -1232,7 +1485,34 @@ fn webui_session_item(session: &serde_json::Value) -> Result<serde_json::Value, 
         "chat_id".to_string(),
         serde_json::Value::String(session_chat_id_from_key(&session_id)),
     );
+    if let Some(metadata) = item
+        .get("extra")
+        .and_then(|extra| extra.get("metadata"))
+        .cloned()
+    {
+        item.insert("metadata".to_string(), metadata);
+    }
     Ok(serde_json::Value::Object(item))
+}
+
+fn add_session_key_fields(value: &mut serde_json::Value) -> Result<(), String> {
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "worker session operation failed: response was not an object".to_string())?;
+    let session_id = object
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    object.insert(
+        "key".to_string(),
+        serde_json::Value::String(session_id.clone()),
+    );
+    object.insert(
+        "chat_id".to_string(),
+        serde_json::Value::String(session_chat_id_from_key(&session_id)),
+    );
+    Ok(())
 }
 
 fn session_chat_id_from_key(key: &str) -> String {
@@ -2295,6 +2575,12 @@ pub fn run() {
             worker_workspace_put_file,
             worker_sessions_list,
             worker_session_messages,
+            worker_session_temporary_files,
+            worker_session_upload_temporary_file,
+            worker_session_clear_temporary_files,
+            worker_session_delete,
+            worker_session_patch,
+            worker_session_clear,
             worker_cowork_route,
             worker_webui_route,
             worker_transport_gateway_frame,
@@ -3220,6 +3506,100 @@ mod tests {
         assert_eq!(messages["key"], "websocket:chat-1");
         assert_eq!(messages["chat_id"], "chat-1");
         assert_eq!(messages["messages"][0]["content"], "Use Rust state");
+        assert_eq!(
+            lock_runtime(&shared).experimental_worker.status().state,
+            WorkerManagerState::Stopped
+        );
+    }
+
+    #[test]
+    fn worker_session_write_commands_use_rust_session_store_without_ts_worker() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write(
+            "sessions/store.json",
+            &serde_json::json!({
+                "version": 1,
+                "sessions": [{
+                    "session_id": "websocket:chat-1",
+                    "title": "Native session",
+                    "workspace_dir": "D:/Code/py/tinybot",
+                    "created_at": "2026-06-29T08:00:00Z",
+                    "updated_at": "2026-06-29T08:30:00Z",
+                    "extra": {
+                        "messages": [{ "role": "user", "content": "Keep this" }],
+                        "metadata": { "pinned": false }
+                    }
+                }]
+            })
+            .to_string(),
+        );
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+
+        let uploaded = worker_session_upload_temporary_file_with_options(
+            &shared,
+            "websocket:chat-1".to_string(),
+            serde_json::json!({
+                "name": "context.md",
+                "file_type": "md",
+                "content": "hello native",
+                "size_bytes": 12
+            }),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("temporary upload should be served by Rust session state");
+        let temporary_files = worker_session_temporary_files_with_options(
+            &shared,
+            "websocket:chat-1".to_string(),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("temporary file list should be served by Rust session state");
+        let patch = worker_session_patch_with_options(
+            &shared,
+            "websocket:chat-1".to_string(),
+            serde_json::json!({ "metadata": { "pinned": true } }),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("session patch should be served by Rust session state");
+        let cleared_files = worker_session_clear_temporary_files_with_options(
+            &shared,
+            "websocket:chat-1".to_string(),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("temporary file clear should be served by Rust session state");
+        let cleared_session = worker_session_clear_with_options(
+            &shared,
+            "websocket:chat-1".to_string(),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("session clear should be served by Rust session state");
+        let deleted = worker_session_delete_with_options(
+            &shared,
+            "websocket:chat-1".to_string(),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("session delete should be served by Rust session state");
+
+        assert_eq!(uploaded["name"], "context.md");
+        assert_eq!(temporary_files["key"], "websocket:chat-1");
+        assert_eq!(temporary_files["temporary_files"][0]["name"], "context.md");
+        assert_eq!(patch["key"], "websocket:chat-1");
+        assert_eq!(patch["metadata"]["pinned"], true);
+        assert_eq!(cleared_files["cleared"], 1);
+        assert_eq!(cleared_session["messages_before"], 1);
+        assert_eq!(deleted["key"], "websocket:chat-1");
+        assert_eq!(deleted["deleted"], true);
         assert_eq!(
             lock_runtime(&shared).experimental_worker.status().state,
             WorkerManagerState::Stopped

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,6 +173,12 @@ struct WorkerWorkspacePutFileInput {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct WorkerSessionInput {
+    key: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct WorkerCoworkRouteInput {
     method: String,
     path: String,
@@ -488,6 +494,30 @@ fn worker_workspace_put_file(
         state.inner(),
         input.path,
         input.body,
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_sessions_list(state: State<'_, SharedGateway>) -> Result<serde_json::Value, String> {
+    worker_sessions_list_with_options(
+        state.inner(),
+        ts_agent_worker_workspace_root(),
+        experimental_worker_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+fn worker_session_messages(
+    input: WorkerSessionInput,
+    state: State<'_, SharedGateway>,
+) -> Result<serde_json::Value, String> {
+    worker_session_messages_with_options(
+        state.inner(),
+        input.key,
         ts_agent_worker_workspace_root(),
         experimental_worker_config_snapshot(),
         Duration::from_secs(10),
@@ -1117,6 +1147,99 @@ fn worker_workspace_put_file_with_options(
         ),
         "worker workspace put file",
     )
+}
+
+fn worker_sessions_list_with_options(
+    _shared: &SharedGateway,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    let sessions = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("sessions-list"),
+            request_id.trace_id("sessions-list"),
+            "session.list_metadata",
+            serde_json::json!({}),
+        ),
+        "worker sessions list",
+    )?;
+    let items = sessions
+        .as_array()
+        .ok_or_else(|| "worker sessions list failed: response was not an array".to_string())?
+        .iter()
+        .map(webui_session_item)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(serde_json::json!({ "items": items }))
+}
+
+fn worker_session_messages_with_options(
+    _shared: &SharedGateway,
+    key: String,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let request_id = next_worker_request_correlation();
+    let mut history = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("session-messages"),
+            request_id.trace_id("session-messages"),
+            "session.get_history",
+            serde_json::json!({ "session_id": key, "limit": 500 }),
+        ),
+        "worker session messages",
+    )?;
+    let object = history
+        .as_object_mut()
+        .ok_or_else(|| "worker session messages failed: response was not an object".to_string())?;
+    let session_id = object
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    object.insert(
+        "key".to_string(),
+        serde_json::Value::String(session_id.clone()),
+    );
+    object.insert(
+        "chat_id".to_string(),
+        serde_json::Value::String(session_chat_id_from_key(&session_id)),
+    );
+    Ok(history)
+}
+
+fn webui_session_item(session: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let mut item = session
+        .as_object()
+        .cloned()
+        .ok_or_else(|| "worker sessions list failed: session item was not an object".to_string())?;
+    let session_id = item
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    item.insert(
+        "key".to_string(),
+        serde_json::Value::String(session_id.clone()),
+    );
+    item.insert(
+        "chat_id".to_string(),
+        serde_json::Value::String(session_chat_id_from_key(&session_id)),
+    );
+    Ok(serde_json::Value::Object(item))
+}
+
+fn session_chat_id_from_key(key: &str) -> String {
+    key.split_once(':')
+        .map(|(_, chat_id)| chat_id)
+        .unwrap_or(key)
+        .to_string()
 }
 
 fn worker_cowork_route_with_options(
@@ -2170,6 +2293,8 @@ pub fn run() {
             worker_workspace_files,
             worker_workspace_file,
             worker_workspace_put_file,
+            worker_sessions_list,
+            worker_session_messages,
             worker_cowork_route,
             worker_webui_route,
             worker_transport_gateway_frame,
@@ -3038,6 +3163,63 @@ mod tests {
                 .expect("written file should read"),
             "new readme"
         );
+        assert_eq!(
+            lock_runtime(&shared).experimental_worker.status().state,
+            WorkerManagerState::Stopped
+        );
+    }
+
+    #[test]
+    fn worker_session_read_commands_use_rust_session_store_without_ts_worker() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write(
+            "sessions/store.json",
+            &serde_json::json!({
+                "version": 1,
+                "sessions": [{
+                    "session_id": "websocket:chat-1",
+                    "title": "Native session",
+                    "workspace_dir": "D:/Code/py/tinybot",
+                    "created_at": "2026-06-29T08:00:00Z",
+                    "updated_at": "2026-06-29T08:30:00Z",
+                    "extra": {
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": "Use Rust state",
+                                "message_id": "msg-1",
+                                "timestamp": "2026-06-29T08:00:01Z"
+                            }
+                        ]
+                    }
+                }]
+            })
+            .to_string(),
+        );
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+
+        let sessions = worker_sessions_list_with_options(
+            &shared,
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("session list should be served by Rust session state");
+        let messages = worker_session_messages_with_options(
+            &shared,
+            "websocket:chat-1".to_string(),
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_millis(10),
+        )
+        .expect("session messages should be served by Rust session state");
+
+        assert_eq!(sessions["items"][0]["key"], "websocket:chat-1");
+        assert_eq!(sessions["items"][0]["chat_id"], "chat-1");
+        assert_eq!(sessions["items"][0]["title"], "Native session");
+        assert_eq!(messages["key"], "websocket:chat-1");
+        assert_eq!(messages["chat_id"], "chat-1");
+        assert_eq!(messages["messages"][0]["content"], "Use Rust state");
         assert_eq!(
             lock_runtime(&shared).experimental_worker.status().state,
             WorkerManagerState::Stopped

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -830,16 +830,17 @@ fn build_worker_run_agent_input_request(
 }
 
 fn worker_skills_list_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    let client = WorkerClient::experimental(shared);
-    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
-
-    let request = build_worker_skills_list_request(next_worker_request_correlation());
-    client.call(&request, timeout, "worker skills list")
+    call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        build_worker_skills_list_request(next_worker_request_correlation()),
+        "worker skills list",
+    )
 }
 
 fn build_worker_skills_list_request(request_id: WorkerRequestCorrelation) -> WorkerRequest {
@@ -852,17 +853,18 @@ fn build_worker_skills_list_request(request_id: WorkerRequestCorrelation) -> Wor
 }
 
 fn worker_skills_detail_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     name: String,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    let client = WorkerClient::experimental(shared);
-    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
-
-    let request = build_worker_skills_detail_request(next_worker_request_correlation(), name);
-    client.call(&request, timeout, "worker skills detail")
+    call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        build_worker_skills_detail_request(next_worker_request_correlation(), name),
+        "worker skills detail",
+    )
 }
 
 fn build_worker_skills_detail_request(
@@ -878,19 +880,17 @@ fn build_worker_skills_detail_request(
 }
 
 fn worker_skills_create_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     body: serde_json::Value,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    send_skills_worker_request(
-        shared,
+    call_rust_state_service(
         workspace_root,
         config_snapshot,
         build_worker_skills_create_request(next_worker_request_correlation(), body),
-        timeout,
-        "create",
+        "worker skills create",
     )
 }
 
@@ -907,20 +907,18 @@ fn build_worker_skills_create_request(
 }
 
 fn worker_skills_update_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     name: String,
     body: serde_json::Value,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    send_skills_worker_request(
-        shared,
+    call_rust_state_service(
         workspace_root,
         config_snapshot,
         build_worker_skills_update_request(next_worker_request_correlation(), name, body),
-        timeout,
-        "update",
+        "worker skills update",
     )
 }
 
@@ -938,19 +936,17 @@ fn build_worker_skills_update_request(
 }
 
 fn worker_skills_delete_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     name: String,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    send_skills_worker_request(
-        shared,
+    call_rust_state_service(
         workspace_root,
         config_snapshot,
         build_worker_skills_delete_request(next_worker_request_correlation(), name),
-        timeout,
-        "delete",
+        "worker skills delete",
     )
 }
 
@@ -967,19 +963,17 @@ fn build_worker_skills_delete_request(
 }
 
 fn worker_skills_validate_with_options(
-    shared: &SharedGateway,
+    _shared: &SharedGateway,
     name: String,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
-    timeout: Duration,
+    _timeout: Duration,
 ) -> Result<serde_json::Value, String> {
-    send_skills_worker_request(
-        shared,
+    call_rust_state_service(
         workspace_root,
         config_snapshot,
         build_worker_skills_validate_request(next_worker_request_correlation(), name),
-        timeout,
-        "validate",
+        "worker skills validate",
     )
 }
 
@@ -1436,17 +1430,20 @@ fn sanitize_worker_run_id_part(value: &str) -> String {
     }
 }
 
-fn send_skills_worker_request(
-    shared: &SharedGateway,
+fn call_rust_state_service(
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
     request: WorkerRequest,
-    timeout: Duration,
-    action: &str,
+    label: &str,
 ) -> Result<serde_json::Value, String> {
-    let client = WorkerClient::experimental(shared);
-    client.ensure_ts_agent_running(workspace_root, config_snapshot)?;
-    client.call(&request, timeout, &format!("worker skills {action}"))
+    let mut router = experimental_worker_router(workspace_root, config_snapshot);
+    let response = router.dispatch(&request);
+    if let Some(error) = response.error {
+        return Err(format!("{label} failed: {}", error.message));
+    }
+    response
+        .result
+        .ok_or_else(|| format!("{label} failed: missing response result"))
 }
 
 fn worker_cancel_agent_with_options(
@@ -2777,7 +2774,7 @@ mod tests {
     }
 
     #[test]
-    fn worker_skills_requests_target_ts_webui_skill_methods() {
+    fn worker_skills_requests_target_rust_webui_skill_methods() {
         let list_request = build_worker_skills_list_request(test_request_correlation("42"));
         let detail_request = build_worker_skills_detail_request(
             test_request_correlation("43"),
@@ -2839,6 +2836,32 @@ mod tests {
         assert_eq!(
             validate_request.params,
             serde_json::json!({ "name": "planner/phase" })
+        );
+    }
+
+    #[test]
+    fn worker_skills_list_reads_rust_workspace_without_ts_worker() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write(
+            "skills/planner/SKILL.md",
+            "---\nname: planner\ndescription: Plan work\n---\nPlan.",
+        );
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+
+        let result = worker_skills_list_with_options(
+            &shared,
+            fixture.root.clone(),
+            serde_json::json!({ "skills": { "enabled": ["planner"] } }),
+            Duration::from_millis(10),
+        )
+        .expect("skills list should be served by Rust workspace state");
+
+        assert_eq!(result["skills"][0]["name"], "planner");
+        assert_eq!(result["skills"][0]["description"], "Plan work");
+        assert_eq!(result["skills"][0]["enabled"], true);
+        assert_eq!(
+            lock_runtime(&shared).experimental_worker.status().state,
+            WorkerManagerState::Stopped
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ pub mod desktop_gateway;
 pub mod desktop_heartbeat;
 pub mod desktop_logging;
 pub mod desktop_menu;
+pub mod native_backend_contract;
 pub mod worker_background;
 pub mod worker_capability;
 pub mod worker_client;

--- a/src-tauri/src/native_backend_contract.rs
+++ b/src-tauri/src/native_backend_contract.rs
@@ -35,6 +35,12 @@ pub const NATIVE_TAURI_COMMANDS: &[&str] = &[
     "worker_workspace_put_file",
     "worker_sessions_list",
     "worker_session_messages",
+    "worker_session_temporary_files",
+    "worker_session_upload_temporary_file",
+    "worker_session_clear_temporary_files",
+    "worker_session_delete",
+    "worker_session_patch",
+    "worker_session_clear",
 ];
 
 pub const NATIVE_AGENT_EVENT_NAMES: &[&str] = &[

--- a/src-tauri/src/native_backend_contract.rs
+++ b/src-tauri/src/native_backend_contract.rs
@@ -1,0 +1,216 @@
+use crate::worker_protocol::{WorkerEvent, WorkerTransportMode};
+use crate::worker_runtime::{WorkerRuntimeState, WorkerRuntimeStatus};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+pub const NATIVE_TAURI_COMMANDS: &[&str] = &[
+    "worker_probe_status",
+    "worker_run_agent",
+    "worker_run_agent_input",
+    "worker_cancel_agent",
+    "worker_restore_agent_checkpoint",
+    "worker_submit_agent_form",
+    "worker_resume_agent_approval",
+    "worker_background_trace_list",
+    "worker_background_trace_get_delegate_trace",
+    "worker_background_trace_get_artifact",
+    "worker_webui_route",
+    "worker_cowork_route",
+    "worker_transport_gateway_frame",
+    "worker_transport_websocket_message",
+    "worker_transport_dispatch_websocket_message",
+    "worker_channel_dispatch_inbound",
+    "worker_channel_start",
+    "worker_channel_status",
+    "worker_channel_stop",
+    "worker_channel_login",
+    "worker_skills_list",
+    "worker_skills_detail",
+    "worker_skills_create",
+    "worker_skills_update",
+    "worker_skills_delete",
+    "worker_skills_validate",
+];
+
+pub const NATIVE_AGENT_EVENT_NAMES: &[&str] = &[
+    "agent.delta",
+    "agent.reasoning_delta",
+    "agent.tool_call.delta",
+    "agent.tool.start",
+    "agent.tool.result",
+    "agent.usage",
+    "agent.checkpoint",
+    "agent.awaiting_form",
+    "agent.awaiting_approval",
+    "agent.memory_reference",
+    "agent.task_progress",
+    "agent.browser_frame",
+    "agent.delegate.started",
+    "agent.delegate.running",
+    "agent.delegate.message_queued",
+    "agent.delegate.awaiting_approval",
+    "agent.delegate.tool.approval_required",
+    "agent.delegate.tool.completed",
+    "agent.delegate.trace.updated",
+    "agent.delegate.completed",
+    "agent.delegate.failed",
+    "agent.delegate.interrupted",
+    "agent.delegate.closed",
+    "heartbeat.delivery",
+    "agent.cancelled",
+    "agent.done",
+    "agent.error",
+    "diagnostics.log",
+    "worker.status",
+];
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeBackendKind {
+    Rust,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompatibilityWorkerKind {
+    TsAgentWorker,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompatibilityWorkerState {
+    Inactive,
+    Starting,
+    Running,
+    Failed,
+    Incompatible,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeBackendEventSource {
+    RustBackend,
+    CompatibilityWorker,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompatibilityWorkerRuntimeStatus {
+    pub kind: CompatibilityWorkerKind,
+    pub state: CompatibilityWorkerState,
+    pub transport_mode: Option<WorkerTransportMode>,
+    pub diagnostics: Vec<crate::worker_protocol::WorkerDiagnosticLine>,
+    pub last_error: Option<String>,
+    pub delegated_capabilities: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeBackendRuntimeStatus {
+    pub backend_kind: NativeBackendKind,
+    pub backend_label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compatibility_worker: Option<CompatibilityWorkerRuntimeStatus>,
+}
+
+impl NativeBackendRuntimeStatus {
+    pub fn rust_without_compatibility() -> Self {
+        Self {
+            backend_kind: NativeBackendKind::Rust,
+            backend_label: "rust".to_string(),
+            compatibility_worker: None,
+        }
+    }
+
+    pub fn rust_with_ts_compatibility(
+        worker: WorkerRuntimeStatus,
+        delegated_capabilities: Vec<String>,
+    ) -> Self {
+        Self {
+            backend_kind: NativeBackendKind::Rust,
+            backend_label: "rust".to_string(),
+            compatibility_worker: Some(CompatibilityWorkerRuntimeStatus {
+                kind: CompatibilityWorkerKind::TsAgentWorker,
+                state: compatibility_state_from_worker(&worker.state),
+                transport_mode: worker.transport_mode,
+                diagnostics: worker.diagnostics,
+                last_error: worker.last_error,
+                delegated_capabilities,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeBackendEvent {
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub trace_id: String,
+    pub event_name: String,
+    pub timestamp: String,
+    pub source: NativeBackendEventSource,
+    #[serde(default)]
+    pub payload: Value,
+}
+
+impl NativeBackendEvent {
+    pub fn from_worker_event(
+        event: WorkerEvent,
+        session_id: impl Into<String>,
+        run_id: Option<impl Into<String>>,
+        timestamp: impl Into<String>,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            run_id: run_id.map(Into::into),
+            trace_id: event.trace_id,
+            event_name: event.event,
+            timestamp: timestamp.into(),
+            source: NativeBackendEventSource::CompatibilityWorker,
+            payload: event.payload,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeBackendMessage {
+    pub role: String,
+    pub content: String,
+    #[serde(default, flatten)]
+    pub additional: Map<String, Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeBackendRunSpec {
+    pub run_id: String,
+    pub session_id: String,
+    #[serde(default)]
+    pub messages: Vec<NativeBackendMessage>,
+    pub model: String,
+    pub max_iterations: u32,
+    pub stream: bool,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+    #[serde(default, flatten)]
+    pub additional: Map<String, Value>,
+}
+
+impl NativeBackendRunSpec {
+    pub fn from_value(value: Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value(value)
+    }
+}
+
+fn compatibility_state_from_worker(state: &WorkerRuntimeState) -> CompatibilityWorkerState {
+    match state {
+        WorkerRuntimeState::Stopped => CompatibilityWorkerState::Inactive,
+        WorkerRuntimeState::Starting => CompatibilityWorkerState::Starting,
+        WorkerRuntimeState::Running => CompatibilityWorkerState::Running,
+        WorkerRuntimeState::Failed => CompatibilityWorkerState::Failed,
+        WorkerRuntimeState::Incompatible => CompatibilityWorkerState::Incompatible,
+    }
+}

--- a/src-tauri/src/native_backend_contract.rs
+++ b/src-tauri/src/native_backend_contract.rs
@@ -33,6 +33,8 @@ pub const NATIVE_TAURI_COMMANDS: &[&str] = &[
     "worker_workspace_files",
     "worker_workspace_file",
     "worker_workspace_put_file",
+    "worker_sessions_list",
+    "worker_session_messages",
 ];
 
 pub const NATIVE_AGENT_EVENT_NAMES: &[&str] = &[

--- a/src-tauri/src/native_backend_contract.rs
+++ b/src-tauri/src/native_backend_contract.rs
@@ -30,6 +30,9 @@ pub const NATIVE_TAURI_COMMANDS: &[&str] = &[
     "worker_skills_update",
     "worker_skills_delete",
     "worker_skills_validate",
+    "worker_workspace_files",
+    "worker_workspace_file",
+    "worker_workspace_put_file",
 ];
 
 pub const NATIVE_AGENT_EVENT_NAMES: &[&str] = &[

--- a/src-tauri/src/worker_rpc.rs
+++ b/src-tauri/src/worker_rpc.rs
@@ -259,6 +259,31 @@ impl WorkerRpcRouter {
             "skills.list" => {
                 serde_json::to_value(self.workspace.list_skills()?).map_err(serialization_error)
             }
+            "skills.webui_list" => self
+                .workspace
+                .webui_list_skills(enabled_skills_from_snapshot(
+                    &self.config.snapshot_public()?.value,
+                )),
+            "skills.webui_detail" => {
+                let params: SkillNameParams = parse_params(request)?;
+                self.workspace.webui_skill_detail(&params.name)
+            }
+            "skills.webui_create" => {
+                let params: SkillCreateParams = parse_params(request)?;
+                self.workspace.webui_create_skill(params.body)
+            }
+            "skills.webui_update" => {
+                let params: SkillUpdateParams = parse_params(request)?;
+                self.workspace.webui_update_skill(&params.name, params.body)
+            }
+            "skills.webui_delete" => {
+                let params: SkillNameParams = parse_params(request)?;
+                self.workspace.webui_delete_skill(&params.name)
+            }
+            "skills.webui_validate" => {
+                let params: SkillNameParams = parse_params(request)?;
+                self.workspace.webui_validate_skill(&params.name)
+            }
             "config.get" => {
                 let params: PathParams = parse_params(request)?;
                 serde_json::to_value(self.config.get(&params.path)?).map_err(serialization_error)
@@ -756,6 +781,22 @@ struct WriteFileParams {
 }
 
 #[derive(Deserialize)]
+struct SkillNameParams {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct SkillCreateParams {
+    body: Value,
+}
+
+#[derive(Deserialize)]
+struct SkillUpdateParams {
+    name: String,
+    body: Value,
+}
+
+#[derive(Deserialize)]
 struct ShellExecuteRequestParams {
     command: String,
     #[serde(default)]
@@ -894,6 +935,19 @@ where
             )));
         }
     })
+}
+
+fn enabled_skills_from_snapshot(snapshot: &Value) -> Option<Vec<String>> {
+    snapshot
+        .get("skills")
+        .and_then(|value| value.get("enabled"))
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
 }
 
 fn serialization_error(error: serde_json::Error) -> crate::worker_protocol::WorkerProtocolError {

--- a/src-tauri/src/worker_runtime.rs
+++ b/src-tauri/src/worker_runtime.rs
@@ -1,3 +1,7 @@
+use crate::native_backend_contract::{
+    CompatibilityWorkerKind, CompatibilityWorkerRuntimeStatus, CompatibilityWorkerState,
+    NativeBackendKind,
+};
 use crate::worker_protocol::{WorkerDiagnosticLine, WorkerTransportMode};
 use serde::Serialize;
 
@@ -14,6 +18,9 @@ pub enum WorkerRuntimeState {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct WorkerRuntimeStatus {
     pub state: WorkerRuntimeState,
+    pub backend_kind: NativeBackendKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compatibility_worker: Option<CompatibilityWorkerRuntimeStatus>,
     pub transport_mode: Option<WorkerTransportMode>,
     pub diagnostics: Vec<WorkerDiagnosticLine>,
     pub last_error: Option<String>,
@@ -24,6 +31,8 @@ impl WorkerRuntimeStatus {
     pub fn stopped() -> Self {
         Self {
             state: WorkerRuntimeState::Stopped,
+            backend_kind: NativeBackendKind::Rust,
+            compatibility_worker: None,
             transport_mode: None,
             diagnostics: Vec::new(),
             last_error: None,
@@ -32,14 +41,23 @@ impl WorkerRuntimeStatus {
     }
 
     pub fn startup_failed(error: impl Into<String>) -> Self {
+        let error = error.into();
         Self {
             state: WorkerRuntimeState::Failed,
+            backend_kind: NativeBackendKind::Rust,
+            compatibility_worker: Some(CompatibilityWorkerRuntimeStatus {
+                kind: CompatibilityWorkerKind::TsAgentWorker,
+                state: CompatibilityWorkerState::Failed,
+                transport_mode: None,
+                diagnostics: Vec::new(),
+                last_error: Some(error.clone()),
+                delegated_capabilities: compatibility_worker_capabilities(),
+            }),
             transport_mode: None,
             diagnostics: Vec::new(),
-            last_error: Some(error.into()),
+            last_error: Some(error),
             recovery_hint: Some(
-                "Managed worker startup failed; retry native TS worker startup."
-                    .to_string(),
+                "Managed worker startup failed; retry native TS worker startup.".to_string(),
             ),
         }
     }
@@ -48,14 +66,34 @@ impl WorkerRuntimeStatus {
         transport_mode: WorkerTransportMode,
         diagnostics: Vec<WorkerDiagnosticLine>,
     ) -> Self {
+        let compatibility_worker = CompatibilityWorkerRuntimeStatus {
+            kind: CompatibilityWorkerKind::TsAgentWorker,
+            state: CompatibilityWorkerState::Running,
+            transport_mode: Some(transport_mode.clone()),
+            diagnostics: diagnostics.clone(),
+            last_error: None,
+            delegated_capabilities: compatibility_worker_capabilities(),
+        };
         Self {
             state: WorkerRuntimeState::Running,
+            backend_kind: NativeBackendKind::Rust,
+            compatibility_worker: Some(compatibility_worker),
             transport_mode: Some(transport_mode),
             diagnostics,
             last_error: None,
             recovery_hint: None,
         }
     }
+}
+
+fn compatibility_worker_capabilities() -> Vec<String> {
+    vec![
+        "agent.run".to_string(),
+        "agent.cancel".to_string(),
+        "agent.checkpoint.restore".to_string(),
+        "agent.form.submit".to_string(),
+        "agent.approval.resume".to_string(),
+    ]
 }
 
 #[cfg(test)]
@@ -68,6 +106,8 @@ mod tests {
         let status = WorkerRuntimeStatus::stopped();
 
         assert_eq!(status.state, WorkerRuntimeState::Stopped);
+        assert_eq!(status.backend_kind, NativeBackendKind::Rust);
+        assert!(status.compatibility_worker.is_none());
         assert_eq!(status.transport_mode, None);
         assert!(status.diagnostics.is_empty());
         assert!(status.last_error.is_none());
@@ -78,6 +118,14 @@ mod tests {
         let status = WorkerRuntimeStatus::startup_failed("worker executable missing");
 
         assert_eq!(status.state, WorkerRuntimeState::Failed);
+        assert_eq!(status.backend_kind, NativeBackendKind::Rust);
+        assert_eq!(
+            status
+                .compatibility_worker
+                .as_ref()
+                .map(|worker| &worker.state),
+            Some(&CompatibilityWorkerState::Failed)
+        );
         assert_eq!(
             status.last_error.as_deref(),
             Some("worker executable missing")
@@ -97,11 +145,18 @@ mod tests {
         );
 
         assert_eq!(status.state, WorkerRuntimeState::Running);
+        assert_eq!(status.backend_kind, NativeBackendKind::Rust);
+        assert_eq!(
+            status
+                .compatibility_worker
+                .as_ref()
+                .map(|worker| &worker.state),
+            Some(&CompatibilityWorkerState::Running)
+        );
         assert_eq!(status.transport_mode, Some(WorkerTransportMode::Stdio));
         assert_eq!(
             status.diagnostics,
             vec![WorkerDiagnosticLine::new("stdout", "worker ready")]
         );
     }
-
 }

--- a/src-tauri/src/worker_workspace/skills.rs
+++ b/src-tauri/src/worker_workspace/skills.rs
@@ -15,6 +15,635 @@ impl WorkerWorkspaceRpc {
         )?;
         Ok(WorkspaceSkillsList { skills })
     }
+
+    pub fn webui_list_skills(
+        &self,
+        enabled_skills: Option<Vec<String>>,
+    ) -> Result<serde_json::Value, WorkerProtocolError> {
+        let skills = self
+            .list_skills()?
+            .skills
+            .into_iter()
+            .map(|skill| webui_skill_list_item(skill, enabled_skills.as_deref()))
+            .collect::<Vec<_>>();
+        Ok(serde_json::json!({ "skills": skills }))
+    }
+
+    pub fn webui_skill_detail(&self, name: &str) -> Result<serde_json::Value, WorkerProtocolError> {
+        let Some(skill) = self
+            .list_skills()?
+            .skills
+            .into_iter()
+            .find(|skill| skill.name == name)
+        else {
+            return Ok(serde_json::Value::Null);
+        };
+        let metadata = parse_skill_frontmatter(&skill.content).unwrap_or_default();
+        let tinybot_meta = skill_tinybot_meta(&metadata);
+        Ok(serde_json::json!({
+            "name": name,
+            "content": strip_skill_frontmatter(&skill.content),
+            "raw_content": skill.content,
+            "metadata": metadata,
+            "tinybot_meta": tinybot_meta,
+            "available": skill_missing_requirements(&tinybot_meta).is_empty(),
+        }))
+    }
+
+    pub fn webui_create_skill(
+        &self,
+        body: serde_json::Value,
+    ) -> Result<serde_json::Value, WorkerProtocolError> {
+        let body = body.as_object().cloned().unwrap_or_default();
+        let name = normalize_skill_name(&truthy_json_string(body.get("name")).unwrap_or_default());
+        if name.is_empty() {
+            return Err(skill_error("name is required", 400));
+        }
+        if name.len() > 64 {
+            return Err(skill_error("skill name too long (max 64 chars)", 400));
+        }
+        if self
+            .list_skills()?
+            .skills
+            .iter()
+            .any(|skill| skill.name == name && skill.source == "workspace")
+        {
+            return Err(skill_error(format!("skill '{name}' already exists"), 409));
+        }
+        let description = body
+            .get("description")
+            .map(json_value_to_string)
+            .unwrap_or_else(|| format!("Custom skill: {name}"));
+        let always = json_truthy(body.get("always"));
+        let content = create_skill_body_content(body.get("content"), always)?;
+        let contents = create_skill_content(&name, &description, &content, always);
+        let path = skill_file_path(&name);
+        if let Err(error) = self.write_file(&path, &contents) {
+            let _ = self.delete_file(&skill_dir_path(&name), true);
+            return Err(skill_error(
+                format!("failed to create skill: {}", error.message),
+                500,
+            ));
+        }
+        for resource in normalize_skill_resources(body.get("resources")) {
+            if let Err(error) = self.create_dir(&format!("{}/{}", skill_dir_path(&name), resource))
+            {
+                let _ = self.delete_file(&skill_dir_path(&name), true);
+                return Err(skill_error(
+                    format!("failed to create skill: {}", error.message),
+                    500,
+                ));
+            }
+        }
+        Ok(serde_json::json!({
+            "created": true,
+            "name": name,
+            "path": path,
+            "message": format!("Skill '{name}' created successfully"),
+        }))
+    }
+
+    pub fn webui_update_skill(
+        &self,
+        name: &str,
+        body: serde_json::Value,
+    ) -> Result<serde_json::Value, WorkerProtocolError> {
+        let path = skill_file_path(name);
+        let file = self.read_file_with_options(
+            &path,
+            WorkspaceReadOptions {
+                offset: None,
+                limit: None,
+                format: WorkspaceReadFormat::Raw,
+            },
+        )?;
+        let body = body.as_object().cloned().unwrap_or_default();
+        let contents = update_skill_content(&file.content, name, &body)?;
+        self.write_file(&path, &contents)?;
+        Ok(serde_json::json!({
+            "updated": true,
+            "name": name,
+            "path": path,
+        }))
+    }
+
+    pub fn webui_delete_skill(&self, name: &str) -> Result<serde_json::Value, WorkerProtocolError> {
+        let Some(skill) = self
+            .list_skills()?
+            .skills
+            .into_iter()
+            .find(|skill| skill.name == name)
+        else {
+            return Err(skill_error("skill not found", 404));
+        };
+        if skill.source == "builtin" {
+            return Err(skill_error("cannot delete builtin skills", 403));
+        }
+        self.delete_file(&skill_dir_path(name), true)
+            .map_err(|error| {
+                skill_error(format!("failed to delete skill: {}", error.message), 500)
+            })?;
+        Ok(serde_json::json!({ "deleted": true, "name": name }))
+    }
+
+    pub fn webui_validate_skill(
+        &self,
+        name: &str,
+    ) -> Result<serde_json::Value, WorkerProtocolError> {
+        let listing = self
+            .list_dir(&skill_dir_path(name), false, None)
+            .map_err(|_| skill_error("skill not found", 404))?;
+        let path = skill_file_path(name);
+        let file = self.read_file_with_options(
+            &path,
+            WorkspaceReadOptions {
+                offset: None,
+                limit: None,
+                format: WorkspaceReadFormat::Raw,
+            },
+        );
+        let content = match file {
+            Ok(file) => file.content,
+            Err(_) => {
+                return Ok(serde_json::json!({
+                    "name": name,
+                    "valid": false,
+                    "message": "SKILL.md not found",
+                }))
+            }
+        };
+        let Some(frontmatter) = parse_skill_frontmatter(&content) else {
+            return Ok(serde_json::json!({
+                "name": name,
+                "valid": false,
+                "message": "Invalid frontmatter format",
+            }));
+        };
+        if let Some(result) = validate_skill_frontmatter(name, &frontmatter) {
+            return Ok(result);
+        }
+        Ok(validate_skill_children(name, &listing.entries))
+    }
+}
+
+fn webui_skill_list_item(
+    skill: WorkspaceSkillEntry,
+    enabled_skills: Option<&[String]>,
+) -> serde_json::Value {
+    let metadata = parse_skill_frontmatter(&skill.content).unwrap_or_default();
+    let tinybot_meta = skill_tinybot_meta(&metadata);
+    let missing_requirements = skill_missing_requirements(&tinybot_meta);
+    let description = metadata
+        .get("description")
+        .and_then(|value| value.as_str())
+        .unwrap_or(&skill.name)
+        .to_string();
+    let mut item = serde_json::json!({
+        "name": skill.name,
+        "path": skill.path,
+        "source": skill.source,
+        "description": description,
+        "available": missing_requirements.is_empty(),
+        "enabled": skill_enabled(&skill.name, enabled_skills),
+        "always": bool_metadata(metadata.get("always")),
+    });
+    if !missing_requirements.is_empty() {
+        item["missing_requirements"] = serde_json::Value::String(missing_requirements);
+    }
+    item
+}
+
+fn skill_enabled(name: &str, enabled_skills: Option<&[String]>) -> bool {
+    enabled_skills.is_none_or(|skills| {
+        skills.is_empty()
+            || skills.iter().any(|skill| skill == "*")
+            || skills.iter().any(|skill| skill == name)
+    })
+}
+
+fn parse_skill_frontmatter(content: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let content = content.strip_prefix("---")?;
+    let content = content
+        .strip_prefix("\r\n")
+        .or_else(|| content.strip_prefix('\n'))?;
+    let end = content.find("\n---").or_else(|| content.find("\r\n---"))?;
+    let raw = &content[..end];
+    let mut metadata = serde_json::Map::new();
+    for line in raw.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        metadata.insert(
+            key.to_string(),
+            serde_json::Value::String(
+                value
+                    .trim()
+                    .trim_matches('"')
+                    .trim_matches('\'')
+                    .to_string(),
+            ),
+        );
+    }
+    Some(metadata)
+}
+
+fn strip_skill_frontmatter(content: &str) -> String {
+    let Some(content_without_open) = content.strip_prefix("---") else {
+        return content.trim().to_string();
+    };
+    let Some(content_without_open) = content_without_open
+        .strip_prefix("\r\n")
+        .or_else(|| content_without_open.strip_prefix('\n'))
+    else {
+        return content.trim().to_string();
+    };
+    let Some(end) = content_without_open
+        .find("\n---")
+        .or_else(|| content_without_open.find("\r\n---"))
+    else {
+        return content.trim().to_string();
+    };
+    let after_marker = &content_without_open[end + 4..];
+    after_marker.trim().to_string()
+}
+
+fn skill_tinybot_meta(
+    metadata: &serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut result = metadata
+        .get("metadata")
+        .and_then(|value| value.as_str())
+        .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    if !result.contains_key("always") {
+        if let Some(always) = metadata.get("always") {
+            result.insert(
+                "always".to_string(),
+                serde_json::Value::Bool(bool_metadata(Some(always))),
+            );
+        }
+    }
+    result
+}
+
+fn skill_missing_requirements(metadata: &serde_json::Map<String, serde_json::Value>) -> String {
+    let Some(requires) = metadata.get("requires").and_then(|value| value.as_object()) else {
+        return String::new();
+    };
+    let mut missing = Vec::new();
+    for bin in requires
+        .get("bins")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str())
+    {
+        missing.push(format!("CLI: {bin}"));
+    }
+    for env in requires
+        .get("env")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str())
+    {
+        if std::env::var_os(env).is_none() {
+            missing.push(format!("ENV: {env}"));
+        }
+    }
+    missing.join(", ")
+}
+
+fn bool_metadata(value: Option<&serde_json::Value>) -> bool {
+    value
+        .and_then(|value| {
+            value
+                .as_bool()
+                .or_else(|| value.as_str().map(json_string_truthy))
+        })
+        .unwrap_or(false)
+}
+
+fn json_string_truthy(value: &str) -> bool {
+    !matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "" | "false" | "0"
+    )
+}
+
+fn normalize_skill_name(name: &str) -> String {
+    let mut normalized = String::new();
+    let mut previous_dash = false;
+    for ch in name.trim().to_ascii_lowercase().chars() {
+        if ch.is_ascii_alphanumeric() {
+            normalized.push(ch);
+            previous_dash = false;
+        } else if !previous_dash {
+            normalized.push('-');
+            previous_dash = true;
+        }
+    }
+    normalized.trim_matches('-').to_string()
+}
+
+fn truthy_json_string(value: Option<&serde_json::Value>) -> Option<String> {
+    value
+        .filter(|value| json_truthy(Some(value)))
+        .map(json_value_to_string)
+}
+
+fn json_value_to_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(value) => value.clone(),
+        other => other.to_string().trim_matches('"').to_string(),
+    }
+}
+
+fn json_truthy(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        None | Some(serde_json::Value::Null) | Some(serde_json::Value::Bool(false)) => false,
+        Some(serde_json::Value::Number(number)) => number.as_f64() != Some(0.0),
+        Some(serde_json::Value::String(value)) => !value.is_empty(),
+        Some(serde_json::Value::Array(values)) => !values.is_empty(),
+        Some(serde_json::Value::Object(values)) => !values.is_empty(),
+        Some(serde_json::Value::Bool(true)) => true,
+    }
+}
+
+fn create_skill_body_content(
+    value: Option<&serde_json::Value>,
+    always: bool,
+) -> Result<String, WorkerProtocolError> {
+    match value {
+        None => Ok(String::new()),
+        Some(serde_json::Value::String(value)) => Ok(value.clone()),
+        Some(value) if !json_truthy(Some(value)) => Ok(String::new()),
+        Some(value) => Err(skill_error(
+            format!(
+                "failed to create skill: sequence item {}: expected str instance, {} found",
+                if always { 8 } else { 7 },
+                compat_type_name(value)
+            ),
+            500,
+        )),
+    }
+}
+
+fn update_skill_body_content(value: &serde_json::Value) -> Result<String, WorkerProtocolError> {
+    match value {
+        serde_json::Value::String(value) => Ok(value.clone()),
+        other => Err(skill_error(
+            format!(
+                "can only concatenate str (not \"{}\") to str",
+                compat_type_name(other)
+            ),
+            500,
+        )),
+    }
+}
+
+fn compat_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "NoneType",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(number) if number.is_i64() || number.is_u64() => "int",
+        serde_json::Value::Number(_) => "float",
+        serde_json::Value::String(_) => "str",
+        serde_json::Value::Array(_) => "list",
+        serde_json::Value::Object(_) => "dict",
+    }
+}
+
+fn create_skill_content(name: &str, description: &str, content: &str, always: bool) -> String {
+    let mut lines = vec![
+        "---".to_string(),
+        format!("name: {name}"),
+        format!("description: {description}"),
+    ];
+    if always {
+        lines.push("always: true".to_string());
+    }
+    lines.extend([
+        "---".to_string(),
+        String::new(),
+        format!("# {}", title_case_skill_name(name)),
+        String::new(),
+        if content.is_empty() {
+            "[TODO: Add skill instructions here]".to_string()
+        } else {
+            content.to_string()
+        },
+    ]);
+    lines.join("\n")
+}
+
+fn update_skill_content(
+    current_content: &str,
+    name: &str,
+    body: &serde_json::Map<String, serde_json::Value>,
+) -> Result<String, WorkerProtocolError> {
+    let (metadata, body_content) = split_skill_frontmatter_for_update(current_content);
+    let mut lines = vec!["---".to_string()];
+    if metadata.is_empty() {
+        lines.push(format!("name: {name}"));
+        lines.push(format!(
+            "description: {}",
+            body.get("description")
+                .map(json_value_to_string)
+                .unwrap_or_else(|| name.to_string())
+        ));
+        if body
+            .get("always")
+            .is_some_and(|value| json_truthy(Some(value)))
+        {
+            lines.push("always: true".to_string());
+        }
+    } else {
+        let mut saw_description = false;
+        let mut saw_always = false;
+        for (key, value) in metadata {
+            if key == "description" {
+                saw_description = true;
+                if let Some(description) = body.get("description") {
+                    lines.push(format!(
+                        "description: {}",
+                        json_value_to_string(description)
+                    ));
+                } else {
+                    lines.push(format!("{key}: {value}"));
+                }
+            } else if key == "always" {
+                saw_always = true;
+                if let Some(always) = body.get("always") {
+                    lines.push(format!("always: {}", json_truthy(Some(always))));
+                } else {
+                    lines.push(format!("{key}: {value}"));
+                }
+            } else {
+                lines.push(format!("{key}: {value}"));
+            }
+        }
+        if !saw_description {
+            if let Some(description) = body.get("description") {
+                lines.push(format!(
+                    "description: {}",
+                    json_value_to_string(description)
+                ));
+            }
+        }
+        if !saw_always {
+            if let Some(always) = body.get("always") {
+                lines.push(format!("always: {}", json_truthy(Some(always))));
+            }
+        }
+    }
+    lines.push("---".to_string());
+    let next_body = if let Some(content) = body.get("content") {
+        update_skill_body_content(content)?
+    } else {
+        body_content.trim().to_string()
+    };
+    Ok(format!("{}\n{}", lines.join("\n"), next_body))
+}
+
+fn split_skill_frontmatter_for_update(content: &str) -> (Vec<(String, String)>, String) {
+    let Some(content_without_open) = content.strip_prefix("---\n") else {
+        return (Vec::new(), content.to_string());
+    };
+    let Some(end) = content_without_open.find("\n---\n") else {
+        return (Vec::new(), content.to_string());
+    };
+    let raw = &content_without_open[..end];
+    let body = content_without_open[end + 5..].trim().to_string();
+    let metadata = raw
+        .lines()
+        .filter_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            Some((key.trim().to_string(), value.trim().to_string()))
+        })
+        .collect();
+    (metadata, body)
+}
+
+fn title_case_skill_name(name: &str) -> String {
+    name.split('-')
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn skill_dir_path(name: &str) -> String {
+    format!("skills/{name}")
+}
+
+fn skill_file_path(name: &str) -> String {
+    format!("{}/SKILL.md", skill_dir_path(name))
+}
+
+fn normalize_skill_resources(value: Option<&serde_json::Value>) -> Vec<String> {
+    let Some(serde_json::Value::Array(values)) = value else {
+        return Vec::new();
+    };
+    let mut resources = Vec::new();
+    for value in values {
+        let Some(value) = value.as_str() else {
+            continue;
+        };
+        if matches!(value, "scripts" | "references" | "assets")
+            && !resources.iter().any(|resource| resource == value)
+        {
+            resources.push(value.to_string());
+        }
+    }
+    resources
+}
+
+fn validate_skill_frontmatter(
+    name: &str,
+    frontmatter: &serde_json::Map<String, serde_json::Value>,
+) -> Option<serde_json::Value> {
+    let skill_name = frontmatter.get("name").and_then(|value| value.as_str());
+    if skill_name.is_none() {
+        return Some(serde_json::json!({
+            "name": name,
+            "valid": false,
+            "message": "Missing 'name' in frontmatter",
+        }));
+    }
+    if !frontmatter.contains_key("description") {
+        return Some(serde_json::json!({
+            "name": name,
+            "valid": false,
+            "message": "Missing 'description' in frontmatter",
+        }));
+    }
+    let skill_name = skill_name.unwrap_or_default();
+    if skill_name != name {
+        return Some(serde_json::json!({
+            "name": name,
+            "valid": false,
+            "message": format!("Skill name '{skill_name}' must match directory name '{name}'"),
+        }));
+    }
+    if normalize_skill_name(skill_name) != skill_name {
+        return Some(serde_json::json!({
+            "name": name,
+            "valid": false,
+            "message": "Name should be hyphen-case (lowercase letters, digits, hyphens)",
+        }));
+    }
+    if frontmatter
+        .get("description")
+        .and_then(|value| value.as_str())
+        .is_none_or(|value| value.trim().is_empty())
+    {
+        return Some(serde_json::json!({
+            "name": name,
+            "valid": false,
+            "message": "Description cannot be empty",
+        }));
+    }
+    None
+}
+
+fn validate_skill_children(name: &str, entries: &[WorkspaceDirectoryEntry]) -> serde_json::Value {
+    for entry in entries {
+        let trimmed_path = entry.path.trim_end_matches('/');
+        let child = trimmed_path.rsplit('/').next().unwrap_or(trimmed_path);
+        if child == "SKILL.md"
+            || entry.kind == "symlink"
+            || (entry.kind == "dir" && matches!(child, "scripts" | "references" | "assets"))
+        {
+            continue;
+        }
+        return serde_json::json!({
+            "name": name,
+            "valid": false,
+            "message": format!("Unexpected file/directory: {child}. Only scripts/, references/, assets/ allowed"),
+        });
+    }
+    serde_json::json!({ "name": name, "valid": true, "message": "Skill is valid" })
+}
+
+fn skill_error(message: impl Into<String>, status: u16) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::WorkerError,
+        message,
+        serde_json::json!({ "status": status }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
 }
 fn collect_skill_entries(
     root: &Path,

--- a/src-tauri/src/worker_workspace/tests.rs
+++ b/src-tauri/src/worker_workspace/tests.rs
@@ -423,7 +423,7 @@ mod tests {
     fn delete_file_refuses_workspace_root_and_requires_recursive_for_nonempty_dirs() {
         let fixture = WorkspaceFixture::new();
         fixture.write("notes/today.md", "hello");
-        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), write_policy());
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_write_policy());
 
         let root_error = rpc
             .delete_file(".", true)
@@ -442,12 +442,98 @@ mod tests {
         assert!(!fixture.root.join("notes").exists());
     }
 
+    #[test]
+    fn webui_skill_lifecycle_runs_in_rust_workspace_service() {
+        let fixture = WorkspaceFixture::new();
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_write_policy());
+
+        let created = rpc
+            .webui_create_skill(serde_json::json!({
+                "name": " Review Work! ",
+                "description": "Review changes",
+                "content": "Check diffs.",
+                "always": true,
+                "resources": ["scripts", "references", "invalid", "assets", "scripts"],
+            }))
+            .expect("skill should create");
+
+        assert_eq!(created["created"], true);
+        assert_eq!(created["name"], "review-work");
+        assert_eq!(created["path"], "skills/review-work/SKILL.md");
+        assert!(fixture.root.join("skills/review-work/scripts").is_dir());
+        assert!(fixture.root.join("skills/review-work/references").is_dir());
+        assert!(fixture.root.join("skills/review-work/assets").is_dir());
+
+        let listed = rpc
+            .webui_list_skills(Some(vec!["review-work".to_string()]))
+            .expect("skills should list");
+        assert_eq!(listed["skills"][0]["name"], "review-work");
+        assert_eq!(listed["skills"][0]["enabled"], true);
+        assert_eq!(listed["skills"][0]["always"], true);
+
+        let detail = rpc
+            .webui_skill_detail("review-work")
+            .expect("skill detail should load");
+        assert_eq!(detail["name"], "review-work");
+        assert_eq!(detail["content"], "# Review Work\n\nCheck diffs.");
+        assert_eq!(detail["metadata"]["description"], "Review changes");
+
+        let updated = rpc
+            .webui_update_skill(
+                "review-work",
+                serde_json::json!({
+                    "description": "Updated review",
+                    "content": "Review the changed files.",
+                    "always": false,
+                }),
+            )
+            .expect("skill should update");
+        assert_eq!(updated["updated"], true);
+
+        let validated = rpc
+            .webui_validate_skill("review-work")
+            .expect("skill should validate");
+        assert_eq!(validated["valid"], true);
+        assert_eq!(validated["message"], "Skill is valid");
+
+        let deleted = rpc
+            .webui_delete_skill("review-work")
+            .expect("skill should delete");
+        assert_eq!(deleted["deleted"], true);
+        assert!(!fixture.root.join("skills/review-work").exists());
+    }
+
+    #[test]
+    fn webui_skill_delete_rejects_builtin_skills() {
+        let fixture = WorkspaceFixture::new();
+        fixture.write_outside(
+            "workers/ts-agent-worker/skills/planner/SKILL.md",
+            "---\nname: planner\ndescription: Builtin planner\n---\nBuiltin body",
+        );
+        let rpc = WorkerWorkspaceRpc::new(fixture.root.clone(), read_write_policy())
+            .with_builtin_skills_root(fixture.outside.clone());
+
+        let error = rpc
+            .webui_delete_skill("planner")
+            .expect_err("builtin skill should not delete");
+
+        assert_eq!(error.message, "cannot delete builtin skills");
+        assert_eq!(error.details["status"], 403);
+    }
+
     fn read_policy() -> CapabilityPolicy {
         CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead])
     }
 
     fn write_policy() -> CapabilityPolicy {
         CapabilityPolicy::new([WorkerCapability::FsWorkspaceWrite])
+    }
+
+    fn read_write_policy() -> CapabilityPolicy {
+        CapabilityPolicy::new([
+            WorkerCapability::FsWorkspaceRead,
+            WorkerCapability::FsWorkspaceWrite,
+        ])
     }
 
     struct WorkspaceFixture {

--- a/src-tauri/tests/native_backend_contract.rs
+++ b/src-tauri/tests/native_backend_contract.rs
@@ -1,0 +1,101 @@
+use serde_json::json;
+use tinybot_desktop_lib::native_backend_contract::{
+    CompatibilityWorkerKind, CompatibilityWorkerState, NativeBackendEvent,
+    NativeBackendEventSource, NativeBackendKind, NativeBackendRunSpec, NativeBackendRuntimeStatus,
+    NATIVE_AGENT_EVENT_NAMES, NATIVE_TAURI_COMMANDS,
+};
+use tinybot_desktop_lib::worker_protocol::{
+    WorkerEvent, WorkerRequest, WorkerResponse, WorkerTransportMode,
+};
+use tinybot_desktop_lib::worker_runtime::WorkerRuntimeStatus;
+
+#[test]
+fn contract_inventory_lists_native_commands_and_events_used_by_frontend() {
+    assert!(NATIVE_TAURI_COMMANDS.contains(&"worker_run_agent"));
+    assert!(NATIVE_TAURI_COMMANDS.contains(&"worker_cancel_agent"));
+    assert!(NATIVE_TAURI_COMMANDS.contains(&"worker_restore_agent_checkpoint"));
+    assert!(NATIVE_TAURI_COMMANDS.contains(&"worker_submit_agent_form"));
+    assert!(NATIVE_TAURI_COMMANDS.contains(&"worker_resume_agent_approval"));
+
+    assert!(NATIVE_AGENT_EVENT_NAMES.contains(&"agent.delta"));
+    assert!(NATIVE_AGENT_EVENT_NAMES.contains(&"agent.awaiting_approval"));
+    assert!(NATIVE_AGENT_EVENT_NAMES.contains(&"agent.awaiting_form"));
+    assert!(NATIVE_AGENT_EVENT_NAMES.contains(&"agent.delegate.trace.updated"));
+    assert!(NATIVE_AGENT_EVENT_NAMES.contains(&"heartbeat.delivery"));
+}
+
+#[test]
+fn run_spec_accepts_frontend_payload_and_preserves_unknown_metadata() {
+    let spec = NativeBackendRunSpec::from_value(json!({
+        "runId": "run-1",
+        "sessionId": "session-1",
+        "messages": [{ "role": "user", "content": "hello" }],
+        "model": "gpt-4.1-mini",
+        "maxIterations": 8,
+        "stream": true,
+        "metadata": { "route": "desktop", "futureField": { "kept": true } },
+        "futureTopLevel": "kept"
+    }))
+    .expect("frontend run spec should parse");
+
+    assert_eq!(spec.run_id, "run-1");
+    assert_eq!(spec.session_id, "session-1");
+    assert_eq!(spec.model, "gpt-4.1-mini");
+    assert_eq!(spec.additional.get("futureTopLevel"), Some(&json!("kept")));
+    assert_eq!(
+        spec.metadata.get("futureField"),
+        Some(&json!({ "kept": true }))
+    );
+}
+
+#[test]
+fn native_event_wraps_worker_event_with_frontend_correlation_fields() {
+    let event = NativeBackendEvent::from_worker_event(
+        WorkerEvent {
+            protocol_version: "1".to_string(),
+            trace_id: "trace-1".to_string(),
+            event: "agent.delta".to_string(),
+            payload: json!({ "runId": "run-1", "delta": "hi" }),
+        },
+        "session-1",
+        Some("run-1"),
+        "2026-06-29T14:30:00.000Z",
+    );
+
+    assert_eq!(event.session_id, "session-1");
+    assert_eq!(event.run_id.as_deref(), Some("run-1"));
+    assert_eq!(event.trace_id, "trace-1");
+    assert_eq!(event.event_name, "agent.delta");
+    assert_eq!(event.source, NativeBackendEventSource::CompatibilityWorker);
+    assert_eq!(event.payload["delta"], "hi");
+}
+
+#[test]
+fn runtime_status_reports_rust_owner_and_optional_ts_compatibility_worker() {
+    let status = NativeBackendRuntimeStatus::rust_with_ts_compatibility(
+        WorkerRuntimeStatus::running(WorkerTransportMode::Stdio, vec![]),
+        vec!["agent.run".to_string(), "agent.cancel".to_string()],
+    );
+
+    assert_eq!(status.backend_kind, NativeBackendKind::Rust);
+    let worker = status
+        .compatibility_worker
+        .as_ref()
+        .expect("TS compatibility worker should be present");
+    assert_eq!(worker.kind, CompatibilityWorkerKind::TsAgentWorker);
+    assert_eq!(worker.state, CompatibilityWorkerState::Running);
+    assert_eq!(worker.delegated_capabilities, ["agent.run", "agent.cancel"]);
+}
+
+#[test]
+fn response_correlation_requires_request_id_and_trace_id() {
+    let request = WorkerRequest::new("req-1", "trace-1", "agent.run", json!({}));
+    let matching = WorkerResponse::success(&request, json!({ "ok": true }));
+    let wrong_trace = WorkerResponse {
+        trace_id: "trace-2".to_string(),
+        ..matching.clone()
+    };
+
+    assert!(matching.matches_request(&request));
+    assert!(!wrong_trace.matches_request(&request));
+}

--- a/src/native-workbench/app/desktopBootstrap.ts
+++ b/src/native-workbench/app/desktopBootstrap.ts
@@ -123,6 +123,7 @@ import {
   type TsCoworkRuntimeRollout,
 } from "../gateway/gatewayHttpClient";
 import { createDesktopNativeCoworkApi } from "../native/desktopNativeCowork";
+import { createDesktopNativeSessionsApi } from "../native/desktopNativeSessions";
 import { createDesktopNativeSkillsApi } from "../native/desktopNativeSkills";
 import { createDesktopNativeWebuiApi } from "../native/desktopNativeWebui";
 import { createDesktopNativeWorkspaceApi } from "../native/desktopNativeWorkspace";
@@ -158,6 +159,7 @@ const gatewayConfig = resolveGatewayConfig(DEFAULT_GATEWAY_CONFIG);
 const gatewayClientOptions: {
   config: typeof gatewayConfig;
   nativeCowork: ReturnType<typeof createDesktopNativeCoworkApi>;
+  nativeSessions: ReturnType<typeof createDesktopNativeSessionsApi>;
   nativeSkills: ReturnType<typeof createDesktopNativeSkillsApi>;
   nativeWebui: ReturnType<typeof createDesktopNativeWebuiApi>;
   nativeWorkspace: ReturnType<typeof createDesktopNativeWorkspaceApi>;
@@ -166,6 +168,7 @@ const gatewayClientOptions: {
 } = {
   config: gatewayConfig,
   nativeCowork: createDesktopNativeCoworkApi({ invoke }),
+  nativeSessions: createDesktopNativeSessionsApi({ invoke }),
   nativeSkills: createDesktopNativeSkillsApi({ invoke }),
   nativeWebui: createDesktopNativeWebuiApi({ invoke }),
   nativeWorkspace: createDesktopNativeWorkspaceApi({ invoke }),

--- a/src/native-workbench/app/desktopBootstrap.ts
+++ b/src/native-workbench/app/desktopBootstrap.ts
@@ -128,6 +128,7 @@ import { createDesktopNativeWebuiApi } from "../native/desktopNativeWebui";
 import { startDesktopNativeChannelRuntime } from "../native/desktopNativeChannelLifecycle";
 import { createDesktopNativeTransportApi } from "../native/desktopNativeTransport";
 import { toDesktopNativeTauriEventName } from "../native/desktopNativeTauriEvents";
+import { normalizeNativeBackendEventPayload } from "../native/nativeBackendContract";
 import { normalizeSessionsPayload } from "../chat/nativeChat";
 import {
   flushGatewaySocketQueue,
@@ -293,7 +294,7 @@ async function bootDesktopWebUi(): Promise<void> {
       nativeWebui: gatewayClientOptions.nativeWebui,
       resolveNativeWebSocketSessionExists,
       listenToNativeAgentEvent: (eventName, handler) => listen(toDesktopNativeTauriEventName(eventName), (event) => {
-        handler(event.payload);
+        handler(normalizeNativeBackendEventPayload(event.payload));
       }),
     });
     installWebUiRenderGlobals();
@@ -733,7 +734,7 @@ function handleNativeTsAgentWorkerEvent(eventName: DesktopTsAgentWorkerEventName
   if (!nativeWorkbenchRuntime) {
     return;
   }
-  nativeWorkbenchRuntime.handleTsAgentWorkerEvent(eventName, payload);
+  nativeWorkbenchRuntime.handleTsAgentWorkerEvent(eventName, normalizeNativeBackendEventPayload(payload));
   updateDesktopNativeChat(document, nativeWorkbenchRuntime.chat, gatewayConfig.httpBaseUrl, nativeChatActions());
 }
 

--- a/src/native-workbench/app/desktopBootstrap.ts
+++ b/src/native-workbench/app/desktopBootstrap.ts
@@ -125,6 +125,7 @@ import {
 import { createDesktopNativeCoworkApi } from "../native/desktopNativeCowork";
 import { createDesktopNativeSkillsApi } from "../native/desktopNativeSkills";
 import { createDesktopNativeWebuiApi } from "../native/desktopNativeWebui";
+import { createDesktopNativeWorkspaceApi } from "../native/desktopNativeWorkspace";
 import { startDesktopNativeChannelRuntime } from "../native/desktopNativeChannelLifecycle";
 import { createDesktopNativeTransportApi } from "../native/desktopNativeTransport";
 import { toDesktopNativeTauriEventName } from "../native/desktopNativeTauriEvents";
@@ -159,6 +160,7 @@ const gatewayClientOptions: {
   nativeCowork: ReturnType<typeof createDesktopNativeCoworkApi>;
   nativeSkills: ReturnType<typeof createDesktopNativeSkillsApi>;
   nativeWebui: ReturnType<typeof createDesktopNativeWebuiApi>;
+  nativeWorkspace: ReturnType<typeof createDesktopNativeWorkspaceApi>;
   nativeTransport: ReturnType<typeof createDesktopNativeTransportApi>;
   tsCoworkRuntime: TsCoworkRuntimeRollout;
 } = {
@@ -166,6 +168,7 @@ const gatewayClientOptions: {
   nativeCowork: createDesktopNativeCoworkApi({ invoke }),
   nativeSkills: createDesktopNativeSkillsApi({ invoke }),
   nativeWebui: createDesktopNativeWebuiApi({ invoke }),
+  nativeWorkspace: createDesktopNativeWorkspaceApi({ invoke }),
   nativeTransport: createDesktopNativeTransportApi({ invoke }),
   tsCoworkRuntime: DEFAULT_TS_COWORK_RUNTIME_ROLLOUT,
 };

--- a/src/native-workbench/gateway/desktopGatewayStartup.ts
+++ b/src/native-workbench/gateway/desktopGatewayStartup.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "./gatewayConfig";
+import type { NativeBackendCompatibilityWorkerStatus, NativeBackendKind } from "../native/nativeBackendContract";
 
 export type GatewayRuntimeStatus = {
   state: "running" | "starting" | "offline" | "failed";
@@ -22,6 +23,8 @@ export type GatewayRuntimeStatus = {
 
 export type DesktopWorkerRuntimeStatus = {
   state: "stopped" | "starting" | "running" | "failed" | "incompatible" | string;
+  backend_kind?: NativeBackendKind | string;
+  compatibility_worker?: NativeBackendCompatibilityWorkerStatus | null;
   transport_mode?: "stdio" | "local_pipe" | string | null;
   diagnostics?: Array<{ stream: string; line: string }>;
   last_error?: string | null;

--- a/src/native-workbench/gateway/gateway.test.ts
+++ b/src/native-workbench/gateway/gateway.test.ts
@@ -710,6 +710,67 @@ describe("gateway HTTP client", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
+  test("prefers native Rust session state mutations when both native paths are available", async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
+    const nativeWebui = {
+      route: vi.fn(async () => {
+        throw new Error("native WebUI session state route should not be used");
+      }),
+    };
+    const nativeSessions = {
+      list: vi.fn(),
+      messages: vi.fn(),
+      temporaryFiles: vi.fn(async (key: string) => ({ key, temporary_files: [{ name: "context.md" }] })),
+      uploadTemporaryFile: vi.fn(async (key: string, body: unknown) => ({ key, uploaded: true, body })),
+      clearTemporaryFiles: vi.fn(async (key: string) => ({ key, cleared: 1 })),
+      delete: vi.fn(async (key: string) => ({ key, deleted: true })),
+      patch: vi.fn(async (key: string, body: unknown) => ({ key, metadata: { pinned: true }, body })),
+      clear: vi.fn(async (key: string) => ({ key, cleared: true })),
+    };
+    const client = createGatewayApiClient({
+      config: DEFAULT_GATEWAY_CONFIG,
+      fetchFn,
+      nativeSessions,
+      nativeWebui,
+    });
+    const form = new FormData();
+    form.append("file", new File(["hello native"], "context.md", { type: "text/markdown" }));
+
+    await expect(client.sessions.temporaryFiles("websocket:chat-1")).resolves.toEqual({
+      key: "websocket:chat-1",
+      temporary_files: [{ name: "context.md" }],
+    });
+    await expect(client.sessions.uploadTemporaryFile("websocket:chat-1", form)).resolves.toEqual({
+      key: "websocket:chat-1",
+      uploaded: true,
+      body: {
+        name: "context.md",
+        file_type: "md",
+        content: "hello native",
+        size_bytes: 12,
+      },
+    });
+    await expect(client.sessions.clearTemporaryFiles("websocket:chat-1")).resolves.toEqual({
+      key: "websocket:chat-1",
+      cleared: 1,
+    });
+    await expect(client.sessions.patch("websocket:chat-1", { metadata: { pinned: true } })).resolves.toEqual({
+      key: "websocket:chat-1",
+      metadata: { pinned: true },
+      body: { metadata: { pinned: true } },
+    });
+    await expect(client.sessions.clear("websocket:chat-1")).resolves.toEqual({
+      key: "websocket:chat-1",
+      cleared: true,
+    });
+    await expect(client.sessions.delete("websocket:chat-1")).resolves.toEqual({
+      key: "websocket:chat-1",
+      deleted: true,
+    });
+    expect(nativeWebui.route).not.toHaveBeenCalled();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
   test("prefers native WebUI session clear route when available", async () => {
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {

--- a/src/native-workbench/gateway/gateway.test.ts
+++ b/src/native-workbench/gateway/gateway.test.ts
@@ -925,21 +925,16 @@ describe("gateway HTTP client", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
-  test("prefers native WebUI skills read routes when available", async () => {
+  test("prefers native Rust skills read operations when both native paths are available", async () => {
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {
-      route: vi.fn(async (request: { method: string; path: string; body?: unknown }) => ({
-        native: true,
-        request,
-      })),
+      route: vi.fn(async () => {
+        throw new Error("native WebUI skills route should not be used");
+      }),
     };
     const nativeSkills = {
-      list: vi.fn(async () => {
-        throw new Error("legacy native skills should not be used");
-      }),
-      detail: vi.fn(async () => {
-        throw new Error("legacy native skills should not be used");
-      }),
+      list: vi.fn(async () => ({ skills: [{ name: "planner" }] })),
+      detail: vi.fn(async (name: string) => ({ name, content: "Plan." })),
       create: vi.fn(async () => ({})),
       update: vi.fn(async () => ({})),
       delete: vi.fn(async () => ({})),
@@ -952,44 +947,28 @@ describe("gateway HTTP client", () => {
       nativeSkills,
     });
 
-    await expect(client.skills.list()).resolves.toEqual({
-      native: true,
-      request: { method: "GET", path: "/api/skills" },
-    });
-    await expect(client.skills.detail("planner/phase")).resolves.toEqual({
-      native: true,
-      request: { method: "GET", path: "/api/skills/planner%2Fphase" },
-    });
-    expect(nativeWebui.route).toHaveBeenCalledWith({ method: "GET", path: "/api/skills" });
-    expect(nativeWebui.route).toHaveBeenCalledWith({ method: "GET", path: "/api/skills/planner%2Fphase" });
-    expect(nativeSkills.list).not.toHaveBeenCalled();
-    expect(nativeSkills.detail).not.toHaveBeenCalled();
+    await expect(client.skills.list()).resolves.toEqual({ skills: [{ name: "planner" }] });
+    await expect(client.skills.detail("planner/phase")).resolves.toEqual({ name: "planner/phase", content: "Plan." });
+    expect(nativeSkills.list).toHaveBeenCalledTimes(1);
+    expect(nativeSkills.detail).toHaveBeenCalledWith("planner/phase");
+    expect(nativeWebui.route).not.toHaveBeenCalled();
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
-  test("prefers native WebUI skills mutation routes when available", async () => {
+  test("prefers native Rust skills mutation operations when both native paths are available", async () => {
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {
-      route: vi.fn(async (request: { method: string; path: string; body?: unknown }) => ({
-        native: true,
-        request,
-      })),
+      route: vi.fn(async () => {
+        throw new Error("native WebUI skills route should not be used");
+      }),
     };
     const nativeSkills = {
       list: vi.fn(async () => ({})),
       detail: vi.fn(async () => ({})),
-      create: vi.fn(async () => {
-        throw new Error("legacy native skills should not be used");
-      }),
-      update: vi.fn(async () => {
-        throw new Error("legacy native skills should not be used");
-      }),
-      delete: vi.fn(async () => {
-        throw new Error("legacy native skills should not be used");
-      }),
-      validate: vi.fn(async () => {
-        throw new Error("legacy native skills should not be used");
-      }),
+      create: vi.fn(async (body: unknown) => ({ created: true, body })),
+      update: vi.fn(async (name: string, body: unknown) => ({ updated: true, name, body })),
+      delete: vi.fn(async (name: string) => ({ deleted: true, name })),
+      validate: vi.fn(async (name: string) => ({ name, valid: true })),
     };
     const client = createGatewayApiClient({
       config: DEFAULT_GATEWAY_CONFIG,
@@ -999,25 +978,27 @@ describe("gateway HTTP client", () => {
     });
 
     await expect(client.skills.create({ name: "planner", content: "Plan." })).resolves.toEqual({
-      native: true,
-      request: { method: "POST", path: "/api/skills", body: { name: "planner", content: "Plan." } },
+      created: true,
+      body: { name: "planner", content: "Plan." },
     });
     await expect(client.skills.update("planner/phase", { content: "Updated." })).resolves.toEqual({
-      native: true,
-      request: { method: "PATCH", path: "/api/skills/planner%2Fphase", body: { content: "Updated." } },
+      updated: true,
+      name: "planner/phase",
+      body: { content: "Updated." },
     });
     await expect(client.skills.delete("planner/phase")).resolves.toEqual({
-      native: true,
-      request: { method: "DELETE", path: "/api/skills/planner%2Fphase" },
+      deleted: true,
+      name: "planner/phase",
     });
     await expect(client.skills.validate("planner/phase")).resolves.toEqual({
-      native: true,
-      request: { method: "POST", path: "/api/skills/planner%2Fphase/validate" },
+      name: "planner/phase",
+      valid: true,
     });
-    expect(nativeSkills.create).not.toHaveBeenCalled();
-    expect(nativeSkills.update).not.toHaveBeenCalled();
-    expect(nativeSkills.delete).not.toHaveBeenCalled();
-    expect(nativeSkills.validate).not.toHaveBeenCalled();
+    expect(nativeSkills.create).toHaveBeenCalledWith({ name: "planner", content: "Plan." });
+    expect(nativeSkills.update).toHaveBeenCalledWith("planner/phase", { content: "Updated." });
+    expect(nativeSkills.delete).toHaveBeenCalledWith("planner/phase");
+    expect(nativeSkills.validate).toHaveBeenCalledWith("planner/phase");
+    expect(nativeWebui.route).not.toHaveBeenCalled();
     expect(fetchFn).not.toHaveBeenCalled();
   });
 

--- a/src/native-workbench/gateway/gateway.test.ts
+++ b/src/native-workbench/gateway/gateway.test.ts
@@ -1043,42 +1043,50 @@ describe("gateway HTTP client", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
-  test("prefers native WebUI workspace file routes when available", async () => {
+  test("prefers native Rust workspace file operations when both native paths are available", async () => {
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {
-      route: vi.fn(async (request: { method: string; path: string; body?: unknown }) => ({
-        native: true,
-        request,
-      })),
+      route: vi.fn(async () => {
+        throw new Error("native WebUI workspace route should not be used");
+      }),
+    };
+    const nativeWorkspace = {
+      files: vi.fn(async () => ({ items: [{ path: "docs/readme.md" }] })),
+      file: vi.fn(async (path: string) => ({ path, content: "# Readme\n" })),
+      putFile: vi.fn(async (path: string, body: unknown) => ({ path, saved: true, body })),
     };
     const client = createGatewayApiClient({
       config: DEFAULT_GATEWAY_CONFIG,
       fetchFn,
       nativeWebui,
+      nativeWorkspace,
     });
 
     await expect(client.workspace.files()).resolves.toEqual({
-      native: true,
-      request: { method: "GET", path: "/api/workspace/files" },
+      items: [{ path: "docs/readme.md" }],
     });
     await expect(client.workspace.file("docs/readme.md")).resolves.toEqual({
-      native: true,
-      request: { method: "GET", path: "/api/workspace/files/docs%2Freadme.md" },
+      path: "docs/readme.md",
+      content: "# Readme\n",
     });
     await expect(client.workspace.putFile("docs/readme.md", {
       content: "# Readme\n",
       expected_updated_at: null,
     })).resolves.toEqual({
-      native: true,
-      request: {
-        method: "PUT",
-        path: "/api/workspace/files/docs%2Freadme.md",
-        body: {
-          content: "# Readme\n",
-          expected_updated_at: null,
-        },
+      path: "docs/readme.md",
+      saved: true,
+      body: {
+        content: "# Readme\n",
+        expected_updated_at: null,
       },
     });
+    expect(nativeWorkspace.files).toHaveBeenCalledTimes(1);
+    expect(nativeWorkspace.file).toHaveBeenCalledWith("docs/readme.md");
+    expect(nativeWorkspace.putFile).toHaveBeenCalledWith("docs/readme.md", {
+      content: "# Readme\n",
+      expected_updated_at: null,
+    });
+    expect(nativeWebui.route).not.toHaveBeenCalled();
     expect(fetchFn).not.toHaveBeenCalled();
   });
 

--- a/src/native-workbench/gateway/gateway.test.ts
+++ b/src/native-workbench/gateway/gateway.test.ts
@@ -652,39 +652,52 @@ describe("gateway HTTP client", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
-  test("prefers native WebUI session list route when available", async () => {
+  test("prefers native Rust session list when both native paths are available", async () => {
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {
-      route: vi.fn(async (request: { method: string; path: string; body?: unknown }) => ({
+      route: vi.fn(async () => {
+        throw new Error("native WebUI session list route should not be used");
+      }),
+    };
+    const nativeSessions = {
+      list: vi.fn(async () => ({
         items: [{ key: "websocket:chat-1", chat_id: "chat-1", title: "Native session" }],
-        request,
       })),
+      messages: vi.fn(),
     };
     const client = createGatewayApiClient({
       config: DEFAULT_GATEWAY_CONFIG,
       fetchFn,
+      nativeSessions,
       nativeWebui,
     });
 
     await expect(client.sessions.list()).resolves.toMatchObject({
       items: [{ key: "websocket:chat-1", chat_id: "chat-1", title: "Native session" }],
     });
-    expect(nativeWebui.route).toHaveBeenCalledWith({ method: "GET", path: "/api/sessions" });
+    expect(nativeSessions.list).toHaveBeenCalledTimes(1);
+    expect(nativeWebui.route).not.toHaveBeenCalled();
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
-  test("prefers native WebUI session messages route when available", async () => {
+  test("prefers native Rust session messages when both native paths are available", async () => {
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ gateway: true }), { status: 200 }));
     const nativeWebui = {
-      route: vi.fn(async (request: { method: string; path: string; body?: unknown }) => ({
-        key: "websocket:chat-1",
+      route: vi.fn(async () => {
+        throw new Error("native WebUI session messages route should not be used");
+      }),
+    };
+    const nativeSessions = {
+      list: vi.fn(),
+      messages: vi.fn(async (key: string) => ({
+        key,
         messages: [{ role: "user", content: "Native history" }],
-        request,
       })),
     };
     const client = createGatewayApiClient({
       config: DEFAULT_GATEWAY_CONFIG,
       fetchFn,
+      nativeSessions,
       nativeWebui,
     });
 
@@ -692,10 +705,8 @@ describe("gateway HTTP client", () => {
       key: "websocket:chat-1",
       messages: [{ role: "user", content: "Native history" }],
     });
-    expect(nativeWebui.route).toHaveBeenCalledWith({
-      method: "GET",
-      path: "/api/sessions/websocket%3Achat-1/messages",
-    });
+    expect(nativeSessions.messages).toHaveBeenCalledWith("websocket:chat-1");
+    expect(nativeWebui.route).not.toHaveBeenCalled();
     expect(fetchFn).not.toHaveBeenCalled();
   });
 

--- a/src/native-workbench/gateway/gatewayHttpClient.ts
+++ b/src/native-workbench/gateway/gatewayHttpClient.ts
@@ -6,6 +6,7 @@ type FetchFn = typeof fetch;
 type ClientOptions = {
   config?: GatewayConfig;
   fetchFn?: FetchFn;
+  nativeSessions?: NativeSessionsApi;
   nativeSkills?: NativeSkillsApi;
   nativeWorkspace?: NativeWorkspaceApi;
   nativeCowork?: NativeCoworkApi;
@@ -59,6 +60,11 @@ export type NativeSkillsApi = {
   update: (name: string, body: unknown) => Promise<unknown>;
   delete: (name: string) => Promise<unknown>;
   validate: (name: string) => Promise<unknown>;
+};
+
+export type NativeSessionsApi = {
+  list: () => Promise<unknown>;
+  messages: (key: string) => Promise<unknown>;
 };
 
 export type NativeWorkspaceApi = {
@@ -340,12 +346,12 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
     },
     sessions: {
       list: () => nativeOrGateway(
-        () => options.nativeWebui?.route({ method: "GET", path: "/api/sessions" }),
+        () => options.nativeSessions?.list() ?? options.nativeWebui?.route({ method: "GET", path: "/api/sessions" }),
         () => request("/api/sessions"),
         "webui.sessions.list",
       ),
       messages: (key: string) => nativeOrGateway(
-        () => options.nativeWebui?.route({ method: "GET", path: `/api/sessions/${encodePathSegment(key)}/messages` }),
+        () => options.nativeSessions?.messages(key) ?? options.nativeWebui?.route({ method: "GET", path: `/api/sessions/${encodePathSegment(key)}/messages` }),
         () => request(`/api/sessions/${encodePathSegment(key)}/messages`),
         "webui.sessions.messages",
       ),

--- a/src/native-workbench/gateway/gatewayHttpClient.ts
+++ b/src/native-workbench/gateway/gatewayHttpClient.ts
@@ -7,6 +7,7 @@ type ClientOptions = {
   config?: GatewayConfig;
   fetchFn?: FetchFn;
   nativeSkills?: NativeSkillsApi;
+  nativeWorkspace?: NativeWorkspaceApi;
   nativeCowork?: NativeCoworkApi;
   nativeWebui?: NativeWebuiApi;
   tsCoworkRuntime?: TsCoworkRuntimeRollout;
@@ -58,6 +59,12 @@ export type NativeSkillsApi = {
   update: (name: string, body: unknown) => Promise<unknown>;
   delete: (name: string) => Promise<unknown>;
   validate: (name: string) => Promise<unknown>;
+};
+
+export type NativeWorkspaceApi = {
+  files: () => Promise<unknown>;
+  file: (path: string) => Promise<unknown>;
+  putFile: (path: string, body: unknown) => Promise<unknown>;
 };
 
 export type NativeCoworkRouteRequest = {
@@ -643,14 +650,14 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
     },
     workspace: {
       files: () => nativeOrGateway(
-        () => options.nativeWebui?.route({ method: "GET", path: "/api/workspace/files" }),
+        () => options.nativeWorkspace?.files() ?? options.nativeWebui?.route({ method: "GET", path: "/api/workspace/files" }),
         () => request("/api/workspace/files"),
         "webui.workspace.files",
       ),
       file: (path: string) => {
         const routePath = `/api/workspace/files/${encodePathSegment(path)}`;
         return nativeOrGateway(
-          () => options.nativeWebui?.route({ method: "GET", path: routePath }),
+          () => options.nativeWorkspace?.file(path) ?? options.nativeWebui?.route({ method: "GET", path: routePath }),
           () => request(routePath),
           "webui.workspace.file",
         );
@@ -658,7 +665,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
       putFile: (path: string, body: unknown) => {
         const routePath = `/api/workspace/files/${encodePathSegment(path)}`;
         return nativeOrGateway(
-          () => options.nativeWebui?.route({ method: "PUT", path: routePath, body }),
+          () => options.nativeWorkspace?.putFile(path, body) ?? options.nativeWebui?.route({ method: "PUT", path: routePath, body }),
           () => request(routePath, jsonRequest("PUT", body)),
           "webui.workspace.putFile",
         );

--- a/src/native-workbench/gateway/gatewayHttpClient.ts
+++ b/src/native-workbench/gateway/gatewayHttpClient.ts
@@ -455,47 +455,47 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
     },
     skills: {
       list: () => nativeOrGateway(
-        () => options.nativeWebui?.route({ method: "GET", path: "/api/skills" }) ?? options.nativeSkills?.list(),
+        () => options.nativeSkills?.list() ?? options.nativeWebui?.route({ method: "GET", path: "/api/skills" }),
         () => request("/api/skills"),
         "skills.list",
       ),
       detail: (name: string) => nativeOrGateway(
-        () => options.nativeWebui?.route({
+        () => options.nativeSkills?.detail(name) ?? options.nativeWebui?.route({
           method: "GET",
           path: `/api/skills/${encodePathSegment(name)}`,
-        }) ?? options.nativeSkills?.detail(name),
+        }),
         () => request(`/api/skills/${encodePathSegment(name)}`),
         "skills.detail",
       ),
       create: (body: unknown) => nativeOrGateway(
-        () => options.nativeWebui?.route({ method: "POST", path: "/api/skills", body })
-          ?? options.nativeSkills?.create(body),
+        () => options.nativeSkills?.create(body)
+          ?? options.nativeWebui?.route({ method: "POST", path: "/api/skills", body }),
         () => request("/api/skills", jsonRequest("POST", body)),
         "skills.create",
       ),
       update: (name: string, body: unknown) =>
         nativeOrGateway(
-          () => options.nativeWebui?.route({
+          () => options.nativeSkills?.update(name, body) ?? options.nativeWebui?.route({
             method: "PATCH",
             path: `/api/skills/${encodePathSegment(name)}`,
             body,
-          }) ?? options.nativeSkills?.update(name, body),
+          }),
           () => request(`/api/skills/${encodePathSegment(name)}`, jsonRequest("PATCH", body)),
           "skills.update",
         ),
       delete: (name: string) => nativeOrGateway(
-        () => options.nativeWebui?.route({
+        () => options.nativeSkills?.delete(name) ?? options.nativeWebui?.route({
           method: "DELETE",
           path: `/api/skills/${encodePathSegment(name)}`,
-        }) ?? options.nativeSkills?.delete(name),
+        }),
         () => request(`/api/skills/${encodePathSegment(name)}`, { method: "DELETE" }),
         "skills.delete",
       ),
       validate: (name: string) => nativeOrGateway(
-        () => options.nativeWebui?.route({
+        () => options.nativeSkills?.validate(name) ?? options.nativeWebui?.route({
           method: "POST",
           path: `/api/skills/${encodePathSegment(name)}/validate`,
-        }) ?? options.nativeSkills?.validate(name),
+        }),
         () => request(`/api/skills/${encodePathSegment(name)}/validate`, { method: "POST" }),
         "skills.validate",
       ),

--- a/src/native-workbench/gateway/gatewayHttpClient.ts
+++ b/src/native-workbench/gateway/gatewayHttpClient.ts
@@ -65,6 +65,12 @@ export type NativeSkillsApi = {
 export type NativeSessionsApi = {
   list: () => Promise<unknown>;
   messages: (key: string) => Promise<unknown>;
+  temporaryFiles?: (key: string) => Promise<unknown>;
+  uploadTemporaryFile?: (key: string, body: unknown) => Promise<unknown>;
+  clearTemporaryFiles?: (key: string) => Promise<unknown>;
+  delete?: (key: string) => Promise<unknown>;
+  patch?: (key: string, body: unknown) => Promise<unknown>;
+  clear?: (key: string) => Promise<unknown>;
 };
 
 export type NativeWorkspaceApi = {
@@ -361,7 +367,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
         "webui.sessions.profile",
       ),
       temporaryFiles: (key: string) => nativeOrGateway(
-        () => options.nativeWebui?.route({
+        () => options.nativeSessions?.temporaryFiles?.(key) ?? options.nativeWebui?.route({
           method: "GET",
           path: `/api/sessions/${encodePathSegment(key)}/temporary-files`,
         }),
@@ -371,7 +377,13 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
       uploadTemporaryFile: (key: string, body: FormData) => nativeOrGateway(
         () => {
           const uploadBody = nativeTemporaryFileUploadBody(body);
-          return options.nativeWebui && uploadBody
+          if (!uploadBody) {
+            return undefined;
+          }
+          if (options.nativeSessions?.uploadTemporaryFile) {
+            return uploadBody.then((payload) => options.nativeSessions?.uploadTemporaryFile?.(key, payload));
+          }
+          return options.nativeWebui
             ? uploadBody.then((payload) => options.nativeWebui?.route({
               method: "POST",
               path: `/api/sessions/${encodePathSegment(key)}/temporary-files`,
@@ -383,7 +395,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
         "webui.sessions.uploadTemporaryFile",
       ),
       clearTemporaryFiles: (key: string) => nativeOrGateway(
-        () => options.nativeWebui?.route({
+        () => options.nativeSessions?.clearTemporaryFiles?.(key) ?? options.nativeWebui?.route({
           method: "DELETE",
           path: `/api/sessions/${encodePathSegment(key)}/temporary-files`,
         }),
@@ -391,12 +403,12 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
         "webui.sessions.clearTemporaryFiles",
       ),
       delete: (key: string) => nativeOrGateway(
-        () => options.nativeWebui?.route({ method: "DELETE", path: `/api/sessions/${encodePathSegment(key)}` }),
+        () => options.nativeSessions?.delete?.(key) ?? options.nativeWebui?.route({ method: "DELETE", path: `/api/sessions/${encodePathSegment(key)}` }),
         () => request(`/api/sessions/${encodePathSegment(key)}`, { method: "DELETE" }),
         "webui.sessions.delete",
       ),
       patch: (key: string, body: unknown) => nativeOrGateway(
-        () => options.nativeWebui?.route({
+        () => options.nativeSessions?.patch?.(key, body) ?? options.nativeWebui?.route({
           method: "PATCH",
           path: `/api/sessions/${encodePathSegment(key)}`,
           body,
@@ -405,7 +417,7 @@ export function createGatewayApiClient(options: ClientOptions = {}) {
         "webui.sessions.patch",
       ),
       clear: (key: string) => nativeOrGateway(
-        () => options.nativeWebui?.route({
+        () => options.nativeSessions?.clear?.(key) ?? options.nativeWebui?.route({
           method: "POST",
           path: `/api/sessions/${encodePathSegment(key)}/clear`,
         }),

--- a/src/native-workbench/native/desktopNativeSessions.test.ts
+++ b/src/native-workbench/native/desktopNativeSessions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createDesktopNativeSessionsApi } from "./desktopNativeSessions";
+
+describe("desktop native sessions API", () => {
+  test("loads session lists and messages through Rust state Tauri commands", async () => {
+    const invoke = vi.fn(async (command: string, args?: Record<string, unknown>) => ({
+      command,
+      args,
+    }));
+    const api = createDesktopNativeSessionsApi({ invoke });
+
+    await expect(api.list()).resolves.toEqual({
+      command: "worker_sessions_list",
+      args: undefined,
+    });
+    await expect(api.messages("websocket:chat-1")).resolves.toEqual({
+      command: "worker_session_messages",
+      args: { input: { key: "websocket:chat-1" } },
+    });
+  });
+});

--- a/src/native-workbench/native/desktopNativeSessions.test.ts
+++ b/src/native-workbench/native/desktopNativeSessions.test.ts
@@ -18,5 +18,29 @@ describe("desktop native sessions API", () => {
       command: "worker_session_messages",
       args: { input: { key: "websocket:chat-1" } },
     });
+    await expect(api.temporaryFiles!("websocket:chat-1")).resolves.toEqual({
+      command: "worker_session_temporary_files",
+      args: { input: { key: "websocket:chat-1" } },
+    });
+    await expect(api.uploadTemporaryFile!("websocket:chat-1", { name: "context.md" })).resolves.toEqual({
+      command: "worker_session_upload_temporary_file",
+      args: { input: { key: "websocket:chat-1", body: { name: "context.md" } } },
+    });
+    await expect(api.clearTemporaryFiles!("websocket:chat-1")).resolves.toEqual({
+      command: "worker_session_clear_temporary_files",
+      args: { input: { key: "websocket:chat-1" } },
+    });
+    await expect(api.delete!("websocket:chat-1")).resolves.toEqual({
+      command: "worker_session_delete",
+      args: { input: { key: "websocket:chat-1" } },
+    });
+    await expect(api.patch!("websocket:chat-1", { metadata: { pinned: true } })).resolves.toEqual({
+      command: "worker_session_patch",
+      args: { input: { key: "websocket:chat-1", body: { metadata: { pinned: true } } } },
+    });
+    await expect(api.clear!("websocket:chat-1")).resolves.toEqual({
+      command: "worker_session_clear",
+      args: { input: { key: "websocket:chat-1" } },
+    });
   });
 });

--- a/src/native-workbench/native/desktopNativeSessions.ts
+++ b/src/native-workbench/native/desktopNativeSessions.ts
@@ -8,5 +8,11 @@ export function createDesktopNativeSessionsApi(options: { invoke?: TauriInvoke }
   return {
     list: () => invoke("worker_sessions_list"),
     messages: (key: string) => invoke("worker_session_messages", { input: { key } }),
+    temporaryFiles: (key: string) => invoke("worker_session_temporary_files", { input: { key } }),
+    uploadTemporaryFile: (key: string, body: unknown) => invoke("worker_session_upload_temporary_file", { input: { key, body } }),
+    clearTemporaryFiles: (key: string) => invoke("worker_session_clear_temporary_files", { input: { key } }),
+    delete: (key: string) => invoke("worker_session_delete", { input: { key } }),
+    patch: (key: string, body: unknown) => invoke("worker_session_patch", { input: { key, body } }),
+    clear: (key: string) => invoke("worker_session_clear", { input: { key } }),
   };
 }

--- a/src/native-workbench/native/desktopNativeSessions.ts
+++ b/src/native-workbench/native/desktopNativeSessions.ts
@@ -1,0 +1,12 @@
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import type { NativeSessionsApi } from "../gateway/gatewayHttpClient";
+
+type TauriInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+export function createDesktopNativeSessionsApi(options: { invoke?: TauriInvoke } = {}): NativeSessionsApi {
+  const invoke = options.invoke ?? tauriInvoke;
+  return {
+    list: () => invoke("worker_sessions_list"),
+    messages: (key: string) => invoke("worker_session_messages", { input: { key } }),
+  };
+}

--- a/src/native-workbench/native/desktopNativeSkills.test.ts
+++ b/src/native-workbench/native/desktopNativeSkills.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import { createDesktopNativeSkillsApi } from "./desktopNativeSkills";
 
 describe("desktop native skills API", () => {
-  test("loads skills list and detail through TS worker Tauri commands", async () => {
+  test("loads and mutates skills through Rust state Tauri commands", async () => {
     const invoke = vi.fn(async (command: string, args?: Record<string, unknown>) => ({
       command,
       args,

--- a/src/native-workbench/native/desktopNativeWebSocketBridge.ts
+++ b/src/native-workbench/native/desktopNativeWebSocketBridge.ts
@@ -1,6 +1,7 @@
 import type { NativeTransportApi, NativeTransportWebSocketDispatchRequest } from "./desktopNativeTransport";
 import { logDesktopNativeDebug, summarizeDebugText } from "./desktopNativeChatDebug";
 import { toDesktopNativeTauriEventName } from "./desktopNativeTauriEvents";
+import type { NativeBackendWebSocketAgentEventName } from "./nativeBackendContract";
 
 export type DesktopNativeWebSocketOptions = {
   url: string | URL;
@@ -13,36 +14,12 @@ export type DesktopNativeWebSocketOptions = {
 };
 
 type Listener = (event: Event) => void;
-export type DesktopNativeWebSocketAgentEventName =
-  | "agent.delta"
-  | "agent.reasoning_delta"
-  | "agent.tool_call.delta"
-  | "agent.tool.start"
-  | "agent.tool.result"
-  | "agent.usage"
-  | "agent.awaiting_form"
-  | "agent.awaiting_approval"
-  | "agent.memory_reference"
-  | "agent.task_progress"
-  | "agent.delegate.started"
-  | "agent.delegate.running"
-  | "agent.delegate.message_queued"
-  | "agent.delegate.awaiting_approval"
-  | "agent.delegate.tool.approval_required"
-  | "agent.delegate.tool.completed"
-  | "agent.delegate.trace.updated"
-  | "agent.delegate.completed"
-  | "agent.delegate.failed"
-  | "agent.delegate.interrupted"
-  | "agent.delegate.closed"
-  | "agent.browser_frame"
+type DesktopNativeCoworkEventName =
   | "cowork_updated"
   | "cowork_state"
   | "cowork_stream"
-  | "cowork_mailbox_stream"
-  | "agent.cancelled"
-  | "agent.done"
-  | "agent.error";
+  | "cowork_mailbox_stream";
+export type DesktopNativeWebSocketAgentEventName = NativeBackendWebSocketAgentEventName | DesktopNativeCoworkEventName;
 export type DesktopNativeWebSocketAgentEventHandler = (payload: unknown) => void;
 export type DesktopNativeWebSocketAgentEventListener = (
   eventName: string,

--- a/src/native-workbench/native/desktopNativeWorkbenchRuntime.test.ts
+++ b/src/native-workbench/native/desktopNativeWorkbenchRuntime.test.ts
@@ -1,5 +1,6 @@
 ﻿import { describe, expect, test, vi } from "vitest";
 import { createDesktopNativeWorkbenchRuntime } from "./desktopNativeWorkbenchRuntime";
+import { normalizeNativeBackendEventPayload } from "./nativeBackendContract";
 
 describe("desktop native workbench runtime", () => {
   test("loads gateway sessions and exposes a live chat model for the native shell", async () => {
@@ -595,6 +596,63 @@ describe("desktop native workbench runtime", () => {
     expect(runtime.chat.responding).toBe(false);
     expect(runtime.chat.composerState).toBe("idle");
     expect(runtime.chat.status).toBe("TS agent response received.");
+  });
+
+  test("projects Rust native backend event envelopes into the active native chat", async () => {
+    let resolveRun: ((value: {
+      finalContent: string;
+      stopReason: string;
+      messages: never[];
+      toolsUsed: never[];
+    }) => void) | undefined;
+    const runPromise = new Promise<{
+      finalContent: string;
+      stopReason: string;
+      messages: never[];
+      toolsUsed: never[];
+    }>((resolve) => {
+      resolveRun = resolve;
+    });
+    const runSpecs: unknown[] = [];
+    const runtime = createDesktopNativeWorkbenchRuntime({
+      api: {
+        listSessions: async () => ({
+          items: [{ key: "WebSocket:chat-rust", chat_id: "chat-rust", title: "Rust route" }],
+        }),
+        loadMessages: async () => ({ messages: [] }),
+      },
+      sendSocketMessage: () => undefined,
+      agentRoute: "ts-agent",
+      runTsAgent: async (spec) => {
+        runSpecs.push(spec);
+        return runPromise;
+      },
+      now: () => "2026-06-29T14:30:00.000Z",
+    });
+    await runtime.loadInitialChatState();
+
+    runtime.submitComposerMessage("Stream through Rust envelope");
+    const runId = String((runSpecs[0] as { runId: string }).runId);
+    const envelope = {
+      sessionId: "WebSocket:chat-rust",
+      runId,
+      traceId: "trace-rust-1",
+      eventName: "agent.delta",
+      timestamp: "2026-06-29T14:30:01.000Z",
+      source: "compatibility_worker",
+      payload: { runId, delta: "rust-owned contract" },
+    } as const;
+
+    runtime.handleTsAgentWorkerEvent(envelope.eventName, normalizeNativeBackendEventPayload(envelope));
+    runtime.handleTsAgentWorkerEvent("agent.done", { runId, stopReason: "final_response" });
+    resolveRun?.({ finalContent: "", stopReason: "final_response", messages: [], toolsUsed: [] });
+    await runPromise;
+    await Promise.resolve();
+
+    expect(runtime.chat.messages).toMatchObject([
+      { role: "user", content: "Stream through Rust envelope" },
+      { role: "assistant", content: "rust-owned contract", messageId: runId },
+    ]);
   });
 
   test("accepts snake_case run metadata from TS agent worker events", async () => {

--- a/src/native-workbench/native/desktopNativeWorkbenchRuntime.ts
+++ b/src/native-workbench/native/desktopNativeWorkbenchRuntime.ts
@@ -23,6 +23,7 @@ import {
   type NativeChatMessage,
   type NativeChatReference,
 } from "../chat/nativeChat";
+import type { NativeBackendCompatibilityWorkerEventName } from "./nativeBackendContract";
 
 export interface DesktopNativeWorkbenchRuntimeOptions {
   api: DesktopChatSessionControllerApi;
@@ -84,33 +85,7 @@ export type DesktopTsAgentRestoreCheckpointResult = {
   checkpoint?: Record<string, unknown> | null;
 };
 
-export type DesktopTsAgentWorkerEventName =
-  | "agent.delta"
-  | "agent.reasoning_delta"
-  | "agent.tool_call.delta"
-  | "agent.tool.start"
-  | "agent.tool.result"
-  | "agent.usage"
-  | "agent.checkpoint"
-  | "agent.awaiting_form"
-  | "agent.awaiting_approval"
-  | "agent.memory_reference"
-  | "agent.task_progress"
-  | "agent.delegate.started"
-  | "agent.delegate.running"
-  | "agent.delegate.message_queued"
-  | "agent.delegate.awaiting_approval"
-  | "agent.delegate.tool.approval_required"
-  | "agent.delegate.tool.completed"
-  | "agent.delegate.trace.updated"
-  | "agent.delegate.completed"
-  | "agent.delegate.failed"
-  | "agent.delegate.interrupted"
-  | "agent.delegate.closed"
-  | "heartbeat.delivery"
-  | "agent.cancelled"
-  | "agent.done"
-  | "agent.error";
+export type DesktopTsAgentWorkerEventName = NativeBackendCompatibilityWorkerEventName;
 
 export interface DesktopNativeWorkbenchRuntime {
   readonly chat: DesktopNativeChatModel;

--- a/src/native-workbench/native/desktopNativeWorkspace.test.ts
+++ b/src/native-workbench/native/desktopNativeWorkspace.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createDesktopNativeWorkspaceApi } from "./desktopNativeWorkspace";
+
+describe("desktop native workspace API", () => {
+  test("loads and writes workspace files through Rust state Tauri commands", async () => {
+    const invoke = vi.fn(async (command: string, args?: Record<string, unknown>) => ({
+      command,
+      args,
+    }));
+    const api = createDesktopNativeWorkspaceApi({ invoke });
+
+    await expect(api.files()).resolves.toEqual({
+      command: "worker_workspace_files",
+      args: undefined,
+    });
+    await expect(api.file("docs/readme.md")).resolves.toEqual({
+      command: "worker_workspace_file",
+      args: { input: { path: "docs/readme.md" } },
+    });
+    await expect(api.putFile("docs/readme.md", { content: "# Readme\n" })).resolves.toEqual({
+      command: "worker_workspace_put_file",
+      args: { input: { path: "docs/readme.md", body: { content: "# Readme\n" } } },
+    });
+  });
+});

--- a/src/native-workbench/native/desktopNativeWorkspace.ts
+++ b/src/native-workbench/native/desktopNativeWorkspace.ts
@@ -1,0 +1,13 @@
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import type { NativeWorkspaceApi } from "../gateway/gatewayHttpClient";
+
+type TauriInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+export function createDesktopNativeWorkspaceApi(options: { invoke?: TauriInvoke } = {}): NativeWorkspaceApi {
+  const invoke = options.invoke ?? tauriInvoke;
+  return {
+    files: () => invoke("worker_workspace_files"),
+    file: (path: string) => invoke("worker_workspace_file", { input: { path } }),
+    putFile: (path: string, body: unknown) => invoke("worker_workspace_put_file", { input: { path, body } }),
+  };
+}

--- a/src/native-workbench/native/nativeBackendContract.test.ts
+++ b/src/native-workbench/native/nativeBackendContract.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+import {
+  isNativeBackendEventEnvelope,
+  NATIVE_BACKEND_AGENT_EVENT_NAMES,
+  NATIVE_BACKEND_COMMAND_NAMES,
+  normalizeNativeBackendEventPayload,
+  type NativeBackendRuntimeStatus,
+} from "./nativeBackendContract";
+
+describe("native backend contract", () => {
+  test("keeps the existing Tauri command names as compatibility entry points", () => {
+    expect(NATIVE_BACKEND_COMMAND_NAMES).toEqual(expect.arrayContaining([
+      "worker_run_agent",
+      "worker_cancel_agent",
+      "worker_restore_agent_checkpoint",
+      "worker_submit_agent_form",
+      "worker_resume_agent_approval",
+    ]));
+  });
+
+  test("covers Rust-owned agent events consumed by native surfaces", () => {
+    expect(NATIVE_BACKEND_AGENT_EVENT_NAMES).toEqual(expect.arrayContaining([
+      "agent.delta",
+      "agent.awaiting_form",
+      "agent.awaiting_approval",
+      "agent.delegate.trace.updated",
+      "agent.browser_frame",
+      "heartbeat.delivery",
+      "diagnostics.log",
+      "worker.status",
+    ]));
+  });
+
+  test("normalizes Rust event envelopes while preserving legacy payloads", () => {
+    const payload = { runId: "run-1", delta: "hello" };
+    const envelope = {
+      sessionId: "WebSocket:chat-1",
+      runId: "run-1",
+      traceId: "trace-1",
+      eventName: "agent.delta",
+      timestamp: "2026-06-29T14:30:00.000Z",
+      source: "compatibility_worker",
+      payload,
+    } as const;
+
+    expect(isNativeBackendEventEnvelope(envelope)).toBe(true);
+    expect(normalizeNativeBackendEventPayload(envelope)).toBe(payload);
+    expect(normalizeNativeBackendEventPayload(payload)).toBe(payload);
+  });
+
+  test("models Rust ownership with optional TS compatibility worker state", () => {
+    const status: NativeBackendRuntimeStatus = {
+      backendKind: "rust",
+      backendLabel: "rust",
+      compatibilityWorker: {
+        kind: "ts_agent_worker",
+        state: "running",
+        transportMode: "stdio",
+        diagnostics: [{ stream: "stdout", line: "worker ready" }],
+        lastError: null,
+        delegatedCapabilities: ["agent.run", "agent.cancel"],
+      },
+    };
+
+    expect(status.backendKind).toBe("rust");
+    expect(status.compatibilityWorker?.state).toBe("running");
+    expect(status.compatibilityWorker?.delegatedCapabilities).toContain("agent.run");
+  });
+});

--- a/src/native-workbench/native/nativeBackendContract.ts
+++ b/src/native-workbench/native/nativeBackendContract.ts
@@ -25,6 +25,9 @@ export const NATIVE_BACKEND_COMMAND_NAMES = [
   "worker_skills_update",
   "worker_skills_delete",
   "worker_skills_validate",
+  "worker_workspace_files",
+  "worker_workspace_file",
+  "worker_workspace_put_file",
 ] as const;
 
 export type NativeBackendCommandName = typeof NATIVE_BACKEND_COMMAND_NAMES[number];

--- a/src/native-workbench/native/nativeBackendContract.ts
+++ b/src/native-workbench/native/nativeBackendContract.ts
@@ -30,6 +30,12 @@ export const NATIVE_BACKEND_COMMAND_NAMES = [
   "worker_workspace_put_file",
   "worker_sessions_list",
   "worker_session_messages",
+  "worker_session_temporary_files",
+  "worker_session_upload_temporary_file",
+  "worker_session_clear_temporary_files",
+  "worker_session_delete",
+  "worker_session_patch",
+  "worker_session_clear",
 ] as const;
 
 export type NativeBackendCommandName = typeof NATIVE_BACKEND_COMMAND_NAMES[number];

--- a/src/native-workbench/native/nativeBackendContract.ts
+++ b/src/native-workbench/native/nativeBackendContract.ts
@@ -1,0 +1,130 @@
+export const NATIVE_BACKEND_COMMAND_NAMES = [
+  "worker_probe_status",
+  "worker_run_agent",
+  "worker_run_agent_input",
+  "worker_cancel_agent",
+  "worker_restore_agent_checkpoint",
+  "worker_submit_agent_form",
+  "worker_resume_agent_approval",
+  "worker_background_trace_list",
+  "worker_background_trace_get_delegate_trace",
+  "worker_background_trace_get_artifact",
+  "worker_webui_route",
+  "worker_cowork_route",
+  "worker_transport_gateway_frame",
+  "worker_transport_websocket_message",
+  "worker_transport_dispatch_websocket_message",
+  "worker_channel_dispatch_inbound",
+  "worker_channel_start",
+  "worker_channel_status",
+  "worker_channel_stop",
+  "worker_channel_login",
+  "worker_skills_list",
+  "worker_skills_detail",
+  "worker_skills_create",
+  "worker_skills_update",
+  "worker_skills_delete",
+  "worker_skills_validate",
+] as const;
+
+export type NativeBackendCommandName = typeof NATIVE_BACKEND_COMMAND_NAMES[number];
+
+export const NATIVE_BACKEND_AGENT_EVENT_NAMES = [
+  "agent.delta",
+  "agent.reasoning_delta",
+  "agent.tool_call.delta",
+  "agent.tool.start",
+  "agent.tool.result",
+  "agent.usage",
+  "agent.checkpoint",
+  "agent.awaiting_form",
+  "agent.awaiting_approval",
+  "agent.memory_reference",
+  "agent.task_progress",
+  "agent.browser_frame",
+  "agent.delegate.started",
+  "agent.delegate.running",
+  "agent.delegate.message_queued",
+  "agent.delegate.awaiting_approval",
+  "agent.delegate.tool.approval_required",
+  "agent.delegate.tool.completed",
+  "agent.delegate.trace.updated",
+  "agent.delegate.completed",
+  "agent.delegate.failed",
+  "agent.delegate.interrupted",
+  "agent.delegate.closed",
+  "heartbeat.delivery",
+  "agent.cancelled",
+  "agent.done",
+  "agent.error",
+  "diagnostics.log",
+  "worker.status",
+] as const;
+
+export type NativeBackendEventName = typeof NATIVE_BACKEND_AGENT_EVENT_NAMES[number];
+export type NativeBackendCompatibilityWorkerEventName = Exclude<
+  NativeBackendEventName,
+  "agent.browser_frame" | "diagnostics.log" | "worker.status"
+>;
+export type NativeBackendWebSocketAgentEventName = Exclude<
+  NativeBackendEventName,
+  "agent.checkpoint" | "heartbeat.delivery" | "diagnostics.log" | "worker.status"
+>;
+
+export type NativeBackendKind = "rust";
+export type CompatibilityWorkerKind = "ts_agent_worker";
+export type CompatibilityWorkerState = "inactive" | "starting" | "running" | "failed" | "incompatible";
+export type NativeBackendEventSource = "rust_backend" | "compatibility_worker";
+export type NativeBackendWorkerTransportMode = "stdio" | "local_pipe";
+
+export type NativeBackendDiagnosticLine = {
+  stream: string;
+  line: string;
+};
+
+export type NativeBackendCompatibilityWorkerStatus = {
+  kind: CompatibilityWorkerKind;
+  state: CompatibilityWorkerState;
+  transportMode?: NativeBackendWorkerTransportMode | null;
+  diagnostics: NativeBackendDiagnosticLine[];
+  lastError?: string | null;
+  delegatedCapabilities: string[];
+};
+
+export type NativeBackendRuntimeStatus = {
+  backendKind: NativeBackendKind;
+  backendLabel: "rust";
+  compatibilityWorker?: NativeBackendCompatibilityWorkerStatus | null;
+};
+
+export type NativeBackendEventEnvelope<TPayload = unknown> = {
+  sessionId: string;
+  runId?: string | null;
+  traceId: string;
+  eventName: NativeBackendEventName;
+  timestamp: string;
+  source: NativeBackendEventSource;
+  payload: TPayload;
+};
+
+export function isNativeBackendEventEnvelope(value: unknown): value is NativeBackendEventEnvelope {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    typeof value.sessionId === "string" &&
+    typeof value.traceId === "string" &&
+    typeof value.eventName === "string" &&
+    typeof value.timestamp === "string" &&
+    typeof value.source === "string" &&
+    "payload" in value
+  );
+}
+
+export function normalizeNativeBackendEventPayload(value: unknown): unknown {
+  return isNativeBackendEventEnvelope(value) ? value.payload : value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/native-workbench/native/nativeBackendContract.ts
+++ b/src/native-workbench/native/nativeBackendContract.ts
@@ -28,6 +28,8 @@ export const NATIVE_BACKEND_COMMAND_NAMES = [
   "worker_workspace_files",
   "worker_workspace_file",
   "worker_workspace_put_file",
+  "worker_sessions_list",
+  "worker_session_messages",
 ] as const;
 
 export type NativeBackendCommandName = typeof NATIVE_BACKEND_COMMAND_NAMES[number];


### PR DESCRIPTION
## Summary
- add Rust/native backend contract inventory and async-openai dependency with cargo mirror config
- route native skills, workspace files, and session state reads/writes through Rust Tauri commands
- add frontend native adapters and focused Rust/TS tests for the cutover paths

## Verification
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml worker_session --lib
- cargo test --manifest-path src-tauri/Cargo.toml worker_workspace --lib
- cargo test --manifest-path src-tauri/Cargo.toml worker_skills --lib
- npm test -- src/native-workbench/gateway/gateway.test.ts src/native-workbench/native/desktopNativeSessions.test.ts src/native-workbench/native/nativeBackendContract.test.ts
- npm run build