### PR TITLE
Add native agent run store

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,6 +98,7 @@ const WORKER_CRON_TIMER_MAX_POLL: Duration = Duration::from_secs(30);
 const WORKER_WEBUI_ROUTE_TIMEOUT: Duration = Duration::from_secs(10);
 const NATIVE_BACKEND_LOG_MAX_BYTES: u64 = 5 * 1024 * 1024;
 const NATIVE_BACKEND_LOG_TAIL_LINES: usize = 100;
+const NATIVE_AGENT_RUN_TRACE_STRING_LIMIT: usize = 256;
 
 struct GatewayRuntime {
     experimental_worker: WorkerManager,
@@ -1263,7 +1264,31 @@ fn worker_run_agent_with_options(
         let runtime = lock_runtime(shared);
         runtime.native_agent_runtime.clone()
     };
+    let start_persistence_error = persist_native_agent_run_start(
+        persistence_spec.clone(),
+        workspace_root.clone(),
+        config_snapshot.clone(),
+    )
+    .err();
     let mut result = run_native_agent_turn_with_config(&services, spec, config_snapshot.clone())?;
+    if let Err(error) = persist_native_agent_run_record(
+        persistence_spec.clone(),
+        &mut result,
+        workspace_root.clone(),
+        config_snapshot.clone(),
+    ) {
+        result["runPersistence"] = serde_json::json!({
+            "ok": false,
+            "error": error,
+        });
+    }
+    if let Some(error) = start_persistence_error {
+        result["runPersistenceDiagnostics"] = serde_json::json!([{
+            "phase": "start",
+            "ok": false,
+            "error": error,
+        }]);
+    }
     persist_native_agent_checkpoint_if_present(
         &result,
         workspace_root.clone(),
@@ -1276,6 +1301,363 @@ fn worker_run_agent_with_options(
         config_snapshot,
     )?;
     Ok(result)
+}
+
+fn persist_native_agent_run_start(
+    spec: serde_json::Value,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+) -> Result<(), String> {
+    let session_id =
+        native_agent_session_id(&spec).unwrap_or_else(|| "native-rust-session".to_string());
+    let run_id = native_agent_run_id(&spec).unwrap_or_else(|| "native-rust-run".to_string());
+    let record = native_agent_run_record(
+        &spec,
+        &serde_json::json!({ "sessionId": session_id, "runId": run_id }),
+        &config_snapshot,
+        &session_id,
+        &run_id,
+    );
+    let request_id = next_worker_request_correlation();
+    call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("agent-run-start-native"),
+            request_id.trace_id("agent-run-start-native"),
+            "agent_run.upsert",
+            serde_json::json!({ "record": record }),
+        ),
+        "native agent run start persistence",
+    )?;
+    Ok(())
+}
+
+fn persist_native_agent_run_record(
+    spec: serde_json::Value,
+    result: &mut serde_json::Value,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+) -> Result<(), String> {
+    let session_id = native_agent_session_id(result)
+        .or_else(|| native_agent_session_id(&spec))
+        .ok_or_else(|| "Rust agent run missing session id for persistence".to_string())?;
+    let run_id = native_agent_run_id(result)
+        .or_else(|| native_agent_run_id(&spec))
+        .unwrap_or_else(|| "native-rust-run".to_string());
+    let record = native_agent_run_record(&spec, result, &config_snapshot, &session_id, &run_id);
+    let request_id = next_worker_request_correlation();
+    let persisted = call_rust_state_service(
+        workspace_root,
+        config_snapshot,
+        WorkerRequest::new(
+            request_id.id("agent-run-upsert-native"),
+            request_id.trace_id("agent-run-upsert-native"),
+            "agent_run.upsert",
+            serde_json::json!({ "record": record }),
+        ),
+        "native agent run persistence",
+    )?;
+    result["runPersistence"] = persisted;
+    Ok(())
+}
+
+fn native_agent_run_record(
+    spec: &serde_json::Value,
+    result: &serde_json::Value,
+    config_snapshot: &serde_json::Value,
+    session_id: &str,
+    run_id: &str,
+) -> serde_json::Value {
+    let timestamp = now_unix_ms().to_string();
+    let stop_reason = result
+        .get("stopReason")
+        .or_else(|| result.get("stop_reason"))
+        .and_then(serde_json::Value::as_str);
+    let status = native_agent_run_status(stop_reason);
+    let checkpoint = result
+        .get("checkpoint")
+        .filter(|value| !value.is_null())
+        .cloned();
+    let phase = checkpoint
+        .as_ref()
+        .and_then(|value| value.get("phase"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| native_agent_run_phase_from_stop_reason(stop_reason))
+        .unwrap_or("active_turn");
+    let error = result
+        .get("error")
+        .filter(|value| !value.is_null())
+        .cloned();
+
+    serde_json::json!({
+        "sessionId": session_id,
+        "runId": run_id,
+        "status": status,
+        "phase": phase,
+        "startedAt": timestamp,
+        "updatedAt": timestamp,
+        "completedAt": native_agent_run_completed_at(status, &timestamp),
+        "stopReason": stop_reason,
+        "model": native_agent_model(spec, config_snapshot),
+        "provider": native_agent_provider(spec, config_snapshot),
+        "maxIterations": native_agent_max_iterations(spec, config_snapshot),
+        "currentIteration": native_agent_current_iteration(result, checkpoint.as_ref()),
+        "conversationMessageIds": [],
+        "traceMessages": native_agent_assistant_messages(result),
+        "traceEvents": result
+            .get("events")
+            .and_then(serde_json::Value::as_array)
+            .map(|values| native_agent_persisted_trace_values(values))
+            .unwrap_or_default(),
+        "completedToolResults": result
+            .get("completedToolResults")
+            .or_else(|| result.get("completed_tool_results"))
+            .and_then(serde_json::Value::as_array)
+            .map(|values| native_agent_persisted_trace_values(values))
+            .unwrap_or_default(),
+        "pendingToolCalls": checkpoint
+            .as_ref()
+            .and_then(|value| value.get("pendingToolCalls").or_else(|| value.get("pending_tool_calls")))
+            .and_then(serde_json::Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        "checkpoint": checkpoint,
+        "artifacts": native_agent_artifacts(result),
+        "usage": native_agent_usage(result),
+        "error": error,
+    })
+}
+
+fn native_agent_run_status(stop_reason: Option<&str>) -> &'static str {
+    match stop_reason {
+        Some("final_response") => "completed",
+        Some("cancelled") => "cancelled",
+        Some("awaiting_approval") | Some("awaiting_form") | Some("awaiting_tool") => "waiting",
+        Some(_) => "failed",
+        None => "running",
+    }
+}
+
+fn native_agent_run_phase_from_stop_reason(stop_reason: Option<&str>) -> Option<&'static str> {
+    match stop_reason {
+        Some("final_response") => Some("done"),
+        Some("cancelled") => Some("cancelled"),
+        Some("awaiting_approval") => Some("awaiting_approval"),
+        Some("awaiting_form") => Some("awaiting_form"),
+        Some("awaiting_tool") => Some("awaiting_tool"),
+        Some(_) => Some("failed"),
+        None => None,
+    }
+}
+
+fn native_agent_run_completed_at(status: &str, timestamp: &str) -> Option<String> {
+    matches!(status, "completed" | "failed" | "cancelled").then(|| timestamp.to_string())
+}
+
+fn native_agent_session_id(value: &serde_json::Value) -> Option<String> {
+    native_agent_string_field(value, "sessionId")
+        .or_else(|| native_agent_string_field(value, "session_id"))
+        .or_else(|| native_agent_string_field(value, "activeSessionId"))
+        .or_else(|| native_agent_string_field(value, "active_session_id"))
+        .or_else(|| native_agent_string_field(value, "sessionKey"))
+        .or_else(|| native_agent_string_field(value, "session_key"))
+}
+
+fn native_agent_run_id(value: &serde_json::Value) -> Option<String> {
+    native_agent_string_field(value, "runId").or_else(|| native_agent_string_field(value, "run_id"))
+}
+
+fn native_agent_model(spec: &serde_json::Value, config_snapshot: &serde_json::Value) -> String {
+    native_agent_string_field(spec, "model")
+        .or_else(|| native_agent_string_field(spec, "modelId"))
+        .or_else(|| native_agent_string_field(spec, "model_id"))
+        .or_else(|| {
+            spec.get("metadata")
+                .and_then(|metadata| native_agent_string_field(metadata, "model"))
+        })
+        .unwrap_or_else(|| crate::native_provider_runtime::configured_model(config_snapshot))
+}
+
+fn native_agent_provider(
+    spec: &serde_json::Value,
+    config_snapshot: &serde_json::Value,
+) -> Option<String> {
+    native_agent_string_field(spec, "provider")
+        .or_else(|| native_agent_string_field(spec, "providerId"))
+        .or_else(|| native_agent_string_field(spec, "provider_id"))
+        .or_else(|| {
+            spec.get("metadata")
+                .and_then(|metadata| native_agent_string_field(metadata, "provider"))
+        })
+        .or_else(|| {
+            config_snapshot
+                .get("agents")
+                .and_then(|agents| agents.get("defaults"))
+                .and_then(|defaults| native_agent_string_field(defaults, "provider"))
+        })
+}
+
+fn native_agent_max_iterations(
+    spec: &serde_json::Value,
+    config_snapshot: &serde_json::Value,
+) -> i64 {
+    spec.get("maxIterations")
+        .or_else(|| spec.get("max_iterations"))
+        .or_else(|| {
+            spec.get("metadata").and_then(|metadata| {
+                metadata
+                    .get("maxIterations")
+                    .or_else(|| metadata.get("max_iterations"))
+            })
+        })
+        .or_else(|| {
+            config_snapshot
+                .get("agents")
+                .and_then(|agents| agents.get("defaults"))
+                .and_then(|defaults| {
+                    defaults
+                        .get("maxIterations")
+                        .or_else(|| defaults.get("max_iterations"))
+                })
+        })
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(1)
+}
+
+fn native_agent_current_iteration(
+    result: &serde_json::Value,
+    checkpoint: Option<&serde_json::Value>,
+) -> i64 {
+    checkpoint
+        .and_then(|value| value.get("iteration"))
+        .and_then(serde_json::Value::as_i64)
+        .or_else(|| {
+            result
+                .get("events")
+                .and_then(serde_json::Value::as_array)
+                .and_then(|events| {
+                    events
+                        .iter()
+                        .rev()
+                        .filter_map(|event| event.get("payload"))
+                        .filter_map(|payload| payload.get("iteration"))
+                        .find_map(serde_json::Value::as_i64)
+                })
+        })
+        .unwrap_or(0)
+}
+
+fn native_agent_usage(result: &serde_json::Value) -> Vec<serde_json::Value> {
+    result
+        .get("events")
+        .and_then(serde_json::Value::as_array)
+        .map(|events| {
+            events
+                .iter()
+                .filter(|event| {
+                    event.get("eventName").and_then(serde_json::Value::as_str)
+                        == Some("agent.usage")
+                })
+                .filter_map(|event| event.get("payload"))
+                .filter_map(|payload| payload.get("usage"))
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn native_agent_persisted_trace_values(values: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    values
+        .iter()
+        .cloned()
+        .map(|value| native_agent_bound_persisted_trace_value(value).0)
+        .collect()
+}
+
+fn native_agent_bound_persisted_trace_value(value: serde_json::Value) -> (serde_json::Value, bool) {
+    match value {
+        serde_json::Value::String(content) => {
+            let char_count = content.chars().count();
+            if char_count <= NATIVE_AGENT_RUN_TRACE_STRING_LIMIT {
+                (serde_json::Value::String(content), false)
+            } else {
+                (
+                    serde_json::Value::String(
+                        content
+                            .chars()
+                            .take(NATIVE_AGENT_RUN_TRACE_STRING_LIMIT)
+                            .collect(),
+                    ),
+                    true,
+                )
+            }
+        }
+        serde_json::Value::Array(items) => {
+            let mut truncated = false;
+            let items = items
+                .into_iter()
+                .map(|item| {
+                    let (item, item_truncated) = native_agent_bound_persisted_trace_value(item);
+                    truncated |= item_truncated;
+                    item
+                })
+                .collect();
+            (serde_json::Value::Array(items), truncated)
+        }
+        serde_json::Value::Object(entries) => {
+            let mut truncated = false;
+            let mut entries = entries
+                .into_iter()
+                .map(|(key, value)| {
+                    let (value, value_truncated) = native_agent_bound_persisted_trace_value(value);
+                    truncated |= value_truncated;
+                    (key, value)
+                })
+                .collect::<serde_json::Map<_, _>>();
+            if truncated {
+                entries.insert(
+                    "tracePersistence".to_string(),
+                    serde_json::json!({
+                        "truncated": true,
+                        "maxStringChars": NATIVE_AGENT_RUN_TRACE_STRING_LIMIT,
+                    }),
+                );
+            }
+            (serde_json::Value::Object(entries), truncated)
+        }
+        value => (value, false),
+    }
+}
+
+fn native_agent_artifacts(result: &serde_json::Value) -> Vec<serde_json::Value> {
+    result
+        .get("completedToolResults")
+        .or_else(|| result.get("completed_tool_results"))
+        .and_then(serde_json::Value::as_array)
+        .map(|results| {
+            results
+                .iter()
+                .flat_map(|result| {
+                    result
+                        .get("envelope")
+                        .and_then(|envelope| envelope.get("artifacts"))
+                        .and_then(serde_json::Value::as_array)
+                        .cloned()
+                        .unwrap_or_default()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn native_agent_string_field(value: &serde_json::Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn persist_native_agent_checkpoint_if_present(
@@ -5134,6 +5516,377 @@ mod tests {
         assert_eq!(history["messages"][0]["content"], "persist me");
         assert_eq!(history["messages"][1]["role"], "assistant");
         assert_eq!(history["messages"][1]["content"], "persisted assistant");
+    }
+
+    #[test]
+    fn worker_run_agent_persists_agent_run_record_and_keeps_history_compact() {
+        let fixture = WorkspaceFixture::new();
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let config = serde_json::json!({
+            "agents": { "defaults": { "provider": "fixture", "model": "fixture-model" } },
+            "providers": {
+                "fixture": {
+                    "responses": [
+                        {
+                            "content": "",
+                            "toolCalls": [{
+                                "id": "call-run-trace",
+                                "name": "workspace.read_file",
+                                "argumentsJson": "{\"path\":\"README.md\"}",
+                                "result": { "content": "README trace body" }
+                            }]
+                        },
+                        { "content": "run trace final" }
+                    ]
+                }
+            }
+        });
+
+        let result = worker_run_agent_with_options(
+            &shared,
+            serde_json::json!({
+                "runtime": "rust",
+                "runId": "run-trace-persist",
+                "sessionId": "websocket:chat-run-trace",
+                "maxIterations": 2,
+                "messages": [{ "role": "user", "content": "read and answer" }]
+            }),
+            fixture.root.clone(),
+            config.clone(),
+            Duration::from_millis(10),
+        )
+        .expect("Rust runtime should complete tool-backed turn");
+        let run = call_rust_state_service(
+            fixture.root.clone(),
+            config.clone(),
+            WorkerRequest::new(
+                "req-agent-run-get",
+                "trace-agent-run-get",
+                "agent_run.get",
+                serde_json::json!({
+                    "session_id": "websocket:chat-run-trace",
+                    "run_id": "run-trace-persist"
+                }),
+            ),
+            "agent run read",
+        )
+        .expect("agent run record should persist");
+        let history = worker_session_messages_with_options(
+            &shared,
+            "websocket:chat-run-trace".to_string(),
+            fixture.root.clone(),
+            config,
+            Duration::from_millis(10),
+        )
+        .expect("session messages should read");
+
+        assert_eq!(result["stopReason"], "final_response");
+        assert_eq!(run["status"], "completed");
+        assert_eq!(run["stopReason"], "final_response");
+        assert_eq!(
+            run["completedToolResults"][0]["toolCallId"],
+            "call-run-trace"
+        );
+        assert!(run["traceEvents"]
+            .as_array()
+            .expect("trace events should be an array")
+            .iter()
+            .any(|event| event["eventName"] == "agent.tool.result"));
+        assert_eq!(history["messages"].as_array().unwrap().len(), 2);
+        assert!(history["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|message| message["role"] != "tool"));
+    }
+
+    #[test]
+    fn worker_run_agent_persists_waiting_approval_run_record() {
+        let fixture = WorkspaceFixture::new();
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let config = serde_json::json!({});
+
+        let result = worker_run_agent_with_options(
+            &shared,
+            serde_json::json!({
+                "runtime": "rust",
+                "runId": "run-waiting-persist",
+                "sessionId": "websocket:chat-waiting-persist",
+                "metadata": {
+                    "fakeAwaitingApproval": {
+                        "approvalId": "approval-waiting-persist",
+                        "toolName": "workspace.write_file"
+                    }
+                }
+            }),
+            fixture.root.clone(),
+            config.clone(),
+            Duration::from_millis(10),
+        )
+        .expect("Rust runtime should return waiting approval");
+        let run = read_agent_run_record(
+            fixture.root.clone(),
+            config,
+            "websocket:chat-waiting-persist",
+            "run-waiting-persist",
+        );
+
+        assert_eq!(result["stopReason"], "awaiting_approval");
+        assert_eq!(run["status"], "waiting");
+        assert_eq!(run["phase"], "awaiting_approval");
+        assert_eq!(
+            run["checkpoint"]["resumeToken"],
+            "approval:approval-waiting-persist"
+        );
+        assert_eq!(
+            run["pendingToolCalls"][0]["toolCallId"],
+            "approval-waiting-persist"
+        );
+    }
+
+    #[test]
+    fn worker_run_agent_persists_failed_tool_run_with_accumulated_trace() {
+        let fixture = WorkspaceFixture::new();
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let config = serde_json::json!({
+            "agents": { "defaults": { "provider": "fixture", "model": "fixture-model" } },
+            "providers": {
+                "fixture": {
+                    "responses": [{
+                        "content": "",
+                        "toolCalls": [
+                            {
+                                "id": "call-before-tool-error",
+                                "name": "workspace.read_file",
+                                "argumentsJson": "{\"path\":\"README.md\"}",
+                                "result": { "content": "README before tool error" }
+                            },
+                            {
+                                "id": "call-tool-error",
+                                "name": "workspace.list_files",
+                                "argumentsJson": "{not json",
+                                "result": { "content": "unused" }
+                            }
+                        ]
+                    }]
+                }
+            }
+        });
+
+        let result = worker_run_agent_with_options(
+            &shared,
+            serde_json::json!({
+                "runtime": "rust",
+                "runId": "run-tool-error-persist",
+                "sessionId": "websocket:chat-tool-error-persist",
+                "maxIterations": 3,
+                "messages": [{ "role": "user", "content": "read then fail" }]
+            }),
+            fixture.root.clone(),
+            config.clone(),
+            Duration::from_millis(10),
+        )
+        .expect("Rust runtime should return structured tool error");
+        let run = read_agent_run_record(
+            fixture.root.clone(),
+            config,
+            "websocket:chat-tool-error-persist",
+            "run-tool-error-persist",
+        );
+
+        assert_eq!(result["stopReason"], "tool_error");
+        assert_eq!(run["status"], "failed");
+        assert_eq!(run["stopReason"], "tool_error");
+        assert_eq!(
+            run["completedToolResults"][0]["toolCallId"],
+            "call-before-tool-error"
+        );
+        assert!(run["traceEvents"]
+            .as_array()
+            .expect("trace events should be an array")
+            .iter()
+            .any(|event| event["eventName"] == "agent.error"
+                && event["payload"]["toolCallId"] == "call-tool-error"));
+    }
+
+    #[test]
+    fn worker_run_agent_persists_cancelled_run_as_cancelled() {
+        let fixture = WorkspaceFixture::new();
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let config = serde_json::json!({});
+
+        let result = worker_run_agent_with_options(
+            &shared,
+            serde_json::json!({
+                "runtime": "rust",
+                "runId": "run-cancel-persist",
+                "sessionId": "websocket:chat-cancel-persist",
+                "metadata": { "fakeCancel": true },
+                "messages": [{ "role": "user", "content": "cancel me" }]
+            }),
+            fixture.root.clone(),
+            config.clone(),
+            Duration::from_millis(10),
+        )
+        .expect("Rust runtime should return structured cancellation");
+        let run = read_agent_run_record(
+            fixture.root.clone(),
+            config,
+            "websocket:chat-cancel-persist",
+            "run-cancel-persist",
+        );
+
+        assert_eq!(result["stopReason"], "cancelled");
+        assert_eq!(run["status"], "cancelled");
+        assert_eq!(run["phase"], "cancelled");
+        assert_eq!(run["checkpoint"]["phase"], "cancelled");
+    }
+
+    #[test]
+    fn worker_run_agent_persists_redacted_bounded_tool_trace() {
+        let fixture = WorkspaceFixture::new();
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let config = serde_json::json!({
+            "agents": {
+                "defaults": {
+                    "provider": "fixture",
+                    "model": "fixture-model",
+                    "maxToolResultChars": 12
+                }
+            },
+            "providers": {
+                "fixture": {
+                    "api_key": "secret-token",
+                    "responses": [
+                        {
+                            "content": "",
+                            "toolCalls": [{
+                                "id": "call-redacted",
+                                "name": "workspace.read_file",
+                                "argumentsJson": "{\"path\":\"README.md\"}",
+                                "result": { "content": "secret-token ABCDEFGHIJKLMNOP" }
+                            }]
+                        },
+                        { "content": "bounded final" }
+                    ]
+                }
+            }
+        });
+
+        worker_run_agent_with_options(
+            &shared,
+            serde_json::json!({
+                "runtime": "rust",
+                "runId": "run-redacted-trace",
+                "sessionId": "websocket:chat-redacted-trace",
+                "maxIterations": 2,
+                "messages": [{ "role": "user", "content": "read bounded" }]
+            }),
+            fixture.root.clone(),
+            config.clone(),
+            Duration::from_millis(10),
+        )
+        .expect("Rust runtime should complete bounded tool run");
+        let run = read_agent_run_record(
+            fixture.root.clone(),
+            config,
+            "websocket:chat-redacted-trace",
+            "run-redacted-trace",
+        );
+        let serialized = run.to_string();
+        let envelope = &run["completedToolResults"][0]["envelope"];
+
+        assert!(!serialized.contains("secret-token"));
+        assert_eq!(envelope["truncation"]["truncated"], true);
+        assert_eq!(envelope["continuation"]["nextOffset"], 12);
+        assert!(envelope["modelContent"].as_str().unwrap().chars().count() <= 12);
+    }
+
+    #[test]
+    fn worker_run_agent_omits_large_raw_tool_trace_from_persisted_run_record() {
+        let fixture = WorkspaceFixture::new();
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let large_output = "A".repeat(12_000);
+        let config = serde_json::json!({
+            "agents": {
+                "defaults": {
+                    "provider": "fixture",
+                    "model": "fixture-model",
+                    "maxToolResultChars": 128
+                }
+            },
+            "providers": {
+                "fixture": {
+                    "responses": [
+                        {
+                            "content": "",
+                            "toolCalls": [{
+                                "id": "call-large",
+                                "name": "workspace.read_file",
+                                "argumentsJson": "{\"path\":\"large.txt\"}",
+                                "result": { "content": large_output }
+                            }]
+                        },
+                        { "content": "large final" }
+                    ]
+                }
+            }
+        });
+
+        worker_run_agent_with_options(
+            &shared,
+            serde_json::json!({
+                "runtime": "rust",
+                "runId": "run-large-trace",
+                "sessionId": "websocket:chat-large-trace",
+                "maxIterations": 2,
+                "messages": [{ "role": "user", "content": "read large" }]
+            }),
+            fixture.root.clone(),
+            config.clone(),
+            Duration::from_millis(10),
+        )
+        .expect("Rust runtime should complete large tool run");
+        let run = read_agent_run_record(
+            fixture.root.clone(),
+            config,
+            "websocket:chat-large-trace",
+            "run-large-trace",
+        );
+        let serialized = run.to_string();
+
+        assert!(
+            serialized.len() < 9_000,
+            "run record was {} bytes",
+            serialized.len()
+        );
+        assert_eq!(
+            run["completedToolResults"][0]["tracePersistence"]["truncated"],
+            true
+        );
+    }
+
+    fn read_agent_run_record(
+        workspace_root: PathBuf,
+        config_snapshot: serde_json::Value,
+        session_id: &str,
+        run_id: &str,
+    ) -> serde_json::Value {
+        call_rust_state_service(
+            workspace_root,
+            config_snapshot,
+            WorkerRequest::new(
+                "req-agent-run-get",
+                "trace-agent-run-get",
+                "agent_run.get",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "run_id": run_id,
+                }),
+            ),
+            "agent run read",
+        )
+        .expect("agent run record should persist")
     }
 
     #[test]

--- a/src-tauri/src/native_backend_contract.rs
+++ b/src-tauri/src/native_backend_contract.rs
@@ -208,6 +208,53 @@ pub const NATIVE_AGENT_CHECKPOINT_FIELDS: &[&str] = &[
     "messages",
 ];
 
+pub const NATIVE_AGENT_RUN_SUMMARY_FIELDS: &[&str] = &[
+    "sessionId",
+    "runId",
+    "status",
+    "phase",
+    "startedAt",
+    "updatedAt",
+    "completedAt",
+    "stopReason",
+    "model",
+    "provider",
+    "toolsUsed",
+    "toolCallCount",
+    "hasCheckpoint",
+    "finalContentPreview",
+    "artifactCount",
+];
+
+pub const NATIVE_AGENT_RUN_DETAIL_FIELDS: &[&str] = &[
+    "sessionId",
+    "runId",
+    "status",
+    "phase",
+    "startedAt",
+    "updatedAt",
+    "completedAt",
+    "stopReason",
+    "model",
+    "provider",
+    "maxIterations",
+    "currentIteration",
+    "conversationMessageIds",
+    "traceMessages",
+    "traceEvents",
+    "completedToolResults",
+    "pendingToolCalls",
+    "checkpoint",
+    "artifacts",
+    "usage",
+    "error",
+];
+
+pub const NATIVE_AGENT_RUN_CHECKPOINT_FIELDS: &[&str] = &["sessionId", "runId", "checkpoint"];
+
+pub const NATIVE_AGENT_RUN_TRACE_PAGE_FIELDS: &[&str] =
+    &["sessionId", "runId", "items", "nextCursor"];
+
 const WEBUI_ROUTE_INVENTORY: &[NativeRouteInventoryEntry] = &[
     rust_webui("health", "GET", "/health", "health", "native health check"),
     rust_webui(
@@ -836,5 +883,43 @@ pub struct NativeBackendRunSpec {
 impl NativeBackendRunSpec {
     pub fn from_value(value: Value) -> Result<Self, serde_json::Error> {
         serde_json::from_value(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_run_timeline_contract_fields_are_stable() {
+        assert_eq!(
+            NATIVE_AGENT_RUN_SUMMARY_FIELDS,
+            &[
+                "sessionId",
+                "runId",
+                "status",
+                "phase",
+                "startedAt",
+                "updatedAt",
+                "completedAt",
+                "stopReason",
+                "model",
+                "provider",
+                "toolsUsed",
+                "toolCallCount",
+                "hasCheckpoint",
+                "finalContentPreview",
+                "artifactCount",
+            ]
+        );
+        assert!(NATIVE_AGENT_RUN_DETAIL_FIELDS.contains(&"traceEvents"));
+        assert!(NATIVE_AGENT_RUN_DETAIL_FIELDS.contains(&"completedToolResults"));
+        assert!(NATIVE_AGENT_RUN_DETAIL_FIELDS.contains(&"pendingToolCalls"));
+        assert!(NATIVE_AGENT_RUN_DETAIL_FIELDS.contains(&"checkpoint"));
+        assert_eq!(
+            NATIVE_AGENT_RUN_TRACE_PAGE_FIELDS,
+            &["sessionId", "runId", "items", "nextCursor"]
+        );
+        assert!(NATIVE_AGENT_RUN_CHECKPOINT_FIELDS.contains(&"checkpoint"));
     }
 }

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -3,7 +3,10 @@ use serde_json::Value;
 use std::{
     collections::{HashMap, HashSet},
     ops::{Deref, DerefMut},
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -384,8 +387,11 @@ pub trait NativeAgentToolDispatcher: Send + Sync {
 
 pub trait NativeAgentCheckpointStore: Send + Sync {
     fn save(&self, session_id: &str, checkpoint: Value);
+    fn save_for_run(&self, session_id: &str, run_id: &str, checkpoint: Value);
     fn restore(&self, session_id: &str) -> Option<Value>;
+    fn restore_for_run(&self, session_id: &str, run_id: &str) -> Option<Value>;
     fn clear(&self, session_id: &str);
+    fn clear_for_run(&self, session_id: &str, run_id: &str);
 }
 
 pub trait NativeAgentCancellation: Send + Sync {
@@ -444,8 +450,26 @@ impl NativeAgentRuntimeServices {
         })
     }
 
+    pub fn restore_run_checkpoint(&self, session_id: &str, run_id: &str) -> Value {
+        serde_json::json!({
+            "runtime": "rust",
+            "sessionId": session_id,
+            "runId": run_id,
+            "checkpoint": self.checkpoints.restore_for_run(session_id, run_id),
+        })
+    }
+
     pub fn save_checkpoint(&self, session_id: &str, checkpoint: Value) {
         self.checkpoints.save(session_id, checkpoint);
+    }
+
+    pub fn save_run_checkpoint(&self, session_id: &str, run_id: &str, checkpoint: Value) {
+        self.checkpoints
+            .save_for_run(session_id, run_id, checkpoint);
+    }
+
+    pub fn clear_run_checkpoint(&self, session_id: &str, run_id: &str) {
+        self.checkpoints.clear_for_run(session_id, run_id);
     }
 }
 
@@ -462,31 +486,106 @@ impl Default for NativeAgentRuntimeServices {
 
 #[derive(Default)]
 pub struct InMemoryNativeAgentCheckpointStore {
-    checkpoints: Mutex<HashMap<String, Value>>,
+    checkpoints: Mutex<HashMap<String, StoredNativeCheckpoint>>,
+    sequence: AtomicU64,
+}
+
+#[derive(Clone, Debug)]
+struct StoredNativeCheckpoint {
+    checkpoint: Value,
+    sequence: u64,
 }
 
 impl NativeAgentCheckpointStore for InMemoryNativeAgentCheckpointStore {
     fn save(&self, session_id: &str, checkpoint: Value) {
+        let run_id =
+            checkpoint_run_id(&checkpoint).unwrap_or_else(|| legacy_session_run_id(session_id));
+        self.save_for_run(session_id, &run_id, checkpoint);
+    }
+
+    fn save_for_run(&self, session_id: &str, run_id: &str, checkpoint: Value) {
+        let sequence = self.sequence.fetch_add(1, Ordering::SeqCst);
         self.checkpoints
             .lock()
             .expect("checkpoint store lock should not be poisoned")
-            .insert(session_id.to_string(), checkpoint);
+            .insert(
+                checkpoint_key(session_id, run_id),
+                StoredNativeCheckpoint {
+                    checkpoint,
+                    sequence,
+                },
+            );
     }
 
     fn restore(&self, session_id: &str) -> Option<Value> {
         self.checkpoints
             .lock()
             .expect("checkpoint store lock should not be poisoned")
-            .get(session_id)
-            .cloned()
+            .iter()
+            .filter_map(|(key, stored)| {
+                checkpoint_key_session(key)
+                    .filter(|key_session_id| *key_session_id == session_id)
+                    .map(|_| stored)
+            })
+            .max_by_key(|stored| stored.sequence)
+            .map(|stored| stored.checkpoint.clone())
     }
 
-    fn clear(&self, session_id: &str) {
+    fn restore_for_run(&self, session_id: &str, run_id: &str) -> Option<Value> {
         self.checkpoints
             .lock()
             .expect("checkpoint store lock should not be poisoned")
-            .remove(session_id);
+            .get(&checkpoint_key(session_id, run_id))
+            .map(|stored| stored.checkpoint.clone())
     }
+
+    fn clear(&self, session_id: &str) {
+        let mut checkpoints = self
+            .checkpoints
+            .lock()
+            .expect("checkpoint store lock should not be poisoned");
+        let Some(key) = checkpoints
+            .iter()
+            .filter(|(key, _stored)| {
+                checkpoint_key_session(key)
+                    .is_some_and(|key_session_id| key_session_id == session_id)
+            })
+            .max_by_key(|(_key, stored)| stored.sequence)
+            .map(|(key, _stored)| key.clone())
+        else {
+            return;
+        };
+        checkpoints.remove(&key);
+    }
+
+    fn clear_for_run(&self, session_id: &str, run_id: &str) {
+        self.checkpoints
+            .lock()
+            .expect("checkpoint store lock should not be poisoned")
+            .remove(&checkpoint_key(session_id, run_id));
+    }
+}
+
+fn checkpoint_key(session_id: &str, run_id: &str) -> String {
+    format!("{session_id}\u{1f}{run_id}")
+}
+
+fn checkpoint_key_session(key: &str) -> Option<&str> {
+    key.split_once('\u{1f}')
+        .map(|(session_id, _run_id)| session_id)
+}
+
+fn checkpoint_run_id(checkpoint: &Value) -> Option<String> {
+    checkpoint
+        .get("runId")
+        .or_else(|| checkpoint.get("run_id"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn legacy_session_run_id(session_id: &str) -> String {
+    format!("legacy-session:{session_id}")
 }
 
 #[derive(Default)]
@@ -939,7 +1038,9 @@ pub fn run_native_agent_turn_with_config(
                             "name": tool_call.name,
                         }),
                     ));
-                    services.checkpoints.clear(&context.session_id);
+                    services
+                        .checkpoints
+                        .clear_for_run(&context.session_id, &context.run_id);
                     return Ok(serde_json::json!({
                         "runtime": "rust",
                         "runId": context.run_id,
@@ -1007,7 +1108,9 @@ pub fn run_native_agent_turn_with_config(
                                 "name": tool_call.name,
                             }),
                         ));
-                        services.checkpoints.clear(&context.session_id);
+                        services
+                            .checkpoints
+                            .clear_for_run(&context.session_id, &context.run_id);
                         return Ok(serde_json::json!({
                             "runtime": "rust",
                             "runId": context.run_id,
@@ -1092,7 +1195,9 @@ pub fn run_native_agent_turn_with_config(
             ));
         }
         state.set_stop_reason("final_response");
-        services.checkpoints.clear(&context.session_id);
+        services
+            .checkpoints
+            .clear_for_run(&context.session_id, &context.run_id);
         state.events.push(event(
             "agent.done",
             serde_json::json!({
@@ -1490,7 +1595,7 @@ fn maybe_awaiting_approval_result(
     );
     services
         .checkpoints
-        .save(&context.session_id, checkpoint.clone());
+        .save_for_run(&context.session_id, &context.run_id, checkpoint.clone());
     let events = vec![
         event(
             "agent.checkpoint",
@@ -1543,9 +1648,13 @@ fn maybe_approval_resume_result(
         .get("approved")
         .and_then(Value::as_bool)
         .unwrap_or_else(|| string_field(&approval, "decision").as_deref() == Some("approved"));
-    let checkpoint = services.checkpoints.restore(&context.session_id);
+    let checkpoint = services
+        .checkpoints
+        .restore_for_run(&context.session_id, &context.run_id);
     if !approved {
-        services.checkpoints.clear(&context.session_id);
+        services
+            .checkpoints
+            .clear_for_run(&context.session_id, &context.run_id);
         return Some(error_result(
             &context.run_id,
             &context.session_id,
@@ -1553,7 +1662,9 @@ fn maybe_approval_resume_result(
             "Rust agent approval was denied.",
         ));
     }
-    services.checkpoints.clear(&context.session_id);
+    services
+        .checkpoints
+        .clear_for_run(&context.session_id, &context.run_id);
     let final_content = string_field(&approval, "finalContent")
         .or_else(|| string_field(&approval, "final_content"))
         .unwrap_or_else(|| "Approved tool completed.".to_string());
@@ -1619,7 +1730,7 @@ fn maybe_awaiting_form_result(
     );
     services
         .checkpoints
-        .save(&context.session_id, checkpoint.clone());
+        .save_for_run(&context.session_id, &context.run_id, checkpoint.clone());
     let events = vec![
         event(
             "agent.checkpoint",
@@ -1667,7 +1778,9 @@ fn maybe_form_submit_result(
 ) -> Option<Value> {
     let form = context.metadata.get("fakeFormSubmit")?.clone();
     if bool_field(&form, "cancelled") {
-        services.checkpoints.clear(&context.session_id);
+        services
+            .checkpoints
+            .clear_for_run(&context.session_id, &context.run_id);
         return Some(error_result(
             &context.run_id,
             &context.session_id,
@@ -1675,8 +1788,12 @@ fn maybe_form_submit_result(
             "Rust agent form was cancelled.",
         ));
     }
-    let checkpoint = services.checkpoints.restore(&context.session_id);
-    services.checkpoints.clear(&context.session_id);
+    let checkpoint = services
+        .checkpoints
+        .restore_for_run(&context.session_id, &context.run_id);
+    services
+        .checkpoints
+        .clear_for_run(&context.session_id, &context.run_id);
     let final_content = string_field(&form, "finalContent")
         .or_else(|| string_field(&form, "final_content"))
         .unwrap_or_else(|| "Form submitted.".to_string());
@@ -1725,7 +1842,7 @@ fn maybe_emit_checkpoint(
     let checkpoint = checkpoint_value(context, &phase, checkpoint_metadata.clone());
     services
         .checkpoints
-        .save(&context.session_id, checkpoint.clone());
+        .save_for_run(&context.session_id, &context.run_id, checkpoint.clone());
     events.push(event(
         "agent.checkpoint",
         serde_json::json!({
@@ -1805,7 +1922,7 @@ fn save_phase_checkpoint(
     let checkpoint = checkpoint_value(context, phase, payload);
     services
         .checkpoints
-        .save(&context.session_id, checkpoint.clone());
+        .save_for_run(&context.session_id, &context.run_id, checkpoint.clone());
     checkpoint
 }
 
@@ -2954,6 +3071,74 @@ mod tests {
             services.restore_checkpoint("websocket:chat-cancel-checkpoint")["checkpoint"]["phase"],
             "cancelled"
         );
+    }
+
+    #[test]
+    fn runtime_checkpoint_store_isolates_same_session_runs() {
+        let services = NativeAgentRuntimeServices::default();
+        services.save_run_checkpoint(
+            "websocket:chat-1",
+            "run-1",
+            json!({
+                "sessionId": "websocket:chat-1",
+                "runId": "run-1",
+                "phase": "awaiting_tool"
+            }),
+        );
+        services.save_run_checkpoint(
+            "websocket:chat-1",
+            "run-2",
+            json!({
+                "sessionId": "websocket:chat-1",
+                "runId": "run-2",
+                "phase": "awaiting_approval"
+            }),
+        );
+
+        assert_eq!(
+            services.restore_run_checkpoint("websocket:chat-1", "run-1")["checkpoint"]["runId"],
+            "run-1"
+        );
+        assert_eq!(
+            services.restore_run_checkpoint("websocket:chat-1", "run-2")["checkpoint"]["runId"],
+            "run-2"
+        );
+
+        services.clear_run_checkpoint("websocket:chat-1", "run-1");
+        assert!(
+            services.restore_run_checkpoint("websocket:chat-1", "run-1")["checkpoint"].is_null()
+        );
+        assert_eq!(
+            services.restore_run_checkpoint("websocket:chat-1", "run-2")["checkpoint"]["runId"],
+            "run-2"
+        );
+    }
+
+    #[test]
+    fn runtime_checkpoint_restore_by_session_uses_latest_resumable_run() {
+        let services = NativeAgentRuntimeServices::default();
+        services.save_run_checkpoint(
+            "websocket:chat-1",
+            "run-old",
+            json!({
+                "sessionId": "websocket:chat-1",
+                "runId": "run-old",
+                "phase": "awaiting_tool"
+            }),
+        );
+        services.save_run_checkpoint(
+            "websocket:chat-1",
+            "run-new",
+            json!({
+                "sessionId": "websocket:chat-1",
+                "runId": "run-new",
+                "phase": "awaiting_form"
+            }),
+        );
+
+        let restored = services.restore_checkpoint("websocket:chat-1");
+
+        assert_eq!(restored["checkpoint"]["runId"], "run-new");
     }
 
     #[test]

--- a/src-tauri/src/worker_rpc.rs
+++ b/src-tauri/src/worker_rpc.rs
@@ -445,7 +445,7 @@ impl WorkerRpcRouter {
                     .map_err(serialization_error)
             }
             "agent_run.list" => {
-                let params: SessionIdParams = parse_params(request)?;
+                let params: AgentRunListParams = parse_params(request)?;
                 let runs = self
                     .session
                     .list_agent_runs(&params.session_id)?
@@ -1004,6 +1004,12 @@ impl SessionPersistTurnParams {
 #[derive(Deserialize)]
 struct AgentRunUpsertParams {
     record: AgentRunRecord,
+}
+
+#[derive(Deserialize)]
+struct AgentRunListParams {
+    #[serde(alias = "sessionId")]
+    session_id: String,
 }
 
 #[derive(Deserialize)]
@@ -2468,7 +2474,7 @@ mod tests {
             "req-list",
             "trace-agent-run",
             "agent_run.list",
-            json!({ "session_id": "session-1" }),
+            json!({ "sessionId": "session-1" }),
         ));
         let get = router.dispatch(&WorkerRequest::new(
             "req-get",

--- a/src-tauri/src/worker_rpc.rs
+++ b/src-tauri/src/worker_rpc.rs
@@ -22,7 +22,7 @@ use crate::worker_protocol::{
     WorkerResponse,
 };
 use crate::worker_secret::{ProviderResolveSecretParams, WorkerSecretRpc};
-use crate::worker_session::{SessionMetadata, WorkerSessionRpc};
+use crate::worker_session::{AgentRunRecord, AgentRunSummary, SessionMetadata, WorkerSessionRpc};
 use crate::worker_shell::{ShellExecuteParams, WorkerShellRpc};
 use crate::worker_task::{TaskPlanIdParams, TaskPlanListParams, TaskPlanSaveParams, WorkerTaskRpc};
 use crate::worker_workspace::{WorkerWorkspaceRpc, WorkspaceReadFormat, WorkspaceReadOptions};
@@ -437,6 +437,104 @@ impl WorkerRpcRouter {
                     params.clear_checkpoint,
                     context_metadata,
                 )?)
+                .map_err(serialization_error)
+            }
+            "agent_run.upsert" => {
+                let params: AgentRunUpsertParams = parse_params(request)?;
+                serde_json::to_value(self.session.upsert_agent_run(params.record)?)
+                    .map_err(serialization_error)
+            }
+            "agent_run.list" => {
+                let params: SessionIdParams = parse_params(request)?;
+                let runs = self
+                    .session
+                    .list_agent_runs(&params.session_id)?
+                    .iter()
+                    .map(AgentRunSummary::from_record)
+                    .collect::<Vec<_>>();
+                Ok(serde_json::json!({
+                    "sessionId": params.session_id,
+                    "runs": runs,
+                }))
+            }
+            "agent_run.get" => {
+                let params: AgentRunIdParams = parse_params(request)?;
+                serde_json::to_value(
+                    self.session
+                        .get_agent_run(&params.session_id, &params.run_id)?,
+                )
+                .map_err(serialization_error)
+            }
+            "agent_run.list_trace" => {
+                let params: AgentRunListTraceParams = parse_params(request)?;
+                serde_json::to_value(self.session.list_agent_run_trace_events(
+                    &params.session_id,
+                    &params.run_id,
+                    params.cursor.as_deref(),
+                    params.limit,
+                )?)
+                .map_err(serialization_error)
+            }
+            "agent_run.append_trace" => {
+                let params: AgentRunAppendTraceParams = parse_params(request)?;
+                serde_json::to_value(self.session.append_agent_run_trace_event(
+                    &params.session_id,
+                    &params.run_id,
+                    params.event,
+                )?)
+                .map_err(serialization_error)
+            }
+            "agent_run.set_checkpoint" => {
+                let params: AgentRunCheckpointParams = parse_params(request)?;
+                serde_json::to_value(self.session.set_agent_run_checkpoint(
+                    &params.session_id,
+                    &params.run_id,
+                    params.checkpoint,
+                )?)
+                .map_err(serialization_error)
+            }
+            "agent_run.get_checkpoint" => {
+                let params: AgentRunIdParams = parse_params(request)?;
+                serde_json::to_value(
+                    self.session
+                        .get_agent_run_checkpoint(&params.session_id, &params.run_id)?,
+                )
+                .map_err(serialization_error)
+            }
+            "agent_run.clear_checkpoint" => {
+                let params: AgentRunIdParams = parse_params(request)?;
+                serde_json::to_value(
+                    self.session
+                        .clear_agent_run_checkpoint(&params.session_id, &params.run_id)?,
+                )
+                .map_err(serialization_error)
+            }
+            "agent_run.mark_completed" => {
+                let params: AgentRunMarkCompletedParams = parse_params(request)?;
+                serde_json::to_value(self.session.mark_agent_run_completed(
+                    &params.session_id,
+                    &params.run_id,
+                    &params.stop_reason,
+                    params.final_content,
+                )?)
+                .map_err(serialization_error)
+            }
+            "agent_run.mark_failed" => {
+                let params: AgentRunMarkFailedParams = parse_params(request)?;
+                serde_json::to_value(self.session.mark_agent_run_failed(
+                    &params.session_id,
+                    &params.run_id,
+                    &params.stop_reason,
+                    params.error,
+                )?)
+                .map_err(serialization_error)
+            }
+            "agent_run.mark_cancelled" => {
+                let params: AgentRunIdParams = parse_params(request)?;
+                serde_json::to_value(
+                    self.session
+                        .mark_agent_run_cancelled(&params.session_id, &params.run_id)?,
+                )
                 .map_err(serialization_error)
             }
             "diagnostics.append" => {
@@ -901,6 +999,72 @@ impl SessionPersistTurnParams {
             .clone()
             .or_else(|| self.context_metadata_camel.clone())
     }
+}
+
+#[derive(Deserialize)]
+struct AgentRunUpsertParams {
+    record: AgentRunRecord,
+}
+
+#[derive(Deserialize)]
+struct AgentRunIdParams {
+    #[serde(alias = "sessionId")]
+    session_id: String,
+    #[serde(alias = "runId")]
+    run_id: String,
+}
+
+#[derive(Deserialize)]
+struct AgentRunListTraceParams {
+    #[serde(alias = "sessionId")]
+    session_id: String,
+    #[serde(alias = "runId")]
+    run_id: String,
+    #[serde(default)]
+    cursor: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct AgentRunAppendTraceParams {
+    #[serde(alias = "sessionId")]
+    session_id: String,
+    #[serde(alias = "runId")]
+    run_id: String,
+    event: Value,
+}
+
+#[derive(Deserialize)]
+struct AgentRunCheckpointParams {
+    #[serde(alias = "sessionId")]
+    session_id: String,
+    #[serde(alias = "runId")]
+    run_id: String,
+    checkpoint: Value,
+}
+
+#[derive(Deserialize)]
+struct AgentRunMarkCompletedParams {
+    #[serde(alias = "sessionId")]
+    session_id: String,
+    #[serde(alias = "runId")]
+    run_id: String,
+    #[serde(alias = "stopReason")]
+    stop_reason: String,
+    #[serde(default, alias = "finalContent")]
+    final_content: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AgentRunMarkFailedParams {
+    #[serde(alias = "sessionId")]
+    session_id: String,
+    #[serde(alias = "runId")]
+    run_id: String,
+    #[serde(alias = "stopReason")]
+    stop_reason: String,
+    error: Value,
 }
 
 #[derive(Deserialize)]
@@ -2219,6 +2383,214 @@ mod tests {
             })
         );
         assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn dispatches_agent_run_store_round_trip_requests() {
+        let fixture = WorkspaceFixture::new();
+        let mut router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([
+                WorkerCapability::SessionMetadataRead,
+                WorkerCapability::SessionWrite,
+            ]),
+        );
+        let record = json!({
+            "sessionId": "session-1",
+            "runId": "run-1",
+            "status": "running",
+            "phase": "active_turn",
+            "startedAt": "unix-ms:1",
+            "updatedAt": "unix-ms:1",
+            "completedAt": null,
+            "stopReason": null,
+            "model": "fixture-model",
+            "provider": "fixture",
+            "maxIterations": 4,
+            "currentIteration": 0,
+            "conversationMessageIds": [],
+            "traceMessages": [],
+            "traceEvents": [],
+            "completedToolResults": [],
+            "pendingToolCalls": [],
+            "checkpoint": null,
+            "artifacts": [],
+            "usage": [],
+            "error": null
+        });
+
+        let upsert = router.dispatch(&WorkerRequest::new(
+            "req-upsert",
+            "trace-agent-run",
+            "agent_run.upsert",
+            json!({ "record": record }),
+        ));
+        let append_trace = router.dispatch(&WorkerRequest::new(
+            "req-trace",
+            "trace-agent-run",
+            "agent_run.append_trace",
+            json!({
+                "session_id": "session-1",
+                "run_id": "run-1",
+                "event": { "eventName": "agent.tool.result" }
+            }),
+        ));
+        let append_second_trace = router.dispatch(&WorkerRequest::new(
+            "req-trace-2",
+            "trace-agent-run",
+            "agent_run.append_trace",
+            json!({
+                "session_id": "session-1",
+                "run_id": "run-1",
+                "event": { "eventName": "agent.done" }
+            }),
+        ));
+        let set_checkpoint = router.dispatch(&WorkerRequest::new(
+            "req-set-checkpoint",
+            "trace-agent-run",
+            "agent_run.set_checkpoint",
+            json!({
+                "session_id": "session-1",
+                "run_id": "run-1",
+                "checkpoint": { "sessionId": "session-1", "runId": "run-1", "phase": "awaiting_tool" }
+            }),
+        ));
+        let get_checkpoint = router.dispatch(&WorkerRequest::new(
+            "req-get-checkpoint",
+            "trace-agent-run",
+            "agent_run.get_checkpoint",
+            json!({ "session_id": "session-1", "run_id": "run-1" }),
+        ));
+        let list = router.dispatch(&WorkerRequest::new(
+            "req-list",
+            "trace-agent-run",
+            "agent_run.list",
+            json!({ "session_id": "session-1" }),
+        ));
+        let get = router.dispatch(&WorkerRequest::new(
+            "req-get",
+            "trace-agent-run",
+            "agent_run.get",
+            json!({ "session_id": "session-1", "run_id": "run-1" }),
+        ));
+        let trace_page = router.dispatch(&WorkerRequest::new(
+            "req-list-trace",
+            "trace-agent-run",
+            "agent_run.list_trace",
+            json!({ "session_id": "session-1", "run_id": "run-1", "limit": 1 }),
+        ));
+        let completed = router.dispatch(&WorkerRequest::new(
+            "req-complete",
+            "trace-agent-run",
+            "agent_run.mark_completed",
+            json!({
+                "session_id": "session-1",
+                "run_id": "run-1",
+                "stop_reason": "final_response",
+                "final_content": "done"
+            }),
+        ));
+        let clear_checkpoint = router.dispatch(&WorkerRequest::new(
+            "req-clear-checkpoint",
+            "trace-agent-run",
+            "agent_run.clear_checkpoint",
+            json!({ "session_id": "session-1", "run_id": "run-1" }),
+        ));
+
+        assert!(upsert.error.is_none());
+        assert!(append_trace.error.is_none());
+        assert!(append_second_trace.error.is_none());
+        assert!(set_checkpoint.error.is_none());
+        assert_eq!(
+            get_checkpoint.result.as_ref().unwrap()["checkpoint"]["phase"],
+            "awaiting_tool"
+        );
+        assert_eq!(list.result.as_ref().unwrap()["sessionId"], "session-1");
+        assert_eq!(list.result.as_ref().unwrap()["runs"][0]["runId"], "run-1");
+        assert!(list.result.as_ref().unwrap()["runs"][0]
+            .get("traceEvents")
+            .is_none());
+        assert_eq!(
+            get.result.as_ref().unwrap()["traceEvents"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(trace_page.error, None);
+        assert_eq!(
+            trace_page.result.as_ref().unwrap()["items"][0]["eventName"],
+            "agent.tool.result"
+        );
+        assert_eq!(trace_page.result.as_ref().unwrap()["nextCursor"], "1");
+        assert_eq!(completed.result.as_ref().unwrap()["status"], "completed");
+        assert_eq!(completed.result.as_ref().unwrap()["phase"], "done");
+        assert_eq!(
+            clear_checkpoint.result.as_ref().unwrap()["checkpoint"],
+            json!(null)
+        );
+    }
+
+    #[test]
+    fn agent_run_rpc_enforces_capabilities_and_unknown_run_errors() {
+        let fixture = WorkspaceFixture::new();
+        let mut denied_router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::default(),
+        );
+        let denied = denied_router.dispatch(&WorkerRequest::new(
+            "req-denied",
+            "trace-agent-run",
+            "agent_run.list",
+            json!({ "session_id": "session-1" }),
+        ));
+        assert_eq!(
+            denied.error.as_ref().unwrap().code,
+            crate::worker_protocol::WorkerProtocolErrorCode::CapabilityDenied
+        );
+
+        let mut read_router = WorkerRpcRouter::new(
+            fixture.root.clone(),
+            json!({}),
+            vec![],
+            20,
+            CapabilityPolicy::new([WorkerCapability::SessionMetadataRead]),
+        );
+        let missing = read_router.dispatch(&WorkerRequest::new(
+            "req-missing",
+            "trace-agent-run",
+            "agent_run.get",
+            json!({ "session_id": "session-1", "run_id": "missing-run" }),
+        ));
+        assert_eq!(
+            missing.error.as_ref().unwrap().code,
+            crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol
+        );
+        assert_eq!(
+            missing.error.as_ref().unwrap().details["run_id"],
+            "missing-run"
+        );
+
+        let malformed = read_router.dispatch(&WorkerRequest::new(
+            "req-malformed",
+            "trace-agent-run",
+            "agent_run.get",
+            json!({ "session_id": "session-1" }),
+        ));
+        assert_eq!(
+            malformed.error.as_ref().unwrap().code,
+            crate::worker_protocol::WorkerProtocolErrorCode::InvalidProtocol
+        );
+        assert_eq!(
+            malformed.error.as_ref().unwrap().details["method"],
+            "agent_run.get"
+        );
     }
 
     #[test]

--- a/src-tauri/src/worker_rpc/method.rs
+++ b/src-tauri/src/worker_rpc/method.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WorkerRpcNamespace {
+    AgentRun,
     Approval,
     Background,
     Channel,
@@ -22,6 +23,7 @@ pub enum WorkerRpcNamespace {
 impl WorkerRpcNamespace {
     pub fn as_str(self) -> &'static str {
         match self {
+            WorkerRpcNamespace::AgentRun => "agent_run",
             WorkerRpcNamespace::Approval => "approval",
             WorkerRpcNamespace::Background => "background",
             WorkerRpcNamespace::Channel => "channel",
@@ -45,6 +47,7 @@ impl WorkerRpcNamespace {
 
 pub fn classify_method(method: &str) -> WorkerRpcNamespace {
     match method.split_once('.').map(|(namespace, _method)| namespace) {
+        Some("agent_run") => WorkerRpcNamespace::AgentRun,
         Some("approval") => WorkerRpcNamespace::Approval,
         Some("background") => WorkerRpcNamespace::Background,
         Some("channel") => WorkerRpcNamespace::Channel,
@@ -79,6 +82,10 @@ mod tests {
         assert_eq!(
             classify_method("provider.resolve_secret"),
             WorkerRpcNamespace::Provider
+        );
+        assert_eq!(
+            classify_method("agent_run.list"),
+            WorkerRpcNamespace::AgentRun
         );
         assert_eq!(classify_method("unknown"), WorkerRpcNamespace::Unknown);
     }

--- a/src-tauri/src/worker_session.rs
+++ b/src-tauri/src/worker_session.rs
@@ -27,6 +27,7 @@ include!("worker_session/turn_persistence.rs");
 include!("worker_session/task_progress.rs");
 
 include!("worker_session/types.rs");
+include!("worker_session/agent_run.rs");
 include!("worker_session/metadata_helpers.rs");
 include!("worker_session/history_helpers.rs");
 include!("worker_session/task_progress_helpers.rs");

--- a/src-tauri/src/worker_session/agent_run.rs
+++ b/src-tauri/src/worker_session/agent_run.rs
@@ -344,16 +344,39 @@ fn clear_compatible_agent_run_checkpoint(
     let Some(run_id) = selected_run_id else {
         return Ok(());
     };
+    clear_agent_run_checkpoint_by_id(session, &run_id)
+}
+
+fn clear_agent_run_checkpoint_by_id(
+    session: &mut SessionMetadata,
+    run_id: &str,
+) -> Result<(), WorkerProtocolError> {
+    update_agent_run_checkpoints(session, |run| run.run_id == run_id)
+}
+
+fn clear_all_agent_run_checkpoints(session: &mut SessionMetadata) -> Result<(), WorkerProtocolError> {
+    update_agent_run_checkpoints(session, |run| run.checkpoint.is_some())
+}
+
+fn update_agent_run_checkpoints(
+    session: &mut SessionMetadata,
+    mut should_clear: impl FnMut(&AgentRunRecord) -> bool,
+) -> Result<(), WorkerProtocolError> {
+    let mut changed = false;
     let mut runs = agent_run_records(session);
+    let timestamp = now_session_timestamp();
     for run in &mut runs {
-        if run.run_id == run_id {
+        if should_clear(run) {
             run.checkpoint = None;
-            run.updated_at = now_session_timestamp();
-            break;
+            run.updated_at = timestamp.clone();
+            changed = true;
         }
     }
-    ensure_agent_runs_array(session);
-    session.extra[AGENT_RUNS_KEY] = serde_json::to_value(runs).map_err(session_serialization_error)?;
+    if changed {
+        ensure_agent_runs_array(session);
+        session.extra[AGENT_RUNS_KEY] =
+            serde_json::to_value(runs).map_err(session_serialization_error)?;
+    }
     Ok(())
 }
 

--- a/src-tauri/src/worker_session/agent_run.rs
+++ b/src-tauri/src/worker_session/agent_run.rs
@@ -1,0 +1,507 @@
+const AGENT_RUNS_KEY: &str = "agent_runs";
+
+impl WorkerSessionRpc {
+    pub fn upsert_agent_run(
+        &mut self,
+        record: AgentRunRecord,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        validate_agent_run_key(&record.session_id, &record.run_id)?;
+        let record = {
+            let session = self.session_mut_or_create(&record.session_id);
+            ensure_extra_object(session);
+            ensure_agent_runs_array(session);
+            let runs = session
+                .extra
+                .get_mut(AGENT_RUNS_KEY)
+                .and_then(Value::as_array_mut)
+                .expect("agent_runs should be an array after ensure");
+            if let Some(existing) = runs
+                .iter_mut()
+                .find(|value| value.get("runId").and_then(Value::as_str) == Some(&record.run_id))
+            {
+                let mut next = record.clone();
+                if let Ok(existing_record) = serde_json::from_value::<AgentRunRecord>((*existing).clone()) {
+                    next.started_at = existing_record.started_at;
+                }
+                *existing = serde_json::to_value(&next).map_err(session_serialization_error)?;
+            } else {
+                runs.push(serde_json::to_value(&record).map_err(session_serialization_error)?);
+            }
+            session.updated_at = now_session_timestamp();
+            record
+        };
+        self.persist_sessions()?;
+        Ok(record)
+    }
+
+    pub fn get_agent_run(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        validate_agent_run_key(session_id, run_id)?;
+        self.sessions
+            .iter()
+            .find(|session| session.session_id == session_id)
+            .and_then(|session| agent_run_records(session).into_iter().find(|run| run.run_id == run_id))
+            .ok_or_else(|| unknown_agent_run_error(session_id, run_id))
+    }
+
+    pub fn list_agent_runs(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<AgentRunRecord>, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        validate_session_id(session_id)?;
+        let mut runs = self
+            .sessions
+            .iter()
+            .find(|session| session.session_id == session_id)
+            .map(agent_run_records)
+            .unwrap_or_default();
+        runs.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| left.run_id.cmp(&right.run_id))
+        });
+        Ok(runs)
+    }
+
+    pub fn list_agent_run_trace_events(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        cursor: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<AgentRunTracePage, WorkerProtocolError> {
+        let record = self.get_agent_run(session_id, run_id)?;
+        let offset = parse_trace_cursor(cursor)?;
+        let limit = limit.unwrap_or(100).clamp(1, 500);
+        let items = record
+            .trace_events
+            .iter()
+            .skip(offset)
+            .take(limit)
+            .cloned()
+            .collect::<Vec<_>>();
+        let next_offset = offset.saturating_add(items.len());
+        let next_cursor = (next_offset < record.trace_events.len()).then(|| next_offset.to_string());
+        Ok(AgentRunTracePage {
+            session_id: record.session_id,
+            run_id: record.run_id,
+            items,
+            next_cursor,
+        })
+    }
+
+    pub fn append_agent_run_trace_event(
+        &mut self,
+        session_id: &str,
+        run_id: &str,
+        event: Value,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        let mut record = self.get_agent_run_for_update(session_id, run_id)?;
+        record.trace_events.push(event);
+        record.updated_at = now_session_timestamp();
+        self.upsert_agent_run(record)
+    }
+
+    pub fn set_agent_run_checkpoint(
+        &mut self,
+        session_id: &str,
+        run_id: &str,
+        checkpoint: Value,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        let mut record = self.get_agent_run_for_update(session_id, run_id)?;
+        record.checkpoint = Some(checkpoint);
+        record.updated_at = now_session_timestamp();
+        self.upsert_agent_run(record)
+    }
+
+    pub fn get_agent_run_checkpoint(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<Option<AgentRunCheckpoint>, WorkerProtocolError> {
+        let record = self.get_agent_run(session_id, run_id)?;
+        Ok(record.checkpoint.map(|checkpoint| AgentRunCheckpoint {
+            session_id: record.session_id,
+            run_id: record.run_id,
+            checkpoint,
+        }))
+    }
+
+    pub fn clear_agent_run_checkpoint(
+        &mut self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        let mut record = self.get_agent_run_for_update(session_id, run_id)?;
+        record.checkpoint = None;
+        record.updated_at = now_session_timestamp();
+        self.upsert_agent_run(record)
+    }
+
+    pub fn mark_agent_run_completed(
+        &mut self,
+        session_id: &str,
+        run_id: &str,
+        stop_reason: &str,
+        final_content: Option<String>,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        let mut record = self.get_agent_run_for_update(session_id, run_id)?;
+        let timestamp = now_session_timestamp();
+        if let Some(final_content) = final_content.filter(|content| !content.trim().is_empty()) {
+            record.trace_messages.push(serde_json::json!({
+                "role": "assistant",
+                "content": final_content,
+            }));
+        }
+        record.status = AgentRunStatus::Completed;
+        record.phase = "done".to_string();
+        record.stop_reason = Some(stop_reason.to_string());
+        record.completed_at = Some(timestamp.clone());
+        record.updated_at = timestamp;
+        record.checkpoint = None;
+        self.upsert_agent_run(record)
+    }
+
+    pub fn mark_agent_run_failed(
+        &mut self,
+        session_id: &str,
+        run_id: &str,
+        stop_reason: &str,
+        error: Value,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        let mut record = self.get_agent_run_for_update(session_id, run_id)?;
+        let timestamp = now_session_timestamp();
+        record.status = AgentRunStatus::Failed;
+        record.phase = "failed".to_string();
+        record.stop_reason = Some(stop_reason.to_string());
+        record.error = Some(error);
+        record.completed_at = Some(timestamp.clone());
+        record.updated_at = timestamp;
+        self.upsert_agent_run(record)
+    }
+
+    pub fn mark_agent_run_cancelled(
+        &mut self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        let mut record = self.get_agent_run_for_update(session_id, run_id)?;
+        let timestamp = now_session_timestamp();
+        record.status = AgentRunStatus::Cancelled;
+        record.phase = "cancelled".to_string();
+        record.stop_reason = Some("cancelled".to_string());
+        record.completed_at = Some(timestamp.clone());
+        record.updated_at = timestamp;
+        self.upsert_agent_run(record)
+    }
+
+    pub fn latest_resumable_agent_run_checkpoint(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<AgentRunCheckpoint>, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        validate_session_id(session_id)?;
+        let mut runs = self.list_agent_runs(session_id)?;
+        runs.retain(|run| run.status.is_resumable() && run.checkpoint.is_some());
+        Ok(runs.into_iter().next().and_then(|run| {
+            run.checkpoint.map(|checkpoint| AgentRunCheckpoint {
+                session_id: run.session_id,
+                run_id: run.run_id,
+                checkpoint,
+            })
+        }))
+    }
+
+    fn get_agent_run_for_update(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        validate_agent_run_key(session_id, run_id)?;
+        self.sessions
+            .iter()
+            .find(|session| session.session_id == session_id)
+            .and_then(|session| agent_run_records(session).into_iter().find(|run| run.run_id == run_id))
+            .ok_or_else(|| unknown_agent_run_error(session_id, run_id))
+    }
+}
+
+impl AgentRunStatus {
+    fn is_resumable(&self) -> bool {
+        matches!(self, AgentRunStatus::Running | AgentRunStatus::Waiting)
+    }
+}
+
+fn mirror_checkpoint_to_agent_run(
+    session: &mut SessionMetadata,
+    session_id: &str,
+    checkpoint: Value,
+    timestamp: &str,
+) -> Result<(), WorkerProtocolError> {
+    let Some(run_id) = checkpoint_run_id(&checkpoint) else {
+        return Ok(());
+    };
+    ensure_agent_runs_array(session);
+    let runs = session
+        .extra
+        .get_mut(AGENT_RUNS_KEY)
+        .and_then(Value::as_array_mut)
+        .expect("agent_runs should be an array after ensure");
+    let mut record = runs
+        .iter()
+        .find_map(|value| {
+            serde_json::from_value::<AgentRunRecord>(value.clone())
+                .ok()
+                .filter(|record| record.run_id == run_id)
+        })
+        .unwrap_or_else(|| agent_run_from_checkpoint(session_id, &run_id, &checkpoint, timestamp));
+    record.phase = checkpoint
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or(record.phase.as_str())
+        .to_string();
+    record.status = agent_run_status_from_checkpoint(&checkpoint);
+    record.updated_at = timestamp.to_string();
+    if matches!(record.status, AgentRunStatus::Completed | AgentRunStatus::Failed | AgentRunStatus::Cancelled)
+        && record.completed_at.is_none()
+    {
+        record.completed_at = Some(timestamp.to_string());
+    }
+    record.current_iteration = checkpoint
+        .get("iteration")
+        .and_then(Value::as_i64)
+        .unwrap_or(record.current_iteration);
+    record.max_iterations = checkpoint
+        .get("maxIterations")
+        .or_else(|| checkpoint.get("max_iterations"))
+        .and_then(Value::as_i64)
+        .unwrap_or(record.max_iterations);
+    record.pending_tool_calls = checkpoint
+        .get("pendingToolCalls")
+        .or_else(|| checkpoint.get("pending_tool_calls"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    record.completed_tool_results = checkpoint
+        .get("completedToolResults")
+        .or_else(|| checkpoint.get("completed_tool_results"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    record.checkpoint = Some(checkpoint);
+    let value = serde_json::to_value(&record).map_err(session_serialization_error)?;
+    if let Some(existing) = runs
+        .iter_mut()
+        .find(|value| value.get("runId").and_then(Value::as_str) == Some(run_id.as_str()))
+    {
+        *existing = value;
+    } else {
+        runs.push(value);
+    }
+    Ok(())
+}
+
+fn latest_resumable_checkpoint_for_session(session: &SessionMetadata) -> Option<AgentRunCheckpoint> {
+    let mut runs = agent_run_records(session);
+    runs.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| left.run_id.cmp(&right.run_id))
+    });
+    runs.into_iter().find_map(|run| {
+        if !run.status.is_resumable() {
+            return None;
+        }
+        run.checkpoint.map(|checkpoint| AgentRunCheckpoint {
+            session_id: run.session_id,
+            run_id: run.run_id,
+            checkpoint,
+        })
+    })
+}
+
+fn clear_compatible_agent_run_checkpoint(
+    session: &mut SessionMetadata,
+    legacy_checkpoint: Option<&Value>,
+) -> Result<(), WorkerProtocolError> {
+    let selected_run_id = legacy_checkpoint
+        .and_then(checkpoint_run_id)
+        .or_else(|| latest_resumable_checkpoint_for_session(session).map(|checkpoint| checkpoint.run_id));
+    let Some(run_id) = selected_run_id else {
+        return Ok(());
+    };
+    let mut runs = agent_run_records(session);
+    for run in &mut runs {
+        if run.run_id == run_id {
+            run.checkpoint = None;
+            run.updated_at = now_session_timestamp();
+            break;
+        }
+    }
+    ensure_agent_runs_array(session);
+    session.extra[AGENT_RUNS_KEY] = serde_json::to_value(runs).map_err(session_serialization_error)?;
+    Ok(())
+}
+
+fn checkpoint_run_id(checkpoint: &Value) -> Option<String> {
+    checkpoint
+        .get("runId")
+        .or_else(|| checkpoint.get("run_id"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn agent_run_from_checkpoint(
+    session_id: &str,
+    run_id: &str,
+    checkpoint: &Value,
+    timestamp: &str,
+) -> AgentRunRecord {
+    AgentRunRecord {
+        session_id: session_id.to_string(),
+        run_id: run_id.to_string(),
+        status: AgentRunStatus::Waiting,
+        phase: checkpoint
+            .get("phase")
+            .and_then(Value::as_str)
+            .unwrap_or("awaiting_checkpoint")
+            .to_string(),
+        started_at: timestamp.to_string(),
+        updated_at: timestamp.to_string(),
+        completed_at: None,
+        stop_reason: checkpoint
+            .get("stopReason")
+            .or_else(|| checkpoint.get("stop_reason"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        model: checkpoint
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        provider: checkpoint
+            .get("provider")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        max_iterations: checkpoint
+            .get("maxIterations")
+            .or_else(|| checkpoint.get("max_iterations"))
+            .and_then(Value::as_i64)
+            .unwrap_or_default(),
+        current_iteration: checkpoint
+            .get("iteration")
+            .and_then(Value::as_i64)
+            .unwrap_or_default(),
+        conversation_message_ids: Vec::new(),
+        trace_messages: checkpoint
+            .get("messages")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        trace_events: Vec::new(),
+        completed_tool_results: checkpoint
+            .get("completedToolResults")
+            .or_else(|| checkpoint.get("completed_tool_results"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        pending_tool_calls: checkpoint
+            .get("pendingToolCalls")
+            .or_else(|| checkpoint.get("pending_tool_calls"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        checkpoint: Some(checkpoint.clone()),
+        artifacts: Vec::new(),
+        usage: Vec::new(),
+        error: None,
+    }
+}
+
+fn agent_run_status_from_checkpoint(checkpoint: &Value) -> AgentRunStatus {
+    match checkpoint
+        .get("stopReason")
+        .or_else(|| checkpoint.get("stop_reason"))
+        .and_then(Value::as_str)
+        .or_else(|| checkpoint.get("phase").and_then(Value::as_str))
+    {
+        Some("final_response") | Some("done") | Some("terminal") => AgentRunStatus::Completed,
+        Some("cancelled") => AgentRunStatus::Cancelled,
+        Some("provider_error")
+        | Some("tool_error")
+        | Some("policy_denied")
+        | Some("max_iterations")
+        | Some("invalid_request")
+        | Some("approval_denied")
+        | Some("form_cancelled")
+        | Some("failed") => AgentRunStatus::Failed,
+        _ => AgentRunStatus::Waiting,
+    }
+}
+
+fn validate_agent_run_key(session_id: &str, run_id: &str) -> Result<(), WorkerProtocolError> {
+    validate_session_id(session_id)?;
+    validate_session_id(run_id)
+}
+
+fn ensure_agent_runs_array(session: &mut SessionMetadata) {
+    if !session.extra.get(AGENT_RUNS_KEY).is_some_and(Value::is_array) {
+        session.extra[AGENT_RUNS_KEY] = serde_json::json!([]);
+    }
+}
+
+fn agent_run_records(session: &SessionMetadata) -> Vec<AgentRunRecord> {
+    session
+        .extra
+        .get(AGENT_RUNS_KEY)
+        .and_then(Value::as_array)
+        .map(|runs| {
+            runs.iter()
+                .filter_map(|value| serde_json::from_value(value.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_trace_cursor(cursor: Option<&str>) -> Result<usize, WorkerProtocolError> {
+    let Some(cursor) = cursor else {
+        return Ok(0);
+    };
+    cursor
+        .parse::<usize>()
+        .map_err(|_| WorkerProtocolError::new(
+            WorkerProtocolErrorCode::InvalidProtocol,
+            "invalid agent run trace cursor",
+            serde_json::json!({ "cursor": cursor }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ))
+}
+
+fn unknown_agent_run_error(session_id: &str, run_id: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "agent run not found",
+        serde_json::json!({
+            "session_id": session_id,
+            "run_id": run_id,
+        }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}

--- a/src-tauri/src/worker_session/checkpoint.rs
+++ b/src-tauri/src/worker_session/checkpoint.rs
@@ -6,7 +6,14 @@ impl WorkerSessionRpc {
             .sessions
             .iter()
             .find(|session| session.session_id == session_id);
-        Ok(session.and_then(|session| session.extra.get("runtime_checkpoint").cloned()))
+        if let Some(checkpoint) =
+            session.and_then(|session| session.extra.get("runtime_checkpoint").cloned())
+        {
+            return Ok(Some(checkpoint));
+        }
+        Ok(session.and_then(|session| {
+            latest_resumable_checkpoint_for_session(session).map(|checkpoint| checkpoint.checkpoint)
+        }))
     }
 
     pub fn set_checkpoint(
@@ -16,11 +23,13 @@ impl WorkerSessionRpc {
     ) -> Result<SessionMetadata, WorkerProtocolError> {
         self.require(WorkerCapability::SessionWrite)?;
         validate_session_id(session_id)?;
+        let timestamp = now_session_timestamp();
         let session = {
             let session = self.session_mut_or_create(session_id);
             ensure_extra_object(session);
-            session.extra["runtime_checkpoint"] = checkpoint;
-            session.updated_at = now_session_timestamp();
+            session.extra["runtime_checkpoint"] = checkpoint.clone();
+            mirror_checkpoint_to_agent_run(session, session_id, checkpoint, &timestamp)?;
+            session.updated_at = timestamp;
             session.clone()
         };
         self.persist_sessions()?;
@@ -35,9 +44,14 @@ impl WorkerSessionRpc {
         validate_session_id(session_id)?;
         let session = {
             let session = self.session_mut_or_create(session_id);
+            let legacy_checkpoint = session
+                .extra
+                .get("runtime_checkpoint")
+                .cloned();
             if let Some(extra) = session.extra.as_object_mut() {
                 extra.remove("runtime_checkpoint");
             }
+            clear_compatible_agent_run_checkpoint(session, legacy_checkpoint.as_ref())?;
             session.updated_at = now_session_timestamp();
             session.clone()
         };

--- a/src-tauri/src/worker_session/metadata.rs
+++ b/src-tauri/src/worker_session/metadata.rs
@@ -61,6 +61,7 @@ impl WorkerSessionRpc {
                 .and_then(Value::as_array)
                 .map_or(0, Vec::len);
             let checkpoint_cleared = session.extra.get("runtime_checkpoint").is_some();
+            clear_all_agent_run_checkpoints(session)?;
             if let Some(extra) = session.extra.as_object_mut() {
                 extra.insert("messages".to_string(), serde_json::json!([]));
                 extra.insert("last_consolidated".to_string(), serde_json::json!(0));

--- a/src-tauri/src/worker_session/tests.rs
+++ b/src-tauri/src/worker_session/tests.rs
@@ -163,6 +163,283 @@ mod tests {
     }
 
     #[test]
+    fn agent_run_record_serializes_run_state() {
+        let record = AgentRunRecord {
+            session_id: "session-1".to_string(),
+            run_id: "run-1".to_string(),
+            status: AgentRunStatus::Waiting,
+            phase: "awaiting_tool".to_string(),
+            started_at: "unix-ms:1".to_string(),
+            updated_at: "unix-ms:2".to_string(),
+            completed_at: None,
+            stop_reason: None,
+            model: "fixture-model".to_string(),
+            provider: Some("fixture".to_string()),
+            max_iterations: 4,
+            current_iteration: 1,
+            conversation_message_ids: vec!["message-1".to_string()],
+            trace_messages: vec![json!({ "role": "tool", "content": "README" })],
+            trace_events: vec![json!({ "eventName": "agent.tool.result" })],
+            completed_tool_results: vec![json!({ "toolCallId": "call-1" })],
+            pending_tool_calls: vec![json!({ "toolCallId": "call-2" })],
+            checkpoint: Some(json!({
+                "schemaVersion": 1,
+                "sessionId": "session-1",
+                "runId": "run-1",
+                "phase": "awaiting_tool"
+            })),
+            artifacts: vec![json!({ "type": "file", "path": "report.md" })],
+            usage: vec![json!({ "totalTokens": 12 })],
+            error: Some(json!({ "message": "waiting" })),
+        };
+
+        let value = serde_json::to_value(&record).expect("run record should serialize");
+        assert_eq!(value["sessionId"], "session-1");
+        assert_eq!(value["runId"], "run-1");
+        assert_eq!(value["status"], "waiting");
+        assert_eq!(value["currentIteration"], 1);
+        assert_eq!(value["completedToolResults"][0]["toolCallId"], "call-1");
+
+        let restored: AgentRunRecord =
+            serde_json::from_value(value).expect("run record should deserialize");
+        assert_eq!(restored, record);
+    }
+
+    #[test]
+    fn agent_run_store_isolates_runs_in_same_session() {
+        let mut rpc = WorkerSessionRpc::new(vec![], read_write_policy());
+        let mut first = agent_run_fixture("session-1", "run-1", AgentRunStatus::Running);
+        first.updated_at = "unix-ms:1".to_string();
+        let mut second = agent_run_fixture("session-1", "run-2", AgentRunStatus::Waiting);
+        second.updated_at = "unix-ms:2".to_string();
+
+        rpc.upsert_agent_run(first)
+            .expect("first run should upsert");
+        rpc.upsert_agent_run(second)
+            .expect("second run should upsert");
+        rpc.append_agent_run_trace_event(
+            "session-1",
+            "run-1",
+            json!({ "eventName": "agent.tool.result", "payload": { "toolCallId": "call-1" } }),
+        )
+        .expect("trace event should append");
+        rpc.set_agent_run_checkpoint(
+            "session-1",
+            "run-2",
+            json!({ "sessionId": "session-1", "runId": "run-2", "phase": "awaiting_approval" }),
+        )
+        .expect("checkpoint should set");
+
+        let first = rpc
+            .get_agent_run("session-1", "run-1")
+            .expect("first run should read");
+        let second = rpc
+            .get_agent_run("session-1", "run-2")
+            .expect("second run should read");
+
+        assert_eq!(first.trace_events.len(), 1);
+        assert_eq!(first.checkpoint, None);
+        assert!(second.trace_events.is_empty());
+        assert_eq!(
+            second.checkpoint.unwrap()["phase"],
+            json!("awaiting_approval")
+        );
+    }
+
+    #[test]
+    fn agent_run_list_orders_by_updated_at_and_latest_resumable_checkpoint() {
+        let mut rpc = WorkerSessionRpc::new(vec![], read_write_policy());
+        let mut older = agent_run_fixture("session-1", "run-old", AgentRunStatus::Waiting);
+        older.updated_at = "unix-ms:1".to_string();
+        older.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-old" }));
+        let mut newer = agent_run_fixture("session-1", "run-new", AgentRunStatus::Waiting);
+        newer.updated_at = "unix-ms:3".to_string();
+        newer.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-new" }));
+        let mut completed = agent_run_fixture("session-1", "run-done", AgentRunStatus::Completed);
+        completed.updated_at = "unix-ms:4".to_string();
+        completed.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-done" }));
+
+        rpc.upsert_agent_run(older).expect("older run should upsert");
+        rpc.upsert_agent_run(newer).expect("newer run should upsert");
+        rpc.upsert_agent_run(completed)
+            .expect("completed run should upsert");
+
+        let runs = rpc
+            .list_agent_runs("session-1")
+            .expect("runs should list");
+        assert_eq!(
+            runs.iter()
+                .map(|run| run.run_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run-done", "run-new", "run-old"]
+        );
+
+        let checkpoint = rpc
+            .latest_resumable_agent_run_checkpoint("session-1")
+            .expect("latest resumable lookup should succeed")
+            .expect("resumable checkpoint should exist");
+        assert_eq!(checkpoint.run_id, "run-new");
+        assert_eq!(checkpoint.checkpoint["runId"], "run-new");
+    }
+
+    #[test]
+    fn agent_run_mark_methods_update_terminal_state() {
+        let mut rpc = WorkerSessionRpc::new(vec![], read_write_policy());
+        rpc.upsert_agent_run(agent_run_fixture(
+            "session-1",
+            "run-1",
+            AgentRunStatus::Running,
+        ))
+        .expect("run should upsert");
+
+        let completed = rpc
+            .mark_agent_run_completed(
+                "session-1",
+                "run-1",
+                "final_response",
+                Some("done".to_string()),
+            )
+            .expect("run should mark completed");
+        assert_eq!(completed.status, AgentRunStatus::Completed);
+        assert_eq!(completed.stop_reason.as_deref(), Some("final_response"));
+        assert_eq!(completed.phase, "done");
+        assert!(completed.completed_at.is_some());
+
+        rpc.upsert_agent_run(agent_run_fixture(
+            "session-1",
+            "run-2",
+            AgentRunStatus::Running,
+        ))
+        .expect("second run should upsert");
+        let failed = rpc
+            .mark_agent_run_failed(
+                "session-1",
+                "run-2",
+                "provider_error",
+                json!({ "message": "provider failed" }),
+            )
+            .expect("run should mark failed");
+        assert_eq!(failed.status, AgentRunStatus::Failed);
+        assert_eq!(failed.error.as_ref().unwrap()["message"], "provider failed");
+
+        rpc.upsert_agent_run(agent_run_fixture(
+            "session-1",
+            "run-3",
+            AgentRunStatus::Running,
+        ))
+        .expect("third run should upsert");
+        let cancelled = rpc
+            .mark_agent_run_cancelled("session-1", "run-3")
+            .expect("run should mark cancelled");
+        assert_eq!(cancelled.status, AgentRunStatus::Cancelled);
+        assert_eq!(cancelled.stop_reason.as_deref(), Some("cancelled"));
+    }
+
+    #[test]
+    fn agent_run_summary_and_trace_page_omit_full_record_payloads() {
+        let mut record = agent_run_fixture("session-1", "run-1", AgentRunStatus::Completed);
+        record.trace_events = vec![json!({ "eventName": "agent.tool.result" })];
+        record.completed_tool_results = vec![json!({ "toolCallId": "call-1", "toolName": "workspace.read_file" })];
+        record.artifacts = vec![json!({ "type": "file" })];
+        record.stop_reason = Some("final_response".to_string());
+        record.completed_at = Some("unix-ms:2".to_string());
+
+        let summary = AgentRunSummary::from_record(&record);
+        assert_eq!(summary.run_id, "run-1");
+        assert_eq!(summary.tool_call_count, 1);
+        assert_eq!(summary.tools_used, vec!["workspace.read_file"]);
+        assert_eq!(summary.artifact_count, 1);
+        assert!(!serde_json::to_value(&summary)
+            .expect("summary should serialize")
+            .get("traceEvents")
+            .is_some());
+
+        let page = AgentRunTracePage::new("session-1", "run-1", vec![json!({ "eventName": "agent.done" })]);
+        assert_eq!(page.session_id, "session-1");
+        assert_eq!(page.run_id, "run-1");
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn agent_run_upsert_preserves_original_started_at() {
+        let mut rpc = WorkerSessionRpc::new(vec![session_fixture()], read_write_policy());
+        let mut running = agent_run_fixture("session-1", "run-1", AgentRunStatus::Running);
+        running.started_at = "unix-ms:1".to_string();
+        running.updated_at = "unix-ms:1".to_string();
+        let mut completed = agent_run_fixture("session-1", "run-1", AgentRunStatus::Completed);
+        completed.started_at = "unix-ms:2".to_string();
+        completed.updated_at = "unix-ms:3".to_string();
+        completed.completed_at = Some("unix-ms:3".to_string());
+
+        rpc.upsert_agent_run(running)
+            .expect("running run should upsert");
+        rpc.upsert_agent_run(completed)
+            .expect("terminal run should upsert");
+        let restored = rpc
+            .get_agent_run("session-1", "run-1")
+            .expect("run should read");
+
+        assert_eq!(restored.started_at, "unix-ms:1");
+        assert_eq!(restored.updated_at, "unix-ms:3");
+        assert_eq!(restored.completed_at.as_deref(), Some("unix-ms:3"));
+    }
+
+    #[test]
+    fn agent_run_trace_pages_are_bounded_by_cursor_and_limit() {
+        let mut rpc = WorkerSessionRpc::new(vec![session_fixture()], read_write_policy());
+        let mut record = agent_run_fixture("session-1", "run-1", AgentRunStatus::Running);
+        record.trace_events = vec![
+            json!({ "eventName": "agent.tool_call.delta" }),
+            json!({ "eventName": "agent.tool.start" }),
+            json!({ "eventName": "agent.tool.result" }),
+        ];
+        rpc.upsert_agent_run(record)
+            .expect("run should upsert");
+
+        let first_page = rpc
+            .list_agent_run_trace_events("session-1", "run-1", None, Some(2))
+            .expect("first trace page should read");
+        let second_page = rpc
+            .list_agent_run_trace_events(
+                "session-1",
+                "run-1",
+                first_page.next_cursor.as_deref(),
+                Some(2),
+            )
+            .expect("second trace page should read");
+
+        assert_eq!(first_page.items.len(), 2);
+        assert_eq!(first_page.items[0]["eventName"], "agent.tool_call.delta");
+        assert_eq!(first_page.next_cursor.as_deref(), Some("2"));
+        assert_eq!(second_page.items.len(), 1);
+        assert_eq!(second_page.items[0]["eventName"], "agent.tool.result");
+        assert_eq!(second_page.next_cursor, None);
+    }
+
+    #[test]
+    fn persistent_store_restores_agent_runs_after_worker_restarts() {
+        let root = temp_workspace_root("agent-run-persistence");
+        let _cleanup = TempWorkspaceCleanup(root.clone());
+        let mut rpc = WorkerSessionRpc::new_persistent(root.clone(), vec![], read_write_policy())
+            .expect("persistent session rpc should initialize");
+        let mut record = agent_run_fixture("websocket:chat-1", "run-1", AgentRunStatus::Completed);
+        record.completed_tool_results = vec![json!({ "toolCallId": "call-1" })];
+
+        rpc.upsert_agent_run(record)
+            .expect("run record should persist");
+
+        let restarted = WorkerSessionRpc::new_persistent(root, vec![], read_policy())
+            .expect("store should load");
+        let restored = restarted
+            .get_agent_run("websocket:chat-1", "run-1")
+            .expect("persisted run should load");
+
+        assert_eq!(restored.status, AgentRunStatus::Completed);
+        assert_eq!(restored.completed_tool_results[0]["toolCallId"], "call-1");
+    }
+
+    #[test]
     fn set_and_clear_checkpoint_update_session_extra_with_write_capability() {
         let mut rpc = WorkerSessionRpc::new(vec![session_fixture()], write_policy());
 
@@ -183,6 +460,93 @@ mod tests {
             .expect("checkpoint should clear");
 
         assert!(cleared.extra.get("runtime_checkpoint").is_none());
+    }
+
+    #[test]
+    fn set_checkpoint_mirrors_run_id_checkpoint_into_agent_run_store() {
+        let mut rpc = WorkerSessionRpc::new(vec![session_fixture()], read_write_policy());
+
+        let updated = rpc
+            .set_checkpoint(
+                "session-1",
+                json!({
+                    "schemaVersion": 1,
+                    "sessionId": "session-1",
+                    "runId": "run-checkpoint",
+                    "phase": "awaiting_tool",
+                    "iteration": 2,
+                    "maxIterations": 4,
+                    "completedToolResults": [{ "toolCallId": "call-1" }]
+                }),
+            )
+            .expect("checkpoint should set");
+
+        assert_eq!(updated.extra["runtime_checkpoint"]["runId"], "run-checkpoint");
+        let run_checkpoint = rpc
+            .get_agent_run_checkpoint("session-1", "run-checkpoint")
+            .expect("run checkpoint should read")
+            .expect("run checkpoint should exist");
+        assert_eq!(run_checkpoint.checkpoint["phase"], "awaiting_tool");
+        let run = rpc
+            .get_agent_run("session-1", "run-checkpoint")
+            .expect("mirrored run should exist");
+        assert_eq!(run.status, AgentRunStatus::Waiting);
+        assert_eq!(run.current_iteration, 2);
+        assert_eq!(run.completed_tool_results[0]["toolCallId"], "call-1");
+    }
+
+    #[test]
+    fn get_checkpoint_falls_back_to_latest_resumable_agent_run() {
+        let mut session = session_fixture();
+        let mut old_run = agent_run_fixture("session-1", "run-old", AgentRunStatus::Waiting);
+        old_run.updated_at = "unix-ms:1".to_string();
+        old_run.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-old" }));
+        let mut new_run = agent_run_fixture("session-1", "run-new", AgentRunStatus::Waiting);
+        new_run.updated_at = "unix-ms:2".to_string();
+        new_run.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-new" }));
+        session.extra = json!({
+            "agent_runs": [
+                serde_json::to_value(old_run).unwrap(),
+                serde_json::to_value(new_run).unwrap()
+            ]
+        });
+        let rpc = WorkerSessionRpc::new(vec![session], read_policy());
+
+        let checkpoint = rpc
+            .get_checkpoint("session-1")
+            .expect("checkpoint should read")
+            .expect("latest resumable checkpoint should exist");
+
+        assert_eq!(checkpoint["runId"], "run-new");
+    }
+
+    #[test]
+    fn clear_checkpoint_clears_only_legacy_and_selected_run_checkpoint() {
+        let mut session = session_fixture();
+        let mut first = agent_run_fixture("session-1", "run-1", AgentRunStatus::Waiting);
+        first.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-1" }));
+        let mut second = agent_run_fixture("session-1", "run-2", AgentRunStatus::Waiting);
+        second.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-2" }));
+        session.extra = json!({
+            "runtime_checkpoint": { "sessionId": "session-1", "runId": "run-1" },
+            "agent_runs": [
+                serde_json::to_value(first).unwrap(),
+                serde_json::to_value(second).unwrap()
+            ]
+        });
+        let mut rpc = WorkerSessionRpc::new(vec![session], read_write_policy());
+
+        rpc.clear_checkpoint("session-1")
+            .expect("checkpoint should clear");
+
+        assert!(rpc
+            .get_agent_run_checkpoint("session-1", "run-1")
+            .expect("first run should read")
+            .is_none());
+        assert!(rpc
+            .get_agent_run_checkpoint("session-1", "run-2")
+            .expect("second run should read")
+            .is_some());
     }
 
     #[test]
@@ -378,6 +742,33 @@ mod tests {
         assert_eq!(
             history.user_profile,
             json!({ "name": "Ada", "preferences": ["concise"] })
+        );
+    }
+
+    #[test]
+    fn get_history_ignores_agent_run_trace_payloads() {
+        let mut run = agent_run_fixture("session-1", "run-1", AgentRunStatus::Completed);
+        run.trace_messages = vec![json!({ "role": "tool", "content": "large tool trace" })];
+        let mut session = session_fixture();
+        session.extra = json!({
+            "messages": [
+                { "role": "user", "content": "hello" },
+                { "role": "assistant", "content": "done" }
+            ],
+            "agent_runs": [serde_json::to_value(run).unwrap()]
+        });
+        let rpc = WorkerSessionRpc::new(vec![session], read_policy());
+
+        let history = rpc
+            .get_history("session-1", 10)
+            .expect("history should read");
+
+        assert_eq!(
+            history.messages,
+            vec![
+                json!({ "role": "user", "content": "hello" }),
+                json!({ "role": "assistant", "content": "done" })
+            ]
         );
     }
 
@@ -1136,6 +1527,13 @@ mod tests {
         CapabilityPolicy::new([WorkerCapability::SessionWrite])
     }
 
+    fn read_write_policy() -> CapabilityPolicy {
+        CapabilityPolicy::new([
+            WorkerCapability::SessionMetadataRead,
+            WorkerCapability::SessionWrite,
+        ])
+    }
+
     fn temp_workspace_root(name: &str) -> PathBuf {
         let nonce = now_session_timestamp().replace(':', "-");
         let root = std::env::temp_dir().join(format!(
@@ -1162,6 +1560,36 @@ mod tests {
             created_at: "2026-06-09T09:00:00Z".to_string(),
             updated_at: "2026-06-09T09:30:00Z".to_string(),
             extra: json!({ "mode": "desktop" }),
+        }
+    }
+
+    fn agent_run_fixture(
+        session_id: &str,
+        run_id: &str,
+        status: AgentRunStatus,
+    ) -> AgentRunRecord {
+        AgentRunRecord {
+            session_id: session_id.to_string(),
+            run_id: run_id.to_string(),
+            status,
+            phase: "active_turn".to_string(),
+            started_at: "unix-ms:0".to_string(),
+            updated_at: "unix-ms:0".to_string(),
+            completed_at: None,
+            stop_reason: None,
+            model: "fixture-model".to_string(),
+            provider: Some("fixture".to_string()),
+            max_iterations: 4,
+            current_iteration: 0,
+            conversation_message_ids: Vec::new(),
+            trace_messages: Vec::new(),
+            trace_events: Vec::new(),
+            completed_tool_results: Vec::new(),
+            pending_tool_calls: Vec::new(),
+            checkpoint: None,
+            artifacts: Vec::new(),
+            usage: Vec::new(),
+            error: None,
         }
     }
 }

--- a/src-tauri/src/worker_session/tests.rs
+++ b/src-tauri/src/worker_session/tests.rs
@@ -583,6 +583,8 @@ mod tests {
     #[test]
     fn clear_session_resets_messages_profile_and_checkpoint_with_write_capability() {
         let mut session = session_fixture();
+        let mut run = agent_run_fixture("session-1", "run-1", AgentRunStatus::Waiting);
+        run.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-1" }));
         session.extra = json!({
             "messages": [
                 { "role": "user", "content": "hello" },
@@ -592,7 +594,10 @@ mod tests {
             "user_profile": { "name": "Ada" },
             "runtime_checkpoint": { "phase": "awaiting_tools" },
             "last_context_metadata": { "historyMessageCount": 2 },
-            "last_persisted_run_id": "run-1"
+            "last_persisted_run_id": "run-1",
+            "agent_runs": [
+                serde_json::to_value(run).unwrap()
+            ]
         });
         let mut rpc = WorkerSessionRpc::new(vec![session], write_policy());
 
@@ -610,6 +615,9 @@ mod tests {
         assert!(result.session.extra.get("runtime_checkpoint").is_none());
         assert!(result.session.extra.get("last_context_metadata").is_none());
         assert!(result.session.extra.get("last_persisted_run_id").is_none());
+        assert!(agent_run_records(&result.session)
+            .into_iter()
+            .all(|run| run.checkpoint.is_none()));
     }
 
     #[test]
@@ -1268,10 +1276,15 @@ mod tests {
     #[test]
     fn persist_turn_appends_messages_and_clears_checkpoint() {
         let mut session = session_fixture();
+        let mut run = agent_run_fixture("session-1", "run-1", AgentRunStatus::Waiting);
+        run.checkpoint = Some(json!({ "sessionId": "session-1", "runId": "run-1" }));
         session.extra = json!({
-            "runtime_checkpoint": { "phase": "tools_completed" },
+            "runtime_checkpoint": { "sessionId": "session-1", "runId": "run-1", "phase": "tools_completed" },
             "messages": [
                 { "role": "user", "content": "existing" }
+            ],
+            "agent_runs": [
+                serde_json::to_value(run).unwrap()
             ]
         });
         let mut rpc = WorkerSessionRpc::new(
@@ -1333,6 +1346,14 @@ mod tests {
             ])
         );
         assert!(updated.extra.get("runtime_checkpoint").is_none());
+        assert!(rpc
+            .get_agent_run_checkpoint("session-1", "run-1")
+            .expect("run checkpoint should read")
+            .is_none());
+        assert!(rpc
+            .get_checkpoint("session-1")
+            .expect("fallback checkpoint should read")
+            .is_none());
         assert_eq!(updated.extra["last_persisted_run_id"], "run-1");
         assert_eq!(
             updated.extra["last_context_metadata"],

--- a/src-tauri/src/worker_session/turn_persistence.rs
+++ b/src-tauri/src/worker_session/turn_persistence.rs
@@ -74,6 +74,7 @@ impl WorkerSessionRpc {
             }
             let mut checkpoint_cleared = false;
             if clear_checkpoint {
+                clear_agent_run_checkpoint_by_id(session, run_id)?;
                 if let Some(extra) = session.extra.as_object_mut() {
                     checkpoint_cleared = extra.remove("runtime_checkpoint").is_some();
                 }

--- a/src-tauri/src/worker_session/types.rs
+++ b/src-tauri/src/worker_session/types.rs
@@ -60,3 +60,149 @@ pub struct DeleteSessionResult {
     pub session_id: String,
     pub deleted: bool,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRunStatus {
+    Running,
+    Waiting,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunKey {
+    pub session_id: String,
+    pub run_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunRecord {
+    pub session_id: String,
+    pub run_id: String,
+    pub status: AgentRunStatus,
+    pub phase: String,
+    pub started_at: String,
+    pub updated_at: String,
+    pub completed_at: Option<String>,
+    pub stop_reason: Option<String>,
+    pub model: String,
+    pub provider: Option<String>,
+    pub max_iterations: i64,
+    pub current_iteration: i64,
+    #[serde(default)]
+    pub conversation_message_ids: Vec<String>,
+    #[serde(default)]
+    pub trace_messages: Vec<Value>,
+    #[serde(default)]
+    pub trace_events: Vec<Value>,
+    #[serde(default)]
+    pub completed_tool_results: Vec<Value>,
+    #[serde(default)]
+    pub pending_tool_calls: Vec<Value>,
+    pub checkpoint: Option<Value>,
+    #[serde(default)]
+    pub artifacts: Vec<Value>,
+    #[serde(default)]
+    pub usage: Vec<Value>,
+    pub error: Option<Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunSummary {
+    pub session_id: String,
+    pub run_id: String,
+    pub status: AgentRunStatus,
+    pub phase: String,
+    pub started_at: String,
+    pub updated_at: String,
+    pub completed_at: Option<String>,
+    pub stop_reason: Option<String>,
+    pub model: String,
+    pub provider: Option<String>,
+    pub tools_used: Vec<String>,
+    pub tool_call_count: usize,
+    pub has_checkpoint: bool,
+    pub final_content_preview: Option<String>,
+    pub artifact_count: usize,
+}
+
+impl AgentRunSummary {
+    pub fn from_record(record: &AgentRunRecord) -> Self {
+        let tools_used = record
+            .completed_tool_results
+            .iter()
+            .filter_map(|result| {
+                result
+                    .get("toolName")
+                    .or_else(|| result.get("tool_name"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>();
+        Self {
+            session_id: record.session_id.clone(),
+            run_id: record.run_id.clone(),
+            status: record.status.clone(),
+            phase: record.phase.clone(),
+            started_at: record.started_at.clone(),
+            updated_at: record.updated_at.clone(),
+            completed_at: record.completed_at.clone(),
+            stop_reason: record.stop_reason.clone(),
+            model: record.model.clone(),
+            provider: record.provider.clone(),
+            tool_call_count: record.completed_tool_results.len(),
+            has_checkpoint: record.checkpoint.is_some(),
+            final_content_preview: final_content_preview(record),
+            artifact_count: record.artifacts.len(),
+            tools_used,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunCheckpoint {
+    pub session_id: String,
+    pub run_id: String,
+    pub checkpoint: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunTracePage {
+    pub session_id: String,
+    pub run_id: String,
+    pub items: Vec<Value>,
+    pub next_cursor: Option<String>,
+}
+
+impl AgentRunTracePage {
+    pub fn new(session_id: &str, run_id: &str, items: Vec<Value>) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            run_id: run_id.to_string(),
+            items,
+            next_cursor: None,
+        }
+    }
+}
+
+fn final_content_preview(record: &AgentRunRecord) -> Option<String> {
+    record.trace_messages.iter().rev().find_map(|message| {
+        let role = message.get("role").and_then(Value::as_str)?;
+        if role != "assistant" {
+            return None;
+        }
+        let content = message.get("content").and_then(Value::as_str)?.trim();
+        if content.is_empty() {
+            None
+        } else {
+            Some(content.chars().take(160).collect())
+        }
+    })
+}


### PR DESCRIPTION
## Summary
- Add first-class native Rust agent run records with run-keyed checkpoint and trace persistence.
- Add agent_run.* RPCs, including bounded trace pagination and stable Run Timeline contract fields.
- Persist native agent lifecycle records for running, waiting, completed, failed, and cancelled turns while keeping session history compact.

## Verification
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- openspec validate add-agent-run-store --strict
- cargo test --manifest-path src-tauri/Cargo.toml --lib -- --test-threads=1