### PR TITLE
Remove legacy chat chrome

### DIFF
--- a/src/native-workbench/components/chat/chatSurface.test.ts
+++ b/src/native-workbench/components/chat/chatSurface.test.ts
@@ -4,6 +4,20 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { mountChatSurface } from "./chatSurface";
 import type { ChatUiProjection } from "../../chat/chatUiProjection";
 
+function dispatchSharedComposerSubmit(host: HTMLElement, content: string) {
+  const detail = {
+    accepted: false,
+    content,
+    handled: false,
+    usePersistentRag: false,
+  };
+  host.dispatchEvent(new CustomEvent("desktop-chat-composer-submit-request", {
+    bubbles: true,
+    detail,
+  }));
+  return detail;
+}
+
 describe("rebuilt chat surface", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -459,8 +473,12 @@ describe("rebuilt chat surface", () => {
     expect(host.querySelector("[data-chat-region='detail-surface']")?.textContent).toContain("Messages are sent only to this subagent");
   });
 
-  test("forwards selected subagent messages into the main composer draft", () => {
+  test("forwards selected subagent messages into the shared bottom composer draft", () => {
     const host = document.createElement("section");
+    const bottomComposer = document.createElement("textarea");
+    bottomComposer.id = "desktop-native-composer-input";
+    bottomComposer.value = "Continue from this context.";
+    document.body.append(bottomComposer);
     const projection = fixtureProjection();
     projection.liveSubagents = [{
       id: "delegate-forward",
@@ -490,17 +508,14 @@ describe("rebuilt chat surface", () => {
 
     mountChatSurface(host, { projection });
 
-    const composerInput = host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]");
-    composerInput!.value = "Continue from this context.";
-    composerInput!.dispatchEvent(new Event("input", { bubbles: true }));
     host.querySelector<HTMLInputElement>("[data-subagent-message-select='sub-msg-assistant']")!.checked = true;
     host.querySelector<HTMLButtonElement>("[data-subagent-action='forward']")?.click();
 
-    const draft = host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]")?.value ?? "";
-    expect(draft).toContain("Continue from this context.");
-    expect(draft).toContain("Forwarded from subagent: Researcher");
-    expect(draft).toContain("assistant: Use read-only analysis.");
-    expect(draft).not.toContain("Prefer lower risk.");
+    expect(bottomComposer.value).toContain("Continue from this context.");
+    expect(bottomComposer.value).toContain("Forwarded from subagent: Researcher");
+    expect(bottomComposer.value).toContain("assistant: Use read-only analysis.");
+    expect(bottomComposer.value).not.toContain("Prefer lower risk.");
+    bottomComposer.remove();
   });
 
   test("preserves subagent message drafts by subagent panel", () => {
@@ -894,7 +909,16 @@ describe("rebuilt chat surface", () => {
     }]);
   });
 
-  test("submits normal composer text as a main chat message event", () => {
+  test("does not render a second main composer inside the chat surface", () => {
+    const host = document.createElement("section");
+
+    mountChatSurface(host, { projection: fixtureProjection() });
+
+    expect(host.querySelector("[data-chat-composer-input]")).toBeNull();
+    expect(host.querySelector("[data-chat-composer-action='send']")).toBeNull();
+  });
+
+  test("submits shared bottom composer text as a main chat message event", () => {
     const host = document.createElement("section");
     const submissions: unknown[] = [];
     host.addEventListener("desktop-chat-message-submit", (event) => {
@@ -903,54 +927,14 @@ describe("rebuilt chat surface", () => {
 
     mountChatSurface(host, { projection: fixtureProjection() });
 
-    const input = host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]");
-    input!.value = "Continue with the local docs.";
-    host.querySelector<HTMLButtonElement>("[data-chat-composer-action='send']")?.click();
+    const request = dispatchSharedComposerSubmit(host, "Continue with the local docs.");
 
     expect(submissions).toEqual([{ content: "Continue with the local docs." }]);
-    expect(input?.value).toBe("");
+    expect(request.handled).toBe(true);
+    expect(request.accepted).toBe(true);
   });
 
-  test("preserves composer drafts per active session across surface updates", () => {
-    const host = document.createElement("section");
-    const mounted = mountChatSurface(host, { projection: fixtureProjection() });
-    const firstInput = host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]");
-    firstInput!.value = "Draft for chat one";
-    firstInput!.dispatchEvent(new Event("input", { bubbles: true }));
-
-    mounted.update({ projection: fixtureProjection() });
-
-    expect(host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]")?.value).toBe("Draft for chat one");
-
-    const secondProjection = fixtureProjection();
-    secondProjection.activeSessionKey = "websocket:chat-2";
-    secondProjection.sessions = [
-      { ...secondProjection.sessions[0], isActive: false },
-      {
-        key: "websocket:chat-2",
-        chatId: "chat-2",
-        title: "Second chat",
-        createdAt: "2026-07-01T11:00:00Z",
-        updatedAt: "2026-07-01T11:05:00Z",
-        primaryBadge: "updated_time",
-        isActive: true,
-      },
-    ];
-    mounted.update({ projection: secondProjection });
-
-    const secondInput = host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]");
-    expect(secondInput?.value).toBe("");
-    secondInput!.value = "Draft for chat two";
-    secondInput!.dispatchEvent(new Event("input", { bubbles: true }));
-
-    mounted.update({ projection: fixtureProjection() });
-    expect(host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]")?.value).toBe("Draft for chat one");
-
-    mounted.update({ projection: secondProjection });
-    expect(host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]")?.value).toBe("Draft for chat two");
-  });
-
-  test("submits composer text as approval guidance while approval is pending", () => {
+  test("submits shared bottom composer text as approval guidance while approval is pending", () => {
     const host = document.createElement("section");
     const guidanceSubmissions: unknown[] = [];
     host.addEventListener("desktop-chat-approval-guidance-submit", (event) => {
@@ -968,18 +952,18 @@ describe("rebuilt chat surface", () => {
 
     mountChatSurface(host, { projection });
 
-    const input = host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]");
-    input!.value = "Do not write files; summarize only.";
-    host.querySelector<HTMLButtonElement>("[data-chat-composer-action='send']")?.click();
+    const request = dispatchSharedComposerSubmit(host, "Do not write files; summarize only.");
 
     expect(guidanceSubmissions).toEqual([{
       approvalId: "approval-1",
       guidance: "Do not write files; summarize only.",
     }]);
+    expect(request.handled).toBe(true);
+    expect(request.accepted).toBe(true);
     expect(host.querySelector("[data-chat-region='queued-inputs']")).toBeNull();
   });
 
-  test("queues composer text while the assistant turn is running and supports deleting it", () => {
+  test("queues shared bottom composer text while the assistant turn is running and supports deleting it", () => {
     const host = document.createElement("section");
     const projection = fixtureProjection();
     projection.turns[1] = {
@@ -993,13 +977,12 @@ describe("rebuilt chat surface", () => {
 
     mountChatSurface(host, { projection });
 
-    const input = host.querySelector<HTMLTextAreaElement>("[data-chat-composer-input]");
-    input!.value = "Summarize after the tools finish.";
-    host.querySelector<HTMLButtonElement>("[data-chat-composer-action='send']")?.click();
+    const request = dispatchSharedComposerSubmit(host, "Summarize after the tools finish.");
 
     const queue = host.querySelector("[data-chat-region='queued-inputs']");
     expect(queue?.textContent).toContain("Summarize after the tools finish.");
-    expect(host.querySelector("[data-chat-composer-input]")?.textContent).toBe("");
+    expect(request.handled).toBe(true);
+    expect(request.accepted).toBe(true);
 
     host.querySelector<HTMLButtonElement>("[data-queued-input-action='delete']")?.click();
 

--- a/src/native-workbench/components/chat/chatSurface.ts
+++ b/src/native-workbench/components/chat/chatSurface.ts
@@ -51,20 +51,69 @@ export function mountChatSurface(host: HTMLElement, options: ChatSurfaceOptions)
   let composerError = "";
   let sessionSearchQuery = "";
   const processExpansionOverrides = new Map<string, boolean>();
-  const composerDrafts = new Map<string, string>();
   const subagentDrafts = new Map<string, string>();
   const loadedSubagents = new Map<string, LiveSubagent>();
   const loadingSubagents = new Set<string>();
-  const currentComposerDraftKey = () => currentProjection.activeSessionKey || "new-session";
-  const clearCurrentComposerDraft = () => {
-    composerDrafts.delete(currentComposerDraftKey());
-  };
-  const appendCurrentComposerDraft = (content: string) => {
-    const key = currentComposerDraftKey();
-    const previous = composerDrafts.get(key)?.trimEnd() ?? "";
-    composerDrafts.set(key, previous ? `${previous}\n\n${content}` : content);
-  };
   const currentViewProjection = () => projectionWithLoadedSubagents(currentProjection, loadedSubagents);
+  const submitSharedComposerText = (content: string) => {
+    const result = submitComposerText({
+      approvals: currentProjection.approvals,
+      content,
+      isRunning: chatSurfaceHasRunningTurn(currentProjection),
+      now: new Date().toISOString(),
+      queuedInputs: currentQueuedInputs,
+    });
+    if (result.kind === "send_message") {
+      composerError = "";
+      host.dispatchEvent(new CustomEvent("desktop-chat-message-submit", {
+        bubbles: true,
+        detail: { content: result.content },
+      }));
+      logChatSurfaceAction(host, "composer.message.submit", { contentLength: result.content.length });
+      return { accepted: true };
+    }
+    if (result.kind === "reject_approval_with_guidance") {
+      composerError = "";
+      host.dispatchEvent(new CustomEvent("desktop-chat-approval-guidance-submit", {
+        bubbles: true,
+        detail: {
+          approvalId: result.approvalId,
+          guidance: result.guidance,
+        },
+      }));
+      logChatSurfaceAction(host, "composer.approval_guidance.submit", {
+        approvalId: result.approvalId,
+        guidanceLength: result.guidance.length,
+      });
+      return { accepted: true };
+    }
+    if (result.kind === "queue_input") {
+      composerError = "";
+      currentQueuedInputs = [...currentQueuedInputs, result.input];
+      logChatSurfaceAction(host, "composer.queue.add", {
+        inputId: result.input.id,
+        queueLength: currentQueuedInputs.length,
+      });
+      renderCurrent();
+      return { accepted: true };
+    }
+    composerError = result.message;
+    logChatSurfaceAction(host, "composer.queue.limit", {
+      maxQueuedInputs: result.maxQueuedInputs,
+    });
+    renderCurrent();
+    return { accepted: false };
+  };
+  const handleSharedComposerSubmit = (event: Event) => {
+    const detail = (event as CustomEvent).detail;
+    if (!detail || typeof detail.content !== "string") {
+      return;
+    }
+    const result = submitSharedComposerText(detail.content);
+    detail.handled = true;
+    detail.accepted = result.accepted;
+  };
+  host.addEventListener("desktop-chat-composer-submit-request", handleSharedComposerSubmit);
   const renderCurrent = () => renderChatSurface(host, {
     ...currentViewProjection(),
     detailPanel: currentDetailPanel,
@@ -206,7 +255,7 @@ export function mountChatSurface(host: HTMLElement, options: ChatSurfaceOptions)
         return;
       }
       const block = createSubagentForwardBlock(subagent, selectedIds);
-      appendCurrentComposerDraft(block.fallbackText);
+      appendSharedComposerDraft(host, block.fallbackText);
       logChatSurfaceAction(host, "subagent.forward.append", {
         messageCount: block.messages.length,
         subagentId,
@@ -230,58 +279,6 @@ export function mountChatSurface(host: HTMLElement, options: ChatSurfaceOptions)
       });
       renderCurrent();
     },
-    submitComposer(content) {
-      const result = submitComposerText({
-        approvals: currentProjection.approvals,
-        content,
-        isRunning: chatSurfaceHasRunningTurn(currentProjection),
-        now: new Date().toISOString(),
-        queuedInputs: currentQueuedInputs,
-      });
-      if (result.kind === "send_message") {
-        composerError = "";
-        clearCurrentComposerDraft();
-        host.dispatchEvent(new CustomEvent("desktop-chat-message-submit", {
-          bubbles: true,
-          detail: { content: result.content },
-        }));
-        logChatSurfaceAction(host, "composer.message.submit", { contentLength: result.content.length });
-        return { accepted: true };
-      }
-      if (result.kind === "reject_approval_with_guidance") {
-        composerError = "";
-        clearCurrentComposerDraft();
-        host.dispatchEvent(new CustomEvent("desktop-chat-approval-guidance-submit", {
-          bubbles: true,
-          detail: {
-            approvalId: result.approvalId,
-            guidance: result.guidance,
-          },
-        }));
-        logChatSurfaceAction(host, "composer.approval_guidance.submit", {
-          approvalId: result.approvalId,
-          guidanceLength: result.guidance.length,
-        });
-        return { accepted: true };
-      }
-      if (result.kind === "queue_input") {
-        composerError = "";
-        clearCurrentComposerDraft();
-        currentQueuedInputs = [...currentQueuedInputs, result.input];
-        logChatSurfaceAction(host, "composer.queue.add", {
-          inputId: result.input.id,
-          queueLength: currentQueuedInputs.length,
-        });
-        renderCurrent();
-        return { accepted: true };
-      }
-      composerError = result.message;
-      logChatSurfaceAction(host, "composer.queue.limit", {
-        maxQueuedInputs: result.maxQueuedInputs,
-      });
-      renderCurrent();
-      return { accepted: false };
-    },
     toggleProcess(turnId) {
       const turn = currentProjection.turns.find((candidate) => candidate.id === turnId);
       if (!turn?.process) {
@@ -298,16 +295,6 @@ export function mountChatSurface(host: HTMLElement, options: ChatSurfaceOptions)
     },
     composerError() {
       return composerError;
-    },
-    composerDraft() {
-      return composerDrafts.get(currentComposerDraftKey()) ?? "";
-    },
-    updateComposerDraft(content) {
-      if (content) {
-        composerDrafts.set(currentComposerDraftKey(), content);
-        return;
-      }
-      clearCurrentComposerDraft();
     },
     subagentDraft(subagentId) {
       return subagentDrafts.get(subagentId) ?? "";
@@ -364,6 +351,7 @@ export function mountChatSurface(host: HTMLElement, options: ChatSurfaceOptions)
       renderCurrent();
     },
     unmount() {
+      host.removeEventListener("desktop-chat-composer-submit-request", handleSharedComposerSubmit);
       host.replaceChildren();
       host.removeAttribute("data-chat-surface");
       host.className = "";
@@ -417,7 +405,6 @@ export function mountChatSurface(host: HTMLElement, options: ChatSurfaceOptions)
 type ChatSurfaceActions = {
   branchFromTurn(turnId: string): void;
   closeDetail(): void;
-  composerDraft(): string;
   composerError(): string;
   continueQueuedInput(): void;
   copyDetail(content: string, source: string): void;
@@ -429,10 +416,8 @@ type ChatSurfaceActions = {
   sessionAction(action: "pin" | "unpin" | "rename" | "delete" | "copy-session-id" | "copy-markdown"): void;
   startNewSession(): void;
   subagentDraft(subagentId: string): string;
-  submitComposer(content: string): { accepted: boolean };
   submitSubagentMessage(subagentId: string, content: string): { accepted: boolean };
   toggleProcess(turnId: string): void;
-  updateComposerDraft(content: string): void;
   updateSessionSearch(query: string): void;
   updateSubagentDraft(subagentId: string, content: string): void;
 };
@@ -832,24 +817,6 @@ function renderComposer(mode: "normal" | "approval_guidance", actions: ChatSurfa
   if (mode === "approval_guidance") {
     composer.append(element("p", "desktop-chat-surface__composer-hint", "发送文字将拒绝此请求，并作为给 Tinybot 的指导。"));
   }
-  const input = activeDocument.createElement("textarea");
-  input.className = "desktop-chat-surface__composer-input";
-  input.setAttribute("data-chat-composer-input", "");
-  input.setAttribute("placeholder", mode === "approval_guidance" ? "输入拒绝原因或下一步建议..." : "要求后续变更");
-  input.value = actions.composerDraft();
-  input.addEventListener("input", () => {
-    actions.updateComposerDraft(input.value);
-  });
-  const button = element("button", "desktop-chat-surface__composer-send", "Send");
-  button.type = "button";
-  button.setAttribute("data-chat-composer-action", "send");
-  button.addEventListener("click", () => {
-    const result = actions.submitComposer(input.value);
-    if (result.accepted) {
-      input.value = "";
-    }
-  });
-  composer.append(input, button);
   const error = actions.composerError();
   if (error) {
     const errorNode = element("p", "desktop-chat-surface__composer-error", error);
@@ -857,6 +824,16 @@ function renderComposer(mode: "normal" | "approval_guidance", actions: ChatSurfa
     composer.append(errorNode);
   }
   return composer;
+}
+
+function appendSharedComposerDraft(host: HTMLElement, content: string): void {
+  const input = host.ownerDocument.getElementById("desktop-native-composer-input") as HTMLTextAreaElement | null;
+  if (!input) {
+    return;
+  }
+  const previous = input.value.trimEnd();
+  input.value = previous ? `${previous}\n\n${content}` : content;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
 function renderSubagentDetail(subagents: LiveSubagent[], panel: DetailPanelState, actions: ChatSurfaceActions): HTMLElement {

--- a/src/native-workbench/components/chat/composerSurfaceIsland.ts
+++ b/src/native-workbench/components/chat/composerSurfaceIsland.ts
@@ -13,6 +13,7 @@ export interface ComposerSurfaceSubmitEvent {
 
 export interface ComposerSurfaceIslandOptions {
   activeSessionKey?: string | null;
+  canSubmitWhileBusy?: boolean;
   composerState: ComposerSurfaceState;
   model?: string | null;
   modelOptions?: string[];
@@ -107,7 +108,7 @@ function createComposerSurfaceApp(state: Ref<ComposerSurfaceIslandOptions>): App
     setup() {
       const content = ref("");
       const input = ref<HTMLTextAreaElement | null>(null);
-      const canSend = () => state.value.composerState === "idle" && Boolean(content.value.trim());
+      const canSend = () => Boolean(content.value.trim()) && (state.value.composerState === "idle" || state.value.canSubmitWhileBusy === true);
       const send = () => {
         if (!canSend()) {
           return;

--- a/src/native-workbench/shell/desktopWorkbenchShell.static-vue-imports.test.ts
+++ b/src/native-workbench/shell/desktopWorkbenchShell.static-vue-imports.test.ts
@@ -84,13 +84,19 @@ describe("desktop workbench shell static Vue imports", () => {
     expect(source).not.toContain('void import("../components/shell/sidebarRowIsland")');
   });
 
-  test("statically imports the chat menu islands", () => {
+  test("does not import retired shell chat header menu islands", () => {
     const source = readFileSync(resolve(__dirname, "desktopWorkbenchShell.ts"), "utf8");
 
-    expect(source).toContain('import { mountChatMenuActionIsland } from "../components/chat/chatMenuActionIsland";');
+    expect(source).not.toContain('import { mountChatMenuActionIsland } from "../components/chat/chatMenuActionIsland";');
     expect(source).not.toContain('void import("../components/chat/chatMenuActionIsland")');
-    expect(source).toContain('import { mountChatMenuEmptyIsland } from "../components/chat/chatMenuEmptyIsland";');
+    expect(source).not.toContain('import { mountChatMenuButtonIsland } from "../components/chat/chatMenuButtonIsland";');
+    expect(source).not.toContain('void import("../components/chat/chatMenuButtonIsland")');
+    expect(source).not.toContain('import { mountChatMenuEmptyIsland } from "../components/chat/chatMenuEmptyIsland";');
     expect(source).not.toContain('void import("../components/chat/chatMenuEmptyIsland")');
+    expect(source).not.toContain('import { mountChatMenuPopoverIsland } from "../components/chat/chatMenuPopoverIsland";');
+    expect(source).not.toContain('void import("../components/chat/chatMenuPopoverIsland")');
+    expect(source).not.toContain('import { mountChatTitleIsland } from "../components/chat/chatTitleIsland";');
+    expect(source).not.toContain('void import("../components/chat/chatTitleIsland")');
   });
 
   test("statically imports the conversation message islands", () => {

--- a/src/native-workbench/shell/desktopWorkbenchShell.test.ts
+++ b/src/native-workbench/shell/desktopWorkbenchShell.test.ts
@@ -902,6 +902,7 @@ describe("desktop workbench shell", () => {
   test("routes native composer send and temporary file attach actions", () => {
     const targetDocument = new FakeDocument();
     const composerActions: string[] = [];
+    const surfaceSubmissions: unknown[] = [];
 
     installDesktopWorkbenchShell({
       targetDocument: targetDocument as unknown as Document,
@@ -927,6 +928,9 @@ describe("desktop workbench shell", () => {
         },
       },
     });
+    targetDocument.body.querySelector(".desktop-chat-surface")?.addEventListener("desktop-chat-message-submit", (event) => {
+      surfaceSubmissions.push((event as CustomEvent).detail);
+    });
 
     const input = targetDocument.getElementById("desktop-native-composer-input");
     const send = targetDocument.getElementById("desktop-native-composer-send");
@@ -947,7 +951,52 @@ describe("desktop workbench shell", () => {
     expect(ragToggle?.getAttribute("aria-pressed")).toBe("false");
     ragToggle?.click();
 
-    expect(composerActions).toEqual(["send:Run live composer:false", "attach", "rag:true"]);
+    expect(surfaceSubmissions).toEqual([{ content: "Run live composer" }]);
+    expect(composerActions).toEqual(["attach", "rag:true"]);
+  });
+
+  test("routes native composer submit through the rebuilt chat surface when available", () => {
+    const targetDocument = new FakeDocument();
+    const composerActions: string[] = [];
+    const surfaceRequests: unknown[] = [];
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+        responding: true,
+        composerState: "sending",
+        usePersistentRag: false,
+      },
+      chatActions: {
+        onComposerSubmit: (event) => {
+          composerActions.push(`send:${event.content}:${event.usePersistentRag}`);
+        },
+      },
+    });
+    const thread = targetDocument.body.querySelector(".desktop-conversation-thread");
+    thread?.addEventListener("desktop-chat-composer-submit-request", (event) => {
+      const detail = (event as CustomEvent).detail;
+      surfaceRequests.push({ content: detail.content, usePersistentRag: detail.usePersistentRag });
+      detail.handled = true;
+      detail.accepted = true;
+    });
+
+    const input = targetDocument.getElementById("desktop-native-composer-input") as HTMLTextAreaElement | null;
+    const send = targetDocument.getElementById("desktop-native-composer-send");
+    input!.value = "Queue this while running";
+    input!.dispatchEvent(new Event("input"));
+    expect(send?.getAttribute("disabled")).toBeNull();
+
+    send?.click();
+
+    expect(surfaceRequests).toEqual([{ content: "Queue this while running", usePersistentRag: false }]);
+    expect(composerActions).toEqual([]);
   });
 
   test("styles native composer input without focus chrome or manual resizing", () => {
@@ -1092,14 +1141,12 @@ describe("desktop workbench shell", () => {
     expect(workbenchSettingsSidebarRule).toContain("min-height: 100%;");
     expect(workbenchSettingsSidebarRule).toContain("overflow: visible;");
 
-    const chatHeader = targetDocument.body.querySelector(".desktop-chat-header");
     const conversationThread = targetDocument.body.querySelector(".desktop-conversation-thread");
     const composerModel = targetDocument.body.querySelector(".desktop-native-composer-model");
-    expect(chatHeader).toBeTruthy();
+    expect(targetDocument.body.querySelector(".desktop-chat-header")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-chat-surface__header")).toBeNull();
     expect(conversationThread).toBeTruthy();
     expect(composerModel).toBeTruthy();
-    expect(chatHeader?.querySelector(".desktop-chat-context")?.textContent).toBe("tinybot");
-    expect(chatHeader?.textContent).toContain("Design native workbench");
     expect(conversationThread?.textContent).toContain("这是目前的 native 界面");
     expect(composerModel?.textContent).toContain("Tinybot Pro");
 
@@ -1109,6 +1156,25 @@ describe("desktop workbench shell", () => {
     expect(inspector?.textContent).not.toContain("Gateway");
     expect(targetDocument.body.querySelector(".desktop-run-chain-tabs")).toBeNull();
     expect(targetDocument.body.querySelector(".desktop-run-chain-cards")).toBeNull();
+  });
+
+  test("uses the rebuilt chat surface header as the only chat title", () => {
+    const targetDocument = new FakeDocument();
+
+    installDesktopWorkbenchShell({
+      targetDocument: targetDocument as unknown as Document,
+      layout: createDefaultWorkbenchLayout(),
+      gatewayHttp: "http://127.0.0.1:18790",
+      chat: {
+        sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
+        activeSessionKey: "WebSocket:chat-live",
+        activeChatId: "chat-live",
+        messages: [],
+      },
+    });
+
+    expect(targetDocument.body.querySelector(".desktop-chat-header")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-chat-surface__header")?.textContent).toContain("Live session");
   });
 
   test.skip("renders explicit desktop navigation links for workbench, docs, gateway, and external routes", () => {
@@ -1405,11 +1471,12 @@ describe("desktop workbench shell", () => {
     const row = targetDocument.body.querySelector('[data-session-key="7e9e439b4487"]');
     expect(row?.getAttribute("aria-current")).toBe("true");
     expect(row?.textContent).toContain("你好");
-    expect(targetDocument.body.querySelector(".desktop-chat-header")?.textContent).toContain("你好");
-    expect(targetDocument.body.querySelector(".desktop-chat-header")?.textContent).not.toContain("New session");
+    expect(targetDocument.body.querySelector(".desktop-chat-header")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-chat-surface__header")?.textContent).toContain("你好");
+    expect(targetDocument.body.querySelector(".desktop-chat-surface__header")?.textContent).not.toContain("New session");
   });
 
-  test("keeps panel controls out of the workbench chrome and chat header", () => {
+  test("keeps panel controls out of the workbench chrome and rebuilt chat header", () => {
     const targetDocument = new FakeDocument();
 
     installDesktopWorkbenchShell({
@@ -1425,35 +1492,25 @@ describe("desktop workbench shell", () => {
       },
     });
 
-    const header = targetDocument.body.querySelector(".desktop-chat-header");
+    const header = targetDocument.body.querySelector(".desktop-chat-surface__header");
+    expect(targetDocument.body.querySelector(".desktop-chat-header")).toBeNull();
     expect(header?.textContent).toContain("Session one");
-    expect(header?.textContent).toContain("...");
     expect(header?.textContent).not.toContain("Session loaded from gateway.");
     expect(targetDocument.body.querySelector(".desktop-chat-runtime-status")).toBeNull();
-    expect(header?.querySelector(".desktop-chat-menu")?.getAttribute("data-desktop-chat-menu")).toBe("more");
-    expect(header?.querySelector(".desktop-chat-menu")?.textContent).toBe("...");
-    const titleRow = header?.querySelector(".desktop-chat-title-row");
-    const headerActions = header?.querySelector(".desktop-chat-header-actions");
-    expect(titleRow?.children[0]?.className).toBe("desktop-chat-title-group");
-    expect(titleRow?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
-    expect(headerActions?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
-    expect(headerActions?.querySelector('[data-desktop-panel-control="inspector"]')).toBeNull();
+    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
+    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')).toBeNull();
     expect(targetDocument.body.querySelector(".desktop-global-panel-controls")).toBeNull();
     expect(targetDocument.body.querySelectorAll("[data-desktop-panel-control]")).toEqual([]);
     expect(targetDocument.body.querySelector("[data-desktop-inspector-restore]")).toBeNull();
   });
 
-  test("keeps the chat header focused on title actions and stop state", () => {
+  test("keeps the rebuilt chat header focused on title actions", () => {
     const targetDocument = new FakeDocument();
-    const interrupts: string[] = [];
 
     installDesktopWorkbenchShell({
       targetDocument: targetDocument as unknown as Document,
       layout: createDefaultWorkbenchLayout(),
       gatewayHttp: "http://127.0.0.1:18790",
-      chatActions: {
-        onInterrupt: () => interrupts.push("stop"),
-      },
       chat: {
         sessions: [{ key: "WebSocket:chat-live", chatId: "chat-live", title: "Live session", createdAt: "", updatedAt: "" }],
         activeSessionKey: "WebSocket:chat-live",
@@ -1475,137 +1532,13 @@ describe("desktop workbench shell", () => {
       },
     });
 
-    const header = targetDocument.body.querySelector(".desktop-chat-header");
-    expect(header?.querySelectorAll(".desktop-chat-header-chip")).toHaveLength(0);
+    const header = targetDocument.body.querySelector(".desktop-chat-surface__header");
+    expect(targetDocument.body.querySelector(".desktop-chat-header")).toBeNull();
     expect(header?.textContent).not.toContain("Model deepseek-chat");
     expect(header?.textContent).not.toContain("Knowledge Off");
     expect(header?.textContent).not.toContain("1 ref");
     expect(header?.textContent).not.toContain("42% tokens");
-
-    const stop = header?.querySelector('[data-desktop-chat-action="stop"]') as HTMLButtonElement | null | undefined;
-    expect(stop?.getAttribute("aria-label")).toBe("Stop current response");
-    expect(stop?.textContent).toBe("Stop");
-    stop?.click();
-    expect(interrupts).toEqual(["stop"]);
-  });
-
-  test("opens chat header menu actions and updates the active session affordances", () => {
-    const targetDocument = new FakeDocument();
-    (targetDocument as unknown as { defaultView: { prompt: () => string } }).defaultView = {
-      prompt: () => {
-        throw new Error("Rename session should edit inline instead of opening a prompt.");
-      },
-    };
-    const pinEvents: unknown[] = [];
-    const renameEvents: unknown[] = [];
-
-    installDesktopWorkbenchShell({
-      targetDocument: targetDocument as unknown as Document,
-      layout: createDefaultWorkbenchLayout(),
-      gatewayHttp: "http://127.0.0.1:18790",
-      chat: {
-        sessions: [
-          { key: "WebSocket:chat-2", chatId: "chat-2", title: "Session two", createdAt: "", updatedAt: "" },
-          { key: "WebSocket:chat-1", chatId: "chat-1", title: "Session one", createdAt: "", updatedAt: "" },
-        ],
-        activeSessionKey: "WebSocket:chat-1",
-        activeChatId: "chat-1",
-        messages: [],
-      },
-      chatActions: {
-        onPinSession: (event) => pinEvents.push(event),
-        onRenameSession: (event) => renameEvents.push(event),
-      },
-    });
-
-    const header = targetDocument.body.querySelector(".desktop-chat-header");
-    const menu = header?.querySelector(".desktop-chat-menu");
-    const popover = header?.querySelector(".desktop-chat-menu-popover") as unknown as { hidden: boolean } | null;
-    expect(menu?.getAttribute("aria-expanded")).toBe("false");
-    expect(popover?.hidden).toBe(true);
-
-    menu?.click();
-    expect(menu?.getAttribute("aria-expanded")).toBe("true");
-    expect(popover?.hidden).toBe(false);
-    targetDocument.dispatchEvent({ type: "click" });
-    expect(menu?.getAttribute("aria-expanded")).toBe("false");
-    expect(popover?.hidden).toBe(true);
-
-    menu?.click();
-    expect(menu?.getAttribute("aria-expanded")).toBe("true");
-    expect(popover?.hidden).toBe(false);
-    header?.querySelector('[data-desktop-chat-menu-action="pin"]')?.click();
-    expect(pinEvents).toEqual([{ sessionKey: "WebSocket:chat-1", chatId: "chat-1", title: "Session one", pinned: true }]);
-    expect(targetDocument.body.querySelector('[data-desktop-session-key]')).toBeNull();
-    expect(header?.querySelector('[data-desktop-chat-menu-action="pin"]')?.textContent).toBe("Unpin session");
-    expect(menu?.getAttribute("aria-expanded")).toBe("false");
-
-    menu?.click();
-    header?.querySelector('[data-desktop-chat-menu-action="rename"]')?.click();
-    const editor = header?.querySelector(".desktop-chat-title-editor");
-    expect(editor).toBeTruthy();
-    expect(editor?.getAttribute("aria-label")).toBe("Rename session");
-    expect(editor?.value).toBe("Session one");
-    editor!.value = "Renamed session";
-    editor!.dispatchEvent({ type: "keydown", key: "Enter", preventDefault: () => undefined });
-    expect(renameEvents).toEqual([{ sessionKey: "WebSocket:chat-1", chatId: "chat-1", title: "Renamed session" }]);
-    expect(header?.querySelector(".desktop-chat-title")?.textContent).toBe("Renamed session");
-    expect(header?.querySelector('[data-desktop-panel-control="sidebar"]')).toBeNull();
-    expect(header?.querySelector('[data-desktop-panel-control="inspector"]')).toBeNull();
-    expect(targetDocument.body.querySelector(".desktop-global-panel-controls")).toBeNull();
-  });
-
-  test("anchors the chat header menu popover inside the main work area", () => {
-    const targetDocument = new FakeDocument();
-
-    installDesktopWorkbenchShell({
-      targetDocument: targetDocument as unknown as Document,
-      layout: createDefaultWorkbenchLayout(),
-      gatewayHttp: "http://127.0.0.1:18790",
-      chat: {
-        sessions: [{ key: "WebSocket:chat-1", chatId: "chat-1", title: "你好", createdAt: "", updatedAt: "" }],
-        activeSessionKey: "WebSocket:chat-1",
-        activeChatId: "chat-1",
-        messages: [],
-      },
-    });
-
-    const styleText = targetDocument.head.querySelector("#desktop-workbench-shell-style")?.textContent ?? "";
-    expect(styleText).toContain("body.desktop-native-workbench .desktop-chat-menu-popover");
-    expect(styleText).toContain("left: 0;");
-    expect(styleText).toContain("right: auto;");
-    expect(styleText).not.toContain("right: 0;\n      z-index: 8;");
-  });
-
-  test("preserves pinned sessions when native chat refreshes", () => {
-    const targetDocument = new FakeDocument();
-    const chat = {
-      sessions: [
-        { key: "WebSocket:chat-2", chatId: "chat-2", title: "Session two", createdAt: "", updatedAt: "" },
-        { key: "WebSocket:chat-1", chatId: "chat-1", title: "Session one", createdAt: "", updatedAt: "" },
-      ],
-      activeSessionKey: "WebSocket:chat-1",
-      activeChatId: "chat-1",
-      messages: [],
-    };
-
-    installDesktopWorkbenchShell({
-      targetDocument: targetDocument as unknown as Document,
-      layout: createDefaultWorkbenchLayout(),
-      gatewayHttp: "http://127.0.0.1:18790",
-      chat,
-    });
-
-    const header = targetDocument.body.querySelector(".desktop-chat-header");
-    header?.querySelector(".desktop-chat-menu")?.click();
-    header?.querySelector('[data-desktop-chat-menu-action="pin"]')?.click();
-
-    updateDesktopNativeChat(targetDocument as unknown as Document, chat, "http://127.0.0.1:18790");
-
-    expect(targetDocument.body.querySelector('[data-desktop-session-key]')).toBeNull();
-    const refreshedHeader = targetDocument.body.querySelector(".desktop-chat-header");
-    refreshedHeader?.querySelector(".desktop-chat-menu")?.click();
-    expect(refreshedHeader?.querySelector('[data-desktop-chat-menu-action="pin"]')?.textContent).toBe("Unpin session");
+    expect(header?.querySelector('[data-chat-header-action="pin"]')).toBeTruthy();
   });
 
   test("does not render duplicate panel controls inside the workbench shell", () => {
@@ -1618,7 +1551,8 @@ describe("desktop workbench shell", () => {
     });
 
     expect(targetDocument.body.querySelector(".desktop-global-panel-controls")).toBeNull();
-    expect(targetDocument.body.querySelector(".desktop-chat-header")?.querySelector("[data-desktop-panel-control]")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-chat-header")).toBeNull();
+    expect(targetDocument.body.querySelector(".desktop-chat-surface__header")?.querySelector("[data-desktop-panel-control]") ?? null).toBeNull();
     expect(targetDocument.body.querySelectorAll("[data-desktop-panel-control]")).toEqual([]);
   });
 
@@ -4327,9 +4261,7 @@ describe("desktop workbench shell", () => {
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-workspace-files');
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-chat-row[data-active="true"]');
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-chat-row:hover');
-    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header h1');
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-conversation-content');
-    expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-popover');
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-search');
     expect(styleText).toContain('html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model');
   });

--- a/src/native-workbench/shell/desktopWorkbenchShell.ts
+++ b/src/native-workbench/shell/desktopWorkbenchShell.ts
@@ -56,11 +56,6 @@ import { mountAgentUiFormFieldIsland } from "../components/agent-ui/agentUiFormF
 import { mountAgentUiFormsSurfaceIsland } from "../components/agent-ui/agentUiFormsSurfaceIsland";
 import { mountBottomRegionIsland } from "../components/shell/bottomRegionIsland";
 import { mountActivityRailIsland } from "../components/shell/activityRailIsland";
-import { mountChatMenuActionIsland } from "../components/chat/chatMenuActionIsland";
-import { mountChatMenuButtonIsland } from "../components/chat/chatMenuButtonIsland";
-import { mountChatMenuEmptyIsland } from "../components/chat/chatMenuEmptyIsland";
-import { mountChatMenuPopoverIsland } from "../components/chat/chatMenuPopoverIsland";
-import { mountChatTitleIsland } from "../components/chat/chatTitleIsland";
 import { mountChatSurface } from "../components/chat/chatSurface";
 import { mountChatWorkbenchIsland } from "../components/chat/chatWorkbenchIsland";
 import { mountCommandPaletteIsland } from "../components/shared/commandPaletteIsland";
@@ -138,7 +133,6 @@ import { mountTokenUsageOrbIsland } from "../components/shell/tokenUsageOrbIslan
 import { mountWorkLensIsland } from "../components/shell/workLensIsland";
 import { mountWorkbenchPanelIsland } from "../components/shell/workbenchPanelIsland";
 
-const desktopPinnedChatSessions = new WeakMap<Document, Set<string>>();
 const DESKTOP_COWORK_STANDALONE_AVAILABLE = false;
 
 type ConversationToolActivityRenderOptions = ToolActivityIslandOptions;
@@ -766,12 +760,6 @@ export function updateDesktopNativeChat(
     dom: summarizeNativeChatDomForDebug(targetDocument),
   });
   syncNativeChatDocumentState(targetDocument, chat);
-  const header = targetDocument.querySelector<HTMLElement>(".desktop-chat-header");
-  if (header) {
-    const next = createChatHeader(targetDocument, chat, chatActions);
-    header.replaceChildren(...Array.from(next.children));
-  }
-
   const thread = targetDocument.querySelector<HTMLElement>(".desktop-conversation-thread");
   if (thread) {
     const scrollState = captureConversationThreadScroll(thread);
@@ -803,11 +791,10 @@ function syncChatWorkbenchChrome(targetDocument: Document, chat: DesktopNativeCh
   if (!workbench) {
     return;
   }
-  const header = workbench.querySelector<HTMLElement>(".desktop-chat-header");
   const thread = workbench.querySelector<HTMLElement>(".desktop-conversation-thread");
   const workLens = workbench.querySelector<HTMLElement>(".desktop-work-lens-inline");
   const composer = workbench.querySelector<HTMLElement>("#desktop-native-composer");
-  const children = [header, thread].filter((child): child is HTMLElement => Boolean(child));
+  const children = [thread].filter((child): child is HTMLElement => Boolean(child));
   if (!hasChatTimelineContent(targetDocument, chat)) {
     children.push(createChatWorkbenchEmptyState(targetDocument, []));
   }
@@ -1100,7 +1087,6 @@ function createMainRegion(
   const workbench = targetDocument.createElement("div");
   workbench.className = "desktop-empty-session desktop-chat-workbench";
   const workbenchChildren = [
-    createChatHeader(targetDocument, chat, chatActions),
     createConversationThread(targetDocument, chat, chatActions),
   ];
   if (showEmptySession) {
@@ -1338,367 +1324,6 @@ function mountMainUtilitiesRegionVueIsland(
     },
     promptProviderId: () => promptForSettingsProviderId(targetDocument),
   });
-}
-
-function createChatHeader(
-  targetDocument: Document,
-  chat: DesktopNativeChatModel | null,
-  chatActions: DesktopNativeChatActionOptions = {},
-): HTMLElement {
-  const header = targetDocument.createElement("header");
-  header.className = "desktop-chat-header";
-
-  const titleRow = targetDocument.createElement("div");
-  titleRow.className = "desktop-chat-title-row";
-
-  const activeSession = activeChatSession(chat);
-  const titleGroup = targetDocument.createElement("div");
-  titleGroup.className = "desktop-chat-title-group";
-  const context = targetDocument.createElement("span");
-  context.className = "desktop-chat-context";
-  context.textContent = "tinybot";
-  const title = targetDocument.createElement("h1");
-  title.className = "desktop-chat-title";
-  title.textContent = activeChatTitle(chat);
-  if (canMountVueIsland(title)) {
-    mountChatTitleIsland(title, { title: activeChatTitle(chat) });
-  }
-  titleGroup.append(context, title);
-  const headerStatus = createChatHeaderStatus(targetDocument, chat, chatActions);
-  if (headerStatus) {
-    titleGroup.append(headerStatus);
-  }
-  const menu = targetDocument.createElement("button");
-  menu.type = "button";
-  menu.className = "desktop-chat-menu";
-  menu.setAttribute("data-desktop-chat-menu", "more");
-  menu.setAttribute("aria-haspopup", "menu");
-  menu.setAttribute("aria-expanded", "false");
-  menu.setAttribute("aria-label", "More chat actions");
-  menu.textContent = "...";
-
-  const popover = createChatMenuPopover(targetDocument, chat, activeSession, title, menu, chatActions);
-  mountChatMenuButtonVueIsland(menu, popover);
-  targetDocument.addEventListener("click", (event) => {
-    if (popover.hidden) {
-      return;
-    }
-    const target = "target" in event ? event.target : null;
-    if (isEventTargetInsideElement(target, menu) || isEventTargetInsideElement(target, popover)) {
-      return;
-    }
-    closeChatMenuPopover(menu, popover);
-  });
-
-  titleRow.append(titleGroup, menu, popover);
-
-  const actions = targetDocument.createElement("div");
-  actions.className = "desktop-chat-header-actions";
-
-  header.append(titleRow, actions);
-  return header;
-}
-
-function createChatHeaderStatus(
-  targetDocument: Document,
-  chat: DesktopNativeChatModel | null,
-  chatActions: DesktopNativeChatActionOptions,
-): HTMLElement | null {
-  if (chat?.responding !== true && chat?.composerState !== "sending" && chat?.composerState !== "queued") {
-    return null;
-  }
-  const status = targetDocument.createElement("div");
-  status.className = "desktop-chat-header-status";
-  status.setAttribute("aria-label", "Chat response controls");
-  status.setAttribute("data-desktop-chat-region", "header-status");
-  const stop = targetDocument.createElement("button");
-  stop.type = "button";
-  stop.className = "desktop-chat-header-stop";
-  stop.setAttribute("aria-label", "Stop current response");
-  stop.setAttribute("data-desktop-chat-action", "stop");
-  stop.textContent = "Stop";
-  stop.addEventListener("click", () => chatActions.onInterrupt?.());
-  status.append(stop);
-  return status;
-}
-
-function mountChatMenuButtonVueIsland(menu: HTMLElement, popover: HTMLElement): void {
-  const toggle = () => toggleChatMenuPopover(menu, popover);
-  const installFallback = () => {
-    menu.addEventListener("click", toggle);
-  };
-  if (!canMountVueIsland(menu)) {
-    installFallback();
-    return;
-  }
-  mountChatMenuButtonIsland(menu, {
-    expanded: menu.getAttribute("aria-expanded") === "true",
-    onToggle: toggle,
-  });
-}
-
-function toggleChatMenuPopover(menu: HTMLElement, popover: HTMLElement): void {
-  const expanded = menu.getAttribute("aria-expanded") === "true";
-  menu.setAttribute("aria-expanded", String(!expanded));
-  popover.hidden = expanded;
-}
-
-function closeChatMenuPopover(menu: HTMLElement, popover: HTMLElement): void {
-  menu.setAttribute("aria-expanded", "false");
-  popover.hidden = true;
-}
-
-function isEventTargetInsideElement(target: EventTarget | null, element: HTMLElement): boolean {
-  return typeof Node !== "undefined" && target instanceof Node && (target === element || element.contains(target));
-}
-
-function activeChatSession(chat: DesktopNativeChatModel | null): NativeChatSession | null {
-  if (!chat?.activeSessionKey) {
-    return null;
-  }
-  return chat.sessions.find((session) => session.key === chat.activeSessionKey) ?? null;
-}
-
-function createChatMenuPopover(
-  targetDocument: Document,
-  chat: DesktopNativeChatModel | null,
-  session: NativeChatSession | null,
-  titleElement: HTMLElement,
-  trigger: HTMLElement,
-  chatActions: DesktopNativeChatActionOptions,
-): HTMLElement {
-  const popover = targetDocument.createElement("div");
-  popover.className = "desktop-chat-menu-popover";
-  popover.setAttribute("role", "menu");
-  popover.setAttribute("aria-label", "Chat session actions");
-  popover.hidden = true;
-
-  const close = () => {
-    popover.hidden = true;
-    trigger.setAttribute("aria-expanded", "false");
-  };
-
-  const popoverActions: Array<{
-    action: string;
-    disabled: boolean;
-    label: string;
-    onAction: () => string | void;
-  }> = [];
-
-  const appendAction = (action: string, label: string, handler: (button: HTMLElement) => void, disabled = false) => {
-    const button = targetDocument.createElement("button");
-    button.type = "button";
-    button.className = "desktop-chat-menu-action";
-    button.setAttribute("role", "menuitem");
-    button.setAttribute("data-desktop-chat-menu-action", action);
-    button.textContent = label;
-    if (disabled) {
-      button.setAttribute("disabled", "");
-    }
-    button.addEventListener("click", (event) => {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      if (disabled) {
-        return;
-      }
-      handler(button);
-      close();
-    });
-    mountChatMenuActionVueIsland(button, { action, disabled, label });
-    popover.append(button);
-    popoverActions.push({
-      action,
-      disabled,
-      label,
-      onAction: () => {
-        if (disabled) {
-          return;
-        }
-        handler(button);
-        close();
-        return button.textContent ?? undefined;
-      },
-    });
-    return button;
-  };
-
-  const initialPinned = session ? isSessionPinned(targetDocument, session.key) : false;
-  appendAction(
-    "pin",
-    initialPinned ? "Unpin session" : "Pin session",
-    (button) => {
-      if (!session) {
-        return;
-      }
-      const pinned = toggleActiveSessionPinned(targetDocument, session);
-      button.textContent = pinned ? "Unpin session" : "Pin session";
-      chatActions.onPinSession?.({
-        sessionKey: session.key,
-        chatId: session.chatId,
-        title: session.title || "New session",
-        pinned,
-      });
-    },
-    !session,
-  );
-  appendAction(
-    "rename",
-    "Rename session",
-    () => {
-      if (!session) {
-        return;
-      }
-      startInlineSessionRename(targetDocument, session, titleElement, chatActions);
-    },
-    !session,
-  );
-  appendAction("new-chat", "New chat", () => chatActions.onNewChat?.(), !chatActions.onNewChat);
-
-  if (!chat?.sessions.length) {
-    const empty = createText(targetDocument, "span", "No active session");
-    empty.className = "desktop-chat-menu-empty";
-    mountChatMenuEmptyVueIsland(empty, "No active session");
-    popover.append(empty);
-  }
-
-  mountChatMenuPopoverVueIsland(popover, {
-    actions: popoverActions,
-    emptyMessage: !chat?.sessions.length ? "No active session" : "",
-  });
-  return popover;
-}
-
-function mountChatMenuPopoverVueIsland(
-  popover: HTMLElement,
-  options: {
-    actions: Array<{
-      action: string;
-      disabled: boolean;
-      label: string;
-      onAction: () => string | void;
-    }>;
-    emptyMessage: string;
-  },
-): void {
-  if (!canMountVueIsland(popover)) {
-    return;
-  }
-  mountChatMenuPopoverIsland(popover, options);
-}
-
-function mountChatMenuEmptyVueIsland(empty: HTMLElement, message: string): void {
-  if (!canMountVueIsland(empty)) {
-    return;
-  }
-  mountChatMenuEmptyIsland(empty, { message });
-}
-
-function mountChatMenuActionVueIsland(
-  button: HTMLElement,
-  options: { action: string; disabled: boolean; label: string },
-): void {
-  if (!canMountVueIsland(button)) {
-    return;
-  }
-  mountChatMenuActionIsland(button, options);
-}
-
-function pinnedSessionKeysForDocument(targetDocument: Document): Set<string> {
-  let keys = desktopPinnedChatSessions.get(targetDocument);
-  if (!keys) {
-    keys = new Set<string>();
-    desktopPinnedChatSessions.set(targetDocument, keys);
-  }
-  return keys;
-}
-
-function isSessionPinned(targetDocument: Document, sessionKey: string): boolean {
-  return pinnedSessionKeysForDocument(targetDocument).has(sessionKey);
-}
-
-function setSessionPinned(targetDocument: Document, sessionKey: string, pinned: boolean): void {
-  const keys = pinnedSessionKeysForDocument(targetDocument);
-  if (pinned) {
-    keys.add(sessionKey);
-    return;
-  }
-  keys.delete(sessionKey);
-}
-
-function toggleActiveSessionPinned(targetDocument: Document, session: NativeChatSession): boolean {
-  const pinned = !isSessionPinned(targetDocument, session.key);
-  setSessionPinned(targetDocument, session.key, pinned);
-  return pinned;
-}
-
-function startInlineSessionRename(
-  targetDocument: Document,
-  session: NativeChatSession,
-  titleElement: HTMLElement,
-  chatActions: DesktopNativeChatActionOptions,
-): void {
-  const existingEditor = titleElement.querySelector<HTMLInputElement>(".desktop-chat-title-editor");
-  if (existingEditor) {
-    focusSessionTitleEditor(existingEditor);
-    return;
-  }
-
-  const currentTitle = session.title || "New session";
-  const editor = targetDocument.createElement("input");
-  editor.type = "text";
-  editor.className = "desktop-chat-title-editor";
-  editor.setAttribute("aria-label", "Rename session");
-  editor.value = currentTitle;
-
-  let closed = false;
-  const closeEditor = (nextTitle = currentTitle) => {
-    closed = true;
-    titleElement.replaceChildren();
-    titleElement.textContent = nextTitle;
-  };
-  const commit = () => {
-    if (closed) {
-      return;
-    }
-    const renamedTitle = editor.value.trim();
-    if (!renamedTitle || renamedTitle === currentTitle) {
-      closeEditor();
-      return;
-    }
-    session.title = renamedTitle;
-    closeEditor(renamedTitle);
-    chatActions.onRenameSession?.({
-      sessionKey: session.key,
-      chatId: session.chatId,
-      title: renamedTitle,
-    });
-  };
-  const cancel = () => {
-    if (!closed) {
-      closeEditor();
-    }
-  };
-
-  editor.addEventListener("keydown", (event) => {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      commit();
-    }
-    if (event.key === "Escape") {
-      event.preventDefault();
-      cancel();
-    }
-  });
-  editor.addEventListener("blur", commit);
-
-  titleElement.textContent = "";
-  titleElement.replaceChildren(editor);
-  focusSessionTitleEditor(editor);
-}
-
-function focusSessionTitleEditor(editor: HTMLInputElement): void {
-  editor.focus?.({ preventScroll: true });
-  editor.setSelectionRange?.(0, editor.value.length);
 }
 
 function createConversationThread(
@@ -2462,10 +2087,10 @@ function createNativeComposerSurface(
   send.setAttribute("data-desktop-composer-action", "send");
   send.setAttribute("aria-label", "Send message");
   send.replaceChildren(createComposerSendIcon(targetDocument));
-  updateNativeComposerSendState(input as HTMLTextAreaElement, send as HTMLButtonElement, chat);
+  updateNativeComposerSendState(input as HTMLTextAreaElement, send as HTMLButtonElement, chat, Boolean(chat));
   input.addEventListener("input", () => {
     resizeNativeComposerInput(input as HTMLTextAreaElement);
-    updateNativeComposerSendState(input as HTMLTextAreaElement, send as HTMLButtonElement, chat);
+    updateNativeComposerSendState(input as HTMLTextAreaElement, send as HTMLButtonElement, chat, Boolean(chat));
   });
   mountComposerSendButtonVueIsland(send, input as HTMLTextAreaElement, chat, chatActions);
 
@@ -2520,6 +2145,7 @@ function mountComposerSurfaceVueIsland(
   }
   mountOrUpdateComposerSurfaceIsland(composer, {
     activeSessionKey: chat?.activeSessionKey || null,
+    canSubmitWhileBusy: Boolean(chat) || hasMountedRebuiltChatSurface(composer.ownerDocument),
     composerState: nativeComposerState(chat),
     model: chat?.runtime?.model || null,
     modelOptions: chat?.runtime?.modelOptions || [],
@@ -2529,7 +2155,7 @@ function mountComposerSurfaceVueIsland(
     onAttach: () => chatActions.onAttachSessionFile?.(),
     onModelSelect: (model) => chatActions.onSelectModel?.(model),
     onPersistentRagChange: (enabled) => chatActions.onPersistentRagChange?.(enabled),
-    onSend: (event) => chatActions.onComposerSubmit?.(event),
+    onSend: (event) => submitNativeComposerSurfaceEvent(composer, event, chat, chatActions),
   });
 }
 
@@ -2562,10 +2188,68 @@ function submitNativeComposerMessage(
   if (send.disabled || !input.value.trim()) {
     return;
   }
+  const surfaceResult = submitNativeComposerToChatSurface(
+    input.ownerDocument,
+    input.value,
+    chat?.usePersistentRag !== false,
+  );
+  if (surfaceResult.handled) {
+    if (surfaceResult.accepted) {
+      input.value = "";
+      resizeNativeComposerInput(input);
+      updateNativeComposerSendState(input, send, chat);
+    }
+    return;
+  }
+  if (nativeComposerState(chat) !== "idle") {
+    return;
+  }
   chatActions.onComposerSubmit?.({
     content: input.value,
     usePersistentRag: chat?.usePersistentRag !== false,
   });
+}
+
+function submitNativeComposerSurfaceEvent(
+  composer: HTMLElement,
+  event: { content: string; usePersistentRag: boolean },
+  chat: DesktopNativeChatModel | null,
+  chatActions: DesktopNativeChatActionOptions,
+): void {
+  const surfaceResult = submitNativeComposerToChatSurface(composer.ownerDocument, event.content, event.usePersistentRag);
+  if (surfaceResult.handled) {
+    return;
+  }
+  if (nativeComposerState(chat) !== "idle") {
+    return;
+  }
+  chatActions.onComposerSubmit?.(event);
+}
+
+function submitNativeComposerToChatSurface(
+  targetDocument: Document,
+  content: string,
+  usePersistentRag: boolean,
+): { accepted: boolean; handled: boolean } {
+  const surface = targetDocument.querySelector<HTMLElement>(".desktop-chat-surface")
+    ?? targetDocument.querySelector<HTMLElement>("[data-chat-surface='rebuild-chat-agent-surface']");
+  if (!surface) {
+    return { accepted: false, handled: false };
+  }
+  const detail = {
+    accepted: false,
+    content,
+    handled: false,
+    usePersistentRag,
+  };
+  surface.dispatchEvent(new CustomEvent("desktop-chat-composer-submit-request", {
+    bubbles: true,
+    detail,
+  }));
+  return {
+    accepted: detail.accepted,
+    handled: detail.handled,
+  };
 }
 
 function mountComposerAttachButtonVueIsland(
@@ -2608,8 +2292,9 @@ function updateNativeComposerSendState(
   input: HTMLTextAreaElement,
   send: HTMLButtonElement,
   chat: DesktopNativeChatModel | null,
+  canSubmitWhileBusy = hasMountedRebuiltChatSurface(input.ownerDocument),
 ): void {
-  const canSend = nativeComposerState(chat) === "idle" && Boolean(input.value.trim());
+  const canSend = Boolean(input.value.trim()) && (nativeComposerState(chat) === "idle" || canSubmitWhileBusy);
   send.disabled = !canSend;
   if (canSend) {
     send.removeAttribute("disabled");
@@ -2618,15 +2303,15 @@ function updateNativeComposerSendState(
   }
 }
 
-function activeChatTitle(chat: DesktopNativeChatModel | null): string {
-  if (!chat) {
-    return "Design native workbench";
-  }
-  return chat.sessions.find((session) => session.key === chat.activeSessionKey)?.title || "New chat";
-}
-
 function nativeComposerState(chat: DesktopNativeChatModel | null): NonNullable<DesktopNativeChatModel["composerState"]> {
   return chat?.composerState ?? (chat?.responding ? "sending" : "idle");
+}
+
+function hasMountedRebuiltChatSurface(targetDocument: Document): boolean {
+  return Boolean(
+    targetDocument.querySelector(".desktop-chat-surface")
+      ?? targetDocument.querySelector("[data-chat-surface='rebuild-chat-agent-surface']"),
+  );
 }
 
 function createComposerModelControl(
@@ -8326,8 +8011,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     body.desktop-native-workbench .desktop-workspace-file-row:focus-visible,
     body.desktop-native-workbench .desktop-workspace-editor:focus-visible,
     body.desktop-native-workbench .desktop-inspector-restore:focus-visible,
-    body.desktop-native-workbench .desktop-chat-header-stop:focus-visible,
-    body.desktop-native-workbench .desktop-chat-header-panel-button:focus-visible,
     body.desktop-native-workbench .desktop-tool-approval-action:focus-visible,
     body.desktop-native-workbench .desktop-run-chain-icon-button:focus-visible,
     body.desktop-native-workbench .desktop-run-chain-summary-item:focus-visible,
@@ -10325,228 +10008,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       max-width: 520px;
       color: #69635d;
       font: 500 13px/1.55 var(--font-sans);
-    }
-
-    body.desktop-native-workbench .desktop-chat-header {
-      grid-column: 1;
-      grid-row: 1;
-      justify-self: center;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      width: min(var(--desktop-chat-column-width), 100%);
-      min-width: 0;
-      min-height: 54px;
-      margin: 0 auto;
-      border-bottom: 0;
-      padding: 0;
-      background: transparent;
-    }
-
-    body.desktop-native-workbench .desktop-chat-title-row {
-      position: relative;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      min-width: 0;
-    }
-
-    body.desktop-native-workbench .desktop-chat-title-group {
-      display: grid;
-      gap: 2px;
-      min-width: 0;
-    }
-
-    body.desktop-native-workbench .desktop-chat-context {
-      overflow: hidden;
-      color: #8a8179;
-      font: 650 11px/1.1 var(--font-sans);
-      letter-spacing: 0;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header h1 {
-      margin: 0;
-      color: #1c1b19;
-      font-family: var(--font-sans);
-      font-size: 18px;
-      font-weight: 650;
-      line-height: 1.2;
-      letter-spacing: 0;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-status {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 5px;
-      min-width: 0;
-      margin-top: 2px;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-stop {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 20px;
-      max-width: 100%;
-      border: 1px solid #eaded8;
-      border-radius: 999px;
-      padding: 0 7px;
-      background: #fffaf5;
-      color: #6f685f;
-      font: 650 10px/1.2 var(--font-sans);
-      letter-spacing: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-stop {
-      border-color: #e6b8a8;
-      background: #fff0ea;
-      color: #b4533c;
-      cursor: pointer;
-    }
-
-    body.desktop-native-workbench .desktop-chat-title-editor {
-      width: min(360px, 42vw);
-      min-width: 120px;
-      border: 1px solid #dfd6cf;
-      border-radius: 6px;
-      padding: 3px 7px;
-      background: #fffdfb;
-      color: #1c1b19;
-      font: 650 18px/1.2 var(--font-sans);
-      letter-spacing: 0;
-      outline: none;
-    }
-
-    body.desktop-native-workbench .desktop-chat-title-editor:focus {
-      border-color: #d5674c;
-      box-shadow: 0 0 0 2px rgba(213, 103, 76, 0.16);
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-actions {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      flex: 0 0 auto;
-      min-width: 0;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-panel-button,
-    body.desktop-native-workbench .desktop-chat-menu {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      height: 30px;
-      min-width: 30px;
-      min-height: 30px;
-      border: 0;
-      border-radius: 6px;
-      background: #ffffff;
-      color: #262522;
-      font: 700 16px/1 var(--font-sans);
-      cursor: pointer;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-panel-button {
-      width: 34px;
-      min-width: 34px;
-      padding: 0;
-      border: 1px solid #e4ddd6;
-      color: #59544f;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-panel-icon {
-      position: relative;
-      display: block;
-      width: 18px;
-      height: 18px;
-      color: #6f6963;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-panel-icon-frame {
-      position: absolute;
-      inset: 2px;
-      border: 1.5px solid currentColor;
-      border-radius: 4px;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-panel-icon-rail {
-      position: absolute;
-      top: 5px;
-      bottom: 5px;
-      width: 3px;
-      border-radius: 2px;
-      background: currentColor;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-panel-icon[data-panel-icon="collapse-left"] .desktop-chat-header-panel-icon-rail {
-      left: 5px;
-    }
-
-    body.desktop-native-workbench .desktop-chat-header-panel-icon[data-panel-icon="collapse-right"] .desktop-chat-header-panel-icon-rail {
-      right: 5px;
-    }
-
-    body.desktop-native-workbench .desktop-chat-menu {
-      width: 30px;
-      padding: 0;
-      font-size: 16px;
-    }
-
-    body.desktop-native-workbench .desktop-chat-menu:hover,
-    body.desktop-native-workbench .desktop-chat-menu:focus-visible,
-    body.desktop-native-workbench .desktop-chat-header-panel-button:hover,
-    body.desktop-native-workbench .desktop-chat-header-panel-button:focus-visible {
-      background: #f7f2ed;
-    }
-
-    body.desktop-native-workbench .desktop-chat-menu-popover {
-      position: absolute;
-      top: calc(100% + 8px);
-      left: 0;
-      right: auto;
-      z-index: 8;
-      display: grid;
-      gap: 4px;
-      min-width: 176px;
-      border: 1px solid #e5ddd7;
-      border-radius: 8px;
-      padding: 6px;
-      background: #ffffff;
-      box-shadow: 0 12px 26px rgba(42, 34, 27, 0.14);
-    }
-
-    body.desktop-native-workbench .desktop-chat-menu-popover[hidden] {
-      display: none;
-    }
-
-    body.desktop-native-workbench .desktop-chat-menu-action {
-      min-height: 30px;
-      border: 0;
-      border-radius: 6px;
-      padding: 0 10px;
-      background: transparent;
-      color: #262522;
-      font: 600 13px/1.2 var(--font-sans);
-      text-align: left;
-      cursor: pointer;
-    }
-
-    body.desktop-native-workbench .desktop-chat-menu-action:hover,
-    body.desktop-native-workbench .desktop-chat-menu-action:focus-visible {
-      background: #f7f2ed;
-    }
-
-    body.desktop-native-workbench .desktop-chat-menu-empty {
-      padding: 7px 10px;
-      color: #77736f;
-      font: 500 12px/1.2 var(--font-sans);
     }
 
     body.desktop-native-workbench .desktop-conversation-thread {
@@ -14291,7 +13752,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-inspector,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-bottom,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-content,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-conversation-thread,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-utility-surfaces,
@@ -14483,7 +13943,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-workbench-chrome h2,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header h1,
     html[data-theme="dark"] body.desktop-native-workbench .n-text,
     html[data-theme="dark"] body.desktop-native-workbench .n-ellipsis,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-row,
@@ -14518,10 +13977,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-sidebar-search,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-title-editor,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header-panel-button,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-popover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-menu,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-token-orb {
@@ -14529,10 +13984,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       color: var(--text);
       border-color: var(--border);
       box-shadow: none;
-    }
-
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-action {
-      color: var(--text);
     }
 
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-menu-title {
@@ -14544,22 +13995,12 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
       color: var(--text);
     }
 
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-empty {
-      color: var(--text-muted);
-    }
-
     html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-secondary-button:hover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-activity-secondary-button:focus-visible,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-link:hover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-workbench-link:focus-visible,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu:hover,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu:focus-visible,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-action:hover,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-menu-action:focus-visible,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-option:hover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model-option:focus-visible,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header-panel-button:hover,
-    html[data-theme="dark"] body.desktop-native-workbench .desktop-chat-header-panel-button:focus-visible,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model:hover,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-model:focus-visible,
     html[data-theme="dark"] body.desktop-native-workbench .desktop-native-composer-rag-toggle:hover,
@@ -14663,12 +14104,6 @@ function ensureDesktopWorkbenchShellStyle(targetDocument: Document): void {
 
       body.desktop-native-workbench .desktop-workbench-main {
         padding: 12px;
-      }
-
-      body.desktop-native-workbench .desktop-chat-header {
-        min-height: 54px;
-        width: min(var(--desktop-chat-column-width), 100%);
-        padding: 0;
       }
 
       body.desktop-native-workbench .desktop-conversation-thread {


### PR DESCRIPTION
## Summary
- route the desktop chat composer through the rebuilt chat surface as the single input path
- remove the retired shell chat header, its menu bridge, and stale header styles
- update shell/chat tests to assert the rebuilt chat surface owns the session title

## Validation
- npx vitest run src/native-workbench/components/chat/chatSurface.test.ts src/native-workbench/shell/desktopWorkbenchShell.test.ts src/native-workbench/shell/desktopWorkbenchShell.static-vue-imports.test.ts src/native-workbench/components/chat/composerSurfaceIsland.test.ts src/native-workbench/components/chat/composerSendButtonIsland.test.ts src/native-workbench/app/desktopBootstrapOrder.test.ts src/native-workbench/chat/chatInputState.test.ts src/native-workbench/chat/chatSubagentForward.test.ts
- npm run build