### PR TITLE
Unify agent runtime events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2559,9 +2559,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src-tauri/src/agent_loop_runtime_protocol.rs
+++ b/src-tauri/src/agent_loop_runtime_protocol.rs
@@ -681,6 +681,20 @@ impl AgentRunEmitter {
         timestamp: impl Into<String>,
         reason: impl Into<String>,
     ) -> AgentRuntimeEventEnvelope {
+        self.cancelled_with_payload(timestamp, reason, Value::Null)
+    }
+
+    pub fn cancelled_with_payload(
+        &mut self,
+        timestamp: impl Into<String>,
+        reason: impl Into<String>,
+        payload: Value,
+    ) -> AgentRuntimeEventEnvelope {
+        let reason = reason.into();
+        let mut payload = object_payload(payload);
+        payload
+            .entry("reason".to_string())
+            .or_insert_with(|| Value::String(reason));
         self.emit(AgentRuntimeEventAppendInput {
             parent_turn_id: None,
             item_id: None,
@@ -689,7 +703,7 @@ impl AgentRunEmitter {
             timestamp: timestamp.into(),
             source: AgentRuntimeEventSource::RustBackend,
             visibility: AgentRuntimeEventVisibility::User,
-            payload: serde_json::json!({ "reason": reason.into() }),
+            payload: Value::Object(payload),
         })
     }
 

--- a/src-tauri/src/agent_loop_runtime_protocol.rs
+++ b/src-tauri/src/agent_loop_runtime_protocol.rs
@@ -356,11 +356,7 @@ impl AgentRunEmitter {
         events: &[AgentRuntimeEventEnvelope],
     ) -> Self {
         Self {
-            appender: AgentRuntimeEventAppender::from_existing_events(
-                session_id,
-                turn_id,
-                events,
-            ),
+            appender: AgentRuntimeEventAppender::from_existing_events(session_id, turn_id, events),
             events: Vec::new(),
         }
     }
@@ -876,11 +872,7 @@ fn projected_item_payload(
 }
 
 fn projected_completed_message_payload(event: &AgentRuntimeEventEnvelope) -> Value {
-    let mut payload = event
-        .payload
-        .as_object()
-        .cloned()
-        .unwrap_or_default();
+    let mut payload = event.payload.as_object().cloned().unwrap_or_default();
     if !payload.contains_key("content") {
         if let Some(content) = payload_text_fragment(&event.payload) {
             payload.insert("content".to_string(), Value::String(content.to_string()));
@@ -1473,12 +1465,18 @@ mod tests {
 
         assert_eq!(first.sequence, 1);
         assert_eq!(second.sequence, 2);
-        assert_eq!(second.event_id, "turn-1:agent-message-completed:0000000000000002");
+        assert_eq!(
+            second.event_id,
+            "turn-1:agent-message-completed:0000000000000002"
+        );
         assert_eq!(emitter.events().len(), 2);
 
         let events = emitter.take_events();
         assert_eq!(
-            events.iter().map(|event| event.event_name.as_str()).collect::<Vec<_>>(),
+            events
+                .iter()
+                .map(|event| event.event_name.as_str())
+                .collect::<Vec<_>>(),
             vec!["agent.phase.changed", "agent.message.completed"]
         );
         assert!(emitter.events().is_empty());
@@ -1489,11 +1487,7 @@ mod tests {
     fn run_emitter_helpers_emit_canonical_payloads() {
         let mut emitter = AgentRunEmitter::new("session-1", "turn-1");
 
-        emitter.user_turn_started(
-            "2026-07-03T00:00:00Z",
-            Some("user-1".to_string()),
-            "Start",
-        );
+        emitter.user_turn_started("2026-07-03T00:00:00Z", Some("user-1".to_string()), "Start");
         emitter.tool_start(
             "2026-07-03T00:00:01Z",
             "call-1",

--- a/src-tauri/src/agent_loop_runtime_protocol.rs
+++ b/src-tauri/src/agent_loop_runtime_protocol.rs
@@ -55,7 +55,7 @@ impl AgentRuntimePhase {
             event_name if event_name.starts_with("agent.delegate.") => Self::AwaitingSubagent,
             "agent.checkpoint" => Self::Planning,
             "agent.usage" => Self::CallingModel,
-            "agent.done" => Self::Completed,
+            "agent.message.completed" | "agent.done" => Self::Completed,
             "agent.error" => Self::Failed,
             "agent.cancelled" => Self::Cancelled,
             _ => Self::Planning,
@@ -80,7 +80,9 @@ impl AgentTurnItemKind {
     pub fn for_legacy_event(event_name: &str) -> Option<Self> {
         match event_name {
             "agent.reasoning_delta" => Some(Self::Reasoning),
-            "agent.delta" | "agent.done" => Some(Self::AssistantMessage),
+            "agent.delta" | "agent.message.completed" | "agent.done" => {
+                Some(Self::AssistantMessage)
+            }
             "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" => {
                 Some(Self::ToolCall)
             }
@@ -242,6 +244,13 @@ pub struct AgentRuntimeEventAppendInput {
     pub payload: Value,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct LegacyNativeAgentEventProjection {
+    #[serde(rename = "eventName")]
+    pub event_name: String,
+    pub payload: Value,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AgentRuntimeEventAppender {
     session_id: String,
@@ -325,6 +334,410 @@ impl AgentRuntimeEventAppender {
         self.next_sequence = self.next_sequence.saturating_add(1);
         sequence
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AgentRunEmitter {
+    appender: AgentRuntimeEventAppender,
+    events: Vec<AgentRuntimeEventEnvelope>,
+}
+
+impl AgentRunEmitter {
+    pub fn new(session_id: impl Into<String>, turn_id: impl Into<String>) -> Self {
+        Self {
+            appender: AgentRuntimeEventAppender::new(session_id, turn_id),
+            events: Vec::new(),
+        }
+    }
+
+    pub fn from_existing_events(
+        session_id: impl Into<String>,
+        turn_id: impl Into<String>,
+        events: &[AgentRuntimeEventEnvelope],
+    ) -> Self {
+        Self {
+            appender: AgentRuntimeEventAppender::from_existing_events(
+                session_id,
+                turn_id,
+                events,
+            ),
+            events: Vec::new(),
+        }
+    }
+
+    pub fn emit(&mut self, input: AgentRuntimeEventAppendInput) -> AgentRuntimeEventEnvelope {
+        let event = self.appender.append(input);
+        self.events.push(event.clone());
+        event
+    }
+
+    pub fn events(&self) -> &[AgentRuntimeEventEnvelope] {
+        &self.events
+    }
+
+    pub fn take_events(&mut self) -> Vec<AgentRuntimeEventEnvelope> {
+        std::mem::take(&mut self.events)
+    }
+
+    pub fn next_sequence(&self) -> u64 {
+        self.appender.next_sequence()
+    }
+
+    pub fn phase_changed(
+        &mut self,
+        timestamp: impl Into<String>,
+        from: AgentRuntimePhase,
+        to: AgentRuntimePhase,
+    ) -> AgentRuntimeEventEnvelope {
+        let to_phase = to.clone();
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.phase.changed".to_string(),
+            phase: to_phase,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::Debug,
+            payload: serde_json::json!({
+                "from": from.as_str(),
+                "to": to.as_str()
+            }),
+        })
+    }
+
+    pub fn user_turn_started(
+        &mut self,
+        timestamp: impl Into<String>,
+        message_id: Option<String>,
+        content: impl Into<String>,
+    ) -> AgentRuntimeEventEnvelope {
+        let content = content.into();
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.turn.started".to_string(),
+            phase: AgentRuntimePhase::Planning,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::User,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({
+                "userMessageId": message_id,
+                "userMessage": {
+                    "id": message_id,
+                    "content": content
+                }
+            }),
+        })
+    }
+
+    pub fn assistant_delta(
+        &mut self,
+        timestamp: impl Into<String>,
+        delta: impl Into<String>,
+    ) -> AgentRuntimeEventEnvelope {
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.delta".to_string(),
+            phase: AgentRuntimePhase::StreamingModel,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::Provider,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({ "delta": delta.into() }),
+        })
+    }
+
+    pub fn message_completed(
+        &mut self,
+        timestamp: impl Into<String>,
+        message_id: Option<String>,
+        content: impl Into<String>,
+    ) -> AgentRuntimeEventEnvelope {
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.message.completed".to_string(),
+            phase: AgentRuntimePhase::Completed,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::Provider,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({
+                "messageId": message_id,
+                "content": content.into()
+            }),
+        })
+    }
+
+    pub fn tool_start(
+        &mut self,
+        timestamp: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        args: Value,
+    ) -> AgentRuntimeEventEnvelope {
+        let tool_call_id = tool_call_id.into();
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: Some(tool_call_id.clone()),
+            event_name: "agent.tool.start".to_string(),
+            phase: AgentRuntimePhase::ToolRunning,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::Tool,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({
+                "toolCallId": tool_call_id,
+                "toolName": tool_name.into(),
+                "args": args
+            }),
+        })
+    }
+
+    pub fn tool_result(
+        &mut self,
+        timestamp: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        envelope: Value,
+    ) -> AgentRuntimeEventEnvelope {
+        let tool_call_id = tool_call_id.into();
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: Some(tool_call_id.clone()),
+            event_name: "agent.tool.result".to_string(),
+            phase: AgentRuntimePhase::ToolRunning,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::Tool,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({
+                "toolCallId": tool_call_id,
+                "toolName": tool_name.into(),
+                "envelope": envelope
+            }),
+        })
+    }
+
+    pub fn checkpoint(
+        &mut self,
+        timestamp: impl Into<String>,
+        payload: Value,
+    ) -> AgentRuntimeEventEnvelope {
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.checkpoint".to_string(),
+            phase: AgentRuntimePhase::Planning,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::Debug,
+            payload,
+        })
+    }
+
+    pub fn awaiting_approval(
+        &mut self,
+        timestamp: impl Into<String>,
+        approval_id: impl Into<String>,
+        payload: Value,
+    ) -> AgentRuntimeEventEnvelope {
+        let approval_id = approval_id.into();
+        let mut payload = object_payload(payload);
+        payload
+            .entry("approvalId".to_string())
+            .or_insert_with(|| Value::String(approval_id.clone()));
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: Some(approval_id),
+            event_name: "agent.awaiting_approval".to_string(),
+            phase: AgentRuntimePhase::AwaitingApproval,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: Value::Object(payload),
+        })
+    }
+
+    pub fn approval_decision(
+        &mut self,
+        timestamp: impl Into<String>,
+        approval_id: impl Into<String>,
+        decision: AgentApprovalDecision,
+        scope: AgentApprovalScope,
+        guidance: Option<String>,
+    ) -> AgentRuntimeEventEnvelope {
+        let approval_id = approval_id.into();
+        let mut payload = serde_json::Map::new();
+        payload.insert("approvalId".to_string(), Value::String(approval_id.clone()));
+        payload.insert(
+            "decision".to_string(),
+            serde_json::to_value(decision).unwrap_or(Value::Null),
+        );
+        payload.insert(
+            "scope".to_string(),
+            serde_json::to_value(scope).unwrap_or(Value::Null),
+        );
+        if let Some(guidance) = guidance {
+            payload.insert("guidance".to_string(), Value::String(guidance));
+        }
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: Some(approval_id),
+            event_name: "agent.approval.decision".to_string(),
+            phase: AgentRuntimePhase::AwaitingApproval,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::User,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: Value::Object(payload),
+        })
+    }
+
+    pub fn awaiting_form(
+        &mut self,
+        timestamp: impl Into<String>,
+        form_id: impl Into<String>,
+        payload: Value,
+    ) -> AgentRuntimeEventEnvelope {
+        let form_id = form_id.into();
+        let mut payload = object_payload(payload);
+        payload
+            .entry("formId".to_string())
+            .or_insert_with(|| Value::String(form_id.clone()));
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: Some(form_id),
+            event_name: "agent.awaiting_form".to_string(),
+            phase: AgentRuntimePhase::AwaitingForm,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: Value::Object(payload),
+        })
+    }
+
+    pub fn form_resolution(
+        &mut self,
+        timestamp: impl Into<String>,
+        form_id: impl Into<String>,
+        action: AgentFormAction,
+        values: Option<Value>,
+    ) -> AgentRuntimeEventEnvelope {
+        let form_id = form_id.into();
+        let mut payload = serde_json::Map::new();
+        payload.insert("formId".to_string(), Value::String(form_id.clone()));
+        payload.insert(
+            "action".to_string(),
+            serde_json::to_value(action).unwrap_or(Value::Null),
+        );
+        if let Some(values) = values {
+            payload.insert("values".to_string(), values);
+        }
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: Some(form_id),
+            event_name: "agent.form.resolution".to_string(),
+            phase: AgentRuntimePhase::AwaitingForm,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::User,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: Value::Object(payload),
+        })
+    }
+
+    pub fn guidance(
+        &mut self,
+        timestamp: impl Into<String>,
+        message_id: Option<String>,
+        content: impl Into<String>,
+    ) -> AgentRuntimeEventEnvelope {
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: message_id.clone(),
+            event_name: "agent.guidance".to_string(),
+            phase: AgentRuntimePhase::Planning,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::User,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({
+                "messageId": message_id,
+                "content": content.into()
+            }),
+        })
+    }
+
+    pub fn error(
+        &mut self,
+        timestamp: impl Into<String>,
+        message: impl Into<String>,
+    ) -> AgentRuntimeEventEnvelope {
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.error".to_string(),
+            phase: AgentRuntimePhase::Failed,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({ "message": message.into() }),
+        })
+    }
+
+    pub fn cancelled(
+        &mut self,
+        timestamp: impl Into<String>,
+        reason: impl Into<String>,
+    ) -> AgentRuntimeEventEnvelope {
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.cancelled".to_string(),
+            phase: AgentRuntimePhase::Cancelled,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({ "reason": reason.into() }),
+        })
+    }
+
+    pub fn done(
+        &mut self,
+        timestamp: impl Into<String>,
+        stop_reason: impl Into<String>,
+        payload: Value,
+    ) -> AgentRuntimeEventEnvelope {
+        let mut payload = object_payload(payload);
+        payload.insert("stopReason".to_string(), Value::String(stop_reason.into()));
+        self.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.done".to_string(),
+            phase: AgentRuntimePhase::Completed,
+            timestamp: timestamp.into(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::Debug,
+            payload: Value::Object(payload),
+        })
+    }
+}
+
+pub fn project_legacy_native_agent_events(
+    events: &[AgentRuntimeEventEnvelope],
+) -> Vec<LegacyNativeAgentEventProjection> {
+    events
+        .iter()
+        .map(project_legacy_native_agent_event)
+        .collect()
+}
+
+pub fn project_legacy_native_agent_event(
+    event: &AgentRuntimeEventEnvelope,
+) -> LegacyNativeAgentEventProjection {
+    LegacyNativeAgentEventProjection {
+        event_name: event.event_name.clone(),
+        payload: event.payload.clone(),
+    }
+}
+
+fn object_payload(payload: Value) -> serde_json::Map<String, Value> {
+    payload.as_object().cloned().unwrap_or_default()
 }
 
 pub fn project_turn_items_from_trace_events(
@@ -414,7 +827,8 @@ fn projected_item_kind(event: &AgentRuntimeEventEnvelope) -> Option<AgentTurnIte
 
 fn projected_item_status(event: &AgentRuntimeEventEnvelope) -> AgentTurnItemStatus {
     match event.event_name.as_str() {
-        "agent.done"
+        "agent.message.completed"
+        | "agent.done"
         | "agent.tool.result"
         | "agent.approval.decision"
         | "agent.form.resolution" => AgentTurnItemStatus::Completed,
@@ -448,13 +862,8 @@ fn projected_item_payload(
             content.push_str(payload_text_fragment(&event.payload).unwrap_or_default());
             serde_json::json!({ "content": content })
         }
-        "agent.done" => {
-            if let Some(content) = payload_text_fragment(&event.payload) {
-                serde_json::json!({ "content": content })
-            } else {
-                event.payload.clone()
-            }
-        }
+        "agent.message.completed" => projected_completed_message_payload(event),
+        "agent.done" => projected_legacy_done_payload(event),
         "agent.tool.start" | "agent.tool.result" => projected_tool_payload(existing_payload, event),
         "agent.awaiting_approval" | "agent.approval.decision" => {
             projected_approval_payload(existing_payload, event)
@@ -463,6 +872,28 @@ fn projected_item_payload(
             projected_form_payload(existing_payload, event)
         }
         _ => event.payload.clone(),
+    }
+}
+
+fn projected_completed_message_payload(event: &AgentRuntimeEventEnvelope) -> Value {
+    let mut payload = event
+        .payload
+        .as_object()
+        .cloned()
+        .unwrap_or_default();
+    if !payload.contains_key("content") {
+        if let Some(content) = payload_text_fragment(&event.payload) {
+            payload.insert("content".to_string(), Value::String(content.to_string()));
+        }
+    }
+    Value::Object(payload)
+}
+
+fn projected_legacy_done_payload(event: &AgentRuntimeEventEnvelope) -> Value {
+    if let Some(content) = payload_text_fragment(&event.payload) {
+        serde_json::json!({ "content": content })
+    } else {
+        event.payload.clone()
     }
 }
 
@@ -1026,6 +1457,111 @@ mod tests {
     }
 
     #[test]
+    fn run_emitter_buffers_events_and_takes_them_in_sequence_order() {
+        let mut emitter = AgentRunEmitter::new("session-1", "turn-1");
+
+        let first = emitter.phase_changed(
+            "2026-07-03T00:00:00Z",
+            AgentRuntimePhase::Planning,
+            AgentRuntimePhase::CallingModel,
+        );
+        let second = emitter.message_completed(
+            "2026-07-03T00:00:01Z",
+            Some("assistant-1".to_string()),
+            "Hello",
+        );
+
+        assert_eq!(first.sequence, 1);
+        assert_eq!(second.sequence, 2);
+        assert_eq!(second.event_id, "turn-1:agent-message-completed:0000000000000002");
+        assert_eq!(emitter.events().len(), 2);
+
+        let events = emitter.take_events();
+        assert_eq!(
+            events.iter().map(|event| event.event_name.as_str()).collect::<Vec<_>>(),
+            vec!["agent.phase.changed", "agent.message.completed"]
+        );
+        assert!(emitter.events().is_empty());
+        assert_eq!(emitter.next_sequence(), 3);
+    }
+
+    #[test]
+    fn run_emitter_helpers_emit_canonical_payloads() {
+        let mut emitter = AgentRunEmitter::new("session-1", "turn-1");
+
+        emitter.user_turn_started(
+            "2026-07-03T00:00:00Z",
+            Some("user-1".to_string()),
+            "Start",
+        );
+        emitter.tool_start(
+            "2026-07-03T00:00:01Z",
+            "call-1",
+            "workspace.read_file",
+            json!({ "path": "README.md" }),
+        );
+        emitter.tool_result(
+            "2026-07-03T00:00:02Z",
+            "call-1",
+            "workspace.read_file",
+            json!({ "status": "ok", "summary": "read README" }),
+        );
+        emitter.awaiting_approval(
+            "2026-07-03T00:00:03Z",
+            "approval-1",
+            json!({ "summary": "Allow write?" }),
+        );
+        emitter.approval_decision(
+            "2026-07-03T00:00:04Z",
+            "approval-1",
+            AgentApprovalDecision::Denied,
+            AgentApprovalScope::Once,
+            Some("Do not write.".to_string()),
+        );
+
+        let events = emitter.take_events();
+        assert_eq!(events[0].event_name, "agent.turn.started");
+        assert_eq!(events[0].payload["userMessage"]["content"], "Start");
+        assert_eq!(events[1].item_id.as_deref(), Some("call-1"));
+        assert_eq!(events[1].payload["args"]["path"], "README.md");
+        assert_eq!(events[2].payload["envelope"]["summary"], "read README");
+        assert_eq!(events[3].phase, AgentRuntimePhase::AwaitingApproval);
+        assert_eq!(events[4].payload["decision"], "denied");
+        assert_eq!(events[4].payload["guidance"], "Do not write.");
+    }
+
+    #[test]
+    fn runtime_events_project_to_legacy_native_event_shape() {
+        let mut emitter = AgentRunEmitter::new("session-1", "turn-1");
+        emitter.message_completed(
+            "2026-07-03T00:00:01Z",
+            Some("assistant-1".to_string()),
+            "Hello",
+        );
+        emitter.done(
+            "2026-07-03T00:00:02Z",
+            "final_response",
+            json!({ "iterationCount": 1 }),
+        );
+
+        let legacy = project_legacy_native_agent_events(emitter.events());
+
+        assert_eq!(legacy.len(), 2);
+        assert_eq!(
+            serde_json::to_value(&legacy[0]).unwrap(),
+            json!({
+                "eventName": "agent.message.completed",
+                "payload": {
+                    "messageId": "assistant-1",
+                    "content": "Hello"
+                }
+            })
+        );
+        assert_eq!(legacy[1].event_name, "agent.done");
+        assert_eq!(legacy[1].payload["stopReason"], "final_response");
+    }
+
+    #[test]
     fn trace_projection_combines_assistant_deltas_into_one_item() {
         let mut appender = AgentRuntimeEventAppender::new("session-1", "turn-1");
         let events = vec![
@@ -1114,6 +1650,75 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].kind, AgentTurnItemKind::ApprovalRequest);
         assert_eq!(items[0].status, AgentTurnItemStatus::Waiting);
+    }
+
+    #[test]
+    fn trace_projection_restores_message_completed_without_legacy_done_content() {
+        let mut appender = AgentRuntimeEventAppender::new("session-1", "turn-1");
+        let events = vec![
+            appender.append(AgentRuntimeEventAppendInput {
+                parent_turn_id: None,
+                item_id: None,
+                event_name: "agent.message.completed".to_string(),
+                phase: AgentRuntimePhase::Completed,
+                timestamp: "2026-07-03T00:00:01Z".to_string(),
+                source: AgentRuntimeEventSource::RustBackend,
+                visibility: AgentRuntimeEventVisibility::User,
+                payload: json!({
+                    "messageId": "assistant-1",
+                    "content": "Hello from canonical completion"
+                }),
+            }),
+            appender.append(AgentRuntimeEventAppendInput {
+                parent_turn_id: None,
+                item_id: None,
+                event_name: "agent.done".to_string(),
+                phase: AgentRuntimePhase::Completed,
+                timestamp: "2026-07-03T00:00:02Z".to_string(),
+                source: AgentRuntimeEventSource::RustBackend,
+                visibility: AgentRuntimeEventVisibility::Debug,
+                payload: json!({ "stopReason": "final_response" }),
+            }),
+        ];
+
+        let items = project_turn_items_from_trace_events(&events);
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].item_id, "turn-1:assistant");
+        assert_eq!(items[0].kind, AgentTurnItemKind::AssistantMessage);
+        assert_eq!(items[0].status, AgentTurnItemStatus::Completed);
+        assert_eq!(
+            items[0].payload,
+            json!({
+                "messageId": "assistant-1",
+                "content": "Hello from canonical completion"
+            })
+        );
+        assert_eq!(items[0].created_at, "2026-07-03T00:00:01Z");
+        assert_eq!(items[0].updated_at, None);
+    }
+
+    #[test]
+    fn trace_projection_restores_canonical_phase_changed_without_turn_item() {
+        let event = runtime_event(
+            "turn-1",
+            "agent.phase.changed",
+            AgentRuntimePhase::CallingModel,
+            None,
+            1,
+            json!({
+                "from": "planning",
+                "to": "calling_model"
+            }),
+        );
+        let encoded = serde_json::to_value(&event).expect("serialize phase event");
+        let restored: AgentRuntimeEventEnvelope =
+            serde_json::from_value(encoded).expect("deserialize phase event");
+
+        assert_eq!(restored.event_name, "agent.phase.changed");
+        assert_eq!(restored.phase, AgentRuntimePhase::CallingModel);
+        assert_eq!(restored.payload["to"], "calling_model");
+        assert!(project_turn_items_from_trace_events(&[restored]).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,7 +69,9 @@ use crate::agent_loop_runtime_protocol::{
 use crate::native_backend_contract::{
     webui_route_inventory_entry, NativeCompatibilityFallbackDiagnostic,
 };
-use crate::worker_agent_runtime::{run_native_agent_turn_with_config, NativeAgentRuntimeServices};
+use crate::worker_agent_runtime::{
+    run_native_agent_turn_with_config, NativeAgentRuntimeServices, NativeAgentTraceSink,
+};
 use crate::worker_background::BackgroundTraceEvent;
 use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
 use crate::worker_client::WorkerClient;
@@ -110,6 +112,41 @@ const WORKER_WEBUI_ROUTE_TIMEOUT: Duration = Duration::from_secs(10);
 const NATIVE_BACKEND_LOG_MAX_BYTES: u64 = 5 * 1024 * 1024;
 const NATIVE_BACKEND_LOG_TAIL_LINES: usize = 100;
 const NATIVE_AGENT_RUN_TRACE_STRING_LIMIT: usize = 256;
+
+#[derive(Clone)]
+struct NativeAgentRunTraceSink {
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+}
+
+impl NativeAgentTraceSink for NativeAgentRunTraceSink {
+    fn append_trace_event(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        event: &AgentRuntimeEventEnvelope,
+    ) -> Result<(), String> {
+        let event = serde_json::to_value(event)
+            .map_err(|error| format!("native agent trace event serialization failed: {error}"))?;
+        let request_id = next_worker_request_correlation();
+        call_rust_state_service(
+            self.workspace_root.clone(),
+            self.config_snapshot.clone(),
+            WorkerRequest::new(
+                request_id.id("agent-run-append-trace"),
+                request_id.trace_id("agent-run-append-trace"),
+                "agent_run.append_trace",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "run_id": run_id,
+                    "event": event,
+                }),
+            ),
+            "native agent run trace append",
+        )
+        .map(|_| ())
+    }
+}
 
 struct GatewayRuntime {
     experimental_worker: WorkerManager,
@@ -1500,7 +1537,7 @@ fn worker_run_agent_with_options(
         workspace_root.clone(),
         config_snapshot.clone(),
     )?;
-    let services = {
+    let base_services = {
         let runtime = lock_runtime(shared);
         runtime.native_agent_runtime.clone()
     };
@@ -1510,6 +1547,10 @@ fn worker_run_agent_with_options(
         config_snapshot.clone(),
     )
     .err();
+    let services = base_services.with_trace_sink(Arc::new(NativeAgentRunTraceSink {
+        workspace_root: workspace_root.clone(),
+        config_snapshot: config_snapshot.clone(),
+    }));
     let mut result =
         run_native_agent_turn_with_config(&services, runtime_spec, config_snapshot.clone())?;
     if let Err(error) = persist_native_agent_run_record(
@@ -6901,14 +6942,21 @@ mod tests {
             assert_eq!(persisted["eventId"], emitted["eventId"]);
         }
         assert_eq!(trace_events[0]["schemaVersion"], "tinybot.agent_event.v1");
-        assert_eq!(trace_events[0]["eventName"], "agent.turn.started");
+        assert_eq!(trace_events[0]["eventName"], "agent.phase.changed");
         assert_eq!(trace_events[0]["sequence"], 1);
+        assert_eq!(trace_events[0]["payload"]["nextPhase"], "hydrating_history");
+        assert_eq!(trace_events[1]["eventName"], "agent.phase.changed");
+        assert_eq!(trace_events[1]["payload"]["nextPhase"], "planning");
+        let turn_started = trace_events
+            .iter()
+            .find(|event| event["eventName"] == "agent.turn.started")
+            .expect("turn started trace event should persist");
         assert_eq!(
-            trace_events[0]["payload"]["userMessageId"],
+            turn_started["payload"]["userMessageId"],
             "user-read-answer"
         );
         assert_eq!(
-            trace_events[0]["payload"]["userMessage"]["content"],
+            turn_started["payload"]["userMessage"]["content"],
             "read and answer"
         );
         assert!(trace_events.iter().any(|event| {
@@ -6983,6 +7031,67 @@ mod tests {
         assert_eq!(
             run["pendingToolCalls"][0]["toolCallId"],
             "approval-waiting-persist"
+        );
+    }
+
+    #[test]
+    fn native_agent_trace_sink_updates_runtime_state_before_final_persistence() {
+        let fixture = WorkspaceFixture::new();
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+        let config = serde_json::json!({});
+        let session_id = "websocket:chat-trace-sink";
+        let run_id = "run-trace-sink";
+        let spec = serde_json::json!({
+            "runtime": "rust",
+            "runId": run_id,
+            "sessionId": session_id,
+        });
+        persist_native_agent_run_start(spec, fixture.root.clone(), config.clone())
+            .expect("run start should persist");
+        let mut emitter = crate::agent_loop_runtime_protocol::AgentRunEmitter::new(
+            session_id,
+            run_id,
+        );
+        let event = emitter.awaiting_approval(
+            "unix-ms:1",
+            "approval-trace-sink",
+            serde_json::json!({
+                "toolName": "workspace.write_file",
+                "summary": "Approval required: workspace.write_file",
+            }),
+        );
+        let sink = NativeAgentRunTraceSink {
+            workspace_root: fixture.root.clone(),
+            config_snapshot: config.clone(),
+        };
+
+        sink.append_trace_event(session_id, run_id, &event)
+            .expect("trace sink should append event");
+        let runtime_state = worker_agent_run_runtime_state_with_options(
+            &shared,
+            session_id.to_string(),
+            run_id.to_string(),
+            fixture.root.clone(),
+            config,
+            Duration::from_millis(10),
+        )
+        .expect("runtime state should read appended trace event");
+
+        assert!(runtime_state["runtimeEvents"]
+            .as_array()
+            .expect("runtime events should be an array")
+            .iter()
+            .any(|event| event["eventName"] == "agent.awaiting_approval"));
+        let approval_item = runtime_state["turnItems"]
+            .as_array()
+            .expect("turn items should be an array")
+            .iter()
+            .find(|item| item["kind"] == "approval_request")
+            .expect("approval request item should be restored");
+        assert_eq!(approval_item["status"], "waiting");
+        assert_eq!(
+            approval_item["payload"]["approvalId"],
+            "approval-trace-sink"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6345,7 +6345,8 @@ mod tests {
         assert_eq!(result["finalContent"], "rust fixture answer");
         assert_eq!(result["events"][0]["eventName"], "agent.delta");
         assert_eq!(result["events"][1]["eventName"], "agent.usage");
-        assert_eq!(result["events"][2]["eventName"], "agent.done");
+        assert_eq!(result["events"][2]["eventName"], "agent.message.completed");
+        assert_eq!(result["events"][3]["eventName"], "agent.done");
         assert_eq!(
             lock_runtime(&shared).experimental_worker.status().state,
             WorkerManagerState::Stopped
@@ -7306,7 +7307,7 @@ mod tests {
         let serialized = run.to_string();
 
         assert!(
-            serialized.len() < large_output.len(),
+            serialized.len() < large_output.len() + 2_000,
             "run record was {} bytes",
             serialized.len()
         );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,10 @@ pub mod worker_subagent_manager;
 pub mod worker_task;
 pub mod worker_workspace;
 
+use crate::agent_loop_runtime_protocol::{
+    AgentRuntimeEventAppendInput, AgentRuntimeEventAppender, AgentRuntimeEventEnvelope,
+    AgentRuntimeEventSource, AgentRuntimeEventVisibility, AgentRuntimePhase,
+};
 use crate::config_store::{
     ConfigEditorSnapshot, ConfigOperationRequest, ConfigPatchApplyResult, ConfigPatchBridgeResult,
     ConfigStore,
@@ -61,10 +65,6 @@ use crate::desktop_gateway::{
 use crate::desktop_logging::append_native_backend_log_line;
 use crate::desktop_menu::{
     install_desktop_application_menu, is_desktop_menu_command, DesktopMenuCommandPayload,
-};
-use crate::agent_loop_runtime_protocol::{
-    AgentRuntimeEventAppendInput, AgentRuntimeEventAppender, AgentRuntimeEventEnvelope,
-    AgentRuntimeEventSource, AgentRuntimeEventVisibility, AgentRuntimePhase,
 };
 use crate::native_backend_contract::{
     webui_route_inventory_entry, NativeCompatibilityFallbackDiagnostic,
@@ -1998,7 +1998,10 @@ fn native_agent_runtime_trace_events(
                 timestamp,
                 event_name,
             );
-            let payload = event.get("payload").cloned().unwrap_or(serde_json::Value::Null);
+            let payload = event
+                .get("payload")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
             trace_events.push(native_agent_persisted_runtime_event(
                 appender.append_legacy_native_event(
                     event_name,
@@ -2043,9 +2046,7 @@ fn native_agent_push_phase_transition(
     *current_phase = next_phase;
 }
 
-fn native_agent_persisted_runtime_event(
-    event: AgentRuntimeEventEnvelope,
-) -> serde_json::Value {
+fn native_agent_persisted_runtime_event(event: AgentRuntimeEventEnvelope) -> serde_json::Value {
     let value = serde_json::to_value(event).unwrap_or_else(|error| {
         serde_json::json!({
             "schemaVersion": crate::agent_loop_runtime_protocol::AGENT_RUNTIME_EVENT_SCHEMA_VERSION,
@@ -2059,18 +2060,16 @@ fn native_agent_persisted_runtime_event(
 }
 
 fn native_agent_trace_event_item_id(event: &serde_json::Value) -> Option<String> {
-    event
-        .get("payload")
-        .and_then(|payload| {
-            native_agent_string_field(payload, "toolCallId")
-                .or_else(|| native_agent_string_field(payload, "tool_call_id"))
-                .or_else(|| native_agent_string_field(payload, "approvalId"))
-                .or_else(|| native_agent_string_field(payload, "approval_id"))
-                .or_else(|| native_agent_string_field(payload, "formId"))
-                .or_else(|| native_agent_string_field(payload, "form_id"))
-                .or_else(|| native_agent_string_field(payload, "delegateId"))
-                .or_else(|| native_agent_string_field(payload, "delegate_id"))
-        })
+    event.get("payload").and_then(|payload| {
+        native_agent_string_field(payload, "toolCallId")
+            .or_else(|| native_agent_string_field(payload, "tool_call_id"))
+            .or_else(|| native_agent_string_field(payload, "approvalId"))
+            .or_else(|| native_agent_string_field(payload, "approval_id"))
+            .or_else(|| native_agent_string_field(payload, "formId"))
+            .or_else(|| native_agent_string_field(payload, "form_id"))
+            .or_else(|| native_agent_string_field(payload, "delegateId"))
+            .or_else(|| native_agent_string_field(payload, "delegate_id"))
+    })
 }
 
 fn native_agent_persisted_trace_values(values: &[serde_json::Value]) -> Vec<serde_json::Value> {
@@ -6783,7 +6782,10 @@ mod tests {
             .expect("recall provider calls lock should not be poisoned");
         let recall_messages = calls.get(2).expect("third provider call should exist");
 
-        assert_eq!(recalled["finalContent"], "You previously said apple and banana.");
+        assert_eq!(
+            recalled["finalContent"],
+            "You previously said apple and banana."
+        );
         assert_eq!(recall_messages.len(), 5);
         assert_eq!(recall_messages[0]["content"], "I said apple");
         assert_eq!(recall_messages[1]["content"], "stored apple");
@@ -6951,10 +6953,7 @@ mod tests {
             .iter()
             .find(|event| event["eventName"] == "agent.turn.started")
             .expect("turn started trace event should persist");
-        assert_eq!(
-            turn_started["payload"]["userMessageId"],
-            "user-read-answer"
-        );
+        assert_eq!(turn_started["payload"]["userMessageId"], "user-read-answer");
         assert_eq!(
             turn_started["payload"]["userMessage"]["content"],
             "read and answer"
@@ -6977,7 +6976,9 @@ mod tests {
         assert_eq!(tool_result["schemaVersion"], "tinybot.agent_event.v1");
         assert_eq!(tool_result["itemId"], "call-run-trace");
         assert_eq!(tool_result["phase"], "tool_running");
-        assert!(tool_result["sequence"].as_u64().is_some_and(|value| value > 1));
+        assert!(tool_result["sequence"]
+            .as_u64()
+            .is_some_and(|value| value > 1));
         assert!(trace_events.iter().any(|event| {
             event["eventName"] == "agent.phase.changed"
                 && event["payload"]["nextPhase"] == "finalizing"
@@ -7048,10 +7049,8 @@ mod tests {
         });
         persist_native_agent_run_start(spec, fixture.root.clone(), config.clone())
             .expect("run start should persist");
-        let mut emitter = crate::agent_loop_runtime_protocol::AgentRunEmitter::new(
-            session_id,
-            run_id,
-        );
+        let mut emitter =
+            crate::agent_loop_runtime_protocol::AgentRunEmitter::new(session_id, run_id);
         let event = emitter.awaiting_approval(
             "unix-ms:1",
             "approval-trace-sink",
@@ -7774,10 +7773,7 @@ mod tests {
         );
         assert_eq!(approval_resolution["body"]["ok"], true);
         assert_eq!(approval_resolution["body"]["status"], "denied");
-        assert_eq!(
-            approval_resolution["body"]["stopReason"],
-            "provider_error"
-        );
+        assert_eq!(approval_resolution["body"]["stopReason"], "provider_error");
         assert!(approval_resolution["body"]["error"]
             .as_str()
             .unwrap_or_default()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1883,6 +1883,14 @@ fn native_agent_runtime_trace_events(
     run_id: &str,
     timestamp: &str,
 ) -> Vec<serde_json::Value> {
+    if let Some(runtime_events) = result
+        .get("runtimeEvents")
+        .and_then(serde_json::Value::as_array)
+        .filter(|events| !events.is_empty())
+    {
+        return native_agent_persisted_trace_values(runtime_events);
+    }
+
     let mut appender = AgentRuntimeEventAppender::new(session_id, run_id);
     let user_message = native_agent_current_user_message(spec);
     let user_message_id = user_message.as_ref().and_then(native_agent_message_id);
@@ -6885,21 +6893,24 @@ mod tests {
         let trace_events = run["traceEvents"]
             .as_array()
             .expect("trace events should be an array");
+        let result_runtime_events = result["runtimeEvents"]
+            .as_array()
+            .expect("runtime events should be returned");
+        assert_eq!(trace_events.len(), result_runtime_events.len());
+        for (persisted, emitted) in trace_events.iter().zip(result_runtime_events) {
+            assert_eq!(persisted["eventId"], emitted["eventId"]);
+        }
         assert_eq!(trace_events[0]["schemaVersion"], "tinybot.agent_event.v1");
         assert_eq!(trace_events[0]["eventName"], "agent.turn.started");
         assert_eq!(trace_events[0]["sequence"], 1);
         assert_eq!(
-            trace_events[0]["payload"]["userMessage"]["messageId"],
+            trace_events[0]["payload"]["userMessageId"],
             "user-read-answer"
         );
         assert_eq!(
             trace_events[0]["payload"]["userMessage"]["content"],
             "read and answer"
         );
-        assert!(trace_events.iter().any(|event| {
-            event["eventName"] == "agent.phase.changed"
-                && event["payload"]["nextPhase"] == "hydrating_history"
-        }));
         assert!(trace_events.iter().any(|event| {
             event["eventName"] == "agent.phase.changed"
                 && event["payload"]["nextPhase"] == "calling_model"

--- a/src-tauri/src/native_provider_runtime.rs
+++ b/src-tauri/src/native_provider_runtime.rs
@@ -85,7 +85,6 @@ const PROVIDER_CATALOG: &[NativeProviderCatalogEntry] = &[
             "gpt-5.4-mini",
             "gpt-5.4-nano",
             "gpt-5-mini",
-            "gpt-5.3-codex",
             "gpt-4.1",
             "gpt-4o",
             "gpt-4o-mini",

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -3153,7 +3153,18 @@ fn cancelled_run_result(
         &context.run_id,
         &runtime_events,
     );
-    runtime_events.push(emitter.cancelled(runtime_event_timestamp(), "cancelled"));
+    runtime_events.push(emitter.cancelled_with_payload(
+        runtime_event_timestamp(),
+        "cancelled",
+        serde_json::json!({
+            "runId": context.run_id,
+            "sessionId": context.session_id,
+            "iteration": iteration,
+            "cancelled": true,
+            "stopReason": "cancelled",
+            "error": "cancelled",
+        }),
+    ));
     let events = legacy_result_events_from_runtime_events(&runtime_events);
     serde_json::json!({
         "runtime": "rust",
@@ -4521,6 +4532,24 @@ mod tests {
             event_names(&result),
             vec!["agent.tool_call.delta", "agent.cancelled"]
         );
+        let cancelled_event = result["events"]
+            .as_array()
+            .expect("events should be an array")
+            .last()
+            .expect("cancelled event should be present");
+        assert_eq!(cancelled_event["eventName"], "agent.cancelled");
+        assert_eq!(
+            cancelled_event["payload"]["runId"],
+            "run-cancel-before-tool"
+        );
+        assert_eq!(
+            cancelled_event["payload"]["sessionId"],
+            "websocket:chat-cancel-before-tool"
+        );
+        assert_eq!(cancelled_event["payload"]["iteration"], 0);
+        assert_eq!(cancelled_event["payload"]["cancelled"], true);
+        assert_eq!(cancelled_event["payload"]["stopReason"], "cancelled");
+        assert_eq!(cancelled_event["payload"]["error"], "cancelled");
         assert!(result["runtimeEvents"]
             .as_array()
             .unwrap()

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -86,6 +86,8 @@ pub struct NativeAgentRunContext {
 
 #[derive(Clone, Debug)]
 struct NativeAgentRunState {
+    run_id: String,
+    session_id: String,
     phase: AgentRuntimePhase,
     iteration: i64,
     max_iterations: i64,
@@ -102,6 +104,8 @@ struct NativeAgentRunState {
 impl NativeAgentRunState {
     fn new(context: &NativeAgentRunContext) -> Self {
         Self {
+            run_id: context.run_id.clone(),
+            session_id: context.session_id.clone(),
             phase: AgentRuntimePhase::Planning,
             iteration: 0,
             max_iterations: context.max_iterations,
@@ -116,9 +120,36 @@ impl NativeAgentRunState {
         }
     }
 
-    fn set_phase(&mut self, phase: AgentRuntimePhase, iteration: i64) {
-        self.phase = phase;
+    fn transition_phase(
+        &mut self,
+        phase: AgentRuntimePhase,
+        iteration: i64,
+        trigger_event_name: &str,
+    ) {
+        let previous_phase = self.phase.clone();
         self.iteration = iteration;
+        if previous_phase == phase {
+            self.phase = phase;
+            return;
+        }
+        self.phase = phase.clone();
+        self.emitter.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.phase.changed".to_string(),
+            phase,
+            timestamp: runtime_event_timestamp(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::Debug,
+            payload: serde_json::json!({
+                "runId": self.run_id,
+                "sessionId": self.session_id,
+                "iteration": iteration,
+                "previousPhase": previous_phase.as_str(),
+                "nextPhase": self.phase.as_str(),
+                "triggerEventName": trigger_event_name,
+            }),
+        });
     }
 
     fn set_stop_reason(&mut self, stop_reason: &str) {
@@ -1304,7 +1335,7 @@ pub fn run_native_agent_turn_with_config(
     let mut state = NativeAgentRunState::new(&context);
     state.emit_turn_started(&context);
     for iteration in 0..context.max_iterations {
-        state.set_phase(AgentRuntimePhase::CallingModel, iteration);
+        state.transition_phase(AgentRuntimePhase::CallingModel, iteration, "provider_call");
         if services.cancellations.is_cancelled(&context.run_id) {
             state.phase = AgentRuntimePhase::Cancelled;
             return Ok(cancelled_run_result(
@@ -1360,7 +1391,11 @@ pub fn run_native_agent_turn_with_config(
         let current_phase = state.phase.as_str().to_string();
         maybe_emit_checkpoint(services, &context, &mut state, &current_phase);
         if let Some(reasoning_delta) = provider_response.reasoning_delta.clone() {
-            state.set_phase(AgentRuntimePhase::StreamingModel, iteration);
+            state.transition_phase(
+                AgentRuntimePhase::StreamingModel,
+                iteration,
+                "agent.reasoning_delta",
+            );
             state.emit_event(
                 "agent.reasoning_delta",
                 serde_json::json!({
@@ -1372,7 +1407,7 @@ pub fn run_native_agent_turn_with_config(
             );
         }
         if context.stream && !provider_response.final_content.is_empty() {
-            state.set_phase(AgentRuntimePhase::StreamingModel, iteration);
+            state.transition_phase(AgentRuntimePhase::StreamingModel, iteration, "agent.delta");
             state.emit_event(
                 "agent.delta",
                 serde_json::json!({
@@ -1386,7 +1421,11 @@ pub fn run_native_agent_turn_with_config(
 
         if !provider_response.tool_calls.is_empty() {
             let tool_calls = provider_response.tool_calls;
-            state.set_phase(AgentRuntimePhase::ToolCalling, iteration);
+            state.transition_phase(
+                AgentRuntimePhase::ToolCalling,
+                iteration,
+                "agent.tool_call.delta",
+            );
             state.messages.push(assistant_tool_calls_message(
                 &provider_response.final_content,
                 &tool_calls,
@@ -1450,6 +1489,7 @@ pub fn run_native_agent_turn_with_config(
                     ));
                 }
                 state.tools_used.push(tool_call.name.clone());
+                state.transition_phase(AgentRuntimePhase::ToolRunning, iteration, "agent.tool.start");
                 state.emit_event(
                     "agent.tool.start",
                     serde_json::json!({
@@ -1557,7 +1597,7 @@ pub fn run_native_agent_turn_with_config(
                 }
                 state.completed_tool_results.push(completed_result);
                 state.clear_pending_tool_calls();
-                state.set_phase(AgentRuntimePhase::Planning, iteration);
+                state.transition_phase(AgentRuntimePhase::Planning, iteration, "agent.tool.result");
                 save_phase_checkpoint(
                     services,
                     &context,
@@ -3038,7 +3078,9 @@ fn legacy_result_events_from_runtime_events(
 ) -> Vec<NativeAgentEvent> {
     project_legacy_native_agent_events(runtime_events)
         .into_iter()
-        .filter(|event| event.event_name != "agent.turn.started")
+        .filter(|event| {
+            event.event_name != "agent.turn.started" && event.event_name != "agent.phase.changed"
+        })
         .map(NativeAgentEvent::from)
         .collect()
 }
@@ -3249,6 +3291,24 @@ mod tests {
             result["runtimeEvents"][0]["payload"]["userMessageId"],
             "run-1:user"
         );
+        assert!(result["runtimeEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| event["eventName"] == "agent.phase.changed"
+                && event["payload"]["previousPhase"] == "planning"
+                && event["payload"]["nextPhase"] == "calling_model"
+                && event["payload"]["triggerEventName"] == "provider_call"));
+        assert_eq!(
+            result["runtimeEvents"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|event| event["eventName"] == "agent.phase.changed"
+                    && event["payload"]["nextPhase"] == "streaming_model")
+                .count(),
+            1
+        );
         assert_eq!(result["events"][0]["eventName"], "agent.delta");
         assert_eq!(result["events"][1]["eventName"], "agent.usage");
         assert_eq!(result["events"][2]["eventName"], "agent.message.completed");
@@ -3296,6 +3356,15 @@ mod tests {
         .expect("fixture tool run should succeed");
 
         let event_names = event_names(&result);
+        let runtime_event_names = runtime_event_names(&result);
+        assert!(runtime_event_names
+            .windows(2)
+            .any(|pair| pair == ["agent.phase.changed", "agent.tool_call.delta"]));
+        assert!(result["runtimeEvents"].as_array().unwrap().iter().any(|event| {
+            event["eventName"] == "agent.phase.changed"
+                && event["payload"]["nextPhase"] == "tool_running"
+                && event["payload"]["triggerEventName"] == "agent.tool.start"
+        }));
         assert_eq!(
             &event_names[..3],
             &[
@@ -5402,6 +5471,15 @@ mod tests {
         result["events"]
             .as_array()
             .expect("events should be an array")
+            .iter()
+            .map(|event| event["eventName"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>()
+    }
+
+    fn runtime_event_names(result: &Value) -> Vec<&str> {
+        result["runtimeEvents"]
+            .as_array()
+            .expect("runtimeEvents should be an array")
             .iter()
             .map(|event| event["eventName"].as_str().unwrap_or_default())
             .collect::<Vec<_>>()

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -1,6 +1,8 @@
 use crate::agent_loop_runtime_protocol::{
-    AgentApprovalDecision, AgentApprovalScope, AgentContinuationInput, AgentFormAction,
-    AgentRuntimePhase,
+    project_legacy_native_agent_events, AgentApprovalDecision, AgentApprovalScope,
+    AgentContinuationInput, AgentFormAction, AgentRunEmitter, AgentRuntimeEventAppendInput,
+    AgentRuntimeEventEnvelope, AgentRuntimeEventSource, AgentRuntimeEventVisibility,
+    AgentRuntimePhase, LegacyNativeAgentEventProjection,
 };
 use crate::worker_subagent_manager::{
     SubagentInputSender, SubagentSendInputParams, SubagentSpawnParams, SubagentTargetParams,
@@ -58,6 +60,15 @@ pub struct NativeAgentEvent {
     pub payload: Value,
 }
 
+impl From<LegacyNativeAgentEventProjection> for NativeAgentEvent {
+    fn from(event: LegacyNativeAgentEventProjection) -> Self {
+        Self {
+            event_name: event.event_name,
+            payload: event.payload,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct NativeAgentRunContext {
     pub run_id: String,
@@ -81,7 +92,7 @@ struct NativeAgentRunState {
     pending_tool_calls: Vec<Value>,
     completed_tool_results: Vec<Value>,
     messages: Vec<Value>,
-    events: Vec<NativeAgentEvent>,
+    emitter: AgentRunEmitter,
     usage: Vec<Value>,
     tools_used: Vec<String>,
     stop_reason: Option<String>,
@@ -97,7 +108,7 @@ impl NativeAgentRunState {
             pending_tool_calls: Vec::new(),
             completed_tool_results: Vec::new(),
             messages: context.messages.clone(),
-            events: Vec::new(),
+            emitter: AgentRunEmitter::new(&context.session_id, &context.run_id),
             usage: Vec::new(),
             tools_used: Vec::new(),
             stop_reason: None,
@@ -141,6 +152,65 @@ impl NativeAgentRunState {
 
     fn clear_pending_tool_calls(&mut self) {
         self.pending_tool_calls.clear();
+    }
+
+    fn emit_event(&mut self, event_name: &str, payload: Value) {
+        self.emitter.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: runtime_event_item_id(event_name, &payload),
+            event_name: event_name.to_string(),
+            phase: AgentRuntimePhase::for_legacy_event(event_name),
+            timestamp: runtime_event_timestamp(),
+            source: runtime_event_source(event_name),
+            visibility: runtime_event_visibility(event_name),
+            payload,
+        });
+    }
+
+    fn emit_native_event(&mut self, event: NativeAgentEvent) {
+        self.emit_event(&event.event_name, event.payload);
+    }
+
+    fn emit_turn_started(&mut self, context: &NativeAgentRunContext) {
+        let current = current_user_message(&context.messages);
+        let message_id = current
+            .as_ref()
+            .and_then(|message| string_field(message, "messageId"))
+            .or_else(|| {
+                current
+                    .as_ref()
+                    .and_then(|message| string_field(message, "message_id"))
+            })
+            .or_else(|| {
+                current
+                    .as_ref()
+                    .and_then(|message| string_field(message, "id"))
+            })
+            .unwrap_or_else(|| format!("{}:user", context.run_id));
+        let content = current
+            .as_ref()
+            .and_then(|message| {
+                message
+                    .get("content")
+                    .or_else(|| message.get("text"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .unwrap_or_default();
+        self.emitter
+            .user_turn_started(runtime_event_timestamp(), Some(message_id), content);
+    }
+
+    fn runtime_events(&self) -> Vec<AgentRuntimeEventEnvelope> {
+        self.emitter.events().to_vec()
+    }
+
+    fn legacy_events(&self) -> Vec<NativeAgentEvent> {
+        legacy_result_events_from_runtime_events(self.emitter.events())
+    }
+
+    fn take_runtime_events(&mut self) -> Vec<AgentRuntimeEventEnvelope> {
+        self.emitter.take_events()
     }
 
     fn drain_pending_guidance(&mut self) -> Option<Value> {
@@ -1232,6 +1302,7 @@ pub fn run_native_agent_turn_with_config(
     }
 
     let mut state = NativeAgentRunState::new(&context);
+    state.emit_turn_started(&context);
     for iteration in 0..context.max_iterations {
         state.set_phase(AgentRuntimePhase::CallingModel, iteration);
         if services.cancellations.is_cancelled(&context.run_id) {
@@ -1239,7 +1310,7 @@ pub fn run_native_agent_turn_with_config(
             return Ok(cancelled_run_result(
                 services,
                 &context,
-                std::mem::take(&mut state.events),
+                state.take_runtime_events(),
                 std::mem::take(&mut state.tools_used),
                 std::mem::take(&mut state.completed_tool_results),
                 iteration,
@@ -1257,7 +1328,7 @@ pub fn run_native_agent_turn_with_config(
             Ok(response) => response,
             Err(error) => {
                 state.set_stop_reason("provider_error");
-                state.events.push(event(
+                state.emit_event(
                     "agent.error",
                     serde_json::json!({
                         "runId": context.run_id,
@@ -1267,7 +1338,9 @@ pub fn run_native_agent_turn_with_config(
                         "message": error,
                         "error": error,
                     }),
-                ));
+                );
+                let runtime_events = state.runtime_events();
+                let events = state.legacy_events();
                 return Ok(serde_json::json!({
                     "runtime": "rust",
                     "runId": context.run_id,
@@ -1278,15 +1351,17 @@ pub fn run_native_agent_turn_with_config(
                     "toolsUsed": state.tools_used,
                     "completedToolResults": state.completed_tool_results,
                     "error": error,
-                    "events": state.events,
+                    "events": events,
+                    "runtimeEvents": runtime_events,
                 }));
             }
         };
 
-        maybe_emit_checkpoint(services, &context, &mut state.events, state.phase.as_str());
+        let current_phase = state.phase.as_str().to_string();
+        maybe_emit_checkpoint(services, &context, &mut state, &current_phase);
         if let Some(reasoning_delta) = provider_response.reasoning_delta.clone() {
             state.set_phase(AgentRuntimePhase::StreamingModel, iteration);
-            state.events.push(event(
+            state.emit_event(
                 "agent.reasoning_delta",
                 serde_json::json!({
                     "runId": context.run_id,
@@ -1294,11 +1369,11 @@ pub fn run_native_agent_turn_with_config(
                     "iteration": iteration,
                     "delta": reasoning_delta,
                 }),
-            ));
+            );
         }
         if context.stream && !provider_response.final_content.is_empty() {
             state.set_phase(AgentRuntimePhase::StreamingModel, iteration);
-            state.events.push(event(
+            state.emit_event(
                 "agent.delta",
                 serde_json::json!({
                     "runId": context.run_id,
@@ -1306,7 +1381,7 @@ pub fn run_native_agent_turn_with_config(
                     "iteration": iteration,
                     "delta": provider_response.final_content,
                 }),
-            ));
+            );
         }
 
         if !provider_response.tool_calls.is_empty() {
@@ -1317,7 +1392,7 @@ pub fn run_native_agent_turn_with_config(
                 &tool_calls,
             ));
             for tool_call in tool_calls {
-                state.events.push(event(
+                state.emit_event(
                     "agent.tool_call.delta",
                     serde_json::json!({
                         "runId": context.run_id,
@@ -1328,10 +1403,10 @@ pub fn run_native_agent_turn_with_config(
                         "name": tool_call.name,
                         "argumentsDelta": tool_call.arguments_json,
                     }),
-                ));
+                );
                 if !native_tool_is_permitted(&tool_call.name) {
                     state.set_stop_reason("policy_denied");
-                    state.events.push(event(
+                    state.emit_event(
                         "agent.error",
                         serde_json::json!({
                             "runId": context.run_id,
@@ -1343,10 +1418,12 @@ pub fn run_native_agent_turn_with_config(
                             "toolName": tool_call.name,
                             "name": tool_call.name,
                         }),
-                    ));
+                    );
                     services
                         .checkpoints
                         .clear_for_run(&context.session_id, &context.run_id);
+                    let runtime_events = state.runtime_events();
+                    let events = state.legacy_events();
                     return Ok(serde_json::json!({
                         "runtime": "rust",
                         "runId": context.run_id,
@@ -1357,7 +1434,8 @@ pub fn run_native_agent_turn_with_config(
                         "toolsUsed": state.tools_used,
                         "completedToolResults": state.completed_tool_results,
                         "error": format!("native tool `{}` is not permitted by Rust capability policy", tool_call.name),
-                        "events": state.events,
+                        "events": events,
+                        "runtimeEvents": runtime_events,
                     }));
                 }
                 if services.cancellations.is_cancelled(&context.run_id) {
@@ -1365,14 +1443,14 @@ pub fn run_native_agent_turn_with_config(
                     return Ok(cancelled_run_result(
                         services,
                         &context,
-                        std::mem::take(&mut state.events),
+                        state.take_runtime_events(),
                         std::mem::take(&mut state.tools_used),
                         std::mem::take(&mut state.completed_tool_results),
                         iteration,
                     ));
                 }
                 state.tools_used.push(tool_call.name.clone());
-                state.events.push(event(
+                state.emit_event(
                     "agent.tool.start",
                     serde_json::json!({
                         "runId": context.run_id,
@@ -1384,7 +1462,7 @@ pub fn run_native_agent_turn_with_config(
                         "detailId": format!("tool:{}", tool_call.id),
                         "status": "running",
                     }),
-                ));
+                );
                 state.set_pending_tool_call(&tool_call);
                 save_phase_checkpoint(
                     services,
@@ -1403,7 +1481,7 @@ pub fn run_native_agent_turn_with_config(
                     Ok(result) => result,
                     Err(error) => {
                         state.set_stop_reason("tool_error");
-                        state.events.push(event(
+                        state.emit_event(
                             "agent.error",
                             serde_json::json!({
                                 "runId": context.run_id,
@@ -1415,10 +1493,12 @@ pub fn run_native_agent_turn_with_config(
                                 "toolName": tool_call.name,
                                 "name": tool_call.name,
                             }),
-                        ));
+                        );
                         services
                             .checkpoints
                             .clear_for_run(&context.session_id, &context.run_id);
+                        let runtime_events = state.runtime_events();
+                        let events = state.legacy_events();
                         return Ok(serde_json::json!({
                             "runtime": "rust",
                             "runId": context.run_id,
@@ -1429,7 +1509,8 @@ pub fn run_native_agent_turn_with_config(
                             "toolsUsed": state.tools_used,
                             "completedToolResults": state.completed_tool_results,
                             "error": error,
-                            "events": state.events,
+                            "events": events,
+                            "runtimeEvents": runtime_events,
                         }));
                     }
                 };
@@ -1439,7 +1520,7 @@ pub fn run_native_agent_turn_with_config(
                 state
                     .messages
                     .push(tool_observation_message(&tool_call, &observation_content));
-                state.events.push(event(
+                state.emit_event(
                     "agent.tool.result",
                     serde_json::json!({
                         "runId": context.run_id,
@@ -1463,15 +1544,17 @@ pub fn run_native_agent_turn_with_config(
                         "content": observation_content,
                         "envelope": result.envelope.clone(),
                     }),
-                ));
+                );
                 if let Some(link_event) =
                     subagent_link_event_from_tool_result(&context, &tool_call, &result)
                 {
-                    state.events.push(link_event);
+                    state.emit_native_event(link_event);
                 }
-                state.events.extend(subagent_activity_events_from_tool_result(
-                    &context, &tool_call, &result,
-                ));
+                for event in
+                    subagent_activity_events_from_tool_result(&context, &tool_call, &result)
+                {
+                    state.emit_native_event(event);
+                }
                 state.completed_tool_results.push(completed_result);
                 state.clear_pending_tool_calls();
                 state.set_phase(AgentRuntimePhase::Planning, iteration);
@@ -1486,7 +1569,7 @@ pub fn run_native_agent_turn_with_config(
                     return Ok(cancelled_run_result(
                         services,
                         &context,
-                        std::mem::take(&mut state.events),
+                        state.take_runtime_events(),
                         std::mem::take(&mut state.tools_used),
                         std::mem::take(&mut state.completed_tool_results),
                         iteration,
@@ -1495,7 +1578,7 @@ pub fn run_native_agent_turn_with_config(
             }
 
             if let Some(message) = state.drain_pending_guidance() {
-                state.events.push(event(
+                state.emit_event(
                     "agent.guidance",
                     serde_json::json!({
                         "runId": context.run_id,
@@ -1503,12 +1586,12 @@ pub fn run_native_agent_turn_with_config(
                         "iteration": iteration,
                         "content": message.get("content").cloned().unwrap_or(Value::Null),
                     }),
-                ));
+                );
             }
 
             if let Some(usage) = provider_response.usage {
                 state.usage.push(usage.clone());
-                state.events.push(event(
+                state.emit_event(
                     "agent.usage",
                     serde_json::json!({
                         "runId": context.run_id,
@@ -1516,7 +1599,7 @@ pub fn run_native_agent_turn_with_config(
                         "iteration": iteration,
                         "usage": usage,
                     }),
-                ));
+                );
             }
             continue;
         }
@@ -1524,7 +1607,7 @@ pub fn run_native_agent_turn_with_config(
         let final_content = provider_response.final_content;
         if let Some(usage) = provider_response.usage {
             state.usage.push(usage.clone());
-            state.events.push(event(
+            state.emit_event(
                 "agent.usage",
                 serde_json::json!({
                     "runId": context.run_id,
@@ -1532,13 +1615,13 @@ pub fn run_native_agent_turn_with_config(
                     "iteration": iteration,
                     "usage": usage,
                 }),
-            ));
+            );
         }
         state.set_stop_reason("final_response");
         services
             .checkpoints
             .clear_for_run(&context.session_id, &context.run_id);
-        state.events.push(event(
+        state.emit_event(
             "agent.message.completed",
             serde_json::json!({
                 "runId": context.run_id,
@@ -1547,8 +1630,8 @@ pub fn run_native_agent_turn_with_config(
                 "messageId": format!("{}:assistant", context.run_id),
                 "content": final_content.clone(),
             }),
-        ));
-        state.events.push(event(
+        );
+        state.emit_event(
             "agent.done",
             serde_json::json!({
                 "runId": context.run_id,
@@ -1556,7 +1639,9 @@ pub fn run_native_agent_turn_with_config(
                 "iteration": iteration,
                 "stopReason": "final_response",
             }),
-        ));
+        );
+        let runtime_events = state.runtime_events();
+        let events = state.legacy_events();
 
         return Ok(serde_json::json!({
             "runtime": "rust",
@@ -1570,13 +1655,14 @@ pub fn run_native_agent_turn_with_config(
             }],
             "toolsUsed": state.tools_used,
             "completedToolResults": state.completed_tool_results,
-            "events": state.events,
+            "events": events,
+            "runtimeEvents": runtime_events,
         }));
     }
 
     let error = "Rust agent runtime reached max iterations before final response.";
     state.set_stop_reason("max_iterations");
-    state.events.push(event(
+    state.emit_event(
         "agent.error",
         serde_json::json!({
             "runId": context.run_id,
@@ -1584,7 +1670,9 @@ pub fn run_native_agent_turn_with_config(
             "stopReason": "max_iterations",
             "error": error,
         }),
-    ));
+    );
+    let runtime_events = state.runtime_events();
+    let events = state.legacy_events();
     Ok(serde_json::json!({
         "runtime": "rust",
         "runId": context.run_id,
@@ -1595,7 +1683,8 @@ pub fn run_native_agent_turn_with_config(
         "toolsUsed": state.tools_used,
         "completedToolResults": state.completed_tool_results,
         "error": error,
-        "events": state.events,
+        "events": events,
+        "runtimeEvents": runtime_events,
     }))
 }
 
@@ -1711,10 +1800,15 @@ fn subagent_link_event_from_tool_result(
         return None;
     }
     let subagent = raw.get("subagent")?;
-    let subagent_id = string_field(subagent, "subagentId")
-        .or_else(|| raw.get("event").and_then(|event| string_field(event, "delegateId")))?;
+    let subagent_id = string_field(subagent, "subagentId").or_else(|| {
+        raw.get("event")
+            .and_then(|event| string_field(event, "delegateId"))
+    })?;
     let child_run_id = string_field(subagent, "childRunId")
-        .or_else(|| raw.get("event").and_then(|event| string_field(event, "childRunId")))
+        .or_else(|| {
+            raw.get("event")
+                .and_then(|event| string_field(event, "childRunId"))
+        })
         .unwrap_or_else(|| subagent_id.clone());
     Some(event(
         "agent.delegate.linked",
@@ -1749,9 +1843,7 @@ fn subagent_activity_events_from_tool_result(
     };
     let mut events = Vec::new();
     if let Some(background_event) = raw.get("event") {
-        if background_event
-            .get("eventType")
-            .and_then(Value::as_str)
+        if background_event.get("eventType").and_then(Value::as_str)
             != Some("agent.delegate.started")
         {
             if let Some(event) = subagent_background_activity_event(context, background_event) {
@@ -1776,7 +1868,11 @@ fn subagent_activity_events_from_tool_result(
             ));
             if let Some(statuses) = raw.get("statuses").and_then(Value::as_array) {
                 for status in statuses {
-                    if status.get("terminalResult").and_then(Value::as_str).is_some() {
+                    if status
+                        .get("terminalResult")
+                        .and_then(Value::as_str)
+                        .is_some()
+                    {
                         events.push(subagent_status_activity_event(
                             context,
                             "agent.delegate.result",
@@ -1785,8 +1881,13 @@ fn subagent_activity_events_from_tool_result(
                             &tool_call.id,
                         ));
                     }
-                    if status.get("blockerSummary").and_then(Value::as_str).is_some()
-                        || status.get("pendingApproval").is_some_and(|value| !value.is_null())
+                    if status
+                        .get("blockerSummary")
+                        .and_then(Value::as_str)
+                        .is_some()
+                        || status
+                            .get("pendingApproval")
+                            .is_some_and(|value| !value.is_null())
                     {
                         events.push(subagent_status_activity_event(
                             context,
@@ -2763,7 +2864,7 @@ fn form_submit_metadata(context: &NativeAgentRunContext) -> Option<(Value, FormC
 fn maybe_emit_checkpoint(
     services: &NativeAgentRuntimeServices,
     context: &NativeAgentRunContext,
-    events: &mut Vec<NativeAgentEvent>,
+    state: &mut NativeAgentRunState,
     default_phase: &str,
 ) {
     let Some(checkpoint_metadata) = context.metadata.get("fakeCheckpoint") else {
@@ -2775,7 +2876,7 @@ fn maybe_emit_checkpoint(
     services
         .checkpoints
         .save_for_run(&context.session_id, &context.run_id, checkpoint.clone());
-    events.push(event(
+    state.emit_event(
         "agent.checkpoint",
         serde_json::json!({
             "runId": context.run_id,
@@ -2783,7 +2884,7 @@ fn maybe_emit_checkpoint(
             "phase": phase,
             "checkpoint": checkpoint,
         }),
-    ));
+    );
 }
 
 fn checkpoint_value(context: &NativeAgentRunContext, phase: &str, payload: Value) -> Value {
@@ -2886,7 +2987,7 @@ fn cancelled_result(run_id: &str, session_id: &str, checkpoint: Value) -> Value 
 fn cancelled_run_result(
     services: &NativeAgentRuntimeServices,
     context: &NativeAgentRunContext,
-    mut events: Vec<NativeAgentEvent>,
+    mut runtime_events: Vec<AgentRuntimeEventEnvelope>,
     tools_used: Vec<String>,
     completed_tool_results: Vec<Value>,
     iteration: i64,
@@ -2902,17 +3003,13 @@ fn cancelled_run_result(
             "stopReason": "cancelled",
         }),
     );
-    events.push(event(
-        "agent.cancelled",
-        serde_json::json!({
-            "runId": context.run_id,
-            "sessionId": context.session_id,
-            "iteration": iteration,
-            "cancelled": true,
-            "stopReason": "cancelled",
-            "error": "cancelled",
-        }),
-    ));
+    let mut emitter = AgentRunEmitter::from_existing_events(
+        &context.session_id,
+        &context.run_id,
+        &runtime_events,
+    );
+    runtime_events.push(emitter.cancelled(runtime_event_timestamp(), "cancelled"));
+    let events = legacy_result_events_from_runtime_events(&runtime_events);
     serde_json::json!({
         "runtime": "rust",
         "runId": context.run_id,
@@ -2925,6 +3022,7 @@ fn cancelled_run_result(
         "error": "cancelled",
         "checkpoint": checkpoint,
         "events": events,
+        "runtimeEvents": runtime_events,
     })
 }
 
@@ -2933,6 +3031,82 @@ fn event(event_name: &str, payload: Value) -> NativeAgentEvent {
         event_name: event_name.to_string(),
         payload,
     }
+}
+
+fn legacy_result_events_from_runtime_events(
+    runtime_events: &[AgentRuntimeEventEnvelope],
+) -> Vec<NativeAgentEvent> {
+    project_legacy_native_agent_events(runtime_events)
+        .into_iter()
+        .filter(|event| event.event_name != "agent.turn.started")
+        .map(NativeAgentEvent::from)
+        .collect()
+}
+
+fn runtime_event_timestamp() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().to_string())
+        .unwrap_or_else(|_| "0".to_string())
+}
+
+fn runtime_event_item_id(event_name: &str, payload: &Value) -> Option<String> {
+    match event_name {
+        "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" => {
+            string_field(payload, "toolCallId")
+                .or_else(|| string_field(payload, "tool_call_id"))
+                .or_else(|| string_field(payload, "id"))
+        }
+        "agent.awaiting_approval" | "agent.approval.decision" => {
+            string_field(payload, "approvalId").or_else(|| string_field(payload, "approval_id"))
+        }
+        "agent.awaiting_form" | "agent.form.resolution" => {
+            string_field(payload, "formId").or_else(|| string_field(payload, "form_id"))
+        }
+        _ if event_name.starts_with("agent.delegate.") => {
+            string_field(payload, "delegateId").or_else(|| string_field(payload, "delegate_id"))
+        }
+        _ => None,
+    }
+}
+
+fn runtime_event_source(event_name: &str) -> AgentRuntimeEventSource {
+    match event_name {
+        "agent.delta" | "agent.reasoning_delta" | "agent.usage" => {
+            AgentRuntimeEventSource::Provider
+        }
+        "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" => {
+            AgentRuntimeEventSource::Tool
+        }
+        "agent.guidance" | "agent.approval.decision" | "agent.form.resolution" => {
+            AgentRuntimeEventSource::User
+        }
+        _ if event_name.starts_with("agent.delegate.") => AgentRuntimeEventSource::Subagent,
+        _ => AgentRuntimeEventSource::RustBackend,
+    }
+}
+
+fn runtime_event_visibility(event_name: &str) -> AgentRuntimeEventVisibility {
+    match event_name {
+        "agent.checkpoint" | "agent.usage" | "agent.done" | "agent.phase.changed" => {
+            AgentRuntimeEventVisibility::Debug
+        }
+        _ => AgentRuntimeEventVisibility::User,
+    }
+}
+
+fn current_user_message(messages: &[Value]) -> Option<Value> {
+    messages
+        .iter()
+        .rev()
+        .find(|message| {
+            message
+                .get("role")
+                .and_then(Value::as_str)
+                .map(|role| role == "user")
+                .unwrap_or(false)
+        })
+        .cloned()
 }
 
 fn event_value(event_name: &str, payload: Value) -> Value {
@@ -3059,13 +3233,26 @@ mod tests {
 
         assert_eq!(result["runtime"], "rust");
         assert_eq!(result["finalContent"], "fixture answer");
+        assert_eq!(
+            result["runtimeEvents"][0]["schemaVersion"],
+            "tinybot.agent_event.v1"
+        );
+        assert_eq!(
+            result["runtimeEvents"][0]["eventName"],
+            "agent.turn.started"
+        );
+        assert_eq!(
+            result["runtimeEvents"][0]["payload"]["userMessage"]["content"],
+            "hello"
+        );
+        assert_eq!(
+            result["runtimeEvents"][0]["payload"]["userMessageId"],
+            "run-1:user"
+        );
         assert_eq!(result["events"][0]["eventName"], "agent.delta");
         assert_eq!(result["events"][1]["eventName"], "agent.usage");
         assert_eq!(result["events"][2]["eventName"], "agent.message.completed");
-        assert_eq!(
-            result["events"][2]["payload"]["content"],
-            "fixture answer"
-        );
+        assert_eq!(result["events"][2]["payload"]["content"], "fixture answer");
         assert_eq!(result["events"][3]["eventName"], "agent.done");
         assert_eq!(
             result["events"][3]["payload"]["stopReason"],
@@ -4339,8 +4526,8 @@ mod tests {
                         tool_calls: vec![NativeAgentToolCall {
                             id: "call-cancel-wait".to_string(),
                             name: "subagent.wait".to_string(),
-                            arguments_json:
-                                "{\"subagentIds\":[\"wait-child\"],\"timeoutMs\":1}".to_string(),
+                            arguments_json: "{\"subagentIds\":[\"wait-child\"],\"timeoutMs\":1}"
+                                .to_string(),
                             result: Value::Null,
                         }],
                     }),
@@ -4631,7 +4818,10 @@ mod tests {
         .expect("approval checkpoint should be created");
 
         assert_eq!(awaiting["stopReason"], "awaiting_approval");
-        assert_eq!(awaiting["events"][1]["eventName"], "agent.awaiting_approval");
+        assert_eq!(
+            awaiting["events"][1]["eventName"],
+            "agent.awaiting_approval"
+        );
         assert_eq!(awaiting["events"][1]["payload"]["status"], "waiting");
         assert_eq!(
             awaiting["events"][1]["payload"]["detailId"],
@@ -4929,7 +5119,10 @@ mod tests {
         assert_eq!(form["events"][0]["eventName"], "agent.form.resolution");
         assert_eq!(form["events"][0]["payload"]["status"], "completed");
         assert_eq!(form["events"][0]["payload"]["action"], "submit");
-        assert_eq!(form["events"][0]["payload"]["values"]["destination"], "Tokyo");
+        assert_eq!(
+            form["events"][0]["payload"]["values"]["destination"],
+            "Tokyo"
+        );
         assert!(services.restore_checkpoint("websocket:chat-typed-form")["checkpoint"].is_null());
     }
 
@@ -5178,10 +5371,7 @@ mod tests {
             "approval-guidance"
         );
         assert_eq!(seen_messages[0][2]["role"], "tool");
-        assert_eq!(
-            seen_messages[0][2]["tool_call_id"],
-            "approval-guidance"
-        );
+        assert_eq!(seen_messages[0][2]["tool_call_id"], "approval-guidance");
         assert!(seen_messages[0][2]["content"]
             .as_str()
             .expect("tool result content should be text")

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -152,13 +152,14 @@ impl NativeAgentRunState {
         });
     }
 
-    fn set_stop_reason(&mut self, stop_reason: &str) {
+    fn set_stop_reason(&mut self, stop_reason: &str, iteration: i64, trigger_event_name: &str) {
         self.stop_reason = Some(stop_reason.to_string());
-        self.phase = match stop_reason {
+        let phase = match stop_reason {
             "final_response" => AgentRuntimePhase::Completed,
             "cancelled" => AgentRuntimePhase::Cancelled,
             _ => AgentRuntimePhase::Failed,
         };
+        self.transition_phase(phase, iteration, trigger_event_name);
     }
 
     fn active_checkpoint_payload(&self, status: &str) -> Value {
@@ -1337,7 +1338,7 @@ pub fn run_native_agent_turn_with_config(
     for iteration in 0..context.max_iterations {
         state.transition_phase(AgentRuntimePhase::CallingModel, iteration, "provider_call");
         if services.cancellations.is_cancelled(&context.run_id) {
-            state.phase = AgentRuntimePhase::Cancelled;
+            state.transition_phase(AgentRuntimePhase::Cancelled, iteration, "agent.cancelled");
             return Ok(cancelled_run_result(
                 services,
                 &context,
@@ -1358,7 +1359,7 @@ pub fn run_native_agent_turn_with_config(
         let provider_response = match services.provider.complete(&context) {
             Ok(response) => response,
             Err(error) => {
-                state.set_stop_reason("provider_error");
+                state.set_stop_reason("provider_error", iteration, "agent.error");
                 state.emit_event(
                     "agent.error",
                     serde_json::json!({
@@ -1444,7 +1445,7 @@ pub fn run_native_agent_turn_with_config(
                     }),
                 );
                 if !native_tool_is_permitted(&tool_call.name) {
-                    state.set_stop_reason("policy_denied");
+                    state.set_stop_reason("policy_denied", iteration, "agent.error");
                     state.emit_event(
                         "agent.error",
                         serde_json::json!({
@@ -1478,7 +1479,7 @@ pub fn run_native_agent_turn_with_config(
                     }));
                 }
                 if services.cancellations.is_cancelled(&context.run_id) {
-                    state.phase = AgentRuntimePhase::Cancelled;
+                    state.transition_phase(AgentRuntimePhase::Cancelled, iteration, "agent.cancelled");
                     return Ok(cancelled_run_result(
                         services,
                         &context,
@@ -1520,7 +1521,7 @@ pub fn run_native_agent_turn_with_config(
                 let result = match services.tools.dispatch(&context, &tool_call) {
                     Ok(result) => result,
                     Err(error) => {
-                        state.set_stop_reason("tool_error");
+                        state.set_stop_reason("tool_error", iteration, "agent.error");
                         state.emit_event(
                             "agent.error",
                             serde_json::json!({
@@ -1605,7 +1606,7 @@ pub fn run_native_agent_turn_with_config(
                     state.active_checkpoint_payload("tool_completed"),
                 );
                 if services.cancellations.is_cancelled(&context.run_id) {
-                    state.phase = AgentRuntimePhase::Cancelled;
+                    state.transition_phase(AgentRuntimePhase::Cancelled, iteration, "agent.cancelled");
                     return Ok(cancelled_run_result(
                         services,
                         &context,
@@ -1657,7 +1658,7 @@ pub fn run_native_agent_turn_with_config(
                 }),
             );
         }
-        state.set_stop_reason("final_response");
+        state.transition_phase(AgentRuntimePhase::Finalizing, iteration, "agent.message.completed");
         services
             .checkpoints
             .clear_for_run(&context.session_id, &context.run_id);
@@ -1671,6 +1672,7 @@ pub fn run_native_agent_turn_with_config(
                 "content": final_content.clone(),
             }),
         );
+        state.set_stop_reason("final_response", iteration, "agent.done");
         state.emit_event(
             "agent.done",
             serde_json::json!({
@@ -1701,7 +1703,7 @@ pub fn run_native_agent_turn_with_config(
     }
 
     let error = "Rust agent runtime reached max iterations before final response.";
-    state.set_stop_reason("max_iterations");
+    state.set_stop_reason("max_iterations", state.iteration, "agent.error");
     state.emit_event(
         "agent.error",
         serde_json::json!({
@@ -4304,6 +4306,11 @@ mod tests {
             event_names(&result),
             vec!["agent.tool_call.delta", "agent.cancelled"]
         );
+        assert!(result["runtimeEvents"].as_array().unwrap().iter().any(|event| {
+            event["eventName"] == "agent.phase.changed"
+                && event["payload"]["nextPhase"] == "cancelled"
+                && event["payload"]["triggerEventName"] == "agent.cancelled"
+        }));
         assert_eq!(result["checkpoint"]["phase"], "cancelled");
         assert_eq!(result["checkpoint"]["iteration"], 0);
     }

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -106,7 +106,7 @@ impl NativeAgentRunState {
         Self {
             run_id: context.run_id.clone(),
             session_id: context.session_id.clone(),
-            phase: AgentRuntimePhase::Planning,
+            phase: AgentRuntimePhase::Queued,
             iteration: 0,
             max_iterations: context.max_iterations,
             pending_tool_calls: Vec::new(),
@@ -1334,6 +1334,12 @@ pub fn run_native_agent_turn_with_config(
     }
 
     let mut state = NativeAgentRunState::new(&context);
+    state.transition_phase(
+        AgentRuntimePhase::HydratingHistory,
+        0,
+        "agent.history.hydrated",
+    );
+    state.transition_phase(AgentRuntimePhase::Planning, 0, "agent.turn.started");
     state.emit_turn_started(&context);
     for iteration in 0..context.max_iterations {
         state.transition_phase(AgentRuntimePhase::CallingModel, iteration, "provider_call");
@@ -1594,6 +1600,13 @@ pub fn run_native_agent_turn_with_config(
                 for event in
                     subagent_activity_events_from_tool_result(&context, &tool_call, &result)
                 {
+                    if event.event_name == "agent.delegate.wait" {
+                        state.transition_phase(
+                            AgentRuntimePhase::AwaitingSubagent,
+                            iteration,
+                            "agent.delegate.wait",
+                        );
+                    }
                     state.emit_native_event(event);
                 }
                 state.completed_tool_results.push(completed_result);
@@ -2289,40 +2302,52 @@ fn maybe_awaiting_approval_result(
     services
         .checkpoints
         .save_for_run(&context.session_id, &context.run_id, checkpoint.clone());
-    let events = vec![
-        event(
-            "agent.checkpoint",
-            serde_json::json!({
-                "runId": context.run_id,
-                "sessionId": context.session_id,
-                "phase": "awaiting_approval",
-                "checkpoint": checkpoint,
-            }),
-        ),
-        event(
-            "agent.awaiting_approval",
-            serde_json::json!({
-                "runId": context.run_id,
-                "sessionId": context.session_id,
-                "approvalId": approval_id,
-                "toolName": tool_name,
-                "detailId": format!("approval:{approval_id}"),
-                "status": "waiting",
-                "summary": format!("Approval required: {tool_name}"),
-                "options": approval_request_options(),
-                "operation": approval,
-                "content": format!("Approval required: {tool_name}"),
-            }),
-        ),
-        event(
-            "agent.done",
-            serde_json::json!({
-                "runId": context.run_id,
-                "sessionId": context.session_id,
-                "stopReason": "awaiting_approval",
-            }),
-        ),
-    ];
+    let runtime_events = waiting_runtime_events(
+        context,
+        AgentRuntimePhase::AwaitingApproval,
+        "agent.awaiting_approval",
+        vec![
+            (
+                "agent.checkpoint",
+                None,
+                AgentRuntimePhase::Planning,
+                serde_json::json!({
+                    "runId": context.run_id,
+                    "sessionId": context.session_id,
+                    "phase": "awaiting_approval",
+                    "checkpoint": checkpoint.clone(),
+                }),
+            ),
+            (
+                "agent.awaiting_approval",
+                Some(approval_id.clone()),
+                AgentRuntimePhase::AwaitingApproval,
+                serde_json::json!({
+                    "runId": context.run_id,
+                    "sessionId": context.session_id,
+                    "approvalId": approval_id.clone(),
+                    "toolName": tool_name.clone(),
+                    "detailId": format!("approval:{approval_id}"),
+                    "status": "waiting",
+                    "summary": format!("Approval required: {tool_name}"),
+                    "options": approval_request_options(),
+                    "operation": approval.clone(),
+                    "content": format!("Approval required: {tool_name}"),
+                }),
+            ),
+            (
+                "agent.done",
+                None,
+                AgentRuntimePhase::AwaitingApproval,
+                serde_json::json!({
+                    "runId": context.run_id,
+                    "sessionId": context.session_id,
+                    "stopReason": "awaiting_approval",
+                }),
+            ),
+        ],
+    );
+    let events = legacy_result_events_from_runtime_events(&runtime_events);
     Some(serde_json::json!({
         "runtime": "rust",
         "runId": context.run_id,
@@ -2333,6 +2358,7 @@ fn maybe_awaiting_approval_result(
         "toolsUsed": [],
         "checkpoint": checkpoint,
         "events": events,
+        "runtimeEvents": runtime_events,
     }))
 }
 
@@ -2715,38 +2741,50 @@ fn maybe_awaiting_form_result(
     services
         .checkpoints
         .save_for_run(&context.session_id, &context.run_id, checkpoint.clone());
-    let events = vec![
-        event(
-            "agent.checkpoint",
-            serde_json::json!({
-                "runId": context.run_id,
-                "sessionId": context.session_id,
-                "phase": "awaiting_form",
-                "checkpoint": checkpoint,
-            }),
-        ),
-        event(
-            "agent.awaiting_form",
-            serde_json::json!({
-                "runId": context.run_id,
-                "sessionId": context.session_id,
-                "formId": form_id,
-                "detailId": format!("form:{form_id}"),
-                "status": "waiting",
-                "summary": string_field(&form, "title")
-                    .unwrap_or_else(|| "Form input required".to_string()),
-                "form": form,
-            }),
-        ),
-        event(
-            "agent.done",
-            serde_json::json!({
-                "runId": context.run_id,
-                "sessionId": context.session_id,
-                "stopReason": "awaiting_form",
-            }),
-        ),
-    ];
+    let runtime_events = waiting_runtime_events(
+        context,
+        AgentRuntimePhase::AwaitingForm,
+        "agent.awaiting_form",
+        vec![
+            (
+                "agent.checkpoint",
+                None,
+                AgentRuntimePhase::Planning,
+                serde_json::json!({
+                    "runId": context.run_id,
+                    "sessionId": context.session_id,
+                    "phase": "awaiting_form",
+                    "checkpoint": checkpoint.clone(),
+                }),
+            ),
+            (
+                "agent.awaiting_form",
+                Some(form_id.clone()),
+                AgentRuntimePhase::AwaitingForm,
+                serde_json::json!({
+                    "runId": context.run_id,
+                    "sessionId": context.session_id,
+                    "formId": form_id.clone(),
+                    "detailId": format!("form:{form_id}"),
+                    "status": "waiting",
+                    "summary": string_field(&form, "title")
+                        .unwrap_or_else(|| "Form input required".to_string()),
+                    "form": form,
+                }),
+            ),
+            (
+                "agent.done",
+                None,
+                AgentRuntimePhase::AwaitingForm,
+                serde_json::json!({
+                    "runId": context.run_id,
+                    "sessionId": context.session_id,
+                    "stopReason": "awaiting_form",
+                }),
+            ),
+        ],
+    );
+    let events = legacy_result_events_from_runtime_events(&runtime_events);
     Some(serde_json::json!({
         "runtime": "rust",
         "runId": context.run_id,
@@ -2757,6 +2795,7 @@ fn maybe_awaiting_form_result(
         "toolsUsed": [],
         "checkpoint": checkpoint,
         "events": events,
+        "runtimeEvents": runtime_events,
     }))
 }
 
@@ -3068,6 +3107,45 @@ fn cancelled_run_result(
     })
 }
 
+fn waiting_runtime_events(
+    context: &NativeAgentRunContext,
+    waiting_phase: AgentRuntimePhase,
+    trigger_event_name: &str,
+    events: Vec<(&'static str, Option<String>, AgentRuntimePhase, Value)>,
+) -> Vec<AgentRuntimeEventEnvelope> {
+    let mut emitter = AgentRunEmitter::new(&context.session_id, &context.run_id);
+    emitter.emit(AgentRuntimeEventAppendInput {
+        parent_turn_id: None,
+        item_id: None,
+        event_name: "agent.phase.changed".to_string(),
+        phase: waiting_phase.clone(),
+        timestamp: runtime_event_timestamp(),
+        source: AgentRuntimeEventSource::RustBackend,
+        visibility: AgentRuntimeEventVisibility::Debug,
+        payload: serde_json::json!({
+            "runId": context.run_id,
+            "sessionId": context.session_id,
+            "iteration": 0,
+            "previousPhase": "planning",
+            "nextPhase": waiting_phase.as_str(),
+            "triggerEventName": trigger_event_name,
+        }),
+    });
+    for (event_name, item_id, phase, payload) in events {
+        emitter.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id,
+            event_name: event_name.to_string(),
+            phase,
+            timestamp: runtime_event_timestamp(),
+            source: runtime_event_source(event_name),
+            visibility: runtime_event_visibility(event_name),
+            payload,
+        });
+    }
+    emitter.take_events()
+}
+
 fn event(event_name: &str, payload: Value) -> NativeAgentEvent {
     NativeAgentEvent {
         event_name: event_name.to_string(),
@@ -3281,31 +3359,39 @@ mod tests {
             result["runtimeEvents"][0]["schemaVersion"],
             "tinybot.agent_event.v1"
         );
+        let runtime_events = result["runtimeEvents"].as_array().unwrap();
         assert_eq!(
-            result["runtimeEvents"][0]["eventName"],
+            runtime_events[0]["payload"]["nextPhase"],
+            "hydrating_history"
+        );
+        assert_eq!(
+            runtime_events[1]["payload"]["nextPhase"],
+            "planning"
+        );
+        let turn_started = runtime_events
+            .iter()
+            .find(|event| event["eventName"] == "agent.turn.started")
+            .expect("turn started event should be present");
+        assert_eq!(
+            turn_started["eventName"],
             "agent.turn.started"
         );
         assert_eq!(
-            result["runtimeEvents"][0]["payload"]["userMessage"]["content"],
+            turn_started["payload"]["userMessage"]["content"],
             "hello"
         );
         assert_eq!(
-            result["runtimeEvents"][0]["payload"]["userMessageId"],
+            turn_started["payload"]["userMessageId"],
             "run-1:user"
         );
-        assert!(result["runtimeEvents"]
-            .as_array()
-            .unwrap()
+        assert!(runtime_events
             .iter()
             .any(|event| event["eventName"] == "agent.phase.changed"
                 && event["payload"]["previousPhase"] == "planning"
                 && event["payload"]["nextPhase"] == "calling_model"
                 && event["payload"]["triggerEventName"] == "provider_call"));
         assert_eq!(
-            result["runtimeEvents"]
-                .as_array()
-                .unwrap()
-                .iter()
+            runtime_events.iter()
                 .filter(|event| event["eventName"] == "agent.phase.changed"
                     && event["payload"]["nextPhase"] == "streaming_model")
                 .count(),
@@ -4668,6 +4754,22 @@ mod tests {
             2
         );
         assert!(event_names.contains(&"agent.delegate.wait"));
+        let runtime_events = result["runtimeEvents"]
+            .as_array()
+            .expect("runtime events should be present");
+        let awaiting_subagent_index = runtime_events
+            .iter()
+            .position(|event| {
+                event["eventName"] == "agent.phase.changed"
+                    && event["payload"]["nextPhase"] == "awaiting_subagent"
+                    && event["payload"]["triggerEventName"] == "agent.delegate.wait"
+            })
+            .expect("awaiting subagent phase should be emitted");
+        let delegate_wait_index = runtime_events
+            .iter()
+            .position(|event| event["eventName"] == "agent.delegate.wait")
+            .expect("delegate wait event should be emitted");
+        assert!(awaiting_subagent_index < delegate_wait_index);
         assert_eq!(event_names.last(), Some(&"agent.cancelled"));
         assert_eq!(result["checkpoint"]["phase"], "cancelled");
     }
@@ -4898,6 +5000,15 @@ mod tests {
             awaiting["events"][1]["eventName"],
             "agent.awaiting_approval"
         );
+        assert!(awaiting["runtimeEvents"].as_array().unwrap().iter().any(|event| {
+            event["eventName"] == "agent.phase.changed"
+                && event["payload"]["nextPhase"] == "awaiting_approval"
+                && event["payload"]["triggerEventName"] == "agent.awaiting_approval"
+        }));
+        assert!(awaiting["runtimeEvents"].as_array().unwrap().iter().any(|event| {
+            event["eventName"] == "agent.awaiting_approval"
+                && event["payload"]["approvalId"] == "approval-1"
+        }));
         assert_eq!(awaiting["events"][1]["payload"]["status"], "waiting");
         assert_eq!(
             awaiting["events"][1]["payload"]["detailId"],
@@ -5051,6 +5162,15 @@ mod tests {
             awaiting_form["events"][1]["eventName"],
             "agent.awaiting_form"
         );
+        assert!(awaiting_form["runtimeEvents"].as_array().unwrap().iter().any(|event| {
+            event["eventName"] == "agent.phase.changed"
+                && event["payload"]["nextPhase"] == "awaiting_form"
+                && event["payload"]["triggerEventName"] == "agent.awaiting_form"
+        }));
+        assert!(awaiting_form["runtimeEvents"].as_array().unwrap().iter().any(|event| {
+            event["eventName"] == "agent.awaiting_form"
+                && event["payload"]["formId"] == "form-1"
+        }));
         assert_eq!(awaiting_form["events"][1]["payload"]["status"], "waiting");
         assert_eq!(
             awaiting_form["events"][1]["payload"]["detailId"],

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -84,7 +84,7 @@ pub struct NativeAgentRunContext {
     pub cancellation: Option<NativeAgentCancellationContext>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct NativeAgentRunState {
     run_id: String,
     session_id: String,
@@ -99,10 +99,14 @@ struct NativeAgentRunState {
     tools_used: Vec<String>,
     stop_reason: Option<String>,
     pending_guidance_message: Option<Value>,
+    trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 }
 
 impl NativeAgentRunState {
-    fn new(context: &NativeAgentRunContext) -> Self {
+    fn new(
+        context: &NativeAgentRunContext,
+        trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
+    ) -> Self {
         Self {
             run_id: context.run_id.clone(),
             session_id: context.session_id.clone(),
@@ -117,6 +121,13 @@ impl NativeAgentRunState {
             tools_used: Vec::new(),
             stop_reason: None,
             pending_guidance_message: guidance_continuation_message(&context.metadata),
+            trace_sink,
+        }
+    }
+
+    fn append_trace_event(&self, event: &AgentRuntimeEventEnvelope) {
+        if let Some(trace_sink) = self.trace_sink.as_ref() {
+            let _ = trace_sink.append_trace_event(&self.session_id, &self.run_id, event);
         }
     }
 
@@ -133,7 +144,7 @@ impl NativeAgentRunState {
             return;
         }
         self.phase = phase.clone();
-        self.emitter.emit(AgentRuntimeEventAppendInput {
+        let event = self.emitter.emit(AgentRuntimeEventAppendInput {
             parent_turn_id: None,
             item_id: None,
             event_name: "agent.phase.changed".to_string(),
@@ -150,6 +161,7 @@ impl NativeAgentRunState {
                 "triggerEventName": trigger_event_name,
             }),
         });
+        self.append_trace_event(&event);
     }
 
     fn set_stop_reason(&mut self, stop_reason: &str, iteration: i64, trigger_event_name: &str) {
@@ -187,7 +199,7 @@ impl NativeAgentRunState {
     }
 
     fn emit_event(&mut self, event_name: &str, payload: Value) {
-        self.emitter.emit(AgentRuntimeEventAppendInput {
+        let event = self.emitter.emit(AgentRuntimeEventAppendInput {
             parent_turn_id: None,
             item_id: runtime_event_item_id(event_name, &payload),
             event_name: event_name.to_string(),
@@ -197,6 +209,7 @@ impl NativeAgentRunState {
             visibility: runtime_event_visibility(event_name),
             payload,
         });
+        self.append_trace_event(&event);
     }
 
     fn emit_native_event(&mut self, event: NativeAgentEvent) {
@@ -229,8 +242,10 @@ impl NativeAgentRunState {
                     .map(str::to_string)
             })
             .unwrap_or_default();
-        self.emitter
-            .user_turn_started(runtime_event_timestamp(), Some(message_id), content);
+        let event =
+            self.emitter
+                .user_turn_started(runtime_event_timestamp(), Some(message_id), content);
+        self.append_trace_event(&event);
     }
 
     fn runtime_events(&self) -> Vec<AgentRuntimeEventEnvelope> {
@@ -557,6 +572,15 @@ pub trait NativeAgentCancellation: Send + Sync {
     fn is_cancelled(&self, run_id: &str) -> bool;
 }
 
+pub trait NativeAgentTraceSink: Send + Sync {
+    fn append_trace_event(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        event: &AgentRuntimeEventEnvelope,
+    ) -> Result<(), String>;
+}
+
 #[derive(Clone)]
 pub struct NativeAgentRuntimeServices {
     provider: Arc<dyn NativeAgentProvider>,
@@ -564,6 +588,7 @@ pub struct NativeAgentRuntimeServices {
     checkpoints: Arc<dyn NativeAgentCheckpointStore>,
     cancellations: Arc<dyn NativeAgentCancellation>,
     subagents: SubagentThreadManager,
+    trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 }
 
 impl NativeAgentRuntimeServices {
@@ -579,6 +604,7 @@ impl NativeAgentRuntimeServices {
             checkpoints,
             cancellations,
             subagents: SubagentThreadManager::default(),
+            trace_sink: None,
         }
     }
 
@@ -594,6 +620,11 @@ impl NativeAgentRuntimeServices {
 
     fn with_subagents(mut self, subagents: SubagentThreadManager) -> Self {
         self.subagents = subagents;
+        self
+    }
+
+    pub fn with_trace_sink(mut self, trace_sink: Arc<dyn NativeAgentTraceSink>) -> Self {
+        self.trace_sink = Some(trace_sink);
         self
     }
 
@@ -1333,7 +1364,7 @@ pub fn run_native_agent_turn_with_config(
         ));
     }
 
-    let mut state = NativeAgentRunState::new(&context);
+    let mut state = NativeAgentRunState::new(&context, services.trace_sink.clone());
     state.transition_phase(
         AgentRuntimePhase::HydratingHistory,
         0,
@@ -2347,6 +2378,7 @@ fn maybe_awaiting_approval_result(
             ),
         ],
     );
+    append_runtime_events_to_sink(context, services.trace_sink.as_ref(), &runtime_events);
     let events = legacy_result_events_from_runtime_events(&runtime_events);
     Some(serde_json::json!({
         "runtime": "rust",
@@ -2784,6 +2816,7 @@ fn maybe_awaiting_form_result(
             ),
         ],
     );
+    append_runtime_events_to_sink(context, services.trace_sink.as_ref(), &runtime_events);
     let events = legacy_result_events_from_runtime_events(&runtime_events);
     Some(serde_json::json!({
         "runtime": "rust",
@@ -3146,6 +3179,18 @@ fn waiting_runtime_events(
     emitter.take_events()
 }
 
+fn append_runtime_events_to_sink(
+    context: &NativeAgentRunContext,
+    trace_sink: Option<&Arc<dyn NativeAgentTraceSink>>,
+    events: &[AgentRuntimeEventEnvelope],
+) {
+    if let Some(trace_sink) = trace_sink {
+        for event in events {
+            let _ = trace_sink.append_trace_event(&context.session_id, &context.run_id, event);
+        }
+    }
+}
+
 fn event(event_name: &str, payload: Value) -> NativeAgentEvent {
     NativeAgentEvent {
         event_name: event_name.to_string(),
@@ -3256,6 +3301,66 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct RecordingTraceSink {
+        events: Arc<Mutex<Vec<AgentRuntimeEventEnvelope>>>,
+    }
+
+    impl NativeAgentTraceSink for RecordingTraceSink {
+        fn append_trace_event(
+            &self,
+            _session_id: &str,
+            _run_id: &str,
+            event: &AgentRuntimeEventEnvelope,
+        ) -> Result<(), String> {
+            self.events
+                .lock()
+                .expect("trace sink lock should not be poisoned")
+                .push(event.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn trace_sink_receives_waiting_boundary_before_runtime_returns() {
+        let sink = Arc::new(RecordingTraceSink::default());
+        let events = sink.events.clone();
+        let services = NativeAgentRuntimeServices::default().with_trace_sink(sink);
+
+        let result = run_native_agent_turn_with_services(
+            &services,
+            json!({
+                "runtime": "rust",
+                "runId": "run-sink-waiting",
+                "sessionId": "websocket:chat-sink-waiting",
+                "metadata": {
+                    "fakeAwaitingApproval": {
+                        "approvalId": "approval-sink",
+                        "toolName": "workspace.write_file"
+                    }
+                }
+            }),
+        )
+        .expect("waiting run should return");
+        let recorded = events
+            .lock()
+            .expect("trace sink lock should not be poisoned")
+            .clone();
+
+        assert_eq!(result["stopReason"], "awaiting_approval");
+        assert!(recorded.iter().any(|event| {
+            event.event_name == "agent.phase.changed"
+                && event.payload["nextPhase"] == "awaiting_approval"
+        }));
+        assert!(recorded
+            .iter()
+            .any(|event| event.event_name == "agent.awaiting_approval"));
+        assert_eq!(
+            recorded.last().map(|event| event.event_name.as_str()),
+            Some("agent.done")
+        );
+    }
 
     #[test]
     fn selects_rust_runtime_from_spec_or_config() {

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -25,6 +25,10 @@ pub enum NativeAgentRuntimeMode {
     Rust,
 }
 
+const TEST_COMPAT_FAKE_AWAITING_APPROVAL: &str = "fakeAwaitingApproval";
+const TEST_COMPAT_FAKE_AWAITING_FORM: &str = "fakeAwaitingForm";
+const TEST_COMPAT_FAKE_CHECKPOINT: &str = "fakeCheckpoint";
+
 #[derive(Clone)]
 pub struct NativeAgentCancellationContext {
     run_id: String,
@@ -1516,7 +1520,11 @@ pub fn run_native_agent_turn_with_config(
                     }));
                 }
                 if services.cancellations.is_cancelled(&context.run_id) {
-                    state.transition_phase(AgentRuntimePhase::Cancelled, iteration, "agent.cancelled");
+                    state.transition_phase(
+                        AgentRuntimePhase::Cancelled,
+                        iteration,
+                        "agent.cancelled",
+                    );
                     return Ok(cancelled_run_result(
                         services,
                         &context,
@@ -1527,7 +1535,11 @@ pub fn run_native_agent_turn_with_config(
                     ));
                 }
                 state.tools_used.push(tool_call.name.clone());
-                state.transition_phase(AgentRuntimePhase::ToolRunning, iteration, "agent.tool.start");
+                state.transition_phase(
+                    AgentRuntimePhase::ToolRunning,
+                    iteration,
+                    "agent.tool.start",
+                );
                 state.emit_event(
                     "agent.tool.start",
                     serde_json::json!({
@@ -1650,7 +1662,11 @@ pub fn run_native_agent_turn_with_config(
                     state.active_checkpoint_payload("tool_completed"),
                 );
                 if services.cancellations.is_cancelled(&context.run_id) {
-                    state.transition_phase(AgentRuntimePhase::Cancelled, iteration, "agent.cancelled");
+                    state.transition_phase(
+                        AgentRuntimePhase::Cancelled,
+                        iteration,
+                        "agent.cancelled",
+                    );
                     return Ok(cancelled_run_result(
                         services,
                         &context,
@@ -1702,7 +1718,11 @@ pub fn run_native_agent_turn_with_config(
                 }),
             );
         }
-        state.transition_phase(AgentRuntimePhase::Finalizing, iteration, "agent.message.completed");
+        state.transition_phase(
+            AgentRuntimePhase::Finalizing,
+            iteration,
+            "agent.message.completed",
+        );
         services
             .checkpoints
             .clear_for_run(&context.session_id, &context.run_id);
@@ -2308,7 +2328,9 @@ fn maybe_awaiting_approval_result(
     services: &NativeAgentRuntimeServices,
     context: &NativeAgentRunContext,
 ) -> Option<Value> {
-    let approval = context.metadata.get("fakeAwaitingApproval")?.clone();
+    let approval =
+        test_compat_runtime_metadata(&context.metadata, TEST_COMPAT_FAKE_AWAITING_APPROVAL)?
+            .clone();
     let approval_id = string_field(&approval, "approvalId")
         .or_else(|| string_field(&approval, "approval_id"))
         .unwrap_or_else(|| "approval-1".to_string());
@@ -2755,7 +2777,8 @@ fn maybe_awaiting_form_result(
     services: &NativeAgentRuntimeServices,
     context: &NativeAgentRunContext,
 ) -> Option<Value> {
-    let form = context.metadata.get("fakeAwaitingForm")?.clone();
+    let form =
+        test_compat_runtime_metadata(&context.metadata, TEST_COMPAT_FAKE_AWAITING_FORM)?.clone();
     let form_id = string_field(&form, "formId")
         .or_else(|| string_field(&form, "form_id"))
         .unwrap_or_else(|| "form-1".to_string());
@@ -2981,7 +3004,9 @@ fn maybe_emit_checkpoint(
     state: &mut NativeAgentRunState,
     default_phase: &str,
 ) {
-    let Some(checkpoint_metadata) = context.metadata.get("fakeCheckpoint") else {
+    let Some(checkpoint_metadata) =
+        test_compat_runtime_metadata(&context.metadata, TEST_COMPAT_FAKE_CHECKPOINT)
+    else {
         return;
     };
     let phase =
@@ -2999,6 +3024,12 @@ fn maybe_emit_checkpoint(
             "checkpoint": checkpoint,
         }),
     );
+}
+
+fn test_compat_runtime_metadata<'a>(metadata: &'a Value, key: &str) -> Option<&'a Value> {
+    // Compatibility fixture hooks only. Normal runtime control should use typed
+    // continuations, checkpoints, provider responses, or tool/subagent results.
+    metadata.get(key)
 }
 
 fn checkpoint_value(context: &NativeAgentRunContext, phase: &str, payload: Value) -> Value {
@@ -3469,26 +3500,14 @@ mod tests {
             runtime_events[0]["payload"]["nextPhase"],
             "hydrating_history"
         );
-        assert_eq!(
-            runtime_events[1]["payload"]["nextPhase"],
-            "planning"
-        );
+        assert_eq!(runtime_events[1]["payload"]["nextPhase"], "planning");
         let turn_started = runtime_events
             .iter()
             .find(|event| event["eventName"] == "agent.turn.started")
             .expect("turn started event should be present");
-        assert_eq!(
-            turn_started["eventName"],
-            "agent.turn.started"
-        );
-        assert_eq!(
-            turn_started["payload"]["userMessage"]["content"],
-            "hello"
-        );
-        assert_eq!(
-            turn_started["payload"]["userMessageId"],
-            "run-1:user"
-        );
+        assert_eq!(turn_started["eventName"], "agent.turn.started");
+        assert_eq!(turn_started["payload"]["userMessage"]["content"], "hello");
+        assert_eq!(turn_started["payload"]["userMessageId"], "run-1:user");
         assert!(runtime_events
             .iter()
             .any(|event| event["eventName"] == "agent.phase.changed"
@@ -3496,7 +3515,8 @@ mod tests {
                 && event["payload"]["nextPhase"] == "calling_model"
                 && event["payload"]["triggerEventName"] == "provider_call"));
         assert_eq!(
-            runtime_events.iter()
+            runtime_events
+                .iter()
                 .filter(|event| event["eventName"] == "agent.phase.changed"
                     && event["payload"]["nextPhase"] == "streaming_model")
                 .count(),
@@ -3553,11 +3573,15 @@ mod tests {
         assert!(runtime_event_names
             .windows(2)
             .any(|pair| pair == ["agent.phase.changed", "agent.tool_call.delta"]));
-        assert!(result["runtimeEvents"].as_array().unwrap().iter().any(|event| {
-            event["eventName"] == "agent.phase.changed"
-                && event["payload"]["nextPhase"] == "tool_running"
-                && event["payload"]["triggerEventName"] == "agent.tool.start"
-        }));
+        assert!(result["runtimeEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| {
+                event["eventName"] == "agent.phase.changed"
+                    && event["payload"]["nextPhase"] == "tool_running"
+                    && event["payload"]["triggerEventName"] == "agent.tool.start"
+            }));
         assert_eq!(
             &event_names[..3],
             &[
@@ -4497,11 +4521,15 @@ mod tests {
             event_names(&result),
             vec!["agent.tool_call.delta", "agent.cancelled"]
         );
-        assert!(result["runtimeEvents"].as_array().unwrap().iter().any(|event| {
-            event["eventName"] == "agent.phase.changed"
-                && event["payload"]["nextPhase"] == "cancelled"
-                && event["payload"]["triggerEventName"] == "agent.cancelled"
-        }));
+        assert!(result["runtimeEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| {
+                event["eventName"] == "agent.phase.changed"
+                    && event["payload"]["nextPhase"] == "cancelled"
+                    && event["payload"]["triggerEventName"] == "agent.cancelled"
+            }));
         assert_eq!(result["checkpoint"]["phase"], "cancelled");
         assert_eq!(result["checkpoint"]["iteration"], 0);
     }
@@ -5105,15 +5133,23 @@ mod tests {
             awaiting["events"][1]["eventName"],
             "agent.awaiting_approval"
         );
-        assert!(awaiting["runtimeEvents"].as_array().unwrap().iter().any(|event| {
-            event["eventName"] == "agent.phase.changed"
-                && event["payload"]["nextPhase"] == "awaiting_approval"
-                && event["payload"]["triggerEventName"] == "agent.awaiting_approval"
-        }));
-        assert!(awaiting["runtimeEvents"].as_array().unwrap().iter().any(|event| {
-            event["eventName"] == "agent.awaiting_approval"
-                && event["payload"]["approvalId"] == "approval-1"
-        }));
+        assert!(awaiting["runtimeEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| {
+                event["eventName"] == "agent.phase.changed"
+                    && event["payload"]["nextPhase"] == "awaiting_approval"
+                    && event["payload"]["triggerEventName"] == "agent.awaiting_approval"
+            }));
+        assert!(awaiting["runtimeEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| {
+                event["eventName"] == "agent.awaiting_approval"
+                    && event["payload"]["approvalId"] == "approval-1"
+            }));
         assert_eq!(awaiting["events"][1]["payload"]["status"], "waiting");
         assert_eq!(
             awaiting["events"][1]["payload"]["detailId"],
@@ -5267,15 +5303,23 @@ mod tests {
             awaiting_form["events"][1]["eventName"],
             "agent.awaiting_form"
         );
-        assert!(awaiting_form["runtimeEvents"].as_array().unwrap().iter().any(|event| {
-            event["eventName"] == "agent.phase.changed"
-                && event["payload"]["nextPhase"] == "awaiting_form"
-                && event["payload"]["triggerEventName"] == "agent.awaiting_form"
-        }));
-        assert!(awaiting_form["runtimeEvents"].as_array().unwrap().iter().any(|event| {
-            event["eventName"] == "agent.awaiting_form"
-                && event["payload"]["formId"] == "form-1"
-        }));
+        assert!(awaiting_form["runtimeEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| {
+                event["eventName"] == "agent.phase.changed"
+                    && event["payload"]["nextPhase"] == "awaiting_form"
+                    && event["payload"]["triggerEventName"] == "agent.awaiting_form"
+            }));
+        assert!(awaiting_form["runtimeEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| {
+                event["eventName"] == "agent.awaiting_form"
+                    && event["payload"]["formId"] == "form-1"
+            }));
         assert_eq!(awaiting_form["events"][1]["payload"]["status"], "waiting");
         assert_eq!(
             awaiting_form["events"][1]["payload"]["detailId"],

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -1539,6 +1539,16 @@ pub fn run_native_agent_turn_with_config(
             .checkpoints
             .clear_for_run(&context.session_id, &context.run_id);
         state.events.push(event(
+            "agent.message.completed",
+            serde_json::json!({
+                "runId": context.run_id,
+                "sessionId": context.session_id,
+                "iteration": iteration,
+                "messageId": format!("{}:assistant", context.run_id),
+                "content": final_content.clone(),
+            }),
+        ));
+        state.events.push(event(
             "agent.done",
             serde_json::json!({
                 "runId": context.run_id,
@@ -3051,7 +3061,17 @@ mod tests {
         assert_eq!(result["finalContent"], "fixture answer");
         assert_eq!(result["events"][0]["eventName"], "agent.delta");
         assert_eq!(result["events"][1]["eventName"], "agent.usage");
-        assert_eq!(result["events"][2]["eventName"], "agent.done");
+        assert_eq!(result["events"][2]["eventName"], "agent.message.completed");
+        assert_eq!(
+            result["events"][2]["payload"]["content"],
+            "fixture answer"
+        );
+        assert_eq!(result["events"][3]["eventName"], "agent.done");
+        assert_eq!(
+            result["events"][3]["payload"]["stopReason"],
+            "final_response"
+        );
+        assert!(result["events"][3]["payload"].get("finalContent").is_none());
     }
 
     #[test]

--- a/src-tauri/src/worker_session/agent_run.rs
+++ b/src-tauri/src/worker_session/agent_run.rs
@@ -129,7 +129,20 @@ impl WorkerSessionRpc {
     ) -> Result<AgentRunRecord, WorkerProtocolError> {
         self.require(WorkerCapability::SessionWrite)?;
         let mut record = self.get_agent_run_for_update(session_id, run_id)?;
-        record.trace_events.push(event);
+        if let Some(event_id) = event.get("eventId").and_then(Value::as_str) {
+            if let Some(existing) = record.trace_events.iter_mut().find(|existing| {
+                existing
+                    .get("eventId")
+                    .and_then(Value::as_str)
+                    == Some(event_id)
+            }) {
+                *existing = event;
+            } else {
+                record.trace_events.push(event);
+            }
+        } else {
+            record.trace_events.push(event);
+        }
         record.updated_at = now_session_timestamp();
         self.upsert_agent_run(record)
     }

--- a/src-tauri/src/worker_session/tests.rs
+++ b/src-tauri/src/worker_session/tests.rs
@@ -1,6 +1,7 @@
 ﻿#[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_loop_runtime_protocol::AgentTurnItemKind;
     use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
     use crate::worker_protocol::{WorkerProtocolErrorCode, WorkerProtocolErrorSource};
     use serde_json::json;
@@ -359,6 +360,53 @@ mod tests {
         assert_eq!(page.run_id, "run-1");
         assert_eq!(page.items.len(), 1);
         assert_eq!(page.next_cursor, None);
+    }
+
+    #[test]
+    fn runtime_state_restores_legacy_stored_trace_events() {
+        let mut rpc = WorkerSessionRpc::new(vec![session_fixture()], read_write_policy());
+        let mut record = agent_run_fixture("session-1", "run-legacy", AgentRunStatus::Completed);
+        record.phase = "completed".to_string();
+        record.completed_at = Some("unix-ms:2".to_string());
+        record.stop_reason = Some("final_response".to_string());
+        record.trace_events = vec![
+            json!({
+                "eventName": "agent.tool.result",
+                "payload": {
+                    "toolCallId": "call-legacy",
+                    "toolName": "workspace.read_file",
+                    "content": "README excerpt"
+                }
+            }),
+            json!({
+                "eventName": "agent.done",
+                "payload": {
+                    "finalContent": "Legacy final answer"
+                }
+            }),
+        ];
+        rpc.upsert_agent_run(record)
+            .expect("legacy run should upsert");
+
+        let runtime_state = rpc
+            .get_agent_run_runtime_state("session-1", "run-legacy")
+            .expect("legacy runtime state should restore");
+
+        assert_eq!(runtime_state.runtime_events.len(), 2);
+        assert_eq!(
+            runtime_state.runtime_events[0].schema_version,
+            "tinybot.agent_event.v1"
+        );
+        assert_eq!(runtime_state.turn_items[0].kind, AgentTurnItemKind::ToolCall);
+        assert_eq!(runtime_state.turn_items[0].item_id, "call-legacy");
+        assert_eq!(
+            runtime_state.turn_items[1].kind,
+            AgentTurnItemKind::AssistantMessage
+        );
+        assert_eq!(
+            runtime_state.turn_items[1].payload["content"],
+            "Legacy final answer"
+        );
     }
 
     #[test]

--- a/src-tauri/src/worker_session/tests.rs
+++ b/src-tauri/src/worker_session/tests.rs
@@ -386,6 +386,37 @@ mod tests {
     }
 
     #[test]
+    fn append_agent_run_trace_event_deduplicates_stable_event_ids() {
+        let mut rpc = WorkerSessionRpc::new(vec![session_fixture()], read_write_policy());
+        rpc.upsert_agent_run(agent_run_fixture(
+            "session-1",
+            "run-1",
+            AgentRunStatus::Running,
+        ))
+        .expect("run should upsert");
+        let event = json!({
+            "schemaVersion": "tinybot.agent_event.v1",
+            "eventId": "run-1:agent-done:0000000000000001",
+            "eventName": "agent.done",
+            "payload": { "stopReason": "final_response" }
+        });
+
+        rpc.append_agent_run_trace_event("session-1", "run-1", event.clone())
+            .expect("first append should persist");
+        rpc.append_agent_run_trace_event("session-1", "run-1", event)
+            .expect("duplicate append should be accepted");
+        let restored = rpc
+            .get_agent_run("session-1", "run-1")
+            .expect("run should read");
+
+        assert_eq!(restored.trace_events.len(), 1);
+        assert_eq!(
+            restored.trace_events[0]["eventId"],
+            "run-1:agent-done:0000000000000001"
+        );
+    }
+
+    #[test]
     fn agent_run_trace_pages_are_bounded_by_cursor_and_limit() {
         let mut rpc = WorkerSessionRpc::new(vec![session_fixture()], read_write_policy());
         let mut record = agent_run_fixture("session-1", "run-1", AgentRunStatus::Running);

--- a/src/native-workbench/chat/chatRunModel.test.ts
+++ b/src/native-workbench/chat/chatRunModel.test.ts
@@ -201,6 +201,54 @@ describe("chat run model", () => {
     expect(turns[0].finalMessage).toBeUndefined();
   });
 
+  test("restores runtime-only completed assistant messages without legacy final messages", () => {
+    const runtimeState = normalizeAgentRunRuntimeStatePayload({
+      sessionId: "WebSocket:chat-1",
+      runId: "run-completed",
+      runtimeEvents: [],
+      turnItems: [
+        {
+          itemId: "run-completed:user",
+          sessionId: "WebSocket:chat-1",
+          turnId: "run-completed",
+          kind: "user_message",
+          status: "completed",
+          createdAt: "2026-07-03T01:00:00Z",
+          payload: {
+            messageId: "user-completed",
+            content: "Say hello",
+          },
+        },
+        {
+          itemId: "run-completed:assistant",
+          sessionId: "WebSocket:chat-1",
+          turnId: "run-completed",
+          kind: "assistant_message",
+          status: "completed",
+          createdAt: "2026-07-03T01:00:01Z",
+          payload: {
+            messageId: "assistant-completed",
+            content: "Hello",
+          },
+        },
+      ],
+    });
+
+    expect(runtimeState).not.toBeNull();
+    const turns = backendRuntimeStatesToTurns("WebSocket:chat-1", [runtimeState!], []);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({
+      id: "run-completed",
+      status: "completed",
+      userMessage: { text: "Say hello" },
+      finalMessage: {
+        id: "assistant-completed",
+        text: "Hello",
+      },
+    });
+  });
+
   test("orders restored runtime states by numeric millisecond timestamps", () => {
     const early = normalizeAgentRunRuntimeStatePayload({
       sessionId: "WebSocket:chat-1",

--- a/src/native-workbench/chat/chatRunModel.ts
+++ b/src/native-workbench/chat/chatRunModel.ts
@@ -696,9 +696,10 @@ function applyTurnItemToTurn(turn: ChatTurn, item: BackendAgentTurnItem, sequenc
   }
   if (item.kind === "assistant_message") {
     const text = safeArtifactText(stringValue(payload.content ?? payload.text ?? payload.finalContent ?? item.summary));
+    const messageId = stringValue(payload.messageId ?? payload.message_id) || item.itemId;
     if (status === "completed") {
       turn.finalMessage = {
-        id: item.itemId,
+        id: messageId,
         role: "assistant",
         text,
         timestamp: item.updatedAt || item.createdAt || turn.updatedAt,

--- a/src/native-workbench/components/chat/chatSurface.test.ts
+++ b/src/native-workbench/components/chat/chatSurface.test.ts
@@ -36,7 +36,7 @@ describe("rebuilt chat surface", () => {
     });
 
     expect(host.getAttribute("data-chat-surface")).toBe("rebuild-chat-agent-surface");
-    expect(host.querySelector(".desktop-chat-surface__shell")?.getAttribute("data-chat-layout")).toBe("codex-reference");
+    expect(host.querySelector(".desktop-chat-surface__shell")?.getAttribute("data-chat-layout")).toBe("native-reference");
     expect(host.querySelector("[data-chat-region='session-list']")).not.toBeNull();
     expect(host.querySelector("[data-chat-region='chat-detail']")).not.toBeNull();
     expect(host.querySelector("[data-chat-region='status-rail']")).not.toBeNull();

--- a/src/native-workbench/components/chat/chatSurface.ts
+++ b/src/native-workbench/components/chat/chatSurface.ts
@@ -480,7 +480,7 @@ function renderChatSurface(
   host.className = "desktop-conversation-thread desktop-chat-surface";
 
   const shell = element("div", "desktop-chat-surface__shell");
-  shell.setAttribute("data-chat-layout", "codex-reference");
+  shell.setAttribute("data-chat-layout", "native-reference");
   shell.append(renderSessionList(projection, sessionSearchQuery, pendingDeleteSessionKey, actions));
   shell.append(renderChatDetail(projection, processExpansionOverrides, actions));
   shell.append(renderStatusRail(projection, actions));

--- a/src/native-workbench/native/desktopNativeWorkbenchRuntime.test.ts
+++ b/src/native-workbench/native/desktopNativeWorkbenchRuntime.test.ts
@@ -639,6 +639,50 @@ describe("desktop native workbench runtime", () => {
     expect(runtime.chat.status).toBe("TS agent response received.");
   });
 
+  test("completes TS agent runs from returned cancelled events with run ids", async () => {
+    const runSpecs: unknown[] = [];
+    const runtime = createDesktopNativeWorkbenchRuntime({
+      api: {
+        listSessions: async () => ({
+          items: [{ key: "WebSocket:chat-ts-cancelled", chat_id: "chat-ts-cancelled", title: "TS cancelled route" }],
+        }),
+        loadMessages: async () => ({ messages: [] }),
+      },
+      sendSocketMessage: () => undefined,
+      agentRoute: "ts-agent",
+      runTsAgent: async (spec) => {
+        runSpecs.push(spec);
+        return {
+          finalContent: "",
+          stopReason: "cancelled",
+          messages: [],
+          toolsUsed: [],
+          error: "cancelled",
+          events: [{
+            eventName: "agent.cancelled",
+            payload: {
+              runId: spec.runId,
+              sessionId: spec.sessionId,
+              cancelled: true,
+              stopReason: "cancelled",
+            },
+          }],
+        };
+      },
+      now: () => "2026-06-03T08:16:00.000Z",
+    });
+    await runtime.loadInitialChatState();
+
+    runtime.submitComposerMessage("Cancel with returned event");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(runSpecs).toHaveLength(1);
+    expect(runtime.chat.responding).toBe(false);
+    expect(runtime.chat.composerState).toBe("idle");
+    expect(runtime.chat.status).toBe("TS agent cancelled.");
+  });
+
   test("projects Rust native backend event envelopes into the active native chat", async () => {
     let resolveRun: ((value: {
       finalContent: string;

--- a/src/native-workbench/native/nativeBackendContract.test.ts
+++ b/src/native-workbench/native/nativeBackendContract.test.ts
@@ -3,6 +3,7 @@ import {
   isNativeBackendEventEnvelope,
   NATIVE_BACKEND_AGENT_EVENT_NAMES,
   NATIVE_BACKEND_COMMAND_NAMES,
+  NATIVE_BACKEND_RUNTIME_EVENT_VISIBILITY,
   normalizeNativeBackendEventPayload,
   type NativeBackendRuntimeStatus,
 } from "./nativeBackendContract";
@@ -29,6 +30,25 @@ describe("native backend contract", () => {
       "diagnostics.log",
       "worker.status",
     ]));
+  });
+
+  test("covers canonical runtime events and their visibility classes", () => {
+    expect(NATIVE_BACKEND_AGENT_EVENT_NAMES).toEqual(expect.arrayContaining([
+      "agent.turn.started",
+      "agent.phase.changed",
+      "agent.guidance",
+      "agent.approval.decision",
+      "agent.form.resolution",
+      "agent.message.completed",
+    ]));
+    expect(NATIVE_BACKEND_RUNTIME_EVENT_VISIBILITY).toMatchObject({
+      "agent.turn.started": "user-visible",
+      "agent.phase.changed": "debug",
+      "agent.guidance": "status",
+      "agent.approval.decision": "websocket-visible",
+      "agent.form.resolution": "websocket-visible",
+      "agent.message.completed": "user-visible",
+    });
   });
 
   test("normalizes Rust event envelopes while preserving payloads", () => {

--- a/src/native-workbench/native/nativeBackendContract.ts
+++ b/src/native-workbench/native/nativeBackendContract.ts
@@ -73,6 +73,12 @@ export const NATIVE_BACKEND_AGENT_EVENT_NAMES = [
   "agent.tool.result",
   "agent.usage",
   "agent.checkpoint",
+  "agent.turn.started",
+  "agent.phase.changed",
+  "agent.guidance",
+  "agent.approval.decision",
+  "agent.form.resolution",
+  "agent.message.completed",
   "agent.awaiting_form",
   "agent.awaiting_approval",
   "agent.memory_reference",
@@ -98,6 +104,22 @@ export const NATIVE_BACKEND_AGENT_EVENT_NAMES = [
 ] as const;
 
 export type NativeBackendEventName = typeof NATIVE_BACKEND_AGENT_EVENT_NAMES[number];
+export type NativeBackendRuntimeEventVisibility =
+  | "trace-only"
+  | "debug"
+  | "status"
+  | "websocket-visible"
+  | "user-visible";
+
+export const NATIVE_BACKEND_RUNTIME_EVENT_VISIBILITY = {
+  "agent.turn.started": "user-visible",
+  "agent.phase.changed": "debug",
+  "agent.guidance": "status",
+  "agent.approval.decision": "websocket-visible",
+  "agent.form.resolution": "websocket-visible",
+  "agent.message.completed": "user-visible",
+} as const satisfies Partial<Record<NativeBackendEventName, NativeBackendRuntimeEventVisibility>>;
+
 export type NativeBackendWorkerEventName = Exclude<
   NativeBackendEventName,
   "agent.browser_frame" | "diagnostics.log" | "worker.status"

--- a/src/native-workbench/shell/desktopChatSurfaceEntry.test.ts
+++ b/src/native-workbench/shell/desktopChatSurfaceEntry.test.ts
@@ -23,7 +23,7 @@ describe("desktop chat surface entry", () => {
 
     const thread = document.querySelector<HTMLElement>(".desktop-conversation-thread");
     expect(thread?.getAttribute("data-chat-surface")).toBe("rebuild-chat-agent-surface");
-    expect(thread?.querySelector(".desktop-chat-surface__shell")?.getAttribute("data-chat-layout")).toBe("codex-reference");
+    expect(thread?.querySelector(".desktop-chat-surface__shell")?.getAttribute("data-chat-layout")).toBe("native-reference");
     expect(thread?.getAttribute("data-desktop-vue-island")).toBeNull();
     expect(thread?.querySelector("[data-chat-region='session-list']")?.textContent).toContain("Live session");
     expect(thread?.querySelector("[data-chat-region='status-rail']")).not.toBeNull();

--- a/src/native-workbench/shell/desktopWorkbenchShell.test.ts
+++ b/src/native-workbench/shell/desktopWorkbenchShell.test.ts
@@ -1172,7 +1172,7 @@ describe("desktop workbench shell", () => {
     expect(targetDocument.getElementById("desktop-native-composer-runtime")?.getAttribute("aria-label")).toBe("Runtime status");
   });
 
-  test("renders the native workbench in the latest Codex-style three-column layout", () => {
+  test("renders the native workbench in the latest native three-column layout", () => {
     const targetDocument = new FakeDocument();
 
     installDesktopWorkbenchShell({

--- a/src/native-workbench/shell/desktopWorkbenchShell.ts
+++ b/src/native-workbench/shell/desktopWorkbenchShell.ts
@@ -1353,7 +1353,7 @@ function createConversationThread(
       author: "You",
       time: "10:28 AM",
       tone: "user",
-      body: ["这是目前的 native 界面，我希望你帮我设计一个更接近 codex 风格的界面。"],
+      body: ["这是目前的 native 界面，我希望你帮我设计一个更接近 Tinybot 风格的界面。"],
     }),
     createConversationMessage(targetDocument, {
       author: "Tinybot",
@@ -1363,7 +1363,7 @@ function createConversationThread(
         "好的，根据你的需求，我为 Tinybot native workbench 设计了一个更统一、简洁、专业的界面方向。",
         "三栏布局：左侧导航 + 主会话区 + 右侧运行链面板",
         "采用轻量配色与更清晰的层级，提升可读性和信息密度",
-        "底部 Composer 贴合 Codex 风格，支持附件与模型选择",
+        "底部 Composer 贴合 Tinybot 风格，支持附件与模型选择",
         "运行链面板提供上下文、文件与任务的快速访问",
       ],
       attachment: "tinybot_native_workbench_design.png",


### PR DESCRIPTION
﻿## Summary
- Emit canonical `AgentRuntimeEventEnvelope` values from the Rust agent runtime via `AgentRunEmitter`.
- Add explicit phase transition and `agent.message.completed` events, with legacy compatibility projections preserved.
- Persist key runtime trace events incrementally through `agent_run.append_trace` and restore runtime state from canonical or legacy traces.
- Extend native frontend runtime event contracts and remove Codex-specific desktop references.

## Validation
- `cargo fmt -p tinybot-desktop --check`
- `cargo test -p tinybot-desktop --lib -- --test-threads=1`
- `npm test -- src/native-workbench/native/nativeBackendContract.test.ts src/native-workbench/chat/chatRunModel.test.ts src/native-workbench/native/desktopNativeWorkbenchRuntime.test.ts src/native-workbench/gateway/desktopGatewayBridge.test.ts`
- `npm test -- src/native-workbench/components/chat/chatSurface.test.ts src/native-workbench/shell/desktopChatSurfaceEntry.test.ts src/native-workbench/shell/desktopWorkbenchShell.test.ts`
- `cargo test -p tinybot-desktop native_provider_runtime --lib`
- `npm test -- src/native-workbench/shell/desktopWorkbenchShell.settingsRenderer.test.ts`
- `npm run build`
- `openspec validate unify-agent-runtime-events`

Note: full `npm test` previously timed out two settings renderer tests during the all-suite run; rerunning that file directly passed.
