### PR TITLE
Fix native chat streaming and live branch actions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5400,6 +5400,20 @@ fn native_websocket_transport_result(
     input: &WorkerTransportWebSocketDispatchInput,
 ) -> Option<serde_json::Value> {
     let frame = input.frame.as_object()?;
+    if json_string_field(frame, "type") == Some("new_chat") {
+        let chat_id = json_string_field(frame, "chat_id")
+            .or_else(|| json_string_field(frame, "chatId"))
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("chat-{}", next_worker_request_correlation().suffix()));
+        let session_id = format!("websocket:{chat_id}");
+        return Some(serde_json::json!({
+            "kind": "new_chat",
+            "chatId": chat_id,
+            "sessionId": session_id,
+            "attachedChatId": chat_id,
+            "frames": [{ "event": "chat_created", "chat_id": chat_id }],
+        }));
+    }
     if json_string_field(frame, "type") != Some("message") {
         return None;
     }
@@ -11027,6 +11041,41 @@ mod tests {
         assert!(build_worker_transport_websocket_run_input_request(
             test_request_correlation("43"),
             &serde_json::json!({ "kind": "ping", "frames": [{ "event": "pong" }] }),
+            WorkerTransportWebSocketDispatchOptions::default(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn worker_transport_websocket_new_chat_returns_created_frame_without_run_request() {
+        let input = WorkerTransportWebSocketDispatchInput {
+            client_id: "client-1".to_string(),
+            frame: serde_json::json!({ "type": "new_chat" }),
+            attached_chat_id: None,
+            session_exists: None,
+            editable_paths: None,
+            model: None,
+            max_iterations: None,
+            run_id: None,
+            stream: None,
+        };
+
+        let result = native_websocket_transport_result(&input)
+            .expect("new chat websocket frame should produce a transport result");
+
+        assert_eq!(result["kind"], "new_chat");
+        assert!(result["chatId"]
+            .as_str()
+            .is_some_and(|chat_id| chat_id.starts_with("chat-")));
+        assert!(result["sessionId"]
+            .as_str()
+            .is_some_and(|session_id| session_id.starts_with("websocket:chat-")));
+        assert_eq!(result["attachedChatId"], result["chatId"]);
+        assert_eq!(result["frames"][0]["event"], "chat_created");
+        assert_eq!(result["frames"][0]["chat_id"], result["chatId"]);
+        assert!(build_worker_transport_websocket_run_input_request(
+            test_request_correlation("44"),
+            &result,
             WorkerTransportWebSocketDispatchOptions::default(),
         )
         .is_none());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -154,6 +154,47 @@ impl NativeAgentTraceSink for NativeAgentRunTraceSink {
 }
 
 #[derive(Clone)]
+struct CompositeNativeAgentTraceSink {
+    sinks: Vec<Arc<dyn NativeAgentTraceSink>>,
+}
+
+impl NativeAgentTraceSink for CompositeNativeAgentTraceSink {
+    fn append_trace_event(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        event: &AgentRuntimeEventEnvelope,
+    ) -> Result<(), String> {
+        let mut first_error = None;
+        for sink in &self.sinks {
+            if let Err(error) = sink.append_trace_event(session_id, run_id, event) {
+                first_error.get_or_insert(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+#[derive(Clone)]
+struct DesktopAgentEventSink<R: Runtime + 'static> {
+    app: tauri::AppHandle<R>,
+}
+
+impl<R: Runtime + 'static> NativeAgentTraceSink for DesktopAgentEventSink<R> {
+    fn append_trace_event(
+        &self,
+        _session_id: &str,
+        _run_id: &str,
+        event: &AgentRuntimeEventEnvelope,
+    ) -> Result<(), String> {
+        let event_name = tauri_safe_event_name(&event.event_name);
+        self.app
+            .emit(&event_name, event.payload.clone())
+            .map_err(|error| format!("native agent frontend event emit failed: {error}"))
+    }
+}
+
+#[derive(Clone)]
 struct NativeAgentToolExecutorDispatcher {
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
@@ -1392,20 +1433,23 @@ fn worker_transport_websocket_message(
 }
 
 #[tauri::command]
-async fn worker_transport_dispatch_websocket_message(
+async fn worker_transport_dispatch_websocket_message<R: Runtime + 'static>(
     input: WorkerTransportWebSocketDispatchInput,
     state: State<'_, SharedGateway>,
+    app: tauri::AppHandle<R>,
 ) -> Result<serde_json::Value, String> {
     let shared = state.inner().clone();
     let workspace_root = native_backend_workspace_root();
     let config_snapshot = experimental_worker_config_snapshot();
+    let live_trace_sink: Arc<dyn NativeAgentTraceSink> = Arc::new(DesktopAgentEventSink { app });
     tauri::async_runtime::spawn_blocking(move || {
-        worker_transport_dispatch_websocket_message_with_options(
+        worker_transport_dispatch_websocket_message_with_live_trace_sink(
             &shared,
             input,
             workspace_root,
             config_snapshot,
             Duration::from_secs(60),
+            Some(live_trace_sink),
         )
     })
     .await
@@ -2023,6 +2067,24 @@ fn worker_run_agent_with_options(
     config_snapshot: serde_json::Value,
     timeout: Duration,
 ) -> Result<serde_json::Value, String> {
+    worker_run_agent_with_live_trace_sink(
+        shared,
+        spec,
+        workspace_root,
+        config_snapshot,
+        timeout,
+        None,
+    )
+}
+
+fn worker_run_agent_with_live_trace_sink(
+    shared: &SharedGateway,
+    spec: serde_json::Value,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    timeout: Duration,
+    live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
+) -> Result<serde_json::Value, String> {
     let _ = timeout;
     let persistence_spec = spec.clone();
     if let Some(rejection) = reject_native_agent_terminal_run_reentry(
@@ -2052,10 +2114,11 @@ fn worker_run_agent_with_options(
         workspace_root.clone(),
         config_snapshot.clone(),
     )
-    .with_trace_sink(Arc::new(NativeAgentRunTraceSink {
-        workspace_root: workspace_root.clone(),
-        config_snapshot: config_snapshot.clone(),
-    }));
+    .with_trace_sink(native_agent_trace_sink(
+        workspace_root.clone(),
+        config_snapshot.clone(),
+        live_trace_sink,
+    ));
     let mut result =
         run_native_agent_turn_with_config(&services, runtime_spec, config_snapshot.clone())?;
     if let Err(error) = persist_native_agent_run_record(
@@ -2088,6 +2151,23 @@ fn worker_run_agent_with_options(
         config_snapshot,
     )?;
     Ok(result)
+}
+
+fn native_agent_trace_sink(
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
+) -> Arc<dyn NativeAgentTraceSink> {
+    let persisted_sink: Arc<dyn NativeAgentTraceSink> = Arc::new(NativeAgentRunTraceSink {
+        workspace_root,
+        config_snapshot,
+    });
+    let Some(live_trace_sink) = live_trace_sink else {
+        return persisted_sink;
+    };
+    Arc::new(CompositeNativeAgentTraceSink {
+        sinks: vec![persisted_sink, live_trace_sink],
+    })
 }
 
 fn reject_native_agent_terminal_run_reentry(
@@ -5358,12 +5438,31 @@ fn worker_transport_websocket_message_with_options(
     unsupported_rust_only_command("worker_transport_websocket_message")
 }
 
+#[allow(dead_code)]
 fn worker_transport_dispatch_websocket_message_with_options(
     shared: &SharedGateway,
     input: WorkerTransportWebSocketDispatchInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
     timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    worker_transport_dispatch_websocket_message_with_live_trace_sink(
+        shared,
+        input,
+        workspace_root,
+        config_snapshot,
+        timeout,
+        None,
+    )
+}
+
+fn worker_transport_dispatch_websocket_message_with_live_trace_sink(
+    shared: &SharedGateway,
+    input: WorkerTransportWebSocketDispatchInput,
+    workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    timeout: Duration,
+    live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 ) -> Result<serde_json::Value, String> {
     let Some(transport_result) = native_websocket_transport_result(&input) else {
         return unsupported_rust_only_command("worker_transport_dispatch_websocket_message");
@@ -5387,8 +5486,14 @@ fn worker_transport_dispatch_websocket_message_with_options(
         .get("input")
         .cloned()
         .ok_or_else(|| "native websocket dispatch missing run input".to_string())?;
-    let agent_result =
-        worker_run_agent_with_options(shared, run_spec, workspace_root, config_snapshot, timeout)?;
+    let agent_result = worker_run_agent_with_live_trace_sink(
+        shared,
+        run_spec,
+        workspace_root,
+        config_snapshot,
+        timeout,
+        live_trace_sink,
+    )?;
 
     Ok(serde_json::json!({
         "transport": transport_result,

--- a/src-tauri/src/native_provider_runtime.rs
+++ b/src-tauri/src/native_provider_runtime.rs
@@ -36,6 +36,12 @@ pub struct NativeProviderProfile {
     pub request_timeout_ms: u64,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum NativeProviderStreamEvent {
+    ContentDelta(String),
+    ReasoningDelta(String),
+}
+
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeProviderModelsRequest {
@@ -282,7 +288,16 @@ pub fn openai_chat_completions_route(config: &Value, body: &Value) -> Value {
 }
 
 pub fn complete_chat_for_agent(config: &Value, body: &Value) -> Result<Value, String> {
-    match native_chat_completion(config, body) {
+    let mut observer = |_event: NativeProviderStreamEvent| {};
+    complete_chat_for_agent_with_observer(config, body, &mut observer)
+}
+
+pub fn complete_chat_for_agent_with_observer(
+    config: &Value,
+    body: &Value,
+    observer: &mut dyn FnMut(NativeProviderStreamEvent),
+) -> Result<Value, String> {
+    match native_chat_completion_with_observer(config, body, Some(observer)) {
         Ok(response) if (200..300).contains(&response.status) && !response.stream => {
             Ok(response.body)
         }
@@ -291,7 +306,11 @@ pub fn complete_chat_for_agent(config: &Value, body: &Value) -> Result<Value, St
                 .body
                 .as_str()
                 .ok_or_else(|| "streaming chat completion returned non-text body".to_string())?;
-            aggregate_chat_completion_sse(body)
+            if response.observed_stream {
+                aggregate_chat_completion_sse(body)
+            } else {
+                aggregate_chat_completion_sse_with_observer(body, Some(observer))
+            }
         }
         Ok(response) => Err(format!(
             "chat completion returned unexpected status {}",
@@ -302,6 +321,13 @@ pub fn complete_chat_for_agent(config: &Value, body: &Value) -> Result<Value, St
 }
 
 fn aggregate_chat_completion_sse(body: &str) -> Result<Value, String> {
+    aggregate_chat_completion_sse_with_observer(body, None)
+}
+
+fn aggregate_chat_completion_sse_with_observer(
+    body: &str,
+    mut observer: Option<&mut dyn FnMut(NativeProviderStreamEvent)>,
+) -> Result<Value, String> {
     let mut content = String::new();
     let mut reasoning_content = String::new();
     let mut model = None::<String>;
@@ -338,6 +364,9 @@ fn aggregate_chat_completion_sse(body: &str) -> Result<Value, String> {
             .and_then(Value::as_str)
         {
             content.push_str(delta);
+            if let Some(observer) = observer.as_deref_mut() {
+                observer(NativeProviderStreamEvent::ContentDelta(delta.to_string()));
+            }
         }
         if let Some(delta) = chunk
             .pointer("/choices/0/delta/reasoning_content")
@@ -345,6 +374,9 @@ fn aggregate_chat_completion_sse(body: &str) -> Result<Value, String> {
             .and_then(Value::as_str)
         {
             reasoning_content.push_str(delta);
+            if let Some(observer) = observer.as_deref_mut() {
+                observer(NativeProviderStreamEvent::ReasoningDelta(delta.to_string()));
+            }
         }
         if let Some(deltas) = chunk
             .pointer("/choices/0/delta/tool_calls")
@@ -588,6 +620,7 @@ struct NativeChatRouteBody {
     status: u16,
     body: Value,
     stream: bool,
+    observed_stream: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -601,6 +634,14 @@ struct NativeChatRouteError {
 fn native_chat_completion(
     config: &Value,
     body: &Value,
+) -> Result<NativeChatRouteBody, NativeChatRouteError> {
+    native_chat_completion_with_observer(config, body, None)
+}
+
+fn native_chat_completion_with_observer(
+    config: &Value,
+    body: &Value,
+    mut observer: Option<&mut dyn FnMut(NativeProviderStreamEvent)>,
 ) -> Result<NativeChatRouteBody, NativeChatRouteError> {
     let request = parse_chat_request(config, body)?;
     let profile = resolve_chat_provider_profile(config, &request.model).ok_or_else(|| {
@@ -619,27 +660,36 @@ fn native_chat_completion(
                 status: 200,
                 body: Value::String(chat_completion_sse(&request.model, &content)),
                 stream: true,
+                observed_stream: false,
             }
         } else {
             NativeChatRouteBody {
                 status: 200,
                 body: chat_completion_body(&request.model, &content),
                 stream: false,
+                observed_stream: false,
             }
         });
     }
 
     if request.stream {
-        complete_openai_chat_stream(profile, request).map(|body| NativeChatRouteBody {
+        let observed_stream = observer.is_some();
+        let stream_result = match observer {
+            Some(ref mut observer) => complete_openai_chat_stream(profile, request, Some(&mut **observer)),
+            None => complete_openai_chat_stream(profile, request, None),
+        };
+        stream_result.map(|body| NativeChatRouteBody {
             status: 200,
             body: Value::String(body),
             stream: true,
+            observed_stream,
         })
     } else {
         complete_openai_chat(profile, request).map(|body| NativeChatRouteBody {
             status: 200,
             body,
             stream: false,
+            observed_stream: false,
         })
     }
 }
@@ -723,6 +773,7 @@ fn complete_openai_chat(
 fn complete_openai_chat_stream(
     profile: NativeProviderProfile,
     mut request: NativeChatRequest,
+    mut observer: Option<&mut dyn FnMut(NativeProviderStreamEvent)>,
 ) -> Result<String, NativeChatRouteError> {
     request.body["stream"] = Value::Bool(true);
     tauri::async_runtime::block_on(async move {
@@ -736,7 +787,12 @@ fn complete_openai_chat_stream(
         let mut body = String::new();
         while let Some(chunk) = stream.next().await {
             match chunk {
-                Ok(chunk) => push_sse_json(&mut body, &chunk),
+                Ok(chunk) => {
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observe_stream_chunk(&chunk, observer);
+                    }
+                    push_sse_json(&mut body, &chunk);
+                }
                 Err(error) => {
                     push_sse_error(&mut body, error.to_string());
                     body.push_str("data: [DONE]\n\n");
@@ -888,6 +944,27 @@ fn push_sse_json(body: &mut String, value: &Value) {
     body.push_str("data: ");
     body.push_str(&line);
     body.push_str("\n\n");
+}
+
+fn observe_stream_chunk(
+    chunk: &Value,
+    observer: &mut dyn FnMut(NativeProviderStreamEvent),
+) {
+    if let Some(delta) = chunk
+        .pointer("/choices/0/delta/content")
+        .and_then(Value::as_str)
+        .filter(|delta| !delta.is_empty())
+    {
+        observer(NativeProviderStreamEvent::ContentDelta(delta.to_string()));
+    }
+    if let Some(delta) = chunk
+        .pointer("/choices/0/delta/reasoning_content")
+        .or_else(|| chunk.pointer("/choices/0/delta/reasoningContent"))
+        .and_then(Value::as_str)
+        .filter(|delta| !delta.is_empty())
+    {
+        observer(NativeProviderStreamEvent::ReasoningDelta(delta.to_string()));
+    }
 }
 
 fn push_sse_error(body: &mut String, message: String) {

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -316,6 +316,12 @@ pub struct NativeAgentProviderResponse {
     pub tool_calls: Vec<NativeAgentToolCall>,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum NativeAgentProviderStreamEvent {
+    ContentDelta(String),
+    ReasoningDelta(String),
+}
+
 #[derive(Clone, Debug)]
 pub struct NativeAgentToolCall {
     pub id: String,
@@ -589,6 +595,14 @@ pub trait NativeAgentProvider: Send + Sync {
         &self,
         context: &NativeAgentRunContext,
     ) -> Result<NativeAgentProviderResponse, String>;
+
+    fn complete_streaming(
+        &self,
+        context: &NativeAgentRunContext,
+        _observer: &mut dyn FnMut(NativeAgentProviderStreamEvent),
+    ) -> Result<NativeAgentProviderResponse, String> {
+        self.complete(context)
+    }
 }
 
 pub trait NativeAgentToolDispatcher: Send + Sync {
@@ -878,10 +892,32 @@ impl NativeAgentProvider for RustNativeAgentProvider {
         &self,
         context: &NativeAgentRunContext,
     ) -> Result<NativeAgentProviderResponse, String> {
+        let mut observer = |_event: NativeAgentProviderStreamEvent| {};
+        self.complete_streaming(context, &mut observer)
+    }
+
+    fn complete_streaming(
+        &self,
+        context: &NativeAgentRunContext,
+        observer: &mut dyn FnMut(NativeAgentProviderStreamEvent),
+    ) -> Result<NativeAgentProviderResponse, String> {
         let request = agent_chat_completion_request(context)?;
         let provider_config = agent_provider_config(context);
-        let completion =
-            crate::native_provider_runtime::complete_chat_for_agent(&provider_config, &request)?;
+        let mut provider_observer = |event: crate::native_provider_runtime::NativeProviderStreamEvent| {
+            match event {
+                crate::native_provider_runtime::NativeProviderStreamEvent::ContentDelta(delta) => {
+                    observer(NativeAgentProviderStreamEvent::ContentDelta(delta));
+                }
+                crate::native_provider_runtime::NativeProviderStreamEvent::ReasoningDelta(delta) => {
+                    observer(NativeAgentProviderStreamEvent::ReasoningDelta(delta));
+                }
+            }
+        };
+        let completion = crate::native_provider_runtime::complete_chat_for_agent_with_observer(
+            &provider_config,
+            &request,
+            &mut provider_observer,
+        )?;
         let fixture_response = fixture_agent_response(&context.config_snapshot, &context.messages);
 
         Ok(NativeAgentProviderResponse {
@@ -1443,7 +1479,54 @@ pub fn run_native_agent_turn_with_config(
         );
         context.messages = state.messages.clone();
         context.spec["messages"] = Value::Array(state.messages.clone());
-        let provider_response = match services.provider.complete(&context) {
+        let mut provider_streamed_content = false;
+        let mut provider_streamed_reasoning = false;
+        let provider_response = {
+            let mut stream_observer = |event: NativeAgentProviderStreamEvent| match event {
+                NativeAgentProviderStreamEvent::ContentDelta(delta) => {
+                    if delta.is_empty() {
+                        return;
+                    }
+                    provider_streamed_content = true;
+                    state.transition_phase(
+                        AgentRuntimePhase::StreamingModel,
+                        iteration,
+                        "agent.delta",
+                    );
+                    state.emit_event(
+                        "agent.delta",
+                        serde_json::json!({
+                            "runId": context.run_id,
+                            "sessionId": context.session_id,
+                            "iteration": iteration,
+                            "delta": delta,
+                        }),
+                    );
+                }
+                NativeAgentProviderStreamEvent::ReasoningDelta(delta) => {
+                    if delta.is_empty() {
+                        return;
+                    }
+                    provider_streamed_reasoning = true;
+                    state.transition_phase(
+                        AgentRuntimePhase::StreamingModel,
+                        iteration,
+                        "agent.reasoning_delta",
+                    );
+                    state.emit_event(
+                        "agent.reasoning_delta",
+                        serde_json::json!({
+                            "runId": context.run_id,
+                            "sessionId": context.session_id,
+                            "iteration": iteration,
+                            "delta": delta,
+                        }),
+                    );
+                }
+            };
+            services.provider.complete_streaming(&context, &mut stream_observer)
+        };
+        let provider_response = match provider_response {
             Ok(response) => response,
             Err(error) => {
                 state.set_stop_reason("provider_error", iteration, "agent.error");
@@ -1478,7 +1561,7 @@ pub fn run_native_agent_turn_with_config(
 
         let current_phase = state.phase.as_str().to_string();
         maybe_emit_checkpoint(services, &context, &mut state, &current_phase);
-        if let Some(reasoning_delta) = provider_response.reasoning_delta.clone() {
+        if let Some(reasoning_delta) = provider_response.reasoning_delta.clone().filter(|_| !provider_streamed_reasoning) {
             state.transition_phase(
                 AgentRuntimePhase::StreamingModel,
                 iteration,
@@ -1494,7 +1577,7 @@ pub fn run_native_agent_turn_with_config(
                 }),
             );
         }
-        if context.stream && !provider_response.final_content.is_empty() {
+        if context.stream && !provider_response.final_content.is_empty() && !provider_streamed_content {
             state.transition_phase(AgentRuntimePhase::StreamingModel, iteration, "agent.delta");
             state.emit_event(
                 "agent.delta",
@@ -5896,6 +5979,81 @@ mod tests {
         assert!(
             services.restore_checkpoint("websocket:chat-approval-guidance")["checkpoint"].is_null()
         );
+    }
+
+    #[test]
+    fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
+        struct StreamingProvider;
+
+        impl NativeAgentProvider for StreamingProvider {
+            fn complete(
+                &self,
+                _context: &NativeAgentRunContext,
+            ) -> Result<NativeAgentProviderResponse, String> {
+                Ok(NativeAgentProviderResponse {
+                    final_content: "Hello".to_string(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: Vec::new(),
+                })
+            }
+
+            fn complete_streaming(
+                &self,
+                _context: &NativeAgentRunContext,
+                observer: &mut dyn FnMut(NativeAgentProviderStreamEvent),
+            ) -> Result<NativeAgentProviderResponse, String> {
+                observer(NativeAgentProviderStreamEvent::ReasoningDelta(
+                    "thinking".to_string(),
+                ));
+                observer(NativeAgentProviderStreamEvent::ContentDelta("Hel".to_string()));
+                observer(NativeAgentProviderStreamEvent::ContentDelta("lo".to_string()));
+                Ok(NativeAgentProviderResponse {
+                    final_content: "Hello".to_string(),
+                    reasoning_delta: Some("thinking".to_string()),
+                    usage: None,
+                    tool_calls: Vec::new(),
+                })
+            }
+        }
+
+        let services = NativeAgentRuntimeServices::new(
+            Arc::new(StreamingProvider),
+            Arc::new(FakeNativeAgentToolDispatcher),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        );
+
+        let result = run_native_agent_turn_with_services(
+            &services,
+            json!({
+                "runtime": "rust",
+                "runId": "run-streaming-provider",
+                "sessionId": "websocket:chat-streaming-provider",
+                "stream": true,
+                "messages": [{ "role": "user", "content": "hello" }]
+            }),
+        )
+        .expect("streaming provider run should succeed");
+
+        let deltas = result["events"]
+            .as_array()
+            .expect("events should be an array")
+            .iter()
+            .filter(|event| event["eventName"] == "agent.delta")
+            .map(|event| event["payload"]["delta"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>();
+        let reasoning_deltas = result["events"]
+            .as_array()
+            .expect("events should be an array")
+            .iter()
+            .filter(|event| event["eventName"] == "agent.reasoning_delta")
+            .map(|event| event["payload"]["delta"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>();
+
+        assert_eq!(deltas, vec!["Hel", "lo"]);
+        assert_eq!(reasoning_deltas, vec!["thinking"]);
+        assert_eq!(result["finalContent"], "Hello");
     }
 
     fn event_names(result: &Value) -> Vec<&str> {

--- a/src-tauri/src/worker_rpc.rs
+++ b/src-tauri/src/worker_rpc.rs
@@ -3182,7 +3182,7 @@ mod tests {
             "session.patch_metadata",
             json!({
                 "session_id": "session-1",
-                "metadata": { "pinned": true }
+                "metadata": { "pinned": true, "title": "Patched title" }
             }),
         );
 
@@ -3192,9 +3192,11 @@ mod tests {
             response.result.as_ref().unwrap()["extra"]["metadata"],
             json!({
                 "pinned": true,
+                "title": "Patched title",
                 "topic": "old"
             })
         );
+        assert_eq!(response.result.as_ref().unwrap()["title"], "Patched title");
         assert!(response.error.is_none());
 
         let thread_list = router.dispatch(&WorkerRequest::new(
@@ -3206,11 +3208,12 @@ mod tests {
         assert_eq!(thread_list.error, None);
         let thread = &thread_list.result.as_ref().unwrap()["threads"][0];
         assert_eq!(thread["sessionKey"], "session-1");
-        assert_eq!(thread["title"], "Native Core Migration");
+        assert_eq!(thread["title"], "Patched title");
         assert_eq!(
             thread["metadata"]["extra"]["metadata"],
             json!({
                 "pinned": true,
+                "title": "Patched title",
                 "topic": "old"
             })
         );

--- a/src-tauri/src/worker_session/metadata.rs
+++ b/src-tauri/src/worker_session/metadata.rs
@@ -146,6 +146,14 @@ impl WorkerSessionRpc {
                     existing.insert(key.clone(), value.clone());
                 }
             }
+            if let Some(title) = patch
+                .get("title")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|title| !title.is_empty())
+            {
+                session.title = title.to_string();
+            }
             session.updated_at = now_session_timestamp();
             session.clone()
         };

--- a/src-tauri/src/worker_session/tests.rs
+++ b/src-tauri/src/worker_session/tests.rs
@@ -865,6 +865,20 @@ mod tests {
     }
 
     #[test]
+    fn patch_metadata_updates_session_title_with_write_capability() {
+        let session = session_fixture();
+        let mut rpc = WorkerSessionRpc::new(vec![session], write_policy());
+
+        let updated = rpc
+            .patch_metadata("session-1", json!({ "title": "你好" }))
+            .expect("metadata title should patch");
+
+        assert_eq!(updated.session_id, "session-1");
+        assert_eq!(updated.title, "你好");
+        assert_eq!(updated.extra["metadata"]["title"], json!("你好"));
+    }
+
+    #[test]
     fn get_checkpoint_returns_runtime_checkpoint_with_read_capability() {
         let mut session = session_fixture();
         session.extra = json!({

--- a/src/app-core/chat/chatRunModel.ts
+++ b/src/app-core/chat/chatRunModel.ts
@@ -504,12 +504,21 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
 
   if (event.event_type === "reasoning.started" || event.event_type === "reasoning.delta" || event.event_type === "reasoning.completed") {
     const visibility = stringValue(event.payload.visibility) || "hidden";
+    const text = visibility === "hidden"
+      ? stringValue(event.payload.summary ?? event.payload.text)
+      : stringValue(event.payload.text ?? event.payload.summary);
+    const messageId = stringValue(event.payload.message_id) || stringValue(event.payload.messageId);
+    const stepId = reasoningStepId(turn.id, messageId);
+    const existingStep = turn.steps.find((step) => step.id === stepId && step.kind === "reasoning");
+    const summary = event.event_type === "reasoning.delta" && existingStep
+      ? `${existingStep.summary ?? ""}${text}`
+      : text || existingStep?.summary || "";
     upsertStep(turn, event, {
       kind: "reasoning",
       status: event.event_type === "reasoning.completed" ? "completed" : "running",
-      summary: visibility === "hidden" ? stringValue(event.payload.summary) : stringValue(event.payload.text ?? event.payload.summary),
+      summary,
       title: event.event_type === "reasoning.completed" ? "Thinking complete" : "Thinking",
-    });
+    }, stepId);
     return state;
   }
 
@@ -1192,6 +1201,10 @@ function upsertStep(
 
 function messageStepId(turnId: string, messageId: string): string {
   return stableId("step", turnId, "message", messageId);
+}
+
+function reasoningStepId(turnId: string, messageId: string): string {
+  return stableId("step", turnId, "reasoning", messageId || "default");
 }
 
 function syntheticTurn(sessionKey: string, index: number, timestamp: string): ChatTurn {

--- a/src/app-core/chat/desktopChatSessionController.test.ts
+++ b/src/app-core/chat/desktopChatSessionController.test.ts
@@ -8,7 +8,7 @@ describe("desktop chat session controller", () => {
     const controller = createDesktopChatSessionController({
       api: {
         listSessions: vi.fn(async () => ({
-          items: [{ key: "WebSocket:chat-1", chat_id: "chat-1", title: "Plan", updated_at: "2026-05-31T08:00:00Z" }],
+          items: [{ key: "websocket:chat-1", chat_id: "chat-1", title: "Plan", updated_at: "2026-05-31T08:00:00Z" }],
         })),
         loadMessages: vi.fn(async (key: string) => ({
           messages: [{ role: "user", content: `loaded ${key}`, message_id: "m-user" }],
@@ -19,24 +19,24 @@ describe("desktop chat session controller", () => {
 
     await expect(controller.loadSessions()).resolves.toBe(1);
 
-    expect(controller.state.activeSessionKey).toBe("WebSocket:chat-1");
-    expect(controller.state.messages.get("WebSocket:chat-1")).toMatchObject([{ content: "loaded WebSocket:chat-1" }]);
+    expect(controller.state.activeSessionKey).toBe("websocket:chat-1");
+    expect(controller.state.messages.get("websocket:chat-1")).toMatchObject([{ content: "loaded websocket:chat-1" }]);
     expect(sent).toEqual([{ type: "attach", chat_id: "chat-1" }]);
   });
 
   test("hydrates restored chat surface messages from backend turn items when available", async () => {
     const sent: unknown[] = [];
     const listAgentRuns = vi.fn(async () => ({
-      sessionId: "WebSocket:chat-1",
+      sessionId: "websocket:chat-1",
       runs: [{ runId: "run-1", startedAt: "2026-07-03T01:00:00Z" }],
     }));
     const getAgentRunRuntimeState = vi.fn(async () => ({
-      sessionId: "WebSocket:chat-1",
+      sessionId: "websocket:chat-1",
       runId: "run-1",
       runtimeEvents: [],
       turnItems: [{
         itemId: "call-read",
-        sessionId: "WebSocket:chat-1",
+        sessionId: "websocket:chat-1",
         turnId: "run-1",
         kind: "tool_call",
         status: "completed",
@@ -54,7 +54,7 @@ describe("desktop chat session controller", () => {
     const controller = createDesktopChatSessionController({
       api: {
         listSessions: vi.fn(async () => ({
-          items: [{ key: "WebSocket:chat-1", chat_id: "chat-1", title: "Plan", updated_at: "2026-07-03T01:00:00Z" }],
+          items: [{ key: "websocket:chat-1", chat_id: "chat-1", title: "Plan", updated_at: "2026-07-03T01:00:00Z" }],
         })),
         loadMessages: vi.fn(async () => ({
           messages: [{ role: "user", content: "Read README", timestamp: "2026-07-03T01:00:00Z", message_id: "m-user" }],
@@ -67,9 +67,9 @@ describe("desktop chat session controller", () => {
 
     await controller.loadSessions();
 
-    expect(listAgentRuns).toHaveBeenCalledWith("WebSocket:chat-1");
-    expect(getAgentRunRuntimeState).toHaveBeenCalledWith("WebSocket:chat-1", "run-1");
-    expect(controller.state.chatRuns.turnsBySession.get("WebSocket:chat-1")?.[0]).toMatchObject({
+    expect(listAgentRuns).toHaveBeenCalledWith("websocket:chat-1");
+    expect(getAgentRunRuntimeState).toHaveBeenCalledWith("websocket:chat-1", "run-1");
+    expect(controller.state.chatRuns.turnsBySession.get("websocket:chat-1")?.[0]).toMatchObject({
       id: "run-1",
       userMessage: { text: "Read README" },
       steps: [expect.objectContaining({
@@ -80,7 +80,7 @@ describe("desktop chat session controller", () => {
         }),
       })],
     });
-    expect(controller.state.messages.get("WebSocket:chat-1")?.flatMap((message) => message.toolActivities ?? [])).toEqual([
+    expect(controller.state.messages.get("websocket:chat-1")?.flatMap((message) => message.toolActivities ?? [])).toEqual([
       expect.objectContaining({
         id: "call-read",
         name: "read_file",
@@ -96,7 +96,7 @@ describe("desktop chat session controller", () => {
       events: [{
         eventId: "trace-event-1",
         eventType: "agent.delegate.trace.updated",
-        sessionKey: "WebSocket:chat-1",
+        sessionKey: "websocket:chat-1",
         turnId: "turn-restored",
         stepId: "step-delegate-1",
         sequence: 1,
@@ -114,7 +114,7 @@ describe("desktop chat session controller", () => {
           trace: {
             delegateId: "delegate-1",
             parentRunId: "run-parent",
-            parentSessionKey: "WebSocket:chat-1",
+            parentSessionKey: "websocket:chat-1",
             status: "completed",
             steps: [{
               id: "message:delegate-1",
@@ -130,7 +130,7 @@ describe("desktop chat session controller", () => {
     const controller = createDesktopChatSessionController({
       api: {
         listSessions: vi.fn(async () => ({
-          items: [{ key: "WebSocket:chat-1", chat_id: "chat-1", title: "Spawn", updated_at: "2026-06-28T04:00:00Z" }],
+          items: [{ key: "websocket:chat-1", chat_id: "chat-1", title: "Spawn", updated_at: "2026-06-28T04:00:00Z" }],
         })),
         loadMessages: vi.fn(async () => ({
           messages: [{ role: "user", content: "spawn a subagent", message_id: "m-user" }],
@@ -142,8 +142,8 @@ describe("desktop chat session controller", () => {
 
     await controller.loadSessions();
 
-    expect(listTraceEvents).toHaveBeenCalledWith({ sessionKey: "WebSocket:chat-1" });
-    const toolActivities = [...(controller.state.messages.get("WebSocket:chat-1") ?? [])]
+    expect(listTraceEvents).toHaveBeenCalledWith({ sessionKey: "websocket:chat-1" });
+    const toolActivities = [...(controller.state.messages.get("websocket:chat-1") ?? [])]
       .flatMap((message) => message.toolActivities ?? []);
     expect(toolActivities).toEqual([
       expect.objectContaining({
@@ -183,7 +183,7 @@ describe("desktop chat session controller", () => {
     await expect(controller.loadArtifact({
       artifactId: "artifact-1",
       delegateId: "delegate-1",
-      sessionKey: "WebSocket:chat-1",
+      sessionKey: "websocket:chat-1",
       traceRef: "trace-1",
     })).resolves.toEqual({
       artifact: {
@@ -195,7 +195,7 @@ describe("desktop chat session controller", () => {
     expect(getArtifact).toHaveBeenCalledWith({
       artifactId: "artifact-1",
       delegateId: "delegate-1",
-      sessionKey: "WebSocket:chat-1",
+      sessionKey: "websocket:chat-1",
       traceRef: "trace-1",
     });
   });
@@ -207,7 +207,7 @@ describe("desktop chat session controller", () => {
         listSessions: vi.fn(async () => ({
           items: [
             { key: "7e9e439b4487", chat_id: "chat-7e9e", title: "你好", updated_at: "2026-06-03T08:11:21Z" },
-            { key: "WebSocket:chat-1", chat_id: "chat-1", title: "New session" },
+            { key: "websocket:chat-1", chat_id: "chat-1", title: "New session" },
           ],
         })),
         loadMessages: vi.fn(async (key: string) => ({
@@ -232,8 +232,8 @@ describe("desktop chat session controller", () => {
     const sent: unknown[] = [];
     const deleted: string[] = [];
     let sessions = [
-      { key: "WebSocket:chat-1", chat_id: "chat-1", title: "First chat" },
-      { key: "WebSocket:chat-2", chat_id: "chat-2", title: "Second chat" },
+      { key: "websocket:chat-1", chat_id: "chat-1", title: "First chat" },
+      { key: "websocket:chat-2", chat_id: "chat-2", title: "Second chat" },
     ];
     const controller = createDesktopChatSessionController({
       api: {
@@ -252,18 +252,18 @@ describe("desktop chat session controller", () => {
 
     await controller.loadSessions();
 
-    await expect(controller.deleteSession("WebSocket:chat-1")).resolves.toEqual({
+    await expect(controller.deleteSession("websocket:chat-1")).resolves.toEqual({
       status: "deleted",
-      deletedSessionKey: "WebSocket:chat-1",
-      nextSessionKey: "WebSocket:chat-2",
+      deletedSessionKey: "websocket:chat-1",
+      nextSessionKey: "websocket:chat-2",
     });
 
-    expect(deleted).toEqual(["WebSocket:chat-1"]);
-    expect(controller.state.sessions.map((session) => session.key)).toEqual(["WebSocket:chat-2"]);
-    expect(controller.state.activeSessionKey).toBe("WebSocket:chat-2");
+    expect(deleted).toEqual(["websocket:chat-1"]);
+    expect(controller.state.sessions.map((session) => session.key)).toEqual(["websocket:chat-2"]);
+    expect(controller.state.activeSessionKey).toBe("websocket:chat-2");
     expect(controller.state.activeChatId).toBe("chat-2");
-    expect(controller.state.messages.has("WebSocket:chat-1")).toBe(false);
-    expect(controller.state.messages.get("WebSocket:chat-2")).toMatchObject([{ content: "loaded WebSocket:chat-2" }]);
+    expect(controller.state.messages.has("websocket:chat-1")).toBe(false);
+    expect(controller.state.messages.get("websocket:chat-2")).toMatchObject([{ content: "loaded websocket:chat-2" }]);
     expect(sent).toEqual([
       { type: "attach", chat_id: "chat-1" },
       { type: "attach", chat_id: "chat-2" },
@@ -274,7 +274,7 @@ describe("desktop chat session controller", () => {
     const deleted: string[] = [];
     let sessions = [
       { key: "5225ad1670a7", chat_id: "5225ad1670a7", title: "New session" },
-      { key: "WebSocket:f9387efaabab", chat_id: "f9387efaabab", title: "Next session" },
+      { key: "websocket:f9387efaabab", chat_id: "f9387efaabab", title: "Next session" },
     ];
     const controller = createDesktopChatSessionController({
       api: {
@@ -299,18 +299,18 @@ describe("desktop chat session controller", () => {
     await expect(controller.deleteSession("5225ad1670a7")).resolves.toEqual({
       status: "deleted",
       deletedSessionKey: "5225ad1670a7",
-      nextSessionKey: "WebSocket:f9387efaabab",
+      nextSessionKey: "websocket:f9387efaabab",
     });
 
-    expect(deleted).toEqual(["5225ad1670a7", "WebSocket:5225ad1670a7"]);
-    expect(controller.state.sessions.map((session) => session.key)).toEqual(["WebSocket:f9387efaabab"]);
-    expect(controller.state.activeSessionKey).toBe("WebSocket:f9387efaabab");
+    expect(deleted).toEqual(["5225ad1670a7", "websocket:5225ad1670a7"]);
+    expect(controller.state.sessions.map((session) => session.key)).toEqual(["websocket:f9387efaabab"]);
+    expect(controller.state.activeSessionKey).toBe("websocket:f9387efaabab");
   });
 
   test("patches session metadata and refreshes the local session list", async () => {
     const patched: unknown[] = [];
     let sessions = [
-      { key: "WebSocket:chat-1", chat_id: "chat-1", title: "First chat", metadata: { pinned: false } },
+      { key: "websocket:chat-1", chat_id: "chat-1", title: "First chat", metadata: { pinned: false } },
     ];
     const controller = createDesktopChatSessionController({
       api: {
@@ -319,7 +319,7 @@ describe("desktop chat session controller", () => {
         patchSession: vi.fn(async (sessionKey: string, body: unknown) => {
           patched.push({ body, sessionKey });
           sessions = [
-            { key: "WebSocket:chat-1", chat_id: "chat-1", title: "Renamed chat", metadata: { pinned: true } },
+            { key: "websocket:chat-1", chat_id: "chat-1", title: "Renamed chat", metadata: { pinned: true } },
           ];
           return { key: sessionKey };
         }),
@@ -329,11 +329,11 @@ describe("desktop chat session controller", () => {
 
     await controller.loadSessions();
 
-    await expect(controller.patchSession("WebSocket:chat-1", { metadata: { pinned: true, title: "Renamed chat" } })).resolves.toBe(true);
+    await expect(controller.patchSession("websocket:chat-1", { metadata: { pinned: true, title: "Renamed chat" } })).resolves.toBe(true);
 
     expect(patched).toEqual([{
       body: { metadata: { pinned: true, title: "Renamed chat" } },
-      sessionKey: "WebSocket:chat-1",
+      sessionKey: "websocket:chat-1",
     }]);
     expect(controller.state.sessions[0]).toMatchObject({
       pinned: true,
@@ -346,7 +346,7 @@ describe("desktop chat session controller", () => {
     const controller = createDesktopChatSessionController({
       api: {
         listSessions: vi.fn(async () => ({
-          items: [{ key: "WebSocket:chat-2", chat_id: "chat-2", title: "", updated_at: "2026-05-31T08:00:00Z" }],
+          items: [{ key: "websocket:chat-2", chat_id: "chat-2", title: "", updated_at: "2026-05-31T08:00:00Z" }],
         })),
         loadMessages: vi.fn(async () => ({ messages: [] })),
       },
@@ -429,7 +429,7 @@ describe("desktop chat session controller", () => {
     const controller = createDesktopChatSessionController({
       api: {
         listSessions: vi.fn(async () => ({
-          items: [{ key: "WebSocket:chat-old", chat_id: "chat-old", title: "Older chat" }],
+          items: [{ key: "websocket:chat-old", chat_id: "chat-old", title: "Older chat" }],
         })),
         loadMessages,
       },
@@ -439,7 +439,7 @@ describe("desktop chat session controller", () => {
     await controller.loadSessions();
     controller.startNewChat();
     await controller.handleGatewayEvent({ kind: "chat.created", chatId: "chat-live", raw: {} });
-    await controller.selectSession("WebSocket:chat-old", "chat-old");
+    await controller.selectSession("websocket:chat-old", "chat-old");
 
     await expect(controller.selectSession(sessionKeyForChat("chat-live"), "chat-live")).resolves.toBeUndefined();
 
@@ -493,7 +493,7 @@ describe("desktop chat session controller", () => {
     const controller = createDesktopChatSessionController({
       api: {
         listSessions: vi.fn(async () => ({
-          items: [{ key: "websocket:chat-native", chat_id: "chat-native", title: "Native chat" }],
+          items: [{ key: "WebSocket:chat-native", chat_id: "chat-native", title: "Native chat" }],
         })),
         loadMessages,
       },

--- a/src/app-core/chat/desktopChatSessionController.ts
+++ b/src/app-core/chat/desktopChatSessionController.ts
@@ -1,6 +1,7 @@
 import {
   appendUserMessage,
   applyChatEvent,
+  canonicalSessionKey,
   createNativeChatState,
   activateSession,
   hydrateAgentRunRuntimeStates,
@@ -90,6 +91,7 @@ export function createDesktopChatSessionController({
   }
 
   async function selectSession(sessionKey: string, chatId: string): Promise<void> {
+    sessionKey = canonicalSessionKey(sessionKey, chatId) || sessionKey;
     logDesktopNativeDebug("session.select.start", {
       ...summarizeSessionState(),
       chatId,
@@ -153,6 +155,7 @@ export function createDesktopChatSessionController({
 
   async function deleteSession(sessionKey: string): Promise<ChatDeleteSessionResult> {
     const deletedSessionKey = sessionKey;
+    sessionKey = canonicalSessionKey(sessionKey) || sessionKey;
     const target = state.sessions.find((session) => session.key === sessionKey);
     logDesktopNativeDebug("session.delete.start", {
       ...summarizeSessionState(),
@@ -263,6 +266,7 @@ export function createDesktopChatSessionController({
   }
 
   async function patchSession(sessionKey: string, body: unknown): Promise<boolean> {
+    sessionKey = canonicalSessionKey(sessionKey) || sessionKey;
     const target = state.sessions.find((session) => session.key === sessionKey);
     logDesktopNativeDebug("session.patch.start", {
       ...summarizeSessionState(),

--- a/src/app-core/chat/nativeChat.test.ts
+++ b/src/app-core/chat/nativeChat.test.ts
@@ -815,15 +815,37 @@ describe("native chat state", () => {
         },
       },
     });
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-reasoning-next",
+        event_type: "reasoning.delta",
+        chat_id: "chat-1",
+        session_key: "websocket:chat-1",
+        turn_id: "turn-1",
+        sequence: 3,
+        created_at: "2026-06-27T04:00:02.000Z",
+        payload: {
+          message_id: "assistant-stream",
+          summary: " Still thinking.",
+          text: " Still thinking.",
+          visibility: "hidden",
+        },
+      },
+    });
 
     expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
       { role: "user", content: "你好" },
       {
         role: "assistant",
         content: "",
-        reasoningContent: "I am checking context.",
+        reasoningContent: "I am checking context. Still thinking.",
       },
     ]);
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toHaveLength(2);
   });
 
   test("normalizes tool activity execution status for timeline rendering", () => {

--- a/src/app-core/chat/nativeChat.test.ts
+++ b/src/app-core/chat/nativeChat.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import {
   activateChat,
   applyChatEvent,
@@ -9,6 +9,7 @@ import {
   normalizeSessionsPayload,
   resolveNativeChatApproval,
   setMessages,
+  setSessions,
   sessionKeyForChat,
 } from "./nativeChat";
 
@@ -18,7 +19,7 @@ describe("native chat state", () => {
       normalizeSessionsPayload({
         items: [
           {
-            key: "WebSocket:chat-1",
+            key: "websocket:chat-1",
             chat_id: "chat-1",
             title: "Existing session",
             created_at: "2026-05-29T08:00:00Z",
@@ -28,7 +29,7 @@ describe("native chat state", () => {
       }),
     ).toEqual([
       {
-        key: "WebSocket:chat-1",
+        key: "websocket:chat-1",
         chatId: "chat-1",
         title: "Existing session",
         createdAt: "2026-05-29T08:00:00Z",
@@ -91,6 +92,44 @@ describe("native chat state", () => {
         messageId: "m-assistant",
       },
     ]);
+  });
+
+  test("canonicalizes legacy WebSocket session keys to the native backend key", () => {
+    expect(
+      normalizeSessionsPayload({
+        items: [
+          {
+            key: "WebSocket:chat-legacy",
+            chat_id: "chat-legacy",
+            title: "Legacy session",
+          },
+        ],
+      })[0],
+    ).toMatchObject({
+      key: "websocket:chat-legacy",
+      chatId: "chat-legacy",
+    });
+
+    const state = createNativeChatState();
+    state.messages.set("WebSocket:chat-legacy", [{
+      role: "user",
+      content: "kept message",
+      reasoningContent: "",
+      timestamp: "2026-07-05T10:00:00.000Z",
+      messageId: "legacy-user",
+    }]);
+
+    setSessions(state, [{
+      key: "WebSocket:chat-legacy",
+      chatId: "chat-legacy",
+      title: "Legacy session",
+      createdAt: "",
+      updatedAt: "",
+    }]);
+
+    expect(state.sessions[0].key).toBe("websocket:chat-legacy");
+    expect(state.messages.has("WebSocket:chat-legacy")).toBe(false);
+    expect(state.messages.get("websocket:chat-legacy")).toMatchObject([{ content: "kept message" }]);
   });
 
   test("tracks active session and merges streaming deltas like the hosted WebUI", () => {
@@ -630,7 +669,7 @@ describe("native chat state", () => {
         event_id: "event-tool-start",
         event_type: "tool.call.started",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "turn-1",
         step_id: "step-tool",
         sequence: 2,
@@ -652,7 +691,7 @@ describe("native chat state", () => {
         event_id: "event-final",
         event_type: "message.completed",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "turn-1",
         step_id: "step-final",
         sequence: 3,
@@ -693,7 +732,7 @@ describe("native chat state", () => {
         event_id: "event-turn-start",
         event_type: "agent.turn.started",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "turn-1",
         sequence: 1,
         created_at: "2026-06-27T04:00:00.000Z",
@@ -712,7 +751,7 @@ describe("native chat state", () => {
         event_id: "event-delta",
         event_type: "message.delta",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "turn-1",
         sequence: 2,
         created_at: "2026-06-27T04:00:01.000Z",
@@ -917,7 +956,7 @@ describe("native chat state", () => {
             delegateId: "delegate-1",
             childRunId: "delegate-1",
             parentRunId: "run-1",
-            parentSessionKey: "WebSocket:chat-1",
+            parentSessionKey: "websocket:chat-1",
             status: "completed",
             steps: [{
               id: "message:delegate-1",
@@ -938,9 +977,9 @@ describe("native chat state", () => {
       ],
     });
 
-    setMessages(state, "WebSocket:chat-1", messages);
+    setMessages(state, "websocket:chat-1", messages);
 
-    const delegate = state.chatRuns.delegatedRunsBySession.get("WebSocket:chat-1")?.get("delegate-1");
+    const delegate = state.chatRuns.delegatedRunsBySession.get("websocket:chat-1")?.get("delegate-1");
     expect(delegate).toMatchObject({
       id: "delegate-1",
       title: "Greeter",
@@ -958,7 +997,7 @@ describe("native chat state", () => {
 
   test("hydrates child trace journal events into delegated run traces", () => {
     const state = createNativeChatState();
-    const sessionKey = "WebSocket:chat-1";
+    const sessionKey = "websocket:chat-1";
     setMessages(state, sessionKey, normalizeMessagesPayload({
       messages: [
         {
@@ -1112,7 +1151,7 @@ describe("native chat state", () => {
         event_id: "event-tool-start",
         event_type: "tool.call.started",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "turn-1",
         step_id: "turn-1:call-spawn",
         sequence: 2,
@@ -1134,7 +1173,7 @@ describe("native chat state", () => {
         event_id: "event-approval",
         event_type: "approval.requested",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "turn-1",
         step_id: "turn-1:approval:approval-1",
         sequence: 3,
@@ -1177,7 +1216,7 @@ describe("native chat state", () => {
         event_id: "event-tool-start",
         event_type: "tool.call.started",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "turn-1",
         step_id: "turn-1:call-spawn",
         sequence: 2,
@@ -1199,7 +1238,7 @@ describe("native chat state", () => {
         event_id: "event-approval",
         event_type: "approval.requested",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "turn-1",
         step_id: "turn-1:approval:approval-1",
         sequence: 3,
@@ -1216,7 +1255,7 @@ describe("native chat state", () => {
     expect(resolveNativeChatApproval(state, {
       approvalId: "approval-1",
       decision: "approved",
-      sessionKey: "WebSocket:chat-1",
+      sessionKey: "websocket:chat-1",
     })).toBe(true);
 
     const assistantMessages = state.messages.get(sessionKeyForChat("chat-1"))?.filter((message) => message.role === "assistant") ?? [];
@@ -1278,7 +1317,7 @@ describe("native chat state", () => {
         event_id: "event-approval",
         event_type: "approval.requested",
         chat_id: "chat-1",
-        session_key: "WebSocket:chat-1",
+        session_key: "websocket:chat-1",
         turn_id: "run-1",
         step_id: "run-1:approval:approval-1",
         sequence: 3,
@@ -1296,7 +1335,7 @@ describe("native chat state", () => {
     expect(resolveNativeChatApproval(state, {
       approvalId: "approval-1",
       decision: "approved",
-      sessionKey: "WebSocket:chat-1",
+      sessionKey: "websocket:chat-1",
     })).toBe(true);
 
     const toolActivities = (state.messages.get(sessionKeyForChat("chat-1")) ?? [])
@@ -1356,7 +1395,7 @@ describe("native chat state", () => {
     expect(resolveNativeChatApproval(state, {
       approvalId: "approval-1",
       decision: "approved",
-      sessionKey: "WebSocket:chat-1",
+      sessionKey: "websocket:chat-1",
     })).toBe(true);
     applyChatEvent(state, {
       kind: "message.completed",

--- a/src/app-core/chat/nativeChat.test.ts
+++ b/src/app-core/chat/nativeChat.test.ts
@@ -772,6 +772,60 @@ describe("native chat state", () => {
     ]);
   });
 
+  test("projects live structured reasoning deltas into message reasoning content", () => {
+    const state = createNativeChatState();
+    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-turn-start",
+        event_type: "agent.turn.started",
+        chat_id: "chat-1",
+        session_key: "websocket:chat-1",
+        turn_id: "turn-1",
+        sequence: 1,
+        created_at: "2026-06-27T04:00:00.000Z",
+        payload: {
+          user_message: { id: "user-1", role: "user", text: "你好" },
+          user_message_id: "user-1",
+        },
+      },
+    });
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-reasoning",
+        event_type: "reasoning.delta",
+        chat_id: "chat-1",
+        session_key: "websocket:chat-1",
+        turn_id: "turn-1",
+        sequence: 2,
+        created_at: "2026-06-27T04:00:01.000Z",
+        payload: {
+          message_id: "assistant-stream",
+          summary: "I am checking context.",
+          text: "I am checking context.",
+          visibility: "hidden",
+        },
+      },
+    });
+
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
+      { role: "user", content: "你好" },
+      {
+        role: "assistant",
+        content: "",
+        reasoningContent: "I am checking context.",
+      },
+    ]);
+  });
+
   test("normalizes tool activity execution status for timeline rendering", () => {
     expect(
       normalizeMessagesPayload({

--- a/src/app-core/chat/nativeChat.ts
+++ b/src/app-core/chat/nativeChat.ts
@@ -113,14 +113,15 @@ export function createNativeChatState(): NativeChatState {
 }
 
 export function sessionKeyForChat(chatId: string): string {
-  return chatId ? `WebSocket:${chatId}` : "";
+  return chatId ? `websocket:${chatId}` : "";
 }
 
 export function sessionKeyForChatState(state: NativeChatState, chatId: string): string {
   if (!chatId) {
     return "";
   }
-  return state.sessions.find((session) => session.chatId === chatId)?.key || sessionKeyForChat(chatId);
+  const session = state.sessions.find((session) => session.chatId === chatId);
+  return canonicalSessionKey(session?.key ?? "", chatId) || sessionKeyForChat(chatId);
 }
 
 export function normalizeSessionsPayload(payload: unknown): NativeChatSession[] {
@@ -129,7 +130,7 @@ export function normalizeSessionsPayload(payload: unknown): NativeChatSession[] 
   }
   return payload.items.filter(isRecord).map((item) => {
     const chatId = stringValue(item.chat_id) || chatIdFromKey(stringValue(item.key));
-    const key = stringValue(item.key) || sessionKeyForChat(chatId);
+    const key = canonicalSessionKey(stringValue(item.key), chatId) || sessionKeyForChat(chatId);
     const metadata = isRecord(item.metadata) ? item.metadata : isRecord(item.extra) && isRecord(item.extra.metadata) ? item.extra.metadata : {};
     return {
       key,
@@ -177,11 +178,29 @@ export function normalizeMessagesPayload(payload: unknown): NativeChatMessage[] 
 }
 
 export function setSessions(state: NativeChatState, sessions: NativeChatSession[]) {
-  state.sessions = sessions;
-  for (const session of sessions) {
-    if (!state.messages.has(session.key)) {
-      state.messages.set(session.key, []);
+  const nextSessions = sessions.map((session) => ({
+    ...session,
+    key: canonicalSessionKey(session.key, session.chatId) || session.key,
+  }));
+  state.activeSessionKey = canonicalSessionKey(state.activeSessionKey, state.activeChatId) || state.activeSessionKey;
+  state.respondingSessionKeys = new Set([...state.respondingSessionKeys].map((key) => canonicalSessionKey(key) || key));
+  state.streamMessageKeys = new Map([...state.streamMessageKeys].map(([messageId, sessionKey]) => [
+    messageId,
+    canonicalSessionKey(sessionKey) || sessionKey,
+  ]));
+  state.sessions = nextSessions;
+  for (const session of nextSessions) {
+    const bucket = sessionKeyAliases(session.key, session.chatId)
+      .map((key) => state.messages.get(key))
+      .find((messages): messages is NativeChatMessage[] => Boolean(messages?.length))
+      ?? state.messages.get(session.key)
+      ?? [];
+    for (const alias of sessionKeyAliases(session.key, session.chatId)) {
+      if (alias !== session.key) {
+        state.messages.delete(alias);
+      }
     }
+    state.messages.set(session.key, bucket);
   }
 }
 
@@ -439,10 +458,11 @@ export function resolveNativeChatApproval(
   state: NativeChatState,
   options: { approvalId: string; decision: "approved" | "denied"; sessionKey: string },
 ): boolean {
+  const sessionKey = canonicalSessionKey(options.sessionKey, state.activeChatId) || options.sessionKey;
   const status = options.decision === "approved" ? "completed" : "failed";
   const resolutionText = options.decision === "approved" ? "Approved." : "Denied.";
   let changed = false;
-  const messages = state.messages.get(options.sessionKey) ?? [];
+  const messages = state.messages.get(sessionKey) ?? [];
   for (const message of messages) {
     if (!message.toolActivities?.length) {
       continue;
@@ -460,7 +480,7 @@ export function resolveNativeChatApproval(
       };
     });
   }
-  const turns = state.chatRuns.turnsBySession.get(options.sessionKey) ?? [];
+  const turns = state.chatRuns.turnsBySession.get(sessionKey) ?? [];
   for (const turn of turns) {
     for (const step of turn.steps) {
       if (step.toolCall?.approvalId === options.approvalId) {
@@ -479,7 +499,7 @@ export function resolveNativeChatApproval(
     }
   }
   if (turns.length && changed) {
-    state.messages.set(options.sessionKey, coalesceToolActivityMessages(conversationMessagesToNativeMessages(turnsToConversationMessages(turns))));
+    state.messages.set(sessionKey, coalesceToolActivityMessages(conversationMessagesToNativeMessages(turnsToConversationMessages(turns))));
   }
   return changed;
 }
@@ -496,7 +516,7 @@ export function activateChat(state: NativeChatState, chatId: string) {
 
 export function activateSession(state: NativeChatState, sessionKey: string, chatId: string) {
   state.activeChatId = chatId;
-  state.activeSessionKey = sessionKey || sessionKeyForChat(chatId);
+  state.activeSessionKey = canonicalSessionKey(sessionKey, chatId) || sessionKeyForChat(chatId);
   ensureMessageBucket(state, state.activeSessionKey);
   if (!state.sessions.some((session) => session.key === state.activeSessionKey)) {
     state.sessions = [
@@ -573,7 +593,10 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
     if (!envelope) {
       return;
     }
-    const sessionKey = envelope.session_key || sessionKeyForChatState(state, envelope.chat_id || state.activeChatId);
+    const sessionKey = canonicalSessionKey(
+      envelope.session_key || sessionKeyForChatState(state, envelope.chat_id || state.activeChatId),
+      envelope.chat_id || state.activeChatId,
+    );
     if (!sessionKey) {
       return;
     }
@@ -1002,7 +1025,7 @@ function agentEventEnvelopeFromRaw(raw: Record<string, unknown>): AgentEventEnve
     payload: isRecord(raw.payload) ? raw.payload : {},
     schema_version: "tinybot.agent_event.v1",
     sequence: numberValue(raw.sequence) ?? 0,
-    session_key: sessionKey || sessionKeyForChat(chatId),
+    session_key: canonicalSessionKey(sessionKey, chatId) || sessionKeyForChat(chatId),
     ...(stringValue(raw.step_id) ? { step_id: stringValue(raw.step_id) } : {}),
     turn_id: turnId,
   };
@@ -1440,6 +1463,30 @@ function arrayRows(value: unknown): Record<string, unknown>[] {
 
 function chatIdFromKey(key: string): string {
   return key.includes(":") ? key.split(":").slice(1).join(":") : key;
+}
+
+export function canonicalSessionKey(key: string, chatId = ""): string {
+  if (!key) {
+    return chatId ? sessionKeyForChat(chatId) : "";
+  }
+  const separator = key.indexOf(":");
+  if (separator < 0) {
+    return key;
+  }
+  const prefix = key.slice(0, separator).toLowerCase();
+  const rest = key.slice(separator + 1);
+  return prefix === "websocket" ? `websocket:${rest}` : key;
+}
+
+function sessionKeyAliases(key: string, chatId = ""): string[] {
+  const canonical = canonicalSessionKey(key, chatId);
+  const id = chatId || chatIdFromKey(key);
+  return [...new Set([
+    canonical,
+    key,
+    id ? `WebSocket:${id}` : "",
+    id ? `websocket:${id}` : "",
+  ].filter(Boolean))];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/app-core/native/desktopNativeWebSocketBridge.test.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.test.ts
@@ -241,6 +241,14 @@ describe("desktop native WebSocket bridge", () => {
       chat_id: "chat-native",
       text: "live final",
     }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "message.completed",
+      payload: expect.objectContaining({
+        text: "live final",
+      }),
+      turn_id: runId,
+    }));
   });
 
   test("does not emit final fallback content after done completes a streamed run first", async () => {
@@ -305,6 +313,14 @@ describe("desktop native WebSocket bridge", () => {
       event: "message",
       chat_id: "chat-native",
       text: "live final",
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "message.completed",
+      payload: expect.objectContaining({
+        text: "live final",
+      }),
+      turn_id: runId,
     }));
   });
 

--- a/src/app-core/native/desktopNativeWebSocketBridge.test.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.test.ts
@@ -104,6 +104,7 @@ describe("desktop native WebSocket bridge", () => {
       turn_id: "run-1",
       payload: expect.objectContaining({
         message_id: "message-1",
+        summary: "thinking",
         text: "thinking",
         visibility: "hidden",
       }),

--- a/src/app-core/native/desktopNativeWebSocketBridge.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.ts
@@ -405,6 +405,7 @@ class DesktopNativeWebSocket extends EventTarget {
       });
       this.emitAgentEventFrame(run, runId, eventName === "agent.reasoning_delta" ? "reasoning.delta" : "message.delta", {
         message_id: run.messageId,
+        ...(eventName === "agent.reasoning_delta" ? { summary: text } : {}),
         text,
         visibility: eventName === "agent.reasoning_delta" ? "hidden" : "visible",
       });

--- a/src/app-core/native/desktopNativeWebSocketBridge.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.ts
@@ -250,11 +250,13 @@ class DesktopNativeWebSocket extends EventTarget {
         message_id: runId || `native:${chatId}`,
         reason: stringValue(agent?.stopReason) || "stop",
       });
-      if (run && runId) {
-        this.emitAgentEventFrame(run, runId, "message.completed", {
-          message_id: run.messageId,
-          text: finalContent,
-        }, `${runId}:final`);
+    }
+    if (finalContent && run && runId) {
+      this.emitAgentEventFrame(run, runId, "message.completed", {
+        message_id: run.messageId,
+        text: finalContent,
+      }, `${runId}:final`);
+      if (!alreadyProjectedStream) {
         this.emitAgentEventFrame(run, runId, "agent.turn.completed", {
           message_id: run.messageId,
           reason: stringValue(agent?.stopReason) || "stop",

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -501,6 +501,49 @@ describe("ChatPage", () => {
     expect(screen.getByText("Branch loaded")).toBeTruthy();
   });
 
+  it("shows branch actions when a live assistant message completes", async () => {
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const stores = createStores();
+    const runningSession = {
+      id: "s1",
+      chatId: "chat-1",
+      title: "Planning notes",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 59, 0),
+      status: "running" as const,
+    };
+    const completedSession = {
+      ...runningSession,
+      status: "idle" as const,
+      updatedAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+    };
+    const assistantMessages: ReactChatMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 11, 58, 0),
+        text: "Yes.",
+        status: "complete",
+      },
+    ];
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([runningSession])
+      .mockResolvedValueOnce([completedSession]);
+    stores.chatStore.load = vi.fn(async () => assistantMessages);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const assistantMessage = await screen.findByTestId("message-a1");
+    expect(within(assistantMessage).queryByRole("button", { name: "Branch from here" })).toBeNull();
+
+    subscribed?.({ type: "message.completed" });
+
+    await waitFor(() => expect(within(assistantMessage).getByRole("button", { name: "Branch from here" })).toBeTruthy());
+  });
+
   it("sends composer text through the chat store", async () => {
     const user = userEvent.setup();
     const stores = createStores();

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -514,6 +514,69 @@ describe("ChatPage", () => {
     expect((input as HTMLTextAreaElement).value).toBe("");
   });
 
+  it("renders the optimistic user message immediately after send", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const stores = createStores();
+    stores.chatStore.load = vi.fn(async () => []);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+    stores.chatStore.send = vi.fn(async () => {
+      subscribed?.({
+        message: {
+          id: "local-user",
+          role: "user",
+          createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+          text: "Hello immediately",
+          status: "complete",
+        },
+        type: "message-sent",
+      });
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "Hello immediately");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
+    expect((await screen.findByTestId("message-local-user")).textContent).toContain("Hello immediately");
+  });
+
+  it("renders assistant thinking and context separately from the answer", async () => {
+    const stores = createStores();
+    const streamingMessages: ReactChatMessage[] = [
+      {
+        id: "assistant-live",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        reasoningText: "I am checking the available context.",
+        text: "Here is the answer.",
+        status: "streaming",
+        contextReferences: [{
+          id: "mem-1",
+          kind: "memory",
+          title: "Project note",
+          detail: "Use current backend contracts.",
+          sourcePath: "memory/MEMORY.md",
+          sourceLine: 12,
+        }],
+      },
+    ];
+    stores.chatStore.load = vi.fn(async () => streamingMessages);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const message = await screen.findByTestId("message-assistant-live");
+    expect(within(message).getByLabelText("Thinking").textContent).toContain("I am checking the available context.");
+    expect(within(message).getByLabelText("Context").textContent).toContain("Project note");
+    expect(within(message).getByLabelText("Context").textContent).toContain("Use current backend contracts.");
+    expect(within(message).getByLabelText("Agent is responding")).toBeTruthy();
+    expect(within(message).getByText("Here is the answer.")).toBeTruthy();
+  });
+
   it("keeps a pending new session visible until chat creation returns a real session", async () => {
     const user = userEvent.setup();
     let subscribed: ((event: ChatEvent) => void) | undefined;

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -514,6 +514,57 @@ describe("ChatPage", () => {
     expect((input as HTMLTextAreaElement).value).toBe("");
   });
 
+  it("keeps a pending new session visible until chat creation returns a real session", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const stores = createStores();
+    const pendingSession = {
+      id: "pending:1",
+      title: "New session",
+      updatedAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      status: "running" as const,
+    };
+    const realSession = {
+      id: "WebSocket:chat-2",
+      chatId: "chat-2",
+      title: "Summarize docs",
+      updatedAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      status: "idle" as const,
+    };
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([pendingSession])
+      .mockResolvedValueOnce([realSession]);
+    stores.sessionStore.create = vi.fn(async () => pendingSession);
+    stores.chatStore.load = vi.fn(async () => []);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await screen.findByText("No sessions yet.");
+    await user.click(screen.getByRole("button", { name: "New Chat" }));
+    expect(await screen.findByRole("heading", { name: "New session" })).toBeTruthy();
+
+    const input = screen.getByRole("textbox", { name: /message/i });
+    await user.type(input, "Summarize docs");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
+    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("pending:1", {
+      text: "Summarize docs",
+      usePersistentRag: true,
+    }));
+    expect(screen.queryByRole("heading", { name: "No session selected" })).toBeNull();
+    expect(screen.getByRole("button", { name: "New session" })).toBeTruthy();
+
+    subscribed?.({ type: "chat.created" });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Summarize docs" })).toBeTruthy());
+    expect(stores.chatStore.load).toHaveBeenLastCalledWith("WebSocket:chat-2");
+  });
+
   it("uses settings-backed model options instead of sample model defaults", async () => {
     const user = userEvent.setup();
     const stores = createStores();

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -27,7 +27,7 @@ import {
   type PastedContent,
 } from "../../components/ui/claude-style-ai-input";
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
-import type { ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
+import type { ChatEvent, ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
 import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
 import { canBranchFromMessage, type ContextReferenceSummary, type ReactChatMessage, type ToolCallSummary } from "./messageActions";
 
@@ -185,7 +185,7 @@ export function ChatPage({
         setMessages((current) => [...current, event.message as ReactChatMessage]);
         return;
       }
-      if (shouldReloadSessionsForChatEvent(event.type)) {
+      if (shouldReloadSessionsForChatEvent(event)) {
         void handleSessionStoreRefresh();
       }
       if (shouldReloadMessagesForChatEvent(event.type)) {
@@ -713,14 +713,25 @@ const MESSAGE_RELOAD_EVENT_TYPES = new Set([
 
 const SESSION_RELOAD_EVENT_TYPES = new Set([
   "chat.created",
+  "interrupted",
+  "message.completed",
+  "message.stream.completed",
+]);
+
+const TERMINAL_AGENT_EVENT_TYPES = new Set([
+  "agent.turn.completed",
+  "agent.turn.failed",
+  "agent.turn.interrupted",
+  "message.completed",
 ]);
 
 function shouldReloadMessagesForChatEvent(type: string): boolean {
   return MESSAGE_RELOAD_EVENT_TYPES.has(type);
 }
 
-function shouldReloadSessionsForChatEvent(type: string): boolean {
-  return SESSION_RELOAD_EVENT_TYPES.has(type);
+function shouldReloadSessionsForChatEvent(event: ChatEvent): boolean {
+  return SESSION_RELOAD_EVENT_TYPES.has(event.type)
+    || (event.type === "agent.event" && Boolean(event.eventType && TERMINAL_AGENT_EVENT_TYPES.has(event.eventType)));
 }
 
 async function writeClipboardText(value: string): Promise<void> {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -29,7 +29,7 @@ import {
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
 import type { ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
 import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
-import { canBranchFromMessage, type ReactChatMessage, type ToolCallSummary } from "./messageActions";
+import { canBranchFromMessage, type ContextReferenceSummary, type ReactChatMessage, type ToolCallSummary } from "./messageActions";
 
 export type ChatPageProps = {
   chatStore: ChatStore;
@@ -472,7 +472,7 @@ export function ChatPage({
               key={message.id}
               message={message}
               onBranch={() => void handleBranchFromMessage(activeSession, message.id)}
-              onCopy={() => void writeClipboardText(message.text)}
+              onCopy={() => void writeClipboardText(formatMessageForCopy(message))}
               onOpenTool={(toolCall) => setDrawer({
                 title: toolCall.name,
                 body: formatToolCallDetails(toolCall),
@@ -703,7 +703,6 @@ function TextType({ text }: { text: string }) {
 
 const MESSAGE_RELOAD_EVENT_TYPES = new Set([
   "attached",
-  "chat.created",
   "agent.event",
   "message.delta",
   "message.completed",
@@ -783,8 +782,11 @@ function MessageBubble({
       data-testid={`message-${message.id}`}
     >
       <div className="react-message__body">
+        {message.reasoningText ? <MessageReasoning text={message.reasoningText} /> : null}
         <MessageText text={message.text} />
+        {message.contextReferences?.length ? <MessageContext references={message.contextReferences} /> : null}
         {message.toolCalls?.length ? <AgentSteps toolCalls={message.toolCalls} onOpenTool={onOpenTool} /> : null}
+        {message.status === "streaming" ? <span className="react-message__streaming" aria-label="Agent is responding" /> : null}
       </div>
       <div className="react-message__actions" data-align={actionAlignment}>
         <button aria-label="Copy message" type="button" onClick={onCopy}>
@@ -798,6 +800,48 @@ function MessageBubble({
       </div>
     </article>
   );
+}
+
+function MessageReasoning({ text }: { text: string }) {
+  return (
+    <section className="react-message-reasoning" aria-label="Thinking">
+      <h3>Thinking</h3>
+      <MessageText text={text} />
+    </section>
+  );
+}
+
+function MessageContext({ references }: { references: ContextReferenceSummary[] }) {
+  return (
+    <section className="react-message-context" aria-label="Context">
+      <h3>Context</h3>
+      <ul>
+        {references.map((reference) => (
+          <li key={reference.id}>
+            <span>{reference.title}</span>
+            {reference.detail ? <small>{reference.detail}</small> : null}
+            {reference.sourcePath ? (
+              <small>
+                {reference.sourcePath}{typeof reference.sourceLine === "number" ? `:${reference.sourceLine}` : ""}
+              </small>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function formatMessageForCopy(message: ReactChatMessage): string {
+  return [
+    message.reasoningText ? `Thinking:\n${message.reasoningText}` : "",
+    message.text,
+    message.contextReferences?.length
+      ? `Context:\n${message.contextReferences.map((reference) => (
+        [reference.title, reference.detail, reference.sourcePath].filter(Boolean).join(" - ")
+      )).join("\n")}`
+      : "",
+  ].filter(Boolean).join("\n\n");
 }
 
 type AgentStepStatus = "pending" | "active" | "success" | "waiting" | "error";

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -185,6 +185,9 @@ export function ChatPage({
         setMessages((current) => [...current, event.message as ReactChatMessage]);
         return;
       }
+      if (shouldReloadSessionsForChatEvent(event.type)) {
+        void handleSessionStoreRefresh();
+      }
       if (shouldReloadMessagesForChatEvent(event.type)) {
         void loadMessages();
       }
@@ -254,8 +257,14 @@ export function ChatPage({
 
   async function handleSessionStoreRefresh() {
     const nextSessions = await sessionStore.list();
+    sessionsRef.current = nextSessions;
     setSessions(nextSessions);
-    setActiveSessionId((current) => current || nextSessions[0]?.id || "");
+    setActiveSessionId((current) => {
+      if (!nextSessions.length) {
+        return "";
+      }
+      return nextSessions.some((session) => session.id === current) ? current : nextSessions[0]?.id ?? "";
+    });
   }
 
   async function handlePinConversation(session: SessionSummary) {
@@ -703,8 +712,16 @@ const MESSAGE_RELOAD_EVENT_TYPES = new Set([
   "interrupted",
 ]);
 
+const SESSION_RELOAD_EVENT_TYPES = new Set([
+  "chat.created",
+]);
+
 function shouldReloadMessagesForChatEvent(type: string): boolean {
   return MESSAGE_RELOAD_EVENT_TYPES.has(type);
+}
+
+function shouldReloadSessionsForChatEvent(type: string): boolean {
+  return SESSION_RELOAD_EVENT_TYPES.has(type);
 }
 
 async function writeClipboardText(value: string): Promise<void> {

--- a/src/react-workbench/chat/messageActions.ts
+++ b/src/react-workbench/chat/messageActions.ts
@@ -5,12 +5,23 @@ export type ToolCallSummary = {
   summary?: string;
 };
 
+export type ContextReferenceSummary = {
+  id: string;
+  kind: string;
+  title: string;
+  detail?: string;
+  sourcePath?: string;
+  sourceLine?: number;
+};
+
 export type ReactChatMessage = {
   id: string;
   role: "user" | "assistant" | "system" | "tool";
   createdAtMs: number;
   text: string;
   status: "streaming" | "complete" | "failed";
+  contextReferences?: ContextReferenceSummary[];
+  reasoningText?: string;
   toolCalls?: ToolCallSummary[];
 };
 

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -100,6 +100,32 @@ describe("default desktop app services", () => {
     expect(mocks.gatewayApi.sessions.messages).toHaveBeenCalledTimes(1);
   });
 
+  test("maps live reasoning deltas to current chat thinking text", async () => {
+    const services = createDesktopAppServices();
+    await services.sessionStore.list();
+
+    const socket = mocks.openGatewaySocket.mock.results[0]?.value;
+    socket.handlers.onEvent({
+      kind: "message.delta",
+      chatId: "chat-1",
+      messageId: "assistant-live",
+      text: "I am checking context.",
+      reasoning: true,
+      raw: {},
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await expect(services.chatStore.load("websocket:chat-1")).resolves.toMatchObject([
+      {
+        id: "assistant-live",
+        reasoningText: "I am checking context.",
+        role: "assistant",
+        status: "streaming",
+      },
+    ]);
+  });
+
   test("emits the user message immediately after send", async () => {
     const services = createDesktopAppServices();
     await services.sessionStore.list();

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -175,6 +175,28 @@ describe("default desktop app services", () => {
     });
   });
 
+  test("keeps pending session cleanup best-effort when auto-title persistence fails", async () => {
+    mocks.gatewayApi.sessions.patch.mockRejectedValueOnce(new Error("unknown session"));
+    const services = createDesktopAppServices();
+    const pending = await services.sessionStore.create();
+
+    await expect(services.chatStore.send(pending.id, { text: "summarize docs", usePersistentRag: true })).resolves.toBeUndefined();
+    const socket = mocks.openGatewaySocket.mock.results[0]?.value;
+    socket.handlers.onEvent({
+      kind: "chat.created",
+      chatId: "chat-new",
+      raw: {},
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(services.sessionStore.list()).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "websocket:chat-new" }),
+    ]));
+    await expect(services.sessionStore.list()).resolves.not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: pending.id }),
+    ]));
+  });
+
   test("does not overwrite existing custom session titles", async () => {
     const services = createDesktopAppServices();
     await services.sessionStore.list();

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createDesktopAppServices } from "./defaultServices";
+
+const mocks = vi.hoisted(() => {
+  const gatewayApi = {
+    config: {
+      get: vi.fn(async () => ({})),
+      providers: vi.fn(async () => []),
+    },
+    knowledge: {
+      documents: vi.fn(async () => []),
+      stats: vi.fn(async () => []),
+    },
+    sessions: {
+      list: vi.fn(),
+      messages: vi.fn(),
+      delete: vi.fn(async () => ({ deleted: true })),
+      patch: vi.fn(async () => ({})),
+    },
+    skills: {
+      list: vi.fn(async () => []),
+    },
+    workspace: {
+      files: vi.fn(async () => []),
+    },
+  };
+  return {
+    checkGatewayHealth: vi.fn(async () => ({ tokenReady: false, wsUrl: "ws://tinybot.test/ws" })),
+    createGatewayApiClient: vi.fn(() => gatewayApi),
+    flushGatewaySocketQueue: vi.fn(() => 0),
+    gatewayApi,
+    openGatewaySocket: vi.fn((_config, handlers) => {
+      return {
+        addEventListener: vi.fn(),
+        handlers,
+        readyState: WebSocket.OPEN,
+        send: vi.fn(),
+      };
+    }),
+    sendGatewaySocketJson: vi.fn(() => "sent"),
+  };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }));
+vi.mock("../app-core/gateway/gatewayHttpClient", () => ({
+  DEFAULT_TS_COWORK_RUNTIME_ROLLOUT: "off",
+  checkGatewayHealth: mocks.checkGatewayHealth,
+  createGatewayApiClient: mocks.createGatewayApiClient,
+}));
+vi.mock("../app-core/gateway/gatewayWebSocketClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../app-core/gateway/gatewayWebSocketClient")>();
+  return {
+    ...actual,
+    flushGatewaySocketQueue: mocks.flushGatewaySocketQueue,
+    openGatewaySocket: mocks.openGatewaySocket,
+    sendGatewaySocketJson: mocks.sendGatewaySocketJson,
+  };
+});
+vi.mock("../app-core/gateway/desktopGatewayBridge", () => ({ installDesktopGatewayBridge: vi.fn() }));
+vi.mock("../app-core/gateway/desktopGatewayStartup", () => ({ ensureGatewayReady: vi.fn() }));
+vi.mock("../app-core/native/desktopNativeChannelLifecycle", () => ({ startDesktopNativeChannelRuntime: vi.fn() }));
+
+describe("default desktop app services", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.gatewayApi.sessions.list.mockResolvedValue({
+      items: [{ key: "websocket:chat-1", chat_id: "chat-1", title: "Live chat" }],
+    });
+    mocks.gatewayApi.sessions.messages.mockResolvedValue({ messages: [] });
+  });
+
+  test("does not reload persisted messages over an active live stream", async () => {
+    const services = createDesktopAppServices();
+    await services.sessionStore.list();
+    expect(mocks.gatewayApi.sessions.messages).toHaveBeenCalledTimes(1);
+
+    const socket = mocks.openGatewaySocket.mock.results[0]?.value;
+    socket.handlers.onEvent({
+      kind: "message.delta",
+      chatId: "chat-1",
+      messageId: "assistant-live",
+      text: "live",
+      reasoning: false,
+      raw: {},
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await expect(services.chatStore.load("websocket:chat-1")).resolves.toMatchObject([
+      {
+        id: "assistant-live",
+        role: "assistant",
+        status: "streaming",
+        text: "live",
+      },
+    ]);
+    expect(mocks.gatewayApi.sessions.messages).toHaveBeenCalledTimes(1);
+  });
+
+  test("emits the user message immediately after send", async () => {
+    const services = createDesktopAppServices();
+    await services.sessionStore.list();
+    const events: unknown[] = [];
+    services.chatStore.subscribe("websocket:chat-1", (event) => events.push(event));
+
+    await services.chatStore.send("websocket:chat-1", { text: "你好", usePersistentRag: true });
+
+    expect(events).toContainEqual(expect.objectContaining({
+      message: expect.objectContaining({
+        role: "user",
+        text: "你好",
+      }),
+      type: "message-sent",
+    }));
+  });
+});

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -116,4 +116,45 @@ describe("default desktop app services", () => {
       type: "message-sent",
     }));
   });
+
+  test("persists the first user message as the title for default sessions", async () => {
+    mocks.gatewayApi.sessions.list.mockResolvedValue({
+      items: [{ key: "websocket:chat-1", chat_id: "chat-1", title: "Desktop Session websocket:chat-1" }],
+    });
+    const services = createDesktopAppServices();
+    await services.sessionStore.list();
+
+    await services.chatStore.send("websocket:chat-1", { text: "你好\n第二行", usePersistentRag: true });
+
+    expect(mocks.gatewayApi.sessions.patch).toHaveBeenCalledWith("websocket:chat-1", {
+      title: "你好",
+    });
+  });
+
+  test("persists the first user message title after a pending session is created", async () => {
+    const services = createDesktopAppServices();
+    const pending = await services.sessionStore.create();
+
+    await services.chatStore.send(pending.id, { text: "帮我总结一份文档", usePersistentRag: true });
+    const socket = mocks.openGatewaySocket.mock.results[0]?.value;
+    socket.handlers.onEvent({
+      kind: "chat.created",
+      chatId: "chat-new",
+      raw: {},
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.gatewayApi.sessions.patch).toHaveBeenCalledWith("websocket:chat-new", {
+      title: "帮我总结一份文档",
+    });
+  });
+
+  test("does not overwrite existing custom session titles", async () => {
+    const services = createDesktopAppServices();
+    await services.sessionStore.list();
+
+    await services.chatStore.send("websocket:chat-1", { text: "new title candidate", usePersistentRag: true });
+
+    expect(mocks.gatewayApi.sessions.patch).not.toHaveBeenCalled();
+  });
 });

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -76,6 +76,7 @@ export function createDesktopAppServices(): AppServices {
   const pendingSocketMessages: unknown[] = [];
   const listeners = new Map<string, Set<Listener>>();
   let pendingNewSessionId = "";
+  let pendingNewSession: SessionSummary | null = null;
 
   const controller = createDesktopChatSessionController({
     api: {
@@ -147,6 +148,7 @@ export function createDesktopAppServices(): AppServices {
     await controller.handleGatewayEvent(event);
     if (event.kind === "chat.created") {
       pendingNewSessionId = "";
+      pendingNewSession = null;
     }
     notifyAll({ type: event.kind });
   }
@@ -185,7 +187,11 @@ export function createDesktopAppServices(): AppServices {
     sessionStore: {
       async list() {
         await initialize();
-        return controller.state.sessions.map((session) => mapSession(session, controller.state.respondingSessionKeys.has(session.key)));
+        const sessions = controller.state.sessions.map((session) => mapSession(session, controller.state.respondingSessionKeys.has(session.key)));
+        if (pendingNewSession && !sessions.some((session) => session.id === pendingNewSession?.id)) {
+          return [pendingNewSession, ...sessions];
+        }
+        return sessions;
       },
       async create(input) {
         await initialize();
@@ -199,6 +205,7 @@ export function createDesktopAppServices(): AppServices {
           updatedAtMs: Date.now(),
           status: "running" as const,
         };
+        pendingNewSession = pendingSession;
         notifySession(pendingNewSessionId, { type: "session-created" });
         return pendingSession;
       },
@@ -206,6 +213,7 @@ export function createDesktopAppServices(): AppServices {
         await initialize();
         if (id.startsWith("pending:")) {
           pendingNewSessionId = "";
+          pendingNewSession = null;
           return;
         }
         await controller.deleteSession(id);

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { createDesktopChatSessionController } from "../app-core/chat/desktopChatSessionController";
-import type { NativeChatMessage, NativeChatReference, NativeChatSession } from "../app-core/chat/nativeChat";
+import { sessionKeyForChat, type NativeChatMessage, type NativeChatReference, type NativeChatSession } from "../app-core/chat/nativeChat";
 import { DEFAULT_GATEWAY_CONFIG, resolveGatewayConfig } from "../app-core/gateway/gatewayConfig";
 import { installDesktopGatewayBridge } from "../app-core/gateway/desktopGatewayBridge";
 import { ensureGatewayReady } from "../app-core/gateway/desktopGatewayStartup";
@@ -77,6 +77,7 @@ export function createDesktopAppServices(): AppServices {
   const listeners = new Map<string, Set<Listener>>();
   let pendingNewSessionId = "";
   let pendingNewSession: SessionSummary | null = null;
+  let pendingNewSessionTitle = "";
 
   const controller = createDesktopChatSessionController({
     api: {
@@ -145,10 +146,15 @@ export function createDesktopAppServices(): AppServices {
   }
 
   async function handleGatewayEvent(event: NormalizedGatewayEvent): Promise<void> {
+    const titleForCreatedSession = event.kind === "chat.created" ? pendingNewSessionTitle : "";
     await controller.handleGatewayEvent(event);
     if (event.kind === "chat.created") {
+      if (titleForCreatedSession) {
+        await persistAutoSessionTitle(sessionKeyForChat(event.chatId), titleForCreatedSession);
+      }
       pendingNewSessionId = "";
       pendingNewSession = null;
+      pendingNewSessionTitle = "";
     }
     notifyAll({ type: event.kind });
   }
@@ -165,6 +171,13 @@ export function createDesktopAppServices(): AppServices {
     for (const callback of listeners.get(sessionId) ?? []) {
       callback(event);
     }
+  }
+
+  async function persistAutoSessionTitle(sessionId: string, title: string): Promise<void> {
+    if (!title) {
+      return;
+    }
+    await controller.patchSession(sessionId, { title });
   }
 
   async function loadSettingsSnapshot(): Promise<unknown> {
@@ -254,6 +267,7 @@ export function createDesktopAppServices(): AppServices {
       },
       async send(sessionId, input) {
         await initialize();
+        const selectedSessionBeforeSend = controller.state.sessions.find((item) => item.key === sessionId);
         if (sessionId === pendingNewSessionId) {
           controller.state.activeSessionKey = "";
           controller.state.activeChatId = "";
@@ -269,6 +283,16 @@ export function createDesktopAppServices(): AppServices {
           : result.status === "creating"
             ? result.pendingContent
             : "";
+        const optimisticTitle = autoSessionTitleFromMessage(optimisticText);
+        if (result.status === "creating") {
+          pendingNewSessionTitle = optimisticTitle;
+        } else if (
+          result.status === "sent"
+          && optimisticTitle
+          && shouldPersistAutoSessionTitle(selectedSessionBeforeSend?.title)
+        ) {
+          await persistAutoSessionTitle(sessionKeyForChat(result.chatId), optimisticTitle);
+        }
         notifySession(sessionId, {
           type: "message-sent",
           ...(optimisticText ? { message: createOptimisticUserMessage(optimisticText) } : {}),
@@ -398,6 +422,18 @@ function createOptimisticUserMessage(text: string): ReactChatMessage {
     text,
     status: "complete",
   };
+}
+
+function autoSessionTitleFromMessage(text: string): string {
+  const firstLine = text.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  return firstLine.slice(0, 80);
+}
+
+function shouldPersistAutoSessionTitle(title: string | undefined): boolean {
+  const normalized = (title ?? "").trim();
+  return !normalized
+    || normalized === "New session"
+    || normalized.startsWith("Desktop Session websocket:");
 }
 
 function mapContextReference(reference: NativeChatReference, index: number) {

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -177,7 +177,11 @@ export function createDesktopAppServices(): AppServices {
     if (!title) {
       return;
     }
-    await controller.patchSession(sessionId, { title });
+    try {
+      await controller.patchSession(sessionId, { title });
+    } catch {
+      // Auto-generated titles should not block chat lifecycle events.
+    }
   }
 
   async function loadSettingsSnapshot(): Promise<unknown> {

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -156,7 +156,7 @@ export function createDesktopAppServices(): AppServices {
       pendingNewSession = null;
       pendingNewSessionTitle = "";
     }
-    notifyAll({ type: event.kind });
+    notifyAll(chatEventFromGatewayEvent(event));
   }
 
   function notifyAll(event: ChatEvent): void {
@@ -540,6 +540,17 @@ function normalizeSettingsSummary(snapshot: unknown, config: { httpBaseUrl: stri
     rows.push({ label: "Providers", value: String(providers.length) });
   }
   return rows;
+}
+
+function chatEventFromGatewayEvent(event: NormalizedGatewayEvent): ChatEvent {
+  if (event.kind !== "agent.event") {
+    return { type: event.kind };
+  }
+  const eventType = stringValue(event.raw.event_type);
+  return {
+    type: event.kind,
+    ...(eventType ? { eventType } : {}),
+  };
 }
 
 function normalizeChatModelOptions(

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { createDesktopChatSessionController } from "../app-core/chat/desktopChatSessionController";
-import type { NativeChatMessage, NativeChatSession } from "../app-core/chat/nativeChat";
+import type { NativeChatMessage, NativeChatReference, NativeChatSession } from "../app-core/chat/nativeChat";
 import { DEFAULT_GATEWAY_CONFIG, resolveGatewayConfig } from "../app-core/gateway/gatewayConfig";
 import { installDesktopGatewayBridge } from "../app-core/gateway/desktopGatewayBridge";
 import { ensureGatewayReady } from "../app-core/gateway/desktopGatewayStartup";
@@ -242,10 +242,15 @@ export function createDesktopAppServices(): AppServices {
           return [];
         }
         const session = controller.state.sessions.find((item) => item.key === sessionId);
-        if (session) {
+        if (session && controller.state.activeSessionKey !== session.key) {
           await controller.selectSession(session.key, session.chatId);
         }
-        return (controller.state.messages.get(sessionId) ?? []).map((message, index) => mapMessage(message, index));
+        const sessionMessages = controller.state.messages.get(sessionId) ?? [];
+        const sessionRunning = controller.state.respondingSessionKeys.has(sessionId);
+        return sessionMessages.map((message, index) => mapMessage(message, index, {
+          isLatest: index === sessionMessages.length - 1,
+          sessionRunning,
+        }));
       },
       async send(sessionId, input) {
         await initialize();
@@ -258,8 +263,16 @@ export function createDesktopAppServices(): AppServices {
             await controller.selectSession(session.key, session.chatId);
           }
         }
-        controller.submitMessage(input.text, input.usePersistentRag ?? true, input.model);
-        notifySession(sessionId, { type: "message-sent" });
+        const result = controller.submitMessage(input.text, input.usePersistentRag ?? true, input.model);
+        const optimisticText = result.status === "sent"
+          ? result.content
+          : result.status === "creating"
+            ? result.pendingContent
+            : "";
+        notifySession(sessionId, {
+          type: "message-sent",
+          ...(optimisticText ? { message: createOptimisticUserMessage(optimisticText) } : {}),
+        });
       },
       async stop() {
         await initialize();
@@ -349,7 +362,11 @@ function mapSession(session: NativeChatSession, responding: boolean, fallbackPay
   };
 }
 
-function mapMessage(message: NativeChatMessage, index: number): ReactChatMessage {
+function mapMessage(
+  message: NativeChatMessage,
+  index: number,
+  options: { isLatest?: boolean; sessionRunning?: boolean } = {},
+): ReactChatMessage {
   const role = message.role === "user" || message.role === "system" || message.role === "tool"
     ? message.role
     : "assistant";
@@ -359,13 +376,38 @@ function mapMessage(message: NativeChatMessage, index: number): ReactChatMessage
     status: activity.status || activity.approvalStatus || (activity.kind === "result" ? "complete" : "running"),
     summary: activity.responseText || activity.argsText,
   }));
+  const streaming = role === "assistant" && Boolean(options.sessionRunning && options.isLatest);
+  const contextReferences = (message.references ?? []).map(mapContextReference);
   return {
     id: message.messageId || `${role}:${index}`,
     role,
     createdAtMs: timestampMs(message.timestamp) ?? Date.now(),
-    text: message.content || message.reasoningContent || (toolCalls.length ? "Tool activity" : ""),
-    status: "complete",
+    text: message.content || (toolCalls.length ? "Tool activity" : ""),
+    status: streaming ? "streaming" : "complete",
+    ...(contextReferences.length ? { contextReferences } : {}),
+    ...(message.reasoningContent ? { reasoningText: message.reasoningContent } : {}),
     ...(toolCalls.length ? { toolCalls } : {}),
+  };
+}
+
+function createOptimisticUserMessage(text: string): ReactChatMessage {
+  return {
+    id: `local:user:${Date.now().toString(36)}`,
+    role: "user",
+    createdAtMs: Date.now(),
+    text,
+    status: "complete",
+  };
+}
+
+function mapContextReference(reference: NativeChatReference, index: number) {
+  return {
+    id: reference.noteId || reference.evidenceId || `${reference.kind}:${index}`,
+    kind: reference.kind,
+    title: reference.title,
+    ...(reference.detail ? { detail: reference.detail } : {}),
+    ...(reference.sourcePath ? { sourcePath: reference.sourcePath } : {}),
+    ...(typeof reference.sourceLine === "number" ? { sourceLine: reference.sourceLine } : {}),
   };
 }
 

--- a/src/react-workbench/services.ts
+++ b/src/react-workbench/services.ts
@@ -18,6 +18,7 @@ export type ChatInput = {
 
 export type ChatEvent = {
   type: string;
+  eventType?: string;
   message?: ReactChatMessage;
 };
 

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -940,6 +940,61 @@ button:disabled {
   gap: 10px;
 }
 
+.react-message-reasoning,
+.react-message-context {
+  display: grid;
+  gap: 7px;
+  margin-bottom: 10px;
+  border-left: 2px solid var(--color-hairline-strong);
+  padding-left: 10px;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-message-reasoning h3,
+.react-message-context h3 {
+  margin: 0;
+  color: var(--color-body);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.react-message-context ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.react-message-context li {
+  display: grid;
+  gap: 2px;
+}
+
+.react-message-context small {
+  color: var(--color-muted);
+}
+
+.react-message__streaming {
+  display: inline-block;
+  width: 24px;
+  height: 8px;
+  margin-top: 8px;
+  border-radius: 999px;
+  background: radial-gradient(circle closest-side, var(--color-muted) 90%, transparent) 0 50% / 8px 8px repeat-x;
+  opacity: 0.55;
+  animation: react-streaming-pulse 900ms ease-in-out infinite;
+}
+
+@keyframes react-streaming-pulse {
+  50% {
+    opacity: 0.25;
+  }
+}
+
 .react-message-table-wrap {
   max-width: 100%;
   overflow-x: auto;


### PR DESCRIPTION
## Summary
- Fix new-session sends so user input is rendered immediately and routed through the native chat flow.
- Stream native provider deltas and reasoning updates into the React chat timeline.
- Preserve completed message state for branch actions and refresh session status when live turns complete.
- Persist patched session titles so restored sessions do not fall back to websocket ids.

## Root Cause
The native desktop chat path mixed legacy websocket frames with structured agent events. Several completion and title updates were only visible after reloading persisted session data, so live UI state could miss completed assistant-message metadata, session idle status, and patched titles.

## Validation
- npm test
- npm run build