### PR TITLE
Improve chat agent experience

### DIFF
--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -1,0 +1,759 @@
+# Rust Backend API Reference
+
+Source snapshot: `c2639409`
+
+This document describes the API surfaces exposed by the Rust/Tauri backend in `src-tauri`.
+It is intended for frontend callers and integrators who need command names, invocation
+patterns, response envelopes, and the current Rust-owned route inventory.
+
+## Surfaces
+
+The Rust backend is reachable through four surfaces:
+
+1. Tauri commands registered in `src-tauri/src/lib.rs`.
+2. `worker_webui_route`, a Tauri command that emulates HTTP/WebUI routes and returns an HTTP-like response envelope.
+3. Worker RPC methods handled by `WorkerRpcRouter`.
+4. Tauri events emitted for live agent/runtime updates.
+
+Most desktop frontend code should prefer typed wrappers under `src/app-core/native/*`.
+Direct `invoke()` calls are still documented here because they are the actual backend contract.
+
+## Tauri Invocation Contract
+
+Use Tauri's `invoke` API:
+
+```ts
+import { invoke } from "@tauri-apps/api/core";
+
+const status = await invoke("gateway_status");
+const messages = await invoke("worker_session_messages", {
+  input: { key: "websocket:chat-1" },
+});
+```
+
+General rules:
+
+- Commands without an input struct are invoked with no second argument.
+- Most worker commands accept `{ input: ... }`.
+- Field names use `camelCase` at the Tauri boundary because the Rust input structs use `#[serde(rename_all = "camelCase")]`.
+- A successful command resolves to the serialized Rust return value.
+- A command returning `Result<T, String>` rejects with the string error if Rust returns `Err`.
+
+## Common Error Shapes
+
+Direct Tauri commands mostly fail as a rejected `invoke()` promise with a string message.
+
+`worker_webui_route` does not reject for ordinary route errors. It returns:
+
+```json
+{
+  "status": 500,
+  "body": {
+    "error": {
+      "message": "error text"
+    }
+  },
+  "headers": {
+    "x-tinybot-route-owner": "rust",
+    "x-tinybot-route-group": "sessions"
+  }
+}
+```
+
+Worker RPC uses this response envelope:
+
+```json
+{
+  "protocol_version": "1",
+  "id": "req-1",
+  "trace_id": "trace-1",
+  "result": {},
+  "error": {
+    "code": "worker_error",
+    "message": "worker crashed",
+    "details": {},
+    "retryable": true,
+    "source": "worker"
+  }
+}
+```
+
+Known worker error codes:
+
+- `invalid_protocol`
+- `incompatible_protocol_version`
+- `capability_denied`
+- `worker_error`
+
+Known worker error sources:
+
+- `rust_core`
+- `worker`
+
+## Core Desktop Commands
+
+| Command | Args | Response |
+| --- | --- | --- |
+| `desktop_status` | none | `{ app_name, gateway_http, gateway_ws, browser_mode }` |
+| `gateway_status` | none | `GatewayRuntimeStatus` |
+| `start_gateway` | none | `GatewayRuntimeStatus` |
+| `stop_gateway` | none | `GatewayRuntimeStatus` |
+| `set_gateway_keep_running` | `{ keepRunning: boolean }` | `GatewayRuntimeStatus` |
+| `worker_probe_status` | none | `WorkerRuntimeStatus` |
+| `worker_echo_agent` | `{ input: string }` | `{ ok, echo, configValue, workspaceFileCount }`; diagnostic/test route |
+
+`GatewayRuntimeStatus` includes:
+
+```json
+{
+  "state": "running",
+  "owner": "shell",
+  "http_ok": true,
+  "gateway_http": "http://127.0.0.1:18790",
+  "gateway_ws": "ws://127.0.0.1:18790/ws",
+  "command": "Tauri Rust backend",
+  "port": 18790,
+  "repo_root": "...",
+  "log_path": "...",
+  "log_tail": [],
+  "logs": [],
+  "last_error": null,
+  "exit_policy": "stop_on_exit",
+  "bootstrap_status": "ready",
+  "response_class": "tinybot-bootstrap",
+  "recovery_hint": null,
+  "worker_runtime": {},
+  "route_owner_summary": { "rustOwned": 0, "unsupported": 0 },
+  "webui_route_inventory": [],
+  "compatibility_fallback_diagnostics": []
+}
+```
+
+## File Dialog Commands
+
+| Command | Args | Response |
+| --- | --- | --- |
+| `pick_upload_file` | `{ options: { title?: string, filters?: { name: string, extensions: string[] }[] } }` | `null` when cancelled, or `{ name, path, mime_type, size_bytes, bytes }` |
+| `save_export_file` | `{ options: { title?: string, defaultPath?: string, filters?: Filter[], contents: string } }` | `null` when cancelled, or `{ path }` |
+| `reveal_workspace_file` | `{ path: string }` | `void` |
+
+`reveal_workspace_file` only accepts these workspace-relative paths:
+
+- `AGENTS.md`
+- `SOUL.md`
+- `USER.md`
+- `TOOLS.md`
+- `HEARTBEAT.md`
+- `memory/MEMORY.md`
+
+## Config Commands
+
+| Command | Args | Response |
+| --- | --- | --- |
+| `get_config_editor_snapshot` | none | `ConfigEditorSnapshot` |
+| `apply_config_patch_result` | `{ result: ConfigPatchBridgeResult }` | `ConfigPatchApplyResult` |
+| `apply_config_operations` | `{ request: ConfigOperationRequest }` | `ConfigPatchApplyResult` |
+
+`ConfigEditorSnapshot`:
+
+```json
+{
+  "configPath": ".../.tinybot/config.json",
+  "revision": "hash",
+  "explicitPublicConfig": {},
+  "effectivePublicConfig": {},
+  "origins": {},
+  "diagnostics": [],
+  "secretPresence": {}
+}
+```
+
+`ConfigOperationRequest`:
+
+```json
+{
+  "expectedRevision": "optional-current-revision",
+  "operations": [
+    { "op": "replace", "path": "agents.defaults.model", "value": "gpt-5" },
+    { "op": "remove", "path": "agents.defaults.timezone" },
+    { "op": "secretReplace", "path": "providers.openai.api_key", "value": "sk-..." },
+    { "op": "secretRemove", "path": "providers.openai.api_key" }
+  ]
+}
+```
+
+`ConfigPatchApplyResult`:
+
+```json
+{
+  "ok": true,
+  "config": {},
+  "revision": "new-revision",
+  "updatedFields": ["agents.defaults.model"],
+  "sideEffects": {
+    "applied": [],
+    "restartRequired": [],
+    "warnings": []
+  },
+  "error": null
+}
+```
+
+## Agent Runtime Commands
+
+| Command | Args | Response |
+| --- | --- | --- |
+| `worker_run_agent` | `{ input: { spec: NativeBackendRunSpec } }` | JSON result from native agent runtime |
+| `worker_run_agent_input` | `{ input: { input: unknown } }` | JSON result from native agent runtime |
+| `worker_cancel_agent` | `{ input: { runId: string } }` | JSON result |
+| `worker_restore_agent_checkpoint` | `{ input: { sessionId: string } }` | JSON result |
+| `worker_submit_agent_form` | `{ input: { sessionId, formId, values?, action? } }` | JSON result |
+| `worker_resume_agent_approval` | `{ input: { sessionId, approvalId, approved, scope?, guidance? } }` | JSON result |
+
+`NativeBackendRunSpec`:
+
+```json
+{
+  "runId": "run-1",
+  "sessionId": "websocket:chat-1",
+  "messages": [{ "role": "user", "content": "Hello" }],
+  "model": "gpt-5",
+  "maxIterations": 20,
+  "stream": true,
+  "metadata": {}
+}
+```
+
+## Session Commands
+
+| Command | Args | Response |
+| --- | --- | --- |
+| `worker_sessions_list` | none | session list payload |
+| `worker_session_messages` | `{ input: { key: string } }` | `{ messages: [...] }` style payload |
+| `worker_agent_runs_list` | `{ input: { key: string } }` | agent run list |
+| `worker_agent_run_runtime_state` | `{ input: { sessionKey: string, runId: string } }` | `AgentRunRuntimeState` |
+| `worker_session_temporary_files` | `{ input: { key: string } }` | temporary file list |
+| `worker_session_upload_temporary_file` | `{ input: { key: string, body: { name, file_type, content, size_bytes? } } }` | uploaded file payload |
+| `worker_session_clear_temporary_files` | `{ input: { key: string } }` | clear result |
+| `worker_session_delete` | `{ input: { key: string } }` | delete result |
+| `worker_session_patch` | `{ input: { key: string, body: { title?, metadata?, archived? } } }` | patched session payload |
+| `worker_session_branch` | `{ input: { body: unknown } }` | branch result |
+| `worker_session_clear` | `{ input: { key: string } }` | clear result |
+| `worker_session_task_progress` | `{ input: { key: string, body: unknown } }` | task progress result |
+
+Key response shapes used by the lower-level session RPC:
+
+```json
+{
+  "session_id": "websocket:chat-1",
+  "title": "Chat title",
+  "workspace_dir": "D:/code/tinybot/tinybot",
+  "created_at": "2026-07-06T00:00:00Z",
+  "updated_at": "2026-07-06T00:00:00Z",
+  "extra": {}
+}
+```
+
+```json
+{
+  "session_id": "websocket:chat-1",
+  "run_id": "run-1",
+  "status": "running",
+  "phase": "tool_calling",
+  "started_at": "...",
+  "updated_at": "...",
+  "completed_at": null,
+  "model": "gpt-5",
+  "provider": "openai",
+  "hasCheckpoint": true,
+  "finalContentPreview": "..."
+}
+```
+
+## Thread Commands
+
+Thread Tauri commands all use `{ input: { body } }`, except the continuation helper commands listed separately.
+
+| Command | Worker RPC method | Body |
+| --- | --- | --- |
+| `worker_thread_create` | `thread.create` | `CreateThreadRequest` |
+| `worker_thread_read` | `thread.read` | `ReadThreadRequest` |
+| `worker_thread_resume` | `thread.resume` | `ResumeThreadRequest` |
+| `worker_threads_list` | `thread.list` | `ListThreadsRequest` |
+| `worker_thread_search` | `thread.search` | `SearchThreadsRequest` |
+| `worker_thread_activity` | `thread.activity` | `ThreadActivityRequest` |
+| `worker_thread_status` | `thread.status` | `{ threadId }` |
+| `worker_thread_update_metadata` | `thread.update_metadata` | `UpdateThreadMetadataRequest` |
+| `worker_thread_agent_registry` | `thread.agent_registry` | `ThreadAgentRegistryRequest` |
+| `worker_thread_start_turn` | `thread.start_turn` | `StartThreadTurnRequest` |
+| `worker_thread_continue_turn` | `thread.continue_turn` | `ContinueThreadTurnRequest` |
+| `worker_thread_interrupt` | `thread.interrupt` | `InterruptThreadRequest` |
+| `worker_thread_apply_op` | `thread.apply_op` | `ThreadApplyOpRequest` |
+| `worker_thread_archive` | `thread.archive` | `ArchiveThreadRequest` |
+| `worker_thread_unarchive` | `thread.unarchive` | `ArchiveThreadRequest` with `archived: false` |
+| `worker_thread_delete` | `thread.delete` | `DeleteThreadRequest` |
+| `worker_thread_fork` | `thread.fork` | `ForkThreadRequest` |
+| `worker_thread_events` | `thread.events` | `ThreadEventsRequest` |
+| `worker_thread_restore_checkpoint` | `thread.restore_checkpoint` | `RestoreThreadCheckpointRequest` |
+
+Thread continuation helper commands:
+
+| Command | Args |
+| --- | --- |
+| `worker_submit_thread_turn` | `{ input: { threadId?: string, input: unknown, spec?: unknown } }` |
+| `worker_resolve_thread_approval` | `{ input: { threadId, approvalId, approved, scope?, guidance? } }` |
+| `worker_submit_thread_form` | `{ input: { threadId, formId, values?, action? } }` |
+
+`ThreadRecord`:
+
+```json
+{
+  "threadId": "thread-1",
+  "title": "New session",
+  "status": "idle",
+  "sessionKey": "websocket:chat-1",
+  "rootRunId": "run-1",
+  "activeRunId": null,
+  "parentThreadId": null,
+  "source": "desktop",
+  "createdAt": "...",
+  "updatedAt": "...",
+  "archivedAt": null,
+  "metadata": {
+    "summary": null,
+    "preview": null,
+    "tags": [],
+    "model": null,
+    "workingDirectory": null,
+    "itemCount": 0,
+    "runCount": 0,
+    "hasActiveRun": false,
+    "extra": {}
+  }
+}
+```
+
+`ThreadSnapshot`:
+
+```json
+{
+  "thread": {},
+  "items": [],
+  "runs": [],
+  "activeRun": null,
+  "latestCheckpoint": null,
+  "children": [],
+  "turnItems": [],
+  "childActivities": [],
+  "pagination": {
+    "cursor": "0",
+    "limit": 100,
+    "itemCount": 0,
+    "previousCursor": null,
+    "nextCursor": null,
+    "hasMoreBefore": false,
+    "hasMoreAfter": false
+  },
+  "nextCursor": null
+}
+```
+
+Thread statuses:
+
+- `empty`
+- `idle`
+- `running`
+- `waiting_for_input`
+- `waiting_for_approval`
+- `cancelling`
+- `failed`
+- `archived`
+
+## Skills Commands
+
+| Command | Args | Response |
+| --- | --- | --- |
+| `worker_skills_list` | none | `{ skills: [...] }` or WebUI list shape |
+| `worker_skills_detail` | `{ input: { name } }` | skill detail |
+| `worker_skills_create` | `{ input: { body } }` | created skill |
+| `worker_skills_update` | `{ input: { name, body } }` | updated skill |
+| `worker_skills_delete` | `{ input: { name } }` | delete result |
+| `worker_skills_validate` | `{ input: { name } }` | validation result |
+
+## Workspace Commands
+
+| Command | Args | Response |
+| --- | --- | --- |
+| `worker_workspace_files` | none | `{ files: WorkspaceFileEntry[] }` |
+| `worker_workspace_file` | `{ input: { path } }` | `WorkspaceReadFileResult` |
+| `worker_workspace_put_file` | `{ input: { path, body } }` | `WorkspaceWriteResult` |
+
+Lower-level workspace RPC also supports:
+
+- `workspace.resolve_path`
+- `workspace.read_file`
+- `workspace.read_bootstrap_files`
+- `workspace.write_file`
+- `workspace.create_dir`
+- `workspace.list_dir`
+- `workspace.delete_file`
+- `workspace.list_files`
+
+`WorkspaceReadFileResult`:
+
+```json
+{
+  "path": "README.md",
+  "contents": "...",
+  "content": "...",
+  "updated_at": "2026-07-06T00:00:00Z",
+  "content_type": "text/plain",
+  "line_start": 1,
+  "line_end": 100,
+  "line_total": 250,
+  "truncated": false
+}
+```
+
+## Knowledge Commands
+
+| Command | Args | Response |
+| --- | --- | --- |
+| `worker_knowledge_documents` | `{ input: { category?: string, limit?: number } }` | documents list |
+| `worker_knowledge_add_document` | `{ input: { body } }` | document/job payload |
+| `worker_knowledge_document` | `{ input: { docId } }` | document detail |
+| `worker_knowledge_delete_document` | `{ input: { docId } }` | delete result |
+| `worker_knowledge_job` | `{ input: { jobId } }` | job detail |
+| `worker_knowledge_rebuild_index` | `{ input: { rebuildType?: string } }` | rebuild job/result |
+| `worker_knowledge_stats` | none | knowledge stats |
+| `worker_knowledge_graph` | `{ input: { docId?, graphType?, limit?, edgeLimit?, minConfidence?, includeOrphans? } }` | graph payload |
+
+Lower-level knowledge RPC additionally supports:
+
+- `knowledge.context`
+- `knowledge.query`
+- `knowledge.start_index_job`
+- `knowledge.document_tree`
+- `knowledge.save_entity_graph_extraction`
+- `knowledge.session_upload`
+- `knowledge.session_list`
+- `knowledge.session_clear`
+
+## Background, Task, Subagent, Transport, and Channel Commands
+
+| Group | Commands |
+| --- | --- |
+| Background trace | `worker_background_trace_list`, `worker_background_trace_get_delegate_trace`, `worker_background_trace_get_artifact`, `worker_background_trace_append` |
+| Background subagent input | `worker_background_subagent_enqueue_input` |
+| Subagent manager | `worker_subagent_spawn`, `worker_subagent_list`, `worker_subagent_query`, `worker_subagent_send_input`, `worker_subagent_wait`, `worker_subagent_cancel`, `worker_subagent_close` |
+| Task plans | `worker_task_plan_list`, `worker_task_plan_get`, `worker_task_plan_save`, `worker_task_plan_delete` |
+| Transport | `worker_transport_gateway_frame`, `worker_transport_websocket_message`, `worker_transport_dispatch_websocket_message` |
+| Channel connector | `worker_channel_dispatch_inbound`, `worker_channel_start`, `worker_channel_status`, `worker_channel_stop`, `worker_channel_login` |
+| Cron | `worker_cron_dispatch_due` |
+| Cowork proxy | `worker_cowork_route` |
+| WebUI proxy | `worker_webui_route` |
+
+Transport input examples:
+
+```ts
+await invoke("worker_transport_dispatch_websocket_message", {
+  input: {
+    clientId: "client-1",
+    frame: { type: "message", content: "hello" },
+    attachedChatId: "chat-1",
+    sessionExists: true,
+    editablePaths: ["src/main.ts"],
+    model: "gpt-5",
+    maxIterations: 20,
+    runId: "run-1",
+    stream: true
+  }
+});
+```
+
+Channel login:
+
+```ts
+await invoke("worker_channel_login", {
+  input: { channel: "slack", force: false }
+});
+```
+
+## WebUI Route Wrapper
+
+Call:
+
+```ts
+const response = await invoke("worker_webui_route", {
+  input: {
+    method: "GET",
+    path: "/api/status",
+    headers: {},
+    body: null
+  }
+});
+```
+
+Response:
+
+```json
+{
+  "status": 200,
+  "body": {},
+  "headers": {
+    "x-tinybot-route-owner": "rust",
+    "x-tinybot-route-group": "status"
+  }
+}
+```
+
+The frontend helper `createDesktopNativeWebuiApi().route()` unwraps 2xx responses and throws for non-2xx responses.
+Use `routeResponse()` if the status and headers are needed.
+
+### Rust-owned WebUI Routes
+
+| Method | Path | Group | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/health` | health | Native health check |
+| `GET` | `/webui/bootstrap` | bootstrap | Returns `{ token, ws_path, refresh_token_path, token_ttl_s }` |
+| `POST` | `/webui/refresh-token` | bootstrap | Returns a fresh bootstrap token |
+| `GET` | `/api/status` | status | Runtime status body |
+| `GET` | `/api/config` | config | Public config snapshot |
+| `GET` | `/api/providers` | providers | Provider catalog |
+| `POST` | `/api/provider-models` | providers | Provider model resolution |
+| `GET` | `/v1/models` | openai | OpenAI-compatible model list |
+| `POST` | `/v1/chat/completions` | openai | OpenAI-compatible chat completion route |
+| `GET` | `/api/approvals` | approvals | Optional query: `session_key`, `chat_id`, `channel` |
+| `POST` | `/api/approvals/{approval_id}/approve` | approvals | Approval continuation |
+| `POST` | `/api/approvals/{approval_id}/deny` | approvals | Approval continuation |
+| `POST` | `/api/agent-ui/forms/{form_id}/submit` | agent-ui | Form continuation |
+| `POST` | `/api/agent-ui/forms/{form_id}/cancel` | agent-ui | Form cancellation |
+| `GET` | `/api/sessions` | sessions | List sessions |
+| `GET` | `/api/sessions/{key}/messages` | sessions | List session messages |
+| `POST` | `/api/sessions/branch` | sessions | Branch from message/session body |
+| `PATCH` | `/api/sessions/{key}` | sessions | Patch session metadata/title/archive state |
+| `DELETE` | `/api/sessions/{key}` | sessions | Delete session |
+| `POST` | `/api/sessions/{key}/clear` | sessions | Clear messages/profile/checkpoint |
+| `GET` | `/api/sessions/{key}/temporary-files` | sessions | List temporary files |
+| `POST` | `/api/sessions/{key}/temporary-files` | sessions | Upload text temporary file |
+| `DELETE` | `/api/sessions/{key}/temporary-files` | sessions | Clear temporary files |
+| `GET` | `/api/skills` | skills | List skills |
+| `POST` | `/api/skills` | skills | Create skill |
+| `GET` | `/api/skills/{name}` | skills | Skill detail |
+| `PATCH` | `/api/skills/{name}` | skills | Update skill |
+| `DELETE` | `/api/skills/{name}` | skills | Delete skill |
+| `POST` | `/api/skills/{name}/validate` | skills | Validate skill |
+| `GET` | `/api/workspace/files` | workspace | List workspace files |
+| `GET` | `/api/workspace/files/{path:.+}` | workspace | Read workspace file |
+| `PUT` | `/api/workspace/files/{path:.+}` | workspace | Write workspace file |
+| `GET` | `/v1/knowledge/documents` | knowledge | Query: `category`, `limit` |
+| `POST` | `/v1/knowledge/documents` | knowledge | Add document |
+| `POST` | `/v1/knowledge/documents/upload` | knowledge | Add uploaded text document |
+| `GET` | `/v1/knowledge/documents/{doc_id}` | knowledge | Document detail |
+| `DELETE` | `/v1/knowledge/documents/{doc_id}` | knowledge | Delete document |
+| `GET` | `/v1/knowledge/stats` | knowledge | Stats |
+| `GET` | `/v1/knowledge/jobs/{job_id}` | knowledge | Job detail |
+| `POST` | `/v1/knowledge/rebuild-index` | knowledge | Query currently reads `type`; direct command uses `rebuildType` |
+| `GET` | `/v1/knowledge/graph` | knowledge | Query: `doc_id`, `graph_type`, `limit`, `edge_limit`, `min_confidence`, `include_orphans` |
+
+### Inventoried But Unsupported WebUI Routes
+
+These return status `501` through `worker_webui_route`:
+
+| Method | Path | Reason |
+| --- | --- | --- |
+| `PATCH` | `/api/config` | Config patch route is not implemented in Rust WebUI route surface |
+| `POST` | `/v1/knowledge/query` | Advanced query route is not exposed as WebUI route |
+| `POST` | `/v1/knowledge/graph/extract` | LLM graph extraction orchestration is not exposed as WebUI route |
+| `GET` | `/v1/knowledge/graphrag` | GraphRAG route is not exposed as WebUI route |
+| `GET/POST/PATCH/DELETE` | `/api/cowork/{path:.+}` | Cowork HTTP routes are not exposed by Rust WebUI route inventory |
+| `GET` | `/api/tools` | Native tool catalog route is not exposed yet |
+
+Unknown, non-inventoried routes return status `404` with:
+
+```json
+{
+  "diagnostic": "unsupported-route",
+  "inventoryStatus": "not-inventoried",
+  "routeGroup": "unknown",
+  "error": { "message": "webui control route unavailable" },
+  "method": "GET",
+  "path": "/missing",
+  "route": "GET /missing"
+}
+```
+
+## Worker RPC Protocol
+
+The lower-level worker RPC router uses this request shape:
+
+```json
+{
+  "protocol_version": "1",
+  "id": "req-1",
+  "trace_id": "trace-1",
+  "method": "workspace.read_file",
+  "params": {
+    "path": "README.md"
+  }
+}
+```
+
+It is primarily used internally by Rust command handlers through `call_rust_state_service`.
+External callers should usually prefer the Tauri commands above.
+
+### Supported Worker RPC Methods
+
+| Namespace | Methods |
+| --- | --- |
+| `agent_run` | `append_trace`, `clear_checkpoint`, `get`, `get_checkpoint`, `list`, `list_trace`, `mark_cancelled`, `mark_completed`, `mark_failed`, `runtime_state`, `set_checkpoint`, `upsert` |
+| `approval` | `list_pending`, `request`, `resolve` |
+| `config` | `apply_operations`, `apply_patch_result`, `get`, `snapshot_public` |
+| `diagnostics` | `append` |
+| `form` | `request` |
+| `knowledge` | `add_document`, `context`, `delete_document`, `document_tree`, `get_document`, `get_job`, `graph`, `list_documents`, `query`, `rebuild_index`, `save_entity_graph_extraction`, `session_clear`, `session_list`, `session_upload`, `start_index_job`, `stats` |
+| `mcp` | `call_tool`, `list_tools` |
+| `memory` | `capture_evidence`, `dream_apply`, `dream_log`, `dream_pending`, `dream_restore`, `dream_run`, `list_evidence`, `migrate_legacy_notes`, `rebuild_index`, `recall`, `refresh_views`, `reject`, `save`, `search`, `supersede`, `trace` |
+| `permission_profile` | `current`, `evaluate_tool`, `request_tool_approval`, `resolve_tool_approval` |
+| `provider` | `resolve_secret` |
+| `rag` | `query` |
+| `runtime` | `now`, `restart` |
+| `session` | `append_messages`, `clear`, `clear_checkpoint`, `delete`, `get_checkpoint`, `get_history`, `get_metadata`, `list_metadata`, `patch_metadata`, `patch_user_profile`, `persist_turn`, `set_checkpoint`, `trim` |
+| `shell` | `execute` |
+| `skills` | `list`, `webui_create`, `webui_delete`, `webui_detail`, `webui_list`, `webui_update`, `webui_validate` |
+| `subagent` | `cancel`, `close`, `list`, `query`, `send_input`, `spawn`, `wait` |
+| `thread` | `activity`, `agent_registry`, `append_items`, `apply_op`, `archive`, `continue_turn`, `create`, `delete`, `events`, `fork`, `interrupt`, `list`, `read`, `restore_checkpoint`, `resume`, `search`, `start_turn`, `status`, `unarchive`, `update_metadata` |
+| `tool_executor` | `execute` |
+| `tool_registry` | `list`, `search` |
+| `workspace` | `create_dir`, `delete_file`, `list_dir`, `list_files`, `read_bootstrap_files`, `read_file`, `resolve_path`, `write_file` |
+
+## Tauri Event Names
+
+The Rust backend can emit live events through Tauri. Dotted worker event names are normalized for frontend listeners elsewhere, but the native contract inventories these source event names:
+
+- `agent.delta`
+- `agent.reasoning_delta`
+- `agent.tool_call.delta`
+- `agent.tool.start`
+- `agent.tool.result`
+- `agent.usage`
+- `agent.checkpoint`
+- `agent.status`
+- `agent.awaiting_form`
+- `agent.awaiting_approval`
+- `agent.memory_reference`
+- `agent.task_progress`
+- `agent.browser_frame`
+- `agent.delegate.started`
+- `agent.delegate.running`
+- `agent.delegate.message_queued`
+- `agent.delegate.awaiting_approval`
+- `agent.delegate.tool.approval_required`
+- `agent.delegate.tool.completed`
+- `agent.delegate.trace.updated`
+- `agent.delegate.completed`
+- `agent.delegate.failed`
+- `agent.delegate.interrupted`
+- `agent.delegate.closed`
+- `heartbeat.delivery`
+- `agent.cancelled`
+- `agent.done`
+- `agent.error`
+- `diagnostics.log`
+- `worker.status`
+
+`NativeBackendEvent` shape:
+
+```json
+{
+  "sessionId": "websocket:chat-1",
+  "runId": "run-1",
+  "traceId": "trace-1",
+  "eventName": "agent.delta",
+  "timestamp": "2026-07-06T00:00:00Z",
+  "source": "rust_backend",
+  "payload": {}
+}
+```
+
+## Recommended Frontend Wrappers
+
+Prefer these wrappers instead of direct command strings:
+
+| Wrapper | File | Commands/routes covered |
+| --- | --- | --- |
+| `createDesktopNativeConfigApi` | `src/app-core/native/desktopNativeConfig.ts` | Config snapshot |
+| `createDesktopNativeSessionsApi` | `src/app-core/native/desktopNativeSessions.ts` | Session commands |
+| `createDesktopNativeThreadsApi` | `src/app-core/native/desktopNativeThreads.ts` | Thread commands |
+| `createDesktopNativeKnowledgeApi` | `src/app-core/native/desktopNativeKnowledge.ts` | Knowledge commands |
+| `createDesktopNativeTransportApi` | `src/app-core/native/desktopNativeTransport.ts` | Transport and channel commands |
+| `createDesktopNativeWebuiApi` | `src/app-core/native/desktopNativeWebui.ts` | `worker_webui_route` |
+| `createGatewayApiClient` | `src/app-core/gateway/gatewayHttpClient.ts` | Chooses native WebUI/native command first, then gateway HTTP fallback when configured |
+
+## Examples
+
+List sessions:
+
+```ts
+await invoke("worker_sessions_list");
+```
+
+Read session messages:
+
+```ts
+await invoke("worker_session_messages", {
+  input: { key: "websocket:chat-1" }
+});
+```
+
+Patch a session title:
+
+```ts
+await invoke("worker_session_patch", {
+  input: {
+    key: "websocket:chat-1",
+    body: { title: "Planning notes" }
+  }
+});
+```
+
+Create and read a thread:
+
+```ts
+const created = await invoke("worker_thread_create", {
+  input: { body: { title: "Investigation" } }
+});
+
+const snapshot = await invoke("worker_thread_read", {
+  input: { body: { threadId: created.thread.threadId, limit: 100 } }
+});
+```
+
+Call an HTTP-compatible route through Rust:
+
+```ts
+const response = await invoke("worker_webui_route", {
+  input: {
+    method: "GET",
+    path: "/v1/knowledge/documents?limit=20"
+  }
+});
+
+if (response.status === 200) {
+  console.log(response.body);
+}
+```
+
+Apply a config operation:
+
+```ts
+await invoke("apply_config_operations", {
+  request: {
+    expectedRevision: currentRevision,
+    operations: [
+      { op: "replace", path: "agents.defaults.model", value: "gpt-5" }
+    ]
+  }
+});
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "3d-force-graph": "^1.80.0",
         "clsx": "^2.1.1",
         "graphology": "^0.26.0",
+        "gsap": "^3.15.0",
         "highlight.js": "^11.11.1",
         "lucide-react": "^1.23.0",
         "marked": "^18.0.4",
@@ -2382,6 +2383,12 @@
       "peerDependencies": {
         "graphology-types": ">=0.23.0"
       }
+    },
+    "node_modules/gsap": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
+      "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/happy-dom": {
       "version": "20.10.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "3d-force-graph": "^1.80.0",
     "clsx": "^2.1.1",
     "graphology": "^0.26.0",
+    "gsap": "^3.15.0",
     "highlight.js": "^11.11.1",
     "lucide-react": "^1.23.0",
     "marked": "^18.0.4",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6768,9 +6768,21 @@ fn renderer_diagnostic_log_line(input: serde_json::Value) -> String {
     if line.len() <= MAX_RENDERER_DIAGNOSTIC_LOG_LINE {
         return line;
     }
-    let mut truncated = line;
-    truncated.truncate(MAX_RENDERER_DIAGNOSTIC_LOG_LINE);
-    format!("{truncated}...")
+    truncate_utf8_with_ellipsis(line, MAX_RENDERER_DIAGNOSTIC_LOG_LINE)
+}
+
+fn truncate_utf8_with_ellipsis(mut value: String, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let boundary = value
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    value.truncate(boundary);
+    format!("{value}...")
 }
 
 fn worker_manager_frontend_event(event: WorkerManagerEvent) -> (String, serde_json::Value) {
@@ -11756,6 +11768,17 @@ mod tests {
         assert!(contents.contains("\"type\":\"react.render\""));
         assert!(contents.contains("\"message\":\"render exploded\""));
         assert!(contents.contains("\"stage\":\"socket.frame\""));
+    }
+
+    #[test]
+    fn renderer_diagnostics_truncate_on_utf8_boundary() {
+        let line = format!("{}你好", "a".repeat((16 * 1024) - 1));
+
+        let truncated = truncate_utf8_with_ellipsis(line, 16 * 1024);
+
+        assert!(truncated.ends_with("..."));
+        assert!(truncated.is_char_boundary(truncated.len()));
+        assert_eq!(truncated, format!("{}...", "a".repeat((16 * 1024) - 1)));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,14 @@ fn desktop_status() -> DesktopStatus {
     }
 }
 
+#[tauri::command]
+fn record_renderer_diagnostic(
+    input: serde_json::Value,
+    state: State<'_, SharedGateway>,
+) -> Result<(), String> {
+    record_renderer_diagnostic_with_options(state.inner(), input)
+}
+
 type SharedGateway = Arc<Mutex<GatewayRuntime>>;
 const WORKER_CRON_TIMER_MAX_POLL: Duration = Duration::from_secs(30);
 const WORKER_WEBUI_ROUTE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -6740,6 +6748,31 @@ fn record_worker_manager_event_for_logs(shared: &SharedGateway, event: &WorkerMa
     );
 }
 
+fn record_renderer_diagnostic_with_options(
+    shared: &SharedGateway,
+    input: serde_json::Value,
+) -> Result<(), String> {
+    let line = renderer_diagnostic_log_line(input);
+    let log_path = {
+        let mut runtime = lock_runtime(shared);
+        append_log(&mut runtime, &format!("renderer {line}"));
+        runtime.persistent_log_path.clone()
+    };
+    append_native_backend_log_line(&log_path, NATIVE_BACKEND_LOG_MAX_BYTES, "renderer", &line)
+}
+
+fn renderer_diagnostic_log_line(input: serde_json::Value) -> String {
+    let line = serde_json::to_string(&input)
+        .unwrap_or_else(|_| "{\"type\":\"renderer.diagnostic.serialize_failed\"}".to_string());
+    const MAX_RENDERER_DIAGNOSTIC_LOG_LINE: usize = 16 * 1024;
+    if line.len() <= MAX_RENDERER_DIAGNOSTIC_LOG_LINE {
+        return line;
+    }
+    let mut truncated = line;
+    truncated.truncate(MAX_RENDERER_DIAGNOSTIC_LOG_LINE);
+    format!("{truncated}...")
+}
+
 fn worker_manager_frontend_event(event: WorkerManagerEvent) -> (String, serde_json::Value) {
     match event {
         WorkerManagerEvent::Status(status) => (
@@ -6817,6 +6850,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             desktop_status,
+            record_renderer_diagnostic,
             gateway_status,
             start_gateway,
             stop_gateway,
@@ -11692,6 +11726,36 @@ mod tests {
         assert!(contents.contains(
             "stderr [native-backend] worker.request.start route=POST /v1/knowledge/graph/extract"
         ));
+    }
+
+    #[test]
+    fn renderer_diagnostics_append_to_persistent_backend_log() {
+        let fixture = WorkspaceFixture::new();
+        let log_path = fixture.root.join("logs").join("native-backend.log");
+        let shared = Arc::new(Mutex::new(GatewayRuntime {
+            persistent_log_path: log_path.clone(),
+            ..GatewayRuntime::default()
+        }));
+
+        record_renderer_diagnostic_with_options(
+            &shared,
+            serde_json::json!({
+                "id": "renderer-1",
+                "type": "react.render",
+                "message": "render exploded",
+                "recentDebugStages": [
+                    { "stage": "socket.frame", "at": "2026-07-06T01:00:00.000Z" }
+                ]
+            }),
+        )
+        .expect("renderer diagnostic should persist");
+
+        let contents =
+            std::fs::read_to_string(log_path).expect("persistent backend log should be written");
+        assert!(contents.contains("renderer"));
+        assert!(contents.contains("\"type\":\"react.render\""));
+        assert!(contents.contains("\"message\":\"render exploded\""));
+        assert!(contents.contains("\"stage\":\"socket.frame\""));
     }
 
     #[test]

--- a/src/app-core/chat/chatInputState.test.ts
+++ b/src/app-core/chat/chatInputState.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "vitest";
 import {
   MAX_QUEUED_INPUTS,
   SESSION_APPROVAL_GRANT_POLICY,
+  deleteQueuedInput,
+  dispatchNextQueuedInput,
   pauseQueuedInputs,
   resolveComposerMode,
   resumeNextQueuedInput,
@@ -106,7 +108,44 @@ describe("chat input state", () => {
       remainingInputs: [{ ...queuedInputs[1], status: "paused" }],
     });
   });
+
+  test("dispatches one queued input on normal completion and preserves the rest", () => {
+    const queuedInputs = [
+      queued("queued-1", "first"),
+      queued("queued-2", "second"),
+      queued("queued-3", "third"),
+    ];
+
+    expect(dispatchNextQueuedInput(queuedInputs)).toEqual({
+      nextInput: { ...queuedInputs[0], status: "queued" },
+      remainingInputs: [queuedInputs[1], queuedInputs[2]],
+    });
+  });
+
+  test("deletes an unsent queued input by id", () => {
+    const queuedInputs = [
+      queued("queued-1", "first"),
+      queued("queued-2", "second"),
+      { ...queued("queued-3", "third"), status: "sent" as const },
+    ];
+
+    expect(deleteQueuedInput(queuedInputs, "queued-2")).toEqual([
+      queuedInputs[0],
+      queuedInputs[2],
+    ]);
+    expect(deleteQueuedInput(queuedInputs, "queued-3")).toEqual(queuedInputs);
+  });
 });
+
+function queued(id: string, content: string): QueuedInput {
+  return {
+    id,
+    mode: "queued",
+    content,
+    createdAt: "2026-07-01T10:12:00Z",
+    status: "queued",
+  };
+}
 
 function approval(id: string): ApprovalRequest {
   return {

--- a/src/app-core/chat/chatInputState.ts
+++ b/src/app-core/chat/chatInputState.ts
@@ -96,3 +96,18 @@ export function resumeNextQueuedInput(inputs: QueuedInput[]): { nextInput?: Queu
     remainingInputs: inputs.filter((_, index) => index !== nextIndex),
   };
 }
+
+export function dispatchNextQueuedInput(inputs: QueuedInput[]): { nextInput?: QueuedInput; remainingInputs: QueuedInput[] } {
+  const nextIndex = inputs.findIndex((input) => input.status === "queued");
+  if (nextIndex === -1) {
+    return { remainingInputs: inputs };
+  }
+  return {
+    nextInput: { ...inputs[nextIndex], status: "queued" },
+    remainingInputs: inputs.filter((_, index) => index !== nextIndex),
+  };
+}
+
+export function deleteQueuedInput(inputs: QueuedInput[], inputId: string): QueuedInput[] {
+  return inputs.filter((input) => input.id !== inputId || input.status === "sent" || input.status === "guided");
+}

--- a/src/app-core/chat/chatRunModel.ts
+++ b/src/app-core/chat/chatRunModel.ts
@@ -95,6 +95,7 @@ export interface ChatMessageProjection {
   author: string;
   body: string[];
   copyable?: boolean;
+  messageId?: string;
   references: ChatReferenceProjection[];
   reasoningContent?: string;
   reasoningLabel?: string;
@@ -196,6 +197,7 @@ export type ChatStep = {
   error?: unknown;
   id: string;
   kind: ChatStepKind;
+  messageId?: string;
   parentStepId?: string;
   references?: NativeChatReference[];
   sequence: number;
@@ -515,6 +517,7 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
       : text || existingStep?.summary || "";
     upsertStep(turn, event, {
       kind: "reasoning",
+      messageId,
       status: event.event_type === "reasoning.completed" ? "completed" : "running",
       summary,
       title: event.event_type === "reasoning.completed" ? "Thinking complete" : "Thinking",
@@ -543,6 +546,7 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
     }
     upsertStep(turn, event, {
       kind: "message",
+      messageId,
       status: event.event_type === "message.completed" ? "completed" : "running",
       summary,
       title: event.event_type === "message.completed" ? "Final answer" : "Assistant message",
@@ -967,6 +971,7 @@ export function turnsToConversationMessages(turns: ChatTurn[]): ChatMessageProje
     const messages: ChatMessageProjection[] = [{
       author: "You",
       body: [turn.userMessage.text],
+      messageId: turn.userMessage.id,
       references: [],
       time: turn.userMessage.timestamp,
       tone: "user",
@@ -983,6 +988,7 @@ export function turnsToConversationMessages(turns: ChatTurn[]): ChatMessageProje
         author: "Tinybot",
         body: [turn.finalMessage.text],
         copyable: true,
+        messageId: turn.finalMessage.id,
         references: conversationReferences(turn.finalMessage.references),
         reasoningContent: "",
         time: turn.finalMessage.timestamp,
@@ -1027,6 +1033,7 @@ function stepToConversationMessage(step: ChatStep): ChatMessageProjection {
     author: "Tinybot",
     body: step.kind === "message" && step.summary ? [step.summary] : [],
     copyable: step.kind === "message" ? false : undefined,
+    messageId: step.messageId,
     references: conversationReferences(step.references),
     reasoningContent: step.kind === "reasoning" ? step.summary : "",
     reasoningLabel: step.title,

--- a/src/app-core/chat/nativeChat.test.ts
+++ b/src/app-core/chat/nativeChat.test.ts
@@ -13,6 +13,39 @@ import {
   sessionKeyForChat,
 } from "./nativeChat";
 
+function agentEvent({
+  chatId = "chat-1",
+  eventId,
+  eventType,
+  payload,
+  sequence,
+  turnId = "turn-1",
+}: {
+  chatId?: string;
+  eventId: string;
+  eventType: string;
+  payload: Record<string, unknown>;
+  sequence: number;
+  turnId?: string;
+}) {
+  return {
+    kind: "agent.event" as const,
+    chatId,
+    raw: {
+      event: "agent_event",
+      schema_version: "tinybot.agent_event.v1",
+      event_id: eventId,
+      event_type: eventType,
+      chat_id: chatId,
+      session_key: sessionKeyForChat(chatId),
+      turn_id: turnId,
+      sequence,
+      created_at: "2026-05-29T08:00:00.000Z",
+      payload,
+    },
+  };
+}
+
 describe("native chat state", () => {
   test("normalizes gateway sessions and messages without changing existing shapes", () => {
     expect(
@@ -132,27 +165,38 @@ describe("native chat state", () => {
     expect(state.messages.get("websocket:chat-legacy")).toMatchObject([{ content: "kept message" }]);
   });
 
-  test("tracks active session and merges streaming deltas like the hosted WebUI", () => {
+  test("tracks active session and merges structured streaming deltas", () => {
     const state = createNativeChatState();
 
     applyChatEvent(state, { kind: "chat.created", chatId: "chat-1", raw: {} });
-    appendUserMessage(state, "hello", "2026-05-29T08:00:00Z");
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "m1",
-      text: "think",
-      reasoning: true,
-      raw: {},
-    });
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "m1",
-      text: "answer",
-      reasoning: false,
-      raw: {},
-    });
+    applyChatEvent(state, agentEvent({
+      eventId: "event-turn-start",
+      eventType: "agent.turn.started",
+      payload: {
+        user_message: { id: "user-1", role: "user", text: "hello" },
+        user_message_id: "user-1",
+      },
+      sequence: 1,
+    }));
+    applyChatEvent(state, agentEvent({
+      eventId: "event-reasoning",
+      eventType: "reasoning.delta",
+      payload: {
+        message_id: "m1",
+        summary: "think",
+        text: "think",
+      },
+      sequence: 2,
+    }));
+    applyChatEvent(state, agentEvent({
+      eventId: "event-message",
+      eventType: "message.delta",
+      payload: {
+        message_id: "m1",
+        text: "answer",
+      },
+      sequence: 3,
+    }));
 
     expect(state.activeChatId).toBe("chat-1");
     expect(state.activeSessionKey).toBe(sessionKeyForChat("chat-1"));
@@ -167,12 +211,15 @@ describe("native chat state", () => {
       },
     ]);
 
-    applyChatEvent(state, {
-      kind: "message.stream.completed",
-      chatId: "chat-1",
-      messageId: "m1",
-      raw: {},
-    });
+    applyChatEvent(state, agentEvent({
+      eventId: "event-turn-completed",
+      eventType: "agent.turn.completed",
+      payload: {
+        message_id: "m1",
+        reason: "final_response",
+      },
+      sequence: 4,
+    }));
 
     expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(false);
   });
@@ -321,14 +368,15 @@ describe("native chat state", () => {
         _memory_references: [{ note_id: "note_complete", content: "Complete memory" }],
       },
     });
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "m-stream",
-      text: "Streamed answer",
-      reasoning: false,
-      raw: {},
-    });
+    applyChatEvent(state, agentEvent({
+      eventId: "event-stream-delta",
+      eventType: "message.delta",
+      payload: {
+        message_id: "m-stream",
+        text: "Streamed answer",
+      },
+      sequence: 1,
+    }));
     applyChatEvent(state, {
       kind: "message.stream.completed",
       chatId: "chat-1",
@@ -338,30 +386,31 @@ describe("native chat state", () => {
       },
     });
 
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      {
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
         messageId: "m-complete",
-        references: [{ kind: "memory", title: "note_complete", detail: "Complete memory" }],
-      },
-      {
+        references: [expect.objectContaining({ kind: "memory", title: "note_complete", detail: "Complete memory" })],
+      }),
+      expect.objectContaining({
         messageId: "m-stream",
-        references: [{ kind: "recent", title: "ev_stream", detail: "Stream context" }],
-      },
-    ]);
+        references: [expect.objectContaining({ kind: "recent", title: "ev_stream", detail: "Stream context" })],
+      }),
+    ]));
   });
 
   test("does not append a completed message for a stream message with the same id", () => {
     const state = createNativeChatState();
     applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
 
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "m-stream",
-      text: "Streamed answer",
-      reasoning: false,
-      raw: {},
-    });
+    applyChatEvent(state, agentEvent({
+      eventId: "event-stream-delta",
+      eventType: "message.delta",
+      payload: {
+        message_id: "m-stream",
+        text: "Streamed answer",
+      },
+      sequence: 1,
+    }));
     applyChatEvent(state, {
       kind: "message.completed",
       chatId: "chat-1",
@@ -372,14 +421,14 @@ describe("native chat state", () => {
       },
     });
 
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      {
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
         content: "Streamed answer",
         messageId: "m-stream",
-        references: [{ kind: "memory", title: "note_stream", detail: "Stream memory" }],
-      },
-    ]);
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toHaveLength(1);
+        references: [expect.objectContaining({ kind: "memory", title: "note_stream", detail: "Stream memory" })],
+      }),
+    ]));
+    expect(state.messages.get(sessionKeyForChat("chat-1"))?.filter((message) => message.messageId === "m-stream")).toHaveLength(1);
   });
 
   test("clears responding state when a stream is interrupted or errors", () => {
@@ -612,14 +661,15 @@ describe("native chat state", () => {
   test("keeps late live tool events before the streamed final answer", () => {
     const state = createNativeChatState();
     applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "answer-1",
-      text: "The workspace contains apps and docs.",
-      reasoning: false,
-      raw: {},
-    });
+    applyChatEvent(state, agentEvent({
+      eventId: "event-answer-delta",
+      eventType: "message.delta",
+      payload: {
+        message_id: "answer-1",
+        text: "The workspace contains apps and docs.",
+      },
+      sequence: 1,
+    }));
     applyChatEvent(state, {
       kind: "message.completed",
       chatId: "chat-1",
@@ -633,26 +683,26 @@ describe("native chat state", () => {
       },
     });
 
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      {
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
         role: "assistant",
         content: "",
         messageId: "tool-list-1",
         toolActivities: [
-          {
+          expect.objectContaining({
             id: "call-list",
             name: "list_dir",
             responseText: "AGENTS.md\napps/\ndocs/",
             status: "completed",
-          },
+          }),
         ],
-      },
-      {
+      }),
+      expect.objectContaining({
         role: "assistant",
         content: "The workspace contains apps and docs.",
         messageId: "answer-1",
-      },
-    ]);
+      }),
+    ]));
   });
 
   test("projects structured agent events through the native chat message timeline", () => {

--- a/src/app-core/chat/nativeChat.test.ts
+++ b/src/app-core/chat/nativeChat.test.ts
@@ -224,6 +224,78 @@ describe("native chat state", () => {
     expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(false);
   });
 
+  test("keeps legacy normalized message deltas streaming without agent events", () => {
+    const state = createNativeChatState();
+    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
+
+    applyChatEvent(state, {
+      kind: "message.delta",
+      chatId: "chat-1",
+      messageId: "legacy-stream-1",
+      text: "Hello",
+      reasoning: false,
+      raw: { event: "delta" },
+    });
+    applyChatEvent(state, {
+      kind: "message.delta",
+      chatId: "chat-1",
+      messageId: "legacy-stream-1",
+      text: " world",
+      reasoning: false,
+      raw: { event: "message_delta" },
+    });
+
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
+      {
+        role: "assistant",
+        content: "Hello world",
+        reasoningContent: "",
+        messageId: "legacy-stream-1",
+      },
+    ]);
+    expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(true);
+
+    applyChatEvent(state, {
+      kind: "message.stream.completed",
+      chatId: "chat-1",
+      messageId: "legacy-stream-1",
+      raw: { event: "stream_end" },
+    });
+
+    expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(false);
+  });
+
+  test("keeps legacy normalized reasoning deltas on the assistant message", () => {
+    const state = createNativeChatState();
+    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
+
+    applyChatEvent(state, {
+      kind: "message.delta",
+      chatId: "chat-1",
+      messageId: "legacy-stream-2",
+      text: "Thinking",
+      reasoning: true,
+      raw: { event: "reasoning_delta" },
+    });
+    applyChatEvent(state, {
+      kind: "message.delta",
+      chatId: "chat-1",
+      messageId: "legacy-stream-2",
+      text: " done",
+      reasoning: false,
+      raw: { event: "delta" },
+    });
+
+    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
+      {
+        role: "assistant",
+        content: " done",
+        reasoningContent: "Thinking",
+        messageId: "legacy-stream-2",
+      },
+    ]);
+  });
+
   test("normalizes backend memory and recent context references from persisted messages", () => {
     expect(
       normalizeMessagesPayload({

--- a/src/app-core/chat/nativeChat.ts
+++ b/src/app-core/chat/nativeChat.ts
@@ -604,6 +604,49 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
     return;
   }
 
+  if (event.kind === "message.delta") {
+    const sessionKey =
+      event.messageId && state.streamMessageKeys.has(event.messageId)
+        ? state.streamMessageKeys.get(event.messageId) || ""
+        : sessionKeyForChatState(state, event.chatId || state.activeChatId);
+    if (!sessionKey) {
+      logDesktopNativeChatDebug("state.event.after", {
+        dropped: "missing session key",
+        event: summarizeChatEvent(event),
+        state: summarizeNativeChatState(state),
+      });
+      return;
+    }
+    const bucket = ensureMessageBucket(state, sessionKey);
+    const existingMessage = findStreamingDeltaMessage(bucket, event.messageId);
+    const targetMessage = existingMessage ?? {
+      role: "assistant",
+      content: "",
+      reasoningContent: "",
+      timestamp: new Date().toISOString(),
+      messageId: event.messageId || "",
+    };
+    if (event.reasoning) {
+      targetMessage.reasoningContent += event.text;
+    } else {
+      targetMessage.content += event.text;
+    }
+    if (!existingMessage) {
+      bucket.push(targetMessage);
+    }
+    if (event.messageId) {
+      state.streamMessageKeys.set(event.messageId, sessionKey);
+    }
+    state.respondingSessionKeys.add(sessionKey);
+    state.error = "";
+    logDesktopNativeChatDebug("state.event.after", {
+      event: summarizeChatEvent(event),
+      state: summarizeNativeChatState(state),
+      targetSessionKey: sessionKey,
+    });
+    return;
+  }
+
   if (event.kind === "message.completed") {
     const sessionKey = sessionKeyForChatState(state, event.chatId || state.activeChatId);
     if (!sessionKey) {
@@ -716,6 +759,19 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
     event: summarizeChatEvent(event),
     state: summarizeNativeChatState(state),
   });
+}
+
+function findStreamingDeltaMessage(bucket: NativeChatMessage[], messageId: string | undefined): NativeChatMessage | undefined {
+  if (messageId) {
+    return bucket.find((message) => message.role === "assistant" && message.messageId === messageId);
+  }
+  for (let index = bucket.length - 1; index >= 0; index -= 1) {
+    const message = bucket[index];
+    if (message.role === "assistant" && !message.messageId) {
+      return message;
+    }
+  }
+  return undefined;
 }
 
 function upsertToolActivityMessage(bucket: NativeChatMessage[], nextActivity: NativeChatToolActivity): boolean {

--- a/src/app-core/chat/nativeChat.ts
+++ b/src/app-core/chat/nativeChat.ts
@@ -565,29 +565,6 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
     return;
   }
 
-  if (event.kind === "message.delta") {
-    const chatId = event.chatId || state.activeChatId;
-    const sessionKey = sessionKeyForChatState(state, chatId);
-    if (!sessionKey) {
-      logDesktopNativeChatDebug("state.event.after", {
-        dropped: "missing session key",
-        event: summarizeChatEvent(event),
-        state: summarizeNativeChatState(state),
-      });
-      return;
-    }
-    const messageId = event.messageId || `stream:${sessionKey}`;
-    upsertStreamMessage(state, sessionKey, messageId, event.text, event.reasoning);
-    state.respondingSessionKeys.add(sessionKey);
-    state.error = "";
-    logDesktopNativeChatDebug("state.event.after", {
-      event: summarizeChatEvent(event),
-      state: summarizeNativeChatState(state),
-      targetSessionKey: sessionKey,
-    });
-    return;
-  }
-
   if (event.kind === "agent.event") {
     const envelope = agentEventEnvelopeFromRaw(event.raw);
     if (!envelope) {
@@ -739,33 +716,6 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
     event: summarizeChatEvent(event),
     state: summarizeNativeChatState(state),
   });
-}
-
-function upsertStreamMessage(
-  state: NativeChatState,
-  sessionKey: string,
-  messageId: string,
-  deltaText: string,
-  reasoning: boolean,
-) {
-  const bucket = ensureMessageBucket(state, sessionKey);
-  let message = bucket.find((item) => item.messageId === messageId);
-  if (!message) {
-    message = {
-      role: "assistant",
-      content: "",
-      reasoningContent: "",
-      timestamp: new Date().toISOString(),
-      messageId,
-    };
-    bucket.push(message);
-    state.streamMessageKeys.set(messageId, sessionKey);
-  }
-  if (reasoning) {
-    message.reasoningContent += deltaText;
-  } else {
-    message.content += deltaText;
-  }
 }
 
 function upsertToolActivityMessage(bucket: NativeChatMessage[], nextActivity: NativeChatToolActivity): boolean {
@@ -1032,8 +982,12 @@ function agentEventEnvelopeFromRaw(raw: Record<string, unknown>): AgentEventEnve
 }
 
 function conversationMessagesToNativeMessages(messages: ReturnType<typeof turnsToConversationMessages>): NativeChatMessage[] {
+  const reasoningByMessageId = reasoningContentToMergeByMessageId(messages);
   return messages.filter((message, index) => {
     const next = messages[index + 1];
+    if (message.messageId && reasoningByMessageId.has(message.messageId) && !message.body.join("\n").trim()) {
+      return false;
+    }
     return !(
       message.tone === "assistant"
       && message.copyable !== true
@@ -1045,7 +999,8 @@ function conversationMessagesToNativeMessages(messages: ReturnType<typeof turnsT
     role: message.tone,
     content: message.body.join("\n"),
     ...(typeof message.copyable === "boolean" ? { copyable: message.copyable } : {}),
-    reasoningContent: message.reasoningContent ?? "",
+    ...(message.messageId ? { messageId: message.messageId } : {}),
+    reasoningContent: `${message.messageId ? reasoningByMessageId.get(message.messageId) ?? "" : ""}${message.reasoningContent ?? ""}`,
     ...(message.toolActivities?.length ? {
       toolActivities: message.toolActivities.map((activity) => ({
         approvalId: activity.approvalId,
@@ -1085,8 +1040,32 @@ function conversationMessagesToNativeMessages(messages: ReturnType<typeof turnsT
       })),
     } : {}),
     timestamp: message.time,
-    messageId: `agent-run:${index}`,
+    messageId: message.messageId || `agent-run:${index}`,
   }));
+}
+
+function reasoningContentToMergeByMessageId(messages: ReturnType<typeof turnsToConversationMessages>): Map<string, string> {
+  const reasoningByMessageId = new Map<string, string>();
+  messages.forEach((message, index) => {
+    if (
+      message.tone !== "assistant"
+      || !message.messageId
+      || message.body.join("\n").trim()
+      || !message.reasoningContent?.trim()
+    ) {
+      return;
+    }
+    const hasAnswerForSameMessage = messages.slice(index + 1).some((next) => (
+      next.tone === "assistant"
+      && next.messageId === message.messageId
+      && Boolean(next.body.join("\n").trim())
+    ));
+    if (!hasAnswerForSameMessage) {
+      return;
+    }
+    reasoningByMessageId.set(message.messageId, `${reasoningByMessageId.get(message.messageId) ?? ""}${message.reasoningContent}`);
+  });
+  return reasoningByMessageId;
 }
 
 function nativeReferenceKind(value: string): NativeChatReference["kind"] {
@@ -1110,6 +1089,10 @@ function normalizeMessageReferences(message: Record<string, unknown>): NativeCha
 }
 
 function normalizeToolActivities(message: Record<string, unknown>): NativeChatToolActivity[] {
+  const directActivities = directToolActivityRows(message.toolActivities ?? message.tool_activities);
+  if (directActivities.length) {
+    return directActivities;
+  }
   const calls = toolCallRows(message.tool_calls ?? message.toolCalls);
   const results = toolResultRows(message.tool_results ?? message.toolResults);
   const usedResultIndexes = new Set<number>();
@@ -1342,6 +1325,39 @@ function shouldSuppressToolActivityContent(message: Record<string, unknown>, act
       || booleanValue(message._tool_detail)
       || booleanValue(message._tool_result),
   );
+}
+
+function directToolActivityRows(value: unknown): NativeChatToolActivity[] {
+  return arrayRows(value).map((row, index) => {
+    const status = normalizeToolActivityStatus(row.status ?? row.state ?? row.phase);
+    const kind = stringValue(row.kind).toLowerCase() === "result" ? "result" : "call";
+    const delegatedTrace = isRecord(row.delegatedTrace)
+      ? row.delegatedTrace
+      : isRecord(row.delegated_trace)
+        ? row.delegated_trace
+        : undefined;
+    return {
+      id: stringValue(row.id ?? row.tool_call_id ?? row.toolCallId) || `tool-activity-${index + 1}`,
+      name: stringValue(row.name ?? row.tool_name ?? row.title) || "tool",
+      argsText: textValue(row.argsText ?? row.args_text ?? row.arguments ?? row.args),
+      responseText: textValue(row.responseText ?? row.response_text ?? row.response ?? row.result ?? row.output),
+      kind,
+      ...(stringValue(row.approvalId ?? row.approval_id ?? row._approval_id) ? { approvalId: stringValue(row.approvalId ?? row.approval_id ?? row._approval_id) } : {}),
+      ...(stringValue(row.approvalStatus ?? row.approval_status ?? row._approval_status) ? { approvalStatus: stringValue(row.approvalStatus ?? row.approval_status ?? row._approval_status) } : {}),
+      ...(stringValue(row.childRunId ?? row.child_run_id) ? { childRunId: stringValue(row.childRunId ?? row.child_run_id) } : {}),
+      ...(stringValue(row.delegateId ?? row.delegate_id) ? { delegateId: stringValue(row.delegateId ?? row.delegate_id) } : {}),
+      ...(stringValue(row.delegateTask ?? row.delegate_task) ? { delegateTask: stringValue(row.delegateTask ?? row.delegate_task) } : {}),
+      ...(stringValue(row.delegateTitle ?? row.delegate_title) ? { delegateTitle: stringValue(row.delegateTitle ?? row.delegate_title) } : {}),
+      ...(stringValue(row.delegateType ?? row.delegate_type) ? { delegateType: stringValue(row.delegateType ?? row.delegate_type) } : {}),
+      ...(delegatedTrace ? { delegatedTrace } : {}),
+      ...(stringValue(row.finalOutput ?? row.final_output) ? { finalOutput: stringValue(row.finalOutput ?? row.final_output) } : {}),
+      ...(stringValue(row.parentRunId ?? row.parent_run_id) ? { parentRunId: stringValue(row.parentRunId ?? row.parent_run_id) } : {}),
+      ...(stringValue(row.parentTurnId ?? row.parent_turn_id) ? { parentTurnId: stringValue(row.parentTurnId ?? row.parent_turn_id) } : {}),
+      ...(stringValue(row.sessionKey ?? row.session_key) ? { sessionKey: stringValue(row.sessionKey ?? row.session_key) } : {}),
+      ...(status ? { status } : {}),
+      ...(stringValue(row.traceRef ?? row.trace_ref) ? { traceRef: stringValue(row.traceRef ?? row.trace_ref) } : {}),
+    };
+  });
 }
 
 function toolCallRows(value: unknown): Array<Pick<NativeChatToolActivity, "id" | "name" | "argsText"> & { approvalId?: string; approvalStatus?: string; status?: string }> {

--- a/src/app-core/native/desktopNativeWebSocketBridge.test.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.test.ts
@@ -4,7 +4,7 @@ import type { NativeTransportApi } from "./desktopNativeTransport";
 import { toDesktopNativeTauriEventName } from "./desktopNativeTauriEvents";
 
 describe("desktop native WebSocket bridge", () => {
-  test("projects TS worker stream events into legacy WebUI WebSocket frames", async () => {
+  test("projects TS worker stream events into structured agent WebSocket frames", async () => {
     const handlers = new Map<string, (payload: unknown) => void>();
     const unlisteners: Array<() => void> = [];
     const dispatch = deferred<unknown>();
@@ -66,20 +66,9 @@ describe("desktop native WebSocket bridge", () => {
     });
     await flushMicrotasks();
 
-    expect(events).toContainEqual({
+    expect(events).not.toContainEqual(expect.objectContaining({
       event: "delta",
-      chat_id: "chat-native",
-      message_id: "message-1",
-      text: "hello",
-      is_reasoning: false,
-    });
-    expect(events).toContainEqual({
-      event: "delta",
-      chat_id: "chat-native",
-      message_id: "message-1",
-      text: "thinking",
-      is_reasoning: true,
-    });
+    }));
     expect(events).toContainEqual({
       event: "stream_end",
       chat_id: "chat-native",
@@ -159,13 +148,16 @@ describe("desktop native WebSocket bridge", () => {
     handlers.get(toDesktopNativeTauriEventName("agent.delta"))?.({ runId, delta: "live", messageId: "message-live" });
     await flushMicrotasks();
 
-    expect(events).toContainEqual({
-      event: "delta",
-      chat_id: "chat-native",
-      message_id: "message-live",
-      text: "live",
-      is_reasoning: false,
-    });
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "message.delta",
+      payload: expect.objectContaining({
+        message_id: "message-live",
+        text: "live",
+        visibility: "visible",
+      }),
+      turn_id: runId,
+    }));
 
     dispatch.resolve({
       transport: {
@@ -232,9 +224,13 @@ describe("desktop native WebSocket bridge", () => {
     await flushMicrotasks();
 
     expect(events).toContainEqual(expect.objectContaining({
-      event: "delta",
-      chat_id: "chat-native",
-      text: "live",
+      event: "agent_event",
+      event_type: "message.delta",
+      payload: expect.objectContaining({
+        text: "live",
+        visibility: "visible",
+      }),
+      turn_id: runId,
     }));
     expect(events).not.toContainEqual(expect.objectContaining({
       event: "message",
@@ -301,9 +297,13 @@ describe("desktop native WebSocket bridge", () => {
     await flushMicrotasks();
 
     expect(events).toContainEqual(expect.objectContaining({
-      event: "delta",
-      chat_id: "chat-native",
-      text: "live",
+      event: "agent_event",
+      event_type: "message.delta",
+      payload: expect.objectContaining({
+        text: "live",
+        visibility: "visible",
+      }),
+      turn_id: runId,
     }));
     expect(events).toContainEqual(expect.objectContaining({
       event: "stream_end",

--- a/src/app-core/native/desktopNativeWebSocketBridge.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.ts
@@ -398,13 +398,6 @@ class DesktopNativeWebSocket extends EventTarget {
         runId,
         text: summarizeDebugText(text),
       });
-      this.emitJson({
-        event: "delta",
-        chat_id: run.chatId,
-        message_id: run.messageId,
-        text,
-        is_reasoning: eventName === "agent.reasoning_delta",
-      });
       this.emitAgentEventFrame(run, runId, eventName === "agent.reasoning_delta" ? "reasoning.delta" : "message.delta", {
         message_id: run.messageId,
         ...(eventName === "agent.reasoning_delta" ? { summary: text } : {}),

--- a/src/app-core/native/nativeBackendContract.ts
+++ b/src/app-core/native/nativeBackendContract.ts
@@ -1,4 +1,5 @@
 export const NATIVE_BACKEND_COMMAND_NAMES = [
+  "record_renderer_diagnostic",
   "worker_probe_status",
   "worker_run_agent",
   "worker_run_agent_input",

--- a/src/app-core/native/rendererDiagnostics.test.ts
+++ b/src/app-core/native/rendererDiagnostics.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  buildRendererDiagnostic,
+  installRendererDiagnosticHandlers,
+  recordRendererDiagnostic,
+  showRendererDiagnosticOverlay,
+} from "./rendererDiagnostics";
+
+describe("renderer diagnostics", () => {
+  afterEach(() => {
+    document.getElementById("tinybot-renderer-diagnostic-overlay")?.remove();
+    window.localStorage.clear();
+    window.__tinybotNativeDebug = [];
+    vi.restoreAllMocks();
+  });
+
+  test("records renderer crashes through the native diagnostic command without chat text", async () => {
+    const invoke = vi.fn(async <T,>() => undefined as T);
+    window.__tinybotNativeDebug = [
+      {
+        at: "2026-07-06T01:00:00.000Z",
+        stage: "socket.frame",
+        details: {
+          chatId: "chat-1",
+          text: { preview: "sensitive answer", length: 16 },
+        },
+      },
+    ];
+
+    const diagnostic = buildRendererDiagnostic("react.render", new Error("render exploded"), {
+      componentStack: "at ChatPage",
+      now: () => "2026-07-06T01:01:00.000Z",
+    });
+
+    await recordRendererDiagnostic(diagnostic, { invoke });
+
+    expect(invoke).toHaveBeenCalledWith("record_renderer_diagnostic", {
+      input: expect.objectContaining({
+        id: diagnostic.id,
+        type: "react.render",
+        message: "render exploded",
+        componentStack: "at ChatPage",
+        recentDebugStages: [
+          {
+            at: "2026-07-06T01:00:00.000Z",
+            stage: "socket.frame",
+          },
+        ],
+      }),
+    });
+    expect(JSON.stringify(invoke.mock.calls)).not.toContain("sensitive answer");
+  });
+
+  test("falls back to a bounded localStorage crash log when native recording fails", async () => {
+    const invoke = vi.fn(async <T,>() => {
+      throw new Error("native unavailable");
+      return undefined as T;
+    });
+
+    await recordRendererDiagnostic(
+      buildRendererDiagnostic("window.error", new Error("boom"), {
+        now: () => "2026-07-06T01:02:00.000Z",
+      }),
+      { invoke },
+    );
+
+    const stored = JSON.parse(window.localStorage.getItem("tinybot.renderer.diagnostics") ?? "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      type: "window.error",
+      message: "boom",
+    });
+  });
+
+  test("installs global handlers for window errors and unhandled rejections", () => {
+    const record = vi.fn();
+    const cleanup = installRendererDiagnosticHandlers({ record });
+
+    window.dispatchEvent(new ErrorEvent("error", { error: new Error("window exploded") }));
+    const rejectionEvent = new Event("unhandledrejection") as PromiseRejectionEvent;
+    Object.defineProperty(rejectionEvent, "reason", { value: new Error("promise exploded") });
+    window.dispatchEvent(rejectionEvent);
+
+    cleanup();
+
+    expect(record).toHaveBeenCalledTimes(2);
+    expect(record.mock.calls[0][0]).toMatchObject({
+      type: "window.error",
+      message: "window exploded",
+    });
+    expect(record.mock.calls[1][0]).toMatchObject({
+      type: "window.unhandledrejection",
+      message: "promise exploded",
+    });
+  });
+
+  test("shows a visible crash overlay with the diagnostic id", () => {
+    const diagnostic = buildRendererDiagnostic("react.render", new Error("render exploded"), {
+      now: () => "2026-07-06T01:03:00.000Z",
+    });
+
+    showRendererDiagnosticOverlay(diagnostic);
+
+    const overlay = document.getElementById("tinybot-renderer-diagnostic-overlay");
+    expect(overlay?.getAttribute("role")).toBe("alert");
+    expect(overlay?.textContent).toContain("Tinybot UI crashed");
+    expect(overlay?.textContent).toContain("render exploded");
+    expect(overlay?.textContent).toContain(diagnostic.id);
+  });
+});

--- a/src/app-core/native/rendererDiagnostics.ts
+++ b/src/app-core/native/rendererDiagnostics.ts
@@ -1,0 +1,265 @@
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import type { DesktopNativeDebugEntry } from "./desktopNativeChatDebug";
+
+export type RendererDiagnosticType = "react.render" | "window.error" | "window.unhandledrejection";
+
+export interface RendererDiagnosticDebugStage {
+  at: string;
+  stage: string;
+}
+
+export interface RendererDiagnostic {
+  componentStack?: string;
+  id: string;
+  message: string;
+  name?: string;
+  recentDebugStages: RendererDiagnosticDebugStage[];
+  stack?: string;
+  timestamp: string;
+  type: RendererDiagnosticType;
+  url?: string;
+  userAgent?: string;
+}
+
+type NativeInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+const RENDERER_DIAGNOSTICS_STORAGE_KEY = "tinybot.renderer.diagnostics";
+const MAX_LOCAL_DIAGNOSTICS = 20;
+const MAX_STACK_LENGTH = 4000;
+const MAX_MESSAGE_LENGTH = 500;
+const MAX_RECENT_DEBUG_STAGES = 20;
+const RENDERER_DIAGNOSTIC_OVERLAY_ID = "tinybot-renderer-diagnostic-overlay";
+
+export function buildRendererDiagnostic(
+  type: RendererDiagnosticType,
+  error: unknown,
+  options: {
+    componentStack?: string;
+    now?: () => string;
+    url?: string;
+    userAgent?: string;
+  } = {},
+): RendererDiagnostic {
+  const timestamp = options.now?.() ?? new Date().toISOString();
+  return {
+    id: createRendererDiagnosticId(timestamp),
+    type,
+    timestamp,
+    message: truncateText(errorMessage(error), MAX_MESSAGE_LENGTH),
+    name: errorName(error),
+    stack: truncateOptionalText(errorStack(error), MAX_STACK_LENGTH),
+    componentStack: truncateOptionalText(options.componentStack, MAX_STACK_LENGTH),
+    url: options.url ?? readLocationHref(),
+    userAgent: options.userAgent ?? readUserAgent(),
+    recentDebugStages: recentDebugStages(),
+  };
+}
+
+export async function recordRendererDiagnostic(
+  diagnostic: RendererDiagnostic,
+  options: {
+    invoke?: NativeInvoke;
+    storage?: Pick<Storage, "getItem" | "setItem">;
+  } = {},
+): Promise<void> {
+  const invoke = options.invoke ?? tauriInvoke;
+  try {
+    await invoke("record_renderer_diagnostic", { input: diagnostic });
+  } catch (error) {
+    persistLocalDiagnostic(diagnostic, options.storage);
+    console.error("[tinybot-renderer-diagnostic]", diagnostic, error);
+  }
+}
+
+export function showRendererDiagnosticOverlay(diagnostic: RendererDiagnostic): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const existingOverlay = document.getElementById(RENDERER_DIAGNOSTIC_OVERLAY_ID);
+  const overlay = existingOverlay ?? document.createElement("section");
+  overlay.id = RENDERER_DIAGNOSTIC_OVERLAY_ID;
+  overlay.setAttribute("role", "alert");
+  overlay.setAttribute("aria-live", "assertive");
+  overlay.replaceChildren();
+  Object.assign(overlay.style, {
+    position: "fixed",
+    inset: "0",
+    zIndex: "2147483647",
+    display: "grid",
+    alignContent: "center",
+    justifyItems: "start",
+    gap: "10px",
+    padding: "40px",
+    boxSizing: "border-box",
+    background: "#fff",
+    color: "#191816",
+    fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif",
+  });
+
+  const title = document.createElement("h1");
+  title.textContent = "Tinybot UI crashed";
+  Object.assign(title.style, {
+    margin: "0",
+    fontSize: "18px",
+    fontWeight: "750",
+  });
+
+  const message = document.createElement("p");
+  message.textContent = diagnostic.message || "An unexpected renderer error occurred.";
+  Object.assign(message.style, {
+    maxWidth: "760px",
+    margin: "0",
+    color: "#5f5a54",
+    fontSize: "13px",
+    lineHeight: "1.5",
+    overflowWrap: "anywhere",
+  });
+
+  const crashId = document.createElement("p");
+  crashId.textContent = `Crash ID: ${diagnostic.id}`;
+  Object.assign(crashId.style, {
+    maxWidth: "760px",
+    margin: "0",
+    color: "#5f5a54",
+    fontSize: "13px",
+    lineHeight: "1.5",
+    overflowWrap: "anywhere",
+  });
+
+  const reloadButton = document.createElement("button");
+  reloadButton.type = "button";
+  reloadButton.textContent = "Reload";
+  Object.assign(reloadButton.style, {
+    minHeight: "34px",
+    border: "1px solid #d8d1c7",
+    borderRadius: "8px",
+    background: "#191816",
+    padding: "0 12px",
+    color: "#fff",
+    fontSize: "12px",
+    fontWeight: "650",
+    cursor: "pointer",
+  });
+  reloadButton.addEventListener("click", () => window.location.reload());
+
+  overlay.append(title, message, crashId, reloadButton);
+  if (!existingOverlay) {
+    document.body.append(overlay);
+  }
+}
+
+export function installRendererDiagnosticHandlers(options: {
+  record?: (diagnostic: RendererDiagnostic) => void | Promise<void>;
+} = {}): () => void {
+  const record = options.record ?? ((diagnostic: RendererDiagnostic) => {
+    void recordRendererDiagnostic(diagnostic);
+  });
+  const handleError = (event: ErrorEvent) => {
+    void record(buildRendererDiagnostic("window.error", event.error ?? event.message, {
+      url: event.filename || undefined,
+    }));
+  };
+  const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+    void record(buildRendererDiagnostic("window.unhandledrejection", event.reason));
+  };
+
+  window.addEventListener("error", handleError);
+  window.addEventListener("unhandledrejection", handleUnhandledRejection);
+
+  return () => {
+    window.removeEventListener("error", handleError);
+    window.removeEventListener("unhandledrejection", handleUnhandledRejection);
+  };
+}
+
+function persistLocalDiagnostic(
+  diagnostic: RendererDiagnostic,
+  storage: Pick<Storage, "getItem" | "setItem"> | undefined,
+): void {
+  const targetStorage = storage ?? readLocalStorage();
+  if (!targetStorage) {
+    return;
+  }
+  try {
+    const existing = JSON.parse(targetStorage.getItem(RENDERER_DIAGNOSTICS_STORAGE_KEY) ?? "[]");
+    const diagnostics = Array.isArray(existing) ? existing : [];
+    diagnostics.push(diagnostic);
+    const start = diagnostics.length > MAX_LOCAL_DIAGNOSTICS
+      ? diagnostics.length - MAX_LOCAL_DIAGNOSTICS
+      : 0;
+    targetStorage.setItem(RENDERER_DIAGNOSTICS_STORAGE_KEY, JSON.stringify(diagnostics.slice(start)));
+  } catch {
+    targetStorage.setItem(RENDERER_DIAGNOSTICS_STORAGE_KEY, JSON.stringify([diagnostic]));
+  }
+}
+
+function recentDebugStages(): RendererDiagnosticDebugStage[] {
+  const entries = readDebugEntries();
+  return entries.slice(-MAX_RECENT_DEBUG_STAGES).map((entry) => ({
+    at: entry.at,
+    stage: entry.stage,
+  }));
+}
+
+function readDebugEntries(): DesktopNativeDebugEntry[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+  return window.__tinybotNativeDebug ?? window.__tinybotNativeChatDebug ?? [];
+}
+
+function readLocalStorage(): Storage | undefined {
+  try {
+    return typeof window === "undefined" ? undefined : window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function readLocationHref(): string | undefined {
+  try {
+    return typeof window === "undefined" ? undefined : window.location.href;
+  } catch {
+    return undefined;
+  }
+}
+
+function readUserAgent(): string | undefined {
+  try {
+    return typeof navigator === "undefined" ? undefined : navigator.userAgent;
+  } catch {
+    return undefined;
+  }
+}
+
+function createRendererDiagnosticId(timestamp: string): string {
+  const compactTime = timestamp.replace(/\D/g, "").slice(0, 14) || String(Date.now());
+  return `renderer-${compactTime}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || error.name;
+  }
+  return typeof error === "string" ? error : String(error);
+}
+
+function errorName(error: unknown): string | undefined {
+  return error instanceof Error ? error.name : undefined;
+}
+
+function errorStack(error: unknown): string | undefined {
+  return error instanceof Error ? error.stack : undefined;
+}
+
+function truncateOptionalText(value: string | undefined, maxLength: number): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return truncateText(value, maxLength);
+}
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}

--- a/src/components/ui/TextType.css
+++ b/src/components/ui/TextType.css
@@ -1,0 +1,18 @@
+.text-type {
+  display: inline-block;
+  white-space: pre-wrap;
+}
+
+.text-type__content {
+  display: inline;
+}
+
+.text-type__cursor {
+  display: inline-block;
+  margin-left: 0.18rem;
+  opacity: 1;
+}
+
+.text-type__cursor--hidden {
+  display: none;
+}

--- a/src/components/ui/TextType.test.tsx
+++ b/src/components/ui/TextType.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TextType } from "./TextType";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("TextType", () => {
+  it("types to the right and deletes from the right when text changes", async () => {
+    vi.useFakeTimers();
+    const { rerender } = render(
+      <TextType ariaLabel="Plan" deletingSpeed={10} loop={false} pauseDuration={1000} text="Plan" typingSpeed={10} />,
+    );
+    const visual = screen.getByTestId("text-type-visual");
+
+    await advanceTimers(0);
+    expect(visual.textContent).toBe("P");
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("Pl");
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("Pla");
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("Plan");
+
+    rerender(
+      <TextType ariaLabel="Task" deletingSpeed={10} loop={false} pauseDuration={1000} text="Task" typingSpeed={10} />,
+    );
+
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("Pla");
+
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("Pl");
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("P");
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("");
+
+    await advanceTimers(0);
+    expect(visual.textContent).toBe("T");
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("Ta");
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("Tas");
+    await advanceTimers(10);
+    expect(visual.textContent).toBe("Task");
+  });
+});
+
+async function advanceTimers(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}

--- a/src/components/ui/TextType.tsx
+++ b/src/components/ui/TextType.tsx
@@ -1,0 +1,235 @@
+import {
+  createElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ElementType,
+  type ReactNode,
+} from "react";
+import { gsap } from "gsap";
+import "./TextType.css";
+
+export type TextTypeProps = {
+  ariaHidden?: boolean;
+  ariaLabel?: string;
+  as?: ElementType;
+  className?: string;
+  cursorBlinkDuration?: number;
+  cursorCharacter?: ReactNode;
+  cursorClassName?: string;
+  deletingSpeed?: number;
+  hideCursorWhileTyping?: boolean;
+  initialDelay?: number;
+  loop?: boolean;
+  onSentenceComplete?: (sentence: string, index: number) => void;
+  pauseDuration?: number;
+  reverseMode?: boolean;
+  showCursor?: boolean;
+  startOnVisible?: boolean;
+  text: string | readonly string[];
+  textColors?: string[];
+  typingSpeed?: number;
+  variableSpeed?: { min: number; max: number };
+};
+
+export function TextType({
+  ariaHidden = false,
+  ariaLabel,
+  as: Component = "span",
+  className = "",
+  cursorBlinkDuration = 0.5,
+  cursorCharacter = "|",
+  cursorClassName = "",
+  deletingSpeed = 30,
+  hideCursorWhileTyping = false,
+  initialDelay = 0,
+  loop = true,
+  onSentenceComplete,
+  pauseDuration = 2000,
+  reverseMode = false,
+  showCursor = true,
+  startOnVisible = false,
+  text,
+  textColors = [],
+  typingSpeed = 50,
+  variableSpeed,
+}: TextTypeProps) {
+  const [displayedText, setDisplayedText] = useState("");
+  const [currentCharIndex, setCurrentCharIndex] = useState(0);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [currentTextIndex, setCurrentTextIndex] = useState(0);
+  const [isVisible, setIsVisible] = useState(!startOnVisible);
+  const cursorRef = useRef<HTMLSpanElement | null>(null);
+  const containerRef = useRef<HTMLElement | null>(null);
+  const textKeyRef = useRef("");
+  const switchingTextRef = useRef(false);
+
+  const textArray = useMemo(() => Array.isArray(text) ? [...text] : [text], [text]);
+  const currentText = textArray[currentTextIndex] ?? "";
+  const processedText = reverseMode ? currentText.split("").reverse().join("") : currentText;
+  const reducedMotion = prefersReducedMotion();
+
+  const getRandomSpeed = useCallback(() => {
+    if (!variableSpeed) {
+      return typingSpeed;
+    }
+    return Math.random() * (variableSpeed.max - variableSpeed.min) + variableSpeed.min;
+  }, [typingSpeed, variableSpeed]);
+
+  const textKey = textArray.join("\u0000");
+
+  useEffect(() => {
+    if (!textKeyRef.current) {
+      textKeyRef.current = textKey;
+      return;
+    }
+    if (textKeyRef.current === textKey) {
+      return;
+    }
+    textKeyRef.current = textKey;
+    setCurrentTextIndex(0);
+    setCurrentCharIndex(0);
+    if (displayedText) {
+      switchingTextRef.current = true;
+      setIsDeleting(true);
+      return;
+    }
+    setIsDeleting(false);
+  }, [displayedText, textKey]);
+
+  useEffect(() => {
+    if (!startOnVisible || !containerRef.current) {
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+        }
+      }
+    }, { threshold: 0.1 });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [startOnVisible]);
+
+  useEffect(() => {
+    if (!showCursor || reducedMotion || !cursorRef.current) {
+      return;
+    }
+    gsap.set(cursorRef.current, { opacity: 1 });
+    const tween = gsap.to(cursorRef.current, {
+      duration: cursorBlinkDuration,
+      ease: "power2.inOut",
+      opacity: 0,
+      repeat: -1,
+      yoyo: true,
+    });
+    return () => {
+      tween.kill();
+    };
+  }, [cursorBlinkDuration, reducedMotion, showCursor]);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      setDisplayedText(processedText);
+      return;
+    }
+    if (!isVisible || !processedText) {
+      return;
+    }
+    let timeout: number | undefined;
+
+    if (isDeleting) {
+      if (displayedText === "") {
+        setIsDeleting(false);
+        if (switchingTextRef.current) {
+          switchingTextRef.current = false;
+          setCurrentCharIndex(0);
+          return;
+        }
+        onSentenceComplete?.(currentText, currentTextIndex);
+        if (currentTextIndex === textArray.length - 1 && !loop) {
+          return;
+        }
+        setCurrentTextIndex((index) => (index + 1) % textArray.length);
+        setCurrentCharIndex(0);
+        return;
+      }
+      timeout = window.setTimeout(() => {
+        setDisplayedText((value) => value.slice(0, -1));
+      }, deletingSpeed);
+      return () => window.clearTimeout(timeout);
+    }
+
+    if (currentCharIndex < processedText.length) {
+      timeout = window.setTimeout(() => {
+        setDisplayedText((value) => value + processedText[currentCharIndex]);
+        setCurrentCharIndex((index) => index + 1);
+      }, currentCharIndex === 0 && displayedText === "" ? initialDelay : (variableSpeed ? getRandomSpeed() : typingSpeed));
+      return () => window.clearTimeout(timeout);
+    }
+
+    if (!loop && currentTextIndex === textArray.length - 1) {
+      return;
+    }
+    timeout = window.setTimeout(() => {
+      setIsDeleting(true);
+    }, pauseDuration);
+    return () => window.clearTimeout(timeout);
+  }, [
+    currentCharIndex,
+    currentText,
+    currentTextIndex,
+    deletingSpeed,
+    displayedText,
+    getRandomSpeed,
+    initialDelay,
+    isDeleting,
+    isVisible,
+    loop,
+    onSentenceComplete,
+    pauseDuration,
+    processedText,
+    reducedMotion,
+    textArray.length,
+    typingSpeed,
+    variableSpeed,
+  ]);
+
+  const currentColor = textColors.length ? textColors[currentTextIndex % textColors.length] : undefined;
+  const shouldHideCursor = hideCursorWhileTyping && (currentCharIndex < processedText.length || isDeleting);
+
+  return createElement(
+    Component,
+    {
+      "aria-hidden": ariaHidden || undefined,
+      "aria-label": ariaHidden ? undefined : ariaLabel,
+      className: ["text-type", className].filter(Boolean).join(" "),
+      "data-text-type": loop ? "loop" : "once",
+      "data-testid": "text-type",
+      ref: containerRef,
+    },
+    <span className="text-type__content" data-testid="text-type-visual" style={{ color: currentColor ?? "inherit" }}>
+      {displayedText}
+    </span>,
+    showCursor && !reducedMotion ? (
+      <span
+        aria-hidden="true"
+        className={["text-type__cursor", cursorClassName, shouldHideCursor ? "text-type__cursor--hidden" : ""].filter(Boolean).join(" ")}
+        ref={cursorRef}
+      >
+        {cursorCharacter}
+      </span>
+    ) : null,
+  );
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export default TextType;

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -14,6 +14,7 @@ import {
   Music,
   Plus,
   SlidersHorizontal,
+  Square,
   Video,
   X,
 } from "lucide-react";
@@ -73,6 +74,8 @@ export interface ClaudeStyleAiInputProps {
   defaultModel?: string;
   onModelChange?: (modelId: string) => void;
   tools?: ComposerToolOption[];
+  responding?: boolean;
+  onStopResponding?: () => void | Promise<void>;
 }
 
 const MAX_FILES = 10;
@@ -98,7 +101,9 @@ export function ClaudeStyleAiInput({
   models = EMPTY_MODELS,
   onModelChange,
   onSendMessage,
+  onStopResponding,
   placeholder = "Message Tinybot",
+  responding = false,
   tools = EMPTY_TOOLS,
 }: ClaudeStyleAiInputProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -171,6 +176,15 @@ export function ClaudeStyleAiInput({
       setError("Message could not be sent.");
     } finally {
       setSending(false);
+    }
+  }
+
+  async function handleStopResponding() {
+    setError("");
+    try {
+      await onStopResponding?.();
+    } catch {
+      setError("Generation could not be stopped.");
     }
   }
 
@@ -411,15 +425,28 @@ export function ClaudeStyleAiInput({
             </div>
           </div>
 
-          <button
-            aria-label="Send message"
-            className="claude-ai-input__send"
-            disabled={!canSend}
-            title="Send message"
-            type="submit"
-          >
-            <ArrowUp aria-hidden="true" size={18} />
-          </button>
+          {responding ? (
+            <button
+              aria-label="Stop generation"
+              className="claude-ai-input__send"
+              disabled={disabled}
+              title="Stop generation"
+              type="button"
+              onClick={() => void handleStopResponding()}
+            >
+              <Square aria-hidden="true" size={15} />
+            </button>
+          ) : (
+            <button
+              aria-label="Send message"
+              className="claude-ai-input__send"
+              disabled={!canSend}
+              title="Send message"
+              type="submit"
+            >
+              <ArrowUp aria-hidden="true" size={18} />
+            </button>
+          )}
         </div>
       </div>
     </form>

--- a/src/react-workbench/App.test.tsx
+++ b/src/react-workbench/App.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { TinybotErrorBoundary } from "./App";
+
+afterEach(() => {
+  cleanup();
+  document.getElementById("tinybot-renderer-diagnostic-overlay")?.remove();
+  vi.restoreAllMocks();
+});
+
+describe("TinybotErrorBoundary", () => {
+  test("renders a visible fallback and records diagnostics after a render crash", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const recordDiagnostic = vi.fn(async () => undefined);
+
+    render(
+      <TinybotErrorBoundary recordDiagnostic={recordDiagnostic}>
+        <CrashingChild />
+      </TinybotErrorBoundary>,
+    );
+
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts.map((alert) => alert.textContent).join("\n")).toContain("Tinybot UI crashed");
+    expect(alerts.map((alert) => alert.textContent).join("\n")).toContain("render exploded");
+    expect(alerts.map((alert) => alert.textContent).join("\n")).toContain("Crash ID");
+    expect(screen.getAllByRole("button", { name: "Reload" }).length).toBeGreaterThan(0);
+    expect(recordDiagnostic).toHaveBeenCalledWith(expect.objectContaining({
+      type: "react.render",
+      message: "render exploded",
+      componentStack: expect.stringContaining("CrashingChild"),
+    }));
+  });
+});
+
+function CrashingChild(): ReactNode {
+  throw new Error("render exploded");
+}

--- a/src/react-workbench/App.tsx
+++ b/src/react-workbench/App.tsx
@@ -1,8 +1,62 @@
-import { useMemo } from "react";
+import { Component, useEffect, useMemo, type ErrorInfo, type ReactNode } from "react";
+import {
+  buildRendererDiagnostic,
+  installRendererDiagnosticHandlers,
+  recordRendererDiagnostic,
+  showRendererDiagnosticOverlay,
+  type RendererDiagnostic,
+} from "../app-core/native/rendererDiagnostics";
 import { createDesktopAppServices } from "./defaultServices";
 import { DesktopShell } from "./shell/DesktopShell";
 
 export function App() {
   const services = useMemo(() => createDesktopAppServices(), []);
-  return <DesktopShell services={services} />;
+  useEffect(() => installRendererDiagnosticHandlers(), []);
+  return (
+    <TinybotErrorBoundary>
+      <DesktopShell services={services} />
+    </TinybotErrorBoundary>
+  );
+}
+
+type TinybotErrorBoundaryProps = {
+  children: ReactNode;
+  recordDiagnostic?: (diagnostic: RendererDiagnostic) => void | Promise<void>;
+};
+
+type TinybotErrorBoundaryState = {
+  crashId: string | null;
+  error: Error | null;
+};
+
+export class TinybotErrorBoundary extends Component<TinybotErrorBoundaryProps, TinybotErrorBoundaryState> {
+  state: TinybotErrorBoundaryState = { crashId: null, error: null };
+
+  static getDerivedStateFromError(error: Error): TinybotErrorBoundaryState {
+    return { crashId: null, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[tinybot-renderer-error]", error, info.componentStack);
+    const diagnostic = buildRendererDiagnostic("react.render", error, {
+      componentStack: info.componentStack ?? undefined,
+    });
+    showRendererDiagnosticOverlay(diagnostic);
+    this.setState({ crashId: diagnostic.id });
+    void (this.props.recordDiagnostic ?? recordRendererDiagnostic)(diagnostic);
+  }
+
+  render(): ReactNode {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+    return (
+      <main className="react-fatal-error" role="alert">
+        <h1>Tinybot UI crashed</h1>
+        <p>{this.state.error.message || "An unexpected renderer error occurred."}</p>
+        {this.state.crashId ? <p>Crash ID: {this.state.crashId}</p> : null}
+        <button type="button" onClick={() => window.location.reload()}>Reload</button>
+      </main>
+    );
+  }
 }

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -1,16 +1,18 @@
 // @vitest-environment happy-dom
 
 import { readFileSync } from "node:fs";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChatPage } from "./ChatPage";
-import type { ChatEvent, ChatStore, SessionStore, SettingsStore } from "../services";
+import type { ChatEvent, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
 import type { ReactChatMessage } from "./messageActions";
+import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 
 afterEach(() => {
   cleanup();
   document.head.querySelectorAll("[data-test-style='workbench']").forEach((element) => element.remove());
+  vi.useRealTimers();
 });
 
 function mountWorkbenchCss(): void {
@@ -20,8 +22,8 @@ function mountWorkbenchCss(): void {
   document.head.append(style);
 }
 
-function createStores(): { chatStore: ChatStore; sessionStore: SessionStore } {
-  const sessions = [
+function createStores(options: { sessions?: SessionSummary[] } = {}): { chatStore: ChatStore; sessionStore: SessionStore } {
+  const sessions = options.sessions ?? [
     {
       id: "s1",
       chatId: "chat-1",
@@ -72,6 +74,10 @@ function createStores(): { chatStore: ChatStore; sessionStore: SessionStore } {
       load: vi.fn(async () => messages),
       send: vi.fn(async () => undefined),
       stop: vi.fn(async () => undefined),
+      resolveApproval: vi.fn(async () => undefined),
+      listAgentUiForms: vi.fn(async () => []),
+      submitAgentUiForm: vi.fn(async () => undefined),
+      cancelAgentUiForm: vi.fn(async () => undefined),
       branchFromMessage: vi.fn(async () => sessions[0]),
       copyMarkdown: vi.fn(async () => "# Planning notes"),
       subscribe: vi.fn(() => () => undefined),
@@ -156,10 +162,12 @@ describe("ChatPage", () => {
 
     expect(sessionEmptyState.classList.contains("react-text-type")).toBe(true);
     expect(sessionEmptyState.getAttribute("data-text-type")).toBe("once");
-    expect(sessionEmptyState.querySelector("[aria-hidden='true']")?.textContent).toBe("No sessions yet.");
+    expect(sessionEmptyState.getAttribute("aria-label")).toBe("No sessions yet.");
+    expect(within(sessionEmptyState).getByTestId("text-type-visual")).toBeTruthy();
     expect(conversationEmptyState.classList.contains("react-text-type")).toBe(true);
     expect(conversationEmptyState.getAttribute("data-text-type")).toBe("once");
-    expect(conversationEmptyState.querySelector("[aria-hidden='true']")?.textContent).toBe("Select or create a session.");
+    expect(conversationEmptyState.getAttribute("aria-label")).toBe("Select or create a session.");
+    expect(within(conversationEmptyState).getByTestId("text-type-visual")).toBeTruthy();
   });
 
   it("adds Animated List hooks to session rows", async () => {
@@ -254,7 +262,8 @@ describe("ChatPage", () => {
     const input = screen.getByRole("textbox", { name: /message/i }) as HTMLTextAreaElement;
 
     expect(start.getAttribute("data-empty-session")).toBe("true");
-    expect(screen.getByRole("heading", { name: "想让 Tinybot 做什么？" })).toBeTruthy();
+    const heading = screen.getByRole("heading", { name: "想让 Tinybot 做什么？" });
+    expect(within(heading).getByTestId("text-type").getAttribute("data-text-type")).toBe("once");
     expect(composer.classList.contains("react-composer--raised")).toBe(true);
     expect(input.placeholder).toBe("输入任务，或粘贴/拖入文件");
     expect(screen.queryByLabelText("Select or create a session.")).toBeNull();
@@ -268,14 +277,13 @@ describe("ChatPage", () => {
 
     const start = await screen.findByLabelText("Start a new chat");
     const suggestions = within(start).getByLabelText("Prompt suggestions");
-    const promptItems = suggestions.querySelectorAll(".react-prompt-cycle__item");
 
     expect(suggestions.getAttribute("data-motion")).toBe("text-type-loop");
-    expect(promptItems).toHaveLength(4);
-    expect(suggestions.textContent).toContain("帮我总结一份文档");
-    expect(suggestions.textContent).toContain("帮我搜索资料并整理结论");
-    expect(suggestions.textContent).toContain("帮我检查这段代码的问题");
-    expect(suggestions.textContent).toContain("帮我把需求拆成可执行任务");
+    expect(within(suggestions).getByTestId("text-type").getAttribute("data-text-type")).toBe("loop");
+    expect(suggestions.textContent).toContain("规划一次旅行行程");
+    expect(suggestions.textContent).toContain("比较几款产品并给出建议");
+    expect(suggestions.textContent).toContain("整理会议记录和待办");
+    expect(suggestions.textContent).toContain("起草一封重要邮件");
   });
 
   it("keeps the normal bottom composer layout when a session has messages", async () => {
@@ -289,6 +297,34 @@ describe("ChatPage", () => {
     expect(composer.classList.contains("react-composer--raised")).toBe(false);
     expect(screen.getByRole("textbox", { name: /message/i }).getAttribute("placeholder")).toBe("Message Tinybot");
     expect(message).toBeTruthy();
+  });
+
+  it("rotates empty-session title and suggestion groups every eight seconds", async () => {
+    vi.useFakeTimers();
+    const stores = createStores();
+    stores.chatStore.load = vi.fn(async () => []);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const start = screen.getByLabelText("Start a new chat");
+    const suggestions = within(start).getByLabelText("Prompt suggestions");
+
+    expect(within(start).getByRole("heading", { name: "想让 Tinybot 做什么？" })).toBeTruthy();
+    expect(suggestions.textContent).toContain("规划一次旅行行程");
+    expect(suggestions.textContent).not.toContain("跟进一个复杂任务");
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    expect(within(start).getByRole("heading", { name: "准备让 Tinybot 接手什么？" })).toBeTruthy();
+    const nextSuggestions = within(start).getByLabelText("Prompt suggestions");
+    expect(nextSuggestions.textContent).toContain("跟进一个复杂任务");
+    expect(nextSuggestions.textContent).toContain("把需求拆成执行计划");
+    expect(nextSuggestions.textContent).not.toContain("规划一次旅行行程");
   });
 
   it("uses a two-click delete confirmation in the session list", async () => {
@@ -399,6 +435,136 @@ describe("ChatPage", () => {
     expect(drawer.getAttribute("data-motion")).toBe("fade-content");
     expect(drawer.getAttribute("data-state")).toBe("open");
     expect(drawer.textContent).toContain("Done");
+  });
+
+  it("shows structured tool activity fields in the details drawer", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const detailedMessages: ReactChatMessage[] = [{
+      id: "a-tool-details",
+      role: "assistant",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      text: "I checked the workspace.",
+      status: "complete",
+      toolCalls: [{
+        approvalId: "approval-1",
+        approvalStatus: "approval_required",
+        argsText: "{\"path\":\"src/main.ts\"}",
+        childRunId: "child-run-1",
+        delegateId: "delegate-1",
+        delegateTask: "Review implementation",
+        delegateTitle: "Code reviewer",
+        delegateType: "review",
+        finalOutput: "Reviewed implementation.",
+        id: "tool-1",
+        name: "workspace.read_file",
+        parentRunId: "parent-run-1",
+        parentTurnId: "parent-turn-1",
+        responseText: "file contents",
+        sessionKey: "websocket:chat-1",
+        status: "completed",
+        summary: "Read src/main.ts",
+        traceRef: "trace-1",
+      } as NonNullable<ReactChatMessage["toolCalls"]>[number]],
+    }];
+    stores.chatStore.load = vi.fn(async () => detailedMessages);
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
+
+    await user.click(await screen.findByRole("button", { name: "Open details for workspace.read_file" }));
+
+    const drawer = screen.getByLabelText("Details drawer");
+    expect(within(drawer).getByText("Arguments")).toBeTruthy();
+    expect(drawer.textContent).toContain("{\"path\":\"src/main.ts\"}");
+    expect(within(drawer).getByText("Response")).toBeTruthy();
+    expect(drawer.textContent).toContain("file contents");
+    expect(within(drawer).getByText("Approval")).toBeTruthy();
+    expect(drawer.textContent).toContain("approval-1");
+    expect(within(drawer).getByText("Delegate")).toBeTruthy();
+    expect(drawer.textContent).toContain("Code reviewer");
+    expect(within(drawer).getByText("Trace")).toBeTruthy();
+    expect(drawer.textContent).toContain("trace-1");
+    expect(within(drawer).getByText("Final output")).toBeTruthy();
+    expect(drawer.textContent).toContain("Reviewed implementation.");
+  });
+
+  it("resolves pending approval steps from the details drawer", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const resolveApproval = vi.fn(async () => undefined);
+    const approvalMessages: ReactChatMessage[] = [{
+      id: "a-approval",
+      role: "assistant",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      text: "Waiting for approval.",
+      status: "complete",
+      toolCalls: [{
+        approvalId: "approval-1",
+        approvalStatus: "approval_required",
+        id: "tool-approval",
+        name: "shell",
+        sessionKey: "websocket:chat-1",
+        status: "approval_required",
+        summary: "Run npm test",
+      } as NonNullable<ReactChatMessage["toolCalls"]>[number]],
+    }];
+    stores.chatStore.load = vi.fn(async () => approvalMessages);
+    (stores.chatStore as any).resolveApproval = resolveApproval;
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
+
+    await user.click(await screen.findByRole("button", { name: "Open details for shell" }));
+    const drawer = screen.getByLabelText("Details drawer");
+
+    expect(within(drawer).getByRole("button", { name: "Approve once" })).toBeTruthy();
+    expect(within(drawer).getByRole("button", { name: "Allow for session" })).toBeTruthy();
+    expect(within(drawer).getByRole("button", { name: "Deny" })).toBeTruthy();
+
+    await user.click(within(drawer).getByRole("button", { name: "Allow for session" }));
+
+    expect(resolveApproval).toHaveBeenCalledWith("s1", {
+      action: "approveSession",
+      approvalId: "approval-1",
+    });
+  });
+
+  it("submits active agent-ui forms from the chat page", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const form: AgentUiForm = {
+      form_id: "travel-preferences-1",
+      title: "Travel preferences",
+      description: "Collect itinerary constraints before planning.",
+      submit_label: "Save preferences",
+      cancel_label: "Skip",
+      correlation: { chat_id: "chat-1" },
+      fields: [
+        { name: "destination", type: "text", label: "Destination", required: true },
+        { name: "nights", type: "number", label: "Nights", required: false, min: 1, max: 30 },
+      ],
+      values: { destination: "Shanghai", nights: 3 },
+      status: "pending",
+      chat_id: "chat-1",
+    };
+    const submitAgentUiForm = vi.fn(async () => undefined);
+    (stores.chatStore as any).listAgentUiForms = vi.fn(async () => [form]);
+    (stores.chatStore as any).submitAgentUiForm = submitAgentUiForm;
+    (stores.chatStore as any).cancelAgentUiForm = vi.fn(async () => undefined);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
+
+    const card = await screen.findByRole("form", { name: "Travel preferences" });
+    expect(card.textContent).toContain("Collect itinerary constraints before planning.");
+
+    await user.clear(within(card).getByLabelText("Destination"));
+    await user.type(within(card).getByLabelText("Destination"), "Singapore");
+    await user.clear(within(card).getByLabelText("Nights"));
+    await user.type(within(card).getByLabelText("Nights"), "4");
+    await user.click(within(card).getByRole("button", { name: "Save preferences" }));
+
+    expect(submitAgentUiForm).toHaveBeenCalledWith("travel-preferences-1", {
+      destination: "Singapore",
+      nights: 4,
+    });
   });
 
   it("places message action buttons under each message on the role side", async () => {
@@ -555,6 +721,271 @@ describe("ChatPage", () => {
 
     expect(stores.chatStore.send).toHaveBeenCalledWith("s1", { text: "Hello from React", usePersistentRag: true });
     expect((input as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("queues composer text while the active session is running", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Planning notes",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "running",
+      }],
+    });
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "Summarize after this run{enter}");
+
+    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    const queuedInputs = screen.getByLabelText("Queued inputs");
+    expect(queuedInputs.textContent).toContain("Summarize after this run");
+    expect(queuedInputs.textContent).toContain("Waiting");
+    expect((input as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("deletes queued composer text before it is sent", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Planning notes",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "running",
+      }],
+    });
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "Delete me{enter}");
+    await user.click(screen.getByRole("button", { name: /delete queued input/i }));
+
+    expect(screen.queryByLabelText("Queued inputs")).toBeNull();
+    expect(stores.chatStore.send).not.toHaveBeenCalled();
+  });
+
+  it("enforces the queued input limit while running", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Planning notes",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "running",
+      }],
+    });
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    for (const message of ["one", "two", "three", "four", "five", "six"]) {
+      await user.type(input, `${message}{enter}`);
+    }
+
+    const queuedInputs = screen.getByLabelText("Queued inputs");
+    expect(queuedInputs.querySelectorAll(".react-queued-input")).toHaveLength(5);
+    expect(queuedInputs.textContent).not.toContain("six");
+    expect(screen.getByText("Already have 5 queued messages. Wait for processing or delete one before sending more.")).toBeTruthy();
+  });
+
+  it("dispatches one queued composer input after normal completion", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const runningSession = {
+      id: "s1",
+      chatId: "chat-1",
+      title: "Planning notes",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+      status: "running" as const,
+    };
+    const idleSession = { ...runningSession, status: "idle" as const };
+    const stores = createStores({ sessions: [runningSession] });
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([runningSession])
+      .mockResolvedValueOnce([idleSession])
+      .mockResolvedValue([idleSession]);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "first queued{enter}");
+    await user.type(input, "second queued{enter}");
+    expect(stores.chatStore.send).not.toHaveBeenCalled();
+
+    subscribed?.({ type: "message.completed" });
+
+    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+      text: "first queued",
+      usePersistentRag: true,
+    }));
+    expect(stores.chatStore.send).toHaveBeenCalledTimes(1);
+    const queuedInputs = screen.getByLabelText("Queued inputs");
+    expect(queuedInputs.textContent).not.toContain("first queued");
+    expect(queuedInputs.textContent).toContain("second queued");
+
+    subscribed?.({ type: "message.completed" });
+
+    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+      text: "second queued",
+      usePersistentRag: true,
+    }));
+    expect(stores.chatStore.send).toHaveBeenCalledTimes(2);
+    expect(screen.queryByLabelText("Queued inputs")).toBeNull();
+  });
+
+  it("dispatches queued input when a completion event also carries a message", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const runningSession = {
+      id: "s1",
+      chatId: "chat-1",
+      title: "Planning notes",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+      status: "running" as const,
+    };
+    const idleSession = { ...runningSession, status: "idle" as const };
+    const stores = createStores({ sessions: [runningSession] });
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([runningSession])
+      .mockResolvedValueOnce([idleSession])
+      .mockResolvedValue([idleSession]);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "queued after event message{enter}");
+
+    subscribed?.({
+      message: {
+        id: "assistant-completed",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+        text: "Done.",
+        status: "complete",
+      },
+      type: "message.completed",
+    });
+
+    expect(await screen.findByTestId("message-assistant-completed")).toBeTruthy();
+    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+      text: "queued after event message",
+      usePersistentRag: true,
+    }));
+  });
+
+  it("keeps queued inputs waiting when completion enters approval state", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const runningSession = {
+      id: "s1",
+      chatId: "chat-1",
+      title: "Planning notes",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+      status: "running" as const,
+    };
+    const approvalSession = { ...runningSession, status: "waiting_approval" as const };
+    const stores = createStores({ sessions: [runningSession] });
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([runningSession])
+      .mockResolvedValueOnce([approvalSession]);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "after approval{enter}");
+
+    subscribed?.({ type: "message.completed" });
+
+    await waitFor(() => expect(stores.sessionStore.list).toHaveBeenCalledTimes(2));
+    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    const queuedInputs = screen.getByLabelText("Queued inputs");
+    expect(queuedInputs.textContent).toContain("after approval");
+    expect(queuedInputs.textContent).toContain("Waiting");
+  });
+
+  it("pauses queued inputs after a failed agent turn", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const runningSession = {
+      id: "s1",
+      chatId: "chat-1",
+      title: "Planning notes",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+      status: "running" as const,
+    };
+    const failedSession = { ...runningSession, status: "failed" as const };
+    const stores = createStores({ sessions: [runningSession] });
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([runningSession])
+      .mockResolvedValueOnce([failedSession]);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "retry later{enter}");
+
+    subscribed?.({ type: "agent.event", eventType: "agent.turn.failed" });
+
+    await waitFor(() => expect(screen.getByLabelText("Queued inputs").textContent).toContain("Paused"));
+    expect(stores.chatStore.send).not.toHaveBeenCalled();
+  });
+
+  it("pauses queued inputs on stop and resumes one input manually", async () => {
+    const user = userEvent.setup();
+    const runningSession = {
+      id: "s1",
+      chatId: "chat-1",
+      title: "Planning notes",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+      status: "running" as const,
+    };
+    const idleSession = { ...runningSession, status: "idle" as const };
+    const stores = createStores({ sessions: [runningSession] });
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([runningSession])
+      .mockResolvedValueOnce([idleSession])
+      .mockResolvedValue([idleSession]);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "resume first{enter}");
+    await user.type(input, "resume second{enter}");
+    await user.click(screen.getByRole("button", { name: "Stop generation" }));
+
+    expect(stores.chatStore.stop).toHaveBeenCalledWith("s1");
+    await waitFor(() => expect(screen.getByLabelText("Queued inputs").textContent).toContain("Paused"));
+    expect(stores.chatStore.send).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Resume queue" }));
+
+    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+      text: "resume first",
+      usePersistentRag: true,
+    }));
+    const queuedInputs = screen.getByLabelText("Queued inputs");
+    expect(queuedInputs.textContent).not.toContain("resume first");
+    expect(queuedInputs.textContent).toContain("resume second");
+    expect(queuedInputs.textContent).toContain("Paused");
   });
 
   it("renders the optimistic user message immediately after send", async () => {
@@ -743,6 +1174,24 @@ describe("ChatPage", () => {
     });
   });
 
+  it("stops the active running session from the composer", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Planning notes",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "running",
+      }],
+    });
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await user.click(await screen.findByRole("button", { name: "Stop generation" }));
+
+    expect(stores.chatStore.stop).toHaveBeenCalledWith("s1");
+  });
+
   it("closes the composer tools menu when another composer area is clicked", async () => {
     const user = userEvent.setup();
     const stores = createStores();
@@ -844,13 +1293,14 @@ describe("ChatPage", () => {
 
   it("defines reduced-motion fallbacks for chat motion primitives", () => {
     const css = readFileSync("src/react-workbench/styles/workbench.css", "utf8");
+    const textTypeCss = readFileSync("src/components/ui/TextType.css", "utf8");
 
     expect(css).toContain("@media (prefers-reduced-motion: reduce)");
-    expect(css).toContain(".react-text-type__text");
+    expect(textTypeCss).toContain(".text-type__content");
+    expect(textTypeCss).toContain(".text-type__cursor");
     expect(css).toContain("react-list-enter");
     expect(css).toContain("react-drawer-enter");
     expect(css).toContain("react-stepper-current");
-    expect(css).toContain("react-prompt-type-delete");
     expect(css).toContain("react-session-dissolve");
     expect(css).toContain("react-session-particle-burst");
     expect(css).toContain(".react-session-row__particles");

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type FormEvent, type ReactNode } from "react";
 import {
   AlertTriangle,
   Check,
@@ -19,6 +19,16 @@ import {
   X,
 } from "lucide-react";
 import {
+  MAX_QUEUED_INPUTS,
+  deleteQueuedInput,
+  dispatchNextQueuedInput,
+  pauseQueuedInputs,
+  resumeNextQueuedInput,
+  submitComposerText,
+  type SubmitComposerTextResult,
+} from "../../app-core/chat/chatInputState";
+import type { QueuedInput } from "../../app-core/chat/chatUiProjection";
+import {
   ClaudeStyleAiInput,
   type ComposerSendOptions,
   type ComposerToolOption,
@@ -26,10 +36,12 @@ import {
   type ModelOption,
   type PastedContent,
 } from "../../components/ui/claude-style-ai-input";
+import { TextType } from "../../components/ui/TextType";
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
-import type { ChatEvent, ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
+import type { ApprovalAction, ChatEvent, ChatInput, ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
 import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
 import { canBranchFromMessage, type ContextReferenceSummary, type ReactChatMessage, type ToolCallSummary } from "./messageActions";
+import type { AgentUiForm, AgentUiFormField } from "../../app-core/agent-ui/agentUiEvents";
 
 export type ChatPageProps = {
   chatStore: ChatStore;
@@ -38,6 +50,7 @@ export type ChatPageProps = {
   createSessionSignal?: number;
   sessionSidebarCollapsed?: boolean;
   onSessionSidebarCollapsedChange?: (collapsed: boolean) => void;
+  onStopGenerationTargetChange?: (sessionId: string) => void;
   onOpenFiles?: () => void;
   onOpenSettings?: () => void;
   now?: () => number;
@@ -45,8 +58,10 @@ export type ChatPageProps = {
 
 type DrawerState = {
   title: string;
-  body: string;
+  toolCall: ToolCallSummary;
 } | null;
+
+type QueuedComposerInput = QueuedInput & Pick<ChatInput, "model" | "usePersistentRag">;
 
 const COMPOSER_TOOLS: ComposerToolOption[] = [
   {
@@ -57,11 +72,36 @@ const COMPOSER_TOOLS: ComposerToolOption[] = [
   },
 ];
 
-const EMPTY_CHAT_PROMPTS = [
-  "帮我总结一份文档",
-  "帮我搜索资料并整理结论",
-  "帮我检查这段代码的问题",
-  "帮我把需求拆成可执行任务",
+const EMPTY_CHAT_GROUP_INTERVAL_MS = 8000;
+
+const EMPTY_CHAT_START_GROUPS = [
+  {
+    title: "想让 Tinybot 做什么？",
+    prompts: [
+      "规划一次旅行行程",
+      "比较几款产品并给出建议",
+      "整理会议记录和待办",
+      "起草一封重要邮件",
+    ],
+  },
+  {
+    title: "准备让 Tinybot 接手什么？",
+    prompts: [
+      "跟进一个复杂任务",
+      "把需求拆成执行计划",
+      "整理资料并形成简报",
+      "检查方案里的遗漏",
+    ],
+  },
+  {
+    title: "想让 Tinybot 查清什么？",
+    prompts: [
+      "查证一个关键问题",
+      "梳理一个陌生主题",
+      "找出决策需要的信息",
+      "汇总不同来源的结论",
+    ],
+  },
 ] as const;
 
 const SESSION_DELETE_DISSOLVE_MS = 760;
@@ -102,6 +142,7 @@ export function ChatPage({
   onOpenFiles,
   onOpenSettings,
   onSessionSidebarCollapsedChange,
+  onStopGenerationTargetChange,
   sessionSidebarCollapsed,
   sessionStore,
   settingsStore,
@@ -116,9 +157,15 @@ export function ChatPage({
   const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
   const [localSessionSidebarCollapsed, setLocalSessionSidebarCollapsed] = useState(false);
   const [drawer, setDrawer] = useState<DrawerState>(null);
+  const [resolvingApprovalId, setResolvingApprovalId] = useState("");
+  const [agentUiForms, setAgentUiForms] = useState<AgentUiForm[]>([]);
+  const [queuedInputsBySession, setQueuedInputsBySession] = useState<Map<string, QueuedComposerInput[]>>(() => new Map());
+  const [queueMessage, setQueueMessage] = useState("");
   const [dissolvingSessionIds, setDissolvingSessionIds] = useState<Set<string>>(() => new Set());
   const [deleteState, dispatchDelete] = useReducer(reduceSessionDeleteState, { confirmingSessionId: "" });
   const sessionsRef = useRef<SessionSummary[]>([]);
+  const queuedInputsRef = useRef<Map<string, QueuedComposerInput[]>>(new Map());
+  const queuedInputSequence = useRef(0);
   const deleteDissolveTimers = useRef<number[]>([]);
   const lastCreateSessionSignal = useRef(createSessionSignal);
   const resolvedSessionSidebarCollapsed = sessionSidebarCollapsed ?? localSessionSidebarCollapsed;
@@ -129,6 +176,8 @@ export function ChatPage({
   const messagesLoaded = Boolean(activeSession) && loadedMessageSessionId === activeSession?.id;
   const emptyActiveSession = messagesLoaded && messages.length === 0;
   const sessionRunning = activeSession?.status === "running" || activeSession?.status === "waiting_approval";
+  const sessionResponding = sessionRunning && !emptyActiveSession;
+  const activeQueuedInputs = activeSession ? queuedInputsBySession.get(activeSession.id) ?? [] : [];
 
   useEffect(() => {
     sessionsRef.current = sessions;
@@ -171,6 +220,7 @@ export function ChatPage({
       return;
     }
     setMessages([]);
+    setAgentUiForms([]);
     setLoadedMessageSessionId("");
     let cancelled = false;
     const loadMessages = () => chatStore.load(activeSessionId).then((nextMessages) => {
@@ -179,17 +229,26 @@ export function ChatPage({
         setLoadedMessageSessionId(activeSessionId);
       }
     });
+    const loadAgentUiForms = () => chatStore.listAgentUiForms(activeSessionId).then((nextForms) => {
+      if (!cancelled) {
+        setAgentUiForms(nextForms);
+      }
+    });
     void loadMessages();
+    void loadAgentUiForms();
     const unsubscribe = chatStore.subscribe(activeSessionId, (event) => {
+      const eventHasMessage = Boolean(event.message);
       if (event.message) {
         setMessages((current) => [...current, event.message as ReactChatMessage]);
-        return;
       }
       if (shouldReloadSessionsForChatEvent(event)) {
-        void handleSessionStoreRefresh();
+        void handleQueueStateAfterChatEvent(activeSessionId, event);
       }
-      if (shouldReloadMessagesForChatEvent(event.type)) {
+      if (!eventHasMessage && shouldReloadMessagesForChatEvent(event.type)) {
         void loadMessages();
+      }
+      if (shouldReloadAgentUiFormsForChatEvent(event.type)) {
+        void loadAgentUiForms();
       }
     });
     return () => {
@@ -223,6 +282,10 @@ export function ChatPage({
     };
   }, [settingsStore]);
 
+  useEffect(() => {
+    onStopGenerationTargetChange?.(activeSession && sessionResponding ? activeSession.id : "");
+  }, [activeSession?.id, onStopGenerationTargetChange, sessionResponding]);
+
   async function handleCreateSession() {
     const created = await sessionStore.create();
     setSessions((current) => [created, ...current]);
@@ -255,7 +318,7 @@ export function ChatPage({
     }
   }
 
-  async function handleSessionStoreRefresh() {
+  async function handleSessionStoreRefresh(): Promise<SessionSummary[]> {
     const nextSessions = await sessionStore.list();
     sessionsRef.current = nextSessions;
     setSessions(nextSessions);
@@ -265,6 +328,7 @@ export function ChatPage({
       }
       return nextSessions.some((session) => session.id === current) ? current : nextSessions[0]?.id ?? "";
     });
+    return nextSessions;
   }
 
   async function handlePinConversation(session: SessionSummary) {
@@ -321,12 +385,168 @@ export function ChatPage({
     if (!text || !activeSession) {
       return;
     }
+    const queuedResult = submitComposerText({
+      approvals: [],
+      content: text,
+      isRunning: isQueueableRunningSession(activeSession, emptyActiveSession),
+      now: nextQueuedInputTimestamp(),
+      queuedInputs: activeQueuedInputs,
+    });
+    if (queuedResult.kind !== "send_message") {
+      handleQueuedComposerResult(activeSession.id, queuedResult, options);
+      return;
+    }
     await chatStore.send(activeSession.id, {
-      text,
+      text: queuedResult.content,
       ...(options.model ? { model: options.model } : {}),
       ...(typeof options.usePersistentRag === "boolean" ? { usePersistentRag: options.usePersistentRag } : {}),
     });
     await handleSessionStoreRefresh();
+  }
+
+  function handleQueuedComposerResult(
+    sessionId: string,
+    result: Exclude<SubmitComposerTextResult, { kind: "send_message" }>,
+    options: ComposerSendOptions,
+  ) {
+    if (result.kind === "queue_limit_reached") {
+      setQueueMessage("Already have 5 queued messages. Wait for processing or delete one before sending more.");
+      return;
+    }
+    if (result.kind === "reject_approval_with_guidance") {
+      return;
+    }
+    setQueueMessage("");
+    updateQueuedInputsBySession((current) => {
+      const next = new Map(current);
+      next.set(sessionId, [...(next.get(sessionId) ?? []), {
+        ...result.input,
+        ...(options.model ? { model: options.model } : {}),
+        ...(typeof options.usePersistentRag === "boolean" ? { usePersistentRag: options.usePersistentRag } : {}),
+      }]);
+      return next;
+    });
+  }
+
+  function handleDeleteQueuedInput(sessionId: string, inputId: string) {
+    setQueueMessage("");
+    updateQueuedInputsBySession((current) => {
+      const next = new Map(current);
+      const remaining = deleteQueuedInput(next.get(sessionId) ?? [], inputId);
+      if (remaining.length) {
+        next.set(sessionId, remaining);
+      } else {
+        next.delete(sessionId);
+      }
+      return next;
+    });
+  }
+
+  async function handleStopGeneration(session: SessionSummary) {
+    pauseQueuedInputsForSession(session.id);
+    await chatStore.stop(session.id);
+    await handleSessionStoreRefresh();
+  }
+
+  function updateQueuedInputsBySession(
+    updater: (current: Map<string, QueuedComposerInput[]>) => Map<string, QueuedComposerInput[]>,
+  ) {
+    setQueuedInputsBySession((current) => {
+      const next = updater(current);
+      queuedInputsRef.current = next;
+      return next;
+    });
+  }
+
+  function nextQueuedInputTimestamp(): string {
+    const sequence = queuedInputSequence.current;
+    queuedInputSequence.current += 1;
+    return new Date(now() + sequence).toISOString();
+  }
+
+  async function handleQueueStateAfterChatEvent(sessionId: string, event: ChatEvent) {
+    const nextSessions = await handleSessionStoreRefresh();
+    if (shouldPauseQueuedInputsForChatEvent(event)) {
+      pauseQueuedInputsForSession(sessionId);
+      return;
+    }
+    if (!shouldDispatchQueuedInputForChatEvent(event)) {
+      return;
+    }
+    const nextSession = nextSessions.find((session) => session.id === sessionId);
+    if (!canDispatchQueuedInputForSession(nextSession)) {
+      return;
+    }
+    await sendNextQueuedInput(sessionId, "normal_completion");
+  }
+
+  async function handleResumeQueuedInputs(sessionId: string) {
+    await sendNextQueuedInput(sessionId, "manual_resume");
+  }
+
+  async function sendNextQueuedInput(sessionId: string, mode: "normal_completion" | "manual_resume") {
+    const inputs = queuedInputsRef.current.get(sessionId) ?? [];
+    const result = mode === "manual_resume" ? resumeNextQueuedInput(inputs) : dispatchNextQueuedInput(inputs);
+    if (!result.nextInput) {
+      return;
+    }
+    await chatStore.send(sessionId, toChatInput(result.nextInput as QueuedComposerInput));
+    updateQueuedInputsBySession((current) => {
+      const next = new Map(current);
+      if (result.remainingInputs.length) {
+        next.set(sessionId, result.remainingInputs as QueuedComposerInput[]);
+      } else {
+        next.delete(sessionId);
+      }
+      return next;
+    });
+    await handleSessionStoreRefresh();
+  }
+
+  function pauseQueuedInputsForSession(sessionId: string) {
+    updateQueuedInputsBySession((current) => {
+      const inputs = current.get(sessionId) ?? [];
+      if (!inputs.length) {
+        return current;
+      }
+      const next = new Map(current);
+      next.set(sessionId, pauseQueuedInputs(inputs) as QueuedComposerInput[]);
+      return next;
+    });
+  }
+
+  async function handleResolveApproval(toolCall: ToolCallSummary, action: ApprovalAction) {
+    if (!activeSession || !toolCall.approvalId) {
+      return;
+    }
+    const sessionId = activeSession.id;
+    setResolvingApprovalId(toolCall.approvalId);
+    try {
+      await chatStore.resolveApproval(sessionId, {
+        action,
+        approvalId: toolCall.approvalId,
+      });
+      await handleSessionStoreRefresh();
+      const nextMessages = await chatStore.load(sessionId);
+      setMessages(nextMessages);
+      setLoadedMessageSessionId(sessionId);
+    } finally {
+      setResolvingApprovalId("");
+    }
+  }
+
+  async function handleSubmitAgentUiForm(form: AgentUiForm, values: Record<string, unknown>) {
+    await chatStore.submitAgentUiForm(form.form_id, values);
+    if (activeSession) {
+      setAgentUiForms(await chatStore.listAgentUiForms(activeSession.id));
+    }
+  }
+
+  async function handleCancelAgentUiForm(form: AgentUiForm) {
+    await chatStore.cancelAgentUiForm(form.form_id);
+    if (activeSession) {
+      setAgentUiForms(await chatStore.listAgentUiForms(activeSession.id));
+    }
   }
 
   function handleSessionSidebarCollapsedChange(collapsed: boolean) {
@@ -341,6 +561,8 @@ export function ChatPage({
     setActiveSessionId(session.id);
     setSessionSearchOpen(false);
   }
+
+  const visibleAgentUiForms = agentUiForms.filter(isVisibleAgentUiForm);
 
   return (
     <section className="react-chat-page" aria-label="Chat" data-session-sidebar-collapsed={resolvedSessionSidebarCollapsed}>
@@ -475,21 +697,43 @@ export function ChatPage({
               onCopy={() => void writeClipboardText(formatMessageForCopy(message))}
               onOpenTool={(toolCall) => setDrawer({
                 title: toolCall.name,
-                body: formatToolCallDetails(toolCall),
+                toolCall,
               })}
               sessionRunning={sessionRunning}
             />
           )) : emptyActiveSession ? <EmptyChatStart /> : activeSession ? null : <EmptyStateText text="Select or create a session." />}
+          {visibleAgentUiForms.length ? (
+            <div className="react-agent-ui-forms" aria-label="Agent forms">
+              {visibleAgentUiForms.map((form) => (
+                <AgentUiFormCard
+                  form={form}
+                  key={form.form_id}
+                  onCancel={() => void handleCancelAgentUiForm(form)}
+                  onSubmit={(values) => void handleSubmitAgentUiForm(form, values)}
+                />
+              ))}
+            </div>
+          ) : null}
         </div>
 
+        {activeSession && activeQueuedInputs.length ? (
+          <QueuedInputsPanel
+            inputs={activeQueuedInputs}
+            onDelete={(inputId) => handleDeleteQueuedInput(activeSession.id, inputId)}
+            onResume={() => void handleResumeQueuedInputs(activeSession.id)}
+          />
+        ) : null}
+        {queueMessage ? <p className="react-queued-inputs__message">{queueMessage}</p> : null}
         <ClaudeStyleAiInput
           className={["react-composer", emptyActiveSession ? "react-composer--raised" : ""].filter(Boolean).join(" ")}
           disabled={!activeSession}
           defaultModel={defaultComposerModel}
           models={composerModels}
+          responding={sessionResponding}
           placeholder={emptyActiveSession ? "输入任务，或粘贴/拖入文件" : "Message Tinybot"}
           tools={COMPOSER_TOOLS}
           onSendMessage={(message, files, pastedContent, options) => handleComposerSend(message, files, pastedContent, options)}
+          onStopResponding={() => activeSession && handleStopGeneration(activeSession)}
         />
       </main>
 
@@ -501,7 +745,11 @@ export function ChatPage({
               <X aria-hidden="true" size={16} />
             </button>
           </div>
-          <p>{drawer.body || "Details placeholder."}</p>
+          <ToolCallDetails
+            resolvingApprovalId={resolvingApprovalId}
+            toolCall={drawer.toolCall}
+            onResolveApproval={(toolCall, action) => void handleResolveApproval(toolCall, action)}
+          />
         </aside>
       ) : null}
 
@@ -648,10 +896,32 @@ function SessionSearchDialog({
 }
 
 function EmptyChatStart() {
+  const [groupIndex, setGroupIndex] = useState(0);
+  const group = EMPTY_CHAT_START_GROUPS[groupIndex] ?? EMPTY_CHAT_START_GROUPS[0];
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setGroupIndex((current) => (current + 1) % EMPTY_CHAT_START_GROUPS.length);
+    }, EMPTY_CHAT_GROUP_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, []);
+
   return (
     <section aria-label="Start a new chat" className="react-empty-chat-start" data-empty-session="true">
-      <h2>想让 Tinybot 做什么？</h2>
-      <PromptCycleText prompts={EMPTY_CHAT_PROMPTS} />
+      <h2>
+        <TextType
+          ariaLabel={group.title}
+          className="react-empty-chat-title-type"
+          cursorClassName="react-empty-chat-title-type__cursor"
+          deletingSpeed={22}
+          loop={false}
+          pauseDuration={6800}
+          showCursor
+          text={group.title}
+          typingSpeed={34}
+        />
+      </h2>
+      <PromptCycleText prompts={group.prompts} />
     </section>
   );
 }
@@ -660,22 +930,16 @@ function PromptCycleText({ prompts }: { prompts: readonly string[] }) {
   return (
     <p aria-label="Prompt suggestions" className="react-prompt-cycle" data-motion="text-type-loop">
       <span className="react-sr-only">{`建议：${prompts.join("；")}`}</span>
-      <span aria-hidden="true" className="react-prompt-cycle__visual">
-        {prompts.map((prompt, index) => (
-          <span
-            className="react-prompt-cycle__item"
-            key={prompt}
-            style={
-              {
-                "--react-prompt-characters": String(Math.max(prompt.length, 1)),
-                "--react-prompt-index": String(index),
-              } as CSSProperties
-            }
-          >
-            {prompt}
-          </span>
-        ))}
-      </span>
+      <TextType
+        ariaHidden
+        className="react-prompt-cycle__text-type"
+        cursorClassName="react-prompt-cycle__cursor"
+        deletingSpeed={24}
+        pauseDuration={1350}
+        showCursor
+        text={prompts}
+        typingSpeed={34}
+      />
     </p>
   );
 }
@@ -683,28 +947,14 @@ function PromptCycleText({ prompts }: { prompts: readonly string[] }) {
 function EmptyStateText({ text }: { text: string }) {
   return (
     <p className="react-empty-state">
-      <TextType text={text} />
+      <TextType ariaLabel={text} className="react-text-type" loop={false} showCursor={false} text={text} />
     </p>
-  );
-}
-
-function TextType({ text }: { text: string }) {
-  return (
-    <span
-      aria-label={text}
-      className="react-text-type"
-      data-text-type="once"
-      style={{ "--react-text-type-characters": String(Math.max(text.length, 1)) } as CSSProperties}
-    >
-      <span aria-hidden="true" className="react-text-type__text">{text}</span>
-    </span>
   );
 }
 
 const MESSAGE_RELOAD_EVENT_TYPES = new Set([
   "attached",
   "agent.event",
-  "message.delta",
   "message.completed",
   "message.stream.completed",
   "message-sent",
@@ -732,6 +982,43 @@ function shouldReloadMessagesForChatEvent(type: string): boolean {
 function shouldReloadSessionsForChatEvent(event: ChatEvent): boolean {
   return SESSION_RELOAD_EVENT_TYPES.has(event.type)
     || (event.type === "agent.event" && Boolean(event.eventType && TERMINAL_AGENT_EVENT_TYPES.has(event.eventType)));
+}
+
+function shouldReloadAgentUiFormsForChatEvent(type: string): boolean {
+  return type === "agent-ui.form" || type === "agent-ui.event";
+}
+
+function shouldDispatchQueuedInputForChatEvent(event: ChatEvent): boolean {
+  return event.type === "message.completed"
+    || event.type === "message.stream.completed"
+    || (event.type === "agent.event" && event.eventType === "agent.turn.completed");
+}
+
+function shouldPauseQueuedInputsForChatEvent(event: ChatEvent): boolean {
+  return event.type === "interrupted"
+    || (event.type === "agent.event" && (
+      event.eventType === "agent.turn.failed" || event.eventType === "agent.turn.interrupted"
+    ));
+}
+
+function canDispatchQueuedInputForSession(session: SessionSummary | undefined): boolean {
+  return session?.status !== "running" && session?.status !== "waiting_approval" && session?.status !== "failed";
+}
+
+function isQueueableRunningSession(session: SessionSummary, emptyActiveSession: boolean): boolean {
+  return session.status === "running" && !emptyActiveSession && !session.id.startsWith("pending:");
+}
+
+function toChatInput(input: QueuedComposerInput): ChatInput {
+  return {
+    text: input.content,
+    ...(input.model ? { model: input.model } : {}),
+    ...(typeof input.usePersistentRag === "boolean" ? { usePersistentRag: input.usePersistentRag } : {}),
+  };
+}
+
+function isVisibleAgentUiForm(form: AgentUiForm): boolean {
+  return form.status !== "submitted" && form.status !== "cancelled" && form.status !== "expired";
 }
 
 async function writeClipboardText(value: string): Promise<void> {
@@ -769,6 +1056,258 @@ function toComposerModelOption(model: ChatModelOption): ModelOption {
     description: model.description || model.providerLabel || "Configured model",
     ...(model.default ? { badge: "Default" } : {}),
   };
+}
+
+function QueuedInputsPanel({
+  inputs,
+  onDelete,
+  onResume,
+}: {
+  inputs: QueuedInput[];
+  onDelete: (inputId: string) => void;
+  onResume: () => void;
+}) {
+  const hasPausedInput = inputs.some((input) => input.status === "paused");
+  return (
+    <section aria-label="Queued inputs" className="react-queued-inputs">
+      <div className="react-queued-inputs__header">
+        <h2>Queued inputs</h2>
+        <div>
+          <span>{inputs.length}/{MAX_QUEUED_INPUTS}</span>
+          {hasPausedInput ? <button type="button" onClick={onResume}>Resume queue</button> : null}
+        </div>
+      </div>
+      <ol>
+        {inputs.map((input) => (
+          <li className="react-queued-input" data-status={input.status} key={input.id}>
+            <span>{queuedInputStatusLabel(input)}</span>
+            <p>{input.content}</p>
+            {input.status === "queued" || input.status === "paused" ? (
+              <button type="button" onClick={() => onDelete(input.id)}>Delete queued input</button>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function queuedInputStatusLabel(input: QueuedInput): string {
+  switch (input.status) {
+    case "guided":
+      return "Guided";
+    case "paused":
+      return "Paused";
+    case "sent":
+      return "Sent";
+    default:
+      return "Waiting";
+  }
+}
+
+function AgentUiFormCard({
+  form,
+  onCancel,
+  onSubmit,
+}: {
+  form: AgentUiForm;
+  onCancel: () => void;
+  onSubmit: (values: Record<string, unknown>) => void;
+}) {
+  const [values, setValues] = useState<Record<string, unknown>>(() => initialAgentUiFormValues(form));
+
+  useEffect(() => {
+    setValues(initialAgentUiFormValues(form));
+  }, [form]);
+
+  function updateValue(field: AgentUiFormField, value: unknown) {
+    setValues((current) => ({ ...current, [field.name]: value }));
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onSubmit(normalizeAgentUiFormValues(form, values));
+  }
+
+  return (
+    <form aria-label={form.title || form.form_id} className="react-agent-ui-form-card" onSubmit={handleSubmit}>
+      <div className="react-agent-ui-form-card__header">
+        <h2>{form.title || "Agent form"}</h2>
+        {form.description ? <p>{form.description}</p> : null}
+      </div>
+      <div className="react-agent-ui-form-card__fields">
+        {form.fields.map((field) => (
+          <AgentUiFormFieldControl
+            field={field}
+            key={field.name}
+            value={values[field.name]}
+            onChange={(value) => updateValue(field, value)}
+          />
+        ))}
+      </div>
+      <div className="react-agent-ui-form-card__actions">
+        <button type="submit">{form.submit_label || "Submit"}</button>
+        <button type="button" onClick={onCancel}>{form.cancel_label || "Cancel"}</button>
+      </div>
+    </form>
+  );
+}
+
+function AgentUiFormFieldControl({
+  field,
+  onChange,
+  value,
+}: {
+  field: AgentUiFormField;
+  onChange: (value: unknown) => void;
+  value: unknown;
+}) {
+  const id = `agent-ui-form-${field.name}`;
+  const stringValue = value === undefined || value === null ? "" : String(value);
+  return (
+    <label className="react-agent-ui-form-field" htmlFor={id}>
+      <span>{field.label}</span>
+      {renderAgentUiFormInput(field, id, stringValue, value, onChange)}
+      {field.help ? <small>{field.help}</small> : null}
+    </label>
+  );
+}
+
+function renderAgentUiFormInput(
+  field: AgentUiFormField,
+  id: string,
+  stringValue: string,
+  value: unknown,
+  onChange: (value: unknown) => void,
+): ReactNode {
+  if (field.type === "textarea") {
+    return (
+      <textarea
+        id={id}
+        maxLength={field.max_length}
+        minLength={field.min_length}
+        placeholder={field.placeholder}
+        required={field.required}
+        value={stringValue}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+    );
+  }
+  if (field.type === "select") {
+    return (
+      <select id={id} required={field.required} value={stringValue} onChange={(event) => onChange(optionValueFromString(field, event.currentTarget.value))}>
+        <option value="">Select...</option>
+        {(field.options ?? []).map((option) => (
+          <option key={String(option.value)} value={String(option.value)}>{option.label}</option>
+        ))}
+      </select>
+    );
+  }
+  if (field.type === "multiselect") {
+    const selected = Array.isArray(value) ? value.map(String) : [];
+    return (
+      <select
+        id={id}
+        multiple
+        required={field.required}
+        value={selected}
+        onChange={(event) => onChange(Array.from(event.currentTarget.selectedOptions).map((option) => optionValueFromString(field, option.value)))}
+      >
+        {(field.options ?? []).map((option) => (
+          <option key={String(option.value)} value={String(option.value)}>{option.label}</option>
+        ))}
+      </select>
+    );
+  }
+  if (field.type === "radio") {
+    return (
+      <span className="react-agent-ui-form-field__choices">
+        {(field.options ?? []).map((option) => (
+          <label key={String(option.value)}>
+            <input
+              checked={stringValue === String(option.value)}
+              name={field.name}
+              required={field.required}
+              type="radio"
+              value={String(option.value)}
+              onChange={(event) => onChange(optionValueFromString(field, event.currentTarget.value))}
+            />
+            <span>{option.label}</span>
+          </label>
+        ))}
+      </span>
+    );
+  }
+  if (field.type === "checkbox") {
+    return (
+      <input
+        checked={value === true}
+        id={id}
+        type="checkbox"
+        onChange={(event) => onChange(event.currentTarget.checked)}
+      />
+    );
+  }
+  return (
+    <input
+      id={id}
+      max={field.max}
+      maxLength={field.max_length}
+      min={field.min}
+      minLength={field.min_length}
+      pattern={field.pattern}
+      placeholder={field.placeholder}
+      required={field.required}
+      type={inputTypeForAgentUiField(field)}
+      value={stringValue}
+      onChange={(event) => onChange(field.type === "number" ? event.currentTarget.valueAsNumber : event.currentTarget.value)}
+    />
+  );
+}
+
+function inputTypeForAgentUiField(field: AgentUiFormField): string {
+  switch (field.type) {
+    case "date":
+    case "time":
+      return field.type;
+    case "datetime":
+      return "datetime-local";
+    case "number":
+      return "number";
+    default:
+      return "text";
+  }
+}
+
+function initialAgentUiFormValues(form: AgentUiForm): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  for (const field of form.fields) {
+    if (field.default !== undefined) {
+      values[field.name] = field.default;
+    }
+  }
+  return {
+    ...values,
+    ...(form.initial_values ?? {}),
+    ...(form.values ?? {}),
+  };
+}
+
+function normalizeAgentUiFormValues(form: AgentUiForm, values: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+  for (const field of form.fields) {
+    const value = values[field.name];
+    if (field.type === "number") {
+      normalized[field.name] = typeof value === "number" && Number.isFinite(value) ? value : undefined;
+      continue;
+    }
+    normalized[field.name] = value;
+  }
+  return normalized;
+}
+
+function optionValueFromString(field: AgentUiFormField, value: string): string | number | boolean {
+  return field.options?.find((option) => String(option.value) === value)?.value ?? value;
 }
 
 function MessageBubble({
@@ -1142,6 +1681,81 @@ function sessionTitleInitial(title: string): string {
   return title.trim().charAt(0).toUpperCase() || "C";
 }
 
-function formatToolCallDetails(toolCall: ToolCallSummary): string {
-  return [toolCall.status, toolCall.summary].filter(Boolean).join("\n\n");
+function ToolCallDetails({
+  resolvingApprovalId = "",
+  toolCall,
+  onResolveApproval,
+}: {
+  resolvingApprovalId?: string;
+  toolCall: ToolCallSummary;
+  onResolveApproval?: (toolCall: ToolCallSummary, action: ApprovalAction) => void;
+}) {
+  const sections = toolCallDetailSections(toolCall);
+  if (!sections.length) {
+    return <p>Details unavailable.</p>;
+  }
+  const showApprovalActions = isPendingApprovalToolCall(toolCall) && Boolean(onResolveApproval);
+  const resolving = Boolean(toolCall.approvalId && resolvingApprovalId === toolCall.approvalId);
+  return (
+    <div className="react-tool-detail">
+      {showApprovalActions ? (
+        <section className="react-tool-detail__approval-actions" aria-label="Approval actions">
+          <h3>Approval actions</h3>
+          <div>
+            <button disabled={resolving} type="button" onClick={() => onResolveApproval?.(toolCall, "approveOnce")}>Approve once</button>
+            <button disabled={resolving} type="button" onClick={() => onResolveApproval?.(toolCall, "approveSession")}>Allow for session</button>
+            <button disabled={resolving} type="button" onClick={() => onResolveApproval?.(toolCall, "deny")}>Deny</button>
+          </div>
+        </section>
+      ) : null}
+      {sections.map((section) => (
+        <section key={section.label}>
+          <h3>{section.label}</h3>
+          <pre>{section.value}</pre>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function isPendingApprovalToolCall(toolCall: ToolCallSummary): boolean {
+  if (!toolCall.approvalId) {
+    return false;
+  }
+  const status = normalizeAgentStepStatus(toolCall.approvalStatus || toolCall.status);
+  return status === "waiting";
+}
+
+function toolCallDetailSections(toolCall: ToolCallSummary): Array<{ label: string; value: string }> {
+  return [
+    { label: "Status", value: toolCall.status },
+    { label: "Summary", value: toolCall.summary ?? "" },
+    { label: "Arguments", value: toolCall.argsText ?? "" },
+    { label: "Response", value: toolCall.responseText ?? "" },
+    { label: "Approval", value: formatDetailLines([
+      ["ID", toolCall.approvalId],
+      ["Status", toolCall.approvalStatus],
+    ]) },
+    { label: "Delegate", value: formatDetailLines([
+      ["Title", toolCall.delegateTitle],
+      ["Type", toolCall.delegateType],
+      ["Task", toolCall.delegateTask],
+      ["ID", toolCall.delegateId],
+    ]) },
+    { label: "Trace", value: formatDetailLines([
+      ["Trace", toolCall.traceRef],
+      ["Child run", toolCall.childRunId],
+      ["Parent run", toolCall.parentRunId],
+      ["Parent turn", toolCall.parentTurnId],
+      ["Session", toolCall.sessionKey],
+    ]) },
+    { label: "Final output", value: toolCall.finalOutput ?? "" },
+  ].filter((section) => section.value.trim());
+}
+
+function formatDetailLines(rows: Array<[string, string | undefined]>): string {
+  return rows
+    .filter(([, value]) => Boolean(value?.trim()))
+    .map(([label, value]) => `${label}: ${value}`)
+    .join("\n");
 }

--- a/src/react-workbench/chat/messageActions.ts
+++ b/src/react-workbench/chat/messageActions.ts
@@ -1,8 +1,22 @@
 export type ToolCallSummary = {
+  approvalId?: string;
+  approvalStatus?: string;
+  argsText?: string;
+  childRunId?: string;
+  delegateId?: string;
+  delegateTask?: string;
+  delegateTitle?: string;
+  delegateType?: string;
+  finalOutput?: string;
   id: string;
   name: string;
+  parentRunId?: string;
+  parentTurnId?: string;
+  responseText?: string;
+  sessionKey?: string;
   status: "pending" | "running" | "complete" | "failed" | "blocked" | string;
   summary?: string;
+  traceRef?: string;
 };
 
 export type ContextReferenceSummary = {

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -22,6 +22,14 @@ const mocks = vi.hoisted(() => {
     skills: {
       list: vi.fn(async () => []),
     },
+    tools: {
+      approveApproval: vi.fn(async () => undefined),
+      denyApproval: vi.fn(async () => undefined),
+    },
+    agentUi: {
+      submitForm: vi.fn(async () => undefined),
+      cancelForm: vi.fn(async () => undefined),
+    },
     workspace: {
       files: vi.fn(async () => []),
     },
@@ -63,6 +71,31 @@ vi.mock("../app-core/gateway/desktopGatewayBridge", () => ({ installDesktopGatew
 vi.mock("../app-core/gateway/desktopGatewayStartup", () => ({ ensureGatewayReady: vi.fn() }));
 vi.mock("../app-core/native/desktopNativeChannelLifecycle", () => ({ startDesktopNativeChannelRuntime: vi.fn() }));
 
+function agentEvent({
+  eventId,
+  eventType,
+  payload,
+  sequence,
+}: {
+  eventId: string;
+  eventType: string;
+  payload: Record<string, unknown>;
+  sequence: number;
+}): Record<string, unknown> {
+  return {
+    event: "agent_event",
+    schema_version: "tinybot.agent_event.v1",
+    event_id: eventId,
+    event_type: eventType,
+    chat_id: "chat-1",
+    session_key: "websocket:chat-1",
+    turn_id: "turn-live",
+    sequence,
+    created_at: "2026-07-04T12:00:00.000Z",
+    payload,
+  };
+}
+
 describe("default desktop app services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,58 +105,247 @@ describe("default desktop app services", () => {
     mocks.gatewayApi.sessions.messages.mockResolvedValue({ messages: [] });
   });
 
-  test("does not reload persisted messages over an active live stream", async () => {
+  test("does not reload persisted messages over an active structured live stream", async () => {
     const services = createDesktopAppServices();
     await services.sessionStore.list();
     expect(mocks.gatewayApi.sessions.messages).toHaveBeenCalledTimes(1);
 
     const socket = mocks.openGatewaySocket.mock.results[0]?.value;
     socket.handlers.onEvent({
-      kind: "message.delta",
+      kind: "agent.event",
       chatId: "chat-1",
-      messageId: "assistant-live",
-      text: "live",
-      reasoning: false,
-      raw: {},
+      raw: agentEvent({
+        eventId: "event-message-delta",
+        eventType: "message.delta",
+        payload: {
+          message_id: "assistant-live",
+          text: "live",
+        },
+        sequence: 1,
+      }),
     });
     await Promise.resolve();
     await Promise.resolve();
 
-    await expect(services.chatStore.load("websocket:chat-1")).resolves.toMatchObject([
-      {
+    await expect(services.chatStore.load("websocket:chat-1")).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({
         id: "assistant-live",
         role: "assistant",
         status: "streaming",
         text: "live",
-      },
-    ]);
+      }),
+    ]));
     expect(mocks.gatewayApi.sessions.messages).toHaveBeenCalledTimes(1);
   });
 
-  test("maps live reasoning deltas to current chat thinking text", async () => {
+  test("maps live structured reasoning deltas to current chat thinking text", async () => {
     const services = createDesktopAppServices();
     await services.sessionStore.list();
 
     const socket = mocks.openGatewaySocket.mock.results[0]?.value;
     socket.handlers.onEvent({
-      kind: "message.delta",
+      kind: "agent.event",
       chatId: "chat-1",
-      messageId: "assistant-live",
-      text: "I am checking context.",
-      reasoning: true,
-      raw: {},
+      raw: agentEvent({
+        eventId: "event-reasoning-delta",
+        eventType: "reasoning.delta",
+        payload: {
+          message_id: "assistant-live",
+          summary: "I am checking context.",
+          text: "I am checking context.",
+          visibility: "hidden",
+        },
+        sequence: 1,
+      }),
     });
     await Promise.resolve();
     await Promise.resolve();
 
-    await expect(services.chatStore.load("websocket:chat-1")).resolves.toMatchObject([
-      {
+    await expect(services.chatStore.load("websocket:chat-1")).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({
         id: "assistant-live",
         reasoningText: "I am checking context.",
         role: "assistant",
         status: "streaming",
-      },
+      }),
+    ]));
+  });
+
+  test("preserves detailed tool activity fields for React chat messages", async () => {
+    mocks.gatewayApi.sessions.messages.mockResolvedValue({
+      messages: [{
+        content: "Tool completed.",
+        message_id: "assistant-tool",
+        role: "assistant",
+        timestamp: "2026-07-04T12:00:00.000Z",
+        toolActivities: [{
+          approvalId: "approval-1",
+          approvalStatus: "approval_required",
+          argsText: "{\"path\":\"src/main.ts\"}",
+          childRunId: "child-run-1",
+          delegateId: "delegate-1",
+          delegateTask: "Review implementation",
+          delegateTitle: "Code reviewer",
+          delegateType: "review",
+          finalOutput: "Reviewed implementation.",
+          id: "tool-1",
+          kind: "result",
+          name: "workspace.read_file",
+          parentRunId: "parent-run-1",
+          parentTurnId: "parent-turn-1",
+          responseText: "file contents",
+          sessionKey: "websocket:chat-1",
+          status: "completed",
+          traceRef: "trace-1",
+        }],
+      }],
+    });
+    const services = createDesktopAppServices();
+
+    await expect(services.chatStore.load("websocket:chat-1")).resolves.toEqual([
+      expect.objectContaining({
+        toolCalls: [expect.objectContaining({
+          approvalId: "approval-1",
+          approvalStatus: "approval_required",
+          argsText: "{\"path\":\"src/main.ts\"}",
+          childRunId: "child-run-1",
+          delegateId: "delegate-1",
+          delegateTask: "Review implementation",
+          delegateTitle: "Code reviewer",
+          delegateType: "review",
+          finalOutput: "Reviewed implementation.",
+          parentRunId: "parent-run-1",
+          parentTurnId: "parent-turn-1",
+          responseText: "file contents",
+          sessionKey: "websocket:chat-1",
+          traceRef: "trace-1",
+        })],
+      }),
     ]);
+  });
+
+  test("resolves approval actions through the gateway approval routes", async () => {
+    const services = createDesktopAppServices();
+
+    await (services.chatStore as any).resolveApproval("WebSocket:chat-1", {
+      action: "approveSession",
+      approvalId: "approval-1",
+    });
+    await (services.chatStore as any).resolveApproval("WebSocket:chat-1", {
+      action: "deny",
+      approvalId: "approval-2",
+      guidance: "Use a read-only command.",
+    });
+
+    expect(mocks.gatewayApi.tools.approveApproval).toHaveBeenCalledWith("approval-1", {
+      auto_retry: true,
+      scope: "session",
+      session_key: "websocket:chat-1",
+    });
+    expect(mocks.gatewayApi.tools.denyApproval).toHaveBeenCalledWith("approval-2", {
+      auto_retry: true,
+      guidance: "Use a read-only command.",
+      session_key: "websocket:chat-1",
+    });
+  });
+
+  test("tracks agent-ui forms and submits or cancels them through the gateway", async () => {
+    const services = createDesktopAppServices();
+    await services.sessionStore.list();
+    const socket = mocks.openGatewaySocket.mock.results[0]?.value;
+
+    socket.handlers.onEvent({
+      kind: "agent-ui.event",
+      eventType: "ui.form.requested",
+      raw: {
+        event: "agent_ui_event",
+        chat_id: "chat-1",
+        agent_ui_event: {
+          event_type: "ui.form.requested",
+          chat_id: "chat-1",
+          message_id: "msg-form-1",
+          run_id: "run-1",
+          payload: {
+            form_id: "travel-preferences-1",
+            title: "Travel preferences",
+            submit_label: "Save preferences",
+            cancel_label: "Skip",
+            correlation: {
+              chat_id: "chat-1",
+              message_id: "msg-form-1",
+              run_id: "run-1",
+            },
+            fields: [
+              { name: "destination", type: "text", label: "Destination", required: true },
+              { name: "nights", type: "number", label: "Nights", min: 1, max: 30 },
+            ],
+            initial_values: { destination: "Shanghai", nights: 3 },
+          },
+        },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await expect((services.chatStore as any).listAgentUiForms("websocket:chat-1")).resolves.toEqual([
+      expect.objectContaining({
+        form_id: "travel-preferences-1",
+        title: "Travel preferences",
+      }),
+    ]);
+
+    await (services.chatStore as any).cancelAgentUiForm("travel-preferences-1");
+    socket.handlers.onEvent({
+      kind: "agent-ui.event",
+      eventType: "ui.form.requested",
+      raw: {
+        event: "agent_ui_event",
+        chat_id: "chat-1",
+        agent_ui_event: {
+          event_type: "ui.form.requested",
+          chat_id: "chat-1",
+          message_id: "msg-form-1",
+          run_id: "run-1",
+          payload: {
+            form_id: "travel-preferences-1",
+            title: "Travel preferences",
+            correlation: {
+              chat_id: "chat-1",
+              message_id: "msg-form-1",
+              run_id: "run-1",
+            },
+            fields: [
+              { name: "destination", type: "text", label: "Destination", required: true },
+              { name: "nights", type: "number", label: "Nights", min: 1, max: 30 },
+            ],
+          },
+        },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await (services.chatStore as any).submitAgentUiForm("travel-preferences-1", {
+      destination: "Singapore",
+      nights: 4,
+    });
+
+    expect(mocks.gatewayApi.agentUi.submitForm).toHaveBeenCalledWith("travel-preferences-1", {
+      values: { destination: "Singapore", nights: 4 },
+      correlation: {
+        form_id: "travel-preferences-1",
+        chat_id: "chat-1",
+        message_id: "msg-form-1",
+        run_id: "run-1",
+      },
+    });
+    expect(mocks.gatewayApi.agentUi.cancelForm).toHaveBeenCalledWith("travel-preferences-1", {
+      correlation: {
+        form_id: "travel-preferences-1",
+        chat_id: "chat-1",
+        message_id: "msg-form-1",
+        run_id: "run-1",
+      },
+    });
   });
 
   test("emits the user message immediately after send", async () => {

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -2,6 +2,16 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { createDesktopChatSessionController } from "../app-core/chat/desktopChatSessionController";
 import { sessionKeyForChat, type NativeChatMessage, type NativeChatReference, type NativeChatSession } from "../app-core/chat/nativeChat";
+import { submitDesktopApprovalAction } from "../app-core/agent-ui/desktopApprovalActions";
+import {
+  AGENT_UI_FORM_STATUSES,
+  buildAgentUiFormCancelRequest,
+  buildAgentUiFormSubmitRequest,
+  createAgentUiEventState,
+  normalizeAgentUiEvents,
+  reduceAgentUiEventState,
+  type AgentUiForm,
+} from "../app-core/agent-ui/agentUiEvents";
 import { DEFAULT_GATEWAY_CONFIG, resolveGatewayConfig } from "../app-core/gateway/gatewayConfig";
 import { installDesktopGatewayBridge } from "../app-core/gateway/desktopGatewayBridge";
 import { ensureGatewayReady } from "../app-core/gateway/desktopGatewayStartup";
@@ -78,6 +88,7 @@ export function createDesktopAppServices(): AppServices {
   let pendingNewSessionId = "";
   let pendingNewSession: SessionSummary | null = null;
   let pendingNewSessionTitle = "";
+  const agentUiState = createAgentUiEventState();
 
   const controller = createDesktopChatSessionController({
     api: {
@@ -148,6 +159,7 @@ export function createDesktopAppServices(): AppServices {
   async function handleGatewayEvent(event: NormalizedGatewayEvent): Promise<void> {
     const titleForCreatedSession = event.kind === "chat.created" ? pendingNewSessionTitle : "";
     await controller.handleGatewayEvent(event);
+    reduceAgentUiEventsFromGatewayEvent(event);
     if (event.kind === "chat.created") {
       if (titleForCreatedSession) {
         await persistAutoSessionTitle(sessionKeyForChat(event.chatId), titleForCreatedSession);
@@ -157,6 +169,15 @@ export function createDesktopAppServices(): AppServices {
       pendingNewSessionTitle = "";
     }
     notifyAll(chatEventFromGatewayEvent(event));
+  }
+
+  function reduceAgentUiEventsFromGatewayEvent(event: NormalizedGatewayEvent): void {
+    if (event.kind !== "agent-ui.form" && event.kind !== "agent-ui.event" && event.kind !== "browser.frame" && event.kind !== "browser.snapshot") {
+      return;
+    }
+    for (const agentUiEvent of normalizeAgentUiEvents(event.raw)) {
+      reduceAgentUiEventState(agentUiState, agentUiEvent);
+    }
   }
 
   function notifyAll(event: ChatEvent): void {
@@ -307,6 +328,61 @@ export function createDesktopAppServices(): AppServices {
         controller.interruptActiveChat();
         notifyAll({ type: "chat-stopped" });
       },
+      async resolveApproval(sessionId, input) {
+        await initialize();
+        await submitDesktopApprovalAction({
+          action: input.action,
+          approvalId: input.approvalId,
+          gatewayTools: gatewayApi.tools,
+          ...(input.guidance ? { guidance: input.guidance } : {}),
+          invoke,
+          preferNativeWorkerResume: nativeMode,
+          sessionKey: sessionId,
+        });
+        await controller.loadSessions();
+        notifySession(sessionId, { type: "approval-resolved" });
+      },
+      async listAgentUiForms(sessionId) {
+        await initialize();
+        return Array.from(agentUiState.forms.values()).filter((form) => formMatchesSession(form, sessionId));
+      },
+      async submitAgentUiForm(formId, values) {
+        await initialize();
+        const form = agentUiState.forms.get(formId);
+        if (!form) {
+          return;
+        }
+        const request = buildAgentUiFormSubmitRequest(form, values);
+        if (!request) {
+          return;
+        }
+        await gatewayApi.agentUi.submitForm(formId, request);
+        agentUiState.forms.set(formId, {
+          ...form,
+          status: AGENT_UI_FORM_STATUSES.submitted,
+          submitting: false,
+          values: { ...values },
+        });
+        notifyAll({ type: "agent-ui.form" });
+      },
+      async cancelAgentUiForm(formId) {
+        await initialize();
+        const form = agentUiState.forms.get(formId);
+        if (!form) {
+          return;
+        }
+        const request = buildAgentUiFormCancelRequest(form);
+        if (!request) {
+          return;
+        }
+        await gatewayApi.agentUi.cancelForm(formId, request);
+        agentUiState.forms.set(formId, {
+          ...form,
+          status: AGENT_UI_FORM_STATUSES.cancelled,
+          submitting: false,
+        });
+        notifyAll({ type: "agent-ui.form" });
+      },
       async branchFromMessage(sessionId, messageId) {
         await initialize();
         const payload = await gatewayApi.sessions.branch?.({ session_key: sessionId, message_id: messageId });
@@ -399,10 +475,24 @@ function mapMessage(
     ? message.role
     : "assistant";
   const toolCalls = (message.toolActivities ?? []).map((activity) => ({
+    ...(activity.approvalId ? { approvalId: activity.approvalId } : {}),
+    ...(activity.approvalStatus ? { approvalStatus: activity.approvalStatus } : {}),
+    ...(activity.argsText ? { argsText: activity.argsText } : {}),
+    ...(activity.childRunId ? { childRunId: activity.childRunId } : {}),
+    ...(activity.delegateId ? { delegateId: activity.delegateId } : {}),
+    ...(activity.delegateTask ? { delegateTask: activity.delegateTask } : {}),
+    ...(activity.delegateTitle ? { delegateTitle: activity.delegateTitle } : {}),
+    ...(activity.delegateType ? { delegateType: activity.delegateType } : {}),
+    ...(activity.finalOutput ? { finalOutput: activity.finalOutput } : {}),
     id: activity.id,
     name: activity.name,
+    ...(activity.parentRunId ? { parentRunId: activity.parentRunId } : {}),
+    ...(activity.parentTurnId ? { parentTurnId: activity.parentTurnId } : {}),
+    ...(activity.responseText ? { responseText: activity.responseText } : {}),
+    ...(activity.sessionKey ? { sessionKey: activity.sessionKey } : {}),
     status: activity.status || activity.approvalStatus || (activity.kind === "result" ? "complete" : "running"),
     summary: activity.responseText || activity.argsText,
+    ...(activity.traceRef ? { traceRef: activity.traceRef } : {}),
   }));
   const streaming = role === "assistant" && Boolean(options.sessionRunning && options.isLatest);
   const contextReferences = (message.references ?? []).map(mapContextReference);
@@ -547,6 +637,12 @@ function normalizeSettingsSummary(snapshot: unknown, config: { httpBaseUrl: stri
 }
 
 function chatEventFromGatewayEvent(event: NormalizedGatewayEvent): ChatEvent {
+  if (event.kind === "agent-ui.event") {
+    return {
+      type: event.kind,
+      ...(event.eventType ? { eventType: event.eventType } : {}),
+    };
+  }
   if (event.kind !== "agent.event") {
     return { type: event.kind };
   }
@@ -555,6 +651,14 @@ function chatEventFromGatewayEvent(event: NormalizedGatewayEvent): ChatEvent {
     type: event.kind,
     ...(eventType ? { eventType } : {}),
   };
+}
+
+function formMatchesSession(form: AgentUiForm, sessionId: string): boolean {
+  const chatId = stringValue(form.chat_id || form.correlation.chat_id);
+  const sessionKey = stringValue(form.correlation.session_key ?? form.correlation.sessionKey);
+  return sessionKey === sessionId
+    || chatId === sessionId
+    || (Boolean(chatId) && sessionId.endsWith(`:${chatId}`));
 }
 
 function normalizeChatModelOptions(

--- a/src/react-workbench/services.ts
+++ b/src/react-workbench/services.ts
@@ -1,4 +1,5 @@
 import type { ReactChatMessage } from "./chat/messageActions";
+import type { AgentUiForm } from "../app-core/agent-ui/agentUiEvents";
 
 export type SessionSummary = {
   id: string;
@@ -22,6 +23,14 @@ export type ChatEvent = {
   message?: ReactChatMessage;
 };
 
+export type ApprovalAction = "approveOnce" | "approveSession" | "deny";
+
+export type ApprovalResolutionInput = {
+  action: ApprovalAction;
+  approvalId: string;
+  guidance?: string;
+};
+
 export type SessionStore = {
   list(): Promise<SessionSummary[]>;
   create(input?: { title?: string }): Promise<SessionSummary>;
@@ -35,6 +44,10 @@ export type ChatStore = {
   load(sessionId: string): Promise<ReactChatMessage[]>;
   send(sessionId: string, input: ChatInput): Promise<void>;
   stop(sessionId: string): Promise<void>;
+  resolveApproval(sessionId: string, input: ApprovalResolutionInput): Promise<void>;
+  listAgentUiForms(sessionId: string): Promise<AgentUiForm[]>;
+  submitAgentUiForm(formId: string, values: Record<string, unknown>): Promise<void>;
+  cancelAgentUiForm(formId: string): Promise<void>;
   branchFromMessage(sessionId: string, messageId: string): Promise<SessionSummary>;
   copyMarkdown(sessionId: string): Promise<string>;
   subscribe(sessionId: string, listener: (event: ChatEvent) => void): () => void;

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -5,11 +5,12 @@ import userEvent from "@testing-library/user-event";
 import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DesktopShell } from "./DesktopShell";
-import type { AppServices } from "../services";
+import type { AppServices, SessionSummary } from "../services";
+import type { ReactChatMessage } from "../chat/messageActions";
 
 afterEach(() => cleanup());
 
-function createServices(): AppServices & {
+function createServices(options: { messages?: ReactChatMessage[]; sessions?: SessionSummary[] } = {}): AppServices & {
   workspaceStore: { listFiles: ReturnType<typeof vi.fn> };
   knowledgeStore: { listDocuments: ReturnType<typeof vi.fn>; stats: ReturnType<typeof vi.fn> };
   toolsStore: { listSkills: ReturnType<typeof vi.fn> };
@@ -17,7 +18,7 @@ function createServices(): AppServices & {
 } {
   return {
     sessionStore: {
-      list: vi.fn(async () => []),
+      list: vi.fn(async () => options.sessions ?? []),
       create: vi.fn(async () => ({ id: "s1", chatId: "chat-1", title: "New session", updatedAtMs: Date.now() })),
       delete: vi.fn(async () => undefined),
       rename: vi.fn(async () => undefined),
@@ -25,9 +26,13 @@ function createServices(): AppServices & {
       archive: vi.fn(async () => undefined),
     },
     chatStore: {
-      load: vi.fn(async () => []),
+      load: vi.fn(async () => options.messages ?? []),
       send: vi.fn(async () => undefined),
       stop: vi.fn(async () => undefined),
+      resolveApproval: vi.fn(async () => undefined),
+      listAgentUiForms: vi.fn(async () => []),
+      submitAgentUiForm: vi.fn(async () => undefined),
+      cancelAgentUiForm: vi.fn(async () => undefined),
       branchFromMessage: vi.fn(async () => ({ id: "s1", chatId: "chat-1", title: "Branch", updatedAtMs: Date.now() })),
       copyMarkdown: vi.fn(async () => ""),
       subscribe: vi.fn(() => () => undefined),
@@ -224,6 +229,61 @@ describe("DesktopShell", () => {
     await user.click(within(screen.getByRole("menu", { name: "Application menu" })).getByRole("menuitem", { name: /Toggle Sidebar/ }));
 
     expect(sidebar.getAttribute("data-collapsed")).toBe("false");
+  });
+
+  it("runs Stop Generation from the App menu for the active running chat", async () => {
+    const user = userEvent.setup();
+    const services = createServices({
+      messages: [{
+        id: "u1",
+        role: "user",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        text: "Keep going",
+        status: "complete",
+      }],
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Running chat",
+        updatedAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        status: "running",
+      }],
+    });
+    render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={services} />);
+
+    await screen.findByRole("heading", { name: "Running chat" });
+    await user.click(screen.getByRole("button", { name: "App" }));
+    const stopCommand = within(screen.getByRole("menu", { name: "Application menu" })).getByRole("menuitem", { name: /Stop Generation/ });
+
+    expect((stopCommand as HTMLButtonElement).disabled).toBe(false);
+    await user.click(stopCommand);
+
+    expect(services.chatStore.stop).toHaveBeenCalledWith("s1");
+  });
+
+  it("runs Stop Generation from the keyboard shortcut for the active running chat", async () => {
+    const services = createServices({
+      messages: [{
+        id: "u1",
+        role: "user",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        text: "Keep going",
+        status: "complete",
+      }],
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Running chat",
+        updatedAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        status: "running",
+      }],
+    });
+    render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={services} />);
+
+    await screen.findByRole("button", { name: "Stop generation" });
+    fireEvent.keyDown(window, { ctrlKey: true, key: "." });
+
+    expect(services.chatStore.stop).toHaveBeenCalledWith("s1");
   });
 
   it("runs route commands from the command palette", async () => {

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -2,6 +2,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   useEffect,
   useMemo,
+  useRef,
   useState,
   type DependencyList,
   type MouseEvent as ReactMouseEvent,
@@ -142,6 +143,8 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
   const [activeTopSubmenu, setActiveTopSubmenu] = useState<string | null>(null);
   const [sessionSidebarCollapsed, setSessionSidebarCollapsed] = useState(false);
   const [createChatSignal, setCreateChatSignal] = useState(0);
+  const [stopGenerationSessionId, setStopGenerationSessionId] = useState("");
+  const stopGenerationSessionIdRef = useRef("");
   const frameControls = useMemo(() => windowControls ?? resolveWindowFrameControls(), [windowControls]);
   const commands = useMemo(() => routeItems.map((item) => ({
     id: `open:${item.id}`,
@@ -151,6 +154,18 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
       setPaletteOpen(false);
     },
   })), []);
+
+  function handleStopGenerationTargetChange(sessionId: string) {
+    stopGenerationSessionIdRef.current = sessionId;
+    setStopGenerationSessionId(sessionId);
+  }
+
+  function stopActiveGeneration() {
+    const sessionId = stopGenerationSessionIdRef.current;
+    if (sessionId) {
+      void services.chatStore.stop(sessionId);
+    }
+  }
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -162,6 +177,10 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
         event.preventDefault();
         setSessionSidebarCollapsed((collapsed) => !collapsed);
       }
+      if ((event.ctrlKey || event.metaKey) && event.key === ".") {
+        event.preventDefault();
+        stopActiveGeneration();
+      }
       if (event.key === "Escape") {
         setPaletteOpen(false);
         setActiveTopMenu(null);
@@ -170,7 +189,7 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, []);
+  }, [services.chatStore]);
 
   useEffect(() => {
     function onWindowPointerDown(event: PointerEvent) {
@@ -228,6 +247,9 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
       case "open-command-palette":
         setPaletteOpen(true);
         return;
+      case "stop-generation":
+        stopActiveGeneration();
+        return;
       case "toggle-theme":
         document.documentElement.dataset.theme = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
         return;
@@ -240,19 +262,22 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
   }
 
   function renderTopMenuCommand(command: TopMenuCommand) {
+    const resolvedCommand = command.id === "stop-generation"
+      ? { ...command, enabled: Boolean(stopGenerationSessionId) }
+      : command;
     return (
       <button
-        aria-label={menuCommandAccessibleLabel(command)}
+        aria-label={menuCommandAccessibleLabel(resolvedCommand)}
         className="react-top-menu__menu-item"
-        disabled={command.enabled === false}
-        key={command.id}
+        disabled={resolvedCommand.enabled === false}
+        key={resolvedCommand.id}
         role="menuitem"
-        title={menuCommandAccessibleLabel(command)}
+        title={menuCommandAccessibleLabel(resolvedCommand)}
         type="button"
-        onClick={() => runTopMenuCommand(command)}
+        onClick={() => runTopMenuCommand(resolvedCommand)}
       >
-        <span className="react-top-menu__menu-label">{command.label}</span>
-        {command.shortcut ? <span className="react-top-menu__shortcut">{command.shortcut}</span> : null}
+        <span className="react-top-menu__menu-label">{resolvedCommand.label}</span>
+        {resolvedCommand.shortcut ? <span className="react-top-menu__shortcut">{resolvedCommand.shortcut}</span> : null}
       </button>
     );
   }
@@ -388,6 +413,7 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
           sessionSidebarCollapsed={sessionSidebarCollapsed}
           onNavigate={setRoute}
           onSessionSidebarCollapsedChange={setSessionSidebarCollapsed}
+          onStopGenerationTargetChange={handleStopGenerationTargetChange}
         />
         </section>
       </div>
@@ -432,6 +458,7 @@ function RouteSurface({
   now,
   onNavigate,
   onSessionSidebarCollapsedChange,
+  onStopGenerationTargetChange,
   route,
   services,
   sessionSidebarCollapsed,
@@ -440,6 +467,7 @@ function RouteSurface({
   now?: () => number;
   onNavigate: (route: AppRoute) => void;
   onSessionSidebarCollapsedChange: (collapsed: boolean) => void;
+  onStopGenerationTargetChange: (sessionId: string) => void;
   route: AppRoute;
   services: AppServices;
   sessionSidebarCollapsed: boolean;
@@ -457,6 +485,7 @@ function RouteSurface({
           onOpenFiles={() => onNavigate("files")}
           onOpenSettings={() => onNavigate("settings")}
           onSessionSidebarCollapsedChange={onSessionSidebarCollapsedChange}
+          onStopGenerationTargetChange={onStopGenerationTargetChange}
         />
       );
     case "files":

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -64,6 +64,43 @@ button:disabled {
   opacity: 0.5;
 }
 
+.react-fatal-error {
+  display: grid;
+  align-content: center;
+  justify-items: start;
+  min-height: 100vh;
+  gap: 12px;
+  padding: 40px;
+  background: #fff;
+  color: var(--color-ink);
+}
+
+.react-fatal-error h1 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 750;
+}
+
+.react-fatal-error p {
+  max-width: 760px;
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.react-fatal-error button {
+  min-height: 34px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: var(--color-ink);
+  padding: 0 12px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 650;
+}
+
 .react-desktop-shell {
   display: grid;
   grid-template-rows: 42px minmax(0, 1fr);
@@ -807,25 +844,16 @@ button:disabled {
   line-height: 1.6;
 }
 
-.react-prompt-cycle__visual {
-  position: relative;
-  display: grid;
-  justify-items: center;
-  min-width: min(360px, 100%);
+.react-empty-chat-title-type,
+.react-prompt-cycle__text-type {
   max-width: 100%;
-  min-height: 1.6em;
   overflow: hidden;
+  white-space: nowrap;
 }
 
-.react-prompt-cycle__item {
-  grid-area: 1 / 1;
-  max-width: 100%;
-  overflow: hidden;
-  clip-path: inset(0 100% 0 0);
-  opacity: 0;
-  white-space: nowrap;
-  animation: react-prompt-type-delete 8s steps(var(--react-prompt-characters, 14), end) infinite;
-  animation-delay: calc(var(--react-prompt-index, 0) * 2s);
+.react-empty-chat-title-type__cursor,
+.react-prompt-cycle__cursor {
+  color: var(--color-muted);
 }
 
 .react-empty-state {
@@ -836,73 +864,6 @@ button:disabled {
   display: inline-block;
   max-width: 100%;
   vertical-align: baseline;
-}
-
-.react-text-type__text {
-  display: inline-block;
-  max-width: 100%;
-  overflow: hidden;
-  clip-path: inset(0 100% 0 0);
-  white-space: nowrap;
-  animation: react-text-type var(--motion-duration-text) steps(var(--react-text-type-characters, 24), end) forwards;
-}
-
-.react-text-type__text::after {
-  display: inline-block;
-  width: 1px;
-  height: 1em;
-  margin-left: 2px;
-  background: currentColor;
-  content: "";
-  opacity: 0.5;
-  vertical-align: -0.15em;
-  animation: react-text-caret var(--motion-duration-text) step-end 1 forwards;
-}
-
-@keyframes react-text-type {
-  to {
-    clip-path: inset(0 0 0 0);
-  }
-}
-
-@keyframes react-text-caret {
-  0%,
-  65% {
-    opacity: 0.5;
-  }
-
-  100% {
-    opacity: 0;
-  }
-}
-
-@keyframes react-prompt-type-delete {
-  0%,
-  2% {
-    clip-path: inset(0 100% 0 0);
-    opacity: 0;
-  }
-
-  4% {
-    clip-path: inset(0 100% 0 0);
-    opacity: 1;
-  }
-
-  13%,
-  20% {
-    clip-path: inset(0 0 0 0);
-    opacity: 1;
-  }
-
-  25% {
-    clip-path: inset(0 0 0 100%);
-    opacity: 0;
-  }
-
-  100% {
-    clip-path: inset(0 0 0 100%);
-    opacity: 0;
-  }
 }
 
 .react-message {
@@ -1618,6 +1579,268 @@ button:disabled {
   gap: 12px;
 }
 
+.react-tool-detail {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.react-tool-detail section {
+  display: grid;
+  gap: 6px;
+}
+
+.react-tool-detail h3 {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-tool-detail__approval-actions > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.react-tool-detail__approval-actions button {
+  min-height: 32px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0 10px;
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-tool-detail__approval-actions button:hover,
+.react-tool-detail__approval-actions button:focus-visible {
+  background: var(--color-surface-soft);
+}
+
+.react-tool-detail pre {
+  overflow: auto;
+  max-height: 180px;
+  margin: 0;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: var(--color-surface-soft);
+  padding: 8px;
+  color: var(--color-ink);
+  font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.react-agent-ui-forms {
+  display: grid;
+  gap: 10px;
+  width: min(720px, 100%);
+  margin: 8px auto 0;
+}
+
+.react-agent-ui-form-card {
+  display: grid;
+  gap: 12px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 14px;
+}
+
+.react-agent-ui-form-card__header {
+  display: grid;
+  gap: 4px;
+}
+
+.react-agent-ui-form-card__header h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.react-agent-ui-form-card__header p,
+.react-agent-ui-form-field small {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.react-agent-ui-form-card__fields {
+  display: grid;
+  gap: 10px;
+}
+
+.react-agent-ui-form-field {
+  display: grid;
+  gap: 5px;
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-agent-ui-form-field input,
+.react-agent-ui-form-field select,
+.react-agent-ui-form-field textarea {
+  width: 100%;
+  min-height: 34px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: var(--color-surface-soft);
+  padding: 7px 9px;
+  color: var(--color-ink);
+  font: 13px/1.4 inherit;
+}
+
+.react-agent-ui-form-field textarea {
+  min-height: 76px;
+  resize: vertical;
+}
+
+.react-agent-ui-form-field input[type="checkbox"] {
+  width: 18px;
+  min-height: 18px;
+}
+
+.react-agent-ui-form-field__choices {
+  display: grid;
+  gap: 6px;
+}
+
+.react-agent-ui-form-field__choices label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.react-agent-ui-form-field__choices input {
+  width: 16px;
+  min-height: 16px;
+}
+
+.react-agent-ui-form-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.react-agent-ui-form-card__actions button {
+  min-height: 34px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0 12px;
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-agent-ui-form-card__actions button[type="submit"] {
+  background: var(--color-ink);
+  color: #fff;
+}
+
+.react-queued-inputs {
+  display: grid;
+  gap: 8px;
+  width: min(720px, 100%);
+  margin: 8px auto 0;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px;
+}
+
+.react-queued-inputs__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.react-queued-inputs__header > div {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.react-queued-inputs h2 {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.react-queued-inputs__header span,
+.react-queued-inputs__message {
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-queued-inputs ol {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.react-queued-input {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border-radius: 6px;
+  background: var(--color-surface-soft);
+  padding: 7px 8px;
+}
+
+.react-queued-input > span {
+  color: var(--color-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.react-queued-input p {
+  overflow: hidden;
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-queued-input button {
+  min-height: 26px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 6px;
+  background: #fff;
+  padding: 0 8px;
+  color: var(--color-ink);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.react-queued-inputs__header button {
+  min-height: 26px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 6px;
+  background: #fff;
+  padding: 0 8px;
+  color: var(--color-ink);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.react-queued-inputs__message {
+  width: min(720px, 100%);
+  margin: 8px auto 0;
+}
+
 .react-placeholder-page {
   display: grid;
   align-content: center;
@@ -1947,24 +2170,6 @@ button:disabled {
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
     transition-duration: 0ms !important;
-  }
-
-  .react-text-type__text {
-    clip-path: inset(0 0 0 0);
-    animation: none !important;
-  }
-
-  .react-text-type__text::after {
-    display: none;
-  }
-
-  .react-prompt-cycle__item {
-    clip-path: inset(0 0 0 0);
-    animation: none !important;
-  }
-
-  .react-prompt-cycle__item:first-child {
-    opacity: 1;
   }
 
   .react-session-list__rows[data-motion="animated-list"] .react-session-row,


### PR DESCRIPTION
## Summary
- Add Rust backend API documentation under `docs/api`.
- Improve the chat agent experience with queued pending prompts, richer agent step details, approval/form UI plumbing, and agent-event based streaming state.
- Add empty chat title/prompt rotation using a reusable React Bits-style `TextType` component.
- Add renderer crash diagnostics with native logging and a visible crash overlay for white-screen failures.

## Why
This collects the chat agent UX work needed to make agent runs easier to inspect, queue, approve, and debug. It also documents the Rust backend APIs and adds crash diagnostics so future renderer failures leave actionable evidence instead of a blank window.

## Validation
- `npm test` (61 files, 436 tests)
- `npm run build`