### PR TITLE
Move chat frontend to agent events

### DIFF
--- a/src/app-core/chat/chatRunModel.test.ts
+++ b/src/app-core/chat/chatRunModel.test.ts
@@ -438,6 +438,9 @@ describe("chat run model", () => {
     }
     let turns = state.turnsBySession.get("WebSocket:chat-1") ?? [];
     expect(turns[0].steps.filter((step) => step.kind === "message")).toHaveLength(1);
+    const streamMessages = turnsToConversationMessages(turns);
+    expect(streamMessages[0]).toEqual(expect.objectContaining({ turnId: "turn-1", turnStatus: "running" }));
+    expect(streamMessages[1]).toEqual(expect.objectContaining({ turnId: "turn-1", turnStatus: "running" }));
     expect(turns[0].steps.find((step) => step.kind === "message")?.summary).toBe("你好!");
     expect(turnsToConversationMessages(turns)).toEqual([
       expect.objectContaining({ body: ["Say hello"], tone: "user" }),
@@ -461,10 +464,26 @@ describe("chat run model", () => {
 
     turns = state.turnsBySession.get("WebSocket:chat-1") ?? [];
     expect(turns[0].steps.filter((step) => step.kind === "message")).toHaveLength(1);
+    const finalMessageBeforeTurnComplete = turnsToConversationMessages(turns)[1];
+    expect(finalMessageBeforeTurnComplete).toEqual(expect.objectContaining({ copyable: true, turnId: "turn-1", turnStatus: "running" }));
     expect(turnsToConversationMessages(turns)).toEqual([
       expect.objectContaining({ body: ["Say hello"], tone: "user" }),
       expect.objectContaining({ body: ["你好!"], copyable: true, tone: "assistant" }),
     ]);
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-turn-completed",
+      event_type: "agent.turn.completed",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-1",
+      sequence: 6,
+      created_at: "2026-06-27T04:00:05.000Z",
+      payload: {},
+    });
+
+    turns = state.turnsBySession.get("WebSocket:chat-1") ?? [];
+    expect(turnsToConversationMessages(turns)[1]).toEqual(expect.objectContaining({ copyable: true, turnId: "turn-1", turnStatus: "completed" }));
   });
 
   test("stores delegated trace updates on the child agent state", () => {

--- a/src/app-core/chat/chatRunModel.ts
+++ b/src/app-core/chat/chatRunModel.ts
@@ -102,6 +102,8 @@ export interface ChatMessageProjection {
   time: string;
   tone: "assistant" | "user";
   toolActivities?: ChatToolActivityProjection[];
+  turnId?: string;
+  turnStatus?: ChatTurnStatus;
 }
 
 export type DelegatedAgentState = {
@@ -526,6 +528,9 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
   }
 
   if (event.event_type === "message.delta" || event.event_type === "message.completed") {
+    if (turn.status === "pending") {
+      turn.status = "running";
+    }
     const text = stringValue(event.payload.text);
     const messageId = stringValue(event.payload.message_id) || stableId("message", turn.id, event.sequence);
     const stepId = messageStepId(turn.id, messageId);
@@ -541,8 +546,6 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
         text,
         timestamp: event.created_at,
       };
-      turn.status = "completed";
-      turn.completedAt = event.created_at;
     }
     upsertStep(turn, event, {
       kind: "message",
@@ -976,12 +979,14 @@ export function turnsToConversationMessages(turns: ChatTurn[]): ChatMessageProje
       time: turn.userMessage.timestamp,
       tone: "user",
       toolActivities: [],
+      turnId: turn.id,
+      turnStatus: turn.status,
     }];
     for (const step of turn.steps) {
       if (turn.finalMessage && step.kind === "message") {
         continue;
       }
-      messages.push(stepToConversationMessage(step));
+      messages.push(stepToConversationMessage(step, turn));
     }
     if (turn.finalMessage) {
       messages.push({
@@ -994,6 +999,8 @@ export function turnsToConversationMessages(turns: ChatTurn[]): ChatMessageProje
         time: turn.finalMessage.timestamp,
         tone: "assistant",
         toolActivities: [],
+        turnId: turn.id,
+        turnStatus: turn.status,
       });
     }
     return messages;
@@ -1028,7 +1035,7 @@ export function sanitizeTextPreview(value: string): string {
     .replace(/\b(api_key|token|secret|password|authorization|cookie|credential|private_key)\s*[:=]\s*([^\s,;]+)/gi, "$1=[redacted]");
 }
 
-function stepToConversationMessage(step: ChatStep): ChatMessageProjection {
+function stepToConversationMessage(step: ChatStep, turn: ChatTurn): ChatMessageProjection {
   return {
     author: "Tinybot",
     body: step.kind === "message" && step.summary ? [step.summary] : [],
@@ -1040,6 +1047,8 @@ function stepToConversationMessage(step: ChatStep): ChatMessageProjection {
     time: step.startedAt || step.completedAt || "",
     tone: "assistant",
     toolActivities: stepToToolActivities(step),
+    turnId: turn.id,
+    turnStatus: turn.status,
   };
 }
 

--- a/src/app-core/chat/desktopChatSessionController.ts
+++ b/src/app-core/chat/desktopChatSessionController.ts
@@ -174,11 +174,6 @@ export function createDesktopChatSessionController({
     await deleteGatewaySession(target);
     state.messages.delete(sessionKey);
     state.respondingSessionKeys.delete(sessionKey);
-    for (const [messageId, messageSessionKey] of state.streamMessageKeys) {
-      if (messageSessionKey === sessionKey) {
-        state.streamMessageKeys.delete(messageId);
-      }
-    }
 
     const sessions = normalizeSessionsPayload(await api.listSessions());
     setSessions(state, sessions);

--- a/src/app-core/chat/nativeChat.test.ts
+++ b/src/app-core/chat/nativeChat.test.ts
@@ -173,7 +173,7 @@ describe("native chat state", () => {
       eventId: "event-turn-start",
       eventType: "agent.turn.started",
       payload: {
-        user_message: { id: "user-1", role: "user", text: "hello" },
+          user_message: { id: "user-1", role: "user", text: "hello" },
         user_message_id: "user-1",
       },
       sequence: 1,
@@ -222,78 +222,6 @@ describe("native chat state", () => {
     }));
 
     expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(false);
-  });
-
-  test("keeps legacy normalized message deltas streaming without agent events", () => {
-    const state = createNativeChatState();
-    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
-
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "legacy-stream-1",
-      text: "Hello",
-      reasoning: false,
-      raw: { event: "delta" },
-    });
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "legacy-stream-1",
-      text: " world",
-      reasoning: false,
-      raw: { event: "message_delta" },
-    });
-
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      {
-        role: "assistant",
-        content: "Hello world",
-        reasoningContent: "",
-        messageId: "legacy-stream-1",
-      },
-    ]);
-    expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(true);
-
-    applyChatEvent(state, {
-      kind: "message.stream.completed",
-      chatId: "chat-1",
-      messageId: "legacy-stream-1",
-      raw: { event: "stream_end" },
-    });
-
-    expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(false);
-  });
-
-  test("keeps legacy normalized reasoning deltas on the assistant message", () => {
-    const state = createNativeChatState();
-    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
-
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "legacy-stream-2",
-      text: "Thinking",
-      reasoning: true,
-      raw: { event: "reasoning_delta" },
-    });
-    applyChatEvent(state, {
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "legacy-stream-2",
-      text: " done",
-      reasoning: false,
-      raw: { event: "delta" },
-    });
-
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      {
-        role: "assistant",
-        content: " done",
-        reasoningContent: "Thinking",
-        messageId: "legacy-stream-2",
-      },
-    ]);
   });
 
   test("normalizes backend memory and recent context references from persisted messages", () => {
@@ -427,45 +355,25 @@ describe("native chat state", () => {
     }]);
   });
 
-  test("attaches backend references from live completed and streamed messages", () => {
+  test("attaches backend references from structured completed messages", () => {
     const state = createNativeChatState();
     applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
 
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "m-complete",
-      text: "Complete answer",
-      raw: {
-        _memory_references: [{ note_id: "note_complete", content: "Complete memory" }],
-      },
-    });
     applyChatEvent(state, agentEvent({
-      eventId: "event-stream-delta",
-      eventType: "message.delta",
+      eventId: "event-complete",
+      eventType: "message.completed",
       payload: {
-        message_id: "m-stream",
-        text: "Streamed answer",
+        message_id: "m-complete",
+        references: [{ title: "note_complete", content: "Complete memory" }],
+        text: "Complete answer",
       },
       sequence: 1,
     }));
-    applyChatEvent(state, {
-      kind: "message.stream.completed",
-      chatId: "chat-1",
-      messageId: "m-stream",
-      raw: {
-        _recent_context_references: [{ evidence_id: "ev_stream", excerpt: "Stream context" }],
-      },
-    });
 
     expect(state.messages.get(sessionKeyForChat("chat-1"))).toEqual(expect.arrayContaining([
       expect.objectContaining({
         messageId: "m-complete",
-        references: [expect.objectContaining({ kind: "memory", title: "note_complete", detail: "Complete memory" })],
-      }),
-      expect.objectContaining({
-        messageId: "m-stream",
-        references: [expect.objectContaining({ kind: "recent", title: "ev_stream", detail: "Stream context" })],
+        references: [expect.objectContaining({ kind: "reference", title: "note_complete", detail: "Complete memory" })],
       }),
     ]));
   });
@@ -483,21 +391,22 @@ describe("native chat state", () => {
       },
       sequence: 1,
     }));
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "m-stream",
-      text: "Streamed answer",
-      raw: {
-        _memory_references: [{ note_id: "note_stream", content: "Stream memory" }],
+    applyChatEvent(state, agentEvent({
+      eventId: "event-stream-complete",
+      eventType: "message.completed",
+      payload: {
+        message_id: "m-stream",
+        references: [{ title: "note_stream", content: "Stream memory" }],
+        text: "Streamed answer",
       },
-    });
+      sequence: 2,
+    }));
 
     expect(state.messages.get(sessionKeyForChat("chat-1"))).toEqual(expect.arrayContaining([
       expect.objectContaining({
         content: "Streamed answer",
         messageId: "m-stream",
-        references: [expect.objectContaining({ kind: "memory", title: "note_stream", detail: "Stream memory" })],
+        references: [expect.objectContaining({ kind: "reference", title: "note_stream", detail: "Stream memory" })],
       }),
     ]));
     expect(state.messages.get(sessionKeyForChat("chat-1"))?.filter((message) => message.messageId === "m-stream")).toHaveLength(1);
@@ -645,91 +554,6 @@ describe("native chat state", () => {
     ]);
   });
 
-  test("routes live tool hint messages into tool activities instead of assistant body text", () => {
-    const state = createNativeChatState();
-    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
-
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "tool-detail-1",
-      text: "list_dir(path=\"C:\\\\Users\\\\12921\\\\tinybot\\\\workspace\\\\web-articles\")",
-      raw: {
-        _tool_hint: true,
-        _tool_detail: true,
-        _tool_name: "list_dir",
-      },
-    });
-
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      {
-        role: "assistant",
-        content: "",
-        messageId: "tool-detail-1",
-        toolActivities: [
-          {
-            id: "tool-detail-1",
-            name: "list_dir",
-            argsText: "list_dir(path=\"C:\\\\Users\\\\12921\\\\tinybot\\\\workspace\\\\web-articles\")",
-            responseText: "",
-            kind: "call",
-            status: "running",
-          },
-        ],
-      },
-    ]);
-  });
-
-  test("updates live tool activity status instead of appending duplicate tool messages", () => {
-    const state = createNativeChatState();
-    applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
-
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "tool-running-1",
-      text: "search_memory_notes(query=\"financial banking\")",
-      raw: {
-        _tool_hint: true,
-        _tool_detail: true,
-        _tool_call_id: "call-search-memory",
-        _tool_name: "search_memory_notes",
-        status: "running",
-      },
-    });
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "tool-completed-1",
-      text: "[{\"summary\":\"User follows AI impact on financial banking.\"}]",
-      raw: {
-        _tool_result: true,
-        tool_call_id: "call-search-memory",
-        _tool_name: "search_memory_notes",
-        status: "completed",
-      },
-    });
-
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      {
-        role: "assistant",
-        content: "",
-        messageId: "tool-running-1",
-        toolActivities: [
-          {
-            id: "call-search-memory",
-            name: "search_memory_notes",
-            argsText: "search_memory_notes(query=\"financial banking\")",
-            responseText: "[{\"summary\":\"User follows AI impact on financial banking.\"}]",
-            kind: "result",
-            status: "completed",
-          },
-        ],
-      },
-    ]);
-    expect(state.messages.get(sessionKeyForChat("chat-1"))).toHaveLength(1);
-  });
-
   test("keeps late live tool events before the streamed final answer", () => {
     const state = createNativeChatState();
     applyChatEvent(state, { kind: "attached", chatId: "chat-1", raw: {} });
@@ -742,24 +566,22 @@ describe("native chat state", () => {
       },
       sequence: 1,
     }));
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "tool-list-1",
-      text: "AGENTS.md\napps/\ndocs/",
-      raw: {
-        _tool_result: true,
-        tool_call_id: "call-list",
-        _tool_name: "list_dir",
+    applyChatEvent(state, agentEvent({
+      eventId: "event-tool-list",
+      eventType: "tool.call.completed",
+      payload: {
+        name: "list_dir",
+        result_preview: "AGENTS.md\napps/\ndocs/",
         status: "completed",
+        tool_call_id: "call-list",
       },
-    });
+      sequence: 2,
+    }));
 
     expect(state.messages.get(sessionKeyForChat("chat-1"))).toEqual(expect.arrayContaining([
       expect.objectContaining({
         role: "assistant",
         content: "",
-        messageId: "tool-list-1",
         toolActivities: [
           expect.objectContaining({
             id: "call-list",
@@ -839,6 +661,28 @@ describe("native chat state", () => {
       },
       { role: "assistant", content: "Files inspected." },
     ]);
+    expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(true);
+
+    applyChatEvent(state, {
+      kind: "agent.event",
+      chatId: "chat-1",
+      raw: {
+        event: "agent_event",
+        schema_version: "tinybot.agent_event.v1",
+        event_id: "event-turn-complete",
+        event_type: "agent.turn.completed",
+        chat_id: "chat-1",
+        session_key: "websocket:chat-1",
+        turn_id: "turn-1",
+        sequence: 4,
+        created_at: "2026-06-27T04:00:03.000Z",
+        payload: {
+          message_id: "assistant-final",
+          reason: "stop",
+        },
+      },
+    });
+
     expect(state.respondingSessionKeys.has(sessionKeyForChat("chat-1"))).toBe(false);
   });
 
@@ -859,7 +703,7 @@ describe("native chat state", () => {
         sequence: 1,
         created_at: "2026-06-27T04:00:00.000Z",
         payload: {
-          user_message: { id: "user-1", role: "user", text: "Use subagent" },
+          user_message: { id: "user-1", role: "user", text: "hello" },
           user_message_id: "user-1",
         },
       },
@@ -885,7 +729,7 @@ describe("native chat state", () => {
     });
 
     expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      { role: "user", content: "Use subagent" },
+      { role: "user", content: "hello" },
       {
         role: "assistant",
         content: "working with a child agent",
@@ -911,7 +755,7 @@ describe("native chat state", () => {
         sequence: 1,
         created_at: "2026-06-27T04:00:00.000Z",
         payload: {
-          user_message: { id: "user-1", role: "user", text: "你好" },
+          user_message: { id: "user-1", role: "user", text: "hello" },
           user_message_id: "user-1",
         },
       },
@@ -960,7 +804,7 @@ describe("native chat state", () => {
     });
 
     expect(state.messages.get(sessionKeyForChat("chat-1"))).toMatchObject([
-      { role: "user", content: "你好" },
+      { role: "user", content: "hello" },
       {
         role: "assistant",
         content: "",
@@ -1069,7 +913,7 @@ describe("native chat state", () => {
           _delegate_event: true,
           _delegate_id: "delegate-1",
           _delegate_status: "awaiting_approval",
-          _delegate_task: "请用中文说一句\"你好\"",
+          _delegate_task: "Ask the delegated agent to say hello",
           timestamp: "2026-06-27T04:00:03Z",
           message_id: "tool-approval",
         },
@@ -1085,7 +929,7 @@ describe("native chat state", () => {
       approvalStatus: "approval_required",
       status: "blocked",
     })]);
-    expect(messages[0].toolActivities?.[0]?.argsText).toContain("请用中文说一句");
+    expect(messages[0].toolActivities?.[0]?.argsText).toContain("Ask the delegated agent to say hello");
   });
 
   test("restores completed delegated results without losing delegated task details", () => {
@@ -1098,9 +942,9 @@ describe("native chat state", () => {
           name: "spawn",
           _delegate_event: true,
           _delegate_id: "delegate-1",
-          _delegate_result: { summary: "你好", status: "completed" },
+          _delegate_result: { summary: "hello", status: "completed" },
           _delegate_status: "completed",
-          _delegate_task: "请用中文说一句\"你好\"",
+          _delegate_task: "Ask the delegated agent to say hello",
           _delegate_trace: {
             steps: [{
               id: "tool:call-1:completed",
@@ -1123,7 +967,7 @@ describe("native chat state", () => {
       kind: "result",
       status: "completed",
     })]);
-    expect(messages[0].toolActivities?.[0]?.argsText).toContain("请用中文说一句");
+    expect(messages[0].toolActivities?.[0]?.argsText).toContain("Ask the delegated agent to say hello");
     expect(messages[0].toolActivities?.[0]?.argsText).toContain("Spawned agent workflow");
     expect(messages[0].toolActivities?.[0]?.argsText).toContain("tool:call-1:completed");
   });
@@ -1147,7 +991,7 @@ describe("native chat state", () => {
           _delegate_id: "delegate-1",
           _delegate_label: "Greeter",
           _delegate_status: "completed",
-          _delegate_task: "Say hello",
+          _delegate_task: "Ask the delegated agent to say hello",
           _delegate_trace_ref: "trace-delegate-1",
           _delegate_result: { summary: "hello", status: "completed" },
           _delegate_trace: {
@@ -1181,7 +1025,7 @@ describe("native chat state", () => {
     expect(delegate).toMatchObject({
       id: "delegate-1",
       title: "Greeter",
-      task: "Say hello",
+      task: "Ask the delegated agent to say hello",
       status: "completed",
       traceRef: "trace-delegate-1",
       trace: {
@@ -1278,61 +1122,6 @@ describe("native chat state", () => {
         })],
       }),
     }));
-  });
-
-  test("merges pending approval tool result messages into the latest running tool by name", () => {
-    const state = createNativeChatState();
-    activateChat(state, "chat-1");
-    appendUserMessage(state, "Use subagent");
-
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "run-1:call-spawn:start",
-      text: "spawn({\"task\":\"say hi\"})",
-      raw: {
-        event: "agent.tool.start",
-        chat_id: "chat-1",
-        content: "spawn({\"task\":\"say hi\"})",
-        message_id: "run-1:call-spawn:start",
-        status: "running",
-        _tool_call_id: "call-spawn",
-        _tool_detail: true,
-        _tool_hint: true,
-        _tool_name: "spawn",
-      },
-    });
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "run-1:approval-1:approval",
-      text: "Waiting for approval.",
-      raw: {
-        event: "agent.awaiting_approval",
-        chat_id: "chat-1",
-        content: "Waiting for approval.",
-        message_id: "run-1:approval-1:approval",
-        status: "blocked",
-        _approval_id: "approval-1",
-        _approval_status: "approval_required",
-        _tool_call_id: "approval-1",
-        _tool_name: "spawn",
-        _tool_result: true,
-      },
-    });
-
-    const assistantMessages = state.messages.get(sessionKeyForChat("chat-1"))?.filter((message) => message.role === "assistant") ?? [];
-    expect(assistantMessages).toHaveLength(1);
-    expect(assistantMessages[0].toolActivities).toEqual([{
-      id: "call-spawn",
-      name: "spawn",
-      argsText: "spawn({\"task\":\"say hi\"})",
-      responseText: "Waiting for approval.",
-      kind: "result",
-      approvalId: "approval-1",
-      approvalStatus: "approval_required",
-      status: "blocked",
-    }]);
   });
 
   test("merges approval requests into the matching tool activity", () => {
@@ -1466,163 +1255,4 @@ describe("native chat state", () => {
     })]);
   });
 
-  test("coalesces resolved approval activities with the original delegated tool call", () => {
-    const state = createNativeChatState();
-    activateChat(state, "chat-1");
-    appendUserMessage(state, "Use subagent");
-
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "run-1:call-spawn:start",
-      text: "spawn({\"task\":\"say hi\"})",
-      raw: {
-        event: "agent.tool.start",
-        chat_id: "chat-1",
-        content: "spawn({\"task\":\"say hi\"})",
-        message_id: "run-1:call-spawn:start",
-        status: "running",
-        _tool_call_id: "call-spawn",
-        _tool_detail: true,
-        _tool_hint: true,
-        _tool_name: "spawn",
-      },
-    });
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "run-1:approval:approval-1:result",
-      text: "Waiting for approval.",
-      raw: {
-        event: "message",
-        chat_id: "chat-1",
-        content: "Waiting for approval.",
-        message_id: "run-1:approval:approval-1:result",
-        status: "blocked",
-        _approval_id: "approval-1",
-        _approval_status: "approval_required",
-        _tool_call_id: "approval-1",
-        _tool_name: "spawn",
-        _tool_result: true,
-      },
-    });
-    applyChatEvent(state, {
-      kind: "agent.event",
-      chatId: "chat-1",
-      raw: {
-        event: "agent_event",
-        schema_version: "tinybot.agent_event.v1",
-        event_id: "event-approval",
-        event_type: "approval.requested",
-        chat_id: "chat-1",
-        session_key: "websocket:chat-1",
-        turn_id: "run-1",
-        step_id: "run-1:approval:approval-1",
-        sequence: 3,
-        created_at: "2026-06-27T04:00:02.000Z",
-        payload: {
-          approval_id: "approval-1",
-          approval_status: "approval_required",
-          args_preview: "",
-          title: "Approval required",
-          tool_call_id: "approval-1",
-        },
-      },
-    });
-
-    expect(resolveNativeChatApproval(state, {
-      approvalId: "approval-1",
-      decision: "approved",
-      sessionKey: "websocket:chat-1",
-    })).toBe(true);
-
-    const toolActivities = (state.messages.get(sessionKeyForChat("chat-1")) ?? [])
-      .flatMap((message) => message.toolActivities ?? []);
-    expect(toolActivities).toHaveLength(1);
-    expect(toolActivities[0]).toEqual(expect.objectContaining({
-      approvalId: "approval-1",
-      approvalStatus: "approved",
-      argsText: "spawn({\"task\":\"say hi\"})",
-      name: "spawn",
-      responseText: "Approved.",
-      status: "completed",
-    }));
-  });
-
-  test("merges completed tool results into the locally approved delegated tool call", () => {
-    const state = createNativeChatState();
-    activateChat(state, "chat-1");
-    appendUserMessage(state, "Use subagent");
-
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "run-1:call-spawn:start",
-      text: "spawn({\"task\":\"say hi\"})",
-      raw: {
-        event: "agent.tool.start",
-        chat_id: "chat-1",
-        content: "spawn({\"task\":\"say hi\"})",
-        message_id: "run-1:call-spawn:start",
-        status: "running",
-        _tool_call_id: "call-spawn",
-        _tool_detail: true,
-        _tool_hint: true,
-        _tool_name: "spawn",
-      },
-    });
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "run-1:approval:approval-1:result",
-      text: "Waiting for approval.",
-      raw: {
-        event: "message",
-        chat_id: "chat-1",
-        content: "Waiting for approval.",
-        message_id: "run-1:approval:approval-1:result",
-        status: "blocked",
-        _approval_id: "approval-1",
-        _approval_status: "approval_required",
-        _tool_call_id: "approval-1",
-        _tool_name: "spawn",
-        _tool_result: true,
-      },
-    });
-
-    expect(resolveNativeChatApproval(state, {
-      approvalId: "approval-1",
-      decision: "approved",
-      sessionKey: "websocket:chat-1",
-    })).toBe(true);
-    applyChatEvent(state, {
-      kind: "message.completed",
-      chatId: "chat-1",
-      messageId: "run-1:approval-1:completed",
-      text: "你好",
-      raw: {
-        event: "message",
-        chat_id: "chat-1",
-        content: "你好",
-        message_id: "run-1:approval-1:completed",
-        status: "completed",
-        _tool_call_id: "approval-1",
-        _tool_name: "spawn",
-        _tool_result: true,
-      },
-    });
-
-    const toolActivities = (state.messages.get(sessionKeyForChat("chat-1")) ?? [])
-      .flatMap((message) => message.toolActivities ?? []);
-    expect(toolActivities).toHaveLength(1);
-    expect(toolActivities[0]).toEqual(expect.objectContaining({
-      approvalId: "approval-1",
-      approvalStatus: "approved",
-      argsText: "spawn({\"task\":\"say hi\"})",
-      id: "call-spawn",
-      name: "spawn",
-      responseText: "你好",
-      status: "completed",
-    }));
-  });
 });

--- a/src/app-core/chat/nativeChat.ts
+++ b/src/app-core/chat/nativeChat.ts
@@ -30,6 +30,8 @@ export type NativeChatMessage = {
   references?: NativeChatReference[];
   timestamp: string;
   messageId: string;
+  turnId?: string;
+  turnStatus?: string;
 };
 
 export type NativeChatToolActivity = {
@@ -95,7 +97,6 @@ export type NativeChatState = {
   activeSessionKey: string;
   activeChatId: string;
   respondingSessionKeys: Set<string>;
-  streamMessageKeys: Map<string, string>;
   error: string;
 };
 
@@ -107,7 +108,6 @@ export function createNativeChatState(): NativeChatState {
     activeSessionKey: "",
     activeChatId: "",
     respondingSessionKeys: new Set(),
-    streamMessageKeys: new Map(),
     error: "",
   };
 }
@@ -184,10 +184,6 @@ export function setSessions(state: NativeChatState, sessions: NativeChatSession[
   }));
   state.activeSessionKey = canonicalSessionKey(state.activeSessionKey, state.activeChatId) || state.activeSessionKey;
   state.respondingSessionKeys = new Set([...state.respondingSessionKeys].map((key) => canonicalSessionKey(key) || key));
-  state.streamMessageKeys = new Map([...state.streamMessageKeys].map(([messageId, sessionKey]) => [
-    messageId,
-    canonicalSessionKey(sessionKey) || sessionKey,
-  ]));
   state.sessions = nextSessions;
   for (const session of nextSessions) {
     const bucket = sessionKeyAliases(session.key, session.chatId)
@@ -595,144 +591,11 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
       envelope.event_type === "agent.turn.completed"
       || envelope.event_type === "agent.turn.failed"
       || envelope.event_type === "agent.turn.interrupted"
-      || envelope.event_type === "message.completed"
     ) {
       state.respondingSessionKeys.delete(sessionKey);
     } else {
       state.respondingSessionKeys.add(sessionKey);
     }
-    return;
-  }
-
-  if (event.kind === "message.delta") {
-    const sessionKey =
-      event.messageId && state.streamMessageKeys.has(event.messageId)
-        ? state.streamMessageKeys.get(event.messageId) || ""
-        : sessionKeyForChatState(state, event.chatId || state.activeChatId);
-    if (!sessionKey) {
-      logDesktopNativeChatDebug("state.event.after", {
-        dropped: "missing session key",
-        event: summarizeChatEvent(event),
-        state: summarizeNativeChatState(state),
-      });
-      return;
-    }
-    const bucket = ensureMessageBucket(state, sessionKey);
-    const existingMessage = findStreamingDeltaMessage(bucket, event.messageId);
-    const targetMessage = existingMessage ?? {
-      role: "assistant",
-      content: "",
-      reasoningContent: "",
-      timestamp: new Date().toISOString(),
-      messageId: event.messageId || "",
-    };
-    if (event.reasoning) {
-      targetMessage.reasoningContent += event.text;
-    } else {
-      targetMessage.content += event.text;
-    }
-    if (!existingMessage) {
-      bucket.push(targetMessage);
-    }
-    if (event.messageId) {
-      state.streamMessageKeys.set(event.messageId, sessionKey);
-    }
-    state.respondingSessionKeys.add(sessionKey);
-    state.error = "";
-    logDesktopNativeChatDebug("state.event.after", {
-      event: summarizeChatEvent(event),
-      state: summarizeNativeChatState(state),
-      targetSessionKey: sessionKey,
-    });
-    return;
-  }
-
-  if (event.kind === "message.completed") {
-    const sessionKey = sessionKeyForChatState(state, event.chatId || state.activeChatId);
-    if (!sessionKey) {
-      logDesktopNativeChatDebug("state.event.after", {
-        dropped: "missing session key",
-        event: summarizeChatEvent(event),
-        state: summarizeNativeChatState(state),
-      });
-      return;
-    }
-    const toolMessage = nativeToolMessageFromEvent(event);
-    const references = normalizeMessageReferences(event.raw);
-    const bucket = ensureMessageBucket(state, sessionKey);
-    const existingMessage = event.messageId
-      ? bucket.find((message) => message.messageId === event.messageId && message.role === "assistant")
-      : undefined;
-    if (!toolMessage && existingMessage) {
-      if (!existingMessage.content && event.text) {
-        existingMessage.content = event.text;
-      }
-      if (references.length) {
-        existingMessage.references = [...(existingMessage.references ?? []), ...references];
-      }
-      state.respondingSessionKeys.delete(sessionKey);
-      state.error = "";
-      logDesktopNativeChatDebug("state.event.after", {
-        event: summarizeChatEvent(event),
-        state: summarizeNativeChatState(state),
-        targetSessionKey: sessionKey,
-      });
-      return;
-    }
-    if (toolMessage && upsertToolActivityMessage(bucket, toolMessage)) {
-      state.respondingSessionKeys.delete(sessionKey);
-      state.error = "";
-      logDesktopNativeChatDebug("state.event.after", {
-        event: summarizeChatEvent(event),
-        state: summarizeNativeChatState(state),
-        targetSessionKey: sessionKey,
-      });
-      return;
-    }
-    const nextMessage: NativeChatMessage = {
-      role: "assistant",
-      content: toolMessage ? "" : event.text,
-      reasoningContent: "",
-      ...(toolMessage ? { toolActivities: [toolMessage] } : {}),
-      ...(references.length ? { references } : {}),
-      timestamp: new Date().toISOString(),
-      messageId: event.messageId || "",
-    };
-    if (toolMessage) {
-      insertToolActivityMessage(bucket, nextMessage);
-    } else {
-      bucket.push(nextMessage);
-    }
-    state.respondingSessionKeys.delete(sessionKey);
-    state.error = "";
-    logDesktopNativeChatDebug("state.event.after", {
-      event: summarizeChatEvent(event),
-      state: summarizeNativeChatState(state),
-      targetSessionKey: sessionKey,
-    });
-    return;
-  }
-
-  if (event.kind === "message.stream.completed") {
-    const sessionKey =
-      event.messageId && state.streamMessageKeys.has(event.messageId)
-        ? state.streamMessageKeys.get(event.messageId) || ""
-        : sessionKeyForChatState(state, event.chatId || state.activeChatId);
-    if (sessionKey) {
-      state.respondingSessionKeys.delete(sessionKey);
-      const references = normalizeMessageReferences(event.raw);
-      if (references.length && event.messageId) {
-        attachMessageReferences(state, sessionKey, event.messageId, references);
-      }
-    }
-    if (event.messageId) {
-      state.streamMessageKeys.delete(event.messageId);
-    }
-    logDesktopNativeChatDebug("state.event.after", {
-      event: summarizeChatEvent(event),
-      state: summarizeNativeChatState(state),
-      targetSessionKey: sessionKey,
-    });
     return;
   }
 
@@ -759,19 +622,6 @@ export function applyChatEvent(state: NativeChatState, event: NormalizedGatewayE
     event: summarizeChatEvent(event),
     state: summarizeNativeChatState(state),
   });
-}
-
-function findStreamingDeltaMessage(bucket: NativeChatMessage[], messageId: string | undefined): NativeChatMessage | undefined {
-  if (messageId) {
-    return bucket.find((message) => message.role === "assistant" && message.messageId === messageId);
-  }
-  for (let index = bucket.length - 1; index >= 0; index -= 1) {
-    const message = bucket[index];
-    if (message.role === "assistant" && !message.messageId) {
-      return message;
-    }
-  }
-  return undefined;
 }
 
 function upsertToolActivityMessage(bucket: NativeChatMessage[], nextActivity: NativeChatToolActivity): boolean {
@@ -904,19 +754,6 @@ function summarizeNativeToolActivity(activity: NativeChatToolActivity): Record<s
   };
 }
 
-function attachMessageReferences(
-  state: NativeChatState,
-  sessionKey: string,
-  messageId: string,
-  references: NativeChatReference[],
-) {
-  const message = ensureMessageBucket(state, sessionKey).find((item) => item.messageId === messageId);
-  if (!message) {
-    return;
-  }
-  message.references = [...(message.references ?? []), ...references];
-}
-
 function coalesceToolActivityMessages(messages: NativeChatMessage[]): NativeChatMessage[] {
   const coalesced: NativeChatMessage[] = [];
   for (const message of messages) {
@@ -997,16 +834,17 @@ function summarizeNativeChatState(state: NativeChatState): Record<string, unknow
     activeSessionKey: state.activeSessionKey,
     respondingSessionKeys: [...state.respondingSessionKeys],
     sessionCount: state.sessions.length,
-    streamMessageKeys: [...state.streamMessageKeys.entries()],
   };
 }
 
 function summarizeChatEvent(event: NormalizedGatewayEvent): Record<string, unknown> {
+  const messageId = "messageId" in event && typeof event.messageId === "string" ? event.messageId : "";
+  const text = "text" in event && typeof event.text === "string" ? event.text : "";
   return {
     chatId: "chatId" in event ? event.chatId : "",
     kind: event.kind,
-    messageId: "messageId" in event ? event.messageId : "",
-    text: "text" in event ? summarizeDebugText(event.text) : undefined,
+    messageId,
+    text: text ? summarizeDebugText(text) : undefined,
   };
 }
 
@@ -1097,6 +935,8 @@ function conversationMessagesToNativeMessages(messages: ReturnType<typeof turnsT
     } : {}),
     timestamp: message.time,
     messageId: message.messageId || `agent-run:${index}`,
+    ...(message.turnId ? { turnId: message.turnId } : {}),
+    ...(message.turnStatus ? { turnStatus: message.turnStatus } : {}),
   }));
 }
 
@@ -1231,14 +1071,6 @@ function normalizeToolActivities(message: Record<string, unknown>): NativeChatTo
   }
 
   return activities;
-}
-
-function nativeToolMessageFromEvent(event: Extract<NormalizedGatewayEvent, { kind: "message.completed" }>): NativeChatToolActivity | null {
-  return toolActivityFromMessage({
-    ...event.raw,
-    content: event.text,
-    message_id: event.messageId,
-  });
 }
 
 function toolActivityFromMessage(message: Record<string, unknown>): NativeChatToolActivity | null {

--- a/src/app-core/gateway/desktopGatewayBridge.test.ts
+++ b/src/app-core/gateway/desktopGatewayBridge.test.ts
@@ -484,9 +484,12 @@ describe("desktop gateway bridge", () => {
 
     expect(events).toContainEqual({ event: "chat_created", chat_id: "chat-native" });
     expect(events).toContainEqual(expect.objectContaining({
-      event: "message",
+      event: "agent_event",
+      event_type: "message.completed",
       chat_id: "chat-native",
-      text: "native done",
+      payload: expect.objectContaining({
+        text: "native done",
+      }),
     }));
     expect(dispatched).toEqual([
       expect.objectContaining({

--- a/src/app-core/gateway/gateway.test.ts
+++ b/src/app-core/gateway/gateway.test.ts
@@ -2130,28 +2130,26 @@ describe("gateway WebSocket client", () => {
     expect(queue).toEqual([]);
   });
 
-  test("normalizes stream, browser, and agent-ui frames", () => {
+  test("normalizes browser, agent-ui, and agent event frames while ignoring legacy message streams", () => {
     expect(normalizeGatewayFrame({ event: "attached", chat_id: "chat-1" })).toMatchObject({
       kind: "attached",
       chatId: "chat-1",
     });
     expect(normalizeGatewayFrame({ event: "delta", text: "hi", message_id: "m1" })).toMatchObject({
-      kind: "message.delta",
-      text: "hi",
-      messageId: "m1",
+      kind: "unknown",
+      event: "delta",
     });
     expect(normalizeGatewayFrame({ event: "delta", text: "plan", is_reasoning: true })).toMatchObject({
-      kind: "message.delta",
-      reasoning: true,
+      kind: "unknown",
+      event: "delta",
     });
     expect(normalizeGatewayFrame({ event: "message", text: "done", message_id: "m2" })).toMatchObject({
-      kind: "message.completed",
-      text: "done",
-      messageId: "m2",
+      kind: "unknown",
+      event: "message",
     });
     expect(normalizeGatewayFrame({ event: "stream_end", chat_id: "chat-1" })).toMatchObject({
-      kind: "message.stream.completed",
-      chatId: "chat-1",
+      kind: "unknown",
+      event: "stream_end",
     });
     expect(normalizeGatewayFrame({ event: "usage", chat_id: "chat-1", usage: { total_tokens: 16384 } })).toMatchObject({
       kind: "usage",
@@ -2210,11 +2208,8 @@ describe("gateway WebSocket client", () => {
         },
       }),
     ).toMatchObject({
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "m3",
-      text: "streamed",
-      reasoning: false,
+      kind: "agent-ui.event",
+      eventType: "message.delta",
     });
     expect(
       normalizeGatewayFrame({
@@ -2245,11 +2240,8 @@ describe("gateway WebSocket client", () => {
         completed: false,
       }),
     ).toMatchObject({
-      kind: "message.delta",
-      chatId: "chat-1",
-      messageId: "cowork:session-1:agent-1:step-1",
-      text: "live answer",
-      reasoning: false,
+      kind: "unknown",
+      event: "cowork_stream",
     });
 
     expect(
@@ -2264,9 +2256,8 @@ describe("gateway WebSocket client", () => {
         completed: true,
       }),
     ).toMatchObject({
-      kind: "message.stream.completed",
-      chatId: "chat-1",
-      messageId: "cowork-mailbox:draft-1",
+      kind: "unknown",
+      event: "cowork_mailbox_stream",
     });
   });
 });

--- a/src/app-core/gateway/gatewayWebSocketClient.ts
+++ b/src/app-core/gateway/gatewayWebSocketClient.ts
@@ -18,9 +18,6 @@ export type NormalizedGatewayEvent =
   | { kind: "attached"; chatId: string; raw: Record<string, unknown> }
   | { kind: "chat.created"; chatId: string; raw: Record<string, unknown> }
   | { kind: "agent.event"; chatId?: string; raw: Record<string, unknown> }
-  | { kind: "message.delta"; chatId?: string; messageId?: string; text: string; reasoning: boolean; raw: Record<string, unknown> }
-  | { kind: "message.completed"; chatId?: string; messageId?: string; text: string; raw: Record<string, unknown> }
-  | { kind: "message.stream.completed"; chatId?: string; messageId?: string; raw: Record<string, unknown> }
   | { kind: "usage"; chatId?: string; tokenUsage: string; raw: Record<string, unknown> }
   | { kind: "browser.frame"; raw: Record<string, unknown> }
   | { kind: "browser.snapshot"; raw: Record<string, unknown> }
@@ -40,44 +37,6 @@ export function normalizeGatewayFrame(frame: unknown): NormalizedGatewayEvent {
       return { kind: "chat.created", chatId: stringValue(raw.chat_id), raw };
     case "agent_event":
       return { kind: "agent.event", chatId: optionalString(raw.chat_id), raw };
-    case "delta":
-    case "message_delta":
-      return {
-        kind: "message.delta",
-        chatId: optionalString(raw.chat_id),
-        messageId: optionalString(raw.message_id),
-        text: stringValue(raw.text ?? raw.delta ?? raw.content),
-        reasoning: raw.reasoning === true || raw.is_reasoning === true || raw.channel === "reasoning",
-        raw,
-      };
-    case "message":
-      return {
-        kind: "message.completed",
-        chatId: optionalString(raw.chat_id),
-        messageId: optionalString(raw.message_id),
-        text: stringValue(raw.text ?? raw.content),
-        raw,
-      };
-    case "reasoning_delta":
-      return {
-        kind: "message.delta",
-        chatId: optionalString(raw.chat_id),
-        messageId: optionalString(raw.message_id),
-        text: stringValue(raw.text ?? raw.delta ?? raw.content),
-        reasoning: true,
-        raw,
-      };
-    case "stream_end":
-      return {
-        kind: "message.stream.completed",
-        chatId: optionalString(raw.chat_id),
-        messageId: optionalString(raw.message_id),
-        raw,
-      };
-    case "cowork_stream":
-      return normalizeCoworkStreamFrame(raw);
-    case "cowork_mailbox_stream":
-      return normalizeCoworkMailboxStreamFrame(raw);
     case "usage":
       return {
         kind: "usage",
@@ -96,33 +55,6 @@ export function normalizeGatewayFrame(frame: unknown): NormalizedGatewayEvent {
       const payload = isRecord(raw.agent_ui_event) ? raw.agent_ui_event : {};
       const eventType = stringValue(payload.event_type ?? payload.type);
       const eventPayload = isRecord(payload.payload) ? payload.payload : {};
-      if (eventType === "message.delta" || eventType === "reasoning.delta") {
-        return {
-          kind: "message.delta",
-          chatId: optionalString(payload.chat_id) ?? optionalString(raw.chat_id),
-          messageId: optionalString(payload.message_id),
-          text: stringValue(eventPayload.text ?? payload.text),
-          reasoning: eventType === "reasoning.delta" || eventPayload.is_reasoning === true,
-          raw,
-        };
-      }
-      if (eventType === "message.completed") {
-        return {
-          kind: "message.completed",
-          chatId: optionalString(payload.chat_id) ?? optionalString(raw.chat_id),
-          messageId: optionalString(payload.message_id),
-          text: stringValue(eventPayload.text ?? payload.text),
-          raw,
-        };
-      }
-      if (eventType === "message.stream.completed") {
-        return {
-          kind: "message.stream.completed",
-          chatId: optionalString(payload.chat_id) ?? optionalString(raw.chat_id),
-          messageId: optionalString(payload.message_id),
-          raw,
-        };
-      }
       if (eventType === "usage.updated") {
         return {
           kind: "usage",
@@ -168,12 +100,14 @@ export function openGatewaySocket(config: GatewayConfig = DEFAULT_GATEWAY_CONFIG
     try {
       const raw = JSON.parse(String(event.data));
       const normalized = normalizeGatewayFrame(raw);
+      const messageId = "messageId" in normalized && typeof normalized.messageId === "string" ? normalized.messageId : "";
+      const text = "text" in normalized && typeof normalized.text === "string" ? normalized.text : "";
       logDesktopNativeChatDebug("socket.frame", {
         chatId: "chatId" in normalized ? normalized.chatId : "",
         event: isRecord(raw) ? stringValue(raw.event) : "",
         kind: normalized.kind,
-        messageId: "messageId" in normalized ? normalized.messageId : "",
-        text: "text" in normalized ? summarizeDebugText(normalized.text) : undefined,
+        messageId,
+        text: text ? summarizeDebugText(text) : undefined,
       });
       handlers.onEvent(normalized);
     } catch {
@@ -233,65 +167,6 @@ function stringValue(value: unknown): string {
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value ? value : undefined;
-}
-
-function normalizeCoworkStreamFrame(raw: Record<string, unknown>): NormalizedGatewayEvent {
-  const messageId = stableMessageId(
-    "cowork",
-    optionalString(raw.session_id),
-    optionalString(raw.agent_id),
-    optionalString(raw.step_id),
-  );
-  if (isTerminalStreamFrame(raw)) {
-    return {
-      kind: "message.stream.completed",
-      chatId: optionalString(raw.chat_id),
-      messageId,
-      raw,
-    };
-  }
-  return {
-    kind: "message.delta",
-    chatId: optionalString(raw.chat_id),
-    messageId,
-    text: stringValue(raw.text),
-    reasoning: false,
-    raw,
-  };
-}
-
-function normalizeCoworkMailboxStreamFrame(raw: Record<string, unknown>): NormalizedGatewayEvent {
-  const messageId = stableMessageId(
-    "cowork-mailbox",
-    optionalString(raw.draft_id) ?? optionalString(raw.tool_call_id) ?? optionalString(raw.session_id),
-  );
-  if (isTerminalStreamFrame(raw)) {
-    return {
-      kind: "message.stream.completed",
-      chatId: optionalString(raw.chat_id),
-      messageId,
-      raw,
-    };
-  }
-  return {
-    kind: "message.delta",
-    chatId: optionalString(raw.chat_id),
-    messageId,
-    text: stringValue(raw.text),
-    reasoning: false,
-    raw,
-  };
-}
-
-function isTerminalStreamFrame(raw: Record<string, unknown>): boolean {
-  const phase = stringValue(raw.phase);
-  const status = stringValue(raw.status);
-  return raw.completed === true || phase === "complete" || phase === "terminal" || status === "completed";
-}
-
-function stableMessageId(prefix: string, ...parts: Array<string | undefined>): string {
-  const values = parts.filter((part): part is string => Boolean(part));
-  return values.length ? `${prefix}:${values.join(":")}` : prefix;
 }
 
 function formatTokenUsage(value: unknown): string {

--- a/src/app-core/native/desktopNativeWebSocketBridge.test.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.test.ts
@@ -1071,6 +1071,72 @@ describe("desktop native WebSocket bridge", () => {
     }));
   });
 
+  test("attaches live memory references to the structured completed message", async () => {
+    const handlers = new Map<string, (payload: unknown) => void>();
+    const dispatch = deferred<unknown>();
+    const nativeTransport: NativeTransportApi = {
+      gatewayFrame: vi.fn(),
+      websocketMessage: vi.fn(),
+      dispatchWebsocketMessage: vi.fn(async () => dispatch.promise),
+      dispatchChannelInbound: vi.fn(),
+      startChannels: vi.fn(),
+      channelStatus: vi.fn(),
+      stopChannels: vi.fn(),
+    };
+    const socket = createDesktopNativeWebSocket({
+      url: "/ws",
+      nativeTransport,
+      listenToAgentEvent: (eventName, handler) => {
+        handlers.set(eventName, handler);
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+    socket.addEventListener("message", (event) => {
+      events.push(JSON.parse(String((event as MessageEvent).data)) as Record<string, unknown>);
+    });
+
+    await flushMicrotasks();
+    socket.send(JSON.stringify({ type: "message", chat_id: "chat-native", content: "hello" }));
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const request = vi.mocked(nativeTransport.dispatchWebsocketMessage).mock.calls[0]?.[0] as { runId?: string };
+    handlers.get(toDesktopNativeTauriEventName("agent.delta"))?.({
+      runId: request.runId,
+      delta: "live answer",
+      messageId: "message-live",
+    });
+    handlers.get(toDesktopNativeTauriEventName("agent.memory_reference"))?.({
+      runId: request.runId,
+      references: [{ title: "note_live", content: "Live memory" }],
+    });
+    dispatch.resolve({
+      transport: {
+        kind: "message",
+        chatId: "chat-native",
+        sessionId: "websocket:chat-native",
+        frames: [],
+      },
+      agent: {
+        runId: request.runId,
+        finalContent: "live answer",
+        stopReason: "final_response",
+      },
+    });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "message.completed",
+      payload: expect.objectContaining({
+        message_id: "message-live",
+        references: [{ title: "note_live", content: "Live memory" }],
+        text: "live answer",
+      }),
+      turn_id: request.runId,
+    }));
+  });
+
   test("projects TS worker browser frames into legacy WebUI browser frame events", async () => {
     const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {

--- a/src/app-core/native/desktopNativeWebSocketBridge.test.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.test.ts
@@ -69,14 +69,10 @@ describe("desktop native WebSocket bridge", () => {
     expect(events).not.toContainEqual(expect.objectContaining({
       event: "delta",
     }));
-    expect(events).toContainEqual({
+    expect(events).not.toContainEqual(expect.objectContaining({
       event: "stream_end",
       chat_id: "chat-native",
-      message_id: "message-1",
-      reason: "final_response",
-      _memory_references: [{ note_id: "note-1" }],
-      _recent_context_references: [{ evidence_id: "ev-1" }],
-    });
+    }));
     expect(events).toContainEqual(expect.objectContaining({
       event: "agent_event",
       event_type: "message.delta",
@@ -305,7 +301,7 @@ describe("desktop native WebSocket bridge", () => {
       }),
       turn_id: runId,
     }));
-    expect(events).toContainEqual(expect.objectContaining({
+    expect(events).not.toContainEqual(expect.objectContaining({
       event: "stream_end",
       chat_id: "chat-native",
     }));
@@ -526,7 +522,7 @@ describe("desktop native WebSocket bridge", () => {
     }));
   });
 
-  test("projects TS worker tool progress into legacy WebUI message frames", async () => {
+  test("projects TS worker tool progress into structured agent event frames", async () => {
     const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {
       gatewayFrame: vi.fn(),
@@ -584,38 +580,18 @@ describe("desktop native WebSocket bridge", () => {
       content: "file contents",
     });
 
-    expect(events).toContainEqual({
-      event: "message",
-      chat_id: "chat-native",
-      message_id: "run-2:call-read:args",
-      text: "read_file({\"path\":\"AGENTS.md\"})",
-      _progress: true,
-      _tool_call_id: "call-read",
-      _tool_detail: true,
-      _tool_hint: true,
-      _tool_name: "read_file",
-    });
-    expect(events).toContainEqual({
-      event: "message",
-      chat_id: "chat-native",
-      message_id: "run-2:call-read:start",
-      text: "read_file({\"path\":\"AGENTS.md\"})",
-      _progress: true,
-      _tool_call_id: "call-read",
-      _tool_detail: true,
-      _tool_hint: true,
-      _tool_name: "read_file",
-    });
-    expect(events).toContainEqual({
-      event: "message",
-      chat_id: "chat-native",
-      message_id: "run-2:call-read:result",
-      text: "file contents",
-      _progress: true,
-      _tool_call_id: "call-read",
-      _tool_name: "read_file",
-      _tool_result: true,
-    });
+    expect(events).not.toContainEqual(expect.objectContaining({ event: "message" }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "tool.call.arguments.delta",
+      step_id: "run-2:call-read",
+      payload: expect.objectContaining({
+        args_preview: "{\"path\":\"AGENTS.md\"}",
+        name: "read_file",
+        status: "running",
+        tool_call_id: "call-read",
+      }),
+    }));
     expect(events).toContainEqual(expect.objectContaining({
       event: "agent_event",
       schema_version: "tinybot.agent_event.v1",
@@ -702,17 +678,7 @@ describe("desktop native WebSocket bridge", () => {
       },
     });
 
-    expect(events).toContainEqual(expect.objectContaining({
-      event: "message",
-      message_id: "run-approval:call-spawn:result",
-      status: "blocked",
-      text: "Waiting for approval.",
-      _approval_id: "approval-1",
-      _approval_status: "approval_required",
-      _tool_call_id: "call-spawn",
-      _tool_name: "spawn",
-      _tool_result: true,
-    }));
+    expect(events).not.toContainEqual(expect.objectContaining({ event: "message" }));
     expect(events).toContainEqual({
       event: "approval_pending",
       chat_id: "chat-native",
@@ -869,16 +835,16 @@ describe("desktop native WebSocket bridge", () => {
       toolName: "spawn",
     });
 
+    expect(events).not.toContainEqual(expect.objectContaining({ event: "message" }));
     expect(events).toContainEqual(expect.objectContaining({
-      event: "message",
-      message_id: "run-approval:approval:approval-1:result",
-      status: "blocked",
-      text: "Waiting for approval.",
-      _approval_id: "approval-1",
-      _approval_status: "approval_required",
-      _tool_call_id: "call-spawn",
-      _tool_name: "spawn",
-      _tool_result: true,
+      event: "agent_event",
+      event_type: "approval.requested",
+      step_id: "run-approval:approval:approval-1",
+      payload: expect.objectContaining({
+        approval_id: "approval-1",
+        tool_call_id: "call-spawn",
+      }),
+      turn_id: "run-approval",
     }));
   });
 
@@ -1042,7 +1008,7 @@ describe("desktop native WebSocket bridge", () => {
     }));
   });
 
-  test("projects TS worker memory references and task progress into legacy WebUI message frames", async () => {
+  test("projects TS worker task progress into structured agent event frames", async () => {
     const handlers = new Map<string, (payload: unknown) => void>();
     const nativeTransport: NativeTransportApi = {
       gatewayFrame: vi.fn(),
@@ -1084,10 +1050,6 @@ describe("desktop native WebSocket bridge", () => {
     expect(handlers.get(toDesktopNativeTauriEventName("agent.memory_reference"))).toBeDefined();
     expect(handlers.get(toDesktopNativeTauriEventName("agent.task_progress"))).toBeDefined();
 
-    handlers.get(toDesktopNativeTauriEventName("agent.memory_reference"))?.({
-      runId: "run-4",
-      references: [{ note_id: "note-1", content: "Remembered preference" }],
-    });
     handlers.get(toDesktopNativeTauriEventName("agent.task_progress"))?.({
       runId: "run-4",
       toolCallId: "task-call",
@@ -1096,26 +1058,17 @@ describe("desktop native WebSocket bridge", () => {
       progress: { plan_id: "plan-1", completed: 1, total: 2 },
     });
 
-    expect(events).toContainEqual({
-      event: "message",
-      chat_id: "chat-native",
-      message_id: "run-4",
-      text: "",
-      _memory_references: [{ note_id: "note-1", content: "Remembered preference" }],
-    });
-    expect(events).toContainEqual({
-      event: "message",
-      chat_id: "chat-native",
-      message_id: "run-4:task-call:task-progress",
-      text: "Task progress updated.",
-      _progress: true,
-      _tool_call_id: "task-call",
-      _tool_name: "task",
-      _tool_result: true,
-      _task_event: true,
-      _task_plan_id: "plan-1",
-      _task_progress: { plan_id: "plan-1", completed: 1, total: 2 },
-    });
+    expect(events).not.toContainEqual(expect.objectContaining({ event: "message" }));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "agent_event",
+      event_type: "tool.call.completed",
+      payload: expect.objectContaining({
+        result_preview: "Task progress updated.",
+        status: "completed",
+        tool_call_id: "task-call",
+      }),
+      turn_id: "run-4",
+    }));
   });
 
   test("projects TS worker browser frames into legacy WebUI browser frame events", async () => {

--- a/src/app-core/native/desktopNativeWebSocketBridge.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.ts
@@ -237,20 +237,6 @@ class DesktopNativeWebSocket extends EventTarget {
     const finalContent = stringValue(agent?.finalContent);
     const run = runId ? this.activeRuns.get(runId) : undefined;
     const alreadyProjectedStream = Boolean((runId && this.completedStreamedRunIds.has(runId)) || run?.streamed);
-    if (finalContent && chatId && !alreadyProjectedStream) {
-      this.emitJson({
-        event: "message",
-        chat_id: chatId,
-        message_id: runId || `native:${chatId}`,
-        text: finalContent,
-      });
-      this.emitJson({
-        event: "stream_end",
-        chat_id: chatId,
-        message_id: runId || `native:${chatId}`,
-        reason: stringValue(agent?.stopReason) || "stop",
-      });
-    }
     if (finalContent && run && runId) {
       this.emitAgentEventFrame(run, runId, "message.completed", {
         message_id: run.messageId,
@@ -414,21 +400,18 @@ class DesktopNativeWebSocket extends EventTarget {
       const toolName = stringValue(payload.toolName) || stringValue(payload.tool_name) || current?.toolName || "tool";
       const argumentsText = `${current?.argumentsText ?? ""}${stringValue(payload.deltaText) || stringValue(payload.delta_text) || stringValue(payload.argumentsDelta) || stringValue(payload.arguments_delta)}`;
       this.activeToolCallDeltas.set(deltaKey, { argumentsText, toolCallId, toolName });
-      this.emitToolProgressFrame(run.chatId, `${runId}:${toolCallId}:args`, toolName, toolCallId, formatToolCallText(toolName, argumentsText), {
-        detail: true,
-        hint: true,
-      });
+      this.emitAgentEventFrame(run, runId, "tool.call.arguments.delta", {
+        args_preview: argumentsText,
+        name: toolName,
+        status: "running",
+        tool_call_id: toolCallId,
+      }, `${runId}:${toolCallId}`);
       return;
     }
     if (eventName === "agent.tool.start") {
       const toolCallId = stringValue(payload.toolCallId) || stringValue(payload.tool_call_id) || `${runId}:tool`;
       const cachedToolCall = this.findToolCallDelta(runId, toolCallId);
       const toolName = cachedToolCall?.toolName || stringValue(payload.toolName) || stringValue(payload.tool_name) || "tool";
-      const text = formatToolCallText(toolName, cachedToolCall?.argumentsText ?? "");
-      this.emitToolProgressFrame(run.chatId, `${runId}:${toolCallId}:start`, toolName, toolCallId, text, {
-        detail: true,
-        hint: true,
-      });
       this.emitAgentEventFrame(run, runId, "tool.call.started", {
         args_preview: cachedToolCall?.argumentsText ?? "",
         name: toolName,
@@ -458,15 +441,6 @@ class DesktopNativeWebSocket extends EventTarget {
       const awaitingApproval = isAwaitingApprovalToolResult(payload, metadata, text);
       const failed = ["failed", "error", "errored"].includes(stringValue(payload.status).toLowerCase());
       if (awaitingApproval) {
-        this.emitApprovalRequiredToolResultFrame({
-          approvalId,
-          messageId: `${runId}:${toolCallId}:result`,
-          run,
-          runId,
-          text: text || "Waiting for approval.",
-          toolCallId,
-          toolName,
-        });
         if (approvalId) {
           this.emitJson({
             event: "approval_pending",
@@ -486,9 +460,6 @@ class DesktopNativeWebSocket extends EventTarget {
         this.deleteToolCallDelta(runId, toolCallId);
         return;
       }
-      this.emitToolProgressFrame(run.chatId, `${runId}:${toolCallId}:result`, toolName, toolCallId, text, {
-        result: true,
-      });
       this.emitAgentEventFrame(run, runId, failed ? "tool.call.failed" : "tool.call.completed", {
         error: failed ? { message: text || "tool failed" } : undefined,
         name: toolName,
@@ -520,15 +491,6 @@ class DesktopNativeWebSocket extends EventTarget {
         || stringValue(operation.toolName)
         || stringValue(operation.tool_name)
         || "tool";
-      this.emitApprovalRequiredToolResultFrame({
-        approvalId,
-        messageId: approvalId ? `${runId}:approval:${approvalId}:result` : `${runId}:${toolCallId}:approval:result`,
-        run,
-        runId,
-        text: stringValue(payload.content) || stringValue(payload.text) || "Waiting for approval.",
-        toolCallId,
-        toolName,
-      });
       this.emitJson({
         event: "approval_pending",
         chat_id: run.chatId,
@@ -545,17 +507,6 @@ class DesktopNativeWebSocket extends EventTarget {
       return;
     }
     if (eventName === "agent.memory_reference") {
-      const references = arrayValue(payload.references);
-      if (references.length === 0) {
-        return;
-      }
-      this.emitJson({
-        event: "message",
-        chat_id: run.chatId,
-        message_id: run.messageId,
-        text: "",
-        _memory_references: references,
-      });
       return;
     }
     if (eventName === "agent.task_progress") {
@@ -563,7 +514,16 @@ class DesktopNativeWebSocket extends EventTarget {
       const toolCallId = stringValue(payload.toolCallId) || stringValue(payload.tool_call_id) || `${runId}:task-progress`;
       const toolName = stringValue(payload.toolName) || stringValue(payload.tool_name) || "task_progress";
       const planId = stringValue(payload.planId) || stringValue(payload.plan_id) || (isRecord(progress) ? stringValue(progress.plan_id) : "");
-      this.emitTaskProgressFrame(run.chatId, `${runId}:${toolCallId}:task-progress`, toolName, toolCallId, progress, planId);
+      this.emitAgentEventFrame(run, runId, "tool.call.completed", {
+        name: toolName,
+        result_json: {
+          ...(planId ? { plan_id: planId } : {}),
+          progress,
+        },
+        result_preview: "Task progress updated.",
+        status: "completed",
+        tool_call_id: toolCallId,
+      }, `${runId}:${toolCallId}:task-progress`);
       return;
     }
     if (isDelegatedAgentEventName(eventName)) {
@@ -622,13 +582,6 @@ class DesktopNativeWebSocket extends EventTarget {
     }
     if (eventName === "agent.done") {
       run.streamed = true;
-      this.emitJson({
-        event: "stream_end",
-        chat_id: run.chatId,
-        message_id: run.messageId,
-        reason: stringValue(payload.stopReason) || stringValue(payload.stop_reason) || "stop",
-        ...referenceMetadata(payload),
-      });
       this.emitAgentEventFrame(run, runId, "agent.turn.completed", {
         message_id: run.messageId,
         reason: stringValue(payload.stopReason) || stringValue(payload.stop_reason) || "stop",
@@ -669,80 +622,6 @@ class DesktopNativeWebSocket extends EventTarget {
         chat_id: run.chatId,
         payload: agentUiPayload,
       },
-    });
-  }
-
-  private emitTaskProgressFrame(
-    chatId: string,
-    messageId: string,
-    toolName: string,
-    toolCallId: string,
-    progress: unknown,
-    planId: string,
-  ): void {
-    this.emitJson({
-      event: "message",
-      chat_id: chatId,
-      message_id: messageId,
-      text: "Task progress updated.",
-      _progress: true,
-      _tool_call_id: toolCallId,
-      _tool_name: toolName,
-      _tool_result: true,
-      _task_event: true,
-      ...(planId ? { _task_plan_id: planId } : {}),
-      _task_progress: progress,
-    });
-  }
-
-  private emitToolProgressFrame(
-    chatId: string,
-    messageId: string,
-    toolName: string,
-    toolCallId: string,
-    text: string,
-    flags: { detail?: boolean; hint?: boolean; result?: boolean },
-    extra: Record<string, unknown> = {},
-  ): void {
-    this.emitJson({
-      event: "message",
-      chat_id: chatId,
-      message_id: messageId,
-      text,
-      _progress: true,
-      _tool_call_id: toolCallId,
-      ...(flags.detail ? { _tool_detail: true } : {}),
-      ...(flags.hint ? { _tool_hint: true } : {}),
-      ...(flags.result ? { _tool_result: true } : {}),
-      _tool_name: toolName,
-      ...extra,
-    });
-  }
-
-  private emitApprovalRequiredToolResultFrame(options: {
-    approvalId: string;
-    messageId: string;
-    run: ActiveRun;
-    runId: string;
-    text: string;
-    toolCallId: string;
-    toolName: string;
-  }): void {
-    this.emitToolProgressFrame(options.run.chatId, options.messageId, options.toolName, options.toolCallId, options.text, {
-      result: true,
-    }, {
-      ...(options.approvalId ? { _approval_id: options.approvalId } : {}),
-      _approval_status: "approval_required",
-      status: "blocked",
-    });
-    logDesktopNativeDebug("nativeWebSocket.agentEvent.projected", {
-      approvalId: options.approvalId,
-      chatId: options.run.chatId,
-      eventName: "agent.awaiting_approval",
-      messageId: options.messageId,
-      runId: options.runId,
-      toolCallId: options.toolCallId,
-      toolName: options.toolName,
     });
   }
 
@@ -1033,21 +912,6 @@ function sanitizeRunIdPart(value: string): string {
   return value.replace(/[^A-Za-z0-9_.:-]/g, "-") || "chat";
 }
 
-function referenceMetadata(payload: Record<string, unknown>): Record<string, unknown> {
-  const memoryReferences = arrayValue(payload._memory_references ?? payload.memoryReferences ?? payload.memory_references);
-  const recentContextReferences = arrayValue(
-    payload._recent_context_references ?? payload.recentContextReferences ?? payload.recent_context_references,
-  );
-  return {
-    ...(memoryReferences.length ? { _memory_references: memoryReferences } : {}),
-    ...(recentContextReferences.length ? { _recent_context_references: recentContextReferences } : {}),
-  };
-}
-
 function toolCallDeltaKey(runId: string, index: number): string {
   return `${runId}:${index}`;
-}
-
-function formatToolCallText(toolName: string, argumentsText: string): string {
-  return `${toolName}(${argumentsText})`;
 }

--- a/src/app-core/native/desktopNativeWebSocketBridge.ts
+++ b/src/app-core/native/desktopNativeWebSocketBridge.ts
@@ -62,6 +62,7 @@ type ActiveRun = {
   chatId: string;
   sessionId?: string;
   messageId: string;
+  references?: unknown[];
   streamed: boolean;
 };
 
@@ -240,6 +241,7 @@ class DesktopNativeWebSocket extends EventTarget {
     if (finalContent && run && runId) {
       this.emitAgentEventFrame(run, runId, "message.completed", {
         message_id: run.messageId,
+        ...(run.references?.length ? { references: run.references } : {}),
         text: finalContent,
       }, `${runId}:final`);
       if (!alreadyProjectedStream) {
@@ -312,7 +314,12 @@ class DesktopNativeWebSocket extends EventTarget {
 
   private registerRun(runId: string, run: ActiveRun): void {
     const existing = this.activeRuns.get(runId);
-    this.activeRuns.set(runId, existing ? { ...run, messageId: existing.messageId, streamed: existing.streamed } : run);
+    this.activeRuns.set(runId, existing ? {
+      ...run,
+      messageId: existing.messageId,
+      references: existing.references,
+      streamed: existing.streamed,
+    } : run);
     const pending = this.pendingAgentEvents.get(runId) ?? [];
     this.pendingAgentEvents.delete(runId);
     for (const event of pending) {
@@ -507,6 +514,14 @@ class DesktopNativeWebSocket extends EventTarget {
       return;
     }
     if (eventName === "agent.memory_reference") {
+      const references = arrayValue(payload.references)
+        .concat(arrayValue(payload._memory_references))
+        .concat(arrayValue(payload.memory_references))
+        .concat(arrayValue(payload._recent_context_references))
+        .concat(arrayValue(payload.recent_context_references));
+      if (references.length) {
+        run.references = [...(run.references ?? []), ...references];
+      }
       return;
     }
     if (eventName === "agent.task_progress") {

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -1164,6 +1164,48 @@ describe("ChatPage", () => {
     expect((await screen.findByTestId("message-local-user")).textContent).toContain("Hello immediately");
   });
 
+  it("preserves the optimistic first message while a pending session is being created", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const stores = createStores({ sessions: [] });
+    const pendingSession = {
+      id: "pending:1",
+      title: "New session",
+      updatedAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      status: "running" as const,
+    };
+    const optimisticMessage: ReactChatMessage = {
+      id: "local-user",
+      role: "user",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      text: "Summarize this pending chat",
+      status: "complete",
+    };
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([pendingSession]);
+    stores.sessionStore.create = vi.fn(async () => pendingSession);
+    stores.chatStore.load = vi.fn(async () => []);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+    stores.chatStore.send = vi.fn(async () => {
+      subscribed?.({ type: "message-sent", message: optimisticMessage });
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await screen.findByText("No sessions yet.");
+    await user.click(screen.getByRole("button", { name: "New Chat" }));
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "Summarize this pending chat");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
+    expect((await screen.findByTestId("message-local-user")).textContent).toContain("Summarize this pending chat");
+    expect(screen.queryByText("No sessions yet.")).toBeNull();
+  });
+
   it("renders assistant thinking and context separately from the answer", async () => {
     const stores = createStores();
     const streamingMessages: ReactChatMessage[] = [

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -375,6 +375,102 @@ describe("ChatPage", () => {
     expect(screen.getByRole("button", { name: /open details for shell/i })).toBeTruthy();
   });
 
+  it("hides copy and branch actions for reasoning-only assistant messages", async () => {
+    const stores = createStores();
+    const reasoningOnlyMessages: ReactChatMessage[] = [
+      {
+        id: "a-thinking",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        text: "",
+        reasoningText: "Checking the current workspace before answering.",
+        status: "complete",
+      },
+    ];
+    stores.chatStore.load = vi.fn(async () => reasoningOnlyMessages);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const message = await screen.findByTestId("message-a-thinking");
+    expect(within(message).getByLabelText("Thinking").textContent).toContain("Checking the current workspace before answering.");
+    expect(within(message).queryByRole("button", { name: "Copy message" })).toBeNull();
+    expect(within(message).queryByRole("button", { name: "Branch from here" })).toBeNull();
+    expect(message.querySelector(".react-message__actions")).toBeNull();
+  });
+
+  it("hides assistant copy and branch actions until the turn completes", async () => {
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Planning notes",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "running",
+      }],
+    });
+    const midTurnMessages: ReactChatMessage[] = [
+      {
+        id: "a-mid-turn",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        text: "Partial body that arrived before the turn completed.",
+        status: "complete",
+      },
+    ];
+    stores.chatStore.load = vi.fn(async () => midTurnMessages);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const message = await screen.findByTestId("message-a-mid-turn");
+    expect(within(message).queryByRole("button", { name: "Copy message" })).toBeNull();
+    expect(within(message).queryByRole("button", { name: "Branch from here" })).toBeNull();
+    expect(message.querySelector(".react-message__actions")).toBeNull();
+  });
+
+  it("keeps actions on completed turn messages while a later turn is running", async () => {
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Planning notes",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "running",
+      }],
+    });
+    const turnScopedMessages: ReactChatMessage[] = [
+      {
+        id: "a-completed-turn",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        text: "Final answer from the previous turn.",
+        status: "complete",
+        turnId: "turn-1",
+        turnStatus: "completed",
+      },
+      {
+        id: "a-running-turn",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+        text: "Current turn body before the turn is done.",
+        status: "complete",
+        turnId: "turn-2",
+        turnStatus: "running",
+      },
+    ];
+    stores.chatStore.load = vi.fn(async () => turnScopedMessages);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const completedMessage = await screen.findByTestId("message-a-completed-turn");
+    expect(within(completedMessage).getByRole("button", { name: "Copy message" })).toBeTruthy();
+    expect(within(completedMessage).getByRole("button", { name: "Branch from here" })).toBeTruthy();
+
+    const runningMessage = await screen.findByTestId("message-a-running-turn");
+    expect(within(runningMessage).queryByRole("button", { name: "Copy message" })).toBeNull();
+    expect(within(runningMessage).queryByRole("button", { name: "Branch from here" })).toBeNull();
+    expect(runningMessage.querySelector(".react-message__actions")).toBeNull();
+  });
+
   it("renders tool activity as collapsible agent steps", async () => {
     const user = userEvent.setup();
     const stores = createStores();
@@ -555,10 +651,8 @@ describe("ChatPage", () => {
     const card = await screen.findByRole("form", { name: "Travel preferences" });
     expect(card.textContent).toContain("Collect itinerary constraints before planning.");
 
-    await user.clear(within(card).getByLabelText("Destination"));
-    await user.type(within(card).getByLabelText("Destination"), "Singapore");
-    await user.clear(within(card).getByLabelText("Nights"));
-    await user.type(within(card).getByLabelText("Nights"), "4");
+    fireEvent.change(within(card).getByLabelText("Destination"), { target: { value: "Singapore" } });
+    fireEvent.change(within(card).getByLabelText("Nights"), { target: { value: "4" } });
     await user.click(within(card).getByRole("button", { name: "Save preferences" }));
 
     expect(submitAgentUiForm).toHaveBeenCalledWith("travel-preferences-1", {
@@ -586,6 +680,21 @@ describe("ChatPage", () => {
     expect(assistantActions?.getAttribute("data-align")).toBe("left");
   });
 
+  it("keeps assistant messages as inline prose instead of rounded bubbles", () => {
+    const css = readFileSync("src/react-workbench/styles/workbench.css", "utf8");
+
+    expect(css).toMatch(/\.react-message__body\s*{\s*min-width:\s*0;\s*padding:\s*2px 0;\s*}/s);
+    expect(css).toMatch(/\.react-message-reasoning\s*{[^}]*margin-bottom:\s*10px;[^}]*color:\s*var\(--color-muted\);/s);
+    expect(css).not.toMatch(/\.react-message-reasoning\s*{[^}]*padding-left:/s);
+    expect(css).not.toMatch(/\.react-message-reasoning\s*{[^}]*border-left:/s);
+    expect(css).toMatch(
+      /\.react-message\[data-role="user"\]\s*{[^}]*justify-self:\s*end;[^}]*max-width:\s*min\(680px, 92%\);[^}]*width:\s*fit-content;/s,
+    );
+    expect(css).toMatch(
+      /\.react-message\[data-role="user"\] \.react-message__body\s*{[^}]*border:\s*1px solid var\(--color-hairline\);[^}]*border-radius:\s*8px;[^}]*background:\s*var\(--color-surface-card\);[^}]*padding:\s*12px 14px;/s,
+    );
+  });
+
   it("renders assistant Markdown tables instead of raw pipe text", async () => {
     const stores = createStores();
     const markdownMessages: ReactChatMessage[] = [
@@ -611,6 +720,18 @@ describe("ChatPage", () => {
   it("copies individual message text from message actions", async () => {
     const user = userEvent.setup();
     const stores = createStores();
+    const copyMessages: ReactChatMessage[] = [
+      {
+        id: "a-copy",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+        text: "Visible answer.",
+        reasoningText: "Hidden planning.",
+        contextReferences: [{ id: "ctx-1", kind: "memory", title: "Memory", detail: "Context detail" }],
+        status: "complete",
+      },
+    ];
+    stores.chatStore.load = vi.fn(async () => copyMessages);
     const writeText = vi.fn(async () => undefined);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -619,10 +740,10 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
-    const assistantMessage = await screen.findByTestId("message-a1");
+    const assistantMessage = await screen.findByTestId("message-a-copy");
     await user.click(within(assistantMessage).getByRole("button", { name: "Copy message" }));
 
-    expect(writeText).toHaveBeenCalledWith("Yes.");
+    expect(writeText).toHaveBeenCalledWith("Visible answer.");
   });
 
   it("switches to the branched session after branching from a message", async () => {
@@ -705,7 +826,7 @@ describe("ChatPage", () => {
     const assistantMessage = await screen.findByTestId("message-a1");
     expect(within(assistantMessage).queryByRole("button", { name: "Branch from here" })).toBeNull();
 
-    subscribed?.({ type: "message.completed" });
+    subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
     await waitFor(() => expect(within(assistantMessage).getByRole("button", { name: "Branch from here" })).toBeTruthy());
   });
@@ -791,7 +912,7 @@ describe("ChatPage", () => {
     expect(screen.getByText("Already have 5 queued messages. Wait for processing or delete one before sending more.")).toBeTruthy();
   });
 
-  it("dispatches one queued composer input after normal completion", async () => {
+  it("dispatches one queued composer input after agent turn completion", async () => {
     const user = userEvent.setup();
     let subscribed: ((event: ChatEvent) => void) | undefined;
     const runningSession = {
@@ -819,7 +940,7 @@ describe("ChatPage", () => {
     await user.type(input, "second queued{enter}");
     expect(stores.chatStore.send).not.toHaveBeenCalled();
 
-    subscribed?.({ type: "message.completed" });
+    subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
     await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
       text: "first queued",
@@ -830,7 +951,7 @@ describe("ChatPage", () => {
     expect(queuedInputs.textContent).not.toContain("first queued");
     expect(queuedInputs.textContent).toContain("second queued");
 
-    subscribed?.({ type: "message.completed" });
+    subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
     await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
       text: "second queued",
@@ -840,7 +961,7 @@ describe("ChatPage", () => {
     expect(screen.queryByLabelText("Queued inputs")).toBeNull();
   });
 
-  it("dispatches queued input when a completion event also carries a message", async () => {
+  it("keeps queued input waiting after structured message completion until the turn completes", async () => {
     const user = userEvent.setup();
     let subscribed: ((event: ChatEvent) => void) | undefined;
     const runningSession = {
@@ -864,27 +985,23 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const input = await screen.findByRole("textbox", { name: /message/i });
-    await user.type(input, "queued after event message{enter}");
+    await user.type(input, "queued after full turn{enter}");
 
-    subscribed?.({
-      message: {
-        id: "assistant-completed",
-        role: "assistant",
-        createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
-        text: "Done.",
-        status: "complete",
-      },
-      type: "message.completed",
-    });
+    subscribed?.({ type: "agent.event", eventType: "message.completed" });
 
-    expect(await screen.findByTestId("message-assistant-completed")).toBeTruthy();
+    expect(stores.sessionStore.list).toHaveBeenCalledTimes(1);
+    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Queued inputs").textContent).toContain("queued after full turn");
+
+    subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
+
     await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
-      text: "queued after event message",
+      text: "queued after full turn",
       usePersistentRag: true,
     }));
   });
 
-  it("keeps queued inputs waiting when completion enters approval state", async () => {
+  it("ignores legacy completion events that carry a message", async () => {
     const user = userEvent.setup();
     let subscribed: ((event: ChatEvent) => void) | undefined;
     const runningSession = {
@@ -894,11 +1011,35 @@ describe("ChatPage", () => {
       updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
       status: "running" as const,
     };
-    const approvalSession = { ...runningSession, status: "waiting_approval" as const };
     const stores = createStores({ sessions: [runningSession] });
-    stores.sessionStore.list = vi.fn()
-      .mockResolvedValueOnce([runningSession])
-      .mockResolvedValueOnce([approvalSession]);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.type(input, "queued after event message{enter}");
+
+    subscribed?.({ type: "message.completed" });
+
+    expect(screen.queryByTestId("message-assistant-completed")).toBeNull();
+    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Queued inputs").textContent).toContain("queued after event message");
+  });
+
+  it("ignores legacy completion events for queued input dispatch", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const runningSession = {
+      id: "s1",
+      chatId: "chat-1",
+      title: "Planning notes",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+      status: "running" as const,
+    };
+    const stores = createStores({ sessions: [runningSession] });
     stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
       subscribed = listener;
       return () => undefined;
@@ -911,8 +1052,8 @@ describe("ChatPage", () => {
 
     subscribed?.({ type: "message.completed" });
 
-    await waitFor(() => expect(stores.sessionStore.list).toHaveBeenCalledTimes(2));
     expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(stores.sessionStore.list).toHaveBeenCalledTimes(1);
     const queuedInputs = screen.getByLabelText("Queued inputs");
     expect(queuedInputs.textContent).toContain("after approval");
     expect(queuedInputs.textContent).toContain("Waiting");
@@ -992,22 +1133,26 @@ describe("ChatPage", () => {
     const user = userEvent.setup();
     let subscribed: ((event: ChatEvent) => void) | undefined;
     const stores = createStores();
-    stores.chatStore.load = vi.fn(async () => []);
+    let sent = false;
+    const optimisticMessages: ReactChatMessage[] = [{
+      id: "local-user",
+      role: "user",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      text: "Hello immediately",
+      status: "complete",
+    }];
+    stores.chatStore.load = vi.fn(async () => (
+      sent
+        ? optimisticMessages
+        : []
+    ));
     stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
       subscribed = listener;
       return () => undefined;
     });
     stores.chatStore.send = vi.fn(async () => {
-      subscribed?.({
-        message: {
-          id: "local-user",
-          role: "user",
-          createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
-          text: "Hello immediately",
-          status: "complete",
-        },
-        type: "message-sent",
-      });
+      sent = true;
+      subscribed?.({ type: "message-sent" });
     });
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -40,7 +40,7 @@ import { TextType } from "../../components/ui/TextType";
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
 import type { ApprovalAction, ChatEvent, ChatInput, ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
 import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
-import { canBranchFromMessage, type ContextReferenceSummary, type ReactChatMessage, type ToolCallSummary } from "./messageActions";
+import { canBranchFromMessage, canCopyMessage, type ContextReferenceSummary, type ReactChatMessage, type ToolCallSummary } from "./messageActions";
 import type { AgentUiForm, AgentUiFormField } from "../../app-core/agent-ui/agentUiEvents";
 
 export type ChatPageProps = {
@@ -237,14 +237,10 @@ export function ChatPage({
     void loadMessages();
     void loadAgentUiForms();
     const unsubscribe = chatStore.subscribe(activeSessionId, (event) => {
-      const eventHasMessage = Boolean(event.message);
-      if (event.message) {
-        setMessages((current) => [...current, event.message as ReactChatMessage]);
-      }
       if (shouldReloadSessionsForChatEvent(event)) {
         void handleQueueStateAfterChatEvent(activeSessionId, event);
       }
-      if (!eventHasMessage && shouldReloadMessagesForChatEvent(event.type)) {
+      if (shouldReloadMessagesForChatEvent(event.type)) {
         void loadMessages();
       }
       if (shouldReloadAgentUiFormsForChatEvent(event.type)) {
@@ -955,8 +951,6 @@ function EmptyStateText({ text }: { text: string }) {
 const MESSAGE_RELOAD_EVENT_TYPES = new Set([
   "attached",
   "agent.event",
-  "message.completed",
-  "message.stream.completed",
   "message-sent",
   "interrupted",
 ]);
@@ -964,15 +958,12 @@ const MESSAGE_RELOAD_EVENT_TYPES = new Set([
 const SESSION_RELOAD_EVENT_TYPES = new Set([
   "chat.created",
   "interrupted",
-  "message.completed",
-  "message.stream.completed",
 ]);
 
 const TERMINAL_AGENT_EVENT_TYPES = new Set([
   "agent.turn.completed",
   "agent.turn.failed",
   "agent.turn.interrupted",
-  "message.completed",
 ]);
 
 function shouldReloadMessagesForChatEvent(type: string): boolean {
@@ -989,9 +980,7 @@ function shouldReloadAgentUiFormsForChatEvent(type: string): boolean {
 }
 
 function shouldDispatchQueuedInputForChatEvent(event: ChatEvent): boolean {
-  return event.type === "message.completed"
-    || event.type === "message.stream.completed"
-    || (event.type === "agent.event" && event.eventType === "agent.turn.completed");
+  return event.type === "agent.event" && event.eventType === "agent.turn.completed";
 }
 
 function shouldPauseQueuedInputsForChatEvent(event: ChatEvent): boolean {
@@ -1324,6 +1313,8 @@ function MessageBubble({
   sessionRunning: boolean;
 }) {
   const actionAlignment = message.role === "user" ? "right" : "left";
+  const showCopyAction = canCopyMessage(message, { sessionRunning });
+  const showBranchAction = canBranchFromMessage(message, { sessionRunning });
   return (
     <article
       className="react-message"
@@ -1338,16 +1329,20 @@ function MessageBubble({
         {message.toolCalls?.length ? <AgentSteps toolCalls={message.toolCalls} onOpenTool={onOpenTool} /> : null}
         {message.status === "streaming" ? <span className="react-message__streaming" aria-label="Agent is responding" /> : null}
       </div>
-      <div className="react-message__actions" data-align={actionAlignment}>
-        <button aria-label="Copy message" type="button" onClick={onCopy}>
-          <Copy aria-hidden="true" size={14} />
-        </button>
-        {canBranchFromMessage(message, { sessionRunning }) ? (
-          <button aria-label="Branch from here" type="button" onClick={onBranch}>
-            <GitBranch aria-hidden="true" size={14} />
-          </button>
-        ) : null}
-      </div>
+      {showCopyAction || showBranchAction ? (
+        <div className="react-message__actions" data-align={actionAlignment}>
+          {showCopyAction ? (
+            <button aria-label="Copy message" type="button" onClick={onCopy}>
+              <Copy aria-hidden="true" size={14} />
+            </button>
+          ) : null}
+          {showBranchAction ? (
+            <button aria-label="Branch from here" type="button" onClick={onBranch}>
+              <GitBranch aria-hidden="true" size={14} />
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </article>
   );
 }
@@ -1383,15 +1378,7 @@ function MessageContext({ references }: { references: ContextReferenceSummary[] 
 }
 
 function formatMessageForCopy(message: ReactChatMessage): string {
-  return [
-    message.reasoningText ? `Thinking:\n${message.reasoningText}` : "",
-    message.text,
-    message.contextReferences?.length
-      ? `Context:\n${message.contextReferences.map((reference) => (
-        [reference.title, reference.detail, reference.sourcePath].filter(Boolean).join(" - ")
-      )).join("\n")}`
-      : "",
-  ].filter(Boolean).join("\n\n");
+  return message.text;
 }
 
 type AgentStepStatus = "pending" | "active" | "success" | "waiting" | "error";

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -237,6 +237,15 @@ export function ChatPage({
     void loadMessages();
     void loadAgentUiForms();
     const unsubscribe = chatStore.subscribe(activeSessionId, (event) => {
+      if (event.message) {
+        setMessages((current) => (
+          current.some((message) => message.id === event.message?.id)
+            ? current
+            : [...current, event.message as ReactChatMessage]
+        ));
+        setLoadedMessageSessionId(activeSessionId);
+        return;
+      }
       if (shouldReloadSessionsForChatEvent(event)) {
         void handleQueueStateAfterChatEvent(activeSessionId, event);
       }

--- a/src/react-workbench/chat/messageActions.test.ts
+++ b/src/react-workbench/chat/messageActions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { canBranchFromMessage, visibleMessageActions, type ReactChatMessage } from "./messageActions";
+import { canBranchFromMessage, canCopyMessage, visibleMessageActions, type ReactChatMessage } from "./messageActions";
 
 const baseMessage: ReactChatMessage = {
   id: "m1",
@@ -13,6 +13,7 @@ describe("message action visibility", () => {
   it("never shows branch on user messages", () => {
     const message = { ...baseMessage, role: "user" as const };
     expect(canBranchFromMessage(message, { sessionRunning: false })).toBe(false);
+    expect(canCopyMessage(message, { sessionRunning: true })).toBe(true);
     expect(visibleMessageActions(message, { sessionRunning: false })).toEqual(["copy"]);
   });
 
@@ -24,5 +25,30 @@ describe("message action visibility", () => {
   it("hides branch while the session is running or the assistant message has tool calls", () => {
     expect(canBranchFromMessage(baseMessage, { sessionRunning: true })).toBe(false);
     expect(canBranchFromMessage({ ...baseMessage, toolCalls: [{ id: "t1", name: "shell", status: "complete" }] }, { sessionRunning: false })).toBe(false);
+  });
+
+  it("hides assistant copy and branch actions while the turn is still running", () => {
+    expect(canCopyMessage(baseMessage, { sessionRunning: true })).toBe(false);
+    expect(visibleMessageActions(baseMessage, { sessionRunning: true })).toEqual([]);
+  });
+
+  it("uses turn status instead of session status when the message has turn metadata", () => {
+    const completedTurnMessage = { ...baseMessage, turnId: "turn-1", turnStatus: "completed" };
+    const runningTurnMessage = { ...baseMessage, turnId: "turn-2", turnStatus: "running" };
+
+    expect(visibleMessageActions(completedTurnMessage, { sessionRunning: true })).toEqual(["copy", "branch"]);
+    expect(visibleMessageActions(runningTurnMessage, { sessionRunning: false })).toEqual([]);
+  });
+
+  it("hides copy and branch actions when a message has thinking but no body text", () => {
+    const reasoningOnlyMessage = {
+      ...baseMessage,
+      text: "  ",
+      reasoningText: "I am planning the response.",
+    };
+
+    expect(canCopyMessage(reasoningOnlyMessage, { sessionRunning: false })).toBe(false);
+    expect(canBranchFromMessage(reasoningOnlyMessage, { sessionRunning: false })).toBe(false);
+    expect(visibleMessageActions(reasoningOnlyMessage, { sessionRunning: false })).toEqual([]);
   });
 });

--- a/src/react-workbench/chat/messageActions.ts
+++ b/src/react-workbench/chat/messageActions.ts
@@ -37,6 +37,8 @@ export type ReactChatMessage = {
   contextReferences?: ContextReferenceSummary[];
   reasoningText?: string;
   toolCalls?: ToolCallSummary[];
+  turnId?: string;
+  turnStatus?: string;
 };
 
 export type MessageActionContext = {
@@ -45,13 +47,32 @@ export type MessageActionContext = {
 
 export type MessageAction = "copy" | "branch";
 
+export function canCopyMessage(message: ReactChatMessage, context: MessageActionContext): boolean {
+  if (!message.text.trim()) {
+    return false;
+  }
+  if (message.role !== "assistant") {
+    return true;
+  }
+  if (message.turnStatus) {
+    return message.status === "complete" && message.turnStatus === "completed";
+  }
+  return message.status === "complete" && !context.sessionRunning;
+}
+
 export function canBranchFromMessage(message: ReactChatMessage, context: MessageActionContext): boolean {
-  return message.role === "assistant"
-    && message.status === "complete"
-    && !context.sessionRunning
-    && !message.toolCalls?.length;
+  if (message.role !== "assistant" || !canCopyMessage(message, context) || message.toolCalls?.length) {
+    return false;
+  }
+  if (message.turnStatus) {
+    return message.turnStatus === "completed";
+  }
+  return !context.sessionRunning;
 }
 
 export function visibleMessageActions(message: ReactChatMessage, context: MessageActionContext): MessageAction[] {
+  if (!canCopyMessage(message, context)) {
+    return [];
+  }
   return canBranchFromMessage(message, context) ? ["copy", "branch"] : ["copy"];
 }

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -505,6 +505,8 @@ function mapMessage(
     ...(contextReferences.length ? { contextReferences } : {}),
     ...(message.reasoningContent ? { reasoningText: message.reasoningContent } : {}),
     ...(toolCalls.length ? { toolCalls } : {}),
+    ...(message.turnId ? { turnId: message.turnId } : {}),
+    ...(message.turnStatus ? { turnStatus: message.turnStatus } : {}),
   };
 }
 

--- a/src/react-workbench/services.ts
+++ b/src/react-workbench/services.ts
@@ -20,7 +20,6 @@ export type ChatInput = {
 export type ChatEvent = {
   type: string;
   eventType?: string;
-  message?: ReactChatMessage;
 };
 
 export type ApprovalAction = "approveOnce" | "approveSession" | "deny";

--- a/src/react-workbench/services.ts
+++ b/src/react-workbench/services.ts
@@ -20,6 +20,7 @@ export type ChatInput = {
 export type ChatEvent = {
   type: string;
   eventType?: string;
+  message?: ReactChatMessage;
 };
 
 export type ApprovalAction = "approveOnce" | "approveSession" | "deny";

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -63,7 +63,8 @@ function createServices(options: { messages?: ReactChatMessage[]; sessions?: Ses
 describe("DesktopShell", () => {
   it("keeps the React window frame draggable and top menus compact", () => {
     const controls = {
-      startDragging: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+      minimize: vi.fn(async () => undefined),
       toggleMaximize: vi.fn(async () => undefined),
     };
     render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={createServices()} windowControls={controls} />);
@@ -75,16 +76,33 @@ describe("DesktopShell", () => {
     expect(appMenuButton.querySelector(".react-top-menu__icon")).toBeTruthy();
     expect(appMenuButton.querySelector(".react-top-menu__label")?.textContent).toBe("App");
 
-    fireEvent.pointerDown(frame as Element);
-    expect(controls.startDragging).toHaveBeenCalledTimes(1);
-
     fireEvent.pointerDown(appMenuButton);
-    expect(controls.startDragging).toHaveBeenCalledTimes(1);
 
     fireEvent.doubleClick(frame as Element);
     expect(controls.toggleMaximize).toHaveBeenCalledTimes(1);
 
     fireEvent.doubleClick(appMenuButton);
+    expect(controls.toggleMaximize).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders working custom window control buttons", async () => {
+    const user = userEvent.setup();
+    const controls = {
+      close: vi.fn(async () => undefined),
+      minimize: vi.fn(async () => undefined),
+      toggleMaximize: vi.fn(async () => undefined),
+    };
+    render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={createServices()} windowControls={controls} />);
+
+    await user.click(screen.getByRole("button", { name: "Minimize window" }));
+    await user.click(screen.getByRole("button", { name: "Maximize window" }));
+    await user.click(screen.getByRole("button", { name: "Close window" }));
+
+    expect(controls.minimize).toHaveBeenCalledTimes(1);
+    expect(controls.toggleMaximize).toHaveBeenCalledTimes(1);
+    expect(controls.close).toHaveBeenCalledTimes(1);
+
+    fireEvent.doubleClick(screen.getByRole("group", { name: "Window controls" }));
     expect(controls.toggleMaximize).toHaveBeenCalledTimes(1);
   });
 
@@ -280,7 +298,8 @@ describe("DesktopShell", () => {
     });
     render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={services} />);
 
-    await screen.findByRole("button", { name: "Stop generation" });
+    const stopButton = await screen.findByRole("button", { name: "Stop generation" });
+    await waitFor(() => expect((stopButton as HTMLButtonElement).disabled).toBe(false));
     fireEvent.keyDown(window, { ctrlKey: true, key: "." });
 
     expect(services.chatStore.stop).toHaveBeenCalledWith("s1");

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -9,7 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
-import { BookOpen, Bot, ChevronRight, Code2, Command, FileText, Folder, MessageSquare, Settings, Wrench, X } from "lucide-react";
+import { BookOpen, Bot, ChevronRight, Code2, Command, FileText, Folder, MessageSquare, Minus, Settings, Square, Wrench, X } from "lucide-react";
 import { ChatPage } from "../chat/ChatPage";
 import type { AppServices, WorkspaceFileSummary } from "../services";
 
@@ -33,7 +33,8 @@ const routeItems: Array<{ id: AppRoute; label: string; icon: typeof MessageSquar
 ];
 
 type WindowFrameControls = {
-  startDragging(): Promise<void>;
+  close(): Promise<void>;
+  minimize(): Promise<void>;
   toggleMaximize(): Promise<void>;
 };
 
@@ -204,18 +205,18 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
     return () => window.removeEventListener("pointerdown", onWindowPointerDown);
   }, []);
 
-  function handleFramePointerDown(event: ReactPointerEvent<HTMLElement>) {
-    if (event.button !== 0 || isWindowFrameInteractiveTarget(event.target, event.currentTarget)) {
-      return;
-    }
-    void frameControls?.startDragging().catch(logWindowFrameError);
-  }
-
   function handleFrameDoubleClick(event: ReactMouseEvent<HTMLElement>) {
     if (isWindowFrameInteractiveTarget(event.target, event.currentTarget)) {
       return;
     }
     void frameControls?.toggleMaximize().catch(logWindowFrameError);
+  }
+
+  function runWindowFrameAction(action: "close" | "minimize" | "toggleMaximize") {
+    if (!frameControls) {
+      return;
+    }
+    void frameControls[action]().catch(logWindowFrameError);
   }
 
   function handleTopMenuTrigger(event: ReactMouseEvent<HTMLButtonElement>, label: TopMenuLabel) {
@@ -335,7 +336,6 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
         data-tauri-drag-region=""
         role="banner"
         onDoubleClick={handleFrameDoubleClick}
-        onPointerDown={handleFramePointerDown}
       >
         <div className="react-window-frame__brand" data-tauri-drag-region="">Tinybot</div>
         <nav className="react-top-menu" aria-label="Application menu">
@@ -383,6 +383,42 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
         >
           <Command aria-hidden="true" size={16} />
         </button>
+        <div
+          aria-label="Window controls"
+          className="react-window-frame__controls"
+          data-no-window-drag=""
+          role="group"
+          onDoubleClick={stopWindowFrameEvent}
+          onPointerDown={stopWindowFrameEvent}
+        >
+          <button
+            aria-label="Minimize window"
+            className="react-window-frame__control"
+            title="Minimize"
+            type="button"
+            onClick={() => runWindowFrameAction("minimize")}
+          >
+            <Minus aria-hidden="true" size={14} />
+          </button>
+          <button
+            aria-label="Maximize window"
+            className="react-window-frame__control"
+            title="Maximize"
+            type="button"
+            onClick={() => runWindowFrameAction("toggleMaximize")}
+          >
+            <Square aria-hidden="true" size={12} />
+          </button>
+          <button
+            aria-label="Close window"
+            className="react-window-frame__control react-window-frame__control--close"
+            title="Close"
+            type="button"
+            onClick={() => runWindowFrameAction("close")}
+          >
+            <X aria-hidden="true" size={15} />
+          </button>
+        </div>
       </header>
 
       <div className="react-workbench-layout">

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -111,10 +111,10 @@ button:disabled {
 
 .react-window-frame {
   display: grid;
-  grid-template-columns: auto auto minmax(80px, 1fr) auto;
+  grid-template-columns: auto auto minmax(80px, 1fr) auto auto;
   align-items: center;
-  gap: 12px;
-  padding: 0 12px;
+  gap: 8px;
+  padding: 0 8px 0 12px;
   border-bottom: 1px solid var(--color-hairline);
   background: var(--color-canvas);
   user-select: none;
@@ -145,6 +145,44 @@ button:disabled {
   min-width: 32px;
   min-height: 32px;
   padding: 6px 9px;
+}
+
+.react-window-frame__controls {
+  display: flex;
+  align-items: stretch;
+  align-self: stretch;
+  margin-right: -8px;
+}
+
+.react-window-frame__control {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  min-width: 44px;
+  height: 100%;
+  min-height: 42px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: default;
+}
+
+.react-window-frame__control:hover,
+.react-window-frame__control:focus-visible {
+  background: var(--color-surface-soft);
+  color: var(--color-ink);
+}
+
+.react-window-frame__control:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 55%, transparent);
+  outline-offset: -2px;
+}
+
+.react-window-frame__control--close:hover,
+.react-window-frame__control--close:focus-visible {
+  background: #c42b1c;
+  color: #fff;
 }
 
 .react-top-menu__group {
@@ -877,18 +915,19 @@ button:disabled {
 .react-message[data-role="user"] {
   justify-self: end;
   max-width: min(680px, 92%);
+  width: fit-content;
 }
 
 .react-message__body {
   min-width: 0;
-  border: 1px solid var(--color-hairline);
-  border-radius: 8px;
-  background: #fff;
-  padding: 12px 14px;
+  padding: 2px 0;
 }
 
 .react-message[data-role="user"] .react-message__body {
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
   background: var(--color-surface-card);
+  padding: 12px 14px;
 }
 
 .react-message__body p {
@@ -901,13 +940,20 @@ button:disabled {
   gap: 10px;
 }
 
-.react-message-reasoning,
 .react-message-context {
   display: grid;
   gap: 7px;
   margin-bottom: 10px;
   border-left: 2px solid var(--color-hairline-strong);
   padding-left: 10px;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-message-reasoning {
+  display: grid;
+  gap: 7px;
+  margin-bottom: 10px;
   color: var(--color-muted);
   font-size: 12px;
 }


### PR DESCRIPTION
﻿## Summary
- Move chat streaming and completion handling to structured `agent.event` frames only.
- Remove legacy top-level message stream handling (`delta`, `message`, `stream_end`, `message.stream.completed`) from the frontend/native chat path.
- Scope message actions to turn state so copy/branch actions appear only after the owning turn completes.
- Include related chat UI updates for assistant prose layout, user alignment, and desktop window controls.

## Impact
- ChatPage now reloads and dispatches queued inputs from `agent.event`, with queued messages sent only after `agent.turn.completed`.
- Native WebSocket projection emits tool, approval, task progress, message, and turn lifecycle updates through structured agent events.
- Legacy compatibility state such as `streamMessageKeys` and direct `ChatEvent.message` injection is removed.

## Validation
- `npm test -- src/app-core/gateway/gateway.test.ts src/react-workbench/chat/ChatPage.test.tsx src/app-core/native/desktopNativeWebSocketBridge.test.ts src/app-core/chat/nativeChat.test.ts src/react-workbench/defaultServices.test.ts`
- `npm run build`
