### PR TITLE
feat: add settings center and context usage UI

### DIFF
--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -155,9 +155,26 @@ Known worker error sources:
 | `apply_config_patch_result` | `{ result: ConfigPatchBridgeResult }` | `ConfigPatchApplyResult` |
 | `apply_config_operations` | `{ request: ConfigOperationRequest }` | `ConfigPatchApplyResult` |
 
+Config commands use `$HOME/.tinybot/config.json`. On Rust backend startup, and before each config
+command loads the store, the backend ensures the config file exists. If the file is missing it creates
+a schema v1 default config with:
+
+- `schemaVersion: 1`
+- `agents.defaults.activeProfile: "deepseek-default"`
+- `agents.defaults.model: "deepseek-v4-pro"`
+- `providers.profiles.deepseek-default` with DeepSeek V4 models
+- `gateway.host: "127.0.0.1"` and `gateway.port: 18790`
+
+Existing files are never overwritten by this initialization path, including invalid JSON or non-object
+config files. If default creation succeeds, config snapshots include an info diagnostic with code
+`DefaultConfigCreated`. If default creation fails, snapshots still return effective in-memory defaults
+and include a warning diagnostic with code `DefaultConfigCreateFailed`.
+
 `SettingsSnapshot` is the Rust-owned settings control-center projection for the first settings MVP.
 It is intended for frontend settings UI callers that need grouped fields, scope/source metadata,
 readonly runtime status, and secret-safe field metadata without reading arbitrary raw config JSON.
+Returned field paths are canonical camelCase config paths; legacy snake_case paths are accepted for
+read compatibility and normalized on save.
 
 ```json
 {
@@ -175,7 +192,7 @@ readonly runtime status, and secret-safe field metadata without reading arbitrar
         {
           "id": "provider-profile-openai-work-api-key",
           "label": "API key",
-          "path": "providers.profiles.openai-work.api_key",
+          "path": "providers.profiles.openai-work.apiKey",
           "scope": "profile",
           "source": "secret",
           "valueType": "secret",
@@ -187,7 +204,7 @@ readonly runtime status, and secret-safe field metadata without reading arbitrar
             "copyable": true,
             "exportable": false,
             "loggable": false,
-            "displayValue": "••••••••"
+            "displayValue": "********"
           },
           "risk": "sensitive",
           "sideEffect": "none"
@@ -218,6 +235,24 @@ The first version intentionally does not include Knowledge, Memory, Cowork, Chan
 web/exec/browser tool toggles, telemetry/crash-report controls, or raw JSON editing fields.
 `gateway.host` is projected as readonly `127.0.0.1`; `gateway.port` is editable. Secret fields
 return `value: null` with `secret` metadata and must remain redacted in exported/public config.
+Provider selection is profile-based. New config should use `agents.defaults.activeProfile` and
+`providers.profiles.<profileId>.provider`; `agents.defaults.provider: "auto"` is a legacy value only.
+The built-in provider catalog currently exposes only `deepseek`, `dashscope`, and `openai`.
+
+Provider model discovery:
+
+- `deepseek` uses the OpenAI-compatible `GET {apiBase}/models` API. The default `apiBase` is
+  `https://api.deepseek.com`, so discovery calls `https://api.deepseek.com/models`.
+- `openai` uses `GET https://api.openai.com/v1/models` by default.
+- `dashscope` uses the same OpenAI-compatible model discovery shape against its configured
+  `apiBase`, so the default discovery URL is
+  `https://dashscope.aliyuncs.com/compatible-mode/v1/models`.
+
+`POST /api/provider-models` accepts `{ provider, profile, apiBase, refreshLive }`. When
+`refreshLive: true` is used for an OpenAI-compatible provider, the backend reads the configured
+profile API key server-side and merges live results into the returned `models` list with source
+`live`. Missing credentials or unsupported discovery are returned as `warning` without exposing
+secrets.
 
 `ConfigEditorSnapshot`:
 
@@ -233,16 +268,20 @@ return `value: null` with `secret` metadata and must remain redacted in exported
 }
 ```
 
+The editor snapshot is intended for expert/debug views and public config summaries. Regular Settings
+UI should prefer `SettingsSnapshot` once the frontend is migrated to the Rust-owned settings schema.
+
 `ConfigOperationRequest`:
 
 ```json
 {
   "expectedRevision": "optional-current-revision",
   "operations": [
-    { "op": "replace", "path": "agents.defaults.model", "value": "gpt-5" },
+    { "op": "replace", "path": "agents.defaults.model", "value": "deepseek-v4-pro" },
+    { "op": "replace", "path": "agents.defaults.activeProfile", "value": "deepseek-default" },
     { "op": "remove", "path": "agents.defaults.timezone" },
-    { "op": "secretReplace", "path": "providers.openai.api_key", "value": "sk-..." },
-    { "op": "secretRemove", "path": "providers.openai.api_key" }
+    { "op": "secretReplace", "path": "providers.profiles.deepseek-default.apiKey", "value": "sk-..." },
+    { "op": "secretRemove", "path": "providers.profiles.deepseek-default.apiKey" }
   ]
 }
 ```
@@ -282,7 +321,7 @@ return `value: null` with `secret` metadata and must remain redacted in exported
   "runId": "run-1",
   "sessionId": "websocket:chat-1",
   "messages": [{ "role": "user", "content": "Hello" }],
-  "model": "gpt-5",
+  "model": "deepseek-v4-pro",
   "maxIterations": 20,
   "stream": true,
   "metadata": {}
@@ -328,8 +367,8 @@ Key response shapes used by the lower-level session RPC:
   "started_at": "...",
   "updated_at": "...",
   "completed_at": null,
-  "model": "gpt-5",
-  "provider": "openai",
+  "model": "deepseek-v4-pro",
+  "provider": "deepseek",
   "hasCheckpoint": true,
   "finalContentPreview": "..."
 }
@@ -528,7 +567,7 @@ await invoke("worker_transport_dispatch_websocket_message", {
     attachedChatId: "chat-1",
     sessionExists: true,
     editablePaths: ["src/main.ts"],
-    model: "gpt-5",
+    model: "deepseek-v4-pro",
     maxIterations: 20,
     runId: "run-1",
     stream: true
@@ -727,6 +766,36 @@ The Rust backend can emit live events through Tauri. Dotted worker event names a
 - `diagnostics.log`
 - `worker.status`
 
+`agent.usage` payloads preserve provider-returned OpenAI-compatible usage fields such as
+`prompt_tokens`, `completion_tokens`, and `total_tokens`. The Rust agent runtime also appends
+context-window budget fields:
+
+- `context_window_tokens` / `contextWindowTokens`: effective context window from
+  `agents.defaults.contextWindowTokens` or the backend default.
+- `context_window_used_tokens` / `contextWindowUsedTokens`: provider `prompt_tokens` when present,
+  then provider `total_tokens`, otherwise the local request estimate.
+- `context_window_remaining_tokens` / `contextWindowRemainingTokens`: remaining context budget.
+- `estimated_context_tokens` / `estimatedContextTokens`: local approximate token count for the
+  request sent after context-window trimming.
+- `context_window_strategy` / `contextWindowStrategy`: effective strategy, currently `discard` or
+  `compact`.
+- `percent`: context-window usage percentage.
+
+Rust agent context-window controls are read from `agents.defaults` or the run spec:
+
+- `contextWindowTokens` / `context_window_tokens`: effective context window. The fallback is
+  `128000`.
+- `contextWindowStrategy` / `context_window_strategy`: `discard` or `compact`. The fallback is
+  `discard`.
+- `compactTriggerPercent` / `compact_trigger_percent`: percentage threshold for `compact`; default
+  `90`.
+- `compactSummaryMaxTokens` / `compact_summary_max_tokens`: max completion tokens for the internal
+  summary request; default `1024`.
+
+`discard` keeps the newest messages that fit the window. `compact` sends older messages through an
+internal non-streaming `chat/completions` request, inserts the returned summary as a system message,
+and keeps recent messages. If compaction fails, the runtime falls back to `discard`.
+
 `NativeBackendEvent` shape:
 
 ```json
@@ -816,7 +885,7 @@ await invoke("apply_config_operations", {
   request: {
     expectedRevision: currentRevision,
     operations: [
-      { op: "replace", path: "agents.defaults.model", value: "gpt-5" }
+      { op: "replace", path: "agents.defaults.model", value: "deepseek-v4-pro" }
     ]
   }
 });

--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -33,6 +33,8 @@ pub enum ConfigDiagnosticLevel {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConfigDiagnosticCode {
     MissingConfig,
+    DefaultConfigCreated,
+    DefaultConfigCreateFailed,
     InvalidJson,
     InvalidConfig,
     AliasConflict,
@@ -560,6 +562,7 @@ fn canonical_config_segment(parent: &[String], _index: usize, segment: &str) -> 
             "active_profile" => "activeProfile".to_string(),
             "max_tokens" => "maxTokens".to_string(),
             "context_block_limit" => "contextBlockLimit".to_string(),
+            "context_window_strategy" => "contextWindowStrategy".to_string(),
             "max_tool_result_chars" => "maxToolResultChars".to_string(),
             "reasoning_effort" => "reasoningEffort".to_string(),
             other => other.to_string(),
@@ -576,6 +579,17 @@ fn canonical_config_segment(parent: &[String], _index: usize, segment: &str) -> 
     }
     if parent == ["gateway", "heartbeat"] && segment == "interval_s" {
         return "intervalS".to_string();
+    }
+    if parent.len() == 3 && parent[0] == "providers" && parent[1] == "profiles" {
+        return match segment {
+            "display_name" => "displayName".to_string(),
+            "api_key" => "apiKey".to_string(),
+            "api_base" => "apiBase".to_string(),
+            "request_timeout_ms" => "requestTimeoutMs".to_string(),
+            "default_model" => "defaultModel".to_string(),
+            "supports_model_discovery" => "supportsModelDiscovery".to_string(),
+            other => other.to_string(),
+        };
     }
     if parent == ["knowledge"] {
         return match segment {
@@ -1190,7 +1204,7 @@ mod tests {
         assert_eq!(snapshot.explicit_public_config, json!({}));
         assert_eq!(
             snapshot.effective_public_config["agents"]["defaults"]["model"],
-            "deepseek-reasoner"
+            "deepseek-v4-pro"
         );
         assert_eq!(snapshot.origins["agents.defaults.model"], "default");
     }
@@ -1373,7 +1387,7 @@ mod tests {
         let fixture = ConfigStoreFixture::new();
         let path = fixture.write(
             "config.json",
-            r#"{"agents":{"defaults":{"maxTokens":2048,"max_tokens":2048}}}"#,
+            r#"{"agents":{"defaults":{"maxTokens":2048,"max_tokens":2048,"contextWindowStrategy":"discard","context_window_strategy":"discard"}}}"#,
         );
         let mut store = ConfigStore::load(path.clone(), default_snapshot())
             .expect("fixture config should load");
@@ -1381,21 +1395,40 @@ mod tests {
         let result = store
             .apply_operations(ConfigOperationRequest {
                 expected_revision: Some(store.revision()),
-                operations: vec![ConfigOperation::Replace {
-                    path: "agents.defaults.max_tokens".to_string(),
-                    value: json!(8192),
-                }],
+                operations: vec![
+                    ConfigOperation::Replace {
+                        path: "agents.defaults.max_tokens".to_string(),
+                        value: json!(8192),
+                    },
+                    ConfigOperation::Replace {
+                        path: "agents.defaults.context_window_strategy".to_string(),
+                        value: json!("compact"),
+                    },
+                ],
             })
             .expect("alias operation should save");
 
         assert!(result.ok);
-        assert_eq!(result.updated_fields, vec!["agents.defaults.maxTokens"]);
+        assert_eq!(
+            result.updated_fields,
+            vec![
+                "agents.defaults.maxTokens",
+                "agents.defaults.contextWindowStrategy"
+            ]
+        );
         let saved = serde_json::from_str::<serde_json::Value>(
             &fs::read_to_string(path).expect("patched config should save"),
         )
         .expect("patched config should be JSON");
         assert_eq!(saved["agents"]["defaults"]["maxTokens"], 8192);
+        assert_eq!(
+            saved["agents"]["defaults"]["contextWindowStrategy"],
+            "compact"
+        );
         assert!(saved["agents"]["defaults"].get("max_tokens").is_none());
+        assert!(saved["agents"]["defaults"]
+            .get("context_window_strategy")
+            .is_none());
     }
 
     #[test]
@@ -1509,7 +1542,7 @@ mod tests {
         json!({
             "agents": {
                 "defaults": {
-                    "model": "deepseek-reasoner"
+                    "model": "deepseek-v4-pro"
                 }
             }
         })

--- a/src-tauri/src/desktop_cron.rs
+++ b/src-tauri/src/desktop_cron.rs
@@ -242,6 +242,6 @@ pub(crate) fn cron_model_from_config(config_snapshot: &serde_json::Value) -> Str
         .pointer("/agents/defaults/model")
         .and_then(serde_json::Value::as_str)
         .filter(|model| !model.trim().is_empty())
-        .unwrap_or("deepseek-reasoner")
+        .unwrap_or("deepseek-v4-pro")
         .to_string()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,8 +55,8 @@ use crate::agent_loop_runtime_protocol::{
     AgentRuntimeEventSource, AgentRuntimeEventVisibility, AgentRuntimePhase,
 };
 use crate::config_store::{
-    ConfigEditorSnapshot, ConfigOperationRequest, ConfigPatchApplyResult, ConfigPatchBridgeResult,
-    ConfigStore,
+    ConfigDiagnostic, ConfigDiagnosticCode, ConfigDiagnosticLevel, ConfigEditorSnapshot,
+    ConfigOperationRequest, ConfigPatchApplyResult, ConfigPatchBridgeResult, ConfigStore,
 };
 use crate::desktop_cron::{
     start_worker_cron_timer, stop_worker_cron_timer, worker_cron_dispatch_due,
@@ -2028,6 +2028,8 @@ fn apply_config_patch_result_to_path(
     default_snapshot: serde_json::Value,
     result: ConfigPatchBridgeResult,
 ) -> Result<ConfigPatchApplyResult, String> {
+    ensure_default_config_file(config_path)
+        .map_err(|error| format!("failed to initialize default config: {error}"))?;
     let mut store = ConfigStore::load(config_path.to_path_buf(), default_snapshot)
         .map_err(|error| format!("failed to load config store: {error}"))?;
     store
@@ -2039,22 +2041,30 @@ fn config_editor_snapshot_from_path(
     config_path: &Path,
     default_snapshot: serde_json::Value,
 ) -> Result<ConfigEditorSnapshot, String> {
+    let ensure_diagnostics = ensure_default_config_file(config_path)
+        .map_err(|error| format!("failed to initialize default config: {error}"))?;
     let store = ConfigStore::load(config_path.to_path_buf(), default_snapshot)
         .map_err(|error| format!("failed to load config store: {error}"))?;
-    Ok(store.editor_snapshot())
+    let mut snapshot = store.editor_snapshot();
+    snapshot.diagnostics.splice(0..0, ensure_diagnostics);
+    Ok(snapshot)
 }
 
 fn get_settings_snapshot_from_path(
     config_path: &Path,
     default_snapshot: serde_json::Value,
 ) -> Result<SettingsSnapshot, String> {
+    let ensure_diagnostics = ensure_default_config_file(config_path)
+        .map_err(|error| format!("failed to initialize default config: {error}"))?;
     let store = ConfigStore::load(config_path.to_path_buf(), default_snapshot)
         .map_err(|error| format!("failed to load config store: {error}"))?;
+    let mut diagnostics = ensure_diagnostics;
+    diagnostics.extend(store.diagnostics().to_vec());
     Ok(build_settings_snapshot(SettingsSnapshotInput {
         config: store.snapshot().clone(),
         config_path: store.config_path().to_path_buf(),
         revision: store.revision(),
-        diagnostics: store.diagnostics().to_vec(),
+        diagnostics,
     }))
 }
 
@@ -2063,11 +2073,45 @@ fn apply_config_operations_to_path(
     default_snapshot: serde_json::Value,
     request: ConfigOperationRequest,
 ) -> Result<ConfigPatchApplyResult, String> {
+    ensure_default_config_file(config_path)
+        .map_err(|error| format!("failed to initialize default config: {error}"))?;
     let mut store = ConfigStore::load(config_path.to_path_buf(), default_snapshot)
         .map_err(|error| format!("failed to load config store: {error}"))?;
     store
         .apply_operations(request)
         .map_err(|error| format!("failed to apply native config operations: {error}"))
+}
+
+fn ensure_default_config_file(config_path: &Path) -> Result<Vec<ConfigDiagnostic>, std::io::Error> {
+    match std::fs::metadata(config_path) {
+        Ok(_) => Ok(Vec::new()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            match write_default_config_file(config_path) {
+                Ok(()) => Ok(vec![ConfigDiagnostic {
+                    level: ConfigDiagnosticLevel::Info,
+                    code: ConfigDiagnosticCode::DefaultConfigCreated,
+                    message: "default config file created".to_string(),
+                    path: Some(config_path.to_path_buf()),
+                }]),
+                Err(error) => Ok(vec![ConfigDiagnostic {
+                    level: ConfigDiagnosticLevel::Warning,
+                    code: ConfigDiagnosticCode::DefaultConfigCreateFailed,
+                    message: format!("failed to create default config file: {error}"),
+                    path: Some(config_path.to_path_buf()),
+                }]),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn write_default_config_file(config_path: &Path) -> Result<(), std::io::Error> {
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let contents = serde_json::to_string_pretty(&experimental_worker_default_config_snapshot())
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))?;
+    std::fs::write(config_path, contents)
 }
 
 fn worker_echo_agent_with_options(
@@ -6711,10 +6755,30 @@ fn expand_tinybot_workspace_path(workspace: &str) -> PathBuf {
 
 fn experimental_worker_default_config_snapshot() -> serde_json::Value {
     serde_json::json!({
+        "schemaVersion": 1,
         "agents": {
             "defaults": {
-                "provider": "auto"
+                "activeProfile": "deepseek-default",
+                "model": "deepseek-v4-pro",
+                "workspace": "~/.tinybot/workspace"
             }
+        },
+        "providers": {
+            "profiles": {
+                "deepseek-default": {
+                    "provider": "deepseek",
+                    "displayName": "DeepSeek",
+                    "enabled": true,
+                    "apiBase": "https://api.deepseek.com",
+                    "models": ["deepseek-v4-pro", "deepseek-v4-flash"],
+                    "defaultModel": "deepseek-v4-pro",
+                    "supportsModelDiscovery": true
+                }
+            }
+        },
+        "gateway": {
+            "host": "127.0.0.1",
+            "port": 18790
         }
     })
 }
@@ -6869,6 +6933,21 @@ pub fn run() {
         .manage(gateway_state)
         .setup(move |app| {
             install_desktop_application_menu(app)?;
+            match ensure_default_config_file(&default_tinybot_config_path()) {
+                Ok(diagnostics) => {
+                    for diagnostic in diagnostics {
+                        if diagnostic.code == ConfigDiagnosticCode::DefaultConfigCreateFailed {
+                            push_log(&setup_state, &diagnostic.message);
+                        }
+                    }
+                }
+                Err(error) => {
+                    push_log(
+                        &setup_state,
+                        &format!("failed to initialize default config: {error}"),
+                    );
+                }
+            }
             let app_handle = app.handle().clone();
             let log_state = setup_state.clone();
             let runtime = lock_runtime(&setup_state);
@@ -7343,17 +7422,37 @@ mod tests {
     }
 
     #[test]
-    fn experimental_worker_config_defaults_to_auto_provider_without_config_file() {
+    fn experimental_worker_config_defaults_to_schema_v1_deepseek_profile_without_config_file() {
         let fixture = WorkspaceFixture::new();
         assert_eq!(
             experimental_worker_config_snapshot_from_path(
                 &fixture.root.join("missing-config.json")
             ),
             serde_json::json!({
+                "schemaVersion": 1,
                 "agents": {
                     "defaults": {
-                        "provider": "auto"
+                        "activeProfile": "deepseek-default",
+                        "model": "deepseek-v4-pro",
+                        "workspace": "~/.tinybot/workspace"
                     }
+                },
+                "providers": {
+                    "profiles": {
+                        "deepseek-default": {
+                            "provider": "deepseek",
+                            "displayName": "DeepSeek",
+                            "enabled": true,
+                            "apiBase": "https://api.deepseek.com",
+                            "models": ["deepseek-v4-pro", "deepseek-v4-flash"],
+                            "defaultModel": "deepseek-v4-pro",
+                            "supportsModelDiscovery": true
+                        }
+                    }
+                },
+                "gateway": {
+                    "host": "127.0.0.1",
+                    "port": 18790
                 }
             })
         );
@@ -10015,7 +10114,7 @@ mod tests {
     fn cron_model_from_config_defaults_to_agent_model() {
         assert_eq!(
             cron_model_from_config(&serde_json::json!({})),
-            "deepseek-reasoner"
+            "deepseek-v4-pro"
         );
     }
 
@@ -11926,6 +12025,141 @@ mod tests {
     }
 
     #[test]
+    fn ensure_default_config_file_creates_schema_v1_deepseek_profile_when_missing() {
+        let fixture = WorkspaceFixture::new();
+        let config_path = fixture.root.join(".tinybot").join("config.json");
+
+        let diagnostics = ensure_default_config_file(&config_path)
+            .expect("missing config should initialize default file");
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code)
+                .collect::<Vec<_>>(),
+            vec![crate::config_store::ConfigDiagnosticCode::DefaultConfigCreated]
+        );
+        let saved = serde_json::from_str::<serde_json::Value>(
+            &std::fs::read_to_string(&config_path).expect("default config should be created"),
+        )
+        .expect("default config should be JSON");
+        assert_eq!(saved["schemaVersion"], 1);
+        assert_eq!(
+            saved["agents"]["defaults"]["activeProfile"],
+            "deepseek-default"
+        );
+        assert_eq!(saved["agents"]["defaults"]["model"], "deepseek-v4-pro");
+        assert!(saved["agents"]["defaults"].get("provider").is_none());
+        assert_eq!(
+            saved["providers"]["profiles"]["deepseek-default"]["provider"],
+            "deepseek"
+        );
+        assert_eq!(
+            saved["providers"]["profiles"]["deepseek-default"]["models"],
+            serde_json::json!(["deepseek-v4-pro", "deepseek-v4-flash"])
+        );
+        assert_eq!(saved["gateway"]["host"], "127.0.0.1");
+        assert_eq!(saved["gateway"]["port"], 18790);
+        assert!(!fixture.root.join(".tinybot").join("workspace").exists());
+    }
+
+    #[test]
+    fn ensure_default_config_file_does_not_overwrite_existing_or_invalid_config() {
+        let fixture = WorkspaceFixture::new();
+        let valid_path = fixture.root.join("valid").join("config.json");
+        if let Some(parent) = valid_path.parent() {
+            std::fs::create_dir_all(parent).expect("valid parent should create");
+        }
+        std::fs::write(&valid_path, r#"{"agents":{"defaults":{"model":"custom"}}}"#)
+            .expect("fixture config should write");
+
+        let diagnostics = ensure_default_config_file(&valid_path)
+            .expect("existing config should not be overwritten");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(&valid_path).expect("valid config should remain"),
+            r#"{"agents":{"defaults":{"model":"custom"}}}"#
+        );
+
+        let invalid_path = fixture.root.join("invalid").join("config.json");
+        if let Some(parent) = invalid_path.parent() {
+            std::fs::create_dir_all(parent).expect("invalid parent should create");
+        }
+        std::fs::write(&invalid_path, "{ invalid json").expect("invalid fixture should write");
+
+        let diagnostics = ensure_default_config_file(&invalid_path)
+            .expect("invalid existing config should not be overwritten");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(&invalid_path).expect("invalid config should remain"),
+            "{ invalid json"
+        );
+    }
+
+    #[test]
+    fn config_editor_snapshot_ensures_missing_default_config_before_loading() {
+        let fixture = WorkspaceFixture::new();
+        let config_path = fixture.root.join(".tinybot").join("config.json");
+
+        let snapshot = config_editor_snapshot_from_path(
+            &config_path,
+            experimental_worker_default_config_snapshot(),
+        )
+        .expect("editor snapshot should initialize missing config");
+
+        assert!(config_path.exists());
+        assert_eq!(
+            snapshot.effective_public_config["agents"]["defaults"]["activeProfile"],
+            "deepseek-default"
+        );
+        assert_eq!(
+            snapshot
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code)
+                .collect::<Vec<_>>(),
+            vec![crate::config_store::ConfigDiagnosticCode::DefaultConfigCreated]
+        );
+    }
+
+    #[test]
+    fn config_editor_snapshot_reports_default_config_create_failure_as_diagnostic() {
+        let fixture = WorkspaceFixture::new();
+        let blocked_parent = fixture.root.join("blocked");
+        std::fs::write(&blocked_parent, "not a directory")
+            .expect("blocking parent file should write");
+        let config_path = blocked_parent.join("config.json");
+
+        let snapshot = config_editor_snapshot_from_path(
+            &config_path,
+            experimental_worker_default_config_snapshot(),
+        )
+        .expect("editor snapshot should remain readable with in-memory defaults");
+
+        assert_eq!(
+            snapshot
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code)
+                .collect::<Vec<_>>(),
+            vec![
+                crate::config_store::ConfigDiagnosticCode::DefaultConfigCreateFailed,
+                crate::config_store::ConfigDiagnosticCode::MissingConfig,
+            ]
+        );
+        assert_eq!(
+            snapshot.effective_public_config["agents"]["defaults"]["activeProfile"],
+            "deepseek-default"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&blocked_parent).expect("blocked parent should remain a file"),
+            "not a directory"
+        );
+    }
+
+    #[test]
     fn native_settings_snapshot_returns_registry_projection() {
         let fixture = WorkspaceFixture::new();
         let config_path = fixture.root.join(".tinybot").join("config.json");
@@ -11977,7 +12211,7 @@ mod tests {
         let api_key = provider_group
             .fields
             .iter()
-            .find(|field| field.path == "providers.profiles.openai-work.api_key")
+            .find(|field| field.path == "providers.profiles.openai-work.apiKey")
             .expect("api key field should exist");
         assert_eq!(api_key.value, serde_json::Value::Null);
         assert_eq!(

--- a/src-tauri/src/native_provider_runtime.rs
+++ b/src-tauri/src/native_provider_runtime.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-const DEFAULT_AGENT_MODEL: &str = "deepseek-reasoner";
+const DEFAULT_AGENT_MODEL: &str = "deepseek-v4-pro";
 const DEFAULT_PROVIDER_TIMEOUT_MS: u64 = 120_000;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -84,17 +84,7 @@ const PROVIDER_CATALOG: &[NativeProviderCatalogEntry] = &[
         Some("https://api.openai.com/v1"),
         &["OPENAI_API_KEY"],
         &["OPENAI_BASE_URL"],
-        &[
-            "gpt-5.5",
-            "gpt-5.5-pro",
-            "gpt-5.4",
-            "gpt-5.4-mini",
-            "gpt-5.4-nano",
-            "gpt-5-mini",
-            "gpt-4.1",
-            "gpt-4o",
-            "gpt-4o-mini",
-        ],
+        &["gpt-4.1"],
         &["gpt", "o1", "o3", "o4"],
     ),
     catalog_entry(
@@ -105,65 +95,21 @@ const PROVIDER_CATALOG: &[NativeProviderCatalogEntry] = &[
         Some("https://api.deepseek.com"),
         &["DEEPSEEK_API_KEY"],
         &["DEEPSEEK_BASE_URL"],
-        &[
-            "deepseek-v4-pro",
-            "deepseek-v4-flash",
-            "deepseek-chat",
-            "deepseek-reasoner",
-        ],
+        &["deepseek-v4-pro", "deepseek-v4-flash"],
         &["deepseek"],
     ),
-    catalog_entry(
-        "openrouter",
-        "OpenRouter",
-        &["open router"],
-        &["built_in", "aggregator"],
-        Some("https://openrouter.ai/api/v1"),
-        &["OPENROUTER_API_KEY", "OPENAI_API_KEY"],
-        &["OPENROUTER_BASE_URL"],
-        &[
-            "anthropic/claude-opus-4.7",
-            "anthropic/claude-sonnet-4.6",
-            "openai/gpt-5.5",
-            "openai/gpt-5.4-mini",
-        ],
-        &["openrouter", "anthropic", "openai", "google", "qwen"],
+    catalog_entry_with_discovery(
+        "dashscope",
+        "DashScope",
+        &["dash scope", "model studio", "qwen"],
+        &["built_in"],
+        Some("https://dashscope.aliyuncs.com/compatible-mode/v1"),
+        &["DASHSCOPE_API_KEY"],
+        &["DASHSCOPE_BASE_URL"],
+        true,
+        &["qwen-plus", "qwen-max", "qwen-turbo"],
+        &["qwen"],
     ),
-    catalog_entry(
-        "ollama",
-        "Ollama",
-        &["local ollama"],
-        &["local"],
-        Some("http://127.0.0.1:11434/v1"),
-        &[],
-        &[],
-        &["llama3.1", "qwen2.5", "mistral"],
-        &["ollama", "llama", "mistral"],
-    ),
-    catalog_entry(
-        "custom",
-        "Custom OpenAI-compatible",
-        &["custom", "openai compatible", "compatible endpoint"],
-        &["custom"],
-        None,
-        &[],
-        &[],
-        &[],
-        &[],
-    ),
-    NativeProviderCatalogEntry {
-        id: "fixture",
-        display_name: "Fixture",
-        aliases: &["test fixture"],
-        categories: &["local", "test"],
-        default_api_base: None,
-        api_key_env_vars: &[],
-        api_base_env_vars: &[],
-        supports_model_discovery: false,
-        curated_model_ids: &["fixture-model"],
-        model_prefixes: &["fixture"],
-        backend: "fixture",
-    },
 ];
 
 const fn catalog_entry(
@@ -177,6 +123,32 @@ const fn catalog_entry(
     curated_model_ids: &'static [&'static str],
     model_prefixes: &'static [&'static str],
 ) -> NativeProviderCatalogEntry {
+    catalog_entry_with_discovery(
+        id,
+        display_name,
+        aliases,
+        categories,
+        default_api_base,
+        api_key_env_vars,
+        api_base_env_vars,
+        true,
+        curated_model_ids,
+        model_prefixes,
+    )
+}
+
+const fn catalog_entry_with_discovery(
+    id: &'static str,
+    display_name: &'static str,
+    aliases: &'static [&'static str],
+    categories: &'static [&'static str],
+    default_api_base: Option<&'static str>,
+    api_key_env_vars: &'static [&'static str],
+    api_base_env_vars: &'static [&'static str],
+    supports_model_discovery: bool,
+    curated_model_ids: &'static [&'static str],
+    model_prefixes: &'static [&'static str],
+) -> NativeProviderCatalogEntry {
     NativeProviderCatalogEntry {
         id,
         display_name,
@@ -185,7 +157,7 @@ const fn catalog_entry(
         default_api_base,
         api_key_env_vars,
         api_base_env_vars,
-        supports_model_discovery: true,
+        supports_model_discovery,
         curated_model_ids,
         model_prefixes,
         backend: "openai",
@@ -530,6 +502,7 @@ pub fn list_provider_models(
                 discover_openai_models(
                     api_base.clone().unwrap_or_default(),
                     api_key.unwrap_or_default(),
+                    profile.request_timeout_ms,
                 )
                 .map(|models| (models, api_base.as_deref().map(join_models_url)))
             };
@@ -593,16 +566,25 @@ pub fn list_provider_models(
     })
 }
 
-fn discover_openai_models(api_base: String, api_key: String) -> Result<Vec<String>, String> {
+fn discover_openai_models(
+    api_base: String,
+    api_key: String,
+    timeout_ms: u64,
+) -> Result<Vec<String>, String> {
     tauri::async_runtime::block_on(async move {
+        let timeout = Duration::from_millis(timeout_ms.max(1));
         let config = OpenAIConfig::new()
             .with_api_base(api_base)
             .with_api_key(api_key);
         let client = Client::with_config(config);
-        client
-            .models()
-            .list()
+        tokio::time::timeout(timeout, client.models().list())
             .await
+            .map_err(|_| {
+                format!(
+                    "provider request timed out after {} ms",
+                    timeout.as_millis()
+                )
+            })?
             .map(|response| response.data.into_iter().map(|model| model.id).collect())
             .map_err(|error| error.to_string())
     })
@@ -675,7 +657,9 @@ fn native_chat_completion_with_observer(
     if request.stream {
         let observed_stream = observer.is_some();
         let stream_result = match observer {
-            Some(ref mut observer) => complete_openai_chat_stream(profile, request, Some(&mut **observer)),
+            Some(ref mut observer) => {
+                complete_openai_chat_stream(profile, request, Some(&mut **observer))
+            }
             None => complete_openai_chat_stream(profile, request, None),
         };
         stream_result.map(|body| NativeChatRouteBody {
@@ -946,10 +930,7 @@ fn push_sse_json(body: &mut String, value: &Value) {
     body.push_str("\n\n");
 }
 
-fn observe_stream_chunk(
-    chunk: &Value,
-    observer: &mut dyn FnMut(NativeProviderStreamEvent),
-) {
+fn observe_stream_chunk(chunk: &Value, observer: &mut dyn FnMut(NativeProviderStreamEvent)) {
     if let Some(delta) = chunk
         .pointer("/choices/0/delta/content")
         .and_then(Value::as_str)
@@ -1338,6 +1319,22 @@ mod tests {
     }
 
     #[test]
+    fn provider_catalog_exposes_current_built_in_providers_only() {
+        let body = provider_catalog_body(&json!({}));
+        let provider_ids = body["providers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|entry| entry["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(provider_ids, vec!["openai", "deepseek", "dashscope"]);
+        assert!(!provider_ids.contains(&"openrouter"));
+        assert!(!provider_ids.contains(&"ollama"));
+        assert!(!provider_ids.contains(&"custom"));
+    }
+
+    #[test]
     fn resolves_provider_profile_from_config_and_defaults() {
         let profile = resolve_provider_profile(
             &json!({
@@ -1466,6 +1463,88 @@ mod tests {
         assert!(result.models.contains(&"profile-model".to_string()));
         assert!(result.models.contains(&"manual-a".to_string()));
         assert!(result.models.contains(&"live-model".to_string()));
+        assert_eq!(result.sources["live"], 1);
+    }
+
+    #[test]
+    fn provider_models_fetches_openai_compatible_model_list() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener should bind");
+        let api_base = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buffer = [0_u8; 2048];
+                let _ = stream.read(&mut buffer);
+                let body = r#"{"object":"list","data":[{"id":"live-a","object":"model","created":1,"owned_by":"test"},{"id":"live-b","object":"model","created":1,"owned_by":"test"}]}"#;
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+            }
+        });
+
+        let result = list_provider_models(
+            &json!({
+                "providers": {
+                    "openai": {
+                        "api_key": "sk-test",
+                        "api_base": api_base
+                    }
+                }
+            }),
+            NativeProviderModelsRequest {
+                provider_id: Some("openai".to_string()),
+                refresh_live: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let _ = server.join();
+
+        assert!(result.ok);
+        assert!(result.models.contains(&"live-a".to_string()));
+        assert!(result.models.contains(&"live-b".to_string()));
+        assert_eq!(result.sources["live"], 2);
+    }
+
+    #[test]
+    fn dashscope_models_use_openai_compatible_discovery() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener should bind");
+        let api_base = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buffer = [0_u8; 2048];
+                let _ = stream.read(&mut buffer);
+                let body = r#"{"object":"list","data":[{"id":"qwen-live","object":"model","created":1,"owned_by":"test"}]}"#;
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+            }
+        });
+
+        let result = list_provider_models(
+            &json!({
+                "providers": {
+                    "dashscope": {
+                        "api_key": "sk-test",
+                        "api_base": api_base
+                    }
+                }
+            }),
+            NativeProviderModelsRequest {
+                provider_id: Some("dashscope".to_string()),
+                refresh_live: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let _ = server.join();
+
+        assert!(result.ok);
+        assert!(result.models.contains(&"qwen-plus".to_string()));
+        assert!(result.models.contains(&"qwen-live".to_string()));
         assert_eq!(result.sources["live"], 1);
     }
 

--- a/src-tauri/src/settings_registry.rs
+++ b/src-tauri/src/settings_registry.rs
@@ -148,11 +148,17 @@ pub fn build_settings_snapshot(input: SettingsSnapshotInput) -> SettingsSnapshot
                 config_field(
                     "active-profile",
                     "Active profile",
-                    "agents.defaults.active_profile",
+                    "agents.defaults.activeProfile",
                     SettingScope::RunDefault,
                     SettingValueType::String,
                     true,
-                    get_path(config, &["agents", "defaults", "active_profile"]),
+                    pick_path(
+                        config,
+                        &[
+                            &["agents", "defaults", "activeProfile"],
+                            &["agents", "defaults", "active_profile"],
+                        ],
+                    ),
                 ),
                 config_field(
                     "default-model",
@@ -184,38 +190,77 @@ pub fn build_settings_snapshot(input: SettingsSnapshotInput) -> SettingsSnapshot
                 config_field(
                     "max-tokens",
                     "Max output tokens",
-                    "agents.defaults.max_tokens",
+                    "agents.defaults.maxTokens",
                     SettingScope::RunDefault,
                     SettingValueType::Number,
                     true,
-                    get_path(config, &["agents", "defaults", "max_tokens"]),
+                    pick_path(
+                        config,
+                        &[
+                            &["agents", "defaults", "maxTokens"],
+                            &["agents", "defaults", "max_tokens"],
+                        ],
+                    ),
                 ),
                 config_field(
                     "context-window-tokens",
                     "Context window budget",
-                    "agents.defaults.context_window_tokens",
+                    "agents.defaults.contextWindowTokens",
                     SettingScope::RunDefault,
                     SettingValueType::Number,
                     true,
-                    get_path(config, &["agents", "defaults", "context_window_tokens"]),
+                    pick_path(
+                        config,
+                        &[
+                            &["agents", "defaults", "contextWindowTokens"],
+                            &["agents", "defaults", "context_window_tokens"],
+                        ],
+                    ),
+                ),
+                config_field(
+                    "context-window-strategy",
+                    "Context window strategy",
+                    "agents.defaults.contextWindowStrategy",
+                    SettingScope::RunDefault,
+                    SettingValueType::String,
+                    true,
+                    pick_path(
+                        config,
+                        &[
+                            &["agents", "defaults", "contextWindowStrategy"],
+                            &["agents", "defaults", "context_window_strategy"],
+                        ],
+                    ),
                 ),
                 config_field(
                     "max-tool-iterations",
                     "Max tool iterations",
-                    "agents.defaults.max_tool_iterations",
+                    "agents.defaults.maxToolIterations",
                     SettingScope::RunDefault,
                     SettingValueType::Number,
                     true,
-                    get_path(config, &["agents", "defaults", "max_tool_iterations"]),
+                    pick_path(
+                        config,
+                        &[
+                            &["agents", "defaults", "maxToolIterations"],
+                            &["agents", "defaults", "max_tool_iterations"],
+                        ],
+                    ),
                 ),
                 config_field(
                     "reasoning-effort",
                     "Reasoning effort",
-                    "agents.defaults.reasoning_effort",
+                    "agents.defaults.reasoningEffort",
                     SettingScope::RunDefault,
                     SettingValueType::String,
                     true,
-                    get_path(config, &["agents", "defaults", "reasoning_effort"]),
+                    pick_path(
+                        config,
+                        &[
+                            &["agents", "defaults", "reasoningEffort"],
+                            &["agents", "defaults", "reasoning_effort"],
+                        ],
+                    ),
                 ),
             ],
         ),
@@ -510,11 +555,17 @@ pub fn build_settings_snapshot(input: SettingsSnapshotInput) -> SettingsSnapshot
                 config_field(
                     "mcp-default-approval-policy",
                     "Default MCP approval policy",
-                    "mcp.default_approval_policy",
+                    "tools.defaultApprovalPolicy",
                     SettingScope::Workspace,
                     SettingValueType::Select,
                     true,
-                    get_path(config, &["mcp", "default_approval_policy"]),
+                    pick_path(
+                        config,
+                        &[
+                            &["tools", "defaultApprovalPolicy"],
+                            &["mcp", "default_approval_policy"],
+                        ],
+                    ),
                 )
                 .with_risk(SettingRisk::Sensitive),
                 config_field(
@@ -656,11 +707,17 @@ fn provider_models_group(config: &Value) -> SettingsGroup {
         config_field(
             "active-profile",
             "Active profile",
-            "agents.defaults.active_profile",
+            "agents.defaults.activeProfile",
             SettingScope::RunDefault,
             SettingValueType::String,
             true,
-            get_path(config, &["agents", "defaults", "active_profile"]),
+            pick_path(
+                config,
+                &[
+                    &["agents", "defaults", "activeProfile"],
+                    &["agents", "defaults", "active_profile"],
+                ],
+            ),
         ),
         config_field(
             "agent-default-model",
@@ -681,11 +738,14 @@ fn provider_models_group(config: &Value) -> SettingsGroup {
             fields.push(config_field(
                 &format!("provider-profile-{profile_id}-display-name"),
                 "Profile display name",
-                &format!("{prefix}.display_name"),
+                &format!("{prefix}.displayName"),
                 SettingScope::Profile,
                 SettingValueType::String,
                 true,
-                profile.get("display_name").cloned(),
+                profile
+                    .get("displayName")
+                    .or_else(|| profile.get("display_name"))
+                    .cloned(),
             ));
             fields.push(config_field(
                 &format!("provider-profile-{profile_id}-provider"),
@@ -708,27 +768,35 @@ fn provider_models_group(config: &Value) -> SettingsGroup {
             fields.push(secret_field(
                 &format!("provider-profile-{profile_id}-api-key"),
                 "API key",
-                &format!("{prefix}.api_key"),
+                &format!("{prefix}.apiKey"),
                 SettingScope::Profile,
-                sensitive_value_configured(profile.get("api_key")),
+                sensitive_value_configured(
+                    profile.get("apiKey").or_else(|| profile.get("api_key")),
+                ),
             ));
             fields.push(config_field(
                 &format!("provider-profile-{profile_id}-api-base"),
                 "API base",
-                &format!("{prefix}.api_base"),
+                &format!("{prefix}.apiBase"),
                 SettingScope::Profile,
                 SettingValueType::String,
                 true,
-                profile.get("api_base").cloned(),
+                profile
+                    .get("apiBase")
+                    .or_else(|| profile.get("api_base"))
+                    .cloned(),
             ));
             fields.push(config_field(
                 &format!("provider-profile-{profile_id}-request-timeout"),
                 "Request timeout",
-                &format!("{prefix}.request_timeout_ms"),
+                &format!("{prefix}.requestTimeoutMs"),
                 SettingScope::Profile,
                 SettingValueType::Number,
                 true,
-                profile.get("request_timeout_ms").cloned(),
+                profile
+                    .get("requestTimeoutMs")
+                    .or_else(|| profile.get("request_timeout_ms"))
+                    .cloned(),
             ));
             fields.push(config_field(
                 &format!("provider-profile-{profile_id}-models"),
@@ -742,11 +810,14 @@ fn provider_models_group(config: &Value) -> SettingsGroup {
             fields.push(config_field(
                 &format!("provider-profile-{profile_id}-default-model"),
                 "Profile default model",
-                &format!("{prefix}.default_model"),
+                &format!("{prefix}.defaultModel"),
                 SettingScope::Profile,
                 SettingValueType::String,
                 true,
-                profile.get("default_model").cloned(),
+                profile
+                    .get("defaultModel")
+                    .or_else(|| profile.get("default_model"))
+                    .cloned(),
             ));
         }
     }
@@ -761,11 +832,18 @@ fn provider_models_group(config: &Value) -> SettingsGroup {
 
 fn mcp_servers_group(config: &Value) -> SettingsGroup {
     let mut fields = Vec::new();
-    if let Some(servers) =
-        get_path(config, &["mcp", "servers"]).and_then(|value| value.as_object().cloned())
+    if let Some(servers) = pick_path(
+        config,
+        &[
+            &["tools", "mcpServers"],
+            &["tools", "mcp_servers"],
+            &["mcp", "servers"],
+        ],
+    )
+    .and_then(|value| value.as_object().cloned())
     {
         for (server_id, server) in servers {
-            let prefix = format!("mcp.servers.{server_id}");
+            let prefix = format!("tools.mcpServers.{server_id}");
             fields.push(config_field(
                 &format!("mcp-{server_id}-enabled"),
                 "Server enabled",
@@ -991,6 +1069,10 @@ fn get_path(value: &Value, path: &[&str]) -> Option<Value> {
     Some(current.clone())
 }
 
+fn pick_path(value: &Value, paths: &[&[&str]]) -> Option<Value> {
+    paths.iter().find_map(|path| get_path(value, path))
+}
+
 fn public_config_snapshot(snapshot: &Value) -> Value {
     omit_sensitive_descendants(snapshot)
 }
@@ -1114,7 +1196,7 @@ mod tests {
         });
 
         let field = snapshot
-            .field("providers.profiles.openai-work.api_key")
+            .field("providers.profiles.openai-work.apiKey")
             .expect("provider api key field should exist");
 
         assert_eq!(field.value_type, SettingValueType::Secret);

--- a/src-tauri/src/settings_registry.rs
+++ b/src-tauri/src/settings_registry.rs
@@ -235,13 +235,15 @@ pub fn build_settings_snapshot(input: SettingsSnapshotInput) -> SettingsSnapshot
                 config_field(
                     "max-tool-iterations",
                     "Max tool iterations",
-                    "agents.defaults.maxToolIterations",
+                    "agents.defaults.maxIterations",
                     SettingScope::RunDefault,
                     SettingValueType::Number,
                     true,
                     pick_path(
                         config,
                         &[
+                            &["agents", "defaults", "maxIterations"],
+                            &["agents", "defaults", "max_iterations"],
                             &["agents", "defaults", "maxToolIterations"],
                             &["agents", "defaults", "max_tool_iterations"],
                         ],
@@ -1234,6 +1236,23 @@ mod tests {
     }
 
     #[test]
+    fn max_tool_iterations_projects_runtime_key_with_legacy_aliases() {
+        let snapshot = build_settings_snapshot(SettingsSnapshotInput {
+            config: config_fixture(),
+            config_path: PathBuf::from("C:/Users/example/.tinybot/config.json"),
+            revision: "rev-1".to_string(),
+            diagnostics: Vec::new(),
+        });
+
+        let field = snapshot
+            .field("agents.defaults.maxIterations")
+            .expect("max tool iterations field should use runtime key");
+
+        assert_eq!(field.value_type, SettingValueType::Number);
+        assert_eq!(field.value, json!(12));
+    }
+
+    #[test]
     fn expert_config_exposes_redacted_effective_config() {
         let snapshot = build_settings_snapshot(SettingsSnapshotInput {
             config: config_fixture(),
@@ -1263,7 +1282,8 @@ mod tests {
                 "defaults": {
                     "active_profile": "openai-work",
                     "model": "gpt-5",
-                    "timezone": "Asia/Singapore"
+                    "timezone": "Asia/Singapore",
+                    "maxToolIterations": 12
                 }
             },
             "providers": {

--- a/src-tauri/src/worker_agent_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime.rs
@@ -28,6 +28,10 @@ pub enum NativeAgentRuntimeMode {
 const TEST_COMPAT_FAKE_AWAITING_APPROVAL: &str = "fakeAwaitingApproval";
 const TEST_COMPAT_FAKE_AWAITING_FORM: &str = "fakeAwaitingForm";
 const TEST_COMPAT_FAKE_CHECKPOINT: &str = "fakeCheckpoint";
+const DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS: i64 = 128_000;
+const DEFAULT_COMPACT_TRIGGER_PERCENT: i64 = 90;
+const DEFAULT_COMPACT_SUMMARY_MAX_TOKENS: i64 = 1024;
+const APPROX_BYTES_PER_TOKEN: usize = 4;
 
 #[derive(Clone)]
 pub struct NativeAgentCancellationContext {
@@ -305,6 +309,26 @@ impl NativeAgentRunState {
         let message = self.pending_guidance_message.take()?;
         self.messages.push(message.clone());
         Some(message)
+    }
+
+    fn record_usage(
+        &mut self,
+        context: &NativeAgentRunContext,
+        iteration: i64,
+        usage: Value,
+        estimated_context_tokens: i64,
+    ) {
+        let usage = enrich_usage_with_context_window(context, usage, estimated_context_tokens);
+        self.usage.push(usage.clone());
+        self.emit_event(
+            "agent.usage",
+            serde_json::json!({
+                "runId": context.run_id,
+                "sessionId": context.session_id,
+                "iteration": iteration,
+                "usage": usage,
+            }),
+        );
     }
 }
 
@@ -903,16 +927,17 @@ impl NativeAgentProvider for RustNativeAgentProvider {
     ) -> Result<NativeAgentProviderResponse, String> {
         let request = agent_chat_completion_request(context)?;
         let provider_config = agent_provider_config(context);
-        let mut provider_observer = |event: crate::native_provider_runtime::NativeProviderStreamEvent| {
-            match event {
+        let mut provider_observer =
+            |event: crate::native_provider_runtime::NativeProviderStreamEvent| match event {
                 crate::native_provider_runtime::NativeProviderStreamEvent::ContentDelta(delta) => {
                     observer(NativeAgentProviderStreamEvent::ContentDelta(delta));
                 }
-                crate::native_provider_runtime::NativeProviderStreamEvent::ReasoningDelta(delta) => {
+                crate::native_provider_runtime::NativeProviderStreamEvent::ReasoningDelta(
+                    delta,
+                ) => {
                     observer(NativeAgentProviderStreamEvent::ReasoningDelta(delta));
                 }
-            }
-        };
+            };
         let completion = crate::native_provider_runtime::complete_chat_for_agent_with_observer(
             &provider_config,
             &request,
@@ -1172,6 +1197,9 @@ fn agent_chat_completion_request(context: &NativeAgentRunContext) -> Result<Valu
         "messages": messages,
         "stream": context.stream,
     });
+    if context.stream {
+        request["stream_options"] = serde_json::json!({ "include_usage": true });
+    }
     if let Some(max_tokens) = context
         .spec
         .get("maxCompletionTokens")
@@ -1223,9 +1251,263 @@ fn set_agent_default(config: &mut Value, key: &str, value: Value) {
 
 fn agent_chat_messages(context: &NativeAgentRunContext) -> Result<Value, String> {
     if !context.messages.is_empty() {
-        return Ok(Value::Array(context.messages.clone()));
+        return Ok(Value::Array(context_window_messages(context)));
     }
     Err("agent run requires at least one chat message".to_string())
+}
+
+fn context_window_messages(context: &NativeAgentRunContext) -> Vec<Value> {
+    let context_window_tokens = effective_context_window_tokens(context);
+    let full_estimate = estimate_messages_tokens(&context.messages);
+    if context_window_strategy(context) == "compact"
+        && compact_threshold_reached(context, full_estimate, context_window_tokens)
+    {
+        if let Some(messages) = compact_messages_to_context_window(context, context_window_tokens) {
+            return messages;
+        }
+    }
+
+    if full_estimate <= context_window_tokens {
+        return context.messages.clone();
+    }
+
+    trim_messages_to_context_window(&context.messages, context_window_tokens)
+}
+
+fn effective_context_window_tokens(context: &NativeAgentRunContext) -> i64 {
+    positive_i64_field(&context.spec, "contextWindowTokens")
+        .or_else(|| positive_i64_field(&context.spec, "context_window_tokens"))
+        .or_else(|| {
+            context
+                .config_snapshot
+                .get("agents")
+                .and_then(|agents| agents.get("defaults"))
+                .and_then(|defaults| {
+                    positive_i64_field(defaults, "contextWindowTokens")
+                        .or_else(|| positive_i64_field(defaults, "context_window_tokens"))
+                })
+        })
+        .unwrap_or(DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS)
+}
+
+fn context_window_strategy(context: &NativeAgentRunContext) -> String {
+    string_config_field(context, "contextWindowStrategy")
+        .or_else(|| string_config_field(context, "context_window_strategy"))
+        .map(|strategy| strategy.to_ascii_lowercase())
+        .filter(|strategy| strategy == "compact")
+        .unwrap_or_else(|| "discard".to_string())
+}
+
+fn compact_trigger_percent(context: &NativeAgentRunContext) -> i64 {
+    positive_i64_field(&context.spec, "compactTriggerPercent")
+        .or_else(|| positive_i64_field(&context.spec, "compact_trigger_percent"))
+        .or_else(|| {
+            context
+                .config_snapshot
+                .get("agents")
+                .and_then(|agents| agents.get("defaults"))
+                .and_then(|defaults| {
+                    positive_i64_field(defaults, "compactTriggerPercent")
+                        .or_else(|| positive_i64_field(defaults, "compact_trigger_percent"))
+                })
+        })
+        .unwrap_or(DEFAULT_COMPACT_TRIGGER_PERCENT)
+        .clamp(1, 100)
+}
+
+fn compact_summary_max_tokens(context: &NativeAgentRunContext) -> i64 {
+    positive_i64_field(&context.spec, "compactSummaryMaxTokens")
+        .or_else(|| positive_i64_field(&context.spec, "compact_summary_max_tokens"))
+        .or_else(|| {
+            context
+                .config_snapshot
+                .get("agents")
+                .and_then(|agents| agents.get("defaults"))
+                .and_then(|defaults| {
+                    positive_i64_field(defaults, "compactSummaryMaxTokens")
+                        .or_else(|| positive_i64_field(defaults, "compact_summary_max_tokens"))
+                })
+        })
+        .unwrap_or(DEFAULT_COMPACT_SUMMARY_MAX_TOKENS)
+}
+
+fn string_config_field(context: &NativeAgentRunContext, key: &str) -> Option<String> {
+    string_field(&context.spec, key).or_else(|| {
+        context
+            .config_snapshot
+            .get("agents")
+            .and_then(|agents| agents.get("defaults"))
+            .and_then(|defaults| string_field(defaults, key))
+    })
+}
+
+fn compact_threshold_reached(
+    context: &NativeAgentRunContext,
+    full_estimate: i64,
+    context_window_tokens: i64,
+) -> bool {
+    let threshold = context_window_tokens.saturating_mul(compact_trigger_percent(context)) / 100;
+    full_estimate >= threshold.max(1)
+}
+
+fn positive_i64_field(value: &Value, key: &str) -> Option<i64> {
+    value
+        .get(key)
+        .and_then(value_as_i64)
+        .filter(|number| *number > 0)
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|number| i64::try_from(number).ok()))
+}
+
+fn trim_messages_to_context_window(messages: &[Value], context_window_tokens: i64) -> Vec<Value> {
+    if messages.is_empty() {
+        return Vec::new();
+    }
+    let budget = context_window_tokens.max(1);
+    let mut selected = Vec::new();
+    let mut used_tokens = 0i64;
+
+    for message in messages.iter().rev() {
+        let message_tokens = estimate_message_tokens(message);
+        if selected.is_empty() || used_tokens.saturating_add(message_tokens) <= budget {
+            selected.push(message.clone());
+            used_tokens = used_tokens.saturating_add(message_tokens);
+        } else {
+            break;
+        }
+    }
+
+    selected.reverse();
+    selected
+}
+
+fn compact_messages_to_context_window(
+    context: &NativeAgentRunContext,
+    context_window_tokens: i64,
+) -> Option<Vec<Value>> {
+    let recent_budget = (context_window_tokens.saturating_mul(2) / 3).max(1);
+    let recent_messages = trim_messages_to_context_window(&context.messages, recent_budget);
+    let old_count = context.messages.len().saturating_sub(recent_messages.len());
+    if old_count == 0 {
+        return None;
+    }
+    let old_messages = &context.messages[..old_count];
+    let summary = compact_old_messages(context, old_messages).ok()?;
+    if summary.trim().is_empty() {
+        return None;
+    }
+
+    let mut compacted = vec![serde_json::json!({
+        "role": "system",
+        "content": format!("Conversation summary so far:\n{}", summary.trim()),
+    })];
+    compacted.extend(recent_messages);
+    Some(trim_messages_to_context_window(
+        &compacted,
+        context_window_tokens,
+    ))
+}
+
+fn compact_old_messages(
+    context: &NativeAgentRunContext,
+    messages: &[Value],
+) -> Result<String, String> {
+    let body = serde_json::json!({
+        "model": context.model,
+        "stream": false,
+        "max_completion_tokens": compact_summary_max_tokens(context),
+        "messages": [
+            {
+                "role": "system",
+                "content": "Summarize earlier conversation context for a coding agent. Preserve user goals, decisions, constraints, file paths, commands, tool results, and unresolved tasks. Be concise and factual."
+            },
+            {
+                "role": "user",
+                "content": format!(
+                    "Summarize these earlier messages so the next model call can continue without the full transcript:\n{}",
+                    serde_json::to_string(messages).unwrap_or_else(|_| "[]".to_string())
+                )
+            }
+        ]
+    });
+    let provider_config = agent_provider_config(context);
+    let completion =
+        crate::native_provider_runtime::complete_chat_for_agent(&provider_config, &body)?;
+    Ok(chat_completion_content(&completion))
+}
+
+fn estimate_context_tokens_for_request(context: &NativeAgentRunContext) -> i64 {
+    agent_chat_messages(context)
+        .ok()
+        .and_then(|messages| messages.as_array().cloned())
+        .unwrap_or_default()
+        .iter()
+        .map(estimate_message_tokens)
+        .fold(0i64, i64::saturating_add)
+}
+
+fn estimate_messages_tokens(messages: &[Value]) -> i64 {
+    messages
+        .iter()
+        .map(estimate_message_tokens)
+        .fold(0i64, i64::saturating_add)
+}
+
+fn estimate_message_tokens(message: &Value) -> i64 {
+    let text = serde_json::to_string(message).unwrap_or_default();
+    let tokens = (text
+        .len()
+        .saturating_add(APPROX_BYTES_PER_TOKEN.saturating_sub(1)))
+        / APPROX_BYTES_PER_TOKEN;
+    i64::try_from(tokens.max(1)).unwrap_or(i64::MAX)
+}
+
+fn enrich_usage_with_context_window(
+    context: &NativeAgentRunContext,
+    usage: Value,
+    estimated_context_tokens: i64,
+) -> Value {
+    let mut usage = match usage {
+        Value::Object(map) => Value::Object(map),
+        other => serde_json::json!({ "raw": other }),
+    };
+    let context_window_tokens = effective_context_window_tokens(context);
+    let used_tokens = usage_context_used_tokens(&usage).unwrap_or(estimated_context_tokens);
+    let remaining_tokens = context_window_tokens.saturating_sub(used_tokens).max(0);
+    let percent = if context_window_tokens > 0 {
+        ((used_tokens as f64 / context_window_tokens as f64) * 100.0).clamp(0.0, 100.0)
+    } else {
+        0.0
+    };
+
+    usage["context_window_strategy"] = serde_json::json!(context_window_strategy(context));
+    usage["contextWindowStrategy"] = serde_json::json!(context_window_strategy(context));
+    usage["context_window_tokens"] = serde_json::json!(context_window_tokens);
+    usage["contextWindowTokens"] = serde_json::json!(context_window_tokens);
+    usage["context_window_used_tokens"] = serde_json::json!(used_tokens);
+    usage["contextWindowUsedTokens"] = serde_json::json!(used_tokens);
+    usage["context_window_remaining_tokens"] = serde_json::json!(remaining_tokens);
+    usage["contextWindowRemainingTokens"] = serde_json::json!(remaining_tokens);
+    usage["estimated_context_tokens"] = serde_json::json!(estimated_context_tokens);
+    usage["estimatedContextTokens"] = serde_json::json!(estimated_context_tokens);
+    usage["percent"] = serde_json::json!(percent);
+    usage
+}
+
+fn usage_context_used_tokens(usage: &Value) -> Option<i64> {
+    [
+        "prompt_tokens",
+        "promptTokens",
+        "total_tokens",
+        "totalTokens",
+        "total",
+    ]
+    .iter()
+    .find_map(|key| positive_i64_field(usage, key))
 }
 
 fn initial_agent_messages(spec: &Value) -> Vec<Value> {
@@ -1479,6 +1761,7 @@ pub fn run_native_agent_turn_with_config(
         );
         context.messages = state.messages.clone();
         context.spec["messages"] = Value::Array(state.messages.clone());
+        let estimated_context_tokens = estimate_context_tokens_for_request(&context);
         let mut provider_streamed_content = false;
         let mut provider_streamed_reasoning = false;
         let provider_response = {
@@ -1524,7 +1807,9 @@ pub fn run_native_agent_turn_with_config(
                     );
                 }
             };
-            services.provider.complete_streaming(&context, &mut stream_observer)
+            services
+                .provider
+                .complete_streaming(&context, &mut stream_observer)
         };
         let provider_response = match provider_response {
             Ok(response) => response,
@@ -1561,7 +1846,11 @@ pub fn run_native_agent_turn_with_config(
 
         let current_phase = state.phase.as_str().to_string();
         maybe_emit_checkpoint(services, &context, &mut state, &current_phase);
-        if let Some(reasoning_delta) = provider_response.reasoning_delta.clone().filter(|_| !provider_streamed_reasoning) {
+        if let Some(reasoning_delta) = provider_response
+            .reasoning_delta
+            .clone()
+            .filter(|_| !provider_streamed_reasoning)
+        {
             state.transition_phase(
                 AgentRuntimePhase::StreamingModel,
                 iteration,
@@ -1577,7 +1866,10 @@ pub fn run_native_agent_turn_with_config(
                 }),
             );
         }
-        if context.stream && !provider_response.final_content.is_empty() && !provider_streamed_content {
+        if context.stream
+            && !provider_response.final_content.is_empty()
+            && !provider_streamed_content
+        {
             state.transition_phase(AgentRuntimePhase::StreamingModel, iteration, "agent.delta");
             state.emit_event(
                 "agent.delta",
@@ -1819,34 +2111,26 @@ pub fn run_native_agent_turn_with_config(
                 );
             }
 
-            if let Some(usage) = provider_response.usage {
-                state.usage.push(usage.clone());
-                state.emit_event(
-                    "agent.usage",
-                    serde_json::json!({
-                        "runId": context.run_id,
-                        "sessionId": context.session_id,
-                        "iteration": iteration,
-                        "usage": usage,
-                    }),
-                );
-            }
+            state.record_usage(
+                &context,
+                iteration,
+                provider_response
+                    .usage
+                    .unwrap_or_else(|| serde_json::json!({})),
+                estimated_context_tokens,
+            );
             continue;
         }
 
         let final_content = provider_response.final_content;
-        if let Some(usage) = provider_response.usage {
-            state.usage.push(usage.clone());
-            state.emit_event(
-                "agent.usage",
-                serde_json::json!({
-                    "runId": context.run_id,
-                    "sessionId": context.session_id,
-                    "iteration": iteration,
-                    "usage": usage,
-                }),
-            );
-        }
+        state.record_usage(
+            &context,
+            iteration,
+            provider_response
+                .usage
+                .unwrap_or_else(|| serde_json::json!({})),
+            estimated_context_tokens,
+        );
         state.transition_phase(
             AgentRuntimePhase::Finalizing,
             iteration,
@@ -3705,6 +3989,221 @@ mod tests {
             "final_response"
         );
         assert!(result["events"][3]["payload"].get("finalContent").is_none());
+    }
+
+    #[test]
+    fn agent_chat_request_trims_old_messages_to_context_window() {
+        let context = NativeAgentRunContext::from_spec(
+            json!({
+                "runtime": "rust",
+                "runId": "run-context-window",
+                "sessionId": "websocket:chat-context-window",
+                "messages": [
+                    { "role": "user", "content": "old message ".repeat(200) },
+                    { "role": "assistant", "content": "old answer ".repeat(200) },
+                    { "role": "user", "content": "current question" }
+                ]
+            }),
+            json!({
+                "agents": {
+                    "defaults": {
+                        "provider": "fixture",
+                        "model": "fixture-model",
+                        "contextWindowTokens": 32
+                    }
+                }
+            }),
+        );
+
+        let request = agent_chat_completion_request(&context).expect("request should build");
+        let messages = request["messages"]
+            .as_array()
+            .expect("messages should be an array");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["content"], "current question");
+    }
+
+    #[test]
+    fn agent_chat_request_requests_stream_usage() {
+        let context = NativeAgentRunContext::from_spec(
+            json!({
+                "runtime": "rust",
+                "runId": "run-stream-usage",
+                "sessionId": "websocket:chat-stream-usage",
+                "stream": true,
+                "messages": [{ "role": "user", "content": "hello" }]
+            }),
+            json!({
+                "agents": {
+                    "defaults": {
+                        "provider": "fixture",
+                        "model": "fixture-model"
+                    }
+                }
+            }),
+        );
+
+        let request = agent_chat_completion_request(&context).expect("request should build");
+
+        assert_eq!(request["stream"], true);
+        assert_eq!(request["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn agent_chat_request_compacts_old_messages_when_strategy_is_compact() {
+        let context = NativeAgentRunContext::from_spec(
+            json!({
+                "runtime": "rust",
+                "runId": "run-context-compact",
+                "sessionId": "websocket:chat-context-compact",
+                "messages": [
+                    { "role": "user", "content": "old context ".repeat(200) },
+                    { "role": "assistant", "content": "old answer ".repeat(200) },
+                    { "role": "user", "content": "current question" }
+                ]
+            }),
+            json!({
+                "agents": {
+                    "defaults": {
+                        "provider": "fixture",
+                        "model": "fixture-model",
+                        "contextWindowTokens": 80,
+                        "contextWindowStrategy": "compact",
+                        "compactTriggerPercent": 50
+                    }
+                },
+                "providers": { "fixture": { "responses": [{ "content": "summary of earlier turns" }] } }
+            }),
+        );
+
+        let request = agent_chat_completion_request(&context).expect("request should build");
+        let messages = request["messages"]
+            .as_array()
+            .expect("messages should be an array");
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "system");
+        assert!(messages[0]["content"]
+            .as_str()
+            .expect("summary content should be text")
+            .contains("summary of earlier turns"));
+        assert_eq!(messages[1]["content"], "current question");
+    }
+
+    #[test]
+    fn agent_usage_event_includes_context_window_budget() {
+        let result = run_native_agent_turn_with_config(
+            &NativeAgentRuntimeServices::default(),
+            json!({
+                "runtime": "rust",
+                "runId": "run-usage-window",
+                "sessionId": "websocket:chat-usage-window",
+                "messages": [{ "role": "user", "content": "hello" }]
+            }),
+            json!({
+                "agents": {
+                    "defaults": {
+                        "provider": "fixture",
+                        "model": "fixture-model",
+                        "contextWindowTokens": 100
+                    }
+                },
+                "providers": { "fixture": { "responses": [{ "content": "fixture answer" }] } }
+            }),
+        )
+        .expect("fixture provider run should succeed");
+
+        let usage_event = result["events"]
+            .as_array()
+            .expect("events should be an array")
+            .iter()
+            .find(|event| event["eventName"] == "agent.usage")
+            .expect("usage event should be present");
+        let usage = &usage_event["payload"]["usage"];
+
+        assert_eq!(usage["context_window_tokens"], 100);
+        assert!(usage["context_window_remaining_tokens"].is_number());
+        assert!(usage["context_window_used_tokens"].is_number());
+    }
+
+    #[test]
+    fn agent_usage_event_falls_back_to_estimated_context_when_provider_omits_usage() {
+        struct NoUsageProvider;
+
+        impl NativeAgentProvider for NoUsageProvider {
+            fn complete(
+                &self,
+                _context: &NativeAgentRunContext,
+            ) -> Result<NativeAgentProviderResponse, String> {
+                Ok(NativeAgentProviderResponse {
+                    final_content: "no usage answer".to_string(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: Vec::new(),
+                })
+            }
+
+            fn complete_streaming(
+                &self,
+                _context: &NativeAgentRunContext,
+                observer: &mut dyn FnMut(NativeAgentProviderStreamEvent),
+            ) -> Result<NativeAgentProviderResponse, String> {
+                observer(NativeAgentProviderStreamEvent::ContentDelta(
+                    "no usage answer".to_string(),
+                ));
+                Ok(NativeAgentProviderResponse {
+                    final_content: "no usage answer".to_string(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: Vec::new(),
+                })
+            }
+        }
+
+        let services = NativeAgentRuntimeServices {
+            provider: Arc::new(NoUsageProvider),
+            ..NativeAgentRuntimeServices::default()
+        };
+        let result = run_native_agent_turn_with_config(
+            &services,
+            json!({
+                "runtime": "rust",
+                "runId": "run-estimated-usage",
+                "sessionId": "websocket:chat-estimated-usage",
+                "messages": [{ "role": "user", "content": "hello world" }]
+            }),
+            json!({
+                "agents": {
+                    "defaults": {
+                        "provider": "fixture",
+                        "model": "fixture-model",
+                        "contextWindowTokens": 128000
+                    }
+                }
+            }),
+        )
+        .expect("run should succeed");
+
+        let usage_event = result["events"]
+            .as_array()
+            .expect("events should be an array")
+            .iter()
+            .find(|event| event["eventName"] == "agent.usage")
+            .expect("usage event should be present");
+        let usage = &usage_event["payload"]["usage"];
+
+        assert_eq!(usage["context_window_tokens"], 128000);
+        assert!(
+            usage["estimated_context_tokens"]
+                .as_i64()
+                .unwrap_or_default()
+                > 0
+        );
+        assert_eq!(
+            usage["context_window_used_tokens"],
+            usage["estimated_context_tokens"]
+        );
     }
 
     #[test]
@@ -6006,8 +6505,12 @@ mod tests {
                 observer(NativeAgentProviderStreamEvent::ReasoningDelta(
                     "thinking".to_string(),
                 ));
-                observer(NativeAgentProviderStreamEvent::ContentDelta("Hel".to_string()));
-                observer(NativeAgentProviderStreamEvent::ContentDelta("lo".to_string()));
+                observer(NativeAgentProviderStreamEvent::ContentDelta(
+                    "Hel".to_string(),
+                ));
+                observer(NativeAgentProviderStreamEvent::ContentDelta(
+                    "lo".to_string(),
+                ));
                 Ok(NativeAgentProviderResponse {
                     final_content: "Hello".to_string(),
                     reasoning_delta: Some("thinking".to_string()),

--- a/src/app-core/chat/chatRunModel.test.ts
+++ b/src/app-core/chat/chatRunModel.test.ts
@@ -479,11 +479,77 @@ describe("chat run model", () => {
       turn_id: "turn-1",
       sequence: 6,
       created_at: "2026-06-27T04:00:05.000Z",
-      payload: {},
+      payload: {
+        usage: {
+          context_window_remaining_tokens: 168000,
+          context_window_strategy: "compact",
+          context_window_tokens: 256000,
+          context_window_used_tokens: 88000,
+          percent: 34.4,
+          prompt_tokens: 88000,
+          total_tokens: 88400,
+        },
+      },
     });
 
     turns = state.turnsBySession.get("WebSocket:chat-1") ?? [];
-    expect(turnsToConversationMessages(turns)[1]).toEqual(expect.objectContaining({ copyable: true, turnId: "turn-1", turnStatus: "completed" }));
+    expect(turns[0].usage).toEqual(expect.objectContaining({
+      contextWindowRemainingTokens: 168000,
+      contextWindowStrategy: "compact",
+      contextWindowTokens: 256000,
+      contextWindowUsedTokens: 88000,
+      percent: 34.4,
+      promptTokens: 88000,
+      totalTokens: 88400,
+    }));
+    expect(turnsToConversationMessages(turns)[1]).toEqual(expect.objectContaining({
+      copyable: true,
+      turnId: "turn-1",
+      turnStatus: "completed",
+      usage: expect.objectContaining({ contextWindowTokens: 256000, contextWindowUsedTokens: 88000 }),
+    }));
+  });
+
+  test("applies standalone agent usage events to the active turn", () => {
+    const state = createChatRunState();
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-turn-start",
+      event_type: "agent.turn.started",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-usage",
+      sequence: 1,
+      created_at: "2026-06-27T04:00:00.000Z",
+      payload: {
+        user_message: { text: "Measure context" },
+        user_message_id: "user-usage",
+      },
+    });
+    reduceAgentEvent(state, {
+      schema_version: "tinybot.agent_event.v1",
+      event_id: "event-usage",
+      event_type: "agent.usage",
+      chat_id: "chat-1",
+      session_key: "WebSocket:chat-1",
+      turn_id: "turn-usage",
+      sequence: 2,
+      created_at: "2026-06-27T04:00:01.000Z",
+      payload: {
+        usage: {
+          contextWindowTokens: 128000,
+          contextWindowUsedTokens: 64000,
+          percent: 50,
+        },
+      },
+    });
+
+    const turns = state.turnsBySession.get("WebSocket:chat-1") ?? [];
+    expect(turns[0].usage).toEqual(expect.objectContaining({
+      contextWindowTokens: 128000,
+      contextWindowUsedTokens: 64000,
+      percent: 50,
+    }));
   });
 
   test("stores delegated trace updates on the child agent state", () => {

--- a/src/app-core/chat/chatRunModel.ts
+++ b/src/app-core/chat/chatRunModel.ts
@@ -33,6 +33,12 @@ export type ArtifactRef = {
 export type TokenUsage = {
   cachedTokens?: number;
   completionTokens?: number;
+  contextWindowRemainingTokens?: number;
+  contextWindowStrategy?: string;
+  contextWindowTokens?: number;
+  contextWindowUsedTokens?: number;
+  estimatedContextTokens?: number;
+  percent?: number;
   promptTokens?: number;
   totalTokens?: number;
 };
@@ -104,6 +110,7 @@ export interface ChatMessageProjection {
   toolActivities?: ChatToolActivityProjection[];
   turnId?: string;
   turnStatus?: ChatTurnStatus;
+  usage?: TokenUsage;
 }
 
 export type DelegatedAgentState = {
@@ -487,6 +494,11 @@ export function reduceAgentEvent(state: ChatRunState, event: AgentEventEnvelope)
   if (event.event_type === "agent.turn.updated") {
     turn.status = turnStatusValue(event.payload.status) || turn.status;
     turn.usage = normalizeUsage(event.payload.usage) ?? turn.usage;
+    return state;
+  }
+
+  if (event.event_type === "agent.usage") {
+    turn.usage = normalizeUsage(event.payload.usage ?? event.payload) ?? turn.usage;
     return state;
   }
 
@@ -1001,6 +1013,7 @@ export function turnsToConversationMessages(turns: ChatTurn[]): ChatMessageProje
         toolActivities: [],
         turnId: turn.id,
         turnStatus: turn.status,
+        ...(turn.usage ? { usage: turn.usage } : {}),
       });
     }
     return messages;
@@ -1049,6 +1062,7 @@ function stepToConversationMessage(step: ChatStep, turn: ChatTurn): ChatMessageP
     toolActivities: stepToToolActivities(step),
     turnId: turn.id,
     turnStatus: turn.status,
+    ...(turn.usage ? { usage: turn.usage } : {}),
   };
 }
 
@@ -1562,6 +1576,12 @@ function normalizeUsage(value: unknown): TokenUsage | undefined {
   return {
     cachedTokens: numberValue(payload.cached_tokens ?? payload.cachedTokens),
     completionTokens: numberValue(payload.completion_tokens ?? payload.completionTokens),
+    contextWindowRemainingTokens: numberValue(payload.context_window_remaining_tokens ?? payload.contextWindowRemainingTokens),
+    contextWindowStrategy: stringValue(payload.context_window_strategy ?? payload.contextWindowStrategy) || undefined,
+    contextWindowTokens: numberValue(payload.context_window_tokens ?? payload.contextWindowTokens),
+    contextWindowUsedTokens: numberValue(payload.context_window_used_tokens ?? payload.contextWindowUsedTokens),
+    estimatedContextTokens: numberValue(payload.estimated_context_tokens ?? payload.estimatedContextTokens),
+    percent: numberValue(payload.percent ?? payload.percentage ?? payload.token_usage_percent ?? payload.tokenUsagePercent),
     promptTokens: numberValue(payload.prompt_tokens ?? payload.promptTokens),
     totalTokens: numberValue(payload.total_tokens ?? payload.totalTokens),
   };

--- a/src/app-core/chat/nativeChat.ts
+++ b/src/app-core/chat/nativeChat.ts
@@ -10,6 +10,7 @@ import {
   type AgentEventEnvelope,
   type BackendAgentRunRuntimeState,
   type ChatRunState,
+  type TokenUsage,
 } from "./chatRunModel";
 
 export type NativeChatSession = {
@@ -32,6 +33,7 @@ export type NativeChatMessage = {
   messageId: string;
   turnId?: string;
   turnStatus?: string;
+  usage?: TokenUsage;
 };
 
 export type NativeChatToolActivity = {
@@ -937,6 +939,7 @@ function conversationMessagesToNativeMessages(messages: ReturnType<typeof turnsT
     messageId: message.messageId || `agent-run:${index}`,
     ...(message.turnId ? { turnId: message.turnId } : {}),
     ...(message.turnStatus ? { turnStatus: message.turnStatus } : {}),
+    ...(message.usage ? { usage: message.usage } : {}),
   }));
 }
 

--- a/src/app-core/native/desktopNativeConfigPatch.test.ts
+++ b/src/app-core/native/desktopNativeConfigPatch.test.ts
@@ -112,7 +112,7 @@ describe("desktop native config patch host action", () => {
 
     await applyNativeConfigPatch(
       {},
-      { agents: { defaults: { max_tokens: 8192 } } },
+      { agents: { defaults: { max_tokens: 8192, context_window_strategy: "compact" } } },
       { invoke },
     );
 
@@ -124,6 +124,11 @@ describe("desktop native config patch host action", () => {
             op: "replace",
             path: "agents.defaults.maxTokens",
             value: 8192,
+          },
+          {
+            op: "replace",
+            path: "agents.defaults.contextWindowStrategy",
+            value: "compact",
           },
         ],
       },

--- a/src/app-core/native/desktopNativeConfigPatch.ts
+++ b/src/app-core/native/desktopNativeConfigPatch.ts
@@ -90,6 +90,7 @@ function canonicalConfigSegment(parent: readonly string[], segment: string): str
       active_profile: "activeProfile",
       max_tokens: "maxTokens",
       context_block_limit: "contextBlockLimit",
+      context_window_strategy: "contextWindowStrategy",
       max_tool_result_chars: "maxToolResultChars",
       reasoning_effort: "reasoningEffort",
     } as Record<string, string>)[segment] ?? segment;

--- a/src/app-core/settings/agentDefaultsSettings.test.ts
+++ b/src/app-core/settings/agentDefaultsSettings.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildAgentDefaultsPatch,
+  buildAgentDefaultsSettings,
+  validateAgentDefaultsInput,
+} from "./agentDefaultsSettings";
+
+describe("agent defaults settings", () => {
+  test("builds form values from backend config", () => {
+    const settings = buildAgentDefaultsSettings({
+      revision: "hash:1",
+      agents: {
+        defaults: {
+          activeProfile: "deepseek-default",
+          model: "deepseek-v4-pro",
+          timezone: "Asia/Singapore",
+          temperature: 0.4,
+          maxTokens: 4096,
+          contextWindowTokens: 128000,
+          contextWindowStrategy: "compact",
+          maxToolIterations: 12,
+          reasoningEffort: "medium",
+        },
+      },
+    });
+
+    expect(settings).toMatchObject({
+      revision: "hash:1",
+      activeProfileId: "deepseek-default",
+      defaultModel: "deepseek-v4-pro",
+      values: {
+        timezone: "Asia/Singapore",
+        temperature: "0.4",
+        maxTokens: "4096",
+        contextWindowTokens: "128000",
+        contextWindowStrategy: "compact",
+        maxToolIterations: "12",
+        reasoningEffort: "medium",
+      },
+    });
+  });
+
+  test("fills runtime default values when backend config omits them", () => {
+    const settings = buildAgentDefaultsSettings({
+      agents: {
+        defaults: {
+          activeProfile: "deepseek-default",
+          model: "deepseek-v4-pro",
+        },
+      },
+    });
+
+    expect(settings.values).toMatchObject({
+      maxTokens: "8192",
+      contextWindowTokens: "128000",
+      contextWindowStrategy: "discard",
+      maxToolIterations: "200",
+      reasoningEffort: "medium",
+    });
+  });
+
+  test("builds agent defaults patch from valid form values", () => {
+    expect(buildAgentDefaultsPatch({
+      timezone: "UTC",
+      temperature: "0.2",
+      maxTokens: "2048",
+      contextWindowTokens: "64000",
+      contextWindowStrategy: "compact",
+      maxToolIterations: "8",
+      reasoningEffort: "high",
+    })).toEqual({
+      agents: {
+        defaults: {
+          timezone: "UTC",
+          temperature: 0.2,
+          maxTokens: 2048,
+          contextWindowTokens: 64000,
+          contextWindowStrategy: "compact",
+          maxToolIterations: 8,
+          reasoningEffort: "high",
+        },
+      },
+    });
+  });
+
+  test("validates numeric agent defaults before save", () => {
+    expect(validateAgentDefaultsInput({
+      timezone: "UTC",
+      temperature: "3",
+      maxTokens: "0",
+      contextWindowTokens: "1.5",
+      contextWindowStrategy: "invalid",
+      maxToolIterations: "-1",
+      reasoningEffort: "medium",
+    })).toEqual({
+      temperature: "Temperature must be between 0 and 2.",
+      maxTokens: "Max output tokens must be a positive integer.",
+      contextWindowTokens: "Context window budget must be a positive integer.",
+      contextWindowStrategy: "Context window strategy must be discard or compact.",
+      maxToolIterations: "Max tool iterations must be a positive integer.",
+    });
+  });
+});

--- a/src/app-core/settings/agentDefaultsSettings.test.ts
+++ b/src/app-core/settings/agentDefaultsSettings.test.ts
@@ -18,7 +18,7 @@ describe("agent defaults settings", () => {
           maxTokens: 4096,
           contextWindowTokens: 128000,
           contextWindowStrategy: "compact",
-          maxToolIterations: 12,
+          maxIterations: 12,
           reasoningEffort: "medium",
         },
       },
@@ -76,8 +76,38 @@ describe("agent defaults settings", () => {
           maxTokens: 2048,
           contextWindowTokens: 64000,
           contextWindowStrategy: "compact",
-          maxToolIterations: 8,
+          maxIterations: 8,
           reasoningEffort: "high",
+        },
+      },
+    });
+  });
+
+  test("rejects non-numeric temperature values before save", () => {
+    expect(validateAgentDefaultsInput({
+      timezone: "UTC",
+      temperature: "abc",
+      maxTokens: "2048",
+      contextWindowTokens: "64000",
+      contextWindowStrategy: "compact",
+      maxToolIterations: "8",
+      reasoningEffort: "high",
+    })).toEqual({
+      temperature: "Temperature must be a number between 0 and 2.",
+    });
+    expect(buildAgentDefaultsPatch({
+      timezone: "UTC",
+      temperature: "abc",
+      maxTokens: "",
+      contextWindowTokens: "",
+      contextWindowStrategy: "discard",
+      maxToolIterations: "",
+      reasoningEffort: "",
+    })).toEqual({
+      agents: {
+        defaults: {
+          timezone: "UTC",
+          contextWindowStrategy: "discard",
         },
       },
     });

--- a/src/app-core/settings/agentDefaultsSettings.ts
+++ b/src/app-core/settings/agentDefaultsSettings.ts
@@ -46,7 +46,7 @@ export function buildAgentDefaultsSettings(config: unknown): AgentDefaultsSettin
         pick(defaults, "contextWindowStrategy", "context_window_strategy"),
       ) || DEFAULT_AGENT_CONTEXT_WINDOW_STRATEGY,
       maxToolIterations: formNumber(
-        pick(defaults, "maxToolIterations", "max_tool_iterations"),
+        pick(defaults, "maxIterations", "max_iterations", "maxToolIterations", "max_tool_iterations"),
         DEFAULT_AGENT_MAX_TOOL_ITERATIONS,
       ),
       reasoningEffort: stringValue(pick(defaults, "reasoningEffort", "reasoning_effort")) || DEFAULT_AGENT_REASONING_EFFORT,
@@ -57,6 +57,9 @@ export function buildAgentDefaultsSettings(config: unknown): AgentDefaultsSettin
 export function validateAgentDefaultsInput(values: AgentDefaultsFormValues): AgentDefaultsValidationErrors {
   const errors: AgentDefaultsValidationErrors = {};
   const temperature = parseOptionalNumber(values.temperature);
+  if (temperature !== null && !Number.isFinite(temperature)) {
+    errors.temperature = "Temperature must be a number between 0 and 2.";
+  }
   if (temperature !== null && (temperature < 0 || temperature > 2)) {
     errors.temperature = "Temperature must be between 0 and 2.";
   }
@@ -82,7 +85,7 @@ export function buildAgentDefaultsPatch(values: AgentDefaultsFormValues): JsonRe
     defaults.timezone = timezone;
   }
   const temperature = parseOptionalNumber(values.temperature);
-  if (temperature !== null) {
+  if (temperature !== null && Number.isFinite(temperature)) {
     defaults.temperature = temperature;
   }
   setOptionalInteger(defaults, "maxTokens", values.maxTokens);
@@ -91,7 +94,7 @@ export function buildAgentDefaultsPatch(values: AgentDefaultsFormValues): JsonRe
   if (contextWindowStrategy) {
     defaults.contextWindowStrategy = contextWindowStrategy;
   }
-  setOptionalInteger(defaults, "maxToolIterations", values.maxToolIterations);
+  setOptionalInteger(defaults, "maxIterations", values.maxToolIterations);
   const reasoningEffort = values.reasoningEffort.trim();
   if (reasoningEffort) {
     defaults.reasoningEffort = reasoningEffort;

--- a/src/app-core/settings/agentDefaultsSettings.ts
+++ b/src/app-core/settings/agentDefaultsSettings.ts
@@ -1,0 +1,163 @@
+export type AgentDefaultsFormValues = {
+  timezone: string;
+  temperature: string;
+  maxTokens: string;
+  contextWindowTokens: string;
+  contextWindowStrategy: string;
+  maxToolIterations: string;
+  reasoningEffort: string;
+};
+
+export type AgentDefaultsSettingsData = {
+  currentConfig: unknown;
+  revision?: string;
+  activeProfileId: string | null;
+  defaultModel: string | null;
+  values: AgentDefaultsFormValues;
+};
+
+export type AgentDefaultsValidationErrors = Partial<Record<keyof AgentDefaultsFormValues, string>>;
+
+type JsonRecord = Record<string, unknown>;
+
+const DEFAULT_AGENT_MAX_TOKENS = 8192;
+const DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS = 128000;
+const DEFAULT_AGENT_CONTEXT_WINDOW_STRATEGY = "discard";
+const DEFAULT_AGENT_MAX_TOOL_ITERATIONS = 200;
+const DEFAULT_AGENT_REASONING_EFFORT = "medium";
+
+export function buildAgentDefaultsSettings(config: unknown): AgentDefaultsSettingsData {
+  const root = asRecord(config);
+  const defaults = asRecord(asRecord(root.agents).defaults);
+  return {
+    currentConfig: config,
+    revision: stringOrUndefined(root.revision) ?? stringOrUndefined(asRecord(root.configMetadata).revision),
+    activeProfileId: stringOrNull(pick(defaults, "activeProfile", "active_profile")),
+    defaultModel: stringOrNull(defaults.model),
+    values: {
+      timezone: stringValue(defaults.timezone),
+      temperature: formNumber(pick(defaults, "temperature")),
+      maxTokens: formNumber(pick(defaults, "maxTokens", "max_tokens"), DEFAULT_AGENT_MAX_TOKENS),
+      contextWindowTokens: formNumber(
+        pick(defaults, "contextWindowTokens", "context_window_tokens"),
+        DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS,
+      ),
+      contextWindowStrategy: contextWindowStrategyValue(
+        pick(defaults, "contextWindowStrategy", "context_window_strategy"),
+      ) || DEFAULT_AGENT_CONTEXT_WINDOW_STRATEGY,
+      maxToolIterations: formNumber(
+        pick(defaults, "maxToolIterations", "max_tool_iterations"),
+        DEFAULT_AGENT_MAX_TOOL_ITERATIONS,
+      ),
+      reasoningEffort: stringValue(pick(defaults, "reasoningEffort", "reasoning_effort")) || DEFAULT_AGENT_REASONING_EFFORT,
+    },
+  };
+}
+
+export function validateAgentDefaultsInput(values: AgentDefaultsFormValues): AgentDefaultsValidationErrors {
+  const errors: AgentDefaultsValidationErrors = {};
+  const temperature = parseOptionalNumber(values.temperature);
+  if (temperature !== null && (temperature < 0 || temperature > 2)) {
+    errors.temperature = "Temperature must be between 0 and 2.";
+  }
+  if (!isOptionalPositiveInteger(values.maxTokens)) {
+    errors.maxTokens = "Max output tokens must be a positive integer.";
+  }
+  if (!isOptionalPositiveInteger(values.contextWindowTokens)) {
+    errors.contextWindowTokens = "Context window budget must be a positive integer.";
+  }
+  if (!isContextWindowStrategy(values.contextWindowStrategy)) {
+    errors.contextWindowStrategy = "Context window strategy must be discard or compact.";
+  }
+  if (!isOptionalPositiveInteger(values.maxToolIterations)) {
+    errors.maxToolIterations = "Max tool iterations must be a positive integer.";
+  }
+  return errors;
+}
+
+export function buildAgentDefaultsPatch(values: AgentDefaultsFormValues): JsonRecord {
+  const defaults: JsonRecord = {};
+  const timezone = values.timezone.trim();
+  if (timezone) {
+    defaults.timezone = timezone;
+  }
+  const temperature = parseOptionalNumber(values.temperature);
+  if (temperature !== null) {
+    defaults.temperature = temperature;
+  }
+  setOptionalInteger(defaults, "maxTokens", values.maxTokens);
+  setOptionalInteger(defaults, "contextWindowTokens", values.contextWindowTokens);
+  const contextWindowStrategy = contextWindowStrategyValue(values.contextWindowStrategy);
+  if (contextWindowStrategy) {
+    defaults.contextWindowStrategy = contextWindowStrategy;
+  }
+  setOptionalInteger(defaults, "maxToolIterations", values.maxToolIterations);
+  const reasoningEffort = values.reasoningEffort.trim();
+  if (reasoningEffort) {
+    defaults.reasoningEffort = reasoningEffort;
+  }
+  return { agents: { defaults } };
+}
+
+function setOptionalInteger(record: JsonRecord, key: string, value: string): void {
+  const text = value.trim();
+  if (text) {
+    record[key] = Number.parseInt(text, 10);
+  }
+}
+
+function isOptionalPositiveInteger(value: string): boolean {
+  const text = value.trim();
+  return !text || (/^\d+$/.test(text) && Number.parseInt(text, 10) > 0);
+}
+
+function isContextWindowStrategy(value: string): boolean {
+  return Boolean(contextWindowStrategyValue(value));
+}
+
+function contextWindowStrategyValue(value: unknown): string {
+  const text = stringValue(value).trim().toLowerCase();
+  return text === "discard" || text === "compact" ? text : "";
+}
+
+function parseOptionalNumber(value: string): number | null {
+  const text = value.trim();
+  if (!text) {
+    return null;
+  }
+  const number = Number(text);
+  return Number.isFinite(number) ? number : Number.NaN;
+}
+
+function formNumber(value: unknown, fallback?: number): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return fallback === undefined ? "" : String(fallback);
+}
+
+function stringOrNull(value: unknown): string | null {
+  const text = stringValue(value).trim();
+  return text ? text : null;
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return stringOrNull(value) ?? undefined;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function pick(record: JsonRecord, ...keys: string[]): unknown {
+  for (const key of keys) {
+    if (key in record) {
+      return record[key];
+    }
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value as JsonRecord : {};
+}

--- a/src/app-core/settings/desktopSettingsProviders.test.ts
+++ b/src/app-core/settings/desktopSettingsProviders.test.ts
@@ -951,6 +951,7 @@ describe("desktop settings and provider helpers", () => {
     expect(Object.fromEntries(editableFields)).toMatchObject({
       "general.model": { persistentPath: "agents.defaults.model", valueOrigin: "explicit", applyEffect: "immediate" },
       "general.temperature": { persistentPath: "agents.defaults.temperature", valueOrigin: "default" },
+      "general.maxToolIterations": { persistentPath: "agents.defaults.maxIterations" },
       "provider-models.selectedProvider": { sourceKind: "local-ui-preference" },
       "provider-models.apiKey": { persistentPath: "providers.deepseek.api_key", sensitive: true },
       "files-workspace.workspace": { persistentPath: "agents.defaults.workspace", applyEffect: "workspace-reload" },

--- a/src/app-core/settings/desktopSettingsProviders.test.ts
+++ b/src/app-core/settings/desktopSettingsProviders.test.ts
@@ -729,6 +729,7 @@ describe("desktop settings and provider helpers", () => {
       ],
     });
     expect(fields["general.temperature"]).toMatchObject({ control: "number", requirement: "optional", configurationMode: "numeric", advanced: true });
+    expect(fields["general.contextWindowStrategy"]).toMatchObject({ control: "select", requirement: "optional", configurationMode: "fixed", advanced: true });
     expect(fields["general.reasoningEffort"]).toMatchObject({ control: "select", requirement: "optional", configurationMode: "fixed", advanced: true });
     expect(fields["tools-approvals.mcpServers"]).toMatchObject({ control: "textarea", requirement: "optional", configurationMode: "json", advanced: true });
     expect(fields["tools-approvals.searchProvider"]).toMatchObject({ control: "select", requirement: "optional", configurationMode: "fixed", advanced: true });

--- a/src/app-core/settings/desktopSettingsProviders.ts
+++ b/src/app-core/settings/desktopSettingsProviders.ts
@@ -39,6 +39,7 @@ export interface DesktopSettingsFormState {
     temperature: number | null;
     maxTokens: number | null;
     contextWindowTokens: number | null;
+    contextWindowStrategy: string | null;
     maxToolIterations: number | null;
     reasoningEffort: string | null;
     timezone: string | null;
@@ -610,7 +611,8 @@ export function buildDesktopSettingsFormState(
       provider: selectedProvider,
       temperature: numberOrDefault(pick(defaults, "temperature"), 0.1),
       maxTokens: numberOrDefault(pick(defaults, "maxTokens", "max_tokens"), 8192),
-      contextWindowTokens: numberOrDefault(pick(defaults, "contextWindowTokens", "context_window_tokens"), 65536),
+      contextWindowTokens: numberOrDefault(pick(defaults, "contextWindowTokens", "context_window_tokens"), 128000),
+      contextWindowStrategy: stringOrDefault(pick(defaults, "contextWindowStrategy", "context_window_strategy"), "discard"),
       maxToolIterations: numberOrDefault(pick(defaults, "maxToolIterations", "max_tool_iterations"), 200),
       reasoningEffort: stringOrNull(pick(defaults, "reasoningEffort", "reasoning_effort")),
       timezone: stringOrDefault(pick(defaults, "timezone"), "UTC"),
@@ -906,6 +908,7 @@ function createDesktopSettingsFullPatch(
         temperature: state.agent.temperature,
         max_tokens: state.agent.maxTokens,
         context_window_tokens: state.agent.contextWindowTokens,
+        context_window_strategy: state.agent.contextWindowStrategy,
         max_tool_iterations: state.agent.maxToolIterations,
         reasoning_effort: state.agent.reasoningEffort,
         timezone: state.agent.timezone,
@@ -1006,6 +1009,8 @@ function getDesktopSettingsPatchPathValue(state: DesktopSettingsFormState, path:
       return state.agent.maxTokens;
     case "agents.defaults.context_window_tokens":
       return state.agent.contextWindowTokens;
+    case "agents.defaults.context_window_strategy":
+      return state.agent.contextWindowStrategy;
     case "agents.defaults.max_tool_iterations":
       return state.agent.maxToolIterations;
     case "agents.defaults.reasoning_effort":
@@ -1424,6 +1429,10 @@ export function applyDesktopSettingsFieldEdit(
     case "contextWindowTokens":
       nextState.agent.contextWindowTokens = numberOrNullInput(text);
       markDesktopSettingsTouched(nextState, "agents.defaults.context_window_tokens");
+      break;
+    case "contextWindowStrategy":
+      nextState.agent.contextWindowStrategy = stringOrNullInput(text) || "discard";
+      markDesktopSettingsTouched(nextState, "agents.defaults.context_window_strategy");
       break;
     case "maxToolIterations":
       nextState.agent.maxToolIterations = numberOrNullInput(text);
@@ -2138,6 +2147,13 @@ function buildDesktopSettingsPaneGroups(
           min: 1,
           step: 1,
         }),
+        field("contextWindowStrategy", "Context window strategy", state.agent.contextWindowStrategy, {
+          control: "select",
+          options: fixedOptions(["discard", "compact"]),
+          requirement: "optional",
+          configurationMode: "fixed",
+          advanced: true,
+        }),
         field("maxToolIterations", "Max tool iterations", state.agent.maxToolIterations, {
           control: "number",
           requirement: "optional",
@@ -2549,6 +2565,7 @@ function getDesktopSettingsPaneFieldPersistentPath(
     "general.temperature": "agents.defaults.temperature",
     "general.maxTokens": "agents.defaults.maxTokens",
     "general.contextWindowTokens": "agents.defaults.contextWindowTokens",
+    "general.contextWindowStrategy": "agents.defaults.contextWindowStrategy",
     "general.maxToolIterations": "agents.defaults.maxToolIterations",
     "general.reasoningEffort": "agents.defaults.reasoningEffort",
     "provider-models.selectedProvider": "desktop.ui.settings.providerEditor.selectedProvider",

--- a/src/app-core/settings/desktopSettingsProviders.ts
+++ b/src/app-core/settings/desktopSettingsProviders.ts
@@ -613,7 +613,7 @@ export function buildDesktopSettingsFormState(
       maxTokens: numberOrDefault(pick(defaults, "maxTokens", "max_tokens"), 8192),
       contextWindowTokens: numberOrDefault(pick(defaults, "contextWindowTokens", "context_window_tokens"), 128000),
       contextWindowStrategy: stringOrDefault(pick(defaults, "contextWindowStrategy", "context_window_strategy"), "discard"),
-      maxToolIterations: numberOrDefault(pick(defaults, "maxToolIterations", "max_tool_iterations"), 200),
+      maxToolIterations: numberOrDefault(pick(defaults, "maxIterations", "max_iterations", "maxToolIterations", "max_tool_iterations"), 200),
       reasoningEffort: stringOrNull(pick(defaults, "reasoningEffort", "reasoning_effort")),
       timezone: stringOrDefault(pick(defaults, "timezone"), "UTC"),
     },
@@ -909,7 +909,7 @@ function createDesktopSettingsFullPatch(
         max_tokens: state.agent.maxTokens,
         context_window_tokens: state.agent.contextWindowTokens,
         context_window_strategy: state.agent.contextWindowStrategy,
-        max_tool_iterations: state.agent.maxToolIterations,
+        maxIterations: state.agent.maxToolIterations,
         reasoning_effort: state.agent.reasoningEffort,
         timezone: state.agent.timezone,
         embedding: {
@@ -1011,7 +1011,7 @@ function getDesktopSettingsPatchPathValue(state: DesktopSettingsFormState, path:
       return state.agent.contextWindowTokens;
     case "agents.defaults.context_window_strategy":
       return state.agent.contextWindowStrategy;
-    case "agents.defaults.max_tool_iterations":
+    case "agents.defaults.maxIterations":
       return state.agent.maxToolIterations;
     case "agents.defaults.reasoning_effort":
       return state.agent.reasoningEffort;
@@ -1436,7 +1436,7 @@ export function applyDesktopSettingsFieldEdit(
       break;
     case "maxToolIterations":
       nextState.agent.maxToolIterations = numberOrNullInput(text);
-      markDesktopSettingsTouched(nextState, "agents.defaults.max_tool_iterations");
+      markDesktopSettingsTouched(nextState, "agents.defaults.maxIterations");
       break;
     case "reasoningEffort":
       nextState.agent.reasoningEffort = stringOrNullInput(text);
@@ -2566,7 +2566,7 @@ function getDesktopSettingsPaneFieldPersistentPath(
     "general.maxTokens": "agents.defaults.maxTokens",
     "general.contextWindowTokens": "agents.defaults.contextWindowTokens",
     "general.contextWindowStrategy": "agents.defaults.contextWindowStrategy",
-    "general.maxToolIterations": "agents.defaults.maxToolIterations",
+    "general.maxToolIterations": "agents.defaults.maxIterations",
     "general.reasoningEffort": "agents.defaults.reasoningEffort",
     "provider-models.selectedProvider": "desktop.ui.settings.providerEditor.selectedProvider",
     "provider-models.profileId": "agents.defaults.activeProfile",

--- a/src/app-core/settings/desktopSettingsSchemaCoverage.test.ts
+++ b/src/app-core/settings/desktopSettingsSchemaCoverage.test.ts
@@ -18,6 +18,8 @@ import {
 describe("desktop settings schema coverage", () => {
   test("canonicalizes known legacy aliases used by settings persistence", () => {
     expect(canonicalizeDesktopSettingsPersistentPath("agents.defaults.max_tokens")).toBe("agents.defaults.maxTokens");
+    expect(canonicalizeDesktopSettingsPersistentPath("agents.defaults.maxToolIterations")).toBe("agents.defaults.maxIterations");
+    expect(canonicalizeDesktopSettingsPersistentPath("agents.defaults.max_tool_iterations")).toBe("agents.defaults.maxIterations");
     expect(canonicalizeDesktopSettingsPersistentPath("agents.defaults.context_window_strategy")).toBe("agents.defaults.contextWindowStrategy");
     expect(canonicalizeDesktopSettingsPersistentPath("tools.mcp_servers.docs.command")).toBe("tools.mcpServers.docs.command");
     expect(canonicalizeDesktopSettingsPersistentPath("gateway.heartbeat.interval_s")).toBe("gateway.heartbeat.intervalS");

--- a/src/app-core/settings/desktopSettingsSchemaCoverage.test.ts
+++ b/src/app-core/settings/desktopSettingsSchemaCoverage.test.ts
@@ -18,6 +18,7 @@ import {
 describe("desktop settings schema coverage", () => {
   test("canonicalizes known legacy aliases used by settings persistence", () => {
     expect(canonicalizeDesktopSettingsPersistentPath("agents.defaults.max_tokens")).toBe("agents.defaults.maxTokens");
+    expect(canonicalizeDesktopSettingsPersistentPath("agents.defaults.context_window_strategy")).toBe("agents.defaults.contextWindowStrategy");
     expect(canonicalizeDesktopSettingsPersistentPath("tools.mcp_servers.docs.command")).toBe("tools.mcpServers.docs.command");
     expect(canonicalizeDesktopSettingsPersistentPath("gateway.heartbeat.interval_s")).toBe("gateway.heartbeat.intervalS");
   });

--- a/src/app-core/settings/desktopSettingsSchemaCoverage.ts
+++ b/src/app-core/settings/desktopSettingsSchemaCoverage.ts
@@ -21,7 +21,7 @@ type DispositionRule = {
 };
 
 const DISPOSITION_RULES: DispositionRule[] = [
-  { pattern: /^agents\.defaults\.(model|provider|activeProfile|temperature|timezone|workspace|maxTokens|contextWindowTokens|contextWindowStrategy|maxToolIterations|reasoningEffort)$/, disposition: "essential" },
+  { pattern: /^agents\.defaults\.(model|provider|activeProfile|temperature|timezone|workspace|maxTokens|contextWindowTokens|contextWindowStrategy|maxIterations|reasoningEffort)$/, disposition: "essential" },
   { pattern: /^agents\.defaults\.(contextBlockLimit|maxToolResultChars|embedding\..+)$/, disposition: "advanced" },
   { pattern: /^providers\.[^.]+\.(api_key|api_base|enabled|models)$/, disposition: "essential" },
   { pattern: /^providers\.profiles\.[^.]+\.(provider|api_key|api_base|enabled|models)$/, disposition: "essential" },
@@ -47,7 +47,8 @@ export function canonicalizeDesktopSettingsPersistentPath(path: string): string 
     .replace(/^agents\.defaults\.context_window_tokens$/, "agents.defaults.contextWindowTokens")
     .replace(/^agents\.defaults\.context_window_strategy$/, "agents.defaults.contextWindowStrategy")
     .replace(/^agents\.defaults\.max_tool_result_chars$/, "agents.defaults.maxToolResultChars")
-    .replace(/^agents\.defaults\.max_tool_iterations$/, "agents.defaults.maxToolIterations")
+    .replace(/^agents\.defaults\.maxToolIterations$/, "agents.defaults.maxIterations")
+    .replace(/^agents\.defaults\.max_tool_iterations$/, "agents.defaults.maxIterations")
     .replace(/^tools\.mcp_servers(?=\.|$)/, "tools.mcpServers")
     .replace(/^tools\.ssrf_whitelist(?=\.|$)/, "tools.ssrfWhitelist")
     .replace(/^channels\.send_progress(?=\.|$)/, "channels.sendProgress")

--- a/src/app-core/settings/desktopSettingsSchemaCoverage.ts
+++ b/src/app-core/settings/desktopSettingsSchemaCoverage.ts
@@ -21,7 +21,7 @@ type DispositionRule = {
 };
 
 const DISPOSITION_RULES: DispositionRule[] = [
-  { pattern: /^agents\.defaults\.(model|provider|activeProfile|temperature|timezone|workspace|maxTokens|contextWindowTokens|maxToolIterations|reasoningEffort)$/, disposition: "essential" },
+  { pattern: /^agents\.defaults\.(model|provider|activeProfile|temperature|timezone|workspace|maxTokens|contextWindowTokens|contextWindowStrategy|maxToolIterations|reasoningEffort)$/, disposition: "essential" },
   { pattern: /^agents\.defaults\.(contextBlockLimit|maxToolResultChars|embedding\..+)$/, disposition: "advanced" },
   { pattern: /^providers\.[^.]+\.(api_key|api_base|enabled|models)$/, disposition: "essential" },
   { pattern: /^providers\.profiles\.[^.]+\.(provider|api_key|api_base|enabled|models)$/, disposition: "essential" },
@@ -45,6 +45,7 @@ export function canonicalizeDesktopSettingsPersistentPath(path: string): string 
     .replace(/^agents\.defaults\.reasoning_effort$/, "agents.defaults.reasoningEffort")
     .replace(/^agents\.defaults\.context_block_limit$/, "agents.defaults.contextBlockLimit")
     .replace(/^agents\.defaults\.context_window_tokens$/, "agents.defaults.contextWindowTokens")
+    .replace(/^agents\.defaults\.context_window_strategy$/, "agents.defaults.contextWindowStrategy")
     .replace(/^agents\.defaults\.max_tool_result_chars$/, "agents.defaults.maxToolResultChars")
     .replace(/^agents\.defaults\.max_tool_iterations$/, "agents.defaults.maxToolIterations")
     .replace(/^tools\.mcp_servers(?=\.|$)/, "tools.mcpServers")

--- a/src/app-core/settings/providerModelsSettings.test.ts
+++ b/src/app-core/settings/providerModelsSettings.test.ts
@@ -102,7 +102,7 @@ describe("provider models settings", () => {
       defaultModel: "custom-model",
       setAgentDefault: true,
     })).toEqual({
-      agents: { defaults: { model: "custom-model" } },
+      agents: { defaults: { activeProfile: "deepseek-default", model: "custom-model" } },
       providers: {
         profiles: {
           "deepseek-default": {

--- a/src/app-core/settings/providerModelsSettings.test.ts
+++ b/src/app-core/settings/providerModelsSettings.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "vitest";
+import {
+  BUILT_IN_PROVIDER_PRESETS,
+  buildProviderConfigurePatch,
+  buildProviderDefaultLlmPatch,
+  buildProviderModelsPatch,
+  buildProviderModelsSettings,
+} from "./providerModelsSettings";
+
+describe("provider models settings", () => {
+  test("builds built-in provider cards from backend config", () => {
+    const settings = buildProviderModelsSettings({
+      revision: "hash:1",
+      agents: { defaults: { activeProfile: "deepseek-default", model: "deepseek-v4-pro" } },
+      providers: {
+        profiles: {
+          "deepseek-default": {
+            provider: "deepseek",
+            displayName: "DeepSeek",
+            enabled: true,
+            apiBase: "https://api.deepseek.com",
+            apiKeyConfigured: true,
+            models: ["deepseek-v4-pro"],
+            defaultModel: "deepseek-v4-pro",
+          },
+        },
+      },
+    });
+
+    expect(settings.revision).toBe("hash:1");
+    expect(settings.activeProfileId).toBe("deepseek-default");
+    expect(settings.providers.map((provider) => provider.id)).toEqual(["deepseek", "dashscope", "openai"]);
+    expect(settings.providers.find((provider) => provider.id === "deepseek")).toMatchObject({
+      label: "DeepSeek",
+      profileId: "deepseek-default",
+      active: true,
+      status: "available",
+      apiKeyConfigured: true,
+      baseUrl: "https://api.deepseek.com",
+      modelCount: 2,
+      defaultModel: "deepseek-v4-pro",
+    });
+    expect(settings.providers.find((provider) => provider.id === "openai")).toMatchObject({
+      status: "not_configured",
+      baseUrl: "https://api.openai.com/v1",
+      modelDiscovery: { status: "openai-compatible", endpoint: "/models" },
+    });
+    expect(settings.providers.find((provider) => provider.id === "dashscope")).toMatchObject({
+      modelDiscovery: { status: "openai-compatible", endpoint: "/models" },
+    });
+    expect(BUILT_IN_PROVIDER_PRESETS.every((preset) => preset.builtIn)).toBe(true);
+  });
+
+  test("builds configure patches without exposing unchanged secrets", () => {
+    expect(buildProviderConfigurePatch({
+      providerId: "openai",
+      profileId: "openai-default",
+      apiBase: "https://api.openai.com/v1",
+      apiKey: "",
+      enabled: true,
+    })).toEqual({
+      providers: {
+        profiles: {
+          "openai-default": {
+            provider: "openai",
+            displayName: "OpenAI",
+            enabled: true,
+            apiBase: "https://api.openai.com/v1",
+          },
+        },
+      },
+    });
+
+    expect(buildProviderConfigurePatch({
+      providerId: "openai",
+      profileId: "openai-default",
+      apiBase: "https://api.openai.com/v1",
+      apiKey: "sk-new",
+      enabled: true,
+      activate: true,
+    })).toEqual({
+      agents: { defaults: { activeProfile: "openai-default" } },
+      providers: {
+        profiles: {
+          "openai-default": {
+            provider: "openai",
+            displayName: "OpenAI",
+            enabled: true,
+            apiBase: "https://api.openai.com/v1",
+            apiKey: "sk-new",
+          },
+        },
+      },
+    });
+  });
+
+  test("builds model patches for manual models and defaults", () => {
+    expect(buildProviderModelsPatch({
+      providerId: "deepseek",
+      profileId: "deepseek-default",
+      models: ["deepseek-v4-pro", "custom-model"],
+      defaultModel: "custom-model",
+      setAgentDefault: true,
+    })).toEqual({
+      agents: { defaults: { model: "custom-model" } },
+      providers: {
+        profiles: {
+          "deepseek-default": {
+            provider: "deepseek",
+            models: ["deepseek-v4-pro", "custom-model"],
+            defaultModel: "custom-model",
+          },
+        },
+      },
+    });
+  });
+
+  test("builds default LLM patch for active profile and model", () => {
+    expect(buildProviderDefaultLlmPatch({
+      profileId: "openai-default",
+      model: "gpt-4.1",
+    })).toEqual({
+      agents: { defaults: { activeProfile: "openai-default", model: "gpt-4.1" } },
+    });
+  });
+});

--- a/src/app-core/settings/providerModelsSettings.ts
+++ b/src/app-core/settings/providerModelsSettings.ts
@@ -1,0 +1,337 @@
+export type ProviderModelDiscovery =
+  | { status: "openai-compatible"; endpoint: "/models" }
+  | { status: "static"; endpoint: null };
+
+export type BuiltInProviderPreset = {
+  id: "deepseek" | "dashscope" | "openai";
+  label: string;
+  builtIn: true;
+  defaultBaseUrl: string;
+  defaultModels: string[];
+  modelDiscovery: ProviderModelDiscovery;
+};
+
+export type ProviderModelSource = "built-in" | "user" | "live";
+
+export type ProviderModelItem = {
+  id: string;
+  label: string;
+  source: ProviderModelSource;
+};
+
+export type ProviderCardStatus = "available" | "not_ready" | "not_configured";
+
+export type ProviderCardModel = {
+  id: string;
+  label: string;
+  builtIn: boolean;
+  active: boolean;
+  configured: boolean;
+  status: ProviderCardStatus;
+  statusLabel: string;
+  profileId: string;
+  baseUrl: string;
+  apiKeyConfigured: boolean;
+  modelCount: number;
+  defaultModel: string | null;
+  models: ProviderModelItem[];
+  modelDiscovery: ProviderModelDiscovery;
+};
+
+export type ProviderModelsSettingsData = {
+  currentConfig: unknown;
+  revision?: string;
+  activeProfileId: string | null;
+  agentDefaultModel: string | null;
+  providers: ProviderCardModel[];
+};
+
+export type ProviderConfigurePatchInput = {
+  providerId: string;
+  profileId?: string | null;
+  apiBase: string;
+  apiKey?: string;
+  enabled?: boolean;
+  activate?: boolean;
+};
+
+export type ProviderModelsPatchInput = {
+  providerId: string;
+  profileId?: string | null;
+  models: string[];
+  defaultModel?: string | null;
+  setAgentDefault?: boolean;
+};
+
+export type ProviderDefaultLlmPatchInput = {
+  profileId: string;
+  model: string;
+};
+
+export type ProviderModelFetchInput = {
+  providerId: string;
+  profileId: string;
+  apiBase: string;
+  modelDiscovery: ProviderModelDiscovery;
+};
+
+export type ProviderModelFetchResult = {
+  ok: boolean;
+  models: string[];
+  warning?: string | null;
+  url?: string | null;
+  error?: string | null;
+};
+
+type JsonRecord = Record<string, unknown>;
+
+export const BUILT_IN_PROVIDER_PRESETS: BuiltInProviderPreset[] = [
+  {
+    id: "deepseek",
+    label: "DeepSeek",
+    builtIn: true,
+    defaultBaseUrl: "https://api.deepseek.com",
+    defaultModels: ["deepseek-v4-pro", "deepseek-v4-flash"],
+    modelDiscovery: { status: "openai-compatible", endpoint: "/models" },
+  },
+  {
+    id: "dashscope",
+    label: "DashScope",
+    builtIn: true,
+    defaultBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    defaultModels: ["qwen-plus", "qwen-max", "qwen-turbo"],
+    modelDiscovery: { status: "openai-compatible", endpoint: "/models" },
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    builtIn: true,
+    defaultBaseUrl: "https://api.openai.com/v1",
+    defaultModels: ["gpt-4.1"],
+    modelDiscovery: { status: "openai-compatible", endpoint: "/models" },
+  },
+];
+
+export function buildProviderModelsSettings(config: unknown): ProviderModelsSettingsData {
+  const root = asRecord(config);
+  const defaults = asRecord(asRecord(root.agents).defaults);
+  const providersRoot = asRecord(root.providers);
+  const profiles = asRecord(providersRoot.profiles);
+  const activeProfileId = stringOrNull(pick(defaults, "activeProfile", "active_profile"));
+  const agentDefaultModel = stringOrNull(defaults.model);
+
+  return {
+    currentConfig: config,
+    revision: stringOrUndefined(root.revision) ?? stringOrUndefined(asRecord(root.configMetadata).revision),
+    activeProfileId,
+    agentDefaultModel,
+    providers: BUILT_IN_PROVIDER_PRESETS.map((preset) => buildProviderCard(preset, profiles, activeProfileId, agentDefaultModel)),
+  };
+}
+
+export function buildProviderConfigurePatch(input: ProviderConfigurePatchInput): JsonRecord {
+  const preset = presetForProvider(input.providerId);
+  const profileId = resolveProviderProfileId(input.providerId, input.profileId);
+  const profile: JsonRecord = {
+    provider: input.providerId,
+    displayName: preset?.label ?? input.providerId,
+    enabled: input.enabled ?? true,
+    apiBase: input.apiBase.trim(),
+  };
+  const apiKey = input.apiKey?.trim();
+  if (apiKey) {
+    profile.apiKey = apiKey;
+  }
+  return withOptionalAgentsPatch(input.activate ? { activeProfile: profileId } : null, {
+    providers: {
+      profiles: {
+        [profileId]: profile,
+      },
+    },
+  });
+}
+
+export function buildProviderModelsPatch(input: ProviderModelsPatchInput): JsonRecord {
+  const profileId = resolveProviderProfileId(input.providerId, input.profileId);
+  const defaultModel = input.defaultModel?.trim() || null;
+  const profile: JsonRecord = {
+    provider: input.providerId,
+    models: uniqueStrings(input.models),
+  };
+  if (defaultModel) {
+    profile.defaultModel = defaultModel;
+  }
+  return withOptionalAgentsPatch(input.setAgentDefault && defaultModel ? { model: defaultModel } : null, {
+    providers: {
+      profiles: {
+        [profileId]: profile,
+      },
+    },
+  });
+}
+
+export function buildProviderDefaultLlmPatch(input: ProviderDefaultLlmPatchInput): JsonRecord {
+  return {
+    agents: {
+      defaults: {
+        activeProfile: input.profileId,
+        model: input.model,
+      },
+    },
+  };
+}
+
+export function normalizeProviderModelFetchResult(payload: unknown): ProviderModelFetchResult {
+  const record = asRecord(payload);
+  return {
+    ok: record.ok === true,
+    models: parseModelList(record.models),
+    warning: stringOrNull(record.warning),
+    url: stringOrNull(record.url),
+    error: stringOrNull(record.error),
+  };
+}
+
+function buildProviderCard(
+  preset: BuiltInProviderPreset,
+  profiles: JsonRecord,
+  activeProfileId: string | null,
+  agentDefaultModel: string | null,
+): ProviderCardModel {
+  const matchedProfiles = Object.entries(profiles)
+    .filter(([, profile]) => stringValue(asRecord(profile).provider) === preset.id);
+  const activeProfile = activeProfileId
+    ? matchedProfiles.find(([profileId]) => profileId === activeProfileId)
+    : undefined;
+  const profileEntry = activeProfile ?? matchedProfiles.find(([profileId]) => profileId === defaultProfileId(preset.id)) ?? matchedProfiles[0];
+  const profileId = profileEntry?.[0] ?? defaultProfileId(preset.id);
+  const profile = asRecord(profileEntry?.[1]);
+  const configured = Boolean(profileEntry);
+  const apiKeyConfigured = configured && hasConfiguredApiKey(profile);
+  const enabled = pick(profile, "enabled") !== false;
+  const manualModels = parseModelList(profile.models);
+  const builtInModels = preset.defaultModels.filter((model) => !manualModels.includes(model));
+  const models = [
+    ...preset.defaultModels.map((model) => ({ id: model, label: model, source: "built-in" as const })),
+    ...manualModels
+      .filter((model) => !preset.defaultModels.includes(model))
+      .map((model) => ({ id: model, label: model, source: "user" as const })),
+  ];
+  const defaultModel = stringOrNull(pick(profile, "defaultModel", "default_model"))
+    ?? (activeProfileId === profileId ? agentDefaultModel : null)
+    ?? preset.defaultModels[0]
+    ?? manualModels[0]
+    ?? null;
+  const status: ProviderCardStatus = !configured
+    ? "not_configured"
+    : apiKeyConfigured && enabled && (builtInModels.length + manualModels.length > 0)
+      ? "available"
+      : "not_ready";
+
+  return {
+    id: preset.id,
+    label: preset.label,
+    builtIn: preset.builtIn,
+    active: activeProfileId === profileId,
+    configured,
+    status,
+    statusLabel: statusLabel(status),
+    profileId,
+    baseUrl: stringValue(pick(profile, "apiBase", "api_base")) || preset.defaultBaseUrl,
+    apiKeyConfigured,
+    modelCount: models.length,
+    defaultModel,
+    models,
+    modelDiscovery: preset.modelDiscovery,
+  };
+}
+
+function withOptionalAgentsPatch(defaults: JsonRecord | null, patch: JsonRecord): JsonRecord {
+  if (!defaults) {
+    return patch;
+  }
+  return {
+    agents: { defaults },
+    ...patch,
+  };
+}
+
+function statusLabel(status: ProviderCardStatus): string {
+  if (status === "available") {
+    return "Available";
+  }
+  if (status === "not_ready") {
+    return "Not ready";
+  }
+  return "Not configured";
+}
+
+function presetForProvider(providerId: string): BuiltInProviderPreset | undefined {
+  return BUILT_IN_PROVIDER_PRESETS.find((preset) => preset.id === providerId);
+}
+
+function resolveProviderProfileId(providerId: string, profileId?: string | null): string {
+  const trimmed = profileId?.trim();
+  return trimmed || defaultProfileId(providerId);
+}
+
+function defaultProfileId(providerId: string): string {
+  return `${providerId}-default`;
+}
+
+function hasConfiguredApiKey(profile: JsonRecord): boolean {
+  if (stringValue(pick(profile, "apiKey", "api_key"))) {
+    return true;
+  }
+  return pick(profile, "apiKeyConfigured", "api_key_configured") === true;
+}
+
+function parseModelList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return uniqueStrings(value);
+  }
+  if (typeof value === "string") {
+    return uniqueStrings(value.split(/\r?\n|,/));
+  }
+  return [];
+}
+
+function uniqueStrings(values: unknown[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const text = stringValue(value).trim();
+    if (!text || seen.has(text)) {
+      continue;
+    }
+    seen.add(text);
+    result.push(text);
+  }
+  return result;
+}
+
+function stringOrNull(value: unknown): string | null {
+  const text = stringValue(value).trim();
+  return text ? text : null;
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return stringOrNull(value) ?? undefined;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function pick(record: JsonRecord, ...keys: string[]): unknown {
+  for (const key of keys) {
+    if (key in record) {
+      return record[key];
+    }
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value as JsonRecord : {};
+}

--- a/src/app-core/settings/providerModelsSettings.ts
+++ b/src/app-core/settings/providerModelsSettings.ts
@@ -161,7 +161,7 @@ export function buildProviderModelsPatch(input: ProviderModelsPatchInput): JsonR
   if (defaultModel) {
     profile.defaultModel = defaultModel;
   }
-  return withOptionalAgentsPatch(input.setAgentDefault && defaultModel ? { model: defaultModel } : null, {
+  return withOptionalAgentsPatch(input.setAgentDefault && defaultModel ? { activeProfile: profileId, model: defaultModel } : null, {
     providers: {
       profiles: {
         [profileId]: profile,

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import type { ChangeEvent, ClipboardEvent, FormEvent, KeyboardEvent, ReactNode } from "react";
+import type { ChangeEvent, ClipboardEvent, FormEvent, KeyboardEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { TokenUsage } from "../../app-core/chat/chatRunModel";
 import {
   AlertCircle,
   Archive,
@@ -73,6 +74,7 @@ export interface ClaudeStyleAiInputProps {
   models?: ModelOption[];
   defaultModel?: string;
   onModelChange?: (modelId: string) => void;
+  contextUsage?: TokenUsage;
   tools?: ComposerToolOption[];
   responding?: boolean;
   onStopResponding?: () => void | Promise<void>;
@@ -94,6 +96,7 @@ function nextInputId(prefix: string): string {
 export function ClaudeStyleAiInput({
   acceptedFileTypes = [],
   className,
+  contextUsage,
   defaultModel,
   disabled = false,
   maxFileSize = MAX_FILE_SIZE,
@@ -107,6 +110,7 @@ export function ClaudeStyleAiInput({
   tools = EMPTY_TOOLS,
 }: ClaudeStyleAiInputProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const modelMenuRef = useRef<HTMLDivElement | null>(null);
   const toolMenuRef = useRef<HTMLDivElement | null>(null);
   const [message, setMessage] = useState("");
@@ -122,6 +126,7 @@ export function ClaudeStyleAiInput({
     () => models.find((model) => model.id === selectedModelId) ?? models[0],
     [models, selectedModelId],
   );
+  const contextUsageView = useMemo(() => buildContextUsageView(contextUsage), [contextUsage]);
   const enabledToolIdSet = useMemo(() => new Set(enabledToolIds), [enabledToolIds]);
   const canSend = !disabled && !sending && Boolean(message.trim() || files.length || pastedContent.length);
 
@@ -272,6 +277,29 @@ export function ClaudeStyleAiInput({
     });
   }
 
+  function handlePanelPointerMove(event: ReactPointerEvent<HTMLDivElement>) {
+    const panel = panelRef.current;
+    if (!panel) {
+      return;
+    }
+
+    const rect = panel.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const edgeDistance = Math.min(x, y, rect.width - x, rect.height - y);
+    const edgeSensitivity = Math.min(76, Math.max(36, Math.min(rect.width, rect.height) * 0.38));
+    const edgeProximity = Math.max(0, Math.min(1, 1 - edgeDistance / edgeSensitivity));
+    const opacity = Math.round(Math.pow(edgeProximity, 0.68) * 100) / 100;
+
+    panel.style.setProperty("--claude-ai-panel-glow-x", `${x}px`);
+    panel.style.setProperty("--claude-ai-panel-glow-y", `${y}px`);
+    panel.style.setProperty("--claude-ai-panel-glow-opacity", `${opacity}`);
+  }
+
+  function handlePanelPointerLeave() {
+    panelRef.current?.style.setProperty("--claude-ai-panel-glow-opacity", "0");
+  }
+
   return (
     <form
       aria-label="Message composer"
@@ -310,7 +338,12 @@ export function ClaudeStyleAiInput({
         </div>
       ) : null}
 
-      <div className="claude-ai-input__panel">
+      <div
+        ref={panelRef}
+        className="claude-ai-input__panel"
+        onPointerLeave={handlePanelPointerLeave}
+        onPointerMove={handlePanelPointerMove}
+      >
         <textarea
           aria-label="Message"
           className="claude-ai-input__textarea"
@@ -423,6 +456,7 @@ export function ClaudeStyleAiInput({
                 </div>
               ) : null}
             </div>
+            {contextUsageView ? <ContextUsageIndicator view={contextUsageView} /> : null}
           </div>
 
           {responding ? (
@@ -451,6 +485,97 @@ export function ClaudeStyleAiInput({
       </div>
     </form>
   );
+}
+
+type ContextUsageView = {
+  ariaLabel: string;
+  leftPercent: number;
+  percent: number;
+  state: "normal" | "warn" | "critical";
+  strategy?: string;
+  tokenLabel: string;
+};
+
+function ContextUsageIndicator({ view }: { view: ContextUsageView }) {
+  return (
+    <div
+      aria-label={view.ariaLabel}
+      className="claude-ai-input__context-usage"
+      data-state={view.state}
+      role="img"
+      tabIndex={0}
+    >
+      <svg aria-hidden="true" viewBox="0 0 24 24">
+        <circle className="claude-ai-input__context-usage-track" cx="12" cy="12" r="8.5" pathLength={100} />
+        <circle
+          className="claude-ai-input__context-usage-value"
+          cx="12"
+          cy="12"
+          r="8.5"
+          pathLength={100}
+          strokeDasharray={`${view.percent} 100`}
+        />
+      </svg>
+      <span className="claude-ai-input__context-usage-tip" role="tooltip">
+        <strong>Context window</strong>
+        <span>{view.percent}% used ({view.leftPercent}% left)</span>
+        <span>{view.tokenLabel}</span>
+        {view.strategy ? <span>Strategy: {view.strategy}</span> : null}
+      </span>
+    </div>
+  );
+}
+
+function buildContextUsageView(usage: TokenUsage | undefined): ContextUsageView | undefined {
+  if (!usage) {
+    return undefined;
+  }
+  const windowTokens = positiveNumber(usage.contextWindowTokens);
+  const usedTokens = positiveNumber(usage.contextWindowUsedTokens ?? usage.promptTokens ?? usage.totalTokens);
+  const percent = boundedPercent(usage.percent ?? (
+    windowTokens !== undefined && usedTokens !== undefined ? (usedTokens / windowTokens) * 100 : undefined
+  ));
+  if (percent === undefined) {
+    return undefined;
+  }
+
+  const leftPercent = Math.max(0, Math.round(100 - percent));
+  const tokenLabel = windowTokens !== undefined && usedTokens !== undefined
+    ? `${formatTokenCount(usedTokens)} / ${formatTokenCount(windowTokens)} tokens used`
+    : "Token budget reported by provider";
+  return {
+    ariaLabel: `Context window ${percent}% used, ${leftPercent}% left`,
+    leftPercent,
+    percent,
+    state: percent >= 85 ? "critical" : percent >= 60 ? "warn" : "normal",
+    strategy: usage.contextWindowStrategy,
+    tokenLabel,
+  };
+}
+
+function boundedPercent(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function positiveNumber(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) {
+    return `${trimDecimal(value / 1_000_000)}M`;
+  }
+  if (value >= 1_000) {
+    return `${trimDecimal(value / 1_000)}k`;
+  }
+  return String(Math.round(value));
+}
+
+function trimDecimal(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/, "");
 }
 
 function AttachmentChip({

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -158,16 +158,51 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const sessionEmptyState = await screen.findByLabelText("No sessions yet.");
-    const conversationEmptyState = await screen.findByLabelText("Select or create a session.");
+    const start = await screen.findByLabelText("Start a new chat");
 
     expect(sessionEmptyState.classList.contains("react-text-type")).toBe(true);
     expect(sessionEmptyState.getAttribute("data-text-type")).toBe("once");
     expect(sessionEmptyState.getAttribute("aria-label")).toBe("No sessions yet.");
     expect(within(sessionEmptyState).getByTestId("text-type-visual")).toBeTruthy();
-    expect(conversationEmptyState.classList.contains("react-text-type")).toBe(true);
-    expect(conversationEmptyState.getAttribute("data-text-type")).toBe("once");
-    expect(conversationEmptyState.getAttribute("aria-label")).toBe("Select or create a session.");
-    expect(within(conversationEmptyState).getByTestId("text-type-visual")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "New Chat" })).toBeTruthy();
+    expect(screen.queryByLabelText("Select or create a session.")).toBeNull();
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    expect(within(start).getByLabelText("Prompt suggestions")).toBeTruthy();
+  });
+
+  it("starts in a draft new chat when there are no sessions", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({ sessions: [] });
+    const created = {
+      id: "s-new",
+      chatId: "chat-new",
+      title: "New session",
+      updatedAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      status: "idle" as const,
+    };
+    stores.sessionStore.create = vi.fn(async () => created);
+    stores.sessionStore.list = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([created]);
+    stores.chatStore.load = vi.fn(async () => []);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await screen.findByLabelText("Start a new chat");
+    const input = screen.getByRole("textbox", { name: /message/i }) as HTMLTextAreaElement;
+
+    expect(input.disabled).toBe(false);
+    expect(screen.getByRole("heading", { name: "New Chat" })).toBeTruthy();
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+
+    await user.type(input, "Hello from an empty app");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
+    await waitFor(() => expect(stores.sessionStore.create).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s-new", {
+      text: "Hello from an empty app",
+      usePersistentRag: true,
+    }));
   });
 
   it("adds Animated List hooks to session rows", async () => {
@@ -297,6 +332,42 @@ describe("ChatPage", () => {
     expect(composer.classList.contains("react-composer--raised")).toBe(false);
     expect(screen.getByRole("textbox", { name: /message/i }).getAttribute("placeholder")).toBe("Message Tinybot");
     expect(message).toBeTruthy();
+  });
+
+  it("renders context window usage as an icon-only composer indicator", async () => {
+    const stores = createStores();
+    const usageMessages: ReactChatMessage[] = [
+      {
+        id: "u1",
+        role: "user",
+        createdAtMs: Date.UTC(2026, 6, 4, 11, 57, 0),
+        text: "Can you help?",
+        status: "complete",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        createdAtMs: Date.UTC(2026, 6, 4, 11, 58, 0),
+        text: "Yes.",
+        status: "complete",
+        usage: {
+          contextWindowRemainingTokens: 168000,
+          contextWindowStrategy: "compact",
+          contextWindowTokens: 256000,
+          contextWindowUsedTokens: 88000,
+          percent: 34.4,
+        },
+      },
+    ];
+    stores.chatStore.load = vi.fn(async () => usageMessages);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const indicator = await screen.findByLabelText("Context window 34% used, 66% left");
+    expect(indicator.classList.contains("claude-ai-input__context-usage")).toBe(true);
+    expect(indicator.getAttribute("data-state")).toBe("normal");
+    expect(indicator.textContent).toContain("88k / 256k tokens used");
+    expect(indicator.textContent).toContain("Strategy: compact");
   });
 
   it("rotates empty-session title and suggestion groups every eight seconds", async () => {
@@ -1491,6 +1562,34 @@ describe("ChatPage", () => {
     expect(css).toContain("react-session-dissolve");
     expect(css).toContain("react-session-particle-burst");
     expect(css).toContain(".react-session-row__particles");
+  });
+
+  it("applies a warm border glow treatment to the composer panel", () => {
+    const css = readFileSync("src/react-workbench/styles/workbench.css", "utf8");
+    const inputSource = readFileSync("src/components/ui/claude-style-ai-input.tsx", "utf8");
+
+    expect(inputSource).toContain("function handlePanelPointerMove");
+    expect(inputSource).toContain("--claude-ai-panel-glow-x");
+    expect(inputSource).toContain("--claude-ai-panel-glow-y");
+    expect(inputSource).toContain("--claude-ai-panel-glow-opacity");
+    expect(css).toContain("--claude-ai-panel-glow-opacity: 0");
+    expect(css).toContain("--claude-ai-panel-glow-x: 50%");
+    expect(css).toContain("--claude-ai-panel-glow-y: 100%");
+    expect(css).toContain("overflow: visible");
+    expect(css).toContain(".claude-ai-input__panel::before");
+    expect(css).toContain("circle at var(--claude-ai-panel-glow-x) var(--claude-ai-panel-glow-y)");
+    expect(css).toContain("var(--color-warning) 0");
+    expect(css).toContain("var(--color-primary) 24px");
+    expect(css).toContain("padding: 2px");
+    expect(css).toContain("transition: opacity 260ms var(--motion-ease-standard)");
+    expect(css).toContain("border-color: color-mix(in srgb, var(--color-primary) 24%, var(--color-hairline))");
+    expect(css).toContain("var(--color-primary)");
+    expect(css).toContain("var(--color-warning)");
+    expect(css).toContain("-webkit-mask-composite: xor");
+    expect(css).toContain(".claude-ai-input__panel:focus-within");
+    expect(css).toContain(".claude-ai-input__context-usage");
+    expect(css).toContain(".claude-ai-input__context-usage-tip");
+    expect(inputSource).toContain("strokeDasharray={`${view.percent} 100`}");
   });
 
   it("uses a dense warm-white micro-particle burst for the session delete dissolve", () => {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -148,6 +148,7 @@ export function ChatPage({
   settingsStore,
 }: ChatPageProps) {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [sessionsLoaded, setSessionsLoaded] = useState(false);
   const [activeSessionId, setActiveSessionId] = useState("");
   const [messages, setMessages] = useState<ReactChatMessage[]>([]);
   const [loadedMessageSessionId, setLoadedMessageSessionId] = useState("");
@@ -168,16 +169,22 @@ export function ChatPage({
   const queuedInputSequence = useRef(0);
   const deleteDissolveTimers = useRef<number[]>([]);
   const lastCreateSessionSignal = useRef(createSessionSignal);
+  const draftSessionCreatePromise = useRef<Promise<SessionSummary> | null>(null);
   const resolvedSessionSidebarCollapsed = sessionSidebarCollapsed ?? localSessionSidebarCollapsed;
   const activeSession = useMemo(
     () => sessions.find((session) => session.id === activeSessionId) ?? sessions[0],
     [activeSessionId, sessions],
   );
+  const draftNewSession = sessionsLoaded && !activeSession;
   const messagesLoaded = Boolean(activeSession) && loadedMessageSessionId === activeSession?.id;
-  const emptyActiveSession = messagesLoaded && messages.length === 0;
+  const emptyActiveSession = draftNewSession || (messagesLoaded && messages.length === 0);
   const sessionRunning = activeSession?.status === "running" || activeSession?.status === "waiting_approval";
   const sessionResponding = sessionRunning && !emptyActiveSession;
   const activeQueuedInputs = activeSession ? queuedInputsBySession.get(activeSession.id) ?? [] : [];
+  const activeContextUsage = useMemo(
+    () => [...messages].reverse().find((message) => message.usage)?.usage,
+    [messages],
+  );
 
   useEffect(() => {
     sessionsRef.current = sessions;
@@ -198,6 +205,7 @@ export function ChatPage({
       }
       sessionsRef.current = nextSessions;
       setSessions(nextSessions);
+      setSessionsLoaded(true);
       setActiveSessionId((current) => current || nextSessions[0]?.id || "");
     });
     return () => {
@@ -293,8 +301,7 @@ export function ChatPage({
 
   async function handleCreateSession() {
     const created = await sessionStore.create();
-    setSessions((current) => [created, ...current]);
-    setActiveSessionId(created.id);
+    activateCreatedSession(created);
   }
 
   async function handleCreateSessionFromSearch() {
@@ -387,21 +394,22 @@ export function ChatPage({
     options: ComposerSendOptions,
   ) {
     const text = formatComposerMessage(message, files, pastedContent);
-    if (!text || !activeSession) {
+    const sendSession = activeSession ?? await createSessionForDraft();
+    if (!text || !sendSession) {
       return;
     }
     const queuedResult = submitComposerText({
       approvals: [],
       content: text,
-      isRunning: isQueueableRunningSession(activeSession, emptyActiveSession),
+      isRunning: isQueueableRunningSession(sendSession, emptyActiveSession),
       now: nextQueuedInputTimestamp(),
       queuedInputs: activeQueuedInputs,
     });
     if (queuedResult.kind !== "send_message") {
-      handleQueuedComposerResult(activeSession.id, queuedResult, options);
+      handleQueuedComposerResult(sendSession.id, queuedResult, options);
       return;
     }
-    await chatStore.send(activeSession.id, {
+    await chatStore.send(sendSession.id, {
       text: queuedResult.content,
       ...(options.model ? { model: options.model } : {}),
       ...(typeof options.usePersistentRag === "boolean" ? { usePersistentRag: options.usePersistentRag } : {}),
@@ -431,6 +439,29 @@ export function ChatPage({
       }]);
       return next;
     });
+  }
+
+  async function createSessionForDraft(): Promise<SessionSummary | null> {
+    if (!draftNewSession) {
+      return null;
+    }
+    if (!draftSessionCreatePromise.current) {
+      draftSessionCreatePromise.current = sessionStore.create()
+        .then((created) => {
+          activateCreatedSession(created);
+          return created;
+        })
+        .finally(() => {
+          draftSessionCreatePromise.current = null;
+        });
+    }
+    return draftSessionCreatePromise.current;
+  }
+
+  function activateCreatedSession(created: SessionSummary): void {
+    sessionsRef.current = [created, ...sessionsRef.current.filter((session) => session.id !== created.id)];
+    setSessions((current) => [created, ...current.filter((session) => session.id !== created.id)]);
+    setActiveSessionId(created.id);
   }
 
   function handleDeleteQueuedInput(sessionId: string, inputId: string) {
@@ -568,6 +599,7 @@ export function ChatPage({
   }
 
   const visibleAgentUiForms = agentUiForms.filter(isVisibleAgentUiForm);
+  const headerTitle = activeSession?.title ?? (draftNewSession ? "New Chat" : "No session selected");
 
   return (
     <section className="react-chat-page" aria-label="Chat" data-session-sidebar-collapsed={resolvedSessionSidebarCollapsed}>
@@ -666,7 +698,7 @@ export function ChatPage({
 
       <main className="react-chat-surface" data-empty-session={emptyActiveSession ? "true" : undefined}>
         <header className="react-chat-header">
-          <h1>{activeSession?.title ?? "No session selected"}</h1>
+          <h1>{headerTitle}</h1>
           <div className="react-chat-header__actions">
             <button
               aria-label="Open conversation menu"
@@ -731,8 +763,9 @@ export function ChatPage({
         {queueMessage ? <p className="react-queued-inputs__message">{queueMessage}</p> : null}
         <ClaudeStyleAiInput
           className={["react-composer", emptyActiveSession ? "react-composer--raised" : ""].filter(Boolean).join(" ")}
-          disabled={!activeSession}
+          disabled={!activeSession && !draftNewSession}
           defaultModel={defaultComposerModel}
+          contextUsage={activeContextUsage}
           models={composerModels}
           responding={sessionResponding}
           placeholder={emptyActiveSession ? "输入任务，或粘贴/拖入文件" : "Message Tinybot"}

--- a/src/react-workbench/chat/messageActions.ts
+++ b/src/react-workbench/chat/messageActions.ts
@@ -1,3 +1,5 @@
+import type { TokenUsage } from "../../app-core/chat/chatRunModel";
+
 export type ToolCallSummary = {
   approvalId?: string;
   approvalStatus?: string;
@@ -39,6 +41,7 @@ export type ReactChatMessage = {
   toolCalls?: ToolCallSummary[];
   turnId?: string;
   turnStatus?: string;
+  usage?: TokenUsage;
 };
 
 export type MessageActionContext = {

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => {
   const gatewayApi = {
     config: {
       get: vi.fn(async () => ({})),
-      providers: vi.fn(async () => []),
+      providers: vi.fn(async (): Promise<unknown> => []),
     },
     knowledge: {
       documents: vi.fn(async () => []),
@@ -426,5 +426,54 @@ describe("default desktop app services", () => {
     await services.chatStore.send("websocket:chat-1", { text: "new title candidate", usePersistentRag: true });
 
     expect(mocks.gatewayApi.sessions.patch).not.toHaveBeenCalled();
+  });
+
+  test("loads chat models only for the current default provider", async () => {
+    mocks.gatewayApi.config.get.mockResolvedValueOnce({
+      agents: {
+        defaults: {
+          provider: "deepseek",
+          activeProfile: "deepseek-default",
+          model: "deepseek-v4-pro",
+        },
+      },
+      providers: {
+        profiles: {
+          "deepseek-default": {
+            provider: "deepseek",
+            api_key_configured: true,
+            models: ["deepseek-v4-pro", "deepseek-v4-flash"],
+          },
+          "dashscope-default": {
+            provider: "dashscope",
+            api_key_configured: true,
+            models: ["qwen3-plus"],
+          },
+        },
+      },
+    });
+    mocks.gatewayApi.config.providers.mockResolvedValueOnce({
+      providers: [
+        { id: "deepseek", displayName: "DeepSeek", status: "ready" },
+        { id: "dashscope", displayName: "DashScope", status: "ready" },
+      ],
+    });
+    const services = createDesktopAppServices();
+    const models = await services.settingsStore.loadChatModels?.();
+
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: "deepseek-v4-pro",
+        providerId: "deepseek",
+        default: true,
+      }),
+      expect.objectContaining({
+        id: "deepseek-v4-flash",
+        providerId: "deepseek",
+      }),
+    ]);
+    expect(models).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "qwen3-plus" }),
+    ]));
   });
 });

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -27,6 +27,7 @@ import {
   type NormalizedGatewayEvent,
 } from "../app-core/gateway/gatewayWebSocketClient";
 import { createDesktopNativeConfigApi } from "../app-core/native/desktopNativeConfig";
+import { applyNativeConfigPatch } from "../app-core/native/desktopNativeConfigPatch";
 import { createDesktopNativeCoworkApi } from "../app-core/native/desktopNativeCowork";
 import { createDesktopNativeKnowledgeApi } from "../app-core/native/desktopNativeKnowledge";
 import { createDesktopNativeSessionsApi } from "../app-core/native/desktopNativeSessions";
@@ -43,6 +44,12 @@ import {
   buildDesktopSettingsFormState,
   buildDesktopSettingsPaneModel,
 } from "../app-core/settings/desktopSettingsProviders";
+import { saveDesktopSettingsConfig } from "../app-core/settings/desktopSettingsSave";
+import { buildAgentDefaultsSettings } from "../app-core/settings/agentDefaultsSettings";
+import {
+  buildProviderModelsSettings,
+  normalizeProviderModelFetchResult,
+} from "../app-core/settings/providerModelsSettings";
 import type {
   AppServices,
   ChatModelOption,
@@ -451,6 +458,58 @@ export function createDesktopAppServices(): AppServices {
         const pane = buildDesktopSettingsPaneModel(state, { providerCatalog });
         return normalizeChatModelOptions(pane);
       },
+      async loadProviderSettings() {
+        await initialize();
+        return buildProviderModelsSettings(await loadSettingsSnapshot());
+      },
+      async loadAgentDefaultsSettings() {
+        await initialize();
+        return buildAgentDefaultsSettings(await loadSettingsSnapshot());
+      },
+      async saveAgentDefaultsSettings(currentConfig, patch) {
+        await initialize();
+        const result = await saveDesktopSettingsConfig(currentConfig, patch, {
+          applyNativeConfigPatch: nativeMode
+            ? (configToPatch, nativePatch) => applyNativeConfigPatch(configToPatch, nativePatch, { invoke })
+            : undefined,
+          applyGatewayConfigPatch: (gatewayPatch) => gatewayApi.config.patch(gatewayPatch),
+        });
+        const savedConfig = result.persistedRevision && isRecord(result.config)
+          ? { ...result.config, revision: result.persistedRevision }
+          : result.config;
+        return buildAgentDefaultsSettings(savedConfig);
+      },
+      async fetchProviderModels(input) {
+        await initialize();
+        if (input.modelDiscovery.status !== "openai-compatible") {
+          return {
+            ok: true,
+            models: [],
+            warning: "This provider uses a static model list.",
+            url: null,
+            error: null,
+          };
+        }
+        return normalizeProviderModelFetchResult(await gatewayApi.config.providerModels({
+          provider: input.providerId,
+          profile: input.profileId,
+          apiBase: input.apiBase,
+          refreshLive: true,
+        }));
+      },
+      async saveProviderSettings(currentConfig, patch) {
+        await initialize();
+        const result = await saveDesktopSettingsConfig(currentConfig, patch, {
+          applyNativeConfigPatch: nativeMode
+            ? (configToPatch, nativePatch) => applyNativeConfigPatch(configToPatch, nativePatch, { invoke })
+            : undefined,
+          applyGatewayConfigPatch: (gatewayPatch) => gatewayApi.config.patch(gatewayPatch),
+        });
+        const savedConfig = result.persistedRevision && isRecord(result.config)
+          ? { ...result.config, revision: result.persistedRevision }
+          : result.config;
+        return buildProviderModelsSettings(savedConfig);
+      },
     },
   };
 }
@@ -507,6 +566,7 @@ function mapMessage(
     ...(toolCalls.length ? { toolCalls } : {}),
     ...(message.turnId ? { turnId: message.turnId } : {}),
     ...(message.turnStatus ? { turnStatus: message.turnStatus } : {}),
+    ...(message.usage ? { usage: normalizeUsage(message.usage) } : {}),
   };
 }
 
@@ -540,6 +600,25 @@ function mapContextReference(reference: NativeChatReference, index: number) {
     ...(reference.detail ? { detail: reference.detail } : {}),
     ...(reference.sourcePath ? { sourcePath: reference.sourcePath } : {}),
     ...(typeof reference.sourceLine === "number" ? { sourceLine: reference.sourceLine } : {}),
+  };
+}
+
+function normalizeUsage(value: unknown) {
+  const payload = isRecord(value) ? value : {};
+  if (!Object.keys(payload).length) {
+    return undefined;
+  }
+  return {
+    cachedTokens: numberValue(payload.cached_tokens ?? payload.cachedTokens),
+    completionTokens: numberValue(payload.completion_tokens ?? payload.completionTokens),
+    contextWindowRemainingTokens: numberValue(payload.context_window_remaining_tokens ?? payload.contextWindowRemainingTokens),
+    contextWindowStrategy: stringValue(payload.context_window_strategy ?? payload.contextWindowStrategy) || undefined,
+    contextWindowTokens: numberValue(payload.context_window_tokens ?? payload.contextWindowTokens),
+    contextWindowUsedTokens: numberValue(payload.context_window_used_tokens ?? payload.contextWindowUsedTokens),
+    estimatedContextTokens: numberValue(payload.estimated_context_tokens ?? payload.estimatedContextTokens),
+    percent: numberValue(payload.percent ?? payload.percentage ?? payload.token_usage_percent ?? payload.tokenUsagePercent),
+    promptTokens: numberValue(payload.prompt_tokens ?? payload.promptTokens),
+    totalTokens: numberValue(payload.total_tokens ?? payload.totalTokens),
   };
 }
 
@@ -668,8 +747,12 @@ function normalizeChatModelOptions(
 ): ChatModelOption[] {
   const defaultModel = stringValue(pane.defaultRouting?.model);
   const defaultProviderId = stringValue(pane.defaultRouting?.providerId);
+  const defaultProvider = pane.providerCatalog.find((provider) => provider.id === defaultProviderId);
+  const providers = defaultProvider
+    ? [defaultProvider]
+    : pane.providerCatalog.filter((provider) => provider.enabled !== false);
   const options = new Map<string, ChatModelOption>();
-  for (const provider of pane.providerCatalog) {
+  for (const provider of providers) {
     if (provider.enabled === false) {
       continue;
     }
@@ -689,7 +772,6 @@ function normalizeChatModelOptions(
     }
   }
   if (defaultModel && !options.has(defaultModel)) {
-    const defaultProvider = pane.providerCatalog.find((provider) => provider.id === defaultProviderId);
     options.set(defaultModel, {
       id: defaultModel,
       label: defaultModel,

--- a/src/react-workbench/services.ts
+++ b/src/react-workbench/services.ts
@@ -1,5 +1,11 @@
 import type { ReactChatMessage } from "./chat/messageActions";
 import type { AgentUiForm } from "../app-core/agent-ui/agentUiEvents";
+import type { AgentDefaultsSettingsData } from "../app-core/settings/agentDefaultsSettings";
+import type {
+  ProviderModelFetchInput,
+  ProviderModelFetchResult,
+  ProviderModelsSettingsData,
+} from "../app-core/settings/providerModelsSettings";
 
 export type SessionSummary = {
   id: string;
@@ -87,6 +93,11 @@ export type ToolsStore = {
 export type SettingsStore = {
   load(): Promise<Array<{ label: string; value: string }>>;
   loadChatModels?(): Promise<ChatModelOption[]>;
+  loadAgentDefaultsSettings?(): Promise<AgentDefaultsSettingsData>;
+  saveAgentDefaultsSettings?(currentConfig: unknown, patch: unknown): Promise<AgentDefaultsSettingsData>;
+  loadProviderSettings?(): Promise<ProviderModelsSettingsData>;
+  fetchProviderModels?(input: ProviderModelFetchInput): Promise<ProviderModelFetchResult>;
+  saveProviderSettings?(currentConfig: unknown, patch: unknown): Promise<ProviderModelsSettingsData>;
 };
 
 export type ChatModelOption = {

--- a/src/react-workbench/settings/AgentDefaultsSettingsPage.tsx
+++ b/src/react-workbench/settings/AgentDefaultsSettingsPage.tsx
@@ -1,0 +1,212 @@
+import { ArrowUpRight, Check } from "lucide-react";
+import { useEffect, useState, type FormEvent } from "react";
+import {
+  buildAgentDefaultsPatch,
+  buildAgentDefaultsSettings,
+  validateAgentDefaultsInput,
+  type AgentDefaultsFormValues,
+  type AgentDefaultsSettingsData,
+  type AgentDefaultsValidationErrors,
+} from "../../app-core/settings/agentDefaultsSettings";
+import type { SettingsStore } from "../services";
+
+type AgentDefaultsSettingsPageProps = {
+  onNavigateToProviderModels: () => void;
+  settingsStore: SettingsStore;
+};
+
+export function AgentDefaultsSettingsPage({ onNavigateToProviderModels, settingsStore }: AgentDefaultsSettingsPageProps) {
+  const [data, setData] = useState<AgentDefaultsSettingsData | null>(null);
+  const [values, setValues] = useState<AgentDefaultsFormValues | null>(null);
+  const [errors, setErrors] = useState<AgentDefaultsValidationErrors>({});
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    settingsStore.loadAgentDefaultsSettings?.()
+      .then((snapshot) => {
+        if (!cancelled) {
+          setData(snapshot);
+          setValues(snapshot.values);
+          setLoadError(null);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setLoadError(error instanceof Error ? error.message : String(error));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [settingsStore]);
+
+  function editValue(field: keyof AgentDefaultsFormValues, value: string) {
+    setValues((current) => current ? { ...current, [field]: value } : current);
+    setErrors((current) => ({ ...current, [field]: undefined }));
+    setSaveStatus(null);
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!data || !values || !settingsStore.saveAgentDefaultsSettings) {
+      return;
+    }
+    const nextErrors = validateAgentDefaultsInput(values);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length) {
+      return;
+    }
+    setSaving(true);
+    setSaveStatus("Saving...");
+    try {
+      const next = await settingsStore.saveAgentDefaultsSettings(data.currentConfig, buildAgentDefaultsPatch(values));
+      const nextData = next.values ? next : buildAgentDefaultsSettings(next.currentConfig);
+      setData(nextData);
+      setValues(nextData.values);
+      setSaveStatus("Saved");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loadError) {
+    return <p className="react-settings-alert" role="alert">{loadError}</p>;
+  }
+  if (!data || !values) {
+    return <p className="react-empty-state">Loading agent defaults...</p>;
+  }
+
+  return (
+    <section className="react-agent-defaults-settings" aria-labelledby="agent-defaults-title">
+      <div className="react-provider-settings__header">
+        <div>
+          <h2 id="agent-defaults-title">Agent Defaults</h2>
+          <p>Runtime defaults apply to new chat and agent runs unless a specific Agent overrides them.</p>
+        </div>
+      </div>
+
+      <section className="react-settings-linked-summary" aria-labelledby="agent-default-model-title">
+        <div>
+          <h3 id="agent-default-model-title">Default LLM</h3>
+          <p>Change the active profile and default model from Provider & Models.</p>
+        </div>
+        <dl>
+          <div>
+            <dt>Active profile</dt>
+            <dd>{data.activeProfileId ?? "Not configured"}</dd>
+          </div>
+          <div>
+            <dt>Default model</dt>
+            <dd>{data.defaultModel ?? "Not configured"}</dd>
+          </div>
+        </dl>
+        <button type="button" aria-label="Change default model in Provider & Models" onClick={onNavigateToProviderModels}>
+          <span>Provider & Models</span>
+          <ArrowUpRight aria-hidden="true" size={15} />
+        </button>
+      </section>
+
+      {saveStatus ? <p className="react-settings-save-status" role="status">{saveStatus}</p> : null}
+
+      <form className="react-agent-defaults-form" onSubmit={submit}>
+        <section aria-labelledby="agent-runtime-title">
+          <h3 id="agent-runtime-title">Runtime</h3>
+          <div className="react-agent-defaults-grid">
+            <AgentDefaultInput
+              error={errors.timezone}
+              label="Timezone"
+              value={values.timezone}
+              onChange={(value) => editValue("timezone", value)}
+            />
+            <AgentDefaultInput
+              error={errors.temperature}
+              label="Temperature"
+              value={values.temperature}
+              onChange={(value) => editValue("temperature", value)}
+            />
+            <AgentDefaultInput
+              error={errors.maxTokens}
+              label="Max output tokens"
+              value={values.maxTokens}
+              onChange={(value) => editValue("maxTokens", value)}
+            />
+            <AgentDefaultInput
+              error={errors.contextWindowTokens}
+              label="Context window budget"
+              value={values.contextWindowTokens}
+              onChange={(value) => editValue("contextWindowTokens", value)}
+            />
+            <label>
+              <span>Context window strategy</span>
+              <select
+                aria-label="Context window strategy"
+                value={values.contextWindowStrategy}
+                onChange={(event) => editValue("contextWindowStrategy", event.currentTarget.value)}
+              >
+                <option value="discard">Discard old messages</option>
+                <option value="compact">Compact old messages</option>
+              </select>
+              {errors.contextWindowStrategy ? (
+                <small role="alert">{errors.contextWindowStrategy}</small>
+              ) : null}
+            </label>
+            <AgentDefaultInput
+              error={errors.maxToolIterations}
+              label="Max tool iterations"
+              value={values.maxToolIterations}
+              onChange={(value) => editValue("maxToolIterations", value)}
+            />
+            <label>
+              <span>Reasoning effort</span>
+              <select
+                aria-label="Reasoning effort"
+                value={values.reasoningEffort}
+                onChange={(event) => editValue("reasoningEffort", event.currentTarget.value)}
+              >
+                <option value="">Default</option>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+              </select>
+            </label>
+          </div>
+        </section>
+        <footer>
+          {data.revision ? <small>Config revision {data.revision}</small> : <span />}
+          <button type="submit" aria-label="Save agent defaults" disabled={saving}>
+            <Check aria-hidden="true" size={15} />
+            {saving ? "Saving" : "Save"}
+          </button>
+        </footer>
+      </form>
+    </section>
+  );
+}
+
+function AgentDefaultInput({
+  error,
+  label,
+  onChange,
+  value,
+}: {
+  error?: string;
+  label: string;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  return (
+    <label>
+      <span>{label}</span>
+      <input
+        aria-describedby={error ? `${label}-error` : undefined}
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+      {error ? <small id={`${label}-error`} role="alert">{error}</small> : null}
+    </label>
+  );
+}

--- a/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
+++ b/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
@@ -1,0 +1,509 @@
+import { Check, KeyRound, Plus, RefreshCw, Search, Settings, Trash2, X } from "lucide-react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import {
+  buildProviderConfigurePatch,
+  buildProviderDefaultLlmPatch,
+  buildProviderModelsPatch,
+  buildProviderModelsSettings,
+  type ProviderModelFetchInput,
+  type ProviderModelFetchResult,
+  type ProviderCardModel,
+  type ProviderModelItem,
+  type ProviderModelsSettingsData,
+} from "../../app-core/settings/providerModelsSettings";
+import type { SettingsStore } from "../services";
+
+type ProviderModelsSettingsPageProps = {
+  settingsStore: SettingsStore;
+};
+
+export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSettingsPageProps) {
+  const [data, setData] = useState<ProviderModelsSettingsData | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<string | null>(null);
+  const [configureProvider, setConfigureProvider] = useState<ProviderCardModel | null>(null);
+  const [modelsProvider, setModelsProvider] = useState<ProviderCardModel | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    settingsStore.loadProviderSettings?.()
+      .then((snapshot) => {
+        if (!cancelled) {
+          setData(snapshot);
+          setLoadError(null);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setLoadError(error instanceof Error ? error.message : String(error));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [settingsStore]);
+
+  async function savePatch(patch: unknown): Promise<void> {
+    if (!data || !settingsStore.saveProviderSettings) {
+      return;
+    }
+    setSaveStatus("Saving...");
+    const next = await settingsStore.saveProviderSettings(data.currentConfig, patch);
+    setData(next.providers.length ? next : buildProviderModelsSettings(next.currentConfig));
+    setSaveStatus("Saved");
+  }
+  const fetchProviderModels = settingsStore.fetchProviderModels;
+
+  if (loadError) {
+    return <p className="react-settings-alert" role="alert">{loadError}</p>;
+  }
+  if (!data) {
+    return <p className="react-empty-state">Loading provider settings...</p>;
+  }
+
+  return (
+    <section className="react-provider-settings" aria-labelledby="provider-models-title">
+      <div className="react-provider-settings__header">
+        <div>
+          <h2 id="provider-models-title">Provider & Models</h2>
+          <p>Built-in providers use backend config profiles for credentials, endpoints, and model defaults.</p>
+        </div>
+      </div>
+
+      <DefaultLlmPanel
+        data={data}
+        onSave={(patch) => savePatch(patch)}
+      />
+
+      {saveStatus ? <p className="react-settings-save-status" role="status">{saveStatus}</p> : null}
+
+      <div className="react-provider-grid">
+        {data.providers.map((provider) => (
+          <ProviderPresetCard
+            key={provider.id}
+            provider={provider}
+            onConfigure={() => setConfigureProvider(provider)}
+            onModels={() => setModelsProvider(provider)}
+          />
+        ))}
+      </div>
+
+      {configureProvider ? (
+        <ProviderConfigureDialog
+          provider={configureProvider}
+          onClose={() => setConfigureProvider(null)}
+          onSave={async (patch) => {
+            await savePatch(patch);
+            setConfigureProvider(null);
+          }}
+        />
+      ) : null}
+
+      {modelsProvider ? (
+        <ProviderModelsDialog
+          provider={modelsProvider}
+          onClose={() => setModelsProvider(null)}
+          onRefresh={fetchProviderModels
+            ? (input) => fetchProviderModels(input)
+            : undefined}
+          onSave={async (patch) => {
+            await savePatch(patch);
+            setModelsProvider(null);
+          }}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function DefaultLlmPanel({
+  data,
+  onSave,
+}: {
+  data: ProviderModelsSettingsData;
+  onSave: (patch: unknown) => Promise<void>;
+}) {
+  const initialProfileId = data.activeProfileId
+    ?? data.providers.find((provider) => provider.configured)?.profileId
+    ?? data.providers[0]?.profileId
+    ?? "";
+  const initialProvider = data.providers.find((provider) => provider.profileId === initialProfileId) ?? data.providers[0];
+  const initialModelOptions = initialProvider?.models ?? [];
+  const initialModel = data.agentDefaultModel
+    && initialModelOptions.some((model) => model.id === data.agentDefaultModel)
+    ? data.agentDefaultModel
+    : initialProvider?.defaultModel ?? initialModelOptions[0]?.id ?? "";
+  const [profileId, setProfileId] = useState(initialProfileId);
+  const selectedProvider = data.providers.find((provider) => provider.profileId === profileId) ?? data.providers[0];
+  const modelOptions = selectedProvider?.models ?? [];
+  const [model, setModel] = useState(initialModel);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setProfileId(initialProfileId);
+    setModel(initialModel);
+  }, [initialModel, initialProfileId]);
+
+  useEffect(() => {
+    const nextProvider = data.providers.find((provider) => provider.profileId === profileId) ?? data.providers[0];
+    const nextModels = nextProvider?.models ?? [];
+    if (!nextModels.some((option) => option.id === model)) {
+      setModel(nextProvider?.defaultModel ?? nextModels[0]?.id ?? "");
+    }
+  }, [data.providers, model, profileId]);
+
+  const dirty = profileId !== (data.activeProfileId ?? "") || model !== (data.agentDefaultModel ?? "");
+  const canSave = Boolean(profileId && model && dirty && !saving);
+
+  async function saveDefaultLlm() {
+    if (!canSave) {
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(buildProviderDefaultLlmPatch({ profileId, model }));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="react-default-llm-panel" aria-labelledby="default-llm-title">
+      <h3 id="default-llm-title">Default LLM</h3>
+      <div className="react-default-llm-panel__controls">
+        <label>
+          <span>Provider</span>
+          <select
+            aria-label="Provider"
+            value={profileId}
+            onChange={(event) => {
+              const nextProfileId = event.currentTarget.value;
+              const nextProvider = data.providers.find((provider) => provider.profileId === nextProfileId);
+              setProfileId(nextProfileId);
+              setModel(nextProvider?.defaultModel ?? nextProvider?.models[0]?.id ?? "");
+            }}
+          >
+            {data.providers.map((provider) => (
+              <option key={provider.profileId} value={provider.profileId}>
+                {provider.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Model</span>
+          <select aria-label="Model" value={model} onChange={(event) => setModel(event.currentTarget.value)}>
+            {modelOptions.length
+              ? modelOptions.map((option) => (
+                <option key={option.id} value={option.id}>{option.label} ({option.id})</option>
+              ))
+              : <option value="">No models configured</option>}
+          </select>
+        </label>
+        <button type="button" aria-label="Save default LLM" disabled={!canSave} onClick={saveDefaultLlm}>
+          <Check aria-hidden="true" size={15} />
+          {saving ? "Saving" : dirty ? "Save" : "Saved"}
+        </button>
+      </div>
+      <p>Set the global default LLM. A specific Agent can still choose a different model from the chat page.</p>
+      {data.revision ? <small>Config revision {data.revision}</small> : null}
+    </section>
+  );
+}
+
+function ProviderPresetCard({
+  onConfigure,
+  onModels,
+  provider,
+}: {
+  provider: ProviderCardModel;
+  onConfigure: () => void;
+  onModels: () => void;
+}) {
+  return (
+    <article className="react-provider-card" aria-label={`${provider.label} provider`} data-status={provider.status}>
+      <div className="react-provider-card__top">
+        <div className="react-provider-card__mark" aria-hidden="true">{provider.label.slice(0, 2)}</div>
+        <span className="react-provider-card__status">
+          <span aria-hidden="true" />
+          {provider.statusLabel}
+        </span>
+      </div>
+      <div className="react-provider-card__title">
+        <h3>{provider.label}</h3>
+        {provider.builtIn ? <span>Built-in</span> : null}
+        {provider.active ? <span>Active</span> : null}
+      </div>
+      <dl className="react-provider-card__facts">
+        <div>
+          <dt>Base URL</dt>
+          <dd>{provider.baseUrl}</dd>
+        </div>
+        <div>
+          <dt>API key</dt>
+          <dd>{provider.apiKeyConfigured ? "Configured" : "Not set"}</dd>
+        </div>
+        <div>
+          <dt>Models</dt>
+          <dd>{provider.modelCount ? `${provider.modelCount} models` : "No models"}</dd>
+        </div>
+      </dl>
+      <div className="react-provider-card__actions">
+        <button type="button" aria-label={`Manage ${provider.label} models`} onClick={onModels}>
+          <Search aria-hidden="true" size={15} />
+          Models
+        </button>
+        <button type="button" aria-label={`Configure ${provider.label}`} onClick={onConfigure}>
+          <Settings aria-hidden="true" size={15} />
+          Configure
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function ProviderConfigureDialog({
+  onClose,
+  onSave,
+  provider,
+}: {
+  provider: ProviderCardModel;
+  onClose: () => void;
+  onSave: (patch: unknown) => Promise<void>;
+}) {
+  const [apiBase, setApiBase] = useState(provider.baseUrl);
+  const [apiKey, setApiKey] = useState("");
+  const [activate, setActivate] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    await onSave(buildProviderConfigurePatch({
+      providerId: provider.id,
+      profileId: provider.profileId,
+      apiBase,
+      apiKey,
+      enabled: true,
+      activate,
+    }));
+  }
+
+  return (
+    <div className="react-settings-dialog-backdrop">
+      <form className="react-settings-dialog" aria-label={`Configure ${provider.label}`} role="dialog" onSubmit={submit}>
+        <header>
+          <h2>Configure {provider.label}</h2>
+          <button type="button" aria-label={`Close ${provider.label} configuration`} onClick={onClose}>
+            <X aria-hidden="true" size={17} />
+          </button>
+        </header>
+        <label>
+          <span>API base</span>
+          <input aria-label="API base" value={apiBase} onChange={(event) => setApiBase(event.currentTarget.value)} />
+        </label>
+        <label>
+          <span>API key</span>
+          <input
+            aria-label="API key"
+            autoComplete="off"
+            placeholder={provider.apiKeyConfigured ? "Leave blank to keep current key" : "Enter API key"}
+            type="password"
+            value={apiKey}
+            onChange={(event) => setApiKey(event.currentTarget.value)}
+          />
+        </label>
+        <label className="react-settings-checkbox">
+          <input checked={activate} type="checkbox" onChange={(event) => setActivate(event.currentTarget.checked)} />
+          <span>Set as active profile</span>
+        </label>
+        <section className="react-settings-dialog__advanced">
+          <h3>Advanced</h3>
+          <p>Custom headers and generation parameters are reserved for a later provider config pass.</p>
+        </section>
+        <footer>
+          <button type="button" onClick={onClose}>Cancel</button>
+          <button type="submit" disabled={saving || !apiBase.trim()}>
+            <KeyRound aria-hidden="true" size={15} />
+            Save
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}
+
+function ProviderModelsDialog({
+  onClose,
+  onRefresh,
+  onSave,
+  provider,
+}: {
+  provider: ProviderCardModel;
+  onClose: () => void;
+  onRefresh?: (input: ProviderModelFetchInput) => Promise<ProviderModelFetchResult>;
+  onSave: (patch: unknown) => Promise<void>;
+}) {
+  const [query, setQuery] = useState("");
+  const [models, setModels] = useState(provider.models);
+  const [newModel, setNewModel] = useState("");
+  const [defaultModel, setDefaultModel] = useState(provider.defaultModel ?? provider.models[0]?.id ?? "");
+  const [setAgentDefault, setSetAgentDefault] = useState(provider.active);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshMessage, setRefreshMessage] = useState<string | null>(null);
+  const filteredModels = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return normalizedQuery
+      ? models.filter((model) => model.id.toLowerCase().includes(normalizedQuery) || model.label.toLowerCase().includes(normalizedQuery))
+      : models;
+  }, [models, query]);
+
+  function addModel() {
+    const id = newModel.trim();
+    if (!id || models.some((model) => model.id === id)) {
+      return;
+    }
+    setModels([...models, { id, label: id, source: "user" }]);
+    setNewModel("");
+    if (!defaultModel) {
+      setDefaultModel(id);
+    }
+  }
+
+  function removeModel(model: ProviderModelItem) {
+    if (model.source !== "user") {
+      return;
+    }
+    const nextModels = models.filter((item) => item.id !== model.id);
+    setModels(nextModels);
+    if (defaultModel === model.id) {
+      setDefaultModel(nextModels[0]?.id ?? "");
+    }
+  }
+
+  async function refreshModels() {
+    if (!onRefresh || provider.modelDiscovery.status !== "openai-compatible") {
+      return;
+    }
+    setRefreshing(true);
+    setRefreshMessage(null);
+    try {
+      const result = await onRefresh({
+        providerId: provider.id,
+        profileId: provider.profileId,
+        apiBase: provider.baseUrl,
+        modelDiscovery: provider.modelDiscovery,
+      });
+      if (!result) {
+        return;
+      }
+      if (result.models.length) {
+        setModels((currentModels) => mergeFetchedModels(currentModels, result.models));
+        if (!defaultModel) {
+          setDefaultModel(result.models[0] ?? "");
+        }
+      }
+      setRefreshMessage(result.error || result.warning || (result.models.length ? `Fetched ${result.models.length} models.` : "No models returned."));
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  const canRefresh = Boolean(onRefresh) && provider.modelDiscovery.status === "openai-compatible";
+
+  return (
+    <div className="react-settings-dialog-backdrop">
+      <section className="react-settings-dialog react-settings-dialog--wide" aria-label={`${provider.label} models`} role="dialog">
+        <header>
+          <h2>{provider.label} models</h2>
+          <button type="button" aria-label="Close models" onClick={onClose}>
+            <X aria-hidden="true" size={17} />
+          </button>
+        </header>
+        <label>
+          <span>Search models</span>
+          <input aria-label="Search models" placeholder="Search models" value={query} onChange={(event) => setQuery(event.currentTarget.value)} />
+        </label>
+        <div className="react-provider-model-list">
+          {filteredModels.map((model) => (
+            <div className="react-provider-model-row" key={model.id}>
+              <div>
+                <strong>{model.label}</strong>
+                <small>{model.id}</small>
+              </div>
+              <span>{modelSourceLabel(model.source)}</span>
+              <button type="button" onClick={() => setDefaultModel(model.id)}>
+                {defaultModel === model.id ? <Check aria-hidden="true" size={15} /> : null}
+                Default
+              </button>
+              <button
+                type="button"
+                aria-label={`Remove ${model.id}`}
+                disabled={model.source !== "user"}
+                onClick={() => removeModel(model)}
+              >
+                <Trash2 aria-hidden="true" size={15} />
+              </button>
+            </div>
+          ))}
+          {!filteredModels.length ? <p className="react-empty-state">No models match the search.</p> : null}
+        </div>
+        <div className="react-provider-model-add">
+          <input aria-label="Add model ID" placeholder="model-id" value={newModel} onChange={(event) => setNewModel(event.currentTarget.value)} />
+          <button type="button" onClick={addModel}>
+            <Plus aria-hidden="true" size={15} />
+            Add model
+          </button>
+        </div>
+        <label className="react-settings-checkbox">
+          <input checked={setAgentDefault} type="checkbox" onChange={(event) => setSetAgentDefault(event.currentTarget.checked)} />
+          <span>Use selected model as agent default</span>
+        </label>
+        {refreshMessage ? <p className="react-settings-save-status" role="status">{refreshMessage}</p> : null}
+        <footer>
+          <button type="button" disabled={!canRefresh || refreshing} onClick={refreshModels}>
+            <RefreshCw aria-hidden="true" size={15} />
+            {provider.modelDiscovery.status === "static" ? "Static list" : refreshing ? "Refreshing" : "Refresh models"}
+          </button>
+          <button type="button" onClick={onClose}>Cancel</button>
+          <button
+            type="button"
+            onClick={() => onSave(buildProviderModelsPatch({
+              providerId: provider.id,
+              profileId: provider.profileId,
+              models: models.map((model) => model.id),
+              defaultModel,
+              setAgentDefault,
+            }))}
+          >
+            Save
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}
+
+function mergeFetchedModels(currentModels: ProviderModelItem[], fetchedModelIds: string[]): ProviderModelItem[] {
+  const next = [...currentModels];
+  const seen = new Set(next.map((model) => model.id));
+  for (const modelId of fetchedModelIds) {
+    const id = modelId.trim();
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    next.push({ id, label: id, source: "live" });
+  }
+  return next;
+}
+
+function modelSourceLabel(source: ProviderModelItem["source"]): string {
+  if (source === "built-in") {
+    return "Built-in";
+  }
+  if (source === "live") {
+    return "Provider fetched";
+  }
+  return "User added";
+}

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -5,6 +5,8 @@ import userEvent from "@testing-library/user-event";
 import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DesktopShell } from "./DesktopShell";
+import { buildAgentDefaultsSettings } from "../../app-core/settings/agentDefaultsSettings";
+import { buildProviderModelsSettings } from "../../app-core/settings/providerModelsSettings";
 import type { AppServices, SessionSummary } from "../services";
 import type { ReactChatMessage } from "../chat/messageActions";
 
@@ -14,7 +16,13 @@ function createServices(options: { messages?: ReactChatMessage[]; sessions?: Ses
   workspaceStore: { listFiles: ReturnType<typeof vi.fn> };
   knowledgeStore: { listDocuments: ReturnType<typeof vi.fn>; stats: ReturnType<typeof vi.fn> };
   toolsStore: { listSkills: ReturnType<typeof vi.fn> };
-  settingsStore: { load: ReturnType<typeof vi.fn> };
+  settingsStore: {
+    load: ReturnType<typeof vi.fn>;
+    loadAgentDefaultsSettings?: ReturnType<typeof vi.fn>;
+    saveAgentDefaultsSettings?: ReturnType<typeof vi.fn>;
+    loadProviderSettings?: ReturnType<typeof vi.fn>;
+    saveProviderSettings?: ReturnType<typeof vi.fn>;
+  };
 } {
   return {
     sessionStore: {
@@ -113,6 +121,11 @@ describe("DesktopShell", () => {
     expect(css).toMatch(/\.react-top-menu__trigger\s*{[^}]*font-size:\s*12px;/s);
     expect(css).toMatch(/\.react-top-menu__menu-item\s*{[^}]*font-size:\s*13px;/s);
     expect(css).toMatch(/\.react-activity-rail button\s*{[^}]*font-size:\s*10px;/s);
+    expect(css).toMatch(/\.react-workbench-layout\s*{[^}]*grid-template-columns:\s*58px minmax\(0,\s*1fr\);/s);
+    expect(css).toMatch(/\.react-activity-rail button span\s*{[^}]*display:\s*none;/s);
+    expect(css).toMatch(/\.react-activity-rail button::after\s*{[^}]*content:\s*attr\(data-label\);/s);
+    expect(css).toMatch(/\.react-session-list\s*{[^}]*transition:\s*width 260ms var\(--motion-ease-standard\);/s);
+    expect(css).toMatch(/\.react-session-list\[data-collapsed="true"\]\s*{[^}]*width:\s*64px;/s);
     expect(css).toMatch(/\.react-session-list__new\s*{[^}]*font-size:\s*12px;/s);
     expect(css).toMatch(/\.react-session-row__title\s*{[^}]*font-size:\s*12px;/s);
   });
@@ -124,19 +137,15 @@ describe("DesktopShell", () => {
 
     await user.click(screen.getByRole("button", { name: "App" }));
     const appMenu = screen.getByRole("menu", { name: "Application menu" });
-    for (const item of ["New Chat", "Search Sessions", "Command Palette", "Stop Generation", "Toggle Theme", "Toggle Sidebar"]) {
+    for (const item of ["New Chat", "Search Sessions", "Stop Generation", "Toggle Theme", "Toggle Sidebar"]) {
       expect(within(appMenu).getByRole("menuitem", { name: new RegExp(item) })).toBeTruthy();
     }
+    expect(within(appMenu).queryByRole("menuitem", { name: /Command Palette/ })).toBeNull();
     expect(within(appMenu).getAllByRole("separator")).toHaveLength(2);
     expect(within(appMenu).getByText("Ctrl+N").classList.contains("react-top-menu__shortcut")).toBe(true);
 
     await user.click(within(appMenu).getByRole("menuitem", { name: /New Chat/ }));
     await waitFor(() => expect(services.sessionStore.create).toHaveBeenCalledTimes(1));
-
-    await user.click(screen.getByRole("button", { name: "App" }));
-    await user.click(within(screen.getByRole("menu", { name: "Application menu" })).getByRole("menuitem", { name: /Command Palette/ }));
-    expect(screen.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
-    await user.click(screen.getByRole("button", { name: "Close command palette" }));
 
     await user.click(screen.getByRole("button", { name: "Resources" }));
     const resourcesMenu = screen.getByRole("menu", { name: "Resources menu" });
@@ -221,14 +230,194 @@ describe("DesktopShell", () => {
     expect(screen.queryByText(/Vue/i)).toBeNull();
   });
 
-  it("opens and closes the command palette from the keyboard", async () => {
+  it("renders provider preset cards and saves provider configuration from Settings", async () => {
+    const user = userEvent.setup();
+    const initialProviderConfig = {
+      revision: "hash:1",
+      agents: { defaults: { activeProfile: "deepseek-default", model: "deepseek-v4-pro" } },
+      providers: {
+        profiles: {
+          "deepseek-default": {
+            provider: "deepseek",
+            enabled: true,
+            apiKeyConfigured: true,
+            models: ["deepseek-v4-pro"],
+            defaultModel: "deepseek-v4-pro",
+          },
+          "openai-default": {
+            provider: "openai",
+            enabled: true,
+            apiKeyConfigured: true,
+            models: ["gpt-4.1"],
+            defaultModel: "gpt-4.1",
+          },
+        },
+      },
+    };
+    const savedProviderConfig = {
+      revision: "hash:2",
+      agents: { defaults: { activeProfile: "openai-default", model: "deepseek-v4-pro" } },
+      providers: {
+        profiles: {
+          "deepseek-default": {
+            provider: "deepseek",
+            enabled: true,
+            apiKeyConfigured: true,
+            models: ["deepseek-v4-pro"],
+          },
+          "openai-default": {
+            provider: "openai",
+            enabled: true,
+            apiBase: "https://api.openai.com/v1",
+            apiKeyConfigured: true,
+          },
+        },
+      },
+    };
+    const saveProviderSettings = vi.fn(async (_currentConfig: unknown, _patch: unknown) => buildProviderModelsSettings(savedProviderConfig));
+    const fetchProviderModels = vi.fn(async () => ({
+      ok: true,
+      models: ["deepseek-v4-pro", "deepseek-live"],
+      warning: null,
+      url: "https://api.deepseek.com/models",
+    }));
+    const services = createServices();
+    services.settingsStore.loadProviderSettings = vi.fn(async () => buildProviderModelsSettings(initialProviderConfig));
+    services.settingsStore.saveProviderSettings = saveProviderSettings;
+    services.settingsStore.fetchProviderModels = fetchProviderModels;
+    render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={services} />);
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(await screen.findByRole("heading", { name: "Provider & Models" })).toBeTruthy();
+    expect(screen.getByRole("navigation", { name: "Settings categories" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Provider & Models" }).getAttribute("aria-current")).toBe("page");
+    expect(screen.getByRole("region", { name: "Provider & Models" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Default LLM" })).toBeTruthy();
+    await user.selectOptions(screen.getByLabelText("Provider"), "openai-default");
+    await user.selectOptions(screen.getByLabelText("Model"), "gpt-4.1");
+    await user.click(screen.getByRole("button", { name: "Save default LLM" }));
+
+    await waitFor(() => expect(saveProviderSettings).toHaveBeenCalledTimes(1));
+    expect(saveProviderSettings.mock.calls[0][1]).toEqual({
+      agents: { defaults: { activeProfile: "openai-default", model: "gpt-4.1" } },
+    });
+
+    expect(screen.getByRole("article", { name: "DeepSeek provider" })).toBeTruthy();
+    expect(screen.getByRole("article", { name: "DashScope provider" })).toBeTruthy();
+    expect(screen.getByRole("article", { name: "OpenAI provider" })).toBeTruthy();
+    expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("button", { name: "Manage DeepSeek models" }));
+    const modelsDialog = screen.getByRole("dialog", { name: "DeepSeek models" });
+    expect(modelsDialog).toBeTruthy();
+    expect(within(modelsDialog).getAllByText("deepseek-v4-pro").length).toBeGreaterThan(0);
+    await user.click(within(modelsDialog).getByRole("button", { name: "Refresh models" }));
+    await waitFor(() => expect(fetchProviderModels).toHaveBeenCalledWith({
+      providerId: "deepseek",
+      profileId: "deepseek-default",
+      apiBase: "https://api.deepseek.com",
+      modelDiscovery: { status: "openai-compatible", endpoint: "/models" },
+    }));
+    await waitFor(() => expect(within(modelsDialog).getAllByText("deepseek-live").length).toBeGreaterThan(0));
+    await user.click(screen.getByRole("button", { name: "Close models" }));
+
+    await user.click(screen.getByRole("button", { name: "Configure OpenAI" }));
+    const dialog = screen.getByRole("dialog", { name: "Configure OpenAI" });
+    expect((within(dialog).getByLabelText("API base") as HTMLInputElement).value).toBe("https://api.openai.com/v1");
+    await user.type(within(dialog).getByLabelText("API key"), "sk-test");
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(saveProviderSettings).toHaveBeenCalledTimes(2));
+    expect(saveProviderSettings.mock.calls[1][1]).toEqual({
+      providers: {
+        profiles: {
+          "openai-default": {
+            provider: "openai",
+            displayName: "OpenAI",
+            enabled: true,
+            apiBase: "https://api.openai.com/v1",
+            apiKey: "sk-test",
+          },
+        },
+      },
+    });
+  });
+
+  it("renders Agent Defaults settings and jumps back to Provider & Models", async () => {
+    const user = userEvent.setup();
+    const initialConfig = {
+      revision: "hash:1",
+      agents: {
+        defaults: {
+          activeProfile: "deepseek-default",
+          model: "deepseek-v4-pro",
+          timezone: "Asia/Singapore",
+          temperature: 0.3,
+          maxTokens: 4096,
+          contextWindowTokens: 128000,
+          contextWindowStrategy: "discard",
+          maxToolIterations: 12,
+          reasoningEffort: "medium",
+        },
+      },
+    };
+    const savedConfig = {
+      revision: "hash:2",
+      agents: {
+        defaults: {
+          ...initialConfig.agents.defaults,
+          temperature: 0.6,
+          maxTokens: 2048,
+        },
+      },
+    };
+    const services = createServices();
+    const saveAgentDefaultsSettings = vi.fn(async (_currentConfig: unknown, _patch: unknown) => buildAgentDefaultsSettings(savedConfig));
+    services.settingsStore.loadProviderSettings = vi.fn(async () => buildProviderModelsSettings(initialConfig));
+    services.settingsStore.saveProviderSettings = vi.fn(async (_currentConfig: unknown, _patch: unknown) => buildProviderModelsSettings(initialConfig));
+    services.settingsStore.loadAgentDefaultsSettings = vi.fn(async () => buildAgentDefaultsSettings(initialConfig));
+    services.settingsStore.saveAgentDefaultsSettings = saveAgentDefaultsSettings;
+    render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={services} />);
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+    await user.click(await screen.findByRole("button", { name: "Agent Defaults" }));
+
+    expect(await screen.findByRole("heading", { name: "Agent Defaults" })).toBeTruthy();
+    expect(screen.getByText("deepseek-default")).toBeTruthy();
+    expect(screen.getByText("deepseek-v4-pro")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Change default model in Provider & Models" }));
+    expect(await screen.findByRole("heading", { name: "Provider & Models" })).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Agent Defaults" }));
+    await user.clear(await screen.findByLabelText("Temperature"));
+    await user.type(screen.getByLabelText("Temperature"), "0.6");
+    await user.clear(screen.getByLabelText("Max output tokens"));
+    await user.type(screen.getByLabelText("Max output tokens"), "2048");
+    await user.selectOptions(screen.getByLabelText("Context window strategy"), "compact");
+    await user.click(screen.getByRole("button", { name: "Save agent defaults" }));
+
+    await waitFor(() => expect(saveAgentDefaultsSettings).toHaveBeenCalledTimes(1));
+    expect(saveAgentDefaultsSettings.mock.calls[0][1]).toEqual({
+      agents: {
+        defaults: {
+          timezone: "Asia/Singapore",
+          temperature: 0.6,
+          maxTokens: 2048,
+          contextWindowTokens: 128000,
+          contextWindowStrategy: "compact",
+          maxToolIterations: 12,
+          reasoningEffort: "medium",
+        },
+      },
+    });
+  });
+
+  it("does not reserve Ctrl+K for a command palette", async () => {
     const user = userEvent.setup();
     render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={createServices()} />);
 
     await user.keyboard("{Control>}k{/Control}");
-    expect(screen.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
-
-    await user.keyboard("{Escape}");
     expect(screen.queryByRole("dialog", { name: "Command palette" })).toBeNull();
   });
 
@@ -305,15 +494,4 @@ describe("DesktopShell", () => {
     expect(services.chatStore.stop).toHaveBeenCalledWith("s1");
   });
 
-  it("runs route commands from the command palette", async () => {
-    const user = userEvent.setup();
-    render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={createServices()} />);
-
-    await user.keyboard("{Control>}k{/Control}");
-    await user.type(screen.getByRole("textbox", { name: "Search commands" }), "files");
-    await user.click(screen.getByRole("button", { name: "Open Files" }));
-
-    expect(await screen.findByRole("heading", { name: "Workspace Files" })).toBeTruthy();
-    expect(screen.queryByRole("dialog", { name: "Command palette" })).toBeNull();
-  });
 });

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -406,7 +406,7 @@ describe("DesktopShell", () => {
           maxTokens: 2048,
           contextWindowTokens: 128000,
           contextWindowStrategy: "compact",
-          maxToolIterations: 12,
+          maxIterations: 12,
           reasoningEffort: "medium",
         },
       },

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -11,6 +11,8 @@ import {
 } from "react";
 import { BookOpen, Bot, ChevronRight, Code2, Command, FileText, Folder, MessageSquare, Minus, Settings, Square, Wrench, X } from "lucide-react";
 import { ChatPage } from "../chat/ChatPage";
+import { AgentDefaultsSettingsPage } from "../settings/AgentDefaultsSettingsPage";
+import { ProviderModelsSettingsPage } from "../settings/ProviderModelsSettingsPage";
 import type { AppServices, WorkspaceFileSummary } from "../services";
 
 type AppRoute = "chat" | "files" | "knowledge" | "cowork" | "github" | "docs" | "tools" | "settings";
@@ -54,7 +56,6 @@ type TopMenuCommandId =
   | "open-safe-mode"
   | "toggle-theme"
   | "toggle-sidebar"
-  | "open-command-palette"
   | "refresh-gateway-status";
 
 type TopMenuCommand = {
@@ -88,7 +89,6 @@ const topMenuItems: TopMenuItem[] = [
       menuCommand({ id: "new-chat", label: "New Chat", shortcut: "Ctrl+N" }),
       menuCommand({ id: "search-sessions", label: "Search Sessions", shortcut: "Ctrl+F", enabled: false }),
       menuSeparator("app-primary-separator"),
-      menuCommand({ id: "open-command-palette", label: "Command Palette", shortcut: "Ctrl+Shift+P / Ctrl+K" }),
       menuCommand({ id: "stop-generation", label: "Stop Generation", shortcut: "Ctrl+.", enabled: false }),
       menuSeparator("app-view-separator"),
       menuCommand({ id: "toggle-theme", label: "Toggle Theme", shortcut: "Ctrl+Shift+T" }),
@@ -139,7 +139,6 @@ const topMenuItems: TopMenuItem[] = [
 
 export function DesktopShell({ now, services, windowControls }: DesktopShellProps) {
   const [route, setRoute] = useState<AppRoute>("chat");
-  const [paletteOpen, setPaletteOpen] = useState(false);
   const [activeTopMenu, setActiveTopMenu] = useState<TopMenuLabel | null>(null);
   const [activeTopSubmenu, setActiveTopSubmenu] = useState<string | null>(null);
   const [sessionSidebarCollapsed, setSessionSidebarCollapsed] = useState(false);
@@ -147,14 +146,6 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
   const [stopGenerationSessionId, setStopGenerationSessionId] = useState("");
   const stopGenerationSessionIdRef = useRef("");
   const frameControls = useMemo(() => windowControls ?? resolveWindowFrameControls(), [windowControls]);
-  const commands = useMemo(() => routeItems.map((item) => ({
-    id: `open:${item.id}`,
-    label: `Open ${item.label}`,
-    run: () => {
-      setRoute(item.id);
-      setPaletteOpen(false);
-    },
-  })), []);
 
   function handleStopGenerationTargetChange(sessionId: string) {
     stopGenerationSessionIdRef.current = sessionId;
@@ -170,10 +161,6 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "k") {
-        event.preventDefault();
-        setPaletteOpen(true);
-      }
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "b") {
         event.preventDefault();
         setSessionSidebarCollapsed((collapsed) => !collapsed);
@@ -183,7 +170,6 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
         stopActiveGeneration();
       }
       if (event.key === "Escape") {
-        setPaletteOpen(false);
         setActiveTopMenu(null);
         setActiveTopSubmenu(null);
       }
@@ -244,9 +230,6 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
         return;
       case "open-docs":
         setRoute("docs");
-        return;
-      case "open-command-palette":
-        setPaletteOpen(true);
         return;
       case "stop-generation":
         stopActiveGeneration();
@@ -372,17 +355,6 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
           ))}
         </nav>
         <div className="react-window-frame__drag-space" data-tauri-drag-region="" />
-        <button
-          aria-label="Open command palette"
-          data-no-window-drag=""
-          title="Open command palette"
-          type="button"
-          onClick={() => setPaletteOpen(true)}
-          onDoubleClick={stopWindowFrameEvent}
-          onPointerDown={stopWindowFrameEvent}
-        >
-          <Command aria-hidden="true" size={16} />
-        </button>
         <div
           aria-label="Window controls"
           className="react-window-frame__controls"
@@ -429,6 +401,7 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
               <button
                 aria-label={item.label}
                 data-active={route === item.id}
+                data-label={item.label}
                 key={item.id}
                 title={item.label}
                 type="button"
@@ -454,7 +427,6 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
         </section>
       </div>
 
-      {paletteOpen ? <CommandPalette commands={commands} onClose={() => setPaletteOpen(false)} /> : null}
     </div>
   );
 }
@@ -604,6 +576,32 @@ function ToolsPage({ services }: { services: AppServices }) {
 
 function SettingsPage({ services }: { services: AppServices }) {
   const settings = useAsyncList(() => services.settingsStore.load(), [services]);
+  const [activeSettingsModuleId, setActiveSettingsModuleId] = useState<SettingsModuleId>("provider-models");
+  if (services.settingsStore.loadProviderSettings && services.settingsStore.saveProviderSettings) {
+    const availableModules = settingsModules.filter((module) => module.id !== "agent-defaults"
+      || (services.settingsStore.loadAgentDefaultsSettings && services.settingsStore.saveAgentDefaultsSettings));
+    const activeModuleId = availableModules.some((module) => module.id === activeSettingsModuleId)
+      ? activeSettingsModuleId
+      : "provider-models";
+    return (
+      <WorkbenchPage title="Settings">
+        <SettingsLayout
+          activeModuleId={activeModuleId}
+          modules={availableModules}
+          onSelectModule={setActiveSettingsModuleId}
+        >
+          {activeModuleId === "agent-defaults" ? (
+            <AgentDefaultsSettingsPage
+              onNavigateToProviderModels={() => setActiveSettingsModuleId("provider-models")}
+              settingsStore={services.settingsStore}
+            />
+          ) : (
+            <ProviderModelsSettingsPage settingsStore={services.settingsStore} />
+          )}
+        </SettingsLayout>
+      </WorkbenchPage>
+    );
+  }
   return (
     <WorkbenchPage title="Settings">
       <DataList
@@ -617,6 +615,49 @@ function SettingsPage({ services }: { services: AppServices }) {
         )}
       />
     </WorkbenchPage>
+  );
+}
+
+type SettingsModuleId = "provider-models" | "agent-defaults";
+
+const settingsModules: Array<{ id: SettingsModuleId; label: string; description: string }> = [
+  { id: "provider-models", label: "Provider & Models", description: "Providers, API keys, and model defaults" },
+  { id: "agent-defaults", label: "Agent Defaults", description: "Runtime behavior for new agent runs" },
+];
+
+function SettingsLayout({
+  activeModuleId,
+  children,
+  modules,
+  onSelectModule,
+}: {
+  activeModuleId: SettingsModuleId;
+  children: ReactNode;
+  modules: Array<{ id: SettingsModuleId; label: string; description: string }>;
+  onSelectModule: (moduleId: SettingsModuleId) => void;
+}) {
+  return (
+    <div className="react-settings-layout">
+      <aside className="react-settings-sidebar">
+        <nav aria-label="Settings categories">
+          {modules.map((module) => (
+            <button
+              key={module.id}
+              aria-current={module.id === activeModuleId ? "page" : undefined}
+              aria-label={module.label}
+              onClick={() => onSelectModule(module.id)}
+              type="button"
+            >
+              <span>{module.label}</span>
+              <small>{module.description}</small>
+            </button>
+          ))}
+        </nav>
+      </aside>
+      <div className="react-settings-detail">
+        {children}
+      </div>
+    </div>
   );
 }
 
@@ -647,43 +688,6 @@ function PlaceholderPage({ title }: { title: string }) {
     <div className="react-placeholder-page">
       <h1>{title}</h1>
       <p>This React placeholder keeps navigation available while the page-specific implementation is rebuilt.</p>
-    </div>
-  );
-}
-
-function CommandPalette({
-  commands,
-  onClose,
-}: {
-  commands: Array<{ id: string; label: string; run: () => void }>;
-  onClose: () => void;
-}) {
-  const [query, setQuery] = useState("");
-  const filteredCommands = commands.filter((command) => command.label.toLowerCase().includes(query.trim().toLowerCase()));
-  return (
-    <div className="react-command-palette-backdrop">
-      <section aria-label="Command palette" className="react-command-palette" role="dialog">
-        <div>
-          <h2>Command palette</h2>
-          <button aria-label="Close command palette" type="button" onClick={onClose}>
-            <X aria-hidden="true" size={16} />
-          </button>
-        </div>
-        <input
-          aria-label="Search commands"
-          autoFocus
-          placeholder="Search commands"
-          value={query}
-          onChange={(event) => setQuery(event.currentTarget.value)}
-        />
-        <div className="react-command-list">
-          {filteredCommands.map((command) => (
-            <button key={command.id} type="button" onClick={command.run}>
-              {command.label}
-            </button>
-          ))}
-        </div>
-      </section>
     </div>
   );
 }

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -354,25 +354,62 @@ button:disabled {
 
 .react-workbench-layout {
   display: grid;
-  grid-template-columns: 76px minmax(0, 1fr);
+  grid-template-columns: 58px minmax(0, 1fr);
   min-height: 0;
 }
 
 .react-activity-rail {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 6px;
-  padding: 10px 8px;
+  overflow: visible;
+  padding: 10px 7px;
   border-right: 1px solid var(--color-hairline);
   background: var(--color-surface-soft);
 }
 
 .react-activity-rail button {
-  gap: 4px;
-  width: 100%;
-  min-height: 48px;
+  position: relative;
+  width: 42px;
+  min-width: 42px;
+  min-height: 42px;
+  padding: 0;
   color: var(--color-muted);
   font-size: 10px;
+}
+
+.react-activity-rail button span {
+  display: none;
+}
+
+.react-activity-rail button::after {
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 9px);
+  z-index: 50;
+  min-width: max-content;
+  border: 1px solid var(--color-hairline);
+  border-radius: 7px;
+  background: #fff;
+  box-shadow: 0 12px 28px rgb(20 20 19 / 12%);
+  color: var(--color-ink);
+  content: attr(data-label);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1;
+  opacity: 0;
+  padding: 7px 9px;
+  pointer-events: none;
+  transform: translate(-4px, -50%);
+  transition: opacity 160ms ease, transform 220ms ease;
+  white-space: nowrap;
+}
+
+.react-activity-rail button:hover::after,
+.react-activity-rail button:focus-visible::after {
+  opacity: 1;
+  transform: translate(0, -50%);
 }
 
 .react-activity-rail button[data-active="true"] {
@@ -387,23 +424,28 @@ button:disabled {
 
 .react-chat-page {
   display: grid;
-  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   width: 100%;
   height: 100%;
   font-size: 13px;
   min-height: 0;
-}
-
-.react-chat-page[data-session-sidebar-collapsed="true"] {
-  grid-template-columns: 64px minmax(0, 1fr);
+  transition: grid-template-columns 260ms var(--motion-ease-standard);
 }
 
 .react-session-list {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
+  width: clamp(220px, 25vw, 280px);
   min-height: 0;
+  overflow: hidden;
   border-right: 1px solid var(--color-hairline);
   background: var(--color-surface-soft);
+  transition: width 260ms var(--motion-ease-standard);
+  will-change: width;
+}
+
+.react-session-list[data-collapsed="true"] {
+  width: 64px;
 }
 
 .react-session-list__header {
@@ -436,6 +478,25 @@ button:disabled {
   line-height: 1.25;
 }
 
+.react-session-list__header h2,
+.react-session-list__search,
+.react-session-list__new span,
+.react-session-row__title,
+.react-session-row__select small,
+.react-session-row__delete {
+  transition:
+    opacity 180ms var(--motion-ease-standard),
+    transform 220ms var(--motion-ease-standard),
+    max-width 240ms var(--motion-ease-standard);
+}
+
+.react-session-list__header h2 {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .react-session-list__new {
   display: inline-flex;
   align-items: center;
@@ -446,6 +507,13 @@ button:disabled {
   color: #fff;
   padding: 0 10px;
   font-size: 12px;
+}
+
+.react-session-list__new span {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .react-session-list__new:hover,
@@ -473,6 +541,11 @@ button:disabled {
   min-height: 32px;
   padding: 0;
   color: var(--color-muted);
+  transition:
+    opacity 180ms var(--motion-ease-standard),
+    transform 220ms var(--motion-ease-standard),
+    width 240ms var(--motion-ease-standard),
+    min-width 240ms var(--motion-ease-standard);
 }
 
 .react-session-list__search:hover,
@@ -503,7 +576,15 @@ button:disabled {
 .react-session-list[data-collapsed="true"] .react-session-row__title,
 .react-session-list[data-collapsed="true"] .react-session-row__select small,
 .react-session-list[data-collapsed="true"] .react-session-row__delete {
-  display: none;
+  max-width: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-6px);
+}
+
+.react-session-list[data-collapsed="true"] .react-session-list__search {
+  width: 0;
+  min-width: 0;
 }
 
 .react-session-list[data-collapsed="true"] .react-session-list__new,
@@ -547,6 +628,7 @@ button:disabled {
   width: 100%;
   min-width: 0;
   min-height: 44px;
+  overflow: hidden;
   border-radius: inherit;
   padding: 10px;
   text-align: left;
@@ -578,11 +660,13 @@ button:disabled {
 }
 
 .react-session-row__title {
+  max-width: 180px;
   color: var(--color-ink);
   font-size: 12px;
 }
 
 .react-session-row__select small {
+  max-width: 44px;
   color: var(--color-muted);
   font-size: 10px;
   justify-self: end;
@@ -602,6 +686,7 @@ button:disabled {
 
 .react-session-list[data-collapsed="true"] .react-session-row__select {
   grid-template-columns: 28px;
+  column-gap: 0;
   justify-content: center;
   width: 40px;
   min-height: 40px;
@@ -1264,10 +1349,13 @@ button:disabled {
 }
 
 .react-composer--raised .claude-ai-input__panel {
+  --claude-ai-panel-bg: color-mix(in srgb, #fff 92%, var(--color-surface-soft));
+  --claude-ai-panel-radius: 18px;
   min-height: 150px;
-  border-radius: 18px;
-  background: color-mix(in srgb, #fff 92%, var(--color-surface-soft));
-  box-shadow: 0 18px 44px rgb(20 20 19 / 11%);
+  box-shadow:
+    0 18px 44px rgb(20 20 19 / 11%),
+    0 0 0 1px color-mix(in srgb, var(--color-primary) 18%, transparent),
+    0 0 34px color-mix(in srgb, var(--color-primary) 16%, transparent);
 }
 
 .react-composer--raised .claude-ai-input__textarea {
@@ -1279,13 +1367,92 @@ button:disabled {
 }
 
 .claude-ai-input__panel {
+  --claude-ai-panel-bg: #fff;
+  --claude-ai-panel-glow-opacity: 0;
+  --claude-ai-panel-glow-x: 50%;
+  --claude-ai-panel-glow-y: 100%;
+  --claude-ai-panel-radius: 16px;
   display: grid;
+  position: relative;
+  isolation: isolate;
+  overflow: visible;
   gap: 8px;
   border: 1px solid var(--color-hairline);
-  border-radius: 16px;
-  background: #fff;
+  border-radius: var(--claude-ai-panel-radius);
+  background: var(--claude-ai-panel-bg);
   padding: 10px;
   box-shadow: 0 1px 3px rgb(20 20 19 / 8%);
+  transition:
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-medium) var(--motion-ease-standard);
+}
+
+.claude-ai-input__panel::before,
+.claude-ai-input__panel::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  transition: opacity 260ms var(--motion-ease-standard);
+}
+
+.claude-ai-input__panel::before {
+  inset: 0;
+  z-index: 2;
+  border-radius: inherit;
+  padding: 2px;
+  background:
+    radial-gradient(
+      circle at var(--claude-ai-panel-glow-x) var(--claude-ai-panel-glow-y),
+      var(--color-warning) 0,
+      var(--color-primary) 24px,
+      color-mix(in srgb, var(--color-primary) 72%, transparent) 46px,
+      transparent 82px
+    );
+  opacity: var(--claude-ai-panel-glow-opacity);
+  filter:
+    drop-shadow(0 0 10px color-mix(in srgb, var(--color-primary) 70%, transparent))
+    drop-shadow(0 0 24px color-mix(in srgb, var(--color-warning) 42%, transparent));
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+}
+
+.claude-ai-input__panel::after {
+  inset: 1px;
+  z-index: 0;
+  border-radius: calc(var(--claude-ai-panel-radius) - 1px);
+  background:
+    radial-gradient(
+      circle at var(--claude-ai-panel-glow-x) var(--claude-ai-panel-glow-y),
+      color-mix(in srgb, var(--color-warning) 16%, transparent) 0,
+      color-mix(in srgb, var(--color-primary) 13%, transparent) 52px,
+      transparent 124px
+    );
+  opacity: calc(var(--claude-ai-panel-glow-opacity) * 0.86);
+}
+
+.claude-ai-input__panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.claude-ai-input__panel:focus-within {
+  border-color: color-mix(in srgb, var(--color-primary) 24%, var(--color-hairline));
+  box-shadow:
+    0 3px 12px rgb(20 20 19 / 9%),
+    0 0 28px color-mix(in srgb, var(--color-primary) 18%, transparent);
+}
+
+.react-composer--raised .claude-ai-input__panel:is(:hover, :focus-within) {
+  box-shadow:
+    0 20px 50px rgb(20 20 19 / 12%),
+    0 0 0 1px color-mix(in srgb, var(--color-primary) 16%, transparent),
+    0 0 42px color-mix(in srgb, var(--color-primary) 16%, transparent);
 }
 
 .claude-ai-input__textarea {
@@ -1378,7 +1545,8 @@ button:disabled {
 }
 
 .claude-ai-input__tool,
-.claude-ai-input__model {
+.claude-ai-input__model,
+.claude-ai-input__context-usage {
   position: relative;
   min-width: 0;
 }
@@ -1398,6 +1566,93 @@ button:disabled {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.claude-ai-input__context-usage {
+  --context-usage-color: var(--color-primary);
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  min-width: 30px;
+  border-radius: 999px;
+  color: var(--context-usage-color);
+  cursor: default;
+}
+
+.claude-ai-input__context-usage[data-state="warn"] {
+  --context-usage-color: var(--color-warning);
+}
+
+.claude-ai-input__context-usage[data-state="critical"] {
+  --context-usage-color: var(--color-error);
+}
+
+.claude-ai-input__context-usage:hover,
+.claude-ai-input__context-usage:focus-visible {
+  background: var(--color-surface-soft);
+  outline: none;
+}
+
+.claude-ai-input__context-usage svg {
+  width: 22px;
+  height: 22px;
+  transform: rotate(-90deg);
+}
+
+.claude-ai-input__context-usage-track,
+.claude-ai-input__context-usage-value {
+  fill: none;
+  stroke-linecap: round;
+  stroke-width: 2.2;
+}
+
+.claude-ai-input__context-usage-track {
+  stroke: var(--color-hairline);
+}
+
+.claude-ai-input__context-usage-value {
+  stroke: currentColor;
+  filter: drop-shadow(0 0 5px color-mix(in srgb, currentColor 34%, transparent));
+}
+
+.claude-ai-input__context-usage-tip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  z-index: 36;
+  display: grid;
+  min-width: 186px;
+  gap: 4px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 18px 42px rgb(20 20 19 / 14%);
+  color: var(--color-body);
+  font-size: 12px;
+  line-height: 1.35;
+  opacity: 0;
+  padding: 9px 10px;
+  pointer-events: none;
+  transform: translate(-50%, 4px);
+  transition:
+    opacity var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.claude-ai-input__context-usage-tip strong {
+  color: var(--color-ink);
+  font-size: 12px;
+}
+
+.claude-ai-input__context-usage-tip span {
+  white-space: nowrap;
+}
+
+.claude-ai-input__context-usage:hover .claude-ai-input__context-usage-tip,
+.claude-ai-input__context-usage:focus-visible .claude-ai-input__context-usage-tip {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .claude-ai-input__tool-menu,
@@ -1980,6 +2235,635 @@ button:disabled {
 .react-data-row small {
   color: var(--color-muted);
   font-size: 12px;
+}
+
+.react-settings-layout {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.react-settings-sidebar {
+  position: sticky;
+  top: 16px;
+}
+
+.react-settings-sidebar nav {
+  display: grid;
+  gap: 6px;
+}
+
+.react-settings-sidebar button {
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  min-height: 44px;
+  border-radius: 8px;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.react-settings-sidebar button[aria-current="page"] {
+  background: var(--color-surface-card);
+  color: var(--color-ink);
+}
+
+.react-settings-sidebar span,
+.react-settings-sidebar small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-settings-sidebar span {
+  color: var(--color-ink);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.react-settings-sidebar small {
+  color: var(--color-muted);
+  font-size: 11px;
+}
+
+.react-settings-detail {
+  min-width: 0;
+}
+
+.react-provider-settings,
+.react-agent-defaults-settings {
+  display: grid;
+  gap: 14px;
+}
+
+.react-provider-settings__header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.react-provider-settings__header h2 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 18px;
+}
+
+.react-provider-settings__header p {
+  max-width: 620px;
+  margin: 4px 0 0;
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.react-provider-settings__summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-provider-settings__summary span {
+  border: 1px solid var(--color-hairline);
+  border-radius: 999px;
+  background: #fff;
+  padding: 4px 8px;
+}
+
+.react-provider-settings__summary strong {
+  color: var(--color-ink);
+  font-weight: 650;
+}
+
+.react-settings-save-status,
+.react-settings-alert {
+  margin: 0;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 9px 10px;
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.react-default-llm-panel {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 18px 20px;
+}
+
+.react-default-llm-panel h3 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 15px;
+}
+
+.react-default-llm-panel__controls {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(220px, 1fr) auto;
+  align-items: end;
+  gap: 12px;
+}
+
+.react-default-llm-panel label {
+  display: grid;
+  gap: 7px;
+  color: var(--color-body);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.react-default-llm-panel select {
+  min-height: 34px;
+  min-width: 0;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0 10px;
+  color: var(--color-ink);
+  font-size: 13px;
+}
+
+.react-default-llm-panel button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 120px;
+  min-height: 34px;
+  gap: 6px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-default-llm-panel button:disabled {
+  opacity: 0.55;
+}
+
+.react-default-llm-panel p,
+.react-default-llm-panel small {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-settings-linked-summary,
+.react-agent-defaults-form {
+  display: grid;
+  gap: 14px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 18px 20px;
+}
+
+.react-settings-linked-summary {
+  grid-template-columns: minmax(180px, 1fr) minmax(220px, 1.2fr) auto;
+  align-items: center;
+}
+
+.react-settings-linked-summary h3,
+.react-agent-defaults-form h3 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 15px;
+}
+
+.react-settings-linked-summary p {
+  margin: 4px 0 0;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-settings-linked-summary dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.react-settings-linked-summary dt,
+.react-settings-linked-summary dd {
+  margin: 0;
+}
+
+.react-settings-linked-summary dt {
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-settings-linked-summary dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--color-ink);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.react-settings-linked-summary button,
+.react-agent-defaults-form button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-settings-linked-summary button {
+  padding: 0 12px;
+}
+
+.react-agent-defaults-form section {
+  display: grid;
+  gap: 12px;
+}
+
+.react-agent-defaults-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.react-agent-defaults-grid label {
+  display: grid;
+  gap: 7px;
+  color: var(--color-body);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.react-agent-defaults-grid input,
+.react-agent-defaults-grid select {
+  min-height: 34px;
+  min-width: 0;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0 10px;
+  color: var(--color-ink);
+  font-size: 13px;
+}
+
+.react-agent-defaults-grid small {
+  color: #b42318;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.react-agent-defaults-form footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.react-agent-defaults-form footer small {
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-agent-defaults-form button {
+  min-width: 120px;
+  padding: 0 12px;
+}
+
+.react-provider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.react-provider-card {
+  display: grid;
+  gap: 14px;
+  min-height: 224px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 16px;
+  transition:
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.react-provider-card:hover,
+.react-provider-card:focus-within {
+  border-color: color-mix(in srgb, var(--color-primary) 42%, var(--color-hairline));
+  box-shadow: 0 12px 30px rgb(20 20 19 / 8%);
+  transform: translateY(-1px);
+}
+
+.react-provider-card__top,
+.react-provider-card__title,
+.react-provider-card__actions,
+.react-provider-model-add,
+.react-provider-model-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.react-provider-card__top {
+  justify-content: space-between;
+}
+
+.react-provider-card__mark {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: var(--color-surface-soft);
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.react-provider-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-provider-card__status span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--color-muted-soft);
+}
+
+.react-provider-card[data-status="available"] .react-provider-card__status {
+  color: var(--color-success);
+}
+
+.react-provider-card[data-status="available"] .react-provider-card__status span {
+  background: var(--color-success);
+}
+
+.react-provider-card[data-status="not_ready"] .react-provider-card__status {
+  color: var(--color-warning);
+}
+
+.react-provider-card[data-status="not_ready"] .react-provider-card__status span {
+  background: var(--color-warning);
+}
+
+.react-provider-card__title {
+  flex-wrap: wrap;
+}
+
+.react-provider-card__title h3 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 18px;
+}
+
+.react-provider-card__title span,
+.react-provider-model-row > span {
+  border-radius: 6px;
+  background: var(--color-surface-soft);
+  padding: 3px 6px;
+  color: var(--color-muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.react-provider-card__facts {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.react-provider-card__facts div {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 8px;
+}
+
+.react-provider-card__facts dt {
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-provider-card__facts dd {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-body);
+  font: 12px/1.35 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-provider-card__actions {
+  margin-top: auto;
+}
+
+.react-provider-card__actions button,
+.react-settings-dialog footer button,
+.react-provider-model-add button,
+.react-provider-model-row button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  gap: 6px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0 10px;
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-provider-card__actions button {
+  flex: 1 1 0;
+}
+
+.react-settings-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  background: rgb(20 20 19 / 34%);
+  padding: 24px;
+}
+
+.react-settings-dialog {
+  display: grid;
+  width: min(760px, 100%);
+  max-height: min(720px, calc(100vh - 48px));
+  gap: 16px;
+  overflow: auto;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 20px;
+  box-shadow: 0 24px 80px rgb(20 20 19 / 18%);
+}
+
+.react-settings-dialog--wide {
+  width: min(820px, 100%);
+}
+
+.react-settings-dialog header,
+.react-settings-dialog footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.react-settings-dialog header h2 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 16px;
+}
+
+.react-settings-dialog header button {
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  padding: 0;
+}
+
+.react-settings-dialog label {
+  display: grid;
+  gap: 7px;
+  color: var(--color-body);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.react-settings-dialog input {
+  min-height: 34px;
+  min-width: 0;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0 10px;
+  color: var(--color-ink);
+  font-size: 13px;
+}
+
+.react-settings-checkbox {
+  display: flex !important;
+  grid-template-columns: unset;
+  align-items: center;
+  gap: 8px !important;
+  font-weight: 500 !important;
+}
+
+.react-settings-checkbox input {
+  min-height: 0;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+}
+
+.react-settings-dialog__advanced {
+  border-top: 1px solid var(--color-hairline);
+  padding-top: 14px;
+}
+
+.react-settings-dialog__advanced h3,
+.react-settings-dialog__advanced p {
+  margin: 0;
+}
+
+.react-settings-dialog__advanced h3 {
+  color: var(--color-ink);
+  font-size: 13px;
+}
+
+.react-settings-dialog__advanced p {
+  margin-top: 4px;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-provider-model-list {
+  display: grid;
+  gap: 8px;
+  overflow: auto;
+  max-height: 340px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.react-provider-model-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
+  min-height: 44px;
+  border-radius: 8px;
+  padding: 7px 8px;
+}
+
+.react-provider-model-row:hover {
+  background: var(--color-surface-soft);
+}
+
+.react-provider-model-row div {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.react-provider-model-row strong,
+.react-provider-model-row small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-provider-model-row strong {
+  color: var(--color-ink);
+  font-size: 13px;
+}
+
+.react-provider-model-row small {
+  color: var(--color-muted);
+  font: 12px/1.3 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.react-provider-model-row button:disabled,
+.react-settings-dialog footer button:disabled {
+  opacity: 0.45;
+}
+
+.react-provider-model-add {
+  align-items: stretch;
+}
+
+.react-provider-model-add input {
+  flex: 1 1 auto;
 }
 
 .react-placeholder-page p,


### PR DESCRIPTION
## Summary
- Add backend-backed provider/model and agent default settings support, including default config creation and API documentation updates.
- Add React settings pages for Provider & Models and Agent Defaults.
- Preserve and surface context-window usage in the chat UI with an icon-only composer indicator.
- Request streaming provider usage and emit estimated context usage when providers omit usage.
- Refine the chat composer, model menu, activity rail, and empty-session behavior.

## Why
The app needed a single backend-backed path for model/provider settings and a visible context-window budget signal in chat. Streaming providers may omit usage unless explicitly requested, so the runtime now asks for usage and falls back to local estimates.

## Validation
- `npm run build`
- `npm test -- src/react-workbench/chat/ChatPage.test.tsx src/react-workbench/shell/DesktopShell.test.tsx src/react-workbench/defaultServices.test.ts src/app-core/chat/chatRunModel.test.ts src/app-core/chat/nativeChat.test.ts src/app-core/settings/agentDefaultsSettings.test.ts src/app-core/settings/providerModelsSettings.test.ts src/app-core/settings/desktopSettingsProviders.test.ts src/app-core/settings/desktopSettingsSchemaCoverage.test.ts src/app-core/native/desktopNativeConfigPatch.test.ts`
- `cargo test usage`
- `git diff --cached --check`