### PR TITLE
Reduce agent run persistence writes

### DIFF
--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3436,56 +3436,56 @@ fn worker_session_read_commands_use_rust_session_store() {
 }
 
 #[test]
-fn worker_agent_run_runtime_commands_use_rust_session_store() {
+fn worker_agent_run_runtime_commands_use_thread_log_agent_run_store() {
     let fixture = WorkspaceFixture::new();
-    fixture.write_session_store(serde_json::json!({
-        "version": 1,
-        "sessions": [{
-            "session_id": "websocket:chat-1",
-            "title": "Native session",
-            "workspace_dir": "D:/Code/py/tinybot",
-            "created_at": "2026-07-03T01:00:00Z",
-            "updated_at": "2026-07-03T01:00:02Z",
-            "extra": {
-                "agent_runs": [{
-                    "sessionId": "websocket:chat-1",
-                    "runId": "run-1",
-                    "status": "completed",
-                    "phase": "completed",
-                    "startedAt": "2026-07-03T01:00:00Z",
-                    "updatedAt": "2026-07-03T01:00:02Z",
-                    "completedAt": "2026-07-03T01:00:02Z",
-                    "stopReason": "stop",
-                    "model": "test-model",
-                    "provider": "test",
-                    "maxIterations": 4,
-                    "currentIteration": 1,
-                    "conversationMessageIds": [],
-                    "traceMessages": [],
-                    "traceEvents": [{
-                        "schemaVersion": "tinybot.agent_event.v1",
-                        "eventId": "run-1:agent-done:0000000000000001",
-                        "sequence": 1,
-                        "sessionId": "websocket:chat-1",
-                        "turnId": "run-1",
-                        "itemId": "run-1:assistant",
-                        "eventName": "agent.done",
-                        "phase": "completed",
-                        "timestamp": "2026-07-03T01:00:02Z",
-                        "source": "rust_backend",
-                        "visibility": "user",
-                        "payload": { "finalContent": "Done from runtime state" }
-                    }],
-                    "completedToolResults": [],
-                    "pendingToolCalls": [],
-                    "checkpoint": null,
-                    "artifacts": [],
-                    "usage": [],
-                    "error": null
-                }]
-            }
-        }]
-    }));
+    let record = serde_json::json!({
+        "sessionId": "websocket:chat-1",
+        "runId": "run-1",
+        "status": "completed",
+        "phase": "completed",
+        "startedAt": "2026-07-03T01:00:00Z",
+        "updatedAt": "2026-07-03T01:00:02Z",
+        "completedAt": "2026-07-03T01:00:02Z",
+        "stopReason": "stop",
+        "model": "test-model",
+        "provider": "test",
+        "maxIterations": 4,
+        "currentIteration": 1,
+        "conversationMessageIds": [],
+        "traceMessages": [],
+        "traceEvents": [{
+            "schemaVersion": "tinybot.agent_event.v1",
+            "eventId": "run-1:agent-done:0000000000000001",
+            "sequence": 1,
+            "sessionId": "websocket:chat-1",
+            "turnId": "run-1",
+            "itemId": "run-1:assistant",
+            "eventName": "agent.done",
+            "phase": "completed",
+            "timestamp": "2026-07-03T01:00:02Z",
+            "source": "rust_backend",
+            "visibility": "user",
+            "payload": { "finalContent": "Done from runtime state" }
+        }],
+        "completedToolResults": [],
+        "pendingToolCalls": [],
+        "checkpoint": null,
+        "artifacts": [],
+        "usage": [],
+        "error": null
+    });
+    call_rust_state_service(
+        fixture.root.clone(),
+        serde_json::json!({}),
+        WorkerRequest::new(
+            "req-seed-agent-run-thread-log",
+            "trace-seed-agent-run-thread-log",
+            "agent_run.upsert",
+            serde_json::json!({ "record": record }),
+        ),
+        "agent run thread log seed",
+    )
+    .expect("agent run should seed thread log store");
     let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
 
     let runs = worker_agent_runs_list_with_options(
@@ -3495,7 +3495,7 @@ fn worker_agent_run_runtime_commands_use_rust_session_store() {
         serde_json::json!({}),
         Duration::from_millis(10),
     )
-    .expect("agent run list should be served by Rust session state");
+    .expect("agent run list should be served by thread log store");
     let runtime_state = worker_agent_run_runtime_state_with_options(
         &shared,
         "websocket:chat-1".to_string(),
@@ -3504,7 +3504,7 @@ fn worker_agent_run_runtime_commands_use_rust_session_store() {
         serde_json::json!({}),
         Duration::from_millis(10),
     )
-    .expect("agent run runtime state should be served by Rust session state");
+    .expect("agent run runtime state should be served by thread log store");
 
     assert_eq!(runs["runs"][0]["runId"], "run-1");
     assert_eq!(runtime_state["sessionId"], "websocket:chat-1");

--- a/src-tauri/src/worker_rpc/persistence_facade.rs
+++ b/src-tauri/src/worker_rpc/persistence_facade.rs
@@ -66,20 +66,73 @@ impl WorkerRpcRouter {
             }
             "session.get_checkpoint" => {
                 let params: SessionIdParams = parse_params(request)?;
-                serde_json::to_value(self.session.get_checkpoint(&params.session_id)?)
-                    .map_err(serialization_error)
+                let checkpoint = self
+                    .thread_log
+                    .latest_agent_run_checkpoint(&params.session_id)?
+                    .map(|checkpoint| checkpoint.checkpoint);
+                let checkpoint = match checkpoint {
+                    Some(checkpoint) => Some(checkpoint),
+                    None => self.session.get_checkpoint(&params.session_id)?,
+                };
+                serde_json::to_value(checkpoint).map_err(serialization_error)
             }
             "session.set_checkpoint" => {
                 let params: SessionCheckpointParams = parse_params(request)?;
+                let run_id = params
+                    .checkpoint
+                    .get("runId")
+                    .or_else(|| params.checkpoint.get("run_id"))
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        WorkerProtocolError::new(
+                            WorkerProtocolErrorCode::InvalidProtocol,
+                            "session checkpoint must include runId",
+                            serde_json::json!({ "session_id": params.session_id }),
+                            false,
+                            WorkerProtocolErrorSource::RustCore,
+                        )
+                    })?
+                    .to_string();
+                let record = self.thread_log.set_agent_run_checkpoint(
+                    &params.session_id,
+                    &run_id,
+                    params.checkpoint,
+                )?;
                 let session = self
-                    .session
-                    .set_checkpoint(&params.session_id, params.checkpoint)?;
-                serde_json::to_value(session).map_err(serialization_error)
+                    .thread_log
+                    .get_session_metadata_for_write_response(&params.session_id)?
+                    .ok_or_else(|| {
+                        WorkerProtocolError::new(
+                            WorkerProtocolErrorCode::WorkerError,
+                            "session metadata missing after checkpoint persistence",
+                            serde_json::json!({ "session_id": params.session_id }),
+                            false,
+                            WorkerProtocolErrorSource::RustCore,
+                        )
+                    })?;
+                let mut value = serde_json::to_value(session).map_err(serialization_error)?;
+                value["extra"]["runtime_checkpoint"] =
+                    record.checkpoint.unwrap_or(serde_json::Value::Null);
+                return Ok(value);
             }
             "session.clear_checkpoint" => {
                 let params: SessionIdParams = parse_params(request)?;
-                serde_json::to_value(self.session.clear_checkpoint(&params.session_id)?)
-                    .map_err(serialization_error)
+                let _ = self
+                    .thread_log
+                    .clear_latest_agent_run_checkpoint(&params.session_id)?;
+                let session = self
+                    .thread_log
+                    .get_session_metadata_for_write_response(&params.session_id)?
+                    .ok_or_else(|| {
+                        WorkerProtocolError::new(
+                            WorkerProtocolErrorCode::InvalidProtocol,
+                            "session metadata not found",
+                            serde_json::json!({ "session_id": params.session_id }),
+                            false,
+                            WorkerProtocolErrorSource::RustCore,
+                        )
+                    })?;
+                serde_json::to_value(session).map_err(serialization_error)
             }
             "session.clear" => {
                 let params: SessionIdParams = parse_params(request)?;
@@ -184,16 +237,21 @@ impl WorkerRpcRouter {
         match request.method.as_str() {
             "agent_run.upsert" => {
                 let params: AgentRunUpsertParams = parse_params(request)?;
-                let record = self.session.upsert_agent_run(params.record)?;
+                let record = self.thread_log.upsert_agent_run(params.record)?;
                 serde_json::to_value(record).map_err(serialization_error)
             }
             "agent_run.list" => {
                 let params: AgentRunListParams = parse_params(request)?;
-                let mut records = self.session.list_agent_runs(&params.session_id)?;
+                let mut records = self.thread_log.list_agent_runs(&params.session_id)?;
                 let mut seen_run_ids = records
                     .iter()
                     .map(|record| record.run_id.clone())
                     .collect::<std::collections::HashSet<_>>();
+                for record in self.session.list_agent_runs(&params.session_id)? {
+                    if seen_run_ids.insert(record.run_id.clone()) {
+                        records.push(record);
+                    }
+                }
                 if self.thread.has_thread_store() {
                     for record in self
                         .thread
@@ -222,37 +280,73 @@ impl WorkerRpcRouter {
             "agent_run.get" => {
                 let params: AgentRunIdParams = parse_params(request)?;
                 let record = match self
-                    .session
-                    .get_agent_run(&params.session_id, &params.run_id)
+                    .thread_log
+                    .get_agent_run(&params.session_id, &params.run_id)?
                 {
-                    Ok(record) => record,
-                    Err(session_error) => match self
-                        .thread
-                        .get_agent_run_from_threads(&params.session_id, &params.run_id)?
+                    Some(record) => record,
+                    None => match self
+                        .session
+                        .get_agent_run(&params.session_id, &params.run_id)
                     {
-                        Some(record) => record,
-                        None => return Err(session_error),
+                        Ok(record) => record,
+                        Err(session_error) => match self
+                            .thread
+                            .get_agent_run_from_threads(&params.session_id, &params.run_id)?
+                        {
+                            Some(record) => record,
+                            None => {
+                                if matches!(
+                                    session_error.code,
+                                    WorkerProtocolErrorCode::InvalidProtocol
+                                ) {
+                                    return Err(agent_run_not_found_error(
+                                        &params.session_id,
+                                        &params.run_id,
+                                    ));
+                                }
+                                return Err(session_error);
+                            }
+                        },
                     },
                 };
                 serde_json::to_value(record).map_err(serialization_error)
             }
             "agent_run.list_trace" => {
                 let params: AgentRunListTraceParams = parse_params(request)?;
-                let trace_page = match self.session.list_agent_run_trace_events(
+                let trace_page = match self.thread_log.list_agent_run_trace_events(
                     &params.session_id,
                     &params.run_id,
                     params.cursor.as_deref(),
                     params.limit,
-                ) {
-                    Ok(trace_page) => trace_page,
-                    Err(session_error) => match self.thread.list_agent_run_trace_events(
+                )? {
+                    Some(trace_page) => trace_page,
+                    None => match self.session.list_agent_run_trace_events(
                         &params.session_id,
                         &params.run_id,
                         params.cursor.as_deref(),
                         params.limit,
-                    )? {
-                        Some(trace_page) => trace_page,
-                        None => return Err(session_error),
+                    ) {
+                        Ok(trace_page) => trace_page,
+                        Err(session_error) => match self.thread.list_agent_run_trace_events(
+                            &params.session_id,
+                            &params.run_id,
+                            params.cursor.as_deref(),
+                            params.limit,
+                        )? {
+                            Some(trace_page) => trace_page,
+                            None => {
+                                if matches!(
+                                    session_error.code,
+                                    WorkerProtocolErrorCode::InvalidProtocol
+                                ) {
+                                    return Err(agent_run_not_found_error(
+                                        &params.session_id,
+                                        &params.run_id,
+                                    ));
+                                }
+                                return Err(session_error);
+                            }
+                        },
                     },
                 };
                 serde_json::to_value(trace_page).map_err(serialization_error)
@@ -260,23 +354,40 @@ impl WorkerRpcRouter {
             "agent_run.runtime_state" => {
                 let params: AgentRunIdParams = parse_params(request)?;
                 let runtime_state = match self
-                    .session
-                    .get_agent_run_runtime_state(&params.session_id, &params.run_id)
+                    .thread_log
+                    .get_agent_run_runtime_state(&params.session_id, &params.run_id)?
                 {
-                    Ok(runtime_state) => runtime_state,
-                    Err(session_error) => match self
-                        .thread
-                        .get_agent_run_runtime_state(&params.session_id, &params.run_id)?
+                    Some(runtime_state) => runtime_state,
+                    None => match self
+                        .session
+                        .get_agent_run_runtime_state(&params.session_id, &params.run_id)
                     {
-                        Some(runtime_state) => runtime_state,
-                        None => return Err(session_error),
+                        Ok(runtime_state) => runtime_state,
+                        Err(session_error) => match self
+                            .thread
+                            .get_agent_run_runtime_state(&params.session_id, &params.run_id)?
+                        {
+                            Some(runtime_state) => runtime_state,
+                            None => {
+                                if matches!(
+                                    session_error.code,
+                                    WorkerProtocolErrorCode::InvalidProtocol
+                                ) {
+                                    return Err(agent_run_not_found_error(
+                                        &params.session_id,
+                                        &params.run_id,
+                                    ));
+                                }
+                                return Err(session_error);
+                            }
+                        },
                     },
                 };
                 serde_json::to_value(runtime_state).map_err(serialization_error)
             }
             "agent_run.append_trace" => {
                 let params: AgentRunAppendTraceParams = parse_params(request)?;
-                let record = self.session.append_agent_run_trace_event(
+                let record = self.thread_log.append_agent_run_trace_event(
                     &params.session_id,
                     &params.run_id,
                     params.event,
@@ -285,7 +396,7 @@ impl WorkerRpcRouter {
             }
             "agent_run.set_checkpoint" => {
                 let params: AgentRunCheckpointParams = parse_params(request)?;
-                let record = self.session.set_agent_run_checkpoint(
+                let record = self.thread_log.set_agent_run_checkpoint(
                     &params.session_id,
                     &params.run_id,
                     params.checkpoint,
@@ -294,43 +405,38 @@ impl WorkerRpcRouter {
             }
             "agent_run.get_checkpoint" => {
                 let params: AgentRunIdParams = parse_params(request)?;
-                serde_json::to_value(
-                    self.session
+                let checkpoint = match self
+                    .thread_log
+                    .get_agent_run_checkpoint(&params.session_id, &params.run_id)?
+                {
+                    Some(checkpoint) => Some(checkpoint),
+                    None => self
+                        .session
                         .get_agent_run_checkpoint(&params.session_id, &params.run_id)?,
-                )
-                .map_err(serialization_error)
+                };
+                serde_json::to_value(checkpoint).map_err(serialization_error)
             }
             "agent_run.clear_checkpoint" => {
                 let params: AgentRunIdParams = parse_params(request)?;
                 serde_json::to_value(
-                    self.session
+                    self.thread_log
                         .clear_agent_run_checkpoint(&params.session_id, &params.run_id)?,
                 )
                 .map_err(serialization_error)
             }
             "agent_run.mark_completed" => {
                 let params: AgentRunMarkCompletedParams = parse_params(request)?;
-                let record = self.session.mark_agent_run_completed(
+                let record = self.thread_log.mark_agent_run_completed(
                     &params.session_id,
                     &params.run_id,
                     &params.stop_reason,
                     params.final_content,
                 )?;
-                if let Some(token_usage_info) = record.token_usage_info.clone() {
-                    let info_value =
-                        serde_json::to_value(token_usage_info).map_err(serialization_error)?;
-                    let info = serde_json::from_value::<crate::worker_thread_log::TokenUsageInfo>(
-                        info_value,
-                    )
-                    .map_err(serialization_error)?;
-                    self.thread_log
-                        .append_token_count(&record.session_id, info)?;
-                }
                 serde_json::to_value(record).map_err(serialization_error)
             }
             "agent_run.mark_failed" => {
                 let params: AgentRunMarkFailedParams = parse_params(request)?;
-                let record = self.session.mark_agent_run_failed(
+                let record = self.thread_log.mark_agent_run_failed(
                     &params.session_id,
                     &params.run_id,
                     &params.stop_reason,
@@ -341,11 +447,24 @@ impl WorkerRpcRouter {
             "agent_run.mark_cancelled" => {
                 let params: AgentRunIdParams = parse_params(request)?;
                 let record = self
-                    .session
+                    .thread_log
                     .mark_agent_run_cancelled(&params.session_id, &params.run_id)?;
                 serde_json::to_value(record).map_err(serialization_error)
             }
             _ => Err(unknown_method_error(request)),
         }
     }
+}
+
+fn agent_run_not_found_error(session_id: &str, run_id: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "agent run not found",
+        serde_json::json!({
+            "session_id": session_id,
+            "run_id": run_id,
+        }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
 }

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -6,6 +6,8 @@ use serde_json::{json, Value};
 use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
+    thread,
+    time::Duration,
 };
 
 static WORKSPACE_FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -1382,18 +1384,32 @@ fn dispatches_session_checkpoint_requests() {
 #[test]
 fn dispatches_session_get_checkpoint_request() {
     let fixture = WorkspaceFixture::new();
-    let mut session = session_fixture();
-    session.extra = json!({
-        "runtime_checkpoint": {
-            "runId": "run-1",
-            "phase": "awaiting_tools",
-            "iteration": 1
-        }
-    });
+    let mut seed_router = WorkerRpcRouter::new(
+        fixture.root.clone(),
+        json!({}),
+        vec![],
+        20,
+        CapabilityPolicy::new([WorkerCapability::SessionWrite]),
+    );
+    let seed = seed_router.dispatch(&WorkerRequest::new(
+        "req-seed-checkpoint",
+        "trace-seed-checkpoint",
+        "session.set_checkpoint",
+        json!({
+            "session_id": "session-1",
+            "checkpoint": {
+                "runId": "run-1",
+                "phase": "awaiting_tools",
+                "iteration": 1
+            }
+        }),
+    ));
+    assert_eq!(seed.error, None);
+
     let mut router = WorkerRpcRouter::new(
         fixture.root.clone(),
         json!({}),
-        vec![session],
+        vec![],
         20,
         CapabilityPolicy::new([WorkerCapability::SessionMetadataRead]),
     );
@@ -1412,6 +1428,44 @@ fn dispatches_session_get_checkpoint_request() {
             "runId": "run-1",
             "phase": "awaiting_tools",
             "iteration": 1
+        }))
+    );
+    assert!(response.error.is_none());
+}
+
+#[test]
+fn dispatches_session_get_checkpoint_falls_back_to_legacy_runtime_checkpoint() {
+    let fixture = WorkspaceFixture::new();
+    let mut session = session_fixture();
+    session.extra = json!({
+        "runtime_checkpoint": {
+            "runId": "run-legacy-checkpoint",
+            "phase": "awaiting_tools",
+            "iteration": 2
+        }
+    });
+    let mut router = WorkerRpcRouter::new(
+        fixture.root.clone(),
+        json!({}),
+        vec![session],
+        20,
+        CapabilityPolicy::new([WorkerCapability::SessionMetadataRead]),
+    );
+    let request = WorkerRequest::new(
+        "req-legacy-checkpoint",
+        "trace-legacy-checkpoint",
+        "session.get_checkpoint",
+        json!({ "session_id": "session-1" }),
+    );
+
+    let response = router.dispatch(&request);
+
+    assert_eq!(
+        response.result,
+        Some(json!({
+            "runId": "run-legacy-checkpoint",
+            "phase": "awaiting_tools",
+            "iteration": 2
         }))
     );
     assert!(response.error.is_none());
@@ -1746,6 +1800,190 @@ fn session_persist_turn_does_not_write_legacy_session_or_thread_stores() {
         .join("threads")
         .join("threads.sqlite")
         .exists());
+}
+
+#[test]
+fn agent_run_persistence_does_not_write_legacy_session_store() {
+    let fixture = WorkspaceFixture::new();
+    let mut router = WorkerRpcRouter::new_persistent_sessions(
+        fixture.root.clone(),
+        json!({}),
+        vec![],
+        50,
+        CapabilityPolicy::new([
+            WorkerCapability::SessionWrite,
+            WorkerCapability::SessionMetadataRead,
+        ]),
+    )
+    .unwrap();
+    let record = json!({
+        "sessionId": "session-agent-log-only",
+        "runId": "run-agent-log-only",
+        "status": "running",
+        "phase": "active_turn",
+        "startedAt": "2026-07-08T10:00:00Z",
+        "updatedAt": "2026-07-08T10:00:00Z",
+        "completedAt": null,
+        "stopReason": null,
+        "model": "fixture-model",
+        "provider": "fixture",
+        "maxIterations": 4,
+        "currentIteration": 0,
+        "conversationMessageIds": [],
+        "traceMessages": [],
+        "traceEvents": [],
+        "completedToolResults": [],
+        "pendingToolCalls": [],
+        "checkpoint": null,
+        "artifacts": [],
+        "usage": [],
+        "error": null
+    });
+
+    let upsert = router.dispatch(&WorkerRequest::new(
+        "req-agent-log-only-upsert",
+        "trace-agent-log-only",
+        "agent_run.upsert",
+        json!({ "record": record }),
+    ));
+    let append_trace = router.dispatch(&WorkerRequest::new(
+        "req-agent-log-only-trace",
+        "trace-agent-log-only",
+        "agent_run.append_trace",
+        json!({
+            "session_id": "session-agent-log-only",
+            "run_id": "run-agent-log-only",
+            "event": {
+                "eventId": "trace-delta",
+                "eventName": "agent.delta",
+                "payload": { "delta": "hello" }
+            }
+        }),
+    ));
+    let completed = router.dispatch(&WorkerRequest::new(
+        "req-agent-log-only-complete",
+        "trace-agent-log-only",
+        "agent_run.mark_completed",
+        json!({
+            "session_id": "session-agent-log-only",
+            "run_id": "run-agent-log-only",
+            "stop_reason": "final_response",
+            "final_content": "hello"
+        }),
+    ));
+    let get = router.dispatch(&WorkerRequest::new(
+        "req-agent-log-only-get",
+        "trace-agent-log-only",
+        "agent_run.get",
+        json!({
+            "session_id": "session-agent-log-only",
+            "run_id": "run-agent-log-only"
+        }),
+    ));
+
+    assert_eq!(upsert.error, None);
+    assert_eq!(append_trace.error, None);
+    assert_eq!(completed.error, None);
+    assert_eq!(get.error, None);
+    assert_eq!(get.result.as_ref().unwrap()["status"], "completed");
+    assert_eq!(
+        get.result.as_ref().unwrap()["traceEvents"][0]["eventName"],
+        "agent.delta"
+    );
+    assert!(!fixture
+        .root
+        .join("sessions")
+        .join("sessions.sqlite")
+        .exists());
+    assert!(fixture
+        .root
+        .join(".tinybot")
+        .join("state")
+        .join("state.sqlite")
+        .exists());
+    assert!(!fixture
+        .root
+        .join(".tinybot")
+        .join("threads")
+        .join("threads.sqlite")
+        .exists());
+}
+
+#[test]
+fn agent_run_trace_append_does_not_update_thread_state_index() {
+    let fixture = WorkspaceFixture::new();
+    let mut router = WorkerRpcRouter::new_persistent_sessions(
+        fixture.root.clone(),
+        json!({}),
+        vec![],
+        50,
+        CapabilityPolicy::new([
+            WorkerCapability::SessionWrite,
+            WorkerCapability::SessionMetadataRead,
+        ]),
+    )
+    .unwrap();
+    let record = json!({
+        "sessionId": "session-trace-state-index",
+        "runId": "run-trace-state-index",
+        "status": "running",
+        "phase": "active_turn",
+        "startedAt": "2026-07-08T10:00:00Z",
+        "updatedAt": "2026-07-08T10:00:00Z",
+        "completedAt": null,
+        "stopReason": null,
+        "model": "fixture-model",
+        "provider": "fixture",
+        "maxIterations": 4,
+        "currentIteration": 0,
+        "conversationMessageIds": [],
+        "traceMessages": [],
+        "traceEvents": [],
+        "completedToolResults": [],
+        "pendingToolCalls": [],
+        "checkpoint": null,
+        "artifacts": [],
+        "usage": [],
+        "error": null
+    });
+
+    let upsert = router.dispatch(&WorkerRequest::new(
+        "req-trace-state-index-upsert",
+        "trace-state-index",
+        "agent_run.upsert",
+        json!({ "record": record }),
+    ));
+    assert_eq!(upsert.error, None);
+    let state_path = fixture
+        .root
+        .join(".tinybot")
+        .join("state")
+        .join("state.sqlite");
+    let before_updated_at = thread_state_updated_at(&state_path, "session-trace-state-index");
+    thread::sleep(Duration::from_millis(5));
+
+    let append_trace = router.dispatch(&WorkerRequest::new(
+        "req-trace-state-index-append",
+        "trace-state-index",
+        "agent_run.append_trace",
+        json!({
+            "session_id": "session-trace-state-index",
+            "run_id": "run-trace-state-index",
+            "event": {
+                "eventId": "trace-state-index-delta",
+                "eventName": "agent.delta",
+                "payload": { "delta": "streamed" }
+            }
+        }),
+    ));
+    assert_eq!(append_trace.error, None);
+
+    let after_updated_at = thread_state_updated_at(&state_path, "session-trace-state-index");
+    assert_eq!(after_updated_at, before_updated_at);
+    assert_eq!(
+        append_trace.result.as_ref().unwrap()["traceEvents"][0]["eventName"],
+        "agent.delta"
+    );
 }
 
 #[test]
@@ -6989,25 +7227,27 @@ fn dispatches_agent_run_store_round_trip_requests() {
 
     assert!(!fixture
         .root
+        .join("sessions")
+        .join("sessions.sqlite")
+        .exists());
+    assert!(!fixture
+        .root
         .join(".tinybot")
         .join("threads")
         .join("threads.sqlite")
         .exists());
 
-    let thread_list = router.dispatch(&WorkerRequest::new(
-        "req-thread-list-after-agent-run",
+    let metadata = router.dispatch(&WorkerRequest::new(
+        "req-session-metadata-after-agent-run",
         "trace-agent-run",
-        "thread.list",
-        json!({ "includeArchived": true }),
+        "session.get_metadata",
+        json!({ "session_id": "session-1" }),
     ));
-    assert_eq!(thread_list.error, None);
+    assert_eq!(metadata.error, None);
+    assert_eq!(metadata.result.as_ref().unwrap()["session_id"], "session-1");
     assert_eq!(
-        thread_list.result.as_ref().unwrap()["threads"][0]["sessionKey"],
-        "session-1"
-    );
-    assert_eq!(
-        thread_list.result.as_ref().unwrap()["threads"][0]["source"],
-        "legacy_session_projection"
+        metadata.result.as_ref().unwrap()["extra"]["threadSource"],
+        "thread_log"
     );
 }
 
@@ -7168,7 +7408,7 @@ fn dispatches_agent_run_trace_and_runtime_state_from_thread_items() {
 }
 
 #[test]
-fn dispatches_agent_run_list_merges_legacy_and_thread_backed_runs() {
+fn dispatches_agent_run_list_merges_thread_log_and_thread_backed_runs() {
     let fixture = WorkspaceFixture::new();
     let mut router = WorkerRpcRouter::new(
         fixture.root.clone(),
@@ -7180,9 +7420,9 @@ fn dispatches_agent_run_list_merges_legacy_and_thread_backed_runs() {
             WorkerCapability::SessionWrite,
         ]),
     );
-    let legacy_record = json!({
+    let thread_log_record = json!({
         "sessionId": "session-1",
-        "runId": "run-legacy",
+        "runId": "run-thread-log",
         "status": "running",
         "phase": "active_turn",
         "startedAt": "2026-07-05T00:00:00Z",
@@ -7208,7 +7448,7 @@ fn dispatches_agent_run_list_merges_legacy_and_thread_backed_runs() {
         "req-mixed-agent-run-upsert",
         "trace-mixed-agent-runs",
         "agent_run.upsert",
-        json!({ "record": legacy_record }),
+        json!({ "record": thread_log_record }),
     ));
     assert_eq!(upsert.error, None);
 
@@ -7232,11 +7472,11 @@ fn dispatches_agent_run_list_merges_legacy_and_thread_backed_runs() {
         "trace-mixed-agent-runs",
         "thread.create",
         json!({
-            "threadId": "thread-run-legacy",
-            "title": "Duplicate legacy run",
+            "threadId": "thread-run-log-duplicate",
+            "title": "Duplicate thread log run",
             "sessionKey": "session-1",
-            "rootRunId": "run-legacy",
-            "activeRunId": "run-legacy",
+            "rootRunId": "run-thread-log",
+            "activeRunId": "run-thread-log",
             "source": "agent_run"
         }),
     ));
@@ -7254,8 +7494,95 @@ fn dispatches_agent_run_list_merges_legacy_and_thread_backed_runs() {
         .as_array()
         .expect("agent_run.list should return runs");
     assert_eq!(runs.len(), 2);
-    assert!(runs.iter().any(|run| run["runId"] == "run-legacy"));
+    assert!(runs.iter().any(|run| run["runId"] == "run-thread-log"));
     assert!(runs.iter().any(|run| run["runId"] == "run-thread-only"));
+}
+
+#[test]
+fn dispatches_agent_run_reads_legacy_session_backed_runs() {
+    let fixture = WorkspaceFixture::new();
+    let mut session = session_fixture();
+    session.extra = json!({
+        "agent_runs": [{
+            "sessionId": "session-1",
+            "runId": "run-legacy-session",
+            "status": "completed",
+            "phase": "completed",
+            "startedAt": "2026-07-05T00:00:00Z",
+            "updatedAt": "2026-07-05T00:00:02Z",
+            "completedAt": "2026-07-05T00:00:02Z",
+            "stopReason": "final_response",
+            "model": "fixture-model",
+            "provider": "fixture",
+            "maxIterations": 4,
+            "currentIteration": 1,
+            "conversationMessageIds": [],
+            "traceMessages": [],
+            "traceEvents": [{
+                "schemaVersion": "tinybot.agent_event.v1",
+                "eventId": "run-legacy-session:agent-done:0000000000000001",
+                "sequence": 1,
+                "sessionId": "session-1",
+                "turnId": "run-legacy-session",
+                "itemId": "run-legacy-session:assistant",
+                "eventName": "agent.done",
+                "phase": "completed",
+                "timestamp": "2026-07-05T00:00:02Z",
+                "source": "rust_backend",
+                "visibility": "user",
+                "payload": { "finalContent": "Legacy final response" }
+            }],
+            "completedToolResults": [],
+            "pendingToolCalls": [],
+            "checkpoint": null,
+            "artifacts": [],
+            "usage": [],
+            "error": null
+        }]
+    });
+    let mut router = WorkerRpcRouter::new(
+        fixture.root.clone(),
+        json!({}),
+        vec![session],
+        20,
+        CapabilityPolicy::new([WorkerCapability::SessionMetadataRead]),
+    );
+
+    let run_list = router.dispatch(&WorkerRequest::new(
+        "req-legacy-agent-run-list",
+        "trace-legacy-agent-run",
+        "agent_run.list",
+        json!({ "sessionId": "session-1" }),
+    ));
+    let get = router.dispatch(&WorkerRequest::new(
+        "req-legacy-agent-run-get",
+        "trace-legacy-agent-run",
+        "agent_run.get",
+        json!({ "session_id": "session-1", "run_id": "run-legacy-session" }),
+    ));
+    let runtime_state = router.dispatch(&WorkerRequest::new(
+        "req-legacy-agent-run-runtime",
+        "trace-legacy-agent-run",
+        "agent_run.runtime_state",
+        json!({ "session_id": "session-1", "run_id": "run-legacy-session" }),
+    ));
+
+    assert_eq!(run_list.error, None);
+    assert_eq!(
+        run_list.result.as_ref().unwrap()["runs"][0]["runId"],
+        "run-legacy-session"
+    );
+    assert_eq!(get.error, None);
+    assert_eq!(get.result.as_ref().unwrap()["status"], "completed");
+    assert_eq!(runtime_state.error, None);
+    assert_eq!(
+        runtime_state.result.as_ref().unwrap()["turnItems"][0]["kind"],
+        "assistant_message"
+    );
+    assert_eq!(
+        runtime_state.result.as_ref().unwrap()["turnItems"][0]["payload"]["content"],
+        "Legacy final response"
+    );
 }
 
 #[test]
@@ -12489,6 +12816,17 @@ fn first_thread_log_file(root: &Path) -> PathBuf {
         None
     }
     visit(&root.join(".tinybot").join("threads")).expect("thread log file should exist")
+}
+
+fn thread_state_updated_at(state_path: &Path, session_id: &str) -> String {
+    let connection = rusqlite::Connection::open(state_path).expect("state db should open");
+    connection
+        .query_row(
+            "SELECT updated_at FROM threads WHERE session_id = ?1",
+            [session_id],
+            |row| row.get(0),
+        )
+        .expect("thread state row should exist")
 }
 
 struct WorkspaceFixture {

--- a/src-tauri/src/worker_thread_log/agent_run.rs
+++ b/src-tauri/src/worker_thread_log/agent_run.rs
@@ -1,0 +1,935 @@
+use super::{
+    now_thread_timestamp, read_thread_lines, thread_id_for_session_id, value_event,
+    WorkerThreadLogRpc,
+};
+use crate::agent_loop_runtime_protocol::{
+    project_turn_items_from_trace_events, AgentRuntimeEventEnvelope,
+    LegacyNativeAgentEventEnvelopeInput,
+};
+use crate::worker_capability::WorkerCapability;
+use crate::worker_protocol::{
+    WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
+};
+use crate::worker_session::{
+    AgentRunCheckpoint, AgentRunRecord, AgentRunRuntimeState, AgentRunStatus, AgentRunTracePage,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+impl WorkerThreadLogRpc {
+    pub fn upsert_agent_run(
+        &self,
+        mut record: AgentRunRecord,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        validate_agent_run_key(&record.session_id, &record.run_id)?;
+        let existing = self.get_agent_run_record(&record.session_id, &record.run_id)?;
+        if let Some(existing) = existing {
+            record.started_at = existing.started_at;
+        }
+        let timestamp = now_thread_timestamp();
+        let mut state = self.ensure_agent_run_thread(&record.session_id, &timestamp)?;
+        let path = PathBuf::from(state.thread_path.clone());
+        self.recorder.validate_thread_path(&path)?;
+        self.recorder.append_item(
+            &path,
+            timestamp.clone(),
+            value_event("agent_run_upsert", serde_json::json!({ "record": record })),
+        )?;
+        state.updated_at = timestamp;
+        if !record.model.trim().is_empty() {
+            state.model = Some(record.model.clone());
+        }
+        state.model_provider = record.provider.clone();
+        if let Some(info) = record.token_usage_info.as_ref() {
+            state.tokens_used = info.total_token_usage.total_tokens;
+        }
+        self.state.upsert_thread(&state)?;
+        Ok(record)
+    }
+
+    pub fn append_agent_run_trace_event(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        event: Value,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        validate_agent_run_key(session_id, run_id)?;
+        let mut record = self
+            .get_agent_run_record(session_id, run_id)?
+            .ok_or_else(|| unknown_agent_run_error(session_id, run_id))?;
+        let timestamp = now_thread_timestamp();
+        let state = self.ensure_agent_run_thread(session_id, &timestamp)?;
+        let path = PathBuf::from(state.thread_path.clone());
+        self.recorder.validate_thread_path(&path)?;
+        self.recorder.append_item(
+            &path,
+            timestamp.clone(),
+            value_event(
+                "agent_run_trace",
+                serde_json::json!({
+                    "sessionId": session_id,
+                    "runId": run_id,
+                    "event": event,
+                }),
+            ),
+        )?;
+        upsert_trace_event(&mut record.trace_events, event.clone());
+        apply_agent_status_snapshot(&mut record, &event);
+        record.updated_at = timestamp.clone();
+        Ok(record)
+    }
+
+    pub fn list_agent_runs(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<AgentRunRecord>, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        self.agent_run_records_for_session(session_id)
+    }
+
+    pub fn get_agent_run(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<Option<AgentRunRecord>, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        validate_agent_run_key(session_id, run_id)?;
+        self.get_agent_run_record(session_id, run_id)
+    }
+
+    pub fn list_agent_run_trace_events(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        cursor: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Option<AgentRunTracePage>, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        let Some(record) = self.get_agent_run(session_id, run_id)? else {
+            return Ok(None);
+        };
+        let offset = parse_trace_cursor(cursor)?;
+        let limit = limit.unwrap_or(100).clamp(1, 500);
+        let items = record
+            .trace_events
+            .iter()
+            .skip(offset)
+            .take(limit)
+            .cloned()
+            .collect::<Vec<_>>();
+        let next_offset = offset.saturating_add(items.len());
+        let next_cursor =
+            (next_offset < record.trace_events.len()).then(|| next_offset.to_string());
+        Ok(Some(AgentRunTracePage {
+            session_id: session_id.to_string(),
+            run_id: run_id.to_string(),
+            items,
+            next_cursor,
+        }))
+    }
+
+    pub fn get_agent_run_runtime_state(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<Option<AgentRunRuntimeState>, WorkerProtocolError> {
+        let Some(record) = self.get_agent_run(session_id, run_id)? else {
+            return Ok(None);
+        };
+        let runtime_events = record
+            .trace_events
+            .iter()
+            .enumerate()
+            .filter_map(|(index, event)| runtime_event_from_trace_value(&record, index, event))
+            .collect::<Vec<_>>();
+        let turn_items = project_turn_items_from_trace_events(&runtime_events);
+        Ok(Some(AgentRunRuntimeState {
+            session_id: session_id.to_string(),
+            run_id: run_id.to_string(),
+            runtime_events,
+            turn_items,
+        }))
+    }
+
+    pub fn set_agent_run_checkpoint(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        checkpoint: Value,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        validate_agent_run_key(session_id, run_id)?;
+        let timestamp = now_thread_timestamp();
+        let mut record = self
+            .get_agent_run_record(session_id, run_id)?
+            .unwrap_or_else(|| {
+                agent_run_from_checkpoint(session_id, run_id, &checkpoint, &timestamp)
+            });
+        let mut state = self.ensure_agent_run_thread(session_id, &timestamp)?;
+        let path = PathBuf::from(state.thread_path.clone());
+        self.recorder.validate_thread_path(&path)?;
+        self.recorder.append_item(
+            &path,
+            timestamp.clone(),
+            value_event(
+                "agent_run_checkpoint_set",
+                serde_json::json!({
+                    "sessionId": session_id,
+                    "runId": run_id,
+                    "checkpoint": checkpoint,
+                }),
+            ),
+        )?;
+        apply_checkpoint_to_record(&mut record, checkpoint, &timestamp);
+        state.updated_at = timestamp;
+        self.state.upsert_thread(&state)?;
+        Ok(record)
+    }
+
+    pub fn latest_agent_run_checkpoint(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<AgentRunCheckpoint>, WorkerProtocolError> {
+        let mut runs = self.list_agent_runs(session_id)?;
+        runs.retain(|run| run.checkpoint.is_some() && agent_run_status_is_resumable(&run.status));
+        Ok(runs.into_iter().next().and_then(|run| {
+            run.checkpoint.map(|checkpoint| AgentRunCheckpoint {
+                session_id: run.session_id,
+                run_id: run.run_id,
+                checkpoint,
+            })
+        }))
+    }
+
+    pub fn clear_latest_agent_run_checkpoint(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<AgentRunRecord>, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        let mut runs = self.agent_run_records_for_session(session_id)?;
+        runs.retain(|run| run.checkpoint.is_some() && agent_run_status_is_resumable(&run.status));
+        let Some(run) = runs.into_iter().next() else {
+            return Ok(None);
+        };
+        self.clear_agent_run_checkpoint(session_id, &run.run_id)
+            .map(Some)
+    }
+
+    pub fn get_agent_run_checkpoint(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<Option<AgentRunCheckpoint>, WorkerProtocolError> {
+        let Some(record) = self.get_agent_run(session_id, run_id)? else {
+            return Ok(None);
+        };
+        Ok(record.checkpoint.map(|checkpoint| AgentRunCheckpoint {
+            session_id: record.session_id,
+            run_id: record.run_id,
+            checkpoint,
+        }))
+    }
+
+    pub fn clear_agent_run_checkpoint(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        validate_agent_run_key(session_id, run_id)?;
+        let mut record = self
+            .get_agent_run_record(session_id, run_id)?
+            .ok_or_else(|| unknown_agent_run_error(session_id, run_id))?;
+        let timestamp = now_thread_timestamp();
+        let mut state = self.ensure_agent_run_thread(session_id, &timestamp)?;
+        let path = PathBuf::from(state.thread_path.clone());
+        self.recorder.validate_thread_path(&path)?;
+        self.recorder.append_item(
+            &path,
+            timestamp.clone(),
+            value_event(
+                "agent_run_checkpoint_clear",
+                serde_json::json!({ "sessionId": session_id, "runId": run_id }),
+            ),
+        )?;
+        record.checkpoint = None;
+        record.updated_at = timestamp.clone();
+        state.updated_at = timestamp;
+        self.state.upsert_thread(&state)?;
+        Ok(record)
+    }
+
+    pub fn mark_agent_run_completed(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        stop_reason: &str,
+        final_content: Option<String>,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        let mut record = self.mark_agent_run_terminal(
+            session_id,
+            run_id,
+            AgentRunStatus::Completed,
+            "completed",
+            Some(stop_reason.to_string()),
+            final_content,
+            None,
+        )?;
+        if let Some(info) = record.token_usage_info.clone() {
+            let info_value = serde_json::to_value(info).map_err(thread_log_serialization_error)?;
+            let info = serde_json::from_value::<super::TokenUsageInfo>(info_value)
+                .map_err(thread_log_serialization_error)?;
+            self.append_token_count(session_id, info)?;
+            record.checkpoint = None;
+        }
+        Ok(record)
+    }
+
+    pub fn mark_agent_run_failed(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        stop_reason: &str,
+        error: Value,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.mark_agent_run_terminal(
+            session_id,
+            run_id,
+            AgentRunStatus::Failed,
+            "failed",
+            Some(stop_reason.to_string()),
+            None,
+            Some(error),
+        )
+    }
+
+    pub fn mark_agent_run_cancelled(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.mark_agent_run_terminal(
+            session_id,
+            run_id,
+            AgentRunStatus::Cancelled,
+            "cancelled",
+            Some("cancelled".to_string()),
+            None,
+            None,
+        )
+    }
+
+    fn get_agent_run_record(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<Option<AgentRunRecord>, WorkerProtocolError> {
+        Ok(self
+            .agent_run_records_for_session(session_id)?
+            .into_iter()
+            .find(|record| record.run_id == run_id))
+    }
+
+    fn agent_run_records_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<AgentRunRecord>, WorkerProtocolError> {
+        self.ensure_state_index()?;
+        let Some(record) = self.find_live_record(session_id)? else {
+            return Ok(Vec::new());
+        };
+        let path = PathBuf::from(record.thread_path);
+        self.recorder.validate_thread_path(&path)?;
+        let lines = read_thread_lines(&path)?;
+        let mut runs = agent_run_records_from_lines(session_id, &lines);
+        runs.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| left.run_id.cmp(&right.run_id))
+        });
+        Ok(runs)
+    }
+
+    fn ensure_agent_run_thread(
+        &self,
+        session_id: &str,
+        timestamp: &str,
+    ) -> Result<super::ThreadStateRecord, WorkerProtocolError> {
+        self.ensure_state_index()?;
+        if let Some(record) = self.state.find_by_session_or_thread_id(session_id)? {
+            return Ok(record);
+        }
+        let thread_id = thread_id_for_session_id(session_id);
+        let meta = super::ThreadMeta {
+            thread_id: thread_id.clone(),
+            session_id: Some(session_id.to_string()),
+            created_at: timestamp.to_string(),
+            cwd: String::new(),
+            source: "desktop".to_string(),
+            model_provider: None,
+            model: None,
+            base_instructions: None,
+            history_mode: Some("default".to_string()),
+            forked_from_thread_id: None,
+            parent_thread_id: None,
+            originator: Some("Tinybot Desktop".to_string()),
+        };
+        let path = self.recorder.create_thread(meta)?;
+        let record = super::ThreadStateRecord {
+            id: thread_id,
+            session_id: Some(session_id.to_string()),
+            thread_path: path.display().to_string(),
+            created_at: timestamp.to_string(),
+            updated_at: timestamp.to_string(),
+            source: "desktop".to_string(),
+            title: "New session".to_string(),
+            preview: String::new(),
+            cwd: String::new(),
+            model_provider: None,
+            model: None,
+            tokens_used: 0,
+            archived: false,
+            archived_at: None,
+        };
+        self.state.upsert_thread(&record)?;
+        Ok(record)
+    }
+
+    fn mark_agent_run_terminal(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        status: AgentRunStatus,
+        phase: &str,
+        stop_reason: Option<String>,
+        final_content: Option<String>,
+        error: Option<Value>,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
+        validate_agent_run_key(session_id, run_id)?;
+        let mut record = self
+            .get_agent_run_record(session_id, run_id)?
+            .ok_or_else(|| unknown_agent_run_error(session_id, run_id))?;
+        let timestamp = now_thread_timestamp();
+        let mut state = self.ensure_agent_run_thread(session_id, &timestamp)?;
+        let path = PathBuf::from(state.thread_path.clone());
+        self.recorder.validate_thread_path(&path)?;
+        self.recorder.append_item(
+            &path,
+            timestamp.clone(),
+            value_event(
+                "agent_run_terminal",
+                serde_json::json!({
+                    "sessionId": session_id,
+                    "runId": run_id,
+                    "status": status,
+                    "phase": phase,
+                    "stopReason": stop_reason,
+                    "finalContent": final_content,
+                    "error": error,
+                }),
+            ),
+        )?;
+        apply_terminal_to_record(
+            &mut record,
+            status,
+            phase,
+            stop_reason,
+            final_content,
+            error,
+            &timestamp,
+        );
+        state.updated_at = timestamp;
+        state.preview = final_content_preview(&record).unwrap_or(state.preview);
+        self.state.upsert_thread(&state)?;
+        Ok(record)
+    }
+}
+
+fn agent_run_status_is_resumable(status: &AgentRunStatus) -> bool {
+    matches!(status, AgentRunStatus::Running | AgentRunStatus::Waiting)
+}
+
+fn agent_run_records_from_lines(
+    session_id: &str,
+    lines: &[super::ThreadLogLine],
+) -> Vec<AgentRunRecord> {
+    let mut runs: HashMap<String, AgentRunRecord> = HashMap::new();
+    for line in lines {
+        let super::ThreadLogItem::EventMsg(event) = &line.item else {
+            continue;
+        };
+        let Some(event_type) = event.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        let payload = event.get("payload").unwrap_or(event);
+        match event_type {
+            "agent_run_upsert" => {
+                if let Some(record) = payload
+                    .get("record")
+                    .cloned()
+                    .and_then(|value| serde_json::from_value::<AgentRunRecord>(value).ok())
+                    .filter(|record| record.session_id == session_id)
+                {
+                    runs.entry(record.run_id.clone())
+                        .and_modify(|existing| {
+                            let started_at = existing.started_at.clone();
+                            *existing = record.clone();
+                            existing.started_at = started_at;
+                        })
+                        .or_insert(record);
+                }
+            }
+            "agent_run_trace" => {
+                let Some(run_id) = payload_run_id(payload) else {
+                    continue;
+                };
+                let Some(event) = payload.get("event").cloned() else {
+                    continue;
+                };
+                if let Some(record) = runs.get_mut(&run_id) {
+                    upsert_trace_event(&mut record.trace_events, event.clone());
+                    apply_agent_status_snapshot(record, &event);
+                    record.updated_at = line.timestamp.clone();
+                }
+            }
+            "agent_run_checkpoint_set" => {
+                let Some(run_id) = payload_run_id(payload) else {
+                    continue;
+                };
+                let Some(checkpoint) = payload.get("checkpoint").cloned() else {
+                    continue;
+                };
+                let record = runs.entry(run_id.clone()).or_insert_with(|| {
+                    agent_run_from_checkpoint(session_id, &run_id, &checkpoint, &line.timestamp)
+                });
+                apply_checkpoint_to_record(record, checkpoint, &line.timestamp);
+            }
+            "agent_run_checkpoint_clear" => {
+                let Some(run_id) = payload_run_id(payload) else {
+                    continue;
+                };
+                if let Some(record) = runs.get_mut(&run_id) {
+                    record.checkpoint = None;
+                    record.updated_at = line.timestamp.clone();
+                }
+            }
+            "agent_run_terminal" => {
+                let Some(run_id) = payload_run_id(payload) else {
+                    continue;
+                };
+                if let Some(record) = runs.get_mut(&run_id) {
+                    let status = match payload.get("status").and_then(Value::as_str) {
+                        Some("completed") => AgentRunStatus::Completed,
+                        Some("failed") => AgentRunStatus::Failed,
+                        Some("cancelled") => AgentRunStatus::Cancelled,
+                        _ => record.status.clone(),
+                    };
+                    let phase = payload
+                        .get("phase")
+                        .and_then(Value::as_str)
+                        .unwrap_or(record.phase.as_str())
+                        .to_string();
+                    let stop_reason = payload
+                        .get("stopReason")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    let final_content = payload
+                        .get("finalContent")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    let error = payload
+                        .get("error")
+                        .filter(|value| !value.is_null())
+                        .cloned();
+                    apply_terminal_to_record(
+                        record,
+                        status,
+                        &phase,
+                        stop_reason,
+                        final_content,
+                        error,
+                        &line.timestamp,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    runs.into_values().collect()
+}
+
+fn payload_run_id(payload: &Value) -> Option<String> {
+    payload
+        .get("runId")
+        .or_else(|| payload.get("run_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn upsert_trace_event(events: &mut Vec<Value>, event: Value) {
+    if let Some(event_id) = event.get("eventId").and_then(Value::as_str) {
+        if let Some(existing) = events
+            .iter_mut()
+            .find(|existing| existing.get("eventId").and_then(Value::as_str) == Some(event_id))
+        {
+            *existing = event;
+            return;
+        }
+    }
+    events.push(event);
+}
+
+fn apply_checkpoint_to_record(record: &mut AgentRunRecord, checkpoint: Value, timestamp: &str) {
+    record.phase = checkpoint
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or(record.phase.as_str())
+        .to_string();
+    record.status = agent_run_status_from_checkpoint(&checkpoint);
+    record.updated_at = timestamp.to_string();
+    record.current_iteration = checkpoint
+        .get("iteration")
+        .and_then(Value::as_i64)
+        .unwrap_or(record.current_iteration);
+    record.max_iterations = checkpoint
+        .get("maxIterations")
+        .or_else(|| checkpoint.get("max_iterations"))
+        .and_then(Value::as_i64)
+        .unwrap_or(record.max_iterations);
+    record.pending_tool_calls = checkpoint
+        .get("pendingToolCalls")
+        .or_else(|| checkpoint.get("pending_tool_calls"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    record.completed_tool_results = checkpoint
+        .get("completedToolResults")
+        .or_else(|| checkpoint.get("completed_tool_results"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    record.checkpoint = Some(checkpoint);
+}
+
+fn apply_terminal_to_record(
+    record: &mut AgentRunRecord,
+    status: AgentRunStatus,
+    phase: &str,
+    stop_reason: Option<String>,
+    final_content: Option<String>,
+    error: Option<Value>,
+    timestamp: &str,
+) {
+    if let Some(final_content) = final_content.filter(|content| !content.trim().is_empty()) {
+        record.trace_messages.push(serde_json::json!({
+            "role": "assistant",
+            "content": final_content,
+        }));
+    }
+    record.status = status;
+    record.phase = phase.to_string();
+    record.stop_reason = stop_reason;
+    record.completed_at = Some(timestamp.to_string());
+    record.updated_at = timestamp.to_string();
+    record.checkpoint = None;
+    record.error = error;
+}
+
+fn final_content_preview(record: &AgentRunRecord) -> Option<String> {
+    record.trace_messages.iter().rev().find_map(|message| {
+        let role = message.get("role").and_then(Value::as_str)?;
+        if role != "assistant" {
+            return None;
+        }
+        let content = message.get("content").and_then(Value::as_str)?.trim();
+        if content.is_empty() {
+            None
+        } else {
+            Some(content.chars().take(160).collect())
+        }
+    })
+}
+
+fn agent_run_from_checkpoint(
+    session_id: &str,
+    run_id: &str,
+    checkpoint: &Value,
+    timestamp: &str,
+) -> AgentRunRecord {
+    AgentRunRecord {
+        session_id: session_id.to_string(),
+        run_id: run_id.to_string(),
+        thread_id: checkpoint
+            .get("threadId")
+            .or_else(|| checkpoint.get("thread_id"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        turn_id: checkpoint
+            .get("turnId")
+            .or_else(|| checkpoint.get("turn_id"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        parent_thread_id: checkpoint
+            .get("parentThreadId")
+            .or_else(|| checkpoint.get("parent_thread_id"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        child_thread_ids: checkpoint
+            .get("childThreadIds")
+            .or_else(|| checkpoint.get("child_thread_ids"))
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        status: AgentRunStatus::Waiting,
+        phase: checkpoint
+            .get("phase")
+            .and_then(Value::as_str)
+            .unwrap_or("awaiting_checkpoint")
+            .to_string(),
+        started_at: timestamp.to_string(),
+        updated_at: timestamp.to_string(),
+        completed_at: None,
+        stop_reason: checkpoint
+            .get("stopReason")
+            .or_else(|| checkpoint.get("stop_reason"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        model: checkpoint
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        provider: checkpoint
+            .get("provider")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        max_iterations: checkpoint
+            .get("maxIterations")
+            .or_else(|| checkpoint.get("max_iterations"))
+            .and_then(Value::as_i64)
+            .unwrap_or_default(),
+        current_iteration: checkpoint
+            .get("iteration")
+            .and_then(Value::as_i64)
+            .unwrap_or_default(),
+        conversation_message_ids: Vec::new(),
+        trace_messages: checkpoint
+            .get("messages")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        trace_events: Vec::new(),
+        completed_tool_results: checkpoint
+            .get("completedToolResults")
+            .or_else(|| checkpoint.get("completed_tool_results"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        pending_tool_calls: checkpoint
+            .get("pendingToolCalls")
+            .or_else(|| checkpoint.get("pending_tool_calls"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        checkpoint: Some(checkpoint.clone()),
+        artifacts: Vec::new(),
+        usage: Vec::new(),
+        token_usage_info: None,
+        error: None,
+    }
+}
+
+fn agent_run_status_from_checkpoint(checkpoint: &Value) -> AgentRunStatus {
+    match checkpoint
+        .get("stopReason")
+        .or_else(|| checkpoint.get("stop_reason"))
+        .and_then(Value::as_str)
+        .or_else(|| checkpoint.get("phase").and_then(Value::as_str))
+    {
+        Some("final_response") | Some("completed") | Some("done") | Some("terminal") => {
+            AgentRunStatus::Completed
+        }
+        Some("cancelled") => AgentRunStatus::Cancelled,
+        Some("provider_error")
+        | Some("tool_error")
+        | Some("policy_denied")
+        | Some("max_iterations")
+        | Some("invalid_request")
+        | Some("approval_denied")
+        | Some("form_cancelled")
+        | Some("failed") => AgentRunStatus::Failed,
+        _ => AgentRunStatus::Waiting,
+    }
+}
+
+fn apply_agent_status_snapshot(record: &mut AgentRunRecord, event: &Value) {
+    if event.get("eventName").and_then(Value::as_str) != Some("agent.status") {
+        return;
+    }
+    let payload = event.get("payload").unwrap_or(event);
+    if let Some(phase) = payload
+        .get("phase")
+        .or_else(|| event.get("phase"))
+        .and_then(Value::as_str)
+    {
+        record.phase = phase.to_string();
+        record.status = agent_run_status_from_phase(phase);
+    }
+    if let Some(iteration) = payload
+        .get("iteration")
+        .or_else(|| event.get("iteration"))
+        .and_then(Value::as_i64)
+    {
+        record.current_iteration = iteration;
+    }
+}
+
+fn agent_run_status_from_phase(phase: &str) -> AgentRunStatus {
+    match phase {
+        "awaiting_approval" | "awaiting_form" | "awaiting_subagent" | "queued" => {
+            AgentRunStatus::Waiting
+        }
+        _ => AgentRunStatus::Running,
+    }
+}
+
+fn runtime_event_from_trace_value(
+    record: &AgentRunRecord,
+    index: usize,
+    event: &Value,
+) -> Option<AgentRuntimeEventEnvelope> {
+    if let Ok(envelope) = serde_json::from_value::<AgentRuntimeEventEnvelope>(event.clone()) {
+        return Some(envelope);
+    }
+    let event_name = event.get("eventName").and_then(Value::as_str)?.to_string();
+    let payload = event
+        .get("payload")
+        .cloned()
+        .unwrap_or_else(|| event.clone());
+    let sequence = event
+        .get("sequence")
+        .and_then(Value::as_u64)
+        .unwrap_or_else(|| index as u64 + 1);
+    Some(AgentRuntimeEventEnvelope::from_legacy_native_event(
+        LegacyNativeAgentEventEnvelopeInput {
+            session_id: record.session_id.clone(),
+            thread_id: record.thread_id.clone(),
+            turn_id: record.run_id.clone(),
+            parent_turn_id: event
+                .get("parentTurnId")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            item_id: event
+                .get("itemId")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| legacy_trace_item_id(&event_name, &payload)),
+            event_name,
+            sequence,
+            timestamp: event
+                .get("timestamp")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| record.updated_at.clone()),
+            payload,
+        },
+    ))
+}
+
+fn legacy_trace_item_id(event_name: &str, payload: &Value) -> Option<String> {
+    match event_name {
+        "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" => {
+            string_from_trace_payload(payload, &["toolCallId", "tool_call_id"])
+        }
+        "agent.awaiting_approval" | "agent.approval.decision" => {
+            string_from_trace_payload(payload, &["approvalId", "approval_id"])
+        }
+        "agent.awaiting_form" | "agent.form.resolution" => {
+            string_from_trace_payload(payload, &["formId", "form_id"])
+        }
+        event_name if event_name.starts_with("agent.delegate.") => {
+            string_from_trace_payload(payload, &["delegateId", "subagentId", "delegate_id"])
+        }
+        _ => None,
+    }
+}
+
+fn string_from_trace_payload(payload: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        payload
+            .get(*key)
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    })
+}
+
+fn parse_trace_cursor(cursor: Option<&str>) -> Result<usize, WorkerProtocolError> {
+    let Some(cursor) = cursor else {
+        return Ok(0);
+    };
+    cursor.parse::<usize>().map_err(|_| {
+        WorkerProtocolError::new(
+            WorkerProtocolErrorCode::InvalidProtocol,
+            "invalid agent run trace cursor",
+            serde_json::json!({ "cursor": cursor }),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        )
+    })
+}
+
+fn validate_agent_run_key(session_id: &str, run_id: &str) -> Result<(), WorkerProtocolError> {
+    validate_path_safe_id(session_id, "session_id")?;
+    validate_path_safe_id(run_id, "run_id")
+}
+
+fn validate_path_safe_id(value: &str, field: &str) -> Result<(), WorkerProtocolError> {
+    if value.trim().is_empty() || value.contains('\0') || value.contains("..") {
+        return Err(invalid_agent_run_key(field, value));
+    }
+    Ok(())
+}
+
+fn invalid_agent_run_key(field: &str, value: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "invalid agent run key",
+        serde_json::json!({ field: value }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn unknown_agent_run_error(session_id: &str, run_id: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "agent run not found",
+        serde_json::json!({
+            "session_id": session_id,
+            "run_id": run_id,
+        }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn thread_log_serialization_error(error: serde_json::Error) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::WorkerError,
+        format!("thread log agent run serialization error: {error}"),
+        serde_json::json!({ "method": "agent_run" }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}

--- a/src-tauri/src/worker_thread_log/mod.rs
+++ b/src-tauri/src/worker_thread_log/mod.rs
@@ -1,3 +1,4 @@
+mod agent_run;
 mod reader;
 mod recorder;
 mod replay;
@@ -60,6 +61,18 @@ impl WorkerThreadLogRpc {
         session_id: &str,
     ) -> Result<Option<SessionMetadata>, WorkerProtocolError> {
         self.require(WorkerCapability::SessionMetadataRead)?;
+        self.ensure_state_index()?;
+        let Some(record) = self.find_live_record(session_id)? else {
+            return Ok(None);
+        };
+        Ok(Some(metadata_from_state(record)))
+    }
+
+    pub fn get_session_metadata_for_write_response(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionMetadata>, WorkerProtocolError> {
+        self.require(WorkerCapability::SessionWrite)?;
         self.ensure_state_index()?;
         let Some(record) = self.find_live_record(session_id)? else {
             return Ok(None);
@@ -607,11 +620,14 @@ fn thread_run_state(path: &Path, run_id: &str) -> Result<ThreadRunState, WorkerP
                     .get("payload")
                     .and_then(|payload| payload.get("runId").or_else(|| payload.get("run_id")))
                     .and_then(Value::as_str);
-                if event_run_id == Some(run_id) {
-                    saw_run = true;
-                    if event_type == Some("turn_complete") {
+                match (event_type, event_run_id) {
+                    (Some("turn_complete"), Some(value)) if value == run_id => {
                         return Ok(ThreadRunState::Complete);
                     }
+                    (Some("turn_started"), Some(value)) if value == run_id => {
+                        saw_run = true;
+                    }
+                    _ => {}
                 }
             }
             ThreadLogItem::ResponseItem(item) => {


### PR DESCRIPTION
## Summary
- Move agent run persistence off the legacy session JSON store and onto append-only thread log events.
- Keep agent run trace appends from updating the thread state SQLite index on every streamed event.
- Update checkpoint and runtime-state tests to use the thread log as the source of truth.

## Root Cause
Agent run stream events were persisted through paths that rewrote SQLite-backed session or state indexes too frequently. After moving run data to thread logs, trace appends still updated `.tinybot/state/state.sqlite`, causing high-frequency `state.sqlite-journal` writes during model streaming.

## Impact
Streaming trace events are still persisted and replayable, but they no longer refresh the low-frequency thread state index on every delta. Run start, checkpoint, terminal, metadata, and completed turn writes still update the state index.

## Validation
- `cargo test agent_run --quiet`
- `cargo test checkpoint --quiet`
- `cargo test worker_run_agent_persists_agent_run_record_and_keeps_history_compact --quiet`