### PR TITLE
Add Codex-style tool runtime scheduling

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4250,6 +4250,7 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "futures-util",
+ "libc",
  "rfd",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,6 @@ serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 tauri-plugin-notification = "2"
 tokio = { version = "1", features = ["time"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,7 +174,7 @@ use crate::native_backend_contract::NativeCompatibilityFallbackDiagnostic;
 use crate::worker_agent_runtime::NativeAgentRuntimeServices;
 #[cfg(test)]
 use crate::worker_agent_runtime::NativeAgentTraceSink;
-use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+use crate::worker_capability::default_desktop_capability_policy;
 use crate::worker_manager::{
     WorkerCommandSpec, WorkerManager, WorkerManagerEvent, WorkerManagerState,
 };
@@ -275,32 +275,7 @@ pub(crate) fn experimental_worker_router(
         config_snapshot,
         vec![],
         200,
-        CapabilityPolicy::new([
-            WorkerCapability::ConfigRead,
-            WorkerCapability::ProviderSecretRead,
-            WorkerCapability::FsWorkspaceRead,
-            WorkerCapability::FsWorkspaceWrite,
-            WorkerCapability::ShellExecute,
-            WorkerCapability::DiagnosticsWrite,
-            WorkerCapability::ApprovalRequest,
-            WorkerCapability::ApprovalResolve,
-            WorkerCapability::FormRequest,
-            WorkerCapability::MemoryRead,
-            WorkerCapability::MemoryWrite,
-            WorkerCapability::KnowledgeRead,
-            WorkerCapability::KnowledgeWrite,
-            WorkerCapability::CronRead,
-            WorkerCapability::CronWrite,
-            WorkerCapability::CronRun,
-            WorkerCapability::BackgroundRead,
-            WorkerCapability::BackgroundWrite,
-            WorkerCapability::TaskRead,
-            WorkerCapability::TaskWrite,
-            WorkerCapability::McpCall,
-            WorkerCapability::ChannelConnector,
-            WorkerCapability::SessionMetadataRead,
-            WorkerCapability::SessionWrite,
-        ]),
+        default_desktop_capability_policy(),
     )
     .expect("persistent session store should initialize")
     .with_builtin_skills_root(repo_root())

--- a/src-tauri/src/native_agent_bridge/tool_dispatcher.rs
+++ b/src-tauri/src/native_agent_bridge/tool_dispatcher.rs
@@ -3,7 +3,7 @@ use crate::worker_agent_runtime::{
     NativeAgentRunContext, NativeAgentRuntimeServices, NativeAgentToolCall,
     NativeAgentToolDispatcher, NativeAgentToolResult,
 };
-use crate::worker_protocol::WorkerRequest;
+use crate::worker_protocol::{WorkerRequest, WorkerRequestCancellation};
 use crate::worker_request_id::next_worker_request_correlation;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -32,6 +32,10 @@ impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
                 )
             })?;
         let request_id = next_worker_request_correlation();
+        let cancellation = context
+            .cancellation
+            .clone()
+            .map(|cancellation| Arc::new(cancellation) as Arc<dyn WorkerRequestCancellation>);
         let executor_result = call_rust_state_service(
             self.workspace_root.clone(),
             self.config_snapshot.clone(),
@@ -43,7 +47,8 @@ impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
                     "toolId": tool_call.name,
                     "arguments": arguments,
                 }),
-            ),
+            )
+            .with_cancellation(cancellation),
             "native tool executor",
         );
         match executor_result {

--- a/src-tauri/src/worker_agent_runtime/context.rs
+++ b/src-tauri/src/worker_agent_runtime/context.rs
@@ -2,6 +2,8 @@ use super::continuations::queued_user_continuation_message;
 use super::{
     string_field, NativeAgentCancellation, NativeAgentCancellationContext, NativeAgentRunContext,
 };
+use crate::worker_capability::default_desktop_capability_policy;
+use crate::worker_tool_registry::WorkerToolRegistryRpc;
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -49,6 +51,9 @@ impl NativeAgentRunContext {
         if let Some(message) = queued_user_continuation_message(&metadata) {
             messages.push(message);
         }
+        let tool_registry_entries = WorkerToolRegistryRpc::new(default_desktop_capability_policy())
+            .list_tools()
+            .tools;
         Self {
             run_id,
             session_id,
@@ -62,6 +67,7 @@ impl NativeAgentRunContext {
             stream,
             max_iterations,
             cancellation: None,
+            tool_registry_entries,
         }
     }
 

--- a/src-tauri/src/worker_agent_runtime/events.rs
+++ b/src-tauri/src/worker_agent_runtime/events.rs
@@ -55,7 +55,7 @@ pub(super) fn runtime_event_timestamp() -> String {
 
 pub(super) fn runtime_event_item_id(event_name: &str, payload: &Value) -> Option<String> {
     match event_name {
-        "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" => {
+        "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" | "agent.tool.debug" => {
             string_field(payload, "toolCallId")
                 .or_else(|| string_field(payload, "tool_call_id"))
                 .or_else(|| string_field(payload, "id"))
@@ -78,7 +78,7 @@ pub(super) fn runtime_event_source(event_name: &str) -> AgentRuntimeEventSource 
         "agent.delta" | "agent.reasoning_delta" | "agent.usage" => {
             AgentRuntimeEventSource::Provider
         }
-        "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" => {
+        "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" | "agent.tool.debug" => {
             AgentRuntimeEventSource::Tool
         }
         "agent.guidance" | "agent.approval.decision" | "agent.form.resolution" => {
@@ -91,9 +91,11 @@ pub(super) fn runtime_event_source(event_name: &str) -> AgentRuntimeEventSource 
 
 pub(super) fn runtime_event_visibility(event_name: &str) -> AgentRuntimeEventVisibility {
     match event_name {
-        "agent.checkpoint" | "agent.usage" | "agent.done" | "agent.phase.changed" => {
-            AgentRuntimeEventVisibility::Debug
-        }
+        "agent.checkpoint"
+        | "agent.usage"
+        | "agent.done"
+        | "agent.phase.changed"
+        | "agent.tool.debug" => AgentRuntimeEventVisibility::Debug,
         _ => AgentRuntimeEventVisibility::User,
     }
 }

--- a/src-tauri/src/worker_agent_runtime/mod.rs
+++ b/src-tauri/src/worker_agent_runtime/mod.rs
@@ -4,6 +4,7 @@ use crate::agent_loop_runtime_protocol::{
 use crate::worker_subagent_manager::{
     SubagentInputSender, SubagentSendInputParams, SubagentTargetParams, SubagentThreadManager,
 };
+use crate::worker_tool_registry::ToolRegistryEntry;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{fmt, sync::Arc};
@@ -20,6 +21,7 @@ mod stores;
 mod tool_dispatcher;
 mod tool_projection;
 mod tool_result;
+mod tool_runtime;
 mod usage;
 
 use self::provider::{
@@ -69,6 +71,12 @@ impl fmt::Debug for NativeAgentCancellationContext {
     }
 }
 
+impl crate::worker_protocol::WorkerRequestCancellation for NativeAgentCancellationContext {
+    fn is_cancelled(&self) -> bool {
+        self.is_cancelled()
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NativeAgentEvent {
     #[serde(rename = "eventName")]
@@ -99,6 +107,7 @@ pub struct NativeAgentRunContext {
     pub stream: bool,
     pub max_iterations: i64,
     pub cancellation: Option<NativeAgentCancellationContext>,
+    pub tool_registry_entries: Vec<ToolRegistryEntry>,
 }
 
 #[derive(Clone, Debug)]
@@ -156,6 +165,16 @@ pub trait NativeAgentToolDispatcher: Send + Sync {
         context: &NativeAgentRunContext,
         tool_call: &NativeAgentToolCall,
     ) -> Result<NativeAgentToolResult, String>;
+
+    fn dispatch_async(
+        &self,
+        context: NativeAgentRunContext,
+        tool_call: NativeAgentToolCall,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send + '_>,
+    > {
+        Box::pin(async move { self.dispatch(&context, &tool_call) })
+    }
 }
 
 pub trait NativeAgentCheckpointStore: Send + Sync {

--- a/src-tauri/src/worker_agent_runtime/provider.rs
+++ b/src-tauri/src/worker_agent_runtime/provider.rs
@@ -2,6 +2,7 @@ use super::{
     context_window_messages, string_field, NativeAgentProvider, NativeAgentProviderResponse,
     NativeAgentProviderStreamEvent, NativeAgentRunContext, NativeAgentToolCall,
 };
+use crate::worker_tool_registry::{ToolExposure, ToolRegistryEntry};
 use serde_json::Value;
 
 pub(super) struct RustNativeAgentProvider;
@@ -82,7 +83,65 @@ pub(super) fn agent_chat_completion_request(
     {
         request["max_completion_tokens"] = max_tokens;
     }
+    let tools = chat_completion_tool_specs(context);
+    if !tools.is_empty() {
+        request["tools"] = Value::Array(tools);
+        request["tool_choice"] = Value::String("auto".to_string());
+        if should_enable_parallel_tool_calls(context) {
+            request["parallel_tool_calls"] = Value::Bool(true);
+        }
+    }
     Ok(request)
+}
+
+fn chat_completion_tool_specs(context: &NativeAgentRunContext) -> Vec<Value> {
+    context
+        .tool_registry_entries
+        .iter()
+        .filter(|entry| entry.available && entry.exposure == ToolExposure::Model)
+        .map(registry_entry_to_chat_tool)
+        .collect()
+}
+
+fn should_enable_parallel_tool_calls(context: &NativeAgentRunContext) -> bool {
+    explicit_parallel_tool_calls_enabled(context)
+        && context.tool_registry_entries.iter().any(|entry| {
+            entry.available
+                && entry.exposure == ToolExposure::Model
+                && entry.supports_parallel_tool_calls
+        })
+}
+
+fn explicit_parallel_tool_calls_enabled(context: &NativeAgentRunContext) -> bool {
+    bool_config_field(&context.spec)
+        .or_else(|| bool_config_field(&context.metadata))
+        .or_else(|| {
+            context
+                .config_snapshot
+                .get("agents")
+                .and_then(|agents| agents.get("defaults"))
+                .and_then(bool_config_field)
+        })
+        .or_else(|| bool_config_field(&context.config_snapshot))
+        .unwrap_or(false)
+}
+
+fn bool_config_field(value: &Value) -> Option<bool> {
+    value
+        .get("parallelToolCalls")
+        .or_else(|| value.get("parallel_tool_calls"))
+        .and_then(Value::as_bool)
+}
+
+fn registry_entry_to_chat_tool(entry: &ToolRegistryEntry) -> Value {
+    serde_json::json!({
+        "type": "function",
+        "function": {
+            "name": entry.method,
+            "description": entry.description,
+            "parameters": entry.input_schema.clone(),
+        },
+    })
 }
 
 pub(super) fn agent_provider_config(context: &NativeAgentRunContext) -> Value {

--- a/src-tauri/src/worker_agent_runtime/provider_loop.rs
+++ b/src-tauri/src/worker_agent_runtime/provider_loop.rs
@@ -5,12 +5,7 @@ use super::continuations::{
 };
 use super::result::{cancelled_result, cancelled_run_result, error_result};
 use super::state::NativeAgentRunState;
-use super::tool_dispatcher::native_tool_is_permitted;
-use super::tool_projection::{
-    assistant_tool_calls_message, completed_tool_result_entry, normalize_tool_result_for_context,
-    subagent_activity_events_from_tool_result, subagent_link_event_from_tool_result,
-    tool_observation_content, tool_observation_message,
-};
+use super::tool_runtime::{execute_tool_calls_for_iteration, NativeAgentToolExecutionOutcome};
 use super::usage::{
     context_window_action_payload, context_window_projection, context_with_projected_messages,
     estimate_context_tokens_for_request,
@@ -229,220 +224,16 @@ pub fn run_native_agent_turn_with_config(
         }
 
         if !provider_response.tool_calls.is_empty() {
-            let tool_calls = provider_response.tool_calls;
-            state.transition_phase(
-                AgentRuntimePhase::ToolCalling,
+            match execute_tool_calls_for_iteration(
+                services,
+                &context,
+                &mut state,
                 iteration,
-                "agent.tool_call.delta",
-            );
-            state.messages.push(assistant_tool_calls_message(
-                &provider_response.final_content,
-                &tool_calls,
-            ));
-            for tool_call in tool_calls {
-                state.emit_event(
-                    "agent.tool_call.delta",
-                    serde_json::json!({
-                        "runId": context.run_id,
-                        "sessionId": context.session_id,
-                        "iteration": iteration,
-                        "toolCallId": tool_call.id,
-                        "toolName": tool_call.name,
-                        "name": tool_call.name,
-                        "argumentsDelta": tool_call.arguments_json,
-                    }),
-                );
-                if !native_tool_is_permitted(&tool_call.name) {
-                    state.set_stop_reason("policy_denied", iteration, "agent.error");
-                    state.emit_event(
-                        "agent.error",
-                        serde_json::json!({
-                            "runId": context.run_id,
-                            "sessionId": context.session_id,
-                            "iteration": iteration,
-                            "stopReason": "policy_denied",
-                            "error": format!("native tool `{}` is not permitted by Rust capability policy", tool_call.name),
-                            "toolCallId": tool_call.id,
-                            "toolName": tool_call.name,
-                            "name": tool_call.name,
-                        }),
-                    );
-                    services
-                        .checkpoints
-                        .clear_for_run(&context.session_id, &context.run_id);
-                    let runtime_events = state.runtime_events();
-                    let events = state.legacy_events();
-                    return Ok(serde_json::json!({
-                        "runtime": "rust",
-                        "runId": context.run_id,
-                        "sessionId": context.session_id,
-                        "finalContent": "",
-                        "stopReason": "policy_denied",
-                        "messages": [],
-                        "toolsUsed": state.tools_used,
-                        "completedToolResults": state.completed_tool_results,
-                        "error": format!("native tool `{}` is not permitted by Rust capability policy", tool_call.name),
-                        "events": events,
-                        "runtimeEvents": runtime_events,
-                    }));
-                }
-                if services.cancellations.is_cancelled(&context.run_id) {
-                    state.transition_phase(
-                        AgentRuntimePhase::Cancelled,
-                        iteration,
-                        "agent.cancelled",
-                    );
-                    return Ok(cancelled_run_result(
-                        services,
-                        &context,
-                        state.take_runtime_events(),
-                        std::mem::take(&mut state.tools_used),
-                        std::mem::take(&mut state.completed_tool_results),
-                        iteration,
-                    ));
-                }
-                state.tools_used.push(tool_call.name.clone());
-                state.transition_phase(
-                    AgentRuntimePhase::ToolRunning,
-                    iteration,
-                    "agent.tool.start",
-                );
-                state.emit_event(
-                    "agent.tool.start",
-                    serde_json::json!({
-                        "runId": context.run_id,
-                        "sessionId": context.session_id,
-                        "iteration": iteration,
-                        "toolCallId": tool_call.id,
-                        "toolName": tool_call.name,
-                        "name": tool_call.name,
-                        "detailId": format!("tool:{}", tool_call.id),
-                        "status": "running",
-                    }),
-                );
-                state.set_pending_tool_call(&tool_call);
-                save_phase_checkpoint(
-                    services,
-                    &context,
-                    state.phase.as_str(),
-                    serde_json::json!({
-                        "iteration": iteration,
-                        "toolCallId": tool_call.id,
-                        "toolName": tool_call.name,
-                        "argumentsJson": tool_call.arguments_json,
-                        "pendingToolCalls": state.pending_tool_calls.clone(),
-                        "completedToolResults": state.completed_tool_results.clone(),
-                    }),
-                );
-                let result = match services.tools.dispatch(&context, &tool_call) {
-                    Ok(result) => result,
-                    Err(error) => {
-                        state.set_stop_reason("tool_error", iteration, "agent.error");
-                        state.emit_event(
-                            "agent.error",
-                            serde_json::json!({
-                                "runId": context.run_id,
-                                "sessionId": context.session_id,
-                                "iteration": iteration,
-                                "stopReason": "tool_error",
-                                "error": error,
-                                "toolCallId": tool_call.id,
-                                "toolName": tool_call.name,
-                                "name": tool_call.name,
-                            }),
-                        );
-                        services
-                            .checkpoints
-                            .clear_for_run(&context.session_id, &context.run_id);
-                        let runtime_events = state.runtime_events();
-                        let events = state.legacy_events();
-                        return Ok(serde_json::json!({
-                            "runtime": "rust",
-                            "runId": context.run_id,
-                            "sessionId": context.session_id,
-                            "finalContent": "",
-                            "stopReason": "tool_error",
-                            "messages": [],
-                            "toolsUsed": state.tools_used,
-                            "completedToolResults": state.completed_tool_results,
-                            "error": error,
-                            "events": events,
-                            "runtimeEvents": runtime_events,
-                        }));
-                    }
-                };
-                let result = normalize_tool_result_for_context(result, &context);
-                let observation_content = tool_observation_content(&result);
-                let completed_result = completed_tool_result_entry(&tool_call, &result);
-                state
-                    .messages
-                    .push(tool_observation_message(&tool_call, &observation_content));
-                state.emit_event(
-                    "agent.tool.result",
-                    serde_json::json!({
-                        "runId": context.run_id,
-                        "sessionId": context.session_id,
-                        "iteration": iteration,
-                        "toolCallId": tool_call.id,
-                        "toolName": tool_call.name,
-                        "name": tool_call.name,
-                        "detailId": format!("tool:{}", tool_call.id),
-                        "status": "completed",
-                        "resultStatus": result.envelope.get("status").cloned().unwrap_or_else(|| serde_json::json!("ok")),
-                        "summary": result.envelope.get("summary").cloned().unwrap_or_else(|| Value::String(observation_content.clone())),
-                        "timing": {
-                            "durationMs": result
-                                .envelope
-                                .get("metrics")
-                                .and_then(|metrics| metrics.get("durationMs"))
-                                .cloned()
-                                .unwrap_or(Value::Null),
-                        },
-                        "content": observation_content,
-                        "envelope": result.envelope.clone(),
-                    }),
-                );
-                if let Some(link_event) =
-                    subagent_link_event_from_tool_result(&context, &tool_call, &result)
-                {
-                    state.emit_native_event(link_event);
-                }
-                for event in
-                    subagent_activity_events_from_tool_result(&context, &tool_call, &result)
-                {
-                    if event.event_name == "agent.delegate.wait" {
-                        state.transition_phase(
-                            AgentRuntimePhase::AwaitingSubagent,
-                            iteration,
-                            "agent.delegate.wait",
-                        );
-                    }
-                    state.emit_native_event(event);
-                }
-                state.completed_tool_results.push(completed_result);
-                state.clear_pending_tool_calls();
-                state.transition_phase(AgentRuntimePhase::Planning, iteration, "agent.tool.result");
-                save_phase_checkpoint(
-                    services,
-                    &context,
-                    state.phase.as_str(),
-                    state.active_checkpoint_payload("tool_completed"),
-                );
-                if services.cancellations.is_cancelled(&context.run_id) {
-                    state.transition_phase(
-                        AgentRuntimePhase::Cancelled,
-                        iteration,
-                        "agent.cancelled",
-                    );
-                    return Ok(cancelled_run_result(
-                        services,
-                        &context,
-                        state.take_runtime_events(),
-                        std::mem::take(&mut state.tools_used),
-                        std::mem::take(&mut state.completed_tool_results),
-                        iteration,
-                    ));
-                }
+                provider_response.final_content.clone(),
+                provider_response.tool_calls,
+            ) {
+                NativeAgentToolExecutionOutcome::Continue => {}
+                NativeAgentToolExecutionOutcome::Finished(result) => return Ok(result),
             }
 
             if let Some(message) = state.drain_pending_guidance() {

--- a/src-tauri/src/worker_agent_runtime/state.rs
+++ b/src-tauri/src/worker_agent_runtime/state.rs
@@ -168,6 +168,31 @@ impl NativeAgentRunState {
         })];
     }
 
+    pub(super) fn set_queued_tool_calls(&mut self, tool_calls: &[(NativeAgentToolCall, &str)]) {
+        self.phase = AgentRuntimePhase::ToolRunning;
+        self.pending_tool_calls = tool_calls
+            .iter()
+            .map(|(tool_call, parallel_mode)| {
+                serde_json::json!({
+                    "toolCallId": tool_call.id,
+                    "toolName": tool_call.name,
+                    "argumentsJson": tool_call.arguments_json,
+                    "parallelMode": parallel_mode,
+                    "status": "queued",
+                })
+            })
+            .collect();
+    }
+
+    pub(super) fn mark_pending_tool_running(&mut self, tool_call_id: &str) {
+        for pending_tool_call in &mut self.pending_tool_calls {
+            if pending_tool_call.get("toolCallId").and_then(Value::as_str) == Some(tool_call_id) {
+                pending_tool_call["status"] = Value::String("running".to_string());
+                break;
+            }
+        }
+    }
+
     pub(super) fn clear_pending_tool_calls(&mut self) {
         self.pending_tool_calls.clear();
     }

--- a/src-tauri/src/worker_agent_runtime/tests.rs
+++ b/src-tauri/src/worker_agent_runtime/tests.rs
@@ -1987,6 +1987,96 @@ fn cancellation_before_queued_write_lock_dispatch_skips_waiting_tool() {
 }
 
 #[test]
+fn terminal_failure_before_queued_write_dispatch_skips_waiting_tool() {
+    struct FailingWriteThenWriteProvider;
+
+    impl NativeAgentProvider for FailingWriteThenWriteProvider {
+        fn complete(
+            &self,
+            _context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            Ok(NativeAgentProviderResponse {
+                final_content: String::new(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: vec![
+                    NativeAgentToolCall {
+                        id: "call-first-write-fails".to_string(),
+                        name: "shell.execute".to_string(),
+                        arguments_json: "{\"command\":\"false\"}".to_string(),
+                        result: json!({ "content": "unused first" }),
+                    },
+                    NativeAgentToolCall {
+                        id: "call-second-write-waits".to_string(),
+                        name: "shell.execute".to_string(),
+                        arguments_json: "{\"command\":\"touch should-not-run\"}".to_string(),
+                        result: json!({ "content": "unused second" }),
+                    },
+                ],
+            })
+        }
+    }
+
+    struct FailingWriteDispatcher {
+        second_write_dispatches: AtomicUsize,
+    }
+
+    impl NativeAgentToolDispatcher for FailingWriteDispatcher {
+        fn dispatch(
+            &self,
+            _context: &NativeAgentRunContext,
+            tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            if tool_call.id == "call-first-write-fails" {
+                return Err("first write failed".to_string());
+            }
+            self.second_write_dispatches.fetch_add(1, Ordering::SeqCst);
+            Ok(NativeAgentToolResult::generic_success(
+                tool_call,
+                tool_call.result.clone(),
+            ))
+        }
+    }
+
+    let dispatcher = Arc::new(FailingWriteDispatcher {
+        second_write_dispatches: AtomicUsize::new(0),
+    });
+    let result = run_native_agent_turn_with_services(
+        &NativeAgentRuntimeServices::new(
+            Arc::new(FailingWriteThenWriteProvider),
+            dispatcher.clone(),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        ),
+        json!({
+            "runtime": "rust",
+            "runId": "run-failed-queued-write",
+            "sessionId": "websocket:chat-failed-queued-write",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "fail then skip write" }]
+        }),
+    )
+    .expect("queued write failure should return a structured result");
+
+    let events = result["events"]
+        .as_array()
+        .expect("events should be returned");
+    assert_eq!(result["stopReason"], "tool_error");
+    assert_eq!(dispatcher.second_write_dispatches.load(Ordering::SeqCst), 0);
+    assert!(!events.iter().any(|event| {
+        event["eventName"] == "agent.tool.start"
+            && event["payload"]["toolCallId"] == "call-second-write-waits"
+            && event["payload"]["status"] == "running"
+    }));
+    assert!(events.iter().any(|event| {
+        event["eventName"] == "agent.tool.debug"
+            && event["payload"]["toolCallId"] == "call-second-write-waits"
+            && event["payload"]["ignoredReason"] == "dispatch_skipped_after_terminal"
+            && event["payload"]["terminalOutcome"] == "failed"
+    }));
+}
+
+#[test]
 fn cancellation_during_non_cleanup_parallel_tool_returns_without_waiting_for_late_result() {
     struct SlowReadProvider;
 

--- a/src-tauri/src/worker_agent_runtime/tests.rs
+++ b/src-tauri/src/worker_agent_runtime/tests.rs
@@ -1,6 +1,11 @@
 use super::*;
+use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
+use crate::worker_tool_registry::WorkerToolRegistryRpc;
 use serde_json::json;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
 
 #[derive(Default)]
 struct RecordingTraceSink {
@@ -119,6 +124,171 @@ fn normalizes_desktop_run_spec_inputs_for_rust_turns() {
     assert_eq!(
         provider_config["agents"]["defaults"]["model"],
         "fixture-model"
+    );
+}
+
+#[test]
+fn chat_completion_request_injects_available_model_tools() {
+    let mut context = NativeAgentRunContext::from_spec(
+        json!({
+            "runtime": "rust",
+            "runId": "run-tools",
+            "sessionId": "websocket:chat-tools",
+            "model": "fixture-model",
+            "messages": [{ "role": "user", "content": "read the workspace" }]
+        }),
+        json!({}),
+    );
+    context.tool_registry_entries = WorkerToolRegistryRpc::new(CapabilityPolicy::new([
+        WorkerCapability::FsWorkspaceRead,
+        WorkerCapability::MemoryRead,
+        WorkerCapability::KnowledgeRead,
+        WorkerCapability::BackgroundWrite,
+        WorkerCapability::SessionWrite,
+    ]))
+    .list_tools()
+    .tools;
+
+    let request = agent_chat_completion_request(&context)
+        .expect("available model tools should produce a chat completion request");
+    let tools = request["tools"]
+        .as_array()
+        .expect("available model tools should be injected");
+    let names = tools
+        .iter()
+        .map(|tool| tool["function"]["name"].as_str().unwrap_or_default())
+        .collect::<Vec<_>>();
+
+    assert_eq!(request["tool_choice"], "auto");
+    assert!(request.get("parallel_tool_calls").is_none());
+    assert!(names.contains(&"workspace.read_file"));
+    assert!(names.contains(&"memory.search"));
+    assert!(names.contains(&"memory.recall"));
+    assert!(names.contains(&"knowledge.query"));
+    assert!(names.contains(&"subagent.spawn"));
+    assert!(names.contains(&"subagent.send_input"));
+    assert!(!names.contains(&"workspace.write_file"));
+    assert!(!names.contains(&"workspace.delete_file"));
+    assert!(!names.contains(&"mcp.call_tool"));
+    assert!(!names.contains(&"shell.execute"));
+    assert_eq!(tools[0]["type"], "function");
+    assert_eq!(
+        tools
+            .iter()
+            .find(|tool| tool["function"]["name"] == "workspace.read_file")
+            .expect("workspace.read_file spec should be present")["function"]["parameters"],
+        json!({
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": { "type": "string" },
+                "offset": { "type": "integer" },
+                "limit": { "type": "integer" },
+                "format": { "type": "string" }
+            }
+        })
+    );
+}
+
+#[test]
+fn chat_completion_request_enables_parallel_tool_calls_only_when_explicitly_requested() {
+    let mut context = NativeAgentRunContext::from_spec(
+        json!({
+            "runtime": "rust",
+            "runId": "run-parallel-request",
+            "sessionId": "websocket:chat-parallel-request",
+            "model": "fixture-model",
+            "parallelToolCalls": true,
+            "messages": [{ "role": "user", "content": "read and search" }]
+        }),
+        json!({}),
+    );
+    context.tool_registry_entries = WorkerToolRegistryRpc::new(CapabilityPolicy::new([
+        WorkerCapability::FsWorkspaceRead,
+        WorkerCapability::MemoryRead,
+    ]))
+    .list_tools()
+    .tools;
+
+    let enabled_request = agent_chat_completion_request(&context)
+        .expect("explicit parallel tool request should build");
+    assert_eq!(enabled_request["parallel_tool_calls"], true);
+
+    context.spec["parallelToolCalls"] = json!(false);
+    let disabled_request = agent_chat_completion_request(&context)
+        .expect("disabled parallel tool request should build");
+    assert!(disabled_request.get("parallel_tool_calls").is_none());
+}
+
+#[test]
+fn chat_completion_request_omits_tools_when_no_model_tools_are_available() {
+    let mut context = NativeAgentRunContext::from_spec(
+        json!({
+            "runtime": "rust",
+            "runId": "run-no-tools",
+            "sessionId": "websocket:chat-no-tools",
+            "model": "fixture-model",
+            "messages": [{ "role": "user", "content": "hello" }]
+        }),
+        json!({}),
+    );
+    context.tool_registry_entries = WorkerToolRegistryRpc::new(CapabilityPolicy::default())
+        .list_tools()
+        .tools;
+
+    let request = agent_chat_completion_request(&context)
+        .expect("request without available model tools should still be built");
+
+    assert!(request.get("tools").is_none());
+    assert!(request.get("tool_choice").is_none());
+}
+
+#[test]
+fn chat_completion_request_keeps_tool_continuation_messages_unchanged() {
+    let mut context = NativeAgentRunContext::from_spec(
+        json!({
+            "runtime": "rust",
+            "runId": "run-tool-continuation",
+            "sessionId": "websocket:chat-tool-continuation",
+            "model": "fixture-model",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call-read",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace.read_file",
+                            "arguments": "{\"path\":\"README.md\"}"
+                        }
+                    }]
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-read",
+                    "name": "workspace.read_file",
+                    "content": "{\"content\":\"README body\"}"
+                },
+                { "role": "user", "content": "continue" }
+            ]
+        }),
+        json!({}),
+    );
+    context.tool_registry_entries =
+        WorkerToolRegistryRpc::new(CapabilityPolicy::new([WorkerCapability::FsWorkspaceRead]))
+            .list_tools()
+            .tools;
+
+    let request =
+        agent_chat_completion_request(&context).expect("tool continuation request should be built");
+
+    assert_eq!(request["messages"][0]["tool_calls"][0]["id"], "call-read");
+    assert_eq!(request["messages"][1]["role"], "tool");
+    assert_eq!(request["messages"][1]["tool_call_id"], "call-read");
+    assert_eq!(
+        request["messages"][1]["content"],
+        "{\"content\":\"README body\"}"
     );
 }
 
@@ -742,6 +912,1208 @@ fn feeds_tool_observation_back_into_second_provider_call() {
                 .as_str()
                 .expect("tool observation should be text")
                 .contains("README body")));
+}
+
+#[test]
+fn registry_model_tool_calls_are_permitted_by_runtime_dispatch() {
+    struct MemorySearchProvider {
+        calls: Mutex<usize>,
+    }
+
+    impl NativeAgentProvider for MemorySearchProvider {
+        fn complete(
+            &self,
+            _context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            let mut calls = self
+                .calls
+                .lock()
+                .expect("provider call count lock should not be poisoned");
+            *calls += 1;
+            if *calls == 1 {
+                return Ok(NativeAgentProviderResponse {
+                    final_content: String::new(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: vec![NativeAgentToolCall {
+                        id: "call-memory-search".to_string(),
+                        name: "memory.search".to_string(),
+                        arguments_json: "{\"query\":\"tool runtime\"}".to_string(),
+                        result: json!({ "notes": [] }),
+                    }],
+                });
+            }
+            Ok(NativeAgentProviderResponse {
+                final_content: "memory search complete".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    let services = NativeAgentRuntimeServices::new(
+        Arc::new(MemorySearchProvider {
+            calls: Mutex::new(0),
+        }),
+        Arc::new(FakeNativeAgentToolDispatcher),
+        Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+        Arc::new(InMemoryNativeAgentCancellation::default()),
+    );
+
+    let result = run_native_agent_turn_with_services(
+        &services,
+        json!({
+            "runtime": "rust",
+            "runId": "run-memory-search-tool",
+            "sessionId": "websocket:chat-memory-search-tool",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "search memory" }]
+        }),
+    )
+    .expect("memory search tool run should return a structured result");
+
+    assert_eq!(result["stopReason"], "final_response");
+    assert_eq!(result["toolsUsed"], json!(["memory.search"]));
+    assert_eq!(result["finalContent"], "memory search complete");
+}
+
+#[test]
+fn tool_runtime_dispatches_through_async_dispatch_seam() {
+    struct OneToolThenFinalProvider {
+        calls: Mutex<usize>,
+    }
+
+    impl NativeAgentProvider for OneToolThenFinalProvider {
+        fn complete(
+            &self,
+            _context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            let mut calls = self.calls.lock().expect("provider calls lock");
+            *calls += 1;
+            if *calls == 1 {
+                return Ok(NativeAgentProviderResponse {
+                    final_content: String::new(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: vec![NativeAgentToolCall {
+                        id: "call-async-dispatch".to_string(),
+                        name: "workspace.read_file".to_string(),
+                        arguments_json: "{\"path\":\"README.md\"}".to_string(),
+                        result: json!({ "content": "sync dispatch must not run" }),
+                    }],
+                });
+            }
+            Ok(NativeAgentProviderResponse {
+                final_content: "async dispatch complete".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    struct AsyncOnlyDispatcher {
+        async_dispatches: AtomicUsize,
+    }
+
+    impl NativeAgentToolDispatcher for AsyncOnlyDispatcher {
+        fn dispatch(
+            &self,
+            _context: &NativeAgentRunContext,
+            _tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            panic!("tool runtime should use dispatch_async, not sync dispatch");
+        }
+
+        fn dispatch_async(
+            &self,
+            _context: NativeAgentRunContext,
+            tool_call: NativeAgentToolCall,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send + '_,
+            >,
+        > {
+            self.async_dispatches.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                Ok(NativeAgentToolResult::generic_success(
+                    &tool_call,
+                    json!({ "content": "async dispatch ran" }),
+                ))
+            })
+        }
+    }
+
+    let dispatcher = Arc::new(AsyncOnlyDispatcher {
+        async_dispatches: AtomicUsize::new(0),
+    });
+    let result = run_native_agent_turn_with_services(
+        &NativeAgentRuntimeServices::new(
+            Arc::new(OneToolThenFinalProvider {
+                calls: Mutex::new(0),
+            }),
+            dispatcher.clone(),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        ),
+        json!({
+            "runtime": "rust",
+            "runId": "run-async-dispatch-seam",
+            "sessionId": "websocket:chat-async-dispatch-seam",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "run async dispatcher" }]
+        }),
+    )
+    .expect("async dispatch seam should complete");
+
+    assert_eq!(result["stopReason"], "final_response");
+    assert_eq!(dispatcher.async_dispatches.load(Ordering::SeqCst), 1);
+    assert_eq!(result["finalContent"], "async dispatch complete");
+}
+
+#[test]
+fn registry_marks_only_read_only_model_tools_as_parallel_safe() {
+    let registry = WorkerToolRegistryRpc::new(CapabilityPolicy::new([
+        WorkerCapability::FsWorkspaceRead,
+        WorkerCapability::FsWorkspaceWrite,
+        WorkerCapability::ApprovalRequest,
+        WorkerCapability::MemoryRead,
+        WorkerCapability::KnowledgeRead,
+        WorkerCapability::McpCall,
+        WorkerCapability::ShellExecute,
+        WorkerCapability::BackgroundWrite,
+        WorkerCapability::SessionWrite,
+    ]));
+    let tools = registry.list_tools().tools;
+    let parallel_methods = tools
+        .iter()
+        .filter(|tool| tool.supports_parallel_tool_calls)
+        .map(|tool| tool.method)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        parallel_methods,
+        vec![
+            "workspace.read_file",
+            "knowledge.query",
+            "memory.search",
+            "memory.recall"
+        ]
+    );
+    assert!(
+        !tools
+            .iter()
+            .find(|tool| tool.method == "workspace.write_file")
+            .expect("workspace.write_file should be registered")
+            .supports_parallel_tool_calls
+    );
+    assert!(
+        !tools
+            .iter()
+            .find(|tool| tool.method == "shell.execute")
+            .expect("shell.execute should be registered")
+            .supports_parallel_tool_calls
+    );
+    assert!(
+        !tools
+            .iter()
+            .find(|tool| tool.method == "subagent.spawn")
+            .expect("subagent.spawn should be registered")
+            .supports_parallel_tool_calls
+    );
+}
+
+#[test]
+fn registry_exposes_runtime_policy_for_cancellation_and_mutation_classification() {
+    let registry = WorkerToolRegistryRpc::new(CapabilityPolicy::new([
+        WorkerCapability::FsWorkspaceRead,
+        WorkerCapability::FsWorkspaceWrite,
+        WorkerCapability::ApprovalRequest,
+        WorkerCapability::MemoryRead,
+        WorkerCapability::KnowledgeRead,
+        WorkerCapability::McpCall,
+        WorkerCapability::ShellExecute,
+        WorkerCapability::BackgroundWrite,
+        WorkerCapability::SessionWrite,
+    ]));
+    let tools = registry.list_tools().tools;
+    let read_file = tools
+        .iter()
+        .find(|tool| tool.method == "workspace.read_file")
+        .expect("workspace.read_file should be registered");
+    let write_file = tools
+        .iter()
+        .find(|tool| tool.method == "workspace.write_file")
+        .expect("workspace.write_file should be registered");
+    let shell = tools
+        .iter()
+        .find(|tool| tool.method == "shell.execute")
+        .expect("shell.execute should be registered");
+    let subagent_spawn = tools
+        .iter()
+        .find(|tool| tool.method == "subagent.spawn")
+        .expect("subagent.spawn should be registered");
+
+    assert!(read_file.runtime_policy.supports_parallel_tool_calls);
+    assert!(!read_file.runtime_policy.waits_for_runtime_cancellation);
+    assert!(!read_file.runtime_policy.mutates_workspace);
+    assert!(!read_file.runtime_policy.mutates_session);
+
+    assert!(!write_file.runtime_policy.supports_parallel_tool_calls);
+    assert!(!write_file.runtime_policy.waits_for_runtime_cancellation);
+    assert!(write_file.runtime_policy.mutates_workspace);
+    assert!(!write_file.runtime_policy.mutates_session);
+
+    assert!(!shell.runtime_policy.supports_parallel_tool_calls);
+    assert!(shell.runtime_policy.waits_for_runtime_cancellation);
+    assert!(shell.runtime_policy.mutates_workspace);
+    assert!(!shell.runtime_policy.mutates_session);
+
+    assert!(!subagent_spawn.runtime_policy.supports_parallel_tool_calls);
+    assert!(subagent_spawn.runtime_policy.waits_for_runtime_cancellation);
+    assert!(!subagent_spawn.runtime_policy.mutates_workspace);
+    assert!(subagent_spawn.runtime_policy.mutates_session);
+}
+
+#[test]
+fn read_only_tool_batch_runs_concurrently_and_preserves_model_ordered_observations() {
+    struct TwoReadOnlyToolsThenFinalProvider {
+        seen_messages: Mutex<Vec<Vec<Value>>>,
+    }
+
+    impl NativeAgentProvider for TwoReadOnlyToolsThenFinalProvider {
+        fn complete(
+            &self,
+            context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            let call_count = {
+                let mut seen_messages = self
+                    .seen_messages
+                    .lock()
+                    .expect("seen messages lock should not be poisoned");
+                seen_messages.push(context.messages.clone());
+                seen_messages.len()
+            };
+            if call_count == 1 {
+                return Ok(NativeAgentProviderResponse {
+                    final_content: String::new(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: vec![
+                        NativeAgentToolCall {
+                            id: "call-read-first".to_string(),
+                            name: "workspace.read_file".to_string(),
+                            arguments_json: "{\"path\":\"README.md\"}".to_string(),
+                            result: json!({ "content": "README first" }),
+                        },
+                        NativeAgentToolCall {
+                            id: "call-memory-second".to_string(),
+                            name: "memory.search".to_string(),
+                            arguments_json: "{\"query\":\"README\"}".to_string(),
+                            result: json!({ "content": "memory second" }),
+                        },
+                    ],
+                });
+            }
+            Ok(NativeAgentProviderResponse {
+                final_content: "parallel tools complete".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    struct OverlapRecordingDispatcher {
+        running: AtomicUsize,
+        max_running: AtomicUsize,
+    }
+
+    impl NativeAgentToolDispatcher for OverlapRecordingDispatcher {
+        fn dispatch(
+            &self,
+            _context: &NativeAgentRunContext,
+            tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            let running = self.running.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_running.fetch_max(running, Ordering::SeqCst);
+            let delay_ms = if tool_call.id == "call-read-first" {
+                120
+            } else {
+                20
+            };
+            thread::sleep(Duration::from_millis(delay_ms));
+            self.running.fetch_sub(1, Ordering::SeqCst);
+            Ok(NativeAgentToolResult::generic_success(
+                tool_call,
+                tool_call.result.clone(),
+            ))
+        }
+    }
+
+    let provider = Arc::new(TwoReadOnlyToolsThenFinalProvider {
+        seen_messages: Mutex::new(Vec::new()),
+    });
+    let dispatcher = Arc::new(OverlapRecordingDispatcher {
+        running: AtomicUsize::new(0),
+        max_running: AtomicUsize::new(0),
+    });
+    let result = run_native_agent_turn_with_services(
+        &NativeAgentRuntimeServices::new(
+            provider.clone(),
+            dispatcher.clone(),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        ),
+        json!({
+            "runtime": "rust",
+            "runId": "run-read-only-parallel-tools",
+            "sessionId": "websocket:chat-read-only-parallel-tools",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "run read-only tools" }]
+        }),
+    )
+    .expect("parallel read-only tool run should complete");
+    let seen_messages = provider
+        .seen_messages
+        .lock()
+        .expect("seen messages lock should not be poisoned");
+    let second_request_messages = &seen_messages[1];
+    let tool_messages = second_request_messages
+        .iter()
+        .filter(|message| message["role"] == "tool")
+        .collect::<Vec<_>>();
+
+    assert_eq!(result["stopReason"], "final_response");
+    assert_eq!(dispatcher.max_running.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        result["toolsUsed"],
+        json!(["workspace.read_file", "memory.search"])
+    );
+    assert_eq!(tool_messages.len(), 2);
+    assert_eq!(tool_messages[0]["tool_call_id"], "call-read-first");
+    assert_eq!(tool_messages[0]["content"], "README first");
+    assert_eq!(tool_messages[1]["tool_call_id"], "call-memory-second");
+    assert_eq!(tool_messages[1]["content"], "memory second");
+}
+
+#[test]
+fn read_only_mcp_tool_calls_use_read_lock_scheduling() {
+    struct TwoMcpToolsThenFinalProvider {
+        calls: Mutex<usize>,
+    }
+
+    impl NativeAgentProvider for TwoMcpToolsThenFinalProvider {
+        fn complete(
+            &self,
+            _context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            let mut calls = self.calls.lock().expect("provider calls lock");
+            *calls += 1;
+            if *calls == 1 {
+                return Ok(NativeAgentProviderResponse {
+                    final_content: String::new(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: vec![
+                        NativeAgentToolCall {
+                            id: "call-mcp-read-one".to_string(),
+                            name: "mcp.call_tool".to_string(),
+                            arguments_json:
+                                "{\"server\":\"docs\",\"tool\":\"lookup\",\"arguments\":{}}"
+                                    .to_string(),
+                            result: json!({ "content": "lookup" }),
+                        },
+                        NativeAgentToolCall {
+                            id: "call-mcp-read-two".to_string(),
+                            name: "mcp.call_tool".to_string(),
+                            arguments_json:
+                                "{\"server\":\"docs\",\"tool\":\"search\",\"arguments\":{}}"
+                                    .to_string(),
+                            result: json!({ "content": "search" }),
+                        },
+                    ],
+                });
+            }
+            Ok(NativeAgentProviderResponse {
+                final_content: "mcp reads complete".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    struct McpOverlapDispatcher {
+        running: AtomicUsize,
+        max_running: AtomicUsize,
+    }
+
+    impl NativeAgentToolDispatcher for McpOverlapDispatcher {
+        fn dispatch(
+            &self,
+            _context: &NativeAgentRunContext,
+            tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            let running = self.running.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_running.fetch_max(running, Ordering::SeqCst);
+            thread::sleep(Duration::from_millis(40));
+            self.running.fetch_sub(1, Ordering::SeqCst);
+            Ok(NativeAgentToolResult::generic_success(
+                tool_call,
+                tool_call.result.clone(),
+            ))
+        }
+    }
+
+    let dispatcher = Arc::new(McpOverlapDispatcher {
+        running: AtomicUsize::new(0),
+        max_running: AtomicUsize::new(0),
+    });
+    let result = run_native_agent_turn_with_config(
+        &NativeAgentRuntimeServices::new(
+            Arc::new(TwoMcpToolsThenFinalProvider {
+                calls: Mutex::new(0),
+            }),
+            dispatcher.clone(),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        ),
+        json!({
+            "runtime": "rust",
+            "runId": "run-read-only-mcp-tools",
+            "sessionId": "websocket:chat-read-only-mcp-tools",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "run read-only mcp tools" }]
+        }),
+        json!({
+            "tools": {
+                "mcpServers": {
+                    "docs": {
+                        "enabledTools": ["lookup", "search"],
+                        "fixtureTools": {
+                            "lookup": {
+                                "content": "lookup",
+                                "annotations": { "readOnlyHint": true }
+                            },
+                            "search": {
+                                "content": "search",
+                                "annotations": { "readOnlyHint": true }
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+    )
+    .expect("read-only MCP tool run should complete");
+    let mcp_start_modes = result["events"]
+        .as_array()
+        .expect("events should be returned")
+        .iter()
+        .filter(|event| {
+            event["eventName"] == "agent.tool.start"
+                && event["payload"]["toolName"] == "mcp.call_tool"
+                && event["payload"]["status"] == "queued"
+        })
+        .map(|event| event["payload"]["parallelMode"].clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(result["stopReason"], "final_response");
+    assert_eq!(dispatcher.max_running.load(Ordering::SeqCst), 2);
+    assert_eq!(mcp_start_modes, vec![json!("read"), json!("read")]);
+}
+
+#[test]
+fn shell_read_only_allowlist_uses_read_lock_only_when_explicitly_enabled() {
+    struct TwoShellReadsThenFinalProvider {
+        calls: Mutex<usize>,
+    }
+
+    impl NativeAgentProvider for TwoShellReadsThenFinalProvider {
+        fn complete(
+            &self,
+            _context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            let mut calls = self.calls.lock().expect("provider calls lock");
+            *calls += 1;
+            if *calls == 1 {
+                return Ok(NativeAgentProviderResponse {
+                    final_content: String::new(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: vec![
+                        NativeAgentToolCall {
+                            id: "call-shell-status".to_string(),
+                            name: "shell.execute".to_string(),
+                            arguments_json: "{\"command\":\"git status\"}".to_string(),
+                            result: json!({ "content": "status" }),
+                        },
+                        NativeAgentToolCall {
+                            id: "call-shell-diff".to_string(),
+                            name: "shell.execute".to_string(),
+                            arguments_json: "{\"command\":\"git diff\"}".to_string(),
+                            result: json!({ "content": "diff" }),
+                        },
+                    ],
+                });
+            }
+            Ok(NativeAgentProviderResponse {
+                final_content: "shell reads complete".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    struct ShellOverlapDispatcher {
+        running: AtomicUsize,
+        max_running: AtomicUsize,
+    }
+
+    impl NativeAgentToolDispatcher for ShellOverlapDispatcher {
+        fn dispatch(
+            &self,
+            _context: &NativeAgentRunContext,
+            tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            let running = self.running.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_running.fetch_max(running, Ordering::SeqCst);
+            thread::sleep(Duration::from_millis(40));
+            self.running.fetch_sub(1, Ordering::SeqCst);
+            Ok(NativeAgentToolResult::generic_success(
+                tool_call,
+                tool_call.result.clone(),
+            ))
+        }
+    }
+
+    let dispatcher = Arc::new(ShellOverlapDispatcher {
+        running: AtomicUsize::new(0),
+        max_running: AtomicUsize::new(0),
+    });
+    let result = run_native_agent_turn_with_config(
+        &NativeAgentRuntimeServices::new(
+            Arc::new(TwoShellReadsThenFinalProvider {
+                calls: Mutex::new(0),
+            }),
+            dispatcher.clone(),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        ),
+        json!({
+            "runtime": "rust",
+            "runId": "run-shell-read-allowlist",
+            "sessionId": "websocket:chat-shell-read-allowlist",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "run read-only shell tools" }]
+        }),
+        json!({
+            "nativeAgent": {
+                "shellParallelPolicy": "readOnlyCommandAllowlist"
+            }
+        }),
+    )
+    .expect("read-only shell allowlist run should complete");
+    let shell_start_modes = result["events"]
+        .as_array()
+        .expect("events should be returned")
+        .iter()
+        .filter(|event| {
+            event["eventName"] == "agent.tool.start"
+                && event["payload"]["toolName"] == "shell.execute"
+                && event["payload"]["status"] == "queued"
+        })
+        .map(|event| event["payload"]["parallelMode"].clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(result["stopReason"], "final_response");
+    assert_eq!(dispatcher.max_running.load(Ordering::SeqCst), 2);
+    assert_eq!(shell_start_modes, vec![json!("read"), json!("read")]);
+}
+
+#[test]
+fn parallel_tool_failures_have_single_terminal_error_and_debug_late_failures() {
+    struct TwoFailingToolsProvider;
+
+    impl NativeAgentProvider for TwoFailingToolsProvider {
+        fn complete(
+            &self,
+            _context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            Ok(NativeAgentProviderResponse {
+                final_content: String::new(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: vec![
+                    NativeAgentToolCall {
+                        id: "call-first-fails".to_string(),
+                        name: "workspace.read_file".to_string(),
+                        arguments_json: "{\"path\":\"first.md\"}".to_string(),
+                        result: json!({ "content": "unused first" }),
+                    },
+                    NativeAgentToolCall {
+                        id: "call-second-fails".to_string(),
+                        name: "memory.search".to_string(),
+                        arguments_json: "{\"query\":\"second\"}".to_string(),
+                        result: json!({ "content": "unused second" }),
+                    },
+                ],
+            })
+        }
+    }
+
+    struct FailingParallelDispatcher;
+
+    impl NativeAgentToolDispatcher for FailingParallelDispatcher {
+        fn dispatch(
+            &self,
+            _context: &NativeAgentRunContext,
+            tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            if tool_call.id == "call-first-fails" {
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(format!("{} failed", tool_call.id))
+        }
+    }
+
+    let result = run_native_agent_turn_with_services(
+        &NativeAgentRuntimeServices::new(
+            Arc::new(TwoFailingToolsProvider),
+            Arc::new(FailingParallelDispatcher),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        ),
+        json!({
+            "runtime": "rust",
+            "runId": "run-two-parallel-failures",
+            "sessionId": "websocket:chat-two-parallel-failures",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "run failing parallel tools" }]
+        }),
+    )
+    .expect("parallel tool failures should return structured failure");
+    let events = result["events"]
+        .as_array()
+        .expect("events should be returned");
+    let terminal_errors = events
+        .iter()
+        .filter(|event| event["eventName"] == "agent.error")
+        .collect::<Vec<_>>();
+    let debug_events = events
+        .iter()
+        .filter(|event| event["eventName"] == "agent.tool.debug")
+        .collect::<Vec<_>>();
+
+    assert_eq!(result["stopReason"], "tool_error");
+    assert_eq!(terminal_errors.len(), 1);
+    assert_eq!(
+        terminal_errors[0]["payload"]["toolCallId"],
+        "call-second-fails"
+    );
+    assert_eq!(debug_events.len(), 1);
+    assert_eq!(
+        debug_events[0]["payload"]["ignoredReason"],
+        "terminal_outcome_already_claimed"
+    );
+    assert_eq!(debug_events[0]["payload"]["terminalOutcome"], "failed");
+    assert_eq!(debug_events[0]["payload"]["toolCallId"], "call-first-fails");
+    assert_eq!(result["completedToolResults"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn mixed_parallel_and_non_parallel_tool_batch_uses_read_write_lock_scheduling() {
+    struct MixedToolsThenFinalProvider {
+        seen_messages: Mutex<Vec<Vec<Value>>>,
+    }
+
+    impl NativeAgentProvider for MixedToolsThenFinalProvider {
+        fn complete(
+            &self,
+            context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            let call_count = {
+                let mut seen_messages = self
+                    .seen_messages
+                    .lock()
+                    .expect("seen messages lock should not be poisoned");
+                seen_messages.push(context.messages.clone());
+                seen_messages.len()
+            };
+            if call_count == 1 {
+                return Ok(NativeAgentProviderResponse {
+                    final_content: String::new(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: vec![
+                        NativeAgentToolCall {
+                            id: "call-read-one".to_string(),
+                            name: "workspace.read_file".to_string(),
+                            arguments_json: "{\"path\":\"README.md\"}".to_string(),
+                            result: json!({ "content": "README" }),
+                        },
+                        NativeAgentToolCall {
+                            id: "call-read-two".to_string(),
+                            name: "memory.search".to_string(),
+                            arguments_json: "{\"query\":\"README\"}".to_string(),
+                            result: json!({ "content": "memory" }),
+                        },
+                        NativeAgentToolCall {
+                            id: "call-write-exclusive".to_string(),
+                            name: "shell.execute".to_string(),
+                            arguments_json: "{\"command\":\"echo hi\"}".to_string(),
+                            result: json!({ "content": "hi" }),
+                        },
+                        NativeAgentToolCall {
+                            id: "call-read-three".to_string(),
+                            name: "knowledge.query".to_string(),
+                            arguments_json: "{\"query\":\"README\"}".to_string(),
+                            result: json!({ "content": "knowledge" }),
+                        },
+                    ],
+                });
+            }
+            Ok(NativeAgentProviderResponse {
+                final_content: "mixed tools complete".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    struct ReadWriteLockRecordingDispatcher {
+        active_reads: AtomicUsize,
+        active_writes: AtomicUsize,
+        max_active_reads: AtomicUsize,
+        write_overlaps: AtomicUsize,
+    }
+
+    impl NativeAgentToolDispatcher for ReadWriteLockRecordingDispatcher {
+        fn dispatch(
+            &self,
+            _context: &NativeAgentRunContext,
+            tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            let is_write = tool_call.name == "shell.execute";
+            if is_write {
+                if self.active_reads.load(Ordering::SeqCst) > 0 {
+                    self.write_overlaps.fetch_add(1, Ordering::SeqCst);
+                }
+                let writes = self.active_writes.fetch_add(1, Ordering::SeqCst) + 1;
+                if writes > 1 {
+                    self.write_overlaps.fetch_add(1, Ordering::SeqCst);
+                }
+                thread::sleep(Duration::from_millis(60));
+                self.active_writes.fetch_sub(1, Ordering::SeqCst);
+            } else {
+                if self.active_writes.load(Ordering::SeqCst) > 0 {
+                    self.write_overlaps.fetch_add(1, Ordering::SeqCst);
+                }
+                let reads = self.active_reads.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_active_reads.fetch_max(reads, Ordering::SeqCst);
+                thread::sleep(Duration::from_millis(60));
+                self.active_reads.fetch_sub(1, Ordering::SeqCst);
+            }
+            Ok(NativeAgentToolResult::generic_success(
+                tool_call,
+                tool_call.result.clone(),
+            ))
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingCheckpointStore {
+        inner: InMemoryNativeAgentCheckpointStore,
+        saved: Mutex<Vec<Value>>,
+    }
+
+    impl NativeAgentCheckpointStore for RecordingCheckpointStore {
+        fn save(&self, session_id: &str, checkpoint: Value) {
+            self.saved
+                .lock()
+                .expect("saved checkpoints lock should not be poisoned")
+                .push(checkpoint.clone());
+            self.inner.save(session_id, checkpoint);
+        }
+
+        fn save_for_run(&self, session_id: &str, run_id: &str, checkpoint: Value) {
+            self.saved
+                .lock()
+                .expect("saved checkpoints lock should not be poisoned")
+                .push(checkpoint.clone());
+            self.inner.save_for_run(session_id, run_id, checkpoint);
+        }
+
+        fn restore(&self, session_id: &str) -> Option<Value> {
+            self.inner.restore(session_id)
+        }
+
+        fn restore_for_run(&self, session_id: &str, run_id: &str) -> Option<Value> {
+            self.inner.restore_for_run(session_id, run_id)
+        }
+
+        fn clear(&self, session_id: &str) {
+            self.inner.clear(session_id);
+        }
+
+        fn clear_for_run(&self, session_id: &str, run_id: &str) {
+            self.inner.clear_for_run(session_id, run_id);
+        }
+    }
+
+    let provider = Arc::new(MixedToolsThenFinalProvider {
+        seen_messages: Mutex::new(Vec::new()),
+    });
+    let dispatcher = Arc::new(ReadWriteLockRecordingDispatcher {
+        active_reads: AtomicUsize::new(0),
+        active_writes: AtomicUsize::new(0),
+        max_active_reads: AtomicUsize::new(0),
+        write_overlaps: AtomicUsize::new(0),
+    });
+    let checkpoints = Arc::new(RecordingCheckpointStore::default());
+    let result = run_native_agent_turn_with_services(
+        &NativeAgentRuntimeServices::new(
+            provider.clone(),
+            dispatcher.clone(),
+            checkpoints.clone(),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        ),
+        json!({
+            "runtime": "rust",
+            "runId": "run-mixed-tool-batch",
+            "sessionId": "websocket:chat-mixed-tool-batch",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "run mixed tools" }]
+        }),
+    )
+    .expect("mixed tool run should complete");
+    let seen_messages = provider
+        .seen_messages
+        .lock()
+        .expect("seen messages lock should not be poisoned");
+    let second_request_messages = &seen_messages[1];
+    let tool_messages = second_request_messages
+        .iter()
+        .filter(|message| message["role"] == "tool")
+        .collect::<Vec<_>>();
+    let tool_start_statuses = result["events"]
+        .as_array()
+        .expect("events should be an array")
+        .iter()
+        .filter(|event| event["eventName"] == "agent.tool.start")
+        .map(|event| {
+            (
+                event["payload"]["toolCallId"].as_str().unwrap_or_default(),
+                event["payload"]["status"].as_str().unwrap_or_default(),
+                event["payload"]["parallelMode"]
+                    .as_str()
+                    .unwrap_or_default(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let saved_checkpoints = checkpoints
+        .saved
+        .lock()
+        .expect("saved checkpoints lock should not be poisoned")
+        .clone();
+
+    assert_eq!(result["stopReason"], "final_response");
+    assert!(
+        dispatcher.max_active_reads.load(Ordering::SeqCst) >= 2,
+        "read guards should allow parallel-safe tools to overlap inside a mixed batch"
+    );
+    assert_eq!(
+        dispatcher.write_overlaps.load(Ordering::SeqCst),
+        0,
+        "write-locked tools must not overlap reads or other writes"
+    );
+    assert_eq!(
+        result["toolsUsed"],
+        json!([
+            "workspace.read_file",
+            "memory.search",
+            "shell.execute",
+            "knowledge.query"
+        ])
+    );
+    assert_eq!(
+        tool_start_statuses
+            .iter()
+            .filter(|(_, status, _)| *status == "queued")
+            .count(),
+        4
+    );
+    assert!(tool_start_statuses.contains(&("call-read-one", "queued", "read")));
+    assert!(tool_start_statuses.contains(&("call-write-exclusive", "queued", "write")));
+    assert!(tool_start_statuses.contains(&("call-write-exclusive", "running", "write")));
+    assert_eq!(tool_messages.len(), 4);
+    assert_eq!(tool_messages[0]["tool_call_id"], "call-read-one");
+    assert_eq!(tool_messages[1]["tool_call_id"], "call-read-two");
+    assert_eq!(tool_messages[2]["tool_call_id"], "call-write-exclusive");
+    assert_eq!(tool_messages[3]["tool_call_id"], "call-read-three");
+    assert!(saved_checkpoints.iter().any(|checkpoint| {
+        checkpoint["pendingToolCalls"]
+            .as_array()
+            .is_some_and(|pending| {
+                pending.len() == 4
+                    && pending.iter().all(|entry| entry["status"] == "queued")
+                    && pending.iter().any(|entry| {
+                        entry["toolCallId"] == "call-write-exclusive"
+                            && entry["parallelMode"] == "write"
+                    })
+            })
+    }));
+    assert!(saved_checkpoints.iter().any(|checkpoint| {
+        checkpoint["pendingToolCalls"]
+            .as_array()
+            .is_some_and(|pending| {
+                pending.iter().any(|entry| {
+                    entry["toolCallId"] == "call-write-exclusive"
+                        && entry["status"] == "running"
+                        && entry["parallelMode"] == "write"
+                })
+            })
+    }));
+}
+
+#[test]
+fn cancellation_before_queued_write_lock_dispatch_skips_waiting_tool() {
+    struct ReadThenWriteProvider {
+        calls: Mutex<usize>,
+    }
+
+    impl NativeAgentProvider for ReadThenWriteProvider {
+        fn complete(
+            &self,
+            _context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            let mut calls = self.calls.lock().expect("provider calls lock");
+            *calls += 1;
+            if *calls == 1 {
+                return Ok(NativeAgentProviderResponse {
+                    final_content: String::new(),
+                    reasoning_delta: None,
+                    usage: None,
+                    tool_calls: vec![
+                        NativeAgentToolCall {
+                            id: "call-read-cancels".to_string(),
+                            name: "workspace.read_file".to_string(),
+                            arguments_json: "{\"path\":\"README.md\"}".to_string(),
+                            result: json!({ "content": "README" }),
+                        },
+                        NativeAgentToolCall {
+                            id: "call-write-waits".to_string(),
+                            name: "shell.execute".to_string(),
+                            arguments_json: "{\"command\":\"echo should-not-run\"}".to_string(),
+                            result: json!({ "content": "should not run" }),
+                        },
+                    ],
+                });
+            }
+            Ok(NativeAgentProviderResponse {
+                final_content: "unreachable after cancellation".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    struct CancellingReadDispatcher {
+        cancellations: Arc<InMemoryNativeAgentCancellation>,
+        write_dispatches: AtomicUsize,
+    }
+
+    impl NativeAgentToolDispatcher for CancellingReadDispatcher {
+        fn dispatch(
+            &self,
+            context: &NativeAgentRunContext,
+            tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            if tool_call.name == "workspace.read_file" {
+                self.cancellations.cancel(&context.run_id);
+                thread::sleep(Duration::from_millis(80));
+                return Ok(NativeAgentToolResult::generic_success(
+                    tool_call,
+                    tool_call.result.clone(),
+                ));
+            }
+            self.write_dispatches.fetch_add(1, Ordering::SeqCst);
+            Ok(NativeAgentToolResult::generic_success(
+                tool_call,
+                tool_call.result.clone(),
+            ))
+        }
+    }
+
+    let cancellations = Arc::new(InMemoryNativeAgentCancellation::default());
+    let dispatcher = Arc::new(CancellingReadDispatcher {
+        cancellations: cancellations.clone(),
+        write_dispatches: AtomicUsize::new(0),
+    });
+    let result = run_native_agent_turn_with_services(
+        &NativeAgentRuntimeServices::new(
+            Arc::new(ReadThenWriteProvider {
+                calls: Mutex::new(0),
+            }),
+            dispatcher.clone(),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            cancellations,
+        ),
+        json!({
+            "runtime": "rust",
+            "runId": "run-cancel-queued-write",
+            "sessionId": "websocket:chat-cancel-queued-write",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "read then cancel write" }]
+        }),
+    )
+    .expect("queued write cancellation should return a structured result");
+
+    assert_eq!(result["stopReason"], "cancelled");
+    assert_eq!(dispatcher.write_dispatches.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        event_names(&result)
+            .into_iter()
+            .filter(|event_name| *event_name == "agent.cancelled")
+            .count(),
+        1
+    );
+    assert_eq!(result["finalContent"], "");
+}
+
+#[test]
+fn cancellation_during_non_cleanup_parallel_tool_returns_without_waiting_for_late_result() {
+    struct SlowReadProvider;
+
+    impl NativeAgentProvider for SlowReadProvider {
+        fn complete(
+            &self,
+            _context: &NativeAgentRunContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            Ok(NativeAgentProviderResponse {
+                final_content: String::new(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: vec![
+                    NativeAgentToolCall {
+                        id: "call-slow-read-one".to_string(),
+                        name: "workspace.read_file".to_string(),
+                        arguments_json: "{\"path\":\"README.md\"}".to_string(),
+                        result: json!({ "content": "late read one" }),
+                    },
+                    NativeAgentToolCall {
+                        id: "call-slow-read-two".to_string(),
+                        name: "memory.search".to_string(),
+                        arguments_json: "{\"query\":\"README\"}".to_string(),
+                        result: json!({ "content": "late read two" }),
+                    },
+                ],
+            })
+        }
+    }
+
+    struct SlowCancellingReadDispatcher {
+        cancellations: Arc<InMemoryNativeAgentCancellation>,
+        cancelled_tx: std::sync::mpsc::Sender<()>,
+        release_rx: Arc<Mutex<std::sync::mpsc::Receiver<()>>>,
+    }
+
+    impl NativeAgentToolDispatcher for SlowCancellingReadDispatcher {
+        fn dispatch(
+            &self,
+            context: &NativeAgentRunContext,
+            tool_call: &NativeAgentToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            self.cancellations.cancel(&context.run_id);
+            let _ = self.cancelled_tx.send(());
+            let _ = self
+                .release_rx
+                .lock()
+                .expect("release receiver lock should not be poisoned")
+                .recv_timeout(Duration::from_secs(30));
+            Ok(NativeAgentToolResult::generic_success(
+                tool_call,
+                tool_call.result.clone(),
+            ))
+        }
+    }
+
+    let cancellations = Arc::new(InMemoryNativeAgentCancellation::default());
+    let (cancelled_tx, cancelled_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    let (result_tx, result_rx) = std::sync::mpsc::channel();
+    let trace_sink = Arc::new(RecordingTraceSink::default());
+    let trace_events = trace_sink.events.clone();
+    let cancellation_probe = cancellations.clone();
+    thread::spawn(move || {
+        let result = run_native_agent_turn_with_services(
+            &NativeAgentRuntimeServices::new(
+                Arc::new(SlowReadProvider),
+                Arc::new(SlowCancellingReadDispatcher {
+                    cancellations: cancellations.clone(),
+                    cancelled_tx,
+                    release_rx,
+                }),
+                Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+                cancellations,
+            )
+            .with_trace_sink(trace_sink),
+            json!({
+                "runtime": "rust",
+                "runId": "run-cancel-slow-read",
+                "sessionId": "websocket:chat-cancel-slow-read",
+                "maxIterations": 2,
+                "messages": [{ "role": "user", "content": "cancel slow read" }]
+            }),
+        );
+        let _ = result_tx.send(result);
+    });
+
+    cancelled_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("slow read dispatcher should trigger cancellation");
+    assert!(
+        cancellation_probe.is_cancelled("run-cancel-slow-read"),
+        "dispatcher cancellation signal must update the runtime cancellation store"
+    );
+    let result = match result_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(result) => result.expect("slow read cancellation should return a structured result"),
+        Err(error) => {
+            let _ = release_tx.send(());
+            let _ = release_tx.send(());
+            let result_after_release = result_rx
+                .recv_timeout(Duration::from_secs(5))
+                .map(|result| result.map(|value| value["stopReason"].clone()));
+            let tool_events = trace_events
+                .lock()
+                .expect("trace event lock should not be poisoned")
+                .iter()
+                .filter(|event| {
+                    event.event_name == "agent.tool.start" || event.event_name == "agent.cancelled"
+                })
+                .map(|event| {
+                    serde_json::json!({
+                        "event": event.event_name,
+                        "payload": event.payload,
+                    })
+                })
+                .collect::<Vec<_>>();
+            panic!(
+                "non-cleanup read tool cancellation should not wait for late result: {error}; result_after_release={result_after_release:?}; tool_events={tool_events:?}"
+            );
+        }
+    };
+    let _ = release_tx.send(());
+    let _ = release_tx.send(());
+
+    assert_eq!(result["stopReason"], "cancelled");
+    assert_eq!(result["completedToolResults"].as_array().unwrap().len(), 0);
 }
 
 #[test]

--- a/src-tauri/src/worker_agent_runtime/tool_dispatcher.rs
+++ b/src-tauri/src/worker_agent_runtime/tool_dispatcher.rs
@@ -15,7 +15,7 @@ impl NativeAgentToolDispatcher for FakeNativeAgentToolDispatcher {
         _context: &NativeAgentRunContext,
         tool_call: &NativeAgentToolCall,
     ) -> Result<NativeAgentToolResult, String> {
-        if !native_tool_is_permitted(&tool_call.name) {
+        if !native_tool_is_permitted(_context, &tool_call.name) {
             return Err(format!(
                 "native tool `{}` is not permitted by Rust capability policy",
                 tool_call.name
@@ -57,7 +57,7 @@ impl NativeAgentToolDispatcher for SubagentNativeAgentToolDispatcher {
         if !is_subagent_tool(&tool_call.name) {
             return self.fallback.dispatch(context, tool_call);
         }
-        if !native_tool_is_permitted(&tool_call.name) {
+        if !native_tool_is_permitted(context, &tool_call.name) {
             return Err(format!(
                 "native tool `{}` is not permitted by Rust capability policy",
                 tool_call.name
@@ -185,24 +185,281 @@ impl NativeAgentToolDispatcher for SubagentNativeAgentToolDispatcher {
     }
 }
 
-pub(super) fn native_tool_is_permitted(name: &str) -> bool {
-    matches!(
-        name,
-        "workspace.read_file"
-            | "workspace.list_files"
-            | "knowledge.search"
-            | "mcp.call_tool"
-            | "subagent.spawn"
-            | "subagent.send_input"
-            | "subagent.wait"
-            | "subagent.query"
-            | "subagent.cancel"
-            | "subagent.close"
-            | "spawn_agent"
-            | "send_input"
-            | "wait_agent"
-            | "close_agent"
-    )
+pub(super) fn native_tool_is_permitted(context: &NativeAgentRunContext, name: &str) -> bool {
+    registry_tool_available(context, name) || legacy_native_tool_alias_is_permitted(context, name)
+}
+
+pub(super) fn native_tool_supports_parallel(context: &NativeAgentRunContext, name: &str) -> bool {
+    registry_tool_supports_parallel(context, name)
+        || legacy_native_tool_alias_supports_parallel(context, name)
+}
+
+pub(super) fn native_tool_call_supports_parallel(
+    context: &NativeAgentRunContext,
+    tool_call: &NativeAgentToolCall,
+) -> bool {
+    if tool_call.name == "mcp.call_tool" {
+        return mcp_call_supports_parallel(context, tool_call);
+    }
+    if tool_call.name == "shell.execute" {
+        return shell_call_supports_parallel(context, tool_call);
+    }
+    native_tool_supports_parallel(context, &tool_call.name)
+}
+
+pub(super) fn native_tool_waits_for_runtime_cancellation(
+    context: &NativeAgentRunContext,
+    name: &str,
+) -> bool {
+    registry_tool_waits_for_runtime_cancellation(context, name)
+        || legacy_native_tool_alias_waits_for_runtime_cancellation(context, name)
+}
+
+pub(super) fn native_tool_mutates_workspace(context: &NativeAgentRunContext, name: &str) -> bool {
+    registry_tool_mutates_workspace(context, name)
+}
+
+pub(super) fn native_tool_mutates_session(context: &NativeAgentRunContext, name: &str) -> bool {
+    registry_tool_mutates_session(context, name)
+        || legacy_native_tool_alias_mutates_session(context, name)
+}
+
+fn registry_tool_available(context: &NativeAgentRunContext, name: &str) -> bool {
+    context
+        .tool_registry_entries
+        .iter()
+        .any(|entry| entry.available && entry.method == name)
+}
+
+fn registry_tool_supports_parallel(context: &NativeAgentRunContext, name: &str) -> bool {
+    context
+        .tool_registry_entries
+        .iter()
+        .any(|entry| entry.available && entry.method == name && entry.supports_parallel_tool_calls)
+}
+
+fn registry_tool_waits_for_runtime_cancellation(
+    context: &NativeAgentRunContext,
+    name: &str,
+) -> bool {
+    context.tool_registry_entries.iter().any(|entry| {
+        entry.available
+            && entry.method == name
+            && entry.runtime_policy.waits_for_runtime_cancellation
+    })
+}
+
+fn registry_tool_mutates_workspace(context: &NativeAgentRunContext, name: &str) -> bool {
+    context.tool_registry_entries.iter().any(|entry| {
+        entry.available && entry.method == name && entry.runtime_policy.mutates_workspace
+    })
+}
+
+fn registry_tool_mutates_session(context: &NativeAgentRunContext, name: &str) -> bool {
+    context.tool_registry_entries.iter().any(|entry| {
+        entry.available && entry.method == name && entry.runtime_policy.mutates_session
+    })
+}
+
+fn legacy_native_tool_alias_is_permitted(context: &NativeAgentRunContext, name: &str) -> bool {
+    match name {
+        "workspace.list_files" => registry_tool_available(context, "workspace.read_file"),
+        "knowledge.search" => registry_tool_available(context, "knowledge.query"),
+        "spawn_agent" => registry_tool_available(context, "subagent.spawn"),
+        "send_input" => registry_tool_available(context, "subagent.send_input"),
+        "subagent.wait" | "subagent.query" | "subagent.cancel" | "subagent.close"
+        | "wait_agent" | "close_agent" => {
+            registry_tool_available(context, "subagent.spawn")
+                || registry_tool_available(context, "subagent.send_input")
+        }
+        _ => false,
+    }
+}
+
+fn legacy_native_tool_alias_supports_parallel(context: &NativeAgentRunContext, name: &str) -> bool {
+    match name {
+        "workspace.list_files" => registry_tool_supports_parallel(context, "workspace.read_file"),
+        "knowledge.search" => registry_tool_supports_parallel(context, "knowledge.query"),
+        _ => false,
+    }
+}
+
+fn legacy_native_tool_alias_waits_for_runtime_cancellation(
+    context: &NativeAgentRunContext,
+    name: &str,
+) -> bool {
+    match name {
+        "spawn_agent" => registry_tool_waits_for_runtime_cancellation(context, "subagent.spawn"),
+        "send_input" => {
+            registry_tool_waits_for_runtime_cancellation(context, "subagent.send_input")
+        }
+        "subagent.wait" | "subagent.query" | "subagent.cancel" | "subagent.close"
+        | "wait_agent" | "close_agent" => {
+            registry_tool_waits_for_runtime_cancellation(context, "subagent.spawn")
+                || registry_tool_waits_for_runtime_cancellation(context, "subagent.send_input")
+        }
+        _ => false,
+    }
+}
+
+fn legacy_native_tool_alias_mutates_session(context: &NativeAgentRunContext, name: &str) -> bool {
+    match name {
+        "spawn_agent" => registry_tool_mutates_session(context, "subagent.spawn"),
+        "send_input" => registry_tool_mutates_session(context, "subagent.send_input"),
+        "subagent.wait" | "subagent.query" | "subagent.cancel" | "subagent.close"
+        | "wait_agent" | "close_agent" => {
+            registry_tool_mutates_session(context, "subagent.spawn")
+                || registry_tool_mutates_session(context, "subagent.send_input")
+        }
+        _ => false,
+    }
+}
+
+fn mcp_call_supports_parallel(
+    context: &NativeAgentRunContext,
+    tool_call: &NativeAgentToolCall,
+) -> bool {
+    let Ok(arguments) = serde_json::from_str::<Value>(&tool_call.arguments_json) else {
+        return false;
+    };
+    let Some(server_name) = arguments
+        .get("server")
+        .and_then(Value::as_str)
+        .map(str::trim)
+    else {
+        return false;
+    };
+    let Some(tool_name) = arguments.get("tool").and_then(Value::as_str).map(str::trim) else {
+        return false;
+    };
+    if server_name.is_empty() || tool_name.is_empty() {
+        return false;
+    }
+    let Some(server) = context
+        .config_snapshot
+        .get("tools")
+        .and_then(|tools| tools.get("mcp_servers").or_else(|| tools.get("mcpServers")))
+        .and_then(|servers| servers.get(server_name))
+    else {
+        return false;
+    };
+    if !mcp_tool_is_enabled(server_name, tool_name, server) {
+        return false;
+    }
+    server
+        .get("supportsParallelToolCalls")
+        .or_else(|| server.get("supports_parallel_tool_calls"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || mcp_tool_read_only_hint(server, tool_name)
+}
+
+fn mcp_tool_is_enabled(server_name: &str, tool_name: &str, server: &Value) -> bool {
+    let Some(enabled_tools) = server
+        .get("enabled_tools")
+        .or_else(|| server.get("enabledTools"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    let wrapped_name = format!("mcp_{server_name}_{tool_name}");
+    enabled_tools.iter().any(|value| {
+        value.as_str().is_some_and(|enabled| {
+            enabled == "*" || enabled == tool_name || enabled == wrapped_name
+        })
+    })
+}
+
+fn mcp_tool_read_only_hint(server: &Value, tool_name: &str) -> bool {
+    let Some(tool) = server
+        .get("fixture_tools")
+        .or_else(|| server.get("fixtureTools"))
+        .and_then(|tools| tools.get(tool_name))
+    else {
+        return false;
+    };
+    tool.get("annotations")
+        .and_then(|annotations| {
+            annotations
+                .get("readOnlyHint")
+                .or_else(|| annotations.get("read_only_hint"))
+        })
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || tool
+            .get("readOnlyHint")
+            .or_else(|| tool.get("read_only_hint"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+}
+
+fn shell_call_supports_parallel(
+    context: &NativeAgentRunContext,
+    tool_call: &NativeAgentToolCall,
+) -> bool {
+    if shell_parallel_policy(context) != Some("readOnlyCommandAllowlist") {
+        return false;
+    }
+    let Ok(arguments) = serde_json::from_str::<Value>(&tool_call.arguments_json) else {
+        return false;
+    };
+    let Some(command) = arguments.get("command").and_then(Value::as_str) else {
+        return false;
+    };
+    shell_command_is_read_only_allowlisted(command)
+}
+
+fn shell_parallel_policy(context: &NativeAgentRunContext) -> Option<&str> {
+    context
+        .spec
+        .get("nativeAgent")
+        .and_then(|native_agent| native_agent.get("shellParallelPolicy"))
+        .or_else(|| context.spec.get("shellParallelPolicy"))
+        .or_else(|| {
+            context
+                .config_snapshot
+                .get("nativeAgent")
+                .and_then(|native_agent| native_agent.get("shellParallelPolicy"))
+        })
+        .and_then(Value::as_str)
+}
+
+fn shell_command_is_read_only_allowlisted(command: &str) -> bool {
+    let command = command.trim();
+    if command.is_empty() || shell_command_contains_unsafe_syntax(command) {
+        return false;
+    }
+    let parts = command.split_whitespace().collect::<Vec<_>>();
+    let Some(program) = parts.first().map(|part| part.to_ascii_lowercase()) else {
+        return false;
+    };
+    match program.as_str() {
+        "pwd" => parts.len() == 1,
+        "ls" | "dir" | "rg" => true,
+        "git" => parts.get(1).is_some_and(|subcommand| {
+            matches!(
+                subcommand.to_ascii_lowercase().as_str(),
+                "status" | "diff" | "show"
+            )
+        }),
+        "cargo" => {
+            parts.len() == 3
+                && parts[1].eq_ignore_ascii_case("fmt")
+                && parts[2].eq_ignore_ascii_case("--check")
+        }
+        _ => false,
+    }
+}
+
+fn shell_command_contains_unsafe_syntax(command: &str) -> bool {
+    command.contains('|')
+        || command.contains(';')
+        || command.contains('>')
+        || command.contains('<')
+        || command.contains('`')
+        || command.contains("&&")
+        || command.contains("||")
+        || command.contains("$(")
 }
 
 pub(super) fn is_subagent_tool(name: &str) -> bool {

--- a/src-tauri/src/worker_agent_runtime/tool_dispatcher.rs
+++ b/src-tauri/src/worker_agent_runtime/tool_dispatcher.rs
@@ -454,12 +454,25 @@ fn shell_command_is_read_only_allowlisted(command: &str) -> bool {
 fn shell_command_contains_unsafe_syntax(command: &str) -> bool {
     command.contains('|')
         || command.contains(';')
+        || command.contains('&')
         || command.contains('>')
         || command.contains('<')
         || command.contains('`')
         || command.contains("&&")
         || command.contains("||")
         || command.contains("$(")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_read_only_allowlist_rejects_chained_commands() {
+        assert!(!shell_command_is_read_only_allowlisted(
+            "git status & touch workspace-marker"
+        ));
+    }
 }
 
 pub(super) fn is_subagent_tool(name: &str) -> bool {

--- a/src-tauri/src/worker_agent_runtime/tool_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime/tool_runtime.rs
@@ -42,6 +42,10 @@ enum ToolDispatchOutcome {
         tool_call: NativeAgentToolCall,
         terminal: bool,
     },
+    Skipped {
+        tool_call: NativeAgentToolCall,
+        terminal_outcome: ToolBatchTerminalOutcome,
+    },
 }
 
 struct SequencedToolDispatchOutcome {
@@ -409,6 +413,17 @@ fn execute_locked_tool_batch(
                                 },
                             );
                         }
+                        if let Some(terminal_outcome) = terminal.outcome() {
+                            return send_tool_dispatch_finished(
+                                sender,
+                                finish_sequence,
+                                index,
+                                ToolDispatchOutcome::Skipped {
+                                    tool_call,
+                                    terminal_outcome,
+                                },
+                            );
+                        }
                         let _ = sender.send(ToolDispatchEvent::Running {
                             tool_call: tool_call.clone(),
                             parallel_mode,
@@ -445,6 +460,17 @@ fn execute_locked_tool_batch(
                                 ToolDispatchOutcome::Cancelled {
                                     tool_call,
                                     terminal: terminal.try_claim_cancelled(),
+                                },
+                            );
+                        }
+                        if let Some(terminal_outcome) = terminal.outcome() {
+                            return send_tool_dispatch_finished(
+                                sender,
+                                finish_sequence,
+                                index,
+                                ToolDispatchOutcome::Skipped {
+                                    tool_call,
+                                    terminal_outcome,
                                 },
                             );
                         }
@@ -661,6 +687,18 @@ fn execute_locked_tool_batch(
                     "terminal_outcome_already_claimed",
                     None,
                 ),
+                ToolDispatchOutcome::Skipped {
+                    tool_call,
+                    terminal_outcome: skipped_terminal_outcome,
+                } => emit_late_terminal_debug(
+                    context,
+                    state,
+                    iteration,
+                    tool_call,
+                    *skipped_terminal_outcome,
+                    "dispatch_skipped_after_terminal",
+                    None,
+                ),
                 _ => {}
             }
         }
@@ -755,7 +793,8 @@ fn tool_dispatch_outcome_tool_call_id(outcome: &ToolDispatchOutcome) -> Option<&
     match outcome {
         ToolDispatchOutcome::Success(success) => Some(&success.tool_call.id),
         ToolDispatchOutcome::Failure { tool_call, .. }
-        | ToolDispatchOutcome::Cancelled { tool_call, .. } => Some(&tool_call.id),
+        | ToolDispatchOutcome::Cancelled { tool_call, .. }
+        | ToolDispatchOutcome::Skipped { tool_call, .. } => Some(&tool_call.id),
     }
 }
 

--- a/src-tauri/src/worker_agent_runtime/tool_runtime.rs
+++ b/src-tauri/src/worker_agent_runtime/tool_runtime.rs
@@ -1,0 +1,984 @@
+use super::checkpoint::save_phase_checkpoint;
+use super::result::cancelled_run_result;
+use super::state::NativeAgentRunState;
+use super::tool_dispatcher::{
+    native_tool_call_supports_parallel, native_tool_is_permitted, native_tool_mutates_session,
+    native_tool_mutates_workspace, native_tool_waits_for_runtime_cancellation,
+};
+use super::tool_projection::{
+    assistant_tool_calls_message, completed_tool_result_entry, normalize_tool_result_for_context,
+    subagent_activity_events_from_tool_result, subagent_link_event_from_tool_result,
+    tool_observation_content, tool_observation_message,
+};
+use super::{
+    NativeAgentRunContext, NativeAgentRuntimeServices, NativeAgentToolCall,
+    NativeAgentToolDispatcher,
+};
+use crate::agent_loop_runtime_protocol::AgentRuntimePhase;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Condvar, Mutex};
+use std::time::Duration;
+
+pub(super) enum NativeAgentToolExecutionOutcome {
+    Continue,
+    Finished(Value),
+}
+
+struct ToolDispatchSuccess {
+    tool_call: NativeAgentToolCall,
+    result: super::NativeAgentToolResult,
+}
+
+enum ToolDispatchOutcome {
+    Success(ToolDispatchSuccess),
+    Failure {
+        tool_call: NativeAgentToolCall,
+        error: String,
+        terminal: bool,
+    },
+    Cancelled {
+        tool_call: NativeAgentToolCall,
+        terminal: bool,
+    },
+}
+
+struct SequencedToolDispatchOutcome {
+    sequence: usize,
+    outcome: ToolDispatchOutcome,
+}
+
+enum ToolDispatchEvent {
+    Running {
+        tool_call: NativeAgentToolCall,
+        parallel_mode: &'static str,
+    },
+    Finished {
+        index: usize,
+        result: SequencedToolDispatchOutcome,
+    },
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ToolBatchTerminalOutcome {
+    Failed,
+    Cancelled,
+}
+
+struct ToolBatchTerminal {
+    outcome: AtomicU8,
+}
+
+impl ToolBatchTerminal {
+    const NONE: u8 = 0;
+    const FAILED: u8 = 1;
+    const CANCELLED: u8 = 2;
+
+    fn new() -> Self {
+        Self {
+            outcome: AtomicU8::new(Self::NONE),
+        }
+    }
+
+    fn try_claim_failure(&self) -> bool {
+        self.outcome
+            .compare_exchange(
+                Self::NONE,
+                Self::FAILED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn try_claim_cancelled(&self) -> bool {
+        self.outcome
+            .compare_exchange(
+                Self::NONE,
+                Self::CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn outcome(&self) -> Option<ToolBatchTerminalOutcome> {
+        match self.outcome.load(Ordering::Acquire) {
+            Self::FAILED => Some(ToolBatchTerminalOutcome::Failed),
+            Self::CANCELLED => Some(ToolBatchTerminalOutcome::Cancelled),
+            _ => None,
+        }
+    }
+}
+
+impl ToolBatchTerminalOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            ToolBatchTerminalOutcome::Failed => "failed",
+            ToolBatchTerminalOutcome::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ToolLockMode {
+    Read,
+    Write,
+}
+
+struct ToolReadWriteLock {
+    state: Mutex<ToolReadWriteLockState>,
+    available: Condvar,
+}
+
+struct ToolReadWriteLockState {
+    pending: BTreeMap<usize, ToolLockMode>,
+    active_readers: usize,
+    active_writer: bool,
+}
+
+struct ToolReadWriteGuard {
+    lock: Arc<ToolReadWriteLock>,
+    mode: ToolLockMode,
+}
+
+impl ToolReadWriteLock {
+    fn new(modes: impl IntoIterator<Item = (usize, ToolLockMode)>) -> Self {
+        Self {
+            state: Mutex::new(ToolReadWriteLockState {
+                pending: modes.into_iter().collect(),
+                active_readers: 0,
+                active_writer: false,
+            }),
+            available: Condvar::new(),
+        }
+    }
+
+    fn read(self: &Arc<Self>, index: usize) -> Result<ToolReadWriteGuard, String> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|error| format!("native tool scheduler lock poisoned: {error}"))?;
+        while state.active_writer || state.pending_write_before(index) {
+            state = self
+                .available
+                .wait(state)
+                .map_err(|error| format!("native tool scheduler lock poisoned: {error}"))?;
+        }
+        state.pending.remove(&index);
+        state.active_readers += 1;
+        Ok(ToolReadWriteGuard {
+            lock: self.clone(),
+            mode: ToolLockMode::Read,
+        })
+    }
+
+    fn write(self: &Arc<Self>, index: usize) -> Result<ToolReadWriteGuard, String> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|error| format!("native tool scheduler lock poisoned: {error}"))?;
+        while state.active_writer || state.active_readers > 0 || state.pending_before(index) {
+            state = self
+                .available
+                .wait(state)
+                .map_err(|error| format!("native tool scheduler lock poisoned: {error}"))?;
+        }
+        state.pending.remove(&index);
+        state.active_writer = true;
+        Ok(ToolReadWriteGuard {
+            lock: self.clone(),
+            mode: ToolLockMode::Write,
+        })
+    }
+}
+
+impl ToolReadWriteLockState {
+    fn pending_before(&self, index: usize) -> bool {
+        self.pending
+            .keys()
+            .any(|pending_index| *pending_index < index)
+    }
+
+    fn pending_write_before(&self, index: usize) -> bool {
+        self.pending
+            .iter()
+            .any(|(pending_index, mode)| *pending_index < index && *mode == ToolLockMode::Write)
+    }
+}
+
+impl Drop for ToolReadWriteGuard {
+    fn drop(&mut self) {
+        let Ok(mut state) = self.lock.state.lock() else {
+            return;
+        };
+        match self.mode {
+            ToolLockMode::Read => {
+                state.active_readers = state.active_readers.saturating_sub(1);
+            }
+            ToolLockMode::Write => {
+                state.active_writer = false;
+            }
+        }
+        self.lock.available.notify_all();
+    }
+}
+
+pub(super) fn execute_tool_calls_for_iteration(
+    services: &NativeAgentRuntimeServices,
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+    final_content: String,
+    tool_calls: Vec<NativeAgentToolCall>,
+) -> NativeAgentToolExecutionOutcome {
+    state.transition_phase(
+        AgentRuntimePhase::ToolCalling,
+        iteration,
+        "agent.tool_call.delta",
+    );
+    state
+        .messages
+        .push(assistant_tool_calls_message(&final_content, &tool_calls));
+
+    for tool_call in &tool_calls {
+        state.emit_event(
+            "agent.tool_call.delta",
+            serde_json::json!({
+                "runId": context.run_id,
+                "sessionId": context.session_id,
+                "iteration": iteration,
+                "toolCallId": tool_call.id,
+                "toolName": tool_call.name,
+                "name": tool_call.name,
+                "argumentsDelta": tool_call.arguments_json,
+            }),
+        );
+        if !native_tool_is_permitted(context, &tool_call.name) {
+            return policy_denied_result(services, context, state, iteration, tool_call);
+        }
+    }
+
+    if services.cancellations.is_cancelled(&context.run_id) {
+        return cancelled_result(services, context, state, iteration);
+    }
+
+    if tool_calls.len() == 1 {
+        execute_sequential_tool_batch(services, context, state, iteration, tool_calls)
+    } else {
+        execute_locked_tool_batch(services, context, state, iteration, tool_calls)
+    }
+}
+
+fn execute_sequential_tool_batch(
+    services: &NativeAgentRuntimeServices,
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+    tool_calls: Vec<NativeAgentToolCall>,
+) -> NativeAgentToolExecutionOutcome {
+    for tool_call in tool_calls {
+        if services.cancellations.is_cancelled(&context.run_id) {
+            return cancelled_result(services, context, state, iteration);
+        }
+        start_tool_call(services, context, state, iteration, &tool_call);
+        let result = match dispatch_tool_blocking(
+            services.tools.clone(),
+            context.clone(),
+            tool_call.clone(),
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                return tool_error_result(services, context, state, iteration, &tool_call, error);
+            }
+        };
+        record_tool_success(context, state, iteration, tool_call, result);
+        state.clear_pending_tool_calls();
+        state.transition_phase(AgentRuntimePhase::Planning, iteration, "agent.tool.result");
+        save_phase_checkpoint(
+            services,
+            context,
+            state.phase.as_str(),
+            state.active_checkpoint_payload("tool_completed"),
+        );
+        if services.cancellations.is_cancelled(&context.run_id) {
+            return cancelled_result(services, context, state, iteration);
+        }
+    }
+    NativeAgentToolExecutionOutcome::Continue
+}
+
+fn execute_locked_tool_batch(
+    services: &NativeAgentRuntimeServices,
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+    tool_calls: Vec<NativeAgentToolCall>,
+) -> NativeAgentToolExecutionOutcome {
+    state.transition_phase(
+        AgentRuntimePhase::ToolRunning,
+        iteration,
+        "agent.tool.start",
+    );
+    let queued_tool_calls = tool_calls
+        .iter()
+        .map(|tool_call| {
+            (
+                tool_call.clone(),
+                parallel_mode_for_tool_call(context, tool_call),
+            )
+        })
+        .collect::<Vec<_>>();
+    for tool_call in &tool_calls {
+        let parallel_mode = parallel_mode_for_tool_call(context, tool_call);
+        let runtime_policy = tool_runtime_policy_payload(context, &tool_call.name);
+        state.tools_used.push(tool_call.name.clone());
+        state.emit_event(
+            "agent.tool.start",
+            serde_json::json!({
+                "runId": context.run_id,
+                "sessionId": context.session_id,
+                "iteration": iteration,
+                "toolCallId": tool_call.id,
+                "toolName": tool_call.name,
+                "name": tool_call.name,
+                "detailId": format!("tool:{}", tool_call.id),
+                "status": "queued",
+                "parallelMode": parallel_mode,
+                "runtimePolicy": runtime_policy,
+            }),
+        );
+    }
+    state.set_queued_tool_calls(&queued_tool_calls);
+    save_phase_checkpoint(
+        services,
+        context,
+        state.phase.as_str(),
+        serde_json::json!({
+            "iteration": iteration,
+            "pendingToolCalls": state.pending_tool_calls.clone(),
+            "completedToolResults": state.completed_tool_results.clone(),
+        }),
+    );
+
+    let scheduler_lock = Arc::new(ToolReadWriteLock::new(
+        queued_tool_calls
+            .iter()
+            .enumerate()
+            .map(|(index, (_tool_call, parallel_mode))| {
+                let mode = if *parallel_mode == "read" {
+                    ToolLockMode::Read
+                } else {
+                    ToolLockMode::Write
+                };
+                (index, mode)
+            }),
+    ));
+    let (sender, receiver) = mpsc::channel();
+    let terminal = Arc::new(ToolBatchTerminal::new());
+    let finish_sequence = Arc::new(AtomicUsize::new(0));
+    let task_count = tool_calls.len();
+    for (index, tool_call) in tool_calls.into_iter().enumerate() {
+        let dispatcher = services.tools.clone();
+        let context = context.clone();
+        let lock = scheduler_lock.clone();
+        let sender = sender.clone();
+        let terminal = terminal.clone();
+        let finish_sequence = finish_sequence.clone();
+        let supports_parallel = native_tool_call_supports_parallel(&context, &tool_call);
+        let parallel_mode = if supports_parallel { "read" } else { "write" };
+        tauri::async_runtime::spawn(async move {
+            let result = if context_is_cancelled(&context) {
+                let terminal = terminal.try_claim_cancelled();
+                ToolDispatchOutcome::Cancelled {
+                    tool_call,
+                    terminal,
+                }
+            } else if supports_parallel {
+                match lock.read(index) {
+                    Ok(_guard) => {
+                        if context_is_cancelled(&context) {
+                            return send_tool_dispatch_finished(
+                                sender,
+                                finish_sequence,
+                                index,
+                                ToolDispatchOutcome::Cancelled {
+                                    tool_call,
+                                    terminal: terminal.try_claim_cancelled(),
+                                },
+                            );
+                        }
+                        let _ = sender.send(ToolDispatchEvent::Running {
+                            tool_call: tool_call.clone(),
+                            parallel_mode,
+                        });
+                        let dispatch_call = tool_call.clone();
+                        match dispatcher.dispatch_async(context, dispatch_call).await {
+                            Ok(result) => ToolDispatchOutcome::Success(ToolDispatchSuccess {
+                                tool_call,
+                                result,
+                            }),
+                            Err(error) => ToolDispatchOutcome::Failure {
+                                tool_call,
+                                error,
+                                terminal: terminal.try_claim_failure(),
+                            },
+                        }
+                    }
+                    Err(error) => ToolDispatchOutcome::Failure {
+                        tool_call,
+                        error: format!(
+                            "native tool scheduler read lock acquisition failed: {error}"
+                        ),
+                        terminal: terminal.try_claim_failure(),
+                    },
+                }
+            } else {
+                match lock.write(index) {
+                    Ok(_guard) => {
+                        if context_is_cancelled(&context) {
+                            return send_tool_dispatch_finished(
+                                sender,
+                                finish_sequence,
+                                index,
+                                ToolDispatchOutcome::Cancelled {
+                                    tool_call,
+                                    terminal: terminal.try_claim_cancelled(),
+                                },
+                            );
+                        }
+                        let _ = sender.send(ToolDispatchEvent::Running {
+                            tool_call: tool_call.clone(),
+                            parallel_mode,
+                        });
+                        let dispatch_call = tool_call.clone();
+                        match dispatcher.dispatch_async(context, dispatch_call).await {
+                            Ok(result) => ToolDispatchOutcome::Success(ToolDispatchSuccess {
+                                tool_call,
+                                result,
+                            }),
+                            Err(error) => ToolDispatchOutcome::Failure {
+                                tool_call,
+                                error,
+                                terminal: terminal.try_claim_failure(),
+                            },
+                        }
+                    }
+                    Err(error) => ToolDispatchOutcome::Failure {
+                        tool_call,
+                        error: format!(
+                            "native tool scheduler write lock acquisition failed: {error}"
+                        ),
+                        terminal: terminal.try_claim_failure(),
+                    },
+                }
+            };
+            send_tool_dispatch_finished(sender, finish_sequence, index, result);
+        });
+    }
+    drop(sender);
+
+    let mut indexed_results = (0..task_count).map(|_| None).collect::<Vec<_>>();
+    let mut finished_count = 0usize;
+    let mut running_cleanup_tools = BTreeSet::<String>::new();
+    let mut cancellation_terminal_claimed = false;
+    while finished_count < task_count {
+        if services.cancellations.is_cancelled(&context.run_id)
+            && (terminal.try_claim_cancelled()
+                || terminal.outcome() == Some(ToolBatchTerminalOutcome::Cancelled))
+        {
+            cancellation_terminal_claimed = true;
+        }
+        if cancellation_terminal_claimed && running_cleanup_tools.is_empty() {
+            state.clear_pending_tool_calls();
+            return cancelled_result(services, context, state, iteration);
+        }
+        match receiver.recv_timeout(Duration::from_millis(10)) {
+            Ok(ToolDispatchEvent::Running {
+                tool_call,
+                parallel_mode,
+            }) => {
+                if native_tool_waits_for_runtime_cancellation(context, &tool_call.name) {
+                    running_cleanup_tools.insert(tool_call.id.clone());
+                }
+                if services.cancellations.is_cancelled(&context.run_id)
+                    && (terminal.try_claim_cancelled()
+                        || terminal.outcome() == Some(ToolBatchTerminalOutcome::Cancelled))
+                {
+                    cancellation_terminal_claimed = true;
+                }
+                if cancellation_terminal_claimed && running_cleanup_tools.is_empty() {
+                    state.clear_pending_tool_calls();
+                    return cancelled_result(services, context, state, iteration);
+                }
+                state.mark_pending_tool_running(&tool_call.id);
+                let runtime_policy = tool_runtime_policy_payload(context, &tool_call.name);
+                state.emit_event(
+                    "agent.tool.start",
+                    serde_json::json!({
+                        "runId": context.run_id,
+                        "sessionId": context.session_id,
+                        "iteration": iteration,
+                        "toolCallId": tool_call.id,
+                        "toolName": tool_call.name,
+                        "name": tool_call.name,
+                        "detailId": format!("tool:{}", tool_call.id),
+                        "status": "running",
+                        "parallelMode": parallel_mode,
+                        "runtimePolicy": runtime_policy,
+                    }),
+                );
+                save_phase_checkpoint(
+                    services,
+                    context,
+                    state.phase.as_str(),
+                    serde_json::json!({
+                        "iteration": iteration,
+                        "pendingToolCalls": state.pending_tool_calls.clone(),
+                        "completedToolResults": state.completed_tool_results.clone(),
+                    }),
+                );
+            }
+            Ok(ToolDispatchEvent::Finished { index, result }) => {
+                finished_count += 1;
+                if let Some(tool_call_id) = tool_dispatch_outcome_tool_call_id(&result.outcome) {
+                    running_cleanup_tools.remove(tool_call_id);
+                }
+                indexed_results[index] = Some(result);
+                if cancellation_terminal_claimed && running_cleanup_tools.is_empty() {
+                    state.clear_pending_tool_calls();
+                    return cancelled_result(services, context, state, iteration);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if services.cancellations.is_cancelled(&context.run_id)
+                    && (terminal.try_claim_cancelled()
+                        || terminal.outcome() == Some(ToolBatchTerminalOutcome::Cancelled))
+                {
+                    cancellation_terminal_claimed = true;
+                }
+                if cancellation_terminal_claimed && running_cleanup_tools.is_empty() {
+                    state.clear_pending_tool_calls();
+                    return cancelled_result(services, context, state, iteration);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                state.clear_pending_tool_calls();
+                return tool_error_result(
+                    services,
+                    context,
+                    state,
+                    iteration,
+                    &NativeAgentToolCall {
+                        id: "parallel-dispatch".to_string(),
+                        name: "parallel-dispatch".to_string(),
+                        arguments_json: "{}".to_string(),
+                        result: Value::Null,
+                    },
+                    "native tool dispatch event channel closed before completion".to_string(),
+                );
+            }
+        }
+    }
+
+    let indexed_results = indexed_results
+        .into_iter()
+        .map(|result| result.expect("tool dispatch should return one result per index"))
+        .collect::<Vec<_>>();
+    let terminal_result = indexed_results
+        .iter()
+        .enumerate()
+        .filter_map(|(index, result)| match &result.outcome {
+            ToolDispatchOutcome::Failure {
+                tool_call,
+                error,
+                terminal: true,
+            } => Some((
+                index,
+                result.sequence,
+                ToolBatchTerminalOutcome::Failed,
+                tool_call,
+                Some(error.as_str()),
+            )),
+            ToolDispatchOutcome::Cancelled {
+                tool_call,
+                terminal: true,
+            } => Some((
+                index,
+                result.sequence,
+                ToolBatchTerminalOutcome::Cancelled,
+                tool_call,
+                None,
+            )),
+            _ => None,
+        })
+        .min_by_key(|(_, sequence, _, _, _)| *sequence);
+
+    if let Some((
+        terminal_index,
+        terminal_sequence,
+        terminal_outcome,
+        terminal_tool_call,
+        terminal_error,
+    )) = terminal_result
+    {
+        for (index, indexed_result) in indexed_results.iter().enumerate() {
+            match &indexed_result.outcome {
+                ToolDispatchOutcome::Success(success)
+                    if indexed_result.sequence < terminal_sequence || index < terminal_index =>
+                {
+                    record_tool_success(
+                        context,
+                        state,
+                        iteration,
+                        success.tool_call.clone(),
+                        success.result.clone(),
+                    );
+                }
+                ToolDispatchOutcome::Failure {
+                    tool_call,
+                    error,
+                    terminal: false,
+                } => emit_late_terminal_debug(
+                    context,
+                    state,
+                    iteration,
+                    tool_call,
+                    terminal_outcome,
+                    "terminal_outcome_already_claimed",
+                    Some(error),
+                ),
+                ToolDispatchOutcome::Cancelled {
+                    tool_call,
+                    terminal: false,
+                } => emit_late_terminal_debug(
+                    context,
+                    state,
+                    iteration,
+                    tool_call,
+                    terminal_outcome,
+                    "terminal_outcome_already_claimed",
+                    None,
+                ),
+                _ => {}
+            }
+        }
+        state.clear_pending_tool_calls();
+        return match terminal_outcome {
+            ToolBatchTerminalOutcome::Failed => tool_error_result(
+                services,
+                context,
+                state,
+                iteration,
+                terminal_tool_call,
+                terminal_error.unwrap_or("native tool failed").to_string(),
+            ),
+            ToolBatchTerminalOutcome::Cancelled => {
+                cancelled_result(services, context, state, iteration)
+            }
+        };
+    }
+
+    for indexed_result in indexed_results {
+        if let ToolDispatchOutcome::Success(success) = indexed_result.outcome {
+            record_tool_success(context, state, iteration, success.tool_call, success.result);
+        }
+    }
+    state.clear_pending_tool_calls();
+    state.transition_phase(AgentRuntimePhase::Planning, iteration, "agent.tool.result");
+    save_phase_checkpoint(
+        services,
+        context,
+        state.phase.as_str(),
+        state.active_checkpoint_payload("tool_completed"),
+    );
+    if services.cancellations.is_cancelled(&context.run_id) {
+        return cancelled_result(services, context, state, iteration);
+    }
+    NativeAgentToolExecutionOutcome::Continue
+}
+
+fn parallel_mode_for_tool_call(
+    context: &NativeAgentRunContext,
+    tool_call: &NativeAgentToolCall,
+) -> &'static str {
+    if native_tool_call_supports_parallel(context, tool_call) {
+        "read"
+    } else {
+        "write"
+    }
+}
+
+fn tool_runtime_policy_payload(context: &NativeAgentRunContext, tool_name: &str) -> Value {
+    serde_json::json!({
+        "waitsForRuntimeCancellation": native_tool_waits_for_runtime_cancellation(context, tool_name),
+        "mutatesWorkspace": native_tool_mutates_workspace(context, tool_name),
+        "mutatesSession": native_tool_mutates_session(context, tool_name),
+    })
+}
+
+fn context_is_cancelled(context: &NativeAgentRunContext) -> bool {
+    context
+        .cancellation
+        .as_ref()
+        .is_some_and(|cancellation| cancellation.is_cancelled())
+}
+
+fn emit_late_terminal_debug(
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+    tool_call: &NativeAgentToolCall,
+    terminal_outcome: ToolBatchTerminalOutcome,
+    ignored_reason: &str,
+    error: Option<&str>,
+) {
+    state.emit_event(
+        "agent.tool.debug",
+        serde_json::json!({
+            "runId": context.run_id,
+            "sessionId": context.session_id,
+            "iteration": iteration,
+            "toolCallId": tool_call.id,
+            "toolName": tool_call.name,
+            "name": tool_call.name,
+            "detailId": format!("tool:{}", tool_call.id),
+            "ignoredReason": ignored_reason,
+            "terminalOutcome": terminal_outcome.as_str(),
+            "error": error,
+        }),
+    );
+}
+
+fn tool_dispatch_outcome_tool_call_id(outcome: &ToolDispatchOutcome) -> Option<&str> {
+    match outcome {
+        ToolDispatchOutcome::Success(success) => Some(&success.tool_call.id),
+        ToolDispatchOutcome::Failure { tool_call, .. }
+        | ToolDispatchOutcome::Cancelled { tool_call, .. } => Some(&tool_call.id),
+    }
+}
+
+fn send_tool_dispatch_finished(
+    sender: mpsc::Sender<ToolDispatchEvent>,
+    finish_sequence: Arc<AtomicUsize>,
+    index: usize,
+    result: ToolDispatchOutcome,
+) {
+    let sequence = finish_sequence.fetch_add(1, Ordering::AcqRel);
+    let _ = sender.send(ToolDispatchEvent::Finished {
+        index,
+        result: SequencedToolDispatchOutcome {
+            sequence,
+            outcome: result,
+        },
+    });
+}
+
+fn dispatch_tool_blocking(
+    dispatcher: Arc<dyn NativeAgentToolDispatcher>,
+    context: NativeAgentRunContext,
+    tool_call: NativeAgentToolCall,
+) -> Result<super::NativeAgentToolResult, String> {
+    tauri::async_runtime::block_on(dispatcher.dispatch_async(context, tool_call))
+}
+
+fn start_tool_call(
+    services: &NativeAgentRuntimeServices,
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+    tool_call: &NativeAgentToolCall,
+) {
+    state.tools_used.push(tool_call.name.clone());
+    state.transition_phase(
+        AgentRuntimePhase::ToolRunning,
+        iteration,
+        "agent.tool.start",
+    );
+    state.emit_event(
+        "agent.tool.start",
+        serde_json::json!({
+            "runId": context.run_id,
+            "sessionId": context.session_id,
+            "iteration": iteration,
+            "toolCallId": tool_call.id,
+            "toolName": tool_call.name,
+            "name": tool_call.name,
+            "detailId": format!("tool:{}", tool_call.id),
+            "status": "running",
+        }),
+    );
+    state.set_pending_tool_call(tool_call);
+    save_phase_checkpoint(
+        services,
+        context,
+        state.phase.as_str(),
+        serde_json::json!({
+            "iteration": iteration,
+            "toolCallId": tool_call.id,
+            "toolName": tool_call.name,
+            "argumentsJson": tool_call.arguments_json,
+            "pendingToolCalls": state.pending_tool_calls.clone(),
+            "completedToolResults": state.completed_tool_results.clone(),
+        }),
+    );
+}
+
+fn record_tool_success(
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+    tool_call: NativeAgentToolCall,
+    result: super::NativeAgentToolResult,
+) {
+    let result = normalize_tool_result_for_context(result, context);
+    let observation_content = tool_observation_content(&result);
+    let completed_result = completed_tool_result_entry(&tool_call, &result);
+    state
+        .messages
+        .push(tool_observation_message(&tool_call, &observation_content));
+    state.emit_event(
+        "agent.tool.result",
+        serde_json::json!({
+            "runId": context.run_id,
+            "sessionId": context.session_id,
+            "iteration": iteration,
+            "toolCallId": tool_call.id,
+            "toolName": tool_call.name,
+            "name": tool_call.name,
+            "detailId": format!("tool:{}", tool_call.id),
+            "status": "completed",
+            "resultStatus": result.envelope.get("status").cloned().unwrap_or_else(|| serde_json::json!("ok")),
+            "summary": result.envelope.get("summary").cloned().unwrap_or_else(|| Value::String(observation_content.clone())),
+            "timing": {
+                "durationMs": result
+                    .envelope
+                    .get("metrics")
+                    .and_then(|metrics| metrics.get("durationMs"))
+                    .cloned()
+                    .unwrap_or(Value::Null),
+            },
+            "content": observation_content,
+            "envelope": result.envelope.clone(),
+        }),
+    );
+    if let Some(link_event) = subagent_link_event_from_tool_result(context, &tool_call, &result) {
+        state.emit_native_event(link_event);
+    }
+    for event in subagent_activity_events_from_tool_result(context, &tool_call, &result) {
+        if event.event_name == "agent.delegate.wait" {
+            state.transition_phase(
+                AgentRuntimePhase::AwaitingSubagent,
+                iteration,
+                "agent.delegate.wait",
+            );
+        }
+        state.emit_native_event(event);
+    }
+    state.completed_tool_results.push(completed_result);
+}
+
+fn policy_denied_result(
+    services: &NativeAgentRuntimeServices,
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+    tool_call: &NativeAgentToolCall,
+) -> NativeAgentToolExecutionOutcome {
+    let error = format!(
+        "native tool `{}` is not permitted by Rust capability policy",
+        tool_call.name
+    );
+    state.set_stop_reason("policy_denied", iteration, "agent.error");
+    state.emit_event(
+        "agent.error",
+        serde_json::json!({
+            "runId": context.run_id,
+            "sessionId": context.session_id,
+            "iteration": iteration,
+            "stopReason": "policy_denied",
+            "error": error,
+            "toolCallId": tool_call.id,
+            "toolName": tool_call.name,
+            "name": tool_call.name,
+        }),
+    );
+    services
+        .checkpoints
+        .clear_for_run(&context.session_id, &context.run_id);
+    let runtime_events = state.runtime_events();
+    let events = state.legacy_events();
+    NativeAgentToolExecutionOutcome::Finished(serde_json::json!({
+        "runtime": "rust",
+        "runId": context.run_id,
+        "sessionId": context.session_id,
+        "finalContent": "",
+        "stopReason": "policy_denied",
+        "messages": [],
+        "toolsUsed": state.tools_used,
+        "completedToolResults": state.completed_tool_results,
+        "error": error,
+        "events": events,
+        "runtimeEvents": runtime_events,
+    }))
+}
+
+fn tool_error_result(
+    services: &NativeAgentRuntimeServices,
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+    tool_call: &NativeAgentToolCall,
+    error: String,
+) -> NativeAgentToolExecutionOutcome {
+    state.set_stop_reason("tool_error", iteration, "agent.error");
+    state.emit_event(
+        "agent.error",
+        serde_json::json!({
+            "runId": context.run_id,
+            "sessionId": context.session_id,
+            "iteration": iteration,
+            "stopReason": "tool_error",
+            "error": error,
+            "toolCallId": tool_call.id,
+            "toolName": tool_call.name,
+            "name": tool_call.name,
+        }),
+    );
+    services
+        .checkpoints
+        .clear_for_run(&context.session_id, &context.run_id);
+    let runtime_events = state.runtime_events();
+    let events = state.legacy_events();
+    NativeAgentToolExecutionOutcome::Finished(serde_json::json!({
+        "runtime": "rust",
+        "runId": context.run_id,
+        "sessionId": context.session_id,
+        "finalContent": "",
+        "stopReason": "tool_error",
+        "messages": [],
+        "toolsUsed": state.tools_used,
+        "completedToolResults": state.completed_tool_results,
+        "error": error,
+        "events": events,
+        "runtimeEvents": runtime_events,
+    }))
+}
+
+fn cancelled_result(
+    services: &NativeAgentRuntimeServices,
+    context: &NativeAgentRunContext,
+    state: &mut NativeAgentRunState,
+    iteration: i64,
+) -> NativeAgentToolExecutionOutcome {
+    state.transition_phase(AgentRuntimePhase::Cancelled, iteration, "agent.cancelled");
+    NativeAgentToolExecutionOutcome::Finished(cancelled_run_result(
+        services,
+        context,
+        state.take_runtime_events(),
+        std::mem::take(&mut state.tools_used),
+        std::mem::take(&mut state.completed_tool_results),
+        iteration,
+    ))
+}

--- a/src-tauri/src/worker_capability.rs
+++ b/src-tauri/src/worker_capability.rs
@@ -84,6 +84,35 @@ impl CapabilityPolicy {
     }
 }
 
+pub fn default_desktop_capability_policy() -> CapabilityPolicy {
+    CapabilityPolicy::new([
+        WorkerCapability::ConfigRead,
+        WorkerCapability::ProviderSecretRead,
+        WorkerCapability::FsWorkspaceRead,
+        WorkerCapability::FsWorkspaceWrite,
+        WorkerCapability::ShellExecute,
+        WorkerCapability::DiagnosticsWrite,
+        WorkerCapability::ApprovalRequest,
+        WorkerCapability::ApprovalResolve,
+        WorkerCapability::FormRequest,
+        WorkerCapability::MemoryRead,
+        WorkerCapability::MemoryWrite,
+        WorkerCapability::KnowledgeRead,
+        WorkerCapability::KnowledgeWrite,
+        WorkerCapability::CronRead,
+        WorkerCapability::CronWrite,
+        WorkerCapability::CronRun,
+        WorkerCapability::BackgroundRead,
+        WorkerCapability::BackgroundWrite,
+        WorkerCapability::TaskRead,
+        WorkerCapability::TaskWrite,
+        WorkerCapability::McpCall,
+        WorkerCapability::ChannelConnector,
+        WorkerCapability::SessionMetadataRead,
+        WorkerCapability::SessionWrite,
+    ])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/worker_protocol.rs
+++ b/src-tauri/src/worker_protocol.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::VecDeque;
+use std::fmt;
+use std::sync::Arc;
 
 pub const WORKER_PROTOCOL_VERSION: &str = "1";
 
@@ -11,7 +13,11 @@ pub enum WorkerTransportMode {
     LocalPipe,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub trait WorkerRequestCancellation: Send + Sync {
+    fn is_cancelled(&self) -> bool;
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 pub struct WorkerRequest {
     pub protocol_version: String,
     pub id: String,
@@ -19,6 +25,8 @@ pub struct WorkerRequest {
     pub method: String,
     #[serde(default = "empty_json_object")]
     pub params: Value,
+    #[serde(skip)]
+    pub cancellation: Option<Arc<dyn WorkerRequestCancellation>>,
 }
 
 impl WorkerRequest {
@@ -34,7 +42,44 @@ impl WorkerRequest {
             trace_id: trace_id.into(),
             method: method.into(),
             params,
+            cancellation: None,
         }
+    }
+
+    pub fn with_cancellation(
+        mut self,
+        cancellation: Option<Arc<dyn WorkerRequestCancellation>>,
+    ) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
+    pub fn cancellation(&self) -> Option<Arc<dyn WorkerRequestCancellation>> {
+        self.cancellation.clone()
+    }
+}
+
+impl fmt::Debug for WorkerRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WorkerRequest")
+            .field("protocol_version", &self.protocol_version)
+            .field("id", &self.id)
+            .field("trace_id", &self.trace_id)
+            .field("method", &self.method)
+            .field("params", &self.params)
+            .field("has_cancellation", &self.cancellation.is_some())
+            .finish()
+    }
+}
+
+impl PartialEq for WorkerRequest {
+    fn eq(&self, other: &Self) -> bool {
+        self.protocol_version == other.protocol_version
+            && self.id == other.id
+            && self.trace_id == other.trace_id
+            && self.method == other.method
+            && self.params == other.params
     }
 }
 

--- a/src-tauri/src/worker_rpc.rs
+++ b/src-tauri/src/worker_rpc.rs
@@ -540,7 +540,8 @@ impl WorkerRpcRouter {
             request.trace_id.clone(),
             tool.method,
             tool_arguments,
-        );
+        )
+        .with_cancellation(request.cancellation());
         match self.dispatch_result(&tool_request) {
             Ok(result) => {
                 if let (Some(thread_id), Some(tool_call_id)) = (&params.thread_id, &tool_call_id) {
@@ -734,12 +735,16 @@ struct ShellExecuteRequestParams {
 }
 
 impl ShellExecuteRequestParams {
-    fn into_shell_params(self) -> ShellExecuteParams {
+    fn into_shell_params(
+        self,
+        cancellation: Option<std::sync::Arc<dyn crate::worker_protocol::WorkerRequestCancellation>>,
+    ) -> ShellExecuteParams {
         ShellExecuteParams {
             command: self.command,
             working_dir: self.working_dir,
             timeout: self.timeout,
             restrict_to_workspace: self.restrict_to_workspace,
+            cancellation,
         }
     }
 }

--- a/src-tauri/src/worker_rpc/interaction_dispatch.rs
+++ b/src-tauri/src/worker_rpc/interaction_dispatch.rs
@@ -32,8 +32,11 @@ impl WorkerRpcRouter {
                         params.session_id.clone(),
                         params.run_id.clone(),
                     ))?;
-                serde_json::to_value(self.shell.execute(params.into_shell_params())?)
-                    .map_err(serialization_error)
+                serde_json::to_value(
+                    self.shell
+                        .execute(params.into_shell_params(request.cancellation()))?,
+                )
+                .map_err(serialization_error)
             }
             "approval.request" => self.approval.request_from_request(request),
             "approval.resolve" => self.approval.resolve_from_request(request),

--- a/src-tauri/src/worker_rpc/mcp.rs
+++ b/src-tauri/src/worker_rpc/mcp.rs
@@ -25,6 +25,12 @@ impl WorkerMcpRpc {
         &self,
         request: &WorkerRequest,
     ) -> Result<Value, WorkerProtocolError> {
+        if request
+            .cancellation()
+            .is_some_and(|cancellation| cancellation.is_cancelled())
+        {
+            return Err(mcp_cancelled_error());
+        }
         self.call_tool(parse_params(request)?)
     }
 
@@ -116,6 +122,16 @@ fn invalid_mcp_request(message: impl Into<String>) -> WorkerProtocolError {
     WorkerProtocolError::new(
         WorkerProtocolErrorCode::InvalidProtocol,
         message,
+        serde_json::json!({ "method": "mcp.call_tool" }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn mcp_cancelled_error() -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::WorkerError,
+        "MCP tool call cancelled",
         serde_json::json!({ "method": "mcp.call_tool" }),
         false,
         WorkerProtocolErrorSource::RustCore,
@@ -229,7 +245,12 @@ fn mcp_fixture_tool_definitions(server_name: &str, server: &Value) -> Vec<Value>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::worker_protocol::WorkerRequestCancellation;
     use serde_json::json;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
     fn mcp_rpc(config_snapshot: Value) -> WorkerMcpRpc {
         WorkerMcpRpc::new(
@@ -364,5 +385,60 @@ mod tests {
         assert_eq!(error.code, WorkerProtocolErrorCode::CapabilityDenied);
         assert_eq!(error.details["server"], "docs");
         assert_eq!(error.details["tool"], "delete_everything");
+    }
+
+    #[test]
+    fn mcp_call_tool_fails_fast_when_request_is_cancelled() {
+        let rpc = mcp_rpc(json!({
+            "tools": {
+                "mcp_servers": {
+                    "docs": {
+                        "enabled_tools": ["search"],
+                        "fixture_tools": {
+                            "search": { "content": "MCP search result" }
+                        }
+                    }
+                }
+            }
+        }));
+        let cancellation = Arc::new(TestCancellation::new(true));
+        let request = WorkerRequest::new(
+            "req-cancelled",
+            "trace-cancelled",
+            "mcp.call_tool",
+            json!({
+                "server": "docs",
+                "tool": "search",
+                "arguments": {}
+            }),
+        )
+        .with_cancellation(Some(cancellation));
+
+        let error = rpc
+            .call_tool_from_request(&request)
+            .expect_err("cancelled MCP request should fail before dispatch");
+
+        assert_eq!(error.code, WorkerProtocolErrorCode::WorkerError);
+        assert_eq!(error.message, "MCP tool call cancelled");
+        assert_eq!(error.details["method"], "mcp.call_tool");
+    }
+
+    #[derive(Debug)]
+    struct TestCancellation {
+        cancelled: AtomicBool,
+    }
+
+    impl TestCancellation {
+        fn new(cancelled: bool) -> Self {
+            Self {
+                cancelled: AtomicBool::new(cancelled),
+            }
+        }
+    }
+
+    impl WorkerRequestCancellation for TestCancellation {
+        fn is_cancelled(&self) -> bool {
+            self.cancelled.load(Ordering::SeqCst)
+        }
     }
 }

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -1,11 +1,14 @@
 use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
-use crate::worker_protocol::WorkerRequest;
+use crate::worker_protocol::{WorkerRequest, WorkerRequestCancellation};
 use crate::worker_rpc::WorkerRpcRouter;
 use crate::worker_subagent_manager::{SubagentSpawnParams, SubagentThreadManager};
 use serde_json::{json, Value};
 use std::{
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
     thread,
     time::Duration,
 };
@@ -12784,6 +12787,115 @@ fn dispatches_shell_execute_request() {
     assert_eq!(result["blocked"], false);
     assert!(result["content"].as_str().unwrap().contains("tinybot"));
     assert!(response.error.is_none());
+}
+
+#[test]
+fn tool_executor_forwards_request_cancellation_to_shell_execute() {
+    let fixture = WorkspaceFixture::new();
+    let mut router = WorkerRpcRouter::new(
+        fixture.root.clone(),
+        json!({}),
+        vec![],
+        20,
+        CapabilityPolicy::new([
+            WorkerCapability::ApprovalRequest,
+            WorkerCapability::ApprovalResolve,
+            WorkerCapability::ShellExecute,
+        ]),
+    );
+    let command = blocking_shell_command_with_marker();
+    let fingerprint = format!("exec:{}", command.to_ascii_lowercase());
+    approve_once(
+        &mut router,
+        "run-shell-cancel",
+        "session-1",
+        json!({
+            "toolName": "exec",
+            "arguments": { "command": command.clone() }
+        }),
+        "shell",
+        "high",
+        "Shell execution can modify files, run programs, or access the network.",
+        &fingerprint,
+        &fingerprint,
+    );
+
+    let cancellation = Arc::new(TestCancellation::default());
+    let request = WorkerRequest::new(
+        "req-tool-shell-cancel",
+        "trace-tool-shell-cancel",
+        "tool_executor.execute",
+        json!({
+            "toolId": "shell.execute",
+            "arguments": {
+                "command": command,
+                "working_dir": ".",
+                "timeout": 30,
+                "sessionId": "session-1",
+                "runId": "run-shell-cancel"
+            }
+        }),
+    )
+    .with_cancellation(Some(cancellation.clone()));
+
+    let started = std::time::Instant::now();
+    let marker = fixture.root.join("started.txt");
+    let handle = thread::spawn(move || router.dispatch(&request));
+    while !marker.exists() {
+        if handle.is_finished() {
+            let response = handle
+                .join()
+                .expect("tool executor dispatch should not panic");
+            panic!("tool executor shell command finished before marker: {response:?}");
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "tool executor shell command should create started marker"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+    cancellation.cancel();
+
+    let response = handle
+        .join()
+        .expect("tool executor dispatch should not panic");
+    let result = response
+        .result
+        .expect("cancelled tool executor shell command should return result");
+    assert!(response.error.is_none());
+    assert_eq!(result["result"]["cancelled"], true);
+    assert_eq!(result["result"]["timed_out"], false);
+    assert!(result["result"]["content"]
+        .as_str()
+        .unwrap()
+        .contains("aborted by user"));
+}
+
+#[cfg(target_os = "windows")]
+fn blocking_shell_command_with_marker() -> String {
+    "echo started > started.txt & for /L %i in (0,0,1) do @rem".to_string()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn blocking_shell_command_with_marker() -> String {
+    "printf started > started.txt; while true; do :; done".to_string()
+}
+
+#[derive(Default, Debug)]
+struct TestCancellation {
+    cancelled: AtomicBool,
+}
+
+impl TestCancellation {
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+    }
+}
+
+impl WorkerRequestCancellation for TestCancellation {
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
 }
 
 fn session_fixture() -> crate::worker_session::SessionMetadata {

--- a/src-tauri/src/worker_shell.rs
+++ b/src-tauri/src/worker_shell.rs
@@ -67,6 +67,11 @@ impl WorkerShellRpc {
             use std::os::windows::process::CommandExt;
             command.creation_flags(0x08000000);
         }
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
 
         let mut child = command.spawn().map_err(|error| {
             shell_error(
@@ -91,12 +96,22 @@ impl WorkerShellRpc {
             }
             if is_cancelled(&params.cancellation) {
                 cancelled = true;
-                terminate_child_process(&mut child);
+                terminate_child_process(&mut child).map_err(|error| {
+                    shell_error(
+                        "failed to terminate shell process tree",
+                        serde_json::json!({ "error": error.to_string() }),
+                    )
+                })?;
                 break;
             }
             if started.elapsed() >= timeout_duration {
                 timed_out = true;
-                terminate_child_process(&mut child);
+                terminate_child_process(&mut child).map_err(|error| {
+                    shell_error(
+                        "failed to terminate shell process tree",
+                        serde_json::json!({ "error": error.to_string() }),
+                    )
+                })?;
                 break;
             }
             std::thread::sleep(Duration::from_millis(20));
@@ -211,7 +226,15 @@ fn join_pipe_reader(reader: Option<JoinHandle<String>>) -> String {
         .unwrap_or_default()
 }
 
-fn terminate_child_process(child: &mut Child) {
+fn terminate_child_process(child: &mut Child) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        let process_group = child.id() as libc::pid_t;
+        // SAFETY: the process group is created from the child PID before exec.
+        if unsafe { libc::kill(-process_group, libc::SIGKILL) } == -1 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
@@ -222,8 +245,13 @@ fn terminate_child_process(child: &mut Child) {
             .stderr(Stdio::null())
             .creation_flags(0x08000000);
         let _ = taskkill.status();
+        let _ = child.kill();
     }
-    let _ = child.kill();
+    #[cfg(not(any(unix, target_os = "windows")))]
+    {
+        child.kill()?;
+    }
+    Ok(())
 }
 
 #[derive(Clone, Deserialize)]
@@ -509,6 +537,55 @@ mod tests {
         assert!(result.content.contains("aborted by user"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn execute_kills_shell_process_group_when_cancelled() {
+        let fixture = ShellFixture::new();
+        let started_marker = fixture.root.join("started.txt");
+        let survived_marker = fixture.root.join("child-survived.txt");
+        let cancellation = Arc::new(TestCancellation::default());
+        let rpc = WorkerShellRpc::new(
+            fixture.root.clone(),
+            CapabilityPolicy::new([WorkerCapability::ShellExecute]),
+        );
+        let execute_cancellation = cancellation.clone();
+
+        let started = std::time::Instant::now();
+        let handle = std::thread::spawn(move || {
+            rpc.execute(ShellExecuteParams {
+                command: child_process_command_with_marker(),
+                working_dir: Some(".".to_string()),
+                timeout: Some(30),
+                restrict_to_workspace: Some(true),
+                cancellation: Some(execute_cancellation),
+            })
+        });
+
+        while !started_marker.exists() {
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "shell command should create the started marker"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        cancellation.cancel();
+
+        let result = handle
+            .join()
+            .expect("shell execute thread should not panic")
+            .expect("cancelled shell execute should return a structured result");
+        assert!(result.cancelled);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "cancelled shell process group should return promptly"
+        );
+        std::thread::sleep(Duration::from_millis(1200));
+        assert!(
+            !survived_marker.exists(),
+            "a cancelled shell child process must not continue after its parent exits"
+        );
+    }
+
     #[cfg(target_os = "windows")]
     fn large_output_command() -> String {
         "for /L %i in (1,1,40000) do @echo xxxxx".to_string()
@@ -527,6 +604,12 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     fn blocking_command_with_marker() -> String {
         "printf started > started.txt; while true; do :; done".to_string()
+    }
+
+    #[cfg(unix)]
+    fn child_process_command_with_marker() -> String {
+        "printf started > started.txt; (sleep 1; printf survived > child-survived.txt) & wait"
+            .to_string()
     }
 
     #[derive(Default, Debug)]

--- a/src-tauri/src/worker_shell.rs
+++ b/src-tauri/src/worker_shell.rs
@@ -1,12 +1,15 @@
 use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
 use crate::worker_protocol::{
     WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
+    WorkerRequestCancellation,
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    fmt,
     io::Read,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Child, Command, Stdio},
+    sync::Arc,
     thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
@@ -44,10 +47,14 @@ impl WorkerShellRpc {
                 stderr: reason.clone(),
                 exit_code: 1,
                 timed_out: false,
+                cancelled: false,
                 blocked: true,
                 truncated: false,
                 content: reason,
             });
+        }
+        if is_cancelled(&params.cancellation) {
+            return Ok(cancelled_shell_result(String::new(), String::new()));
         }
 
         let mut command = shell_command(&params.command);
@@ -72,6 +79,7 @@ impl WorkerShellRpc {
         let started = Instant::now();
         let timeout_duration = Duration::from_secs(timeout);
         let mut timed_out = false;
+        let mut cancelled = false;
         loop {
             if let Some(_status) = child.try_wait().map_err(|error| {
                 shell_error(
@@ -81,9 +89,14 @@ impl WorkerShellRpc {
             })? {
                 break;
             }
+            if is_cancelled(&params.cancellation) {
+                cancelled = true;
+                terminate_child_process(&mut child);
+                break;
+            }
             if started.elapsed() >= timeout_duration {
                 timed_out = true;
-                let _ = child.kill();
+                terminate_child_process(&mut child);
                 break;
             }
             std::thread::sleep(Duration::from_millis(20));
@@ -97,12 +110,12 @@ impl WorkerShellRpc {
         })?;
         let stdout = join_pipe_reader(stdout_reader);
         let stderr = join_pipe_reader(stderr_reader);
-        let exit_code = if timed_out {
+        let exit_code = if timed_out || cancelled {
             -1
         } else {
             status.code().unwrap_or(-1)
         };
-        let mut content = format_shell_content(&stdout, &stderr, exit_code, timed_out);
+        let mut content = format_shell_content(&stdout, &stderr, exit_code, timed_out, cancelled);
         let truncated = content.chars().count() > MAX_OUTPUT_CHARS;
         if truncated {
             content = truncate_head_tail(&content, MAX_OUTPUT_CHARS);
@@ -112,6 +125,7 @@ impl WorkerShellRpc {
             stderr,
             exit_code,
             timed_out,
+            cancelled,
             blocked: false,
             truncated,
             content,
@@ -197,7 +211,22 @@ fn join_pipe_reader(reader: Option<JoinHandle<String>>) -> String {
         .unwrap_or_default()
 }
 
-#[derive(Clone, Debug, Deserialize)]
+fn terminate_child_process(child: &mut Child) {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        let mut taskkill = Command::new("taskkill");
+        taskkill
+            .args(["/PID", &child.id().to_string(), "/T", "/F"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .creation_flags(0x08000000);
+        let _ = taskkill.status();
+    }
+    let _ = child.kill();
+}
+
+#[derive(Clone, Deserialize)]
 pub struct ShellExecuteParams {
     pub command: String,
     #[serde(default)]
@@ -206,6 +235,21 @@ pub struct ShellExecuteParams {
     pub timeout: Option<u64>,
     #[serde(default)]
     pub restrict_to_workspace: Option<bool>,
+    #[serde(skip)]
+    pub cancellation: Option<Arc<dyn WorkerRequestCancellation>>,
+}
+
+impl fmt::Debug for ShellExecuteParams {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ShellExecuteParams")
+            .field("command", &self.command)
+            .field("working_dir", &self.working_dir)
+            .field("timeout", &self.timeout)
+            .field("restrict_to_workspace", &self.restrict_to_workspace)
+            .field("has_cancellation", &self.cancellation.is_some())
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -214,6 +258,7 @@ pub struct ShellExecuteResult {
     pub stderr: String,
     pub exit_code: i32,
     pub timed_out: bool,
+    pub cancelled: bool,
     pub blocked: bool,
     pub truncated: bool,
     pub content: String,
@@ -306,7 +351,35 @@ fn contains_absolute_path_outside_workspace(
     })
 }
 
-fn format_shell_content(stdout: &str, stderr: &str, exit_code: i32, timed_out: bool) -> String {
+fn is_cancelled(cancellation: &Option<Arc<dyn WorkerRequestCancellation>>) -> bool {
+    cancellation
+        .as_ref()
+        .is_some_and(|cancellation| cancellation.is_cancelled())
+}
+
+fn cancelled_shell_result(stdout: String, stderr: String) -> ShellExecuteResult {
+    ShellExecuteResult {
+        stdout,
+        stderr,
+        exit_code: -1,
+        timed_out: false,
+        cancelled: true,
+        blocked: false,
+        truncated: false,
+        content: "Error: Command aborted by user\n\nExit code: -1".to_string(),
+    }
+}
+
+fn format_shell_content(
+    stdout: &str,
+    stderr: &str,
+    exit_code: i32,
+    timed_out: bool,
+    cancelled: bool,
+) -> String {
+    if cancelled {
+        return "Error: Command aborted by user\n\nExit code: -1".to_string();
+    }
     if timed_out {
         return "Error: Command timed out\n\nExit code: -1".to_string();
     }
@@ -358,6 +431,12 @@ fn shell_error(message: impl Into<String>, details: serde_json::Value) -> Worker
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::worker_protocol::WorkerRequestCancellation;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
 
     #[test]
     fn execute_drains_large_output_while_command_is_running() {
@@ -373,13 +452,61 @@ mod tests {
                 working_dir: Some(".".to_string()),
                 timeout: Some(15),
                 restrict_to_workspace: Some(true),
+                cancellation: None,
             })
             .expect("large output command should complete");
 
         assert!(!result.timed_out);
+        assert!(!result.cancelled);
         assert_eq!(result.exit_code, 0);
         assert!(result.stdout.len() >= 200_000);
         assert!(result.truncated);
+    }
+
+    #[test]
+    fn execute_kills_running_command_when_cancelled() {
+        let fixture = ShellFixture::new();
+        let started_marker = fixture.root.join("started.txt");
+        let cancellation = Arc::new(TestCancellation::default());
+        let rpc = WorkerShellRpc::new(
+            fixture.root.clone(),
+            CapabilityPolicy::new([WorkerCapability::ShellExecute]),
+        );
+        let execute_cancellation = cancellation.clone();
+        let command = blocking_command_with_marker();
+
+        let started = std::time::Instant::now();
+        let handle = std::thread::spawn(move || {
+            rpc.execute(ShellExecuteParams {
+                command,
+                working_dir: Some(".".to_string()),
+                timeout: Some(30),
+                restrict_to_workspace: Some(true),
+                cancellation: Some(execute_cancellation),
+            })
+        });
+
+        while !started_marker.exists() {
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "blocking shell command should create the started marker"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        cancellation.cancel();
+
+        let result = handle
+            .join()
+            .expect("shell execute thread should not panic")
+            .expect("cancelled shell execute should return a structured result");
+        assert!(result.cancelled);
+        assert!(!result.timed_out);
+        assert_eq!(result.exit_code, -1);
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "cancelled shell execute should return promptly"
+        );
+        assert!(result.content.contains("aborted by user"));
     }
 
     #[cfg(target_os = "windows")]
@@ -390,6 +517,33 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     fn large_output_command() -> String {
         "yes x | head -c 200000".to_string()
+    }
+
+    #[cfg(target_os = "windows")]
+    fn blocking_command_with_marker() -> String {
+        "echo started > started.txt & for /L %i in (0,0,1) do @rem".to_string()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn blocking_command_with_marker() -> String {
+        "printf started > started.txt; while true; do :; done".to_string()
+    }
+
+    #[derive(Default, Debug)]
+    struct TestCancellation {
+        cancelled: AtomicBool,
+    }
+
+    impl TestCancellation {
+        fn cancel(&self) {
+            self.cancelled.store(true, Ordering::SeqCst);
+        }
+    }
+
+    impl WorkerRequestCancellation for TestCancellation {
+        fn is_cancelled(&self) -> bool {
+            self.cancelled.load(Ordering::SeqCst)
+        }
     }
 
     struct ShellFixture {

--- a/src-tauri/src/worker_tool_registry.rs
+++ b/src-tauri/src/worker_tool_registry.rs
@@ -52,11 +52,22 @@ pub struct ToolRegistryEntry {
     pub description: &'static str,
     pub exposure: ToolExposure,
     pub dynamic: bool,
+    pub supports_parallel_tool_calls: bool,
+    #[serde(skip_serializing)]
+    pub runtime_policy: ToolRuntimePolicy,
     pub required_capabilities: Vec<WorkerCapability>,
     pub available: bool,
     pub approval: ToolApprovalMetadata,
     pub input_schema: Value,
     pub output_schema: Value,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ToolRuntimePolicy {
+    pub supports_parallel_tool_calls: bool,
+    pub waits_for_runtime_cancellation: bool,
+    pub mutates_workspace: bool,
+    pub mutates_session: bool,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -180,6 +191,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Read a file under the current workspace.",
             ToolExposure::Model,
             false,
+            runtime_policy(true, false, false, false),
             vec![WorkerCapability::FsWorkspaceRead],
             approval(false, None, None),
             json!({
@@ -200,6 +212,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Write a file under the current workspace.",
             ToolExposure::Deferred,
             false,
+            runtime_policy(false, false, true, false),
             vec![
                 WorkerCapability::FsWorkspaceWrite,
                 WorkerCapability::ApprovalRequest,
@@ -222,6 +235,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Delete a file or directory under the current workspace.",
             ToolExposure::Deferred,
             false,
+            runtime_policy(false, false, true, false),
             vec![
                 WorkerCapability::FsWorkspaceWrite,
                 WorkerCapability::ApprovalRequest,
@@ -243,6 +257,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Search the local knowledge index.",
             ToolExposure::Model,
             false,
+            runtime_policy(true, false, false, false),
             vec![WorkerCapability::KnowledgeRead],
             approval(false, None, None),
             json!({
@@ -263,6 +278,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Search saved memory notes.",
             ToolExposure::Model,
             false,
+            runtime_policy(true, false, false, false),
             vec![WorkerCapability::MemoryRead],
             approval(false, None, None),
             json!({
@@ -281,6 +297,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Recall memory context for the current turn.",
             ToolExposure::Model,
             false,
+            runtime_policy(true, false, false, false),
             vec![WorkerCapability::MemoryRead],
             approval(false, None, None),
             json!({
@@ -298,6 +315,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Call a tool exposed by a configured MCP server.",
             ToolExposure::Deferred,
             true,
+            runtime_policy(false, true, true, true),
             vec![WorkerCapability::McpCall],
             approval(true, Some("mcp_tool"), Some("per_request")),
             json!({
@@ -317,6 +335,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Run a shell command in the workspace.",
             ToolExposure::Deferred,
             false,
+            runtime_policy(false, true, true, false),
             vec![WorkerCapability::ShellExecute],
             approval(true, Some("command"), Some("per_request")),
             json!({
@@ -336,6 +355,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Create a child agent thread for delegated work.",
             ToolExposure::Model,
             false,
+            runtime_policy(false, true, false, true),
             vec![
                 WorkerCapability::BackgroundWrite,
                 WorkerCapability::SessionWrite,
@@ -359,6 +379,7 @@ fn builtin_tool_entries() -> Vec<ToolRegistryEntry> {
             "Send input to an active child agent thread.",
             ToolExposure::Model,
             false,
+            runtime_policy(false, true, false, true),
             vec![
                 WorkerCapability::BackgroundWrite,
                 WorkerCapability::SessionWrite,
@@ -385,6 +406,7 @@ fn tool(
     description: &'static str,
     exposure: ToolExposure,
     dynamic: bool,
+    runtime_policy: ToolRuntimePolicy,
     required_capabilities: Vec<WorkerCapability>,
     approval: ToolApprovalMetadata,
     input_schema: Value,
@@ -397,11 +419,27 @@ fn tool(
         description,
         exposure,
         dynamic,
+        supports_parallel_tool_calls: runtime_policy.supports_parallel_tool_calls,
+        runtime_policy,
         required_capabilities,
         available: false,
         approval,
         input_schema,
         output_schema: json!({ "type": "object" }),
+    }
+}
+
+fn runtime_policy(
+    supports_parallel_tool_calls: bool,
+    waits_for_runtime_cancellation: bool,
+    mutates_workspace: bool,
+    mutates_session: bool,
+) -> ToolRuntimePolicy {
+    ToolRuntimePolicy {
+        supports_parallel_tool_calls,
+        waits_for_runtime_cancellation,
+        mutates_workspace,
+        mutates_session,
     }
 }
 


### PR DESCRIPTION
﻿## Summary

- Adds Codex-style read/write lock scheduling for native agent tool batches.
- Introduces runtime policy metadata for parallel safety, mutation, and cancellation cleanup.
- Moves batch dispatch onto the async runtime seam and hardens terminal ownership for failures and cancellation.
- Propagates request cancellation into shell execution, kills cancelled shell process trees, and fails fast for cancelled MCP requests.

## Why

Tinybot's native tool runtime needed to close the practical gaps with Codex-style scheduling: safe read-only concurrency, deterministic terminal outcomes, explicit runtime policy metadata, and cooperative cancellation for tools that own cleanup.

## Validation

- `cargo fmt --check`
- `git diff --cached --check`
- `cargo check`
- `cargo test --lib` (686 passed)
