### PR TITLE
Add signed Windows auto updates and release pipeline

### DIFF
--- a/.github/scripts/check-release-version.mjs
+++ b/.github/scripts/check-release-version.mjs
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+
+function fail(message) {
+  console.error(`release version check failed: ${message}`);
+  process.exit(1);
+}
+
+const tag = process.argv[2] ?? process.env.GITHUB_REF_NAME;
+if (!tag) {
+  fail("pass a v<semver> tag as the first argument or GITHUB_REF_NAME");
+}
+
+const tagMatch = /^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/.exec(tag);
+if (!tagMatch) {
+  fail(`tag ${tag} must use v<semver>`);
+}
+
+const expected = tagMatch[1];
+const tauriConfig = JSON.parse(readFileSync("src-tauri/tauri.conf.json", "utf8"));
+const npmPackage = JSON.parse(readFileSync("package.json", "utf8"));
+const cargoManifest = readFileSync("src-tauri/Cargo.toml", "utf8");
+const cargoPackage = /^\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/m.exec(cargoManifest);
+
+if (!cargoPackage) {
+  fail("could not read [package] version from src-tauri/Cargo.toml");
+}
+
+const versions = new Map([
+  ["src-tauri/tauri.conf.json", tauriConfig.version],
+  ["package.json", npmPackage.version],
+  ["src-tauri/Cargo.toml", cargoPackage[1]],
+]);
+
+for (const [source, version] of versions) {
+  if (version !== expected) {
+    fail(`${source} is ${version ?? "missing"}, expected ${expected} from ${tag}`);
+  }
+}
+
+console.log(`release version check passed: ${tag}`);

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,78 @@
+name: Release Windows x64
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release-windows-x64:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      CARGO_HTTP_TIMEOUT: "120"
+      CARGO_NET_RETRY: "10"
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Verify release version
+        run: node .github/scripts/check-release-version.mjs "${{ github.ref_name }}"
+
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Check Rust formatting
+        working-directory: src-tauri
+        run: cargo fmt --check
+
+      - name: Run updater tests
+        working-directory: src-tauri
+        run: cargo test --lib desktop_update::tests -- --test-threads=1
+
+      - name: Build and upload signed updater artifacts
+        uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: v__VERSION__
+          releaseName: Tinybot Desktop v__VERSION__
+          releaseBody: |
+            Initial Windows x64 release of Tinybot Desktop.
+
+            The installer is not Authenticode-signed yet, so Windows SmartScreen may show an unknown publisher warning.
+          releaseDraft: true
+          prerelease: false
+          generateReleaseNotes: true
+          updaterJsonPreferNsis: true
+          args: --bundles nsis --target x86_64-pc-windows-msvc
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --latest

--- a/README.md
+++ b/README.md
@@ -316,6 +316,12 @@ npm run tauri -- dev
 npm run tauri -- build
 ```
 
+### Windows x64 Release and Updates
+
+Windows x64 installers are published on the [GitHub Releases page](https://github.com/SudoJacky/tinybot/releases). Tinybot Desktop checks that release channel once at startup. When a newer signed release is available, it downloads and verifies the updater package, shuts down the native runtime, and installs the update automatically.
+
+The initial release is not Authenticode-signed. Windows SmartScreen may therefore show an unknown publisher warning during installation even though updater packages are cryptographically signed and verified by Tinybot.
+
 ## WebUI Usage
 
 Tinybot now runs the WebUI inside the Tauri desktop app. The Rust native backend exposes WebUI-compatible routes on the local runtime endpoint used by the desktop shell.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -313,6 +313,12 @@ npm run tauri -- dev
 npm run tauri -- build
 ```
 
+### Windows x64 发布与自动更新
+
+Windows x64 安装包发布在 [GitHub Releases 页面](https://github.com/SudoJacky/tinybot/releases)。Tinybot Desktop 每次启动时会检查一次该发布渠道；发现更高版本后，会下载并验证已签名的更新包，停止原生运行时，然后自动安装更新。
+
+首版暂未进行 Authenticode 代码签名，因此安装时 Windows SmartScreen 可能提示“未知发布者”。这不影响 Tinybot 对自动更新包执行独立的加密签名校验。
+
 ## WebUI 使用
 
 Tinybot 现在在 Tauri 桌面应用中加载 WebUI。Rust 原生后端会在桌面壳使用的本地运行时端点上提供兼容 WebUI 的路由。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +895,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1267,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2408,6 +2438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +2757,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,6 +2900,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4171,6 +4233,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,6 +4417,38 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -4572,6 +4677,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "tauri-plugin-updater",
  "tokio",
  "tokio-util",
  "url",
@@ -5635,6 +5741,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5666,11 +5781,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5713,6 +5845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5723,6 +5861,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5737,10 +5881,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5755,6 +5911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5765,6 +5927,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5779,6 +5947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5789,6 +5963,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5999,6 +6179,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6160,6 +6350,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,13 +24,14 @@ http = "1"
 portable-pty = "0.9.0"
 rmcp = { version = "1.8.0", default-features = false, features = ["client", "reqwest-native-tls", "transport-child-process", "transport-streamable-http-client-reqwest", "which-command"] }
 tauri = { version = "2", features = [] }
+tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-updater = { version = "2", default-features = false, features = ["native-tls", "zip"] }
 rfd = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 rusqlite = { version = "0.32", features = ["bundled"] }
-tauri-plugin-notification = "2"
 tokio = { version = "1", features = ["io-util", "process", "rt-multi-thread", "sync", "time"] }
 tokio-util = "0.7"
 url = "2"

--- a/src-tauri/src/desktop_update.rs
+++ b/src-tauri/src/desktop_update.rs
@@ -1,0 +1,182 @@
+use serde::Serialize;
+
+use crate::{
+    append_log, append_native_backend_log_line, lock_runtime, SharedGateway,
+    NATIVE_BACKEND_LOG_MAX_BYTES,
+};
+
+#[cfg(windows)]
+use crate::{desktop_commands::gateway::stop_owned_gateway, stop_worker_cron_timer};
+#[cfg(windows)]
+use tauri::AppHandle;
+#[cfg(windows)]
+use tauri_plugin_updater::UpdaterExt;
+
+#[derive(Serialize)]
+struct UpdateDiagnostic<'a> {
+    event: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    current_version: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    available_version: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<&'a str>,
+}
+
+fn update_diagnostic_line(
+    event: &str,
+    current_version: Option<&str>,
+    available_version: Option<&str>,
+    detail: Option<&str>,
+) -> Result<String, String> {
+    serde_json::to_string(&UpdateDiagnostic {
+        event,
+        current_version,
+        available_version,
+        detail,
+    })
+    .map_err(|error| format!("failed to serialize updater diagnostic: {error}"))
+}
+
+fn record_update_event(
+    shared: &SharedGateway,
+    event: &str,
+    current_version: Option<&str>,
+    available_version: Option<&str>,
+    detail: Option<&str>,
+) -> Result<(), String> {
+    let line = update_diagnostic_line(event, current_version, available_version, detail)?;
+    let log_path = {
+        let mut runtime = lock_runtime(shared);
+        append_log(&mut runtime, &format!("updater {line}"));
+        runtime.persistent_log_path.clone()
+    };
+    append_native_backend_log_line(&log_path, NATIVE_BACKEND_LOG_MAX_BYTES, "updater", &line)
+}
+
+fn report_update_event(
+    shared: &SharedGateway,
+    event: &str,
+    current_version: Option<&str>,
+    available_version: Option<&str>,
+    detail: Option<&str>,
+) {
+    if let Err(error) =
+        record_update_event(shared, event, current_version, available_version, detail)
+    {
+        eprintln!("[tinybot updater] {event}; diagnostic write failed: {error}");
+    }
+}
+
+fn require_clean_shutdown(shutdown_result: Result<(), String>) -> Result<(), String> {
+    shutdown_result.map_err(|error| {
+        format!("automatic update installation aborted because runtime shutdown failed: {error}")
+    })
+}
+
+#[cfg(windows)]
+pub(crate) fn spawn_startup_auto_update(app: AppHandle, shared: SharedGateway) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = run_startup_auto_update(app, shared.clone()).await {
+            report_update_event(&shared, "update_failed", None, None, Some(&error));
+            eprintln!("[tinybot updater] {error}");
+        }
+    });
+}
+
+#[cfg(windows)]
+async fn run_startup_auto_update(app: AppHandle, shared: SharedGateway) -> Result<(), String> {
+    let current_version = app.package_info().version.to_string();
+    report_update_event(&shared, "check_started", Some(&current_version), None, None);
+
+    let updater = app
+        .updater()
+        .map_err(|error| format!("failed to initialize updater: {error}"))?;
+    let Some(update) = updater
+        .check()
+        .await
+        .map_err(|error| format!("update check failed: {error}"))?
+    else {
+        report_update_event(&shared, "up_to_date", Some(&current_version), None, None);
+        return Ok(());
+    };
+
+    report_update_event(
+        &shared,
+        "update_available",
+        Some(&current_version),
+        Some(&update.version),
+        None,
+    );
+    report_update_event(
+        &shared,
+        "download_started",
+        Some(&current_version),
+        Some(&update.version),
+        None,
+    );
+    let bytes = update
+        .download(|_chunk_length, _content_length| {}, || {})
+        .await
+        .map_err(|error| format!("update download or signature verification failed: {error}"))?;
+    report_update_event(
+        &shared,
+        "signature_verified",
+        Some(&current_version),
+        Some(&update.version),
+        None,
+    );
+
+    let shutdown_shared = shared.clone();
+    let shutdown_result = tauri::async_runtime::spawn_blocking(move || {
+        stop_worker_cron_timer(&shutdown_shared);
+        stop_owned_gateway(&shutdown_shared, true)
+    })
+    .await
+    .map_err(|error| format!("runtime shutdown task failed: {error}"))?;
+    require_clean_shutdown(shutdown_result)?;
+    report_update_event(
+        &shared,
+        "install_started",
+        Some(&current_version),
+        Some(&update.version),
+        None,
+    );
+
+    update
+        .install(bytes)
+        .map_err(|error| format!("failed to launch update installer: {error}"))?;
+    Err("update installer returned without terminating the application".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{require_clean_shutdown, update_diagnostic_line};
+
+    #[test]
+    fn update_diagnostic_records_version_selection() {
+        let line = update_diagnostic_line("update_available", Some("0.1.0"), Some("0.2.0"), None)
+            .expect("update diagnostic should serialize");
+        let value: serde_json::Value =
+            serde_json::from_str(&line).expect("update diagnostic should be JSON");
+
+        assert_eq!(value["event"], "update_available");
+        assert_eq!(value["current_version"], "0.1.0");
+        assert_eq!(value["available_version"], "0.2.0");
+        assert!(value.get("detail").is_none());
+    }
+
+    #[test]
+    fn installation_gate_accepts_clean_shutdown() {
+        assert_eq!(require_clean_shutdown(Ok(())), Ok(()));
+    }
+
+    #[test]
+    fn installation_gate_rejects_failed_shutdown_with_cause() {
+        let error = require_clean_shutdown(Err("worker drain timed out".to_string()))
+            .expect_err("failed cleanup must abort installation");
+
+        assert!(error.contains("installation aborted"));
+        assert!(error.contains("worker drain timed out"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub mod desktop_files;
 pub mod desktop_heartbeat;
 pub mod desktop_logging;
 pub mod desktop_menu;
+mod desktop_update;
 pub mod native_agent_bridge;
 pub mod native_backend_contract;
 pub mod native_provider_runtime;
@@ -487,6 +488,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(gateway_state)
         .setup(move |app| {
             install_desktop_application_menu(app)?;
@@ -541,6 +543,8 @@ pub fn run() {
             });
             drop(runtime);
             start_worker_cron_timer(&setup_state);
+            #[cfg(windows)]
+            desktop_update::spawn_startup_auto_update(app.handle().clone(), setup_state.clone());
             push_log(
                 &setup_state,
                 "Rust backend startup skipped legacy heartbeat worker",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,6 +30,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -37,5 +38,16 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/SudoJacky/tinybot/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY5NTI3MkE5M0ZERTlBQUUKUldTdW10NC9xWEpTK2VsU2RPWENJandkNXZ3Nm9qR0NGTmpNazdyeURaeit0Z1Q1WmtYSEtKLzEK",
+      "windows": {
+        "installMode": "quiet"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- add a Rust-owned startup updater with signed GitHub Release artifacts
- stop the native runtime before installation and abort on cleanup failures
- add a tag-triggered Windows x64 NSIS release workflow and release version guard
- document the unsigned publisher warning and automatic update behavior

## Validation

- `npm test` (580 passed)
- `npm run build`
- `cargo test --lib desktop_update::tests -- --test-threads=1` (3 passed)
- local signed Windows x64 NSIS build produced the installer and `.sig`
- `cargo fmt --check`
- `git diff --check`
- `node .github/scripts/check-release-version.mjs v0.1.0`

## Notes

- The first release is Windows x64 only.
- The installer is not Authenticode-signed yet, so Windows SmartScreen may show an unknown publisher warning.