### PR TITLE
Fix cross-platform Rust CI test expectations

### DIFF
--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1330,7 +1330,7 @@ fn worker_run_agent_stops_before_provider_when_run_start_persistence_fails() {
 }
 
 #[test]
-fn worker_run_agent_fails_when_run_record_persistence_fails() {
+fn worker_run_agent_fails_when_trace_persistence_breaks_after_provider_response() {
     #[derive(Clone)]
     struct PersistenceBreakingProvider {
         workspace_root: PathBuf,
@@ -1387,9 +1387,12 @@ fn worker_run_agent_fails_when_run_record_persistence_fails() {
         serde_json::json!({}),
         Duration::from_millis(10),
     )
-    .expect_err("run-record persistence failure should fail the command");
+    .expect_err("trace persistence failure should fail the command");
 
-    assert!(error.contains("run persistence failed"), "{error}");
+    assert!(
+        error.contains("native agent run trace batch append failed"),
+        "{error}"
+    );
     assert_eq!(
         *calls
             .lock()

--- a/src-tauri/src/worker_shell/process_manager_tests.rs
+++ b/src-tauri/src/worker_shell/process_manager_tests.rs
@@ -289,7 +289,11 @@ fn interactive_process_accepts_input_resizes_and_exits_cleanly() {
     assert_eq!(output.status, "exited");
     assert_eq!(output.exit_code, Some(0));
     assert!(
-        transcript.contains("answer=hello"),
+        transcript.contains(if cfg!(target_os = "windows") {
+            "answer=hello"
+        } else {
+            "got:hello"
+        }),
         "{transcript:?}; {output:?}"
     );
     assert_eq!(rpc.active_process_count(), 0);


### PR DESCRIPTION
## Summary
- align the post-provider persistence failure test with the trace flush stage that now fails first
- assert the platform-specific interactive shell output on Windows and Unix

## Verification
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo test --manifest-path src-tauri/Cargo.toml worker_run_agent_fails_when_trace_persistence_breaks_after_provider_response --jobs 4 -- --test-threads=1
- cargo test --manifest-path src-tauri/Cargo.toml interactive_process_accepts_input_resizes_and_exits_cleanly --jobs 4 -- --test-threads=1
- git diff --check