### PR TITLE
Stabilize failure recovery focus test

### DIFF
--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -1459,7 +1459,7 @@ describe("ChatPage", () => {
     const details = screen.getByRole("button", { name: /Agent steps, 1 step/i });
     const error = screen.getByRole("alert", { name: "任务执行失败" });
     expect(plan.compareDocumentPosition(details) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(document.activeElement).toBe(error);
+    await waitFor(() => expect(document.activeElement).toBe(error));
     expect(planToggle.getAttribute("aria-expanded")).toBe("true");
     await user.click(planToggle);
     expect(planToggle.getAttribute("aria-expanded")).toBe("false");


### PR DESCRIPTION
## Summary

- wait for the failure recovery card focus effect before asserting focus
- remove the Windows runner race that blocked the v0.1.0 release workflow

## Root cause

The component focuses the recovery card in a React effect after mount, but the test asserted `document.activeElement` immediately. On slower Windows runners, the assertion ran before the effect and observed `document.body`.

## Validation

- focused test passed 5 consecutive runs
- `npm test` (522 passed)
- `npm run build`
- pre-commit checks passed