### PR TITLE
feat(tinyos): deliver interactive simulation workspace

### DIFF
--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -1292,6 +1292,8 @@ Thread statuses:
 | `worker_workspace_files` | none | `{ files: WorkspaceFileEntry[] }` |
 | `worker_workspace_file` | `{ input: { path } }` | `WorkspaceReadFileResult` |
 | `worker_workspace_put_file` | `{ input: { path, body } }` | `WorkspaceWriteResult` |
+| `worker_workspace_directory` | `{ input: { path, cursor?, nameQuery? } }` | Worker response containing `WorkspaceDirectoryPage` |
+| `worker_workspace_file_chunk` | `{ input: { path, cursor? } }` | Worker response containing `WorkspaceFileChunk` |
 
 Lower-level workspace RPC also supports:
 
@@ -1320,6 +1322,51 @@ Lower-level workspace RPC also supports:
   "truncated": false
 }
 ```
+
+TinyOS Files uses revision-bound, paginated read commands instead of loading an unbounded workspace
+tree or file. `worker_workspace_directory` returns a Worker response whose `result` has this shape:
+
+```json
+{
+  "path": "src",
+  "workspace_key": "D:/code/tinybot",
+  "listing_revision": "...",
+  "entries": [
+    {
+      "path": "src/app-core",
+      "kind": "directory",
+      "size_bytes": null,
+      "updated_at": "2026-07-14T00:00:00Z"
+    }
+  ],
+  "next_cursor": null
+}
+```
+
+Directories sort before files, entries are then ordered by normalized path, and `nameQuery` filters
+entry names before pagination. A continuation cursor is bound to `listing_revision`; using it after
+the directory changes fails visibly with query code `listing_changed`.
+
+`worker_workspace_file_chunk` returns a Worker response whose `result` has this shape:
+
+```json
+{
+  "path": "src/main.ts",
+  "content_type": "text",
+  "revision": "...",
+  "size_bytes": 1024,
+  "updated_at": "2026-07-14T00:00:00Z",
+  "content": "...",
+  "line_start": 1,
+  "line_end": 40,
+  "next_cursor": null
+}
+```
+
+Binary files return `content_type: "binary"` without invented text content or line numbers. File
+continuation cursors are bound to `revision`; using one after the file changes fails visibly with
+query code `source_changed`. Other workspace query failures retain their protocol error, path, and
+retryable metadata rather than returning an empty successful page.
 
 `workspace.apply_patch` accepts:
 

--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -1003,6 +1003,26 @@ the references on the new canonical `user_message`, emits the correlated command
 and completes at the new run's terminal canonical item. Requests issued from a History view still
 create this new live run and never mutate the historical snapshot.
 
+TinyOS Time Machine indexes every raw canonical item revision as an exact event boundary. History
+reconstruction passes that event index together with run, turn, and item identity to projector
+version `1`; an identity mismatch is an error rather than a nearest-match fallback. A boundary with
+an invalid or missing timestamp is explicitly shown as unavailable, and native snapshots observed
+after a historical boundary are excluded so current native state cannot leak backward in time.
+
+Replay is local presentation state and advances only through those indexed canonical boundaries.
+Every runtime-scoped command in the shared shell registry is denied in History with
+`reasonCode: "history_read_only"`; window, navigation, evidence pinning, and Return-to-Live commands
+remain local. Inspector pins retain their event index, timestamp availability, resource identity,
+revision, and provenance so two boundaries are compared without merging evidence. Layout
+preferences survive History navigation and Return to Live re-evaluates the current backend
+capabilities instead of retaining historical availability.
+
+Replay checkpoint data is disposable and keyed by projector version and event index. Incompatible
+checkpoint data is discarded and rebuilt from canonical events. The automated large-timeline guard
+samples the first, middle, and final boundaries of a 2,000-event replay against a 250 ms target. The
+current projector remains below that threshold, so Time Machine does not create or persist replay
+checkpoints yet.
+
 TinyOS controlled-host actions use the same `tinybot.command.v1` gateway and dedicated
 `tinyos-host-*` run identities. They are never inferred from local window state:
 
@@ -1013,8 +1033,10 @@ TinyOS controlled-host actions use the same `tinybot.command.v1` gateway and ded
 - `terminal.execute` carries the exact `command`, optional workspace-relative `cwd`, and
   `confirmed`;
 - `terminal.cancel` targets the running `tinyos-host-terminal-*` run;
-- `browser.interact` defines the correlated `capture_id` and typed action contract, but currently
-  fails closed because the desktop has no real browser interaction backend.
+- `browser.interact` requires the correlated `browser_session_id`, `tab_id`, `capture_id`, explicit
+  confirmation, and a typed `click`, `navigate`, or `type` action. The native boundary validates
+  those identities and action parameters before failing closed because the desktop has no real
+  browser interaction backend.
 
 File changes are workspace-bound and revision guarded. The frontend keeps edits as local drafts,
 shows the before/after content before enabling save, and submits the revision returned by the
@@ -1031,10 +1053,32 @@ to the host run and records a canonical cancelled terminal outcome. On capabilit
 a restart, a persisted active `tinyos-host-*` run without a matching live terminal process is
 marked failed with an explicit interrupted-recovery event instead of remaining active indefinitely.
 
-TinyOS browser surfaces label backend raster evidence as `Real capture` and all other projections as
-`Structured simulation`. `browser.realCapture` and `browser.interact` remain unavailable with
-`reasonCode: "backend_unavailable"`; clients must not convert structured browser metadata into a
-claim of real capture or successful host interaction.
+The delivered Terminal contract is `retained_execution_v1`, not a persistent PTY session. Every
+reviewed command creates one non-TTY `tinyos-host-terminal-*` execution; cwd, command history, and
+foreground process state do not carry implicitly into a later execution. Canonical Tool result data
+for this contract includes the native `processId`, `executionContract`, `tty`, `sandboxMode`,
+`networkMode`, `exitCode`, `startedAtMs`, `lastActivityMs`, `durationMs`, `stdoutBytes`,
+`stderrBytes`, `truncated`, and `droppedBytes` fields alongside the bounded sanitized stdout/stderr.
+Clients may retain those canonical executions as tabs and history, but must not label them as live
+shell sessions. A future long-lived PTY requires a new versioned capability and lifecycle contract.
+
+TinyOS Browser separates three evidence states. `Structured projection` is canonical timeline
+metadata without raster evidence. `Local preview` is a raster artifact without an owning native
+browser session. `Real capture` requires a `browser_session_v1` snapshot whose current, non-stale
+capture identity matches the raster artifact. Structured entries and local previews never create
+synthetic tabs, navigation history, or successful host interactions.
+
+`browser_session_v1` snapshots bind `browserSessionId`, `sessionId`, `runId`, `activeTabId`, tab
+history, per-tab capture history, and the backend-authored `click`/`navigate`/`type` interaction
+decisions. An interaction must target the same session, an existing tab, and that tab's exact
+current non-stale capture. A stale capture stays visible for diagnosis, but controls remain disabled
+and the client offers recovery to the current capture instead of silently retargeting the command.
+
+The current effective capability declares `projectionContract: "structured_projection_v1"`,
+`sessionContract: "browser_session_v1"`, `interactionRequires: "current_real_capture"`, and
+`sessionSnapshot: false`. `browser.realCapture` and `browser.interact` remain unavailable with
+`reasonCode: "backend_unavailable"`; a future backend must publish a valid session snapshot and
+enable each action before the client can dispatch it.
 
 `GET /api/sessions/{key}/effective-capabilities` and the native
 `worker_session_effective_capabilities` command return `tinybot.effective_capabilities.v1` decisions.
@@ -1042,8 +1086,14 @@ Unavailable decisions include both `reasonCode` and a user-facing `reason`; the 
 the evaluated run used for the decision when present. Retry is available only when that latest run
 is failed and no active run supersedes it. `files.requestChange` is available when workspace read
 access is granted, the workspace root is available, and no run is active.
+The `terminal` capability group also declares `contract: "retained_execution_v1"` and
+`persistentPty: false`; clients reject a different or missing execution contract instead of
+silently treating it as the delivered retained-execution model.
 `files.directEdit`, `files.save`, and `terminal.execute` additionally require their corresponding
-desktop capability, an available workspace, and no active run. `terminal.cancel` is available only
+desktop capability, an available workspace, and no active run. The current native shell backend
+cannot enforce denied-network execution, so `terminal.execute` fails closed with
+`reasonCode: "network_enforcement_unavailable"` instead of starting a less restricted process.
+`terminal.cancel` is available only
 for a running `tinyos-host-terminal-*` run. The generic Agent cancel control remains unavailable for
 host-operation runs so the owning TinyOS application remains the single control surface.
 `agent.pause` is available for a running run; `agent.resume` is available only when the evaluated

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "highlight.js": "^11.11.1",
         "lucide-react": "^1.23.0",
         "marked": "^18.0.4",
+        "ogl": "^1.0.11",
         "openai": "^6.42.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -4991,6 +4992,12 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/ogl": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ogl/-/ogl-1.0.11.tgz",
+      "integrity": "sha512-kUpC154AFfxi16pmZUK4jk3J+8zxwTWGPo03EoYA8QPbzikHoaC82n6pNTbd+oEaJonaE8aPWBlX7ad9zrqLsA==",
+      "license": "Unlicense"
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "highlight.js": "^11.11.1",
     "lucide-react": "^1.23.0",
     "marked": "^18.0.4",
+    "ogl": "^1.0.11",
     "openai": "^6.42.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/src-tauri/src/desktop_commands/session.rs
+++ b/src-tauri/src/desktop_commands/session.rs
@@ -414,23 +414,7 @@ fn recover_interrupted_tinyos_host_operations(
         .filter(|process| process.running)
         .filter_map(|process| process.run_id)
         .collect::<std::collections::HashSet<_>>();
-    let interrupted = runs
-        .get("runs")
-        .and_then(serde_json::Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|run| {
-            let run_id = run.get("runId").and_then(serde_json::Value::as_str)?;
-            let active = matches!(
-                run.get("status").and_then(serde_json::Value::as_str),
-                Some("running" | "waiting")
-            );
-            let host_run = run_id.starts_with("tinyos-host-");
-            let terminal_live =
-                run_id.starts_with("tinyos-host-terminal-") && live_process_runs.contains(run_id);
-            (active && host_run && !terminal_live).then(|| run_id.to_string())
-        })
-        .collect::<Vec<_>>();
+    let interrupted = interrupted_tinyos_host_run_ids(runs, &live_process_runs);
     for run_id in &interrupted {
         let request_id = next_worker_request_correlation();
         call_rust_state_service(
@@ -475,6 +459,28 @@ fn recover_interrupted_tinyos_host_operations(
         )?;
     }
     Ok(!interrupted.is_empty())
+}
+
+pub(crate) fn interrupted_tinyos_host_run_ids(
+    runs: &serde_json::Value,
+    live_process_runs: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    runs.get("runs")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|run| {
+            let run_id = run.get("runId").and_then(serde_json::Value::as_str)?;
+            let active = matches!(
+                run.get("status").and_then(serde_json::Value::as_str),
+                Some("running" | "waiting")
+            );
+            let host_run = run_id.starts_with("tinyos-host-");
+            let terminal_live =
+                run_id.starts_with("tinyos-host-terminal-") && live_process_runs.contains(run_id);
+            (active && host_run && !terminal_live).then(|| run_id.to_string())
+        })
+        .collect()
 }
 
 pub(crate) fn build_worker_session_effective_capabilities(
@@ -607,17 +613,20 @@ pub(crate) fn build_worker_session_effective_capabilities(
             "run_active",
             "Terminal execution is unavailable while another run is active.",
         )
-    } else if policy.allows(&WorkerCapability::ShellExecute) && workspace_available {
-        available_capability()
     } else if !workspace_available {
         unavailable_capability(
             "workspace_unavailable",
             "The configured workspace root is unavailable.",
         )
-    } else {
+    } else if !policy.allows(&WorkerCapability::ShellExecute) {
         unavailable_capability(
             "permission_denied",
             "Shell execution permission is not granted.",
+        )
+    } else {
+        unavailable_capability(
+            "network_enforcement_unavailable",
+            "Terminal execution requires denied-network enforcement, which is unavailable in the current native shell backend.",
         )
     };
     let terminal_cancel = if evaluated_is_terminal_run && evaluated_run_status == Some("running") {
@@ -647,13 +656,19 @@ pub(crate) fn build_worker_session_effective_capabilities(
                 "save": workspace_write,
             },
             "terminal": {
+                "contract": "retained_execution_v1",
+                "persistentPty": false,
                 "inspect": available_capability(),
                 "execute": terminal_execute,
                 "cancel": terminal_cancel,
             },
             "browser": {
+                "interactionRequires": "current_real_capture",
                 "structured": available_capability(),
+                "projectionContract": "structured_projection_v1",
                 "realCapture": unavailable_capability("backend_unavailable", "No real browser capture backend is configured."),
+                "sessionContract": "browser_session_v1",
+                "sessionSnapshot": false,
                 "interact": unavailable_capability("backend_unavailable", "No real browser interaction backend is configured."),
             },
         },

--- a/src-tauri/src/desktop_commands/transport.rs
+++ b/src-tauri/src/desktop_commands/transport.rs
@@ -234,9 +234,19 @@ pub(crate) fn native_websocket_transport_result(
             .cloned()
             .unwrap_or(serde_json::Value::Null);
     } else if command_kind == "browser.interact" {
+        transport["browserSessionId"] = frame
+            .get("browser_session_id")
+            .or_else(|| frame.get("browserSessionId"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
         transport["captureId"] = frame
             .get("capture_id")
             .or_else(|| frame.get("captureId"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        transport["tabId"] = frame
+            .get("tab_id")
+            .or_else(|| frame.get("tabId"))
             .cloned()
             .unwrap_or(serde_json::Value::Null);
         transport["action"] = frame
@@ -313,10 +323,7 @@ async fn dispatch_tinyos_command(
             )
             .await
         }
-        Some("browser.interact") => Err(
-            "browser.interact is unavailable because no real browser capture backend is configured"
-                .to_string(),
-        ),
+        Some("browser.interact") => dispatch_tinyos_browser_command(transport),
         command_kind => Err(format!(
             "unsupported TinyOS command kind: {}",
             command_kind.unwrap_or("missing")
@@ -1607,6 +1614,7 @@ fn append_tinyos_terminal_event(
 ) -> Result<(), String> {
     let stdout = sanitize_tinyos_host_text(&output.stdout, &config_snapshot);
     let stderr = sanitize_tinyos_host_text(&output.stderr, &config_snapshot);
+    let result = tinyos_terminal_result_payload(output, &stdout, &stderr);
     append_tinyos_host_event(
         workspace_root,
         config_snapshot,
@@ -1631,15 +1639,7 @@ fn append_tinyos_terminal_event(
                     "status": if terminal { "completed" } else { "running" },
                     "summary": if terminal { "Terminal command finished" } else { "Terminal command running" },
                 },
-                "result": {
-                    "cancelled": output.status == "cancelled",
-                    "droppedBytes": output.dropped_bytes,
-                    "exitCode": output.exit_code,
-                    "processId": output.process_id,
-                    "stderr": stderr,
-                    "stdout": stdout,
-                    "truncated": output.truncated,
-                },
+                "result": result,
                 "stderr": stderr,
                 "stdout": stdout,
                 "summary": if terminal { "Terminal command finished" } else { "Terminal command running" },
@@ -1648,6 +1648,102 @@ fn append_tinyos_terminal_event(
             }
         }),
     )
+}
+
+fn dispatch_tinyos_browser_command(
+    transport: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let run_id = required_transport_string(&transport, "runId")?;
+    let command_kind = required_transport_string(&transport, "commandKind")?;
+    if !run_id.starts_with("tinyos-host-browser-") {
+        return Err(format!(
+            "{command_kind} requires a dedicated TinyOS browser operation run"
+        ));
+    }
+    if transport
+        .get("confirmed")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+    {
+        return Err("browser.interact requires explicit user confirmation".to_string());
+    }
+    required_transport_string(&transport, "sessionId")?;
+    required_transport_string(&transport, "commandId")?;
+    required_transport_string(&transport, "browserSessionId")?;
+    required_transport_string(&transport, "tabId")?;
+    required_transport_string(&transport, "captureId")?;
+
+    let action = transport
+        .get("action")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| "browser.interact requires an action object".to_string())?;
+    let action_type = action
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "browser.interact action is missing type".to_string())?;
+    match action_type {
+        "click" => {
+            for coordinate in ["x", "y"] {
+                action
+                    .get(coordinate)
+                    .and_then(serde_json::Value::as_f64)
+                    .filter(|value| value.is_finite() && *value >= 0.0)
+                    .ok_or_else(|| {
+                        format!("browser.interact click requires a non-negative {coordinate}")
+                    })?;
+            }
+        }
+        "navigate" => {
+            action
+                .get("url")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| "browser.interact navigate requires url".to_string())?;
+        }
+        "type" => {
+            action
+                .get("text")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| "browser.interact type requires text".to_string())?;
+        }
+        unsupported => {
+            return Err(format!(
+                "browser.interact action type `{unsupported}` is unsupported"
+            ));
+        }
+    }
+
+    Err(
+        "browser.interact is unavailable because no real browser capture backend is configured"
+            .to_string(),
+    )
+}
+
+pub(crate) fn tinyos_terminal_result_payload(
+    output: &ShellProcessOutput,
+    stdout: &str,
+    stderr: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "cancelled": output.status == "cancelled",
+        "droppedBytes": output.dropped_bytes,
+        "durationMs": output.last_activity_ms.saturating_sub(output.started_at_ms),
+        "executionContract": "retained_execution_v1",
+        "exitCode": output.exit_code,
+        "lastActivityMs": output.last_activity_ms,
+        "networkMode": output.network_mode,
+        "processId": output.process_id,
+        "sandboxMode": output.sandbox_mode,
+        "stderr": stderr,
+        "stderrBytes": stderr.len(),
+        "startedAtMs": output.started_at_ms,
+        "stdout": stdout,
+        "stdoutBytes": stdout.len(),
+        "tty": output.tty,
+        "truncated": output.truncated,
+    })
 }
 
 fn tinyos_terminal_process_failure(output: &ShellProcessOutput) -> Option<String> {

--- a/src-tauri/src/native_agent_bridge/thread_flow.rs
+++ b/src-tauri/src/native_agent_bridge/thread_flow.rs
@@ -228,24 +228,32 @@ pub(crate) async fn resolve_thread_approval_with_services(
         .get("thread")
         .cloned()
         .ok_or_else(|| "thread approval target read returned no thread".to_string())?;
-    let thread_checkpoint = target_snapshot
+    let thread_id = thread_thread_id(&thread)?;
+    let session_id = thread_session_key(&thread).unwrap_or_else(|| thread_id.clone());
+    let approval_checkpoint = target_snapshot
         .get("latestCheckpoint")
         .and_then(|checkpoint| checkpoint.get("restorePayload"))
         .cloned()
-        .ok_or_else(|| "thread approval target has no canonical checkpoint".to_string())?;
-    let thread_id = thread_thread_id(&thread)?;
-    let session_id = thread_session_key(&thread).unwrap_or_else(|| thread_id.clone());
+        .or_else(|| {
+            base_services
+                .restore_checkpoint(&session_id)
+                .get("checkpoint")
+                .filter(|checkpoint| !checkpoint.is_null())
+                .cloned()
+        });
     let approval_id = input.approval_id.clone();
     let approved = input.approved;
     let scope = input.scope.clone();
     let guidance = input.guidance.clone();
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "session_key": session_id.clone(),
         "thread_id": thread_id.clone(),
         "scope": input.scope,
         "guidance": input.guidance,
-        "threadCheckpoint": thread_checkpoint,
     });
+    if let Some(checkpoint) = approval_checkpoint {
+        body["threadCheckpoint"] = checkpoint;
+    }
     let mut result = resolve_approval_body_with_services(
         base_services,
         input.approval_id,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3054,6 +3054,109 @@ fn worker_thread_commands_expose_thread_service_surface() {
 }
 
 #[test]
+fn worker_resolve_thread_approval_uses_runtime_checkpoint_before_thread_projection_catches_up() {
+    let fixture = WorkspaceFixture::new();
+    let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+    let config = serde_json::json!({
+        "agents": { "defaults": { "provider": "fixture", "model": "fixture-model" } },
+        "providers": {
+            "fixture": {
+                "responses": [{ "content": "runtime checkpoint approval final" }]
+            }
+        }
+    });
+    let thread_id = "thread-runtime-checkpoint-approval";
+    let session_id = "session-runtime-checkpoint-approval";
+    let run_id = "run-runtime-checkpoint-approval";
+    let approval_id = "approval-runtime-checkpoint-approval";
+    let create_request = next_worker_request_correlation();
+    call_rust_state_service(
+        fixture.root.clone(),
+        config.clone(),
+        WorkerRequest::new(
+            create_request.id("runtime-checkpoint-thread-create"),
+            create_request.trace_id("runtime-checkpoint-thread-create"),
+            "thread.create",
+            serde_json::json!({
+                "threadId": thread_id,
+                "sessionKey": session_id,
+                "title": "Runtime checkpoint approval"
+            }),
+        ),
+        "runtime checkpoint thread create",
+    )
+    .expect("approval thread should create");
+    let start_request = next_worker_request_correlation();
+    call_rust_state_service(
+        fixture.root.clone(),
+        config.clone(),
+        WorkerRequest::new(
+            start_request.id("runtime-checkpoint-thread-start"),
+            start_request.trace_id("runtime-checkpoint-thread-start"),
+            "thread.start_turn",
+            serde_json::json!({
+                "threadId": thread_id,
+                "runId": run_id,
+                "turnId": run_id,
+                "input": { "role": "user", "content": "run shell command" }
+            }),
+        ),
+        "runtime checkpoint thread start",
+    )
+    .expect("approval thread turn should start");
+
+    let runtime_services = lock_runtime(&shared).native_agent_runtime.clone();
+    let awaiting = crate::worker_agent_runtime::run_native_agent_turn_with_services(
+        &runtime_services,
+        serde_json::json!({
+            "runtime": "rust",
+            "runId": run_id,
+            "sessionId": session_id,
+            "threadId": thread_id,
+            "metadata": {
+                "threadId": thread_id,
+                "fakeAwaitingApproval": {
+                    "approvalId": approval_id,
+                    "toolName": "shell.execute"
+                }
+            }
+        }),
+    )
+    .expect("runtime approval checkpoint should exist before thread projection");
+    assert_eq!(awaiting["stopReason"], "awaiting_approval");
+
+    let snapshot = worker_thread_request_with_options(
+        &shared,
+        "runtime-checkpoint-thread-read",
+        "thread.read",
+        serde_json::json!({ "threadId": thread_id }),
+        fixture.root.clone(),
+        config.clone(),
+        Duration::from_millis(10),
+    )
+    .expect("approval thread should remain readable");
+    assert!(snapshot["latestCheckpoint"].is_null());
+
+    let result = worker_resolve_thread_approval_with_options(
+        &shared,
+        WorkerResolveThreadApprovalInput {
+            thread_id: thread_id.to_string(),
+            approval_id: approval_id.to_string(),
+            approved: true,
+            scope: Some("once".to_string()),
+            guidance: None,
+        },
+        fixture.root.clone(),
+        config,
+        Duration::from_millis(10),
+    )
+    .expect("runtime checkpoint should allow approval before thread projection finishes");
+
+    assert_eq!(result["approvalResult"]["stopReason"], "final_response");
+    assert_eq!(result["snapshot"]["thread"]["status"], "idle");
+}
+
+#[test]
 fn worker_resolve_thread_approval_resumes_checkpoint_and_updates_thread() {
     let fixture = WorkspaceFixture::new();
     let shared = Arc::new(Mutex::new(GatewayRuntime::default()));

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -5486,7 +5486,9 @@ fn worker_transport_websocket_maps_controlled_host_commands() {
             "command_id": "command-browser-1",
             "command_kind": "browser.interact",
             "run_id": "tinyos-host-browser-1",
+            "browser_session_id": "browser-session-1",
             "capture_id": "capture-1",
+            "tab_id": "tab-1",
             "action": { "type": "click", "x": 12, "y": 34 },
             "confirmed": true
         }),
@@ -5505,7 +5507,9 @@ fn worker_transport_websocket_maps_controlled_host_commands() {
     assert_eq!(file["baseRevision"], "metadata:12:34");
     assert_eq!(file["confirmed"], true);
     assert_eq!(browser["commandKind"], "browser.interact");
+    assert_eq!(browser["browserSessionId"], "browser-session-1");
     assert_eq!(browser["captureId"], "capture-1");
+    assert_eq!(browser["tabId"], "tab-1");
     assert_eq!(browser["action"]["type"], "click");
 }
 
@@ -5587,7 +5591,9 @@ fn worker_transport_dispatches_a_revision_guarded_file_command_and_rejects_fake_
                 "command_id": "command-browser-1",
                 "command_kind": "browser.interact",
                 "run_id": "tinyos-host-browser-test",
+                "browser_session_id": "browser-session-1",
                 "capture_id": "capture-1",
+                "tab_id": "tab-1",
                 "action": { "type": "click", "x": 12, "y": 34 },
                 "confirmed": true
             }),
@@ -5605,6 +5611,91 @@ fn worker_transport_dispatches_a_revision_guarded_file_command_and_rejects_fake_
     )
     .expect_err("browser control must fail closed without a real backend");
     assert!(browser_error.contains("no real browser"), "{browser_error}");
+
+    let missing_identity_error = worker_transport_dispatch_websocket_message_with_options(
+        &shared,
+        WorkerTransportWebSocketDispatchInput {
+            client_id: "client-host-browser".to_string(),
+            frame: serde_json::json!({
+                "type": "command",
+                "chat_id": "chat-host-file",
+                "session_id": session_id,
+                "command_id": "command-browser-2",
+                "command_kind": "browser.interact",
+                "run_id": "tinyos-host-browser-missing-identity",
+                "capture_id": "capture-1",
+                "tab_id": "tab-1",
+                "action": { "type": "click", "x": 12, "y": 34 },
+                "confirmed": true
+            }),
+            attached_chat_id: Some("chat-host-file".to_string()),
+            session_exists: Some(true),
+            editable_paths: None,
+            model: None,
+            max_iterations: None,
+            run_id: Some("tinyos-host-browser-missing-identity".to_string()),
+            stream: None,
+        },
+        fixture.root.clone(),
+        serde_json::json!({}),
+        Duration::from_millis(100),
+    )
+    .expect_err("browser control must reject incomplete capture identity");
+    assert!(
+        missing_identity_error.contains("missing browserSessionId"),
+        "{missing_identity_error}"
+    );
+
+    let invalid_action_error = worker_transport_dispatch_websocket_message_with_options(
+        &shared,
+        WorkerTransportWebSocketDispatchInput {
+            client_id: "client-host-browser".to_string(),
+            frame: serde_json::json!({
+                "type": "command",
+                "chat_id": "chat-host-file",
+                "session_id": session_id,
+                "command_id": "command-browser-3",
+                "command_kind": "browser.interact",
+                "run_id": "tinyos-host-browser-invalid-action",
+                "browser_session_id": "browser-session-1",
+                "capture_id": "capture-1",
+                "tab_id": "tab-1",
+                "action": { "type": "click", "x": -1, "y": 34 },
+                "confirmed": true
+            }),
+            attached_chat_id: Some("chat-host-file".to_string()),
+            session_exists: Some(true),
+            editable_paths: None,
+            model: None,
+            max_iterations: None,
+            run_id: Some("tinyos-host-browser-invalid-action".to_string()),
+            stream: None,
+        },
+        fixture.root.clone(),
+        serde_json::json!({}),
+        Duration::from_millis(100),
+    )
+    .expect_err("browser control must reject invalid coordinates");
+    assert!(
+        invalid_action_error.contains("non-negative x"),
+        "{invalid_action_error}"
+    );
+    let runs_after_rejections = worker_agent_runs_list_with_options(
+        &shared,
+        session_id.to_string(),
+        fixture.root.clone(),
+        serde_json::json!({}),
+        Duration::from_millis(10),
+    )
+    .expect("host run list should remain readable after browser rejections");
+    assert_eq!(
+        runs_after_rejections["runs"]
+            .as_array()
+            .expect("host runs should be an array")
+            .len(),
+        1,
+        "rejected browser commands must not create runtime state"
+    );
 }
 
 #[test]
@@ -5963,6 +6054,63 @@ fn worker_transport_operation_retry_starts_new_correlated_run() {
 }
 
 #[test]
+fn tinyos_terminal_execute_fails_closed_without_network_enforcement_and_leaks_no_process() {
+    let fixture = WorkspaceFixture::new();
+    let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+    let session_id = "websocket:chat-host-terminal";
+    let run_id = "tinyos-host-terminal-cancel-test";
+    let error = worker_transport_dispatch_websocket_message_with_options(
+        &shared,
+        WorkerTransportWebSocketDispatchInput {
+            client_id: "client-host-terminal".to_string(),
+            frame: serde_json::json!({
+                "type": "command",
+                "chat_id": "chat-host-terminal",
+                "session_id": session_id,
+                "command_id": "command-terminal-execute-1",
+                "command_kind": "terminal.execute",
+                "run_id": run_id,
+                "command": lifecycle_blocking_command(),
+                "cwd": ".",
+                "confirmed": true
+            }),
+            attached_chat_id: Some("chat-host-terminal".to_string()),
+            session_exists: Some(true),
+            editable_paths: None,
+            model: None,
+            max_iterations: None,
+            run_id: Some(run_id.to_string()),
+            stream: None,
+        },
+        fixture.root.clone(),
+        serde_json::json!({}),
+        Duration::from_millis(100),
+    )
+    .expect_err(
+        "terminal execution must fail before process start when network denial cannot be enforced",
+    );
+
+    assert!(error.contains("network enforcement is unavailable"));
+    assert_eq!(
+        lock_runtime(&shared)
+            .native_agent_runtime
+            .shell_runtime()
+            .active_process_count(),
+        0
+    );
+
+    let runs = worker_agent_runs_list_with_options(
+        &shared,
+        session_id.to_string(),
+        fixture.root.clone(),
+        serde_json::json!({}),
+        Duration::from_millis(10),
+    )
+    .expect("failed terminal run should remain inspectable");
+    assert_eq!(runs["runs"][0]["status"], "failed");
+}
+
+#[test]
 fn tinyos_effective_capabilities_are_backend_authored_and_run_scoped() {
     let policy = default_desktop_capability_policy();
     let running = crate::desktop_commands::session::build_worker_session_effective_capabilities(
@@ -6047,7 +6195,11 @@ fn tinyos_effective_capabilities_are_backend_authored_and_run_scoped() {
     assert_eq!(failed["capabilities"]["files"]["save"]["available"], true);
     assert_eq!(
         failed["capabilities"]["terminal"]["execute"]["available"],
-        true
+        false
+    );
+    assert_eq!(
+        failed["capabilities"]["terminal"]["execute"]["reasonCode"],
+        "network_enforcement_unavailable"
     );
     assert_eq!(
         failed["capabilities"]["browser"]["structured"]["available"],
@@ -6061,6 +6213,15 @@ fn tinyos_effective_capabilities_are_backend_authored_and_run_scoped() {
         failed["capabilities"]["browser"]["interact"]["available"],
         false
     );
+    assert_eq!(
+        failed["capabilities"]["browser"]["projectionContract"],
+        "structured_projection_v1"
+    );
+    assert_eq!(
+        failed["capabilities"]["browser"]["sessionContract"],
+        "browser_session_v1"
+    );
+    assert_eq!(failed["capabilities"]["browser"]["sessionSnapshot"], false);
 
     let terminal = crate::desktop_commands::session::build_worker_session_effective_capabilities(
         "websocket:chat-1",
@@ -6081,6 +6242,85 @@ fn tinyos_effective_capabilities_are_backend_authored_and_run_scoped() {
     assert_eq!(
         terminal["capabilities"]["terminal"]["execute"]["available"],
         false
+    );
+    assert_eq!(
+        terminal["capabilities"]["terminal"]["contract"],
+        "retained_execution_v1"
+    );
+    assert_eq!(terminal["capabilities"]["terminal"]["persistentPty"], false);
+}
+
+#[test]
+fn tinyos_terminal_result_payload_preserves_retained_execution_boundaries() {
+    let output = crate::worker_shell::ShellProcessOutput {
+        process_id: "shell-1".to_string(),
+        system_process_id: Some(42),
+        run_id: Some("tinyos-host-terminal-1".to_string()),
+        tool_call_id: Some("command-1".to_string()),
+        command: "cargo test".to_string(),
+        working_dir: ".".to_string(),
+        tty: false,
+        status: "completed".to_string(),
+        running: false,
+        exit_code: Some(0),
+        stdout: "ignored unsanitized output".to_string(),
+        stderr: "ignored unsanitized error".to_string(),
+        output: String::new(),
+        chunks: Vec::new(),
+        cursor: 3,
+        truncated: true,
+        dropped_bytes: 17,
+        started_at_ms: 1_000,
+        last_activity_ms: 1_250,
+        sandbox_mode: "read_only".to_string(),
+        network_mode: "denied".to_string(),
+        approval_decision: "user_confirmed".to_string(),
+        failure: None,
+    };
+
+    let payload = crate::desktop_commands::transport::tinyos_terminal_result_payload(
+        &output,
+        "safe stdout",
+        "safe stderr",
+    );
+
+    assert_eq!(payload["executionContract"], "retained_execution_v1");
+    assert_eq!(payload["processId"], "shell-1");
+    assert_eq!(payload["tty"], false);
+    assert_eq!(payload["sandboxMode"], "read_only");
+    assert_eq!(payload["networkMode"], "denied");
+    assert_eq!(payload["durationMs"], 250);
+    assert_eq!(payload["stdout"], "safe stdout");
+    assert_eq!(payload["stdoutBytes"], 11);
+    assert_eq!(payload["stderr"], "safe stderr");
+    assert_eq!(payload["stderrBytes"], 11);
+    assert_eq!(payload["truncated"], true);
+    assert_eq!(payload["droppedBytes"], 17);
+}
+
+#[test]
+fn tinyos_host_restart_recovery_keeps_live_terminal_and_marks_stale_runs() {
+    let live_process_runs =
+        std::collections::HashSet::from(["tinyos-host-terminal-live".to_string()]);
+    let interrupted = crate::desktop_commands::session::interrupted_tinyos_host_run_ids(
+        &serde_json::json!({
+            "runs": [
+                { "runId": "tinyos-host-terminal-live", "status": "running" },
+                { "runId": "tinyos-host-terminal-stale", "status": "running" },
+                { "runId": "tinyos-host-file-stale", "status": "waiting" },
+                { "runId": "tinyos-host-terminal-done", "status": "completed" },
+                { "runId": "agent-run", "status": "running" }
+            ]
+        }),
+        &live_process_runs,
+    );
+
+    assert_eq!(
+        interrupted,
+        vec![
+            "tinyos-host-terminal-stale".to_string(),
+            "tinyos-host-file-stale".to_string(),
+        ]
     );
 }
 

--- a/src/app-core/chat/desktopChatSessionController.test.ts
+++ b/src/app-core/chat/desktopChatSessionController.test.ts
@@ -86,6 +86,21 @@ describe("desktop native chat session controller", () => {
     });
   });
 
+  test("uses the desktop command id as the Thread client event id", async () => {
+    const { controller, submitThreadTurn } = createController();
+    await controller.loadSessions();
+
+    await expect(controller.submitMessage("hello", true, undefined, undefined, "command-turn-1")).resolves.toEqual(
+      expect.objectContaining({ clientEventId: "command-turn-1", status: "sent" }),
+    );
+    expect(submitThreadTurn).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({ clientEventId: "command-turn-1" }),
+      spec: expect.objectContaining({
+        metadata: expect.objectContaining({ clientEventId: "command-turn-1" }),
+      }),
+    }));
+  });
+
   test("applies typed timeline patches after the Thread timeline is loaded", async () => {
     const { controller } = createController();
     await controller.loadSessions();

--- a/src/app-core/chat/desktopChatSessionController.ts
+++ b/src/app-core/chat/desktopChatSessionController.ts
@@ -52,7 +52,7 @@ export interface DesktopChatSessionController {
   selectSession(sessionKey: string, chatId: string): Promise<void>;
   deleteSession(sessionKey: string): Promise<ChatDeleteSessionResult>;
   patchSession(sessionKey: string, body: unknown): Promise<boolean>;
-  submitMessage(content: string, usePersistentRag?: boolean, model?: string, references?: NativeChatReference[]): Promise<ChatSubmitResult>;
+  submitMessage(content: string, usePersistentRag?: boolean, model?: string, references?: NativeChatReference[], clientEventId?: string): Promise<ChatSubmitResult>;
   loadTimeline(sessionKey: string): Promise<ChatTimelineSnapshot>;
   reloadTimeline(sessionKey: string): Promise<ChatTimelineSnapshot>;
   applyTimelinePatch(sessionKey: string, payload: unknown): Promise<ChatTimelineSnapshot | null>;
@@ -307,7 +307,7 @@ export function createDesktopChatSessionController({
     return true;
   }
 
-  async function submitMessage(content: string, usePersistentRag = true, model?: string, references?: NativeChatReference[]): Promise<ChatSubmitResult> {
+  async function submitMessage(content: string, usePersistentRag = true, model?: string, references?: NativeChatReference[], suppliedClientEventId?: string): Promise<ChatSubmitResult> {
     const trimmed = content.trim();
     if (!trimmed) {
       logDesktopNativeDebug("session.message.empty", summarizeSessionState());
@@ -316,7 +316,7 @@ export function createDesktopChatSessionController({
     if (!state.activeSessionKey) {
       throw new Error("Cannot submit a turn without an active Thread");
     }
-    const clientEventId = createClientEventId();
+    const clientEventId = suppliedClientEventId || createClientEventId();
     const runId = createRunId();
     const activeSession = state.sessions.find((session) => session.key === state.activeSessionKey);
     const threadId = activeSession?.threadId || state.activeSessionKey;

--- a/src/app-core/chat/desktopCommand.test.ts
+++ b/src/app-core/chat/desktopCommand.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+
+import { createDesktopStopCommand, createDesktopTurnSubmitCommand } from "./desktopCommand";
+
+describe("desktop command", () => {
+  test("creates a correlated turn command", () => {
+    expect(createDesktopTurnSubmitCommand({
+      commandId: "command-1",
+      issuedAt: "2026-07-15T00:00:00.000Z",
+      message: { text: "hello", model: "model-1" },
+      sessionId: "thread-1",
+      source: { control: "composer-send", surface: "chat" },
+    })).toEqual({
+      schemaVersion: "tinybot.command.v1",
+      commandId: "command-1",
+      issuedAt: "2026-07-15T00:00:00.000Z",
+      kind: "turn.submit",
+      source: { control: "composer-send", surface: "chat" },
+      target: { sessionId: "thread-1" },
+      input: { text: "hello", model: "model-1" },
+    });
+  });
+
+  test("creates a stop intent without leaking active-run lookup to the caller", () => {
+    expect(createDesktopStopCommand({
+      commandId: "command-2",
+      issuedAt: "2026-07-15T00:00:00.000Z",
+      sessionId: "thread-1",
+      source: { control: "keyboard-shortcut", surface: "chat" },
+    })).toEqual({
+      schemaVersion: "tinybot.command.v1",
+      commandId: "command-2",
+      issuedAt: "2026-07-15T00:00:00.000Z",
+      kind: "agent.stop",
+      source: { control: "keyboard-shortcut", surface: "chat" },
+      target: { sessionId: "thread-1" },
+    });
+  });
+});

--- a/src/app-core/chat/desktopCommand.ts
+++ b/src/app-core/chat/desktopCommand.ts
@@ -1,0 +1,68 @@
+import type { NativeChatReference } from "./nativeChat";
+import type { TinyOsCommand, TinyOsCommandSource } from "./tinyOsCommandGateway";
+
+export type DesktopChatInput = {
+  text: string;
+  model?: string;
+  references?: NativeChatReference[];
+  usePersistentRag?: boolean;
+};
+
+export type DesktopTurnSubmitCommand = {
+  schemaVersion: "tinybot.command.v1";
+  commandId: string;
+  issuedAt: string;
+  kind: "turn.submit";
+  source: TinyOsCommandSource;
+  target: { sessionId: string };
+  input: DesktopChatInput;
+};
+
+export type DesktopStopCommand = {
+  schemaVersion: "tinybot.command.v1";
+  commandId: string;
+  issuedAt: string;
+  kind: "agent.stop";
+  source: TinyOsCommandSource;
+  target: { sessionId: string };
+};
+
+export type DesktopCommand = DesktopTurnSubmitCommand | DesktopStopCommand | TinyOsCommand;
+
+export function createDesktopTurnSubmitCommand(input: {
+  commandId?: string;
+  issuedAt?: string;
+  message: DesktopChatInput;
+  sessionId: string;
+  source: TinyOsCommandSource;
+}): DesktopTurnSubmitCommand {
+  return {
+    schemaVersion: "tinybot.command.v1",
+    commandId: input.commandId ?? createDesktopCommandId(),
+    issuedAt: input.issuedAt ?? new Date().toISOString(),
+    kind: "turn.submit",
+    source: input.source,
+    target: { sessionId: input.sessionId },
+    input: input.message,
+  };
+}
+
+export function createDesktopStopCommand(input: {
+  commandId?: string;
+  issuedAt?: string;
+  sessionId: string;
+  source: TinyOsCommandSource;
+}): DesktopStopCommand {
+  return {
+    schemaVersion: "tinybot.command.v1",
+    commandId: input.commandId ?? createDesktopCommandId(),
+    issuedAt: input.issuedAt ?? new Date().toISOString(),
+    kind: "agent.stop",
+    source: input.source,
+    target: { sessionId: input.sessionId },
+  };
+}
+
+function createDesktopCommandId(): string {
+  return `desktop-command-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/src/app-core/chat/tinyOsBrowserSession.test.ts
+++ b/src/app-core/chat/tinyOsBrowserSession.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import type { TinyOsNativeBrowserSession } from "./tinyOsNativeSnapshot";
+import { validateTinyOsBrowserInteractionTarget } from "./tinyOsBrowserSession";
+
+function session(): TinyOsNativeBrowserSession {
+  return {
+    activeTabId: "tab-1",
+    browserSessionId: "browser-1",
+    contract: "browser_session_v1",
+    interaction: { click: true, navigate: true, type: true },
+    kind: "browser_session",
+    runId: "run-1",
+    sessionId: "session-1",
+    state: "running",
+    tabs: [{
+      activeHistoryIndex: 1,
+      captures: [
+        { captureId: "capture-old", observedAt: "2026-07-14T01:00:00Z", stale: true },
+        { captureId: "capture-current", observedAt: "2026-07-14T01:01:00Z", stale: false },
+      ],
+      currentCaptureId: "capture-current",
+      history: [{ url: "https://example.com" }, { captureId: "capture-current", url: "https://example.com/current" }],
+      loading: false,
+      tabId: "tab-1",
+      title: "Current",
+      url: "https://example.com/current",
+    }],
+  };
+}
+
+describe("TinyOS browser interaction target", () => {
+  it("accepts only the current compatible capture", () => {
+    expect(validateTinyOsBrowserInteractionTarget(session(), {
+      browserSessionId: "browser-1",
+      captureId: "capture-current",
+      tabId: "tab-1",
+    }).status).toBe("accepted");
+  });
+
+  it("preserves stale evidence and returns the current capture for recovery", () => {
+    expect(validateTinyOsBrowserInteractionTarget(session(), {
+      browserSessionId: "browser-1",
+      captureId: "capture-old",
+      tabId: "tab-1",
+    })).toMatchObject({
+      currentCapture: { captureId: "capture-current" },
+      reasonCode: "capture_stale",
+      status: "rejected",
+    });
+  });
+
+  it("rejects missing sessions and tabs without inventing recovery state", () => {
+    expect(validateTinyOsBrowserInteractionTarget(undefined, {
+      browserSessionId: "browser-1",
+      captureId: "capture-current",
+      tabId: "tab-1",
+    })).toMatchObject({ reasonCode: "session_mismatch", status: "rejected" });
+    expect(validateTinyOsBrowserInteractionTarget(session(), {
+      browserSessionId: "browser-1",
+      captureId: "capture-current",
+      tabId: "tab-missing",
+    })).toMatchObject({ reasonCode: "tab_missing", status: "rejected" });
+  });
+});

--- a/src/app-core/chat/tinyOsBrowserSession.ts
+++ b/src/app-core/chat/tinyOsBrowserSession.ts
@@ -1,0 +1,69 @@
+import type {
+  TinyOsBrowserCaptureV1,
+  TinyOsBrowserTabV1,
+  TinyOsNativeBrowserSession,
+} from "./tinyOsNativeSnapshot";
+
+export type TinyOsBrowserInteractionKind = "click" | "navigate" | "type";
+
+export type TinyOsBrowserInteractionTarget = {
+  browserSessionId: string;
+  captureId: string;
+  tabId: string;
+};
+
+export type TinyOsBrowserInteractionValidation =
+  | {
+      capture: TinyOsBrowserCaptureV1;
+      session: TinyOsNativeBrowserSession;
+      status: "accepted";
+      tab: TinyOsBrowserTabV1;
+    }
+  | {
+      currentCapture?: TinyOsBrowserCaptureV1;
+      reason: string;
+      reasonCode: "capture_missing" | "capture_stale" | "session_mismatch" | "tab_missing";
+      status: "rejected";
+    };
+
+export function validateTinyOsBrowserInteractionTarget(
+  session: TinyOsNativeBrowserSession | undefined,
+  target: TinyOsBrowserInteractionTarget,
+): TinyOsBrowserInteractionValidation {
+  if (!session || session.browserSessionId !== target.browserSessionId) {
+    return {
+      reason: "The browser session is unavailable or no longer matches this action.",
+      reasonCode: "session_mismatch",
+      status: "rejected",
+    };
+  }
+  const tab = session.tabs.find(({ tabId }) => tabId === target.tabId);
+  if (!tab) {
+    return {
+      reason: "The target browser tab is no longer present in the current session snapshot.",
+      reasonCode: "tab_missing",
+      status: "rejected",
+    };
+  }
+  const currentCapture = tab.currentCaptureId
+    ? tab.captures.find(({ captureId }) => captureId === tab.currentCaptureId)
+    : undefined;
+  const capture = tab.captures.find(({ captureId }) => captureId === target.captureId);
+  if (!capture) {
+    return {
+      ...(currentCapture ? { currentCapture } : {}),
+      reason: "The target browser capture is no longer retained by the current tab.",
+      reasonCode: "capture_missing",
+      status: "rejected",
+    };
+  }
+  if (capture.stale || capture.captureId !== tab.currentCaptureId) {
+    return {
+      ...(currentCapture ? { currentCapture } : {}),
+      reason: "The target browser capture is stale. Review the current capture before interacting.",
+      reasonCode: "capture_stale",
+      status: "rejected",
+    };
+  }
+  return { capture, session, status: "accepted", tab };
+}

--- a/src/app-core/chat/tinyOsCapabilities.test.ts
+++ b/src/app-core/chat/tinyOsCapabilities.test.ts
@@ -14,8 +14,22 @@ function payload() {
     capabilities: {
       agent: { pause: unavailable, resume: unavailable, cancel: available, retry: unavailable },
       files: { read: available, requestChange: unavailable, directEdit: unavailable, save: unavailable },
-      terminal: { inspect: available, execute: unavailable, cancel: unavailable },
-      browser: { structured: available, realCapture: unavailable, interact: unavailable },
+      terminal: {
+        contract: "retained_execution_v1",
+        persistentPty: false,
+        inspect: available,
+        execute: unavailable,
+        cancel: unavailable,
+      },
+      browser: {
+        interactionRequires: "current_real_capture",
+        structured: available,
+        projectionContract: "structured_projection_v1",
+        realCapture: unavailable,
+        sessionContract: "browser_session_v1",
+        sessionSnapshot: false,
+        interact: unavailable,
+      },
     },
   };
 }
@@ -24,7 +38,25 @@ describe("TinyOS effective capabilities", () => {
   test("normalizes a backend-authored per-session decision", () => {
     expect(normalizeTinyOsEffectiveCapabilities(payload(), "websocket:chat-1")).toMatchObject({
       evaluatedRunId: "run-1",
-      capabilities: { agent: { cancel: { available: true } } },
+      capabilities: {
+        agent: { cancel: { available: true } },
+        terminal: { contract: "retained_execution_v1", persistentPty: false },
+      },
+    });
+  });
+
+  test("rejects unsupported terminal execution contracts", () => {
+    const invalid = payload();
+    invalid.capabilities.terminal.contract = "pty_v1" as "retained_execution_v1";
+    expect(() => normalizeTinyOsEffectiveCapabilities(invalid, "websocket:chat-1")).toThrow("unsupported execution contract");
+  });
+
+  test("normalizes browser projection truth without advertising a native session", () => {
+    expect(normalizeTinyOsEffectiveCapabilities(payload(), "websocket:chat-1").capabilities.browser).toMatchObject({
+      interactionRequires: "current_real_capture",
+      projectionContract: "structured_projection_v1",
+      sessionContract: "browser_session_v1",
+      sessionSnapshot: false,
     });
   });
 

--- a/src/app-core/chat/tinyOsCapabilities.ts
+++ b/src/app-core/chat/tinyOsCapabilities.ts
@@ -4,6 +4,23 @@ export type TinyOsCapabilityDecision = {
   reasonCode?: string;
 };
 
+export const TINYOS_CAPABILITY_IDS = [
+  "agent.pause",
+  "agent.resume",
+  "agent.cancel",
+  "agent.retry",
+  "files.read",
+  "files.requestChange",
+  "files.directEdit",
+  "files.save",
+  "terminal.inspect",
+  "terminal.execute",
+  "terminal.cancel",
+  "browser.structured",
+  "browser.realCapture",
+  "browser.interact",
+] as const;
+
 export type TinyOsEffectiveCapabilities = {
   schemaVersion: "tinybot.effective_capabilities.v1";
   sessionId: string;

--- a/src/app-core/chat/tinyOsCapabilities.ts
+++ b/src/app-core/chat/tinyOsCapabilities.ts
@@ -39,13 +39,19 @@ export type TinyOsEffectiveCapabilities = {
       save: TinyOsCapabilityDecision;
     };
     terminal: {
+      contract: "retained_execution_v1";
+      persistentPty: false;
       inspect: TinyOsCapabilityDecision;
       execute: TinyOsCapabilityDecision;
       cancel: TinyOsCapabilityDecision;
     };
     browser: {
+      interactionRequires: "current_real_capture";
       structured: TinyOsCapabilityDecision;
+      projectionContract: "structured_projection_v1";
       realCapture: TinyOsCapabilityDecision;
+      sessionContract: "browser_session_v1";
+      sessionSnapshot: boolean;
       interact: TinyOsCapabilityDecision;
     };
   };
@@ -86,13 +92,19 @@ export function normalizeTinyOsEffectiveCapabilities(
         save: normalizeDecision(files.save, "files.save"),
       },
       terminal: {
+        contract: normalizeTerminalContract(terminal),
+        persistentPty: normalizePersistentPty(terminal),
         inspect: normalizeDecision(terminal.inspect, "terminal.inspect"),
         execute: normalizeDecision(terminal.execute, "terminal.execute"),
         cancel: normalizeDecision(terminal.cancel, "terminal.cancel"),
       },
       browser: {
+        interactionRequires: normalizeLiteral(browser.interactionRequires, "current_real_capture", "browser interaction requirement"),
         structured: normalizeDecision(browser.structured, "browser.structured"),
+        projectionContract: normalizeLiteral(browser.projectionContract, "structured_projection_v1", "browser projection contract"),
         realCapture: normalizeDecision(browser.realCapture, "browser.realCapture"),
+        sessionContract: normalizeLiteral(browser.sessionContract, "browser_session_v1", "browser session contract"),
+        sessionSnapshot: normalizeBoolean(browser.sessionSnapshot, "browser session snapshot"),
         interact: normalizeDecision(browser.interact, "browser.interact"),
       },
     },
@@ -111,10 +123,48 @@ export function unavailableTinyOsEffectiveCapabilities(
     capabilities: {
       agent: { pause: unavailable(), resume: unavailable(), cancel: unavailable(), retry: unavailable() },
       files: { read: unavailable(), requestChange: unavailable(), directEdit: unavailable(), save: unavailable() },
-      terminal: { inspect: unavailable(), execute: unavailable(), cancel: unavailable() },
-      browser: { structured: unavailable(), realCapture: unavailable(), interact: unavailable() },
+      terminal: {
+        contract: "retained_execution_v1",
+        persistentPty: false,
+        inspect: unavailable(),
+        execute: unavailable(),
+        cancel: unavailable(),
+      },
+      browser: {
+        interactionRequires: "current_real_capture",
+        structured: unavailable(),
+        projectionContract: "structured_projection_v1",
+        realCapture: unavailable(),
+        sessionContract: "browser_session_v1",
+        sessionSnapshot: false,
+        interact: unavailable(),
+      },
     },
   };
+}
+
+function normalizeTerminalContract(value: Record<string, unknown>): "retained_execution_v1" {
+  if (value.contract !== "retained_execution_v1") {
+    throw new Error("TinyOS terminal capability uses an unsupported execution contract");
+  }
+  return value.contract;
+}
+
+function normalizePersistentPty(value: Record<string, unknown>): false {
+  if (value.persistentPty !== false) {
+    throw new Error("TinyOS retained terminal capability must declare persistentPty=false");
+  }
+  return false;
+}
+
+function normalizeLiteral<T extends string>(value: unknown, expected: T, label: string): T {
+  if (value !== expected) throw new Error(`TinyOS ${label} is unsupported`);
+  return expected;
+}
+
+function normalizeBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`TinyOS ${label} availability is missing`);
+  return value;
 }
 
 function normalizeDecision(value: unknown, name: string): TinyOsCapabilityDecision {

--- a/src/app-core/chat/tinyOsCommandGateway.test.ts
+++ b/src/app-core/chat/tinyOsCommandGateway.test.ts
@@ -191,10 +191,12 @@ describe("TinyOS command lifecycle", () => {
     });
     const browser = createTinyOsBrowserInteractCommand({
       action: { type: "click", x: 12, y: 34 },
+      browserSessionId: "browser-session-1",
       captureId: "capture-1",
       commandId: "command-browser-1",
       sessionId: "websocket:chat-1",
       source,
+      tabId: "tab-1",
     });
 
     expect(save).toMatchObject({ kind: "file.save", file: { confirmed: true, baseRevision: "metadata:12:34" } });
@@ -207,7 +209,13 @@ describe("TinyOS command lifecycle", () => {
     expect(cancel).toMatchObject({ kind: "terminal.cancel", target: { runId: execute.target.runId } });
     expect(browser).toMatchObject({
       kind: "browser.interact",
-      browser: { captureId: "capture-1", confirmed: true, action: { type: "click", x: 12, y: 34 } },
+      browser: {
+        browserSessionId: "browser-session-1",
+        captureId: "capture-1",
+        confirmed: true,
+        tabId: "tab-1",
+        action: { type: "click", x: 12, y: 34 },
+      },
     });
   });
 

--- a/src/app-core/chat/tinyOsCommandGateway.ts
+++ b/src/app-core/chat/tinyOsCommandGateway.ts
@@ -212,7 +212,13 @@ export type TinyOsBrowserInteractCommand = {
   kind: "browser.interact";
   source: TinyOsCommandSource;
   target: { runId: string; sessionId: string; threadId?: string };
-  browser: { action: TinyOsBrowserAction; captureId: string; confirmed: true };
+  browser: {
+    action: TinyOsBrowserAction;
+    browserSessionId: string;
+    captureId: string;
+    confirmed: true;
+    tabId: string;
+  };
 };
 
 export type TinyOsCommand = TinyOsAgentCancelCommand
@@ -289,8 +295,10 @@ export function toNativeTinyOsHostCommandFrame(sessionId: string, command: TinyO
   if (command.kind === "browser.interact") return {
     ...envelope,
     action: command.browser.action,
+    browser_session_id: command.browser.browserSessionId,
     capture_id: command.browser.captureId,
     confirmed: command.browser.confirmed,
+    tab_id: command.browser.tabId,
   };
   throw new Error(`Unsupported Native host command: ${command.kind}`);
 }
@@ -654,11 +662,13 @@ export function createTinyOsTerminalCancelCommand(input: {
 
 export function createTinyOsBrowserInteractCommand(input: {
   action: TinyOsBrowserAction;
+  browserSessionId: string;
   captureId: string;
   commandId?: string;
   issuedAt?: string;
   sessionId: string;
   source: TinyOsCommandSource;
+  tabId: string;
   threadId?: string;
 }): TinyOsBrowserInteractCommand {
   return {
@@ -670,8 +680,10 @@ export function createTinyOsBrowserInteractCommand(input: {
     target: hostCommandTarget("browser", input.sessionId, input.threadId),
     browser: {
       action: { ...input.action },
+      browserSessionId: requiredHostText(input.browserSessionId, "Browser session id"),
       captureId: requiredHostText(input.captureId, "Browser capture id"),
       confirmed: true,
+      tabId: requiredHostText(input.tabId, "Browser tab id"),
     },
   };
 }

--- a/src/app-core/chat/tinyOsCommandGateway.ts
+++ b/src/app-core/chat/tinyOsCommandGateway.ts
@@ -3,6 +3,23 @@ import type { NativeChatReference } from "./nativeChat";
 
 export const TINYOS_COMMAND_ACK_TIMEOUT_MS = 5_000;
 
+export const TINYOS_COMMAND_KINDS = [
+  "agent.cancel",
+  "agent.pause",
+  "agent.resume",
+  "approval.resolve",
+  "form.submit",
+  "form.cancel",
+  "operation.retry",
+  "agent.request_change",
+  "file.save",
+  "file.move",
+  "file.delete",
+  "terminal.execute",
+  "terminal.cancel",
+  "browser.interact",
+] as const;
+
 export type TinyOsCommandSource = {
   control: string;
   surface: "chat" | "tinyos";

--- a/src/app-core/chat/tinyOsContractParity.test.ts
+++ b/src/app-core/chat/tinyOsContractParity.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { TINYOS_CAPABILITY_IDS } from "./tinyOsCapabilities";
+import { TINYOS_COMMAND_KINDS } from "./tinyOsCommandGateway";
+import { TINYOS_PRE_KERNEL_APP_IDS } from "./tinyOsDesktopModel";
+
+describe("TinyOS pre-kernel contract parity", () => {
+  it("records the supported application surface", () => {
+    expect(TINYOS_PRE_KERNEL_APP_IDS).toEqual([
+      "files",
+      "terminal",
+      "browser",
+      "plan",
+      "memory",
+      "subagents",
+      "artifacts",
+      "inspector",
+    ]);
+  });
+
+  it("records backend-authored effective capability decisions", () => {
+    expect(TINYOS_CAPABILITY_IDS).toEqual([
+      "agent.pause",
+      "agent.resume",
+      "agent.cancel",
+      "agent.retry",
+      "files.read",
+      "files.requestChange",
+      "files.directEdit",
+      "files.save",
+      "terminal.inspect",
+      "terminal.execute",
+      "terminal.cancel",
+      "browser.structured",
+      "browser.realCapture",
+      "browser.interact",
+    ]);
+  });
+
+  it("records typed runtime-affecting command kinds", () => {
+    expect(TINYOS_COMMAND_KINDS).toEqual([
+      "agent.cancel",
+      "agent.pause",
+      "agent.resume",
+      "approval.resolve",
+      "form.submit",
+      "form.cancel",
+      "operation.retry",
+      "agent.request_change",
+      "file.save",
+      "file.move",
+      "file.delete",
+      "terminal.execute",
+      "terminal.cancel",
+      "browser.interact",
+    ]);
+  });
+});

--- a/src/app-core/chat/tinyOsDesktopModel.test.ts
+++ b/src/app-core/chat/tinyOsDesktopModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { ChatStep } from "./chatRunModel";
-import { projectTinyOsDesktop, tinyOsAppForStep, type TinyOsTimelineEntry } from "./tinyOsDesktopModel";
+import type { BackendAgentTurnItem, ChatStep } from "./chatRunModel";
+import { projectKernelBackedTinyOsDesktop, projectTinyOsDesktop, tinyOsAppForStep, type TinyOsTimelineEntry } from "./tinyOsDesktopModel";
 
 function step(id: string, overrides: Partial<ChatStep> = {}): ChatStep {
   return {
@@ -86,5 +86,39 @@ describe("TinyOS desktop projector", () => {
     expect(tinyOsAppForStep(step("tool-search", {
       toolCall: { id: "tool-search", name: "tool_search" },
     }))).toBe("inspector");
+  });
+
+  it("attaches a kernel snapshot without changing the compatibility desktop", () => {
+    const entries = [entry("turn-1", step("read-1", { toolCall: { id: "call-1", name: "workspace.read_file" } }))];
+    const canonicalItems: BackendAgentTurnItem[] = [{
+      schemaVersion: "tinybot.turn_item.v2",
+      createdAt: "2026-07-14T00:00:00Z",
+      data: {
+        args: {},
+        name: "workspace.read_file",
+        result: null,
+        status: "running",
+        timing: {},
+        toolCallId: "call-1",
+        type: "tool_call",
+      },
+      itemId: "read-1",
+      kind: "tool_call",
+      revision: 1,
+      runId: "turn-1",
+      sequence: 1,
+      sessionId: "session-1",
+      status: "running",
+      turnId: "turn-1",
+    }];
+    const legacy = projectTinyOsDesktop(entries, { mode: "live_follow" });
+    const backed = projectKernelBackedTinyOsDesktop(entries, canonicalItems, { mode: "live_follow" });
+
+    expect({ ...backed, kernel: undefined }).toEqual({ ...legacy, kernel: undefined });
+    expect(backed.kernel).toMatchObject({
+      cursor: { eventCount: 1, eventIndex: 0, mode: "live" },
+      processes: expect.arrayContaining([expect.objectContaining({ kind: "tool_operation", state: "running" })]),
+      truth: "derived",
+    });
   });
 });

--- a/src/app-core/chat/tinyOsDesktopModel.ts
+++ b/src/app-core/chat/tinyOsDesktopModel.ts
@@ -1,5 +1,5 @@
 import type { BackendAgentTurnItem, ChatStep, ChatStepStatus } from "./chatRunModel";
-import { projectTinyOsKernel, type TinyOsKernelSnapshot } from "./tinyOsKernelModel";
+import { projectTinyOsKernel, type TinyOsKernelProjectionOptions, type TinyOsKernelSnapshot } from "./tinyOsKernelModel";
 
 export type TinyOsAppId =
   | "files"
@@ -18,8 +18,10 @@ export type TinyOsTimelineEntry = {
 };
 
 export type TinyOsCursor = {
+  eventIndex?: number;
   itemId?: string;
   mode: "live_follow" | "history";
+  runId?: string;
   turnId?: string;
 };
 
@@ -160,11 +162,27 @@ export function projectKernelBackedTinyOsDesktop(
   entries: readonly TinyOsTimelineEntry[],
   canonicalItems: readonly BackendAgentTurnItem[],
   cursor: TinyOsCursor,
+  options: TinyOsKernelProjectionOptions = {},
 ): TinyOsDesktopSnapshot {
   const kernel = projectTinyOsKernel(canonicalItems, cursor.mode === "history" && cursor.itemId
-    ? { itemId: cursor.itemId, mode: "history", turnId: cursor.turnId }
-    : { mode: "live" });
-  return projectTinyOsDesktop(entries, cursor, kernel);
+    ? {
+        ...(cursor.eventIndex !== undefined ? { eventIndex: cursor.eventIndex } : {}),
+        itemId: cursor.itemId,
+        mode: "history",
+        ...(cursor.runId ? { runId: cursor.runId } : {}),
+        ...(cursor.turnId ? { turnId: cursor.turnId } : {}),
+      }
+    : { mode: "live" }, options);
+  if (cursor.mode !== "history") return projectTinyOsDesktop(entries, cursor, kernel);
+  const visibleCanonicalKeys = new Set(canonicalItems
+    .slice(0, kernel.cursor.eventIndex + 1)
+    .map((item) => `${item.turnId}:${item.itemId}`));
+  let visibleEntryCount = 0;
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    if (visibleCanonicalKeys.has(`${entry.turnId}:${entry.step.id}`)) visibleEntryCount = index + 1;
+  }
+  return projectTinyOsDesktop(entries.slice(0, visibleEntryCount), { mode: "live_follow" }, kernel);
 }
 
 export function tinyOsAppForStep(step: ChatStep): TinyOsAppId | undefined {

--- a/src/app-core/chat/tinyOsDesktopModel.ts
+++ b/src/app-core/chat/tinyOsDesktopModel.ts
@@ -1,4 +1,5 @@
-import type { ChatStep, ChatStepStatus } from "./chatRunModel";
+import type { BackendAgentTurnItem, ChatStep, ChatStepStatus } from "./chatRunModel";
+import { projectTinyOsKernel, type TinyOsKernelSnapshot } from "./tinyOsKernelModel";
 
 export type TinyOsAppId =
   | "files"
@@ -8,7 +9,8 @@ export type TinyOsAppId =
   | "memory"
   | "subagents"
   | "artifacts"
-  | "inspector";
+  | "inspector"
+  | "system_monitor";
 
 export type TinyOsTimelineEntry = {
   step: ChatStep;
@@ -57,13 +59,14 @@ export type TinyOsDesktopSnapshot = {
   cursorItemId?: string;
   cursorTurnId?: string;
   dialog?: TinyOsDialog;
+  kernel?: TinyOsKernelSnapshot;
   notifications: TinyOsNotification[];
   operations: TinyOsOperation[];
   truth: "structured";
   windows: TinyOsWindow[];
 };
 
-const APP_ORDER: TinyOsAppId[] = [
+export const TINYOS_PRE_KERNEL_APP_IDS = [
   "files",
   "terminal",
   "browser",
@@ -72,7 +75,12 @@ const APP_ORDER: TinyOsAppId[] = [
   "subagents",
   "artifacts",
   "inspector",
-];
+] as const satisfies readonly TinyOsAppId[];
+
+export const TINYOS_APP_IDS = [
+  ...TINYOS_PRE_KERNEL_APP_IDS,
+  "system_monitor",
+] as const satisfies readonly TinyOsAppId[];
 
 const APP_TITLES: Record<TinyOsAppId, string> = {
   artifacts: "Artifacts",
@@ -82,6 +90,7 @@ const APP_TITLES: Record<TinyOsAppId, string> = {
   memory: "Memory",
   plan: "Plan",
   subagents: "Subagents",
+  system_monitor: "System Monitor",
   terminal: "Terminal",
 };
 
@@ -94,6 +103,7 @@ const FILE_TOOL_RE = /(?:^|[\s._-])(file|workspace|path|directory|search|grep|gl
 export function projectTinyOsDesktop(
   entries: readonly TinyOsTimelineEntry[],
   cursor: TinyOsCursor,
+  kernel?: TinyOsKernelSnapshot,
 ): TinyOsDesktopSnapshot {
   const visibleEntries = entries.slice(0, replayEndIndex(entries, cursor));
   const appEntries = new Map<TinyOsAppId, TinyOsTimelineEntry[]>();
@@ -110,7 +120,7 @@ export function projectTinyOsDesktop(
     routedEntries.push({ appId, entry });
   }
 
-  const windows = APP_ORDER.flatMap((appId): TinyOsWindow[] => {
+  const windows = TINYOS_APP_IDS.flatMap((appId): TinyOsWindow[] => {
     const grouped = appEntries.get(appId);
     if (!grouped?.length) return [];
     return [{
@@ -132,6 +142,7 @@ export function projectTinyOsDesktop(
       cursorTurnId: latestEntry.turnId,
     } : {}),
     ...dialogFromEntries(visibleEntries),
+    ...(kernel ? { kernel } : {}),
     notifications: notificationsFromEntries(visibleEntries),
     operations: recentDistinctOperations(routedEntries).map(({ appId, entry }) => ({
       appId,
@@ -143,6 +154,17 @@ export function projectTinyOsDesktop(
     truth: "structured",
     windows,
   };
+}
+
+export function projectKernelBackedTinyOsDesktop(
+  entries: readonly TinyOsTimelineEntry[],
+  canonicalItems: readonly BackendAgentTurnItem[],
+  cursor: TinyOsCursor,
+): TinyOsDesktopSnapshot {
+  const kernel = projectTinyOsKernel(canonicalItems, cursor.mode === "history" && cursor.itemId
+    ? { itemId: cursor.itemId, mode: "history", turnId: cursor.turnId }
+    : { mode: "live" });
+  return projectTinyOsDesktop(entries, cursor, kernel);
 }
 
 export function tinyOsAppForStep(step: ChatStep): TinyOsAppId | undefined {

--- a/src/app-core/chat/tinyOsFilesModel.test.ts
+++ b/src/app-core/chat/tinyOsFilesModel.test.ts
@@ -93,6 +93,7 @@ describe("TinyOS Files state", () => {
       chunk: fileChunk({ nextCursor: "chunk-2" }),
       requestId: "file-1",
       type: "file_loaded",
+      workspaceKey: "workspace-a",
     });
     const loadingNextChunk = reduceTinyOsFilesState(firstChunk, {
       path: "README.md",
@@ -104,6 +105,7 @@ describe("TinyOS Files state", () => {
       chunk: fileChunk({ content: "three\n", lineEnd: 3, lineStart: 3, nextCursor: undefined }),
       requestId: "file-2",
       type: "file_loaded",
+      workspaceKey: "workspace-a",
     });
 
     expect(resourceValue(nextChunk.documents["README.md"])?.content).toBe("one\ntwo\nthree\n");
@@ -118,6 +120,7 @@ describe("TinyOS Files state", () => {
         chunk: fileChunk({ path }),
         requestId: `load-${path}`,
         type: "file_loaded",
+        workspaceKey: "workspace-a",
       });
     }
     state = reduceTinyOsFilesState(state, { path: "a.ts", type: "activate_file" });
@@ -143,6 +146,7 @@ describe("TinyOS Files state", () => {
       chunk: fileChunk(),
       requestId: "file-1",
       type: "file_loaded",
+      workspaceKey: "workspace-a",
     });
     const stale = reduceTinyOsFilesState(loaded, { path: "README.md", type: "mark_stale" });
 
@@ -154,7 +158,7 @@ describe("TinyOS Files state", () => {
     state = reduceTinyOsFilesState(state, { requestId: "init-a", type: "initialize" });
     state = reduceTinyOsFilesState(state, { page: directoryPage({ workspaceKey: "workspace-a" }), requestId: "init-a", type: "initialized" });
     state = reduceTinyOsFilesState(state, { path: "README.md", requestId: "file-a", type: "file_loading" });
-    state = reduceTinyOsFilesState(state, { append: false, chunk: fileChunk(), requestId: "file-a", type: "file_loaded" });
+    state = reduceTinyOsFilesState(state, { append: false, chunk: fileChunk(), requestId: "file-a", type: "file_loaded", workspaceKey: "workspace-a" });
     state = reduceTinyOsFilesState(state, { requestId: "init-b", type: "initialize" });
     state = reduceTinyOsFilesState(state, { page: directoryPage({ workspaceKey: "workspace-b" }), requestId: "init-b", type: "initialized" });
 

--- a/src/app-core/chat/tinyOsFilesModel.ts
+++ b/src/app-core/chat/tinyOsFilesModel.ts
@@ -21,11 +21,14 @@ export type TinyOsDirectoryView = {
 };
 
 export type TinyOsDocumentView = {
+  access: "read_only" | "read_write";
   content: string;
   contentType: WorkspaceFileChunk["contentType"];
   lineEnd?: number;
   nextCursor?: string;
   path: string;
+  provenance: { kind: "native_query"; sourceId: string };
+  resourceId: string;
   revision: string;
   sizeBytes: number;
   stale: boolean;
@@ -62,7 +65,7 @@ export type TinyOsFilesAction =
   | { append: boolean; page: WorkspaceDirectoryPage; requestId: string; type: "directory_loaded" }
   | { error: WorkspaceQueryError; path: string; requestId: string; type: "directory_failed" }
   | { path: string; requestId: string; type: "file_loading" }
-  | { append: boolean; chunk: WorkspaceFileChunk; requestId: string; type: "file_loaded" }
+  | { append: boolean; chunk: WorkspaceFileChunk; requestId: string; type: "file_loaded"; workspaceKey: string }
   | { error: WorkspaceQueryError; path: string; requestId: string; type: "file_failed" }
   | { path: string; type: "activate_file" }
   | { path: string; type: "close_file" }
@@ -202,7 +205,7 @@ export function reduceTinyOsFilesState(state: TinyOsFilesState, action: TinyOsFi
       const current = state.documents[action.chunk.path];
       if (!matchesRequest(current, action.requestId)) return state;
       const previous = resourceValue(current);
-      const next = documentView(action.chunk, action.append ? previous : undefined);
+      const next = documentView(action.chunk, action.workspaceKey, action.append ? previous : undefined);
       return {
         ...state,
         documents: { ...state.documents, [action.chunk.path]: { status: "ready", value: next } },
@@ -281,18 +284,25 @@ function directoryView(page: WorkspaceDirectoryPage, filter: string): TinyOsDire
   };
 }
 
-function documentView(chunk: WorkspaceFileChunk, previous?: TinyOsDocumentView): TinyOsDocumentView {
+function documentView(chunk: WorkspaceFileChunk, workspaceKey: string, previous?: TinyOsDocumentView): TinyOsDocumentView {
   return {
+    access: "read_only",
     content: `${previous?.content ?? ""}${chunk.content ?? ""}`,
     contentType: chunk.contentType,
     lineEnd: chunk.lineEnd ?? previous?.lineEnd,
     nextCursor: chunk.nextCursor,
     path: chunk.path,
+    provenance: { kind: "native_query", sourceId: workspaceKey },
+    resourceId: tinyOsWorkspaceResourceId(workspaceKey, chunk.path),
     revision: chunk.revision,
     sizeBytes: chunk.sizeBytes,
     stale: false,
     updatedAt: chunk.updatedAt,
   };
+}
+
+export function tinyOsWorkspaceResourceId(workspaceKey: string, path: string): string {
+  return `workspace:${workspaceKey}:${path.replace(/\\/g, "/")}`;
 }
 
 function appStatusForError(error: WorkspaceQueryError): TinyOsFilesState["appStatus"] {

--- a/src/app-core/chat/tinyOsKernelModel.test.ts
+++ b/src/app-core/chat/tinyOsKernelModel.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it } from "vitest";
+
+import type { BackendAgentTurnItem, CanonicalTurnItemKind } from "./chatRunModel";
+import {
+  assertTinyOsMetricSupported,
+  assertTinyOsResourceMutationReady,
+  createTinyOsDerivedMetric,
+  createTinyOsProcessId,
+  mergeTinyOsProcessObservation,
+  projectTinyOsKernel,
+  type TinyOsProcess,
+  type TinyOsResource,
+} from "./tinyOsKernelModel";
+import {
+  createTinyOsBrowserCaptureSnapshot,
+  createTinyOsTerminalProcessSnapshot,
+  createTinyOsWorkspaceResourceSnapshot,
+} from "./tinyOsNativeSnapshot";
+
+function item(
+  itemId: string,
+  kind: CanonicalTurnItemKind,
+  status: string,
+  data: Record<string, unknown>,
+  overrides: Partial<BackendAgentTurnItem> = {},
+): BackendAgentTurnItem {
+  return {
+    schemaVersion: "tinybot.turn_item.v2",
+    createdAt: `2026-07-14T00:00:0${overrides.sequence ?? 0}Z`,
+    data: data as BackendAgentTurnItem["data"],
+    itemId,
+    kind,
+    revision: 1,
+    runId: "run-1",
+    sequence: 0,
+    sessionId: "session-1",
+    status,
+    turnId: "turn-1",
+    ...overrides,
+  };
+}
+
+function timeline(): BackendAgentTurnItem[] {
+  return [
+    item("user-1", "user_message", "completed", { content: "Build it", type: "user_message" }, { sequence: 1 }),
+    item("tool-1", "tool_call", "running", {
+      args: {},
+      name: "workspace.read_file",
+      result: null,
+      status: "running",
+      timing: {},
+      toolCallId: "call-1",
+      type: "tool_call",
+    }, { sequence: 2, title: "Read workspace file" }),
+    item("approval-1", "approval", "pending", {
+      approvalId: "approval-1",
+      status: "pending",
+      toolCallId: "call-1",
+      type: "approval",
+    }, { sequence: 3 }),
+    item("subagent-1", "subagent_lifecycle", "completed", {
+      action: "completed",
+      agentId: "agent-child",
+      status: "completed",
+      type: "subagent_lifecycle",
+    }, { sequence: 4 }),
+    item("answer-1", "assistant_message", "completed", {
+      content: "Done",
+      messageId: "message-1",
+      modelCallId: "model-call-1",
+      phase: "final_answer",
+      type: "assistant_message",
+    }, { sequence: 5 }),
+  ];
+}
+
+describe("TinyOS simulation kernel", () => {
+  it("derives stable process identities from canonical correlation", () => {
+    const input = {
+      itemId: "tool/1",
+      kind: "tool_operation" as const,
+      runId: "run:1",
+      sessionId: "session 1",
+      turnId: "turn-1",
+    };
+    const first = createTinyOsProcessId(input);
+    const afterReload = createTinyOsProcessId(JSON.parse(JSON.stringify(input)));
+
+    expect(afterReload).toBe(first);
+    expect(first).toBe("tinyos:process:tool_operation:session%201:run%3A1:turn-1:tool%2F1");
+    expect(() => createTinyOsProcessId({ kind: "agent_run", runId: " ", sessionId: "session-1" })).toThrow(/non-empty/i);
+  });
+
+  it("projects canonical run, turn, work lifecycle, and source-backed parents", () => {
+    const snapshot = projectTinyOsKernel(timeline());
+    const run = snapshot.processes.find((process) => process.kind === "agent_run");
+    const turn = snapshot.processes.find((process) => process.kind === "agent_turn");
+    const tool = snapshot.processes.find((process) => process.kind === "tool_operation");
+    const approval = snapshot.processes.find((process) => process.kind === "user_input_wait");
+    const subagent = snapshot.processes.find((process) => process.kind === "subagent");
+
+    expect(snapshot).toMatchObject({
+      cursor: { eventCount: 5, eventIndex: 4, mode: "live" },
+      truth: "derived",
+    });
+    expect(run).toMatchObject({ state: "completed", provenance: { kind: "canonical_event", sourceId: "answer-1" } });
+    expect(turn).toMatchObject({ parentProcessId: run?.id, state: "completed" });
+    expect(tool).toMatchObject({ parentProcessId: turn?.id, state: "running" });
+    expect(tool?.parentProcessId).not.toBe(tool?.id);
+    expect(approval).toMatchObject({ parentProcessId: tool?.id, state: "waiting_for_user" });
+    expect(subagent).toMatchObject({ parentProcessId: turn?.id, state: "completed" });
+  });
+
+  it("reconstructs the same identities after reload and at a History boundary", () => {
+    const source = timeline();
+    const reloaded = JSON.parse(JSON.stringify(source)) as BackendAgentTurnItem[];
+    const live = projectTinyOsKernel(source);
+    const liveAfterReload = projectTinyOsKernel(reloaded);
+    const history = projectTinyOsKernel(reloaded, { itemId: "approval-1", mode: "history" });
+
+    expect(liveAfterReload.processes.map((process) => process.id)).toEqual(live.processes.map((process) => process.id));
+    expect(history.cursor).toMatchObject({
+      boundary: { itemId: "approval-1", sequence: 3 },
+      eventCount: 5,
+      eventIndex: 2,
+      mode: "history",
+    });
+    expect(history.processes.some((process) => process.kind === "subagent")).toBe(false);
+    expect(history.processes.find((process) => process.kind === "agent_run")?.state).toBe("waiting_for_user");
+    expect(() => projectTinyOsKernel(source, { itemId: "missing", mode: "history" })).toThrow(/boundary is unavailable/i);
+  });
+
+  it("uses the newest canonical item revision without changing its stable identity", () => {
+    const original = timeline()[1];
+    const completed = { ...original, revision: 2, status: "completed", updatedAt: "2026-07-14T00:00:06Z" };
+    const snapshot = projectTinyOsKernel([original, completed]);
+    const tool = snapshot.processes.find((process) => process.kind === "tool_operation");
+
+    expect(tool).toMatchObject({
+      provenance: { revision: 2, sourceId: "tool-1" },
+      state: "completed",
+    });
+    expect(snapshot.processes.filter((process) => process.kind === "tool_operation")).toHaveLength(1);
+  });
+
+  it("projects only canonically evidenced resources and preserves missing revisions", () => {
+    const resources = projectTinyOsKernel([
+      item("file-1", "file_reference", "completed", {
+        id: "ref-1",
+        path: "src/main.ts",
+        referenceKind: "modified",
+        type: "file_reference",
+      }, { sequence: 1 }),
+      item("terminal-1", "tool_call", "completed", {
+        args: {},
+        name: "shell.execute",
+        result: {
+          artifacts: [
+            { id: "capture-1", kind: "browser_snapshot", title: "Browser result" },
+            { id: "report-1", kind: "markdown", title: "Report" },
+          ],
+        },
+        status: "completed",
+        timing: {},
+        toolCallId: "call-terminal",
+        type: "tool_call",
+      }, { sequence: 2 }),
+      item("memory-1", "tool_call", "completed", {
+        args: {},
+        name: "memory.recall",
+        result: {},
+        status: "completed",
+        timing: {},
+        toolCallId: "call-memory",
+        type: "tool_call",
+      }, { sequence: 3 }),
+      item("plan-1", "plan_progress", "running", {
+        completed: 0,
+        id: "plan",
+        steps: [],
+        summary: "Planning",
+        total: 1,
+        type: "plan_progress",
+      }, { sequence: 4 }),
+    ]).resources;
+
+    expect(resources.map((resource) => resource.kind)).toEqual([
+      "file",
+      "terminal_execution",
+      "browser_capture",
+      "artifact",
+      "memory_result",
+      "plan",
+    ]);
+    expect(resources.find((resource) => resource.kind === "file")).toMatchObject({
+      path: "src/main.ts",
+      provenance: { kind: "canonical_event", sourceId: "file-1" },
+      relatedProcessIds: [expect.stringContaining("agent_turn")],
+    });
+    expect(resources.find((resource) => resource.kind === "file")).not.toHaveProperty("revision");
+    expect(resources.find((resource) => resource.kind === "browser_capture")?.id).toContain("capture-1");
+  });
+
+  it("preserves native observations and exposes canonical/native discrepancies", () => {
+    const canonicalFile = item("file-1", "file_reference", "completed", {
+      id: "ref-1",
+      path: "src/main.ts",
+      referenceKind: "modified",
+      revision: "canonical-1",
+      type: "file_reference",
+    }, { sequence: 1 });
+    const canonicalTool = item("tool-1", "tool_call", "running", {
+      args: {},
+      name: "shell.execute",
+      result: null,
+      status: "running",
+      timing: {},
+      toolCallId: "call-1",
+      type: "tool_call",
+    }, { sequence: 2 });
+    const metadata = { observedAt: "2026-07-14T00:00:03Z", revision: "native-2", sourceId: "native-query" };
+    const snapshot = projectTinyOsKernel([canonicalFile, canonicalTool], { mode: "live" }, {
+      nativeSnapshots: [
+        createTinyOsWorkspaceResourceSnapshot({
+          access: "read_write",
+          kind: "workspace_resource",
+          path: "src/main.ts",
+          resourceKind: "file",
+          workspaceKey: "workspace-1",
+        }, metadata),
+        createTinyOsTerminalProcessSnapshot({
+          command: "npm test",
+          kind: "terminal_process",
+          nativeProcessId: "process-1",
+          runId: "run-1",
+          sessionId: "session-1",
+          state: "completed",
+          toolCallId: "call-1",
+        }, metadata),
+        createTinyOsBrowserCaptureSnapshot({
+          captureId: "capture-native-1",
+          kind: "browser_capture",
+          realCapture: true,
+          title: "Native capture",
+        }, metadata),
+      ],
+    });
+
+    expect(snapshot.resources.filter((resource) => resource.path === "src/main.ts")).toHaveLength(2);
+    expect(snapshot.resources.find((resource) => resource.title === "Native capture")?.provenance.kind).toBe("real_capture");
+    expect(snapshot.processes.find((process) => process.kind === "terminal_process")).toMatchObject({
+      parentProcessId: snapshot.processes.find((process) => process.kind === "tool_operation")?.id,
+      provenance: { kind: "native_query", sourceId: "native-query" },
+      state: "completed",
+    });
+    expect(snapshot.discrepancies).toEqual([
+      expect.objectContaining({
+        canonical: expect.objectContaining({ value: "canonical-1" }),
+        kind: "revision",
+        native: expect.objectContaining({ value: "native-2" }),
+      }),
+      expect.objectContaining({
+        canonical: expect.objectContaining({ value: "running" }),
+        kind: "lifecycle",
+        native: expect.objectContaining({ value: "completed" }),
+      }),
+    ]);
+  });
+
+  it("creates only auditable derived metrics", () => {
+    expect(createTinyOsDerivedMetric({
+      calculation: "UTF-8 byte length of retained stdout",
+      id: "terminal-output-bytes",
+      inputIds: ["chunk-1", "chunk-1", "chunk-2"],
+      label: "Retained output",
+      unit: "bytes",
+      value: 128,
+    })).toMatchObject({
+      calculation: "UTF-8 byte length of retained stdout",
+      inputIds: ["chunk-1", "chunk-2"],
+      provenance: { kind: "derived_measurement" },
+      value: 128,
+    });
+    expect(() => createTinyOsDerivedMetric({
+      calculation: "Decorative estimate",
+      id: "cpu",
+      inputIds: [],
+      label: "CPU",
+      value: 42,
+    })).toThrow(/input identity/i);
+    expect(() => assertTinyOsMetricSupported({
+      id: "cpu",
+      label: "CPU",
+      provenance: { kind: "local_presentation", sourceId: "widget" },
+      value: 42,
+    })).toThrow(/unsupported provenance/i);
+  });
+
+  it("requires writable revisioned resources before mutation", () => {
+    const resource: TinyOsResource = {
+      access: "read_write",
+      id: "file-1",
+      kind: "file",
+      path: "src/main.ts",
+      provenance: { kind: "native_query", sourceId: "workspace.read" },
+      relatedProcessIds: [],
+      title: "src/main.ts",
+    };
+    expect(() => assertTinyOsResourceMutationReady(resource)).toThrow(/base revision/i);
+    expect(() => assertTinyOsResourceMutationReady({ ...resource, revision: "revision-1" })).not.toThrow();
+  });
+
+  it("rejects terminal process-state regression", () => {
+    const process: TinyOsProcess = {
+      correlation: { runId: "run-1", sessionId: "session-1" },
+      id: "process-1",
+      kind: "terminal_process",
+      provenance: { kind: "native_query", sourceId: "shell.list" },
+      state: "completed",
+      title: "npm test",
+    };
+    expect(() => mergeTinyOsProcessObservation(process, { ...process, state: "running" })).toThrow(/terminal state/i);
+    expect(() => projectTinyOsKernel([
+      item("tool-1", "tool_call", "completed", {
+        args: {}, name: "shell.execute", result: {}, status: "completed", timing: {}, toolCallId: "call-1", type: "tool_call",
+      }, { revision: 1, sequence: 1 }),
+      item("tool-1", "tool_call", "running", {
+        args: {}, name: "shell.execute", result: {}, status: "running", timing: {}, toolCallId: "call-1", type: "tool_call",
+      }, { revision: 2, sequence: 1 }),
+    ])).toThrow(/terminal state/i);
+  });
+
+  it("handles empty and partial canonical input without inventing state", () => {
+    expect(projectTinyOsKernel([])).toEqual({
+      capabilities: [],
+      cursor: { eventCount: 0, eventIndex: -1, mode: "live" },
+      discrepancies: [],
+      metrics: [],
+      notifications: [],
+      processes: [],
+      resources: [],
+      truth: "derived",
+    });
+    const partial = projectTinyOsKernel([
+      item("tool-1", "tool_call", "unknown", {
+        args: {}, name: "custom.tool", result: null, status: "unknown", timing: {}, toolCallId: "call-1", type: "tool_call",
+      }, { createdAt: "", sequence: 1 }),
+    ]);
+    expect(partial.processes.find((process) => process.kind === "tool_operation")?.state).toBe("queued");
+    expect(partial.cursor).not.toHaveProperty("wallClockTime");
+    expect(partial.metrics).toEqual([]);
+  });
+
+  it("ignores an older out-of-order revision after a terminal observation", () => {
+    const completed = item("tool-1", "tool_call", "completed", {
+      args: {}, name: "custom.tool", result: {}, status: "completed", timing: {}, toolCallId: "call-1", type: "tool_call",
+    }, { revision: 2, sequence: 1 });
+    const olderRunning = { ...completed, revision: 1, status: "running" };
+    const snapshot = projectTinyOsKernel([completed, olderRunning]);
+
+    expect(snapshot.processes.find((process) => process.kind === "tool_operation")).toMatchObject({
+      provenance: { revision: 2 },
+      state: "completed",
+    });
+  });
+
+  it("projects a large timeline deterministically", () => {
+    const items = Array.from({ length: 2_000 }, (_, index) => item(
+      `tool-${index}`,
+      "tool_call",
+      index % 2 ? "completed" : "running",
+      {
+        args: {},
+        name: "custom.tool",
+        result: {},
+        status: index % 2 ? "completed" : "running",
+        timing: {},
+        toolCallId: `call-${index}`,
+        type: "tool_call",
+      },
+      { sequence: index + 1 },
+    ));
+    const first = projectTinyOsKernel(items);
+    const second = projectTinyOsKernel(JSON.parse(JSON.stringify(items)) as BackendAgentTurnItem[]);
+
+    expect(first.processes).toHaveLength(2_002);
+    expect(second.processes.map((process) => process.id)).toEqual(first.processes.map((process) => process.id));
+    expect(first.cursor).toMatchObject({ eventCount: 2_000, eventIndex: 1_999 });
+  });
+});

--- a/src/app-core/chat/tinyOsKernelModel.test.ts
+++ b/src/app-core/chat/tinyOsKernelModel.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./tinyOsKernelModel";
 import {
   createTinyOsBrowserCaptureSnapshot,
+  createTinyOsBrowserSessionSnapshot,
   createTinyOsTerminalProcessSnapshot,
   createTinyOsWorkspaceResourceSnapshot,
 } from "./tinyOsNativeSnapshot";
@@ -116,7 +117,7 @@ describe("TinyOS simulation kernel", () => {
     const reloaded = JSON.parse(JSON.stringify(source)) as BackendAgentTurnItem[];
     const live = projectTinyOsKernel(source);
     const liveAfterReload = projectTinyOsKernel(reloaded);
-    const history = projectTinyOsKernel(reloaded, { itemId: "approval-1", mode: "history" });
+    const history = projectTinyOsKernel(reloaded, { eventIndex: 2, itemId: "approval-1", mode: "history" });
 
     expect(liveAfterReload.processes.map((process) => process.id)).toEqual(live.processes.map((process) => process.id));
     expect(history.cursor).toMatchObject({
@@ -128,6 +129,31 @@ describe("TinyOS simulation kernel", () => {
     expect(history.processes.some((process) => process.kind === "subagent")).toBe(false);
     expect(history.processes.find((process) => process.kind === "agent_run")?.state).toBe("waiting_for_user");
     expect(() => projectTinyOsKernel(source, { itemId: "missing", mode: "history" })).toThrow(/boundary is unavailable/i);
+    expect(() => projectTinyOsKernel(source, { eventIndex: 2, itemId: "wrong", mode: "history" })).toThrow(/identity does not match/i);
+  });
+
+  it("does not leak current native snapshots into an earlier History boundary", () => {
+    const source = timeline();
+    const history = projectTinyOsKernel(source, {
+      eventIndex: 1,
+      itemId: source[1].itemId,
+      mode: "history",
+      runId: source[1].runId,
+      turnId: source[1].turnId,
+    }, {
+      nativeSnapshots: [createTinyOsBrowserCaptureSnapshot({
+        captureId: "future-capture",
+        kind: "browser_capture",
+        realCapture: true,
+        title: "Future capture",
+      }, {
+        observedAt: "2026-07-14T00:10:00Z",
+        revision: 1,
+        sourceId: "browser.capture",
+      })],
+    });
+
+    expect(history.resources.some(({ title }) => title === "Future capture")).toBe(false);
   });
 
   it("uses the newest canonical item revision without changing its stable identity", () => {
@@ -296,6 +322,45 @@ describe("TinyOS simulation kernel", () => {
     })).toThrow(/unsupported provenance/i);
   });
 
+  it("projects a versioned native browser session without fabricating missing history", () => {
+    const snapshot = projectTinyOsKernel([], { mode: "live" }, {
+      nativeSnapshots: [createTinyOsBrowserSessionSnapshot({
+        activeTabId: "tab-1",
+        browserSessionId: "browser-session-1",
+        contract: "browser_session_v1",
+        interaction: { click: true, navigate: true, type: false },
+        kind: "browser_session",
+        runId: "run-browser-1",
+        sessionId: "session-1",
+        state: "running",
+        tabs: [{
+          activeHistoryIndex: 0,
+          captures: [{ captureId: "capture-1", observedAt: "2026-07-14T00:00:03Z", stale: false }],
+          currentCaptureId: "capture-1",
+          history: [{ captureId: "capture-1", url: "https://example.com" }],
+          loading: false,
+          tabId: "tab-1",
+          title: "Example",
+          url: "https://example.com",
+        }],
+      }, { observedAt: "2026-07-14T00:00:03Z", revision: "browser-revision-1", sourceId: "browser.session" })],
+    });
+
+    expect(snapshot.browserSessions).toEqual([
+      expect.objectContaining({
+        activeTabId: "tab-1",
+        browserSessionId: "browser-session-1",
+        provenance: { kind: "native_query", observedAt: "2026-07-14T00:00:03Z", revision: "browser-revision-1", sourceId: "browser.session" },
+      }),
+    ]);
+    expect(snapshot.processes.find(({ kind }) => kind === "browser_session")).toMatchObject({
+      applicationId: "browser",
+      state: "running",
+    });
+    expect(snapshot.resources.filter(({ kind }) => kind === "browser_capture")).toHaveLength(1);
+    expect(snapshot.browserSessions[0].tabs[0].history).toHaveLength(1);
+  });
+
   it("requires writable revisioned resources before mutation", () => {
     const resource: TinyOsResource = {
       access: "read_write",
@@ -332,6 +397,7 @@ describe("TinyOS simulation kernel", () => {
 
   it("handles empty and partial canonical input without inventing state", () => {
     expect(projectTinyOsKernel([])).toEqual({
+      browserSessions: [],
       capabilities: [],
       cursor: { eventCount: 0, eventIndex: -1, mode: "live" },
       discrepancies: [],

--- a/src/app-core/chat/tinyOsKernelModel.ts
+++ b/src/app-core/chat/tinyOsKernelModel.ts
@@ -1,5 +1,5 @@
 import type { BackendAgentTurnItem } from "./chatRunModel";
-import type { TinyOsNativeSnapshot } from "./tinyOsNativeSnapshot";
+import type { TinyOsNativeBrowserSession, TinyOsNativeSnapshot } from "./tinyOsNativeSnapshot";
 
 export type TinyOsProvenanceKind =
   | "canonical_event"
@@ -146,6 +146,7 @@ export type TinyOsSimulationCursor = {
 };
 
 export type TinyOsKernelSnapshot = {
+  browserSessions: TinyOsBrowserSessionProjection[];
   capabilities: TinyOsCapability[];
   cursor: TinyOsSimulationCursor;
   discrepancies: TinyOsDiscrepancy[];
@@ -154,6 +155,12 @@ export type TinyOsKernelSnapshot = {
   processes: TinyOsProcess[];
   resources: TinyOsResource[];
   truth: "derived";
+};
+
+export type TinyOsBrowserSessionProjection = TinyOsNativeBrowserSession & {
+  observedAt: string;
+  provenance: TinyOsProvenance;
+  revision: number | string;
 };
 
 export type TinyOsResourceIdentityInput = {
@@ -180,7 +187,7 @@ export type TinyOsProcessIdentityInput =
 
 export type TinyOsKernelCursorInput =
   | { mode: "live" }
-  | { itemId: string; mode: "history"; runId?: string; turnId?: string };
+  | { eventIndex?: number; itemId: string; mode: "history"; runId?: string; turnId?: string };
 
 export type TinyOsKernelProjectionOptions = {
   nativeSnapshots?: readonly TinyOsNativeSnapshot[];
@@ -337,11 +344,15 @@ export function projectTinyOsKernel(
   }
 
   const canonicalResources = projectCanonicalResources(latestItems, processIdByItemId, processIdByToolCallId);
-  const native = projectNativeSnapshots(options.nativeSnapshots ?? [], processIdByToolCallId);
+  const native = projectNativeSnapshots(
+    nativeSnapshotsAtCursor(options.nativeSnapshots ?? [], visibleItems, cursorInput),
+    processIdByToolCallId,
+  );
   const resources = [...canonicalResources, ...native.resources];
   const allProcesses = [...processes, ...native.processes];
 
   return {
+    browserSessions: native.browserSessions,
     capabilities: [],
     cursor: simulationCursor(items, visibleItems, cursorInput),
     discrepancies: projectDiscrepancies(processes, canonicalResources, native.processes, native.resources),
@@ -356,7 +367,8 @@ export function projectTinyOsKernel(
 function projectNativeSnapshots(
   snapshots: readonly TinyOsNativeSnapshot[],
   processIdByToolCallId: ReadonlyMap<string, string>,
-): { processes: TinyOsProcess[]; resources: TinyOsResource[] } {
+): { browserSessions: TinyOsBrowserSessionProjection[]; processes: TinyOsProcess[]; resources: TinyOsResource[] } {
+  const browserSessions: TinyOsBrowserSessionProjection[] = [];
   const processes: TinyOsProcess[] = [];
   const resources: TinyOsResource[] = [];
   for (const snapshot of latestNativeSnapshots(snapshots)) {
@@ -384,6 +396,56 @@ function projectNativeSnapshots(
         revision: snapshot.revision,
         title: data.title || data.url || data.captureId,
       });
+      continue;
+    }
+    if (data.kind === "browser_session") {
+      const processId = createTinyOsProcessId({
+        browserSessionId: data.browserSessionId,
+        kind: "browser_session",
+        runId: data.runId,
+        sessionId: data.sessionId,
+      });
+      browserSessions.push({
+        ...data,
+        observedAt: snapshot.observedAt,
+        provenance: snapshot.provenance,
+        revision: snapshot.revision,
+      });
+      processes.push({
+        applicationId: "browser",
+        correlation: {
+          browserSessionId: data.browserSessionId,
+          runId: data.runId,
+          sessionId: data.sessionId,
+        },
+        id: processId,
+        kind: "browser_session",
+        provenance: snapshot.provenance,
+        state: data.state,
+        title: data.tabs.find(({ tabId }) => tabId === data.activeTabId)?.title || `Browser session ${shortIdentity(data.browserSessionId)}`,
+      });
+      resources.push({
+        access: data.interaction.navigate || data.interaction.click || data.interaction.type ? "execute" : "read_only",
+        id: nativeResourceId("browser_session", [data.browserSessionId]),
+        kind: "browser_session",
+        provenance: snapshot.provenance,
+        relatedProcessIds: [processId],
+        revision: snapshot.revision,
+        title: `Browser session ${shortIdentity(data.browserSessionId)}`,
+      });
+      for (const tab of data.tabs) {
+        for (const capture of tab.captures) {
+          resources.push({
+            access: "read_only",
+            id: nativeResourceId("browser_capture", [data.browserSessionId, tab.tabId, capture.captureId]),
+            kind: "browser_capture",
+            provenance: snapshot.provenance,
+            relatedProcessIds: [processId],
+            revision: snapshot.revision,
+            title: `${tab.title} capture ${shortIdentity(capture.captureId)}`,
+          });
+        }
+      }
       continue;
     }
     const id = createTinyOsProcessId({
@@ -422,7 +484,7 @@ function projectNativeSnapshots(
       title: data.command || `Terminal execution ${shortIdentity(data.nativeProcessId)}`,
     });
   }
-  return { processes, resources };
+  return { browserSessions, processes, resources };
 }
 
 function latestNativeSnapshots(snapshots: readonly TinyOsNativeSnapshot[]): TinyOsNativeSnapshot[] {
@@ -442,6 +504,7 @@ function nativeSnapshotEntityKey(snapshot: TinyOsNativeSnapshot): string {
   const { data } = snapshot;
   if (data.kind === "workspace_resource") return `${data.kind}:${data.workspaceKey}:${data.path}`;
   if (data.kind === "browser_capture") return `${data.kind}:${data.captureId}`;
+  if (data.kind === "browser_session") return `${data.kind}:${data.browserSessionId}`;
   return `${data.kind}:${data.sessionId}:${data.runId}:${data.nativeProcessId}`;
 }
 
@@ -625,11 +688,35 @@ function stableIdentityPart(value: string): string {
 
 function projectionEndIndex(items: readonly BackendAgentTurnItem[], cursor: TinyOsKernelCursorInput): number {
   if (cursor.mode === "live") return items.length;
+  if (cursor.eventIndex !== undefined) {
+    if (!Number.isInteger(cursor.eventIndex) || cursor.eventIndex < 0 || cursor.eventIndex >= items.length) {
+      throw new Error(`TinyOS history event index is unavailable: ${cursor.eventIndex}`);
+    }
+    const boundary = items[cursor.eventIndex];
+    if (boundary.itemId !== cursor.itemId
+      || (cursor.runId && boundary.runId !== cursor.runId)
+      || (cursor.turnId && boundary.turnId !== cursor.turnId)) {
+      throw new Error(`TinyOS history boundary identity does not match event index ${cursor.eventIndex}.`);
+    }
+    return cursor.eventIndex + 1;
+  }
   const index = items.findIndex((item) => item.itemId === cursor.itemId
     && (!cursor.runId || item.runId === cursor.runId)
     && (!cursor.turnId || item.turnId === cursor.turnId));
   if (index < 0) throw new Error(`TinyOS history boundary is unavailable: ${cursor.itemId}`);
   return index + 1;
+}
+
+function nativeSnapshotsAtCursor(
+  snapshots: readonly TinyOsNativeSnapshot[],
+  visibleItems: readonly BackendAgentTurnItem[],
+  cursor: TinyOsKernelCursorInput,
+): readonly TinyOsNativeSnapshot[] {
+  if (cursor.mode === "live") return snapshots;
+  const boundaryTime = reliableCanonicalTimestamp(visibleItems[visibleItems.length - 1]);
+  if (!boundaryTime) return [];
+  const boundaryMs = Date.parse(boundaryTime);
+  return snapshots.filter((snapshot) => Date.parse(snapshot.observedAt) <= boundaryMs);
 }
 
 function latestCanonicalItemRevisions(items: readonly BackendAgentTurnItem[]): BackendAgentTurnItem[] {
@@ -808,6 +895,7 @@ function simulationCursor(
   input: TinyOsKernelCursorInput,
 ): TinyOsSimulationCursor {
   const boundary = visibleItems[visibleItems.length - 1];
+  const wallClockTime = reliableCanonicalTimestamp(boundary);
   return {
     ...(boundary ? {
       boundary: {
@@ -816,12 +904,17 @@ function simulationCursor(
         sequence: boundary.sequence,
         turnId: boundary.turnId,
       },
-      ...(boundary.updatedAt || boundary.createdAt ? { wallClockTime: boundary.updatedAt || boundary.createdAt } : {}),
+      ...(wallClockTime ? { wallClockTime } : {}),
     } : {}),
     eventCount: allItems.length,
     eventIndex: visibleItems.length - 1,
     mode: input.mode,
   };
+}
+
+function reliableCanonicalTimestamp(item: BackendAgentTurnItem | undefined): string {
+  const value = item?.updatedAt || item?.createdAt || "";
+  return value && Number.isFinite(Date.parse(value)) ? value : "";
 }
 
 function shortIdentity(value: string): string {

--- a/src/app-core/chat/tinyOsKernelModel.ts
+++ b/src/app-core/chat/tinyOsKernelModel.ts
@@ -1,0 +1,854 @@
+import type { BackendAgentTurnItem } from "./chatRunModel";
+import type { TinyOsNativeSnapshot } from "./tinyOsNativeSnapshot";
+
+export type TinyOsProvenanceKind =
+  | "canonical_event"
+  | "native_query"
+  | "real_capture"
+  | "derived_measurement"
+  | "local_presentation";
+
+export type TinyOsProvenance = {
+  kind: TinyOsProvenanceKind;
+  observedAt?: string;
+  revision?: number | string;
+  sourceId: string;
+};
+
+export type TinyOsProcessState =
+  | "queued"
+  | "running"
+  | "waiting_for_user"
+  | "blocked"
+  | "paused"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type TinyOsProcessKind =
+  | "agent_run"
+  | "agent_turn"
+  | "tool_operation"
+  | "terminal_process"
+  | "browser_session"
+  | "subagent"
+  | "user_input_wait";
+
+export type TinyOsProcessCorrelation = {
+  browserSessionId?: string;
+  commandId?: string;
+  itemId?: string;
+  nativeProcessId?: string;
+  runId: string;
+  sessionId: string;
+  threadId?: string;
+  toolCallId?: string;
+  turnId?: string;
+};
+
+export type TinyOsProcess = {
+  applicationId?: string;
+  correlation: TinyOsProcessCorrelation;
+  id: string;
+  kind: TinyOsProcessKind;
+  ownerAgentId?: string;
+  parentProcessId?: string;
+  provenance: TinyOsProvenance;
+  state: TinyOsProcessState;
+  title: string;
+};
+
+export type TinyOsResourceKind =
+  | "file"
+  | "directory"
+  | "terminal_execution"
+  | "terminal_session"
+  | "browser_capture"
+  | "browser_session"
+  | "artifact"
+  | "memory_result"
+  | "plan"
+  | "approval"
+  | "form";
+
+export type TinyOsResourceAccess = "read_only" | "read_write" | "execute" | "unavailable";
+
+export type TinyOsResource = {
+  access: TinyOsResourceAccess;
+  id: string;
+  kind: TinyOsResourceKind;
+  path?: string;
+  provenance: TinyOsProvenance;
+  relatedProcessIds: string[];
+  revision?: number | string;
+  title: string;
+};
+
+export type TinyOsCapability = {
+  available: boolean;
+  id: string;
+  provenance: TinyOsProvenance;
+  processId?: string;
+  reason?: string;
+  reasonCode?: string;
+};
+
+export type TinyOsNotification = {
+  id: string;
+  kind: "info" | "success" | "warning" | "error";
+  message: string;
+  processId?: string;
+  provenance: TinyOsProvenance;
+  resourceId?: string;
+  timestamp?: string;
+  title: string;
+};
+
+export type TinyOsMetric = {
+  calculation?: string;
+  id: string;
+  inputIds?: string[];
+  label: string;
+  provenance: TinyOsProvenance;
+  processId?: string;
+  resourceId?: string;
+  unit?: string;
+  value: number;
+};
+
+export type TinyOsDiscrepancy = {
+  canonical: {
+    entityId: string;
+    provenance: TinyOsProvenance;
+    value: string;
+  };
+  id: string;
+  kind: "lifecycle" | "revision";
+  message: string;
+  native: {
+    entityId: string;
+    provenance: TinyOsProvenance;
+    value: string;
+  };
+};
+
+export type TinyOsSimulationCursor = {
+  boundary?: {
+    itemId: string;
+    runId: string;
+    sequence: number;
+    turnId: string;
+  };
+  eventCount: number;
+  eventIndex: number;
+  mode: "live" | "history";
+  wallClockTime?: string;
+};
+
+export type TinyOsKernelSnapshot = {
+  capabilities: TinyOsCapability[];
+  cursor: TinyOsSimulationCursor;
+  discrepancies: TinyOsDiscrepancy[];
+  metrics: TinyOsMetric[];
+  notifications: TinyOsNotification[];
+  processes: TinyOsProcess[];
+  resources: TinyOsResource[];
+  truth: "derived";
+};
+
+export type TinyOsResourceIdentityInput = {
+  discriminator?: string;
+  itemId: string;
+  kind: TinyOsResourceKind;
+  runId: string;
+  sessionId: string;
+  turnId: string;
+};
+
+export type TinyOsProcessIdentityInput =
+  | { kind: "agent_run"; runId: string; sessionId: string }
+  | { kind: "agent_turn"; runId: string; sessionId: string; turnId: string }
+  | {
+      itemId: string;
+      kind: "tool_operation" | "subagent" | "user_input_wait";
+      runId: string;
+      sessionId: string;
+      turnId: string;
+    }
+  | { kind: "terminal_process"; nativeProcessId: string; runId: string; sessionId: string }
+  | { browserSessionId: string; kind: "browser_session"; runId: string; sessionId: string };
+
+export type TinyOsKernelCursorInput =
+  | { mode: "live" }
+  | { itemId: string; mode: "history"; runId?: string; turnId?: string };
+
+export type TinyOsKernelProjectionOptions = {
+  nativeSnapshots?: readonly TinyOsNativeSnapshot[];
+};
+
+export function createTinyOsProcessId(input: TinyOsProcessIdentityInput): string {
+  const parts = [input.sessionId, input.runId];
+  if (input.kind === "agent_turn") parts.push(input.turnId);
+  if (input.kind === "tool_operation" || input.kind === "subagent" || input.kind === "user_input_wait") {
+    parts.push(input.turnId, input.itemId);
+  }
+  if (input.kind === "terminal_process") parts.push(input.nativeProcessId);
+  if (input.kind === "browser_session") parts.push(input.browserSessionId);
+  return `tinyos:process:${input.kind}:${parts.map(stableIdentityPart).join(":")}`;
+}
+
+export function createTinyOsResourceId(input: TinyOsResourceIdentityInput): string {
+  const parts = [input.sessionId, input.runId, input.turnId, input.itemId];
+  if (input.discriminator) parts.push(input.discriminator);
+  return `tinyos:resource:${input.kind}:${parts.map(stableIdentityPart).join(":")}`;
+}
+
+export function createTinyOsDerivedMetric(input: {
+  calculation: string;
+  id: string;
+  inputIds: string[];
+  label: string;
+  unit?: string;
+  value: number;
+}): TinyOsMetric {
+  const id = stableIdentityPart(input.id);
+  const calculation = requiredKernelText(input.calculation, "TinyOS metric calculation");
+  const inputIds = [...new Set(input.inputIds.map((value) => requiredKernelText(value, "TinyOS metric input id")))];
+  if (!inputIds.length) throw new Error("TinyOS derived metrics require at least one input identity.");
+  if (!Number.isFinite(input.value)) throw new Error("TinyOS metric value must be finite.");
+  const metric: TinyOsMetric = {
+    calculation,
+    id: `tinyos:metric:${id}`,
+    inputIds,
+    label: requiredKernelText(input.label, "TinyOS metric label"),
+    provenance: {
+      kind: "derived_measurement",
+      sourceId: `tinyos:metric:${id}`,
+    },
+    ...(input.unit ? { unit: input.unit } : {}),
+    value: input.value,
+  };
+  assertTinyOsMetricSupported(metric);
+  return metric;
+}
+
+export function assertTinyOsMetricSupported(metric: TinyOsMetric): void {
+  if (!Number.isFinite(metric.value)) throw new Error(`TinyOS metric ${metric.id} has a non-finite value.`);
+  if (metric.provenance.kind === "canonical_event" || metric.provenance.kind === "native_query") return;
+  if (metric.provenance.kind !== "derived_measurement") {
+    throw new Error(`TinyOS metric ${metric.id} has unsupported provenance ${metric.provenance.kind}.`);
+  }
+  if (!metric.calculation?.trim() || !metric.inputIds?.length) {
+    throw new Error(`TinyOS derived metric ${metric.id} is missing auditable inputs or calculation.`);
+  }
+}
+
+export function assertTinyOsResourceMutationReady(resource: TinyOsResource): void {
+  if (resource.kind !== "file") throw new Error(`TinyOS resource ${resource.id} is not a mutable file.`);
+  if (resource.access !== "read_write") throw new Error(`TinyOS file resource ${resource.id} is not writable.`);
+  if (resource.revision === undefined || String(resource.revision).trim() === "") {
+    throw new Error(`TinyOS file resource ${resource.id} requires a base revision.`);
+  }
+}
+
+export function mergeTinyOsProcessObservation(
+  current: TinyOsProcess,
+  next: TinyOsProcess,
+): TinyOsProcess {
+  if (current.id !== next.id) throw new Error("TinyOS process observations must share an identity.");
+  assertTinyOsProcessStateTransition(current.state, next.state, current.id);
+  return next;
+}
+
+export function projectTinyOsKernel(
+  items: readonly BackendAgentTurnItem[],
+  cursorInput: TinyOsKernelCursorInput = { mode: "live" },
+  options: TinyOsKernelProjectionOptions = {},
+): TinyOsKernelSnapshot {
+  const visibleItems = items.slice(0, projectionEndIndex(items, cursorInput));
+  const latestItems = latestCanonicalItemRevisions(visibleItems);
+  const processItems = latestItems.filter(isProcessItem);
+  const processIdByItemId = new Map(processItems.map((item) => [item.itemId, itemProcessId(item)]));
+  const processIdByToolCallId = new Map(processItems.filter((item) => item.kind === "tool_call").flatMap((item) => {
+    const toolCallId = canonicalToolCallId(item);
+    return toolCallId ? [[toolCallId, itemProcessId(item)] as const] : [];
+  }));
+  const grouped = groupCanonicalItems(latestItems);
+  const processes: TinyOsProcess[] = [];
+
+  for (const runItems of grouped.runs.values()) {
+    const first = runItems[0];
+    const latest = runItems[runItems.length - 1];
+    processes.push({
+      correlation: canonicalCorrelation(first),
+      id: createTinyOsProcessId({ kind: "agent_run", runId: first.runId, sessionId: first.sessionId }),
+      kind: "agent_run",
+      ...(canonicalOwnerAgentId(latest) ? { ownerAgentId: canonicalOwnerAgentId(latest) } : {}),
+      provenance: canonicalProvenance(latest),
+      state: aggregateCanonicalState(runItems),
+      title: `Agent run ${shortIdentity(first.runId)}`,
+    });
+  }
+
+  for (const turnItems of grouped.turns.values()) {
+    const first = turnItems[0];
+    const latest = turnItems[turnItems.length - 1];
+    processes.push({
+      correlation: canonicalCorrelation(first),
+      id: createTinyOsProcessId({
+        kind: "agent_turn",
+        runId: first.runId,
+        sessionId: first.sessionId,
+        turnId: first.turnId,
+      }),
+      kind: "agent_turn",
+      ...(canonicalOwnerAgentId(latest) ? { ownerAgentId: canonicalOwnerAgentId(latest) } : {}),
+      parentProcessId: createTinyOsProcessId({ kind: "agent_run", runId: first.runId, sessionId: first.sessionId }),
+      provenance: canonicalProvenance(latest),
+      state: aggregateCanonicalState(turnItems),
+      title: `Agent turn ${shortIdentity(first.turnId)}`,
+    });
+  }
+
+  for (const item of processItems) {
+    const kind = processKind(item);
+    const toolParentProcessId = item.kind === "tool_call"
+      ? undefined
+      : processIdByToolCallId.get(canonicalToolCallId(item));
+    const parentProcessId = item.parentItemId && processIdByItemId.get(item.parentItemId)
+      || toolParentProcessId
+      || createTinyOsProcessId({
+        kind: "agent_turn",
+        runId: item.runId,
+        sessionId: item.sessionId,
+        turnId: item.turnId,
+      });
+    processes.push({
+      ...(canonicalApplicationId(item) ? { applicationId: canonicalApplicationId(item) } : {}),
+      correlation: canonicalCorrelation(item),
+      id: itemProcessId(item),
+      kind,
+      ...(canonicalOwnerAgentId(item) ? { ownerAgentId: canonicalOwnerAgentId(item) } : {}),
+      parentProcessId,
+      provenance: canonicalProvenance(item),
+      state: canonicalItemState(item),
+      title: canonicalProcessTitle(item),
+    });
+  }
+
+  const canonicalResources = projectCanonicalResources(latestItems, processIdByItemId, processIdByToolCallId);
+  const native = projectNativeSnapshots(options.nativeSnapshots ?? [], processIdByToolCallId);
+  const resources = [...canonicalResources, ...native.resources];
+  const allProcesses = [...processes, ...native.processes];
+
+  return {
+    capabilities: [],
+    cursor: simulationCursor(items, visibleItems, cursorInput),
+    discrepancies: projectDiscrepancies(processes, canonicalResources, native.processes, native.resources),
+    metrics: [],
+    notifications: [],
+    processes: allProcesses,
+    resources,
+    truth: "derived",
+  };
+}
+
+function projectNativeSnapshots(
+  snapshots: readonly TinyOsNativeSnapshot[],
+  processIdByToolCallId: ReadonlyMap<string, string>,
+): { processes: TinyOsProcess[]; resources: TinyOsResource[] } {
+  const processes: TinyOsProcess[] = [];
+  const resources: TinyOsResource[] = [];
+  for (const snapshot of latestNativeSnapshots(snapshots)) {
+    const { data } = snapshot;
+    if (data.kind === "workspace_resource") {
+      resources.push({
+        access: data.access,
+        id: nativeResourceId(data.resourceKind, [data.workspaceKey, data.path]),
+        kind: data.resourceKind,
+        path: data.path,
+        provenance: snapshot.provenance,
+        relatedProcessIds: [],
+        revision: snapshot.revision,
+        title: data.path,
+      });
+      continue;
+    }
+    if (data.kind === "browser_capture") {
+      resources.push({
+        access: "read_only",
+        id: nativeResourceId("browser_capture", [data.captureId]),
+        kind: "browser_capture",
+        provenance: snapshot.provenance,
+        relatedProcessIds: [],
+        revision: snapshot.revision,
+        title: data.title || data.url || data.captureId,
+      });
+      continue;
+    }
+    const id = createTinyOsProcessId({
+      kind: "terminal_process",
+      nativeProcessId: data.nativeProcessId,
+      runId: data.runId,
+      sessionId: data.sessionId,
+    });
+    const toolParentId = data.toolCallId ? processIdByToolCallId.get(data.toolCallId) : undefined;
+    processes.push({
+      applicationId: "terminal",
+      correlation: {
+        nativeProcessId: data.nativeProcessId,
+        runId: data.runId,
+        sessionId: data.sessionId,
+        ...(data.toolCallId ? { toolCallId: data.toolCallId } : {}),
+      },
+      id,
+      kind: "terminal_process",
+      parentProcessId: toolParentId || createTinyOsProcessId({
+        kind: "agent_run",
+        runId: data.runId,
+        sessionId: data.sessionId,
+      }),
+      provenance: snapshot.provenance,
+      state: data.state,
+      title: data.command || `Terminal process ${shortIdentity(data.nativeProcessId)}`,
+    });
+    resources.push({
+      access: "execute",
+      id: nativeResourceId("terminal_execution", [data.sessionId, data.runId, data.nativeProcessId]),
+      kind: "terminal_execution",
+      provenance: snapshot.provenance,
+      relatedProcessIds: [id],
+      revision: snapshot.revision,
+      title: data.command || `Terminal execution ${shortIdentity(data.nativeProcessId)}`,
+    });
+  }
+  return { processes, resources };
+}
+
+function latestNativeSnapshots(snapshots: readonly TinyOsNativeSnapshot[]): TinyOsNativeSnapshot[] {
+  const latest = new Map<string, TinyOsNativeSnapshot>();
+  for (const snapshot of snapshots) {
+    if (snapshot.schemaVersion !== "tinybot.tinyos_native_snapshot.v1") {
+      throw new Error(`Unsupported TinyOS native snapshot schema: ${snapshot.schemaVersion}`);
+    }
+    const key = nativeSnapshotEntityKey(snapshot);
+    const current = latest.get(key);
+    if (!current || Date.parse(snapshot.observedAt) >= Date.parse(current.observedAt)) latest.set(key, snapshot);
+  }
+  return [...latest.values()];
+}
+
+function nativeSnapshotEntityKey(snapshot: TinyOsNativeSnapshot): string {
+  const { data } = snapshot;
+  if (data.kind === "workspace_resource") return `${data.kind}:${data.workspaceKey}:${data.path}`;
+  if (data.kind === "browser_capture") return `${data.kind}:${data.captureId}`;
+  return `${data.kind}:${data.sessionId}:${data.runId}:${data.nativeProcessId}`;
+}
+
+function nativeResourceId(kind: TinyOsResourceKind, parts: string[]): string {
+  return `tinyos:resource:${kind}:native:${parts.map(stableIdentityPart).join(":")}`;
+}
+
+function projectDiscrepancies(
+  canonicalProcesses: readonly TinyOsProcess[],
+  canonicalResources: readonly TinyOsResource[],
+  nativeProcesses: readonly TinyOsProcess[],
+  nativeResources: readonly TinyOsResource[],
+): TinyOsDiscrepancy[] {
+  const discrepancies: TinyOsDiscrepancy[] = [];
+  for (const canonical of canonicalResources) {
+    if (canonical.kind !== "file" || !canonical.path || canonical.revision === undefined) continue;
+    const native = nativeResources.find((resource) => resource.kind === "file"
+      && normalizeResourcePath(resource.path) === normalizeResourcePath(canonical.path));
+    if (!native || native.revision === undefined || String(native.revision) === String(canonical.revision)) continue;
+    discrepancies.push(discrepancy(
+      "revision",
+      canonical,
+      String(canonical.revision),
+      native,
+      String(native.revision),
+      `File revision differs for ${canonical.path}.`,
+    ));
+  }
+  for (const native of nativeProcesses) {
+    if (!native.correlation.toolCallId) continue;
+    const canonical = canonicalProcesses.find((process) => process.kind === "tool_operation"
+      && process.correlation.toolCallId === native.correlation.toolCallId);
+    if (!canonical || canonical.state === native.state) continue;
+    discrepancies.push(discrepancy(
+      "lifecycle",
+      canonical,
+      canonical.state,
+      native,
+      native.state,
+      `Process lifecycle differs for Tool call ${native.correlation.toolCallId}.`,
+    ));
+  }
+  return discrepancies;
+}
+
+function discrepancy(
+  kind: TinyOsDiscrepancy["kind"],
+  canonical: Pick<TinyOsProcess | TinyOsResource, "id" | "provenance">,
+  canonicalValue: string,
+  native: Pick<TinyOsProcess | TinyOsResource, "id" | "provenance">,
+  nativeValue: string,
+  message: string,
+): TinyOsDiscrepancy {
+  return {
+    canonical: { entityId: canonical.id, provenance: canonical.provenance, value: canonicalValue },
+    id: `tinyos:discrepancy:${kind}:${stableIdentityPart(canonical.id)}:${stableIdentityPart(native.id)}`,
+    kind,
+    message,
+    native: { entityId: native.id, provenance: native.provenance, value: nativeValue },
+  };
+}
+
+function normalizeResourcePath(value?: string): string {
+  return (value ?? "").replace(/\\/g, "/").replace(/^\.\//, "").toLowerCase();
+}
+
+function projectCanonicalResources(
+  items: readonly BackendAgentTurnItem[],
+  processIdByItemId: ReadonlyMap<string, string>,
+  processIdByToolCallId: ReadonlyMap<string, string>,
+): TinyOsResource[] {
+  return items.flatMap((item): TinyOsResource[] => {
+    const relatedProcessIds = relatedProcessIdsForResource(item, processIdByItemId, processIdByToolCallId);
+    if (item.kind === "file_reference") {
+      const path = stringValue(item.data.path);
+      if (!path) return [];
+      return [canonicalResource(item, "file", path, relatedProcessIds, {
+        path,
+        revision: scalarRevision(item.data.revision),
+      })];
+    }
+    if (item.kind === "plan_progress") {
+      return [canonicalResource(item, "plan", item.title || "Plan", relatedProcessIds)];
+    }
+    if (item.kind === "approval") {
+      return [canonicalResource(item, "approval", item.title || "Approval", relatedProcessIds, {
+        revision: item.revision,
+      })];
+    }
+    if (item.kind === "form") {
+      return [canonicalResource(item, "form", stringValue(item.data.title) || item.title || "Form", relatedProcessIds, {
+        revision: item.revision,
+      })];
+    }
+    if (item.kind !== "tool_call") return [];
+    const toolName = stringValue(item.data.name);
+    const resources: TinyOsResource[] = [];
+    if (TERMINAL_TOOL_RE.test(toolName)) {
+      resources.push(canonicalResource(item, "terminal_execution", toolName, relatedProcessIds));
+    }
+    if (MEMORY_TOOL_RE.test(toolName)) {
+      resources.push(canonicalResource(item, "memory_result", toolName, relatedProcessIds));
+    }
+    for (const artifact of canonicalArtifacts(item)) {
+      const artifactId = stringValue(artifact.id ?? artifact.artifactId ?? artifact.artifact_id);
+      if (!artifactId) continue;
+      const artifactKind = stringValue(artifact.kind);
+      const kind: TinyOsResourceKind = artifactKind === "browser_snapshot" ? "browser_capture" : "artifact";
+      resources.push(canonicalResource(
+        item,
+        kind,
+        stringValue(artifact.title) || artifactId,
+        relatedProcessIds,
+        { discriminator: artifactId },
+      ));
+    }
+    return resources;
+  });
+}
+
+function canonicalResource(
+  item: BackendAgentTurnItem,
+  kind: TinyOsResourceKind,
+  title: string,
+  relatedProcessIds: string[],
+  options: { discriminator?: string; path?: string; revision?: number | string } = {},
+): TinyOsResource {
+  return {
+    access: "read_only",
+    id: createTinyOsResourceId({
+      ...(options.discriminator ? { discriminator: options.discriminator } : {}),
+      itemId: item.itemId,
+      kind,
+      runId: item.runId,
+      sessionId: item.sessionId,
+      turnId: item.turnId,
+    }),
+    kind,
+    ...(options.path ? { path: options.path } : {}),
+    provenance: canonicalProvenance(item),
+    relatedProcessIds,
+    ...(options.revision !== undefined ? { revision: options.revision } : {}),
+    title,
+  };
+}
+
+function relatedProcessIdsForResource(
+  item: BackendAgentTurnItem,
+  processIdByItemId: ReadonlyMap<string, string>,
+  processIdByToolCallId: ReadonlyMap<string, string>,
+): string[] {
+  const itemProcessId = processIdByItemId.get(item.itemId);
+  if (itemProcessId) return [itemProcessId];
+  const toolProcessId = processIdByToolCallId.get(canonicalToolCallId(item));
+  if (toolProcessId) return [toolProcessId];
+  return [createTinyOsProcessId({
+    kind: "agent_turn",
+    runId: item.runId,
+    sessionId: item.sessionId,
+    turnId: item.turnId,
+  })];
+}
+
+function canonicalArtifacts(item: BackendAgentTurnItem): Record<string, unknown>[] {
+  const result = recordValue(item.data.result);
+  const candidates = [item.data.artifacts, result.artifacts];
+  return candidates.flatMap((value) => Array.isArray(value) ? value.filter(isRecord) : []);
+}
+
+function scalarRevision(value: unknown): number | string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const normalized = stringValue(value);
+  return normalized || undefined;
+}
+
+function stableIdentityPart(value: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error("TinyOS stable identity parts must be non-empty.");
+  return encodeURIComponent(normalized);
+}
+
+function projectionEndIndex(items: readonly BackendAgentTurnItem[], cursor: TinyOsKernelCursorInput): number {
+  if (cursor.mode === "live") return items.length;
+  const index = items.findIndex((item) => item.itemId === cursor.itemId
+    && (!cursor.runId || item.runId === cursor.runId)
+    && (!cursor.turnId || item.turnId === cursor.turnId));
+  if (index < 0) throw new Error(`TinyOS history boundary is unavailable: ${cursor.itemId}`);
+  return index + 1;
+}
+
+function latestCanonicalItemRevisions(items: readonly BackendAgentTurnItem[]): BackendAgentTurnItem[] {
+  const latestByIdentity = new Map<string, BackendAgentTurnItem>();
+  for (const item of items) {
+    const key = `${item.sessionId}:${item.runId}:${item.itemId}`;
+    const current = latestByIdentity.get(key);
+    if (!current) {
+      latestByIdentity.set(key, item);
+      continue;
+    }
+    if (item.revision >= current.revision) {
+      if (isProcessItem(current) && isProcessItem(item)) {
+        assertTinyOsProcessStateTransition(canonicalItemState(current), canonicalItemState(item), item.itemId);
+      }
+      latestByIdentity.set(key, item);
+    }
+  }
+  return [...latestByIdentity.values()];
+}
+
+function groupCanonicalItems(items: readonly BackendAgentTurnItem[]) {
+  const runs = new Map<string, BackendAgentTurnItem[]>();
+  const turns = new Map<string, BackendAgentTurnItem[]>();
+  for (const item of items) {
+    appendGrouped(runs, `${item.sessionId}:${item.runId}`, item);
+    appendGrouped(turns, `${item.sessionId}:${item.runId}:${item.turnId}`, item);
+  }
+  return { runs, turns };
+}
+
+function appendGrouped(
+  groups: Map<string, BackendAgentTurnItem[]>,
+  key: string,
+  item: BackendAgentTurnItem,
+): void {
+  const group = groups.get(key) ?? [];
+  group.push(item);
+  groups.set(key, group);
+}
+
+function isProcessItem(item: BackendAgentTurnItem): boolean {
+  return item.kind === "tool_call"
+    || item.kind === "approval"
+    || item.kind === "form"
+    || item.kind === "subagent_lifecycle";
+}
+
+function processKind(item: BackendAgentTurnItem): Extract<
+  TinyOsProcessKind,
+  "tool_operation" | "subagent" | "user_input_wait"
+> {
+  if (item.kind === "tool_call") return "tool_operation";
+  if (item.kind === "subagent_lifecycle") return "subagent";
+  return "user_input_wait";
+}
+
+function itemProcessId(item: BackendAgentTurnItem): string {
+  return createTinyOsProcessId({
+    itemId: item.itemId,
+    kind: processKind(item),
+    runId: item.runId,
+    sessionId: item.sessionId,
+    turnId: item.turnId,
+  });
+}
+
+function canonicalCorrelation(item: BackendAgentTurnItem): TinyOsProcessCorrelation {
+  const toolCallId = canonicalToolCallId(item);
+  const commandId = stringValue(item.data.commandId ?? item.data.command_id);
+  return {
+    itemId: item.itemId,
+    runId: item.runId,
+    sessionId: item.sessionId,
+    ...(item.threadId ? { threadId: item.threadId } : {}),
+    ...(toolCallId ? { toolCallId } : {}),
+    ...(item.turnId ? { turnId: item.turnId } : {}),
+    ...(commandId ? { commandId } : {}),
+  };
+}
+
+function canonicalToolCallId(item: BackendAgentTurnItem): string {
+  return stringValue(item.data.toolCallId ?? item.data.tool_call_id);
+}
+
+function canonicalOwnerAgentId(item: BackendAgentTurnItem): string {
+  return stringValue(item.data.agentId ?? item.data.agent_id);
+}
+
+function canonicalApplicationId(item: BackendAgentTurnItem): string {
+  if (item.kind === "approval" || item.kind === "form") return "inspector";
+  if (item.kind === "subagent_lifecycle") return "subagents";
+  if (item.kind !== "tool_call") return "";
+  const toolName = stringValue(item.data.name);
+  if (TERMINAL_TOOL_RE.test(toolName)) return "terminal";
+  if (MEMORY_TOOL_RE.test(toolName)) return "memory";
+  if (BROWSER_TOOL_RE.test(toolName)) return "browser";
+  if (PLAN_TOOL_RE.test(toolName)) return "plan";
+  if (FILE_TOOL_RE.test(toolName)) return "files";
+  return "inspector";
+}
+
+function canonicalProvenance(item: BackendAgentTurnItem): TinyOsProvenance {
+  return {
+    kind: "canonical_event",
+    observedAt: item.updatedAt || item.createdAt,
+    revision: item.revision,
+    sourceId: item.itemId,
+  };
+}
+
+function canonicalItemState(item: BackendAgentTurnItem): TinyOsProcessState {
+  const status = item.status.trim().toLowerCase();
+  if ((item.kind === "approval" || item.kind === "form") && !isTerminalStatus(status)) return "waiting_for_user";
+  if (status === "running" || status === "in_progress") return "running";
+  if (status === "waiting_for_user" || status === "awaiting_user" || status === "awaiting_approval") return "waiting_for_user";
+  if (status === "blocked" || status === "denied") return "blocked";
+  if (status === "paused") return "paused";
+  if (status === "completed" || status === "succeeded" || status === "success") return "completed";
+  if (status === "failed" || status === "error") return "failed";
+  if (status === "cancelled" || status === "canceled" || status === "interrupted") return "cancelled";
+  return "queued";
+}
+
+function aggregateCanonicalState(items: readonly BackendAgentTurnItem[]): TinyOsProcessState {
+  const latest = items[items.length - 1];
+  if (!latest) return "queued";
+  if (latest.kind === "error") {
+    return latest.data.cancelled || latest.status === "cancelled" ? "cancelled" : "failed";
+  }
+  if (latest.kind === "assistant_message" && latest.data.phase === "final_answer" && latest.status === "completed") {
+    return "completed";
+  }
+  const itemStates = items.map(canonicalItemState);
+  if (itemStates.includes("waiting_for_user")) return "waiting_for_user";
+  if (itemStates.includes("paused")) return "paused";
+  if (itemStates.includes("blocked")) return "blocked";
+  if (itemStates.includes("running")) return "running";
+  return "queued";
+}
+
+function isTerminalStatus(status: string): boolean {
+  return status === "completed"
+    || status === "succeeded"
+    || status === "success"
+    || status === "failed"
+    || status === "error"
+    || status === "cancelled"
+    || status === "canceled"
+    || status === "interrupted";
+}
+
+function assertTinyOsProcessStateTransition(
+  current: TinyOsProcessState,
+  next: TinyOsProcessState,
+  processId: string,
+): void {
+  if (!TERMINAL_PROCESS_STATES.has(current)) return;
+  if (current !== next) {
+    throw new Error(`TinyOS process ${processId} cannot transition from terminal state ${current} to ${next}.`);
+  }
+}
+
+function canonicalProcessTitle(item: BackendAgentTurnItem): string {
+  if (item.title?.trim()) return item.title;
+  if (item.kind === "tool_call") return stringValue(item.data.name) || "Tool operation";
+  if (item.kind === "approval") return "Approval required";
+  if (item.kind === "form") return stringValue(item.data.title) || "Input required";
+  if (item.kind === "subagent_lifecycle") return stringValue(item.data.agentId) || "Subagent";
+  return item.kind;
+}
+
+function simulationCursor(
+  allItems: readonly BackendAgentTurnItem[],
+  visibleItems: readonly BackendAgentTurnItem[],
+  input: TinyOsKernelCursorInput,
+): TinyOsSimulationCursor {
+  const boundary = visibleItems[visibleItems.length - 1];
+  return {
+    ...(boundary ? {
+      boundary: {
+        itemId: boundary.itemId,
+        runId: boundary.runId,
+        sequence: boundary.sequence,
+        turnId: boundary.turnId,
+      },
+      ...(boundary.updatedAt || boundary.createdAt ? { wallClockTime: boundary.updatedAt || boundary.createdAt } : {}),
+    } : {}),
+    eventCount: allItems.length,
+    eventIndex: visibleItems.length - 1,
+    mode: input.mode,
+  };
+}
+
+function shortIdentity(value: string): string {
+  return value.length <= 12 ? value : value.slice(0, 12);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requiredKernelText(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} is required.`);
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+const TERMINAL_TOOL_RE = /(?:^|[._-])(shell|terminal|command|exec|process|powershell|bash)(?:$|[._-])/i;
+const MEMORY_TOOL_RE = /(?:^|[._-])(memory|knowledge|recall)(?:$|[._-])/i;
+const BROWSER_TOOL_RE = /(?:^|[._-])(browser|web|navigate|screenshot|page)(?:$|[._-])/i;
+const PLAN_TOOL_RE = /(?:^|[._-])(plan|update_plan|task_progress)(?:$|[._-])/i;
+const FILE_TOOL_RE = /(?:^|[._-])(file|workspace|path|directory|search|grep|glob|read|write|patch)(?:$|[._-])/i;
+const TERMINAL_PROCESS_STATES = new Set<TinyOsProcessState>(["completed", "failed", "cancelled"]);

--- a/src/app-core/chat/tinyOsNativeSnapshot.test.ts
+++ b/src/app-core/chat/tinyOsNativeSnapshot.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createTinyOsBrowserCaptureSnapshot,
+  createTinyOsTerminalProcessSnapshot,
+  createTinyOsWorkspaceResourceSnapshot,
+} from "./tinyOsNativeSnapshot";
+
+const metadata = {
+  observedAt: "2026-07-14T01:02:03Z",
+  revision: "revision-1",
+  sourceId: "native-query-1",
+};
+
+describe("TinyOS native snapshot adapters", () => {
+  it("adds version, revision, observation time, and native-query provenance", () => {
+    const snapshot = createTinyOsWorkspaceResourceSnapshot({
+      access: "read_only",
+      kind: "workspace_resource",
+      path: "src/main.ts",
+      resourceKind: "file",
+      workspaceKey: "workspace-1",
+    }, metadata);
+
+    expect(snapshot).toEqual({
+      data: {
+        access: "read_only",
+        kind: "workspace_resource",
+        path: "src/main.ts",
+        resourceKind: "file",
+        workspaceKey: "workspace-1",
+      },
+      observedAt: metadata.observedAt,
+      provenance: {
+        kind: "native_query",
+        observedAt: metadata.observedAt,
+        revision: metadata.revision,
+        sourceId: metadata.sourceId,
+      },
+      revision: metadata.revision,
+      schemaVersion: "tinybot.tinyos_native_snapshot.v1",
+      sourceId: metadata.sourceId,
+    });
+  });
+
+  it("distinguishes terminal observations and real browser captures", () => {
+    const terminal = createTinyOsTerminalProcessSnapshot({
+      kind: "terminal_process",
+      nativeProcessId: "process-1",
+      runId: "run-1",
+      sessionId: "session-1",
+      state: "running",
+      toolCallId: "call-1",
+    }, { ...metadata, sourceId: "shell.list" });
+    const capture = createTinyOsBrowserCaptureSnapshot({
+      captureId: "capture-1",
+      kind: "browser_capture",
+      realCapture: true,
+      title: "Home",
+      url: "https://example.com",
+    }, { ...metadata, sourceId: "browser.capture" });
+
+    expect(terminal.provenance.kind).toBe("native_query");
+    expect(capture.provenance.kind).toBe("real_capture");
+  });
+
+  it("fails fast for missing revision, identity, or invalid observation time", () => {
+    expect(() => createTinyOsWorkspaceResourceSnapshot({
+      access: "read_only",
+      kind: "workspace_resource",
+      path: "src/main.ts",
+      resourceKind: "file",
+      workspaceKey: "workspace-1",
+    }, { ...metadata, revision: "" })).toThrow(/revision is required/i);
+    expect(() => createTinyOsTerminalProcessSnapshot({
+      kind: "terminal_process",
+      nativeProcessId: "",
+      runId: "run-1",
+      sessionId: "session-1",
+      state: "running",
+    }, metadata)).toThrow(/process id is required/i);
+    expect(() => createTinyOsBrowserCaptureSnapshot({
+      captureId: "capture-1",
+      kind: "browser_capture",
+      realCapture: false,
+    }, { ...metadata, observedAt: "not-a-time" })).toThrow(/valid timestamp/i);
+  });
+});

--- a/src/app-core/chat/tinyOsNativeSnapshot.test.ts
+++ b/src/app-core/chat/tinyOsNativeSnapshot.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   createTinyOsBrowserCaptureSnapshot,
+  createTinyOsBrowserSessionSnapshot,
   createTinyOsTerminalProcessSnapshot,
   createTinyOsWorkspaceResourceSnapshot,
 } from "./tinyOsNativeSnapshot";
@@ -61,6 +62,7 @@ describe("TinyOS native snapshot adapters", () => {
     }, { ...metadata, sourceId: "browser.capture" });
 
     expect(terminal.provenance.kind).toBe("native_query");
+    expect(terminal.data.executionContract).toBe("retained_execution_v1");
     expect(capture.provenance.kind).toBe("real_capture");
   });
 
@@ -79,10 +81,54 @@ describe("TinyOS native snapshot adapters", () => {
       sessionId: "session-1",
       state: "running",
     }, metadata)).toThrow(/process id is required/i);
+    expect(() => createTinyOsTerminalProcessSnapshot({
+      droppedBytes: -1,
+      kind: "terminal_process",
+      nativeProcessId: "process-1",
+      runId: "run-1",
+      sessionId: "session-1",
+      state: "running",
+    }, metadata)).toThrow(/dropped bytes must be non-negative/i);
     expect(() => createTinyOsBrowserCaptureSnapshot({
       captureId: "capture-1",
       kind: "browser_capture",
       realCapture: false,
     }, { ...metadata, observedAt: "not-a-time" })).toThrow(/valid timestamp/i);
+  });
+
+  it("validates browser session tab, history, and current-capture identity", () => {
+    const snapshot = createTinyOsBrowserSessionSnapshot({
+      activeTabId: "tab-1",
+      browserSessionId: "browser-session-1",
+      contract: "browser_session_v1",
+      interaction: { click: true, navigate: true, type: false },
+      kind: "browser_session",
+      runId: "run-1",
+      sessionId: "session-1",
+      state: "running",
+      tabs: [{
+        activeHistoryIndex: 0,
+        captures: [{ captureId: "capture-1", observedAt: metadata.observedAt, stale: false }],
+        currentCaptureId: "capture-1",
+        history: [{ captureId: "capture-1", observedAt: metadata.observedAt, title: "Home", url: "https://example.com" }],
+        loading: false,
+        tabId: "tab-1",
+        title: "Home",
+        url: "https://example.com",
+      }],
+    }, metadata);
+
+    expect(snapshot.data.contract).toBe("browser_session_v1");
+    expect(snapshot.data.tabs[0].currentCaptureId).toBe("capture-1");
+    expect(snapshot.provenance.kind).toBe("native_query");
+
+    expect(() => createTinyOsBrowserSessionSnapshot({
+      ...snapshot.data,
+      activeTabId: "tab-missing",
+    }, metadata)).toThrow(/not present/i);
+    expect(() => createTinyOsBrowserSessionSnapshot({
+      ...snapshot.data,
+      tabs: [{ ...snapshot.data.tabs[0], currentCaptureId: "capture-missing" }],
+    }, metadata)).toThrow(/current capture.*missing/i);
   });
 });

--- a/src/app-core/chat/tinyOsNativeSnapshot.ts
+++ b/src/app-core/chat/tinyOsNativeSnapshot.ts
@@ -14,13 +14,29 @@ export type TinyOsNativeWorkspaceResource = {
 
 export type TinyOsNativeTerminalProcess = {
   command?: string;
+  droppedBytes?: number;
+  durationMs?: number;
+  executionContract: "retained_execution_v1";
+  exitCode?: number;
   kind: "terminal_process";
+  networkMode?: "denied" | "unavailable";
   nativeProcessId: string;
+  outputTruncated?: boolean;
   runId: string;
+  sandboxMode?: "read_only" | "unavailable";
   sessionId: string;
   state: TinyOsProcessState;
+  stderrBytes?: number;
+  stdoutBytes?: number;
   toolCallId?: string;
   workingDirectory?: string;
+};
+
+export type TinyOsRetainedTerminalCapabilityV1 = {
+  cancel: boolean;
+  contract: "retained_execution_v1";
+  persistentPty: false;
+  start: boolean;
 };
 
 export type TinyOsNativeBrowserCapture = {
@@ -28,14 +44,57 @@ export type TinyOsNativeBrowserCapture = {
   captureId: string;
   kind: "browser_capture";
   realCapture: boolean;
+  stale?: boolean;
+  tabId?: string;
   title?: string;
   url?: string;
+};
+
+export type TinyOsBrowserNavigationEntryV1 = {
+  captureId?: string;
+  observedAt?: string;
+  title?: string;
+  url: string;
+};
+
+export type TinyOsBrowserCaptureV1 = {
+  captureId: string;
+  observedAt: string;
+  stale: boolean;
+};
+
+export type TinyOsBrowserTabV1 = {
+  activeHistoryIndex: number;
+  captures: TinyOsBrowserCaptureV1[];
+  currentCaptureId?: string;
+  history: TinyOsBrowserNavigationEntryV1[];
+  loading: boolean;
+  tabId: string;
+  title: string;
+  url: string;
+};
+
+export type TinyOsNativeBrowserSession = {
+  activeTabId: string;
+  browserSessionId: string;
+  contract: "browser_session_v1";
+  interaction: {
+    click: boolean;
+    navigate: boolean;
+    type: boolean;
+  };
+  kind: "browser_session";
+  runId: string;
+  sessionId: string;
+  state: TinyOsProcessState;
+  tabs: TinyOsBrowserTabV1[];
 };
 
 export type TinyOsNativeSnapshotData =
   | TinyOsNativeWorkspaceResource
   | TinyOsNativeTerminalProcess
-  | TinyOsNativeBrowserCapture;
+  | TinyOsNativeBrowserCapture
+  | TinyOsNativeBrowserSession;
 
 export type TinyOsNativeSnapshot<T extends TinyOsNativeSnapshotData = TinyOsNativeSnapshotData> = {
   data: T;
@@ -64,14 +123,19 @@ export function createTinyOsWorkspaceResourceSnapshot(
 }
 
 export function createTinyOsTerminalProcessSnapshot(
-  data: TinyOsNativeTerminalProcess,
+  data: Omit<TinyOsNativeTerminalProcess, "executionContract"> & { executionContract?: "retained_execution_v1" },
   metadata: NativeSnapshotMetadata,
 ): TinyOsNativeSnapshot<TinyOsNativeTerminalProcess> {
   return createTinyOsNativeSnapshot({
     ...data,
+    executionContract: data.executionContract ?? "retained_execution_v1",
     nativeProcessId: requiredText(data.nativeProcessId, "Native process id"),
     runId: requiredText(data.runId, "Terminal run id"),
     sessionId: requiredText(data.sessionId, "Terminal session id"),
+    ...optionalNonNegative(data.droppedBytes, "Terminal dropped bytes", "droppedBytes"),
+    ...optionalNonNegative(data.durationMs, "Terminal duration", "durationMs"),
+    ...optionalNonNegative(data.stderrBytes, "Terminal stderr bytes", "stderrBytes"),
+    ...optionalNonNegative(data.stdoutBytes, "Terminal stdout bytes", "stdoutBytes"),
   }, metadata, "native_query");
 }
 
@@ -83,6 +147,69 @@ export function createTinyOsBrowserCaptureSnapshot(
     ...data,
     captureId: requiredText(data.captureId, "Browser capture id"),
   }, metadata, data.realCapture ? "real_capture" : "native_query");
+}
+
+export function createTinyOsBrowserSessionSnapshot(
+  data: TinyOsNativeBrowserSession,
+  metadata: NativeSnapshotMetadata,
+): TinyOsNativeSnapshot<TinyOsNativeBrowserSession> {
+  if (data.contract !== "browser_session_v1") {
+    throw new Error("TinyOS browser session uses an unsupported contract.");
+  }
+  const tabs = data.tabs.map(normalizeBrowserTab);
+  if (!tabs.length) throw new Error("TinyOS browser session requires at least one tab.");
+  assertUnique(tabs.map(({ tabId }) => tabId), "TinyOS browser tab id");
+  const activeTabId = requiredText(data.activeTabId, "Active browser tab id");
+  if (!tabs.some(({ tabId }) => tabId === activeTabId)) {
+    throw new Error(`Active browser tab ${activeTabId} is not present in the session snapshot.`);
+  }
+  return createTinyOsNativeSnapshot({
+    ...data,
+    activeTabId,
+    browserSessionId: requiredText(data.browserSessionId, "Browser session id"),
+    runId: requiredText(data.runId, "Browser run id"),
+    sessionId: requiredText(data.sessionId, "Browser owner session id"),
+    tabs,
+  }, metadata, "native_query");
+}
+
+function normalizeBrowserTab(tab: TinyOsBrowserTabV1): TinyOsBrowserTabV1 {
+  const tabId = requiredText(tab.tabId, "Browser tab id");
+  const history = tab.history.map((entry) => ({
+    ...entry,
+    ...(entry.captureId ? { captureId: requiredText(entry.captureId, "Browser history capture id") } : {}),
+    ...(entry.observedAt ? { observedAt: requiredObservationTime(entry.observedAt) } : {}),
+    url: requiredText(entry.url, "Browser history URL"),
+  }));
+  const maxHistoryIndex = history.length - 1;
+  if (tab.activeHistoryIndex < 0 || tab.activeHistoryIndex > maxHistoryIndex) {
+    throw new Error(`Browser tab ${tabId} active history index is outside its history.`);
+  }
+  const captures = tab.captures.map((capture) => ({
+    ...capture,
+    captureId: requiredText(capture.captureId, "Browser capture id"),
+    observedAt: requiredObservationTime(capture.observedAt),
+  }));
+  assertUnique(captures.map(({ captureId }) => captureId), `Browser tab ${tabId} capture id`);
+  const currentCaptureId = tab.currentCaptureId
+    ? requiredText(tab.currentCaptureId, "Current browser capture id")
+    : undefined;
+  if (currentCaptureId && !captures.some(({ captureId }) => captureId === currentCaptureId)) {
+    throw new Error(`Browser tab ${tabId} current capture ${currentCaptureId} is missing.`);
+  }
+  return {
+    ...tab,
+    captures,
+    ...(currentCaptureId ? { currentCaptureId } : {}),
+    history,
+    tabId,
+    title: requiredText(tab.title, "Browser tab title"),
+    url: requiredText(tab.url, "Browser tab URL"),
+  };
+}
+
+function assertUnique(values: string[], label: string): void {
+  if (new Set(values).size !== values.length) throw new Error(`${label}s must be unique.`);
 }
 
 function createTinyOsNativeSnapshot<T extends TinyOsNativeSnapshotData>(
@@ -128,4 +255,14 @@ function requiredRevision(value: number | string): number | string {
     return value;
   }
   return requiredText(value, "Native snapshot revision");
+}
+
+function optionalNonNegative<TName extends "droppedBytes" | "durationMs" | "stderrBytes" | "stdoutBytes">(
+  value: number | undefined,
+  label: string,
+  name: TName,
+): Partial<Record<TName, number>> {
+  if (value === undefined) return {};
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${label} must be non-negative.`);
+  return { [name]: value } as Partial<Record<TName, number>>;
 }

--- a/src/app-core/chat/tinyOsNativeSnapshot.ts
+++ b/src/app-core/chat/tinyOsNativeSnapshot.ts
@@ -1,0 +1,131 @@
+import type {
+  TinyOsProcessState,
+  TinyOsProvenance,
+  TinyOsResourceAccess,
+} from "./tinyOsKernelModel";
+
+export type TinyOsNativeWorkspaceResource = {
+  access: TinyOsResourceAccess;
+  kind: "workspace_resource";
+  path: string;
+  resourceKind: "directory" | "file";
+  workspaceKey: string;
+};
+
+export type TinyOsNativeTerminalProcess = {
+  command?: string;
+  kind: "terminal_process";
+  nativeProcessId: string;
+  runId: string;
+  sessionId: string;
+  state: TinyOsProcessState;
+  toolCallId?: string;
+  workingDirectory?: string;
+};
+
+export type TinyOsNativeBrowserCapture = {
+  browserSessionId?: string;
+  captureId: string;
+  kind: "browser_capture";
+  realCapture: boolean;
+  title?: string;
+  url?: string;
+};
+
+export type TinyOsNativeSnapshotData =
+  | TinyOsNativeWorkspaceResource
+  | TinyOsNativeTerminalProcess
+  | TinyOsNativeBrowserCapture;
+
+export type TinyOsNativeSnapshot<T extends TinyOsNativeSnapshotData = TinyOsNativeSnapshotData> = {
+  data: T;
+  observedAt: string;
+  provenance: TinyOsProvenance;
+  revision: number | string;
+  schemaVersion: "tinybot.tinyos_native_snapshot.v1";
+  sourceId: string;
+};
+
+type NativeSnapshotMetadata = {
+  observedAt: string;
+  revision: number | string;
+  sourceId: string;
+};
+
+export function createTinyOsWorkspaceResourceSnapshot(
+  data: TinyOsNativeWorkspaceResource,
+  metadata: NativeSnapshotMetadata,
+): TinyOsNativeSnapshot<TinyOsNativeWorkspaceResource> {
+  return createTinyOsNativeSnapshot({
+    ...data,
+    path: requiredText(data.path, "Workspace resource path"),
+    workspaceKey: requiredText(data.workspaceKey, "Workspace key"),
+  }, metadata, "native_query");
+}
+
+export function createTinyOsTerminalProcessSnapshot(
+  data: TinyOsNativeTerminalProcess,
+  metadata: NativeSnapshotMetadata,
+): TinyOsNativeSnapshot<TinyOsNativeTerminalProcess> {
+  return createTinyOsNativeSnapshot({
+    ...data,
+    nativeProcessId: requiredText(data.nativeProcessId, "Native process id"),
+    runId: requiredText(data.runId, "Terminal run id"),
+    sessionId: requiredText(data.sessionId, "Terminal session id"),
+  }, metadata, "native_query");
+}
+
+export function createTinyOsBrowserCaptureSnapshot(
+  data: TinyOsNativeBrowserCapture,
+  metadata: NativeSnapshotMetadata,
+): TinyOsNativeSnapshot<TinyOsNativeBrowserCapture> {
+  return createTinyOsNativeSnapshot({
+    ...data,
+    captureId: requiredText(data.captureId, "Browser capture id"),
+  }, metadata, data.realCapture ? "real_capture" : "native_query");
+}
+
+function createTinyOsNativeSnapshot<T extends TinyOsNativeSnapshotData>(
+  data: T,
+  metadata: NativeSnapshotMetadata,
+  provenanceKind: Extract<TinyOsProvenance["kind"], "native_query" | "real_capture">,
+): TinyOsNativeSnapshot<T> {
+  const sourceId = requiredText(metadata.sourceId, "Native snapshot source id");
+  const observedAt = requiredObservationTime(metadata.observedAt);
+  const revision = requiredRevision(metadata.revision);
+  return {
+    data,
+    observedAt,
+    provenance: {
+      kind: provenanceKind,
+      observedAt,
+      revision,
+      sourceId,
+    },
+    revision,
+    schemaVersion: "tinybot.tinyos_native_snapshot.v1",
+    sourceId,
+  };
+}
+
+function requiredText(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} is required.`);
+  return normalized;
+}
+
+function requiredObservationTime(value: string): string {
+  const normalized = requiredText(value, "Native snapshot observation time");
+  if (!Number.isFinite(Date.parse(normalized))) {
+    throw new Error("Native snapshot observation time must be a valid timestamp.");
+  }
+  return normalized;
+}
+
+function requiredRevision(value: number | string): number | string {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value < 0) throw new Error("Native snapshot revision must be non-negative.");
+    return value;
+  }
+  return requiredText(value, "Native snapshot revision");
+}

--- a/src/app-core/chat/tinyOsReferenceTransfer.test.ts
+++ b/src/app-core/chat/tinyOsReferenceTransfer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  readTinyOsReferenceTransfer,
+  TINYOS_REFERENCE_MIME,
+  tinyOsReferenceAcceptedBy,
+  writeTinyOsReferenceTransfer,
+  type TinyOsCrossAppReference,
+} from "./tinyOsReferenceTransfer";
+
+describe("TinyOS reference transfer", () => {
+  it("round-trips a typed file context reference", () => {
+    const stored = new Map<string, string>();
+    const transfer = {
+      effectAllowed: "none" as DataTransfer["effectAllowed"],
+      getData: (type: string) => stored.get(type) ?? "",
+      setData: (type: string, value: string) => stored.set(type, value),
+    };
+    const reference: TinyOsCrossAppReference = {
+      kind: "context",
+      reference: {
+        kind: "file",
+        path: "src/app.ts",
+        provenance: { kind: "canonical", sourceItemId: "item-1", turnId: "turn-1" },
+        startLine: 2,
+      },
+    };
+
+    writeTinyOsReferenceTransfer(transfer, reference);
+
+    expect(transfer.effectAllowed).toBe("copy");
+    expect(stored.has(TINYOS_REFERENCE_MIME)).toBe(true);
+    expect(readTinyOsReferenceTransfer(transfer)).toEqual({ reference, status: "accepted" });
+  });
+
+  it("rejects malformed payloads instead of guessing", () => {
+    expect(readTinyOsReferenceTransfer({ getData: () => "not-json" })).toEqual({
+      reason: "The TinyOS reference payload is not valid JSON.",
+      status: "rejected",
+    });
+    expect(readTinyOsReferenceTransfer({ getData: () => JSON.stringify({ schemaVersion: "tinyos.reference.v2" }) })).toEqual({
+      reason: "The TinyOS reference payload does not match tinyos.reference.v1.",
+      status: "rejected",
+    });
+  });
+
+  it("rejects unsupported targets without invoking a dispatcher", () => {
+    const dispatch = vi.fn();
+    const result = tinyOsReferenceAcceptedBy({ itemId: "item-1", kind: "evidence", title: "Result", turnId: "turn-1" }, "chat");
+    if (result.status === "accepted") dispatch(result.reference);
+
+    expect(result).toEqual({
+      reason: "Chat accepts file and terminal context, not evidence references.",
+      status: "rejected",
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/app-core/chat/tinyOsReferenceTransfer.ts
+++ b/src/app-core/chat/tinyOsReferenceTransfer.ts
@@ -1,0 +1,101 @@
+import type { TinyOsContextReference } from "./tinyOsUiState";
+
+export const TINYOS_REFERENCE_MIME = "application/x-tinyos-reference+json";
+
+export type TinyOsCrossAppReference =
+  | { kind: "context"; reference: TinyOsContextReference }
+  | { itemId: string; kind: "evidence"; title: string; turnId: string }
+  | { kind: "resource"; resourceId: string; resourceKind: string; title: string };
+
+export type TinyOsReferenceReadResult =
+  | { reference: TinyOsCrossAppReference; status: "accepted" }
+  | { reason: string; status: "rejected" };
+
+type TinyOsTargetReadResult<TReference extends TinyOsCrossAppReference> =
+  | { reference: TReference; status: "accepted" }
+  | { reason: string; status: "rejected" };
+
+type TinyOsReferenceEnvelope = {
+  reference: TinyOsCrossAppReference;
+  schemaVersion: "tinyos.reference.v1";
+};
+
+export function writeTinyOsReferenceTransfer(
+  dataTransfer: Pick<DataTransfer, "effectAllowed" | "setData">,
+  reference: TinyOsCrossAppReference,
+): void {
+  const envelope: TinyOsReferenceEnvelope = {
+    reference,
+    schemaVersion: "tinyos.reference.v1",
+  };
+  dataTransfer.effectAllowed = "copy";
+  dataTransfer.setData(TINYOS_REFERENCE_MIME, JSON.stringify(envelope));
+}
+
+export function readTinyOsReferenceTransfer(
+  dataTransfer: Pick<DataTransfer, "getData">,
+): TinyOsReferenceReadResult {
+  const raw = dataTransfer.getData(TINYOS_REFERENCE_MIME);
+  if (!raw) return { reason: "The drag does not contain a TinyOS structured reference.", status: "rejected" };
+
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return { reason: "The TinyOS reference payload is not valid JSON.", status: "rejected" };
+  }
+  if (!isRecord(value) || value.schemaVersion !== "tinyos.reference.v1" || !isCrossAppReference(value.reference)) {
+    return { reason: "The TinyOS reference payload does not match tinyos.reference.v1.", status: "rejected" };
+  }
+  return { reference: value.reference, status: "accepted" };
+}
+
+export function tinyOsReferenceAcceptedBy(
+  reference: TinyOsCrossAppReference,
+  target: "chat",
+): TinyOsTargetReadResult<Extract<TinyOsCrossAppReference, { kind: "context" }>>;
+export function tinyOsReferenceAcceptedBy(
+  reference: TinyOsCrossAppReference,
+  target: "inspector",
+): TinyOsTargetReadResult<Extract<TinyOsCrossAppReference, { kind: "evidence" }>>;
+export function tinyOsReferenceAcceptedBy(
+  reference: TinyOsCrossAppReference,
+  target: "chat" | "inspector",
+): TinyOsReferenceReadResult {
+  if (target === "chat" && reference.kind === "context") return { reference, status: "accepted" };
+  if (target === "inspector" && reference.kind === "evidence") return { reference, status: "accepted" };
+  return {
+    reason: target === "chat"
+      ? `Chat accepts file and terminal context, not ${reference.kind} references.`
+      : `Inspector accepts canonical evidence, not ${reference.kind} references.`,
+    status: "rejected",
+  };
+}
+
+function isCrossAppReference(value: unknown): value is TinyOsCrossAppReference {
+  if (!isRecord(value) || typeof value.kind !== "string") return false;
+  if (value.kind === "evidence") {
+    return isNonEmptyString(value.itemId) && isNonEmptyString(value.title) && isNonEmptyString(value.turnId);
+  }
+  if (value.kind === "resource") {
+    return isNonEmptyString(value.resourceId) && isNonEmptyString(value.resourceKind) && isNonEmptyString(value.title);
+  }
+  return value.kind === "context" && isContextReference(value.reference);
+}
+
+function isContextReference(value: unknown): value is TinyOsContextReference {
+  if (!isRecord(value) || (value.kind !== "file" && value.kind !== "terminal")) return false;
+  if (value.kind === "file") {
+    return isNonEmptyString(value.path) && isRecord(value.provenance)
+      && (value.provenance.kind === "canonical" || value.provenance.kind === "workspace_read");
+  }
+  return isNonEmptyString(value.command) && isNonEmptyString(value.sourceItemId) && isNonEmptyString(value.turnId);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && Boolean(value.trim());
+}

--- a/src/app-core/chat/tinyOsShellCommandRegistry.test.ts
+++ b/src/app-core/chat/tinyOsShellCommandRegistry.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createTinyOsShellCommandRegistry,
+  defineTinyOsShellCommand,
+  executeTinyOsShellCommand,
+} from "./tinyOsShellCommandRegistry";
+
+describe("TinyOS shell command registry", () => {
+  it("registers and executes typed local presentation commands", async () => {
+    const dispatch = vi.fn();
+    const command = defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "application",
+      dispatch,
+      id: "app.open:terminal",
+      input: { kind: "none" },
+      keywords: ["Terminal", " terminal ", "shell"],
+      label: "Open Terminal",
+      scope: "local_presentation",
+      target: { appId: "terminal", kind: "application" },
+    });
+    const registry = createTinyOsShellCommandRegistry([command]);
+
+    await expect(registry.execute(command.id)).resolves.toEqual({ commandId: command.id, status: "executed" });
+    expect(dispatch).toHaveBeenCalledWith({ appId: "terminal", kind: "application" }, undefined);
+    expect(registry.get(command.id)?.keywords).toEqual(["terminal", "shell"]);
+  });
+
+  it("rejects unavailable runtime commands without dispatch", async () => {
+    const dispatch = vi.fn();
+    const command = defineTinyOsShellCommand({
+      availability: { available: false, reason: "History snapshots are read-only.", reasonCode: "history_read_only" },
+      category: "process",
+      dispatch,
+      id: "agent.cancel",
+      input: { kind: "none" },
+      keywords: ["cancel", "stop"],
+      label: "Cancel Agent run",
+      scope: "runtime",
+      target: { kind: "run", runId: "run-1" },
+    });
+
+    await expect(executeTinyOsShellCommand(command)).resolves.toEqual({
+      commandId: "agent.cancel",
+      reason: "History snapshots are read-only.",
+      reasonCode: "history_read_only",
+      status: "rejected",
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("enforces History read-only at the registry boundary while keeping local commands available", async () => {
+    const runtimeDispatch = vi.fn();
+    const localDispatch = vi.fn();
+    const registry = createTinyOsShellCommandRegistry([
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "process",
+        dispatch: runtimeDispatch,
+        id: "terminal.execute",
+        input: { kind: "none" },
+        keywords: ["terminal"],
+        label: "Run command",
+        scope: "runtime",
+        target: { kind: "shell" },
+      }),
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "window",
+        dispatch: localDispatch,
+        id: "window.focus:terminal",
+        input: { kind: "none" },
+        keywords: ["terminal"],
+        label: "Focus Terminal",
+        scope: "local_presentation",
+        target: { appId: "terminal", kind: "window" },
+      }),
+    ], { simulationMode: "history" });
+
+    await expect(registry.execute("terminal.execute")).resolves.toMatchObject({
+      reasonCode: "history_read_only",
+      status: "rejected",
+    });
+    await expect(registry.execute("window.focus:terminal")).resolves.toMatchObject({ status: "executed" });
+    expect(registry.get("terminal.execute")?.availability).toMatchObject({
+      available: false,
+      reason: "History snapshots are read-only.",
+    });
+    expect(runtimeDispatch).not.toHaveBeenCalled();
+    expect(localDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails fast for invalid or ambiguous registrations", () => {
+    const dispatch = vi.fn();
+    expect(() => defineTinyOsShellCommand({
+      availability: { available: false, reason: "" },
+      category: "system",
+      dispatch,
+      id: "shell.overview",
+      input: { kind: "none" },
+      keywords: [],
+      label: "Overview",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    })).toThrow("unavailable without a reason");
+
+    const command = defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "system",
+      dispatch,
+      id: "shell.overview",
+      input: { kind: "none" },
+      keywords: [],
+      label: "Overview",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    });
+    expect(() => createTinyOsShellCommandRegistry([command, command])).toThrow("Duplicate TinyOS shell command id");
+  });
+
+  it("does not swallow dispatcher failures", async () => {
+    const command = defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "process",
+      dispatch: () => { throw new Error("gateway dispatch failed"); },
+      id: "agent.pause",
+      input: { kind: "none" },
+      keywords: [],
+      label: "Pause Agent run",
+      scope: "runtime",
+      target: { kind: "run", runId: "run-1" },
+    });
+
+    await expect(executeTinyOsShellCommand(command)).rejects.toThrow("gateway dispatch failed");
+  });
+
+  it("validates structured runtime command input before dispatch", async () => {
+    const dispatch = vi.fn();
+    const command = defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "process",
+      dispatch,
+      id: "terminal.execute",
+      input: {
+        fields: [
+          { label: "command", name: "command", required: true },
+          { label: "working directory", name: "cwd", required: false },
+        ],
+        kind: "fields",
+      },
+      keywords: ["terminal"],
+      label: "Run Terminal command",
+      scope: "runtime",
+      target: { kind: "shell" },
+    });
+    const registry = createTinyOsShellCommandRegistry([command]);
+
+    await expect(registry.execute("terminal.execute")).rejects.toThrow("requires structured input");
+    await expect(registry.execute("terminal.execute", { command: "  " })).rejects.toThrow("requires command");
+    await expect(registry.execute("terminal.execute", { command: "cargo test", cwd: "." })).resolves.toEqual({
+      commandId: "terminal.execute",
+      status: "executed",
+    });
+    expect(dispatch).toHaveBeenCalledWith({ kind: "shell" }, { command: "cargo test", cwd: "." });
+  });
+});

--- a/src/app-core/chat/tinyOsShellCommandRegistry.ts
+++ b/src/app-core/chat/tinyOsShellCommandRegistry.ts
@@ -1,0 +1,175 @@
+import type { TinyOsAppId } from "./tinyOsDesktopModel";
+
+export type TinyOsShellCommandId =
+  | "agent.cancel"
+  | "agent.pause"
+  | "agent.resume"
+  | "browser.click"
+  | "browser.navigate"
+  | "browser.type"
+  | "history.next"
+  | "history.previous"
+  | "history.return_live"
+  | `history.select_event:${number}`
+  | "shell.close"
+  | "shell.expanded_toggle"
+  | "shell.notification_center"
+  | "shell.overview"
+  | "shell.palette"
+  | "shell.reset_layout"
+  | "shell.workspace_toggle"
+  | "terminal.cancel"
+  | "terminal.execute"
+  | `app.open:${TinyOsAppId}`
+  | `evidence.inspect:${string}`
+  | `history.select:${string}`
+  | `notification.open:${string}`
+  | `notification.read:${string}`
+  | `operation.retry:${string}`
+  | `process.inspect:${string}`
+  | `process.reveal:${string}`
+  | `reference.attach:${string}`
+  | `resource.reveal:${string}`
+  | `window.focus:${TinyOsAppId}`
+  | `window.maximize:${TinyOsAppId}`
+  | `window.minimize:${TinyOsAppId}`;
+
+export type TinyOsShellCommandTarget =
+  | { appId: TinyOsAppId; kind: "application" }
+  | { appId: TinyOsAppId; kind: "window" }
+  | { itemId: string; kind: "evidence"; turnId?: string }
+  | { itemId: string; kind: "history"; turnId: string }
+  | { itemId: string; kind: "operation"; runId: string; turnId: string }
+  | { kind: "process"; processId: string; runId: string }
+  | { kind: "resource"; resourceId: string }
+  | { kind: "run"; runId: string }
+  | { kind: "shell" };
+
+export type TinyOsShellCommandInputSchema =
+  | { kind: "none" }
+  | { fields: readonly { label: string; name: string; required: boolean }[]; kind: "fields" }
+  | { kind: "text"; label: string; required: boolean }
+  | { acceptedKinds: readonly string[]; kind: "reference" };
+
+export type TinyOsShellCommandInput = Readonly<Record<string, string>> | string | undefined;
+
+export type TinyOsShellCommandAvailability =
+  | { available: true }
+  | { available: false; reason: string; reasonCode?: string };
+
+export type TinyOsShellCommand<TTarget extends TinyOsShellCommandTarget = TinyOsShellCommandTarget> = {
+  availability: TinyOsShellCommandAvailability;
+  category: "application" | "history" | "operation" | "process" | "resource" | "system" | "window";
+  dispatch(target: TTarget, input?: TinyOsShellCommandInput): void | Promise<void>;
+  id: TinyOsShellCommandId;
+  input: TinyOsShellCommandInputSchema;
+  keywords: readonly string[];
+  label: string;
+  scope: "local_presentation" | "runtime";
+  target: TTarget;
+};
+
+export type TinyOsShellCommandExecution =
+  | { commandId: TinyOsShellCommandId; status: "executed" }
+  | { commandId: TinyOsShellCommandId; reason: string; reasonCode?: string; status: "rejected" };
+
+export type TinyOsShellCommandRegistry = {
+  commands: readonly TinyOsShellCommand[];
+  execute: (id: TinyOsShellCommandId, input?: TinyOsShellCommandInput) => Promise<TinyOsShellCommandExecution>;
+  get: (id: TinyOsShellCommandId) => TinyOsShellCommand | undefined;
+};
+
+export type TinyOsShellCommandRegistryOptions = {
+  simulationMode?: "history" | "live";
+};
+
+export function defineTinyOsShellCommand<TTarget extends TinyOsShellCommandTarget>(
+  command: TinyOsShellCommand<TTarget>,
+): TinyOsShellCommand<TTarget> {
+  const label = command.label.trim();
+  if (!label) throw new Error(`TinyOS shell command ${command.id} requires an accessible label.`);
+  if (!command.availability.available && !command.availability.reason.trim()) {
+    throw new Error(`TinyOS shell command ${command.id} is unavailable without a reason.`);
+  }
+  if (command.input.kind === "reference" && !command.input.acceptedKinds.length) {
+    throw new Error(`TinyOS shell command ${command.id} reference input requires at least one accepted kind.`);
+  }
+  if (command.input.kind === "fields" && !command.input.fields.length) {
+    throw new Error(`TinyOS shell command ${command.id} field input requires at least one field.`);
+  }
+  return {
+    ...command,
+    label,
+    keywords: uniqueSearchTerms(command.keywords),
+  };
+}
+
+export function createTinyOsShellCommandRegistry(
+  commands: readonly TinyOsShellCommand[],
+  options: TinyOsShellCommandRegistryOptions = {},
+): TinyOsShellCommandRegistry {
+  const byId = new Map<TinyOsShellCommandId, TinyOsShellCommand>();
+  for (const sourceCommand of commands) {
+    const command = options.simulationMode === "history" && sourceCommand.scope === "runtime"
+      ? {
+          ...sourceCommand,
+          availability: {
+            available: false as const,
+            reason: "History snapshots are read-only.",
+            reasonCode: "history_read_only",
+          },
+        }
+      : sourceCommand;
+    if (byId.has(command.id)) throw new Error(`Duplicate TinyOS shell command id: ${command.id}`);
+    byId.set(command.id, command);
+  }
+  const registered = [...byId.values()];
+  return {
+    commands: registered,
+    execute: async (id, input) => {
+      const command = byId.get(id);
+      if (!command) throw new Error(`Unknown TinyOS shell command: ${id}`);
+      return executeTinyOsShellCommand(command, input);
+    },
+    get: (id) => byId.get(id),
+  };
+}
+
+export async function executeTinyOsShellCommand(
+  command: TinyOsShellCommand,
+  input?: TinyOsShellCommandInput,
+): Promise<TinyOsShellCommandExecution> {
+  if (!command.availability.available) {
+    return {
+      commandId: command.id,
+      reason: command.availability.reason,
+      ...(command.availability.reasonCode ? { reasonCode: command.availability.reasonCode } : {}),
+      status: "rejected",
+    };
+  }
+  validateTinyOsShellCommandInput(command, input);
+  await command.dispatch(command.target, input);
+  return { commandId: command.id, status: "executed" };
+}
+
+function validateTinyOsShellCommandInput(command: TinyOsShellCommand, input?: TinyOsShellCommandInput): void {
+  if (command.input.kind === "none" || command.input.kind === "reference") return;
+  if (command.input.kind === "text") {
+    if (command.input.required && (typeof input !== "string" || !input.trim())) {
+      throw new Error(`TinyOS shell command ${command.id} requires ${command.input.label}.`);
+    }
+    return;
+  }
+  if (!input || typeof input === "string") {
+    throw new Error(`TinyOS shell command ${command.id} requires structured input.`);
+  }
+  for (const field of command.input.fields) {
+    if (field.required && !input[field.name]?.trim()) {
+      throw new Error(`TinyOS shell command ${command.id} requires ${field.label}.`);
+    }
+  }
+}
+
+function uniqueSearchTerms(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim().toLocaleLowerCase()).filter(Boolean))];
+}

--- a/src/app-core/chat/tinyOsTimeMachine.test.ts
+++ b/src/app-core/chat/tinyOsTimeMachine.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import type { BackendAgentTurnItem } from "./chatRunModel";
+import {
+  benchmarkTinyOsReplay,
+  createTinyOsTimeMachineIndex,
+  reconstructTinyOsKernelAt,
+  tinyOsSimulationCursorAt,
+  TINYOS_REPLAY_PROJECTOR_VERSION,
+  TINYOS_REPLAY_TARGET_MS,
+} from "./tinyOsTimeMachine";
+
+function item(index: number, overrides: Partial<BackendAgentTurnItem> = {}): BackendAgentTurnItem {
+  return {
+    schemaVersion: "tinybot.turn_item.v2",
+    createdAt: `2026-07-14T00:00:${String(index).padStart(2, "0")}Z`,
+    data: {
+      args: {},
+      name: "workspace.read_file",
+      result: {},
+      status: "completed",
+      timing: {},
+      toolCallId: `call-${index}`,
+      type: "tool_call",
+    },
+    itemId: `item-${index}`,
+    kind: "tool_call",
+    revision: 1,
+    runId: "run-1",
+    sequence: index,
+    sessionId: "session-1",
+    status: "completed",
+    title: `Event ${index}`,
+    turnId: index < 2 ? "turn-1" : "turn-2",
+    ...overrides,
+  };
+}
+
+describe("TinyOS Time Machine", () => {
+  it("indexes every canonical boundary and groups it without inventing timestamps", () => {
+    const index = createTinyOsTimeMachineIndex([
+      item(0),
+      item(1, { createdAt: "not-a-timestamp" }),
+      item(2),
+    ]);
+
+    expect(index).toMatchObject({ eventCount: 3, projectorVersion: TINYOS_REPLAY_PROJECTOR_VERSION });
+    expect(index.groups.map((group) => group.boundaryIndexes)).toEqual([[0, 1], [2]]);
+    expect(index.boundaries[0].wallClockTime).toBe("2026-07-14T00:00:00Z");
+    expect(index.boundaries[1]).not.toHaveProperty("wallClockTime");
+    expect(tinyOsSimulationCursorAt(index, 1)).toMatchObject({
+      boundary: { itemId: "item-1", turnId: "turn-1" },
+      eventCount: 3,
+      eventIndex: 1,
+      mode: "history",
+    });
+    expect(() => tinyOsSimulationCursorAt(index, 3)).toThrow(/event index is unavailable/i);
+  });
+
+  it("reconstructs deterministically at an exact revision boundary", () => {
+    const firstRevision = item(0, { itemId: "same-item", revision: 1, status: "running" });
+    const secondRevision = item(1, { itemId: "same-item", revision: 2, status: "completed" });
+    const items = [firstRevision, secondRevision];
+    const index = createTinyOsTimeMachineIndex(items);
+    const first = reconstructTinyOsKernelAt(items, tinyOsSimulationCursorAt(index, 0));
+    const second = reconstructTinyOsKernelAt(items, tinyOsSimulationCursorAt(index, 1));
+    const reloaded = reconstructTinyOsKernelAt(
+      JSON.parse(JSON.stringify(items)) as BackendAgentTurnItem[],
+      tinyOsSimulationCursorAt(index, 1),
+    );
+
+    expect(first.snapshot.processes.find(({ kind }) => kind === "tool_operation")?.state).toBe("running");
+    expect(second.snapshot.processes.find(({ kind }) => kind === "tool_operation")?.state).toBe("completed");
+    expect(reloaded.snapshot).toEqual(second.snapshot);
+  });
+
+  it("discards an incompatible disposable checkpoint and rebuilds from canonical events", () => {
+    const items = [item(0), item(1)];
+    const index = createTinyOsTimeMachineIndex(items);
+    const cursor = tinyOsSimulationCursorAt(index, 1);
+    const rebuilt = reconstructTinyOsKernelAt(items, cursor, {
+      checkpoint: {
+        eventIndex: 1,
+        projectorVersion: TINYOS_REPLAY_PROJECTOR_VERSION + 1,
+        snapshot: { truth: "stale" },
+      },
+    });
+
+    expect(rebuilt.checkpointStatus).toBe("discarded_incompatible");
+    expect(rebuilt.snapshot.cursor.eventIndex).toBe(1);
+    expect(rebuilt.snapshot.truth).toBe("derived");
+  });
+
+  it("benchmarks large replay before recommending checkpoints", () => {
+    const items = Array.from({ length: 2_000 }, (_, index) => item(index % 60, {
+      itemId: `benchmark-${index}`,
+      sequence: index,
+      turnId: `turn-${Math.floor(index / 25)}`,
+    }));
+    const benchmark = benchmarkTinyOsReplay(items);
+
+    expect(benchmark.sampleEventIndexes).toEqual([0, 999, 1_999]);
+    expect(benchmark.maxDurationMs).toBeLessThan(TINYOS_REPLAY_TARGET_MS);
+    expect(benchmark.checkpointRecommended).toBe(false);
+  });
+});

--- a/src/app-core/chat/tinyOsTimeMachine.ts
+++ b/src/app-core/chat/tinyOsTimeMachine.ts
@@ -1,0 +1,200 @@
+import type { BackendAgentTurnItem } from "./chatRunModel";
+import {
+  projectTinyOsKernel,
+  type TinyOsKernelProjectionOptions,
+  type TinyOsKernelSnapshot,
+  type TinyOsSimulationCursor,
+} from "./tinyOsKernelModel";
+
+export const TINYOS_REPLAY_PROJECTOR_VERSION = 1;
+export const TINYOS_REPLAY_TARGET_MS = 250;
+
+export type TinyOsTimeMachineBoundary = {
+  eventIndex: number;
+  groupId: string;
+  itemId: string;
+  kind: BackendAgentTurnItem["kind"];
+  revision: number;
+  runId: string;
+  sequence: number;
+  status: string;
+  title: string;
+  turnId: string;
+  wallClockTime?: string;
+};
+
+export type TinyOsTimeMachineGroup = {
+  boundaryIndexes: number[];
+  firstEventIndex: number;
+  id: string;
+  label: string;
+  lastEventIndex: number;
+  runId: string;
+  turnId: string;
+};
+
+export type TinyOsTimeMachineIndex = {
+  boundaries: TinyOsTimeMachineBoundary[];
+  eventCount: number;
+  groups: TinyOsTimeMachineGroup[];
+  projectorVersion: number;
+};
+
+export type TinyOsReplayCheckpoint = {
+  eventIndex: number;
+  projectorVersion: number;
+  snapshot: TinyOsKernelSnapshot;
+};
+
+export type TinyOsReplayResult = {
+  checkpointStatus: "discarded_incompatible" | "rebuilt" | "restored";
+  snapshot: TinyOsKernelSnapshot;
+};
+
+export type TinyOsReplayBenchmark = {
+  checkpointRecommended: boolean;
+  eventCount: number;
+  maxDurationMs: number;
+  sampleEventIndexes: number[];
+  targetMs: number;
+};
+
+export function createTinyOsTimeMachineIndex(
+  items: readonly BackendAgentTurnItem[],
+): TinyOsTimeMachineIndex {
+  const boundaries = items.map((item, eventIndex): TinyOsTimeMachineBoundary => {
+    const wallClockTime = reliableTimestamp(item.updatedAt || item.createdAt);
+    return {
+      eventIndex,
+      groupId: `${item.runId}:${item.turnId}`,
+      itemId: item.itemId,
+      kind: item.kind,
+      revision: item.revision,
+      runId: item.runId,
+      sequence: item.sequence,
+      status: item.status,
+      title: item.title?.trim() || humanizeKind(item.kind),
+      turnId: item.turnId,
+      ...(wallClockTime ? { wallClockTime } : {}),
+    };
+  });
+  const groupsById = new Map<string, TinyOsTimeMachineGroup>();
+  for (const boundary of boundaries) {
+    const current = groupsById.get(boundary.groupId);
+    if (current) {
+      current.boundaryIndexes.push(boundary.eventIndex);
+      current.lastEventIndex = boundary.eventIndex;
+      continue;
+    }
+    groupsById.set(boundary.groupId, {
+      boundaryIndexes: [boundary.eventIndex],
+      firstEventIndex: boundary.eventIndex,
+      id: boundary.groupId,
+      label: `Turn ${shortIdentity(boundary.turnId)}`,
+      lastEventIndex: boundary.eventIndex,
+      runId: boundary.runId,
+      turnId: boundary.turnId,
+    });
+  }
+  return {
+    boundaries,
+    eventCount: boundaries.length,
+    groups: [...groupsById.values()],
+    projectorVersion: TINYOS_REPLAY_PROJECTOR_VERSION,
+  };
+}
+
+export function tinyOsSimulationCursorAt(
+  index: TinyOsTimeMachineIndex,
+  eventIndex: number,
+): TinyOsSimulationCursor {
+  const boundary = index.boundaries[eventIndex];
+  if (!boundary) throw new Error(`TinyOS history event index is unavailable: ${eventIndex}`);
+  return {
+    boundary: {
+      itemId: boundary.itemId,
+      runId: boundary.runId,
+      sequence: boundary.sequence,
+      turnId: boundary.turnId,
+    },
+    eventCount: index.eventCount,
+    eventIndex,
+    mode: "history",
+    ...(boundary.wallClockTime ? { wallClockTime: boundary.wallClockTime } : {}),
+  };
+}
+
+export function reconstructTinyOsKernelAt(
+  items: readonly BackendAgentTurnItem[],
+  cursor: TinyOsSimulationCursor,
+  options: TinyOsKernelProjectionOptions & { checkpoint?: unknown } = {},
+): TinyOsReplayResult {
+  const checkpoint = compatibleCheckpoint(options.checkpoint, cursor);
+  if (checkpoint) return { checkpointStatus: "restored", snapshot: checkpoint.snapshot };
+  const boundary = cursor.boundary;
+  if (!boundary || cursor.mode !== "history") {
+    return { checkpointStatus: options.checkpoint ? "discarded_incompatible" : "rebuilt", snapshot: projectTinyOsKernel(items, { mode: "live" }, options) };
+  }
+  return {
+    checkpointStatus: options.checkpoint ? "discarded_incompatible" : "rebuilt",
+    snapshot: projectTinyOsKernel(items, {
+      eventIndex: cursor.eventIndex,
+      itemId: boundary.itemId,
+      mode: "history",
+      runId: boundary.runId,
+      turnId: boundary.turnId,
+    }, options),
+  };
+}
+
+export function benchmarkTinyOsReplay(
+  items: readonly BackendAgentTurnItem[],
+  sampleEventIndexes = defaultBenchmarkIndexes(items.length),
+  now: () => number = () => performance.now(),
+): TinyOsReplayBenchmark {
+  const index = createTinyOsTimeMachineIndex(items);
+  let maxDurationMs = 0;
+  for (const eventIndex of sampleEventIndexes) {
+    const cursor = tinyOsSimulationCursorAt(index, eventIndex);
+    const startedAt = now();
+    reconstructTinyOsKernelAt(items, cursor);
+    maxDurationMs = Math.max(maxDurationMs, now() - startedAt);
+  }
+  return {
+    checkpointRecommended: maxDurationMs > TINYOS_REPLAY_TARGET_MS,
+    eventCount: items.length,
+    maxDurationMs,
+    sampleEventIndexes: [...sampleEventIndexes],
+    targetMs: TINYOS_REPLAY_TARGET_MS,
+  };
+}
+
+function compatibleCheckpoint(
+  value: unknown,
+  cursor: TinyOsSimulationCursor,
+): TinyOsReplayCheckpoint | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const checkpoint = value as Partial<TinyOsReplayCheckpoint>;
+  return checkpoint.projectorVersion === TINYOS_REPLAY_PROJECTOR_VERSION
+    && checkpoint.eventIndex === cursor.eventIndex
+    && checkpoint.snapshot?.cursor.eventIndex === cursor.eventIndex
+    ? checkpoint as TinyOsReplayCheckpoint
+    : undefined;
+}
+
+function defaultBenchmarkIndexes(eventCount: number): number[] {
+  if (eventCount <= 0) return [];
+  return [...new Set([0, Math.floor((eventCount - 1) / 2), eventCount - 1])];
+}
+
+function reliableTimestamp(value: string): string {
+  return value && Number.isFinite(Date.parse(value)) ? value : "";
+}
+
+function humanizeKind(value: string): string {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (character: string) => character.toUpperCase());
+}
+
+function shortIdentity(value: string): string {
+  return value.length <= 12 ? value : value.slice(0, 12);
+}

--- a/src/app-core/chat/tinyOsUiState.test.ts
+++ b/src/app-core/chat/tinyOsUiState.test.ts
@@ -44,6 +44,10 @@ describe("TinyOS UI state", () => {
     expect(tinyOsLayoutModeForWidth(521)).toBe("workspace");
     const compact = createTinyOsUiState({ appIds: ["files"], bounds: { height: 400, width: 420 }, layoutMode: "compact" });
     expect(compact.windowLayout.files).toMatchObject({ height: 380, width: 400, x: 10, y: 10 });
+
+    const workspace = createTinyOsUiState({ appIds: ["files", "terminal"], bounds, layoutMode: "workspace" });
+    expect(workspace.windowLayout.files).toMatchObject({ height: 365, width: 462, x: 10, y: 28 });
+    expect(workspace.windowLayout.terminal).toMatchObject({ height: 307, width: 476, x: 214, y: 68 });
   });
 
   it("persists only versioned window layout and rejects incompatible data", () => {

--- a/src/app-core/chat/tinyOsUiState.ts
+++ b/src/app-core/chat/tinyOsUiState.ts
@@ -33,6 +33,9 @@ export type TinyOsFileReference = {
 export type TinyOsTerminalReference = {
   command: string;
   endLine?: number;
+  executionId: string;
+  processId?: string;
+  provenance: { kind: "canonical"; sourceItemId: string; turnId: string };
   sourceItemId: string;
   selectedText?: string;
   startLine?: number;

--- a/src/app-core/chat/tinyOsUiState.ts
+++ b/src/app-core/chat/tinyOsUiState.ts
@@ -85,7 +85,7 @@ export type TinyOsUiAction =
 const MIN_WINDOW_WIDTH = 260;
 const MIN_WINDOW_HEIGHT = 180;
 const DESKTOP_INSET = 10;
-const PERSISTENCE_VERSION = 1;
+const PERSISTENCE_VERSION = 2;
 const STORAGE_PREFIX = "tinybot.tinyos.layout";
 
 const APP_INDEX: Record<TinyOsAppId, number> = {
@@ -97,6 +97,7 @@ const APP_INDEX: Record<TinyOsAppId, number> = {
   subagents: 5,
   artifacts: 6,
   inspector: 7,
+  system_monitor: 8,
 };
 
 export function tinyOsLayoutModeForWidth(width: number, expanded = false): TinyOsLayoutMode {
@@ -287,14 +288,30 @@ function defaultWindowLayout(
   const index = APP_INDEX[appId];
   const availableWidth = Math.max(1, bounds.width - DESKTOP_INSET * 2);
   const availableHeight = Math.max(1, bounds.height - DESKTOP_INSET * 2);
-  const primary = appId === "files" || appId === "terminal";
-  const width = primary ? availableWidth * .86 : availableWidth * .82;
-  const height = primary ? availableHeight * .58 : availableHeight * .76;
+  if (appId === "files") {
+    return normalizeWindowLayout({
+      height: Math.round(availableHeight * .76),
+      width: Math.round(availableWidth * .68),
+      x: DESKTOP_INSET,
+      y: DESKTOP_INSET + 18,
+    }, bounds);
+  }
+  if (appId === "terminal") {
+    const width = Math.round(availableWidth * .7);
+    return normalizeWindowLayout({
+      height: Math.round(availableHeight * .64),
+      width,
+      x: bounds.width - DESKTOP_INSET - width,
+      y: DESKTOP_INSET + Math.round(availableHeight * .12),
+    }, bounds);
+  }
+  const width = Math.round(availableWidth * .78);
+  const height = Math.round(availableHeight * .72);
   return normalizeWindowLayout({
     height,
     width,
-    x: DESKTOP_INSET + (index % 4) * 14,
-    y: DESKTOP_INSET + (index % 5) * 18,
+    x: DESKTOP_INSET + (index % 4) * 18,
+    y: DESKTOP_INSET + 18 + (index % 5) * 22,
   }, bounds);
 }
 

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChatPage } from "./ChatPage";
 import type { ChatEvent, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
+import type { DesktopTurnSubmitCommand } from "../../app-core/chat/desktopCommand";
 import type { ReactChatMessage } from "./messageActions";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { createTinyOsAgentCancelCommand } from "../../app-core/chat/tinyOsCommandGateway";
@@ -116,18 +117,41 @@ function createStores(options: { sessions?: SessionSummary[] } = {}): { chatStor
     chatStore: {
       load: vi.fn(async (sessionId) => timelineFromReactMessages(sessionId, messages)),
       loadTinyOsCapabilities: vi.fn(async (sessionId) => effectiveCapabilities(sessionId)),
-      send: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-      dispatchCommand: vi.fn(async () => undefined),
-      resolveApproval: vi.fn(async () => undefined),
+      dispatch: vi.fn(async () => undefined),
       listAgentUiForms: vi.fn(async () => []),
-      submitAgentUiForm: vi.fn(async () => undefined),
-      cancelAgentUiForm: vi.fn(async () => undefined),
       branchFromMessage: vi.fn(async () => sessions[0]),
       copyMarkdown: vi.fn(async () => "# Planning notes"),
       subscribe: vi.fn(() => () => undefined),
     },
   };
+}
+
+function turnSubmitCommands(chatStore: ChatStore): DesktopTurnSubmitCommand[] {
+  return vi.mocked(chatStore.dispatch).mock.calls
+    .map(([command]) => command)
+    .filter((command): command is DesktopTurnSubmitCommand => command.kind === "turn.submit");
+}
+
+function expectTurnSubmit(chatStore: ChatStore, sessionId: string, input: unknown): void {
+  expect(turnSubmitCommands(chatStore)).toContainEqual(expect.objectContaining({
+    input,
+    kind: "turn.submit",
+    target: { sessionId },
+  }));
+}
+
+function mockTurnSubmit(
+  chatStore: ChatStore,
+  implementation: (command: DesktopTurnSubmitCommand) => void | Promise<void>,
+): void {
+  const fallback = chatStore.dispatch;
+  chatStore.dispatch = vi.fn(async (command) => {
+    if (command.kind === "turn.submit") {
+      await implementation(command);
+      return;
+    }
+    await fallback(command);
+  });
 }
 
 function failedPlanTimeline(sessionId = "s1") {
@@ -310,7 +334,7 @@ describe("ChatPage", () => {
     await user.type(screen.getByRole("textbox", { name: "Message" }), "Explain this line");
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
-    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", expect.objectContaining({
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", expect.objectContaining({
       references: [expect.objectContaining({
         evidenceId: "file-reference",
         sourceLine: 1,
@@ -551,7 +575,7 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
     await waitFor(() => expect(stores.sessionStore.create).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s-new", {
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s-new", {
       text: "Hello from an empty app",
       usePersistentRag: true,
     }));
@@ -578,7 +602,7 @@ describe("ChatPage", () => {
     await user.type(input, "Hello from an empty app");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
-    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s-new", {
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s-new", {
       text: "Hello from an empty app",
       usePersistentRag: true,
     }));
@@ -698,7 +722,7 @@ describe("ChatPage", () => {
     await user.click(suggestion);
 
     expect((screen.getByRole("textbox", { name: /message/i }) as HTMLTextAreaElement).value).toBe("规划一个任务并列出执行步骤");
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
   });
 
   it("keeps the normal bottom composer layout when a session has messages", async () => {
@@ -1165,7 +1189,7 @@ describe("ChatPage", () => {
   it("resolves pending approval steps from the details drawer", async () => {
     const user = userEvent.setup();
     const stores = createStores();
-    const dispatchCommand = vi.fn(async () => undefined);
+    const dispatch = vi.fn(async () => undefined);
     const approvalMessages: ReactChatMessage[] = [{
       id: "a-approval",
       role: "assistant",
@@ -1184,7 +1208,7 @@ describe("ChatPage", () => {
       } as NonNullable<ReactChatMessage["toolCalls"]>[number]],
     }];
     stores.chatStore.load = vi.fn(async (sessionId) => timelineFromReactMessages(sessionId, approvalMessages));
-    stores.chatStore.dispatchCommand = dispatchCommand;
+    stores.chatStore.dispatch = dispatch;
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
@@ -1198,7 +1222,7 @@ describe("ChatPage", () => {
 
     await user.click(within(drawer).getByRole("button", { name: "Allow for session" }));
 
-    expect(dispatchCommand).toHaveBeenCalledWith(expect.objectContaining({
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
       approval: { approvalId: "approval-1", approved: true, scope: "session" },
       kind: "approval.resolve",
       source: { control: "tool-approval", surface: "chat" },
@@ -1249,7 +1273,6 @@ describe("ChatPage", () => {
     });
     stores.chatStore.load = vi.fn(async () => canonical);
     (stores.chatStore as any).listAgentUiForms = vi.fn(async () => [form]);
-    (stores.chatStore as any).cancelAgentUiForm = vi.fn(async () => undefined);
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
@@ -1263,7 +1286,7 @@ describe("ChatPage", () => {
     fireEvent.change(within(card).getByLabelText("Nights"), { target: { value: "4" } });
     await user.click(within(card).getByRole("button", { name: "Save preferences" }));
 
-    expect(stores.chatStore.dispatchCommand).toHaveBeenCalledWith(expect.objectContaining({
+    expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
       form: {
         formId: "travel-preferences-1",
         values: { destination: "Singapore", nights: 4 },
@@ -1315,14 +1338,13 @@ describe("ChatPage", () => {
     const card = await screen.findByRole("form", { name: "Travel preferences" });
     await user.click(within(card).getByRole("button", { name: "Skip" }));
 
-    expect(stores.chatStore.dispatchCommand).toHaveBeenCalledWith(expect.objectContaining({
+    expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
       form: { formId: "travel-preferences-1" },
       kind: "form.cancel",
       source: { control: "chat-form", surface: "chat" },
       target: expect.objectContaining({ runId: "run-1", sessionId: "s1" }),
     }));
     expect(within(card).getByRole("button", { name: "Skip" }).hasAttribute("disabled")).toBe(true);
-    expect(stores.chatStore.cancelAgentUiForm).not.toHaveBeenCalled();
   });
 
   it("renders a resolved canonical form as a read-only submission summary", async () => {
@@ -1800,7 +1822,7 @@ describe("ChatPage", () => {
     const error = await screen.findByRole("alert", { name: "任务执行失败" });
     await user.click(within(error).getByRole("button", { name: "继续执行" }));
 
-    expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+    expectTurnSubmit(stores.chatStore, "s1", {
       text: "请从刚才中断的位置继续，沿用现有上下文和计划；先确认当前进度，再完成剩余任务。",
     });
   });
@@ -1820,12 +1842,12 @@ describe("ChatPage", () => {
     const error = await screen.findByRole("alert", { name: "任务执行失败" });
     await user.click(within(error).getByRole("button", { name: "重试当前步骤" }));
 
-    expect(stores.chatStore.dispatchCommand).toHaveBeenCalledWith(expect.objectContaining({
+    expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
       kind: "operation.retry",
       operation: { itemId: "error-failed-plan", turnId: timeline.turns[0].id },
       target: expect.objectContaining({ sessionId: "s1" }),
     }));
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
   });
 
   it("restarts a failed task in a new titled session", async () => {
@@ -1839,7 +1861,7 @@ describe("ChatPage", () => {
     await user.click(within(error).getByRole("button", { name: "重新开始" }));
 
     expect(stores.sessionStore.create).toHaveBeenCalledWith({ title: "Inspect the project and repo…" });
-    expect(stores.chatStore.send).toHaveBeenCalledWith("s2", { text: "Inspect the project and report findings" });
+    expectTurnSubmit(stores.chatStore, "s2", { text: "Inspect the project and report findings" });
   });
 
   it("loads owner-associated image references through the artifact API before previewing", async () => {
@@ -2131,7 +2153,7 @@ describe("ChatPage", () => {
     await user.type(input, "Hello from React");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
-    expect(stores.chatStore.send).toHaveBeenCalledWith("s1", { text: "Hello from React", usePersistentRag: true });
+    expectTurnSubmit(stores.chatStore, "s1", { text: "Hello from React", usePersistentRag: true });
     expect((input as HTMLTextAreaElement).value).toBe("");
   });
 
@@ -2151,7 +2173,7 @@ describe("ChatPage", () => {
     const input = await screen.findByRole("textbox", { name: /message/i });
     await user.type(input, "Summarize after this run{enter}");
 
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
     const queuedInputs = screen.getByLabelText("Queued inputs");
     expect(queuedInputs.textContent).toContain("Summarize after this run");
     expect(queuedInputs.textContent).toContain("Waiting");
@@ -2176,7 +2198,7 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: /delete queued input/i }));
 
     expect(screen.queryByLabelText("Queued inputs")).toBeNull();
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
   });
 
   it("enforces the queued input limit while running", async () => {
@@ -2229,26 +2251,26 @@ describe("ChatPage", () => {
     const input = await screen.findByRole("textbox", { name: /message/i });
     await user.type(input, "first queued{enter}");
     await user.type(input, "second queued{enter}");
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
 
     subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
-    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
       text: "first queued",
       usePersistentRag: true,
     }));
-    expect(stores.chatStore.send).toHaveBeenCalledTimes(1);
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(1);
     const queuedInputs = screen.getByLabelText("Queued inputs");
     expect(queuedInputs.textContent).not.toContain("first queued");
     expect(queuedInputs.textContent).toContain("second queued");
 
     subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
-    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
       text: "second queued",
       usePersistentRag: true,
     }));
-    expect(stores.chatStore.send).toHaveBeenCalledTimes(2);
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(2);
     expect(screen.queryByLabelText("Queued inputs")).toBeNull();
   });
 
@@ -2281,12 +2303,12 @@ describe("ChatPage", () => {
     subscribed?.({ type: "agent.event", eventType: "message.completed" });
 
     expect(stores.sessionStore.list).toHaveBeenCalledTimes(1);
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
     expect(screen.getByLabelText("Queued inputs").textContent).toContain("queued after full turn");
 
     subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
-    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
       text: "queued after full turn",
       usePersistentRag: true,
     }));
@@ -2316,7 +2338,7 @@ describe("ChatPage", () => {
     subscribed?.({ type: "message.completed" });
 
     expect(screen.queryByTestId("message-assistant-completed")).toBeNull();
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
     expect(screen.getByLabelText("Queued inputs").textContent).toContain("queued after event message");
   });
 
@@ -2343,7 +2365,7 @@ describe("ChatPage", () => {
 
     subscribed?.({ type: "message.completed" });
 
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
     expect(stores.sessionStore.list).toHaveBeenCalledTimes(1);
     const queuedInputs = screen.getByLabelText("Queued inputs");
     expect(queuedInputs.textContent).toContain("after approval");
@@ -2378,7 +2400,7 @@ describe("ChatPage", () => {
     subscribed?.({ type: "agent.event", eventType: "agent.turn.failed" });
 
     await waitFor(() => expect(screen.getByLabelText("Queued inputs").textContent).toContain("Paused"));
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
   });
 
   it("pauses queued inputs on stop and resumes one input manually", async () => {
@@ -2407,17 +2429,17 @@ describe("ChatPage", () => {
     await user.type(input, "resume second{enter}");
     await user.click(screen.getByRole("button", { name: "Stop generation" }));
 
-    expect(stores.chatStore.dispatchCommand).toHaveBeenCalledWith(expect.objectContaining({
+    expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
       kind: "agent.cancel",
       source: { control: "stop-response", surface: "chat" },
       target: expect.objectContaining({ sessionId: "s1" }),
     }));
     await waitFor(() => expect(screen.getByLabelText("Queued inputs").textContent).toContain("Paused"));
-    expect(stores.chatStore.send).not.toHaveBeenCalled();
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
 
     await user.click(screen.getByRole("button", { name: "Resume queue" }));
 
-    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
       text: "resume first",
       usePersistentRag: true,
     }));
@@ -2490,7 +2512,7 @@ describe("ChatPage", () => {
       subscribed = listener;
       return () => undefined;
     });
-    stores.chatStore.send = vi.fn(async () => {
+    mockTurnSubmit(stores.chatStore, async () => {
       sent = true;
       subscribed?.({ type: "message-sent", message: optimisticMessages[0] });
     });
@@ -2520,7 +2542,7 @@ describe("ChatPage", () => {
       subscribed = listener;
       return () => undefined;
     });
-    stores.chatStore.send = vi.fn(async () => {
+    mockTurnSubmit(stores.chatStore, async () => {
       subscribed?.({ type: "message-sent", message: optimisticMessage });
     });
 
@@ -2573,7 +2595,7 @@ describe("ChatPage", () => {
       subscribed = listener;
       return () => undefined;
     });
-    stores.chatStore.send = vi.fn(async () => {
+    mockTurnSubmit(stores.chatStore, async () => {
       subscribed?.({ type: "message-sent", message: optimisticMessage });
     });
 
@@ -2661,7 +2683,7 @@ describe("ChatPage", () => {
     await user.type(input, "Summarize docs");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
-    await waitFor(() => expect(stores.chatStore.send).toHaveBeenCalledWith("pending:1", {
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "pending:1", {
       text: "Summarize docs",
       usePersistentRag: true,
     }));
@@ -2698,7 +2720,7 @@ describe("ChatPage", () => {
       subscribed = listener;
       return () => undefined;
     });
-    stores.chatStore.send = vi.fn(() => new Promise<void>((resolve) => {
+    mockTurnSubmit(stores.chatStore, () => new Promise<void>((resolve) => {
       resolveSend = resolve;
     }));
 
@@ -2757,7 +2779,7 @@ describe("ChatPage", () => {
     await user.type(screen.getByRole("textbox", { name: /message/i }), "Use a specific model");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
-    expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+    expectTurnSubmit(stores.chatStore, "s1", {
       model: "deepseek-reasoner",
       text: "Use a specific model",
       usePersistentRag: true,
@@ -2783,7 +2805,7 @@ describe("ChatPage", () => {
     await user.type(screen.getByRole("textbox", { name: /message/i }), "No retrieved material");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
-    expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+    expectTurnSubmit(stores.chatStore, "s1", {
       text: "No retrieved material",
       usePersistentRag: false,
     });
@@ -2807,7 +2829,7 @@ describe("ChatPage", () => {
 
     await user.click(await screen.findByRole("button", { name: "Stop generation" }));
 
-    expect(stores.chatStore.dispatchCommand).toHaveBeenCalledWith(expect.objectContaining({
+    expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
       kind: "agent.cancel",
       source: { control: "stop-response", surface: "chat" },
       target: expect.objectContaining({ sessionId: "s1" }),
@@ -2837,7 +2859,7 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     await user.click(await screen.findByRole("button", { name: "Pause" }));
-    expect(stores.chatStore.dispatchCommand).toHaveBeenCalledWith(expect.objectContaining({
+    expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
       kind: "agent.pause",
       source: { control: "chat-pause", surface: "chat" },
       target: expect.objectContaining({ runId: run.id, sessionId: "s1" }),
@@ -2864,7 +2886,7 @@ describe("ChatPage", () => {
     const stop = await screen.findByRole("button", { name: /Stop generation unavailable/ });
     expect((stop as HTMLButtonElement).disabled).toBe(true);
     await waitFor(() => expect(stop.getAttribute("title")).toBe("Not supported."));
-    expect(stores.chatStore.dispatchCommand).not.toHaveBeenCalled();
+    expect(stores.chatStore.dispatch).not.toHaveBeenCalled();
   });
 
   it("closes the composer tools menu when another composer area is clicked", async () => {
@@ -2900,7 +2922,7 @@ describe("ChatPage", () => {
     await user.type(input, "Summarize this");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
-    expect(stores.chatStore.send).toHaveBeenCalledWith("s1", {
+    expectTurnSubmit(stores.chatStore, "s1", {
       text: `Summarize this\n\nPasted content:\n${pastedText}`,
       usePersistentRag: true,
     });

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -25,6 +25,17 @@ function mountWorkbenchCss(): void {
   document.head.append(style);
 }
 
+function dragTransfer(): DataTransfer {
+  const values = new Map<string, string>();
+  return {
+    dropEffect: "none",
+    effectAllowed: "none",
+    getData: (type: string) => values.get(type) ?? "",
+    setData: (type: string, value: string) => values.set(type, value),
+    get types() { return [...values.keys()]; },
+  } as unknown as DataTransfer;
+}
+
 function effectiveCapabilities(sessionId: string, cancelAvailable = true): TinyOsEffectiveCapabilities {
   const unavailable = { available: false, reasonCode: "runtime_unsupported", reason: "Not supported." };
   const available = { available: true };
@@ -34,8 +45,22 @@ function effectiveCapabilities(sessionId: string, cancelAvailable = true): TinyO
     capabilities: {
       agent: { pause: unavailable, resume: unavailable, cancel: cancelAvailable ? available : unavailable, retry: unavailable },
       files: { read: available, requestChange: unavailable, directEdit: unavailable, save: unavailable },
-      terminal: { inspect: available, execute: unavailable, cancel: unavailable },
-      browser: { structured: available, realCapture: unavailable, interact: unavailable },
+      terminal: {
+        contract: "retained_execution_v1",
+        persistentPty: false,
+        inspect: available,
+        execute: unavailable,
+        cancel: unavailable,
+      },
+      browser: {
+        interactionRequires: "current_real_capture",
+        structured: available,
+        projectionContract: "structured_projection_v1",
+        realCapture: unavailable,
+        sessionContract: "browser_session_v1",
+        sessionSnapshot: false,
+        interact: unavailable,
+      },
     },
   };
 }
@@ -301,6 +326,48 @@ describe("ChatPage", () => {
     expect(screen.queryByText("src/main.ts · L1")).toBeNull();
   });
 
+  it("attaches a dragged TinyOS file reference to the Chat composer", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const timeline = timelineFromReactMessages("s1", [{
+      id: "u-tinyos-drag-reference",
+      role: "user" as const,
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      text: "Inspect this file",
+      status: "complete" as const,
+    }]);
+    timeline.turns[0].steps = [{
+      agentContext: { id: "main", title: "Tinybot", type: "main" },
+      id: "file-drag-reference",
+      kind: "tool_call",
+      sequence: 1,
+      status: "completed",
+      title: "workspace.read_file",
+      toolCall: {
+        argsJson: { path: "src/drag.ts" },
+        id: "file-drag-reference",
+        name: "workspace.read_file",
+        resultPreview: "export const dragged = true;",
+      },
+    }];
+    timeline.turns[0].executionItems = timeline.turns[0].steps;
+    stores.chatStore.load = vi.fn(async () => timeline);
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
+
+    await user.click(await screen.findByRole("button", { name: /^Open Live Canvas/ }));
+    const filesWindow = screen.getByLabelText("Files window");
+    await user.click(within(filesWindow).getByRole("button", { name: "export const dragged = true;" }));
+    const source = within(filesWindow).getByRole("button", { name: /Attach src\/drag\.ts/ });
+    const target = document.querySelector<HTMLElement>(".tinyos-composer-drop-target")!;
+    const dataTransfer = dragTransfer();
+
+    fireEvent.dragStart(source, { dataTransfer });
+    fireEvent.dragOver(target, { dataTransfer });
+    fireEvent.drop(target, { dataTransfer });
+
+    expect(within(screen.getByLabelText("Composer attachments")).getByText("src/drag.ts · L1")).toBeTruthy();
+  });
+
   it("opens exact timeline items in history and returns to the latest live frame", async () => {
     const user = userEvent.setup();
     const stores = createStores();
@@ -389,7 +456,7 @@ describe("ChatPage", () => {
     expect(within(canvas).getByText("History")).toBeTruthy();
     expect(within(canvas).getAllByText("src/main.ts").length).toBeGreaterThan(0);
 
-    await user.click(within(canvas).getByRole("button", { name: "Return to live" }));
+    await user.click(within(canvas).getByRole("button", { name: "Return to Live" }));
     expect(within(canvas).getByText("Live follow")).toBeTruthy();
     expect(within(canvas).getByRole("article", { name: "Memory window" })).toBeTruthy();
     expect(within(canvas).getAllByText("memory.search").length).toBeGreaterThan(0);

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -358,11 +358,23 @@ export function ChatPage({
   const latestFailedTurnId = useMemo(() => (
     [...(timeline?.turns ?? [])].reverse().find((turn) => turn.status === "failed" || turn.status === "interrupted")?.id ?? ""
   ), [timeline]);
+  const retryCapability = tinyOsCapabilities.capabilities.agent.retry;
+  const canRetryRun = Boolean(
+    activeSession
+    && latestFailedTurnId
+    && tinyOsCapabilities.sessionId === activeSession.id
+    && tinyOsCapabilities.evaluatedRunId === latestFailedTurnId
+    && retryCapability.available
+  );
+  const retryUnavailableReason = retryCapability.reason || "Retry is unavailable for this Agent run.";
   const liveCanvasOpen = liveCanvas.visibility === "open";
   const liveCanvasEntries = useMemo<LiveCanvasEntry[]>(() => (
     (timelineLoaded ? timeline?.turns ?? [] : []).flatMap((turn) => (
       (turn.executionItems ?? turn.steps).map((step) => ({ step, turnId: turn.id }))
     ))
+  ), [timeline, timelineLoaded]);
+  const liveCanvasCanonicalItems = useMemo(() => (
+    (timelineLoaded ? timeline?.turns ?? [] : []).flatMap((turn) => turn.canonicalItems ?? [])
   ), [timeline, timelineLoaded]);
   const latestLiveCanvasEntry = liveCanvasEntries[liveCanvasEntries.length - 1];
   const latestLiveCanvasAttention = useMemo(() => [...liveCanvasEntries].reverse().find(({ step }) => (
@@ -1662,7 +1674,9 @@ export function ChatPage({
 
       {liveCanvasOpen ? (
         <LiveCanvas
+          activeRunId={activeRun?.id}
           agentUiForms={visibleAgentUiForms}
+          canonicalItems={liveCanvasCanonicalItems}
           canCancelTerminal={canCancelTerminal}
           canDirectEdit={canDirectEdit}
           canExecuteTerminal={canExecuteTerminal}
@@ -1674,13 +1688,7 @@ export function ChatPage({
           canPauseRun={canPauseRun}
           canRequestChange={canRequestChange}
           canResumeRun={canResumeRun}
-          canRetryRun={Boolean(
-            activeSession
-            && latestFailedTurnId
-            && tinyOsCapabilities.sessionId === activeSession.id
-            && tinyOsCapabilities.evaluatedRunId === latestFailedTurnId
-            && tinyOsCapabilities.capabilities.agent.retry.available
-          )}
+          canRetryRun={canRetryRun}
           canSaveFile={canSaveFile}
           cancelUnavailableReason={activeRun && !canCancelRun ? cancelUnavailableReason : undefined}
           pauseUnavailableReason={activeRun && !canPauseRun ? pauseUnavailableReason : undefined}
@@ -1714,6 +1722,8 @@ export function ChatPage({
           onSubmitForm={(form, values) => void handleSubmitAgentUiForm(form, values, "tinyos")}
           onSaveFile={handleSaveTinyOsFile}
           requestChangeUnavailableReason={requestChangeUnavailableReason}
+          retryRunId={latestFailedTurnId || undefined}
+          retryUnavailableReason={retryUnavailableReason}
           runningTerminalRunId={runningTerminalRunId}
           saveFileUnavailableReason={saveFileUnavailableReason}
           terminalCancelUnavailableReason={terminalCancelUnavailableReason}

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useReducer, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useId, useMemo, useReducer, useRef, useState, type CSSProperties, type DragEvent } from "react";
 import {
   AlertTriangle,
   Check,
@@ -55,6 +55,7 @@ import {
   applyLoadedDelegatedAgentTrace,
   projectLoadedArtifactDetail,
   type ArtifactRef,
+  type BackendAgentTurnItem,
   type ChatStep,
   type ChatTurn,
   type DelegatedAgentState,
@@ -65,6 +66,7 @@ import {
 import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
 import type { NativeChatReference } from "../../app-core/chat/nativeChat";
 import type { TinyOsAgentRequestIntent, TinyOsAgentRequestReference, TinyOsContextReference } from "../../app-core/chat/tinyOsUiState";
+import { readTinyOsReferenceTransfer, tinyOsReferenceAcceptedBy, TINYOS_REFERENCE_MIME } from "../../app-core/chat/tinyOsReferenceTransfer";
 import { useTinyOsFilesController } from "./useTinyOsFilesController";
 import {
   TINYOS_COMMAND_ACK_TIMEOUT_MS,
@@ -74,6 +76,7 @@ import {
   createTinyOsAgentRequestChangeCommand,
   createTinyOsAgentRunControlCommand,
   createTinyOsApprovalResolveCommand,
+  createTinyOsBrowserInteractCommand,
   createTinyOsFileDeleteCommand,
   createTinyOsFileMoveCommand,
   createTinyOsFileSaveCommand,
@@ -86,6 +89,7 @@ import {
   reduceTinyOsCommandLifecycle,
   type TinyOsCommandLifecycle,
   type TinyOsCommand,
+  type TinyOsBrowserAction,
 } from "../../app-core/chat/tinyOsCommandGateway";
 import {
   unavailableTinyOsEffectiveCapabilities,
@@ -115,7 +119,7 @@ type DrawerState =
 
 type LiveCanvasState = {
   mode: LiveCanvasMode;
-  selection?: { itemId: string; turnId: string };
+  selection?: { eventIndex?: number; itemId: string; runId?: string; turnId: string };
   surface: "panel" | "expanded";
   visibility: "closed" | "open";
 };
@@ -124,7 +128,7 @@ type LiveCanvasAction =
   | { type: "close" }
   | { type: "expand_toggle" }
   | { type: "return_live" }
-  | { type: "select"; itemId: string; turnId: string }
+  | { type: "select"; eventIndex?: number; itemId: string; runId?: string; turnId: string }
   | { type: "toggle" };
 
 const INITIAL_LIVE_CANVAS_STATE: LiveCanvasState = {
@@ -142,7 +146,17 @@ function reduceLiveCanvasState(state: LiveCanvasState, action: LiveCanvasAction)
     case "return_live":
       return { ...state, mode: "live_follow", visibility: "open" };
     case "select":
-      return { ...state, mode: "history", selection: { itemId: action.itemId, turnId: action.turnId }, visibility: "open" };
+      return {
+        ...state,
+        mode: "history",
+        selection: {
+          ...(action.eventIndex !== undefined ? { eventIndex: action.eventIndex } : {}),
+          itemId: action.itemId,
+          ...(action.runId ? { runId: action.runId } : {}),
+          turnId: action.turnId,
+        },
+        visibility: "open",
+      };
     case "toggle":
       return state.visibility === "open"
         ? { ...state, visibility: "closed" }
@@ -156,6 +170,18 @@ type QueuedComposerInput = QueuedInput & Pick<ChatInput, "model" | "references" 
 
 function shouldFrameBatchTimeline(timeline: ChatTimelineSnapshot): boolean {
   return timeline.turns[timeline.turns.length - 1]?.status === "running";
+}
+
+function lastCanonicalEventIndex(
+  items: readonly BackendAgentTurnItem[],
+  turnId: string,
+  itemId: string,
+): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item.turnId === turnId && item.itemId === itemId) return index;
+  }
+  return -1;
 }
 
 function readStoredTinyOsWidth(): number {
@@ -253,6 +279,7 @@ export function ChatPage({
   const [queueMessage, setQueueMessage] = useState("");
   const [composerDraft, setComposerDraft] = useState("");
   const [tinyOsContextReferences, setTinyOsContextReferences] = useState<TinyOsContextReference[]>([]);
+  const [tinyOsDropError, setTinyOsDropError] = useState("");
   const [recoveringTurnId, setRecoveringTurnId] = useState("");
   const [showBackToLatest, setShowBackToLatest] = useState(false);
   const [dissolvingSessionIds, setDissolvingSessionIds] = useState<Set<string>>(() => new Set());
@@ -337,14 +364,19 @@ export function ChatPage({
   const saveFileCapability = tinyOsCapabilities.capabilities.files.save;
   const terminalExecuteCapability = tinyOsCapabilities.capabilities.terminal.execute;
   const terminalCancelCapability = tinyOsCapabilities.capabilities.terminal.cancel;
+  const browserInteractCapability = tinyOsCapabilities.capabilities.browser.interact;
   const canDirectEdit = Boolean(activeSession && directEditCapability.available && !cancelInFlight);
   const canSaveFile = Boolean(activeSession && saveFileCapability.available && !cancelInFlight);
   const canExecuteTerminal = Boolean(activeSession && terminalExecuteCapability.available && !cancelInFlight);
   const canCancelTerminal = Boolean(activeSession && terminalCancelCapability.available);
+  const canInteractBrowser = Boolean(activeSession && browserInteractCapability.available && !cancelInFlight);
   const directEditUnavailableReason = cancelInFlight ? "Another TinyOS command is in flight." : directEditCapability.reason;
   const saveFileUnavailableReason = cancelInFlight ? "Another TinyOS command is in flight." : saveFileCapability.reason;
   const terminalExecuteUnavailableReason = cancelInFlight ? "Another TinyOS command is in flight." : terminalExecuteCapability.reason;
   const terminalCancelUnavailableReason = terminalCancelCapability.reason;
+  const browserInteractUnavailableReason = cancelInFlight
+    ? "Another TinyOS command is in flight."
+    : browserInteractCapability.reason || "Browser interaction is unavailable.";
   const runningTerminalRunId = [...(timeline?.turns ?? [])].reverse().find((turn) => (
     turn.id.startsWith("tinyos-host-terminal-") && (turn.status === "running" || turn.status === "pending")
   ))?.id;
@@ -388,7 +420,15 @@ export function ChatPage({
     : liveCanvasEntries.find((entry) => entry.turnId === liveCanvas.selection?.turnId && entry.step.id === liveCanvas.selection.itemId);
 
   const openLiveCanvasItem = (turnId: string, step: ChatStep) => {
-    dispatchLiveCanvas({ type: "select", itemId: step.id, turnId });
+    const eventIndex = lastCanonicalEventIndex(liveCanvasCanonicalItems, turnId, step.id);
+    const boundary = eventIndex >= 0 ? liveCanvasCanonicalItems[eventIndex] : undefined;
+    dispatchLiveCanvas({
+      ...(eventIndex >= 0 ? { eventIndex } : {}),
+      itemId: step.id,
+      ...(boundary?.runId ? { runId: boundary.runId } : {}),
+      turnId,
+      type: "select",
+    });
   };
 
   const handleAttachTinyOsContext = (reference: TinyOsContextReference) => {
@@ -397,6 +437,22 @@ export function ChatPage({
       ...current.filter((candidate) => tinyOsContextReferenceId(candidate) !== id),
       reference,
     ]);
+  };
+
+  const handleTinyOsComposerDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const parsed = readTinyOsReferenceTransfer(event.dataTransfer);
+    if (parsed.status === "rejected") {
+      setTinyOsDropError(parsed.reason);
+      return;
+    }
+    const accepted = tinyOsReferenceAcceptedBy(parsed.reference, "chat");
+    if (accepted.status === "rejected") {
+      setTinyOsDropError(accepted.reason);
+      return;
+    }
+    setTinyOsDropError("");
+    handleAttachTinyOsContext(accepted.reference.reference);
   };
 
   async function handleTinyOsAgentRequest(
@@ -494,6 +550,22 @@ export function ChatPage({
       sessionId: activeSession.id,
       source: { control: "terminal-cancel", surface: "tinyos" },
     }), true);
+  }
+
+  async function handleInteractTinyOsBrowser(input: {
+    action: TinyOsBrowserAction;
+    browserSessionId: string;
+    captureId: string;
+    tabId: string;
+  }): Promise<void> {
+    if (!activeSession || !browserInteractCapability.available) {
+      throw new Error(browserInteractUnavailableReason);
+    }
+    await dispatchTinyOsHostCommand(createTinyOsBrowserInteractCommand({
+      ...input,
+      sessionId: activeSession.id,
+      source: { control: `browser-${input.action.type}`, surface: "tinyos" },
+    }));
   }
 
   useEffect(() => {
@@ -1650,8 +1722,17 @@ export function ChatPage({
             {tinyOsCommandLifecycleLabel(commandLifecycle)}
           </p>
         ) : null}
-        <ClaudeStyleAiInput
-          className={["react-composer", emptyActiveSession ? "react-composer--raised" : ""].filter(Boolean).join(" ")}
+        <div
+          className="tinyos-composer-drop-target"
+          onDragOver={(event) => {
+            if (!Array.from(event.dataTransfer.types).includes(TINYOS_REFERENCE_MIME)) return;
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "copy";
+          }}
+          onDrop={handleTinyOsComposerDrop}
+        >
+          <ClaudeStyleAiInput
+            className={["react-composer", emptyActiveSession ? "react-composer--raised" : ""].filter(Boolean).join(" ")}
           contextReferences={tinyOsContextReferences.map(composerReferenceFromTinyOs)}
           disabled={!activeSession && !draftNewSession}
           disabledReason={!sessionsLoaded ? "正在加载会话…" : !activeSession && !draftNewSession ? "请先创建或选择一个会话" : undefined}
@@ -1668,8 +1749,10 @@ export function ChatPage({
           onRemoveContextReference={(id) => setTinyOsContextReferences((current) => current.filter((reference) => tinyOsContextReferenceId(reference) !== id))}
           onValueChange={setComposerDraft}
           onSendMessage={(message, files, pastedContent, options) => handleComposerSend(message, files, pastedContent, options)}
-          onStopResponding={() => activeSession && handleStopGeneration(activeSession, "chat")}
-        />
+            onStopResponding={() => activeSession && handleStopGeneration(activeSession, "chat")}
+          />
+          {tinyOsDropError ? <p className="tinyos-composer-drop-error" role="alert">{tinyOsDropError}</p> : null}
+        </div>
       </main>
 
       {liveCanvasOpen ? (
@@ -1678,6 +1761,7 @@ export function ChatPage({
           agentUiForms={visibleAgentUiForms}
           canonicalItems={liveCanvasCanonicalItems}
           canCancelTerminal={canCancelTerminal}
+          canInteractBrowser={canInteractBrowser}
           canDirectEdit={canDirectEdit}
           canExecuteTerminal={canExecuteTerminal}
           entries={liveCanvasEntries}
@@ -1695,10 +1779,12 @@ export function ChatPage({
           commandLifecycle={commandLifecycle}
           resolvingApprovalId={resolvingApprovalId}
           selection={selectedLiveCanvasEntry}
+          selectionEventIndex={liveCanvas.selection?.eventIndex}
           sessionKey={`${tinyOsUiScope}:${activeSession?.id ?? "draft"}`}
           widthPx={tinyOsWidth}
           filesController={tinyOsFiles}
           directEditUnavailableReason={directEditUnavailableReason}
+          browserInteractUnavailableReason={browserInteractUnavailableReason}
           onAttachContext={handleAttachTinyOsContext}
           onCancelForm={(form) => void handleCancelAgentUiForm(form, "tinyos")}
           onCancelRun={() => activeSession && void handleStopGeneration(activeSession, "tinyos")}
@@ -1708,6 +1794,7 @@ export function ChatPage({
           onOpenArtifact={(artifact) => void handleOpenArtifact(artifact)}
           onAgentRequest={(reference, intent, fromHistory) => void handleTinyOsAgentRequest(reference, intent, fromHistory)}
           onCancelTerminal={handleCancelTinyOsTerminal}
+          onBrowserInteract={handleInteractTinyOsBrowser}
           onDeleteFile={handleDeleteTinyOsFile}
           onExecuteTerminal={handleExecuteTinyOsTerminal}
           onMoveFile={handleMoveTinyOsFile}
@@ -1719,6 +1806,13 @@ export function ChatPage({
           onReturnToLive={() => dispatchLiveCanvas({ type: "return_live" })}
           onResumeRun={() => void handleAgentRunControl("agent.resume", "tinyos")}
           onSelectEntry={(entry) => openLiveCanvasItem(entry.turnId, entry.step)}
+          onSelectBoundary={(boundary) => dispatchLiveCanvas({
+            eventIndex: boundary.eventIndex,
+            itemId: boundary.itemId,
+            runId: boundary.runId,
+            turnId: boundary.turnId,
+            type: "select",
+          })}
           onSubmitForm={(form, values) => void handleSubmitAgentUiForm(form, values, "tinyos")}
           onSaveFile={handleSaveTinyOsFile}
           requestChangeUnavailableReason={requestChangeUnavailableReason}

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -45,6 +45,7 @@ import {
 import { TextType } from "../../components/ui/TextType";
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
 import type { ApprovalAction, ChatEvent, ChatInput, ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore, WorkspaceStore } from "../services";
+import { createDesktopTurnSubmitCommand } from "../../app-core/chat/desktopCommand";
 import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
 import { canBranchFromMessage, canCopyMessage, type ContextReferenceSummary, type ReactChatMessage, type ToolCallSummary } from "./messageActions";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
@@ -476,7 +477,7 @@ export function ChatPage({
     dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
     if (fromHistory) dispatchLiveCanvas({ type: "return_live" });
     try {
-      await chatStore.dispatchCommand(command);
+      await chatStore.dispatch(command);
     } catch (error) {
       dispatchCommandLifecycle({
         commandId: command.commandId,
@@ -497,7 +498,7 @@ export function ChatPage({
     setTimelineError("");
     dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
     try {
-      await chatStore.dispatchCommand(command);
+      await chatStore.dispatch(command);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       dispatchCommandLifecycle({ commandId: command.commandId, error: message, type: "rejected" });
@@ -1008,6 +1009,14 @@ export function ChatPage({
     setActiveSessionId(branched.id);
   }
 
+  function dispatchTurn(sessionId: string, input: ChatInput, control: string): Promise<void> {
+    return chatStore.dispatch(createDesktopTurnSubmitCommand({
+      message: input,
+      sessionId,
+      source: { control, surface: "chat" },
+    }));
+  }
+
   async function handleComposerSend(
     message: string,
     files: FileWithPreview[],
@@ -1042,12 +1051,12 @@ export function ChatPage({
       optimisticSessionTitlesRef.current.set(sendSession.id, optimisticSession.title);
       setSessions((current) => current.map((session) => session.id === sendSession.id ? optimisticSession : session));
     }
-    await chatStore.send(sendSession.id, {
+    await dispatchTurn(sendSession.id, {
       text: queuedResult.content,
       ...(options.model ? { model: options.model } : {}),
       ...(references.length ? { references } : {}),
       ...(typeof options.usePersistentRag === "boolean" ? { usePersistentRag: options.usePersistentRag } : {}),
-    });
+    }, "composer-send");
     await handleSessionStoreRefresh(optimisticSession);
   }
 
@@ -1086,7 +1095,7 @@ export function ChatPage({
         setTimelineError("");
         dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
         try {
-          await chatStore.dispatchCommand(command);
+          await chatStore.dispatch(command);
         } catch (error) {
           dispatchCommandLifecycle({
             commandId: command.commandId,
@@ -1099,12 +1108,12 @@ export function ChatPage({
       if (action === "restart") {
         const created = await sessionStore.create({ title: deriveSessionTitle(turn.userMessage.text) });
         activateCreatedSession(created);
-        await chatStore.send(created.id, { text: turn.userMessage.text });
+        await dispatchTurn(created.id, { text: turn.userMessage.text }, "recovery-restart");
         await handleSessionStoreRefresh(created);
         return;
       }
       const text = "请从刚才中断的位置继续，沿用现有上下文和计划；先确认当前进度，再完成剩余任务。";
-      await chatStore.send(activeSession.id, { text });
+      await dispatchTurn(activeSession.id, { text }, "recovery-continue");
       await handleSessionStoreRefresh(activeSession);
     } finally {
       setRecoveringTurnId("");
@@ -1210,7 +1219,7 @@ export function ChatPage({
     pauseQueuedInputsForSession(session.id);
     dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
     try {
-      await chatStore.dispatchCommand(command);
+      await chatStore.dispatch(command);
     } catch (error) {
       dispatchCommandLifecycle({
         commandId: command.commandId,
@@ -1262,7 +1271,7 @@ export function ChatPage({
     if (!result.nextInput) {
       return;
     }
-    await chatStore.send(sessionId, toChatInput(result.nextInput as QueuedComposerInput));
+    await dispatchTurn(sessionId, toChatInput(result.nextInput as QueuedComposerInput), `queue-${mode}`);
     updateQueuedInputsBySession((current) => {
       const next = new Map(current);
       if (result.remainingInputs.length) {
@@ -1311,7 +1320,7 @@ export function ChatPage({
     setTimelineError("");
     dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
     try {
-      await chatStore.dispatchCommand(command);
+      await chatStore.dispatch(command);
     } catch (error) {
       dispatchCommandLifecycle({
         commandId: command.commandId,
@@ -1402,7 +1411,7 @@ export function ChatPage({
     setTimelineError("");
     dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
     try {
-      await chatStore.dispatchCommand(command);
+      await chatStore.dispatch(command);
     } catch (error) {
       dispatchCommandLifecycle({
         commandId: command.commandId,
@@ -1437,7 +1446,7 @@ export function ChatPage({
     setTimelineError("");
     dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
     try {
-      await chatStore.dispatchCommand(command);
+      await chatStore.dispatch(command);
     } catch (error) {
       dispatchCommandLifecycle({
         commandId: command.commandId,
@@ -1470,7 +1479,7 @@ export function ChatPage({
     setTimelineError("");
     dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
     try {
-      await chatStore.dispatchCommand(command);
+      await chatStore.dispatch(command);
     } catch (error) {
       dispatchCommandLifecycle({
         commandId: command.commandId,

--- a/src/react-workbench/chat/LiveCanvas.test.tsx
+++ b/src/react-workbench/chat/LiveCanvas.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, fireEvent, render, screen, within } from "@testing-library/rea
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
-import type { ChatStep } from "../../app-core/chat/chatRunModel";
+import type { BackendAgentTurnItem, ChatStep } from "../../app-core/chat/chatRunModel";
 import { LiveCanvas, type LiveCanvasEntry } from "./LiveCanvas";
 
 afterEach(() => {
@@ -169,6 +169,9 @@ describe("LiveCanvas TinyOS", () => {
     const canvas = screen.getByLabelText("Live Canvas");
     expect(within(canvas).getByRole("heading", { name: "TinyOS" })).toBeTruthy();
     expect(within(canvas).getAllByText("Structured simulation").length).toBeGreaterThan(0);
+    const desktop = within(canvas).getByRole("region", { name: "TinyOS desktop" });
+    expect(within(desktop).getByRole("navigation", { name: "TinyOS applications" })).toBeTruthy();
+    expect(within(desktop).getByText("Agent workspace")).toBeTruthy();
     expect(canvas.querySelector("[data-app='files']")).toBeTruthy();
     expect(canvas.querySelector("[data-app='terminal']")).toBeTruthy();
     expect(within(canvas).getAllByText("src/app.ts").length).toBeGreaterThan(0);
@@ -343,9 +346,75 @@ describe("LiveCanvas TinyOS", () => {
     const canvas = screen.getByLabelText("Live Canvas");
     expect(canvas.querySelector("[data-app='terminal']")).toBeTruthy();
     expect(canvas.querySelector("[data-app='files']")).toBeNull();
-    await user.click(within(canvas).getByRole("button", { name: "Open Files" }));
+    const filesLauncher = within(canvas).getByRole("button", { name: "Open Files" });
+    expect(filesLauncher.getAttribute("aria-pressed")).toBe("false");
+    await user.click(filesLauncher);
     expect(canvas.querySelector("[data-app='files']")).toBeTruthy();
     expect(canvas.querySelector("[data-app='terminal']")).toBeNull();
+    expect(within(canvas).getByRole("button", { name: "Open Files" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("opens the kernel-backed System Monitor from the TinyOS Dock", async () => {
+    const user = userEvent.setup();
+    const onPauseRun = vi.fn();
+    const terminalStep = step({
+      id: "tool-1",
+      status: "running",
+      title: "Run tests",
+      toolCall: { id: "call-1", name: "shell.execute" },
+    });
+    const canonicalItems: BackendAgentTurnItem[] = [{
+      schemaVersion: "tinybot.turn_item.v2",
+      createdAt: "2026-07-14T00:00:00Z",
+      data: {
+        args: {},
+        name: "shell.execute",
+        result: null,
+        status: "running",
+        timing: {},
+        toolCallId: "call-1",
+        type: "tool_call",
+      },
+      itemId: "tool-1",
+      kind: "tool_call",
+      revision: 1,
+      runId: "turn-1",
+      sequence: 1,
+      sessionId: "session-1",
+      status: "running",
+      title: "Run tests",
+      turnId: "turn-1",
+    }];
+    render(<LiveCanvas {...canvasProps([entry(terminalStep)], {
+      activeRunId: "turn-1",
+      canPauseRun: true,
+      canonicalItems,
+      onPauseRun,
+      widthPx: 480,
+    })} />);
+
+    await user.click(screen.getByRole("button", { name: "Open System Monitor" }));
+    expect(screen.getByRole("region", { name: "TinyOS processes" })).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Pause run" }));
+    expect(onPauseRun).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: /Run tests/ })).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: /Run tests/ }));
+    await user.click(screen.getByRole("button", { name: "Reveal app" }));
+    expect(screen.getByLabelText("Terminal window")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Open System Monitor" }));
+    await user.click(screen.getByRole("button", { name: /Run tests/ }));
+    await user.click(screen.getByRole("button", { name: "Inspect evidence" }));
+    expect(screen.getByLabelText("TinyOS Inspector")).toBeTruthy();
+  });
+
+  it("keeps System Monitor available when the kernel has no processes", async () => {
+    const user = userEvent.setup();
+    render(<LiveCanvas {...canvasProps([], { widthPx: 480 })} />);
+
+    const launcher = screen.getByRole("button", { name: "Open System Monitor" });
+    expect(launcher.hasAttribute("disabled")).toBe(false);
+    await user.click(launcher);
+    expect(screen.getByText("No processes match the current filters.")).toBeTruthy();
   });
 
   it("supports keyboard window movement, snapping, maximize, and minimize", async () => {

--- a/src/react-workbench/chat/LiveCanvas.test.tsx
+++ b/src/react-workbench/chat/LiveCanvas.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import type { BackendAgentTurnItem, ChatStep } from "../../app-core/chat/chatRunModel";
+import { createTinyOsBrowserSessionSnapshot } from "../../app-core/chat/tinyOsNativeSnapshot";
 import { LiveCanvas, type LiveCanvasEntry } from "./LiveCanvas";
 
 afterEach(() => {
@@ -27,6 +28,37 @@ function step(overrides: Partial<ChatStep>): ChatStep {
 
 function entry(canvasStep: ChatStep, turnId = "turn-1"): LiveCanvasEntry {
   return { step: canvasStep, turnId };
+}
+
+function canonicalItemForEntry(
+  canvasEntry: LiveCanvasEntry,
+  eventIndex: number,
+  overrides: Partial<BackendAgentTurnItem> = {},
+): BackendAgentTurnItem {
+  const { step: canvasStep, turnId } = canvasEntry;
+  return {
+    schemaVersion: "tinybot.turn_item.v2",
+    createdAt: `2026-07-14T00:00:${String(eventIndex).padStart(2, "0")}Z`,
+    data: {
+      args: canvasStep.toolCall?.argsJson ?? {},
+      name: canvasStep.toolCall?.name ?? canvasStep.title,
+      result: canvasStep.toolCall?.resultJson ?? {},
+      status: canvasStep.status,
+      timing: {},
+      toolCallId: canvasStep.toolCall?.id ?? `call-${eventIndex}`,
+      type: "tool_call",
+    },
+    itemId: canvasStep.id,
+    kind: "tool_call",
+    revision: 1,
+    runId: "run-1",
+    sequence: eventIndex,
+    sessionId: "session-1",
+    status: canvasStep.status,
+    title: canvasStep.title,
+    turnId,
+    ...overrides,
+  } as BackendAgentTurnItem;
 }
 
 function canvasProps(entries: LiveCanvasEntry[], overrides: Record<string, unknown> = {}) {
@@ -59,6 +91,59 @@ function canvasProps(entries: LiveCanvasEntry[], overrides: Record<string, unkno
     widthPx: 480,
     ...overrides,
   };
+}
+
+function dragTransfer(): DataTransfer {
+  const values = new Map<string, string>();
+  return {
+    dropEffect: "none",
+    effectAllowed: "none",
+    getData: (type: string) => values.get(type) ?? "",
+    setData: (type: string, value: string) => values.set(type, value),
+    get types() { return [...values.keys()]; },
+  } as unknown as DataTransfer;
+}
+
+function browserSessionSnapshot() {
+  return createTinyOsBrowserSessionSnapshot({
+    activeTabId: "tab-1",
+    browserSessionId: "browser-session-1",
+    contract: "browser_session_v1",
+    interaction: { click: true, navigate: true, type: true },
+    kind: "browser_session",
+    runId: "run-browser-1",
+    sessionId: "session-1",
+    state: "running",
+    tabs: [{
+      activeHistoryIndex: 1,
+      captures: [
+        { captureId: "capture-old", observedAt: "2026-07-14T01:00:00Z", stale: true },
+        { captureId: "capture-current", observedAt: "2026-07-14T01:01:00Z", stale: false },
+      ],
+      currentCaptureId: "capture-current",
+      history: [
+        { captureId: "capture-old", title: "Old", url: "https://example.com/old" },
+        { captureId: "capture-current", title: "Current", url: "https://example.com/current" },
+      ],
+      loading: false,
+      tabId: "tab-1",
+      title: "Current",
+      url: "https://example.com/current",
+    }, {
+      activeHistoryIndex: 0,
+      captures: [{ captureId: "capture-second", observedAt: "2026-07-14T01:02:00Z", stale: false }],
+      currentCaptureId: "capture-second",
+      history: [{ captureId: "capture-second", title: "Second", url: "https://example.org" }],
+      loading: true,
+      tabId: "tab-2",
+      title: "Second",
+      url: "https://example.org",
+    }],
+  }, {
+    observedAt: "2026-07-14T01:02:00Z",
+    revision: "browser-revision-1",
+    sourceId: "browser.session",
+  });
 }
 
 describe("LiveCanvas TinyOS", () => {
@@ -203,6 +288,22 @@ describe("LiveCanvas TinyOS", () => {
     expect(onExecuteTerminal).toHaveBeenCalledWith({ command: "npm test", cwd: "." });
   });
 
+  it("routes Terminal cancellation through the registered runtime command", async () => {
+    const onCancelTerminal = vi.fn(async () => undefined);
+    render(<LiveCanvas {...canvasProps([], {
+      canCancelTerminal: true,
+      onCancelTerminal,
+      runningTerminalRunId: "tinyos-host-terminal-1",
+      sessionKey: "websocket:chat-1",
+    })} />);
+
+    const terminal = document.querySelector<HTMLElement>("[data-app='terminal']");
+    expect(terminal).toBeTruthy();
+    await userEvent.click(within(terminal!).getByRole("button", { name: "Cancel process" }));
+
+    expect(onCancelTerminal).toHaveBeenCalledTimes(1);
+  });
+
   it("reconstructs a historical desktop and returns to live", async () => {
     const user = userEvent.setup();
     const onReturnToLive = vi.fn();
@@ -212,16 +313,94 @@ describe("LiveCanvas TinyOS", () => {
       entry(step({ id: "memory", title: "memory.search", toolCall: { argsJson: { query: "TinyOS" }, id: "memory", name: "memory.search" } })),
     ];
 
-    render(<LiveCanvas {...canvasProps(entries, { mode: "history", onReturnToLive, onSelectEntry, selection: entries[0] })} />);
+    const canonicalItems = entries.map((canvasEntry, index) => canonicalItemForEntry(canvasEntry, index));
+    render(<LiveCanvas {...canvasProps(entries, {
+      canonicalItems,
+      mode: "history",
+      onReturnToLive,
+      onSelectEntry,
+      selection: entries[0],
+      selectionEventIndex: 0,
+    })} />);
 
     const canvas = screen.getByLabelText("Live Canvas");
     expect(within(canvas).getByText("History")).toBeTruthy();
     expect(canvas.querySelector("[data-app='files']")).toBeTruthy();
     expect(canvas.querySelector("[data-app='memory']")).toBeNull();
-    await user.click(within(canvas).getByRole("button", { name: "Next canonical operation" }));
+    expect(within(canvas).getByText("Event 1 of 2")).toBeTruthy();
+    await user.click(within(canvas).getByRole("button", { name: "Next canonical event" }));
     expect(onSelectEntry).toHaveBeenCalledWith(entries[1]);
-    await user.click(within(canvas).getByRole("button", { name: "Return to live" }));
+    await user.click(within(canvas).getByRole("button", { name: "Return to Live" }));
     expect(onReturnToLive).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps layout preferences and restores runtime capabilities on Return to Live", () => {
+    const fileEntry = entry(step({
+      id: "history-layout-file",
+      title: "Read workspace",
+      toolCall: { argsJson: { path: "README.md" }, id: "history-layout-file", name: "workspace.read_file" },
+    }));
+    const canonicalItems = [canonicalItemForEntry(fileEntry, 0)];
+    const shared = canvasProps([fileEntry], {
+      canExecuteTerminal: true,
+      canonicalItems,
+      selection: fileEntry,
+      selectionEventIndex: 0,
+      sessionKey: "history-layout-session",
+      widthPx: 680,
+    });
+    const { rerender } = render(<LiveCanvas {...shared} mode="history" />);
+
+    const historicalTerminal = screen.getByLabelText("Terminal window");
+    const historicalLayout = historicalTerminal.getAttribute("style");
+    expect((within(historicalTerminal).getByLabelText("TinyOS terminal command") as HTMLInputElement).disabled).toBe(true);
+    expect(within(historicalTerminal).getByRole("button", { name: "Review command" }).getAttribute("title")).toBe("History snapshots are read-only.");
+
+    rerender(<LiveCanvas {...shared} mode="live_follow" />);
+    const liveTerminal = screen.getByLabelText("Terminal window");
+    expect(liveTerminal.getAttribute("style")).toBe(historicalLayout);
+    expect((within(liveTerminal).getByLabelText("TinyOS terminal command") as HTMLInputElement).disabled).toBe(false);
+    expect(within(liveTerminal).getByRole("button", { name: "Review command" }).getAttribute("title")).toBe("Review the exact command and execution boundary");
+  });
+
+  it("compares the same resource at two exact canonical boundaries without merging revisions", async () => {
+    const user = userEvent.setup();
+    const fileEntry = entry(step({
+      id: "versioned-file",
+      title: "Read versioned file",
+      toolCall: { argsJson: { path: "src/versioned.ts" }, id: "versioned-file", name: "workspace.read_file" },
+    }));
+    const first = canonicalItemForEntry(fileEntry, 0, {
+      data: { id: "versioned-file", path: "src/versioned.ts", referenceKind: "file", revision: "rev-1", type: "file_reference" },
+      kind: "file_reference",
+      revision: 1,
+    });
+    const second = canonicalItemForEntry(fileEntry, 1, {
+      data: { id: "versioned-file", path: "src/versioned.ts", referenceKind: "file", revision: "rev-2", type: "file_reference" },
+      kind: "file_reference",
+      revision: 2,
+    });
+    const canonicalItems = [first, second];
+    const shared = canvasProps([fileEntry], {
+      canonicalItems,
+      mode: "history",
+      selection: fileEntry,
+      sessionKey: "history-inspector-session",
+      widthPx: 680,
+    });
+    const { rerender } = render(<LiveCanvas {...shared} selectionEventIndex={0} />);
+
+    await user.click(screen.getByRole("button", { name: "Inspect Files" }));
+    rerender(<LiveCanvas {...shared} selectionEventIndex={1} />);
+    await user.click(screen.getByRole("button", { name: "Inspect Files" }));
+
+    const inspector = screen.getByLabelText("TinyOS Inspector");
+    expect(inspector.dataset.split).toBe("true");
+    expect(within(inspector).getByText("Canonical evidence · Event 1")).toBeTruthy();
+    expect(within(inspector).getByText("Canonical evidence · Event 2")).toBeTruthy();
+    expect(within(inspector).getByText("rev-1")).toBeTruthy();
+    expect(within(inspector).getByText("rev-2")).toBeTruthy();
+    expect(within(inspector).getAllByText(/canonical_event · versioned-file/)).toHaveLength(2);
   });
 
   it("resolves approvals directly from a TinyOS system dialog", async () => {
@@ -487,12 +666,131 @@ describe("LiveCanvas TinyOS", () => {
     expect(onAttachContext).toHaveBeenCalledWith({
       command: "npm test",
       endLine: 2,
+      executionId: "shell-a",
       kind: "terminal",
+      provenance: { kind: "canonical", sourceItemId: "shell-a", turnId: "turn-1" },
       selectedText: "$ npm test\nPASS tinyos",
       sourceItemId: "shell-a",
       startLine: 1,
       turnId: "turn-1",
     });
+  });
+
+  it("labels retained terminal executions with real boundary, identity, byte, and lifecycle state", async () => {
+    const user = userEvent.setup();
+    const terminalEntry = entry(step({
+      id: "retained-terminal",
+      status: "completed",
+      title: "Run checks",
+      toolCall: {
+        argsJson: { command: "npm test", cwd: "src", networkMode: "denied", sandboxMode: "read_only" },
+        durationMs: 87,
+        id: "retained-terminal-call",
+        name: "shell.execute",
+        resultJson: { droppedBytes: 32, exitCode: 0, processId: "native-process-7", stderr: "warn", stdout: "PASS", truncated: true },
+      },
+    }));
+    const command = {
+      schemaVersion: "tinybot.command.v1" as const,
+      commandId: "terminal-command-1",
+      issuedAt: "2026-07-14T00:00:00Z",
+      kind: "terminal.execute" as const,
+      source: { control: "terminal-execute", surface: "tinyos" as const },
+      target: { runId: "tinyos-host-terminal-1", sessionId: "session-1" },
+      terminal: { command: "npm test", confirmed: true as const, cwd: "src" },
+    };
+    render(<LiveCanvas {...canvasProps([terminalEntry], {
+      commandLifecycle: { command, dispatchedAtMs: 1, transportAcceptedAtMs: 2, stage: "waiting_for_canonical" },
+      sessionKey: "session-1",
+      widthPx: 480,
+    })} />);
+    await user.click(screen.getByRole("button", { name: "Open Terminal" }));
+
+    const identity = screen.getByRole("group", { name: "Terminal execution identity" });
+    expect(within(identity).getByText("retained execution v1")).toBeTruthy();
+    expect(within(identity).getByText("native-process-7")).toBeTruthy();
+    expect(within(identity).getByText("read_only · network denied · non-TTY")).toBeTruthy();
+    expect(within(identity).getByText(/4 B stdout · 4 B stderr · 32 B dropped/)).toBeTruthy();
+    expect(within(identity).getByText("canonical_event · retained-terminal")).toBeTruthy();
+    expect(screen.getByText("Execution awaiting runtime")).toBeTruthy();
+    expect(screen.getByText(/Retained boundary · last 499 lines · 32 B dropped/)).toBeTruthy();
+  });
+
+  it("keeps structured browser projections and standalone raster previews read-only", () => {
+    const structured = entry(step({ id: "browser-structured", kind: "browser", summary: "Structured browser metadata" }));
+    const { rerender } = render(<LiveCanvas {...canvasProps([structured])} />);
+
+    let browser = screen.getByLabelText("Browser window");
+    expect(within(browser).getByText("Structured projection")).toBeTruthy();
+    expect(within(browser).getByText("Read-only projection")).toBeTruthy();
+    expect(within(browser).queryByRole("tablist", { name: "Native browser tabs" })).toBeNull();
+
+    const preview = entry(step({
+      artifacts: [{ id: "preview-1", kind: "browser_snapshot", preview: "data:image/png;base64,AAAA", title: "Preview" }],
+      id: "browser-preview",
+      kind: "browser",
+    }));
+    rerender(<LiveCanvas {...canvasProps([preview])} />);
+    browser = screen.getByLabelText("Browser window");
+    expect(within(browser).getByText("Local preview")).toBeTruthy();
+    expect(within(browser).queryByText("Real capture")).toBeNull();
+  });
+
+  it("projects native Browser tabs and routes interactions with session, tab, and capture identity", async () => {
+    const onBrowserInteract = vi.fn(async () => undefined);
+    const browserEntry = entry(step({
+      artifacts: [{ id: "capture-current", kind: "browser_snapshot", preview: "data:image/png;base64,AAAA", title: "Current capture" }],
+      id: "browser-native",
+      kind: "browser",
+    }));
+    render(<LiveCanvas {...canvasProps([browserEntry], {
+      canInteractBrowser: true,
+      nativeSnapshots: [browserSessionSnapshot()],
+      onBrowserInteract,
+    })} />);
+
+    const browser = screen.getByLabelText("Browser window");
+    expect(within(browser).getByText("Real capture")).toBeTruthy();
+    expect(within(browser).getAllByRole("tab")).toHaveLength(2);
+    expect(within(browser).getByRole("region", { name: "Browser session identity" })).toBeTruthy();
+    await userEvent.click(within(browser).getByRole("button", { name: "Interact with current browser capture" }));
+    expect(onBrowserInteract).toHaveBeenCalledWith({
+      action: { type: "click", x: 0, y: 0 },
+      browserSessionId: "browser-session-1",
+      captureId: "capture-current",
+      tabId: "tab-1",
+    });
+    await userEvent.click(within(browser).getByRole("button", { name: "Browser back" }));
+    expect(onBrowserInteract).toHaveBeenCalledWith(expect.objectContaining({
+      action: { type: "navigate", url: "https://example.com/old" },
+      browserSessionId: "browser-session-1",
+      captureId: "capture-current",
+      tabId: "tab-1",
+    }));
+    const typeInput = within(browser).getByLabelText("Text for browser");
+    await userEvent.type(typeInput, "hello browser");
+    await userEvent.click(within(browser).getByRole("button", { name: "Type" }));
+    expect(onBrowserInteract).toHaveBeenCalledWith(expect.objectContaining({
+      action: { text: "hello browser", type: "type" },
+      captureId: "capture-current",
+    }));
+  });
+
+  it("preserves stale Browser evidence, rejects interaction, and reveals the current capture", async () => {
+    const onBrowserInteract = vi.fn(async () => undefined);
+    render(<LiveCanvas {...canvasProps([], {
+      canInteractBrowser: true,
+      nativeSnapshots: [browserSessionSnapshot()],
+      onBrowserInteract,
+    })} />);
+
+    const browser = screen.getByLabelText("Browser window");
+    await userEvent.click(within(browser).getByRole("button", { name: /capture-old.*Stale evidence/ }));
+    expect(within(browser).getByRole("alert").textContent).toContain("Stale capture");
+    expect((within(browser).getByLabelText("Text for browser") as HTMLInputElement).disabled).toBe(true);
+    expect(onBrowserInteract).not.toHaveBeenCalled();
+    await userEvent.click(within(browser).getByRole("button", { name: "Show current capture" }));
+    expect(within(browser).queryByRole("alert")).toBeNull();
   });
 
   it("switches applications with keyboard shortcuts and restores session UI state", async () => {
@@ -515,6 +813,151 @@ describe("LiveCanvas TinyOS", () => {
     const restored = screen.getByLabelText("Live Canvas");
     expect(restored.querySelector("[data-app='terminal']")).toBeTruthy();
     expect(within(restored).getByRole("button", { name: "Open Files" }).getAttribute("data-minimized")).toBe("true");
+  });
+
+  it("switches available applications with an accessible Alt+Tab overlay", () => {
+    const entries = [
+      entry(step({ id: "switch-file", toolCall: { argsJson: { path: "README.md" }, id: "switch-file", name: "workspace.read_file" } })),
+      entry(step({ id: "switch-shell", toolCall: { argsJson: { cmd: "npm test" }, id: "switch-shell", name: "shell.exec" } })),
+    ];
+    render(<LiveCanvas {...canvasProps(entries, { widthPx: 480 })} />);
+
+    const activeTitlebar = screen.getByLabelText("Move Terminal window");
+    fireEvent.keyDown(activeTitlebar, { altKey: true, key: "Tab" });
+
+    const switcher = screen.getByRole("dialog", { name: "application switcher" });
+    expect(within(switcher).getByRole("listbox", { name: "Available TinyOS applications" })).toBeTruthy();
+    expect(within(switcher).getAllByRole("option").length).toBeGreaterThan(1);
+    fireEvent.keyUp(switcher, { key: "Alt" });
+    expect(screen.queryByRole("dialog", { name: "application switcher" })).toBeNull();
+  });
+
+  it("restores minimized windows from Overview and returns focus to its trigger", async () => {
+    const user = userEvent.setup();
+    const entries = [
+      entry(step({ id: "overview-file", toolCall: { argsJson: { path: "README.md" }, id: "overview-file", name: "workspace.read_file" } })),
+      entry(step({ id: "overview-shell", toolCall: { argsJson: { cmd: "npm test" }, id: "overview-shell", name: "shell.exec" } })),
+    ];
+    render(<LiveCanvas {...canvasProps(entries, { widthPx: 680 })} />);
+
+    await user.click(screen.getByRole("button", { name: "Minimize Files" }));
+    const overviewTrigger = screen.getByRole("button", { name: "Open window Overview" });
+    overviewTrigger.focus();
+    await user.click(overviewTrigger);
+    const overview = screen.getByRole("dialog", { name: "window Overview" });
+    const filesPreview = within(overview).getByRole("button", { name: /Files.*Minimized/ });
+    await user.click(filesPreview);
+
+    expect(screen.queryByRole("dialog", { name: "window Overview" })).toBeNull();
+    expect(screen.getByLabelText("Files window")).toBeTruthy();
+
+    await user.click(overviewTrigger);
+    await user.click(within(screen.getByRole("dialog", { name: "window Overview" })).getByRole("button", { name: "Close window Overview" }));
+    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    expect(document.activeElement).toBe(overviewTrigger);
+  });
+
+  it("traps keyboard focus inside compact shell overlays and closes with Escape", async () => {
+    const user = userEvent.setup();
+    const fileEntry = entry(step({ id: "compact-overlay-file", toolCall: { argsJson: { path: "README.md" }, id: "compact-overlay-file", name: "workspace.read_file" } }));
+    render(<LiveCanvas {...canvasProps([fileEntry], { widthPx: 480 })} />);
+
+    await user.click(screen.getByRole("button", { name: "Open window Overview" }));
+    const overview = screen.getByRole("dialog", { name: "window Overview" });
+    const close = within(overview).getByRole("button", { name: "Close window Overview" });
+    close.focus();
+    fireEvent.keyDown(close, { key: "Tab", shiftKey: true });
+    expect(overview.contains(document.activeElement)).toBe(true);
+    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "window Overview" })).toBeNull();
+  });
+
+  it("searches registered application and unavailable runtime commands from Ctrl+K", async () => {
+    const user = userEvent.setup();
+    const fileEntry = entry(step({ id: "palette-file", toolCall: { argsJson: { path: "src/app.ts" }, id: "palette-file", name: "workspace.read_file" } }));
+    render(<LiveCanvas {...canvasProps([fileEntry], { pauseUnavailableReason: "The backend did not advertise pause.", widthPx: 680 })} />);
+
+    fireEvent.keyDown(screen.getByLabelText("Move Files window"), { ctrlKey: true, key: "k" });
+    const palette = screen.getByRole("dialog", { name: "command palette" });
+    const search = within(palette).getByRole("searchbox", { name: "Search TinyOS commands" });
+    await user.type(search, "open files");
+    expect(within(palette).getByRole("option", { name: /Open Files/ })).toBeTruthy();
+
+    await user.clear(search);
+    await user.type(search, "pause active");
+    const pause = within(palette).getByRole("option", { name: /Pause active Agent run/ });
+    expect((pause as HTMLButtonElement).disabled).toBe(true);
+    expect(pause.getAttribute("title")).toBe("The backend did not advertise pause.");
+  });
+
+  it("runs Dock and window context-menu actions through registered commands", async () => {
+    const user = userEvent.setup();
+    const fileEntry = entry(step({ id: "menu-file", toolCall: { argsJson: { path: "README.md" }, id: "menu-file", name: "workspace.read_file" } }));
+    render(<LiveCanvas {...canvasProps([fileEntry], { widthPx: 680 })} />);
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Open Files" }), { clientX: 120, clientY: 180 });
+    const menu = screen.getByRole("menu", { name: "Files menu" });
+    await user.click(within(menu).getByRole("menuitem", { name: /Minimize Files/ }));
+
+    expect(screen.queryByLabelText("Files window")).toBeNull();
+    expect(screen.getByRole("button", { name: "Open Files" }).getAttribute("data-minimized")).toBe("true");
+  });
+
+  it("keeps derived notification history and local read state in the notification center", async () => {
+    const user = userEvent.setup();
+    const failed = entry(step({ id: "notification-failed", kind: "error", status: "failed", summary: "Build exited with code 1", title: "Build failed" }));
+    render(<LiveCanvas {...canvasProps([failed], { widthPx: 680 })} />);
+
+    await user.click(screen.getByRole("button", { name: "Open notification center" }));
+    const center = screen.getByRole("dialog", { name: "notification center" });
+    expect(within(center).getByText("Build failed")).toBeTruthy();
+    await user.click(within(center).getByRole("button", { name: "Mark read" }));
+    expect(within(center).getByRole("button", { name: "Read" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getAllByText("Build failed").length).toBeGreaterThan(1);
+  });
+
+  it("pins dragged canonical evidence into Inspector", async () => {
+    const user = userEvent.setup();
+    const entries = [
+      entry(step({ id: "drag-file", title: "Read config", toolCall: { id: "drag-file", name: "workspace.read_file" } })),
+      entry(step({ id: "drag-shell", title: "Run tests", toolCall: { id: "drag-shell", name: "shell.exec" } })),
+    ];
+    render(<LiveCanvas {...canvasProps(entries, { widthPx: 680 })} />);
+    await user.click(screen.getByRole("button", { name: "Inspect Files" }));
+    const inspector = screen.getByLabelText("TinyOS Inspector");
+    const latestOperation = within(screen.getByRole("navigation", { name: "TinyOS recent operations" })).getByRole("button", { name: /Latest canonical operation/ });
+    const dataTransfer = dragTransfer();
+
+    fireEvent.dragStart(latestOperation, { dataTransfer });
+    fireEvent.dragOver(inspector, { dataTransfer });
+    fireEvent.drop(inspector, { dataTransfer });
+
+    expect(within(inspector).getByText("Read config")).toBeTruthy();
+    expect(within(inspector).getByText("Run tests")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toContain("pinned in Inspector");
+  });
+
+  it("visibly rejects a file-context drop on Inspector without attaching it", async () => {
+    const user = userEvent.setup();
+    const onAttachContext = vi.fn();
+    const fileEntry = entry(step({
+      id: "drop-file",
+      title: "Read source",
+      toolCall: { argsJson: { path: "src/app.ts" }, id: "drop-file", name: "workspace.read_file", resultPreview: "const ready = true;" },
+    }));
+    render(<LiveCanvas {...canvasProps([fileEntry], { onAttachContext, widthPx: 680 })} />);
+    await user.click(screen.getByRole("button", { name: "Inspect Files" }));
+    await user.click(within(screen.getByLabelText("Files window")).getByRole("button", { name: "const ready = true;" }));
+    const source = within(screen.getByLabelText("Files window")).getByRole("button", { name: /Attach src\/app\.ts/ });
+    const inspector = screen.getByLabelText("TinyOS Inspector");
+    const dataTransfer = dragTransfer();
+
+    fireEvent.dragStart(source, { dataTransfer });
+    fireEvent.dragOver(inspector, { dataTransfer });
+    fireEvent.drop(inspector, { dataTransfer });
+
+    expect(screen.getByRole("alert").textContent).toBe("Inspector accepts canonical evidence, not context references.");
+    expect(onAttachContext).not.toHaveBeenCalled();
   });
 
   it("pins two canonical evidence items into a split Inspector", async () => {

--- a/src/react-workbench/chat/LiveCanvas.tsx
+++ b/src/react-workbench/chat/LiveCanvas.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent, type RefObject } from "react";
 import { Bell, Bot, ChevronLeft, ChevronRight, Loader2, Maximize2, Minimize2, MonitorDot, PanelRightClose, PanelRightOpen, Pause, Play, RotateCcw, ShieldCheck, StopCircle, X } from "lucide-react";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
-import { projectTinyOsDesktop, tinyOsAppForStep, type TinyOsTimelineEntry } from "../../app-core/chat/tinyOsDesktopModel";
+import { projectKernelBackedTinyOsDesktop, projectTinyOsDesktop, tinyOsAppForStep, type TinyOsTimelineEntry } from "../../app-core/chat/tinyOsDesktopModel";
 import { tinyOsLayoutModeForWidth, type TinyOsAgentRequestIntent, type TinyOsAgentRequestReference, type TinyOsContextReference } from "../../app-core/chat/tinyOsUiState";
-import type { ArtifactRef, ChatStep } from "../../app-core/chat/chatRunModel";
+import type { ArtifactRef, BackendAgentTurnItem, ChatStep } from "../../app-core/chat/chatRunModel";
 import type { ApprovalAction } from "../services";
 import { TinyOsShell } from "./TinyOsShell";
 import type { TinyOsFilesController } from "./useTinyOsFilesController";
@@ -20,6 +20,7 @@ const TINYOS_BOOT_DURATION_MS = 1_000;
 let tinyOsBootedInRuntime = false;
 
 export function LiveCanvas({
+  activeRunId,
   agentUiForms,
   canCancelTerminal = false,
   canDirectEdit = false,
@@ -31,6 +32,7 @@ export function LiveCanvas({
   canRetryRun,
   canSaveFile = false,
   cancelUnavailableReason,
+  canonicalItems = [],
   pauseUnavailableReason,
   commandLifecycle,
   entries,
@@ -61,6 +63,8 @@ export function LiveCanvas({
   resolvingApprovalId,
   requestChangeUnavailableReason,
   directEditUnavailableReason,
+  retryRunId,
+  retryUnavailableReason,
   resumeUnavailableReason,
   runningTerminalRunId,
   saveFileUnavailableReason,
@@ -71,6 +75,7 @@ export function LiveCanvas({
   widthPx,
   workspaceKey = "desktop-workspace",
 }: {
+  activeRunId?: string;
   agentUiForms: AgentUiForm[];
   canCancelTerminal?: boolean;
   canDirectEdit?: boolean;
@@ -82,6 +87,7 @@ export function LiveCanvas({
   canRetryRun: boolean;
   canSaveFile?: boolean;
   cancelUnavailableReason?: string;
+  canonicalItems?: BackendAgentTurnItem[];
   pauseUnavailableReason?: string;
   commandLifecycle: TinyOsCommandLifecycle;
   entries: LiveCanvasEntry[];
@@ -112,6 +118,8 @@ export function LiveCanvas({
   resolvingApprovalId: string;
   requestChangeUnavailableReason?: string;
   directEditUnavailableReason?: string;
+  retryRunId?: string;
+  retryUnavailableReason?: string;
   resumeUnavailableReason?: string;
   runningTerminalRunId?: string;
   saveFileUnavailableReason?: string;
@@ -122,11 +130,16 @@ export function LiveCanvas({
   widthPx: number;
   workspaceKey?: string;
 }) {
-  const snapshot = useMemo(() => projectTinyOsDesktop(entries, {
-    itemId: mode === "history" ? selection?.step.id : undefined,
-    mode,
-    turnId: mode === "history" ? selection?.turnId : undefined,
-  }), [entries, mode, selection?.step.id, selection?.turnId]);
+  const snapshot = useMemo(() => {
+    const cursor = {
+      itemId: mode === "history" ? selection?.step.id : undefined,
+      mode,
+      turnId: mode === "history" ? selection?.turnId : undefined,
+    } as const;
+    return canonicalItems.length || (entries.length === 0 && mode === "live_follow")
+      ? projectKernelBackedTinyOsDesktop(entries, canonicalItems, cursor)
+      : projectTinyOsDesktop(entries, cursor);
+  }, [canonicalItems, entries, mode, selection?.step.id, selection?.turnId]);
   const actionableDialog = Boolean(snapshot.dialog && mode === "live_follow");
   const commandPending = isTinyOsCommandInFlight(commandLifecycle);
   const commandKind = commandLifecycle.stage === "idle" ? "" : commandLifecycle.command.kind;
@@ -294,13 +307,19 @@ export function LiveCanvas({
 
       <TinyOsShell
         key={sessionKey}
+        activeRunId={activeRunId}
         agentUiForms={agentUiForms}
+        canCancelRun={canCancelRun}
         canCancelTerminal={canCancelTerminal}
         canDirectEdit={canDirectEdit}
         canExecuteTerminal={canExecuteTerminal}
+        canPauseRun={canPauseRun}
         canRequestChange={canRequestChange}
+        canResumeRun={canResumeRun}
         canRetryRun={canRetryRun}
         canSaveFile={canSaveFile}
+        cancelUnavailableReason={cancelUnavailableReason}
+        commandLifecycle={commandLifecycle}
         directEditUnavailableReason={directEditUnavailableReason}
         filesController={filesController}
         history={mode === "history"}
@@ -312,18 +331,25 @@ export function LiveCanvas({
         sessionKey={sessionKey}
         workspaceKey={filesController?.state.workspaceKey ?? workspaceKey}
         onCancelForm={onCancelForm}
+        onCancelRun={onCancelRun}
         onOpenArtifact={onOpenArtifact}
         onAgentRequest={(reference, intent) => onAgentRequest(reference, intent, mode === "history")}
         onCancelTerminal={onCancelTerminal}
         onDeleteFile={onDeleteFile}
         onExecuteTerminal={onExecuteTerminal}
         onMoveFile={onMoveFile}
+        onPauseRun={onPauseRun}
         onResolveApproval={onResolveApproval}
         onRetryOperation={onRetryOperation}
+        onResumeRun={onResumeRun}
         onSelectEntry={onSelectEntry}
         onSubmitForm={onSubmitForm}
         onSaveFile={onSaveFile}
         requestChangeUnavailableReason={requestChangeUnavailableReason}
+        pauseUnavailableReason={pauseUnavailableReason}
+        retryRunId={retryRunId}
+        retryUnavailableReason={retryUnavailableReason}
+        resumeUnavailableReason={resumeUnavailableReason}
         runningTerminalRunId={runningTerminalRunId}
         saveFileUnavailableReason={saveFileUnavailableReason}
         terminalCancelUnavailableReason={terminalCancelUnavailableReason}

--- a/src/react-workbench/chat/LiveCanvas.tsx
+++ b/src/react-workbench/chat/LiveCanvas.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent, type RefObject } from "react";
-import { Bell, Bot, ChevronLeft, ChevronRight, Loader2, Maximize2, Minimize2, MonitorDot, PanelRightClose, PanelRightOpen, Pause, Play, RotateCcw, ShieldCheck, StopCircle, X } from "lucide-react";
+import { Bell, Bot, Loader2, Maximize2, Minimize2, MonitorDot, PanelRightClose, PanelRightOpen, Pause, Play, ShieldCheck, StopCircle, X } from "lucide-react";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
-import { projectKernelBackedTinyOsDesktop, projectTinyOsDesktop, tinyOsAppForStep, type TinyOsTimelineEntry } from "../../app-core/chat/tinyOsDesktopModel";
+import { projectKernelBackedTinyOsDesktop, projectTinyOsDesktop, type TinyOsTimelineEntry } from "../../app-core/chat/tinyOsDesktopModel";
 import { tinyOsLayoutModeForWidth, type TinyOsAgentRequestIntent, type TinyOsAgentRequestReference, type TinyOsContextReference } from "../../app-core/chat/tinyOsUiState";
 import type { ArtifactRef, BackendAgentTurnItem, ChatStep } from "../../app-core/chat/chatRunModel";
+import type { TinyOsBrowserAction } from "../../app-core/chat/tinyOsCommandGateway";
+import type { TinyOsNativeSnapshot } from "../../app-core/chat/tinyOsNativeSnapshot";
 import type { ApprovalAction } from "../services";
 import { TinyOsShell } from "./TinyOsShell";
 import type { TinyOsFilesController } from "./useTinyOsFilesController";
 import { isTinyOsCommandInFlight, type TinyOsCommandLifecycle } from "../../app-core/chat/tinyOsCommandGateway";
+import { createTinyOsShellCommandRegistry, defineTinyOsShellCommand, type TinyOsShellCommandAvailability } from "../../app-core/chat/tinyOsShellCommandRegistry";
+import { createTinyOsTimeMachineIndex, type TinyOsTimeMachineBoundary } from "../../app-core/chat/tinyOsTimeMachine";
+import { TinyOsTimeMachine } from "./TinyOsTimeMachine";
 
 export type LiveCanvasMode = "live_follow" | "history";
 export type LiveCanvasEntry = TinyOsTimelineEntry;
@@ -25,6 +30,7 @@ export function LiveCanvas({
   canCancelTerminal = false,
   canDirectEdit = false,
   canExecuteTerminal = false,
+  canInteractBrowser = false,
   canCancelRun,
   canPauseRun,
   canRequestChange,
@@ -33,6 +39,7 @@ export function LiveCanvas({
   canSaveFile = false,
   cancelUnavailableReason,
   canonicalItems = [],
+  nativeSnapshots = [],
   pauseUnavailableReason,
   commandLifecycle,
   entries,
@@ -49,6 +56,7 @@ export function LiveCanvas({
   onOpenArtifact,
   onAgentRequest,
   onCancelTerminal = async () => undefined,
+  onBrowserInteract = async () => undefined,
   onDeleteFile = async () => undefined,
   onExecuteTerminal = async () => undefined,
   onMoveFile = async () => undefined,
@@ -57,6 +65,7 @@ export function LiveCanvas({
   onReturnToLive,
   onResumeRun,
   onSelectEntry,
+  onSelectBoundary,
   onSubmitForm,
   onSaveFile = async () => undefined,
   onWidthChange,
@@ -70,7 +79,9 @@ export function LiveCanvas({
   saveFileUnavailableReason,
   terminalCancelUnavailableReason,
   terminalExecuteUnavailableReason,
+  browserInteractUnavailableReason,
   selection,
+  selectionEventIndex,
   sessionKey,
   widthPx,
   workspaceKey = "desktop-workspace",
@@ -80,6 +91,7 @@ export function LiveCanvas({
   canCancelTerminal?: boolean;
   canDirectEdit?: boolean;
   canExecuteTerminal?: boolean;
+  canInteractBrowser?: boolean;
   canCancelRun: boolean;
   canPauseRun: boolean;
   canRequestChange: boolean;
@@ -88,6 +100,7 @@ export function LiveCanvas({
   canSaveFile?: boolean;
   cancelUnavailableReason?: string;
   canonicalItems?: BackendAgentTurnItem[];
+  nativeSnapshots?: TinyOsNativeSnapshot[];
   pauseUnavailableReason?: string;
   commandLifecycle: TinyOsCommandLifecycle;
   entries: LiveCanvasEntry[];
@@ -104,6 +117,7 @@ export function LiveCanvas({
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent, fromHistory: boolean) => void;
   onCancelTerminal?: () => Promise<void>;
+  onBrowserInteract?: (input: { action: TinyOsBrowserAction; browserSessionId: string; captureId: string; tabId: string }) => Promise<void>;
   onDeleteFile?: (input: { baseRevision: string; path: string }) => Promise<void>;
   onExecuteTerminal?: (input: { command: string; cwd?: string }) => Promise<void>;
   onMoveFile?: (input: { baseRevision: string; path: string; targetPath: string }) => Promise<void>;
@@ -112,6 +126,7 @@ export function LiveCanvas({
   onReturnToLive: () => void;
   onResumeRun: () => void;
   onSelectEntry: (entry: LiveCanvasEntry) => void;
+  onSelectBoundary?: (boundary: TinyOsTimeMachineBoundary) => void;
   onSubmitForm: (form: AgentUiForm, values: Record<string, unknown>) => void;
   onSaveFile?: (input: { baseRevision?: string; content: string; createOnly: boolean; path: string }) => Promise<void>;
   onWidthChange: (widthPx: number) => void;
@@ -125,26 +140,92 @@ export function LiveCanvas({
   saveFileUnavailableReason?: string;
   terminalCancelUnavailableReason?: string;
   terminalExecuteUnavailableReason?: string;
+  browserInteractUnavailableReason?: string;
   selection?: LiveCanvasEntry;
+  selectionEventIndex?: number;
   sessionKey?: string;
   widthPx: number;
   workspaceKey?: string;
 }) {
+  const timeMachineIndex = useMemo(() => createTinyOsTimeMachineIndex(canonicalItems), [canonicalItems]);
+  const historyEventIndex = mode === "history"
+    ? resolveHistoryEventIndex(timeMachineIndex.boundaries, selectionEventIndex, selection)
+    : timeMachineIndex.eventCount - 1;
+  const historyBoundary = timeMachineIndex.boundaries[historyEventIndex];
   const snapshot = useMemo(() => {
-    const cursor = {
-      itemId: mode === "history" ? selection?.step.id : undefined,
-      mode,
-      turnId: mode === "history" ? selection?.turnId : undefined,
-    } as const;
-    return canonicalItems.length || (entries.length === 0 && mode === "live_follow")
-      ? projectKernelBackedTinyOsDesktop(entries, canonicalItems, cursor)
+    const cursor = mode === "history" && historyBoundary
+      ? {
+          eventIndex: historyBoundary.eventIndex,
+          itemId: historyBoundary.itemId,
+          mode,
+          runId: historyBoundary.runId,
+          turnId: historyBoundary.turnId,
+        } as const
+      : {
+          itemId: mode === "history" ? selection?.step.id : undefined,
+          mode,
+          turnId: mode === "history" ? selection?.turnId : undefined,
+        } as const;
+    return canonicalItems.length || nativeSnapshots.length || (entries.length === 0 && mode === "live_follow")
+      ? projectKernelBackedTinyOsDesktop(entries, canonicalItems, cursor, { nativeSnapshots })
       : projectTinyOsDesktop(entries, cursor);
-  }, [canonicalItems, entries, mode, selection?.step.id, selection?.turnId]);
+  }, [canonicalItems, entries, historyBoundary, mode, nativeSnapshots, selection?.step.id, selection?.turnId]);
   const actionableDialog = Boolean(snapshot.dialog && mode === "live_follow");
   const commandPending = isTinyOsCommandInFlight(commandLifecycle);
   const commandKind = commandLifecycle.stage === "idle" ? "" : commandLifecycle.command.kind;
   const commandLabel = tinyOsLifecycleCommandLabel(commandKind);
   const commandAction = commandLabel.toLocaleLowerCase();
+  const runtimeCommandRegistry = useMemo(() => {
+    const target = { kind: "run", runId: activeRunId || "unavailable" } as const;
+    const availability = (available: boolean, reason?: string): TinyOsShellCommandAvailability => available
+      ? { available: true }
+      : {
+          available: false,
+          reason: mode === "history"
+            ? "History snapshots are read-only."
+            : commandPending
+              ? "A command is awaiting runtime confirmation."
+              : reason || "The backend reports that this command is unavailable.",
+        };
+    return createTinyOsShellCommandRegistry([
+      defineTinyOsShellCommand({
+        availability: availability(mode === "live_follow" && canPauseRun && !commandPending, pauseUnavailableReason),
+        category: "process",
+        dispatch: onPauseRun,
+        id: "agent.pause",
+        input: { kind: "none" },
+        keywords: ["pause", "agent", "run"],
+        label: "Pause active Agent run",
+        scope: "runtime",
+        target,
+      }),
+      defineTinyOsShellCommand({
+        availability: availability(mode === "live_follow" && canResumeRun && !commandPending, resumeUnavailableReason),
+        category: "process",
+        dispatch: onResumeRun,
+        id: "agent.resume",
+        input: { kind: "none" },
+        keywords: ["resume", "agent", "run"],
+        label: "Resume paused Agent run",
+        scope: "runtime",
+        target,
+      }),
+      defineTinyOsShellCommand({
+        availability: availability(mode === "live_follow" && canCancelRun && !commandPending, cancelUnavailableReason),
+        category: "process",
+        dispatch: onCancelRun,
+        id: "agent.cancel",
+        input: { kind: "none" },
+        keywords: ["cancel", "stop", "agent", "run"],
+        label: "Cancel active Agent run",
+        scope: "runtime",
+        target,
+      }),
+    ], { simulationMode: mode === "history" ? "history" : "live" });
+  }, [activeRunId, canCancelRun, canPauseRun, canResumeRun, cancelUnavailableReason, commandPending, mode, onCancelRun, onPauseRun, onResumeRun, pauseUnavailableReason, resumeUnavailableReason]);
+  const pauseCommand = runtimeCommandRegistry.get("agent.pause")!;
+  const resumeCommand = runtimeCommandRegistry.get("agent.resume")!;
+  const cancelCommand = runtimeCommandRegistry.get("agent.cancel")!;
   const submittingFormId = commandLifecycle.stage !== "idle"
     && (commandLifecycle.command.kind === "form.submit" || commandLifecycle.command.kind === "form.cancel")
     && isTinyOsCommandInFlight(commandLifecycle)
@@ -153,12 +234,102 @@ export function LiveCanvas({
   const skipBoot = Boolean(snapshot.dialog) || prefersReducedMotion();
   const [booting, setBooting] = useState(() => !tinyOsBootedInRuntime && !skipBoot);
   const dragRef = useRef<{ pointerId: number; startWidth: number; startX: number } | undefined>(undefined);
-  const visualEntries = useMemo(() => entries.filter(({ step }) => Boolean(tinyOsAppForStep(step))), [entries]);
-  const selectedVisualIndex = mode === "history" && selection
-    ? visualEntries.findIndex((entry) => entry.turnId === selection.turnId && entry.step.id === selection.step.id)
-    : visualEntries.length - 1;
-  const previousEntry = selectedVisualIndex > 0 ? visualEntries[selectedVisualIndex - 1] : undefined;
-  const nextEntry = selectedVisualIndex >= 0 && selectedVisualIndex < visualEntries.length - 1 ? visualEntries[selectedVisualIndex + 1] : undefined;
+  const previousBoundary = timeMachineIndex.boundaries[historyEventIndex - 1];
+  const nextBoundary = timeMachineIndex.boundaries[historyEventIndex + 1];
+  const selectBoundary = (boundary: TinyOsTimeMachineBoundary) => {
+    if (onSelectBoundary) {
+      onSelectBoundary(boundary);
+      return;
+    }
+    const entry = entries.find((candidate) => candidate.turnId === boundary.turnId && candidate.step.id === boundary.itemId);
+    if (entry) onSelectEntry(entry);
+  };
+  const canvasCommandRegistry = createTinyOsShellCommandRegistry([
+    ...runtimeCommandRegistry.commands,
+    defineTinyOsShellCommand({
+      availability: previousBoundary ? { available: true } : { available: false, reason: "There is no previous canonical event." },
+      category: "history",
+      dispatch: () => {
+        if (previousBoundary) selectBoundary(previousBoundary);
+      },
+      id: "history.previous",
+      input: { kind: "none" },
+      keywords: ["previous", "history", "operation"],
+      label: "Previous canonical event",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    defineTinyOsShellCommand({
+      availability: nextBoundary ? { available: true } : { available: false, reason: "There is no next canonical event." },
+      category: "history",
+      dispatch: () => {
+        if (nextBoundary) selectBoundary(nextBoundary);
+      },
+      id: "history.next",
+      input: { kind: "none" },
+      keywords: ["next", "history", "operation"],
+      label: "Next canonical event",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    ...timeMachineIndex.boundaries.map((boundary) => defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "history",
+      dispatch: () => selectBoundary(boundary),
+      id: `history.select_event:${boundary.eventIndex}` as const,
+      input: { kind: "none" },
+      keywords: [boundary.title, boundary.kind, boundary.status, boundary.runId, boundary.turnId, "history", "event"],
+      label: `Show event ${boundary.eventIndex + 1}: ${boundary.title}`,
+      scope: "local_presentation",
+      target: { itemId: boundary.itemId, kind: "history", turnId: boundary.turnId },
+    })),
+    defineTinyOsShellCommand({
+      availability: mode === "history" ? { available: true } : { available: false, reason: "TinyOS is already following Live." },
+      category: "history",
+      dispatch: onReturnToLive,
+      id: "history.return_live",
+      input: { kind: "none" },
+      keywords: ["return", "live", "history"],
+      label: "Return to live",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "system",
+      dispatch: toggleWorkspaceWidth,
+      id: "shell.workspace_toggle",
+      input: { kind: "none" },
+      keywords: ["workspace", "compact", "width"],
+      label: widthPx <= 520 ? "Expand TinyOS workspace" : "Use compact TinyOS workspace",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    defineTinyOsShellCommand({
+      availability: onExpandedChange ? { available: true } : { available: false, reason: "Expanded TinyOS is unavailable on this surface." },
+      category: "system",
+      dispatch: () => onExpandedChange?.(),
+      id: "shell.expanded_toggle",
+      input: { kind: "none" },
+      keywords: ["expand", "restore", "surface"],
+      label: expanded ? "Exit expanded TinyOS" : "Expand TinyOS to Chat surface",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    defineTinyOsShellCommand({
+      availability: actionableDialog
+        ? { available: false, reason: "Finish the active TinyOS system request before closing." }
+        : { available: true },
+      category: "system",
+      dispatch: onClose,
+      id: "shell.close",
+      input: { kind: "none" },
+      keywords: ["close", "hide", "tinyos"],
+      label: "Close TinyOS",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+  ], { simulationMode: mode === "history" ? "history" : "live" });
 
   useEffect(() => {
     tinyOsBootedInRuntime = true;
@@ -208,7 +379,7 @@ export function LiveCanvas({
           aria-label="Close TinyOS overlay"
           className="tinyos-overlay-backdrop"
           type="button"
-          onClick={onClose}
+          onClick={() => void canvasCommandRegistry.execute("shell.close")}
         />
       ) : null}
       <aside aria-label="Live Canvas" className="react-live-canvas tinyos" data-expanded={expanded ? "true" : undefined} data-mode={mode} id="tinybot-live-canvas">
@@ -247,10 +418,10 @@ export function LiveCanvas({
           {mode === "live_follow" ? (
             <button
               aria-label={commandPending && commandKind === "agent.pause" ? "Pause command pending" : "Pause active Agent run"}
-              disabled={!canPauseRun || commandPending}
-              title={commandPending ? "Waiting for runtime confirmation" : canPauseRun ? "Pause at the next safe runtime boundary" : pauseUnavailableReason || "No pausable run"}
+              disabled={!pauseCommand.availability.available}
+              title={pauseCommand.availability.available ? "Pause at the next safe runtime boundary" : pauseCommand.availability.reason}
               type="button"
-              onClick={onPauseRun}
+              onClick={() => void canvasCommandRegistry.execute(pauseCommand.id)}
             >
               {commandPending && commandKind === "agent.pause" ? <Loader2 aria-hidden="true" className="tinyos-command-spinner" size={15} /> : <Pause aria-hidden="true" size={15} />}
               <span>{commandPending && commandKind === "agent.pause" ? "Pausing" : "Pause"}</span>
@@ -259,10 +430,10 @@ export function LiveCanvas({
           {mode === "live_follow" ? (
             <button
               aria-label={commandPending && commandKind === "agent.resume" ? "Resume command pending" : "Resume paused Agent run"}
-              disabled={!canResumeRun || commandPending}
-              title={commandPending ? "Waiting for runtime confirmation" : canResumeRun ? "Resume the same Agent run" : resumeUnavailableReason || "No paused run"}
+              disabled={!resumeCommand.availability.available}
+              title={resumeCommand.availability.available ? "Resume the same Agent run" : resumeCommand.availability.reason}
               type="button"
-              onClick={onResumeRun}
+              onClick={() => void canvasCommandRegistry.execute(resumeCommand.id)}
             >
               {commandPending && commandKind === "agent.resume" ? <Loader2 aria-hidden="true" className="tinyos-command-spinner" size={15} /> : <Play aria-hidden="true" size={15} />}
               <span>{commandPending && commandKind === "agent.resume" ? "Resuming" : "Resume"}</span>
@@ -271,21 +442,13 @@ export function LiveCanvas({
           {mode === "live_follow" ? (
             <button
               aria-label={commandPending && commandKind === "agent.cancel" ? "Cancel command pending" : "Cancel active Agent run"}
-              disabled={!canCancelRun || commandPending}
-              title={commandPending ? "Waiting for runtime confirmation" : canCancelRun ? "Cancel active run" : cancelUnavailableReason || "No cancellable run"}
+              disabled={!cancelCommand.availability.available}
+              title={cancelCommand.availability.available ? "Cancel active run" : cancelCommand.availability.reason}
               type="button"
-              onClick={onCancelRun}
+              onClick={() => void canvasCommandRegistry.execute(cancelCommand.id)}
             >
               {commandPending && commandKind === "agent.cancel" ? <Loader2 aria-hidden="true" className="tinyos-command-spinner" size={15} /> : <StopCircle aria-hidden="true" size={15} />}
               <span>{commandPending && commandKind === "agent.cancel" ? "Cancelling" : "Cancel"}</span>
-            </button>
-          ) : null}
-          <button aria-label="Previous canonical operation" disabled={!previousEntry} title="Previous operation" type="button" onClick={() => previousEntry && onSelectEntry(previousEntry)}><ChevronLeft aria-hidden="true" size={15} /></button>
-          <button aria-label="Next canonical operation" disabled={!nextEntry} title="Next operation" type="button" onClick={() => nextEntry && onSelectEntry(nextEntry)}><ChevronRight aria-hidden="true" size={15} /></button>
-          {mode === "history" ? (
-            <button aria-label="Return to live" title="Return to live" type="button" onClick={onReturnToLive}>
-              <RotateCcw aria-hidden="true" size={15} />
-              <span>Return to live</span>
             </button>
           ) : null}
           <button
@@ -293,34 +456,39 @@ export function LiveCanvas({
             className="tinyos-workspace-toggle"
             title={widthPx <= 520 ? "Workspace layout" : "Compact layout"}
             type="button"
-            onClick={toggleWorkspaceWidth}
+            onClick={() => void canvasCommandRegistry.execute("shell.workspace_toggle")}
           >
             {widthPx <= 520 ? <PanelRightOpen aria-hidden="true" size={15} /> : <PanelRightClose aria-hidden="true" size={15} />}
             <span>{widthPx <= 520 ? "Workspace" : "Compact"}</span>
           </button>
-          {onExpandedChange ? <button aria-label={expanded ? "Exit expanded TinyOS" : "Expand TinyOS to Chat surface"} title={expanded ? "Exit expanded mode" : "Expanded mode"} type="button" onClick={onExpandedChange}>{expanded ? <Minimize2 aria-hidden="true" size={15} /> : <Maximize2 aria-hidden="true" size={15} />}</button> : null}
-          <button aria-label="Close Live Canvas panel" title="Close TinyOS" type="button" onClick={onClose}>
+          {onExpandedChange ? <button aria-label={expanded ? "Exit expanded TinyOS" : "Expand TinyOS to Chat surface"} title={expanded ? "Exit expanded mode" : "Expanded mode"} type="button" onClick={() => void canvasCommandRegistry.execute("shell.expanded_toggle")}>{expanded ? <Minimize2 aria-hidden="true" size={15} /> : <Maximize2 aria-hidden="true" size={15} />}</button> : null}
+          <button aria-label="Close Live Canvas panel" title="Close TinyOS" type="button" onClick={() => void canvasCommandRegistry.execute("shell.close")}>
             <X aria-hidden="true" size={16} />
           </button>
         </div>
       </header>
 
+      <TinyOsTimeMachine
+        currentEventIndex={Math.max(0, historyEventIndex)}
+        index={timeMachineIndex}
+        live={mode === "live_follow"}
+        onReturnToLive={() => void canvasCommandRegistry.execute("history.return_live")}
+        onSelect={(boundary) => void canvasCommandRegistry.execute(`history.select_event:${boundary.eventIndex}`)}
+      />
+
       <TinyOsShell
         key={sessionKey}
-        activeRunId={activeRunId}
         agentUiForms={agentUiForms}
-        canCancelRun={canCancelRun}
         canCancelTerminal={canCancelTerminal}
         canDirectEdit={canDirectEdit}
         canExecuteTerminal={canExecuteTerminal}
-        canPauseRun={canPauseRun}
+        canInteractBrowser={canInteractBrowser}
         canRequestChange={canRequestChange}
-        canResumeRun={canResumeRun}
         canRetryRun={canRetryRun}
         canSaveFile={canSaveFile}
-        cancelUnavailableReason={cancelUnavailableReason}
         commandLifecycle={commandLifecycle}
         directEditUnavailableReason={directEditUnavailableReason}
+        browserInteractUnavailableReason={browserInteractUnavailableReason}
         filesController={filesController}
         history={mode === "history"}
         onAttachContext={onAttachContext}
@@ -331,25 +499,22 @@ export function LiveCanvas({
         sessionKey={sessionKey}
         workspaceKey={filesController?.state.workspaceKey ?? workspaceKey}
         onCancelForm={onCancelForm}
-        onCancelRun={onCancelRun}
         onOpenArtifact={onOpenArtifact}
         onAgentRequest={(reference, intent) => onAgentRequest(reference, intent, mode === "history")}
         onCancelTerminal={onCancelTerminal}
+        onBrowserInteract={onBrowserInteract}
         onDeleteFile={onDeleteFile}
         onExecuteTerminal={onExecuteTerminal}
         onMoveFile={onMoveFile}
-        onPauseRun={onPauseRun}
         onResolveApproval={onResolveApproval}
         onRetryOperation={onRetryOperation}
-        onResumeRun={onResumeRun}
         onSelectEntry={onSelectEntry}
         onSubmitForm={onSubmitForm}
         onSaveFile={onSaveFile}
         requestChangeUnavailableReason={requestChangeUnavailableReason}
-        pauseUnavailableReason={pauseUnavailableReason}
+        runtimeCommandRegistry={canvasCommandRegistry}
         retryRunId={retryRunId}
         retryUnavailableReason={retryUnavailableReason}
-        resumeUnavailableReason={resumeUnavailableReason}
         runningTerminalRunId={runningTerminalRunId}
         saveFileUnavailableReason={saveFileUnavailableReason}
         terminalCancelUnavailableReason={terminalCancelUnavailableReason}
@@ -367,6 +532,19 @@ export function LiveCanvas({
       </aside>
     </>
   );
+}
+
+function resolveHistoryEventIndex(
+  boundaries: readonly TinyOsTimeMachineBoundary[],
+  requestedEventIndex: number | undefined,
+  selection: LiveCanvasEntry | undefined,
+): number {
+  if (requestedEventIndex !== undefined && boundaries[requestedEventIndex]) return requestedEventIndex;
+  for (let index = boundaries.length - 1; index >= 0; index -= 1) {
+    const boundary = boundaries[index];
+    if (boundary.itemId === selection?.step.id && boundary.turnId === selection.turnId) return index;
+  }
+  return boundaries.length - 1;
 }
 
 export function clampTinyOsWidth(widthPx: number): number {

--- a/src/react-workbench/chat/TinyOsFilesExplorer.test.tsx
+++ b/src/react-workbench/chat/TinyOsFilesExplorer.test.tsx
@@ -4,6 +4,8 @@ import { cleanup, fireEvent, render, screen, within } from "@testing-library/rea
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTinyOsFilesState, type TinyOsFilesState } from "../../app-core/chat/tinyOsFilesModel";
+import { createTinyOsFileSaveCommand } from "../../app-core/chat/tinyOsCommandGateway";
+import { createTinyOsShellCommandRegistry, defineTinyOsShellCommand } from "../../app-core/chat/tinyOsShellCommandRegistry";
 import { TinyOsFilesExplorer } from "./TinyOsFilesExplorer";
 import type { TinyOsFilesController } from "./useTinyOsFilesController";
 
@@ -53,6 +55,32 @@ function treeState(): TinyOsFilesState {
   };
 }
 
+function openDocumentState(path = "README.md"): TinyOsFilesState {
+  return {
+    ...treeState(),
+    activePath: path,
+    documents: {
+      [path]: {
+        status: "ready",
+        value: {
+          access: "read_only",
+          content: "before\n",
+          contentType: "text",
+          lineEnd: 1,
+          path,
+          provenance: { kind: "native_query", sourceId: "workspace-a" },
+          resourceId: `workspace:workspace-a:${path}`,
+          revision: "metadata:7:12",
+          sizeBytes: 7,
+          stale: false,
+        },
+      },
+    },
+    mruPaths: [path],
+    openPaths: [path],
+  };
+}
+
 describe("TinyOS Workspace Explorer", () => {
   it("loads tree items without recursive enumeration and supports tree keyboard navigation", async () => {
     const files = controller(treeState());
@@ -81,10 +109,13 @@ describe("TinyOS Workspace Explorer", () => {
         "src/main.ts": {
           status: "ready",
           value: {
+            access: "read_only",
             content: "const one = 1;\nconst two = 2;",
             contentType: "text",
             lineEnd: 2,
             path: "src/main.ts",
+            provenance: { kind: "native_query", sourceId: "workspace-a" },
+            resourceId: "workspace:workspace-a:src/main.ts",
             revision: "revision-1",
             sizeBytes: 31,
             stale: false,
@@ -150,10 +181,13 @@ describe("TinyOS Workspace Explorer", () => {
         "README.md": {
           status: "ready",
           value: {
+            access: "read_only",
             content: "before\n",
             contentType: "text",
             lineEnd: 1,
             path: "README.md",
+            provenance: { kind: "native_query", sourceId: "workspace-a" },
+            resourceId: "workspace:workspace-a:README.md",
             revision: "metadata:7:12",
             sizeBytes: 7,
             stale: false,
@@ -193,7 +227,7 @@ describe("TinyOS Workspace Explorer", () => {
   });
 
   it("keeps a rejected draft visible for conflict recovery", async () => {
-    const onSaveFile = vi.fn(async () => { throw new Error("version conflict"); });
+    const onSaveFile = vi.fn(async () => { throw new Error('file.save failed: version conflict: {"revision":"metadata:9:18"}'); });
     const files = controller({
       ...treeState(),
       activePath: "README.md",
@@ -201,10 +235,13 @@ describe("TinyOS Workspace Explorer", () => {
         "README.md": {
           status: "ready",
           value: {
+            access: "read_only",
             content: "before\n",
             contentType: "text",
             lineEnd: 1,
             path: "README.md",
+            provenance: { kind: "native_query", sourceId: "workspace-a" },
+            resourceId: "workspace:workspace-a:README.md",
             revision: "metadata:7:12",
             sizeBytes: 7,
             stale: false,
@@ -234,5 +271,119 @@ describe("TinyOS Workspace Explorer", () => {
 
     expect((await screen.findByRole("alert")).textContent).toContain("version conflict");
     expect((screen.getByRole("textbox", { name: "Editable draft of README.md" }) as HTMLTextAreaElement).value).toBe("keep this draft");
+    const conflict = screen.getByRole("region", { name: "File revision conflict" });
+    expect(within(conflict).getByText("metadata:7:12")).toBeTruthy();
+    expect(within(conflict).getByText("metadata:9:18")).toBeTruthy();
+  });
+
+  it("shows stable native resource identity, registered Open With handlers, and process occupancy", async () => {
+    const attach = vi.fn();
+    const resourceId = "workspace:workspace-a:README.md";
+    const registry = createTinyOsShellCommandRegistry([defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "resource",
+      dispatch: attach,
+      id: `reference.attach:${resourceId}`,
+      input: { acceptedKinds: ["file"], kind: "reference" },
+      keywords: ["readme", "chat"],
+      label: "Attach README.md to Chat",
+      scope: "local_presentation",
+      target: { kind: "resource", resourceId },
+    })]);
+    const files = controller(openDocumentState());
+    render(<TinyOsFilesExplorer
+      canRequestChange={false}
+      commandRegistry={registry}
+      controller={files}
+      kernel={{
+        browserSessions: [],
+        capabilities: [],
+        cursor: { eventCount: 1, eventIndex: 1, mode: "live" },
+        discrepancies: [],
+        metrics: [],
+        notifications: [],
+        processes: [{
+          applicationId: "files",
+          correlation: { runId: "run-1", sessionId: "session-1" },
+          id: "process-file-1",
+          kind: "tool_operation",
+          provenance: { kind: "canonical_event", sourceId: "item-1" },
+          state: "running",
+          title: "Read README",
+        }],
+        resources: [{
+          access: "read_only",
+          id: "kernel-file-1",
+          kind: "file",
+          path: "README.md",
+          provenance: { kind: "canonical_event", sourceId: "item-1" },
+          relatedProcessIds: ["process-file-1"],
+          revision: "metadata:7:12",
+          title: "README.md",
+        }],
+        truth: "derived",
+      }}
+      layoutMode="workspace"
+      onAttachContext={vi.fn()}
+      onRequestExplanation={vi.fn()}
+      onRequestModification={vi.fn()}
+    />);
+
+    const identity = screen.getByRole("group", { name: "File resource identity" });
+    expect(within(identity).getByText(resourceId)).toBeTruthy();
+    expect(within(identity).getByText(/native_query/)).toBeTruthy();
+    expect(within(identity).getByText("1 related process")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Open With" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Attach README.md to Chat" }));
+    expect(attach).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps recent files and favorites as local views over known resources", async () => {
+    const files = controller(openDocumentState());
+    render(<TinyOsFilesExplorer canRequestChange={false} controller={files} layoutMode="workspace" onAttachContext={vi.fn()} onRequestExplanation={vi.fn()} onRequestModification={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Add README.md to favorites" }));
+    await userEvent.click(screen.getByRole("button", { name: "Show favorite files" }));
+    await userEvent.click(within(screen.getByLabelText("Favorite files")).getByRole("button", { name: /README.md/ }));
+    expect(files.openFile).toHaveBeenCalledWith("README.md");
+
+    await userEvent.click(screen.getByRole("button", { name: "Show recent files" }));
+    expect(within(screen.getByLabelText("Recent files")).getByRole("button", { name: /README.md/ })).toBeTruthy();
+  });
+
+  it("tracks file dispatch, acknowledgement, completion, and conflict without presenting Trash", () => {
+    const files = controller(openDocumentState());
+    const command = createTinyOsFileSaveCommand({
+      baseRevision: "metadata:7:12",
+      commandId: "file-command-1",
+      content: "after\n",
+      issuedAt: "2026-07-14T00:00:00Z",
+      path: "README.md",
+      sessionId: "session-1",
+      source: { control: "files-save", surface: "tinyos" },
+    });
+    const props = {
+      canRequestChange: false,
+      controller: files,
+      layoutMode: "workspace" as const,
+      onAttachContext: vi.fn(),
+      onRequestExplanation: vi.fn(),
+      onRequestModification: vi.fn(),
+    };
+    const { rerender } = render(<TinyOsFilesExplorer {...props} commandLifecycle={{ command, dispatchedAtMs: 1, stage: "sending" }} />);
+    expect(within(screen.getByLabelText("File operation queue")).getByText("dispatching")).toBeTruthy();
+
+    rerender(<TinyOsFilesExplorer {...props} commandLifecycle={{ command, dispatchedAtMs: 1, transportAcceptedAtMs: 2, stage: "waiting_for_canonical" }} />);
+    expect(within(screen.getByLabelText("File operation queue")).getByText("awaiting runtime")).toBeTruthy();
+    rerender(<TinyOsFilesExplorer {...props} commandLifecycle={{ acknowledgement: { itemId: "item-1", revision: 1 }, acknowledgedAtMs: 3, command, dispatchedAtMs: 1, stage: "acknowledged" }} />);
+    expect(within(screen.getByLabelText("File operation queue")).getByText("acknowledged")).toBeTruthy();
+    rerender(<TinyOsFilesExplorer {...props} commandLifecycle={{ acknowledgement: { itemId: "item-1", revision: 1 }, command, completedAtMs: 4, completion: { itemId: "item-1", revision: 2, status: "completed" }, dispatchedAtMs: 1, stage: "completed" }} />);
+    expect(within(screen.getByLabelText("File operation queue")).getByText("completed")).toBeTruthy();
+
+    const conflictCommand = { ...command, commandId: "file-command-2" };
+    rerender(<TinyOsFilesExplorer {...props} commandLifecycle={{ command: conflictCommand, dispatchedAtMs: 5, error: "version conflict", stage: "rejected" }} />);
+    expect(within(screen.getByLabelText("File operation queue")).getByText("conflict")).toBeTruthy();
+    expect(screen.getByText("Permanent delete · Trash unavailable")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Trash/ })).toBeNull();
   });
 });

--- a/src/react-workbench/chat/TinyOsFilesExplorer.tsx
+++ b/src/react-workbench/chat/TinyOsFilesExplorer.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import {
   AlertCircle,
+  Activity,
   ArrowLeft,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  Clock3,
   FilePlus2,
   FileText,
   Folder,
@@ -16,10 +18,17 @@ import {
   RefreshCw,
   Save,
   Search,
+  ShieldCheck,
+  Star,
   Trash2,
   X,
 } from "lucide-react";
 import { resourceValue, type TinyOsDirectoryView, type TinyOsResourceState } from "../../app-core/chat/tinyOsFilesModel";
+import { tinyOsWorkspaceResourceId } from "../../app-core/chat/tinyOsFilesModel";
+import type { TinyOsCommandLifecycle } from "../../app-core/chat/tinyOsCommandGateway";
+import type { TinyOsKernelSnapshot } from "../../app-core/chat/tinyOsKernelModel";
+import type { TinyOsShellCommandRegistry } from "../../app-core/chat/tinyOsShellCommandRegistry";
+import { writeTinyOsReferenceTransfer } from "../../app-core/chat/tinyOsReferenceTransfer";
 import type { TinyOsContextReference, TinyOsLayoutMode } from "../../app-core/chat/tinyOsUiState";
 import type { WorkspaceDirectoryEntry } from "../../app-core/workspace/workspaceExplorer";
 import type { TinyOsFilesController } from "./useTinyOsFilesController";
@@ -28,9 +37,12 @@ export function TinyOsFilesExplorer({
   canDirectEdit = false,
   canRequestChange,
   canSave = false,
+  commandLifecycle = { stage: "idle" },
+  commandRegistry,
   controller,
   directEditUnavailableReason,
   layoutMode,
+  kernel,
   onAttachContext,
   onRequestExplanation,
   onRequestModification,
@@ -43,9 +55,12 @@ export function TinyOsFilesExplorer({
   canDirectEdit?: boolean;
   canRequestChange: boolean;
   canSave?: boolean;
+  commandLifecycle?: TinyOsCommandLifecycle;
+  commandRegistry?: TinyOsShellCommandRegistry;
   controller: TinyOsFilesController;
   directEditUnavailableReason?: string;
   layoutMode: TinyOsLayoutMode;
+  kernel?: TinyOsKernelSnapshot;
   onAttachContext: (reference: TinyOsContextReference) => void;
   onRequestExplanation: (reference: TinyOsContextReference) => void;
   onRequestModification: (reference: TinyOsContextReference) => void;
@@ -62,6 +77,8 @@ export function TinyOsFilesExplorer({
   const [newFilePath, setNewFilePath] = useState("");
   const [creatingFile, setCreatingFile] = useState(false);
   const [createError, setCreateError] = useState("");
+  const [favoritePaths, setFavoritePaths] = useState<Set<string>>(() => new Set());
+  const [localView, setLocalView] = useState<"favorites" | "recent" | "tree">("tree");
   const compactDocument = layoutMode === "compact" && state.compactSurface === "document";
   const showTree = layoutMode !== "compact" || !compactDocument;
   const showDocument = layoutMode !== "compact" || compactDocument;
@@ -84,6 +101,9 @@ export function TinyOsFilesExplorer({
         <aside aria-label="Workspace Explorer" className="tinyos-workspace-explorer__tree">
           <header>
             <span><FolderOpen aria-hidden="true" size={14} /><strong>Workspace</strong></span>
+            <button aria-label="Show workspace tree" aria-pressed={localView === "tree"} title="Workspace tree" type="button" onClick={() => setLocalView("tree")}><Folder aria-hidden="true" size={13} /></button>
+            <button aria-label="Show recent files" aria-pressed={localView === "recent"} title="Recent files" type="button" onClick={() => setLocalView("recent")}><Clock3 aria-hidden="true" size={13} /></button>
+            <button aria-label="Show favorite files" aria-pressed={localView === "favorites"} title="Favorite files" type="button" onClick={() => setLocalView("favorites")}><Star aria-hidden="true" size={13} /></button>
             <button aria-label="Create workspace file" disabled={!canSave} title={canSave ? "Create an empty workspace file" : saveUnavailableReason} type="button" onClick={() => setCreatingFile((current) => !current)}><FilePlus2 aria-hidden="true" size={13} /></button>
             <button aria-label="Refresh current directory" title="Refresh directory" type="button" onClick={() => void controller.refreshDirectory(currentDirectory)}><RefreshCw aria-hidden="true" size={13} /></button>
           </header>
@@ -110,7 +130,13 @@ export function TinyOsFilesExplorer({
             <Search aria-hidden="true" size={12} />
             <input aria-label={`Filter ${displayPath(currentDirectory)}`} placeholder="Filter current folder" value={filter} onChange={(event) => setFilter(event.currentTarget.value)} />
           </form>
-          <WorkspaceTree controller={controller} currentDirectory={currentDirectory} onSelectDirectory={selectDirectory} />
+          {localView === "tree" ? <WorkspaceTree controller={controller} currentDirectory={currentDirectory} onSelectDirectory={selectDirectory} /> : (
+            <LocalFileView
+              label={localView === "recent" ? "Recent files" : "Favorite files"}
+              paths={localView === "recent" ? [...state.mruPaths].reverse() : [...favoritePaths]}
+              onOpen={(path) => void controller.openFile(path)}
+            />
+          )}
           <div aria-live="polite" className="tinyos-workspace-explorer__status">
             {directory?.filter ? `Filtered ${displayPath(currentDirectory)} by “${directory.filter}”` : displayPath(currentDirectory)}
           </div>
@@ -121,9 +147,12 @@ export function TinyOsFilesExplorer({
           canDirectEdit={canDirectEdit}
           canRequestChange={canRequestChange}
           canSave={canSave}
+          commandRegistry={commandRegistry}
           controller={controller}
           compact={layoutMode === "compact"}
           directEditUnavailableReason={directEditUnavailableReason}
+          favorite={Boolean(state.activePath && favoritePaths.has(state.activePath))}
+          kernel={kernel}
           onAttachContext={onAttachContext}
           onBrowseDirectory={browseDirectory}
           onRequestExplanation={onRequestExplanation}
@@ -131,11 +160,69 @@ export function TinyOsFilesExplorer({
           onDeleteFile={onDeleteFile}
           onMoveFile={onMoveFile}
           onSaveFile={onSaveFile}
+          onToggleFavorite={() => state.activePath && setFavoritePaths((current) => {
+            const next = new Set(current);
+            if (next.has(state.activePath!)) next.delete(state.activePath!);
+            else next.add(state.activePath!);
+            return next;
+          })}
           requestChangeUnavailableReason={requestChangeUnavailableReason}
           saveUnavailableReason={saveUnavailableReason}
         />
       ) : null}
+      <TinyOsFileOperationQueue lifecycle={commandLifecycle} />
     </div>
+  );
+}
+
+function LocalFileView({ label, onOpen, paths }: { label: string; onOpen: (path: string) => void; paths: string[] }) {
+  return (
+    <div aria-label={label} className="tinyos-workspace-local-view">
+      {paths.length ? paths.map((path) => <button key={path} title={path} type="button" onClick={() => onOpen(path)}><FileText aria-hidden="true" size={13} /><span>{fileName(path)}</span><small>{path}</small></button>) : <ExplorerMessage text={`No ${label.toLocaleLowerCase()} yet.`} />}
+    </div>
+  );
+}
+
+type TinyOsFileOperationView = {
+  commandId: string;
+  detail?: string;
+  kind: "delete" | "move" | "save";
+  path: string;
+  state: "acknowledged" | "awaiting_runtime" | "completed" | "conflict" | "dispatching" | "failed";
+};
+
+function TinyOsFileOperationQueue({ lifecycle }: { lifecycle: TinyOsCommandLifecycle }) {
+  const [operations, setOperations] = useState<TinyOsFileOperationView[]>([]);
+  useEffect(() => {
+    if (lifecycle.stage === "idle") return;
+    const command = lifecycle.command;
+    if (command.kind !== "file.save" && command.kind !== "file.move" && command.kind !== "file.delete") return;
+    const error = lifecycle.stage === "rejected" || lifecycle.stage === "timed_out" ? lifecycle.error : undefined;
+    const state: TinyOsFileOperationView["state"] = lifecycle.stage === "sending"
+      ? "dispatching"
+      : lifecycle.stage === "waiting_for_canonical"
+        ? "awaiting_runtime"
+        : lifecycle.stage === "acknowledged"
+          ? "acknowledged"
+          : lifecycle.stage === "completed"
+            ? lifecycle.completion.status === "completed" ? "completed" : "failed"
+            : error?.toLocaleLowerCase().includes("version conflict") ? "conflict" : "failed";
+    const next: TinyOsFileOperationView = {
+      commandId: command.commandId,
+      detail: error,
+      kind: command.kind.replace("file.", "") as TinyOsFileOperationView["kind"],
+      path: command.file.path,
+      state,
+    };
+    setOperations((current) => [next, ...current.filter((operation) => operation.commandId !== next.commandId)].slice(0, 5));
+  }, [lifecycle]);
+
+  if (!operations.length) return null;
+  return (
+    <aside aria-label="File operation queue" className="tinyos-file-operation-queue">
+      <header><strong>File operations</strong><span>{operations.length}</span></header>
+      {operations.map((operation) => <article data-state={operation.state} key={operation.commandId}><span><strong>{operation.kind}</strong><small>{operation.path}</small></span><span>{operation.state.replace("_", " ")}</span>{operation.detail ? <small title={operation.detail}>{operation.detail}</small> : null}</article>)}
+    </aside>
   );
 }
 
@@ -227,6 +314,8 @@ function TreeEntry({
         className="tinyos-workspace-tree__entry"
         data-active={(isDirectory ? currentDirectory === entry.path : state.activePath === entry.path) ? "true" : undefined}
         data-kind={entry.kind}
+        data-provenance="native_query"
+        data-resource-id={tinyOsWorkspaceResourceId(state.workspaceKey ?? "workspace", entry.path)}
         role="treeitem"
         style={{ paddingInlineStart: `${8 + depth * 14}px` }}
         title={entry.path}
@@ -260,9 +349,12 @@ function WorkspaceDocument({
   canDirectEdit,
   canRequestChange,
   canSave,
+  commandRegistry,
   compact,
   controller,
   directEditUnavailableReason,
+  favorite,
+  kernel,
   onAttachContext,
   onBrowseDirectory,
   onDeleteFile,
@@ -270,15 +362,19 @@ function WorkspaceDocument({
   onRequestExplanation,
   onRequestModification,
   onSaveFile,
+  onToggleFavorite,
   requestChangeUnavailableReason,
   saveUnavailableReason,
 }: {
   canDirectEdit: boolean;
   canRequestChange: boolean;
   canSave: boolean;
+  commandRegistry?: TinyOsShellCommandRegistry;
   compact: boolean;
   controller: TinyOsFilesController;
   directEditUnavailableReason?: string;
+  favorite: boolean;
+  kernel?: TinyOsKernelSnapshot;
   onAttachContext: (reference: TinyOsContextReference) => void;
   onBrowseDirectory: (path: string) => void;
   onDeleteFile: (input: { baseRevision: string; path: string }) => Promise<void>;
@@ -286,6 +382,7 @@ function WorkspaceDocument({
   onRequestExplanation: (reference: TinyOsContextReference) => void;
   onRequestModification: (reference: TinyOsContextReference) => void;
   onSaveFile: (input: { baseRevision?: string; content: string; createOnly: boolean; path: string }) => Promise<void>;
+  onToggleFavorite: () => void;
   requestChangeUnavailableReason?: string;
   saveUnavailableReason?: string;
 }) {
@@ -312,6 +409,8 @@ function WorkspaceDocument({
   const [moving, setMoving] = useState(false);
   const [deleteConfirmed, setDeleteConfirmed] = useState(false);
   const [mutationError, setMutationError] = useState("");
+  const [mutationConflict, setMutationConflict] = useState<{ baseRevision: string; currentRevision?: string; message: string }>();
+  const [openWith, setOpenWith] = useState(false);
   const activeMatchRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
@@ -321,6 +420,8 @@ function WorkspaceDocument({
     setMoving(false);
     setDeleteConfirmed(false);
     setMutationError("");
+    setMutationConflict(undefined);
+    setOpenWith(false);
   }, [path]);
   useEffect(() => activeMatchRef.current?.scrollIntoView({ block: "center" }), [matchLine]);
 
@@ -353,10 +454,17 @@ function WorkspaceDocument({
   const editing = editingPath === path;
   const draft = drafts[path] ?? document?.content ?? "";
   const dirty = Boolean(document && draft !== document.content);
+  const kernelResource = document && kernel?.resources.find((candidate) => candidate.path?.replace(/\\/g, "/") === path.replace(/\\/g, "/"));
+  const relatedProcesses = kernelResource
+    ? kernel?.processes.filter((process) => kernelResource.relatedProcessIds.includes(process.id)) ?? []
+    : [];
+  const resourceId = document?.resourceId ?? tinyOsWorkspaceResourceId(state.workspaceKey ?? "workspace", path);
+  const openWithCommands = commandRegistry?.commands.filter((command) => command.target.kind === "resource" && command.target.resourceId === resourceId) ?? [];
 
   async function saveDraft() {
     if (!document || !dirty) return;
     setMutationError("");
+    setMutationConflict(undefined);
     try {
       await onSaveFile({ baseRevision: document.revision, content: draft, createOnly: false, path });
       setDrafts((current) => {
@@ -368,7 +476,9 @@ function WorkspaceDocument({
       setReviewing(false);
       await controller.refreshFile(path);
     } catch (error) {
-      setMutationError(error instanceof Error ? error.message : String(error));
+      const message = error instanceof Error ? error.message : String(error);
+      setMutationError(message);
+      setMutationConflict(fileVersionConflict(message, document.revision));
     }
   }
 
@@ -378,7 +488,7 @@ function WorkspaceDocument({
         {compact ? <button aria-label="Back to workspace" title="Back to workspace" type="button" onClick={controller.showTree}><ArrowLeft aria-hidden="true" size={13} /></button> : null}
         {state.openPaths.map((openPath) => (
           <span data-active={openPath === path ? "true" : undefined} key={openPath}>
-            <button aria-selected={openPath === path} role="tab" title={openPath} type="button" onClick={() => controller.activateFile(openPath)}>{fileName(openPath)}</button>
+            <button aria-selected={openPath === path} data-provenance="native_query" data-resource-id={tinyOsWorkspaceResourceId(state.workspaceKey ?? "workspace", openPath)} role="tab" title={openPath} type="button" onClick={() => controller.activateFile(openPath)}>{fileName(openPath)}</button>
             <button aria-label={`Close ${openPath}`} title={`Close ${openPath}`} type="button" onClick={() => controller.closeFile(openPath)}><X aria-hidden="true" size={11} /></button>
           </span>
         ))}
@@ -386,6 +496,8 @@ function WorkspaceDocument({
       <div className="tinyos-workspace-document__path">
         <nav aria-label="File breadcrumb">{breadcrumbPaths(path).map(({ label, value }) => <button aria-current={value === path ? "page" : undefined} disabled={value === path} key={value} title={value} type="button" onClick={() => onBrowseDirectory(value)}>{label}</button>)}</nav>
         <button aria-label={`Refresh ${path}`} title="Refresh file" type="button" onClick={() => void controller.refreshFile(path)}><RefreshCw aria-hidden="true" size={13} /></button>
+        <button aria-label={favorite ? `Remove ${path} from favorites` : `Add ${path} to favorites`} aria-pressed={favorite} title={favorite ? "Remove favorite" : "Add favorite"} type="button" onClick={onToggleFavorite}><Star aria-hidden="true" fill={favorite ? "currentColor" : "none"} size={13} /></button>
+        <button aria-expanded={openWith} disabled={!openWithCommands.length} title={openWithCommands.length ? "Open with a registered TinyOS handler" : "No registered handler is available"} type="button" onClick={() => setOpenWith((current) => !current)}>Open With</button>
         <button
           aria-label={editing ? `Close editor for ${path}` : `Edit ${path}`}
           disabled={!editing && (!canDirectEdit || document?.contentType !== "text" || Boolean(document?.nextCursor))}
@@ -400,6 +512,20 @@ function WorkspaceDocument({
           }}
         ><PencilLine aria-hidden="true" size={12} />{editing ? "Close editor" : "Edit draft"}</button>
       </div>
+      {openWith ? (
+        <div aria-label={`Open ${path} with`} className="tinyos-file-open-with" role="menu">
+          {openWithCommands.map((command) => <button disabled={!command.availability.available} key={command.id} role="menuitem" title={command.availability.available ? command.label : command.availability.reason} type="button" onClick={() => void commandRegistry?.execute(command.id).then((result) => result.status === "executed" && setOpenWith(false))}>{command.label}</button>)}
+        </div>
+      ) : null}
+      {document ? (
+        <dl aria-label="File resource identity" className="tinyos-file-resource-meta" role="group">
+          <div><dt>Resource</dt><dd><code>{resourceId}</code></dd></div>
+          <div><dt>Revision</dt><dd><code>{document.revision}</code></dd></div>
+          <div><dt>Access</dt><dd>{canSave ? "read / write commands" : document.access.replace("_", " ")}</dd></div>
+          <div><dt>Provenance</dt><dd><ShieldCheck aria-hidden="true" size={11} />{document.provenance.kind} · {document.provenance.sourceId}</dd></div>
+          <div><dt>Occupancy</dt><dd><Activity aria-hidden="true" size={11} />{relatedProcesses.length ? `${relatedProcesses.length} related process${relatedProcesses.length === 1 ? "" : "es"}` : "No correlated process evidence"}</dd></div>
+        </dl>
+      ) : null}
       <div className="tinyos-workspace-document__search">
         <Search aria-hidden="true" size={12} />
         <input aria-label="Search loaded file content" placeholder="Search loaded content" value={search.query} onChange={(event) => controller.setSearch(path, event.currentTarget.value, 0)} />
@@ -454,7 +580,7 @@ function WorkspaceDocument({
         {document?.nextCursor ? <button type="button" onClick={() => void controller.loadMoreFile(path)}>Load more</button> : null}
         {search.query && document?.nextCursor ? <span>Search covers loaded content only</span> : null}
         {selectedReference ? (
-          <button type="button" onClick={() => onAttachContext(selectedReference)}><Paperclip aria-hidden="true" size={11} />Attach L{selectedReference.startLine}{selectedReference.endLine === selectedReference.startLine ? "" : `–${selectedReference.endLine}`}</button>
+          <button draggable="true" title="Attach to Chat or drag this structured file reference" type="button" onClick={() => onAttachContext(selectedReference)} onDragStart={(event) => writeTinyOsReferenceTransfer(event.dataTransfer, { kind: "context", reference: selectedReference })}><Paperclip aria-hidden="true" size={11} />Attach L{selectedReference.startLine}{selectedReference.endLine === selectedReference.startLine ? "" : `–${selectedReference.endLine}`}</button>
         ) : null}
         {selectedReference ? (
           <button
@@ -480,13 +606,18 @@ function WorkspaceDocument({
               if (!targetPath) return;
               setMutationError("");
               void onMoveFile({ baseRevision: document.revision, path, targetPath }).then(async () => {
+                setMutationConflict(undefined);
                 setMoving(false);
                 setMoveTarget("");
                 controller.closeFile(path);
                 await controller.refreshDirectory(parentDirectory(path));
                 await controller.refreshDirectory(parentDirectory(targetPath));
                 await controller.revealFile(targetPath);
-              }).catch((error) => setMutationError(error instanceof Error ? error.message : String(error)));
+              }).catch((error) => {
+                const message = error instanceof Error ? error.message : String(error);
+                setMutationError(message);
+                setMutationConflict(fileVersionConflict(message, document.revision));
+              });
             }}>
               <input aria-label={`Move ${path} to`} autoFocus placeholder="new/path/name" value={moveTarget} onChange={(event) => setMoveTarget(event.currentTarget.value)} />
               <button disabled={!canSave || !moveTarget.trim()} type="submit">Move</button>
@@ -507,15 +638,29 @@ function WorkspaceDocument({
               }
               setMutationError("");
               void onDeleteFile({ baseRevision: document.revision, path }).then(async () => {
+                setMutationConflict(undefined);
                 controller.closeFile(path);
                 await controller.refreshDirectory(parentDirectory(path));
-              }).catch((error) => setMutationError(error instanceof Error ? error.message : String(error)));
+              }).catch((error) => {
+                const message = error instanceof Error ? error.message : String(error);
+                setMutationError(message);
+                setMutationConflict(fileVersionConflict(message, document.revision));
+              });
             }}
           ><Trash2 aria-hidden="true" size={11} />{deleteConfirmed ? "Confirm delete" : "Delete"}</button>
         ) : null}
+        {document?.contentType === "text" && !editing ? <span title="TinyOS has no recoverable-delete contract">Permanent delete · Trash unavailable</span> : null}
         <span>{document ? `${formatBytes(document.content.length)} loaded / ${formatBytes(document.sizeBytes)}` : ""}</span>
       </footer>
       {mutationError ? <p className="tinyos-file-mutation-error" role="alert">{mutationError}</p> : null}
+      {mutationConflict ? (
+        <section aria-label="File revision conflict" className="tinyos-file-conflict">
+          <header><AlertCircle aria-hidden="true" size={14} /><strong>Stale base revision</strong></header>
+          <p>The reviewed draft is preserved. TinyOS will not overwrite the newer native file.</p>
+          <dl><div><dt>Draft base</dt><dd><code>{mutationConflict.baseRevision}</code></dd></div><div><dt>Current native</dt><dd><code>{mutationConflict.currentRevision ?? "Reported without a revision"}</code></dd></div></dl>
+          <button type="button" onClick={() => void controller.refreshFile(path)}>Refresh native revision</button>
+        </section>
+      ) : null}
     </section>
   );
 }
@@ -607,6 +752,12 @@ function lineChangeSummary(before: string, after: string): string {
   const unchanged = beforeLines.filter((line, index) => line === afterLines[index]).length;
   const changed = Math.max(beforeLines.length, afterLines.length) - unchanged;
   return `${changed} changed line${changed === 1 ? "" : "s"} · ${before.length} → ${after.length} bytes`;
+}
+
+function fileVersionConflict(message: string, baseRevision: string): { baseRevision: string; currentRevision?: string; message: string } | undefined {
+  if (!message.toLocaleLowerCase().includes("version conflict")) return undefined;
+  const currentRevision = message.match(/["']revision["']\s*:\s*["']([^"']+)["']/i)?.[1];
+  return { baseRevision, ...(currentRevision ? { currentRevision } : {}), message };
 }
 
 function boundedSelectionText(value: string): string {

--- a/src/react-workbench/chat/TinyOsGlassSurface.tsx
+++ b/src/react-workbench/chat/TinyOsGlassSurface.tsx
@@ -1,0 +1,64 @@
+import { gsap } from "gsap";
+import { useLayoutEffect, useMemo, useRef } from "react";
+
+interface GlassTargetDetail {
+  visible: boolean;
+  x: number;
+}
+
+type GlassTargetEvent = CustomEvent<GlassTargetDetail>;
+
+const SURFACE_SIZE = 64;
+
+export default function TinyOsGlassSurface() {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const surfaceRef = useRef<HTMLSpanElement>(null);
+  const reducedMotion = useMemo(() => globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false, []);
+
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    const surface = surfaceRef.current;
+    const eventHost = host?.parentElement;
+    const launcher = eventHost?.closest<HTMLElement>(".tinyos-launcher");
+    if (!host || !surface || !eventHost || !launcher) return;
+
+    const positionSurface = (detail: GlassTargetDetail, immediate = false) => {
+      const x = detail.x * eventHost.getBoundingClientRect().width - SURFACE_SIZE / 2;
+      gsap.to(surface, {
+        duration: immediate || reducedMotion ? .001 : .22,
+        ease: "power3.out",
+        opacity: detail.visible ? 1 : 0,
+        overwrite: "auto",
+        x,
+        yPercent: -50,
+      });
+    };
+    const syncFromDom = () => {
+      const current = launcher.querySelector<HTMLElement>(".tinyos-launcher__app[data-lens-target=\"true\"]");
+      const eventBounds = eventHost.getBoundingClientRect();
+      const currentBounds = current?.getBoundingClientRect();
+      if (!currentBounds || eventBounds.width < 1) return;
+      positionSurface({
+        visible: launcher.hasAttribute("data-lens-visible"),
+        x: (currentBounds.left + currentBounds.width / 2 - eventBounds.left) / eventBounds.width,
+      }, true);
+    };
+    const handleTarget = (event: Event) => positionSurface((event as GlassTargetEvent).detail);
+    const resizeObserver = new ResizeObserver(syncFromDom);
+
+    eventHost.addEventListener("tinyos:glass-target", handleTarget);
+    resizeObserver.observe(eventHost);
+    syncFromDom();
+    return () => {
+      eventHost.removeEventListener("tinyos:glass-target", handleTarget);
+      resizeObserver.disconnect();
+      gsap.killTweensOf(surface);
+    };
+  }, [reducedMotion]);
+
+  return (
+    <div className="tinyos-launcher__glass-surface-host" ref={hostRef}>
+      <span aria-hidden="true" className="tinyos-launcher__glass-surface" ref={surfaceRef} />
+    </div>
+  );
+}

--- a/src/react-workbench/chat/TinyOsShell.tsx
+++ b/src/react-workbench/chat/TinyOsShell.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type DragEvent, type KeyboardEvent, type MouseEvent, type PointerEvent } from "react";
+import { useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type DragEvent, type KeyboardEvent, type MouseEvent, type PointerEvent } from "react";
+import { gsap } from "gsap";
 import {
   Activity,
   AlertTriangle,
@@ -63,6 +64,7 @@ import {
 import type { ApprovalAction } from "../services";
 import { AgentUiFormCard } from "./AgentUiFormCard";
 import { TinyOsFilesExplorer } from "./TinyOsFilesExplorer";
+import { TinyOsSideRays } from "./TinyOsSideRays";
 import { TinyOsSystemMonitor, type TinyOsSystemMonitorControls } from "./TinyOsSystemMonitor";
 import type { TinyOsFilesController } from "./useTinyOsFilesController";
 
@@ -190,7 +192,9 @@ export function TinyOsShell({
   layoutMode: TinyOsLayoutMode;
   workspaceKey: string;
 }) {
+  const shellRef = useRef<HTMLDivElement>(null);
   const desktopRef = useRef<HTMLElement>(null);
+  const launcherRef = useRef<HTMLElement>(null);
   const overlayReturnFocusRef = useRef<HTMLElement | null>(null);
   const [overlay, setOverlay] = useState<TinyOsShellOverlay | null>(null);
   const [paletteQuery, setPaletteQuery] = useState("");
@@ -251,6 +255,84 @@ export function TinyOsShell({
       restoredLayout,
     });
   });
+
+  useLayoutEffect(() => {
+    const shell = shellRef.current;
+    if (!shell || globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
+    const context = gsap.context(() => {
+      gsap.timeline({ defaults: { ease: "power3.out" } })
+        .from(".tinyos-desktop", { duration: .48, opacity: 0 })
+        .from(".tinyos-desktop__side-rays", { clearProps: "opacity", duration: .62, opacity: 0 }, "<")
+        .from(".tinyos-desktop__environment > *", { clearProps: "opacity,transform", duration: .42, opacity: 0, stagger: .08, y: -10 }, "-=.26")
+        .from(".tinyos-desktop__system-tools", { clearProps: "opacity,transform", duration: .42, opacity: 0, scale: .9, x: 12 }, "<")
+        .from(".tinyos-launcher", { clearProps: "opacity,transform", duration: .56, opacity: 0, scale: .94, y: 28 }, "-=.2")
+        .from(".tinyos-launcher__app", { clearProps: "opacity,transform", duration: .34, opacity: 0, scale: .72, stagger: .035, y: 10 }, "-=.3");
+    }, shell);
+
+    return () => context.revert();
+  }, []);
+
+  useLayoutEffect(() => {
+    const launcher = launcherRef.current;
+    if (!launcher || globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
+    type DockMotion = { scale: (value: number) => void; y: (value: number) => void };
+    const motions = new Map<HTMLElement, DockMotion>();
+    const dockItems = () => Array.from(launcher.querySelectorAll<HTMLElement>(".tinyos-launcher__app"));
+    const motionFor = (item: HTMLElement) => {
+      const current = motions.get(item);
+      if (current) return current;
+      const motion = {
+        scale: gsap.quickTo(item, "scale", { duration: .24, ease: "power3.out" }),
+        y: gsap.quickTo(item, "y", { duration: .24, ease: "power3.out" }),
+      };
+      motions.set(item, motion);
+      return motion;
+    };
+    const resetDock = () => {
+      const items = dockItems();
+      launcher.removeAttribute("data-magnifying");
+      gsap.killTweensOf(items);
+      motions.clear();
+      gsap.to(items, {
+        clearProps: "transform",
+        duration: .52,
+        ease: "elastic.out(1, .48)",
+        overwrite: true,
+        scale: 1,
+        y: 0,
+        onComplete: () => items.forEach((item) => item.style.removeProperty("z-index")),
+      });
+    };
+    const magnifyDock = (event: globalThis.PointerEvent) => {
+      launcher.setAttribute("data-magnifying", "true");
+      dockItems().forEach((item) => {
+        const bounds = item.getBoundingClientRect();
+        if (bounds.width < 1 || (item instanceof HTMLButtonElement && item.disabled)) return;
+        const distance = Math.abs(event.clientX - bounds.left - bounds.width / 2);
+        const proximity = Math.max(0, 1 - distance / 126);
+        const influence = proximity * proximity * (3 - 2 * proximity);
+        const motion = motionFor(item);
+        motion.scale(1 + influence * .36);
+        motion.y(-influence * 11);
+        item.style.zIndex = `${Math.round(1 + influence * 10)}`;
+      });
+    };
+
+    launcher.addEventListener("pointermove", magnifyDock);
+    launcher.addEventListener("pointerleave", resetDock);
+    return () => {
+      launcher.removeEventListener("pointermove", magnifyDock);
+      launcher.removeEventListener("pointerleave", resetDock);
+      const items = dockItems();
+      gsap.killTweensOf(items);
+      items.forEach((item) => {
+        item.style.removeProperty("transform");
+        item.style.removeProperty("z-index");
+      });
+    };
+  }, [appWindows.length]);
 
   useEffect(() => {
     const returningToLive = previousHistoryMode.current && !history;
@@ -840,15 +922,17 @@ export function TinyOsShell({
   }
 
   return (
-    <div className="tinyos-shell" data-has-dialog={snapshot.dialog ? "true" : undefined} onKeyDown={handleShellKeyDown} onKeyUp={handleShellKeyUp}>
+    <div className="tinyos-shell" data-has-dialog={snapshot.dialog ? "true" : undefined} ref={shellRef} onKeyDown={handleShellKeyDown} onKeyUp={handleShellKeyUp}>
       <section
         aria-label="TinyOS desktop"
         className="tinyos-desktop"
         data-app-count={availableApps.size}
+        data-has-windows={windows.length ? "true" : undefined}
         data-layout-mode={uiState.layoutMode}
         ref={desktopRef}
         onContextMenu={(event) => openContextMenu(event, "Desktop menu", ["shell.overview", "shell.palette", "shell.reset_layout"])}
       >
+        <TinyOsSideRays />
         <div aria-hidden="true" className="tinyos-desktop__environment">
           <span className="tinyos-desktop__brand"><MonitorDot size={17} /><strong>TinyOS</strong><small>Agent workspace</small></span>
           <span className="tinyos-desktop__mode">{history ? "History snapshot" : "Live workspace"}</span>
@@ -866,7 +950,7 @@ export function TinyOsShell({
           ><Bell aria-hidden="true" size={15} /></button>
         </div>
 
-        <nav aria-label="TinyOS applications" className="tinyos-launcher">
+        <nav aria-label="TinyOS applications" className="tinyos-launcher" ref={launcherRef}>
           {APP_ORDER.map((appId, index) => {
             const Icon = APP_ICONS[appId];
             const available = availableApps.has(appId);
@@ -1294,6 +1378,7 @@ function TinyOsAppWindow({
 }) {
   const Icon = APP_ICONS[window.appId];
   const latest = window.entries[window.entries.length - 1];
+  const windowRef = useRef<HTMLElement>(null);
   const pointerState = useRef<{
     kind: "move" | "resize";
     pointerId: number;
@@ -1308,6 +1393,32 @@ function TinyOsAppWindow({
     width: `${layout.width}px`,
     zIndex,
   } satisfies CSSProperties : { zIndex };
+
+  useLayoutEffect(() => {
+    const element = windowRef.current;
+    if (!element || globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const context = gsap.context(() => {
+      gsap.fromTo(element, {
+        opacity: 0,
+        scale: .982,
+        y: 12,
+      }, {
+        clearProps: "opacity,transform",
+        duration: .26,
+        ease: "power3.out",
+        opacity: active ? 1 : .86,
+        scale: active ? 1 : .99,
+        y: 0,
+      });
+      gsap.fromTo(element, { filter: "blur(1.5px)" }, {
+        clearProps: "filter",
+        duration: .09,
+        ease: "power1.out",
+        filter: "blur(0px)",
+      });
+    }, element);
+    return () => context.revert();
+  }, []);
 
   function startPointer(event: PointerEvent<HTMLElement>, kind: "move" | "resize") {
     if (!layout || event.button !== 0) return;
@@ -1392,6 +1503,7 @@ function TinyOsAppWindow({
       data-maximized={layout?.maximized ? "true" : undefined}
       onMouseDown={onFocus}
       onContextMenu={onOpenContextMenu}
+      ref={windowRef}
       style={style}
     >
       <header

--- a/src/react-workbench/chat/TinyOsShell.tsx
+++ b/src/react-workbench/chat/TinyOsShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type DragEvent, type KeyboardEvent, type MouseEvent, type PointerEvent } from "react";
+import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type DragEvent, type KeyboardEvent, type MouseEvent, type PointerEvent } from "react";
 import { gsap } from "gsap";
 import {
   Activity,
@@ -67,6 +67,8 @@ import { TinyOsFilesExplorer } from "./TinyOsFilesExplorer";
 import { TinyOsSideRays } from "./TinyOsSideRays";
 import { TinyOsSystemMonitor, type TinyOsSystemMonitorControls } from "./TinyOsSystemMonitor";
 import type { TinyOsFilesController } from "./useTinyOsFilesController";
+
+const TinyOsGlassSurface = lazy(() => import("./TinyOsGlassSurface"));
 
 const APP_ICONS = {
   artifacts: Archive,
@@ -255,7 +257,6 @@ export function TinyOsShell({
       restoredLayout,
     });
   });
-
   useLayoutEffect(() => {
     const shell = shellRef.current;
     if (!shell || globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
@@ -275,64 +276,91 @@ export function TinyOsShell({
 
   useLayoutEffect(() => {
     const launcher = launcherRef.current;
-    if (!launcher || globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const lens = launcher?.querySelector<HTMLElement>(".tinyos-launcher__lens");
+    if (!launcher || !lens) return;
 
-    type DockMotion = { scale: (value: number) => void; y: (value: number) => void };
-    const motions = new Map<HTMLElement, DockMotion>();
-    const dockItems = () => Array.from(launcher.querySelectorAll<HTMLElement>(".tinyos-launcher__app"));
-    const motionFor = (item: HTMLElement) => {
-      const current = motions.get(item);
-      if (current) return current;
-      const motion = {
-        scale: gsap.quickTo(item, "scale", { duration: .24, ease: "power3.out" }),
-        y: gsap.quickTo(item, "y", { duration: .24, ease: "power3.out" }),
-      };
-      motions.set(item, motion);
-      return motion;
-    };
-    const resetDock = () => {
-      const items = dockItems();
-      launcher.removeAttribute("data-magnifying");
-      gsap.killTweensOf(items);
-      motions.clear();
-      gsap.to(items, {
-        clearProps: "transform",
-        duration: .52,
-        ease: "elastic.out(1, .48)",
-        overwrite: true,
-        scale: 1,
-        y: 0,
-        onComplete: () => items.forEach((item) => item.style.removeProperty("z-index")),
-      });
-    };
-    const magnifyDock = (event: globalThis.PointerEvent) => {
-      launcher.setAttribute("data-magnifying", "true");
-      dockItems().forEach((item) => {
-        const bounds = item.getBoundingClientRect();
-        if (bounds.width < 1 || (item instanceof HTMLButtonElement && item.disabled)) return;
-        const distance = Math.abs(event.clientX - bounds.left - bounds.width / 2);
-        const proximity = Math.max(0, 1 - distance / 126);
-        const influence = proximity * proximity * (3 - 2 * proximity);
-        const motion = motionFor(item);
-        motion.scale(1 + influence * .36);
-        motion.y(-influence * 11);
-        item.style.zIndex = `${Math.round(1 + influence * 10)}`;
-      });
-    };
+    let currentItem: HTMLElement | null = null;
+    let resting = false;
 
-    launcher.addEventListener("pointermove", magnifyDock);
-    launcher.addEventListener("pointerleave", resetDock);
+    const activeItem = () => launcher.querySelector<HTMLElement>(".tinyos-launcher__app[data-active=\"true\"]");
+    const clearLensTarget = () => {
+      currentItem?.removeAttribute("data-lens-target");
+    };
+    const publishLensTarget = (item: HTMLElement | null) => {
+      const lensBounds = lens.getBoundingClientRect();
+      const itemBounds = item?.getBoundingClientRect();
+      const visible = Boolean(itemBounds && lensBounds.width > 0);
+      const x = visible && itemBounds
+        ? (itemBounds.left + itemBounds.width / 2 - lensBounds.left) / lensBounds.width
+        : .5;
+      lens.dispatchEvent(new CustomEvent("tinyos:glass-target", { detail: { visible, x } }));
+    };
+    const positionLens = (item: HTMLElement, nextResting: boolean) => {
+      if (item === currentItem && resting === nextResting) return;
+      const lensBounds = lens.getBoundingClientRect();
+      const itemBounds = item.getBoundingClientRect();
+      if (lensBounds.width < 1 || itemBounds.width < 1) return;
+      clearLensTarget();
+      currentItem = item;
+      resting = nextResting;
+      item.setAttribute("data-lens-target", "true");
+      launcher.setAttribute("data-lens-visible", "true");
+      publishLensTarget(item);
+    };
+    const settleLens = () => {
+      const active = activeItem();
+      if (active) {
+        positionLens(active, true);
+        return;
+      }
+      clearLensTarget();
+      currentItem = null;
+      resting = false;
+      launcher.removeAttribute("data-lens-visible");
+      publishLensTarget(null);
+    };
+    const handlePointerMove = (event: globalThis.PointerEvent) => {
+      const target = event.target instanceof Element
+        ? event.target.closest<HTMLElement>(".tinyos-launcher__app")
+        : null;
+      if (target && launcher.contains(target)) {
+        positionLens(target, false);
+      }
+    };
+    const handleFocusIn = (event: globalThis.FocusEvent) => {
+      const target = event.target instanceof Element
+        ? event.target.closest<HTMLElement>(".tinyos-launcher__app")
+        : null;
+      if (target && launcher.contains(target)) positionLens(target, false);
+    };
+    const handleFocusOut = (event: globalThis.FocusEvent) => {
+      if (event.relatedTarget instanceof Node && launcher.contains(event.relatedTarget)) return;
+      settleLens();
+    };
+    const resizeObserver = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(() => {
+      if (currentItem) {
+        const item = currentItem;
+        currentItem = null;
+        positionLens(item, resting);
+      }
+    });
+
+    launcher.addEventListener("pointermove", handlePointerMove);
+    launcher.addEventListener("pointerleave", settleLens);
+    launcher.addEventListener("focusin", handleFocusIn);
+    launcher.addEventListener("focusout", handleFocusOut);
+    resizeObserver?.observe(launcher);
+    settleLens();
     return () => {
-      launcher.removeEventListener("pointermove", magnifyDock);
-      launcher.removeEventListener("pointerleave", resetDock);
-      const items = dockItems();
-      gsap.killTweensOf(items);
-      items.forEach((item) => {
-        item.style.removeProperty("transform");
-        item.style.removeProperty("z-index");
-      });
+      launcher.removeEventListener("pointermove", handlePointerMove);
+      launcher.removeEventListener("pointerleave", settleLens);
+      launcher.removeEventListener("focusin", handleFocusIn);
+      launcher.removeEventListener("focusout", handleFocusOut);
+      resizeObserver?.disconnect();
+      clearLensTarget();
+      launcher.removeAttribute("data-lens-visible");
     };
-  }, [appWindows.length]);
+  }, [appWindows.length, uiState.focusedAppId]);
 
   useEffect(() => {
     const returningToLive = previousHistoryMode.current && !history;
@@ -951,6 +979,11 @@ export function TinyOsShell({
         </div>
 
         <nav aria-label="TinyOS applications" className="tinyos-launcher" ref={launcherRef}>
+          <span aria-hidden="true" className="tinyos-launcher__lens">
+            <Suspense fallback={null}>
+              <TinyOsGlassSurface />
+            </Suspense>
+          </span>
           {APP_ORDER.map((appId, index) => {
             const Icon = APP_ICONS[appId];
             const available = availableApps.has(appId);

--- a/src/react-workbench/chat/TinyOsShell.tsx
+++ b/src/react-workbench/chat/TinyOsShell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent, type PointerEvent } from "react";
 import {
+  Activity,
   AlertTriangle,
   Archive,
   Bot,
@@ -20,6 +21,7 @@ import {
   MemoryStick,
   MessageCircleQuestion,
   Minus,
+  MonitorDot,
   Pause,
   Paperclip,
   PencilLine,
@@ -32,6 +34,8 @@ import {
 } from "lucide-react";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import type { ArtifactRef, ChatStep, ChatStepStatus } from "../../app-core/chat/chatRunModel";
+import type { TinyOsCommandLifecycle } from "../../app-core/chat/tinyOsCommandGateway";
+import type { TinyOsKernelSnapshot } from "../../app-core/chat/tinyOsKernelModel";
 import type {
   TinyOsAppId,
   TinyOsDesktopSnapshot,
@@ -52,6 +56,7 @@ import {
 import type { ApprovalAction } from "../services";
 import { AgentUiFormCard } from "./AgentUiFormCard";
 import { TinyOsFilesExplorer } from "./TinyOsFilesExplorer";
+import { TinyOsSystemMonitor, type TinyOsSystemMonitorControls } from "./TinyOsSystemMonitor";
 import type { TinyOsFilesController } from "./useTinyOsFilesController";
 
 const APP_ICONS = {
@@ -62,6 +67,7 @@ const APP_ICONS = {
   memory: MemoryStick,
   plan: ListChecks,
   subagents: Bot,
+  system_monitor: Activity,
   terminal: TerminalSquare,
 } satisfies Record<TinyOsAppId, typeof Folder>;
 
@@ -73,10 +79,11 @@ const APP_LABELS: Record<TinyOsAppId, string> = {
   memory: "Memory",
   plan: "Plan",
   subagents: "Subagents",
+  system_monitor: "System Monitor",
   terminal: "Terminal",
 };
 
-const APP_ORDER: TinyOsAppId[] = ["files", "terminal", "browser", "plan", "memory", "subagents", "artifacts", "inspector"];
+const APP_ORDER: TinyOsAppId[] = ["files", "terminal", "system_monitor", "browser", "plan", "memory", "subagents", "artifacts", "inspector"];
 const tinyOsSessionUiState = new Map<string, ReturnType<typeof createTinyOsUiState>>();
 type TinyOsFileSaveInput = { baseRevision?: string; content: string; createOnly: boolean; path: string };
 type TinyOsFileMoveInput = { baseRevision: string; path: string; targetPath: string };
@@ -84,16 +91,23 @@ type TinyOsFileDeleteInput = { baseRevision: string; path: string };
 type TinyOsTerminalExecuteInput = { command: string; cwd?: string };
 
 export function TinyOsShell({
+  activeRunId,
   agentUiForms,
+  canCancelRun,
   canCancelTerminal = false,
   canDirectEdit = false,
   canExecuteTerminal = false,
+  canPauseRun,
   canRequestChange,
+  canResumeRun,
   canRetryRun,
   canSaveFile = false,
   filesController,
   history = false,
+  cancelUnavailableReason,
+  commandLifecycle,
   onCancelForm,
+  onCancelRun,
   onAttachContext,
   onOpenArtifact,
   onAgentRequest,
@@ -101,14 +115,20 @@ export function TinyOsShell({
   onDeleteFile = async () => undefined,
   onExecuteTerminal = async () => undefined,
   onMoveFile = async () => undefined,
+  onPauseRun,
   onResolveApproval,
   onRetryOperation,
+  onResumeRun,
   onSelectEntry,
   onSubmitForm,
   onSaveFile = async () => undefined,
   resolvingApprovalId,
   requestChangeUnavailableReason,
   directEditUnavailableReason,
+  pauseUnavailableReason,
+  retryRunId,
+  retryUnavailableReason,
+  resumeUnavailableReason,
   saveFileUnavailableReason,
   terminalCancelUnavailableReason,
   terminalExecuteUnavailableReason,
@@ -119,16 +139,23 @@ export function TinyOsShell({
   layoutMode,
   workspaceKey,
 }: {
+  activeRunId?: string;
   agentUiForms: AgentUiForm[];
+  canCancelRun: boolean;
   canCancelTerminal?: boolean;
   canDirectEdit?: boolean;
   canExecuteTerminal?: boolean;
+  canPauseRun: boolean;
   canRequestChange: boolean;
+  canResumeRun: boolean;
   canRetryRun: boolean;
   canSaveFile?: boolean;
   filesController?: TinyOsFilesController;
   history?: boolean;
+  cancelUnavailableReason?: string;
+  commandLifecycle: TinyOsCommandLifecycle;
   onCancelForm: (form: AgentUiForm) => void;
+  onCancelRun: () => void;
   onAttachContext: (reference: TinyOsContextReference) => void;
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void;
@@ -136,14 +163,20 @@ export function TinyOsShell({
   onDeleteFile?: (input: TinyOsFileDeleteInput) => Promise<void>;
   onExecuteTerminal?: (input: TinyOsTerminalExecuteInput) => Promise<void>;
   onMoveFile?: (input: TinyOsFileMoveInput) => Promise<void>;
+  onPauseRun: () => void;
   onResolveApproval: (approvalId: string, action: ApprovalAction) => void;
   onRetryOperation: (entry: TinyOsTimelineEntry) => void;
+  onResumeRun: () => void;
   onSelectEntry: (entry: TinyOsTimelineEntry) => void;
   onSubmitForm: (form: AgentUiForm, values: Record<string, unknown>) => void;
   onSaveFile?: (input: TinyOsFileSaveInput) => Promise<void>;
   resolvingApprovalId: string;
   requestChangeUnavailableReason?: string;
   directEditUnavailableReason?: string;
+  pauseUnavailableReason?: string;
+  retryRunId?: string;
+  retryUnavailableReason?: string;
+  resumeUnavailableReason?: string;
   saveFileUnavailableReason?: string;
   terminalCancelUnavailableReason?: string;
   terminalExecuteUnavailableReason?: string;
@@ -160,11 +193,20 @@ export function TinyOsShell({
     if (filesController && !windows.some(({ appId }) => appId === "files")) {
       windows.unshift({ appId: "files", entries: [], id: "tinyos-window-files", sourceItemIds: [], title: "Files" });
     }
+    if (snapshot.kernel && !windows.some(({ appId }) => appId === "system_monitor")) {
+      windows.push({
+        appId: "system_monitor",
+        entries: [],
+        id: "tinyos-window-system-monitor",
+        sourceItemIds: snapshot.kernel.processes.flatMap((process) => process.correlation.itemId ? [process.correlation.itemId] : []),
+        title: "System Monitor",
+      });
+    }
     if (sessionKey && !windows.some(({ appId }) => appId === "terminal")) {
       windows.push({ appId: "terminal", entries: [], id: "tinyos-window-terminal", sourceItemIds: [], title: "Terminal" });
     }
     return windows;
-  }, [filesController, sessionKey, snapshot.windows]);
+  }, [filesController, sessionKey, snapshot.kernel, snapshot.windows]);
   const initialAppIds = appWindows.map((window) => window.appId);
   const seenFileOperations = useRef(new Set<string>());
   const revealedCursorItemId = useRef<string | undefined>(undefined);
@@ -264,6 +306,39 @@ export function TinyOsShell({
   }, [appWindows, uiState.focusedAppId, uiState.layoutMode, uiState.minimizedAppIds, uiState.zOrder]);
   const availableApps = new Set(appWindows.map((window) => window.appId));
   const allEntries = snapshot.windows.flatMap((window) => window.entries);
+  const systemMonitorControls: TinyOsSystemMonitorControls = {
+    activeRunId,
+    canCancelRun,
+    canPauseRun,
+    canResumeRun,
+    canRetryRun,
+    cancelUnavailableReason,
+    commandLifecycle,
+    history,
+    inspectableItemIds: allEntries.map((entry) => entry.step.id),
+    onCancelRun,
+    onInspect: (process) => {
+      const entry = allEntries.find((candidate) => candidate.step.id === process.correlation.itemId);
+      if (!entry) return;
+      dispatchUi({ itemId: entry.step.id, type: "inspect" });
+    },
+    onPauseRun,
+    onResumeRun,
+    onRetry: (process) => {
+      const entry = allEntries.find((candidate) => candidate.step.id === process.correlation.itemId);
+      if (entry) onRetryOperation(entry);
+    },
+    onReveal: (process) => {
+      if (process.applicationId && availableApps.has(process.applicationId as TinyOsAppId)) {
+        focusApp(process.applicationId as TinyOsAppId);
+      }
+    },
+    pauseUnavailableReason,
+    resumeUnavailableReason,
+    retryRunId,
+    retryUnavailableReason,
+    revealableApplicationIds: [...availableApps],
+  };
   const inspectorEntries = uiState.inspectorItemIds.flatMap((itemId) => {
     const entry = allEntries.find((candidate) => candidate.step.id === itemId);
     return entry ? [entry] : [];
@@ -299,40 +374,47 @@ export function TinyOsShell({
 
   return (
     <div className="tinyos-shell" data-has-dialog={snapshot.dialog ? "true" : undefined} onKeyDown={handleShellKeyDown}>
-      <nav aria-label="TinyOS applications" className="tinyos-launcher">
-        {APP_ORDER.map((appId) => {
-          const Icon = APP_ICONS[appId];
-          const available = availableApps.has(appId);
-          const active = uiState.focusedAppId === appId && !uiState.minimizedAppIds.includes(appId);
-          const window = appWindows.find((candidate) => candidate.appId === appId);
-          const status = window?.entries[window.entries.length - 1]?.step.status;
-          return (
-            <button
-              aria-label={`Open ${APP_LABELS[appId]}`}
-              className="tinyos-launcher__app"
-              data-active={active ? "true" : undefined}
-              data-available={available ? "true" : undefined}
-              data-minimized={uiState.minimizedAppIds.includes(appId) ? "true" : undefined}
-              data-status={status}
-              disabled={!available}
-              key={appId}
-              title={available ? APP_LABELS[appId] : `${APP_LABELS[appId]} has no activity yet`}
-              type="button"
-              onClick={() => focusApp(appId)}
-            >
-              <Icon aria-hidden="true" size={18} />
-              <span>{APP_LABELS[appId]}</span>
-              {available ? <Circle aria-hidden="true" className="tinyos-launcher__state" fill="currentColor" size={6} /> : null}
-            </button>
-          );
-        })}
-        <button aria-label="Reset TinyOS layout" className="tinyos-launcher__app tinyos-launcher__reset" title="Reset layout" type="button" onClick={() => dispatchUi({ type: "reset" })}>
-          <RotateCcw aria-hidden="true" size={17} />
-          <span>Reset</span>
-        </button>
-      </nav>
+      <section aria-label="TinyOS desktop" className="tinyos-desktop" data-app-count={availableApps.size} data-layout-mode={uiState.layoutMode} ref={desktopRef}>
+        <div aria-hidden="true" className="tinyos-desktop__environment">
+          <span className="tinyos-desktop__brand"><MonitorDot size={17} /><strong>TinyOS</strong><small>Agent workspace</small></span>
+          <span className="tinyos-desktop__mode">{history ? "History snapshot" : "Live workspace"}</span>
+        </div>
 
-      <section aria-label="TinyOS desktop" className="tinyos-desktop" data-layout-mode={uiState.layoutMode} ref={desktopRef}>
+        <nav aria-label="TinyOS applications" className="tinyos-launcher">
+          {APP_ORDER.map((appId, index) => {
+            const Icon = APP_ICONS[appId];
+            const available = availableApps.has(appId);
+            const active = uiState.focusedAppId === appId && !uiState.minimizedAppIds.includes(appId);
+            const window = appWindows.find((candidate) => candidate.appId === appId);
+            const status = window?.entries[window.entries.length - 1]?.step.status;
+            return (
+              <button
+                aria-label={`Open ${APP_LABELS[appId]}`}
+                aria-pressed={active}
+                className="tinyos-launcher__app"
+                data-active={active ? "true" : undefined}
+                data-available={available ? "true" : undefined}
+                data-minimized={uiState.minimizedAppIds.includes(appId) ? "true" : undefined}
+                data-status={status}
+                disabled={!available}
+                key={appId}
+                title={available ? `${APP_LABELS[appId]} · Alt+${index + 1}` : `${APP_LABELS[appId]} has no activity yet`}
+                type="button"
+                onClick={() => focusApp(appId)}
+              >
+                <Icon aria-hidden="true" size={19} />
+                <span>{APP_LABELS[appId]}</span>
+                {available ? <Circle aria-hidden="true" className="tinyos-launcher__state" fill="currentColor" size={6} /> : null}
+              </button>
+            );
+          })}
+          <span aria-hidden="true" className="tinyos-launcher__divider" />
+          <button aria-label="Reset TinyOS layout" className="tinyos-launcher__app tinyos-launcher__reset" title="Reset layout" type="button" onClick={() => dispatchUi({ type: "reset" })}>
+            <RotateCcw aria-hidden="true" size={18} />
+            <span>Reset</span>
+          </button>
+        </nav>
+
         {!windows.length ? <TinyOsDesktopEmpty /> : windows.map((window) => (
           <TinyOsAppWindow
             active={uiState.focusedAppId === window.appId}
@@ -343,6 +425,8 @@ export function TinyOsShell({
             canRequestChange={canRequestChange}
             canSaveFile={canSaveFile && !history}
             key={window.id}
+            kernel={snapshot.kernel}
+            systemMonitorControls={systemMonitorControls}
             layout={uiState.windowLayout[window.appId]}
             zIndex={uiState.zOrder.indexOf(window.appId) + 2}
             window={window}
@@ -417,8 +501,8 @@ function TinyOsDesktopEmpty() {
   return (
     <div className="tinyos-desktop__empty">
       <FileCode2 aria-hidden="true" size={26} />
-      <strong>Desktop ready</strong>
-      <span>Agent applications will open here as canonical work begins.</span>
+      <strong>Your workspace is ready</strong>
+      <span>Files, terminals, plans, and browser activity will open here as the Agent works.</span>
     </div>
   );
 }
@@ -435,6 +519,7 @@ function TinyOsAppWindow({
   filesController,
   layout,
   layoutMode,
+  kernel,
   onFocus,
   onAttachContext,
   onInspect,
@@ -453,6 +538,7 @@ function TinyOsAppWindow({
   requestChangeUnavailableReason,
   runningTerminalRunId,
   saveFileUnavailableReason,
+  systemMonitorControls,
   terminalCancelUnavailableReason,
   terminalExecuteUnavailableReason,
   window,
@@ -469,6 +555,7 @@ function TinyOsAppWindow({
   filesController?: TinyOsFilesController;
   layout?: TinyOsWindowRect & { maximized: boolean };
   layoutMode: TinyOsLayoutMode;
+  kernel?: TinyOsKernelSnapshot;
   onFocus: () => void;
   onAttachContext: (reference: TinyOsContextReference) => void;
   onInspect: (entry: TinyOsTimelineEntry) => void;
@@ -487,6 +574,7 @@ function TinyOsAppWindow({
   requestChangeUnavailableReason?: string;
   runningTerminalRunId?: string;
   saveFileUnavailableReason?: string;
+  systemMonitorControls: TinyOsSystemMonitorControls;
   terminalCancelUnavailableReason?: string;
   terminalExecuteUnavailableReason?: string;
   window: TinyOsWindow;
@@ -605,7 +693,7 @@ function TinyOsAppWindow({
         onPointerUp={endPointer}
       >
         <span><Icon aria-hidden="true" size={15} /><strong>{window.title}</strong></span>
-        <span className="tinyos-window__source">{latest?.step.title ?? "Workspace Explorer"}</span>
+        <span className="tinyos-window__source">{latest?.step.title ?? (window.appId === "system_monitor" ? `${kernel?.processes.length ?? 0} processes` : "Workspace Explorer")}</span>
         {latest ? <TinyOsStatus status={latest.step.status} /> : null}
         {latest ? <button aria-label={`Inspect ${window.title}`} title={`Inspect ${window.title}`} type="button" onClick={() => onInspect(latest)}><Info aria-hidden="true" size={14} /></button> : null}
         <button aria-label={`${layout?.maximized ? "Restore" : "Maximize"} ${window.title}`} title={layout?.maximized ? "Restore" : "Maximize"} type="button" onClick={onMaximize}><Maximize2 aria-hidden="true" size={14} /></button>
@@ -622,6 +710,7 @@ function TinyOsAppWindow({
           directEditUnavailableReason={directEditUnavailableReason}
           filesController={filesController}
           layoutMode={layoutMode}
+          kernel={kernel}
           window={window}
           onAttachContext={onAttachContext}
           onOpenArtifact={onOpenArtifact}
@@ -635,6 +724,7 @@ function TinyOsAppWindow({
           requestChangeUnavailableReason={requestChangeUnavailableReason}
           runningTerminalRunId={runningTerminalRunId}
           saveFileUnavailableReason={saveFileUnavailableReason}
+          systemMonitorControls={systemMonitorControls}
           terminalCancelUnavailableReason={terminalCancelUnavailableReason}
           terminalExecuteUnavailableReason={terminalExecuteUnavailableReason}
         />
@@ -652,7 +742,7 @@ function TinyOsAppWindow({
   );
 }
 
-function TinyOsAppContent({ activeTabId, canCancelTerminal, canDirectEdit, canExecuteTerminal, canRequestChange, canSaveFile, directEditUnavailableReason, filesController, layoutMode, window, onAgentRequest, onAttachContext, onCancelTerminal, onDeleteFile, onExecuteTerminal, onMoveFile, onOpenArtifact, onSaveFile, onTabChange, requestChangeUnavailableReason, runningTerminalRunId, saveFileUnavailableReason, terminalCancelUnavailableReason, terminalExecuteUnavailableReason }: {
+function TinyOsAppContent({ activeTabId, canCancelTerminal, canDirectEdit, canExecuteTerminal, canRequestChange, canSaveFile, directEditUnavailableReason, filesController, kernel, layoutMode, window, onAgentRequest, onAttachContext, onCancelTerminal, onDeleteFile, onExecuteTerminal, onMoveFile, onOpenArtifact, onSaveFile, onTabChange, requestChangeUnavailableReason, runningTerminalRunId, saveFileUnavailableReason, systemMonitorControls, terminalCancelUnavailableReason, terminalExecuteUnavailableReason }: {
   activeTabId?: string;
   canCancelTerminal: boolean;
   canDirectEdit: boolean;
@@ -661,6 +751,7 @@ function TinyOsAppContent({ activeTabId, canCancelTerminal, canDirectEdit, canEx
   canSaveFile: boolean;
   directEditUnavailableReason?: string;
   filesController?: TinyOsFilesController;
+  kernel?: TinyOsKernelSnapshot;
   layoutMode: TinyOsLayoutMode;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void;
   onAttachContext: (reference: TinyOsContextReference) => void;
@@ -674,6 +765,7 @@ function TinyOsAppContent({ activeTabId, canCancelTerminal, canDirectEdit, canEx
   requestChangeUnavailableReason?: string;
   runningTerminalRunId?: string;
   saveFileUnavailableReason?: string;
+  systemMonitorControls: TinyOsSystemMonitorControls;
   terminalCancelUnavailableReason?: string;
   terminalExecuteUnavailableReason?: string;
   window: TinyOsWindow;
@@ -691,6 +783,7 @@ function TinyOsAppContent({ activeTabId, canCancelTerminal, canDirectEdit, canEx
     case "subagents": return <TinyOsSubagents window={window} />;
     case "artifacts": return <TinyOsArtifacts window={window} onOpenArtifact={onOpenArtifact} />;
     case "inspector": return <TinyOsStructured entry={window.entries[window.entries.length - 1]} />;
+    case "system_monitor": return kernel ? <TinyOsSystemMonitor controls={systemMonitorControls} snapshot={kernel} /> : <EmptyCopy text="Kernel process data is unavailable." />;
   }
 }
 

--- a/src/react-workbench/chat/TinyOsShell.tsx
+++ b/src/react-workbench/chat/TinyOsShell.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent, type PointerEvent } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type DragEvent, type KeyboardEvent, type MouseEvent, type PointerEvent } from "react";
 import {
   Activity,
   AlertTriangle,
   Archive,
+  Bell,
   Bot,
   Check,
   CheckCircle2,
@@ -10,6 +11,7 @@ import {
   ChevronRight,
   Circle,
   Copy,
+  Command,
   FileCode2,
   FileText,
   Folder,
@@ -17,6 +19,7 @@ import {
   Globe2,
   Info,
   ListChecks,
+  LayoutGrid,
   Maximize2,
   MemoryStick,
   MessageCircleQuestion,
@@ -34,8 +37,12 @@ import {
 } from "lucide-react";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import type { ArtifactRef, ChatStep, ChatStepStatus } from "../../app-core/chat/chatRunModel";
-import type { TinyOsCommandLifecycle } from "../../app-core/chat/tinyOsCommandGateway";
-import type { TinyOsKernelSnapshot } from "../../app-core/chat/tinyOsKernelModel";
+import type { TinyOsBrowserAction, TinyOsCommandLifecycle } from "../../app-core/chat/tinyOsCommandGateway";
+import { validateTinyOsBrowserInteractionTarget } from "../../app-core/chat/tinyOsBrowserSession";
+import { createTinyOsShellCommandRegistry, defineTinyOsShellCommand, type TinyOsShellCommand, type TinyOsShellCommandId, type TinyOsShellCommandInput, type TinyOsShellCommandRegistry } from "../../app-core/chat/tinyOsShellCommandRegistry";
+import { readTinyOsReferenceTransfer, tinyOsReferenceAcceptedBy, TINYOS_REFERENCE_MIME, writeTinyOsReferenceTransfer } from "../../app-core/chat/tinyOsReferenceTransfer";
+import type { TinyOsKernelSnapshot, TinyOsResource, TinyOsSimulationCursor } from "../../app-core/chat/tinyOsKernelModel";
+import { resourceValue, tinyOsWorkspaceResourceId } from "../../app-core/chat/tinyOsFilesModel";
 import type {
   TinyOsAppId,
   TinyOsDesktopSnapshot,
@@ -85,53 +92,55 @@ const APP_LABELS: Record<TinyOsAppId, string> = {
 
 const APP_ORDER: TinyOsAppId[] = ["files", "terminal", "system_monitor", "browser", "plan", "memory", "subagents", "artifacts", "inspector"];
 const tinyOsSessionUiState = new Map<string, ReturnType<typeof createTinyOsUiState>>();
+type TinyOsShellOverlay = "notifications" | "overview" | "palette" | "switcher";
+type TinyOsContextMenuState = { commandIds: TinyOsShellCommandId[]; label: string; x: number; y: number };
 type TinyOsFileSaveInput = { baseRevision?: string; content: string; createOnly: boolean; path: string };
 type TinyOsFileMoveInput = { baseRevision: string; path: string; targetPath: string };
 type TinyOsFileDeleteInput = { baseRevision: string; path: string };
 type TinyOsTerminalExecuteInput = { command: string; cwd?: string };
+type TinyOsPinnedEvidence = {
+  cursor: TinyOsSimulationCursor;
+  entry: TinyOsTimelineEntry;
+  id: string;
+  resources: TinyOsResource[];
+};
 
 export function TinyOsShell({
-  activeRunId,
   agentUiForms,
-  canCancelRun,
   canCancelTerminal = false,
   canDirectEdit = false,
   canExecuteTerminal = false,
-  canPauseRun,
+  canInteractBrowser = false,
   canRequestChange,
-  canResumeRun,
   canRetryRun,
   canSaveFile = false,
   filesController,
   history = false,
-  cancelUnavailableReason,
   commandLifecycle,
   onCancelForm,
-  onCancelRun,
   onAttachContext,
   onOpenArtifact,
   onAgentRequest,
   onCancelTerminal = async () => undefined,
+  onBrowserInteract = async () => undefined,
   onDeleteFile = async () => undefined,
   onExecuteTerminal = async () => undefined,
   onMoveFile = async () => undefined,
-  onPauseRun,
   onResolveApproval,
   onRetryOperation,
-  onResumeRun,
   onSelectEntry,
   onSubmitForm,
   onSaveFile = async () => undefined,
   resolvingApprovalId,
   requestChangeUnavailableReason,
   directEditUnavailableReason,
-  pauseUnavailableReason,
   retryRunId,
   retryUnavailableReason,
-  resumeUnavailableReason,
+  runtimeCommandRegistry,
   saveFileUnavailableReason,
   terminalCancelUnavailableReason,
   terminalExecuteUnavailableReason,
+  browserInteractUnavailableReason,
   runningTerminalRunId,
   sessionKey,
   submittingFormId,
@@ -139,47 +148,41 @@ export function TinyOsShell({
   layoutMode,
   workspaceKey,
 }: {
-  activeRunId?: string;
   agentUiForms: AgentUiForm[];
-  canCancelRun: boolean;
   canCancelTerminal?: boolean;
   canDirectEdit?: boolean;
   canExecuteTerminal?: boolean;
-  canPauseRun: boolean;
+  canInteractBrowser?: boolean;
   canRequestChange: boolean;
-  canResumeRun: boolean;
   canRetryRun: boolean;
   canSaveFile?: boolean;
   filesController?: TinyOsFilesController;
   history?: boolean;
-  cancelUnavailableReason?: string;
   commandLifecycle: TinyOsCommandLifecycle;
   onCancelForm: (form: AgentUiForm) => void;
-  onCancelRun: () => void;
   onAttachContext: (reference: TinyOsContextReference) => void;
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void;
   onCancelTerminal?: () => Promise<void>;
+  onBrowserInteract?: (input: { action: TinyOsBrowserAction; browserSessionId: string; captureId: string; tabId: string }) => Promise<void>;
   onDeleteFile?: (input: TinyOsFileDeleteInput) => Promise<void>;
   onExecuteTerminal?: (input: TinyOsTerminalExecuteInput) => Promise<void>;
   onMoveFile?: (input: TinyOsFileMoveInput) => Promise<void>;
-  onPauseRun: () => void;
   onResolveApproval: (approvalId: string, action: ApprovalAction) => void;
   onRetryOperation: (entry: TinyOsTimelineEntry) => void;
-  onResumeRun: () => void;
   onSelectEntry: (entry: TinyOsTimelineEntry) => void;
   onSubmitForm: (form: AgentUiForm, values: Record<string, unknown>) => void;
   onSaveFile?: (input: TinyOsFileSaveInput) => Promise<void>;
   resolvingApprovalId: string;
   requestChangeUnavailableReason?: string;
   directEditUnavailableReason?: string;
-  pauseUnavailableReason?: string;
   retryRunId?: string;
   retryUnavailableReason?: string;
-  resumeUnavailableReason?: string;
+  runtimeCommandRegistry: TinyOsShellCommandRegistry;
   saveFileUnavailableReason?: string;
   terminalCancelUnavailableReason?: string;
   terminalExecuteUnavailableReason?: string;
+  browserInteractUnavailableReason?: string;
   runningTerminalRunId?: string;
   sessionKey?: string;
   submittingFormId?: string;
@@ -188,6 +191,14 @@ export function TinyOsShell({
   workspaceKey: string;
 }) {
   const desktopRef = useRef<HTMLElement>(null);
+  const overlayReturnFocusRef = useRef<HTMLElement | null>(null);
+  const [overlay, setOverlay] = useState<TinyOsShellOverlay | null>(null);
+  const [paletteQuery, setPaletteQuery] = useState("");
+  const [readNotificationIds, setReadNotificationIds] = useState<Set<string>>(() => new Set());
+  const [switcherAppId, setSwitcherAppId] = useState<TinyOsAppId | undefined>(undefined);
+  const [transferMessage, setTransferMessage] = useState<{ kind: "error" | "success"; text: string }>();
+  const [contextMenu, setContextMenu] = useState<TinyOsContextMenuState>();
+  const [pinnedEvidence, setPinnedEvidence] = useState<TinyOsPinnedEvidence[]>([]);
   const appWindows = useMemo(() => {
     const windows = [...snapshot.windows];
     if (filesController && !windows.some(({ appId }) => appId === "files")) {
@@ -204,6 +215,9 @@ export function TinyOsShell({
     }
     if (sessionKey && !windows.some(({ appId }) => appId === "terminal")) {
       windows.push({ appId: "terminal", entries: [], id: "tinyos-window-terminal", sourceItemIds: [], title: "Terminal" });
+    }
+    if (snapshot.kernel?.browserSessions.length && !windows.some(({ appId }) => appId === "browser")) {
+      windows.push({ appId: "browser", entries: [], id: "tinyos-window-browser", sourceItemIds: [], title: "Browser" });
     }
     return windows;
   }, [filesController, sessionKey, snapshot.kernel, snapshot.windows]);
@@ -297,6 +311,10 @@ export function TinyOsShell({
     if (sessionUiKey) tinyOsSessionUiState.set(sessionUiKey, uiState);
   }, [sessionUiKey, uiState]);
 
+  useEffect(() => {
+    if (snapshot.dialog && overlay) closeShellOverlay();
+  }, [overlay, snapshot.dialog?.id]);
+
   const windows = useMemo(() => {
     const visible = appWindows.filter((window) => (
       !uiState.minimizedAppIds.includes(window.appId)
@@ -306,43 +324,465 @@ export function TinyOsShell({
   }, [appWindows, uiState.focusedAppId, uiState.layoutMode, uiState.minimizedAppIds, uiState.zOrder]);
   const availableApps = new Set(appWindows.map((window) => window.appId));
   const allEntries = snapshot.windows.flatMap((window) => window.entries);
+  const distinctEntries = [...new Map(allEntries.map((entry) => [entry.step.id, entry])).values()];
+  const workspaceDocuments = filesController
+    ? Object.entries(filesController.state.documents).flatMap(([path, resource]) => {
+        const document = resourceValue(resource);
+        return document ? [{ document, path }] : [];
+      })
+    : [];
+  const shellOverlayAvailability = snapshot.dialog
+    ? { available: false as const, reason: "Finish the active TinyOS system request before opening another shell overlay." }
+    : { available: true as const };
+  const retryAvailability = history
+    ? { available: false as const, reason: "History snapshots are read-only.", reasonCode: "history_read_only" }
+    : canRetryRun
+      ? { available: true as const }
+      : { available: false as const, reason: retryUnavailableReason || "The backend reports that retry is unavailable." };
+  const terminalExecuteAvailability = history
+    ? { available: false as const, reason: "Direct host actions are disabled while viewing History.", reasonCode: "history_read_only" }
+    : canExecuteTerminal
+      ? { available: true as const }
+      : { available: false as const, reason: terminalExecuteUnavailableReason || "Terminal execution is unavailable." };
+  const terminalCancelAvailability = history
+    ? { available: false as const, reason: "Direct host actions are disabled while viewing History.", reasonCode: "history_read_only" }
+    : canCancelTerminal && runningTerminalRunId
+      ? { available: true as const }
+      : { available: false as const, reason: terminalCancelUnavailableReason || "There is no running Terminal execution to cancel." };
+  const browserSession = snapshot.kernel?.browserSessions[0];
+  const browserCommandAvailability = (kind: "click" | "navigate" | "type") => history
+    ? { available: false as const, reason: "Direct host actions are disabled while viewing History.", reasonCode: "history_read_only" }
+    : !canInteractBrowser
+      ? { available: false as const, reason: browserInteractUnavailableReason || "Browser interaction is unavailable." }
+      : !browserSession
+        ? { available: false as const, reason: "No compatible native browser session snapshot is available." }
+        : browserSession.interaction[kind]
+          ? { available: true as const }
+          : { available: false as const, reason: `The native browser session does not allow ${kind}.` };
+  const shellCommandRegistry = createTinyOsShellCommandRegistry([
+    ...runtimeCommandRegistry.commands,
+    defineTinyOsShellCommand({
+      availability: terminalExecuteAvailability,
+      category: "process",
+      dispatch: (_target, input) => {
+        if (!input || typeof input === "string") throw new Error("Terminal execution requires structured input.");
+        return onExecuteTerminal({
+          command: input.command,
+          ...(input.cwd?.trim() ? { cwd: input.cwd.trim() } : {}),
+        });
+      },
+      id: "terminal.execute",
+      input: {
+        fields: [
+          { label: "command", name: "command", required: true },
+          { label: "working directory", name: "cwd", required: false },
+        ],
+        kind: "fields",
+      },
+      keywords: ["terminal", "run", "command", "shell"],
+      label: "Run Terminal command",
+      scope: "runtime",
+      target: { kind: "shell" },
+    }),
+    defineTinyOsShellCommand({
+      availability: terminalCancelAvailability,
+      category: "process",
+      dispatch: () => onCancelTerminal(),
+      id: "terminal.cancel",
+      input: { kind: "none" },
+      keywords: ["terminal", "cancel", "stop", "interrupt"],
+      label: "Cancel Terminal execution",
+      scope: "runtime",
+      target: { kind: "run", runId: runningTerminalRunId ?? "no-active-terminal" },
+    }),
+    ...(["navigate", "click", "type"] as const).map((kind) => defineTinyOsShellCommand({
+      availability: browserCommandAvailability(kind),
+      category: "resource",
+      dispatch: (_target, input) => {
+        const commandInput = browserInteractionCommandInput(input);
+        const session = snapshot.kernel?.browserSessions.find(({ browserSessionId }) => (
+          browserSessionId === commandInput.browserSessionId
+        ));
+        const validation = validateTinyOsBrowserInteractionTarget(session, commandInput);
+        if (validation.status === "rejected") throw new Error(validation.reason);
+        return onBrowserInteract({
+          action: browserActionFromCommandInput(kind, commandInput),
+          browserSessionId: commandInput.browserSessionId,
+          captureId: commandInput.captureId,
+          tabId: commandInput.tabId,
+        });
+      },
+      id: `browser.${kind}` as const,
+      input: {
+        fields: [
+          { label: "browser session id", name: "browserSessionId", required: true },
+          { label: "browser tab id", name: "tabId", required: true },
+          { label: "browser capture id", name: "captureId", required: true },
+          ...(kind === "navigate" ? [{ label: "URL", name: "url", required: true }] : []),
+          ...(kind === "type" ? [{ label: "text", name: "text", required: true }] : []),
+          ...(kind === "click" ? [
+            { label: "x coordinate", name: "x", required: true },
+            { label: "y coordinate", name: "y", required: true },
+          ] : []),
+        ],
+        kind: "fields",
+      },
+      keywords: ["browser", kind, "capture", "session"],
+      label: `${kind[0].toUpperCase()}${kind.slice(1)} in Browser`,
+      scope: "runtime",
+      target: { kind: "resource", resourceId: browserSession ? `browser-session:${browserSession.browserSessionId}` : "browser-session:unavailable" },
+    })),
+    defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "system",
+      dispatch: () => dispatchUi({ type: "reset" }),
+      id: "shell.reset_layout",
+      input: { kind: "none" },
+      keywords: ["reset", "layout", "windows"],
+      label: "Reset TinyOS layout",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    defineTinyOsShellCommand({
+      availability: appWindows.length && shellOverlayAvailability.available
+        ? { available: true }
+        : !shellOverlayAvailability.available
+          ? shellOverlayAvailability
+        : { available: false, reason: "No TinyOS applications are available." },
+      category: "system",
+      dispatch: () => openShellOverlay("overview"),
+      id: "shell.overview",
+      input: { kind: "none" },
+      keywords: ["overview", "windows", "applications"],
+      label: "Open window Overview",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    defineTinyOsShellCommand({
+      availability: shellOverlayAvailability,
+      category: "system",
+      dispatch: () => {
+        setPaletteQuery("");
+        openShellOverlay("palette");
+      },
+      id: "shell.palette",
+      input: { kind: "text", label: "Search commands", required: false },
+      keywords: ["command", "palette", "search"],
+      label: "Open command palette",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    defineTinyOsShellCommand({
+      availability: snapshot.notifications.length && shellOverlayAvailability.available
+        ? { available: true }
+        : !shellOverlayAvailability.available
+          ? shellOverlayAvailability
+          : { available: false, reason: "No derived notifications are available." },
+      category: "system",
+      dispatch: () => openShellOverlay("notifications"),
+      id: "shell.notification_center",
+      input: { kind: "none" },
+      keywords: ["notifications", "history", "alerts"],
+      label: "Open notification center",
+      scope: "local_presentation",
+      target: { kind: "shell" },
+    }),
+    ...appWindows.flatMap((window) => [
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "application",
+        dispatch: () => focusApp(window.appId),
+        id: `app.open:${window.appId}` as const,
+        input: { kind: "none" },
+        keywords: [window.title, "open", "application"],
+        label: `Open ${window.title}`,
+        scope: "local_presentation",
+        target: { appId: window.appId, kind: "application" },
+      }),
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "window",
+        dispatch: () => focusApp(window.appId),
+        id: `window.focus:${window.appId}` as const,
+        input: { kind: "none" },
+        keywords: [window.title, "focus", "restore"],
+        label: `Focus ${window.title}`,
+        scope: "local_presentation",
+        target: { appId: window.appId, kind: "window" },
+      }),
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "window",
+        dispatch: () => dispatchUi({ appId: window.appId, type: "maximize_toggle" }),
+        id: `window.maximize:${window.appId}` as const,
+        input: { kind: "none" },
+        keywords: [window.title, "maximize", "restore"],
+        label: `Maximize ${window.title}`,
+        scope: "local_presentation",
+        target: { appId: window.appId, kind: "window" },
+      }),
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "window",
+        dispatch: () => minimizeApp(window.appId),
+        id: `window.minimize:${window.appId}` as const,
+        input: { kind: "none" },
+        keywords: [window.title, "minimize"],
+        label: `Minimize ${window.title}`,
+        scope: "local_presentation",
+        target: { appId: window.appId, kind: "window" },
+      }),
+    ]),
+    ...distinctEntries.flatMap((entry) => [
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "operation",
+        dispatch: () => pinEvidence(entry),
+        id: `evidence.inspect:${entry.step.id}` as const,
+        input: { kind: "none" },
+        keywords: [entry.step.title, "inspect", "evidence"],
+        label: `Inspect ${entry.step.title}`,
+        scope: "local_presentation",
+        target: { itemId: entry.step.id, kind: "evidence", turnId: entry.turnId },
+      }),
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "history",
+        dispatch: () => {
+          const sourceWindow = appWindows.find(({ sourceItemIds }) => sourceItemIds.includes(entry.step.id));
+          if (sourceWindow) focusApp(sourceWindow.appId);
+          onSelectEntry(entry);
+        },
+        id: `history.select:${entry.step.id}` as const,
+        input: { kind: "none" },
+        keywords: [entry.step.title, "history", "show"],
+        label: `Show ${entry.step.title}`,
+        scope: "local_presentation",
+        target: { itemId: entry.step.id, kind: "history", turnId: entry.turnId },
+      }),
+    ]),
+    ...distinctEntries.map((entry) => defineTinyOsShellCommand({
+      availability: retryAvailability,
+      category: "operation",
+      dispatch: () => onRetryOperation(entry),
+      id: `operation.retry:${entry.step.id}` as const,
+      input: { kind: "none" },
+      keywords: [entry.step.title, "retry", "operation"],
+      label: `Retry ${entry.step.title}`,
+      scope: "runtime",
+      target: { itemId: entry.step.id, kind: "operation", runId: entry.turnId, turnId: entry.turnId },
+    })),
+    ...snapshot.notifications.flatMap((notification) => [
+      defineTinyOsShellCommand({
+        availability: { available: true },
+        category: "operation",
+        dispatch: () => {
+          const sourceWindow = snapshot.windows.find((candidate) => candidate.sourceItemIds.includes(notification.entry.step.id));
+          if (sourceWindow) focusApp(sourceWindow.appId);
+          pinEvidence(notification.entry);
+        },
+        id: `notification.open:${notification.id}` as const,
+        input: { kind: "none" },
+        keywords: [notification.title, notification.message, notification.kind, "notification"],
+        label: `Open notification: ${notification.title}`,
+        scope: "local_presentation",
+        target: { itemId: notification.entry.step.id, kind: "evidence", turnId: notification.entry.turnId },
+      }),
+      defineTinyOsShellCommand({
+        availability: readNotificationIds.has(notification.id)
+          ? { available: false, reason: "This notification is already marked read." }
+          : { available: true },
+        category: "operation",
+        dispatch: () => setReadNotificationIds((current) => new Set(current).add(notification.id)),
+        id: `notification.read:${notification.id}` as const,
+        input: { kind: "none" },
+        keywords: [notification.title, "read", "notification"],
+        label: `Mark ${notification.title} read`,
+        scope: "local_presentation",
+        target: { itemId: notification.entry.step.id, kind: "evidence", turnId: notification.entry.turnId },
+      }),
+    ]),
+    ...(snapshot.kernel?.resources.map((resource) => {
+      const appId = tinyOsAppForResourceKind(resource.kind);
+      const revealable = Boolean(appId && availableApps.has(appId));
+      return defineTinyOsShellCommand({
+        availability: revealable
+          ? { available: true }
+          : { available: false, reason: "No TinyOS application can reveal this resource." },
+        category: "resource",
+        dispatch: () => {
+          if (appId) focusApp(appId);
+        },
+        id: `resource.reveal:${resource.id}` as const,
+        input: { kind: "none" },
+        keywords: [resource.title, resource.path || "", resource.kind, resource.provenance.kind, "resource"],
+        label: `Reveal ${resource.title}`,
+        scope: "local_presentation",
+        target: { kind: "resource", resourceId: resource.id },
+      });
+    }) ?? []),
+    ...workspaceDocuments.flatMap(({ document, path }) => {
+      const resourceId = tinyOsWorkspaceResourceId(filesController?.state.workspaceKey ?? workspaceKey, path);
+      return [
+        defineTinyOsShellCommand({
+          availability: { available: true },
+          category: "resource",
+          dispatch: () => {
+            focusApp("files");
+            void filesController?.revealFile(path);
+          },
+          id: `resource.reveal:${resourceId}` as const,
+          input: { kind: "none" },
+          keywords: [path, fileName(path), document.provenance.kind, "workspace", "file"],
+          label: `Open ${path} in Files`,
+          scope: "local_presentation",
+          target: { kind: "resource", resourceId },
+        }),
+        defineTinyOsShellCommand({
+          availability: { available: true },
+          category: "resource",
+          dispatch: () => onAttachContext({
+            kind: "file",
+            path,
+            provenance: { kind: "workspace_read", workspaceKey: filesController?.state.workspaceKey ?? workspaceKey },
+            revision: document.revision,
+          }),
+          id: `reference.attach:${resourceId}` as const,
+          input: { acceptedKinds: ["file"], kind: "reference" },
+          keywords: [path, "attach", "chat", "reference"],
+          label: `Attach ${path} to Chat`,
+          scope: "local_presentation",
+          target: { kind: "resource", resourceId },
+        }),
+      ];
+    }),
+    ...(snapshot.kernel?.processes.flatMap((process) => {
+      const revealable = Boolean(process.applicationId && availableApps.has(process.applicationId as TinyOsAppId));
+      const inspectable = Boolean(process.correlation.itemId && distinctEntries.some((entry) => entry.step.id === process.correlation.itemId));
+      return [
+        defineTinyOsShellCommand({
+          availability: revealable ? { available: true } : { available: false, reason: "No related TinyOS application is available." },
+          category: "process",
+          dispatch: () => {
+            if (process.applicationId) focusApp(process.applicationId as TinyOsAppId);
+          },
+          id: `process.reveal:${process.id}` as const,
+          input: { kind: "none" },
+          keywords: [process.title, "reveal", "application"],
+          label: `Reveal ${process.title}`,
+          scope: "local_presentation",
+          target: { kind: "process", processId: process.id, runId: process.correlation.runId },
+        }),
+        defineTinyOsShellCommand({
+          availability: inspectable ? { available: true } : { available: false, reason: "No correlated canonical item is available to inspect." },
+          category: "process",
+          dispatch: () => {
+            const entry = distinctEntries.find((candidate) => candidate.step.id === process.correlation.itemId);
+            if (entry) pinEvidence(entry);
+          },
+          id: `process.inspect:${process.id}` as const,
+          input: { kind: "none" },
+          keywords: [process.title, "inspect", "evidence"],
+          label: `Inspect ${process.title}`,
+          scope: "local_presentation",
+          target: { kind: "process", processId: process.id, runId: process.correlation.runId },
+        }),
+      ];
+    }) ?? []),
+  ], { simulationMode: history ? "history" : "live" });
+  const pauseCommand = requiredShellCommand(shellCommandRegistry, "agent.pause");
+  const resumeCommand = requiredShellCommand(shellCommandRegistry, "agent.resume");
+  const cancelCommand = requiredShellCommand(shellCommandRegistry, "agent.cancel");
+  const activeRunId = pauseCommand.target.kind === "run" ? pauseCommand.target.runId : undefined;
   const systemMonitorControls: TinyOsSystemMonitorControls = {
     activeRunId,
-    canCancelRun,
-    canPauseRun,
-    canResumeRun,
+    canCancelRun: cancelCommand.availability.available,
+    canPauseRun: pauseCommand.availability.available,
+    canResumeRun: resumeCommand.availability.available,
     canRetryRun,
-    cancelUnavailableReason,
+    cancelUnavailableReason: cancelCommand.availability.available ? undefined : cancelCommand.availability.reason,
     commandLifecycle,
     history,
     inspectableItemIds: allEntries.map((entry) => entry.step.id),
-    onCancelRun,
+    onCancelRun: () => void shellCommandRegistry.execute(cancelCommand.id),
     onInspect: (process) => {
-      const entry = allEntries.find((candidate) => candidate.step.id === process.correlation.itemId);
-      if (!entry) return;
-      dispatchUi({ itemId: entry.step.id, type: "inspect" });
+      void shellCommandRegistry.execute(`process.inspect:${process.id}`);
     },
-    onPauseRun,
-    onResumeRun,
+    onOpenProcessMenu: (process, clientX, clientY) => openContextMenuAt(clientX, clientY, `${process.title} process menu`, [
+      `process.reveal:${process.id}`,
+      `process.inspect:${process.id}`,
+      ...(process.correlation.itemId ? [`operation.retry:${process.correlation.itemId}` as const] : []),
+    ]),
+    onOpenResourceMenu: (resource, clientX, clientY) => openContextMenuAt(clientX, clientY, `${resource.title} resource menu`, [
+      `resource.reveal:${resource.id}`,
+    ]),
+    onPauseRun: () => void shellCommandRegistry.execute(pauseCommand.id),
+    onResumeRun: () => void shellCommandRegistry.execute(resumeCommand.id),
     onRetry: (process) => {
-      const entry = allEntries.find((candidate) => candidate.step.id === process.correlation.itemId);
-      if (entry) onRetryOperation(entry);
+      if (process.correlation.itemId) void shellCommandRegistry.execute(`operation.retry:${process.correlation.itemId}`);
     },
     onReveal: (process) => {
-      if (process.applicationId && availableApps.has(process.applicationId as TinyOsAppId)) {
-        focusApp(process.applicationId as TinyOsAppId);
-      }
+      void shellCommandRegistry.execute(`process.reveal:${process.id}`);
     },
-    pauseUnavailableReason,
-    resumeUnavailableReason,
+    pauseUnavailableReason: pauseCommand.availability.available ? undefined : pauseCommand.availability.reason,
+    resumeUnavailableReason: resumeCommand.availability.available ? undefined : resumeCommand.availability.reason,
     retryRunId,
     retryUnavailableReason,
     revealableApplicationIds: [...availableApps],
   };
-  const inspectorEntries = uiState.inspectorItemIds.flatMap((itemId) => {
-    const entry = allEntries.find((candidate) => candidate.step.id === itemId);
-    return entry ? [entry] : [];
-  });
+  function pinEvidence(entry: TinyOsTimelineEntry) {
+    const cursor = snapshot.kernel?.cursor ?? {
+      boundary: {
+        itemId: entry.step.id,
+        runId: entry.turnId,
+        sequence: entry.step.sequence,
+        turnId: entry.turnId,
+      },
+      eventCount: allEntries.length,
+      eventIndex: Math.max(0, entry.step.sequence),
+      mode: history ? "history" as const : "live" as const,
+    };
+    const pin: TinyOsPinnedEvidence = {
+      cursor,
+      entry,
+      id: `${cursor.eventIndex}:${entry.turnId}:${entry.step.id}`,
+      resources: snapshot.kernel?.resources.filter(({ provenance }) => provenance.sourceId === entry.step.id) ?? [],
+    };
+    setPinnedEvidence((current) => [...current.filter(({ id }) => id !== pin.id), pin].slice(-2));
+  }
+
+  function openShellOverlay(nextOverlay: TinyOsShellOverlay) {
+    if (!overlay && typeof document !== "undefined" && document.activeElement instanceof HTMLElement) {
+      overlayReturnFocusRef.current = document.activeElement;
+    }
+    setOverlay(nextOverlay);
+  }
+
+  function closeShellOverlay() {
+    setOverlay(null);
+    setSwitcherAppId(undefined);
+    const returnTarget = overlayReturnFocusRef.current;
+    overlayReturnFocusRef.current = null;
+    if (returnTarget?.isConnected) window.requestAnimationFrame(() => returnTarget.focus());
+  }
+
+  function openContextMenu(event: MouseEvent<HTMLElement>, label: string, commandIds: TinyOsShellCommandId[]) {
+    event.preventDefault();
+    event.stopPropagation();
+    openContextMenuAt(event.clientX, event.clientY, label, commandIds);
+  }
+
+  function openContextMenuAt(clientX: number, clientY: number, label: string, commandIds: TinyOsShellCommandId[]) {
+    const bounds = desktopRef.current?.getBoundingClientRect();
+    const relativeX = clientX - (bounds?.left ?? 0);
+    const relativeY = clientY - (bounds?.top ?? 0);
+    setContextMenu({
+      commandIds,
+      label,
+      x: Math.min(Math.max(8, relativeX), Math.max(8, (bounds?.width ?? 440) - 220)),
+      y: Math.min(Math.max(8, relativeY), Math.max(8, (bounds?.height ?? 480) - commandIds.length * 38 - 20)),
+    });
+  }
 
   function focusApp(appId: TinyOsAppId) {
     if (!availableApps.has(appId)) return;
@@ -354,12 +794,35 @@ export function TinyOsShell({
   }
 
   function handleShellKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLocaleLowerCase() === "k") {
+      event.preventDefault();
+      void shellCommandRegistry.execute("shell.palette");
+      return;
+    }
+    if (event.altKey && event.key === "Tab") {
+      const orderedApps = [...uiState.zOrder].reverse().filter((appId) => availableApps.has(appId));
+      if (orderedApps.length < 2) return;
+      const current = switcherAppId ?? uiState.focusedAppId ?? orderedApps[0];
+      const currentIndex = Math.max(0, orderedApps.indexOf(current));
+      const direction = event.shiftKey ? -1 : 1;
+      const nextAppId = orderedApps[(currentIndex + direction + orderedApps.length) % orderedApps.length];
+      event.preventDefault();
+      if (overlay !== "switcher") openShellOverlay("switcher");
+      setSwitcherAppId(nextAppId);
+      void shellCommandRegistry.execute(`window.focus:${nextAppId}`);
+      return;
+    }
+    if (event.key === "Escape" && overlay) {
+      event.preventDefault();
+      closeShellOverlay();
+      return;
+    }
     const digit = event.altKey && !event.ctrlKey ? Number(event.key) : 0;
     if (digit >= 1 && digit <= APP_ORDER.length) {
       const appId = APP_ORDER[digit - 1];
       if (availableApps.has(appId)) {
         event.preventDefault();
-        focusApp(appId);
+        void shellCommandRegistry.execute(`app.open:${appId}`);
       }
       return;
     }
@@ -369,15 +832,38 @@ export function TinyOsShell({
     const current = Math.max(0, available.indexOf(uiState.focusedAppId ?? available[0]));
     const delta = event.key === "ArrowRight" ? 1 : -1;
     event.preventDefault();
-    focusApp(available[(current + delta + available.length) % available.length]);
+    void shellCommandRegistry.execute(`window.focus:${available[(current + delta + available.length) % available.length]}`);
+  }
+
+  function handleShellKeyUp(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Alt" && overlay === "switcher") closeShellOverlay();
   }
 
   return (
-    <div className="tinyos-shell" data-has-dialog={snapshot.dialog ? "true" : undefined} onKeyDown={handleShellKeyDown}>
-      <section aria-label="TinyOS desktop" className="tinyos-desktop" data-app-count={availableApps.size} data-layout-mode={uiState.layoutMode} ref={desktopRef}>
+    <div className="tinyos-shell" data-has-dialog={snapshot.dialog ? "true" : undefined} onKeyDown={handleShellKeyDown} onKeyUp={handleShellKeyUp}>
+      <section
+        aria-label="TinyOS desktop"
+        className="tinyos-desktop"
+        data-app-count={availableApps.size}
+        data-layout-mode={uiState.layoutMode}
+        ref={desktopRef}
+        onContextMenu={(event) => openContextMenu(event, "Desktop menu", ["shell.overview", "shell.palette", "shell.reset_layout"])}
+      >
         <div aria-hidden="true" className="tinyos-desktop__environment">
           <span className="tinyos-desktop__brand"><MonitorDot size={17} /><strong>TinyOS</strong><small>Agent workspace</small></span>
           <span className="tinyos-desktop__mode">{history ? "History snapshot" : "Live workspace"}</span>
+        </div>
+        <div aria-label="TinyOS system tools" className="tinyos-desktop__system-tools" role="toolbar">
+          <button aria-label="Open window Overview" title="Overview" type="button" onClick={() => void shellCommandRegistry.execute("shell.overview")}><LayoutGrid aria-hidden="true" size={15} /></button>
+          <button aria-label="Open command palette" title="Command palette · Ctrl+K" type="button" onClick={() => void shellCommandRegistry.execute("shell.palette")}><Command aria-hidden="true" size={15} /></button>
+          <button
+            aria-label="Open notification center"
+            data-attention={snapshot.notifications.some((notification) => !readNotificationIds.has(notification.id)) ? "true" : undefined}
+            disabled={!requiredShellCommand(shellCommandRegistry, "shell.notification_center").availability.available}
+            title={snapshot.notifications.length ? "Notification center" : "No notifications"}
+            type="button"
+            onClick={() => void shellCommandRegistry.execute("shell.notification_center")}
+          ><Bell aria-hidden="true" size={15} /></button>
         </div>
 
         <nav aria-label="TinyOS applications" className="tinyos-launcher">
@@ -400,7 +886,12 @@ export function TinyOsShell({
                 key={appId}
                 title={available ? `${APP_LABELS[appId]} · Alt+${index + 1}` : `${APP_LABELS[appId]} has no activity yet`}
                 type="button"
-                onClick={() => focusApp(appId)}
+                onClick={() => void shellCommandRegistry.execute(`app.open:${appId}`)}
+                onContextMenu={(event) => available && openContextMenu(event, `${APP_LABELS[appId]} menu`, [
+                  `window.focus:${appId}`,
+                  `window.maximize:${appId}`,
+                  `window.minimize:${appId}`,
+                ])}
               >
                 <Icon aria-hidden="true" size={19} />
                 <span>{APP_LABELS[appId]}</span>
@@ -409,7 +900,7 @@ export function TinyOsShell({
             );
           })}
           <span aria-hidden="true" className="tinyos-launcher__divider" />
-          <button aria-label="Reset TinyOS layout" className="tinyos-launcher__app tinyos-launcher__reset" title="Reset layout" type="button" onClick={() => dispatchUi({ type: "reset" })}>
+          <button aria-label="Reset TinyOS layout" className="tinyos-launcher__app tinyos-launcher__reset" title="Reset layout" type="button" onClick={() => void shellCommandRegistry.execute("shell.reset_layout")}>
             <RotateCcw aria-hidden="true" size={18} />
             <span>Reset</span>
           </button>
@@ -419,9 +910,8 @@ export function TinyOsShell({
           <TinyOsAppWindow
             active={uiState.focusedAppId === window.appId}
             activeTabId={uiState.activeTabs[window.appId]}
-            canCancelTerminal={canCancelTerminal && !history}
+            commandRegistry={shellCommandRegistry}
             canDirectEdit={canDirectEdit && !history}
-            canExecuteTerminal={canExecuteTerminal && !history}
             canRequestChange={canRequestChange}
             canSaveFile={canSaveFile && !history}
             key={window.id}
@@ -432,16 +922,20 @@ export function TinyOsShell({
             window={window}
             filesController={filesController}
             layoutMode={layoutMode}
-            onFocus={() => dispatchUi({ appId: window.appId, type: "focus" })}
+            onFocus={() => void shellCommandRegistry.execute(`window.focus:${window.appId}`)}
             onAttachContext={onAttachContext}
-            onInspect={(entry) => dispatchUi({ itemId: entry.step.id, type: "inspect" })}
-            onMaximize={() => dispatchUi({ appId: window.appId, type: "maximize_toggle" })}
-            onMinimize={() => minimizeApp(window.appId)}
+            onInspect={(entry) => void shellCommandRegistry.execute(`evidence.inspect:${entry.step.id}`)}
+            onMaximize={() => void shellCommandRegistry.execute(`window.maximize:${window.appId}`)}
+            onMinimize={() => void shellCommandRegistry.execute(`window.minimize:${window.appId}`)}
+            onOpenContextMenu={(event) => openContextMenu(event, `${window.title} window menu`, [
+              `window.focus:${window.appId}`,
+              `window.maximize:${window.appId}`,
+              `window.minimize:${window.appId}`,
+              ...(window.entries.length ? [`evidence.inspect:${window.entries[window.entries.length - 1].step.id}` as const] : []),
+            ])}
             onOpenArtifact={onOpenArtifact}
             onAgentRequest={onAgentRequest}
-            onCancelTerminal={onCancelTerminal}
             onDeleteFile={onDeleteFile}
-            onExecuteTerminal={onExecuteTerminal}
             onMoveFile={onMoveFile}
             onSaveFile={onSaveFile}
             onSetRect={(rect) => dispatchUi({ appId: window.appId, rect, type: "set_rect" })}
@@ -450,20 +944,31 @@ export function TinyOsShell({
             requestChangeUnavailableReason={requestChangeUnavailableReason}
             directEditUnavailableReason={history ? "Direct host actions are disabled while viewing History." : directEditUnavailableReason}
             saveFileUnavailableReason={history ? "Direct host actions are disabled while viewing History." : saveFileUnavailableReason}
-            terminalCancelUnavailableReason={history ? "Direct host actions are disabled while viewing History." : terminalCancelUnavailableReason}
-            terminalExecuteUnavailableReason={history ? "Direct host actions are disabled while viewing History." : terminalExecuteUnavailableReason}
             runningTerminalRunId={runningTerminalRunId}
           />
         ))}
 
         <TinyOsNotifications
           notifications={snapshot.notifications}
-          onSelect={(entry) => {
-            const window = snapshot.windows.find((candidate) => candidate.sourceItemIds.includes(entry.step.id));
-            if (window) focusApp(window.appId);
-            dispatchUi({ itemId: entry.step.id, type: "inspect" });
-          }}
+          onSelect={(notificationId) => void shellCommandRegistry.execute(`notification.open:${notificationId}`)}
         />
+
+        {overlay ? (
+          <TinyOsShellOverlay
+            appWindows={appWindows}
+            commandRegistry={shellCommandRegistry}
+            minimizedAppIds={uiState.minimizedAppIds}
+            notifications={snapshot.notifications}
+            overlay={overlay}
+            paletteQuery={paletteQuery}
+            readNotificationIds={readNotificationIds}
+            switcherAppId={switcherAppId}
+            zOrder={uiState.zOrder}
+            onClose={closeShellOverlay}
+            onPaletteQueryChange={setPaletteQuery}
+          />
+        ) : null}
+        {contextMenu ? <TinyOsContextMenu commandRegistry={shellCommandRegistry} menu={contextMenu} onClose={() => setContextMenu(undefined)} /> : null}
 
         {snapshot.dialog && history ? (
           <TinyOsHistoricalDialog dialog={snapshot.dialog} />
@@ -479,20 +984,235 @@ export function TinyOsShell({
           />
         ) : null}
 
-        {inspectorEntries.length ? (
+        {pinnedEvidence.length ? (
           <TinyOsInspector
-            entries={inspectorEntries}
-            onClose={(entry) => dispatchUi({ itemId: entry.step.id, type: "uninspect" })}
+            evidence={pinnedEvidence}
+            onClose={(pin) => setPinnedEvidence((current) => current.filter(({ id }) => id !== pin.id))}
             onOpenArtifact={onOpenArtifact}
+            onReferenceDrop={(event) => {
+              const parsed = readTinyOsReferenceTransfer(event.dataTransfer);
+              if (parsed.status === "rejected") {
+                setTransferMessage({ kind: "error", text: parsed.reason });
+                return;
+              }
+              const accepted = tinyOsReferenceAcceptedBy(parsed.reference, "inspector");
+              if (accepted.status === "rejected") {
+                setTransferMessage({ kind: "error", text: accepted.reason });
+                return;
+              }
+              void shellCommandRegistry.execute(`evidence.inspect:${accepted.reference.itemId}`);
+              setTransferMessage({ kind: "success", text: `${accepted.reference.title} pinned in Inspector.` });
+            }}
           />
         ) : null}
+        {transferMessage ? <p className="tinyos-transfer-status" data-kind={transferMessage.kind} role={transferMessage.kind === "error" ? "alert" : "status"}>{transferMessage.text}</p> : null}
       </section>
 
-      <TinyOsOperationShelf canRetryRun={canRetryRun} operations={snapshot.operations} onRetryOperation={onRetryOperation} onSelectEntry={(entry) => {
-        const sourceWindow = appWindows.find(({ sourceItemIds }) => sourceItemIds.includes(entry.step.id));
-        if (sourceWindow) focusApp(sourceWindow.appId);
-        onSelectEntry(entry);
-      }} />
+      <TinyOsOperationShelf commandRegistry={shellCommandRegistry} operations={snapshot.operations} />
+    </div>
+  );
+}
+
+function TinyOsContextMenu({ commandRegistry, menu, onClose }: {
+  commandRegistry: TinyOsShellCommandRegistry;
+  menu: TinyOsContextMenuState;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => menuRef.current?.querySelector<HTMLElement>("button:not(:disabled)")?.focus(), []);
+
+  async function execute(commandId: TinyOsShellCommandId) {
+    const result = await commandRegistry.execute(commandId);
+    if (result.status === "executed") onClose();
+  }
+
+  return (
+    <div className="tinyos-context-menu-layer">
+      <button aria-label={`Close ${menu.label}`} className="tinyos-context-menu-layer__backdrop" type="button" onClick={onClose} />
+      <div aria-label={menu.label} className="tinyos-context-menu" ref={menuRef} role="menu" style={{ left: menu.x, top: menu.y }} onKeyDown={(event) => {
+        if (event.key !== "Escape") return;
+        event.preventDefault();
+        onClose();
+      }}>
+        {menu.commandIds.map((commandId) => {
+          const command = requiredShellCommand(commandRegistry, commandId);
+          return (
+            <button
+              disabled={!command.availability.available}
+              key={command.id}
+              role="menuitem"
+              title={command.availability.available ? command.label : command.availability.reason}
+              type="button"
+              onClick={() => void execute(command.id)}
+            ><span>{command.label}</span><small>{command.scope === "runtime" ? "Runtime" : "Local"}</small></button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TinyOsShellOverlay({
+  appWindows,
+  commandRegistry,
+  minimizedAppIds,
+  notifications,
+  onClose,
+  onPaletteQueryChange,
+  overlay,
+  paletteQuery,
+  readNotificationIds,
+  switcherAppId,
+  zOrder,
+}: {
+  appWindows: TinyOsWindow[];
+  commandRegistry: TinyOsShellCommandRegistry;
+  minimizedAppIds: TinyOsAppId[];
+  notifications: TinyOsDesktopSnapshot["notifications"];
+  onClose: () => void;
+  onPaletteQueryChange: (query: string) => void;
+  overlay: TinyOsShellOverlay;
+  paletteQuery: string;
+  readNotificationIds: Set<string>;
+  switcherAppId?: TinyOsAppId;
+  zOrder: TinyOsAppId[];
+}) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const orderedWindows = [...appWindows].sort((left, right) => zOrder.indexOf(right.appId) - zOrder.indexOf(left.appId));
+  const normalizedQuery = paletteQuery.trim().toLocaleLowerCase();
+  const paletteCommands = commandRegistry.commands.filter((command) => {
+    if (command.input.kind === "fields") return false;
+    if (!normalizedQuery) return command.id !== "shell.palette";
+    const searchable = [command.id, command.label, command.category, command.scope, ...command.keywords].join(" ").toLocaleLowerCase();
+    return searchable.includes(normalizedQuery);
+  }).slice(0, 40);
+
+  useEffect(() => {
+    const overlayElement = overlayRef.current;
+    if (!overlayElement) return;
+    const preferred = overlayElement.querySelector<HTMLElement>("[data-autofocus='true']");
+    const firstFocusable = overlayElement.querySelector<HTMLElement>("input, button:not(:disabled), [tabindex='0']");
+    (preferred ?? firstFocusable)?.focus();
+  }, [overlay]);
+
+  async function executeAndClose(commandId: TinyOsShellCommandId) {
+    const execution = await commandRegistry.execute(commandId);
+    if (execution.status === "executed") onClose();
+  }
+
+  function handleOverlayKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusable = [...(overlayRef.current?.querySelectorAll<HTMLElement>("input, button:not(:disabled), [tabindex='0']") ?? [])];
+    if (!focusable.length) return;
+    const currentIndex = focusable.indexOf(document.activeElement as HTMLElement);
+    const nextIndex = event.shiftKey
+      ? (currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1)
+      : (currentIndex === focusable.length - 1 ? 0 : currentIndex + 1);
+    event.preventDefault();
+    focusable[nextIndex]?.focus();
+  }
+
+  return (
+    <div className="tinyos-shell-overlay" data-overlay={overlay}>
+      <button aria-label={`Close ${overlayLabel(overlay)}`} className="tinyos-shell-overlay__backdrop" type="button" onClick={onClose} />
+      <div
+        aria-label={overlayLabel(overlay)}
+        aria-modal="true"
+        className="tinyos-shell-overlay__panel"
+        ref={overlayRef}
+        role="dialog"
+        onKeyDown={handleOverlayKeyDown}
+      >
+        {overlay === "switcher" ? (
+          <>
+            <header><span><Command aria-hidden="true" size={16} /><strong>Switch applications</strong></span><small>Release Alt to continue</small></header>
+            <div aria-label="Available TinyOS applications" className="tinyos-window-switcher" role="listbox">
+              {orderedWindows.map((window) => {
+                const Icon = APP_ICONS[window.appId];
+                const selected = window.appId === switcherAppId;
+                return (
+                  <button
+                    aria-selected={selected}
+                    data-autofocus={selected ? "true" : undefined}
+                    data-selected={selected ? "true" : undefined}
+                    key={window.id}
+                    role="option"
+                    type="button"
+                    onClick={() => void executeAndClose(`window.focus:${window.appId}`)}
+                  ><Icon aria-hidden="true" size={19} /><span><strong>{window.title}</strong><small>{minimizedAppIds.includes(window.appId) ? "Minimized · will restore" : "Available"}</small></span></button>
+                );
+              })}
+            </div>
+          </>
+        ) : null}
+
+        {overlay === "overview" ? (
+          <>
+            <header><span><LayoutGrid aria-hidden="true" size={16} /><strong>Window Overview</strong></span><button aria-label="Close window Overview" type="button" onClick={onClose}><X aria-hidden="true" size={15} /></button></header>
+            <div className="tinyos-window-overview">
+              {orderedWindows.map((window, index) => {
+                const Icon = APP_ICONS[window.appId];
+                const minimized = minimizedAppIds.includes(window.appId);
+                return (
+                  <button data-autofocus={index === 0 ? "true" : undefined} key={window.id} type="button" onClick={() => void executeAndClose(`window.focus:${window.appId}`)}>
+                    <span className="tinyos-window-overview__preview"><Icon aria-hidden="true" size={24} /><small>{window.entries.length} canonical item{window.entries.length === 1 ? "" : "s"}</small></span>
+                    <span><strong>{window.title}</strong><small>{minimized ? "Minimized · select to restore" : "Open"}</small></span>
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        ) : null}
+
+        {overlay === "palette" ? (
+          <>
+            <header className="tinyos-command-palette__search"><Search aria-hidden="true" size={16} /><input aria-label="Search TinyOS commands" autoComplete="off" data-autofocus="true" placeholder="Search apps, resources, processes, operations…" type="search" value={paletteQuery} onChange={(event) => onPaletteQueryChange(event.currentTarget.value)} /><kbd>Esc</kbd></header>
+            <div aria-label="TinyOS command results" className="tinyos-command-palette__results" role="listbox">
+              {paletteCommands.length ? paletteCommands.map((command) => (
+                <button
+                  aria-disabled={!command.availability.available}
+                  disabled={!command.availability.available}
+                  key={command.id}
+                  role="option"
+                  title={command.availability.available ? command.label : command.availability.reason}
+                  type="button"
+                  onClick={() => void executeAndClose(command.id)}
+                >
+                  <span><strong>{command.label}</strong><small>{command.category} · {command.scope === "runtime" ? "runtime" : "local"}</small></span>
+                  <small>{command.availability.available ? command.id : command.availability.reason}</small>
+                </button>
+              )) : <p className="tinyos-shell-overlay__empty">No registered command matches “{paletteQuery}”.</p>}
+            </div>
+          </>
+        ) : null}
+
+        {overlay === "notifications" ? (
+          <>
+            <header><span><Bell aria-hidden="true" size={16} /><strong>Notification center</strong></span><button aria-label="Close notification center" type="button" onClick={onClose}><X aria-hidden="true" size={15} /></button></header>
+            <div aria-label="Derived notification history" className="tinyos-notification-center">
+              {[...notifications].reverse().map((notification, index) => {
+                const read = readNotificationIds.has(notification.id);
+                const readCommand = requiredShellCommand(commandRegistry, `notification.read:${notification.id}`);
+                return (
+                  <article data-read={read ? "true" : undefined} key={notification.id}>
+                    <button data-autofocus={index === 0 ? "true" : undefined} type="button" onClick={() => void executeAndClose(`notification.open:${notification.id}`)}>
+                      {notification.kind === "completed" ? <CheckCircle2 aria-hidden="true" size={16} /> : <AlertTriangle aria-hidden="true" size={16} />}
+                      <span><strong>{notification.title}</strong><small>{notification.message}</small><code>canonical item · {notification.entry.step.id}</code></span>
+                    </button>
+                    <button disabled={!readCommand.availability.available} title={readCommand.availability.available ? readCommand.label : readCommand.availability.reason} type="button" onClick={() => void commandRegistry.execute(readCommand.id)}>{read ? "Read" : "Mark read"}</button>
+                  </article>
+                );
+              })}
+            </div>
+          </>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -510,11 +1230,10 @@ function TinyOsDesktopEmpty() {
 function TinyOsAppWindow({
   active,
   activeTabId,
-  canCancelTerminal,
   canDirectEdit,
-  canExecuteTerminal,
   canRequestChange,
   canSaveFile,
+  commandRegistry,
   directEditUnavailableReason,
   filesController,
   layout,
@@ -525,11 +1244,10 @@ function TinyOsAppWindow({
   onInspect,
   onMaximize,
   onMinimize,
+  onOpenContextMenu,
   onOpenArtifact,
   onAgentRequest,
-  onCancelTerminal,
   onDeleteFile,
-  onExecuteTerminal,
   onMoveFile,
   onSaveFile,
   onSetRect,
@@ -539,18 +1257,15 @@ function TinyOsAppWindow({
   runningTerminalRunId,
   saveFileUnavailableReason,
   systemMonitorControls,
-  terminalCancelUnavailableReason,
-  terminalExecuteUnavailableReason,
   window,
   zIndex,
 }: {
   active: boolean;
   activeTabId?: string;
-  canCancelTerminal: boolean;
   canDirectEdit: boolean;
-  canExecuteTerminal: boolean;
   canRequestChange: boolean;
   canSaveFile: boolean;
+  commandRegistry: TinyOsShellCommandRegistry;
   directEditUnavailableReason?: string;
   filesController?: TinyOsFilesController;
   layout?: TinyOsWindowRect & { maximized: boolean };
@@ -561,11 +1276,10 @@ function TinyOsAppWindow({
   onInspect: (entry: TinyOsTimelineEntry) => void;
   onMaximize: () => void;
   onMinimize: () => void;
+  onOpenContextMenu: (event: MouseEvent<HTMLElement>) => void;
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void;
-  onCancelTerminal: () => Promise<void>;
   onDeleteFile: (input: TinyOsFileDeleteInput) => Promise<void>;
-  onExecuteTerminal: (input: TinyOsTerminalExecuteInput) => Promise<void>;
   onMoveFile: (input: TinyOsFileMoveInput) => Promise<void>;
   onSaveFile: (input: TinyOsFileSaveInput) => Promise<void>;
   onSetRect: (rect: TinyOsWindowRect) => void;
@@ -575,8 +1289,6 @@ function TinyOsAppWindow({
   runningTerminalRunId?: string;
   saveFileUnavailableReason?: string;
   systemMonitorControls: TinyOsSystemMonitorControls;
-  terminalCancelUnavailableReason?: string;
-  terminalExecuteUnavailableReason?: string;
   window: TinyOsWindow;
   zIndex: number;
 }) {
@@ -679,6 +1391,7 @@ function TinyOsAppWindow({
       data-app={window.appId}
       data-maximized={layout?.maximized ? "true" : undefined}
       onMouseDown={onFocus}
+      onContextMenu={onOpenContextMenu}
       style={style}
     >
       <header
@@ -702,11 +1415,11 @@ function TinyOsAppWindow({
       <div className="tinyos-window__content">
         <TinyOsAppContent
           activeTabId={activeTabId}
-          canCancelTerminal={canCancelTerminal}
           canDirectEdit={canDirectEdit}
-          canExecuteTerminal={canExecuteTerminal}
           canRequestChange={canRequestChange}
           canSaveFile={canSaveFile}
+          commandLifecycle={systemMonitorControls.commandLifecycle}
+          commandRegistry={commandRegistry}
           directEditUnavailableReason={directEditUnavailableReason}
           filesController={filesController}
           layoutMode={layoutMode}
@@ -715,9 +1428,7 @@ function TinyOsAppWindow({
           onAttachContext={onAttachContext}
           onOpenArtifact={onOpenArtifact}
           onAgentRequest={onAgentRequest}
-          onCancelTerminal={onCancelTerminal}
           onDeleteFile={onDeleteFile}
-          onExecuteTerminal={onExecuteTerminal}
           onMoveFile={onMoveFile}
           onSaveFile={onSaveFile}
           onTabChange={onTabChange}
@@ -725,8 +1436,6 @@ function TinyOsAppWindow({
           runningTerminalRunId={runningTerminalRunId}
           saveFileUnavailableReason={saveFileUnavailableReason}
           systemMonitorControls={systemMonitorControls}
-          terminalCancelUnavailableReason={terminalCancelUnavailableReason}
-          terminalExecuteUnavailableReason={terminalExecuteUnavailableReason}
         />
       </div>
       <div
@@ -742,22 +1451,20 @@ function TinyOsAppWindow({
   );
 }
 
-function TinyOsAppContent({ activeTabId, canCancelTerminal, canDirectEdit, canExecuteTerminal, canRequestChange, canSaveFile, directEditUnavailableReason, filesController, kernel, layoutMode, window, onAgentRequest, onAttachContext, onCancelTerminal, onDeleteFile, onExecuteTerminal, onMoveFile, onOpenArtifact, onSaveFile, onTabChange, requestChangeUnavailableReason, runningTerminalRunId, saveFileUnavailableReason, systemMonitorControls, terminalCancelUnavailableReason, terminalExecuteUnavailableReason }: {
+function TinyOsAppContent({ activeTabId, canDirectEdit, canRequestChange, canSaveFile, commandLifecycle, commandRegistry, directEditUnavailableReason, filesController, kernel, layoutMode, window, onAgentRequest, onAttachContext, onDeleteFile, onMoveFile, onOpenArtifact, onSaveFile, onTabChange, requestChangeUnavailableReason, runningTerminalRunId, saveFileUnavailableReason, systemMonitorControls }: {
   activeTabId?: string;
-  canCancelTerminal: boolean;
   canDirectEdit: boolean;
-  canExecuteTerminal: boolean;
   canRequestChange: boolean;
   canSaveFile: boolean;
+  commandLifecycle: TinyOsCommandLifecycle;
+  commandRegistry: TinyOsShellCommandRegistry;
   directEditUnavailableReason?: string;
   filesController?: TinyOsFilesController;
   kernel?: TinyOsKernelSnapshot;
   layoutMode: TinyOsLayoutMode;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void;
   onAttachContext: (reference: TinyOsContextReference) => void;
-  onCancelTerminal: () => Promise<void>;
   onDeleteFile: (input: TinyOsFileDeleteInput) => Promise<void>;
-  onExecuteTerminal: (input: TinyOsTerminalExecuteInput) => Promise<void>;
   onMoveFile: (input: TinyOsFileMoveInput) => Promise<void>;
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onSaveFile: (input: TinyOsFileSaveInput) => Promise<void>;
@@ -766,18 +1473,16 @@ function TinyOsAppContent({ activeTabId, canCancelTerminal, canDirectEdit, canEx
   runningTerminalRunId?: string;
   saveFileUnavailableReason?: string;
   systemMonitorControls: TinyOsSystemMonitorControls;
-  terminalCancelUnavailableReason?: string;
-  terminalExecuteUnavailableReason?: string;
   window: TinyOsWindow;
 }) {
   switch (window.appId) {
     case "files": return filesController?.queryAvailable || !window.entries.length
       ? filesController
-        ? <TinyOsFilesExplorer canDirectEdit={canDirectEdit} canRequestChange={canRequestChange} canSave={canSaveFile} controller={filesController} directEditUnavailableReason={directEditUnavailableReason} layoutMode={layoutMode} onAttachContext={onAttachContext} onDeleteFile={onDeleteFile} onMoveFile={onMoveFile} onRequestExplanation={(reference) => onAgentRequest(reference, "explain")} onRequestModification={(reference) => onAgentRequest(reference, "modify")} onSaveFile={onSaveFile} requestChangeUnavailableReason={requestChangeUnavailableReason} saveUnavailableReason={saveFileUnavailableReason} />
+        ? <TinyOsFilesExplorer canDirectEdit={canDirectEdit} canRequestChange={canRequestChange} canSave={canSaveFile} commandLifecycle={commandLifecycle} commandRegistry={commandRegistry} controller={filesController} directEditUnavailableReason={directEditUnavailableReason} kernel={kernel} layoutMode={layoutMode} onAttachContext={onAttachContext} onDeleteFile={onDeleteFile} onMoveFile={onMoveFile} onRequestExplanation={(reference) => onAgentRequest(reference, "explain")} onRequestModification={(reference) => onAgentRequest(reference, "modify")} onSaveFile={onSaveFile} requestChangeUnavailableReason={requestChangeUnavailableReason} saveUnavailableReason={saveFileUnavailableReason} />
         : <EmptyCopy text="Workspace Explorer is unavailable." />
       : <TinyOsFiles activeTabId={activeTabId} canRequestChange={canRequestChange} window={window} onAgentRequest={onAgentRequest} onAttachContext={onAttachContext} onTabChange={onTabChange} requestChangeUnavailableReason={requestChangeUnavailableReason} />;
-    case "terminal": return <div className="tinyos-terminal-host"><TinyOsTerminalHostControls canCancel={canCancelTerminal} canExecute={canExecuteTerminal} cancelUnavailableReason={terminalCancelUnavailableReason} executeUnavailableReason={terminalExecuteUnavailableReason} onCancel={onCancelTerminal} onExecute={onExecuteTerminal} runningRunId={runningTerminalRunId} />{window.entries.length ? <TinyOsTerminal activeTabId={activeTabId} canRequestChange={canRequestChange} window={window} onAgentRequest={onAgentRequest} onAttachContext={onAttachContext} onTabChange={onTabChange} requestChangeUnavailableReason={requestChangeUnavailableReason} /> : <EmptyCopy text="Run a reviewed command to create canonical terminal output." />}</div>;
-    case "browser": return <TinyOsBrowser window={window} onOpenArtifact={onOpenArtifact} />;
+    case "terminal": return <div className="tinyos-terminal-host"><TinyOsTerminalHostControls commandLifecycle={commandLifecycle} commandRegistry={commandRegistry} runningRunId={runningTerminalRunId} />{window.entries.length ? <TinyOsTerminal activeTabId={activeTabId} canRequestChange={canRequestChange} kernel={kernel} window={window} onAgentRequest={onAgentRequest} onAttachContext={onAttachContext} onTabChange={onTabChange} requestChangeUnavailableReason={requestChangeUnavailableReason} /> : <EmptyCopy text="Run a reviewed command to create a retained canonical execution. TinyOS does not present this as a persistent PTY session." />}</div>;
+    case "browser": return <TinyOsBrowser commandRegistry={commandRegistry} kernel={kernel} window={window} onOpenArtifact={onOpenArtifact} />;
     case "plan": return <TinyOsPlan canRequestChange={canRequestChange} entry={[...window.entries].reverse().find(({ step }) => Boolean(step.plan)) ?? window.entries[window.entries.length - 1]} onAgentRequest={onAgentRequest} requestChangeUnavailableReason={requestChangeUnavailableReason} />;
     case "memory": return <TinyOsMemory window={window} />;
     case "subagents": return <TinyOsSubagents window={window} />;
@@ -835,31 +1540,35 @@ function TinyOsFiles({ activeTabId, canRequestChange, onAgentRequest, onAttachCo
           const selected = selectionStart !== undefined && selectionEnd !== undefined && lineNumber >= selectionStart && lineNumber <= selectionEnd;
           return <li data-selected={selected ? "true" : undefined} key={index}><button type="button" onClick={(event) => selectLine(lineNumber, event.shiftKey)}><code>{line || " "}</code></button></li>;
         })}</ol> : <EmptyCopy text={active.entry.step.summary || "No file preview was returned."} />}
-        <footer className="tinyos-files__status"><span>{fileLanguage(active.path)}</span><span>UTF-8</span>{selectedReference ? <button type="button" onClick={() => onAttachContext(selectedReference)}><Paperclip aria-hidden="true" size={11} />Attach {active.path} · L{selectionStart}{selectionEnd !== selectionStart ? `–${selectionEnd}` : ""}</button> : null}{selectedReference ? <button disabled={!canRequestChange} title={canRequestChange ? "Ask Agent to explain this selection" : requestChangeUnavailableReason} type="button" onClick={() => onAgentRequest(selectedReference, "explain")}><MessageCircleQuestion aria-hidden="true" size={11} />Explain</button> : null}{selectedReference ? <button disabled={!canRequestChange} title={canRequestChange ? "Ask Agent to modify this selection" : requestChangeUnavailableReason} type="button" onClick={() => onAgentRequest(selectedReference, "modify")}><PencilLine aria-hidden="true" size={11} />Modify</button> : null}<span>Canonical item {active.entry.step.sequence + 1}</span></footer>
+        <footer className="tinyos-files__status"><span>{fileLanguage(active.path)}</span><span>UTF-8</span>{selectedReference ? <button draggable="true" title="Attach to Chat or drag this structured file reference" type="button" onClick={() => onAttachContext(selectedReference)} onDragStart={(event) => writeTinyOsReferenceTransfer(event.dataTransfer, { kind: "context", reference: selectedReference })}><Paperclip aria-hidden="true" size={11} />Attach {active.path} · L{selectionStart}{selectionEnd !== selectionStart ? `–${selectionEnd}` : ""}</button> : null}{selectedReference ? <button disabled={!canRequestChange} title={canRequestChange ? "Ask Agent to explain this selection" : requestChangeUnavailableReason} type="button" onClick={() => onAgentRequest(selectedReference, "explain")}><MessageCircleQuestion aria-hidden="true" size={11} />Explain</button> : null}{selectedReference ? <button disabled={!canRequestChange} title={canRequestChange ? "Ask Agent to modify this selection" : requestChangeUnavailableReason} type="button" onClick={() => onAgentRequest(selectedReference, "modify")}><PencilLine aria-hidden="true" size={11} />Modify</button> : null}<span>Canonical item {active.entry.step.sequence + 1}</span></footer>
       </section>
     </div>
   );
 }
 
-function TinyOsTerminalHostControls({ canCancel, canExecute, cancelUnavailableReason, executeUnavailableReason, onCancel, onExecute, runningRunId }: {
-  canCancel: boolean;
-  canExecute: boolean;
-  cancelUnavailableReason?: string;
-  executeUnavailableReason?: string;
-  onCancel: () => Promise<void>;
-  onExecute: (input: TinyOsTerminalExecuteInput) => Promise<void>;
+function TinyOsTerminalHostControls({ commandLifecycle, commandRegistry, runningRunId }: {
+  commandLifecycle: TinyOsCommandLifecycle;
+  commandRegistry: TinyOsShellCommandRegistry;
   runningRunId?: string;
 }) {
   const [command, setCommand] = useState("");
   const [cwd, setCwd] = useState(".");
   const [reviewed, setReviewed] = useState(false);
   const [error, setError] = useState("");
+  const executeCommand = requiredShellCommand(commandRegistry, "terminal.execute");
+  const cancelCommand = requiredShellCommand(commandRegistry, "terminal.cancel");
+  const canExecute = executeCommand.availability.available;
+  const canCancel = cancelCommand.availability.available;
   return (
     <form className="tinyos-terminal-command" onSubmit={(event) => {
       event.preventDefault();
       if (!reviewed || !canExecute || !command.trim()) return;
       setError("");
-      void onExecute({ command: command.trim(), ...(cwd.trim() ? { cwd: cwd.trim() } : {}) }).then(() => {
+      void commandRegistry.execute("terminal.execute", {
+        command: command.trim(),
+        ...(cwd.trim() ? { cwd: cwd.trim() } : {}),
+      }).then((execution) => {
+        if (execution.status === "rejected") throw new Error(execution.reason);
         setCommand("");
         setReviewed(false);
       }).catch((reason) => setError(reason instanceof Error ? reason.message : String(reason)));
@@ -867,17 +1576,33 @@ function TinyOsTerminalHostControls({ canCancel, canExecute, cancelUnavailableRe
       <label><span>Command</span><input aria-label="TinyOS terminal command" disabled={!canExecute || Boolean(runningRunId)} placeholder="Enter a workspace command" value={command} onChange={(event) => { setCommand(event.currentTarget.value); setReviewed(false); }} /></label>
       <label><span>cwd</span><input aria-label="TinyOS terminal working directory" disabled={!canExecute || Boolean(runningRunId)} value={cwd} onChange={(event) => { setCwd(event.currentTarget.value); setReviewed(false); }} /></label>
       <div>
-        <button disabled={!canExecute || !command.trim() || Boolean(runningRunId)} title={canExecute ? "Review the exact command and execution boundary" : executeUnavailableReason} type="button" onClick={() => setReviewed(true)}>Review command</button>
+        <button disabled={!canExecute || !command.trim() || Boolean(runningRunId)} title={canExecute ? "Review the exact command and execution boundary" : executeCommand.availability.reason} type="button" onClick={() => setReviewed(true)}>Review command</button>
         <button disabled={!canExecute || !reviewed || !command.trim() || Boolean(runningRunId)} title="Execute read-only with network denied" type="submit"><Play aria-hidden="true" size={12} />Run command</button>
-        <button disabled={!canCancel || !runningRunId} title={canCancel ? "Interrupt the correlated TinyOS terminal process" : cancelUnavailableReason} type="button" onClick={() => { setError(""); void onCancel().catch((reason) => setError(reason instanceof Error ? reason.message : String(reason))); }}><Pause aria-hidden="true" size={12} />Cancel process</button>
+        <button disabled={!canCancel || !runningRunId} title={canCancel ? "Interrupt the correlated TinyOS terminal process" : cancelCommand.availability.reason} type="button" onClick={() => {
+          setError("");
+          void commandRegistry.execute("terminal.cancel").then((execution) => {
+            if (execution.status === "rejected") throw new Error(execution.reason);
+          }).catch((reason) => setError(reason instanceof Error ? reason.message : String(reason)));
+        }}><Pause aria-hidden="true" size={12} />Cancel process</button>
       </div>
       {reviewed ? <p role="status"><ShieldCheck aria-hidden="true" size={12} />Read-only sandbox · network denied · cwd {cwd || "."}</p> : null}
+      <p className="tinyos-terminal-command__contract"><ShieldCheck aria-hidden="true" size={12} />Retained execution · non-TTY · no persistent shell state</p>
+      {commandLifecycle.stage !== "idle" && (commandLifecycle.command.kind === "terminal.execute" || commandLifecycle.command.kind === "terminal.cancel") ? <TinyOsTerminalLifecycle lifecycle={commandLifecycle} /> : null}
       {error ? <p role="alert">{error}</p> : null}
     </form>
   );
 }
 
-function TinyOsTerminal({ activeTabId, canRequestChange, onAgentRequest, onAttachContext, onTabChange, requestChangeUnavailableReason, window }: { activeTabId?: string; canRequestChange: boolean; onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void; onAttachContext: (reference: TinyOsContextReference) => void; onTabChange: (tabId: string) => void; requestChangeUnavailableReason?: string; window: TinyOsWindow }) {
+function TinyOsTerminalLifecycle({ lifecycle }: { lifecycle: Exclude<TinyOsCommandLifecycle, { stage: "idle" }> }) {
+  const label = lifecycle.command.kind === "terminal.cancel" ? "Cancel" : "Execution";
+  if (lifecycle.stage === "sending") return <p className="tinyos-terminal-lifecycle" role="status"><strong>{label} dispatching</strong><span>Native transport has not accepted the command yet.</span></p>;
+  if (lifecycle.stage === "waiting_for_canonical") return <p className="tinyos-terminal-lifecycle" role="status"><strong>{label} awaiting runtime</strong><span>Transport accepted · waiting for canonical acknowledgement.</span></p>;
+  if (lifecycle.stage === "acknowledged") return <p className="tinyos-terminal-lifecycle" role="status"><strong>{label} acknowledged</strong><span>Canonical item {lifecycle.acknowledgement.itemId}</span></p>;
+  if (lifecycle.stage === "completed") return <p className="tinyos-terminal-lifecycle" data-state={lifecycle.completion.status} role="status"><strong>{label} {lifecycle.completion.status}</strong><span>Canonical revision {lifecycle.completion.revision}</span></p>;
+  return <p className="tinyos-terminal-lifecycle" data-state="failed" role="alert"><strong>{label} {lifecycle.stage.replace("_", " ")}</strong><span>{lifecycle.error}</span></p>;
+}
+
+function TinyOsTerminal({ activeTabId, canRequestChange, kernel, onAgentRequest, onAttachContext, onTabChange, requestChangeUnavailableReason, window }: { activeTabId?: string; canRequestChange: boolean; kernel?: TinyOsKernelSnapshot; onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void; onAttachContext: (reference: TinyOsContextReference) => void; onTabChange: (tabId: string) => void; requestChangeUnavailableReason?: string; window: TinyOsWindow }) {
   const active = window.entries.find((entry) => entry.step.id === activeTabId) ?? window.entries[window.entries.length - 1];
   const [follow, setFollow] = useState(true);
   const [query, setQuery] = useState("");
@@ -886,13 +1611,14 @@ function TinyOsTerminal({ activeTabId, canRequestChange, onAgentRequest, onAttac
   const [activeMatch, setActiveMatch] = useState(0);
   const outputRef = useRef<HTMLDivElement>(null);
   const stdout = terminalOutput(active.step);
-  const stderr = active.step.toolCall?.stderrPreview ?? "";
+  const stderr = terminalStderr(active.step);
   const output = stream === "stdout" ? stdout : stream === "stderr" ? stderr : [stdout, stderr].filter(Boolean).join("\n");
   const rawOutputLines = output.split("\n");
   const outputTruncated = rawOutputLines.length > 499;
   const outputLines = [`$ ${terminalCommand(active.step)}`, ...rawOutputLines.slice(-499)];
   const matches = query ? outputLines.flatMap((line, index) => line.toLocaleLowerCase().includes(query.toLocaleLowerCase()) ? [index] : []) : [];
   const currentMatch = matches.length ? matches[Math.min(activeMatch, matches.length - 1)] : undefined;
+  const execution = terminalExecutionView(active, kernel);
   const selectionStart = selection ? Math.min(selection.anchor, selection.end) : undefined;
   const selectionEnd = selection ? Math.max(selection.anchor, selection.end) : undefined;
   const selectedText = selectionStart !== undefined && selectionEnd !== undefined
@@ -901,7 +1627,10 @@ function TinyOsTerminal({ activeTabId, canRequestChange, onAgentRequest, onAttac
   const selectedReference: TinyOsContextReference | undefined = selectionStart !== undefined && selectionEnd !== undefined ? {
     command: terminalCommand(active.step),
     endLine: selectionEnd + 1,
+    executionId: active.step.id,
     kind: "terminal",
+    ...(execution.processId ? { processId: execution.processId } : {}),
+    provenance: { kind: "canonical", sourceItemId: active.step.id, turnId: active.turnId },
     selectedText,
     sourceItemId: active.step.id,
     startLine: selectionStart + 1,
@@ -938,6 +1667,16 @@ function TinyOsTerminal({ activeTabId, canRequestChange, onAgentRequest, onAttac
         {window.entries.slice(-6).map((entry) => <button aria-selected={entry === active} data-active={entry === active ? "true" : undefined} key={`${entry.turnId}:${entry.step.id}`} role="tab" title={terminalCommand(entry.step)} type="button" onClick={() => onTabChange(entry.step.id)}>{terminalCommand(entry.step)}</button>)}
         <TinyOsStatus status={active.step.status} />
       </div>
+      <dl aria-label="Terminal execution identity" className="tinyos-terminal__identity" role="group">
+        <div><dt>Contract</dt><dd>retained execution v1</dd></div>
+        <div><dt>Run / item</dt><dd><code>{active.turnId} / {active.step.id}</code></dd></div>
+        <div><dt>Process</dt><dd><code>{execution.processId || "Unavailable"}</code></dd></div>
+        <div><dt>cwd</dt><dd><code>{metadata.cwd || "Unavailable"}</code></dd></div>
+        <div><dt>Boundary</dt><dd>{execution.sandboxMode} · network {execution.networkMode} · non-TTY</dd></div>
+        <div><dt>Output</dt><dd>{execution.stdoutBytes} B stdout · {execution.stderrBytes} B stderr{execution.droppedBytes ? ` · ${execution.droppedBytes} B dropped` : ""}</dd></div>
+        <div><dt>Exit / timing</dt><dd>{metadata.exit} · {active.step.toolCall?.durationMs !== undefined ? `${active.step.toolCall.durationMs} ms` : "timing unavailable"}</dd></div>
+        <div><dt>Provenance</dt><dd><ShieldCheck aria-hidden="true" size={11} />canonical_event · {active.step.id}</dd></div>
+      </dl>
       <div className="tinyos-terminal__toolbar">
         <label><Search aria-hidden="true" size={12} /><input aria-label="Search terminal output" placeholder="Search output" value={query} onChange={(event) => { setQuery(event.currentTarget.value); setActiveMatch(0); }} /></label>
         <span aria-live="polite">{query ? `${matches.length ? Math.min(activeMatch, matches.length - 1) + 1 : 0}/${matches.length}` : ""}</span>
@@ -955,20 +1694,115 @@ function TinyOsTerminal({ activeTabId, canRequestChange, onAgentRequest, onAttac
           return <li data-current-match={currentMatch === index ? "true" : undefined} data-line={index} data-match={matches ? "true" : undefined} data-selected={selected ? "true" : undefined} key={index}><button type="button" onClick={(event) => selectLine(index, event.shiftKey)}><code>{line || " "}</code></button></li>;
         })}</ol>
       </div>
-      <footer><span>{metadata.cwd ? `cwd ${metadata.cwd}` : `Agent ${active.step.agentContext.title}`}</span><span>{metadata.exit}</span><span>{active.step.toolCall?.durationMs !== undefined ? `${active.step.toolCall.durationMs} ms` : statusLabel(active.step.status)}</span>{selectedReference ? <button type="button" onClick={() => onAttachContext(selectedReference)}><Paperclip aria-hidden="true" size={11} />Attach L{selectedReference.startLine}{selectedReference.endLine === selectedReference.startLine ? "" : `–${selectedReference.endLine}`}</button> : <span>{follow ? "Following output" : "Follow paused"}</span>}{selectedReference ? <button disabled={!canRequestChange} title={canRequestChange ? "Ask Agent to explain this output" : requestChangeUnavailableReason} type="button" onClick={() => onAgentRequest(selectedReference, "explain")}><MessageCircleQuestion aria-hidden="true" size={11} />Explain</button> : null}{selectedReference ? <button disabled={!canRequestChange} title={canRequestChange ? "Continue with Agent using this output" : requestChangeUnavailableReason} type="button" onClick={() => onAgentRequest(selectedReference, "follow_up")}><Play aria-hidden="true" size={11} />Continue with Agent</button> : null}{outputTruncated ? <span>Showing last 499 output lines</span> : null}<span>{stream} · Canonical item {active.step.sequence + 1}</span></footer>
+      <footer><span>{metadata.cwd ? `cwd ${metadata.cwd}` : `Agent ${active.step.agentContext.title}`}</span><span>{metadata.exit}</span><span>{active.step.toolCall?.durationMs !== undefined ? `${active.step.toolCall.durationMs} ms` : statusLabel(active.step.status)}</span>{selectedReference ? <button draggable="true" title="Attach to Chat or drag this structured terminal reference" type="button" onClick={() => onAttachContext(selectedReference)} onDragStart={(event) => writeTinyOsReferenceTransfer(event.dataTransfer, { kind: "context", reference: selectedReference })}><Paperclip aria-hidden="true" size={11} />Attach L{selectedReference.startLine}{selectedReference.endLine === selectedReference.startLine ? "" : `–${selectedReference.endLine}`}</button> : <span>{follow ? "Following output" : "Follow paused"}</span>}{selectedReference ? <button disabled={!canRequestChange} title={canRequestChange ? "Ask Agent to explain this output" : requestChangeUnavailableReason} type="button" onClick={() => onAgentRequest(selectedReference, "explain")}><MessageCircleQuestion aria-hidden="true" size={11} />Explain</button> : null}{selectedReference ? <button disabled={!canRequestChange} title={canRequestChange ? "Continue with Agent using this output" : requestChangeUnavailableReason} type="button" onClick={() => onAgentRequest(selectedReference, "follow_up")}><Play aria-hidden="true" size={11} />Continue with Agent</button> : null}{outputTruncated || execution.truncated ? <span>Retained boundary · last 499 lines{execution.droppedBytes ? ` · ${execution.droppedBytes} B dropped` : ""}</span> : null}<span>{stream} · Canonical item {active.step.sequence + 1}</span></footer>
     </div>
   );
 }
 
-function TinyOsBrowser({ window, onOpenArtifact }: { window: TinyOsWindow; onOpenArtifact: (artifact: ArtifactRef) => void }) {
+function TinyOsBrowser({ commandRegistry, kernel, window, onOpenArtifact }: {
+  commandRegistry: TinyOsShellCommandRegistry;
+  kernel?: TinyOsKernelSnapshot;
+  onOpenArtifact: (artifact: ArtifactRef) => void;
+  window: TinyOsWindow;
+}) {
   const latest = window.entries[window.entries.length - 1];
-  const artifacts = latest.step.artifacts ?? [];
-  const capture = artifacts.find((artifact) => artifact.kind === "browser_snapshot");
-  const image = capture?.preview && safeRasterDataUrl(capture.preview) ? capture.preview : undefined;
+  const session = kernel?.browserSessions[0];
+  const [selectedTabId, setSelectedTabId] = useState(session?.activeTabId);
+  const activeTabId = session?.tabs.some(({ tabId }) => tabId === selectedTabId) ? selectedTabId : session?.activeTabId;
+  const tab = session?.tabs.find(({ tabId }) => tabId === activeTabId);
+  const [selectedCaptureId, setSelectedCaptureId] = useState(tab?.currentCaptureId);
+  const selectedCapture = tab?.captures.find(({ captureId }) => captureId === selectedCaptureId)
+    ?? tab?.captures.find(({ captureId }) => captureId === tab.currentCaptureId);
+  const target = session && tab && selectedCapture ? {
+    browserSessionId: session.browserSessionId,
+    captureId: selectedCapture.captureId,
+    tabId: tab.tabId,
+  } : undefined;
+  const validation = target ? validateTinyOsBrowserInteractionTarget(session, target) : undefined;
+  const currentCapture = validation?.status === "rejected" ? validation.currentCapture : selectedCapture;
+  const artifacts = window.entries.flatMap(({ step }) => step.artifacts ?? []);
+  const standaloneCapture = [...artifacts].reverse().find((artifact) => artifact.kind === "browser_snapshot");
+  const captureArtifact = selectedCapture
+    ? artifacts.find((artifact) => artifact.kind === "browser_snapshot" && artifact.id === selectedCapture.captureId)
+    : standaloneCapture;
+  const image = captureArtifact?.preview && safeRasterDataUrl(captureArtifact.preview) ? captureArtifact.preview : undefined;
+  const truth = session ? (image ? "real_capture" : "native_session") : image ? "local_preview" : "structured_projection";
+  const canonicalUrl = latest ? browserLocation(latest.step) : "";
+  const [url, setUrl] = useState(tab?.url ?? canonicalUrl);
+  const [typedText, setTypedText] = useState("");
+  const [error, setError] = useState("");
+  const navigateCommand = requiredShellCommand(commandRegistry, "browser.navigate");
+  const clickCommand = requiredShellCommand(commandRegistry, "browser.click");
+  const typeCommand = requiredShellCommand(commandRegistry, "browser.type");
+  const historyIndex = tab?.activeHistoryIndex ?? -1;
+
+  useEffect(() => {
+    setSelectedTabId(session?.activeTabId);
+  }, [session?.activeTabId, session?.browserSessionId, session?.revision]);
+  useEffect(() => {
+    setSelectedCaptureId(tab?.currentCaptureId);
+    setUrl(tab?.url ?? canonicalUrl);
+    setError("");
+  }, [canonicalUrl, latest?.step.id, tab?.currentCaptureId, tab?.tabId, tab?.url]);
+
+  async function executeBrowserCommand(commandId: "browser.click" | "browser.navigate" | "browser.type", values: Record<string, string>) {
+    if (!target) {
+      setError("A compatible native browser session, tab, and capture are required.");
+      return;
+    }
+    setError("");
+    try {
+      const execution = await commandRegistry.execute(commandId, { ...target, ...values });
+      if (execution.status === "rejected") setError(execution.reason);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    }
+  }
+
+  function navigateHistory(nextIndex: number) {
+    const entry = tab?.history[nextIndex];
+    if (!entry) return;
+    void executeBrowserCommand("browser.navigate", { url: entry.url });
+  }
+
   return (
-    <div className="tinyos-browser" data-truth={image ? "real_capture" : "structured"}>
-      <div className="tinyos-browser__bar"><span /><span /><span /><Globe2 aria-hidden="true" size={13} /><strong>{browserLocation(latest.step)}</strong><b>{image ? "Real capture" : "Structured simulation"}</b></div>
-      {image ? <button type="button" onClick={() => capture && onOpenArtifact(capture)}><img alt={capture?.title || "Browser capture"} src={image} /></button> : <div className="tinyos-browser__page"><Globe2 aria-hidden="true" size={28} /><strong>{latest.step.title}</strong><p>{latest.step.summary || "No real browser capture is attached. This is a structured browser view."}</p></div>}
+    <div className="tinyos-browser" data-truth={truth}>
+      {session ? <div aria-label="Native browser tabs" className="tinyos-browser__tabs" role="tablist">
+        {session.tabs.map((candidate) => <button aria-selected={candidate.tabId === tab?.tabId} key={candidate.tabId} role="tab" type="button" onClick={() => setSelectedTabId(candidate.tabId)}>{candidate.loading ? <Circle aria-hidden="true" size={9} /> : null}{candidate.title}</button>)}
+      </div> : null}
+      <div className="tinyos-browser__bar">
+        <button aria-label="Browser back" disabled={!tab || historyIndex <= 0 || !navigateCommand.availability.available || validation?.status !== "accepted"} title={navigateCommand.availability.available ? "Back" : navigateCommand.availability.reason} type="button" onClick={() => navigateHistory(historyIndex - 1)}><ChevronLeft aria-hidden="true" size={13} /></button>
+        <button aria-label="Browser forward" disabled={!tab || historyIndex < 0 || historyIndex >= tab.history.length - 1 || !navigateCommand.availability.available || validation?.status !== "accepted"} title={navigateCommand.availability.available ? "Forward" : navigateCommand.availability.reason} type="button" onClick={() => navigateHistory(historyIndex + 1)}><ChevronRight aria-hidden="true" size={13} /></button>
+        <Globe2 aria-hidden="true" size={13} />
+        <form onSubmit={(event) => { event.preventDefault(); void executeBrowserCommand("browser.navigate", { url }); }}><input aria-label="Browser URL" disabled={!navigateCommand.availability.available || validation?.status !== "accepted"} value={url} onChange={(event) => setUrl(event.currentTarget.value)} /><button disabled={!url.trim() || !navigateCommand.availability.available || validation?.status !== "accepted"} type="submit">Go</button></form>
+        <b>{truth === "real_capture" ? "Real capture" : truth === "native_session" ? "Native session · capture unavailable" : truth === "local_preview" ? "Local preview" : "Structured projection"}</b>
+      </div>
+      {session && tab ? <section aria-label="Browser session identity" className="tinyos-browser__identity">
+        <span><strong>Session</strong><code>{session.browserSessionId}</code></span>
+        <span><strong>Tab</strong><code>{tab.tabId}</code></span>
+        <span><strong>Capture</strong><code>{selectedCapture?.captureId ?? "Unavailable"}</code></span>
+        <span><strong>Observed</strong><time>{selectedCapture?.observedAt ?? session.observedAt}</time></span>
+        <span><strong>Provenance</strong>{session.provenance.kind}</span>
+        <span><strong>State</strong>{tab.loading ? "loading" : "ready"}</span>
+      </section> : null}
+      {tab?.captures.length ? <nav aria-label="Browser capture history" className="tinyos-browser__captures">
+        {tab.captures.map((capture) => <button aria-current={capture.captureId === selectedCapture?.captureId ? "true" : undefined} data-stale={capture.stale ? "true" : undefined} key={capture.captureId} type="button" onClick={() => setSelectedCaptureId(capture.captureId)}><span>{capture.captureId}</span><small>{capture.stale ? "Stale evidence" : capture.captureId === tab.currentCaptureId ? "Current capture" : "Retained capture"}</small></button>)}
+      </nav> : null}
+      {validation?.status === "rejected" ? <div className="tinyos-browser__stale" role="alert"><AlertTriangle aria-hidden="true" size={14} /><span><strong>{validation.reasonCode === "capture_stale" ? "Stale capture" : "Capture unavailable"}</strong>{validation.reason}</span>{currentCapture ? <button type="button" onClick={() => setSelectedCaptureId(currentCapture.captureId)}>Show current capture</button> : null}</div> : null}
+      {image ? <button aria-label={validation?.status === "accepted" && clickCommand.availability.available ? "Interact with current browser capture" : "Open browser capture artifact"} className="tinyos-browser__capture" type="button" onClick={(event) => {
+        if (validation?.status !== "accepted" || !clickCommand.availability.available) {
+          if (captureArtifact) onOpenArtifact(captureArtifact);
+          return;
+        }
+        const bounds = event.currentTarget.getBoundingClientRect();
+        void executeBrowserCommand("browser.click", {
+          x: String(Math.max(0, Math.round(event.clientX - bounds.left))),
+          y: String(Math.max(0, Math.round(event.clientY - bounds.top))),
+        });
+      }}><img alt={captureArtifact?.title || "Browser capture"} src={image} /></button> : <div className="tinyos-browser__page"><Globe2 aria-hidden="true" size={28} /><strong>{tab?.title ?? latest?.step.title ?? "Browser session"}</strong><p>{tab ? "The native session snapshot has no compatible raster capture to display." : latest?.step.summary || "No real browser session or capture is attached. This is a structured projection."}</p></div>}
+      <form className="tinyos-browser__type" onSubmit={(event) => { event.preventDefault(); void executeBrowserCommand("browser.type", { text: typedText }); }}><input aria-label="Text for browser" disabled={!typeCommand.availability.available || validation?.status !== "accepted"} placeholder="Type into the focused browser target" value={typedText} onChange={(event) => setTypedText(event.currentTarget.value)} /><button disabled={!typedText.trim() || !typeCommand.availability.available || validation?.status !== "accepted"} title={typeCommand.availability.available ? "Type into current capture" : typeCommand.availability.reason} type="submit">Type</button></form>
+      {!session ? <p className="tinyos-browser__readonly" role="status"><ShieldCheck aria-hidden="true" size={13} /><span><strong>Read-only projection</strong>{clickCommand.availability.available ? "A compatible native session snapshot is required." : clickCommand.availability.reason}</span></p> : null}
+      {error ? <p className="tinyos-browser__error" role="alert">{error}</p> : null}
     </div>
   );
 }
@@ -1058,13 +1892,13 @@ function TinyOsNotifications({
   onSelect,
 }: {
   notifications: TinyOsDesktopSnapshot["notifications"];
-  onSelect: (entry: TinyOsTimelineEntry) => void;
+  onSelect: (notificationId: string) => void;
 }) {
   if (!notifications.length) return null;
   return (
     <aside aria-label="TinyOS notifications" className="tinyos-notifications">
       {notifications.slice(-2).map((notification) => (
-        <button data-kind={notification.kind} key={notification.id} type="button" onClick={() => onSelect(notification.entry)}>
+        <button data-kind={notification.kind} key={notification.id} type="button" onClick={() => onSelect(notification.id)}>
           {notification.kind === "completed" ? <CheckCircle2 aria-hidden="true" size={15} /> : <AlertTriangle aria-hidden="true" size={15} />}
           <span><strong>{notification.title}</strong><small>{notification.message}</small></span>
         </button>
@@ -1118,23 +1952,42 @@ function TinyOsSystemDialog({
   );
 }
 
-function TinyOsInspector({ entries, onClose, onOpenArtifact }: { entries: TinyOsTimelineEntry[]; onClose: (entry: TinyOsTimelineEntry) => void; onOpenArtifact: (artifact: ArtifactRef) => void }) {
+function TinyOsInspector({ evidence, onClose, onOpenArtifact, onReferenceDrop }: { evidence: TinyOsPinnedEvidence[]; onClose: (pin: TinyOsPinnedEvidence) => void; onOpenArtifact: (artifact: ArtifactRef) => void; onReferenceDrop: (event: DragEvent<HTMLElement>) => void }) {
   return (
-    <aside aria-label="TinyOS Inspector" className="tinyos-inspector" data-split={entries.length > 1 ? "true" : undefined}>
-      {entries.map((entry) => {
+    <aside
+      aria-label="TinyOS Inspector"
+      className="tinyos-inspector"
+      data-split={evidence.length > 1 ? "true" : undefined}
+      onDragOver={(event) => {
+        if (!Array.from(event.dataTransfer.types).includes(TINYOS_REFERENCE_MIME)) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "copy";
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        onReferenceDrop(event);
+      }}
+    >
+      {evidence.map((pin) => {
+        const { entry } = pin;
         const artifacts = entry.step.artifacts ?? entry.step.delegate?.artifacts ?? [];
         return (
-          <article key={`${entry.turnId}:${entry.step.id}`}>
-            <header><div><small>Canonical evidence</small><strong>{entry.step.title}</strong></div><button aria-label={`Close ${entry.step.title} evidence`} type="button" onClick={() => onClose(entry)}><X aria-hidden="true" size={15} /></button></header>
+          <article key={pin.id}>
+            <header><div><small>Canonical evidence · Event {pin.cursor.eventIndex + 1}</small><strong>{entry.step.title}</strong></div><button aria-label={`Close ${entry.step.title} evidence at event ${pin.cursor.eventIndex + 1}`} type="button" onClick={() => onClose(pin)}><X aria-hidden="true" size={15} /></button></header>
             <TinyOsStatus status={entry.step.status} />
+            <dl className="tinyos-inspector__correlation">
+              <div><dt>Boundary</dt><dd>Event {pin.cursor.eventIndex + 1} of {pin.cursor.eventCount}</dd></div>
+              <div><dt>Observed</dt><dd>{pin.cursor.wallClockTime ?? "Unavailable"}</dd></div>
+            </dl>
             {entry.step.summary ? <p>{entry.step.summary}</p> : null}
             {entry.step.toolCall ? <dl className="tinyos-inspector__correlation"><div><dt>Tool call</dt><dd>{entry.step.toolCall.id}</dd></div>{entry.step.toolCall.resultRef ? <div><dt>Result ref</dt><dd>{entry.step.toolCall.resultRef}</dd></div> : null}<div><dt>Turn</dt><dd>{entry.turnId}</dd></div><div><dt>Agent</dt><dd>{entry.step.agentContext.title}</dd></div></dl> : null}
             {entry.step.toolCall?.argsJson !== undefined ? <section><strong>Arguments</strong><pre>{sanitizedJsonPreview(entry.step.toolCall.argsJson)}</pre></section> : null}
             {entry.step.toolCall?.resultJson !== undefined ? <section><strong>Result</strong><pre>{sanitizedJsonPreview(entry.step.toolCall.resultJson)}</pre></section> : null}
             {entry.step.toolCall?.resultPreview ? <section><strong>Result preview</strong><pre>{entry.step.toolCall.resultPreview}</pre></section> : null}
             {entry.step.toolCall?.stderrPreview ? <section><strong>Stderr</strong><pre>{entry.step.toolCall.stderrPreview}</pre></section> : null}
+            {pin.resources.length ? <section><strong>Resources at this boundary</strong>{pin.resources.map((resource) => <dl className="tinyos-inspector__resource" key={resource.id}><div><dt>Identity</dt><dd>{resource.id}</dd></div><div><dt>Revision</dt><dd>{resource.revision ?? resource.provenance.revision ?? "Unavailable"}</dd></div><div><dt>Provenance</dt><dd>{resource.provenance.kind} · {resource.provenance.sourceId}</dd></div></dl>)}</section> : null}
             {artifacts.length ? <section><strong>Artifacts</strong>{artifacts.map((artifact) => <button key={artifact.id} type="button" onClick={() => onOpenArtifact(artifact)}>{artifact.title}</button>)}</section> : null}
-            <footer>Canonical timeline item {entry.step.sequence + 1} · Agent {entry.step.agentContext.title}</footer>
+            <footer>Event {pin.cursor.eventIndex + 1} · Canonical timeline item {entry.step.sequence + 1} · Agent {entry.step.agentContext.title}</footer>
           </article>
         );
       })}
@@ -1143,23 +1996,38 @@ function TinyOsInspector({ entries, onClose, onOpenArtifact }: { entries: TinyOs
 }
 
 function TinyOsOperationShelf({
-  canRetryRun,
-  onRetryOperation,
-  onSelectEntry,
+  commandRegistry,
   operations,
 }: {
-  canRetryRun: boolean;
-  onRetryOperation: (entry: TinyOsTimelineEntry) => void;
-  onSelectEntry: (entry: TinyOsTimelineEntry) => void;
+  commandRegistry: TinyOsShellCommandRegistry;
   operations: TinyOsDesktopSnapshot["operations"];
 }) {
   const operation = operations[operations.length - 1];
   const Icon = operation ? APP_ICONS[operation.appId] : undefined;
+  const selectCommand = operation
+    ? requiredShellCommand(commandRegistry, `history.select:${operation.entry.step.id}`)
+    : undefined;
+  const retryCommand = operation
+    ? requiredShellCommand(commandRegistry, `operation.retry:${operation.entry.step.id}`)
+    : undefined;
   return (
     <nav aria-label="TinyOS recent operations" className="tinyos-operation-shelf">
-      {operation && Icon ? (
+      {operation && Icon && selectCommand && retryCommand ? (
         <>
-          <button className="tinyos-operation-shelf__select" data-status={operation.status} type="button" onClick={() => onSelectEntry(operation.entry)}>
+          <button
+            className="tinyos-operation-shelf__select"
+            data-status={operation.status}
+            draggable="true"
+            title="Open operation or drag its canonical evidence"
+            type="button"
+            onClick={() => void commandRegistry.execute(selectCommand.id)}
+            onDragStart={(event) => writeTinyOsReferenceTransfer(event.dataTransfer, {
+              itemId: operation.entry.step.id,
+              kind: "evidence",
+              title: operation.title,
+              turnId: operation.entry.turnId,
+            })}
+          >
             <span className="tinyos-operation-shelf__state"><Icon aria-hidden="true" size={15} /></span>
             <span><small>Latest canonical operation</small><strong>{operation.title}</strong></span>
             <span><small>Status</small><strong>{statusLabel(operation.status)}</strong></span>
@@ -1167,7 +2035,13 @@ function TinyOsOperationShelf({
             <span><small>Source</small><strong>Canonical events</strong></span>
           </button>
           {operation.status === "failed" ? (
-            <button className="tinyos-operation-shelf__retry" disabled={!canRetryRun} type="button" onClick={() => onRetryOperation(operation.entry)}>
+            <button
+              className="tinyos-operation-shelf__retry"
+              disabled={!retryCommand.availability.available}
+              title={retryCommand.availability.available ? "Retry operation" : retryCommand.availability.reason}
+              type="button"
+              onClick={() => void commandRegistry.execute(retryCommand.id)}
+            >
               <RotateCcw aria-hidden="true" size={14} />Retry
             </button>
           ) : null}
@@ -1248,6 +2122,40 @@ function distinctLatestFiles<T extends { path: string }>(files: T[]): T[] {
   return [...latestByPath.values()];
 }
 
+function requiredShellCommand(
+  registry: TinyOsShellCommandRegistry,
+  id: TinyOsShellCommandId,
+): TinyOsShellCommand {
+  const command = registry.get(id);
+  if (!command) throw new Error(`Required TinyOS shell command is not registered: ${id}`);
+  return command;
+}
+
+function overlayLabel(overlay: TinyOsShellOverlay): string {
+  switch (overlay) {
+    case "notifications": return "notification center";
+    case "overview": return "window Overview";
+    case "palette": return "command palette";
+    case "switcher": return "application switcher";
+  }
+}
+
+function tinyOsAppForResourceKind(kind: TinyOsKernelSnapshot["resources"][number]["kind"]): TinyOsAppId | undefined {
+  switch (kind) {
+    case "file":
+    case "directory": return "files";
+    case "terminal_execution":
+    case "terminal_session": return "terminal";
+    case "browser_capture":
+    case "browser_session": return "browser";
+    case "artifact": return "artifacts";
+    case "memory_result": return "memory";
+    case "plan": return "plan";
+    case "approval":
+    case "form": return "inspector";
+  }
+}
+
 function fileLanguage(path: string): string {
   const parts = fileName(path).split(".");
   const extension = parts[parts.length - 1]?.toLowerCase();
@@ -1266,7 +2174,54 @@ function terminalCommand(step: ChatStep): string {
 }
 
 function terminalOutput(step: ChatStep): string {
-  return step.toolCall?.resultPreview || jsonPreview(step.toolCall?.resultJson) || (step.status === "running" ? "Running..." : "No output returned.");
+  const result = recordValue(step.toolCall?.resultJson);
+  return firstString(result.stdout, result.output, step.toolCall?.resultPreview)
+    || (Object.keys(result).length ? jsonPreview(result) : "")
+    || (step.status === "running" ? "Running..." : "No output returned.");
+}
+
+function terminalStderr(step: ChatStep): string {
+  const result = recordValue(step.toolCall?.resultJson);
+  return firstString(result.stderr, step.toolCall?.stderrPreview);
+}
+
+function terminalExecutionView(entry: TinyOsTimelineEntry, kernel?: TinyOsKernelSnapshot): {
+  droppedBytes: number;
+  networkMode: string;
+  processId: string;
+  sandboxMode: string;
+  stderrBytes: number;
+  stdoutBytes: number;
+  truncated: boolean;
+} {
+  const args = recordValue(entry.step.toolCall?.argsJson);
+  const result = recordValue(entry.step.toolCall?.resultJson);
+  const stdout = firstString(result.stdout, entry.step.toolCall?.resultPreview);
+  const stderr = firstString(result.stderr, entry.step.toolCall?.stderrPreview);
+  const correlatedProcess = kernel?.processes.find((process) => (
+    process.correlation.itemId === entry.step.id
+    || process.correlation.toolCallId === entry.step.toolCall?.id
+  ));
+  const processId = firstString(result.processId, result.process_id, correlatedProcess?.correlation.nativeProcessId, correlatedProcess?.id);
+  const droppedBytes = nonNegativeNumber(result.droppedBytes, result.dropped_bytes) ?? 0;
+  return {
+    droppedBytes,
+    networkMode: firstString(result.networkMode, result.network_mode, args.networkMode, args.network_mode) || "unavailable",
+    processId,
+    sandboxMode: firstString(result.sandboxMode, result.sandbox_mode, args.sandboxMode, args.sandbox_mode) || "unavailable",
+    stderrBytes: nonNegativeNumber(result.stderrBytes, result.stderr_bytes) ?? utf8ByteLength(stderr),
+    stdoutBytes: nonNegativeNumber(result.stdoutBytes, result.stdout_bytes) ?? utf8ByteLength(stdout),
+    truncated: result.truncated === true || droppedBytes > 0,
+  };
+}
+
+function nonNegativeNumber(...values: unknown[]): number | undefined {
+  const value = values.find((candidate): candidate is number => typeof candidate === "number" && Number.isFinite(candidate) && candidate >= 0);
+  return value;
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
 }
 
 function terminalMetadata(step: ChatStep): { cwd: string; exit: string } {
@@ -1284,6 +2239,43 @@ function copyText(value: string): void {
   void navigator.clipboard?.writeText(value).catch((error) => {
     console.error("TinyOS could not copy terminal content.", error);
   });
+}
+
+type BrowserInteractionCommandInput = {
+  browserSessionId: string;
+  captureId: string;
+  tabId: string;
+  text?: string;
+  url?: string;
+  x?: string;
+  y?: string;
+};
+
+function browserInteractionCommandInput(input?: TinyOsShellCommandInput): BrowserInteractionCommandInput {
+  if (!input || typeof input === "string") throw new Error("Browser interaction requires structured input.");
+  return {
+    browserSessionId: input.browserSessionId?.trim() || "",
+    captureId: input.captureId?.trim() || "",
+    tabId: input.tabId?.trim() || "",
+    ...(input.text !== undefined ? { text: input.text } : {}),
+    ...(input.url !== undefined ? { url: input.url.trim() } : {}),
+    ...(input.x !== undefined ? { x: input.x } : {}),
+    ...(input.y !== undefined ? { y: input.y } : {}),
+  };
+}
+
+function browserActionFromCommandInput(
+  kind: "click" | "navigate" | "type",
+  input: BrowserInteractionCommandInput,
+): TinyOsBrowserAction {
+  if (kind === "navigate") return { type: "navigate", url: input.url?.trim() || "" };
+  if (kind === "type") return { text: input.text || "", type: "type" };
+  const x = Number(input.x);
+  const y = Number(input.y);
+  if (!Number.isFinite(x) || x < 0 || !Number.isFinite(y) || y < 0) {
+    throw new Error("Browser click coordinates must be non-negative finite numbers.");
+  }
+  return { type: "click", x, y };
 }
 
 function browserLocation(step: ChatStep): string {

--- a/src/react-workbench/chat/TinyOsSideRays.tsx
+++ b/src/react-workbench/chat/TinyOsSideRays.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef } from "react";
+import { Mesh, Program, Renderer, Triangle } from "ogl";
+
+const VERTEX_SHADER = `
+attribute vec2 position;
+
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+`;
+
+const FRAGMENT_SHADER = `
+precision highp float;
+
+uniform float iTime;
+uniform vec2 iResolution;
+uniform vec3 iRayColor1;
+uniform vec3 iRayColor2;
+uniform float iSpeed;
+uniform float iIntensity;
+uniform float iSpread;
+uniform float iTilt;
+uniform float iSaturation;
+uniform float iBlend;
+uniform float iFalloff;
+uniform float iOpacity;
+
+float rayStrength(vec2 source, vec2 direction, vec2 coord, float seedA, float seedB, float speed) {
+  vec2 sourceToCoord = coord - source;
+  float cosAngle = dot(normalize(sourceToCoord), direction);
+  float movement =
+    (0.42 + 0.23 * sin(cosAngle * seedA + iTime * speed)) +
+    (0.28 + 0.28 * cos(-cosAngle * seedB + iTime * speed));
+
+  return clamp(movement, 0.0, 1.0) *
+    clamp((iResolution.x - length(sourceToCoord)) / iResolution.x, 0.5, 1.0);
+}
+
+void main() {
+  vec2 fragCoord = gl_FragCoord.xy;
+  vec2 coord = vec2(fragCoord.x, iResolution.y - fragCoord.y);
+  vec2 rayPosition = vec2(iResolution.x * 1.1, -0.5 * iResolution.y);
+  vec2 relativeCoord = coord - rayPosition;
+  float tilt = iTilt * 3.14159265 / 180.0;
+  vec2 tiltedCoord = vec2(
+    relativeCoord.x * cos(tilt) - relativeCoord.y * sin(tilt),
+    relativeCoord.x * sin(tilt) + relativeCoord.y * cos(tilt)
+  ) + rayPosition;
+  float halfSpread = iSpread * 0.275;
+  vec2 direction1 = normalize(vec2(cos(0.785398 + halfSpread), sin(0.785398 + halfSpread)));
+  vec2 direction2 = normalize(vec2(cos(0.785398 - halfSpread), sin(0.785398 - halfSpread)));
+  float cyanShift = 0.17 + 0.09 * sin(iTime * 0.31);
+  float violetShift = 0.14 + 0.08 * cos(iTime * 0.24);
+  vec3 cyanColor = mix(iRayColor1, vec3(0.376, 0.647, 0.980), cyanShift);
+  vec3 violetColor = mix(iRayColor2, vec3(0.957, 0.447, 0.714), violetShift);
+  vec4 ray1 = vec4(cyanColor, 1.0) * rayStrength(rayPosition, direction1, tiltedCoord, 36.2214, 21.11349, iSpeed);
+  vec4 ray2 = vec4(violetColor, 1.0) * rayStrength(rayPosition, direction2, tiltedCoord, 22.3991, 18.0234, iSpeed * 0.2);
+  vec4 color = ray1 * (1.0 - iBlend) * 0.9 + ray2 * iBlend * 0.9;
+  float distanceToLight = length(fragCoord - vec2(rayPosition.x, iResolution.y - rayPosition.y)) / iResolution.y;
+  float brightness = iIntensity * 0.4 / pow(max(distanceToLight, 0.001), iFalloff);
+
+  color.rgb *= brightness;
+  float gray = dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  color.rgb = mix(vec3(gray), color.rgb, iSaturation);
+  color.a = max(color.r, max(color.g, color.b)) * iOpacity;
+  gl_FragColor = color;
+}
+`;
+
+export function TinyOsSideRays() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof window.WebGLRenderingContext === "undefined") return;
+
+    let renderer: Renderer;
+    try {
+      renderer = new Renderer({
+        alpha: true,
+        antialias: false,
+        dpr: Math.min(window.devicePixelRatio, 1.5),
+      });
+    } catch (error) {
+      console.warn("TinyOS Side Rays could not initialize WebGL; the static background will remain active.", error);
+      return;
+    }
+
+    const { gl } = renderer;
+    const canvas = gl.canvas as HTMLCanvasElement;
+    canvas.setAttribute("aria-hidden", "true");
+    canvas.style.height = "100%";
+    canvas.style.width = "100%";
+    container.appendChild(canvas);
+
+    const uniforms = {
+      iTime: { value: 0 },
+      iResolution: { value: [1, 1] },
+      iRayColor1: { value: [94 / 255, 234 / 255, 212 / 255] },
+      iRayColor2: { value: [167 / 255, 139 / 255, 250 / 255] },
+      iSpeed: { value: 2 },
+      iIntensity: { value: 1.7 },
+      iSpread: { value: 2 },
+      iTilt: { value: 0 },
+      iSaturation: { value: 1.4 },
+      iBlend: { value: .7 },
+      iFalloff: { value: 1.6 },
+      iOpacity: { value: .85 },
+    };
+    const geometry = new Triangle(gl);
+    const program = new Program(gl, {
+      fragment: FRAGMENT_SHADER,
+      uniforms,
+      vertex: VERTEX_SHADER,
+    });
+    const mesh = new Mesh(gl, { geometry, program });
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    let animationFrame = 0;
+    let running = false;
+
+    const draw = (time = 0) => {
+      uniforms.iTime.value = time * .001;
+      renderer.render({ scene: mesh });
+    };
+    const renderFrame = (time: number) => {
+      if (!running) return;
+      draw(time);
+      animationFrame = window.requestAnimationFrame(renderFrame);
+    };
+    const start = () => {
+      if (reducedMotion || running || document.hidden) return;
+      running = true;
+      animationFrame = window.requestAnimationFrame(renderFrame);
+    };
+    const stop = () => {
+      running = false;
+      if (animationFrame) window.cancelAnimationFrame(animationFrame);
+      animationFrame = 0;
+    };
+    const updateSize = () => {
+      const width = Math.max(1, container.clientWidth);
+      const height = Math.max(1, container.clientHeight);
+      renderer.dpr = Math.min(window.devicePixelRatio, 1.5);
+      renderer.setSize(width, height);
+      uniforms.iResolution.value = [width * renderer.dpr, height * renderer.dpr];
+      draw();
+    };
+    const handleVisibilityChange = () => {
+      if (document.hidden) stop();
+      else start();
+    };
+    const visibilityObserver = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) start();
+      else stop();
+    }, { threshold: .05 });
+    const resizeObserver = new ResizeObserver(updateSize);
+
+    updateSize();
+    visibilityObserver.observe(container);
+    resizeObserver.observe(container);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      resizeObserver.disconnect();
+      visibilityObserver.disconnect();
+      geometry.remove();
+      program.remove();
+      const loseContext = gl.getExtension("WEBGL_lose_context");
+      loseContext?.loseContext();
+      canvas.remove();
+    };
+  }, []);
+
+  return <div aria-hidden="true" className="tinyos-desktop__side-rays" ref={containerRef} />;
+}

--- a/src/react-workbench/chat/TinyOsSystemMonitor.test.tsx
+++ b/src/react-workbench/chat/TinyOsSystemMonitor.test.tsx
@@ -39,6 +39,7 @@ function snapshot(): TinyOsKernelSnapshot {
     title: "Review tests",
   });
   return {
+    browserSessions: [],
     capabilities: [],
     cursor: { eventCount: 4, eventIndex: 3, mode: "live" },
     discrepancies: [],

--- a/src/react-workbench/chat/TinyOsSystemMonitor.test.tsx
+++ b/src/react-workbench/chat/TinyOsSystemMonitor.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { TinyOsKernelSnapshot, TinyOsProcess } from "../../app-core/chat/tinyOsKernelModel";
+import { TinyOsSystemMonitor, tinyOsSystemMonitorRows, type TinyOsSystemMonitorControls } from "./TinyOsSystemMonitor";
+
+afterEach(cleanup);
+
+function process(overrides: Partial<TinyOsProcess> & Pick<TinyOsProcess, "id" | "kind" | "state" | "title">): TinyOsProcess {
+  return {
+    correlation: { runId: "run-1", sessionId: "session-1", turnId: "turn-1" },
+    provenance: { kind: "canonical_event", revision: 1, sourceId: overrides.id },
+    ...overrides,
+  };
+}
+
+function snapshot(): TinyOsKernelSnapshot {
+  const run = process({ id: "run", kind: "agent_run", state: "running", title: "Agent run run-1" });
+  const turn = process({ id: "turn", kind: "agent_turn", parentProcessId: run.id, state: "running", title: "Agent turn turn-1" });
+  const tool = process({
+    applicationId: "terminal",
+    correlation: { itemId: "tool-1", runId: "run-1", sessionId: "session-1", toolCallId: "call-1", turnId: "turn-1" },
+    id: "tool",
+    kind: "tool_operation",
+    parentProcessId: turn.id,
+    provenance: { kind: "canonical_event", observedAt: "2026-07-14T00:00:00Z", revision: 2, sourceId: "tool-1" },
+    state: "running",
+    title: "Run tests",
+  });
+  const failed = process({
+    id: "failed",
+    kind: "subagent",
+    ownerAgentId: "agent-child",
+    parentProcessId: turn.id,
+    state: "failed",
+    title: "Review tests",
+  });
+  return {
+    capabilities: [],
+    cursor: { eventCount: 4, eventIndex: 3, mode: "live" },
+    discrepancies: [],
+    metrics: [],
+    notifications: [],
+    processes: [run, turn, tool, failed],
+    resources: [{
+      access: "execute",
+      id: "terminal-resource",
+      kind: "terminal_execution",
+      provenance: { kind: "canonical_event", revision: 2, sourceId: "tool-1" },
+      relatedProcessIds: [tool.id],
+      title: "npm test",
+    }],
+    truth: "derived",
+  };
+}
+
+function controls(overrides: Partial<TinyOsSystemMonitorControls> = {}): TinyOsSystemMonitorControls {
+  return {
+    activeRunId: "run-1",
+    canCancelRun: true,
+    canPauseRun: true,
+    canResumeRun: false,
+    canRetryRun: false,
+    commandLifecycle: { stage: "idle" },
+    history: false,
+    inspectableItemIds: ["tool-1"],
+    onCancelRun: vi.fn(),
+    onInspect: vi.fn(),
+    onPauseRun: vi.fn(),
+    onResumeRun: vi.fn(),
+    onRetry: vi.fn(),
+    onReveal: vi.fn(),
+    resumeUnavailableReason: "The backend reports that this run is not paused.",
+    revealableApplicationIds: ["terminal"],
+    ...overrides,
+  };
+}
+
+describe("TinyOS System Monitor", () => {
+  it("renders a process tree and truthful process details", async () => {
+    const user = userEvent.setup();
+    render(<TinyOsSystemMonitor snapshot={snapshot()} />);
+
+    expect(screen.getByText("Processes").previousSibling?.textContent).toBe("4");
+    await user.click(screen.getByRole("button", { name: /Run tests/ }));
+    const details = screen.getByRole("complementary", { name: "Process details" });
+    expect(within(details).getAllByText("tool-1")).toHaveLength(2);
+    expect(within(details).getByText("Terminal")).toBeTruthy();
+    expect(within(details).getByText("npm test")).toBeTruthy();
+    expect(within(details).getByText(/Runtime metrics unavailable/)).toBeTruthy();
+    expect(within(details).getByText(/does not estimate CPU/)).toBeTruthy();
+  });
+
+  it("filters by lifecycle, Agent, run, turn, and application", async () => {
+    const user = userEvent.setup();
+    render(<TinyOsSystemMonitor snapshot={snapshot()} />);
+
+    await user.click(screen.getByRole("button", { name: "List" }));
+    await user.selectOptions(screen.getByRole("combobox", { name: "Filter by state" }), "failed");
+    expect(screen.getByRole("button", { name: /Review tests/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Run tests/ })).toBeNull();
+    await user.selectOptions(screen.getByRole("combobox", { name: "Filter by Agent" }), "agent-child");
+    await user.type(screen.getByRole("searchbox", { name: "Search processes" }), "review");
+    expect(screen.getByRole("button", { name: /Review tests/ })).toBeTruthy();
+  });
+
+  it("keeps source-backed ancestors in filtered tree view", () => {
+    const processes = snapshot().processes;
+    const rows = tinyOsSystemMonitorRows(processes, {
+      agentId: "agent-child",
+      applicationId: "",
+      query: "",
+      runId: "run-1",
+      state: "failed",
+      turnId: "turn-1",
+    }, "tree");
+
+    expect(rows.map((row) => [row.process.id, row.depth])).toEqual([
+      ["run", 0],
+      ["turn", 1],
+      ["failed", 2],
+    ]);
+  });
+
+  it("routes only target-safe controls and exposes backend unavailability", async () => {
+    const user = userEvent.setup();
+    const monitorControls = controls();
+    render(<TinyOsSystemMonitor controls={monitorControls} snapshot={snapshot()} />);
+
+    await user.click(screen.getByRole("button", { name: "Pause run" }));
+    expect(monitorControls.onPauseRun).toHaveBeenCalledTimes(1);
+    const resume = screen.getByRole("button", { name: "Resume run" }) as HTMLButtonElement;
+    expect(resume.disabled).toBe(true);
+    expect(resume.title).toBe("The backend reports that this run is not paused.");
+
+    await user.click(screen.getByRole("button", { name: /Run tests/ }));
+    await user.click(screen.getByRole("button", { name: "Reveal app" }));
+    await user.click(screen.getByRole("button", { name: "Inspect evidence" }));
+    expect(monitorControls.onReveal).toHaveBeenCalledWith(expect.objectContaining({ id: "tool" }));
+    expect(monitorControls.onInspect).toHaveBeenCalledWith(expect.objectContaining({ id: "tool" }));
+  });
+
+  it("keeps acknowledgement timeout visible and correlated to the selected run", () => {
+    render(<TinyOsSystemMonitor controls={controls({
+      commandLifecycle: {
+        command: {
+          schemaVersion: "tinybot.command.v1",
+          commandId: "command-1",
+          issuedAt: "2026-07-14T00:00:00Z",
+          kind: "agent.pause",
+          source: { control: "system-monitor", surface: "tinyos" },
+          target: { runId: "run-1", sessionId: "session-1" },
+        },
+        dispatchedAtMs: 1,
+        error: "No canonical acknowledgement within 5000 ms",
+        stage: "timed_out",
+      },
+    })} snapshot={snapshot()} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Acknowledgement timed out");
+    expect(alert.textContent).toContain("No canonical acknowledgement within 5000 ms");
+  });
+});

--- a/src/react-workbench/chat/TinyOsSystemMonitor.tsx
+++ b/src/react-workbench/chat/TinyOsSystemMonitor.tsx
@@ -6,6 +6,7 @@ import type {
   TinyOsKernelSnapshot,
   TinyOsProcess,
   TinyOsProcessState,
+  TinyOsResource,
 } from "../../app-core/chat/tinyOsKernelModel";
 
 type TinyOsSystemMonitorFilters = {
@@ -34,6 +35,8 @@ export type TinyOsSystemMonitorControls = {
   inspectableItemIds: readonly string[];
   onCancelRun: () => void;
   onInspect: (process: TinyOsProcess) => void;
+  onOpenProcessMenu?: (process: TinyOsProcess, clientX: number, clientY: number) => void;
+  onOpenResourceMenu?: (resource: TinyOsResource, clientX: number, clientY: number) => void;
   onPauseRun: () => void;
   onResumeRun: () => void;
   onRetry: (process: TinyOsProcess) => void;
@@ -149,6 +152,11 @@ export function TinyOsSystemMonitor({ controls, snapshot }: { controls?: TinyOsS
                     data-selected={selected?.id === process.id ? "true" : undefined}
                     type="button"
                     onClick={() => setSelectedProcessId(process.id)}
+                    onContextMenu={(event) => {
+                      if (!controls?.onOpenProcessMenu) return;
+                      event.preventDefault();
+                      controls.onOpenProcessMenu(process, event.clientX, event.clientY);
+                    }}
                   >
                     <span className="tinyos-process-list__identity">
                       <Activity aria-hidden="true" size={13} />
@@ -193,7 +201,11 @@ export function TinyOsSystemMonitor({ controls, snapshot }: { controls?: TinyOsS
                 <small>Revision {selected.provenance.revision ?? "unavailable"} · Observed {selected.provenance.observedAt || "time unavailable"}</small>
               </DetailSection>
               <DetailSection title={`Resources · ${relatedResources.length}`}>
-                {relatedResources.length ? relatedResources.map((resource) => <p key={resource.id}><span><strong>{resource.title}</strong><small>{formatLabel(resource.kind)} · revision {resource.revision ?? "unavailable"}</small></span></p>) : <small>No related resource observation.</small>}
+                {relatedResources.length ? relatedResources.map((resource) => <p key={resource.id} onContextMenu={(event) => {
+                  if (!controls?.onOpenResourceMenu) return;
+                  event.preventDefault();
+                  controls.onOpenResourceMenu(resource, event.clientX, event.clientY);
+                }}><span><strong>{resource.title}</strong><small>{formatLabel(resource.kind)} · revision {resource.revision ?? "unavailable"}</small></span></p>) : <small>No related resource observation.</small>}
               </DetailSection>
               <DetailSection title={`Capabilities · ${relatedCapabilities.length}`}>
                 {relatedCapabilities.length ? relatedCapabilities.map((capability) => <p key={capability.id}><span><strong>{capability.id}</strong><small>{capability.available ? "Available" : capability.reason || "Unavailable"}</small></span></p>) : <small>No backend capability observation is correlated to this process.</small>}

--- a/src/react-workbench/chat/TinyOsSystemMonitor.tsx
+++ b/src/react-workbench/chat/TinyOsSystemMonitor.tsx
@@ -1,0 +1,345 @@
+import { Activity, Eye, GitBranch, Info, List, Pause, Play, RotateCcw, Search, ShieldCheck, StopCircle } from "lucide-react";
+import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+
+import { isTinyOsCommandInFlight, type TinyOsCommandLifecycle } from "../../app-core/chat/tinyOsCommandGateway";
+import type {
+  TinyOsKernelSnapshot,
+  TinyOsProcess,
+  TinyOsProcessState,
+} from "../../app-core/chat/tinyOsKernelModel";
+
+type TinyOsSystemMonitorFilters = {
+  agentId: string;
+  applicationId: string;
+  query: string;
+  runId: string;
+  state: string;
+  turnId: string;
+};
+
+export type TinyOsProcessRow = {
+  depth: number;
+  process: TinyOsProcess;
+};
+
+export type TinyOsSystemMonitorControls = {
+  activeRunId?: string;
+  canCancelRun: boolean;
+  canPauseRun: boolean;
+  canResumeRun: boolean;
+  canRetryRun: boolean;
+  cancelUnavailableReason?: string;
+  commandLifecycle: TinyOsCommandLifecycle;
+  history: boolean;
+  inspectableItemIds: readonly string[];
+  onCancelRun: () => void;
+  onInspect: (process: TinyOsProcess) => void;
+  onPauseRun: () => void;
+  onResumeRun: () => void;
+  onRetry: (process: TinyOsProcess) => void;
+  onReveal: (process: TinyOsProcess) => void;
+  pauseUnavailableReason?: string;
+  resumeUnavailableReason?: string;
+  retryRunId?: string;
+  retryUnavailableReason?: string;
+  revealableApplicationIds: readonly string[];
+};
+
+const EMPTY_FILTERS: TinyOsSystemMonitorFilters = {
+  agentId: "",
+  applicationId: "",
+  query: "",
+  runId: "",
+  state: "",
+  turnId: "",
+};
+
+const ATTENTION_STATES = new Set<TinyOsProcessState>(["waiting_for_user", "blocked", "failed", "cancelled"]);
+
+export function TinyOsSystemMonitor({ controls, snapshot }: { controls?: TinyOsSystemMonitorControls; snapshot: TinyOsKernelSnapshot }) {
+  const [filters, setFilters] = useState(EMPTY_FILTERS);
+  const [view, setView] = useState<"list" | "tree">("tree");
+  const rows = useMemo(
+    () => tinyOsSystemMonitorRows(snapshot.processes, filters, view),
+    [filters, snapshot.processes, view],
+  );
+  const [selectedProcessId, setSelectedProcessId] = useState(() => rows[0]?.process.id ?? "");
+  const selected = snapshot.processes.find((process) => process.id === selectedProcessId) ?? rows[0]?.process;
+  const relatedResources = selected
+    ? snapshot.resources.filter((resource) => resource.relatedProcessIds.includes(selected.id))
+    : [];
+  const relatedMetrics = selected
+    ? snapshot.metrics.filter((metric) => metric.processId === selected.id || relatedResources.some((resource) => resource.id === metric.resourceId))
+    : [];
+  const relatedCapabilities = selected
+    ? snapshot.capabilities.filter((capability) => !capability.processId || capability.processId === selected.id)
+    : [];
+  const relatedDiscrepancies = selected
+    ? snapshot.discrepancies.filter((entry) => entry.canonical.entityId === selected.id || entry.native.entityId === selected.id)
+    : [];
+  const commandLifecycle = controls?.commandLifecycle;
+  const commandTargetsSelectedRun = Boolean(
+    selected
+    && commandLifecycle
+    && commandLifecycle.stage !== "idle"
+    && commandLifecycle.command.target.runId === selected.correlation.runId,
+  );
+  const activeCount = snapshot.processes.filter((process) => ["queued", "running", "waiting_for_user", "blocked", "paused"].includes(process.state)).length;
+  const attentionCount = snapshot.processes.filter((process) => ATTENTION_STATES.has(process.state)).length + snapshot.discrepancies.length;
+  const sourceCount = new Set(snapshot.processes.map((process) => `${process.provenance.kind}:${process.provenance.sourceId}`)).size;
+
+  useEffect(() => {
+    if (selected && rows.some((row) => row.process.id === selected.id)) return;
+    setSelectedProcessId(rows[0]?.process.id ?? "");
+  }, [rows, selected]);
+
+  const options = useMemo(() => ({
+    agents: uniqueValues(snapshot.processes.map((process) => process.ownerAgentId || "__unattributed__")),
+    applications: uniqueValues(snapshot.processes.map((process) => process.applicationId || "__unattributed__")),
+    runs: uniqueValues(snapshot.processes.map((process) => process.correlation.runId)),
+    states: uniqueValues(snapshot.processes.map((process) => process.state)),
+    turns: uniqueValues(snapshot.processes.map((process) => process.correlation.turnId).filter(Boolean) as string[]),
+  }), [snapshot.processes]);
+
+  function updateFilter(key: keyof TinyOsSystemMonitorFilters, value: string) {
+    setFilters((current) => ({ ...current, [key]: value }));
+  }
+
+  return (
+    <section className="tinyos-system-monitor">
+      <header className="tinyos-system-monitor__summary">
+        <SummaryStat label="Processes" value={snapshot.processes.length} />
+        <SummaryStat label="Active" value={activeCount} />
+        <SummaryStat attention={attentionCount > 0} label="Attention" value={attentionCount} />
+        <SummaryStat label="Evidence sources" value={sourceCount} />
+      </header>
+
+      <div className="tinyos-system-monitor__toolbar">
+        <label className="tinyos-system-monitor__search">
+          <Search aria-hidden="true" size={13} />
+          <span className="sr-only">Search processes</span>
+          <input
+            aria-label="Search processes"
+            placeholder="Search process or identity"
+            type="search"
+            value={filters.query}
+            onChange={(event) => updateFilter("query", event.currentTarget.value)}
+          />
+        </label>
+        <div aria-label="Process view" className="tinyos-system-monitor__view" role="group">
+          <button aria-pressed={view === "tree"} title="Process tree" type="button" onClick={() => setView("tree")}><GitBranch aria-hidden="true" size={13} />Tree</button>
+          <button aria-pressed={view === "list"} title="Process list" type="button" onClick={() => setView("list")}><List aria-hidden="true" size={13} />List</button>
+        </div>
+        <MonitorSelect ariaLabel="Filter by state" value={filters.state} values={options.states} onChange={(value) => updateFilter("state", value)} />
+        <MonitorSelect ariaLabel="Filter by Agent" format={formatAgent} value={filters.agentId} values={options.agents} onChange={(value) => updateFilter("agentId", value)} />
+        <MonitorSelect ariaLabel="Filter by run" value={filters.runId} values={options.runs} onChange={(value) => updateFilter("runId", value)} />
+        <MonitorSelect ariaLabel="Filter by turn" value={filters.turnId} values={options.turns} onChange={(value) => updateFilter("turnId", value)} />
+        <MonitorSelect ariaLabel="Filter by application" format={formatApplication} value={filters.applicationId} values={options.applications} onChange={(value) => updateFilter("applicationId", value)} />
+      </div>
+
+      <div className="tinyos-system-monitor__body">
+        <div className="tinyos-process-list" role="region" aria-label="TinyOS processes">
+          <div aria-hidden="true" className="tinyos-process-list__head"><span>Process</span><span>State</span><span>Source</span></div>
+          {rows.length ? (
+            <ol>
+              {rows.map(({ depth, process }) => (
+                <li key={process.id} style={{ "--tinyos-process-depth": depth } as CSSProperties}>
+                  <button
+                    aria-pressed={selected?.id === process.id}
+                    data-selected={selected?.id === process.id ? "true" : undefined}
+                    type="button"
+                    onClick={() => setSelectedProcessId(process.id)}
+                  >
+                    <span className="tinyos-process-list__identity">
+                      <Activity aria-hidden="true" size={13} />
+                      <span><strong>{process.title}</strong><code>{shortId(process.id)}</code></span>
+                    </span>
+                    <span className="tinyos-process-state" data-state={process.state}>{formatLabel(process.state)}</span>
+                    <span className="tinyos-process-list__source">{formatLabel(process.provenance.kind)}</span>
+                  </button>
+                </li>
+              ))}
+            </ol>
+          ) : <p className="tinyos-system-monitor__empty">No processes match the current filters.</p>}
+        </div>
+
+        <aside aria-label="Process details" className="tinyos-process-detail">
+          {selected ? (
+            <>
+              <header>
+                <span><Activity aria-hidden="true" size={14} /><strong>{selected.title}</strong></span>
+                <span className="tinyos-process-state" data-state={selected.state}>{formatLabel(selected.state)}</span>
+              </header>
+              <dl>
+                <Detail label="Process ID" value={selected.id} code />
+                <Detail label="Kind" value={formatLabel(selected.kind)} />
+                <Detail label="Agent" value={selected.ownerAgentId || "Unavailable in canonical data"} />
+                <Detail label="Run" value={selected.correlation.runId} code />
+                <Detail label="Turn" value={selected.correlation.turnId || "Unavailable"} code={Boolean(selected.correlation.turnId)} />
+                <Detail label="Item" value={selected.correlation.itemId || "Unavailable"} code={Boolean(selected.correlation.itemId)} />
+                <Detail label="Tool call" value={selected.correlation.toolCallId || "Unavailable"} code={Boolean(selected.correlation.toolCallId)} />
+                <Detail label="Related window" value={selected.applicationId ? formatApplication(selected.applicationId) : "Unavailable"} />
+              </dl>
+              {controls ? (
+                <ProcessActions
+                  controls={controls}
+                  pending={Boolean(commandTargetsSelectedRun && commandLifecycle && isTinyOsCommandInFlight(commandLifecycle))}
+                  process={selected}
+                />
+              ) : null}
+              {commandTargetsSelectedRun && commandLifecycle && commandLifecycle.stage !== "idle" ? <CommandState lifecycle={commandLifecycle} /> : null}
+              <DetailSection title="Provenance">
+                <p><ShieldCheck aria-hidden="true" size={13} /><span><strong>{formatLabel(selected.provenance.kind)}</strong><code>{selected.provenance.sourceId}</code></span></p>
+                <small>Revision {selected.provenance.revision ?? "unavailable"} · Observed {selected.provenance.observedAt || "time unavailable"}</small>
+              </DetailSection>
+              <DetailSection title={`Resources · ${relatedResources.length}`}>
+                {relatedResources.length ? relatedResources.map((resource) => <p key={resource.id}><span><strong>{resource.title}</strong><small>{formatLabel(resource.kind)} · revision {resource.revision ?? "unavailable"}</small></span></p>) : <small>No related resource observation.</small>}
+              </DetailSection>
+              <DetailSection title={`Capabilities · ${relatedCapabilities.length}`}>
+                {relatedCapabilities.length ? relatedCapabilities.map((capability) => <p key={capability.id}><span><strong>{capability.id}</strong><small>{capability.available ? "Available" : capability.reason || "Unavailable"}</small></span></p>) : <small>No backend capability observation is correlated to this process.</small>}
+              </DetailSection>
+              <DetailSection title={`Measurements · ${relatedMetrics.length}`}>
+                {relatedMetrics.length ? relatedMetrics.map((metric) => <p key={metric.id}><span><strong>{metric.label}</strong><small>{metric.value} {metric.unit || ""} · {formatLabel(metric.provenance.kind)}</small></span></p>) : <small>Runtime metrics unavailable. TinyOS does not estimate CPU, memory, disk, or network usage.</small>}
+              </DetailSection>
+              {relatedDiscrepancies.length ? <DetailSection title={`Discrepancies · ${relatedDiscrepancies.length}`}>{relatedDiscrepancies.map((entry) => <p className="tinyos-process-detail__warning" key={entry.id}><span><strong>{formatLabel(entry.kind)}</strong><small>{entry.message}</small></span></p>)}</DetailSection> : null}
+            </>
+          ) : <p className="tinyos-system-monitor__empty">Select a process to inspect its evidence.</p>}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function ProcessActions({ controls, pending, process }: { controls: TinyOsSystemMonitorControls; pending: boolean; process: TinyOsProcess }) {
+  const targetsActiveRun = process.correlation.runId === controls.activeRunId;
+  const targetsRetryRun = process.correlation.runId === controls.retryRunId;
+  const inspectable = Boolean(process.correlation.itemId && controls.inspectableItemIds.includes(process.correlation.itemId));
+  const revealable = Boolean(process.applicationId && controls.revealableApplicationIds.includes(process.applicationId));
+  const historyReason = controls.history ? "History snapshots are read-only." : undefined;
+  const targetReason = targetsActiveRun ? undefined : "This process is not part of the backend-selected active run.";
+  const retryTargetReason = targetsRetryRun
+    ? process.correlation.itemId ? undefined : "Retry requires a correlated canonical item."
+    : "This process is not part of the backend-selected retry run.";
+  return (
+    <section aria-label="Process controls" className="tinyos-process-actions">
+      <h4>Controls</h4>
+      <div>
+        <ProcessAction available={!pending && !historyReason && !targetReason && controls.canPauseRun} icon={<Pause aria-hidden="true" size={12} />} label="Pause run" reason={pending ? "A command is awaiting runtime confirmation." : historyReason || targetReason || controls.pauseUnavailableReason} onClick={controls.onPauseRun} />
+        <ProcessAction available={!pending && !historyReason && !targetReason && controls.canResumeRun} icon={<Play aria-hidden="true" size={12} />} label="Resume run" reason={pending ? "A command is awaiting runtime confirmation." : historyReason || targetReason || controls.resumeUnavailableReason} onClick={controls.onResumeRun} />
+        <ProcessAction available={!pending && !historyReason && !targetReason && controls.canCancelRun} icon={<StopCircle aria-hidden="true" size={12} />} label="Cancel run" reason={pending ? "A command is awaiting runtime confirmation." : historyReason || targetReason || controls.cancelUnavailableReason} onClick={controls.onCancelRun} />
+        <ProcessAction available={!pending && !historyReason && !retryTargetReason && inspectable && controls.canRetryRun} icon={<RotateCcw aria-hidden="true" size={12} />} label="Retry operation" reason={pending ? "A command is awaiting runtime confirmation." : historyReason || retryTargetReason || (!inspectable ? "The canonical operation is unavailable in this view." : controls.retryUnavailableReason)} onClick={() => controls.onRetry(process)} />
+        <ProcessAction available={revealable} icon={<Eye aria-hidden="true" size={12} />} label="Reveal app" reason={revealable ? undefined : "No related TinyOS application is available."} onClick={() => controls.onReveal(process)} />
+        <ProcessAction available={inspectable} icon={<Info aria-hidden="true" size={12} />} label="Inspect evidence" reason={inspectable ? undefined : "No correlated canonical item is available to inspect."} onClick={() => controls.onInspect(process)} />
+      </div>
+    </section>
+  );
+}
+
+function ProcessAction({ available, icon, label, onClick, reason }: { available: boolean; icon: ReactNode; label: string; onClick: () => void; reason?: string }) {
+  return <button disabled={!available} title={available ? label : reason || `${label} is unavailable.`} type="button" onClick={onClick}>{icon}<span>{label}</span></button>;
+}
+
+function CommandState({ lifecycle }: { lifecycle: Exclude<TinyOsCommandLifecycle, { stage: "idle" }> }) {
+  const kind = formatLabel(lifecycle.command.kind);
+  if (lifecycle.stage === "timed_out") return <p className="tinyos-process-command-state" data-state="error" role="alert"><strong>Acknowledgement timed out</strong><span>{kind} · {lifecycle.error}</span></p>;
+  if (lifecycle.stage === "rejected") return <p className="tinyos-process-command-state" data-state="error" role="alert"><strong>Command rejected</strong><span>{kind} · {lifecycle.error}</span></p>;
+  if (lifecycle.stage === "completed") return <p className="tinyos-process-command-state" data-state={lifecycle.completion.status === "completed" ? "success" : "error"} role="status"><strong>{formatLabel(lifecycle.completion.status)}</strong><span>{kind} · canonical item {lifecycle.completion.itemId}</span></p>;
+  if (lifecycle.stage === "acknowledged") return <p className="tinyos-process-command-state" role="status"><strong>Command acknowledged</strong><span>{kind} · waiting for completion</span></p>;
+  return <p className="tinyos-process-command-state" role="status"><strong>Awaiting runtime confirmation</strong><span>{kind}</span></p>;
+}
+
+export function tinyOsSystemMonitorRows(
+  processes: readonly TinyOsProcess[],
+  filters: TinyOsSystemMonitorFilters,
+  view: "list" | "tree",
+): TinyOsProcessRow[] {
+  const byId = new Map(processes.map((process) => [process.id, process]));
+  const matchingIds = new Set(processes.filter((process) => processMatches(process, filters)).map((process) => process.id));
+  if (view === "list") return processes.filter((process) => matchingIds.has(process.id)).map((process) => ({ depth: 0, process }));
+  const includedIds = new Set(matchingIds);
+  for (const id of matchingIds) {
+    let parentId = byId.get(id)?.parentProcessId;
+    const ancestry = new Set<string>();
+    while (parentId && !ancestry.has(parentId)) {
+      ancestry.add(parentId);
+      includedIds.add(parentId);
+      parentId = byId.get(parentId)?.parentProcessId;
+    }
+  }
+  const children = new Map<string, TinyOsProcess[]>();
+  for (const process of processes) {
+    if (!includedIds.has(process.id) || !process.parentProcessId || !includedIds.has(process.parentProcessId)) continue;
+    children.set(process.parentProcessId, [...(children.get(process.parentProcessId) ?? []), process]);
+  }
+  const rows: TinyOsProcessRow[] = [];
+  const visited = new Set<string>();
+  function visit(process: TinyOsProcess, depth: number) {
+    if (visited.has(process.id)) return;
+    visited.add(process.id);
+    rows.push({ depth, process });
+    for (const child of children.get(process.id) ?? []) visit(child, depth + 1);
+  }
+  for (const process of processes) {
+    if (!includedIds.has(process.id) || process.parentProcessId && includedIds.has(process.parentProcessId)) continue;
+    visit(process, 0);
+  }
+  for (const process of processes) if (includedIds.has(process.id)) visit(process, 0);
+  return rows;
+}
+
+function processMatches(process: TinyOsProcess, filters: TinyOsSystemMonitorFilters): boolean {
+  const query = filters.query.trim().toLowerCase();
+  return (!filters.state || process.state === filters.state)
+    && (!filters.agentId || (process.ownerAgentId || "__unattributed__") === filters.agentId)
+    && (!filters.applicationId || (process.applicationId || "__unattributed__") === filters.applicationId)
+    && (!filters.runId || process.correlation.runId === filters.runId)
+    && (!filters.turnId || process.correlation.turnId === filters.turnId)
+    && (!query || [
+      process.id,
+      process.title,
+      process.kind,
+      process.state,
+      process.ownerAgentId,
+      process.applicationId,
+      process.correlation.runId,
+      process.correlation.turnId,
+      process.correlation.itemId,
+      process.correlation.toolCallId,
+    ].some((value) => value?.toLowerCase().includes(query)));
+}
+
+function SummaryStat({ attention = false, label, value }: { attention?: boolean; label: string; value: number }) {
+  return <span data-attention={attention ? "true" : undefined}><strong>{value}</strong><small>{label}</small></span>;
+}
+
+function MonitorSelect({ ariaLabel, format = formatLabel, onChange, value, values }: { ariaLabel: string; format?: (value: string) => string; onChange: (value: string) => void; value: string; values: string[] }) {
+  return <select aria-label={ariaLabel} value={value} onChange={(event) => onChange(event.currentTarget.value)}><option value="">{ariaLabel.replace("Filter by ", "All ")}</option>{values.map((option) => <option key={option} value={option}>{format(option)}</option>)}</select>;
+}
+
+function Detail({ code = false, label, value }: { code?: boolean; label: string; value: string }) {
+  return <><dt>{label}</dt><dd>{code ? <code>{value}</code> : value}</dd></>;
+}
+
+function DetailSection({ children, title }: { children: ReactNode; title: string }) {
+  return <section><h4>{title}</h4>{children}</section>;
+}
+
+function uniqueValues(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function formatAgent(value: string): string {
+  return value === "__unattributed__" ? "Unattributed Agent" : value;
+}
+
+function formatApplication(value: string): string {
+  return value === "__unattributed__" ? "Unrelated application" : formatLabel(value);
+}
+
+function formatLabel(value: string): string {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function shortId(value: string): string {
+  return value.length <= 36 ? value : `…${value.slice(-35)}`;
+}

--- a/src/react-workbench/chat/TinyOsTimeMachine.test.tsx
+++ b/src/react-workbench/chat/TinyOsTimeMachine.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import { useState } from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BackendAgentTurnItem } from "../../app-core/chat/chatRunModel";
+import { createTinyOsTimeMachineIndex } from "../../app-core/chat/tinyOsTimeMachine";
+import { TinyOsTimeMachine } from "./TinyOsTimeMachine";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function item(eventIndex: number, overrides: Partial<BackendAgentTurnItem> = {}): BackendAgentTurnItem {
+  return {
+    schemaVersion: "tinybot.turn_item.v2",
+    createdAt: `2026-07-14T00:00:0${eventIndex}Z`,
+    data: {
+      args: {},
+      name: "workspace.read_file",
+      result: {},
+      status: "completed",
+      timing: {},
+      toolCallId: `call-${eventIndex}`,
+      type: "tool_call",
+    },
+    itemId: `item-${eventIndex}`,
+    kind: "tool_call",
+    revision: 1,
+    runId: "run-1",
+    sequence: eventIndex,
+    sessionId: "session-1",
+    status: "completed",
+    title: `Event ${eventIndex + 1}`,
+    turnId: eventIndex < 2 ? "turn-1" : "turn-2",
+    ...overrides,
+  };
+}
+
+describe("TinyOS Time Machine", () => {
+  it("always allows an empty historical view to return to Live", () => {
+    const onReturnToLive = vi.fn();
+    render(<TinyOsTimeMachine currentEventIndex={0} index={createTinyOsTimeMachineIndex([])} live={false} onReturnToLive={onReturnToLive} onSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to Live" }));
+    expect(onReturnToLive).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes native keyboard scrubbing, event groups, and unavailable wall-clock state", () => {
+    const index = createTinyOsTimeMachineIndex([item(0, { createdAt: "invalid" }), item(1), item(2)]);
+    const onSelect = vi.fn();
+    render(<TinyOsTimeMachine currentEventIndex={0} index={index} live={false} onReturnToLive={vi.fn()} onSelect={onSelect} />);
+
+    const scrubber = screen.getByRole("slider", { name: "Canonical event boundary" });
+    expect(scrubber.getAttribute("type")).toBe("range");
+    expect(screen.getByText("Wall-clock time unavailable")).toBeTruthy();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+
+    fireEvent.change(scrubber, { target: { value: "1" } });
+    expect(onSelect).toHaveBeenCalledWith(index.boundaries[1]);
+    fireEvent.click(screen.getByRole("button", { name: /turn turn-2/i }));
+    expect(onSelect).toHaveBeenLastCalledWith(index.boundaries[2]);
+  });
+
+  it("plays locally at the selected speed and visits only canonical boundaries", () => {
+    vi.useFakeTimers();
+    const index = createTinyOsTimeMachineIndex([item(0), item(1), item(2)]);
+    const visited: number[] = [];
+
+    function Harness() {
+      const [currentEventIndex, setCurrentEventIndex] = useState(0);
+      return <TinyOsTimeMachine
+        currentEventIndex={currentEventIndex}
+        index={index}
+        live={false}
+        onReturnToLive={vi.fn()}
+        onSelect={(boundary) => {
+          visited.push(boundary.eventIndex);
+          setCurrentEventIndex(boundary.eventIndex);
+        }}
+      />;
+    }
+
+    render(<Harness />);
+    fireEvent.change(screen.getByRole("combobox", { name: "Replay speed" }), { target: { value: "4" } });
+    fireEvent.click(screen.getByRole("button", { name: "Play historical replay" }));
+    act(() => vi.advanceTimersByTime(200));
+    act(() => vi.advanceTimersByTime(200));
+
+    expect(visited).toEqual([1, 2]);
+    expect(screen.getByText("Event 3 of 3")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Play historical replay" }).hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/src/react-workbench/chat/TinyOsTimeMachine.tsx
+++ b/src/react-workbench/chat/TinyOsTimeMachine.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight, Pause, Play, RotateCcw } from "lucide-react";
+
+import type {
+  TinyOsTimeMachineBoundary,
+  TinyOsTimeMachineIndex,
+} from "../../app-core/chat/tinyOsTimeMachine";
+
+const REPLAY_SPEEDS = [0.5, 1, 2, 4] as const;
+
+export function TinyOsTimeMachine({
+  currentEventIndex,
+  index,
+  live,
+  onReturnToLive,
+  onSelect,
+}: {
+  currentEventIndex: number;
+  index: TinyOsTimeMachineIndex;
+  live: boolean;
+  onReturnToLive: () => void;
+  onSelect: (boundary: TinyOsTimeMachineBoundary) => void;
+}) {
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState<(typeof REPLAY_SPEEDS)[number]>(1);
+  const onSelectRef = useRef(onSelect);
+  const lastEventIndex = index.eventCount - 1;
+  const boundary = index.boundaries[currentEventIndex];
+  const previous = index.boundaries[currentEventIndex - 1];
+  const next = index.boundaries[currentEventIndex + 1];
+
+  useEffect(() => {
+    if (live || !playing) return;
+    if (!next) {
+      setPlaying(false);
+      return;
+    }
+    const timer = window.setTimeout(() => onSelectRef.current(next), 800 / speed);
+    return () => window.clearTimeout(timer);
+  }, [live, next, playing, speed]);
+
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+  }, [onSelect]);
+
+  useEffect(() => {
+    if (live) setPlaying(false);
+  }, [live]);
+
+  if (!index.eventCount) {
+    return (
+      <section aria-label="Time Machine" className="tinyos-time-machine" data-empty="true">
+        <strong>Time Machine</strong>
+        <span>No canonical event boundaries are available.</span>
+        {!live ? (
+          <div className="tinyos-time-machine__controls">
+            <button className="tinyos-time-machine__live" type="button" onClick={onReturnToLive}>
+              <RotateCcw aria-hidden="true" size={13} />Return to Live
+            </button>
+          </div>
+        ) : null}
+      </section>
+    );
+  }
+
+  function select(nextBoundary: TinyOsTimeMachineBoundary | undefined) {
+    if (!nextBoundary) return;
+    setPlaying(false);
+    onSelect(nextBoundary);
+  }
+
+  return (
+    <section aria-label="Time Machine" className="tinyos-time-machine" data-live={live ? "true" : undefined}>
+      <div className="tinyos-time-machine__heading">
+        <div>
+          <small>{live ? "Live boundary" : "Historical boundary"}</small>
+          <strong>Time Machine</strong>
+        </div>
+        <span aria-live="polite">
+          Event {currentEventIndex + 1} of {index.eventCount}
+        </span>
+      </div>
+
+      <div className="tinyos-time-machine__controls">
+        <button aria-label="Previous canonical event" disabled={!previous} type="button" onClick={() => select(previous)}>
+          <ChevronLeft aria-hidden="true" size={14} />
+        </button>
+        <button
+          aria-label={playing ? "Pause historical replay" : "Play historical replay"}
+          disabled={live || (!next && !playing)}
+          type="button"
+          onClick={() => setPlaying((current) => !current)}
+        >
+          {playing ? <Pause aria-hidden="true" size={13} /> : <Play aria-hidden="true" size={13} />}
+        </button>
+        <label>
+          <span>Canonical event boundary</span>
+          <input
+            aria-label="Canonical event boundary"
+            max={lastEventIndex}
+            min={0}
+            step={1}
+            type="range"
+            value={currentEventIndex}
+            onChange={(event) => select(index.boundaries[Number(event.currentTarget.value)])}
+          />
+        </label>
+        <button aria-label="Next canonical event" disabled={!next} type="button" onClick={() => select(next)}>
+          <ChevronRight aria-hidden="true" size={14} />
+        </button>
+        <label className="tinyos-time-machine__speed">
+          <span>Replay speed</span>
+          <select aria-label="Replay speed" value={speed} onChange={(event) => setSpeed(Number(event.currentTarget.value) as typeof speed)}>
+            {REPLAY_SPEEDS.map((value) => <option key={value} value={value}>{value}×</option>)}
+          </select>
+        </label>
+        {!live ? (
+          <button className="tinyos-time-machine__live" type="button" onClick={onReturnToLive}>
+            <RotateCcw aria-hidden="true" size={13} />Return to Live
+          </button>
+        ) : null}
+      </div>
+
+      <ul aria-label="Canonical event groups" className="tinyos-time-machine__groups">
+        {index.groups.map((group) => (
+          <li key={group.id}>
+            <button
+              aria-current={group.boundaryIndexes.includes(currentEventIndex) ? "true" : undefined}
+              type="button"
+              onClick={() => select(index.boundaries[group.firstEventIndex])}
+            >
+              <span>{group.label}</span><small>{group.boundaryIndexes.length} events</small>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="tinyos-time-machine__boundary">
+        <span data-kind={boundary.kind}>{boundary.title}</span>
+        <span>{boundary.kind.replace(/_/g, " ")} · {boundary.status} · revision {boundary.revision}</span>
+        {boundary.wallClockTime
+          ? <time dateTime={boundary.wallClockTime}>{boundary.wallClockTime}</time>
+          : <span data-unavailable="true">Wall-clock time unavailable</span>}
+      </div>
+    </section>
+  );
+}

--- a/src/react-workbench/chat/useTinyOsFilesController.ts
+++ b/src/react-workbench/chat/useTinyOsFilesController.ts
@@ -114,7 +114,8 @@ export function useTinyOsFilesController(
         path,
         ...(options.append && currentValue?.nextCursor ? { cursor: currentValue.nextCursor } : {}),
       });
-      dispatchFor(key, { append: Boolean(options.append), chunk, requestId: id, type: "file_loaded" });
+      const workspaceKey = (statesRef.current[key] ?? createTinyOsFilesState()).workspaceKey ?? key;
+      dispatchFor(key, { append: Boolean(options.append), chunk, requestId: id, type: "file_loaded", workspaceKey });
     } catch (error) {
       dispatchFor(key, {
         error: normalizeQueryError(error, path),

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -3,6 +3,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createDesktopAppServices } from "./defaultServices";
 import type { ChatEvent } from "./services";
+import { createDesktopStopCommand, createDesktopTurnSubmitCommand } from "../app-core/chat/desktopCommand";
+import { createTinyOsApprovalResolveCommand } from "../app-core/chat/tinyOsCommandGateway";
 
 const mocks = vi.hoisted(() => ({
   invoke: vi.fn(),
@@ -117,13 +119,23 @@ describe("desktop native app services", () => {
     const events: ChatEvent[] = [];
     services.chatStore.subscribe("thread-1", (event) => events.push(event));
 
-    await services.chatStore.send("thread-1", { text: "hello", model: "model-1" });
+    await services.chatStore.dispatch(createDesktopTurnSubmitCommand({
+      commandId: "command-turn-1",
+      message: { text: "hello", model: "model-1" },
+      sessionId: "thread-1",
+      source: { control: "test", surface: "chat" },
+    }));
 
     expect(mocks.invoke).toHaveBeenCalledWith("worker_submit_thread_turn", {
       input: expect.objectContaining({
         threadId: "thread-1",
-        input: expect.objectContaining({ role: "user", content: "hello" }),
-        spec: expect.objectContaining({ sessionId: "thread-1", stream: true, model: "model-1" }),
+        input: expect.objectContaining({ role: "user", content: "hello", clientEventId: "command-turn-1" }),
+        spec: expect.objectContaining({
+          sessionId: "thread-1",
+          stream: true,
+          model: "model-1",
+          metadata: expect.objectContaining({ clientEventId: "command-turn-1" }),
+        }),
       }),
     });
     expect(events).toContainEqual(expect.objectContaining({ type: "message-sent" }));
@@ -174,14 +186,28 @@ describe("desktop native app services", () => {
     const services = createDesktopAppServices();
     await services.sessionStore.list();
 
-    await services.chatStore.stop("thread-1");
-    await services.chatStore.resolveApproval("thread-1", {
+    await services.chatStore.dispatch(createDesktopStopCommand({
+      commandId: "command-stop-1",
+      sessionId: "thread-1",
+      source: { control: "test", surface: "chat" },
+    }));
+    await services.chatStore.dispatch(createTinyOsApprovalResolveCommand({
       action: "approveSession",
       approvalId: "approval-1",
-    });
+      commandId: "command-approval-1",
+      runId: "run-live",
+      sessionId: "thread-1",
+      source: { control: "test", surface: "chat" },
+      threadId: "thread-1",
+      turnId: "run-live",
+    }));
 
     expect(mocks.invoke).toHaveBeenCalledWith("worker_thread_interrupt", {
-      input: { body: expect.objectContaining({ threadId: "thread-1", runId: "run-live" }) },
+      input: { body: expect.objectContaining({
+        threadId: "thread-1",
+        runId: "run-live",
+        clientEventId: "command-stop-1",
+      }) },
     });
     expect(mocks.invoke).toHaveBeenCalledWith("worker_resolve_thread_approval", {
       input: {

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -3,14 +3,12 @@ import { listen } from "@tauri-apps/api/event";
 import { createDesktopChatSessionController } from "../app-core/chat/desktopChatSessionController";
 import type { NativeChatReference, NativeChatSession } from "../app-core/chat/nativeChat";
 import {
-  AGENT_UI_FORM_STATUSES,
-  buildAgentUiFormCancelRequest,
-  buildAgentUiFormSubmitRequest,
   createAgentUiEventState,
   normalizeAgentUiEvents,
   reduceAgentUiEventState,
   type AgentUiForm,
 } from "../app-core/agent-ui/agentUiEvents";
+import type { DesktopCommand, DesktopTurnSubmitCommand } from "../app-core/chat/desktopCommand";
 import { DEFAULT_GATEWAY_CONFIG, resolveGatewayConfig } from "../app-core/gateway/gatewayConfig";
 import { ensureGatewayReady } from "../app-core/gateway/desktopGatewayStartup";
 import { createDesktopNativeConfigApi } from "../app-core/native/desktopNativeConfig";
@@ -247,6 +245,64 @@ export function createDesktopAppServices(): AppServices {
     notifySession(command.target.sessionId, { commandId: command.commandId, type: "command.canonical-updated" });
   }
 
+  async function dispatchTurnSubmit(command: DesktopTurnSubmitCommand): Promise<void> {
+    await initialize();
+    const sessionId = command.target.sessionId;
+    const session = controller.state.sessions.find((item) => item.key === sessionId);
+    if (!session) throw new Error(`Cannot send to unknown Thread ${sessionId}`);
+    if (controller.state.activeSessionKey !== session.key) {
+      await controller.selectSession(session.key, session.chatId);
+    }
+    const input = command.input;
+    const result = await controller.submitMessage(
+      input.text,
+      input.usePersistentRag ?? true,
+      input.model,
+      input.references,
+      command.commandId,
+    );
+    const optimisticText = result.status === "sent" ? result.content : "";
+    const optimisticMessage = result.status === "empty"
+      ? undefined
+      : createOptimisticUserMessage(result.clientEventId, optimisticText, input.references);
+    notifySession(sessionId, {
+      type: "message-sent",
+      ...(optimisticMessage ? { message: optimisticMessage } : {}),
+    });
+  }
+
+  async function dispatchDesktopCommand(command: DesktopCommand): Promise<void> {
+    if (command.kind === "turn.submit") {
+      await dispatchTurnSubmit(command);
+      return;
+    }
+    if (command.kind === "agent.stop") {
+      await initialize();
+      const sessionId = command.target.sessionId;
+      const timeline = await controller.loadTimeline(sessionId);
+      const turn = [...timeline.turns].reverse().find((candidate) => (
+        candidate.status === "pending"
+        || candidate.status === "running"
+        || candidate.status === "awaiting_approval"
+        || candidate.status === "awaiting_user"
+      ));
+      if (!turn) throw new Error("Cannot cancel: the session has no active run");
+      const cancelCommand = createTinyOsAgentCancelCommand({
+        commandId: command.commandId,
+        issuedAt: command.issuedAt,
+        runId: turn.id,
+        sessionId,
+        source: command.source,
+        threadId: turn.canonicalItems?.find((item) => item.threadId)?.threadId,
+        turnId: turn.id,
+      });
+      notifySession(sessionId, { command: cancelCommand, type: "command.dispatched" });
+      await dispatchTinyOsCommand(cancelCommand);
+      return;
+    }
+    await dispatchTinyOsCommand(command);
+  }
+
   return {
     sessionStore: {
       async list() {
@@ -311,114 +367,12 @@ export function createDesktopAppServices(): AppServices {
           sessionId,
         );
       },
-      async send(sessionId, input) {
-        await initialize();
-        const session = controller.state.sessions.find((item) => item.key === sessionId);
-        if (!session) throw new Error(`Cannot send to unknown Thread ${sessionId}`);
-        if (controller.state.activeSessionKey !== session.key) {
-          await controller.selectSession(session.key, session.chatId);
-        }
-        const result = await controller.submitMessage(input.text, input.usePersistentRag ?? true, input.model, input.references);
-        const optimisticText = result.status === "sent" ? result.content : "";
-        const optimisticMessage = result.status === "empty"
-          ? undefined
-          : createOptimisticUserMessage(result.clientEventId, optimisticText, input.references);
-        notifySession(sessionId, {
-          type: "message-sent",
-          ...(optimisticMessage ? { message: optimisticMessage } : {}),
-        });
-      },
-      async dispatchCommand(command) {
-        await dispatchTinyOsCommand(command);
-      },
-      async stop(sessionId) {
-        await initialize();
-        const timeline = await controller.loadTimeline(sessionId);
-        const turn = [...timeline.turns].reverse().find((candidate) => (
-          candidate.status === "pending"
-          || candidate.status === "running"
-          || candidate.status === "awaiting_approval"
-          || candidate.status === "awaiting_user"
-        ));
-        if (!turn) throw new Error("Cannot cancel: the session has no active run");
-        const command = createTinyOsAgentCancelCommand({
-          runId: turn.id,
-          sessionId,
-          source: { control: "keyboard-shortcut", surface: "chat" },
-          threadId: turn.canonicalItems?.find((item) => item.threadId)?.threadId,
-          turnId: turn.id,
-        });
-        notifySession(sessionId, { command, type: "command.dispatched" });
-        await dispatchTinyOsCommand(command);
-      },
-      async resolveApproval(sessionId, input) {
-        await initialize();
-        try {
-          const session = controller.state.sessions.find((candidate) => candidate.key === sessionId);
-          if (!session) throw new Error(`Cannot resolve approval for unknown Thread ${sessionId}`);
-          await requireNative(nativeThreads, "Thread").resolveApproval({
-            threadId: session.threadId || session.key,
-            approvalId: input.approvalId,
-            approved: input.action !== "deny",
-            scope: input.action === "approveSession" ? "session" : "once",
-            ...(input.guidance ? { guidance: input.guidance } : {}),
-          });
-        } finally {
-          await controller.reloadTimeline(sessionId);
-        }
-        await controller.loadSessions();
-        notifySession(sessionId, { type: "approval-resolved" });
+      async dispatch(command) {
+        await dispatchDesktopCommand(command);
       },
       async listAgentUiForms(sessionId) {
         await initialize();
         return Array.from(agentUiState.forms.values()).filter((form) => formMatchesSession(form, sessionId));
-      },
-      async submitAgentUiForm(formId, values) {
-        await initialize();
-        const form = agentUiState.forms.get(formId);
-        if (!form) {
-          return;
-        }
-        const request = buildAgentUiFormSubmitRequest(form, values);
-        if (!request) {
-          return;
-        }
-        await requireNative(nativeThreads, "Thread").submitForm({
-          threadId: threadIdForForm(form),
-          formId,
-          values: request.values,
-          action: "submit",
-        });
-        agentUiState.forms.set(formId, {
-          ...form,
-          status: AGENT_UI_FORM_STATUSES.submitted,
-          submitting: false,
-          values: { ...values },
-        });
-        notifyAll({ type: "agent-ui.form" });
-      },
-      async cancelAgentUiForm(formId) {
-        await initialize();
-        const form = agentUiState.forms.get(formId);
-        if (!form) {
-          return;
-        }
-        const request = buildAgentUiFormCancelRequest(form);
-        if (!request) {
-          return;
-        }
-        await requireNative(nativeThreads, "Thread").submitForm({
-          threadId: threadIdForForm(form),
-          formId,
-          values: {},
-          action: "cancel",
-        });
-        agentUiState.forms.set(formId, {
-          ...form,
-          status: AGENT_UI_FORM_STATUSES.cancelled,
-          submitting: false,
-        });
-        notifyAll({ type: "agent-ui.form" });
       },
       async loadDelegateTrace(selection) {
         await initialize();
@@ -885,17 +839,6 @@ function formMatchesSession(form: AgentUiForm, sessionId: string): boolean {
   return sessionKey === sessionId
     || chatId === sessionId
     || (Boolean(chatId) && sessionId.endsWith(`:${chatId}`));
-}
-
-function threadIdForForm(form: AgentUiForm): string {
-  const threadId = stringValue(
-    form.correlation.thread_id
-    ?? form.correlation.threadId
-    ?? form.correlation.session_key
-    ?? form.correlation.sessionKey,
-  );
-  if (!threadId) throw new Error(`Agent UI form ${form.form_id} is missing thread correlation`);
-  return threadId;
 }
 
 function nativeThreadMetadataPatch(body: unknown): Record<string, unknown> {

--- a/src/react-workbench/services.ts
+++ b/src/react-workbench/services.ts
@@ -15,7 +15,7 @@ export type {
   WorkspaceQueryErrorCode,
 } from "../app-core/workspace/workspaceExplorer";
 import type { AgentDefaultsSettingsData } from "../app-core/settings/agentDefaultsSettings";
-import type { NativeChatReference } from "../app-core/chat/nativeChat";
+import type { DesktopChatInput, DesktopCommand } from "../app-core/chat/desktopCommand";
 import type { TinyOsCommand } from "../app-core/chat/tinyOsCommandGateway";
 import type { TinyOsEffectiveCapabilities } from "../app-core/chat/tinyOsCapabilities";
 import type {
@@ -39,12 +39,7 @@ export type SessionSummary = {
   status?: "idle" | "running" | "waiting_approval" | "failed";
 };
 
-export type ChatInput = {
-  text: string;
-  model?: string;
-  references?: NativeChatReference[];
-  usePersistentRag?: boolean;
-};
+export type ChatInput = DesktopChatInput;
 
 export type ChatEvent = {
   type: string;
@@ -58,12 +53,6 @@ export type ChatEvent = {
 
 export type ApprovalAction = "approveOnce" | "approveSession" | "deny";
 
-export type ApprovalResolutionInput = {
-  action: ApprovalAction;
-  approvalId: string;
-  guidance?: string;
-};
-
 export type SessionStore = {
   list(): Promise<SessionSummary[]>;
   create(input?: { title?: string }): Promise<SessionSummary>;
@@ -76,13 +65,8 @@ export type SessionStore = {
 export type ChatStore = {
   load(sessionId: string): Promise<ChatTimelineSnapshot>;
   loadTinyOsCapabilities(sessionId: string): Promise<TinyOsEffectiveCapabilities>;
-  send(sessionId: string, input: ChatInput): Promise<void>;
-  stop(sessionId: string): Promise<void>;
-  dispatchCommand(command: TinyOsCommand): Promise<void>;
-  resolveApproval(sessionId: string, input: ApprovalResolutionInput): Promise<void>;
+  dispatch(command: DesktopCommand): Promise<void>;
   listAgentUiForms(sessionId: string): Promise<AgentUiForm[]>;
-  submitAgentUiForm(formId: string, values: Record<string, unknown>): Promise<void>;
-  cancelAgentUiForm(formId: string): Promise<void>;
   loadDelegateTrace?(selection: { sessionKey: string; delegateId?: string; traceRef?: string }): Promise<unknown>;
   loadArtifact?(selection: { sessionKey: string; delegateId?: string; traceRef?: string; artifactId: string }): Promise<unknown>;
   branchFromMessage(sessionId: string, messageId: string): Promise<SessionSummary>;

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -52,13 +52,8 @@ function createServices(options: { messages?: ReactChatMessage[]; sessions?: Ses
         capabilities.capabilities.agent.cancel = { available: true };
         return capabilities;
       }),
-      send: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-      dispatchCommand: vi.fn(async () => undefined),
-      resolveApproval: vi.fn(async () => undefined),
+      dispatch: vi.fn(async () => undefined),
       listAgentUiForms: vi.fn(async () => []),
-      submitAgentUiForm: vi.fn(async () => undefined),
-      cancelAgentUiForm: vi.fn(async () => undefined),
       branchFromMessage: vi.fn(async () => ({ id: "s1", chatId: "chat-1", title: "Branch", updatedAtMs: Date.now() })),
       copyMarkdown: vi.fn(async () => ""),
       subscribe: vi.fn(() => () => undefined),
@@ -662,7 +657,11 @@ describe("DesktopShell", () => {
     expect((stopCommand as HTMLButtonElement).disabled).toBe(false);
     await user.click(stopCommand);
 
-    expect(services.chatStore.stop).toHaveBeenCalledWith("s1");
+    expect(services.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "agent.stop",
+      source: { control: "keyboard-shortcut", surface: "chat" },
+      target: { sessionId: "s1" },
+    }));
   });
 
   it("runs Stop Generation from the keyboard shortcut for the active running chat", async () => {
@@ -688,7 +687,11 @@ describe("DesktopShell", () => {
     await waitFor(() => expect((stopButton as HTMLButtonElement).disabled).toBe(false));
     fireEvent.keyDown(window, { ctrlKey: true, key: "." });
 
-    expect(services.chatStore.stop).toHaveBeenCalledWith("s1");
+    expect(services.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "agent.stop",
+      source: { control: "keyboard-shortcut", surface: "chat" },
+      target: { sessionId: "s1" },
+    }));
   });
 
 });

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { BookOpen, Bot, ChevronRight, Code2, Command, FileText, Folder, MessageSquare, Minus, Settings, Square, Wrench, X } from "lucide-react";
+import { createDesktopStopCommand } from "../../app-core/chat/desktopCommand";
 import { ChatPage } from "../chat/ChatPage";
 import { AgentDefaultsSettingsPage } from "../settings/AgentDefaultsSettingsPage";
 import { ConfigSettingsPage, type ConfigSettingsGroupId } from "../settings/ConfigSettingsPage";
@@ -156,7 +157,10 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
   function stopActiveGeneration() {
     const sessionId = stopGenerationSessionIdRef.current;
     if (sessionId) {
-      void services.chatStore.stop(sessionId);
+      void services.chatStore.dispatch(createDesktopStopCommand({
+        sessionId,
+        source: { control: "keyboard-shortcut", surface: "chat" },
+      }));
     }
   }
 

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1523,7 +1523,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 .react-live-canvas.tinyos {
   grid-template-rows: 58px minmax(0, 1fr);
   container-type: inline-size;
-  background: #f3efe7;
+  background: #ded5c8;
   color: var(--color-body);
 }
 
@@ -1531,9 +1531,11 @@ button.tinyos-overlay-backdrop:focus-visible {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;
   gap: 10px;
-  background: color-mix(in srgb, var(--color-canvas) 94%, transparent);
-  padding: 0 12px;
-  backdrop-filter: blur(16px);
+  border-bottom-color: rgb(72 59 45 / 10%);
+  background: rgb(250 248 243 / 88%);
+  padding: 0 14px;
+  box-shadow: 0 1px 0 rgb(255 255 255 / 64%);
+  backdrop-filter: blur(22px) saturate(1.2);
 }
 
 .tinyos-system-bar__identity,
@@ -1547,11 +1549,13 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-system-bar__identity > svg {
   flex: 0 0 auto;
   color: var(--color-primary);
+  filter: drop-shadow(0 2px 5px rgb(204 120 92 / 24%));
 }
 
 .tinyos-system-bar__identity h2 {
   flex: 0 0 auto;
-  font-size: 14px;
+  font-size: 15px;
+  letter-spacing: -.025em;
 }
 
 .tinyos-system-bar__status {
@@ -1562,6 +1566,10 @@ button.tinyos-overlay-backdrop:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  border: 1px solid rgb(75 67 57 / 8%);
+  border-radius: 999px;
+  background: rgb(255 255 255 / 42%);
+  padding: 4px 7px;
   white-space: nowrap;
 }
 
@@ -1590,8 +1598,8 @@ button.tinyos-overlay-backdrop:focus-visible {
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--color-primary) 24%, var(--color-hairline));
   border-radius: 999px;
-  background: color-mix(in srgb, var(--color-primary) 7%, #fff);
-  padding: 4px 7px;
+  background: color-mix(in srgb, var(--color-primary) 6%, rgb(255 255 255 / 72%));
+  padding: 4px 8px;
   color: color-mix(in srgb, var(--color-primary) 82%, var(--color-body)) !important;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1637,55 +1645,85 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .tinyos-shell {
+  --tinyos-dock-surface: rgb(250 247 241 / 78%);
+  --tinyos-window-surface: rgb(255 253 249 / 94%);
+  position: relative;
   display: grid;
-  grid-template-columns: 64px minmax(0, 1fr);
   grid-template-rows: minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  background: #eee8df;
+  background: #ded5c8;
 }
 
 .tinyos-launcher {
-  z-index: 12;
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  z-index: 24;
   display: flex;
-  grid-row: 1 / 3;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 2px;
-  min-height: 0;
-  overflow: auto;
-  border-right: 1px solid rgb(82 72 58 / 11%);
-  background: #f8f5ef;
-  padding: 10px 6px;
+  max-width: calc(100% - 24px);
+  align-items: center;
+  gap: 4px;
+  overflow: visible;
+  border: 1px solid rgb(76 65 52 / 14%);
+  border-radius: 18px;
+  background: var(--tinyos-dock-surface);
+  padding: 6px;
+  box-shadow: 0 18px 42px rgb(62 47 34 / 18%), inset 0 1px 0 rgb(255 255 255 / 74%);
+  transform: translateX(-50%);
+  backdrop-filter: blur(24px) saturate(1.3);
 }
 
 .tinyos-launcher__app {
   position: relative;
-  display: grid;
-  min-width: 0;
-  min-height: 52px;
+  display: inline-grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 42px;
   place-items: center;
-  gap: 3px;
-  border-radius: 10px;
-  color: #777168;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  color: #655f57;
   cursor: pointer;
-  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard), color var(--motion-duration-fast) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard), border-color var(--motion-duration-fast) var(--motion-ease-standard), color var(--motion-duration-fast) var(--motion-ease-standard), transform var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
 .tinyos-launcher__app > span {
-  overflow: hidden;
-  max-width: 100%;
-  font-size: 8px;
-  text-overflow: ellipsis;
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  z-index: 2;
+  border: 1px solid rgb(75 67 57 / 13%);
+  border-radius: 7px;
+  background: rgb(255 253 249 / 96%);
+  padding: 5px 7px;
+  box-shadow: 0 8px 20px rgb(57 45 34 / 16%);
+  color: var(--color-ink);
+  font-size: 9px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 4px);
+  transition: opacity var(--motion-duration-fast) var(--motion-ease-standard), transform var(--motion-duration-fast) var(--motion-ease-standard);
   white-space: nowrap;
+}
+
+.tinyos-launcher__app:hover > span,
+.tinyos-launcher__app:focus-visible > span {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .tinyos-launcher__app:hover:not(:disabled),
 .tinyos-launcher__app:focus-visible,
 .tinyos-launcher__app[data-active="true"] {
-  background: color-mix(in srgb, var(--color-primary) 9%, #fff);
+  border-color: color-mix(in srgb, var(--color-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--color-primary) 10%, rgb(255 255 255 / 78%));
   color: var(--color-primary);
+}
+
+.tinyos-launcher__app:hover:not(:disabled) {
+  transform: translateY(-2px);
 }
 
 .tinyos-launcher__app:focus-visible {
@@ -1695,18 +1733,23 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .tinyos-launcher__app:disabled {
   cursor: default;
-  opacity: .42;
+  opacity: .36;
 }
 
 .tinyos-launcher__state {
   position: absolute;
-  top: 7px;
-  right: 8px;
+  bottom: 3px;
+  left: 50%;
   color: #8f8a80;
+  transform: translateX(-50%);
 }
 
-.tinyos-launcher__reset {
-  margin-top: auto;
+.tinyos-launcher__divider {
+  width: 1px;
+  height: 26px;
+  flex: 0 0 1px;
+  margin: 0 2px;
+  background: rgb(75 67 57 / 14%);
 }
 
 .tinyos-launcher__app[data-status="running"] .tinyos-launcher__state {
@@ -1723,7 +1766,10 @@ button.tinyos-overlay-backdrop:focus-visible {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  background: #eee8df;
+  background:
+    radial-gradient(circle at 18% 8%, rgb(255 255 255 / 68%) 0, transparent 36%),
+    radial-gradient(circle at 86% 84%, rgb(204 120 92 / 13%) 0, transparent 34%),
+    linear-gradient(145deg, #eee9e0 0%, #e6ddd0 48%, #dcd1c2 100%);
   isolation: isolate;
 }
 
@@ -1731,8 +1777,56 @@ button.tinyos-overlay-backdrop:focus-visible {
   position: absolute;
   inset: 0;
   z-index: -1;
-  background: rgb(204 120 92 / 3%);
+  background-image:
+    linear-gradient(rgb(93 78 61 / 3.5%) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(93 78 61 / 3.5%) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: linear-gradient(to bottom, rgb(0 0 0 / 40%), transparent 70%);
   content: "";
+}
+
+.tinyos-desktop__environment {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  left: 16px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: rgb(78 69 59 / 62%);
+  pointer-events: none;
+}
+
+.tinyos-desktop__brand,
+.tinyos-desktop__brand > span {
+  display: inline-flex;
+  align-items: center;
+}
+
+.tinyos-desktop__brand {
+  gap: 6px;
+}
+
+.tinyos-desktop__brand strong {
+  color: rgb(58 51 44 / 74%);
+  font-size: 10px;
+  letter-spacing: -.01em;
+}
+
+.tinyos-desktop__brand small {
+  border-left: 1px solid rgb(75 67 57 / 18%);
+  padding-left: 7px;
+  font-size: 8px;
+}
+
+.tinyos-desktop__mode {
+  border: 1px solid rgb(75 67 57 / 10%);
+  border-radius: 999px;
+  background: rgb(255 255 255 / 28%);
+  padding: 4px 7px;
+  font-size: 8px;
+  backdrop-filter: blur(8px);
 }
 
 .tinyos-desktop__empty {
@@ -1741,20 +1835,30 @@ button.tinyos-overlay-backdrop:focus-visible {
   display: grid;
   place-content: center;
   justify-items: center;
-  gap: 8px;
-  padding: 28px;
-  color: #777168;
+  gap: 9px;
+  padding: 28px 28px 92px;
+  color: #6e675e;
   text-align: center;
+}
+
+.tinyos-desktop__empty > svg {
+  box-sizing: content-box;
+  border: 1px solid rgb(75 67 57 / 12%);
+  border-radius: 15px;
+  background: rgb(255 255 255 / 38%);
+  padding: 13px;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 62%);
 }
 
 .tinyos-desktop__empty strong {
   color: var(--color-ink);
-  font-size: 14px;
+  font-size: 15px;
+  letter-spacing: -.02em;
 }
 
 .tinyos-desktop__empty span {
-  max-width: 260px;
-  font-size: 11px;
+  max-width: 290px;
+  font-size: 10px;
   line-height: 1.55;
 }
 
@@ -1766,16 +1870,16 @@ button.tinyos-overlay-backdrop:focus-visible {
   left: 5%;
   z-index: 2;
   display: grid;
-  grid-template-rows: 40px minmax(0, 1fr);
+  grid-template-rows: 44px minmax(0, 1fr);
   min-width: 0;
   min-height: 180px;
   overflow: hidden;
-  border: 1px solid rgb(75 67 57 / 16%);
-  border-radius: 13px;
-  background: rgb(252 250 246 / 96%);
-  box-shadow: 0 16px 34px rgb(66 53 40 / 12%);
-  opacity: .82;
-  transform: scale(.985);
+  border: 1px solid rgb(75 64 51 / 15%);
+  border-radius: 16px;
+  background: var(--tinyos-window-surface);
+  box-shadow: 0 18px 42px rgb(61 48 35 / 13%), inset 0 1px 0 rgb(255 255 255 / 72%);
+  opacity: .86;
+  transform: scale(.99);
   transform-origin: center;
   transition: opacity var(--motion-duration-medium) var(--motion-ease-standard), transform var(--motion-duration-medium) var(--motion-ease-standard), box-shadow var(--motion-duration-medium) var(--motion-ease-standard);
   will-change: left, top, width, height;
@@ -1792,7 +1896,8 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-window[data-active="true"] {
   z-index: 9;
   opacity: 1;
-  box-shadow: 0 20px 44px rgb(66 53 40 / 18%);
+  border-color: rgb(75 64 51 / 20%);
+  box-shadow: 0 26px 64px rgb(61 48 35 / 22%), 0 2px 8px rgb(61 48 35 / 9%), inset 0 1px 0 rgb(255 255 255 / 82%);
   transform: none;
 }
 
@@ -1801,9 +1906,10 @@ button.tinyos-overlay-backdrop:focus-visible {
   grid-template-columns: auto minmax(0, 1fr) auto 32px 32px 32px;
   align-items: center;
   gap: 6px;
-  border-bottom: 1px solid rgb(75 67 57 / 11%);
-  background: #fdfbf7;
-  padding: 0 6px 0 11px;
+  border-bottom: 1px solid rgb(75 67 57 / 9%);
+  background: rgb(250 248 243 / 88%);
+  padding: 0 6px 0 12px;
+  backdrop-filter: blur(18px);
   user-select: none;
   cursor: move;
   touch-action: none;
@@ -1819,7 +1925,11 @@ button.tinyos-overlay-backdrop:focus-visible {
   align-items: center;
   gap: 6px;
   color: var(--color-ink);
-  font-size: 11px;
+  font-size: 10px;
+}
+
+.tinyos-window__titlebar > span:first-child > svg {
+  color: var(--color-primary);
 }
 
 .tinyos-window__source {
@@ -1834,10 +1944,10 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-window__titlebar > button,
 .tinyos-inspector header button {
   display: inline-grid;
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   place-items: center;
-  border-radius: 7px;
+  border-radius: 9px;
   color: var(--color-muted);
   cursor: pointer;
 }
@@ -1859,6 +1969,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-window__content {
   min-height: 0;
   overflow: auto;
+  background: rgb(255 253 249 / 74%);
 }
 
 .tinyos-window__resize-handle {
@@ -2879,12 +2990,13 @@ button.tinyos-overlay-backdrop:focus-visible {
   position: relative;
   z-index: 13;
   display: grid;
-  grid-column: 2;
+  grid-column: 1;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 7px;
-  border-top: 1px solid rgb(82 72 58 / 11%);
-  background: #faf8f3;
-  padding: 7px 9px;
+  border-top: 1px solid rgb(72 59 45 / 10%);
+  background: rgb(248 245 239 / 94%);
+  padding: 7px 10px;
+  box-shadow: 0 -1px 0 rgb(255 255 255 / 62%);
 }
 
 .tinyos-operation-shelf__select {
@@ -2893,10 +3005,10 @@ button.tinyos-overlay-backdrop:focus-visible {
   align-items: center;
   gap: 4px;
   min-width: 0;
-  min-height: 52px;
-  border: 1px solid var(--color-hairline);
-  border-radius: 10px;
-  background: #fffdfa;
+  min-height: 48px;
+  border: 1px solid rgb(75 67 57 / 11%);
+  border-radius: 11px;
+  background: rgb(255 253 249 / 76%);
   padding: 6px 9px;
   text-align: left;
   cursor: pointer;
@@ -3025,18 +3137,48 @@ button.tinyos-overlay-backdrop:focus-visible {
   }
 }
 
-@container (max-width: 520px) {
+@container (max-width: 720px) {
   .tinyos-system-bar__status > span:not(:first-child),
-  .tinyos-workspace-toggle > span {
+  .react-live-canvas__header-actions > button > span {
     display: none;
   }
 
+  .react-live-canvas__header-actions > button:disabled {
+    display: none;
+  }
+
+  .react-live-canvas__header-actions > button:first-child:not(:last-child),
+  .react-live-canvas__header-actions > button.tinyos-workspace-toggle {
+    width: 44px;
+    padding: 0;
+  }
+}
+
+@container (max-width: 520px) {
+  .tinyos-system-bar__status,
+  .tinyos-truth-badge {
+    display: none;
+  }
+
+  .tinyos-system-bar.react-live-canvas__header {
+    grid-template-columns: minmax(70px, 1fr) auto;
+    gap: 6px;
+    padding-inline: 10px;
+  }
+
+  .tinyos-system-bar__identity {
+    overflow: hidden;
+  }
+
   .tinyos-shell {
-    grid-template-columns: 58px minmax(0, 1fr);
+    --tinyos-dock-surface: rgb(250 247 241 / 86%);
   }
 
   .tinyos-launcher__app {
-    min-height: 48px;
+    width: 38px;
+    height: 38px;
+    min-height: 38px;
+    flex-basis: 38px;
   }
 
   .tinyos-window:not([data-active="true"]) {
@@ -3077,7 +3219,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   }
 
   .tinyos-operation-shelf {
-    grid-column: 2;
+    grid-column: 1;
   }
 
   .tinyos-operation-shelf__select {
@@ -3088,6 +3230,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   .tinyos-operation-shelf__select > span:nth-child(5) {
     display: none;
   }
+
 }
 
 @container (max-width: 430px) {
@@ -3096,8 +3239,24 @@ button.tinyos-overlay-backdrop:focus-visible {
     display: none;
   }
 
-  .tinyos-shell {
-    grid-template-columns: 50px minmax(0, 1fr);
+  .tinyos-launcher {
+    bottom: 10px;
+    max-width: calc(100% - 12px);
+    gap: 2px;
+    border-radius: 16px;
+    padding: 5px;
+  }
+
+  .tinyos-launcher__app {
+    width: 34px;
+    height: 36px;
+    min-height: 36px;
+    flex-basis: 34px;
+    border-radius: 10px;
+  }
+
+  .tinyos-launcher__divider {
+    margin: 0 1px;
   }
 }
 
@@ -7094,4 +7253,476 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .tinyos-browser[data-truth="real_capture"] .tinyos-browser__bar b {
   color: var(--color-warning);
+}
+
+.tinyos-system-monitor {
+  display: grid;
+  height: 100%;
+  min-height: 0;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  color: var(--color-ink);
+}
+
+.tinyos-window[data-app="system_monitor"] .tinyos-window__content {
+  container-type: inline-size;
+}
+
+.tinyos-system-monitor__summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  border-bottom: 1px solid var(--color-hairline);
+  background: var(--color-hairline);
+}
+
+.tinyos-system-monitor__summary > span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  background: rgb(255 253 249 / 94%);
+  padding: 10px 12px;
+}
+
+.tinyos-system-monitor__summary strong {
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -.03em;
+}
+
+.tinyos-system-monitor__summary small {
+  overflow: hidden;
+  color: var(--color-muted);
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tinyos-system-monitor__summary > span[data-attention="true"] strong {
+  color: var(--color-error);
+}
+
+.tinyos-system-monitor__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--color-hairline);
+  background: rgb(247 244 238 / 92%);
+  padding: 7px 8px;
+  scrollbar-width: thin;
+}
+
+.tinyos-system-monitor__search {
+  display: flex;
+  min-width: 176px;
+  flex: 1 0 176px;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: var(--color-canvas);
+  padding: 0 8px;
+  color: var(--color-muted);
+}
+
+.tinyos-system-monitor__search input {
+  width: 100%;
+  min-width: 0;
+  height: 32px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-ink);
+  font-size: 11px;
+}
+
+.tinyos-system-monitor__toolbar select,
+.tinyos-system-monitor__view button {
+  height: 34px;
+  flex: 0 0 auto;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: var(--color-canvas);
+  color: var(--color-muted);
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.tinyos-system-monitor__toolbar select {
+  max-width: 132px;
+  padding: 0 24px 0 8px;
+}
+
+.tinyos-system-monitor__view {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.tinyos-system-monitor__view button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px;
+}
+
+.tinyos-system-monitor__view button[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--color-primary) 24%, var(--color-hairline));
+  background: color-mix(in srgb, var(--color-primary) 9%, var(--color-canvas));
+  color: var(--color-primary);
+}
+
+.tinyos-system-monitor__search:focus-within,
+.tinyos-system-monitor__toolbar select:focus-visible,
+.tinyos-system-monitor__view button:focus-visible,
+.tinyos-process-list button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.tinyos-system-monitor__body {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  grid-template-columns: minmax(280px, 1.2fr) minmax(210px, .8fr);
+}
+
+.tinyos-process-list {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  background: rgb(255 253 249 / 72%);
+}
+
+.tinyos-process-list__head,
+.tinyos-process-list li > button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 92px 96px;
+  align-items: center;
+  gap: 8px;
+}
+
+.tinyos-process-list__head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  min-height: 28px;
+  border-bottom: 1px solid var(--color-hairline);
+  background: rgb(247 244 238 / 96%);
+  padding: 0 10px;
+  color: var(--color-muted);
+  font-size: 8px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  backdrop-filter: blur(10px);
+}
+
+.tinyos-process-list ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tinyos-process-list li > button {
+  width: 100%;
+  min-height: 44px;
+  border-bottom: 1px solid rgb(75 67 57 / 7%);
+  padding: 5px 10px 5px calc(10px + var(--tinyos-process-depth, 0) * 14px);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard), color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.tinyos-process-list li > button:hover,
+.tinyos-process-list li > button[data-selected="true"] {
+  background: color-mix(in srgb, var(--color-primary) 8%, rgb(255 255 255 / 76%));
+}
+
+.tinyos-process-list li > button[data-selected="true"] {
+  box-shadow: inset 3px 0 0 var(--color-primary);
+}
+
+.tinyos-process-list__identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.tinyos-process-list__identity > svg {
+  flex: 0 0 auto;
+  color: var(--color-primary);
+}
+
+.tinyos-process-list__identity > span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.tinyos-process-list__identity strong,
+.tinyos-process-list__identity code,
+.tinyos-process-list__source {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tinyos-process-list__identity strong {
+  font-size: 10px;
+}
+
+.tinyos-process-list__identity code,
+.tinyos-process-list__source {
+  color: var(--color-muted);
+  font-size: 8px;
+}
+
+.tinyos-process-state {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  border-radius: 999px;
+  background: #f0eee9;
+  padding: 3px 6px;
+  color: #625d55;
+  font-size: 8px;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+.tinyos-process-state[data-state="running"] { background: #e8f4ff; color: #21638c; }
+.tinyos-process-state[data-state="completed"] { background: #e7f6eb; color: #267b46; }
+.tinyos-process-state[data-state="waiting_for_user"],
+.tinyos-process-state[data-state="blocked"],
+.tinyos-process-state[data-state="failed"],
+.tinyos-process-state[data-state="cancelled"] { background: #fff0ed; color: #9a3d2e; }
+.tinyos-process-state[data-state="paused"] { background: #fff5db; color: #815e13; }
+
+.tinyos-process-detail {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  border-left: 1px solid var(--color-hairline);
+  background: rgb(249 247 242 / 94%);
+  padding: 11px;
+}
+
+.tinyos-process-detail > header,
+.tinyos-process-detail > header > span,
+.tinyos-process-detail section p,
+.tinyos-process-detail section p > span {
+  display: flex;
+  align-items: center;
+}
+
+.tinyos-process-detail > header {
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.tinyos-process-detail > header > span {
+  min-width: 0;
+  gap: 6px;
+}
+
+.tinyos-process-detail > header strong {
+  overflow: hidden;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tinyos-process-detail dl {
+  display: grid;
+  grid-template-columns: 82px minmax(0, 1fr);
+  gap: 6px 8px;
+  margin: 0;
+  font-size: 9px;
+}
+
+.tinyos-process-detail dt {
+  color: var(--color-muted);
+}
+
+.tinyos-process-detail dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.tinyos-process-detail code {
+  font-size: 8px;
+}
+
+.tinyos-process-actions {
+  margin-top: 12px;
+  border-top: 1px solid var(--color-hairline);
+  padding-top: 9px;
+}
+
+.tinyos-process-actions > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.tinyos-process-actions button {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 7px;
+  background: var(--color-canvas);
+  padding: 0 7px;
+  color: var(--color-body);
+  font-size: 8px;
+  cursor: pointer;
+}
+
+.tinyos-process-actions button:hover:not(:disabled),
+.tinyos-process-actions button:focus-visible {
+  border-color: color-mix(in srgb, var(--color-primary) 34%, var(--color-hairline));
+  color: var(--color-primary);
+}
+
+.tinyos-process-actions button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.tinyos-process-actions button:disabled {
+  cursor: not-allowed;
+  opacity: .42;
+}
+
+.tinyos-process-command-state {
+  display: grid;
+  gap: 2px;
+  margin: 9px 0 0;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--color-accent) 7%, transparent);
+  padding: 7px;
+  font-size: 8px;
+}
+
+.tinyos-process-command-state strong {
+  font-size: 9px;
+}
+
+.tinyos-process-command-state span {
+  color: var(--color-muted);
+  overflow-wrap: anywhere;
+}
+
+.tinyos-process-command-state[data-state="error"] {
+  background: color-mix(in srgb, var(--color-error) 8%, transparent);
+  color: var(--color-error);
+}
+
+.tinyos-process-command-state[data-state="success"] {
+  background: color-mix(in srgb, #267b46 9%, transparent);
+  color: #267b46;
+}
+
+.tinyos-process-detail section {
+  margin-top: 12px;
+  border-top: 1px solid var(--color-hairline);
+  padding-top: 9px;
+}
+
+.tinyos-process-detail h4 {
+  margin: 0 0 6px;
+  color: var(--color-muted);
+  font-size: 8px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.tinyos-process-detail section p {
+  gap: 6px;
+  margin: 5px 0;
+  font-size: 9px;
+}
+
+.tinyos-process-detail section p > span {
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.tinyos-process-detail section p code,
+.tinyos-process-detail section p small,
+.tinyos-process-detail section > small {
+  color: var(--color-muted);
+  font-size: 8px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.tinyos-process-detail__warning {
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--color-error) 7%, transparent);
+  padding: 6px;
+  color: var(--color-error);
+}
+
+.tinyos-system-monitor__empty {
+  margin: 0;
+  padding: 18px;
+  color: var(--color-muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+@container (max-width: 520px) {
+  .tinyos-terminal-command {
+    align-items: stretch;
+  }
+
+  .tinyos-terminal-command label {
+    flex-basis: 100%;
+  }
+
+  .tinyos-terminal-command > div {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .tinyos-system-monitor__summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tinyos-system-monitor__toolbar {
+    flex-wrap: wrap;
+    overflow-x: visible;
+  }
+
+  .tinyos-system-monitor__search {
+    flex-basis: 100%;
+  }
+
+  .tinyos-system-monitor__body {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(180px, 1fr) minmax(180px, .9fr);
+  }
+
+  .tinyos-process-detail {
+    border-top: 1px solid var(--color-hairline);
+    border-left: 0;
+  }
+
+  .tinyos-process-list__head,
+  .tinyos-process-list li > button {
+    grid-template-columns: minmax(0, 1fr) 90px;
+  }
+
+  .tinyos-process-list__head > span:last-child,
+  .tinyos-process-list__source {
+    display: none;
+  }
 }

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1834,13 +1834,45 @@ button.tinyos-overlay-backdrop:focus-visible {
   transition: border-color var(--motion-duration-fast) var(--motion-ease-standard), box-shadow var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
-.tinyos-launcher[data-magnifying="true"] {
+.tinyos-launcher[data-lens-visible="true"] {
   border-color: rgb(94 234 212 / 24%);
   box-shadow: 0 28px 70px rgb(0 0 0 / 48%), 0 0 42px rgb(94 234 212 / 13%), inset 0 1px 0 rgb(255 255 255 / 18%);
 }
 
+.tinyos-launcher__lens {
+  position: absolute;
+  z-index: 4;
+  inset: -10px;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.tinyos-launcher__glass-surface-host {
+  position: absolute;
+  inset: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.tinyos-launcher__glass-surface {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 64px;
+  height: 64px;
+  overflow: hidden;
+  border: 1px solid rgb(207 250 254 / 25%);
+  border-radius: 23px;
+  background: linear-gradient(135deg, rgb(255 255 255 / 10%), rgb(165 243 252 / 3%) 46%, rgb(15 23 42 / 8%));
+  box-shadow: 0 9px 26px rgb(0 0 0 / 24%), inset 0 0 2px 1px rgb(255 255 255 / 25%), inset 0 0 11px 4px rgb(207 250 254 / 9%);
+  opacity: 0;
+  pointer-events: none;
+  will-change: transform, opacity;
+}
+
 .tinyos-launcher__app {
   position: relative;
+  z-index: 3;
   display: inline-grid;
   width: 42px;
   height: 42px;
@@ -1850,9 +1882,12 @@ button.tinyos-overlay-backdrop:focus-visible {
   border-radius: 12px;
   color: #cbd5e1;
   cursor: pointer;
-  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard), border-color var(--motion-duration-fast) var(--motion-ease-standard), box-shadow var(--motion-duration-fast) var(--motion-ease-standard), color var(--motion-duration-fast) var(--motion-ease-standard);
-  transform-origin: center bottom;
-  will-change: transform;
+  transition: color var(--motion-duration-fast) var(--motion-ease-standard), filter var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.tinyos-launcher__app:hover,
+.tinyos-launcher__app:focus-visible {
+  background: transparent;
 }
 
 .tinyos-launcher__app > span {
@@ -1883,13 +1918,12 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-launcher__app:hover:not(:disabled),
 .tinyos-launcher__app:focus-visible,
 .tinyos-launcher__app[data-active="true"] {
-  border-color: rgb(94 234 212 / 32%);
-  background: linear-gradient(145deg, rgb(94 234 212 / 16%), rgb(167 139 250 / 13%));
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 14%), 0 8px 20px rgb(0 0 0 / 20%);
   color: #f8fafc;
+  filter: drop-shadow(0 2px 7px rgb(94 234 212 / 34%));
 }
 
 .tinyos-launcher__app:focus-visible {
+  z-index: 5;
   outline: 2px solid var(--color-accent);
   outline-offset: -2px;
 }
@@ -2797,9 +2831,10 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .tinyos-workspace-document {
   display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto auto auto minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
   background: #fffdfa;
 }
 

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1523,7 +1523,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 .react-live-canvas.tinyos {
   grid-template-rows: 58px auto minmax(0, 1fr);
   container-type: inline-size;
-  background: #ded5c8;
+  background: #07111d;
   color: var(--color-body);
 }
 
@@ -1801,15 +1801,17 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .tinyos-shell {
-  --tinyos-dock-surface: rgb(250 247 241 / 78%);
-  --tinyos-window-surface: rgb(255 253 249 / 94%);
+  --tinyos-dock-surface: rgb(8 18 31 / 76%);
+  --tinyos-window-surface: rgb(250 252 255 / 91%);
+  --tinyos-cyan: #5eead4;
+  --tinyos-violet: #a78bfa;
   position: relative;
   display: grid;
   grid-template-rows: minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  background: #ded5c8;
+  background: #07111d;
 }
 
 .tinyos-launcher {
@@ -1822,13 +1824,19 @@ button.tinyos-overlay-backdrop:focus-visible {
   align-items: center;
   gap: 4px;
   overflow: visible;
-  border: 1px solid rgb(76 65 52 / 14%);
+  border: 1px solid rgb(255 255 255 / 15%);
   border-radius: 18px;
   background: var(--tinyos-dock-surface);
   padding: 6px;
-  box-shadow: 0 18px 42px rgb(62 47 34 / 18%), inset 0 1px 0 rgb(255 255 255 / 74%);
+  box-shadow: 0 24px 60px rgb(0 0 0 / 42%), 0 0 34px rgb(94 234 212 / 8%), inset 0 1px 0 rgb(255 255 255 / 16%);
   transform: translateX(-50%);
-  backdrop-filter: blur(24px) saturate(1.3);
+  backdrop-filter: blur(26px) saturate(1.55);
+  transition: border-color var(--motion-duration-fast) var(--motion-ease-standard), box-shadow var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.tinyos-launcher[data-magnifying="true"] {
+  border-color: rgb(94 234 212 / 24%);
+  box-shadow: 0 28px 70px rgb(0 0 0 / 48%), 0 0 42px rgb(94 234 212 / 13%), inset 0 1px 0 rgb(255 255 255 / 18%);
 }
 
 .tinyos-launcher__app {
@@ -1840,9 +1848,11 @@ button.tinyos-overlay-backdrop:focus-visible {
   place-items: center;
   border: 1px solid transparent;
   border-radius: 12px;
-  color: #655f57;
+  color: #cbd5e1;
   cursor: pointer;
-  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard), border-color var(--motion-duration-fast) var(--motion-ease-standard), color var(--motion-duration-fast) var(--motion-ease-standard), transform var(--motion-duration-fast) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard), border-color var(--motion-duration-fast) var(--motion-ease-standard), box-shadow var(--motion-duration-fast) var(--motion-ease-standard), color var(--motion-duration-fast) var(--motion-ease-standard);
+  transform-origin: center bottom;
+  will-change: transform;
 }
 
 .tinyos-launcher__app > span {
@@ -1850,12 +1860,12 @@ button.tinyos-overlay-backdrop:focus-visible {
   bottom: calc(100% + 10px);
   left: 50%;
   z-index: 2;
-  border: 1px solid rgb(75 67 57 / 13%);
+  border: 1px solid rgb(255 255 255 / 13%);
   border-radius: 7px;
-  background: rgb(255 253 249 / 96%);
+  background: rgb(8 18 31 / 94%);
   padding: 5px 7px;
-  box-shadow: 0 8px 20px rgb(57 45 34 / 16%);
-  color: var(--color-ink);
+  box-shadow: 0 12px 30px rgb(0 0 0 / 34%);
+  color: #f8fafc;
   font-size: 9px;
   opacity: 0;
   pointer-events: none;
@@ -1873,13 +1883,10 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-launcher__app:hover:not(:disabled),
 .tinyos-launcher__app:focus-visible,
 .tinyos-launcher__app[data-active="true"] {
-  border-color: color-mix(in srgb, var(--color-primary) 18%, transparent);
-  background: color-mix(in srgb, var(--color-primary) 10%, rgb(255 255 255 / 78%));
-  color: var(--color-primary);
-}
-
-.tinyos-launcher__app:hover:not(:disabled) {
-  transform: translateY(-2px);
+  border-color: rgb(94 234 212 / 32%);
+  background: linear-gradient(145deg, rgb(94 234 212 / 16%), rgb(167 139 250 / 13%));
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 14%), 0 8px 20px rgb(0 0 0 / 20%);
+  color: #f8fafc;
 }
 
 .tinyos-launcher__app:focus-visible {
@@ -1896,7 +1903,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   position: absolute;
   bottom: 3px;
   left: 50%;
-  color: #8f8a80;
+  color: #64748b;
   transform: translateX(-50%);
 }
 
@@ -1905,7 +1912,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   height: 26px;
   flex: 0 0 1px;
   margin: 0 2px;
-  background: rgb(75 67 57 / 14%);
+  background: rgb(255 255 255 / 14%);
 }
 
 .tinyos-launcher__app[data-status="running"] .tinyos-launcher__state {
@@ -1924,12 +1931,12 @@ button.tinyos-overlay-backdrop:focus-visible {
   z-index: 23;
   display: flex;
   gap: 3px;
-  border: 1px solid rgb(76 65 52 / 12%);
+  border: 1px solid rgb(255 255 255 / 12%);
   border-radius: 11px;
-  background: rgb(250 247 241 / 78%);
+  background: rgb(8 18 31 / 68%);
   padding: 3px;
-  box-shadow: 0 8px 22px rgb(62 47 34 / 10%);
-  backdrop-filter: blur(18px);
+  box-shadow: 0 12px 30px rgb(0 0 0 / 24%), inset 0 1px 0 rgb(255 255 255 / 10%);
+  backdrop-filter: blur(20px) saturate(1.4);
 }
 
 .tinyos-desktop__system-tools > button {
@@ -1940,14 +1947,14 @@ button.tinyos-overlay-backdrop:focus-visible {
   place-items: center;
   border: 0;
   border-radius: 8px;
-  color: #655f57;
+  color: #cbd5e1;
   cursor: pointer;
 }
 
 .tinyos-desktop__system-tools > button:hover:not(:disabled),
 .tinyos-desktop__system-tools > button:focus-visible {
-  background: color-mix(in srgb, var(--color-primary) 10%, white);
-  color: var(--color-primary);
+  background: rgb(94 234 212 / 13%);
+  color: var(--tinyos-cyan);
 }
 
 .tinyos-desktop__system-tools > button:focus-visible {
@@ -1978,22 +1985,46 @@ button.tinyos-overlay-backdrop:focus-visible {
   min-height: 0;
   overflow: hidden;
   background:
-    radial-gradient(circle at 18% 8%, rgb(255 255 255 / 68%) 0, transparent 36%),
-    radial-gradient(circle at 86% 84%, rgb(204 120 92 / 13%) 0, transparent 34%),
-    linear-gradient(145deg, #eee9e0 0%, #e6ddd0 48%, #dcd1c2 100%);
+    radial-gradient(circle at 18% 8%, rgb(56 189 248 / 12%) 0, transparent 34%),
+    radial-gradient(circle at 82% 78%, rgb(167 139 250 / 13%) 0, transparent 36%),
+    linear-gradient(145deg, #0b1b2b 0%, #07131f 48%, #0d1727 100%);
   isolation: isolate;
+  box-shadow: inset 0 0 80px rgb(0 0 0 / 32%);
 }
 
 .tinyos-desktop::before {
   position: absolute;
   inset: 0;
-  z-index: -1;
+  z-index: 0;
   background-image:
-    linear-gradient(rgb(93 78 61 / 3.5%) 1px, transparent 1px),
-    linear-gradient(90deg, rgb(93 78 61 / 3.5%) 1px, transparent 1px);
+    linear-gradient(rgb(148 163 184 / 5%) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(148 163 184 / 5%) 1px, transparent 1px);
   background-size: 32px 32px;
-  mask-image: linear-gradient(to bottom, rgb(0 0 0 / 40%), transparent 70%);
+  mask-image: linear-gradient(to bottom, rgb(0 0 0 / 56%), transparent 78%);
   content: "";
+  pointer-events: none;
+}
+
+.tinyos-desktop__side-rays {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  background:
+    conic-gradient(from 225deg at 104% -8%, transparent 0 38deg, rgb(94 234 212 / 16%) 48deg, transparent 57deg),
+    conic-gradient(from 214deg at 108% -12%, transparent 0 25deg, rgb(167 139 250 / 14%) 36deg, transparent 49deg);
+  opacity: .72;
+  pointer-events: none;
+  transition: opacity 420ms var(--motion-ease-standard);
+}
+
+.tinyos-desktop__side-rays > canvas {
+  display: block;
+  mix-blend-mode: screen;
+}
+
+.tinyos-desktop[data-has-windows="true"] .tinyos-desktop__side-rays {
+  opacity: .46;
 }
 
 .tinyos-desktop__environment {
@@ -2005,7 +2036,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: rgb(78 69 59 / 62%);
+  color: rgb(226 232 240 / 66%);
   pointer-events: none;
 }
 
@@ -2020,21 +2051,21 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .tinyos-desktop__brand strong {
-  color: rgb(58 51 44 / 74%);
+  color: rgb(248 250 252 / 90%);
   font-size: 10px;
   letter-spacing: -.01em;
 }
 
 .tinyos-desktop__brand small {
-  border-left: 1px solid rgb(75 67 57 / 18%);
+  border-left: 1px solid rgb(226 232 240 / 20%);
   padding-left: 7px;
   font-size: 8px;
 }
 
 .tinyos-desktop__mode {
-  border: 1px solid rgb(75 67 57 / 10%);
+  border: 1px solid rgb(255 255 255 / 11%);
   border-radius: 999px;
-  background: rgb(255 255 255 / 28%);
+  background: rgb(8 18 31 / 32%);
   padding: 4px 7px;
   font-size: 8px;
   backdrop-filter: blur(8px);
@@ -2048,21 +2079,21 @@ button.tinyos-overlay-backdrop:focus-visible {
   justify-items: center;
   gap: 9px;
   padding: 28px 28px 92px;
-  color: #6e675e;
+  color: #cbd5e1;
   text-align: center;
 }
 
 .tinyos-desktop__empty > svg {
   box-sizing: content-box;
-  border: 1px solid rgb(75 67 57 / 12%);
+  border: 1px solid rgb(255 255 255 / 14%);
   border-radius: 15px;
-  background: rgb(255 255 255 / 38%);
+  background: rgb(255 255 255 / 7%);
   padding: 13px;
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 62%);
+  box-shadow: 0 18px 50px rgb(0 0 0 / 24%), inset 0 1px 0 rgb(255 255 255 / 13%);
 }
 
 .tinyos-desktop__empty strong {
-  color: var(--color-ink);
+  color: #f8fafc;
   font-size: 15px;
   letter-spacing: -.02em;
 }
@@ -2085,14 +2116,15 @@ button.tinyos-overlay-backdrop:focus-visible {
   min-width: 0;
   min-height: 180px;
   overflow: hidden;
-  border: 1px solid rgb(75 64 51 / 15%);
+  border: 1px solid rgb(255 255 255 / 42%);
   border-radius: 16px;
   background: var(--tinyos-window-surface);
-  box-shadow: 0 18px 42px rgb(61 48 35 / 13%), inset 0 1px 0 rgb(255 255 255 / 72%);
+  box-shadow: 0 24px 58px rgb(0 0 0 / 30%), inset 0 1px 0 rgb(255 255 255 / 78%);
   opacity: .86;
   transform: scale(.99);
   transform-origin: center;
   transition: opacity var(--motion-duration-medium) var(--motion-ease-standard), transform var(--motion-duration-medium) var(--motion-ease-standard), box-shadow var(--motion-duration-medium) var(--motion-ease-standard);
+  backdrop-filter: blur(22px) saturate(1.08);
   will-change: left, top, width, height;
 }
 
@@ -2107,9 +2139,22 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-window[data-active="true"] {
   z-index: 9;
   opacity: 1;
-  border-color: rgb(75 64 51 / 20%);
-  box-shadow: 0 26px 64px rgb(61 48 35 / 22%), 0 2px 8px rgb(61 48 35 / 9%), inset 0 1px 0 rgb(255 255 255 / 82%);
+  border-color: rgb(148 226 255 / 56%);
+  box-shadow: 0 30px 78px rgb(0 0 0 / 42%), 0 0 34px rgb(94 234 212 / 10%), 0 2px 8px rgb(0 0 0 / 18%), inset 0 1px 0 rgb(255 255 255 / 86%);
   transform: none;
+}
+
+.tinyos-window[data-active="true"]::after {
+  position: absolute;
+  top: 0;
+  right: 18px;
+  left: 18px;
+  z-index: 2;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--tinyos-cyan), var(--tinyos-violet), transparent);
+  box-shadow: 0 0 12px rgb(94 234 212 / 48%);
+  content: "";
+  pointer-events: none;
 }
 
 .tinyos-window__titlebar {
@@ -2118,7 +2163,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   align-items: center;
   gap: 6px;
   border-bottom: 1px solid rgb(75 67 57 / 9%);
-  background: rgb(250 248 243 / 88%);
+  background: linear-gradient(180deg, rgb(255 255 255 / 86%), rgb(245 248 252 / 76%));
   padding: 0 6px 0 12px;
   backdrop-filter: blur(18px);
   user-select: none;
@@ -2140,7 +2185,8 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .tinyos-window__titlebar > span:first-child > svg {
-  color: var(--color-primary);
+  color: color-mix(in srgb, var(--tinyos-cyan) 68%, var(--color-primary));
+  filter: drop-shadow(0 2px 5px rgb(34 211 238 / 22%));
 }
 
 .tinyos-window__source {
@@ -2180,7 +2226,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-window__content {
   min-height: 0;
   overflow: auto;
-  background: rgb(255 253 249 / 74%);
+  background: rgb(255 255 255 / 72%);
 }
 
 .tinyos-window__resize-handle {
@@ -2863,10 +2909,6 @@ button.tinyos-overlay-backdrop:focus-visible {
   background: rgb(239 184 80 / 15%);
 }
 
-.tinyos-workspace-document__code li[data-current-match="true"] {
-  box-shadow: inset 3px 0 #df9830;
-}
-
 .tinyos-workspace-document__footer {
   display: flex;
   min-width: 0;
@@ -3059,10 +3101,6 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .tinyos-terminal__output li[data-match="true"] {
   background: rgb(239 184 80 / 17%);
-}
-
-.tinyos-terminal__output li[data-current-match="true"] {
-  box-shadow: inset 3px 0 #efb850;
 }
 
 .tinyos-terminal__output li[data-selected="true"] {
@@ -3935,7 +3973,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   }
 
   .tinyos-shell {
-    --tinyos-dock-surface: rgb(250 247 241 / 86%);
+    --tinyos-dock-surface: rgb(8 18 31 / 86%);
   }
 
   .tinyos-shell-overlay {
@@ -7935,6 +7973,11 @@ button.tinyos-overlay-backdrop:focus-visible {
   .react-session-row__particles {
     display: none;
   }
+
+  .tinyos-desktop__side-rays {
+    opacity: .5;
+  }
+
 }
 
 .tinyos-workspace-explorer__create,
@@ -8272,10 +8315,6 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-process-list li > button:hover,
 .tinyos-process-list li > button[data-selected="true"] {
   background: color-mix(in srgb, var(--color-primary) 8%, rgb(255 255 255 / 76%));
-}
-
-.tinyos-process-list li > button[data-selected="true"] {
-  box-shadow: inset 3px 0 0 var(--color-primary);
 }
 
 .tinyos-process-list__identity {

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1521,10 +1521,166 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 /* TinyOS Live Canvas */
 .react-live-canvas.tinyos {
-  grid-template-rows: 58px minmax(0, 1fr);
+  grid-template-rows: 58px auto minmax(0, 1fr);
   container-type: inline-size;
   background: #ded5c8;
   color: var(--color-body);
+}
+
+.tinyos-time-machine {
+  display: grid;
+  gap: 7px;
+  border-bottom: 1px solid rgb(72 59 45 / 10%);
+  background: rgb(250 248 243 / 92%);
+  padding: 8px 12px;
+  box-shadow: 0 4px 12px rgb(72 59 45 / 5%);
+}
+
+.tinyos-time-machine[data-empty="true"] {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  color: var(--color-muted);
+  font-size: 10px;
+}
+
+.tinyos-time-machine__heading,
+.tinyos-time-machine__controls,
+.tinyos-time-machine__boundary {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.tinyos-time-machine__heading {
+  justify-content: space-between;
+}
+
+.tinyos-time-machine__heading > div {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.tinyos-time-machine__heading small,
+.tinyos-time-machine__heading > span,
+.tinyos-time-machine__groups small,
+.tinyos-time-machine__boundary {
+  color: var(--color-muted);
+  font-size: 9px;
+}
+
+.tinyos-time-machine__heading strong {
+  color: var(--color-ink);
+  font-size: 11px;
+}
+
+.tinyos-time-machine__controls > button,
+.tinyos-time-machine__groups button,
+.tinyos-time-machine__speed select {
+  border: 1px solid var(--color-hairline);
+  border-radius: 7px;
+  background: rgb(255 255 255 / 68%);
+  color: var(--color-body);
+  cursor: pointer;
+}
+
+.tinyos-time-machine__controls > button {
+  display: inline-flex;
+  min-width: 30px;
+  min-height: 30px;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 0 8px;
+}
+
+.tinyos-time-machine__controls > button:focus-visible,
+.tinyos-time-machine__groups button:focus-visible,
+.tinyos-time-machine__speed select:focus-visible,
+.tinyos-time-machine input[type="range"]:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.tinyos-time-machine__controls > button:disabled {
+  cursor: not-allowed;
+  opacity: .42;
+}
+
+.tinyos-time-machine__controls > label:not(.tinyos-time-machine__speed) {
+  display: grid;
+  min-width: 100px;
+  flex: 1;
+  gap: 2px;
+}
+
+.tinyos-time-machine__controls label > span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.tinyos-time-machine input[type="range"] {
+  width: 100%;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
+
+.tinyos-time-machine__speed select {
+  min-height: 30px;
+  padding: 0 5px;
+  font-size: 9px;
+}
+
+.tinyos-time-machine__live {
+  white-space: nowrap;
+}
+
+.tinyos-time-machine__groups {
+  display: flex;
+  min-width: 0;
+  margin: 0;
+  gap: 5px;
+  overflow-x: auto;
+  padding: 0;
+  list-style: none;
+  scrollbar-width: thin;
+}
+
+.tinyos-time-machine__groups button {
+  display: grid;
+  flex: 0 0 auto;
+  justify-items: start;
+  gap: 1px;
+  padding: 4px 7px;
+  text-align: left;
+}
+
+.tinyos-time-machine__groups button[aria-current="true"] {
+  border-color: color-mix(in srgb, var(--color-primary) 36%, var(--color-hairline));
+  background: color-mix(in srgb, var(--color-primary) 9%, white);
+  color: var(--color-primary);
+}
+
+.tinyos-time-machine__boundary {
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.tinyos-time-machine__boundary > span:first-child {
+  overflow: hidden;
+  max-width: 220px;
+  color: var(--color-ink);
+  font-weight: 600;
+  text-overflow: ellipsis;
+}
+
+.tinyos-time-machine__boundary [data-unavailable="true"] {
+  color: #8a5d1e;
 }
 
 .tinyos-system-bar.react-live-canvas__header {
@@ -1759,6 +1915,61 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-launcher__app[data-status="blocked"] .tinyos-launcher__state,
 .tinyos-launcher__app[data-status="failed"] .tinyos-launcher__state {
   color: var(--color-error);
+}
+
+.tinyos-desktop__system-tools {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 23;
+  display: flex;
+  gap: 3px;
+  border: 1px solid rgb(76 65 52 / 12%);
+  border-radius: 11px;
+  background: rgb(250 247 241 / 78%);
+  padding: 3px;
+  box-shadow: 0 8px 22px rgb(62 47 34 / 10%);
+  backdrop-filter: blur(18px);
+}
+
+.tinyos-desktop__system-tools > button {
+  position: relative;
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  color: #655f57;
+  cursor: pointer;
+}
+
+.tinyos-desktop__system-tools > button:hover:not(:disabled),
+.tinyos-desktop__system-tools > button:focus-visible {
+  background: color-mix(in srgb, var(--color-primary) 10%, white);
+  color: var(--color-primary);
+}
+
+.tinyos-desktop__system-tools > button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.tinyos-desktop__system-tools > button[data-attention="true"]::after {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 6px;
+  height: 6px;
+  border: 1px solid #fff;
+  border-radius: 50%;
+  background: var(--color-error);
+  content: "";
+}
+
+.tinyos-desktop__system-tools > button:disabled {
+  cursor: default;
+  opacity: .38;
 }
 
 .tinyos-desktop {
@@ -2243,6 +2454,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .tinyos-workspace-explorer {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(150px, 30%) minmax(0, 1fr);
   height: 100%;
@@ -2276,8 +2488,17 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .tinyos-workspace-explorer__tree > header {
-  justify-content: space-between;
+  justify-content: flex-start;
   color: var(--color-muted);
+}
+
+.tinyos-workspace-explorer__tree > header > span:first-child {
+  margin-right: auto;
+}
+
+.tinyos-workspace-explorer__tree > header > button[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--color-primary) 10%, white);
+  color: var(--color-primary);
 }
 
 .tinyos-workspace-explorer__tree > header > span {
@@ -2325,6 +2546,40 @@ button.tinyos-overlay-backdrop:focus-visible {
   overflow: auto;
   padding: 3px 5px;
 }
+
+.tinyos-workspace-local-view {
+  min-height: 0;
+  overflow: auto;
+  padding: 5px;
+}
+
+.tinyos-workspace-local-view > button {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 5px;
+  border-radius: 6px;
+  padding: 6px;
+  color: var(--color-body);
+  text-align: left;
+}
+
+.tinyos-workspace-local-view > button:hover,
+.tinyos-workspace-local-view > button:focus-visible {
+  background: color-mix(in srgb, var(--color-primary) 9%, white);
+}
+
+.tinyos-workspace-local-view > button > span,
+.tinyos-workspace-local-view > button > small {
+  grid-column: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tinyos-workspace-local-view > button > span { font-size: 9px; }
+.tinyos-workspace-local-view > button > small { color: var(--color-muted); font-size: 7px; }
 
 .tinyos-workspace-tree__entry {
   display: flex;
@@ -2399,6 +2654,100 @@ button.tinyos-overlay-backdrop:focus-visible {
   padding: 4px 7px;
   color: var(--color-primary);
 }
+
+.tinyos-file-open-with {
+  position: absolute;
+  top: 69px;
+  right: 8px;
+  z-index: 8;
+  display: grid;
+  width: min(250px, calc(100% - 16px));
+  gap: 2px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 9px;
+  background: #fffdfa;
+  padding: 5px;
+  box-shadow: 0 14px 36px rgb(45 36 28 / 18%);
+}
+
+.tinyos-file-open-with > button {
+  border-radius: 6px;
+  padding: 7px;
+  font-size: 9px;
+  text-align: left;
+}
+
+.tinyos-file-open-with > button:hover,
+.tinyos-file-open-with > button:focus-visible { background: color-mix(in srgb, var(--color-primary) 8%, white); }
+
+.tinyos-file-resource-meta {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  border-bottom: 1px solid rgb(75 67 57 / 10%);
+  background: rgb(75 67 57 / 8%);
+}
+
+.tinyos-file-resource-meta > div {
+  min-width: 0;
+  background: #faf7f1;
+  padding: 5px 7px;
+}
+
+.tinyos-file-resource-meta dt { color: var(--color-muted); font-size: 7px; text-transform: uppercase; }
+.tinyos-file-resource-meta dd { display: flex; min-width: 0; align-items: center; gap: 4px; margin: 2px 0 0; overflow: hidden; color: var(--color-body); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.tinyos-file-resource-meta code { overflow: hidden; text-overflow: ellipsis; }
+
+.tinyos-file-operation-queue {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  z-index: 12;
+  display: grid;
+  width: min(310px, calc(100% - 16px));
+  max-height: 180px;
+  overflow: auto;
+  border: 1px solid var(--color-hairline);
+  border-radius: 10px;
+  background: rgb(255 253 249 / 97%);
+  padding: 5px;
+  box-shadow: 0 14px 36px rgb(45 36 28 / 18%);
+}
+
+.tinyos-file-operation-queue > header,
+.tinyos-file-operation-queue > article {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 6px;
+}
+
+.tinyos-file-operation-queue > header { border-bottom: 1px solid var(--color-hairline); font-size: 9px; }
+.tinyos-file-operation-queue > article { border-radius: 6px; font-size: 8px; }
+.tinyos-file-operation-queue > article[data-state="conflict"],
+.tinyos-file-operation-queue > article[data-state="failed"] { background: color-mix(in srgb, var(--color-error) 7%, white); color: var(--color-error); }
+.tinyos-file-operation-queue strong,
+.tinyos-file-operation-queue small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tinyos-file-operation-queue small { color: var(--color-muted); font-size: 7px; }
+.tinyos-file-operation-queue > article > small { grid-column: 1 / -1; }
+
+.tinyos-file-conflict {
+  margin: 7px;
+  border: 1px solid color-mix(in srgb, var(--color-error) 30%, var(--color-hairline));
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--color-error) 5%, white);
+  padding: 9px;
+}
+
+.tinyos-file-conflict > header { display: flex; align-items: center; gap: 6px; color: var(--color-error); font-size: 10px; }
+.tinyos-file-conflict > p { margin: 5px 0; color: var(--color-body); font-size: 8px; }
+.tinyos-file-conflict dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 5px; margin: 0; }
+.tinyos-file-conflict dl > div { min-width: 0; border: 1px solid var(--color-hairline); border-radius: 6px; padding: 5px; }
+.tinyos-file-conflict dt { color: var(--color-muted); font-size: 7px; }
+.tinyos-file-conflict dd { margin: 2px 0 0; overflow: hidden; font-size: 8px; text-overflow: ellipsis; }
+.tinyos-file-conflict > button { margin-top: 6px; border-radius: 6px; background: color-mix(in srgb, var(--color-primary) 9%, white); padding: 5px 7px; color: var(--color-primary); font-size: 8px; }
 
 .tinyos-workspace-document {
   display: grid;
@@ -2599,7 +2948,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .tinyos-terminal {
   display: grid;
-  grid-template-rows: 34px 34px minmax(0, 1fr) 28px;
+  grid-template-rows: 34px auto 34px minmax(0, 1fr) 28px;
   height: 100%;
   min-height: 0;
   overflow: auto;
@@ -2732,11 +3081,48 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .tinyos-browser {
   display: grid;
-  grid-template-rows: 38px minmax(0, 1fr);
+  grid-template-rows: auto auto auto auto minmax(120px, 1fr) auto auto;
   height: 100%;
   min-height: 0;
   background: #fff;
+  overflow: hidden;
 }
+
+.tinyos-browser__tabs,
+.tinyos-browser__captures {
+  display: flex;
+  min-width: 0;
+  gap: 4px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 5px 7px;
+}
+
+.tinyos-browser__tabs button,
+.tinyos-browser__captures button {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  border-radius: 6px;
+  padding: 5px 7px;
+  white-space: nowrap;
+}
+
+.tinyos-browser__tabs button[aria-selected="true"],
+.tinyos-browser__captures button[aria-current="true"] {
+  background: color-mix(in srgb, var(--color-primary) 10%, white);
+  color: var(--color-primary);
+}
+
+.tinyos-browser__captures button {
+  display: grid;
+  justify-items: start;
+  font-size: 9px;
+}
+
+.tinyos-browser__captures button[data-stale="true"] { color: var(--color-muted); }
+.tinyos-browser__captures small { font-size: 8px; }
 
 .tinyos-browser__bar {
   display: flex;
@@ -2747,26 +3133,49 @@ button.tinyos-overlay-backdrop:focus-visible {
   padding: 0 9px;
 }
 
-.tinyos-browser__bar > span {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #d2cec6;
+.tinyos-browser__bar > button,
+.tinyos-browser__bar form button,
+.tinyos-browser__type button {
+  min-height: 26px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 6px;
+  background: #fff;
+  padding: 0 7px;
 }
 
-.tinyos-browser__bar > strong {
-  overflow: hidden;
-  border-radius: 999px;
-  background: #f3f1ed;
-  padding: 5px 9px;
+.tinyos-browser__bar form {
+  display: flex;
+  min-width: 80px;
+  flex: 1;
+  gap: 4px;
+}
+
+.tinyos-browser__bar input,
+.tinyos-browser__type input {
+  min-width: 0;
+  flex: 1;
+  border: 1px solid var(--color-hairline);
+  border-radius: 6px;
+  background: #f7f6f3;
+  padding: 5px 8px;
+  font-size: 9px;
+}
+
+.tinyos-browser__identity {
+  display: flex;
+  min-width: 0;
+  gap: 9px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 6px 9px;
   color: var(--color-muted);
   font-size: 8px;
-  font-weight: 500;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.tinyos-browser > button {
+.tinyos-browser__identity span { display: grid; gap: 2px; white-space: nowrap; }
+.tinyos-browser__identity strong { color: var(--color-ink); font-size: 8px; }
+
+.tinyos-browser__capture {
   min-width: 0;
   min-height: 0;
   overflow: auto;
@@ -2792,6 +3201,26 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .tinyos-browser__page strong { color: var(--color-ink); font-size: 13px; }
 .tinyos-browser__page p { max-width: 280px; margin: 0; font-size: 10px; line-height: 1.55; }
+
+.tinyos-browser__stale,
+.tinyos-browser__readonly,
+.tinyos-browser__error {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0;
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 7px 9px;
+  font-size: 9px;
+}
+
+.tinyos-browser__stale { background: #fff7e5; color: #855b12; }
+.tinyos-browser__stale span,
+.tinyos-browser__readonly span { display: grid; min-width: 0; flex: 1; }
+.tinyos-browser__stale button { border-radius: 6px; background: #fff; padding: 4px 7px; }
+.tinyos-browser__readonly { color: var(--color-muted); }
+.tinyos-browser__error { background: #fff1ef; color: var(--color-error); }
+.tinyos-browser__type { display: flex; gap: 5px; border-top: 1px solid var(--color-hairline); padding: 6px 9px; }
 
 .tinyos-plan,
 .tinyos-memory,
@@ -2889,6 +3318,337 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-notifications strong { color: var(--color-ink); font-size: 9px; }
 .tinyos-notifications small { margin-top: 2px; color: var(--color-muted); font-size: 8px; }
 
+.tinyos-shell-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 36;
+  display: grid;
+  place-items: center;
+  padding: 14px;
+}
+
+.tinyos-terminal__identity {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  border-bottom: 1px solid #2a2d34;
+  background: #2a2d34;
+}
+
+.tinyos-terminal__identity > div {
+  min-width: 0;
+  background: #202329;
+  padding: 5px 7px;
+}
+
+.tinyos-terminal__identity dt { color: #818894; font-size: 7px; text-transform: uppercase; }
+.tinyos-terminal__identity dd { display: flex; min-width: 0; align-items: center; gap: 4px; margin: 2px 0 0; overflow: hidden; color: #c4c8d0; font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.tinyos-terminal__identity code { overflow: hidden; text-overflow: ellipsis; }
+
+.tinyos-shell-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: rgb(48 40 33 / 24%);
+  cursor: default;
+  backdrop-filter: blur(5px);
+}
+
+.tinyos-shell-overlay__panel {
+  position: relative;
+  display: grid;
+  width: min(560px, 100%);
+  max-height: min(520px, 100%);
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgb(75 67 57 / 16%);
+  border-radius: 16px;
+  background: rgb(255 253 249 / 98%);
+  box-shadow: 0 28px 80px rgb(45 36 28 / 28%), inset 0 1px 0 rgb(255 255 255 / 88%);
+  animation: tinyos-dialog-enter var(--motion-duration-medium) var(--motion-ease-standard) both;
+}
+
+.tinyos-shell-overlay[data-overlay="switcher"] .tinyos-shell-overlay__panel {
+  width: min(440px, 100%);
+}
+
+.tinyos-shell-overlay__panel > header {
+  display: flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 9px 12px;
+}
+
+.tinyos-shell-overlay__panel > header > span {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+  color: var(--color-ink);
+  font-size: 11px;
+}
+
+.tinyos-shell-overlay__panel > header > small {
+  color: var(--color-muted);
+  font-size: 9px;
+}
+
+.tinyos-shell-overlay__panel > header > button {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 8px;
+  color: var(--color-muted);
+}
+
+.tinyos-shell-overlay__panel button:focus-visible,
+.tinyos-shell-overlay__panel input:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.tinyos-window-switcher {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
+  gap: 7px;
+  overflow: auto;
+  padding: 12px;
+}
+
+.tinyos-window-switcher > button {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 11px;
+  padding: 10px;
+  text-align: left;
+}
+
+.tinyos-window-switcher > button[data-selected="true"] {
+  border-color: color-mix(in srgb, var(--color-primary) 48%, var(--color-hairline));
+  background: color-mix(in srgb, var(--color-primary) 8%, white);
+  color: var(--color-primary);
+}
+
+.tinyos-window-switcher span,
+.tinyos-window-switcher strong,
+.tinyos-window-switcher small {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tinyos-window-switcher strong { color: var(--color-ink); font-size: 10px; }
+.tinyos-window-switcher small { margin-top: 2px; color: var(--color-muted); font-size: 8px; }
+
+.tinyos-window-overview {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+  overflow: auto;
+  padding: 12px;
+}
+
+.tinyos-window-overview > button {
+  display: grid;
+  min-width: 0;
+  gap: 7px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 12px;
+  padding: 8px;
+  text-align: left;
+}
+
+.tinyos-window-overview > button:hover,
+.tinyos-window-overview > button:focus-visible {
+  border-color: color-mix(in srgb, var(--color-primary) 42%, var(--color-hairline));
+}
+
+.tinyos-window-overview__preview {
+  display: grid;
+  min-height: 74px;
+  place-items: center;
+  border-radius: 8px;
+  background: linear-gradient(145deg, #eee9e0, #e2d8ca);
+  color: #655f57;
+}
+
+.tinyos-window-overview__preview small { font-size: 8px; }
+.tinyos-window-overview > button > span:last-child strong,
+.tinyos-window-overview > button > span:last-child small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tinyos-window-overview > button > span:last-child strong { color: var(--color-ink); font-size: 10px; }
+.tinyos-window-overview > button > span:last-child small { margin-top: 2px; color: var(--color-muted); font-size: 8px; }
+
+.tinyos-command-palette__search {
+  display: grid !important;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  justify-content: stretch !important;
+}
+
+.tinyos-command-palette__search input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-ink);
+  font-size: 11px;
+}
+
+.tinyos-command-palette__search kbd {
+  border: 1px solid var(--color-hairline);
+  border-radius: 5px;
+  padding: 2px 5px;
+  color: var(--color-muted);
+  font-size: 8px;
+}
+
+.tinyos-command-palette__results {
+  display: grid;
+  max-height: 390px;
+  overflow: auto;
+  padding: 6px;
+}
+
+.tinyos-command-palette__results > button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(90px, 38%);
+  align-items: center;
+  gap: 10px;
+  border-radius: 8px;
+  padding: 8px;
+  text-align: left;
+}
+
+.tinyos-command-palette__results > button:hover:not(:disabled),
+.tinyos-command-palette__results > button:focus-visible {
+  background: color-mix(in srgb, var(--color-primary) 8%, white);
+}
+
+.tinyos-command-palette__results > button:disabled { opacity: .58; }
+.tinyos-command-palette__results span,
+.tinyos-command-palette__results strong,
+.tinyos-command-palette__results small { display: block; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tinyos-command-palette__results strong { color: var(--color-ink); font-size: 10px; }
+.tinyos-command-palette__results small { color: var(--color-muted); font-size: 8px; }
+.tinyos-command-palette__results > button > small { text-align: right; }
+.tinyos-shell-overlay__empty { margin: 0; padding: 24px; color: var(--color-muted); font-size: 10px; text-align: center; }
+
+.tinyos-notification-center {
+  display: grid;
+  gap: 7px;
+  overflow: auto;
+  padding: 10px;
+}
+
+.tinyos-notification-center article {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 11px;
+  padding: 5px;
+}
+
+.tinyos-notification-center article[data-read="true"] { opacity: .62; }
+.tinyos-notification-center article > button:first-child { display: grid; min-width: 0; grid-template-columns: 24px minmax(0, 1fr); align-items: center; gap: 7px; padding: 6px; text-align: left; }
+.tinyos-notification-center article > button:last-child { border: 1px solid var(--color-hairline); border-radius: 7px; padding: 5px 7px; color: var(--color-muted); font-size: 8px; }
+.tinyos-notification-center article > button:last-child:disabled { opacity: .7; }
+.tinyos-notification-center span,
+.tinyos-notification-center strong,
+.tinyos-notification-center small,
+.tinyos-notification-center code { display: block; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tinyos-notification-center strong { color: var(--color-ink); font-size: 10px; }
+.tinyos-notification-center small { margin-top: 2px; color: var(--color-muted); font-size: 8px; }
+.tinyos-notification-center code { margin-top: 4px; color: var(--color-muted); font-size: 7px; }
+
+.tinyos-transfer-status {
+  position: absolute;
+  right: 12px;
+  bottom: 78px;
+  z-index: 35;
+  max-width: min(320px, calc(100% - 24px));
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--color-primary) 24%, var(--color-hairline));
+  border-radius: 9px;
+  background: rgb(255 253 249 / 97%);
+  padding: 8px 10px;
+  box-shadow: 0 12px 28px rgb(62 47 34 / 16%);
+  color: var(--color-ink);
+  font-size: 9px;
+}
+
+.tinyos-transfer-status[data-kind="error"] {
+  border-color: color-mix(in srgb, var(--color-error) 35%, var(--color-hairline));
+  color: var(--color-error);
+}
+
+.tinyos-context-menu-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 39;
+}
+
+.tinyos-context-menu-layer__backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: transparent;
+  cursor: default;
+}
+
+.tinyos-context-menu {
+  position: absolute;
+  display: grid;
+  width: 212px;
+  gap: 2px;
+  border: 1px solid rgb(75 67 57 / 16%);
+  border-radius: 11px;
+  background: rgb(255 253 249 / 98%);
+  padding: 5px;
+  box-shadow: 0 18px 48px rgb(45 36 28 / 24%);
+  backdrop-filter: blur(20px);
+}
+
+.tinyos-context-menu > button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  border-radius: 7px;
+  padding: 7px 8px;
+  color: var(--color-ink);
+  font-size: 9px;
+  text-align: left;
+}
+
+.tinyos-context-menu > button:hover:not(:disabled),
+.tinyos-context-menu > button:focus-visible {
+  background: color-mix(in srgb, var(--color-primary) 9%, white);
+}
+
+.tinyos-context-menu > button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.tinyos-context-menu > button:disabled { opacity: .48; }
+.tinyos-context-menu > button > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tinyos-context-menu > button > small { color: var(--color-muted); font-size: 7px; }
+
 .tinyos-system-dialog {
   position: absolute;
   top: 52%;
@@ -2984,6 +3744,10 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-inspector article > section > strong { color: var(--color-muted); font-size: 8px; text-transform: uppercase; }
 .tinyos-inspector article > section > pre { margin-top: 5px; border-radius: 8px; background: #f4f1eb; }
 .tinyos-inspector article > section > button { display: block; margin-top: 5px; color: var(--color-primary); font-size: 9px; cursor: pointer; }
+.tinyos-inspector__resource { display: grid; gap: 4px; margin: 6px 0 0; border: 1px solid var(--color-hairline); border-radius: 8px; background: #f8f5ef; padding: 7px; }
+.tinyos-inspector__resource > div { display: grid; grid-template-columns: 58px minmax(0, 1fr); gap: 6px; }
+.tinyos-inspector__resource dt { color: var(--color-muted); font-size: 8px; text-transform: uppercase; }
+.tinyos-inspector__resource dd { min-width: 0; margin: 0; overflow-wrap: anywhere; color: var(--color-body); font-size: 9px; }
 .tinyos-inspector article > footer { margin-top: 12px; border-top: 1px solid var(--color-hairline); padding-top: 8px; color: var(--color-muted); font-size: 8px; }
 
 .tinyos-operation-shelf {
@@ -3172,6 +3936,39 @@ button.tinyos-overlay-backdrop:focus-visible {
 
   .tinyos-shell {
     --tinyos-dock-surface: rgb(250 247 241 / 86%);
+  }
+
+  .tinyos-shell-overlay {
+    padding: 8px;
+  }
+
+  .tinyos-shell-overlay__panel {
+    max-height: calc(100% - 8px);
+    border-radius: 13px;
+  }
+
+  .tinyos-window-overview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .tinyos-window-overview__preview {
+    min-height: 58px;
+  }
+
+  .tinyos-file-resource-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tinyos-terminal__identity {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tinyos-command-palette__results > button {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .tinyos-command-palette__results > button > small {
+    text-align: left;
   }
 
   .tinyos-launcher__app {
@@ -3812,6 +4609,28 @@ button.tinyos-overlay-backdrop:focus-visible {
   width: min(860px, calc(100% - 48px));
   margin: 0 auto;
   padding: 14px 0 18px;
+}
+
+.tinyos-composer-drop-target {
+  position: relative;
+  display: grid;
+  width: 100%;
+  min-width: 0;
+}
+
+.tinyos-composer-drop-error {
+  position: absolute;
+  right: max(24px, calc((100% - 860px) / 2));
+  bottom: 8px;
+  left: max(24px, calc((100% - 860px) / 2));
+  z-index: 2;
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--color-error) 30%, var(--color-hairline));
+  border-radius: 8px;
+  background: #fff;
+  padding: 6px 8px;
+  color: var(--color-error);
+  font-size: 10px;
 }
 
 .react-composer--raised {
@@ -7254,6 +8073,23 @@ button.tinyos-overlay-backdrop:focus-visible {
 .tinyos-browser[data-truth="real_capture"] .tinyos-browser__bar b {
   color: var(--color-warning);
 }
+
+.tinyos-terminal-command__contract {
+  color: var(--color-muted);
+}
+
+.tinyos-terminal-lifecycle {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 6px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--color-primary) 7%, transparent);
+  padding: 5px 7px;
+}
+
+.tinyos-terminal-lifecycle > span { overflow: hidden; color: var(--color-muted); text-overflow: ellipsis; white-space: nowrap; }
+.tinyos-terminal-lifecycle[data-state="failed"],
+.tinyos-terminal-lifecycle[data-state="cancelled"] { background: color-mix(in srgb, var(--color-error) 7%, transparent); color: var(--color-error); }
 
 .tinyos-system-monitor {
   display: grid;

--- a/src/react-workbench/styles/workbench.test.ts
+++ b/src/react-workbench/styles/workbench.test.ts
@@ -11,4 +11,14 @@ describe("workbench CSS interaction contracts", () => {
 
     expect(backdropInteractionRule?.[1]).toContain("background: rgb(20 20 19 / 18%)");
   });
+
+  test("keeps TinyOS shell overlays compact and removes non-essential reduced-motion transitions", () => {
+    expect(stylesheet).toContain("@container (max-width: 520px)");
+    expect(stylesheet).toContain(".tinyos-shell-overlay");
+    expect(stylesheet).toContain("max-height: calc(100% - 8px)");
+    expect(stylesheet).toContain("grid-template-columns: minmax(0, 1fr)");
+    expect(stylesheet).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(stylesheet).toContain("animation-duration: 1ms !important");
+    expect(stylesheet).toContain("transition-duration: 0ms !important");
+  });
 });


### PR DESCRIPTION
## Summary

- add the TinyOS simulation workspace, canonical event replay, system monitor, files, terminal, plans, browser, and artifact surfaces
- polish the desktop experience with Side Rays, faster macOS-style transitions, a dock-scoped glass focus surface, and responsive file document layout
- unify desktop mutations behind typed commands and preserve command IDs through Thread submission
- make approval resume use the runtime checkpoint when the Thread projection has not caught up yet

## Why

TinyOS needed a cohesive simulation workspace and a single frontend mutation path. Approval could also fail immediately after a checkpoint because the Thread projection lagged behind the runtime checkpoint.

## Impact

The workspace is more responsive and visually coherent, dock controls remain clickable, frontend command handling has one typed entry point, and approvals can resume safely during projection lag.

## Validation

- `npm run build`
- targeted Vitest coverage: 73 tests passed
- `cargo fmt --check`
- `cargo test -j 4 worker_resolve_thread_approval_uses_runtime_checkpoint_before_thread_projection_catches_up` (1 passed)

The full ChatPage test file still has one pre-existing 5-second focus/animation timeout on this HDD; the related 31-test subset passed.