### PR TITLE
Fix canonical session persistence and desktop flows

### DIFF
--- a/src-tauri/src/desktop_commands/agent.rs
+++ b/src-tauri/src/desktop_commands/agent.rs
@@ -712,13 +712,10 @@ pub(crate) async fn worker_submit_thread_turn_with_live_trace_sink_async(
     live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 ) -> Result<serde_json::Value, String> {
     let _ = timeout;
-    let mut base_services = {
+    let base_services = {
         let runtime = lock_runtime(shared);
         runtime.native_agent_runtime.clone()
     };
-    if let Some(live_trace_sink) = live_trace_sink {
-        base_services = base_services.with_trace_sink(live_trace_sink);
-    }
     submit_thread_turn_with_services(
         base_services,
         SubmitThreadTurnInput {
@@ -728,6 +725,7 @@ pub(crate) async fn worker_submit_thread_turn_with_live_trace_sink_async(
         },
         workspace_root,
         config_snapshot,
+        live_trace_sink,
     )
     .await
 }

--- a/src-tauri/src/desktop_commands/gateway.rs
+++ b/src-tauri/src/desktop_commands/gateway.rs
@@ -292,7 +292,24 @@ pub(crate) fn stop_owned_gateway(shared: &SharedGateway, explicit: bool) -> Resu
     stop_owned_gateway_with_timeout(shared, explicit, Duration::from_secs(5))
 }
 
+pub(crate) async fn stop_owned_gateway_for_window_close(
+    shared: SharedGateway,
+    explicit: bool,
+) -> Result<(), String> {
+    stop_owned_gateway_async_with_timeout(&shared, explicit, Duration::from_secs(5)).await
+}
+
 pub(crate) fn stop_owned_gateway_with_timeout(
+    shared: &SharedGateway,
+    explicit: bool,
+    timeout: Duration,
+) -> Result<(), String> {
+    tauri::async_runtime::block_on(stop_owned_gateway_async_with_timeout(
+        shared, explicit, timeout,
+    ))
+}
+
+async fn stop_owned_gateway_async_with_timeout(
     shared: &SharedGateway,
     explicit: bool,
     timeout: Duration,
@@ -315,7 +332,7 @@ pub(crate) fn stop_owned_gateway_with_timeout(
             runtime.experimental_worker.status().state == WorkerManagerState::Running,
         )
     };
-    let report = tauri::async_runtime::block_on(lifecycle.shutdown(timeout));
+    let report = lifecycle.shutdown(timeout).await;
     let report_line =
         serde_json::to_string(&report).expect("runtime shutdown report should serialize");
     let failures = report
@@ -336,5 +353,22 @@ pub(crate) fn stop_owned_gateway_with_timeout(
         Ok(())
     } else {
         Err(failures.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::GatewayRuntime;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn window_close_shutdown_does_not_nest_async_runtime() {
+        let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
+
+        let result =
+            tauri::async_runtime::block_on(stop_owned_gateway_for_window_close(shared, false));
+
+        assert!(result.is_ok(), "{result:?}");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@
 use serde::Serialize;
 use std::{
     collections::VecDeque,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -11,6 +11,9 @@ use std::{
     time::Duration,
 };
 use tauri::{Emitter, Manager, Runtime, State, WindowEvent};
+
+#[cfg(test)]
+use std::path::Path;
 
 mod adapters;
 pub mod agent_loop_runtime_protocol;
@@ -65,13 +68,16 @@ pub mod worker_tool_executor;
 pub mod worker_tool_registry;
 pub mod worker_workspace;
 
+#[cfg(test)]
 use crate::config_application::{
     apply_config_operations_to_path, apply_config_patch_result_to_path,
-    config_editor_snapshot_from_path, default_tinybot_config_path, default_tinybot_workspace_root,
-    ensure_default_config_file, experimental_worker_config_snapshot,
+    config_editor_snapshot_from_path, default_tinybot_workspace_root,
     experimental_worker_config_snapshot_from_path, experimental_worker_default_config_snapshot,
-    get_settings_snapshot_from_path, native_backend_workspace_root,
-    resolve_native_backend_workspace_root_from_config_path,
+    get_settings_snapshot_from_path,
+};
+use crate::config_application::{
+    default_tinybot_config_path, ensure_default_config_file, experimental_worker_config_snapshot,
+    native_backend_workspace_root, resolve_native_backend_workspace_root_from_config_path,
 };
 use crate::config_store::ConfigDiagnosticCode;
 #[cfg(test)]
@@ -108,40 +114,48 @@ use crate::desktop_commands::config::{
     apply_config_operations, apply_config_patch_result, get_config_editor_snapshot,
     get_settings_snapshot,
 };
+#[cfg(test)]
+use crate::desktop_commands::gateway::stop_owned_gateway;
 use crate::desktop_commands::gateway::{
     gateway_exit_policy_preference_path, gateway_status, load_gateway_exit_policy,
     native_backend_log_path, set_gateway_keep_running, start_gateway,
-    start_gateway_with_workspace_root, stop_gateway, stop_owned_gateway,
+    start_gateway_with_workspace_root, stop_gateway, stop_owned_gateway_for_window_close,
 };
 use crate::desktop_commands::session::{
-    worker_agent_run_runtime_state, worker_agent_run_runtime_state_with_options,
-    worker_agent_runs_list, worker_agent_runs_list_with_options, worker_session_branch,
-    worker_session_branch_with_options, worker_session_clear, worker_session_clear_temporary_files,
-    worker_session_clear_temporary_files_with_options, worker_session_clear_with_options,
-    worker_session_delete, worker_session_delete_with_options,
-    worker_session_effective_capabilities, worker_session_messages,
-    worker_session_messages_with_options, worker_session_patch, worker_session_patch_with_options,
-    worker_session_task_progress, worker_session_task_progress_with_options,
-    worker_session_temporary_files, worker_session_temporary_files_with_options,
-    worker_session_upload_temporary_file, worker_session_upload_temporary_file_with_options,
-    worker_sessions_list, worker_sessions_list_with_options,
+    worker_agent_run_runtime_state, worker_agent_runs_list, worker_session_branch,
+    worker_session_clear, worker_session_clear_temporary_files, worker_session_delete,
+    worker_session_effective_capabilities, worker_session_messages, worker_session_patch,
+    worker_session_task_progress, worker_session_temporary_files,
+    worker_session_upload_temporary_file, worker_sessions_list,
+};
+#[cfg(test)]
+use crate::desktop_commands::session::{
+    worker_agent_run_runtime_state_with_options, worker_agent_runs_list_with_options,
+    worker_session_branch_with_options, worker_session_clear_temporary_files_with_options,
+    worker_session_clear_with_options, worker_session_delete_with_options,
+    worker_session_messages_with_options, worker_session_patch_with_options,
+    worker_session_task_progress_with_options, worker_session_temporary_files_with_options,
+    worker_session_upload_temporary_file_with_options, worker_sessions_list_with_options,
 };
 #[cfg(test)]
 use crate::desktop_commands::skills::{
     build_worker_skills_create_request, build_worker_skills_delete_request,
     build_worker_skills_detail_request, build_worker_skills_list_request,
     build_worker_skills_update_request, build_worker_skills_validate_request,
+    worker_skills_list_with_options,
 };
 use crate::desktop_commands::skills::{
     worker_skills_create, worker_skills_delete, worker_skills_detail, worker_skills_list,
-    worker_skills_list_with_options, worker_skills_update, worker_skills_validate,
+    worker_skills_update, worker_skills_validate,
 };
+#[cfg(test)]
+use crate::desktop_commands::thread::worker_thread_request_with_options;
 use crate::desktop_commands::thread::{
     worker_thread_activity, worker_thread_agent_registry, worker_thread_apply_op,
     worker_thread_archive, worker_thread_continue_turn, worker_thread_create, worker_thread_delete,
     worker_thread_events, worker_thread_fork, worker_thread_interrupt, worker_thread_read,
-    worker_thread_request_with_options, worker_thread_restore_checkpoint, worker_thread_resume,
-    worker_thread_search, worker_thread_start_turn, worker_thread_status, worker_thread_unarchive,
+    worker_thread_restore_checkpoint, worker_thread_resume, worker_thread_search,
+    worker_thread_start_turn, worker_thread_status, worker_thread_unarchive,
     worker_thread_update_metadata, worker_threads_list,
 };
 use crate::desktop_commands::transport::worker_dispatch_tinyos_host_command;
@@ -161,8 +175,11 @@ use crate::desktop_commands::webui::{
 };
 use crate::desktop_commands::workspace::{
     worker_workspace_directory, worker_workspace_file, worker_workspace_file_chunk,
-    worker_workspace_file_with_options, worker_workspace_files,
-    worker_workspace_files_with_options, worker_workspace_put_file,
+    worker_workspace_files, worker_workspace_put_file,
+};
+#[cfg(test)]
+use crate::desktop_commands::workspace::{
+    worker_workspace_file_with_options, worker_workspace_files_with_options,
     worker_workspace_put_file_with_options,
 };
 use crate::desktop_files::{pick_upload_file, reveal_workspace_file, save_export_file};
@@ -170,6 +187,7 @@ use crate::desktop_logging::append_native_backend_log_line;
 use crate::desktop_menu::{
     install_desktop_application_menu, is_desktop_menu_command, DesktopMenuCommandPayload,
 };
+#[cfg(test)]
 use crate::native_agent_bridge::{native_agent_run_record, persist_native_agent_run_start};
 use crate::native_backend_contract::NativeCompatibilityFallbackDiagnostic;
 use crate::native_browser::{
@@ -186,10 +204,11 @@ use crate::worker_agent_runtime::NativeAgentRuntimeServices;
 #[cfg(test)]
 use crate::worker_agent_runtime::NativeAgentTraceSink;
 use crate::worker_capability::default_desktop_capability_policy;
-use crate::worker_manager::{
-    WorkerCommandSpec, WorkerManager, WorkerManagerEvent, WorkerManagerState,
-};
+#[cfg(test)]
+use crate::worker_manager::{WorkerCommandSpec, WorkerManagerState};
+use crate::worker_manager::{WorkerManager, WorkerManagerEvent};
 use crate::worker_protocol::WorkerRequest;
+#[cfg(test)]
 use crate::worker_request_id::{next_worker_request_correlation, WorkerRequestCorrelation};
 use crate::worker_rpc::WorkerRpcRouter;
 use crate::worker_subagent_manager::SubagentThreadManager;
@@ -663,20 +682,33 @@ pub fn run() {
             if let WindowEvent::CloseRequested { api, .. } = event {
                 if !close_started.swap(true, Ordering::AcqRel) {
                     api.prevent_close();
+                    eprintln!("desktop_window_close_cleanup_started");
                     let browser_runtime = window
                         .app_handle()
                         .state::<native_browser::SharedBrowserRuntime>()
                         .inner()
                         .clone();
                     let close_state = close_state.clone();
+                    let close_started = close_started.clone();
                     let window = window.clone();
                     tauri::async_runtime::spawn(async move {
                         if let Err(error) = browser_runtime.shutdown().await {
-                            eprintln!("native browser shutdown cleanup failed: {error}");
+                            eprintln!("desktop_window_close_browser_cleanup_failed error={error}");
+                        } else {
+                            eprintln!("desktop_window_close_browser_cleanup_completed");
                         }
-                        let _ = stop_owned_gateway(&close_state, false);
+                        if let Err(error) =
+                            stop_owned_gateway_for_window_close(close_state, false).await
+                        {
+                            eprintln!("desktop_window_close_gateway_cleanup_failed error={error}");
+                        } else {
+                            eprintln!("desktop_window_close_gateway_cleanup_completed");
+                        }
                         if let Err(error) = window.destroy() {
-                            eprintln!("failed to destroy desktop window after cleanup: {error}");
+                            close_started.store(false, Ordering::Release);
+                            eprintln!("desktop_window_close_destroy_failed error={error}");
+                        } else {
+                            eprintln!("desktop_window_close_destroy_completed");
                         }
                     });
                 } else {

--- a/src-tauri/src/native_agent_bridge/mod.rs
+++ b/src-tauri/src/native_agent_bridge/mod.rs
@@ -20,11 +20,13 @@ pub(crate) use history::{
     native_agent_assistant_messages, native_agent_current_user_message, native_agent_message_id,
     native_agent_thread_id, native_agent_user_messages,
 };
+#[cfg(test)]
+pub(crate) use persistence::native_agent_run_record;
 pub(crate) use persistence::{
-    cancel_agent_with_services, native_agent_run_record,
-    persist_native_agent_checkpoint_if_present, persist_native_agent_run_record,
-    persist_native_agent_run_start, persist_native_agent_turn_if_final,
-    reject_native_agent_terminal_run_reentry, restore_agent_checkpoint_with_services,
+    cancel_agent_with_services, persist_native_agent_checkpoint_if_present,
+    persist_native_agent_run_record, persist_native_agent_run_start,
+    persist_native_agent_turn_if_final, reject_native_agent_terminal_run_reentry,
+    restore_agent_checkpoint_with_services,
 };
 pub(crate) use result_projection::{
     native_agent_artifacts, native_agent_current_iteration, native_agent_max_iterations,
@@ -42,9 +44,9 @@ pub(crate) use thread_flow::{
 pub(crate) use tool_dispatcher::native_agent_services_with_tool_executor;
 #[cfg(test)]
 pub(crate) use tool_dispatcher::{dispatch_agent_browser_interact, dispatch_agent_browser_observe};
-pub(crate) use trace_sink::{
-    desktop_agent_event_sink, native_agent_trace_sink, NativeAgentRunTraceSink,
-};
+#[cfg(test)]
+pub(crate) use trace_sink::NativeAgentRunTraceSink;
+pub(crate) use trace_sink::{desktop_agent_event_sink, native_agent_trace_sink};
 pub(crate) use webui_continuation::{
     native_session_checkpoint, pending_approvals_from_checkpoint,
     resolve_agent_ui_form_body_with_services, resolve_approval_body_with_services,

--- a/src-tauri/src/native_agent_bridge/thread_flow.rs
+++ b/src-tauri/src/native_agent_bridge/thread_flow.rs
@@ -6,10 +6,12 @@ use crate::native_agent_bridge::{
 };
 use crate::worker_agent_runtime::{
     ensure_agent_trace_context, AgentHookInvocation, AgentHookStage, NativeAgentRuntimeServices,
+    NativeAgentTraceSink,
 };
 use crate::worker_protocol::WorkerRequest;
 use crate::worker_request_id::next_worker_request_correlation;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::agent_flow::run_agent_with_services;
@@ -44,6 +46,7 @@ pub(crate) async fn submit_thread_turn_with_services(
     input: SubmitThreadTurnInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
+    live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 ) -> Result<serde_json::Value, String> {
     let thread = ensure_thread_turn_target(
         input.thread_id,
@@ -174,7 +177,7 @@ pub(crate) async fn submit_thread_turn_with_services(
         spec,
         workspace_root.clone(),
         config_snapshot.clone(),
-        None,
+        live_trace_sink,
     )
     .await?;
     let snapshot = read_thread_snapshot(

--- a/src-tauri/src/native_browser/mod.rs
+++ b/src-tauri/src/native_browser/mod.rs
@@ -6,6 +6,11 @@ mod model;
 mod platform;
 #[cfg(any(test, all(windows, feature = "native-browser-integration")))]
 mod test_fixture;
+#[cfg(any(
+    test,
+    not(windows),
+    all(windows, not(feature = "native-browser-runtime"))
+))]
 mod unsupported;
 #[cfg(all(windows, feature = "native-browser-runtime"))]
 mod windows;

--- a/src-tauri/src/native_browser/model.rs
+++ b/src-tauri/src/native_browser/model.rs
@@ -7,6 +7,16 @@ macro_rules! string_id {
         #[serde(transparent)]
         pub struct $name(pub String);
 
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+    };
+}
+
+macro_rules! string_id_new {
+    ($name:ident) => {
         impl $name {
             pub fn new(value: impl Into<String>) -> Result<Self, String> {
                 let value = value.into();
@@ -16,15 +26,15 @@ macro_rules! string_id {
                 }
                 Ok(Self(value.to_string()))
             }
+        }
+    };
+}
 
+macro_rules! string_id_as_str {
+    ($name:ident) => {
+        impl $name {
             pub fn as_str(&self) -> &str {
                 &self.0
-            }
-        }
-
-        impl fmt::Display for $name {
-            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str(&self.0)
             }
         }
     };
@@ -38,6 +48,16 @@ string_id!(BrowserCaptureId);
 string_id!(BrowserSurfaceId);
 string_id!(BrowserCommandId);
 string_id!(BrowserPolicyRequestId);
+
+string_id_new!(BrowserProfileId);
+#[cfg(any(test, all(windows, feature = "native-browser-integration")))]
+string_id_new!(BrowserSurfaceId);
+#[cfg(any(test, all(windows, feature = "native-browser-integration")))]
+string_id_new!(BrowserCommandId);
+
+string_id_as_str!(BrowserSessionId);
+string_id_as_str!(BrowserProfileId);
+string_id_as_str!(BrowserTabId);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -697,8 +717,8 @@ mod tests {
 
     #[test]
     fn browser_ids_reject_blank_values() {
-        assert!(BrowserSessionId::new("  ").is_err());
-        assert_eq!(BrowserTabId::new("tab-1").unwrap().as_str(), "tab-1");
+        assert!(BrowserProfileId::new("  ").is_err());
+        assert_eq!(BrowserTabId("tab-1".to_string()).as_str(), "tab-1");
     }
 
     #[test]

--- a/src-tauri/src/native_browser/platform.rs
+++ b/src-tauri/src/native_browser/platform.rs
@@ -162,6 +162,11 @@ pub(crate) trait BrowserRuntimeAdapter: Send + Sync {
     async fn delete_profile(&self, profile: &BrowserPlatformProfile) -> Result<(), String>;
 }
 
+#[cfg(any(
+    test,
+    not(windows),
+    all(windows, not(feature = "native-browser-runtime"))
+))]
 pub(crate) fn unsupported_capabilities(
     reason_code: &str,
     reason: &str,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2553,6 +2553,146 @@ fn worker_submit_thread_turn_creates_thread_and_runs_native_agent() {
 }
 
 #[test]
+fn worker_submit_thread_turn_forwards_live_streaming_timeline_patches() {
+    struct StreamingProvider;
+
+    impl crate::worker_agent_runtime::NativeAgentProvider for StreamingProvider {
+        fn complete(
+            &self,
+            _context: &crate::worker_agent_runtime::NativeAgentRunContext,
+        ) -> Result<crate::worker_agent_runtime::NativeAgentProviderResponse, String> {
+            Ok(crate::worker_agent_runtime::NativeAgentProviderResponse {
+                final_content: "streamed desktop answer".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: Vec::new(),
+            })
+        }
+
+        fn complete_streaming(
+            &self,
+            context: &crate::worker_agent_runtime::NativeAgentRunContext,
+            observer: &mut (dyn FnMut(crate::worker_agent_runtime::NativeAgentProviderStreamEvent)
+                      + Send),
+        ) -> Result<crate::worker_agent_runtime::NativeAgentProviderResponse, String> {
+            observer(
+                crate::worker_agent_runtime::NativeAgentProviderStreamEvent::ContentDelta(
+                    "streamed ".to_string(),
+                ),
+            );
+            observer(
+                crate::worker_agent_runtime::NativeAgentProviderStreamEvent::ContentDelta(
+                    "desktop answer".to_string(),
+                ),
+            );
+            self.complete(context)
+        }
+    }
+
+    #[derive(Default)]
+    struct LivePatchSink {
+        patches: Mutex<Vec<crate::agent_loop_runtime_protocol::AgentTimelinePatch>>,
+    }
+
+    impl crate::worker_agent_runtime::NativeAgentTraceSink for LivePatchSink {
+        fn append_trace_event(
+            &self,
+            _session_id: &str,
+            _run_id: &str,
+            _event: &crate::agent_loop_runtime_protocol::AgentRuntimeEventEnvelope,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn append_timeline_patch(
+            &self,
+            _session_id: &str,
+            _run_id: &str,
+            patch: &crate::agent_loop_runtime_protocol::AgentTimelinePatch,
+        ) -> Result<(), String> {
+            self.patches
+                .lock()
+                .expect("live patch sink should lock")
+                .push(patch.clone());
+            Ok(())
+        }
+    }
+
+    let fixture = WorkspaceFixture::new();
+    let services = NativeAgentRuntimeServices::new(
+        Arc::new(StreamingProvider),
+        Arc::new(crate::worker_agent_runtime::FakeNativeAgentToolDispatcher),
+        Arc::new(crate::worker_agent_runtime::InMemoryNativeAgentCheckpointStore::default()),
+        Arc::new(crate::worker_agent_runtime::InMemoryNativeAgentCancellation::default()),
+    );
+    let shared = Arc::new(Mutex::new(GatewayRuntime {
+        native_agent_runtime: services,
+        ..GatewayRuntime::default()
+    }));
+    let sink = Arc::new(LivePatchSink::default());
+
+    let result = tauri::async_runtime::block_on(
+        crate::desktop_commands::agent::worker_submit_thread_turn_with_live_trace_sink_async(
+            &shared,
+            WorkerSubmitThreadTurnInput {
+                thread_id: None,
+                input: serde_json::json!({ "content": "stream this answer" }),
+                spec: serde_json::json!({
+                    "runtime": "rust",
+                    "runId": "run-thread-live-stream"
+                }),
+            },
+            fixture.root.clone(),
+            serde_json::json!({}),
+            Duration::from_secs(1),
+            Some(sink.clone()),
+        ),
+    )
+    .expect("desktop thread submit should complete");
+
+    assert_eq!(result["agentResult"]["stopReason"], "final_response");
+    let patches = sink.patches.lock().expect("live patches should lock");
+    let assistant_patches = patches
+        .iter()
+        .filter(|patch| {
+            patch.item.kind
+                == crate::agent_loop_runtime_protocol::AgentTurnItemKind::AssistantMessage
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        assistant_patches.iter().any(|patch| {
+            patch.item.status
+                == crate::agent_loop_runtime_protocol::AgentTurnItemStatus::Running
+        }),
+        "desktop live sink should receive a running assistant patch before completion: {assistant_patches:#?}"
+    );
+    assert!(
+        assistant_patches.iter().any(|patch| {
+            patch.item.status == crate::agent_loop_runtime_protocol::AgentTurnItemStatus::Completed
+        }),
+        "desktop live sink should receive the completed assistant patch"
+    );
+    assert!(
+        assistant_patches.windows(2).all(|pair| {
+            assistant_patch_content(pair[0]).len() <= assistant_patch_content(pair[1]).len()
+        }),
+        "streamed assistant content should grow monotonically"
+    );
+
+    fn assistant_patch_content(
+        patch: &crate::agent_loop_runtime_protocol::AgentTimelinePatch,
+    ) -> &str {
+        match &patch.item.data {
+            crate::agent_loop_runtime_protocol::AgentTurnItemData::AssistantMessage {
+                content,
+                ..
+            } => content,
+            _ => "",
+        }
+    }
+}
+
+#[test]
 fn thread_owned_compaction_commits_installed_checkpoint_before_finalization() {
     let fixture = WorkspaceFixture::new();
     let shared = Arc::new(Mutex::new(GatewayRuntime::default()));

--- a/src-tauri/src/worker_agent_runtime/mod.rs
+++ b/src-tauri/src/worker_agent_runtime/mod.rs
@@ -4,8 +4,10 @@ use crate::agent_loop_runtime_protocol::{
 use crate::runtime::agent_task::{AgentCancelReason, AgentTaskRuntime};
 use crate::runtime::mcp::McpRuntime;
 use crate::worker_shell::WorkerShellRuntime;
+use crate::worker_subagent_manager::SubagentThreadManager;
+#[cfg(test)]
 use crate::worker_subagent_manager::{
-    SubagentInputSender, SubagentSendInputParams, SubagentTargetParams, SubagentThreadManager,
+    SubagentInputSender, SubagentSendInputParams, SubagentTargetParams,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -53,18 +55,17 @@ pub use self::items::{
     AgentMessageContent, AgentPlanProgressItem, AgentPlanStep, AgentPlanStepStatus,
     AgentReasoningItem, AgentToolCallItem, AgentToolResultItem, AgentUsageItem,
 };
-use self::provider::{
-    agent_chat_completion_request, agent_provider_config, chat_completion_content,
-    RustNativeAgentProvider,
-};
+#[cfg(test)]
+use self::provider::agent_chat_completion_request;
+use self::provider::{agent_provider_config, chat_completion_content, RustNativeAgentProvider};
 use self::result::event_value;
 pub use self::settings::{
     AgentOutputSchema, AgentReasoningSettings, AgentTurnSettings, ContextWindowStrategy,
 };
 use self::tool_router::NativeToolRouter;
-use self::usage::{
-    context_window_messages, context_window_messages_async, enrich_usage_with_context_window,
-};
+#[cfg(test)]
+use self::usage::enrich_usage_with_context_window;
+use self::usage::{context_window_messages, context_window_messages_async};
 pub use crate::runtime::observability::AgentRuntimeMetrics;
 pub(crate) use provider_loop::run_native_agent_turn_with_workspace_and_instructions_async;
 pub use provider_loop::{

--- a/src-tauri/src/worker_connection.rs
+++ b/src-tauri/src/worker_connection.rs
@@ -366,9 +366,9 @@ mod tests {
     use crate::worker_rpc::WorkerRpcRouter;
     use serde_json::json;
     use std::{
-        io::Cursor,
+        io::{BufReader, Cursor, Read},
         path::PathBuf,
-        sync::{Arc, Mutex},
+        sync::{Arc, Condvar, Mutex},
         time::Duration,
     };
 
@@ -376,17 +376,18 @@ mod tests {
     fn full_duplex_request_allows_worker_to_call_rust_rpc_before_final_response() {
         let fixture = WorkspaceFixture::new();
         fixture.write("AGENTS.md", "agents");
-        let reader = Cursor::new(
+        let (writer, response_gate) = SharedWriter::with_response_gate();
+        let reader = BufReader::new(GatedReader::new(
             concat!(
                 r#"{"protocol_version":"1","id":"worker-req-1","trace_id":"trace-worker","method":"workspace.list_files","params":{}}"#,
                 "\n",
+            ),
+            concat!(
                 r#"{"protocol_version":"1","id":"agent-req-1","trace_id":"trace-agent","result":{"ok":true}}"#,
                 "\n",
-            )
-            .as_bytes()
-            .to_vec(),
-        );
-        let writer = SharedWriter::default();
+            ),
+            response_gate,
+        ));
         let router = WorkerRpcRouter::new(
             fixture.root.clone(),
             json!({}),
@@ -511,12 +512,56 @@ mod tests {
         assert!(lock_pending(&pending).waiting.is_empty());
     }
 
+    type ResponseGate = Arc<(Mutex<bool>, Condvar)>;
+
+    struct GatedReader {
+        request: Cursor<Vec<u8>>,
+        response: Cursor<Vec<u8>>,
+        response_gate: ResponseGate,
+    }
+
+    impl GatedReader {
+        fn new(request: &str, response: &str, response_gate: ResponseGate) -> Self {
+            Self {
+                request: Cursor::new(request.as_bytes().to_vec()),
+                response: Cursor::new(response.as_bytes().to_vec()),
+                response_gate,
+            }
+        }
+    }
+
+    impl Read for GatedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            if self.request.position() < self.request.get_ref().len() as u64 {
+                return self.request.read(buffer);
+            }
+            let (ready, wake) = &*self.response_gate;
+            let mut ready = ready.lock().expect("response gate should lock");
+            while !*ready {
+                ready = wake.wait(ready).expect("response gate should wait");
+            }
+            self.response.read(buffer)
+        }
+    }
+
     #[derive(Clone, Default)]
     struct SharedWriter {
         bytes: Arc<Mutex<Vec<u8>>>,
+        response_gate: Option<ResponseGate>,
     }
 
     impl SharedWriter {
+        fn with_response_gate() -> (Self, ResponseGate) {
+            let response_gate = Arc::new((Mutex::new(false), Condvar::new()));
+            (
+                Self {
+                    bytes: Arc::new(Mutex::new(Vec::new())),
+                    response_gate: Some(response_gate.clone()),
+                },
+                response_gate,
+            )
+        }
+
         fn text(&self) -> String {
             let bytes = self.bytes.lock().expect("writer should lock").clone();
             String::from_utf8(bytes).expect("writer output should be utf-8")
@@ -533,6 +578,13 @@ mod tests {
         }
 
         fn flush(&mut self) -> std::io::Result<()> {
+            if self.text().contains(r#""method":"agent.echo""#) {
+                if let Some(response_gate) = &self.response_gate {
+                    let (ready, wake) = &**response_gate;
+                    *ready.lock().expect("response gate should lock") = true;
+                    wake.notify_all();
+                }
+            }
             Ok(())
         }
     }

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -2798,7 +2798,27 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
         "currentIteration": 0,
         "conversationMessageIds": [],
         "traceMessages": [],
-        "traceEvents": [],
+        "traceEvents": [{
+            "eventId": "reasoning-reload-1",
+            "eventName": "agent.reasoning_delta",
+            "sequence": 1,
+            "turnId": "run-reasoning-reload",
+            "payload": {
+                "delta": "Inspect ",
+                "modelCallId": "provider-1",
+                "reasoningId": "reasoning-1"
+            }
+        }, {
+            "eventId": "reasoning-reload-2",
+            "eventName": "agent.reasoning_delta",
+            "sequence": 2,
+            "turnId": "run-reasoning-reload",
+            "payload": {
+                "delta": "first.",
+                "modelCallId": "provider-1",
+                "reasoningId": "reasoning-1"
+            }
+        }],
         "completedToolResults": [],
         "pendingToolCalls": [],
         "checkpoint": null,
@@ -2831,18 +2851,7 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
                     "modelCallId": "provider-1",
                     "reasoningId": "reasoning-1"
                 }
-            }]
-        }),
-    ));
-    assert_eq!(append_trace.error, None);
-    let append_trace = router.dispatch(&WorkerRequest::new(
-        "req-reasoning-reload-trace-continued",
-        "trace-reasoning-reload",
-        "agent_run.append_trace_batch",
-        json!({
-            "session_id": "session-reasoning-reload",
-            "run_id": "run-reasoning-reload",
-            "events": [{
+            }, {
                 "eventId": "reasoning-reload-2",
                 "eventName": "agent.reasoning_delta",
                 "sequence": 2,
@@ -2912,9 +2921,12 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
     let items = runtime_state.result.as_ref().unwrap()["timeline"]["items"]
         .as_array()
         .expect("timeline items should be an array");
-    assert!(items.iter().any(|item| {
-        item["kind"] == "reasoning" && item["data"]["summary"] == "Inspect first."
-    }));
+    let reasoning = items
+        .iter()
+        .filter(|item| item["kind"] == "reasoning")
+        .collect::<Vec<_>>();
+    assert_eq!(reasoning.len(), 1);
+    assert_eq!(reasoning[0]["data"]["summary"], "Inspect first.");
 }
 
 #[test]

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -2770,6 +2770,154 @@ fn agent_run_persistence_drops_transient_trace_and_does_not_write_legacy_session
 }
 
 #[test]
+fn agent_run_reasoning_survives_canonical_rollout_reload() {
+    let fixture = WorkspaceFixture::new();
+    let mut router = WorkerRpcRouter::new_persistent_sessions(
+        fixture.root.clone(),
+        json!({}),
+        vec![],
+        50,
+        CapabilityPolicy::new([
+            WorkerCapability::SessionWrite,
+            WorkerCapability::SessionMetadataRead,
+        ]),
+    )
+    .unwrap();
+    let record = json!({
+        "sessionId": "session-reasoning-reload",
+        "runId": "run-reasoning-reload",
+        "status": "running",
+        "phase": "active_turn",
+        "startedAt": "2026-07-19T10:00:00Z",
+        "updatedAt": "2026-07-19T10:00:00Z",
+        "completedAt": null,
+        "stopReason": null,
+        "model": "fixture-model",
+        "provider": "fixture",
+        "maxIterations": 4,
+        "currentIteration": 0,
+        "conversationMessageIds": [],
+        "traceMessages": [],
+        "traceEvents": [],
+        "completedToolResults": [],
+        "pendingToolCalls": [],
+        "checkpoint": null,
+        "artifacts": [],
+        "usage": [],
+        "error": null
+    });
+    let upsert = router.dispatch(&WorkerRequest::new(
+        "req-reasoning-reload-upsert",
+        "trace-reasoning-reload",
+        "agent_run.upsert",
+        json!({ "record": record }),
+    ));
+    assert_eq!(upsert.error, None);
+
+    let append_trace = router.dispatch(&WorkerRequest::new(
+        "req-reasoning-reload-trace",
+        "trace-reasoning-reload",
+        "agent_run.append_trace_batch",
+        json!({
+            "session_id": "session-reasoning-reload",
+            "run_id": "run-reasoning-reload",
+            "events": [{
+                "eventId": "reasoning-reload-1",
+                "eventName": "agent.reasoning_delta",
+                "sequence": 1,
+                "turnId": "run-reasoning-reload",
+                "payload": {
+                    "delta": "Inspect ",
+                    "modelCallId": "provider-1",
+                    "reasoningId": "reasoning-1"
+                }
+            }]
+        }),
+    ));
+    assert_eq!(append_trace.error, None);
+    let append_trace = router.dispatch(&WorkerRequest::new(
+        "req-reasoning-reload-trace-continued",
+        "trace-reasoning-reload",
+        "agent_run.append_trace_batch",
+        json!({
+            "session_id": "session-reasoning-reload",
+            "run_id": "run-reasoning-reload",
+            "events": [{
+                "eventId": "reasoning-reload-2",
+                "eventName": "agent.reasoning_delta",
+                "sequence": 2,
+                "turnId": "run-reasoning-reload",
+                "payload": {
+                    "delta": "first.",
+                    "modelCallId": "provider-1",
+                    "reasoningId": "reasoning-1"
+                }
+            }, {
+                "eventId": "reasoning-reload-completed",
+                "eventName": "agent.message.completed",
+                "sequence": 3,
+                "turnId": "run-reasoning-reload",
+                "payload": {
+                    "content": "Done.",
+                    "messageId": "assistant-reasoning-reload",
+                    "messagePhase": "final_answer",
+                    "modelCallId": "provider-1"
+                }
+            }]
+        }),
+    ));
+    assert_eq!(append_trace.error, None);
+    let completed = router.dispatch(&WorkerRequest::new(
+        "req-reasoning-reload-complete",
+        "trace-reasoning-reload",
+        "agent_run.mark_completed",
+        json!({
+            "session_id": "session-reasoning-reload",
+            "run_id": "run-reasoning-reload",
+            "stop_reason": "final_response",
+            "final_content": "Done."
+        }),
+    ));
+    assert_eq!(completed.error, None);
+    drop(router);
+
+    let state_path = fixture
+        .root
+        .join(".tinybot")
+        .join("state")
+        .join("state.sqlite");
+    std::fs::remove_file(&state_path).expect("state index should be removable");
+
+    let mut restarted = WorkerRpcRouter::new_persistent_sessions(
+        fixture.root.clone(),
+        json!({}),
+        vec![],
+        50,
+        CapabilityPolicy::new([
+            WorkerCapability::SessionWrite,
+            WorkerCapability::SessionMetadataRead,
+        ]),
+    )
+    .unwrap();
+    let runtime_state = restarted.dispatch(&WorkerRequest::new(
+        "req-reasoning-reload-state",
+        "trace-reasoning-reload",
+        "agent_run.runtime_state",
+        json!({
+            "session_id": "session-reasoning-reload",
+            "run_id": "run-reasoning-reload"
+        }),
+    ));
+    assert_eq!(runtime_state.error, None);
+    let items = runtime_state.result.as_ref().unwrap()["timeline"]["items"]
+        .as_array()
+        .expect("timeline items should be an array");
+    assert!(items.iter().any(|item| {
+        item["kind"] == "reasoning" && item["data"]["summary"] == "Inspect first."
+    }));
+}
+
+#[test]
 fn agent_run_trace_append_preserves_thread_updated_at_and_keeps_index_clean() {
     let fixture = WorkspaceFixture::new();
     let mut router = WorkerRpcRouter::new_persistent_sessions(
@@ -5287,13 +5435,36 @@ fn thread_fork_inherits_effective_history_from_canonical_rollout() {
     ));
     assert_eq!(rollback.error, None);
 
+    let source = router.dispatch(&WorkerRequest::new(
+        "req-rollout-fork-source-read",
+        "trace-rollout-fork",
+        "thread.read",
+        json!({
+            "threadId": "thread-rollout-fork-source",
+            "limit": 80
+        }),
+    ));
+    assert_eq!(source.error, None);
+    let fork_after_sequence = source.result.as_ref().unwrap()["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| {
+            item["kind"]["type"] == "assistant_message_completed"
+                && item["kind"]["payload"]["content"] == "keep assistant"
+        })
+        .unwrap()["sequence"]
+        .as_u64()
+        .unwrap();
+
     let fork = router.dispatch(&WorkerRequest::new(
         "req-rollout-fork",
         "trace-rollout-fork",
         "thread.fork",
         json!({
             "threadId": "thread-rollout-fork-source",
-            "title": "Canonical fork"
+            "title": "Canonical fork",
+            "forkAfterSequence": fork_after_sequence
         }),
     ));
     assert_eq!(fork.error, None);
@@ -5317,6 +5488,87 @@ fn thread_fork_inherits_effective_history_from_canonical_rollout() {
         .map(|message| message["content"].as_str().unwrap())
         .collect::<Vec<_>>();
     assert_eq!(contents, vec!["keep user", "keep assistant"]);
+
+    let runs = router.dispatch(&WorkerRequest::new(
+        "req-rollout-fork-runs",
+        "trace-rollout-fork",
+        "agent_run.list",
+        json!({ "sessionId": fork_thread_id }),
+    ));
+    assert_eq!(runs.error, None);
+    let fork_run_id = runs.result.as_ref().unwrap()["runs"][0]["runId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(fork_run_id, "run-rollout-fork-1");
+    let runtime_state = router.dispatch(&WorkerRequest::new(
+        "req-rollout-fork-runtime-state",
+        "trace-rollout-fork",
+        "agent_run.runtime_state",
+        json!({
+            "session_id": fork_thread_id,
+            "run_id": fork_run_id
+        }),
+    ));
+    assert_eq!(runtime_state.error, None);
+    assert_eq!(
+        runtime_state.result.as_ref().unwrap()["timeline"]["items"][0]["kind"],
+        "user_message"
+    );
+    assert_eq!(
+        runtime_state.result.as_ref().unwrap()["timeline"]["items"][0]["data"]["content"],
+        "keep user"
+    );
+    assert_eq!(
+        runtime_state.result.as_ref().unwrap()["timeline"]["items"][1]["kind"],
+        "assistant_message"
+    );
+    assert_eq!(
+        runtime_state.result.as_ref().unwrap()["timeline"]["items"][1]["data"]["content"],
+        "keep assistant"
+    );
+
+    let rename = router.dispatch(&WorkerRequest::new(
+        "req-rollout-fork-rename",
+        "trace-rollout-fork",
+        "thread.update_metadata",
+        json!({
+            "threadId": fork_thread_id,
+            "metadata": { "title": "Durable fork title" }
+        }),
+    ));
+    assert_eq!(rename.error, None);
+    drop(router);
+
+    let state_path = fixture
+        .root
+        .join(".tinybot")
+        .join("state")
+        .join("state.sqlite");
+    std::fs::remove_file(&state_path).expect("state index should be removable");
+
+    let mut router = WorkerRpcRouter::new_persistent_sessions(
+        fixture.root.clone(),
+        json!({}),
+        vec![],
+        20,
+        CapabilityPolicy::new([
+            WorkerCapability::SessionMetadataRead,
+            WorkerCapability::SessionWrite,
+        ]),
+    )
+    .unwrap();
+    let reloaded = router.dispatch(&WorkerRequest::new(
+        "req-rollout-fork-reloaded",
+        "trace-rollout-fork",
+        "thread.read",
+        json!({ "threadId": fork_thread_id, "limit": 80 }),
+    ));
+    assert_eq!(reloaded.error, None);
+    assert_eq!(
+        reloaded.result.as_ref().unwrap()["thread"]["title"],
+        "Durable fork title"
+    );
 }
 
 #[test]

--- a/src-tauri/src/worker_thread/mod.rs
+++ b/src-tauri/src/worker_thread/mod.rs
@@ -5,7 +5,7 @@ mod types;
 
 pub use self::live_thread::LiveThread;
 pub use self::runtime::ThreadRuntime;
-pub(crate) use self::store::run_summaries_from_items;
+pub(crate) use self::store::{run_summaries_from_items, runtime_events_from_thread_items};
 pub use self::store::{
     MemoryThreadStore, ThreadPersistenceRepairMode, ThreadPersistenceRepairRequest, ThreadStore,
 };

--- a/src-tauri/src/worker_thread/store/memory.rs
+++ b/src-tauri/src/worker_thread/store/memory.rs
@@ -408,6 +408,7 @@ impl MemoryThreadStore {
         };
         let events = items
             .iter()
+            .filter(|item| !matches!(&item.kind, ThreadItemKind::UserMessage(_)))
             .filter_map(trace_event_from_thread_item)
             .collect::<Vec<_>>();
         let page_items = events

--- a/src-tauri/src/worker_thread/store/mod.rs
+++ b/src-tauri/src/worker_thread/store/mod.rs
@@ -44,9 +44,8 @@ use self::query::{
     parse_sequence_cursor, parse_trace_cursor, read_cursor_from_request,
     thread_matches_list_filters, thread_matches_query,
 };
-use self::runtime_projection::{
-    runtime_events_from_thread_items, trace_event_from_thread_item, turn_items_from_thread_items,
-};
+pub(crate) use self::runtime_projection::runtime_events_from_thread_items;
+use self::runtime_projection::{trace_event_from_thread_item, turn_items_from_thread_items};
 use self::subagent_projection::{
     active_child_run_id_for_status, inherited_subagent_history_items, status_value,
     subagent_agent_control_payload, subagent_child_status_item, subagent_initial_child_items,

--- a/src-tauri/src/worker_thread/store/runtime_projection.rs
+++ b/src-tauri/src/worker_thread/store/runtime_projection.rs
@@ -7,12 +7,31 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 pub(super) fn trace_event_from_thread_item(item: &ThreadItem) -> Option<Value> {
-    let (payload, fallback_event_name) = match &item.kind {
-        ThreadItemKind::AssistantMessageDelta(value) => (value, Some("agent.assistant.delta")),
-        ThreadItemKind::AssistantMessageCompleted(value) => {
-            (value, Some("agent.assistant.completed"))
+    if let ThreadItemKind::Reasoning(value) = &item.kind {
+        let has_trace_shape = value.get("eventName").is_some()
+            || value.get("event_name").is_some()
+            || value.get("schemaVersion").is_some()
+            || value.get("schema_version").is_some();
+        if has_trace_shape {
+            return Some(value.clone());
         }
-        ThreadItemKind::Reasoning(value) => (value, Some("agent.reasoning")),
+        let mut payload = value.as_object().cloned().unwrap_or_default();
+        payload.insert(
+            "delta".to_string(),
+            Value::String(reasoning_response_text(value)),
+        );
+        return Some(serde_json::json!({
+            "eventName": "agent.reasoning_delta",
+            "payload": payload,
+        }));
+    }
+    let (payload, fallback_event_name) = match &item.kind {
+        ThreadItemKind::UserMessage(value) => (value, Some("agent.turn.started")),
+        ThreadItemKind::AssistantMessageDelta(value) => (value, Some("agent.delta")),
+        ThreadItemKind::AssistantMessageCompleted(value) => {
+            (value, Some("agent.message.completed"))
+        }
+        ThreadItemKind::Reasoning(_) => unreachable!("reasoning items return above"),
         ThreadItemKind::ToolCallStarted(value) => (value, Some("agent.tool.start")),
         ThreadItemKind::ToolCallOutput(value) => (value, Some("agent.tool.result")),
         ThreadItemKind::ApprovalRequested(value) => (value, Some("agent.awaiting_approval")),
@@ -27,8 +46,7 @@ pub(super) fn trace_event_from_thread_item(item: &ThreadItem) -> Option<Value> {
         ThreadItemKind::Error(value) => (value, Some("agent.error")),
         ThreadItemKind::Cancelled(value) => (value, Some("agent.cancelled")),
         ThreadItemKind::Event(value) => (value, None),
-        ThreadItemKind::UserMessage(_)
-        | ThreadItemKind::AgentRunStarted(_)
+        ThreadItemKind::AgentRunStarted(_)
         | ThreadItemKind::AgentRunCompleted(_)
         | ThreadItemKind::SettingsChanged(_) => return None,
     };
@@ -45,6 +63,30 @@ pub(super) fn trace_event_from_thread_item(item: &ThreadItem) -> Option<Value> {
             "payload": payload,
         })
     })
+}
+
+fn reasoning_response_text(value: &Value) -> String {
+    if let Some(text) = value
+        .get("summary")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("text").and_then(Value::as_str))
+        .next()
+    {
+        return text.to_string();
+    }
+    value
+        .get("content")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("text").and_then(Value::as_str))
+        .next()
+        .or_else(|| value.get("summary").and_then(Value::as_str))
+        .or_else(|| value.get("content").and_then(Value::as_str))
+        .unwrap_or_default()
+        .to_string()
 }
 
 fn runtime_event_from_thread_item(
@@ -114,7 +156,7 @@ fn runtime_event_from_thread_item(
     ))
 }
 
-pub(super) fn runtime_events_from_thread_items(
+pub(crate) fn runtime_events_from_thread_items(
     items: &[ThreadItem],
     session_id: &str,
     run_id: &str,

--- a/src-tauri/src/worker_thread_log/agent_run.rs
+++ b/src-tauri/src/worker_thread_log/agent_run.rs
@@ -125,6 +125,7 @@ impl WorkerThreadLogRpc {
                 event.get("eventName").and_then(Value::as_str),
                 Some(
                     "agent.turn.started"
+                        | "agent.reasoning_delta"
                         | "agent.message.classified"
                         | "agent.message.completed"
                         | "agent.tool_call.delta"
@@ -133,8 +134,40 @@ impl WorkerThreadLogRpc {
             )
         });
         let mut items = Vec::new();
+        let mut pending_reasoning = None::<ReasoningResponseAccumulator>;
         for event in events.iter().cloned() {
+            if let Some(fragment) = ReasoningResponseFragment::from_runtime_event(&event) {
+                if pending_reasoning
+                    .as_ref()
+                    .is_some_and(|pending| !pending.matches(&fragment))
+                {
+                    push_reasoning_response_item(
+                        &mut items,
+                        pending_reasoning
+                            .take()
+                            .expect("pending reasoning should exist"),
+                        run_id,
+                    )?;
+                }
+                pending_reasoning
+                    .get_or_insert_with(|| ReasoningResponseAccumulator::from_fragment(&fragment))
+                    .push(fragment);
+            } else if let Some(pending) = pending_reasoning.take() {
+                push_reasoning_response_item(&mut items, pending, run_id)?;
+            }
             let response_item = response_item_from_runtime_event(&event)
+                .map(|mut item| {
+                    item["runId"] = Value::String(run_id.to_string());
+                    item["turnId"] = Value::String(
+                        event
+                            .get("turnId")
+                            .and_then(Value::as_str)
+                            .unwrap_or(run_id)
+                            .to_string(),
+                    );
+                    item["threadItemPayload"] = event.clone();
+                    item
+                })
                 .map(|item| super::typed_response_item(item, "agent run trace"))
                 .transpose()?;
             let token_info = (event.get("eventName").and_then(Value::as_str)
@@ -163,6 +196,9 @@ impl WorkerThreadLogRpc {
             if let Some(response_item) = response_item {
                 items.push(ThreadLogItem::ResponseItem(response_item));
             }
+        }
+        if let Some(pending) = pending_reasoning {
+            push_reasoning_response_item(&mut items, pending, run_id)?;
         }
         self.recorder
             .append_items(&path, timestamp.clone(), items)?;
@@ -303,20 +339,88 @@ impl WorkerThreadLogRpc {
         session_id: &str,
         run_id: &str,
     ) -> Result<Option<AgentRunRuntimeState>, WorkerProtocolError> {
-        let Some(record) = self.get_agent_run(session_id, run_id)? else {
+        self.require(WorkerCapability::SessionMetadataRead)?;
+        validate_agent_run_key(session_id, run_id)?;
+        self.ensure_state_index()?;
+        let mut selected = None;
+        for state_record in self.state.list_threads()?.into_iter().filter(|record| {
+            !record.archived
+                && (record.id == session_id || record.session_id.as_deref() == Some(session_id))
+        }) {
+            let path = PathBuf::from(state_record.thread_path);
+            self.recorder.validate_thread_path(&path)?;
+            let reconstructed =
+                super::reconstruction::reconstruct_canonical_rollout(&read_thread_lines(&path)?)?;
+            let Some(record) = reconstructed
+                .agent_runs
+                .iter()
+                .find(|record| record.run_id == run_id)
+                .cloned()
+            else {
+                continue;
+            };
+            if selected
+                .as_ref()
+                .is_none_or(|(current, _): &(AgentRunRecord, Vec<_>)| {
+                    record.updated_at > current.updated_at
+                })
+            {
+                selected = Some((record, reconstructed.thread_items));
+            }
+        }
+        let Some((record, thread_items)) = selected else {
             return Ok(None);
         };
-        let runtime_events = record
-            .trace_events
-            .iter()
-            .enumerate()
-            .filter_map(|(index, event)| runtime_event_from_trace_value(&record, index, event))
-            .collect::<Vec<_>>();
-        Ok(Some(AgentRunRuntimeState::from_runtime_events(
+        let canonical_events = crate::worker_thread::runtime_events_from_thread_items(
+            &thread_items,
             session_id,
             run_id,
-            runtime_events,
-        )?))
+        );
+        let mut runtime_events = Vec::new();
+        for event in canonical_events {
+            if !runtime_events
+                .iter()
+                .any(|existing| same_projected_runtime_event(existing, &event))
+            {
+                runtime_events.push(event);
+            }
+        }
+        for (index, event) in record.trace_events.iter().enumerate() {
+            let Some(event) = runtime_event_from_trace_value(&record, index, event) else {
+                continue;
+            };
+            let already_projected = runtime_events
+                .iter()
+                .any(|existing| same_projected_runtime_event(existing, &event));
+            if !already_projected {
+                runtime_events.push(event);
+            }
+        }
+        let runtime_state =
+            AgentRunRuntimeState::from_runtime_events(session_id, run_id, runtime_events.clone())
+                .map_err(|error| {
+                    let diagnostics = runtime_events
+                        .iter()
+                        .map(|event| {
+                            serde_json::json!({
+                                "eventId": event.event_id,
+                                "eventName": event.event_name,
+                                "itemId": event.item_id,
+                                "sequence": event.sequence,
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    eprintln!(
+                        "agent_run_runtime_state_projection_failed session_id={} run_id={} error={} details={} events={}",
+                        session_id,
+                        run_id,
+                        error.message,
+                        error.details,
+                        Value::Array(diagnostics),
+                    );
+                    error
+                })?;
+        Ok(Some(runtime_state))
     }
 
     pub fn set_agent_run_checkpoint(
@@ -732,6 +836,97 @@ fn response_item_from_runtime_event(event: &Value) -> Option<Value> {
         })),
         _ => None,
     }
+}
+
+struct ReasoningResponseFragment {
+    event_id: String,
+    turn_id: String,
+    model_call_id: Option<String>,
+    reasoning_id: Option<String>,
+    text: String,
+}
+
+impl ReasoningResponseFragment {
+    fn from_runtime_event(event: &Value) -> Option<Self> {
+        if event.get("eventName").and_then(Value::as_str) != Some("agent.reasoning_delta") {
+            return None;
+        }
+        let payload = event.get("payload")?;
+        let text = payload.get("delta").and_then(Value::as_str)?;
+        Some(Self {
+            event_id: event.get("eventId").and_then(Value::as_str)?.to_string(),
+            turn_id: event
+                .get("turnId")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            model_call_id: payload
+                .get("modelCallId")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            reasoning_id: payload
+                .get("reasoningId")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            text: text.to_string(),
+        })
+    }
+}
+
+struct ReasoningResponseAccumulator {
+    event_id: String,
+    turn_id: String,
+    model_call_id: Option<String>,
+    reasoning_id: Option<String>,
+    text: String,
+}
+
+impl ReasoningResponseAccumulator {
+    fn from_fragment(fragment: &ReasoningResponseFragment) -> Self {
+        Self {
+            event_id: fragment.event_id.clone(),
+            turn_id: fragment.turn_id.clone(),
+            model_call_id: fragment.model_call_id.clone(),
+            reasoning_id: fragment.reasoning_id.clone(),
+            text: String::new(),
+        }
+    }
+
+    fn matches(&self, fragment: &ReasoningResponseFragment) -> bool {
+        self.turn_id == fragment.turn_id
+            && self.model_call_id == fragment.model_call_id
+            && self.reasoning_id == fragment.reasoning_id
+    }
+
+    fn push(&mut self, fragment: ReasoningResponseFragment) {
+        self.text.push_str(&fragment.text);
+    }
+}
+
+fn push_reasoning_response_item(
+    items: &mut Vec<ThreadLogItem>,
+    reasoning: ReasoningResponseAccumulator,
+    run_id: &str,
+) -> Result<(), WorkerProtocolError> {
+    let response_item = super::typed_response_item(
+        serde_json::json!({
+            "type": "reasoning",
+            "id": reasoning.event_id,
+            "summary": [{
+                "type": "summary_text",
+                "text": reasoning.text,
+            }],
+            "content": null,
+            "encrypted_content": null,
+            "runId": run_id,
+            "turnId": reasoning.turn_id,
+            "modelCallId": reasoning.model_call_id,
+            "reasoningId": reasoning.reasoning_id,
+        }),
+        "agent reasoning",
+    )?;
+    items.push(ThreadLogItem::ResponseItem(response_item));
+    Ok(())
 }
 
 fn agent_run_status_is_resumable(status: &AgentRunStatus) -> bool {
@@ -1244,8 +1439,56 @@ fn runtime_event_from_trace_value(
     ))
 }
 
+fn same_projected_runtime_event(
+    left: &AgentRuntimeEventEnvelope,
+    right: &AgentRuntimeEventEnvelope,
+) -> bool {
+    if left.event_id == right.event_id {
+        return true;
+    }
+    if matches!(
+        left.event_name.as_str(),
+        "agent.delta" | "agent.reasoning_delta"
+    ) || matches!(
+        right.event_name.as_str(),
+        "agent.delta" | "agent.reasoning_delta"
+    ) {
+        return false;
+    }
+    if left.event_name == right.event_name
+        && matches!(
+            left.event_name.as_str(),
+            "agent.done" | "agent.error" | "agent.cancelled"
+        )
+    {
+        return true;
+    }
+    left.item_id.is_some() && left.event_name == right.event_name && left.item_id == right.item_id
+}
+
 fn legacy_trace_item_id(event_name: &str, payload: &Value) -> Option<String> {
     match event_name {
+        "agent.delta"
+        | "agent.message.phase"
+        | "agent.message.classified"
+        | "agent.message.completed" => {
+            string_from_trace_payload(payload, &["messageId", "message_id"]).or_else(|| {
+                prefixed_string_from_trace_payload(
+                    payload,
+                    "assistant",
+                    &["modelCallId", "model_call_id"],
+                )
+            })
+        }
+        "agent.reasoning_delta" => {
+            string_from_trace_payload(payload, &["reasoningId", "reasoning_id"]).or_else(|| {
+                prefixed_string_from_trace_payload(
+                    payload,
+                    "reasoning",
+                    &["modelCallId", "model_call_id"],
+                )
+            })
+        }
         "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" => {
             string_from_trace_payload(payload, &["toolCallId", "tool_call_id"])
         }
@@ -1269,6 +1512,14 @@ fn string_from_trace_payload(payload: &Value, keys: &[&str]) -> Option<String> {
             .and_then(Value::as_str)
             .map(str::to_string)
     })
+}
+
+fn prefixed_string_from_trace_payload(
+    payload: &Value,
+    prefix: &str,
+    keys: &[&str],
+) -> Option<String> {
+    string_from_trace_payload(payload, keys).map(|value| format!("{prefix}:{value}"))
 }
 
 fn parse_trace_cursor(cursor: Option<&str>) -> Result<usize, WorkerProtocolError> {

--- a/src-tauri/src/worker_thread_log/agent_run.rs
+++ b/src-tauri/src/worker_thread_log/agent_run.rs
@@ -14,7 +14,7 @@ use crate::worker_session::{
     AgentRunCheckpoint, AgentRunRecord, AgentRunRuntimeState, AgentRunStatus, AgentRunTracePage,
 };
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 impl WorkerThreadLogRpc {
@@ -376,6 +376,11 @@ impl WorkerThreadLogRpc {
             session_id,
             run_id,
         );
+        let canonical_reasoning_item_ids = canonical_events
+            .iter()
+            .filter(|event| event.event_name == "agent.reasoning_delta")
+            .filter_map(|event| event.item_id.clone())
+            .collect::<HashSet<_>>();
         let mut runtime_events = Vec::new();
         for event in canonical_events {
             if !runtime_events
@@ -389,6 +394,14 @@ impl WorkerThreadLogRpc {
             let Some(event) = runtime_event_from_trace_value(&record, index, event) else {
                 continue;
             };
+            if event.event_name == "agent.reasoning_delta"
+                && event
+                    .item_id
+                    .as_ref()
+                    .is_some_and(|item_id| canonical_reasoning_item_ids.contains(item_id))
+            {
+                continue;
+            }
             let already_projected = runtime_events
                 .iter()
                 .any(|existing| same_projected_runtime_event(existing, &event));

--- a/src-tauri/src/worker_thread_log/mod.rs
+++ b/src-tauri/src/worker_thread_log/mod.rs
@@ -2681,7 +2681,7 @@ fn fork_rollout_line_indexes(
                 .iter()
                 .enumerate()
                 .filter_map(|(index, line)| {
-                    thread_item_sequence_from_rollout_line(line).map(|value| (index, value))
+                    thread_item_sequence_from_rollout_line(line, index).map(|value| (index, value))
                 })
                 .collect::<Vec<_>>();
             let Some(max_sequence) = sequenced.iter().map(|(_, value)| *value).max() else {
@@ -2785,19 +2785,60 @@ fn fork_inherits_rollout_item(item: &ThreadLogItem, include_checkpoints: bool) -
     }
 }
 
-fn thread_item_sequence_from_rollout_line(line: &ThreadLogLine) -> Option<u64> {
+fn thread_item_sequence_from_rollout_line(line: &ThreadLogLine, index: usize) -> Option<u64> {
+    let rollout_sequence = line.ordinal.unwrap_or(index as u64);
     match &line.item {
-        ThreadLogItem::ResponseItem(message) => {
-            message.get("threadItemSequence").and_then(Value::as_u64)
+        ThreadLogItem::ResponseItem(message) => message
+            .get("threadItemSequence")
+            .or_else(|| message.get("thread_item_sequence"))
+            .and_then(Value::as_u64)
+            .or(Some(rollout_sequence)),
+        ThreadLogItem::Compacted(_) | ThreadLogItem::InterAgentCommunication(_) => {
+            Some(rollout_sequence)
         }
-        ThreadLogItem::Compacted(checkpoint) => checkpoint
-            .get("_threadItemSequence")
-            .and_then(Value::as_u64),
         ThreadLogItem::EventMsg(event) if event.kind() == &EventKind::ThreadItem => event
             .payload()
             .get("item")
             .and_then(|item| item.get("sequence"))
-            .and_then(Value::as_u64),
+            .and_then(Value::as_u64)
+            .filter(|sequence| *sequence != 0)
+            .or(Some(rollout_sequence)),
+        ThreadLogItem::EventMsg(event)
+            if matches!(
+                event.kind(),
+                EventKind::TurnStarted | EventKind::TurnComplete | EventKind::UserMessage
+            ) =>
+        {
+            event
+                .payload()
+                .get("_threadItemSequence")
+                .and_then(Value::as_u64)
+                .or(Some(rollout_sequence))
+        }
+        ThreadLogItem::EventMsg(event) if event.kind() == &EventKind::AgentRunTrace => {
+            let event_name = event
+                .payload()
+                .get("event")
+                .and_then(|event| event.get("eventName").or_else(|| event.get("event_name")))
+                .and_then(Value::as_str);
+            if matches!(
+                event_name,
+                Some(
+                    "agent.context.compacted"
+                        | "agent.delta"
+                        | "agent.message.phase"
+                        | "agent.message.classified"
+                        | "agent.message.completed"
+                )
+            ) {
+                None
+            } else {
+                Some(rollout_sequence)
+            }
+        }
+        ThreadLogItem::EventMsg(event) if event.kind() == &EventKind::AgentRunCheckpointSet => {
+            Some(rollout_sequence)
+        }
         _ => None,
     }
 }

--- a/src/app-core/chat/desktopChatSessionController.test.ts
+++ b/src/app-core/chat/desktopChatSessionController.test.ts
@@ -52,7 +52,7 @@ describe("desktop native chat session controller", () => {
     const { controller, submitThreadTurn } = createController();
     await controller.loadSessions();
 
-    await expect(controller.submitMessage("hello", {
+    const result = await controller.submitMessage("hello", {
       model: "model-1",
       references: [{
         kind: "reference",
@@ -66,14 +66,22 @@ describe("desktop native chat session controller", () => {
         sizeBytes: 7,
         content: "# Notes",
       }],
-    })).resolves.toEqual({
+    });
+    expect(result).toEqual({
       status: "sent",
       sessionId: "thread-1",
       threadId: "thread-1",
       runId: "run-1",
       content: "hello",
       clientEventId: "client-1",
+      completion: expect.any(Promise),
     });
+    if (result.status === "sent") {
+      await expect(result.completion).resolves.toMatchObject({
+        sessionId: "thread-1",
+        turns: [],
+      });
+    }
     expect(submitThreadTurn).toHaveBeenCalledWith({
       threadId: "thread-1",
       input: {

--- a/src/app-core/chat/desktopChatSessionController.ts
+++ b/src/app-core/chat/desktopChatSessionController.ts
@@ -40,7 +40,15 @@ export interface DesktopChatSessionControllerOptions {
 
 export type ChatSubmitResult =
   | { status: "empty" }
-  | { status: "sent"; sessionId: string; threadId: string; runId: string; content: string; clientEventId: string };
+  | {
+    status: "sent";
+    sessionId: string;
+    threadId: string;
+    runId: string;
+    content: string;
+    clientEventId: string;
+    completion: Promise<ChatTimelineSnapshot>;
+  };
 
 export type ChatDeleteSessionResult =
   | { status: "missing"; deletedSessionKey: string; nextSessionKey: "" }
@@ -350,15 +358,43 @@ export function createDesktopChatSessionController({
         },
       },
     };
-    void api.submitThreadTurn(request).catch((error) => {
-      state.error = error instanceof Error ? error.message : String(error);
-      logDesktopNativeDebug("session.message.failed", {
-        ...summarizeSessionState(),
-        error: state.error,
-        runId,
-        threadId,
+    const sessionId = state.activeSessionKey;
+    const completion = api.submitThreadTurn(request)
+      .then(async (result) => {
+        if (result.sessionId !== sessionId || result.runId !== runId) {
+          throw new Error(
+            `Completed Thread turn identity mismatch: ${result.sessionId}/${result.runId}, expected ${sessionId}/${runId}`,
+          );
+        }
+        const liveTimeline = timelineModel.snapshot(sessionId);
+        const liveTurn = liveTimeline.turns.find((turn) => turn.id === runId);
+        const hasLiveTerminalTurn = liveTurn
+          ? ["completed", "failed", "interrupted"].includes(liveTurn.status)
+          : false;
+        const timeline = hasLiveTerminalTurn
+          ? liveTimeline
+          : await reloadTimeline(sessionId);
+        state.error = "";
+        logDesktopNativeDebug("session.message.completed", {
+          ...summarizeSessionState(),
+          convergenceSource: hasLiveTerminalTurn ? "live_timeline" : "runtime_reload",
+          runId,
+          sessionId,
+          threadId,
+          turnCount: timeline.turns.length,
+        });
+        return timeline;
+      })
+      .catch((error) => {
+        state.error = error instanceof Error ? error.message : String(error);
+        logDesktopNativeDebug("session.message.failed", {
+          ...summarizeSessionState(),
+          error: state.error,
+          runId,
+          threadId,
+        });
+        throw error;
       });
-    });
     logDesktopNativeDebug("session.message.sent", {
       ...summarizeSessionState(),
       content: summarizeDebugText(trimmed),
@@ -369,11 +405,12 @@ export function createDesktopChatSessionController({
     });
     return {
       status: "sent",
-      sessionId: state.activeSessionKey,
+      sessionId,
       threadId,
       runId,
       content: trimmed,
       clientEventId,
+      completion,
     };
   }
 

--- a/src/app-core/native/desktopNativeThreads.ts
+++ b/src/app-core/native/desktopNativeThreads.ts
@@ -97,7 +97,7 @@ export type NativeThreadsApi = {
   applyOp(body: Record<string, unknown>): Promise<unknown>;
   archive(body: { threadId: string; archived?: boolean }): Promise<NativeThreadRecord>;
   unarchive(body: { threadId: string }): Promise<NativeThreadRecord>;
-  delete(body: { threadId: string }): Promise<unknown>;
+  delete(body: { threadId: string; deleteChildren?: boolean }): Promise<unknown>;
   fork(body: Record<string, unknown>): Promise<unknown>;
   events(body: Record<string, unknown>): Promise<unknown>;
   restoreCheckpoint(body: Record<string, unknown>): Promise<unknown>;

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -2744,6 +2744,10 @@ describe("ChatPage", () => {
     fireEvent.change(input, { target: { value: "Keep this optimistic title" } });
     fireEvent.click(screen.getByRole("button", { name: /send message/i }));
     expect(await screen.findByRole("heading", { name: "Keep this optimistic title" })).toBeTruthy();
+    await waitFor(() => expect(stores.sessionStore.rename).toHaveBeenCalledWith(
+      "s1",
+      "Keep this optimistic title",
+    ));
 
     act(() => subscribed?.({ type: "chat.created" }));
     await waitFor(() => expect(stores.sessionStore.list).toHaveBeenCalledTimes(2));

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1083,6 +1083,7 @@ export function ChatPage({
     if (optimisticSession !== sendSession) {
       optimisticSessionTitlesRef.current.set(sendSession.id, optimisticSession.title);
       setSessions((current) => current.map((session) => session.id === sendSession.id ? optimisticSession : session));
+      await sessionStore.rename(sendSession.id, optimisticSession.title);
     }
     await dispatchTurn(sendSession.id, {
       text: queuedResult.content,

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -113,6 +113,22 @@ describe("desktop native app services", () => {
     });
   });
 
+  test("persists session renames through Thread metadata", async () => {
+    const services = createDesktopAppServices();
+
+    await services.sessionStore.list();
+    await services.sessionStore.rename("thread-1", "Durable title");
+
+    expect(mocks.invoke).toHaveBeenCalledWith("worker_thread_update_metadata", {
+      input: {
+        body: {
+          threadId: "thread-1",
+          metadata: { title: "Durable title" },
+        },
+      },
+    });
+  });
+
   test("submits chat messages through the typed Thread command", async () => {
     const services = createDesktopAppServices();
     await services.sessionStore.list();
@@ -141,6 +157,181 @@ describe("desktop native app services", () => {
     expect(events).toContainEqual(expect.objectContaining({ type: "message-sent" }));
   });
 
+  test("preserves live reasoning after the completed Thread result arrives", async () => {
+    let completedRunId = "";
+    let resolveSubmit!: (value: unknown) => void;
+    const pendingSubmit = new Promise((resolve) => {
+      resolveSubmit = resolve;
+    });
+    mocks.invoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "worker_threads_list") return { threads: [thread], total: 1 };
+      if (command === "worker_agent_runs_list") {
+        return { runs: completedRunId ? [{ runId: completedRunId }] : [] };
+      }
+      if (command === "worker_agent_run_runtime_state") {
+        return canonicalRuntimeState(completedRunId, "completed");
+      }
+      if (command === "worker_submit_thread_turn") {
+        const input = args?.input as { spec?: { runId?: string } } | undefined;
+        completedRunId = input?.spec?.runId ?? "";
+        return pendingSubmit;
+      }
+      return {};
+    });
+    const services = createDesktopAppServices();
+    await services.chatStore.load("thread-1");
+    const events: ChatEvent[] = [];
+    services.chatStore.subscribe("thread-1", (event) => events.push(event));
+
+    await services.chatStore.dispatch(createDesktopTurnSubmitCommand({
+      commandId: "command-live-reasoning",
+      message: { text: "hello" },
+      sessionId: "thread-1",
+      source: { control: "test", surface: "chat" },
+    }));
+    const listener = mocks.listeners.get("agent:timeline:patch");
+    expect(listener).toBeTypeOf("function");
+    const baseItem = canonicalRuntimeState(completedRunId).timeline.items[0];
+    listener?.({
+      payload: {
+        schemaVersion: "tinybot.timeline_patch.v2",
+        sessionId: "thread-1",
+        runId: completedRunId,
+        snapshotRevision: 1,
+        item: {
+          ...baseItem,
+          itemId: `${completedRunId}:user`,
+          runId: completedRunId,
+          turnId: completedRunId,
+        },
+      },
+    });
+    listener?.({
+      payload: {
+        schemaVersion: "tinybot.timeline_patch.v2",
+        sessionId: "thread-1",
+        runId: completedRunId,
+        snapshotRevision: 2,
+        item: {
+          ...baseItem,
+          itemId: `${completedRunId}:reasoning`,
+          runId: completedRunId,
+          turnId: completedRunId,
+          sequence: 2,
+          kind: "reasoning",
+          status: "completed",
+          data: {
+            type: "reasoning",
+            modelCallId: "call-1",
+            summary: "The user is",
+          },
+        },
+      },
+    });
+    listener?.({
+      payload: {
+        schemaVersion: "tinybot.timeline_patch.v2",
+        sessionId: "thread-1",
+        runId: completedRunId,
+        snapshotRevision: 3,
+        item: {
+          ...canonicalRuntimeState(completedRunId, "completed").timeline.items[1],
+          sequence: 3,
+        },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const liveTimelineEvents = events.filter((event) => event.type === "timeline.patch");
+    expect(liveTimelineEvents[liveTimelineEvents.length - 1]?.timeline?.turns[0].executionItems).toEqual([
+      expect.objectContaining({
+        id: `${completedRunId}:reasoning`,
+        kind: "reasoning",
+        summary: "The user is",
+      }),
+    ]);
+
+    resolveSubmit({
+      threadId: "thread-1",
+      sessionId: "thread-1",
+      runId: completedRunId,
+      agentResult: { finalContent: "hi", stopReason: "final_response" },
+      snapshot: {},
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const timelineEvents = events.filter((event) => event.type === "timeline.patch");
+    expect(timelineEvents[timelineEvents.length - 1]?.timeline?.turns[0].executionItems).toEqual([
+      expect.objectContaining({
+        id: `${completedRunId}:reasoning`,
+        kind: "reasoning",
+        summary: "The user is",
+      }),
+    ]);
+  });
+
+  test("converges from the completed Thread result when the live timeline patch is missed", async () => {
+    let completedRunId = "";
+    mocks.invoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "worker_threads_list") return { threads: [thread], total: 1 };
+      if (command === "worker_agent_runs_list") {
+        return { runs: completedRunId ? [{ runId: completedRunId }] : [] };
+      }
+      if (command === "worker_agent_run_runtime_state") {
+        return canonicalRuntimeState(completedRunId, "completed");
+      }
+      if (command === "worker_submit_thread_turn") {
+        const input = args?.input as { spec?: { runId?: string } } | undefined;
+        completedRunId = input?.spec?.runId ?? "";
+        return {
+          threadId: "thread-1",
+          sessionId: "thread-1",
+          runId: completedRunId,
+          agentResult: {
+            finalContent: "hi",
+            stopReason: "final_response",
+          },
+          snapshot: {
+            items: [{
+              itemId: `${completedRunId}:assistant`,
+              kind: {
+                type: "assistant_message_completed",
+                payload: { content: "hi", role: "assistant" },
+              },
+            }],
+            turnItems: [],
+          },
+        };
+      }
+      return {};
+    });
+    const services = createDesktopAppServices();
+    await services.chatStore.load("thread-1");
+    const events: ChatEvent[] = [];
+    services.chatStore.subscribe("thread-1", (event) => events.push(event));
+
+    await services.chatStore.dispatch(createDesktopTurnSubmitCommand({
+      commandId: "command-completed-result",
+      message: { text: "hello" },
+      sessionId: "thread-1",
+      source: { control: "test", surface: "chat" },
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "timeline.patch",
+      timeline: expect.objectContaining({
+        turns: [expect.objectContaining({
+          id: completedRunId,
+          status: "completed",
+          finalAnswer: expect.objectContaining({ text: "hi" }),
+        })],
+      }),
+    }));
+    expect(events).toContainEqual({ type: "agent.event", eventType: "agent.turn.completed" });
+  });
+
   test("consumes typed Tauri timeline patches without a Gateway frame", async () => {
     mocks.invoke.mockImplementation(async (command: string) => {
       if (command === "worker_threads_list") return { threads: [thread], total: 1 };
@@ -155,6 +346,7 @@ describe("desktop native app services", () => {
     const listener = mocks.listeners.get("agent:timeline:patch");
     expect(listener).toBeTypeOf("function");
 
+    const assistantItem = canonicalRuntimeState("run-live").timeline.items[1];
     listener?.({
       payload: {
         schemaVersion: "tinybot.timeline_patch.v2",
@@ -162,17 +354,52 @@ describe("desktop native app services", () => {
         runId: "run-live",
         snapshotRevision: 3,
         item: {
-          ...canonicalRuntimeState("run-live", "completed").timeline.items[1],
+          ...assistantItem,
           revision: 2,
-          status: "completed",
+          status: "running",
           updatedAt: "2026-07-14T00:00:03.000Z",
+          data: { ...assistantItem.data, content: "hi there" },
+        },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    listener?.({
+      payload: {
+        schemaVersion: "tinybot.timeline_patch.v2",
+        sessionId: "thread-1",
+        runId: "run-live",
+        snapshotRevision: 4,
+        item: {
+          ...assistantItem,
+          revision: 3,
+          status: "completed",
+          updatedAt: "2026-07-14T00:00:04.000Z",
+          data: { ...assistantItem.data, content: "hi there!" },
         },
       },
     });
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(events).toContainEqual(expect.objectContaining({ type: "timeline.patch" }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "timeline.patch",
+      timeline: expect.objectContaining({
+        turns: [expect.objectContaining({
+          status: "running",
+          finalAnswer: expect.objectContaining({ text: "hi there" }),
+        })],
+      }),
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "timeline.patch",
+      timeline: expect.objectContaining({
+        turns: [expect.objectContaining({
+          status: "completed",
+          finalAnswer: expect.objectContaining({ text: "hi there!" }),
+        })],
+      }),
+    }));
     expect(events).toContainEqual({ type: "agent.event", eventType: "agent.turn.completed" });
   });
 
@@ -219,32 +446,101 @@ describe("desktop native app services", () => {
     });
   });
 
-  test("branches a completed canonical turn with portable message history", async () => {
-    mocks.invoke.mockImplementation(async (command: string) => {
-      if (command === "worker_threads_list") return { threads: [thread], total: 1 };
+  test("forks a completed canonical turn into a registered Thread at the selected message boundary", async () => {
+    const branchThread = {
+      ...thread,
+      parentThreadId: "thread-1",
+      source: "fork",
+      threadId: "thread-branch",
+      sessionKey: "thread-branch",
+      title: "Native thread · 分叉",
+    };
+    const subagentThread = {
+      ...thread,
+      parentThreadId: "thread-1",
+      source: "subagent",
+      threadId: "thread-subagent",
+      sessionKey: "thread-subagent",
+      title: "Internal subagent",
+    };
+    let forked = false;
+    mocks.invoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "worker_threads_list") {
+        const body = (args?.input as { body?: Record<string, unknown> } | undefined)?.body;
+        const threads = forked && body?.includeChildThreads === true
+          ? [branchThread, subagentThread, thread]
+          : [thread];
+        return { threads, total: threads.length };
+      }
       if (command === "worker_agent_runs_list") return { runs: [{ runId: "run-completed" }] };
       if (command === "worker_agent_run_runtime_state") return canonicalRuntimeState("run-completed", "completed");
-      if (command === "worker_session_branch") return { key: "thread-branch", title: "Native thread · Branch" };
+      if (command === "worker_thread_read") {
+        return {
+          items: [{
+            itemId: "run-completed:assistant",
+            sequence: 42,
+            kind: {
+              type: "assistant_message_completed",
+              payload: { content: "hi", messageId: "run-completed:assistant" },
+            },
+          }],
+          nextCursor: null,
+        };
+      }
+      if (command === "worker_thread_fork") {
+        forked = true;
+        return branchThread;
+      }
       return {};
     });
     const services = createDesktopAppServices();
 
     await expect(services.chatStore.branchFromMessage("thread-1", "run-completed:assistant")).resolves.toEqual(
-      expect.objectContaining({ id: "thread-branch", title: "Native thread · Branch" }),
+      expect.objectContaining({ id: "thread-branch", title: "Native thread · 分叉" }),
     );
+    await expect(services.sessionStore.list()).resolves.toEqual([
+      expect.objectContaining({ id: "thread-branch" }),
+      expect.objectContaining({ id: "thread-1" }),
+    ]);
 
-    expect(mocks.invoke).toHaveBeenCalledWith("worker_session_branch", {
+    expect(mocks.invoke).toHaveBeenCalledWith("worker_thread_fork", {
       input: {
         body: {
-          branchedFromMessageId: "run-completed:assistant",
-          branchedFromSessionId: "thread-1",
-          messages: [
-            { content: "hello", messageId: "run-completed:user", role: "user" },
-            { content: "hi", messageId: "run-completed:assistant", role: "assistant" },
-          ],
-          portableContext: { chatId: "thread-1", sessionKey: "thread-1" },
-          runtimeState: {},
+          clientEventId: "fork:thread-1:run-completed:assistant",
+          forkAfterSequence: 42,
+          threadId: "thread-1",
           title: "Native thread · 分叉",
+        },
+      },
+    });
+  });
+
+  test("deletes the Thread tree when a conversation has fork children", async () => {
+    let deleted = false;
+    mocks.invoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "worker_threads_list") {
+        return { threads: deleted ? [] : [thread], total: deleted ? 0 : 1 };
+      }
+      if (command === "worker_thread_delete") {
+        const body = (args?.input as { body?: Record<string, unknown> } | undefined)?.body;
+        if (body?.deleteChildren !== true) {
+          throw new Error("thread-delete failed: thread has child threads; pass deleteChildren to delete the tree");
+        }
+        deleted = true;
+        return { deleted: true, deletedChildren: ["thread-branch"] };
+      }
+      if (command === "worker_agent_runs_list") return { runs: [] };
+      return {};
+    });
+    const services = createDesktopAppServices();
+
+    await expect(services.sessionStore.delete("thread-1")).resolves.toBeUndefined();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("worker_thread_delete", {
+      input: {
+        body: {
+          deleteChildren: true,
+          threadId: "thread-1",
         },
       },
     });

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -113,6 +113,35 @@ describe("desktop native app services", () => {
     });
   });
 
+  test("loads later Thread pages before filtering internal child sessions", async () => {
+    const childThread = {
+      ...thread,
+      parentThreadId: "thread-1",
+      source: "subagent",
+      threadId: "thread-child",
+      sessionKey: "thread-child",
+    };
+    mocks.invoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "worker_threads_list") {
+        const body = (args?.input as { body?: Record<string, unknown> } | undefined)?.body;
+        return body?.offset === 1
+          ? { threads: [thread], total: 2 }
+          : { threads: [childThread], total: 2, nextOffset: 1 };
+      }
+      if (command === "worker_agent_runs_list") return { runs: [] };
+      if (command === "worker_agent_run_runtime_state") return null;
+      return {};
+    });
+    const services = createDesktopAppServices();
+
+    await expect(services.sessionStore.list()).resolves.toEqual([
+      expect.objectContaining({ id: "thread-1" }),
+    ]);
+    expect(mocks.invoke).toHaveBeenCalledWith("worker_threads_list", {
+      input: { body: { includeChildThreads: true, offset: 1 } },
+    });
+  });
+
   test("persists session renames through Thread metadata", async () => {
     const services = createDesktopAppServices();
 

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -15,7 +15,11 @@ import { createDesktopNativeConfigApi } from "../app-core/native/desktopNativeCo
 import { applyNativeConfigPatch } from "../app-core/native/desktopNativeConfigPatch";
 import { createDesktopNativeSessionsApi } from "../app-core/native/desktopNativeSessions";
 import { createDesktopNativeSkillsApi } from "../app-core/native/desktopNativeSkills";
-import { createDesktopNativeThreadsApi } from "../app-core/native/desktopNativeThreads";
+import {
+  createDesktopNativeThreadsApi,
+  type NativeThreadListResult,
+  type NativeThreadRecord,
+} from "../app-core/native/desktopNativeThreads";
 import { createDesktopNativeHostCommandApi } from "../app-core/native/desktopNativeHostCommand";
 import { createDesktopNativeBrowserApi, normalizeNativeBrowserSnapshot } from "../app-core/native/desktopNativeBrowser";
 import { toDesktopNativeTauriEventName } from "../app-core/native/desktopNativeTauriEvents";
@@ -93,15 +97,32 @@ export function createDesktopAppServices(): AppServices {
   });
 
   async function listConversationThreads() {
-    const result = await requireNative(nativeThreads, "Thread").list({ includeChildThreads: true });
-    const threads = result.threads.filter((thread) => {
-      const parentThreadId = stringValue(thread.parentThreadId ?? thread.parent_thread_id);
-      return !parentThreadId || stringValue(thread.source) === "fork";
-    });
+    const threads: NativeThreadRecord[] = [];
+    let offset: number | undefined;
+    let result: NativeThreadListResult;
+    while (true) {
+      result = await requireNative(nativeThreads, "Thread").list({
+        includeChildThreads: true,
+        ...(offset === undefined ? {} : { offset }),
+      });
+      threads.push(...result.threads.filter((thread) => {
+        const parentThreadId = stringValue(thread.parentThreadId ?? thread.parent_thread_id);
+        return !parentThreadId || stringValue(thread.source) === "fork";
+      }));
+      const nextOffset = numberValue(result.nextOffset);
+      if (nextOffset === undefined) {
+        break;
+      }
+      if (nextOffset <= (offset ?? -1)) {
+        throw new Error("Thread pagination returned a non-advancing next offset");
+      }
+      offset = nextOffset;
+    }
     return {
       ...result,
       threads,
       total: threads.length,
+      nextOffset: undefined,
     };
   }
 

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -1,7 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { createDesktopChatSessionController } from "../app-core/chat/desktopChatSessionController";
-import { createBranchSessionDraft } from "../app-core/chat/chatBranchSession";
 import type { NativeChatReference, NativeChatSession } from "../app-core/chat/nativeChat";
 import {
   createAgentUiEventState,
@@ -78,10 +77,13 @@ export function createDesktopAppServices(): AppServices {
 
   const controller = createDesktopChatSessionController({
     api: {
-      listSessions: () => requireNative(nativeThreads, "Thread").list(),
+      listSessions: listConversationThreads,
       listAgentRuns: (sessionKey) => requireNative(nativeSessions, "Session").agentRuns?.(sessionKey) ?? Promise.resolve({ runs: [] }),
       getAgentRunRuntimeState: (sessionKey, runId) => requireNative(nativeSessions, "Session").agentRunRuntimeState?.(sessionKey, runId) ?? Promise.resolve(null),
-      deleteSession: (threadId) => requireNative(nativeThreads, "Thread").delete({ threadId }),
+      deleteSession: (threadId) => requireNative(nativeThreads, "Thread").delete({
+        threadId,
+        deleteChildren: true,
+      }),
       patchSession: (threadId, body) => requireNative(nativeThreads, "Thread").updateMetadata({
         threadId,
         metadata: nativeThreadMetadataPatch(body),
@@ -89,6 +91,19 @@ export function createDesktopAppServices(): AppServices {
       submitThreadTurn: (input) => requireNative(nativeThreads, "Thread").submitTurn(input),
     },
   });
+
+  async function listConversationThreads() {
+    const result = await requireNative(nativeThreads, "Thread").list({ includeChildThreads: true });
+    const threads = result.threads.filter((thread) => {
+      const parentThreadId = stringValue(thread.parentThreadId ?? thread.parent_thread_id);
+      return !parentThreadId || stringValue(thread.source) === "fork";
+    });
+    return {
+      ...result,
+      threads,
+      total: threads.length,
+    };
+  }
 
   async function initialize(): Promise<void> {
     initialized ??= (async () => {
@@ -279,6 +294,19 @@ export function createDesktopAppServices(): AppServices {
       type: "message-sent",
       ...(optimisticMessage ? { message: optimisticMessage } : {}),
     });
+    if (result.status === "sent") {
+      void result.completion
+        .then((timeline) => {
+          notifySession(sessionId, { type: "timeline.patch", timeline });
+          notifyTerminalTimelineState(sessionId, timeline);
+        })
+        .catch((error) => {
+          notifySession(sessionId, {
+            type: "timeline.error",
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    }
   }
 
   async function dispatchDesktopCommand(command: DesktopCommand): Promise<void> {
@@ -311,6 +339,48 @@ export function createDesktopAppServices(): AppServices {
       return;
     }
     await dispatchTinyOsCommand(command);
+  }
+
+  async function resolveForkSequence(threadId: string, itemIds: Set<string>): Promise<number | undefined> {
+    let cursor = "";
+    const seenCursors = new Set<string>();
+    while (true) {
+      const payload = await requireNative(nativeThreads, "Thread").read({
+        threadId,
+        limit: 500,
+        ...(cursor ? { cursor } : {}),
+      });
+      if (!isRecord(payload)) {
+        throw new Error(`Thread ${threadId} returned an invalid read result while resolving a fork boundary`);
+      }
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      for (const value of items) {
+        if (!isRecord(value)) continue;
+        const kind = isRecord(value.kind) ? value.kind : {};
+        const itemPayload = isRecord(kind.payload) ? kind.payload : {};
+        const itemId = stringValue(value.itemId ?? value.item_id);
+        const messageId = stringValue(itemPayload.messageId ?? itemPayload.message_id);
+        if (!itemIds.has(itemId) && !itemIds.has(messageId)) continue;
+        const sequence = numberValue(value.sequence);
+        if (sequence === undefined) {
+          throw new Error(`Thread item ${itemId || messageId} is missing its canonical sequence`);
+        }
+        return sequence;
+      }
+      const nextCursor = stringValue(
+        payload.nextCursor
+        ?? payload.next_cursor
+        ?? (isRecord(payload.pagination)
+          ? payload.pagination.nextCursor ?? payload.pagination.next_cursor
+          : undefined),
+      );
+      if (!nextCursor) return undefined;
+      if (seenCursors.has(nextCursor)) {
+        throw new Error(`Thread ${threadId} returned a repeated pagination cursor while resolving a fork boundary`);
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    }
   }
 
   return {
@@ -400,35 +470,46 @@ export function createDesktopAppServices(): AppServices {
           throw new Error(`Cannot branch from unknown Thread ${sessionId}`);
         }
         const timeline = await controller.loadTimeline(sessionId);
-        const draft = createBranchSessionDraft({
-          sessionId,
-          chatId: sourceSession.chatId,
-          title: sourceSession.title,
-          messages: timeline.turns.flatMap((turn) => {
-            const finalAnswer = turn.finalAnswer ?? turn.finalMessage;
-            return [
-              { messageId: turn.userMessage.id, role: "user", content: turn.userMessage.text },
-              ...(finalAnswer ? [{ messageId: finalAnswer.id, role: "assistant", content: finalAnswer.text }] : []),
-            ];
-          }),
-          portableContext: { chatId: sourceSession.chatId, sessionKey: sourceSession.key },
-          runtimeState: {},
-        }, messageId);
-        const branch = requireNative(nativeSessions, "Session").branch;
-        if (!branch) {
-          throw new Error("Session branch API is unavailable");
+        const canonicalItem = timeline.turns
+          .flatMap((turn) => turn.canonicalItems ?? [])
+          .find((item) => (
+            item.itemId === messageId
+            || stringValue(item.data.messageId ?? item.data.message_id) === messageId
+          ));
+        if (!canonicalItem) {
+          throw new Error(`Cannot fork Thread ${sessionId} at unknown canonical message ${messageId}`);
         }
-        const payload = await branch(draft);
+        const sourceThreadId = sourceSession.threadId || sourceSession.key;
+        const forkAfterSequence = await resolveForkSequence(sourceThreadId, new Set([
+          messageId,
+          canonicalItem.itemId,
+          stringValue(canonicalItem.data.messageId ?? canonicalItem.data.message_id),
+        ].filter(Boolean)));
+        if (forkAfterSequence === undefined) {
+          throw new Error(`Cannot resolve persisted fork boundary for canonical message ${messageId}`);
+        }
+        const title = `${sourceSession.title} · 分叉`;
+        const payload = await requireNative(nativeThreads, "Thread").fork({
+          threadId: sourceThreadId,
+          clientEventId: `fork:${sourceThreadId}:${messageId}`,
+          title,
+          forkAfterSequence,
+        });
         await controller.loadSessions();
         const payloadRecord = isRecord(payload) ? payload : {};
-        const branchKey = stringValue(payloadRecord.key ?? payloadRecord.sessionKey ?? payloadRecord.session_key);
-        return mapSession(controller.state.sessions.find((session) => session.key === branchKey) ?? {
-          key: branchKey || sessionId,
-          chatId: stringValue(payloadRecord.chatId ?? payloadRecord.chat_id),
-          title: stringValue(payloadRecord.title) || draft.title,
-          createdAt: stringValue(payloadRecord.createdAt ?? payloadRecord.created_at),
-          updatedAt: stringValue(payloadRecord.updatedAt ?? payloadRecord.updated_at) || new Date().toISOString(),
-        }, false, payload);
+        const branchKey = stringValue(
+          payloadRecord.sessionKey
+          ?? payloadRecord.session_key
+          ?? payloadRecord.threadId
+          ?? payloadRecord.thread_id,
+        );
+        const branchSession = controller.state.sessions.find((session) => (
+          session.key === branchKey || session.threadId === branchKey
+        ));
+        if (!branchKey || !branchSession) {
+          throw new Error(`Forked Thread ${branchKey || "<missing>"} is missing from the Thread list`);
+        }
+        return mapSession(branchSession, false, payload);
       },
       async copyMarkdown(sessionId) {
         await initialize();


### PR DESCRIPTION
## Summary

- persist streamed assistant output, reasoning, and canonical agent-run records so execution details survive session reloads
- align thread fork, clear, delete, and temporary-resource lifecycle handling with the canonical rollout model
- keep desktop session projections and streaming UI state synchronized, with regression coverage for reload and fork flows
- clean up native desktop lifecycle handling and related Rust warnings uncovered along these paths

## Root cause

Live run events and persisted rollout records were projected through partially separate paths. Some transient reasoning and session metadata never became durable canonical records, while fork and lifecycle operations could create thread state that the runtime could not subsequently resolve.

## Impact

Reloaded sessions retain their reasoning and execution details, streamed responses remain visible, forked threads are usable and reload consistently, and session cleanup no longer leaves stale temporary resources.

## Validation

- `npm test` — 76 files, 565 tests passed
- `npm run build`
- `cargo check`
- targeted Rust persistence, replay, approval-continuation, and agent-run tests