### PR TITLE
Fix canonical agent run rollout projection

### DIFF
--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -1844,7 +1844,9 @@ External callers should usually prefer the Tauri commands above.
 events must be written with `agent_run.append_trace` or `agent_run.append_trace_batch`; semantic
 message, reasoning, and tool records are materialized as Rollout response items, while selected
 durable lifecycle events remain Rollout event records. Agent-run reads never fall back to the
-in-memory thread store.
+in-memory thread store. Appended events require non-empty `eventName` and `eventId` fields, and
+response-backed events are rejected unless they contain enough data to materialize their canonical
+Rollout response item.
 
 ### MCP Runtime RPC
 

--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -861,9 +861,10 @@ checkpoint and returns `stopReason: "form_cancelled"` with an observable resolut
 | `worker_session_clear` | `{ input: { key: string } }` | clear result |
 | `worker_session_task_progress` | `{ input: { key: string, body: unknown } }` | task progress result |
 
-`worker_agent_run_runtime_state` returns raw runtime events for diagnostics and one canonical
-timeline snapshot for product rendering. The former `turnItems` response field is not part of the
-contract.
+`worker_agent_run_runtime_state` returns runtime events projected from the session's canonical
+Rollout plus one canonical timeline snapshot for product rendering. Rollout ordinals define event
+order; embedded event sequence values and in-memory thread items are not reconstruction sources.
+The former `turnItems` response field is not part of the contract.
 
 ```json
 {
@@ -1838,6 +1839,12 @@ External callers should usually prefer the Tauri commands above.
 | `tool_executor` | `execute` |
 | `tool_registry` | `list`, `search` |
 | `workspace` | `apply_patch`, `create_dir`, `delete_file`, `list_dir`, `list_files`, `read_bootstrap_files`, `read_file`, `resolve_path`, `write_file` |
+
+`agent_run.upsert` persists run metadata only and requires an empty `traceEvents` field. Runtime
+events must be written with `agent_run.append_trace` or `agent_run.append_trace_batch`; semantic
+message, reasoning, and tool records are materialized as Rollout response items, while selected
+durable lifecycle events remain Rollout event records. Agent-run reads never fall back to the
+in-memory thread store.
 
 ### MCP Runtime RPC
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -261,10 +261,11 @@ fn startup_reconciles_orphaned_run_and_preserves_waiting_checkpoint() {
         ))
         .expect("running recovery record should deserialize");
     running_record.thread_id = Some("thread-recovery".to_string());
+    running_record.trace_events.clear();
     thread_log
         .upsert_agent_run(running_record)
         .expect("running recovery record should persist");
-    let waiting_record: crate::worker_session::AgentRunRecord =
+    let mut waiting_record: crate::worker_session::AgentRunRecord =
         serde_json::from_value(native_agent_run_record(
             &serde_json::json!({
                 "runId": "run-waiting",
@@ -284,6 +285,7 @@ fn startup_reconciles_orphaned_run_and_preserves_waiting_checkpoint() {
             "run-waiting",
         ))
         .expect("waiting recovery record should deserialize");
+    waiting_record.trace_events.clear();
     thread_log
         .upsert_agent_run(waiting_record)
         .expect("waiting recovery record should persist");
@@ -2829,7 +2831,7 @@ fn canonical_thread_reads_supersede_stale_session_and_share_rollout_writes() {
     let fixture = WorkspaceFixture::new();
     let config = serde_json::json!({});
     let session_id = "canonical-thread-session";
-    let stale_record = native_agent_run_record(
+    let mut stale_record = native_agent_run_record(
         &serde_json::json!({
             "runtime": "rust",
             "runId": "stale-session-run",
@@ -2844,6 +2846,7 @@ fn canonical_thread_reads_supersede_stale_session_and_share_rollout_writes() {
         session_id,
         "stale-session-run",
     );
+    stale_record["traceEvents"] = serde_json::json!([]);
     call_rust_state_service(
         fixture.root.clone(),
         config.clone(),
@@ -2942,9 +2945,8 @@ fn canonical_thread_reads_supersede_stale_session_and_share_rollout_writes() {
         ),
         "list canonical thread runs",
     )
-    .expect("compatibility run list should project canonical thread");
-    assert_eq!(runs["runs"].as_array().map(Vec::len), Some(1));
-    assert_eq!(runs["runs"][0]["runId"], "canonical-thread-run");
+    .expect("agent run list should read only canonical agent run records");
+    assert!(runs["runs"].as_array().is_some_and(Vec::is_empty));
     let checkpoint = call_rust_state_service(
         fixture.root.clone(),
         config.clone(),
@@ -2977,7 +2979,7 @@ fn canonical_thread_reads_supersede_stale_session_and_share_rollout_writes() {
     .expect("thread-owned session.persist_turn should append to canonical Rollout");
     assert_eq!(compatibility_turn["saved_message_count"], 1);
 
-    let duplicate_record = native_agent_run_record(
+    let mut duplicate_record = native_agent_run_record(
         &serde_json::json!({
             "runtime": "rust",
             "sessionId": session_id,
@@ -2991,6 +2993,7 @@ fn canonical_thread_reads_supersede_stale_session_and_share_rollout_writes() {
         session_id,
         "duplicate-run",
     );
+    duplicate_record["traceEvents"] = serde_json::json!([]);
     let compatibility_run = call_rust_state_service(
         fixture.root.clone(),
         config,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -5176,20 +5176,7 @@ fn worker_agent_run_runtime_commands_use_thread_log_agent_run_store() {
         "currentIteration": 1,
         "conversationMessageIds": [],
         "traceMessages": [],
-        "traceEvents": [{
-            "schemaVersion": "tinybot.agent_event.v1",
-            "eventId": "run-1:agent-done:0000000000000001",
-            "sequence": 1,
-            "sessionId": "websocket:chat-1",
-            "turnId": "run-1",
-            "itemId": "run-1:assistant",
-            "eventName": "agent.done",
-            "phase": "completed",
-            "timestamp": "2026-07-03T01:00:02Z",
-            "source": "rust_backend",
-            "visibility": "user",
-            "payload": { "finalContent": "Done from runtime state" }
-        }],
+        "traceEvents": [],
         "completedToolResults": [],
         "pendingToolCalls": [],
         "checkpoint": null,
@@ -5209,6 +5196,35 @@ fn worker_agent_run_runtime_commands_use_thread_log_agent_run_store() {
         "agent run thread log seed",
     )
     .expect("agent run should seed thread log store");
+    call_rust_state_service(
+        fixture.root.clone(),
+        serde_json::json!({}),
+        WorkerRequest::new(
+            "req-seed-agent-run-trace",
+            "trace-seed-agent-run-thread-log",
+            "agent_run.append_trace",
+            serde_json::json!({
+                "session_id": "websocket:chat-1",
+                "run_id": "run-1",
+                "event": {
+                    "schemaVersion": "tinybot.agent_event.v1",
+                    "eventId": "run-1:agent-done:0000000000000001",
+                    "sequence": 1,
+                    "sessionId": "websocket:chat-1",
+                    "turnId": "run-1",
+                    "itemId": "run-1:assistant",
+                    "eventName": "agent.done",
+                    "phase": "completed",
+                    "timestamp": "2026-07-03T01:00:02Z",
+                    "source": "rust_backend",
+                    "visibility": "user",
+                    "payload": { "finalContent": "Done from runtime state" }
+                }
+            }),
+        ),
+        "agent run trace seed",
+    )
+    .expect("agent run trace should seed thread log store");
     let shared = Arc::new(Mutex::new(GatewayRuntime::default()));
 
     let runs = worker_agent_runs_list_with_options(

--- a/src-tauri/src/worker_rpc/persistence_facade.rs
+++ b/src-tauri/src/worker_rpc/persistence_facade.rs
@@ -241,17 +241,6 @@ impl WorkerRpcRouter {
             "agent_run.list" => {
                 let params: AgentRunListParams = parse_params(request)?;
                 let mut records = self.thread_log.list_agent_runs(&params.session_id)?;
-                for record in self
-                    .thread
-                    .list_agent_runs_from_threads(&params.session_id)?
-                {
-                    if !records
-                        .iter()
-                        .any(|existing| existing.run_id == record.run_id)
-                    {
-                        records.push(record);
-                    }
-                }
                 records.sort_by(|left, right| {
                     right
                         .updated_at
@@ -272,9 +261,6 @@ impl WorkerRpcRouter {
                 let record = self
                     .thread_log
                     .get_agent_run(&params.session_id, &params.run_id)?
-                    .or(self
-                        .thread
-                        .get_agent_run_from_threads(&params.session_id, &params.run_id)?)
                     .ok_or_else(|| agent_run_not_found_error(&params.session_id, &params.run_id))?;
                 serde_json::to_value(record).map_err(serialization_error)
             }
@@ -288,12 +274,6 @@ impl WorkerRpcRouter {
                         params.cursor.as_deref(),
                         params.limit,
                     )?
-                    .or(self.thread.list_agent_run_trace_events(
-                        &params.session_id,
-                        &params.run_id,
-                        params.cursor.as_deref(),
-                        params.limit,
-                    )?)
                     .ok_or_else(|| agent_run_not_found_error(&params.session_id, &params.run_id))?;
                 serde_json::to_value(trace_page).map_err(serialization_error)
             }
@@ -302,9 +282,6 @@ impl WorkerRpcRouter {
                 let runtime_state = self
                     .thread_log
                     .get_agent_run_runtime_state(&params.session_id, &params.run_id)?
-                    .or(self
-                        .thread
-                        .get_agent_run_runtime_state(&params.session_id, &params.run_id)?)
                     .ok_or_else(|| agent_run_not_found_error(&params.session_id, &params.run_id))?;
                 serde_json::to_value(runtime_state).map_err(serialization_error)
             }

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -9131,6 +9131,40 @@ fn dispatches_agent_run_store_round_trip_requests() {
         "agent_run.upsert",
         json!({ "record": record }),
     ));
+    let invalid_trace = router.dispatch(&WorkerRequest::new(
+        "req-invalid-trace",
+        "trace-agent-run",
+        "agent_run.append_trace",
+        json!({
+            "session_id": "session-1",
+            "run_id": "run-1",
+            "event": {
+                "eventName": "agent.reasoning_delta",
+                "payload": {
+                    "delta": "must not be persisted",
+                    "modelCallId": "provider-invalid",
+                    "reasoningId": "reasoning-invalid"
+                }
+            }
+        }),
+    ));
+    let invalid_response_trace = router.dispatch(&WorkerRequest::new(
+        "req-invalid-response-trace",
+        "trace-agent-run",
+        "agent_run.append_trace",
+        json!({
+            "session_id": "session-1",
+            "run_id": "run-1",
+            "event": {
+                "eventId": "invalid-reasoning",
+                "eventName": "agent.reasoning_delta",
+                "payload": {
+                    "modelCallId": "provider-invalid",
+                    "reasoningId": "reasoning-invalid"
+                }
+            }
+        }),
+    ));
     let append_trace = router.dispatch(&WorkerRequest::new(
         "req-trace",
         "trace-agent-run",
@@ -9227,6 +9261,22 @@ fn dispatches_agent_run_store_round_trip_requests() {
     ));
 
     assert!(upsert.error.is_none());
+    assert!(invalid_trace.result.is_none());
+    assert_eq!(
+        invalid_trace
+            .error
+            .as_ref()
+            .map(|error| error.message.as_str()),
+        Some("agent run trace event is missing eventId")
+    );
+    assert!(invalid_response_trace.result.is_none());
+    assert_eq!(
+        invalid_response_trace
+            .error
+            .as_ref()
+            .map(|error| error.message.as_str()),
+        Some("response-backed agent run trace event cannot be materialized")
+    );
     assert!(append_trace.error.is_none());
     assert!(append_second_trace.error.is_none());
     assert!(set_checkpoint.error.is_none());

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -8376,11 +8376,10 @@ fn dispatches_thread_apply_op_records_terminal_error() {
         "agent_run.get",
         json!({ "session_id": "session-error-op", "run_id": "run-error-op-1" }),
     ));
-    assert_eq!(run_get.error, None);
-    assert_eq!(run_get.result.as_ref().unwrap()["status"], "failed");
+    assert!(run_get.result.is_none());
     assert_eq!(
-        run_get.result.as_ref().unwrap()["error"]["message"],
-        "thread run failed"
+        run_get.error.as_ref().map(|error| error.message.as_str()),
+        Some("agent run not found")
     );
 }
 
@@ -8635,14 +8634,10 @@ fn dispatches_thread_apply_op_for_agent_step_events() {
             "runId": "run-agent-step-op"
         }),
     ));
-    assert_eq!(trace.error, None);
+    assert!(trace.result.is_none());
     assert_eq!(
-        trace.result.as_ref().unwrap()["items"][0]["eventName"],
-        "agent.step"
-    );
-    assert_eq!(
-        trace.result.as_ref().unwrap()["items"][0]["payload"]["summary"],
-        "Preparing the tool plan"
+        trace.error.as_ref().map(|error| error.message.as_str()),
+        Some("agent run not found")
     );
 }
 
@@ -8782,14 +8777,10 @@ fn dispatches_thread_apply_op_for_runtime_events() {
             "runId": "run-runtime-event-op"
         }),
     ));
-    assert_eq!(trace.error, None);
+    assert!(trace.result.is_none());
     assert_eq!(
-        trace.result.as_ref().unwrap()["items"][0]["eventName"],
-        "agent.browser.search"
-    );
-    assert_eq!(
-        trace.result.as_ref().unwrap()["items"][0]["payload"]["query"],
-        "thread event log design"
+        trace.error.as_ref().map(|error| error.message.as_str()),
+        Some("agent run not found")
     );
 }
 

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -2798,27 +2798,7 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
         "currentIteration": 0,
         "conversationMessageIds": [],
         "traceMessages": [],
-        "traceEvents": [{
-            "eventId": "reasoning-reload-1",
-            "eventName": "agent.reasoning_delta",
-            "sequence": 1,
-            "turnId": "run-reasoning-reload",
-            "payload": {
-                "delta": "Inspect ",
-                "modelCallId": "provider-1",
-                "reasoningId": "reasoning-1"
-            }
-        }, {
-            "eventId": "reasoning-reload-2",
-            "eventName": "agent.reasoning_delta",
-            "sequence": 2,
-            "turnId": "run-reasoning-reload",
-            "payload": {
-                "delta": "first.",
-                "modelCallId": "provider-1",
-                "reasoningId": "reasoning-1"
-            }
-        }],
+        "traceEvents": [],
         "completedToolResults": [],
         "pendingToolCalls": [],
         "checkpoint": null,
@@ -2833,6 +2813,19 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
         json!({ "record": record }),
     ));
     assert_eq!(upsert.error, None);
+
+    for index in 0..70 {
+        let padding = router.dispatch(&WorkerRequest::new(
+            format!("req-reasoning-reload-padding-{index}"),
+            "trace-reasoning-reload",
+            "session.patch_metadata",
+            json!({
+                "session_id": "session-reasoning-reload",
+                "metadata": { "reloadPadding": index }
+            }),
+        ));
+        assert_eq!(padding.error, None);
+    }
 
     let append_trace = router.dispatch(&WorkerRequest::new(
         "req-reasoning-reload-trace",
@@ -2862,9 +2855,49 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
                     "reasoningId": "reasoning-1"
                 }
             }, {
+                "eventId": "reasoning-reload-tool-a",
+                "eventName": "agent.tool_call.delta",
+                "sequence": 3,
+                "turnId": "run-reasoning-reload",
+                "payload": {
+                    "toolCallId": "call-a",
+                    "toolName": "workspace.read_file",
+                    "argumentsDelta": "{\"path\":\"A.md\"}"
+                }
+            }, {
+                "eventId": "reasoning-reload-tool-b",
+                "eventName": "agent.tool_call.delta",
+                "sequence": 4,
+                "turnId": "run-reasoning-reload",
+                "payload": {
+                    "toolCallId": "call-b",
+                    "toolName": "workspace.read_file",
+                    "argumentsDelta": "{\"path\":\"B.md\"}"
+                }
+            }, {
+                "eventId": "reasoning-reload-result-b",
+                "eventName": "agent.tool.result",
+                "sequence": 5,
+                "turnId": "run-reasoning-reload",
+                "payload": {
+                    "toolCallId": "call-b",
+                    "toolName": "workspace.read_file",
+                    "content": "B"
+                }
+            }, {
+                "eventId": "reasoning-reload-result-a",
+                "eventName": "agent.tool.result",
+                "sequence": 6,
+                "turnId": "run-reasoning-reload",
+                "payload": {
+                    "toolCallId": "call-a",
+                    "toolName": "workspace.read_file",
+                    "content": "A"
+                }
+            }, {
                 "eventId": "reasoning-reload-completed",
                 "eventName": "agent.message.completed",
-                "sequence": 3,
+                "sequence": 7,
                 "turnId": "run-reasoning-reload",
                 "payload": {
                     "content": "Done.",
@@ -2918,6 +2951,40 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
         }),
     ));
     assert_eq!(runtime_state.error, None);
+    let runtime_events = runtime_state.result.as_ref().unwrap()["runtimeEvents"]
+        .as_array()
+        .expect("runtime events should be an array");
+    assert!(runtime_events
+        .windows(2)
+        .all(|pair| pair[0]["sequence"].as_u64() < pair[1]["sequence"].as_u64()));
+    assert_eq!(
+        runtime_events
+            .iter()
+            .filter(|event| event["eventName"] == "agent.reasoning_delta")
+            .count(),
+        1
+    );
+    assert_eq!(
+        runtime_events
+            .iter()
+            .filter(|event| event["eventName"] == "agent.message.completed")
+            .count(),
+        1
+    );
+    assert_eq!(
+        runtime_events
+            .iter()
+            .filter(|event| event["eventName"] == "agent.tool_call.delta")
+            .count(),
+        2
+    );
+    assert_eq!(
+        runtime_events
+            .iter()
+            .filter(|event| event["eventName"] == "agent.tool.result")
+            .count(),
+        2
+    );
     let items = runtime_state.result.as_ref().unwrap()["timeline"]["items"]
         .as_array()
         .expect("timeline items should be an array");
@@ -2927,6 +2994,16 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
         .collect::<Vec<_>>();
     assert_eq!(reasoning.len(), 1);
     assert_eq!(reasoning[0]["data"]["summary"], "Inspect first.");
+    let tools = items
+        .iter()
+        .filter(|item| item["kind"] == "tool_call")
+        .collect::<Vec<_>>();
+    assert_eq!(tools.len(), 2);
+    assert!(tools
+        .iter()
+        .all(|item| item["status"] == "completed" && item["data"]["status"] == "completed"));
+    assert_eq!(items.last().unwrap()["kind"], "assistant_message");
+    assert_eq!(items.last().unwrap()["data"]["content"], "Done.");
 }
 
 #[test]
@@ -5508,37 +5585,10 @@ fn thread_fork_inherits_effective_history_from_canonical_rollout() {
         json!({ "sessionId": fork_thread_id }),
     ));
     assert_eq!(runs.error, None);
-    let fork_run_id = runs.result.as_ref().unwrap()["runs"][0]["runId"]
-        .as_str()
+    assert!(runs.result.as_ref().unwrap()["runs"]
+        .as_array()
         .unwrap()
-        .to_string();
-    assert_eq!(fork_run_id, "run-rollout-fork-1");
-    let runtime_state = router.dispatch(&WorkerRequest::new(
-        "req-rollout-fork-runtime-state",
-        "trace-rollout-fork",
-        "agent_run.runtime_state",
-        json!({
-            "session_id": fork_thread_id,
-            "run_id": fork_run_id
-        }),
-    ));
-    assert_eq!(runtime_state.error, None);
-    assert_eq!(
-        runtime_state.result.as_ref().unwrap()["timeline"]["items"][0]["kind"],
-        "user_message"
-    );
-    assert_eq!(
-        runtime_state.result.as_ref().unwrap()["timeline"]["items"][0]["data"]["content"],
-        "keep user"
-    );
-    assert_eq!(
-        runtime_state.result.as_ref().unwrap()["timeline"]["items"][1]["kind"],
-        "assistant_message"
-    );
-    assert_eq!(
-        runtime_state.result.as_ref().unwrap()["timeline"]["items"][1]["data"]["content"],
-        "keep assistant"
-    );
+        .is_empty());
 
     let rename = router.dispatch(&WorkerRequest::new(
         "req-rollout-fork-rename",
@@ -9089,12 +9139,11 @@ fn dispatches_agent_run_store_round_trip_requests() {
             "session_id": "session-1",
             "run_id": "run-1",
             "event": {
-                "eventId": "trace-tool-result",
-                "eventName": "agent.tool.result",
+                "eventId": "trace-status",
+                "eventName": "agent.status",
                 "payload": {
-                    "toolCallId": "call-1",
-                    "toolName": "workspace.read_file",
-                    "content": "README"
+                    "phase": "active_turn",
+                    "status": "running"
                 }
             }
         }),
@@ -9214,7 +9263,7 @@ fn dispatches_agent_run_store_round_trip_requests() {
     assert_eq!(trace_page.error, None);
     assert_eq!(
         trace_page.result.as_ref().unwrap()["items"][0]["eventName"],
-        "agent.tool.result"
+        "agent.status"
     );
     assert_eq!(trace_page.result.as_ref().unwrap()["nextCursor"], "1");
     assert_eq!(runtime_state.error, None);
@@ -9233,14 +9282,11 @@ fn dispatches_agent_run_store_round_trip_requests() {
         runtime_state.result.as_ref().unwrap()["runtimeEvents"][0]["turnId"],
         "run-1"
     );
-    assert_eq!(
-        runtime_state.result.as_ref().unwrap()["timeline"]["items"][0]["kind"],
-        "tool_call"
-    );
-    assert_eq!(
-        runtime_state.result.as_ref().unwrap()["timeline"]["items"][1]["kind"],
-        "assistant_message"
-    );
+    let timeline_items = runtime_state.result.as_ref().unwrap()["timeline"]["items"]
+        .as_array()
+        .unwrap();
+    assert_eq!(timeline_items.len(), 1);
+    assert_eq!(timeline_items[0]["kind"], "assistant_message");
     assert_eq!(completed.result.as_ref().unwrap()["status"], "completed");
     assert_eq!(completed.result.as_ref().unwrap()["phase"], "completed");
     assert_eq!(completed.result.as_ref().unwrap()["threadId"], json!(null));
@@ -9275,7 +9321,7 @@ fn dispatches_agent_run_store_round_trip_requests() {
 }
 
 #[test]
-fn dispatches_agent_run_trace_and_runtime_state_from_thread_items() {
+fn agent_run_requests_ignore_thread_only_items() {
     let fixture = WorkspaceFixture::new();
     let mut router = WorkerRpcRouter::new(
         fixture.root.clone(),
@@ -9345,14 +9391,10 @@ fn dispatches_agent_run_trace_and_runtime_state_from_thread_items() {
     ));
     assert_eq!(run_list.error, None);
     assert_eq!(run_list.result.as_ref().unwrap()["sessionId"], "session-1");
-    assert_eq!(
-        run_list.result.as_ref().unwrap()["runs"][0]["runId"],
-        "run-thread-only"
-    );
-    assert_eq!(
-        run_list.result.as_ref().unwrap()["runs"][0]["status"],
-        "waiting"
-    );
+    assert!(run_list.result.as_ref().unwrap()["runs"]
+        .as_array()
+        .unwrap()
+        .is_empty());
 
     let run_get = router.dispatch(&WorkerRequest::new(
         "req-thread-backed-run-get",
@@ -9360,13 +9402,10 @@ fn dispatches_agent_run_trace_and_runtime_state_from_thread_items() {
         "agent_run.get",
         json!({ "session_id": "session-1", "run_id": "run-thread-only" }),
     ));
-    assert_eq!(run_get.error, None);
-    assert_eq!(run_get.result.as_ref().unwrap()["sessionId"], "session-1");
-    assert_eq!(run_get.result.as_ref().unwrap()["runId"], "run-thread-only");
-    assert_eq!(run_get.result.as_ref().unwrap()["status"], "waiting");
+    assert!(run_get.result.is_none());
     assert_eq!(
-        run_get.result.as_ref().unwrap()["traceEvents"][0]["eventName"],
-        "agent.awaiting_approval"
+        run_get.error.as_ref().map(|error| error.message.as_str()),
+        Some("agent run not found")
     );
 
     let trace_page = router.dispatch(&WorkerRequest::new(
@@ -9375,10 +9414,13 @@ fn dispatches_agent_run_trace_and_runtime_state_from_thread_items() {
         "agent_run.list_trace",
         json!({ "session_id": "session-1", "run_id": "run-thread-only" }),
     ));
-    assert_eq!(trace_page.error, None);
+    assert!(trace_page.result.is_none());
     assert_eq!(
-        trace_page.result.as_ref().unwrap()["items"][0]["eventName"],
-        "agent.awaiting_approval"
+        trace_page
+            .error
+            .as_ref()
+            .map(|error| error.message.as_str()),
+        Some("agent run not found")
     );
 
     let runtime_state = router.dispatch(&WorkerRequest::new(
@@ -9387,14 +9429,13 @@ fn dispatches_agent_run_trace_and_runtime_state_from_thread_items() {
         "agent_run.runtime_state",
         json!({ "session_id": "session-1", "run_id": "run-thread-only" }),
     ));
-    assert_eq!(runtime_state.error, None);
+    assert!(runtime_state.result.is_none());
     assert_eq!(
-        runtime_state.result.as_ref().unwrap()["runtimeEvents"][0]["eventName"],
-        "agent.awaiting_approval"
-    );
-    assert_eq!(
-        runtime_state.result.as_ref().unwrap()["timeline"]["items"][0]["kind"],
-        "approval"
+        runtime_state
+            .error
+            .as_ref()
+            .map(|error| error.message.as_str()),
+        Some("agent run not found")
     );
 
     let status = router.dispatch(&WorkerRequest::new(
@@ -9431,7 +9472,7 @@ fn dispatches_agent_run_trace_and_runtime_state_from_thread_items() {
 }
 
 #[test]
-fn dispatches_agent_run_list_merges_thread_log_and_thread_backed_runs() {
+fn agent_run_list_reads_canonical_rollout_runs() {
     let fixture = WorkspaceFixture::new();
     let mut router = WorkerRpcRouter::new(
         fixture.root.clone(),
@@ -9475,36 +9516,6 @@ fn dispatches_agent_run_list_merges_thread_log_and_thread_backed_runs() {
     ));
     assert_eq!(upsert.error, None);
 
-    let thread_only = router.dispatch(&WorkerRequest::new(
-        "req-mixed-agent-run-thread-only",
-        "trace-mixed-agent-runs",
-        "thread.create",
-        json!({
-            "threadId": "thread-run-only",
-            "title": "Thread-backed run",
-            "sessionKey": "session-1",
-            "rootRunId": "run-thread-only",
-            "activeRunId": "run-thread-only",
-            "source": "agent_run"
-        }),
-    ));
-    assert_eq!(thread_only.error, None);
-
-    let duplicate = router.dispatch(&WorkerRequest::new(
-        "req-mixed-agent-run-duplicate",
-        "trace-mixed-agent-runs",
-        "thread.create",
-        json!({
-            "threadId": "thread-run-log-duplicate",
-            "title": "Duplicate thread log run",
-            "sessionKey": "session-1",
-            "rootRunId": "run-thread-log",
-            "activeRunId": "run-thread-log",
-            "source": "agent_run"
-        }),
-    ));
-    assert_eq!(duplicate.error, None);
-
     let run_list = router.dispatch(&WorkerRequest::new(
         "req-mixed-agent-run-list",
         "trace-mixed-agent-runs",
@@ -9516,9 +9527,8 @@ fn dispatches_agent_run_list_merges_thread_log_and_thread_backed_runs() {
     let runs = run_list.result.as_ref().unwrap()["runs"]
         .as_array()
         .expect("agent_run.list should return runs");
-    assert_eq!(runs.len(), 2);
+    assert_eq!(runs.len(), 1);
     assert!(runs.iter().any(|run| run["runId"] == "run-thread-log"));
-    assert!(runs.iter().any(|run| run["runId"] == "run-thread-only"));
 }
 
 #[test]

--- a/src-tauri/src/worker_thread/mod.rs
+++ b/src-tauri/src/worker_thread/mod.rs
@@ -28,7 +28,6 @@ use crate::worker_capability::{CapabilityPolicy, WorkerCapability};
 use crate::worker_protocol::{
     WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
 };
-use crate::worker_session::{AgentRunRecord, AgentRunRuntimeState, AgentRunTracePage};
 use crate::worker_subagent_manager::{SubagentMailboxInput, SubagentThreadSummary};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -244,44 +243,6 @@ impl WorkerThreadRpc {
     ) -> Result<ThreadTurnRuntimeResult, WorkerProtocolError> {
         self.require(WorkerCapability::SessionWrite)?;
         self.runtime.interrupt(request)
-    }
-
-    pub fn list_agent_run_trace_events(
-        &self,
-        session_id: &str,
-        run_id: &str,
-        cursor: Option<&str>,
-        limit: Option<usize>,
-    ) -> Result<Option<AgentRunTracePage>, WorkerProtocolError> {
-        self.require(WorkerCapability::SessionMetadataRead)?;
-        self.store
-            .list_agent_run_trace_events(session_id, run_id, cursor, limit)
-    }
-
-    pub fn get_agent_run_runtime_state(
-        &self,
-        session_id: &str,
-        run_id: &str,
-    ) -> Result<Option<AgentRunRuntimeState>, WorkerProtocolError> {
-        self.require(WorkerCapability::SessionMetadataRead)?;
-        self.store.get_agent_run_runtime_state(session_id, run_id)
-    }
-
-    pub fn list_agent_runs_from_threads(
-        &self,
-        session_id: &str,
-    ) -> Result<Vec<AgentRunRecord>, WorkerProtocolError> {
-        self.require(WorkerCapability::SessionMetadataRead)?;
-        self.store.list_agent_runs_from_threads(session_id)
-    }
-
-    pub fn get_agent_run_from_threads(
-        &self,
-        session_id: &str,
-        run_id: &str,
-    ) -> Result<Option<AgentRunRecord>, WorkerProtocolError> {
-        self.require(WorkerCapability::SessionMetadataRead)?;
-        self.store.get_agent_run_from_threads(session_id, run_id)
     }
 
     pub fn record_subagent_spawn(

--- a/src-tauri/src/worker_thread/store/agent_run_projection.rs
+++ b/src-tauri/src/worker_thread/store/agent_run_projection.rs
@@ -1,10 +1,9 @@
-use crate::worker_session::{AgentRunRecord, AgentRunStatus};
 use crate::worker_thread::types::{
     ThreadItem, ThreadItemKind, ThreadRecord, ThreadRunSummary, ThreadStatus,
 };
 use serde_json::Value;
 
-use super::{string_field, trace_event_from_thread_item};
+use super::string_field;
 
 pub(crate) fn run_summaries_from_items(
     thread: &ThreadRecord,
@@ -58,67 +57,6 @@ pub(crate) fn run_summaries_from_items(
         }
     }
     runs
-}
-
-pub(super) fn agent_run_record_from_thread_run(
-    session_id: &str,
-    thread: &ThreadRecord,
-    run: &ThreadRunSummary,
-    items: &[ThreadItem],
-) -> AgentRunRecord {
-    let trace_events = items
-        .iter()
-        .filter(|item| item.run_id.as_deref() == Some(run.run_id.as_str()))
-        .filter_map(trace_event_from_thread_item)
-        .collect::<Vec<_>>();
-    AgentRunRecord {
-        session_id: session_id.to_string(),
-        run_id: run.run_id.clone(),
-        thread_id: Some(thread.thread_id.clone()),
-        turn_id: turn_id_for_run(run, items),
-        parent_thread_id: thread.parent_thread_id.clone(),
-        child_thread_ids: child_thread_ids_for_run(thread, run, items),
-        status: agent_run_status_from_thread_run(run),
-        phase: agent_run_phase_from_thread_run(run).to_string(),
-        started_at: run
-            .started_at
-            .clone()
-            .unwrap_or_else(|| thread.created_at.clone()),
-        updated_at: run
-            .updated_at
-            .clone()
-            .unwrap_or_else(|| thread.updated_at.clone()),
-        completed_at: run.completed_at.clone(),
-        stop_reason: run
-            .completed_at
-            .as_ref()
-            .map(|_| "thread_projected".to_string()),
-        model: run
-            .model
-            .clone()
-            .or_else(|| thread.metadata.model.clone())
-            .unwrap_or_default(),
-        provider: run.provider.clone(),
-        max_iterations: 0,
-        current_iteration: 0,
-        conversation_message_ids: Vec::new(),
-        trace_messages: Vec::new(),
-        trace_events,
-        completed_tool_results: Vec::new(),
-        pending_tool_calls: Vec::new(),
-        checkpoint: None,
-        artifacts: Vec::new(),
-        usage: Vec::new(),
-        token_usage_info: thread_token_usage_info(thread),
-        instruction_provenance: instruction_provenance_for_run(run, items),
-        instruction_diagnostics: instruction_diagnostics_for_run(run, items),
-        trace_context: trace_context_for_run(run, items),
-        error: (run.status == ThreadStatus::Failed).then(|| {
-            serde_json::json!({
-                "message": "thread run failed"
-            })
-        }),
-    }
 }
 
 fn update_run_summary_from_item(run: &mut ThreadRunSummary, item: &ThreadItem) {
@@ -179,120 +117,4 @@ fn update_run_summary_from_item(run: &mut ThreadRunSummary, item: &ThreadItem) {
         }
         _ => {}
     }
-}
-
-fn thread_token_usage_info(thread: &ThreadRecord) -> Option<crate::worker_session::TokenUsageInfo> {
-    thread
-        .metadata
-        .extra
-        .get("tokenUsageInfo")
-        .cloned()
-        .and_then(|value| serde_json::from_value(value).ok())
-}
-
-fn child_thread_ids_for_run(
-    thread: &ThreadRecord,
-    run: &ThreadRunSummary,
-    items: &[ThreadItem],
-) -> Vec<String> {
-    let mut child_thread_ids = items
-        .iter()
-        .filter(|item| item.run_id.as_deref() == Some(run.run_id.as_str()))
-        .filter_map(|item| child_thread_id_from_item(&item.kind))
-        .collect::<Vec<_>>();
-    child_thread_ids.sort();
-    child_thread_ids.dedup();
-    if thread.parent_thread_id.is_some() || !child_thread_ids.is_empty() {
-        return child_thread_ids;
-    }
-    Vec::new()
-}
-
-fn turn_id_for_run(run: &ThreadRunSummary, items: &[ThreadItem]) -> Option<String> {
-    items
-        .iter()
-        .find(|item| item.run_id.as_deref() == Some(run.run_id.as_str()))
-        .and_then(|item| item.turn_id.clone())
-        .or_else(|| Some(run.run_id.clone()))
-}
-
-fn child_thread_id_from_item(kind: &ThreadItemKind) -> Option<String> {
-    match kind {
-        ThreadItemKind::SubagentSpawned(value)
-        | ThreadItemKind::SubagentMessage(value)
-        | ThreadItemKind::SubagentCompleted(value) => value
-            .get("childThreadId")
-            .or_else(|| value.get("child_thread_id"))
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-            .map(str::to_string),
-        _ => None,
-    }
-}
-
-fn agent_run_status_from_thread_run(run: &ThreadRunSummary) -> AgentRunStatus {
-    match &run.status {
-        ThreadStatus::Failed => AgentRunStatus::Failed,
-        ThreadStatus::Cancelling => AgentRunStatus::Cancelled,
-        ThreadStatus::WaitingForApproval | ThreadStatus::WaitingForInput => AgentRunStatus::Waiting,
-        ThreadStatus::Running => AgentRunStatus::Running,
-        ThreadStatus::Empty | ThreadStatus::Idle | ThreadStatus::Archived => {
-            if run.active {
-                AgentRunStatus::Running
-            } else {
-                AgentRunStatus::Completed
-            }
-        }
-    }
-}
-
-fn agent_run_phase_from_thread_run(run: &ThreadRunSummary) -> &'static str {
-    match agent_run_status_from_thread_run(run) {
-        AgentRunStatus::Running => "active_turn",
-        AgentRunStatus::Waiting => "waiting",
-        AgentRunStatus::Completed => "completed",
-        AgentRunStatus::Failed => "failed",
-        AgentRunStatus::Cancelled => "cancelled",
-        AgentRunStatus::Interrupted => "interrupted",
-    }
-}
-
-fn trace_context_for_run(
-    run: &ThreadRunSummary,
-    items: &[ThreadItem],
-) -> Option<crate::agent_loop_runtime_protocol::AgentTraceContext> {
-    items
-        .iter()
-        .filter(|item| item.run_id.as_deref() == Some(run.run_id.as_str()))
-        .find_map(|item| match &item.kind {
-            ThreadItemKind::AgentRunStarted(payload) => payload.get("traceContext"),
-            _ => None,
-        })
-        .cloned()
-        .and_then(|value| serde_json::from_value(value).ok())
-}
-
-fn instruction_provenance_for_run(run: &ThreadRunSummary, items: &[ThreadItem]) -> Option<Value> {
-    completed_run_payload(run, items)
-        .and_then(|payload| payload.get("instructionProvenance"))
-        .filter(|value| !value.is_null())
-        .cloned()
-}
-
-fn instruction_diagnostics_for_run(run: &ThreadRunSummary, items: &[ThreadItem]) -> Vec<Value> {
-    completed_run_payload(run, items)
-        .and_then(|payload| payload.get("instructionDiagnostics"))
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
-}
-
-fn completed_run_payload<'a>(run: &ThreadRunSummary, items: &'a [ThreadItem]) -> Option<&'a Value> {
-    items
-        .iter()
-        .filter(|item| item.run_id.as_deref() == Some(run.run_id.as_str()))
-        .find_map(|item| match &item.kind {
-            ThreadItemKind::AgentRunCompleted(payload) => Some(payload),
-            _ => None,
-        })
 }

--- a/src-tauri/src/worker_thread/store/memory.rs
+++ b/src-tauri/src/worker_thread/store/memory.rs
@@ -1,20 +1,18 @@
 use super::index::ThreadIndex;
 use super::{
-    active_child_run_id_for_status, agent_registry_entry, agent_run_record_from_thread_run,
-    apply_metadata_patch, bounded_limit, checkpoint_from_item, descendant_thread_ids,
-    generate_item_id, generate_thread_id, inherited_subagent_history_items, invalid_thread_request,
-    latest_checkpoint_from_items, non_empty_string, now_timestamp, parse_sequence_cursor,
-    parse_trace_cursor, pending_approvals_from_items, read_cursor_from_request,
-    recompute_dynamic_metadata, remember_client_event_items, run_summaries_from_items,
-    running_tools_from_items, runtime_events_from_thread_items, status_value,
+    active_child_run_id_for_status, agent_registry_entry, apply_metadata_patch, bounded_limit,
+    checkpoint_from_item, descendant_thread_ids, generate_item_id, generate_thread_id,
+    inherited_subagent_history_items, invalid_thread_request, latest_checkpoint_from_items,
+    non_empty_string, now_timestamp, parse_sequence_cursor, pending_approvals_from_items,
+    read_cursor_from_request, recompute_dynamic_metadata, remember_client_event_items,
+    run_summaries_from_items, running_tools_from_items, status_value,
     subagent_agent_control_payload, subagent_child_status_item, subagent_initial_child_items,
     subagent_input_item, subagent_lifecycle_item_label, subagent_parent_item,
     thread_items_match_query, thread_matches_list_filters, thread_matches_query,
-    thread_status_for_subagent, trace_event_from_thread_item, turn_items_from_thread_items,
-    unknown_thread_error, validate_context_checkpoint_lineage, validate_thread_id, AgentRunRecord,
-    AgentRunRuntimeState, AgentRunTracePage, AppendThreadItemsResult, CreateThreadRequest,
-    DeleteThreadRequest, DeleteThreadResult, ForkThreadRequest, ListThreadsRequest,
-    ListThreadsResult, ReadThreadRequest, RestoreThreadCheckpointRequest,
+    thread_status_for_subagent, turn_items_from_thread_items, unknown_thread_error,
+    validate_context_checkpoint_lineage, validate_thread_id, AppendThreadItemsResult,
+    CreateThreadRequest, DeleteThreadRequest, DeleteThreadResult, ForkThreadRequest,
+    ListThreadsRequest, ListThreadsResult, ReadThreadRequest, RestoreThreadCheckpointRequest,
     RestoreThreadCheckpointResult, ResumeThreadRequest, SearchThreadsRequest, SearchThreadsResult,
     SubagentMailboxInput, SubagentThreadStatus, SubagentThreadSummary, ThreadActivityRequest,
     ThreadActivityResult, ThreadActivitySummary, ThreadAgentRegistryRequest,
@@ -392,137 +390,6 @@ impl MemoryThreadStore {
             agents,
             summary,
         })
-    }
-
-    pub(crate) fn list_agent_run_trace_events(
-        &self,
-        session_id: &str,
-        run_id: &str,
-        cursor: Option<&str>,
-        limit: Option<usize>,
-    ) -> Result<Option<AgentRunTracePage>, WorkerProtocolError> {
-        let offset = parse_trace_cursor(cursor)?;
-        let limit = bounded_limit(limit, 100, 500);
-        let Some(items) = self.agent_run_thread_items(session_id, run_id)? else {
-            return Ok(None);
-        };
-        let events = items
-            .iter()
-            .filter(|item| !matches!(&item.kind, ThreadItemKind::UserMessage(_)))
-            .filter_map(trace_event_from_thread_item)
-            .collect::<Vec<_>>();
-        let page_items = events
-            .iter()
-            .skip(offset)
-            .take(limit)
-            .cloned()
-            .collect::<Vec<_>>();
-        let next_offset = offset.saturating_add(page_items.len());
-        Ok(Some(AgentRunTracePage {
-            session_id: session_id.to_string(),
-            run_id: run_id.to_string(),
-            items: page_items,
-            next_cursor: (next_offset < events.len()).then(|| next_offset.to_string()),
-        }))
-    }
-
-    pub(crate) fn get_agent_run_runtime_state(
-        &self,
-        session_id: &str,
-        run_id: &str,
-    ) -> Result<Option<AgentRunRuntimeState>, WorkerProtocolError> {
-        let Some(items) = self.agent_run_thread_items(session_id, run_id)? else {
-            return Ok(None);
-        };
-        Ok(Some(AgentRunRuntimeState::from_runtime_events(
-            session_id,
-            run_id,
-            runtime_events_from_thread_items(&items, session_id, run_id),
-        )?))
-    }
-
-    pub(crate) fn list_agent_runs_from_threads(
-        &self,
-        session_id: &str,
-    ) -> Result<Vec<AgentRunRecord>, WorkerProtocolError> {
-        let state = self.lock()?;
-        let mut records = Vec::new();
-        for thread in state
-            .threads
-            .iter()
-            .filter(|thread| thread.session_key.as_deref() == Some(session_id))
-            .filter(|thread| thread.status != ThreadStatus::Archived)
-        {
-            let items = state
-                .items
-                .get(&thread.thread_id)
-                .map(Vec::as_slice)
-                .unwrap_or(&[]);
-            records.extend(
-                run_summaries_from_items(thread, items)
-                    .into_iter()
-                    .map(|run| agent_run_record_from_thread_run(session_id, thread, &run, items)),
-            );
-        }
-        records.sort_by(|left, right| {
-            right
-                .updated_at
-                .cmp(&left.updated_at)
-                .then_with(|| left.run_id.cmp(&right.run_id))
-        });
-        Ok(records)
-    }
-
-    pub(crate) fn get_agent_run_from_threads(
-        &self,
-        session_id: &str,
-        run_id: &str,
-    ) -> Result<Option<AgentRunRecord>, WorkerProtocolError> {
-        Ok(self
-            .list_agent_runs_from_threads(session_id)?
-            .into_iter()
-            .find(|record| record.run_id == run_id))
-    }
-
-    fn agent_run_thread_items(
-        &self,
-        session_id: &str,
-        run_id: &str,
-    ) -> Result<Option<Vec<ThreadItem>>, WorkerProtocolError> {
-        let state = self.lock()?;
-        let mut matched = false;
-        let mut items = Vec::new();
-        for thread in state
-            .threads
-            .iter()
-            .filter(|thread| thread.session_key.as_deref() == Some(session_id))
-        {
-            let mut thread_items = state
-                .items
-                .get(&thread.thread_id)
-                .into_iter()
-                .flatten()
-                .filter(|item| item.run_id.as_deref() == Some(run_id))
-                .cloned()
-                .collect::<Vec<_>>();
-            if thread.root_run_id.as_deref() == Some(run_id)
-                || thread.active_run_id.as_deref() == Some(run_id)
-                || !thread_items.is_empty()
-            {
-                matched = true;
-                items.append(&mut thread_items);
-            }
-        }
-        if !matched {
-            return Ok(None);
-        }
-        items.sort_by(|left, right| {
-            left.created_at
-                .cmp(&right.created_at)
-                .then_with(|| left.sequence.cmp(&right.sequence))
-                .then_with(|| left.item_id.cmp(&right.item_id))
-        });
-        Ok(Some(items))
     }
 
     pub(crate) fn record_subagent_spawn(

--- a/src-tauri/src/worker_thread/store/mod.rs
+++ b/src-tauri/src/worker_thread/store/mod.rs
@@ -22,7 +22,6 @@ use super::types::{
 use crate::worker_protocol::{
     WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
 };
-use crate::worker_session::{AgentRunRecord, AgentRunRuntimeState, AgentRunTracePage};
 use crate::worker_subagent_manager::{
     SubagentMailboxInput, SubagentThreadStatus, SubagentThreadSummary,
 };
@@ -34,18 +33,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use self::activity::{
     agent_registry_entry, pending_approvals_from_items, running_tools_from_items,
 };
-use self::agent_run_projection::agent_run_record_from_thread_run;
 pub(crate) use self::agent_run_projection::run_summaries_from_items;
 use self::checkpoint::{checkpoint_from_item, latest_checkpoint_from_items};
 pub use self::memory::MemoryThreadStore;
 use self::metadata::{apply_metadata_patch, recompute_dynamic_metadata};
 use self::query::{
     bounded_limit, descendant_thread_ids, items_match_query as thread_items_match_query,
-    parse_sequence_cursor, parse_trace_cursor, read_cursor_from_request,
-    thread_matches_list_filters, thread_matches_query,
+    parse_sequence_cursor, read_cursor_from_request, thread_matches_list_filters,
+    thread_matches_query,
 };
 pub(crate) use self::runtime_projection::runtime_events_from_thread_items;
-use self::runtime_projection::{trace_event_from_thread_item, turn_items_from_thread_items};
+use self::runtime_projection::turn_items_from_thread_items;
 use self::subagent_projection::{
     active_child_run_id_for_status, inherited_subagent_history_items, status_value,
     subagent_agent_control_payload, subagent_child_status_item, subagent_initial_child_items,

--- a/src-tauri/src/worker_thread/store/query.rs
+++ b/src-tauri/src/worker_thread/store/query.rs
@@ -107,18 +107,6 @@ pub(super) fn descendant_thread_ids(index: &ThreadIndex, thread_id: &str) -> Vec
     descendants
 }
 
-pub(super) fn parse_trace_cursor(cursor: Option<&str>) -> Result<usize, WorkerProtocolError> {
-    match cursor {
-        Some(value) if !value.trim().is_empty() => value.parse::<usize>().map_err(|error| {
-            invalid_thread_request(
-                "agent run trace cursor must be an offset",
-                serde_json::json!({ "cursor": value, "error": error.to_string() }),
-            )
-        }),
-        _ => Ok(0),
-    }
-}
-
 pub(super) fn parse_sequence_cursor(cursor: Option<&str>) -> Result<u64, WorkerProtocolError> {
     match cursor {
         Some(value) if !value.trim().is_empty() => value.parse::<u64>().map_err(|error| {

--- a/src-tauri/src/worker_thread/store/runtime_projection.rs
+++ b/src-tauri/src/worker_thread/store/runtime_projection.rs
@@ -4,7 +4,6 @@ use crate::agent_loop_runtime_protocol::{
 };
 use crate::worker_thread::types::{ThreadItem, ThreadItemKind};
 use serde_json::Value;
-use std::collections::HashMap;
 
 pub(super) fn trace_event_from_thread_item(item: &ThreadItem) -> Option<Value> {
     if let ThreadItemKind::Reasoning(value) = &item.kind {
@@ -95,7 +94,16 @@ fn runtime_event_from_thread_item(
     run_id: &str,
 ) -> Option<AgentRuntimeEventEnvelope> {
     let event = trace_event_from_thread_item(item)?;
-    if let Ok(envelope) = serde_json::from_value::<AgentRuntimeEventEnvelope>(event.clone()) {
+    if let Ok(mut envelope) = serde_json::from_value::<AgentRuntimeEventEnvelope>(event.clone()) {
+        envelope.sequence = item.sequence;
+        envelope.timestamp = item.created_at.clone();
+        envelope.session_id = session_id.to_string();
+        envelope.thread_id = Some(item.thread_id.clone());
+        envelope.turn_id = item
+            .turn_id
+            .clone()
+            .or_else(|| item.run_id.clone())
+            .unwrap_or_else(|| run_id.to_string());
         return Some(envelope);
     }
     let event_name = event
@@ -114,29 +122,10 @@ fn runtime_event_from_thread_item(
         .map(str::to_string)
         .or_else(|| legacy_trace_item_id(&event_name, &payload))
         .or_else(|| Some(item.item_id.clone()));
-    let sequence = event
-        .get("sequence")
-        .and_then(Value::as_u64)
-        .unwrap_or(item.sequence);
-    let timestamp = event
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .unwrap_or_else(|| item.created_at.clone());
     Some(AgentRuntimeEventEnvelope::from_legacy_native_event(
         LegacyNativeAgentEventEnvelopeInput {
-            session_id: event
-                .get("sessionId")
-                .or_else(|| event.get("session_id"))
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .unwrap_or_else(|| session_id.to_string()),
-            thread_id: event
-                .get("threadId")
-                .or_else(|| event.get("thread_id"))
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .or_else(|| Some(item.thread_id.clone())),
+            session_id: session_id.to_string(),
+            thread_id: Some(item.thread_id.clone()),
             turn_id: item
                 .turn_id
                 .clone()
@@ -149,8 +138,8 @@ fn runtime_event_from_thread_item(
                 .map(str::to_string),
             item_id,
             event_name,
-            sequence,
-            timestamp,
+            sequence: item.sequence,
+            timestamp: item.created_at.clone(),
             payload,
         },
     ))
@@ -161,56 +150,11 @@ pub(crate) fn runtime_events_from_thread_items(
     session_id: &str,
     run_id: &str,
 ) -> Vec<AgentRuntimeEventEnvelope> {
-    let mut events = items
+    items
         .iter()
         .filter(|item| item.run_id.as_deref() == Some(run_id))
         .filter_map(|item| runtime_event_from_thread_item(item, session_id, run_id))
-        .collect::<Vec<_>>();
-    normalize_interaction_resolution_order(&mut events);
-    events
-}
-
-fn normalize_interaction_resolution_order(events: &mut [AgentRuntimeEventEnvelope]) {
-    let mut positions = HashMap::<(String, String), Vec<usize>>::new();
-    for (index, event) in events.iter().enumerate() {
-        if let Some((kind, interaction_id, _)) = interaction_order_key(event) {
-            positions
-                .entry((kind.to_string(), interaction_id.to_string()))
-                .or_default()
-                .push(index);
-        }
-    }
-    for indexes in positions.into_values() {
-        let mut ordered = indexes
-            .iter()
-            .map(|index| events[*index].clone())
-            .collect::<Vec<_>>();
-        ordered.sort_by_key(|event| {
-            interaction_order_key(event)
-                .map(|(_, _, rank)| rank)
-                .unwrap_or_default()
-        });
-        for (index, event) in indexes.into_iter().zip(ordered) {
-            events[index] = event;
-        }
-    }
-}
-
-fn interaction_order_key(event: &AgentRuntimeEventEnvelope) -> Option<(&str, &str, u8)> {
-    let (kind, id_keys, rank) = match event.event_name.as_str() {
-        "agent.awaiting_approval" => ("approval", &["approvalId", "approval_id"][..], 0),
-        "agent.approval.decision" => ("approval", &["approvalId", "approval_id"][..], 1),
-        "agent.awaiting_form" => ("form", &["formId", "form_id"][..], 0),
-        "agent.form.resolution" => ("form", &["formId", "form_id"][..], 1),
-        _ => return None,
-    };
-    id_keys.iter().find_map(|key| {
-        event
-            .payload
-            .get(*key)
-            .and_then(Value::as_str)
-            .map(|interaction_id| (kind, interaction_id, rank))
-    })
+        .collect()
 }
 
 pub(super) fn turn_items_from_thread_items(
@@ -281,9 +225,7 @@ fn prefixed_string_from_trace_payload(
 #[cfg(test)]
 mod tests {
     use super::{runtime_events_from_thread_items, turn_items_from_thread_items};
-    use crate::agent_loop_runtime_protocol::{
-        AgentTurnItemData, AgentTurnItemKind, AgentTurnItemStatus,
-    };
+    use crate::agent_loop_runtime_protocol::{AgentTurnItemData, AgentTurnItemKind};
     use crate::worker_thread::types::{ThreadItem, ThreadItemKind};
     use serde_json::{json, Value};
 
@@ -316,7 +258,7 @@ mod tests {
     }
 
     #[test]
-    fn persisted_approval_resolution_is_replayed_after_its_request() {
+    fn persisted_approval_order_follows_rollout_order() {
         let approval_id = "approval:run-1:call-1";
         let items = vec![
             approval_item(
@@ -334,11 +276,46 @@ mod tests {
         ];
 
         let events = runtime_events_from_thread_items(&items, "thread-1", "run-1");
-        assert_eq!(events[0].event_name, "agent.awaiting_approval");
-        assert_eq!(events[1].event_name, "agent.approval.decision");
-        let projected = turn_items_from_thread_items(&items, "thread-1", "run-1");
-        assert_eq!(projected.len(), 1);
-        assert_eq!(projected[0].status, AgentTurnItemStatus::Completed);
+        assert_eq!(events[0].event_name, "agent.approval.decision");
+        assert_eq!(events[1].event_name, "agent.awaiting_approval");
+        assert_eq!(events[0].sequence, 1);
+        assert_eq!(events[1].sequence, 209);
+    }
+
+    #[test]
+    fn full_envelope_uses_rollout_identity_sequence_and_timestamp() {
+        let items = vec![ThreadItem {
+            item_id: "rollout-item-99".to_string(),
+            thread_id: "canonical-thread".to_string(),
+            run_id: Some("canonical-run".to_string()),
+            turn_id: Some("canonical-run".to_string()),
+            parent_item_id: None,
+            sequence: 99,
+            created_at: "2026-07-20T00:00:99Z".to_string(),
+            kind: ThreadItemKind::Event(json!({
+                "schemaVersion": "tinybot.agent_event.v1",
+                "eventId": "event-1",
+                "sequence": 1,
+                "sessionId": "embedded-session",
+                "threadId": "embedded-thread",
+                "turnId": "embedded-run",
+                "eventName": "agent.done",
+                "phase": "completed",
+                "timestamp": "2026-07-20T00:00:01Z",
+                "source": "rust_backend",
+                "visibility": "user",
+                "payload": { "finalContent": "Done." }
+            })),
+        }];
+
+        let events = runtime_events_from_thread_items(&items, "canonical-session", "canonical-run");
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].sequence, 99);
+        assert_eq!(events[0].timestamp, "2026-07-20T00:00:99Z");
+        assert_eq!(events[0].session_id, "canonical-session");
+        assert_eq!(events[0].thread_id.as_deref(), Some("canonical-thread"));
+        assert_eq!(events[0].turn_id, "canonical-run");
     }
 
     #[test]

--- a/src-tauri/src/worker_thread_log/agent_run.rs
+++ b/src-tauri/src/worker_thread_log/agent_run.rs
@@ -89,6 +89,9 @@ impl WorkerThreadLogRpc {
         if events.is_empty() {
             return Err(empty_agent_run_trace_batch_error(session_id, run_id));
         }
+        for (index, event) in events.iter().enumerate() {
+            validate_agent_run_trace_event(session_id, run_id, index, event)?;
+        }
         let mut record = self
             .get_agent_run_record(session_id, run_id)?
             .ok_or_else(|| unknown_agent_run_error(session_id, run_id))?;
@@ -115,17 +118,10 @@ impl WorkerThreadLogRpc {
                 .and_then(Value::as_i64)
         });
         let has_response_items = events.iter().any(|event| {
-            matches!(
-                event.get("eventName").and_then(Value::as_str),
-                Some(
-                    "agent.turn.started"
-                        | "agent.reasoning_delta"
-                        | "agent.message.classified"
-                        | "agent.message.completed"
-                        | "agent.tool_call.delta"
-                        | "agent.tool.result"
-                )
-            )
+            event
+                .get("eventName")
+                .and_then(Value::as_str)
+                .is_some_and(agent_run_trace_event_is_response_backed)
         });
         let mut items = Vec::new();
         let mut pending_reasoning = None::<ReasoningResponseAccumulator>;
@@ -812,6 +808,70 @@ fn response_item_from_runtime_event(event: &Value) -> Option<Value> {
     }
 }
 
+fn agent_run_trace_event_is_response_backed(event_name: &str) -> bool {
+    matches!(
+        event_name,
+        "agent.turn.started"
+            | "agent.reasoning_delta"
+            | "agent.message.classified"
+            | "agent.message.completed"
+            | "agent.tool_call.delta"
+            | "agent.tool.result"
+    )
+}
+
+fn validate_agent_run_trace_event(
+    session_id: &str,
+    run_id: &str,
+    index: usize,
+    event: &Value,
+) -> Result<(), WorkerProtocolError> {
+    let event_name = event
+        .get("eventName")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            invalid_agent_run_trace_event_error(
+                "agent run trace event is missing eventName",
+                session_id,
+                run_id,
+                index,
+                None,
+            )
+        })?;
+    event
+        .get("eventId")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            invalid_agent_run_trace_event_error(
+                "agent run trace event is missing eventId",
+                session_id,
+                run_id,
+                index,
+                Some(event_name),
+            )
+        })?;
+    if !agent_run_trace_event_is_response_backed(event_name) {
+        return Ok(());
+    }
+    let materializes_response = if event_name == "agent.reasoning_delta" {
+        ReasoningResponseFragment::from_runtime_event(event).is_some()
+    } else {
+        response_item_from_runtime_event(event).is_some()
+    };
+    if !materializes_response {
+        return Err(invalid_agent_run_trace_event_error(
+            "response-backed agent run trace event cannot be materialized",
+            session_id,
+            run_id,
+            index,
+            Some(event_name),
+        ));
+    }
+    Ok(())
+}
+
 struct ReasoningResponseFragment {
     event_id: String,
     turn_id: String,
@@ -1421,6 +1481,27 @@ fn embedded_agent_run_trace_error(session_id: &str, run_id: &str) -> WorkerProto
         serde_json::json!({
             "session_id": session_id,
             "run_id": run_id,
+        }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn invalid_agent_run_trace_event_error(
+    message: &str,
+    session_id: &str,
+    run_id: &str,
+    index: usize,
+    event_name: Option<&str>,
+) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        message,
+        serde_json::json!({
+            "session_id": session_id,
+            "run_id": run_id,
+            "event_index": index,
+            "event_name": event_name,
         }),
         false,
         WorkerProtocolErrorSource::RustCore,

--- a/src-tauri/src/worker_thread_log/agent_run.rs
+++ b/src-tauri/src/worker_thread_log/agent_run.rs
@@ -3,9 +3,6 @@ use super::{
     thread_id_for_session_id, title_from_messages, value_event, AgentRunRecoveryEntry,
     AgentRunRecoveryReport, ThreadLogItem, WorkerThreadLogRpc,
 };
-use crate::agent_loop_runtime_protocol::{
-    AgentRuntimeEventEnvelope, LegacyNativeAgentEventEnvelopeInput,
-};
 use crate::worker_capability::WorkerCapability;
 use crate::worker_protocol::{
     WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource,
@@ -14,7 +11,7 @@ use crate::worker_session::{
     AgentRunCheckpoint, AgentRunRecord, AgentRunRuntimeState, AgentRunStatus, AgentRunTracePage,
 };
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 impl WorkerThreadLogRpc {
@@ -28,31 +25,28 @@ impl WorkerThreadLogRpc {
 
     fn upsert_agent_run_at(
         &self,
-        mut record: AgentRunRecord,
+        record: AgentRunRecord,
         timestamp: String,
     ) -> Result<AgentRunRecord, WorkerProtocolError> {
         self.require(WorkerCapability::SessionWrite)?;
         validate_agent_run_key(&record.session_id, &record.run_id)?;
-        let incoming_trace_events = std::mem::take(&mut record.trace_events);
-        let existing = self.get_agent_run_record(&record.session_id, &record.run_id)?;
-        if let Some(existing) = existing {
-            record.started_at = existing.started_at;
-            let mut trace_events = existing.trace_events;
-            for event in incoming_trace_events.iter().cloned() {
-                upsert_trace_event(&mut trace_events, event);
-            }
-            record.trace_events = trace_events;
-        } else {
-            record.trace_events = incoming_trace_events.clone();
+        if !record.trace_events.is_empty() {
+            return Err(embedded_agent_run_trace_error(
+                &record.session_id,
+                &record.run_id,
+            ));
         }
+        let existing = self.get_agent_run_record(&record.session_id, &record.run_id)?;
         let mut persisted_record = record.clone();
-        persisted_record.trace_events = incoming_trace_events;
+        if let Some(existing) = existing {
+            persisted_record.started_at = existing.started_at;
+        }
         let mut state = self.ensure_agent_run_thread(&record.session_id, &timestamp)?;
         let path = PathBuf::from(state.thread_path.clone());
         self.recorder.validate_thread_path(&path)?;
         let mut items = vec![value_event(
             super::EventKind::AgentRunUpsert,
-            serde_json::json!({ "record": persisted_record }),
+            serde_json::json!({ "record": persisted_record.clone() }),
         )];
         if let Some(info) = record.token_usage_info.as_ref() {
             items.push(value_event(
@@ -72,7 +66,7 @@ impl WorkerThreadLogRpc {
             state.tokens_used = info.total_token_usage.total_tokens;
         }
         self.state.upsert_thread_projection(&state, &log_head)?;
-        Ok(record)
+        Ok(persisted_record)
     }
 
     pub fn append_agent_run_trace_event(
@@ -368,47 +362,14 @@ impl WorkerThreadLogRpc {
                 selected = Some((record, reconstructed.thread_items));
             }
         }
-        let Some((record, thread_items)) = selected else {
+        let Some((_, thread_items)) = selected else {
             return Ok(None);
         };
-        let canonical_events = crate::worker_thread::runtime_events_from_thread_items(
+        let runtime_events = crate::worker_thread::runtime_events_from_thread_items(
             &thread_items,
             session_id,
             run_id,
         );
-        let canonical_reasoning_item_ids = canonical_events
-            .iter()
-            .filter(|event| event.event_name == "agent.reasoning_delta")
-            .filter_map(|event| event.item_id.clone())
-            .collect::<HashSet<_>>();
-        let mut runtime_events = Vec::new();
-        for event in canonical_events {
-            if !runtime_events
-                .iter()
-                .any(|existing| same_projected_runtime_event(existing, &event))
-            {
-                runtime_events.push(event);
-            }
-        }
-        for (index, event) in record.trace_events.iter().enumerate() {
-            let Some(event) = runtime_event_from_trace_value(&record, index, event) else {
-                continue;
-            };
-            if event.event_name == "agent.reasoning_delta"
-                && event
-                    .item_id
-                    .as_ref()
-                    .is_some_and(|item_id| canonical_reasoning_item_ids.contains(item_id))
-            {
-                continue;
-            }
-            let already_projected = runtime_events
-                .iter()
-                .any(|existing| same_projected_runtime_event(existing, &event));
-            if !already_projected {
-                runtime_events.push(event);
-            }
-        }
         let runtime_state =
             AgentRunRuntimeState::from_runtime_events(session_id, run_id, runtime_events.clone())
                 .map_err(|error| {
@@ -977,6 +938,16 @@ pub(super) fn agent_run_records_from_lines(
                             }),
                         )
                     })?;
+                if !record.trace_events.is_empty() {
+                    return Err(agent_run_replay_error(
+                        "canonical agent_run_upsert record must not embed trace events",
+                        line,
+                        &serde_json::json!({
+                            "runId": &record.run_id,
+                            "traceEventCount": record.trace_events.len(),
+                        }),
+                    ));
+                }
                 let belongs_to_session = record.session_id == session_id;
                 let belongs_to_thread = record.session_id == thread_id;
                 if !belongs_to_session && !belongs_to_thread {
@@ -994,10 +965,7 @@ pub(super) fn agent_run_records_from_lines(
                 runs.entry(record.run_id.clone())
                     .and_modify(|existing| {
                         let started_at = existing.started_at.clone();
-                        let mut trace_events = existing.trace_events.clone();
-                        for event in record.trace_events.iter().cloned() {
-                            upsert_trace_event(&mut trace_events, event);
-                        }
+                        let trace_events = existing.trace_events.clone();
                         *existing = record.clone();
                         existing.started_at = started_at;
                         existing.trace_events = trace_events;
@@ -1409,132 +1377,6 @@ fn agent_run_status_from_phase(phase: &str) -> AgentRunStatus {
     }
 }
 
-fn runtime_event_from_trace_value(
-    record: &AgentRunRecord,
-    index: usize,
-    event: &Value,
-) -> Option<AgentRuntimeEventEnvelope> {
-    if let Ok(envelope) = serde_json::from_value::<AgentRuntimeEventEnvelope>(event.clone()) {
-        return Some(envelope);
-    }
-    let event_name = event.get("eventName").and_then(Value::as_str)?.to_string();
-    let payload = event
-        .get("payload")
-        .cloned()
-        .unwrap_or_else(|| event.clone());
-    let sequence = event
-        .get("sequence")
-        .and_then(Value::as_u64)
-        .unwrap_or_else(|| index as u64 + 1);
-    Some(AgentRuntimeEventEnvelope::from_legacy_native_event(
-        LegacyNativeAgentEventEnvelopeInput {
-            session_id: record.session_id.clone(),
-            thread_id: record.thread_id.clone(),
-            turn_id: record.run_id.clone(),
-            parent_turn_id: event
-                .get("parentTurnId")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            item_id: event
-                .get("itemId")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .or_else(|| legacy_trace_item_id(&event_name, &payload)),
-            event_name,
-            sequence,
-            timestamp: event
-                .get("timestamp")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .unwrap_or_else(|| record.updated_at.clone()),
-            payload,
-        },
-    ))
-}
-
-fn same_projected_runtime_event(
-    left: &AgentRuntimeEventEnvelope,
-    right: &AgentRuntimeEventEnvelope,
-) -> bool {
-    if left.event_id == right.event_id {
-        return true;
-    }
-    if matches!(
-        left.event_name.as_str(),
-        "agent.delta" | "agent.reasoning_delta"
-    ) || matches!(
-        right.event_name.as_str(),
-        "agent.delta" | "agent.reasoning_delta"
-    ) {
-        return false;
-    }
-    if left.event_name == right.event_name
-        && matches!(
-            left.event_name.as_str(),
-            "agent.done" | "agent.error" | "agent.cancelled"
-        )
-    {
-        return true;
-    }
-    left.item_id.is_some() && left.event_name == right.event_name && left.item_id == right.item_id
-}
-
-fn legacy_trace_item_id(event_name: &str, payload: &Value) -> Option<String> {
-    match event_name {
-        "agent.delta"
-        | "agent.message.phase"
-        | "agent.message.classified"
-        | "agent.message.completed" => {
-            string_from_trace_payload(payload, &["messageId", "message_id"]).or_else(|| {
-                prefixed_string_from_trace_payload(
-                    payload,
-                    "assistant",
-                    &["modelCallId", "model_call_id"],
-                )
-            })
-        }
-        "agent.reasoning_delta" => {
-            string_from_trace_payload(payload, &["reasoningId", "reasoning_id"]).or_else(|| {
-                prefixed_string_from_trace_payload(
-                    payload,
-                    "reasoning",
-                    &["modelCallId", "model_call_id"],
-                )
-            })
-        }
-        "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" => {
-            string_from_trace_payload(payload, &["toolCallId", "tool_call_id"])
-        }
-        "agent.awaiting_approval" | "agent.approval.decision" => {
-            string_from_trace_payload(payload, &["approvalId", "approval_id"])
-        }
-        "agent.awaiting_form" | "agent.form.resolution" => {
-            string_from_trace_payload(payload, &["formId", "form_id"])
-        }
-        event_name if event_name.starts_with("agent.delegate.") => {
-            string_from_trace_payload(payload, &["delegateId", "subagentId", "delegate_id"])
-        }
-        _ => None,
-    }
-}
-
-fn string_from_trace_payload(payload: &Value, keys: &[&str]) -> Option<String> {
-    keys.iter().find_map(|key| {
-        payload
-            .get(*key)
-            .and_then(Value::as_str)
-            .map(str::to_string)
-    })
-}
-
-fn prefixed_string_from_trace_payload(
-    payload: &Value,
-    prefix: &str,
-    keys: &[&str],
-) -> Option<String> {
-    string_from_trace_payload(payload, keys).map(|value| format!("{prefix}:{value}"))
-}
-
 fn parse_trace_cursor(cursor: Option<&str>) -> Result<usize, WorkerProtocolError> {
     let Some(cursor) = cursor else {
         return Ok(0);
@@ -1567,6 +1409,19 @@ fn invalid_agent_run_key(field: &str, value: &str) -> WorkerProtocolError {
         WorkerProtocolErrorCode::InvalidProtocol,
         "invalid agent run key",
         serde_json::json!({ field: value }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
+}
+
+fn embedded_agent_run_trace_error(session_id: &str, run_id: &str) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        "agent_run.upsert must not embed trace events; use agent_run.append_trace",
+        serde_json::json!({
+            "session_id": session_id,
+            "run_id": run_id,
+        }),
         false,
         WorkerProtocolErrorSource::RustCore,
     )

--- a/src-tauri/src/worker_thread_log/mod.rs
+++ b/src-tauri/src/worker_thread_log/mod.rs
@@ -3741,11 +3741,15 @@ fn thread_item_from_agent_run_trace(
         })?;
     if matches!(
         event_name,
-        "agent.context.compacted"
+        "agent.turn.started"
+            | "agent.context.compacted"
             | "agent.delta"
+            | "agent.reasoning_delta"
             | "agent.message.phase"
             | "agent.message.classified"
             | "agent.message.completed"
+            | "agent.tool_call.delta"
+            | "agent.tool.result"
     ) {
         return Ok(None);
     }
@@ -3769,15 +3773,13 @@ fn thread_item_from_agent_run_trace(
     let event_id = string_value(event, "eventId")
         .or_else(|| string_value(event, "event_id"))
         .unwrap_or_else(|| format!("{event_name}:{sequence}"));
-    let event_payload = serde_json::json!({
-        "eventName": event_name,
-        "runId": run_id,
-        "turnId": turn_id,
-        "source": event.get("source").cloned().unwrap_or(Value::Null),
-        "visibility": event.get("visibility").cloned().unwrap_or(Value::Null),
-        "payload": event.get("payload").cloned().unwrap_or(Value::Null),
-        "threadSource": "rollout.agent_run_trace",
-    });
+    let mut event_payload = event.clone();
+    if let Some(object) = event_payload.as_object_mut() {
+        object.insert(
+            "threadSource".to_string(),
+            Value::String("rollout.agent_run_trace".to_string()),
+        );
+    }
     let kind = match event_name {
         "agent.awaiting_approval" => ThreadItemKind::ApprovalRequested(event_payload),
         "agent.approval.decision" => ThreadItemKind::ApprovalResolved(event_payload),
@@ -3933,6 +3935,7 @@ fn response_item_thread_kind(item: &Value) -> ThreadItemKind {
     match item.get("role").and_then(Value::as_str) {
         Some("user") => ThreadItemKind::UserMessage(payload),
         Some("assistant") => ThreadItemKind::AssistantMessageCompleted(payload),
+        Some("tool") => ThreadItemKind::ToolCallOutput(payload),
         _ => match item.get("type").and_then(Value::as_str) {
             Some("reasoning") => ThreadItemKind::Reasoning(item.clone()),
             Some("function_call" | "tool_call") => ThreadItemKind::ToolCallStarted(item.clone()),


### PR DESCRIPTION
## Summary

- make the canonical Rollout the only persistence and reconstruction source for agent run runtime state
- remove raw trace merging and in-memory ThreadStore fallbacks from agent run reads
- use Rollout ordinals, timestamps, and identities when projecting runtime events
- persist semantic messages, reasoning, and tool activity through ResponseItems while retaining selected durable lifecycle events
- reject embedded `traceEvents` in `agent_run.upsert`; callers must use append-trace APIs
- preserve tool-result ResponseItems as `ToolCallOutput` during canonical reconstruction
- stop synthesizing inherited agent runs from forked message history

## Root cause

Runtime-state reconstruction combined canonical Rollout items with `AgentRunRecord.trace_events`. The two sources used different sequence domains: Rollout-global ordinals and run-local event sequences. On longer sessions this could place reasoning after the final answer and fail timeline projection. The fallback also hid incomplete canonical projections, including role=`tool` ResponseItems.

## Impact

Reloaded sessions now reconstruct messages, reasoning, parallel tool calls/results, and final answers from one ordered source. Historical Rollouts that embed trace events inside an upsert are intentionally rejected instead of being interpreted through compatibility logic.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib agent_run_ --jobs 4` (16 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib worker_thread::store::runtime_projection::tests --jobs 4` (3 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib thread_fork_inherits_effective_history_from_canonical_rollout --jobs 4`
- long Rollout reload regression covering reasoning, two parallel tool calls with reverse completion order, final answer, and state-index rebuild