### PR TITLE
Fix canonical rollout persistence

### DIFF
--- a/src-tauri/src/agent_loop_runtime_protocol.rs
+++ b/src-tauri/src/agent_loop_runtime_protocol.rs
@@ -65,7 +65,9 @@ impl AgentRuntimePhase {
 
     pub fn for_legacy_event(event_name: &str) -> Self {
         match event_name {
-            "agent.reasoning_delta" | "agent.delta" => Self::StreamingModel,
+            "agent.reasoning_delta" | "agent.reasoning.completed" | "agent.delta" => {
+                Self::StreamingModel
+            }
             "agent.tool_call.delta" => Self::ToolCalling,
             "agent.tool.start" | "agent.tool.result" => Self::ToolRunning,
             "agent.awaiting_approval" | "agent.approval.decision" => Self::AwaitingApproval,
@@ -111,7 +113,7 @@ pub enum AgentTurnItemKind {
 impl AgentTurnItemKind {
     pub fn for_legacy_event(event_name: &str) -> Option<Self> {
         match event_name {
-            "agent.reasoning_delta" => Some(Self::Reasoning),
+            "agent.reasoning_delta" | "agent.reasoning.completed" => Some(Self::Reasoning),
             "agent.delta"
             | "agent.message.phase"
             | "agent.message.classified"
@@ -1944,6 +1946,7 @@ fn projected_item_status(event: &AgentRuntimeEventEnvelope) -> AgentTurnItemStat
         }
         "agent.message.classified"
         | "agent.message.completed"
+        | "agent.reasoning.completed"
         | "agent.done"
         | "agent.command.acknowledged"
         | "agent.paused"
@@ -1985,6 +1988,22 @@ fn projected_item_payload(
                 .to_string();
             content.push_str(payload_text_fragment(&event.payload).unwrap_or_default());
             payload.insert("content".to_string(), Value::String(content));
+            merge_message_identity_fields(&mut payload, &event.payload);
+            Value::Object(payload)
+        }
+        "agent.reasoning.completed" => {
+            let mut payload = existing_payload
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            payload.insert(
+                "content".to_string(),
+                event
+                    .payload
+                    .get("summary")
+                    .cloned()
+                    .unwrap_or_else(|| Value::String(String::new())),
+            );
             merge_message_identity_fields(&mut payload, &event.payload);
             Value::Object(payload)
         }

--- a/src-tauri/src/native_agent_bridge/README.md
+++ b/src-tauri/src/native_agent_bridge/README.md
@@ -32,7 +32,7 @@ Thread data model. Those belong to `worker_agent_runtime` and `worker_thread`.
    trace path.
 7. Run the native agent loop and flush the trace sink.
 8. Preserve attachment files only when the result still references them.
-9. Persist the run record, checkpoint, and final turn as applicable.
+9. Persist the run metadata, checkpoint, and final turn boundary as applicable.
 
 Changing this order requires care. In particular, a run must be recoverable
 after its start is visible, and trace flushing must not be reported as success
@@ -57,6 +57,12 @@ when it failed.
 - Flush trace output before final persistence reports success.
 - Keep Thread-owned events on the Thread path; avoid duplicating them through
   the direct-session trace sink.
+- Send lossless runtime events to the canonical persistence boundary. Bound or
+  redact only the diagnostic EventMsg after its model-visible ResponseItem has
+  been materialized.
+- Persist each completed assistant message and model-call reasoning item once.
+  Final turn persistence closes the Turn and clears checkpoints; it does not
+  append the same user or assistant messages again.
 - Temporary attachment files are owned by a lease and survive only when the
   returned result needs them.
 - Approval and form resolution must preserve run, turn, request, and trace

--- a/src-tauri/src/native_agent_bridge/agent_flow.rs
+++ b/src-tauri/src/native_agent_bridge/agent_flow.rs
@@ -2,8 +2,8 @@ use crate::native_agent_bridge::{
     hydrate_native_agent_history_for_runtime, materialize_turn_attachments,
     native_agent_context_checkpoint_committer, native_agent_run_id,
     native_agent_services_with_tool_executor, native_agent_session_id, native_agent_trace_sink,
-    persist_native_agent_checkpoint_if_present, persist_native_agent_run_record,
-    persist_native_agent_run_start, persist_native_agent_turn_if_final,
+    persist_native_agent_checkpoint_if_present, persist_native_agent_run_start,
+    persist_native_agent_run_terminal_if_present, persist_native_agent_turn_if_final,
     reject_native_agent_terminal_run_reentry, turn_result_needs_attachment_files,
     TurnAttachmentLease,
 };
@@ -87,7 +87,7 @@ pub(crate) async fn run_agent_with_services(
         attachment_lease.preserve();
     }
     merge_persisted_runtime_events(&services, &persistence_spec, &mut result)?;
-    persist_native_agent_run_record(
+    persist_native_agent_run_terminal_if_present(
         persistence_spec.clone(),
         &mut result,
         workspace_root.clone(),

--- a/src-tauri/src/native_agent_bridge/history.rs
+++ b/src-tauri/src/native_agent_bridge/history.rs
@@ -1,7 +1,5 @@
 use crate::call_rust_state_service;
-use crate::native_agent_bridge::{
-    native_agent_session_id, native_agent_string_field, native_agent_usage,
-};
+use crate::native_agent_bridge::{native_agent_session_id, native_agent_string_field};
 use crate::worker_protocol::WorkerRequest;
 use crate::worker_request_id::next_worker_request_correlation;
 use std::path::PathBuf;
@@ -53,54 +51,6 @@ pub(crate) fn native_agent_thread_id(spec: &serde_json::Value) -> Option<String>
             spec.get("metadata")
                 .and_then(|metadata| native_agent_string_field(metadata, "thread_id"))
         })
-}
-
-pub(crate) fn native_agent_message_id(message: &serde_json::Value) -> Option<String> {
-    message
-        .get("messageId")
-        .or_else(|| message.get("message_id"))
-        .or_else(|| message.get("id"))
-        .and_then(serde_json::Value::as_str)
-        .filter(|value| !value.trim().is_empty())
-        .map(str::to_string)
-}
-
-pub(crate) fn native_agent_assistant_messages(
-    result: &serde_json::Value,
-) -> Vec<serde_json::Value> {
-    result
-        .get("messages")
-        .and_then(serde_json::Value::as_array)
-        .map(|messages| {
-            messages
-                .iter()
-                .filter(|message| {
-                    message.get("role").and_then(serde_json::Value::as_str) == Some("assistant")
-                })
-                .cloned()
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-pub(crate) fn attach_native_agent_latest_usage(
-    messages: &mut [serde_json::Value],
-    result: &serde_json::Value,
-) {
-    let Some(usage) = native_agent_usage(result).into_iter().last() else {
-        return;
-    };
-    let Some(message) = messages.iter_mut().rev().find(|message| {
-        message.get("role").and_then(serde_json::Value::as_str) == Some("assistant")
-    }) else {
-        return;
-    };
-    let Some(object) = message.as_object_mut() else {
-        return;
-    };
-    if !object.get("usage").is_some_and(|value| !value.is_null()) {
-        object.insert("usage".to_string(), usage);
-    }
 }
 
 pub(crate) fn hydrate_native_agent_history_for_runtime(

--- a/src-tauri/src/native_agent_bridge/mod.rs
+++ b/src-tauri/src/native_agent_bridge/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use history::{
 pub(crate) use persistence::native_agent_run_record;
 pub(crate) use persistence::{
     cancel_agent_with_services, persist_native_agent_checkpoint_if_present,
-    persist_native_agent_run_record, persist_native_agent_run_start,
+    persist_native_agent_run_start, persist_native_agent_run_terminal_if_present,
     persist_native_agent_turn_if_final, reject_native_agent_terminal_run_reentry,
     restore_agent_checkpoint_with_services,
 };

--- a/src-tauri/src/native_agent_bridge/mod.rs
+++ b/src-tauri/src/native_agent_bridge/mod.rs
@@ -16,8 +16,7 @@ pub(crate) use attachments::{
 };
 pub(crate) use context_checkpoint::native_agent_context_checkpoint_committer;
 pub(crate) use history::{
-    attach_native_agent_latest_usage, hydrate_native_agent_history_for_runtime,
-    native_agent_assistant_messages, native_agent_current_user_message, native_agent_message_id,
+    hydrate_native_agent_history_for_runtime, native_agent_current_user_message,
     native_agent_thread_id, native_agent_user_messages,
 };
 #[cfg(test)]
@@ -30,11 +29,10 @@ pub(crate) use persistence::{
 };
 pub(crate) use result_projection::{
     native_agent_artifacts, native_agent_current_iteration, native_agent_max_iterations,
-    native_agent_model, native_agent_persisted_runtime_event, native_agent_persisted_trace_values,
-    native_agent_provider, native_agent_run_completed_at, native_agent_run_id,
-    native_agent_run_phase_from_stop_reason, native_agent_run_status, native_agent_session_id,
-    native_agent_string_field, native_agent_token_usage_info, native_agent_trace_event_item_id,
-    native_agent_usage,
+    native_agent_model, native_agent_persisted_trace_values, native_agent_provider,
+    native_agent_run_completed_at, native_agent_run_id, native_agent_run_phase_from_stop_reason,
+    native_agent_run_status, native_agent_session_id, native_agent_string_field,
+    native_agent_token_usage_info, native_agent_usage,
 };
 pub(crate) use thread_flow::{
     resolve_thread_approval_with_services, submit_thread_form_with_services,

--- a/src-tauri/src/native_agent_bridge/persistence.rs
+++ b/src-tauri/src/native_agent_bridge/persistence.rs
@@ -1,15 +1,10 @@
-use crate::agent_loop_runtime_protocol::{
-    AgentRuntimeEventAppendInput, AgentRuntimeEventAppender, AgentRuntimeEventSource,
-    AgentRuntimeEventVisibility, AgentRuntimePhase, AgentTraceContext,
-};
+use crate::agent_loop_runtime_protocol::AgentTraceContext;
 use crate::native_agent_bridge::{
-    attach_native_agent_latest_usage, native_agent_artifacts, native_agent_assistant_messages,
-    native_agent_current_iteration, native_agent_current_user_message, native_agent_max_iterations,
-    native_agent_message_id, native_agent_model, native_agent_persisted_runtime_event,
-    native_agent_persisted_trace_values, native_agent_provider, native_agent_run_completed_at,
-    native_agent_run_id, native_agent_run_phase_from_stop_reason, native_agent_run_status,
-    native_agent_session_id, native_agent_thread_id, native_agent_token_usage_info,
-    native_agent_trace_event_item_id, native_agent_usage, native_agent_user_messages,
+    native_agent_artifacts, native_agent_current_iteration, native_agent_max_iterations,
+    native_agent_model, native_agent_persisted_trace_values, native_agent_provider,
+    native_agent_run_completed_at, native_agent_run_id, native_agent_run_phase_from_stop_reason,
+    native_agent_run_status, native_agent_session_id, native_agent_thread_id,
+    native_agent_token_usage_info, native_agent_usage, native_agent_user_messages,
 };
 use crate::worker_agent_runtime::{agent_trace_context_from_value, NativeAgentRuntimeServices};
 use crate::worker_protocol::WorkerRequest;
@@ -120,14 +115,13 @@ pub(crate) fn persist_native_agent_run_start(
     let session_id =
         native_agent_rollout_id(&spec).unwrap_or_else(|| "native-rust-session".to_string());
     let run_id = native_agent_run_id(&spec).unwrap_or_else(|| "native-rust-run".to_string());
-    let mut record = native_agent_run_record(
+    let record = native_agent_run_record(
         &spec,
         &serde_json::json!({ "sessionId": session_id, "runId": run_id }),
         &config_snapshot,
         &session_id,
         &run_id,
     );
-    record["traceEvents"] = serde_json::json!([]);
     let turn_context = native_agent_turn_context(&spec, &config_snapshot, &run_id);
     let trace_context = agent_trace_context_from_value(&spec);
     call_traced_state_service(
@@ -254,8 +248,7 @@ pub(crate) fn persist_native_agent_run_record(
     let run_id = native_agent_run_id(result)
         .or_else(|| native_agent_run_id(&spec))
         .unwrap_or_else(|| "native-rust-run".to_string());
-    let mut record = native_agent_run_record(&spec, result, &config_snapshot, &session_id, &run_id);
-    record["traceEvents"] = serde_json::json!([]);
+    let record = native_agent_run_record(&spec, result, &config_snapshot, &session_id, &run_id);
     let trace_context = trace_context_from_result_or_spec(result, &spec);
     let persisted = call_traced_state_service(
         workspace_root,
@@ -329,8 +322,8 @@ pub(crate) fn native_agent_run_record(
         "maxIterations": native_agent_max_iterations(spec, config_snapshot),
         "currentIteration": native_agent_current_iteration(result, checkpoint.as_ref()),
         "conversationMessageIds": [],
-        "traceMessages": native_agent_assistant_messages(result),
-        "traceEvents": native_agent_runtime_trace_events(spec, result, session_id, run_id, &timestamp),
+        "traceMessages": [],
+        "traceEvents": [],
         "completedToolResults": result
             .get("completedToolResults")
             .or_else(|| result.get("completed_tool_results"))
@@ -401,13 +394,6 @@ pub(crate) fn persist_native_agent_turn_if_final(
         .or_else(|| result.get("run_id"))
         .and_then(serde_json::Value::as_str)
         .unwrap_or("native-rust-run");
-    let mut messages = native_agent_user_messages(&spec);
-    let mut assistant_messages = native_agent_assistant_messages(result);
-    attach_native_agent_latest_usage(&mut assistant_messages, result);
-    messages.extend(assistant_messages);
-    if messages.is_empty() {
-        return Ok(());
-    }
     let trace_context = trace_context_from_result_or_spec(result, &spec);
     let persisted = call_traced_state_service(
         workspace_root,
@@ -421,7 +407,7 @@ pub(crate) fn persist_native_agent_turn_if_final(
             serde_json::json!({
                 "session_id": session_id,
                 "run_id": run_id,
-                "messages": messages,
+                "messages": [],
                 "clear_checkpoint": true,
                 "context_metadata": {
                     "runtime": "rust",
@@ -513,113 +499,6 @@ fn validate_native_agent_checkpoint_version(
     ))
 }
 
-fn native_agent_runtime_trace_events(
-    spec: &serde_json::Value,
-    result: &serde_json::Value,
-    session_id: &str,
-    run_id: &str,
-    timestamp: &str,
-) -> Vec<serde_json::Value> {
-    if let Some(runtime_events) = result
-        .get("runtimeEvents")
-        .and_then(serde_json::Value::as_array)
-        .filter(|events| !events.is_empty())
-    {
-        return native_agent_persisted_trace_values(runtime_events);
-    }
-
-    let mut trace_context = trace_context_from_result_or_spec(result, spec);
-    trace_context.run_id = run_id.to_string();
-    if trace_context.turn_id.trim().is_empty() {
-        trace_context.turn_id = run_id.to_string();
-    }
-    trace_context.thread_id = trace_context
-        .thread_id
-        .or_else(|| native_agent_thread_id(spec));
-    let mut appender = AgentRuntimeEventAppender::new_with_trace_context(session_id, trace_context);
-    let user_message = native_agent_current_user_message(spec);
-    let user_message_id = user_message.as_ref().and_then(native_agent_message_id);
-    let mut trace_events = vec![native_agent_persisted_runtime_event(appender.append(
-        AgentRuntimeEventAppendInput {
-            parent_turn_id: None,
-            item_id: None,
-            event_name: "agent.turn.started".to_string(),
-            phase: AgentRuntimePhase::Planning,
-            timestamp: timestamp.to_string(),
-            source: AgentRuntimeEventSource::RustBackend,
-            visibility: AgentRuntimeEventVisibility::User,
-            payload: serde_json::json!({
-                "sessionId": session_id,
-                "runId": run_id,
-                "userMessageId": user_message_id,
-                "userMessage": user_message,
-            }),
-        },
-    ))];
-
-    let mut current_phase = AgentRuntimePhase::Planning;
-    native_agent_push_phase_transition(
-        &mut trace_events,
-        &mut appender,
-        &mut current_phase,
-        AgentRuntimePhase::HydratingHistory,
-        timestamp,
-        "agent.history.hydrated",
-    );
-    native_agent_push_phase_transition(
-        &mut trace_events,
-        &mut appender,
-        &mut current_phase,
-        AgentRuntimePhase::CallingModel,
-        timestamp,
-        "agent.model.calling",
-    );
-    if let Some(events) = result.get("events").and_then(serde_json::Value::as_array) {
-        for event in events {
-            let event_name = event
-                .get("eventName")
-                .and_then(serde_json::Value::as_str)
-                .filter(|value| !value.trim().is_empty());
-            let Some(event_name) = event_name else {
-                continue;
-            };
-            let next_phase = AgentRuntimePhase::for_legacy_event(event_name);
-            if event_name == "agent.done" {
-                native_agent_push_phase_transition(
-                    &mut trace_events,
-                    &mut appender,
-                    &mut current_phase,
-                    AgentRuntimePhase::Finalizing,
-                    timestamp,
-                    event_name,
-                );
-            }
-            native_agent_push_phase_transition(
-                &mut trace_events,
-                &mut appender,
-                &mut current_phase,
-                next_phase,
-                timestamp,
-                event_name,
-            );
-            let payload = event
-                .get("payload")
-                .cloned()
-                .unwrap_or(serde_json::Value::Null);
-            trace_events.push(native_agent_persisted_runtime_event(
-                appender.append_legacy_native_event(
-                    event_name,
-                    native_agent_trace_event_item_id(event),
-                    timestamp,
-                    payload,
-                ),
-            ));
-        }
-    }
-
-    trace_events
-}
-
 fn trace_context_from_result_or_spec(
     result: &serde_json::Value,
     spec: &serde_json::Value,
@@ -668,34 +547,4 @@ fn call_traced_state_service(
         }
     ));
     result
-}
-
-fn native_agent_push_phase_transition(
-    trace_events: &mut Vec<serde_json::Value>,
-    appender: &mut AgentRuntimeEventAppender,
-    current_phase: &mut AgentRuntimePhase,
-    next_phase: AgentRuntimePhase,
-    timestamp: &str,
-    trigger_event_name: &str,
-) {
-    if next_phase == *current_phase {
-        return;
-    }
-    trace_events.push(native_agent_persisted_runtime_event(appender.append(
-        AgentRuntimeEventAppendInput {
-            parent_turn_id: None,
-            item_id: None,
-            event_name: "agent.phase.changed".to_string(),
-            phase: next_phase.clone(),
-            timestamp: timestamp.to_string(),
-            source: AgentRuntimeEventSource::RustBackend,
-            visibility: AgentRuntimeEventVisibility::Debug,
-            payload: serde_json::json!({
-                "previousPhase": current_phase.clone(),
-                "nextPhase": next_phase.clone(),
-                "triggerEventName": trigger_event_name,
-            }),
-        },
-    )));
-    *current_phase = next_phase;
 }

--- a/src-tauri/src/native_agent_bridge/persistence.rs
+++ b/src-tauri/src/native_agent_bridge/persistence.rs
@@ -177,30 +177,30 @@ fn native_agent_turn_context(
         .unwrap_or_default();
     let trace_context = agent_trace_context_from_value(spec);
     serde_json::json!({
-        "turnId": if trace_context.turn_id.trim().is_empty() {
+        "turn_id": if trace_context.turn_id.trim().is_empty() {
             run_id
         } else {
             trace_context.turn_id.as_str()
         },
         "cwd": cwd,
-        "workspaceRoots": if cwd.is_empty() {
+        "workspace_roots": if cwd.is_empty() {
             serde_json::Value::Null
         } else {
             serde_json::json!([cwd])
         },
-        "currentDate": spec.get("currentDate").cloned().unwrap_or(serde_json::Value::Null),
+        "current_date": spec.get("currentDate").cloned().unwrap_or(serde_json::Value::Null),
         "timezone": spec.get("timezone").cloned().unwrap_or(serde_json::Value::Null),
-        "approvalPolicy": spec
+        "approval_policy": spec
             .get("approvalPolicy")
             .or_else(|| defaults.get("approvalPolicy"))
             .cloned()
             .unwrap_or_else(|| serde_json::json!("on_request")),
-        "sandboxPolicy": spec
+        "sandbox_policy": spec
             .get("sandboxPolicy")
             .or_else(|| defaults.get("sandboxPolicy"))
             .cloned()
             .unwrap_or_else(|| serde_json::json!("workspace_write")),
-        "permissionProfile": spec
+        "permission_profile": spec
             .get("permissionProfile")
             .or_else(|| defaults.get("permissionProfile"))
             .cloned()
@@ -208,7 +208,7 @@ fn native_agent_turn_context(
         "network": spec.get("network").cloned().unwrap_or(serde_json::Value::Null),
         "model": native_agent_model(spec, config_snapshot),
         "provider": native_agent_provider(spec, config_snapshot),
-        "compHash": spec
+        "comp_hash": spec
             .get("compHash")
             .or_else(|| spec.get("comp_hash"))
             .cloned()
@@ -218,7 +218,7 @@ fn native_agent_turn_context(
             .or_else(|| defaults.get("personality"))
             .cloned()
             .unwrap_or(serde_json::Value::Null),
-        "collaborationMode": spec
+        "collaboration_mode": spec
             .get("collaborationMode")
             .or_else(|| defaults.get("collaborationMode"))
             .cloned()
@@ -236,7 +236,7 @@ fn native_agent_turn_context(
     })
 }
 
-pub(crate) fn persist_native_agent_run_record(
+pub(crate) fn persist_native_agent_run_terminal_if_present(
     spec: serde_json::Value,
     result: &mut serde_json::Value,
     workspace_root: PathBuf,
@@ -248,7 +248,69 @@ pub(crate) fn persist_native_agent_run_record(
     let run_id = native_agent_run_id(result)
         .or_else(|| native_agent_run_id(&spec))
         .unwrap_or_else(|| "native-rust-run".to_string());
-    let record = native_agent_run_record(&spec, result, &config_snapshot, &session_id, &run_id);
+    let Some(stop_reason) = result
+        .get("stopReason")
+        .or_else(|| result.get("stop_reason"))
+        .and_then(serde_json::Value::as_str)
+    else {
+        return Ok(());
+    };
+    let status = native_agent_run_status(Some(stop_reason));
+    let (method, params) = match status {
+        "completed" => (
+            "agent_run.mark_completed",
+            serde_json::json!({
+                "session_id": session_id,
+                "run_id": run_id,
+                "stop_reason": stop_reason,
+                "final_content": result
+                    .get("finalContent")
+                    .or_else(|| result.get("final_content"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+            }),
+        ),
+        "failed" => (
+            "agent_run.mark_failed",
+            serde_json::json!({
+                "session_id": session_id,
+                "run_id": run_id,
+                "stop_reason": stop_reason,
+                "error": result
+                    .get("error")
+                    .filter(|value| !value.is_null())
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({
+                        "code": stop_reason,
+                        "message": format!("agent run stopped: {stop_reason}"),
+                    })),
+            }),
+        ),
+        "cancelled" => (
+            "agent_run.mark_cancelled",
+            serde_json::json!({
+                "session_id": session_id,
+                "run_id": run_id,
+            }),
+        ),
+        "interrupted" => (
+            "agent_run.mark_interrupted",
+            serde_json::json!({
+                "session_id": session_id,
+                "run_id": run_id,
+                "reason": result
+                    .get("error")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(stop_reason),
+            }),
+        ),
+        "running" | "waiting" => return Ok(()),
+        _ => {
+            return Err(format!(
+                "unsupported native agent terminal status `{status}`"
+            ))
+        }
+    };
     let trace_context = trace_context_from_result_or_spec(result, &spec);
     let persisted = call_traced_state_service(
         workspace_root,
@@ -256,12 +318,12 @@ pub(crate) fn persist_native_agent_run_record(
         &trace_context,
         "run-record",
         WorkerRequest::new(
-            format!("{}:run-record", trace_context.request_id),
+            format!("{}:run-terminal", trace_context.request_id),
             trace_context.trace_id.clone(),
-            "agent_run.upsert",
-            serde_json::json!({ "record": record }),
+            method,
+            params,
         ),
-        "native agent run persistence",
+        "native agent run terminal persistence",
         "write",
     )?;
     result["runPersistence"] = persisted;

--- a/src-tauri/src/native_agent_bridge/result_projection.rs
+++ b/src-tauri/src/native_agent_bridge/result_projection.rs
@@ -1,6 +1,4 @@
-use crate::agent_loop_runtime_protocol::AgentRuntimeEventEnvelope;
-
-const NATIVE_AGENT_RUN_TRACE_STRING_LIMIT: usize = 256;
+use crate::worker_rollout::bound_persisted_trace_value;
 
 pub(crate) fn native_agent_run_status(stop_reason: Option<&str>) -> &'static str {
     match stop_reason {
@@ -206,35 +204,16 @@ pub(crate) fn native_agent_token_usage_info(
     }))
 }
 
-pub(crate) fn native_agent_persisted_runtime_event(
-    event: AgentRuntimeEventEnvelope,
-) -> serde_json::Value {
-    let value = serde_json::to_value(event).unwrap_or_else(|error| {
-        serde_json::json!({
-            "schemaVersion": crate::agent_loop_runtime_protocol::AGENT_RUNTIME_EVENT_SCHEMA_VERSION,
-            "eventName": "agent.trace.serialization_failed",
-            "payload": {
-                "error": error.to_string(),
-            },
-        })
-    });
-    native_agent_bound_persisted_trace_value(value).0
-}
-
-pub(crate) fn native_agent_trace_event_item_id(event: &serde_json::Value) -> Option<String> {
-    event.get("payload").and_then(|payload| {
-        native_agent_string_field(payload, "toolCallId")
-            .or_else(|| native_agent_string_field(payload, "tool_call_id"))
-            .or_else(|| native_agent_string_field(payload, "approvalId"))
-            .or_else(|| native_agent_string_field(payload, "approval_id"))
-            .or_else(|| native_agent_string_field(payload, "formId"))
-            .or_else(|| native_agent_string_field(payload, "form_id"))
-            .or_else(|| native_agent_string_field(payload, "delegateId"))
-            .or_else(|| native_agent_string_field(payload, "delegate_id"))
-    })
-}
-
 pub(crate) fn native_agent_persisted_trace_values(
+    values: &[serde_json::Value],
+) -> Vec<serde_json::Value> {
+    native_agent_canonical_trace_values(values)
+        .into_iter()
+        .map(bound_persisted_trace_value)
+        .collect()
+}
+
+pub(crate) fn native_agent_canonical_trace_values(
     values: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
     values
@@ -244,7 +223,6 @@ pub(crate) fn native_agent_persisted_trace_values(
                 != Some("agent.provider.requested")
         })
         .cloned()
-        .map(|value| native_agent_bound_persisted_trace_value(value).0)
         .collect()
 }
 
@@ -286,75 +264,4 @@ fn usage_i64_field(value: &serde_json::Value, keys: &[&str]) -> Option<i64> {
                 .or_else(|| value.as_u64().and_then(|number| i64::try_from(number).ok()))
         })
     })
-}
-
-fn native_agent_bound_persisted_trace_value(value: serde_json::Value) -> (serde_json::Value, bool) {
-    match value {
-        serde_json::Value::String(content) => {
-            let char_count = content.chars().count();
-            if char_count <= NATIVE_AGENT_RUN_TRACE_STRING_LIMIT {
-                (serde_json::Value::String(content), false)
-            } else {
-                (
-                    serde_json::Value::String(
-                        content
-                            .chars()
-                            .take(NATIVE_AGENT_RUN_TRACE_STRING_LIMIT)
-                            .collect(),
-                    ),
-                    true,
-                )
-            }
-        }
-        serde_json::Value::Array(items) => {
-            let mut truncated = false;
-            let items = items
-                .into_iter()
-                .map(|item| {
-                    let (item, item_truncated) = native_agent_bound_persisted_trace_value(item);
-                    truncated |= item_truncated;
-                    item
-                })
-                .collect();
-            (serde_json::Value::Array(items), truncated)
-        }
-        serde_json::Value::Object(entries) => {
-            let mut truncated = false;
-            let mut entries = entries;
-            let retain_trace_context = entries
-                .get("eventName")
-                .and_then(serde_json::Value::as_str)
-                .map(persisted_event_needs_trace_context)
-                .unwrap_or(true);
-            if !retain_trace_context {
-                entries.remove("traceContext");
-            }
-            let mut entries = entries
-                .into_iter()
-                .map(|(key, value)| {
-                    let (value, value_truncated) = native_agent_bound_persisted_trace_value(value);
-                    truncated |= value_truncated;
-                    (key, value)
-                })
-                .collect::<serde_json::Map<_, _>>();
-            if truncated {
-                entries.insert(
-                    "tracePersistence".to_string(),
-                    serde_json::json!({
-                        "truncated": true,
-                        "maxStringChars": NATIVE_AGENT_RUN_TRACE_STRING_LIMIT,
-                    }),
-                );
-            }
-            (serde_json::Value::Object(entries), truncated)
-        }
-        value => (value, false),
-    }
-}
-
-fn persisted_event_needs_trace_context(event_name: &str) -> bool {
-    matches!(
-        event_name,
-        "agent.provider.completed" | "agent.tool.result" | "agent.hook.decision"
-    )
 }

--- a/src-tauri/src/native_agent_bridge/trace_sink.rs
+++ b/src-tauri/src/native_agent_bridge/trace_sink.rs
@@ -1,4 +1,4 @@
-use super::result_projection::native_agent_persisted_trace_values;
+use super::result_projection::native_agent_canonical_trace_values;
 use crate::agent_loop_runtime_protocol::{AgentRuntimeEventEnvelope, AgentTimelinePatch};
 use crate::worker_agent_runtime::NativeAgentTraceSink;
 use crate::worker_protocol::WorkerRequest;
@@ -87,7 +87,7 @@ impl NativeAgentTraceSink for NativeAgentRunTraceSink {
             .unwrap_or_else(|| generated.trace_id("agent-run-append-trace-batch"));
         let events = serde_json::to_value(events)
             .map_err(|error| format!("native agent trace batch serialization failed: {error}"))?;
-        let events = native_agent_persisted_trace_values(
+        let events = native_agent_canonical_trace_values(
             events
                 .as_array()
                 .expect("serialized native agent trace batch must be an array"),

--- a/src-tauri/src/native_agent_bridge/webui_continuation.rs
+++ b/src-tauri/src/native_agent_bridge/webui_continuation.rs
@@ -2,7 +2,7 @@ use crate::call_rust_state_service;
 use crate::native_agent_bridge::{
     cleanup_turn_attachments, native_agent_context_checkpoint_committer,
     native_agent_services_with_tool_executor, native_agent_trace_sink,
-    persist_native_agent_checkpoint_if_present, persist_native_agent_run_record,
+    persist_native_agent_checkpoint_if_present, persist_native_agent_run_terminal_if_present,
     persist_native_agent_turn_if_final, turn_result_needs_attachment_files,
 };
 use crate::worker_agent_runtime::{
@@ -341,7 +341,7 @@ pub(crate) async fn resolve_approval_continuation_with_services(
     )
     .await?;
     services.flush_trace_sink()?;
-    persist_native_agent_run_record(
+    persist_native_agent_run_terminal_if_present(
         continuation_spec.clone(),
         &mut continuation,
         workspace_root.clone(),
@@ -663,7 +663,7 @@ pub(crate) async fn resolve_agent_ui_form_with_services(
     )
     .await?;
     services.flush_trace_sink()?;
-    persist_native_agent_run_record(
+    persist_native_agent_run_terminal_if_present(
         continuation_spec.clone(),
         &mut continuation,
         workspace_root.clone(),

--- a/src-tauri/src/native_backend_contract.rs
+++ b/src-tauri/src/native_backend_contract.rs
@@ -170,6 +170,7 @@ pub const NATIVE_AGENT_EVENT_NAMES: &[&str] = &[
     "agent.timeline.patch",
     "agent.delta",
     "agent.reasoning_delta",
+    "agent.reasoning.completed",
     "agent.tool_call.delta",
     "agent.tool.start",
     "agent.tool.result",

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1284,6 +1284,120 @@ fn worker_run_agent_persists_rust_turn_messages_in_canonical_rollout() {
 }
 
 #[test]
+fn worker_run_agent_persists_one_lossless_long_final_response() {
+    let fixture = WorkspaceFixture::new();
+    let shared = Arc::new(Mutex::new(GatewayRuntime {
+        native_agent_runtime: NativeAgentRuntimeServices::new(
+            Arc::new(LongFinalNativeAgentProvider),
+            Arc::new(crate::worker_agent_runtime::FakeNativeAgentToolDispatcher),
+            Arc::new(crate::worker_agent_runtime::InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(crate::worker_agent_runtime::InMemoryNativeAgentCancellation::default()),
+        ),
+        ..GatewayRuntime::default()
+    }));
+    let config = serde_json::json!({
+        "agents": { "defaults": { "provider": "fixture", "model": "fixture-model" } },
+    });
+    let session_id = "websocket:chat-long-final";
+    let run_id = "run-long-final";
+    let expected = long_final_content();
+
+    let result = worker_run_agent_with_options(
+        &shared,
+        serde_json::json!({
+            "runtime": "rust",
+            "runId": run_id,
+            "sessionId": session_id,
+            "messages": [{ "role": "user", "content": "return a long answer" }]
+        }),
+        fixture.root.clone(),
+        config.clone(),
+        Duration::from_millis(10),
+    )
+    .expect("Rust runtime should durably complete a long final response");
+    let runtime_state = worker_agent_run_runtime_state_with_options(
+        &shared,
+        session_id.to_string(),
+        run_id.to_string(),
+        fixture.root.clone(),
+        config.clone(),
+        Duration::from_millis(10),
+    )
+    .expect("long final response should project from canonical Rollout");
+    let history = worker_session_messages_with_options(
+        &shared,
+        session_id.to_string(),
+        fixture.root.clone(),
+        config.clone(),
+        Duration::from_millis(10),
+    )
+    .expect("long final response should reload from canonical Rollout");
+    let metadata = call_rust_state_service(
+        fixture.root.clone(),
+        config,
+        WorkerRequest::new(
+            "req-long-final-metadata",
+            "trace-long-final-metadata",
+            "session.get_metadata",
+            serde_json::json!({ "session_id": session_id }),
+        ),
+        "long final session metadata",
+    )
+    .expect("long final session metadata should be readable");
+    let rollout_path = metadata["extra"]["threadPath"]
+        .as_str()
+        .expect("session metadata should expose the canonical Rollout path");
+    let rollout_lines = std::fs::read_to_string(rollout_path)
+        .expect("canonical Rollout should be readable")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    let assistant_items = rollout_lines
+        .iter()
+        .filter(|line| line["type"] == "response_item" && line["payload"]["role"] == "assistant")
+        .collect::<Vec<_>>();
+    let diagnostic_final = rollout_lines
+        .iter()
+        .find(|line| {
+            line["type"] == "event_msg"
+                && line["payload"]["type"] == "agent_run_trace"
+                && line["payload"]["payload"]["event"]["eventName"] == "agent.message.completed"
+        })
+        .expect("diagnostic final response event should remain available");
+
+    assert_eq!(result["finalContent"], expected);
+    assert_eq!(history["messages"][1]["content"], expected);
+    assert_eq!(assistant_items.len(), 1);
+    assert_eq!(assistant_items[0]["payload"]["type"], "message");
+    assert_eq!(assistant_items[0]["payload"]["phase"], "final_answer");
+    assert_eq!(
+        assistant_items[0]["payload"]["content"][0]["text"],
+        long_final_content()
+    );
+    assert_eq!(
+        diagnostic_final["payload"]["payload"]["event"]["payload"]["content"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count(),
+        crate::worker_rollout::ROLLOUT_TRACE_STRING_LIMIT
+    );
+    assert_eq!(
+        diagnostic_final["payload"]["payload"]["event"]["tracePersistence"]["truncated"],
+        true
+    );
+    assert_eq!(
+        runtime_state["timeline"]["items"]
+            .as_array()
+            .expect("runtime timeline items should be an array")
+            .iter()
+            .filter(|item| item["kind"] == "assistant_message")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn worker_run_agent_stops_before_provider_when_run_start_persistence_fails() {
     #[derive(Clone)]
     struct CountingProvider {
@@ -1488,6 +1602,27 @@ impl crate::worker_agent_runtime::NativeAgentProvider for UsageNativeAgentProvid
                 "completion_tokens": 97,
                 "total_tokens": 107,
             })),
+            tool_calls: Vec::new(),
+        })
+    }
+}
+
+fn long_final_content() -> String {
+    "完整的最终结论🦀".repeat(48)
+}
+
+#[derive(Clone)]
+struct LongFinalNativeAgentProvider;
+
+impl crate::worker_agent_runtime::NativeAgentProvider for LongFinalNativeAgentProvider {
+    fn complete(
+        &self,
+        _context: &crate::worker_agent_runtime::NativeAgentRunContext,
+    ) -> Result<crate::worker_agent_runtime::NativeAgentProviderResponse, String> {
+        Ok(crate::worker_agent_runtime::NativeAgentProviderResponse {
+            final_content: long_final_content(),
+            reasoning_delta: None,
+            usage: None,
             tool_calls: Vec::new(),
         })
     }
@@ -1713,10 +1848,30 @@ fn worker_run_agent_combines_session_history_with_current_tool_results() {
         &shared,
         "websocket:chat-tool-memory".to_string(),
         fixture.root.clone(),
-        config,
+        config.clone(),
         Duration::from_millis(10),
     )
     .expect("session messages should stay compact after hydrated run");
+    let metadata = call_rust_state_service(
+        fixture.root.clone(),
+        config,
+        WorkerRequest::new(
+            "req-tool-memory-metadata",
+            "trace-tool-memory-metadata",
+            "session.get_metadata",
+            serde_json::json!({ "session_id": "websocket:chat-tool-memory" }),
+        ),
+        "tool memory session metadata",
+    )
+    .expect("tool memory metadata should be readable");
+    let rollout = std::fs::read_to_string(metadata["extra"]["threadPath"].as_str().unwrap())
+        .expect("tool memory Rollout should be readable");
+    let response_types = rollout
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .filter(|line| line["type"] == "response_item")
+        .filter_map(|line| line["payload"]["type"].as_str().map(str::to_string))
+        .collect::<Vec<_>>();
     let calls = calls
         .lock()
         .expect("recording provider calls lock should not be poisoned");
@@ -1747,6 +1902,8 @@ fn worker_run_agent_combines_session_history_with_current_tool_results() {
         .unwrap()
         .iter()
         .all(|message| message["role"] != "tool"));
+    assert!(response_types.contains(&"custom_tool_call".to_string()));
+    assert!(response_types.contains(&"custom_tool_call_output".to_string()));
 }
 
 #[test]

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1364,6 +1364,17 @@ fn worker_run_agent_persists_one_lossless_long_final_response() {
                 && line["payload"]["payload"]["event"]["eventName"] == "agent.message.completed"
         })
         .expect("diagnostic final response event should remain available");
+    let session_meta = rollout_lines
+        .first()
+        .expect("rollout should start with session metadata");
+    let turn_context = rollout_lines
+        .iter()
+        .find(|line| line["type"] == "turn_context")
+        .expect("turn context should be persisted");
+    let terminal = rollout_lines
+        .iter()
+        .find(|line| line["type"] == "event_msg" && line["payload"]["type"] == "agent_run_terminal")
+        .expect("run terminal boundary should be persisted");
 
     assert_eq!(result["finalContent"], expected);
     assert_eq!(history["messages"][1]["content"], expected);
@@ -1385,6 +1396,16 @@ fn worker_run_agent_persists_one_lossless_long_final_response() {
     assert_eq!(
         diagnostic_final["payload"]["payload"]["event"]["tracePersistence"]["truncated"],
         true
+    );
+    assert!(session_meta["payload"]["id"].as_str().is_some());
+    assert_eq!(session_meta["payload"]["session_id"], session_id);
+    assert!(session_meta["payload"].get("threadId").is_none());
+    assert!(session_meta["payload"].get("schemaVersion").is_none());
+    assert_eq!(turn_context["payload"]["turn_id"], run_id);
+    assert!(turn_context["payload"].get("turnId").is_none());
+    assert!(
+        terminal["ordinal"].as_u64().unwrap() > assistant_items[0]["ordinal"].as_u64().unwrap(),
+        "terminal boundary must be persisted after the canonical final response"
     );
     assert_eq!(
         runtime_state["timeline"]["items"]

--- a/src-tauri/src/worker_agent_runtime/continuations.rs
+++ b/src-tauri/src/worker_agent_runtime/continuations.rs
@@ -372,6 +372,7 @@ pub(super) async fn maybe_approval_resume_result(
                 "delta": final_content,
             }),
         ),
+        final_message_event(context, &final_content),
         event(
             "agent.done",
             serde_json::json!({
@@ -721,6 +722,7 @@ async fn approval_denied_guidance_result(
                     }),
                 ));
             }
+            events.push(final_message_event(context, &final_content));
             events.push(event(
                 "agent.done",
                 serde_json::json!({
@@ -1124,6 +1126,7 @@ pub(super) fn maybe_form_submit_result(
                 "delta": final_content,
             }),
         ),
+        final_message_event(context, &final_content),
         event(
             "agent.done",
             serde_json::json!({
@@ -1156,6 +1159,19 @@ pub(super) fn maybe_form_submit_result(
         "events": events,
         "runtimeEvents": runtime_events,
     })))
+}
+
+fn final_message_event(context: &NativeAgentRunContext, content: &str) -> NativeAgentEvent {
+    event(
+        "agent.message.completed",
+        serde_json::json!({
+            "runId": context.run_id,
+            "sessionId": context.session_id,
+            "messageId": format!("{}:assistant:0", context.run_id),
+            "messagePhase": "final_answer",
+            "content": content,
+        }),
+    )
 }
 
 fn form_resolution_event(

--- a/src-tauri/src/worker_agent_runtime/events.rs
+++ b/src-tauri/src/worker_agent_runtime/events.rs
@@ -69,9 +69,13 @@ pub(super) fn runtime_event_item_id(event_name: &str, payload: &Value) -> Option
         | "agent.message.completed" => string_field(payload, "messageId")
             .or_else(|| string_field(payload, "message_id"))
             .or_else(|| string_field(payload, "modelCallId").map(|id| format!("assistant:{id}"))),
-        "agent.reasoning_delta" => string_field(payload, "reasoningId")
-            .or_else(|| string_field(payload, "reasoning_id"))
-            .or_else(|| string_field(payload, "modelCallId").map(|id| format!("reasoning:{id}"))),
+        "agent.reasoning_delta" | "agent.reasoning.completed" => {
+            string_field(payload, "reasoningId")
+                .or_else(|| string_field(payload, "reasoning_id"))
+                .or_else(|| {
+                    string_field(payload, "modelCallId").map(|id| format!("reasoning:{id}"))
+                })
+        }
         "agent.tool_call.delta" | "agent.tool.start" | "agent.tool.result" | "agent.tool.debug" => {
             string_field(payload, "toolCallId")
                 .or_else(|| string_field(payload, "tool_call_id"))
@@ -97,6 +101,7 @@ pub(super) fn runtime_event_source(event_name: &str) -> AgentRuntimeEventSource 
         | "agent.message.classified"
         | "agent.message.completed"
         | "agent.reasoning_delta"
+        | "agent.reasoning.completed"
         | "agent.usage"
         | "agent.provider.requested"
         | "agent.provider.completed" => AgentRuntimeEventSource::Provider,

--- a/src-tauri/src/worker_agent_runtime/provider_loop.rs
+++ b/src-tauri/src/worker_agent_runtime/provider_loop.rs
@@ -547,6 +547,7 @@ async fn run_native_agent_turn_with_instructions_async(
         let provider_started_at = Instant::now();
         let mut provider_streamed_content = false;
         let mut provider_streamed_reasoning = false;
+        let mut provider_reasoning_content = String::new();
         let mut provider_message_phase =
             crate::agent_loop_runtime_protocol::AgentAssistantMessagePhase::Unknown;
         let mut provider_observer_cancelled = false;
@@ -599,6 +600,7 @@ async fn run_native_agent_turn_with_instructions_async(
                             return;
                         }
                         provider_streamed_reasoning = true;
+                        provider_reasoning_content.push_str(&delta);
                         state.transition_phase(
                             AgentRuntimePhase::StreamingModel,
                             iteration,
@@ -745,6 +747,7 @@ async fn run_native_agent_turn_with_instructions_async(
             .clone()
             .filter(|_| !provider_streamed_reasoning)
         {
+            provider_reasoning_content.push_str(&reasoning_delta);
             state.transition_phase(
                 AgentRuntimePhase::StreamingModel,
                 iteration,
@@ -759,6 +762,19 @@ async fn run_native_agent_turn_with_instructions_async(
                     "modelCallId": provider_attempt_id,
                     "reasoningId": reasoning_item_id,
                     "delta": reasoning_delta,
+                }),
+            );
+        }
+        if !provider_reasoning_content.is_empty() {
+            state.emit_event(
+                "agent.reasoning.completed",
+                serde_json::json!({
+                    "runId": context.run_id,
+                    "sessionId": context.session_id,
+                    "iteration": iteration,
+                    "modelCallId": provider_attempt_id,
+                    "reasoningId": reasoning_item_id,
+                    "summary": provider_reasoning_content,
                 }),
             );
         }

--- a/src-tauri/src/worker_agent_runtime/result.rs
+++ b/src-tauri/src/worker_agent_runtime/result.rs
@@ -138,6 +138,32 @@ pub(super) fn waiting_runtime_events(
 ) -> Vec<AgentRuntimeEventEnvelope> {
     let mut emitter =
         AgentRunEmitter::new_with_trace_context(&context.session_id, context.trace_context.clone());
+    if let Some(message) = super::state::current_user_message(&context.messages) {
+        let message_id = message
+            .get("messageId")
+            .or_else(|| message.get("message_id"))
+            .or_else(|| message.get("id"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("{}:user", context.run_id));
+        let client_event_id = message
+            .get("clientEventId")
+            .or_else(|| message.get("client_event_id"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let references = message
+            .get("references")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        emitter.user_turn_started(
+            runtime_event_timestamp(),
+            Some(message_id),
+            client_event_id,
+            super::state::user_message_text(&message),
+            references,
+        );
+    }
     emitter.emit(AgentRuntimeEventAppendInput {
         parent_turn_id: None,
         item_id: None,

--- a/src-tauri/src/worker_agent_runtime/state.rs
+++ b/src-tauri/src/worker_agent_runtime/state.rs
@@ -569,7 +569,7 @@ fn context_messages_version(messages: &[Value]) -> String {
     format!("sha256:{:x}", Sha256::digest(encoded))
 }
 
-fn user_message_text(message: &Value) -> String {
+pub(super) fn user_message_text(message: &Value) -> String {
     let content = message.get("content").or_else(|| message.get("text"));
     if let Some(text) = content.and_then(Value::as_str) {
         return text.to_string();
@@ -628,7 +628,7 @@ fn user_reference_payloads(
         .collect()
 }
 
-fn current_user_message(messages: &[Value]) -> Option<Value> {
+pub(super) fn current_user_message(messages: &[Value]) -> Option<Value> {
     messages
         .iter()
         .rev()

--- a/src-tauri/src/worker_agent_runtime/tests.rs
+++ b/src-tauri/src/worker_agent_runtime/tests.rs
@@ -7982,7 +7982,12 @@ fn approval_denial_guidance_becomes_tool_result_before_next_model_call() {
     assert_eq!(result["events"][1]["payload"]["resultStatus"], "denied");
     assert_eq!(
         events,
-        vec!["agent.approval.decision", "agent.tool.result", "agent.done"]
+        vec![
+            "agent.approval.decision",
+            "agent.tool.result",
+            "agent.message.completed",
+            "agent.done"
+        ]
     );
     assert!(
         services.restore_checkpoint("websocket:chat-approval-guidance")["checkpoint"].is_null()
@@ -8062,9 +8067,17 @@ fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
         .filter(|event| event["eventName"] == "agent.reasoning_delta")
         .map(|event| event["payload"]["delta"].as_str().unwrap_or_default())
         .collect::<Vec<_>>();
+    let reasoning_completed = result["events"]
+        .as_array()
+        .expect("events should be an array")
+        .iter()
+        .filter(|event| event["eventName"] == "agent.reasoning.completed")
+        .collect::<Vec<_>>();
 
     assert_eq!(deltas, vec!["Hel", "lo"]);
     assert_eq!(reasoning_deltas, vec!["thinking"]);
+    assert_eq!(reasoning_completed.len(), 1);
+    assert_eq!(reasoning_completed[0]["payload"]["summary"], "thinking");
     assert_eq!(result["finalContent"], "Hello");
 }
 

--- a/src-tauri/src/worker_rollout/mod.rs
+++ b/src-tauri/src/worker_rollout/mod.rs
@@ -2,7 +2,9 @@ mod policy;
 mod reconstruction;
 mod types;
 
-pub use self::policy::should_persist_rollout_item;
+pub use self::policy::{
+    bound_persisted_trace_value, should_persist_rollout_item, ROLLOUT_TRACE_STRING_LIMIT,
+};
 pub use self::reconstruction::{
     effective_rollout_line_indexes, latest_effective_compaction_index, reconstruct_rollout,
     reconstruct_transcript,

--- a/src-tauri/src/worker_rollout/policy.rs
+++ b/src-tauri/src/worker_rollout/policy.rs
@@ -4,6 +4,8 @@ use crate::worker_protocol::{
 };
 use serde_json::Value;
 
+pub const ROLLOUT_TRACE_STRING_LIMIT: usize = 256;
+
 pub fn should_persist_rollout_item(item: &RolloutItem) -> Result<bool, WorkerProtocolError> {
     match item {
         RolloutItem::SessionMeta(_)
@@ -21,8 +23,11 @@ pub fn should_persist_rollout_item(item: &RolloutItem) -> Result<bool, WorkerPro
             | ResponseItemKind::CustomToolCallOutput
             | ResponseItemKind::WebSearchCall
             | ResponseItemKind::LocalShellCall
-            | ResponseItemKind::ComputerCall
-            | ResponseItemKind::Unspecified => Ok(true),
+            | ResponseItemKind::ComputerCall => Ok(true),
+            ResponseItemKind::Unspecified => Err(persistence_policy_error(
+                "untyped response item cannot enter canonical Rollout",
+                serde_json::json!({ "item": item.as_value() }),
+            )),
             ResponseItemKind::Other(kind) => Err(persistence_policy_error(
                 "unsupported response item cannot enter canonical Rollout",
                 serde_json::json!({ "responseItemKind": kind, "item": item.as_value() }),
@@ -53,6 +58,75 @@ pub fn should_persist_rollout_item(item: &RolloutItem) -> Result<bool, WorkerPro
             )),
         },
     }
+}
+
+pub fn bound_persisted_trace_value(value: Value) -> Value {
+    bound_persisted_trace_value_inner(value).0
+}
+
+fn bound_persisted_trace_value_inner(value: Value) -> (Value, bool) {
+    match value {
+        Value::String(content) => {
+            let char_count = content.chars().count();
+            if char_count <= ROLLOUT_TRACE_STRING_LIMIT {
+                (Value::String(content), false)
+            } else {
+                (
+                    Value::String(content.chars().take(ROLLOUT_TRACE_STRING_LIMIT).collect()),
+                    true,
+                )
+            }
+        }
+        Value::Array(items) => {
+            let mut truncated = false;
+            let items = items
+                .into_iter()
+                .map(|item| {
+                    let (item, item_truncated) = bound_persisted_trace_value_inner(item);
+                    truncated |= item_truncated;
+                    item
+                })
+                .collect();
+            (Value::Array(items), truncated)
+        }
+        Value::Object(mut entries) => {
+            let mut truncated = false;
+            let retain_trace_context = entries
+                .get("eventName")
+                .and_then(Value::as_str)
+                .map(persisted_event_needs_trace_context)
+                .unwrap_or(true);
+            if !retain_trace_context {
+                entries.remove("traceContext");
+            }
+            let mut entries = entries
+                .into_iter()
+                .map(|(key, value)| {
+                    let (value, value_truncated) = bound_persisted_trace_value_inner(value);
+                    truncated |= value_truncated;
+                    (key, value)
+                })
+                .collect::<serde_json::Map<_, _>>();
+            if truncated {
+                entries.insert(
+                    "tracePersistence".to_string(),
+                    serde_json::json!({
+                        "truncated": true,
+                        "maxStringChars": ROLLOUT_TRACE_STRING_LIMIT,
+                    }),
+                );
+            }
+            (Value::Object(entries), truncated)
+        }
+        value => (value, false),
+    }
+}
+
+fn persisted_event_needs_trace_context(event_name: &str) -> bool {
+    matches!(
+        event_name,
+        "agent.provider.completed" | "agent.tool.result" | "agent.hook.decision"
+    )
 }
 
 fn is_transient_agent_trace(payload: &Value) -> bool {
@@ -117,5 +191,33 @@ mod tests {
 
         assert!(should_persist_rollout_item(&unknown_event).is_err());
         assert!(should_persist_rollout_item(&unknown_response).is_err());
+    }
+
+    #[test]
+    fn persisted_trace_bounding_is_lossy_only_for_diagnostics() {
+        for length in [255, 256, 257] {
+            let value = bound_persisted_trace_value(json!({
+                "eventName": "agent.message.completed",
+                "traceContext": {"traceId": "trace-1"},
+                "payload": {"content": "界".repeat(length)}
+            }));
+
+            assert_eq!(
+                value["payload"]["content"]
+                    .as_str()
+                    .unwrap()
+                    .chars()
+                    .count(),
+                length.min(ROLLOUT_TRACE_STRING_LIMIT)
+            );
+            assert_eq!(
+                value
+                    .get("tracePersistence")
+                    .and_then(|metadata| metadata.get("truncated"))
+                    .and_then(Value::as_bool),
+                (length > ROLLOUT_TRACE_STRING_LIMIT).then_some(true)
+            );
+            assert!(value.get("traceContext").is_none());
+        }
     }
 }

--- a/src-tauri/src/worker_rollout/reconstruction.rs
+++ b/src-tauri/src/worker_rollout/reconstruction.rs
@@ -38,6 +38,7 @@ const PRESERVED_MESSAGE_FIELDS: &[&str] = &[
     "argumentsJson",
     "arguments_json",
     "function",
+    "phase",
     "status",
 ];
 
@@ -263,17 +264,20 @@ fn apply_compaction_metadata(replay: &mut RolloutReconstruction, compacted: &Com
 }
 
 fn apply_response_item(replay: &mut RolloutReconstruction, item: &ResponseItem, timestamp: &str) {
+    let Some(item) = response_item_message_projection(item) else {
+        return;
+    };
     let role = item
         .get("role")
         .and_then(Value::as_str)
         .unwrap_or("assistant");
-    let content = thread_item_content(item);
+    let content = thread_item_content(&item);
     let mut message = json!({
         "role": role,
         "content": content,
         "timestamp": timestamp
     });
-    copy_optional_message_fields(item, &mut message, PRESERVED_MESSAGE_FIELDS);
+    copy_optional_message_fields(&item, &mut message, PRESERVED_MESSAGE_FIELDS);
     if role == "user" {
         if let Some(index) = replay.messages.iter().rposition(|candidate| {
             candidate
@@ -295,6 +299,49 @@ fn apply_response_item(replay: &mut RolloutReconstruction, item: &ResponseItem, 
     }
     replay.messages.push(message);
     replay.updated_at = timestamp.to_string();
+}
+
+fn response_item_message_projection(item: &ResponseItem) -> Option<Value> {
+    match item.kind() {
+        super::ResponseItemKind::Message => Some(item.as_value().clone()),
+        super::ResponseItemKind::FunctionCall | super::ResponseItemKind::CustomToolCall => {
+            let call_id = field_any(item, &["call_id", "callId", "id"])?.clone();
+            let name = field_any(item, &["name"]).cloned().unwrap_or(Value::Null);
+            let arguments = field_any(item, &["input", "arguments", "argumentsJson"])
+                .cloned()
+                .unwrap_or_else(|| Value::String("{}".to_string()));
+            Some(json!({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": arguments,
+                    }
+                }]
+            }))
+        }
+        super::ResponseItemKind::FunctionCallOutput
+        | super::ResponseItemKind::CustomToolCallOutput => {
+            let call_id = field_any(item, &["call_id", "callId", "id"])?.clone();
+            let output = field_any(item, &["output", "content"])
+                .cloned()
+                .unwrap_or(Value::Null);
+            Some(json!({
+                "role": "tool",
+                "content": output,
+                "tool_call_id": call_id,
+            }))
+        }
+        super::ResponseItemKind::Reasoning
+        | super::ResponseItemKind::WebSearchCall
+        | super::ResponseItemKind::LocalShellCall
+        | super::ResponseItemKind::ComputerCall
+        | super::ResponseItemKind::Other(_)
+        | super::ResponseItemKind::Unspecified => None,
+    }
 }
 
 fn apply_event(
@@ -615,6 +662,15 @@ fn thread_item_content(payload: &Value) -> String {
     if content.is_null() {
         return String::new();
     }
+    if let Some(parts) = content.as_array() {
+        return parts
+            .iter()
+            .filter_map(|part| {
+                part.as_str()
+                    .or_else(|| part.get("text").and_then(Value::as_str))
+            })
+            .collect::<String>();
+    }
     content
         .as_str()
         .map(str::to_string)
@@ -859,10 +915,7 @@ mod tests {
 
         let message = &replay.messages[0];
         assert_eq!(replay.session_id, "thread-fields");
-        assert_eq!(
-            message["content"],
-            "[{\"text\":\"structured\",\"type\":\"output_text\"}]"
-        );
+        assert_eq!(message["content"], "structured");
         assert_eq!(message["id"], "response-id");
         assert_eq!(message["messageId"], "message-camel");
         assert_eq!(message["message_id"], "message-snake");

--- a/src-tauri/src/worker_rollout/types.rs
+++ b/src-tauri/src/worker_rollout/types.rs
@@ -619,7 +619,6 @@ impl WorldStateItem {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct TurnContextItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_id: Option<String>,
@@ -651,31 +650,41 @@ pub struct TurnContextItem {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SessionMeta {
+    #[serde(skip, default = "current_rollout_schema_version")]
     pub schema_version: u32,
+    #[serde(rename = "id")]
     pub thread_id: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    #[serde(rename = "timestamp")]
     pub created_at: String,
     #[serde(default)]
     pub cwd: String,
     #[serde(default)]
     pub source: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_provider: Option<String>,
-    #[serde(default)]
+    #[serde(skip, default)]
     pub model: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_instructions: Option<Value>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub history_mode: Option<String>,
-    #[serde(default)]
+    #[serde(
+        rename = "forked_from_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub forked_from_thread_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_thread_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub originator: Option<String>,
+}
+
+fn current_rollout_schema_version() -> u32 {
+    ROLLOUT_SCHEMA_VERSION
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
@@ -809,7 +818,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn rollout_line_serializes_session_meta_with_snake_type() {
+    fn rollout_line_serializes_codex_compatible_session_meta() {
         let line = RolloutLine {
             timestamp: "2026-07-08T10:12:30Z".to_string(),
             ordinal: None,
@@ -832,20 +841,65 @@ mod tests {
 
         let value = serde_json::to_value(line).unwrap();
         assert_eq!(value["type"], "session_meta");
-        assert_eq!(value["payload"]["schemaVersion"], 1);
-        assert_eq!(value["payload"]["threadId"], "thread-1");
-        assert_eq!(value["payload"]["sessionId"], "session-1");
+        assert_eq!(value["payload"]["id"], "thread-1");
+        assert_eq!(value["payload"]["session_id"], "session-1");
+        assert_eq!(value["payload"]["timestamp"], "2026-07-08T10:12:30Z");
+        assert_eq!(value["payload"]["model_provider"], "deepseek");
+        assert!(value["payload"].get("schemaVersion").is_none());
+        assert!(value["payload"].get("schema_version").is_none());
+        assert!(value["payload"].get("threadId").is_none());
+        assert!(value["payload"].get("createdAt").is_none());
+        assert!(value["payload"].get("model").is_none());
     }
 
     #[test]
-    fn session_meta_requires_schema_version() {
-        let error = serde_json::from_value::<SessionMeta>(json!({
-            "threadId": "thread-legacy",
-            "createdAt": "2026-07-08T10:12:30Z"
+    fn session_meta_reads_codex_wire_keys_without_a_tinybot_schema_field() {
+        let meta = serde_json::from_value::<SessionMeta>(json!({
+            "id": "thread-codex",
+            "session_id": "session-codex",
+            "timestamp": "2026-07-08T10:12:30Z",
+            "cwd": "D:/workspace",
+            "source": "desktop",
+            "forked_from_id": "thread-parent"
         }))
-        .unwrap_err();
+        .unwrap();
 
-        assert!(error.to_string().contains("schemaVersion"));
+        assert_eq!(meta.schema_version, ROLLOUT_SCHEMA_VERSION);
+        assert_eq!(meta.thread_id, "thread-codex");
+        assert_eq!(meta.session_id.as_deref(), Some("session-codex"));
+        assert_eq!(meta.forked_from_thread_id.as_deref(), Some("thread-parent"));
+    }
+
+    #[test]
+    fn turn_context_serializes_with_codex_snake_case_keys() {
+        let context = TurnContextItem {
+            turn_id: Some("turn-1".to_string()),
+            cwd: "D:/workspace".to_string(),
+            workspace_roots: Some(vec!["D:/workspace".to_string()]),
+            current_date: Some("2026-07-20".to_string()),
+            timezone: Some("Asia/Singapore".to_string()),
+            approval_policy: json!("on_request"),
+            sandbox_policy: json!("workspace_write"),
+            permission_profile: Some(json!({"name": "default"})),
+            network: Some(json!({"enabled": true})),
+            model: "deepseek-v4-pro".to_string(),
+            provider: Some("deepseek".to_string()),
+            comp_hash: Some("hash".to_string()),
+            personality: None,
+            collaboration_mode: None,
+            effort: Some(json!("high")),
+            summary: json!("auto"),
+        };
+
+        let value = serde_json::to_value(context).unwrap();
+        assert_eq!(value["turn_id"], "turn-1");
+        assert_eq!(value["workspace_roots"][0], "D:/workspace");
+        assert_eq!(value["approval_policy"], "on_request");
+        assert_eq!(value["sandbox_policy"], "workspace_write");
+        assert_eq!(value["comp_hash"], "hash");
+        assert!(value.get("turnId").is_none());
+        assert!(value.get("workspaceRoots").is_none());
+        assert!(value.get("approvalPolicy").is_none());
     }
 
     #[test]

--- a/src-tauri/src/worker_rollout/types.rs
+++ b/src-tauri/src/worker_rollout/types.rs
@@ -315,6 +315,7 @@ impl ResponseItem {
             .get("role")
             .and_then(Value::as_str)
             .map(ResponseRole::from_str);
+        validate_response_item(&kind, &raw)?;
         Ok(Self { kind, role, raw })
     }
 
@@ -336,6 +337,61 @@ impl ResponseItem {
 
     pub fn into_value(self) -> Value {
         self.raw
+    }
+}
+
+fn validate_response_item(kind: &ResponseItemKind, raw: &Value) -> Result<(), String> {
+    match kind {
+        ResponseItemKind::Message => {
+            required_response_string(raw, &["role"], "message role")?;
+            let content = raw
+                .get("content")
+                .ok_or_else(|| "message response item is missing `content`".to_string())?;
+            if !content.is_string() && !content.is_array() && !content.is_null() {
+                return Err("message response item `content` must be a string or array".to_string());
+            }
+        }
+        ResponseItemKind::Reasoning => {
+            required_response_string(raw, &["id"], "reasoning id")?;
+            if raw.get("summary").is_none() && raw.get("content").is_none() {
+                return Err("reasoning response item requires `summary` or `content`".to_string());
+            }
+        }
+        ResponseItemKind::CustomToolCall => {
+            required_response_string(raw, &["call_id", "callId"], "custom tool call id")?;
+            required_response_string(raw, &["name"], "custom tool name")?;
+            if raw.get("input").is_none() {
+                return Err("custom tool call response item is missing `input`".to_string());
+            }
+        }
+        ResponseItemKind::CustomToolCallOutput => {
+            required_response_string(raw, &["call_id", "callId"], "custom tool call output id")?;
+            if raw.get("output").is_none() {
+                return Err("custom tool output response item is missing `output`".to_string());
+            }
+        }
+        ResponseItemKind::Unspecified => {
+            return Err("response item is missing string field `type` or `role`".to_string());
+        }
+        ResponseItemKind::FunctionCall
+        | ResponseItemKind::FunctionCallOutput
+        | ResponseItemKind::WebSearchCall
+        | ResponseItemKind::LocalShellCall
+        | ResponseItemKind::ComputerCall
+        | ResponseItemKind::Other(_) => {}
+    }
+    Ok(())
+}
+
+fn required_response_string(raw: &Value, keys: &[&str], description: &str) -> Result<(), String> {
+    if keys.iter().any(|key| {
+        raw.get(*key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    }) {
+        Ok(())
+    } else {
+        Err(format!("response item is missing {description}"))
     }
 }
 

--- a/src-tauri/src/worker_rpc.rs
+++ b/src-tauri/src/worker_rpc.rs
@@ -1095,6 +1095,15 @@ struct AgentRunMarkFailedParams {
 }
 
 #[derive(Deserialize)]
+struct AgentRunMarkInterruptedParams {
+    #[serde(alias = "sessionId")]
+    session_id: String,
+    #[serde(alias = "runId")]
+    run_id: String,
+    reason: String,
+}
+
+#[derive(Deserialize)]
 struct DiagnosticsAppendParams {
     stream: String,
     line: String,

--- a/src-tauri/src/worker_rpc/persistence_facade.rs
+++ b/src-tauri/src/worker_rpc/persistence_facade.rs
@@ -354,6 +354,15 @@ impl WorkerRpcRouter {
                     .mark_agent_run_cancelled(&params.session_id, &params.run_id)?;
                 serde_json::to_value(record).map_err(serialization_error)
             }
+            "agent_run.mark_interrupted" => {
+                let params: AgentRunMarkInterruptedParams = parse_params(request)?;
+                let record = self.thread_log.mark_agent_run_interrupted_terminal(
+                    &params.session_id,
+                    &params.run_id,
+                    &params.reason,
+                )?;
+                serde_json::to_value(record).map_err(serialization_error)
+            }
             _ => Err(unknown_method_error(request)),
         }
     }

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -2766,7 +2766,39 @@ fn agent_run_persistence_drops_transient_trace_and_does_not_write_legacy_session
         .join("state")
         .join("state.sqlite")
         .exists());
-    assert!(first_thread_log_file_under(&fixture.root, "threads").is_some());
+    let rollout_path =
+        first_thread_log_file_under(&fixture.root, "threads").expect("rollout should exist");
+    let upsert_record = std::fs::read_to_string(rollout_path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .find(|line| line["type"] == "event_msg" && line["payload"]["type"] == "agent_run_upsert")
+        .map(|line| line["payload"]["payload"]["record"].clone())
+        .expect("agent run seed should be persisted");
+    assert_eq!(upsert_record["sessionId"], "session-agent-log-only");
+    assert_eq!(upsert_record["runId"], "run-agent-log-only");
+    for derived_field in [
+        "status",
+        "phase",
+        "updatedAt",
+        "completedAt",
+        "stopReason",
+        "currentIteration",
+        "traceMessages",
+        "traceEvents",
+        "completedToolResults",
+        "pendingToolCalls",
+        "checkpoint",
+        "artifacts",
+        "usage",
+        "tokenUsageInfo",
+        "error",
+    ] {
+        assert!(
+            upsert_record.get(derived_field).is_none(),
+            "agent_run_upsert must not persist derived field `{derived_field}`"
+        );
+    }
 }
 
 #[test]

--- a/src-tauri/src/worker_rpc/tests.rs
+++ b/src-tauri/src/worker_rpc/tests.rs
@@ -2855,9 +2855,19 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
                     "reasoningId": "reasoning-1"
                 }
             }, {
+                "eventId": "reasoning-reload-reasoning-completed",
+                "eventName": "agent.reasoning.completed",
+                "sequence": 3,
+                "turnId": "run-reasoning-reload",
+                "payload": {
+                    "summary": "Inspect first.",
+                    "modelCallId": "provider-1",
+                    "reasoningId": "reasoning-1"
+                }
+            }, {
                 "eventId": "reasoning-reload-tool-a",
                 "eventName": "agent.tool_call.delta",
-                "sequence": 3,
+                "sequence": 4,
                 "turnId": "run-reasoning-reload",
                 "payload": {
                     "toolCallId": "call-a",
@@ -2867,7 +2877,7 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
             }, {
                 "eventId": "reasoning-reload-tool-b",
                 "eventName": "agent.tool_call.delta",
-                "sequence": 4,
+                "sequence": 5,
                 "turnId": "run-reasoning-reload",
                 "payload": {
                     "toolCallId": "call-b",
@@ -2877,7 +2887,7 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
             }, {
                 "eventId": "reasoning-reload-result-b",
                 "eventName": "agent.tool.result",
-                "sequence": 5,
+                "sequence": 6,
                 "turnId": "run-reasoning-reload",
                 "payload": {
                     "toolCallId": "call-b",
@@ -2887,7 +2897,7 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
             }, {
                 "eventId": "reasoning-reload-result-a",
                 "eventName": "agent.tool.result",
-                "sequence": 6,
+                "sequence": 7,
                 "turnId": "run-reasoning-reload",
                 "payload": {
                     "toolCallId": "call-a",
@@ -2897,7 +2907,7 @@ fn agent_run_reasoning_survives_canonical_rollout_reload() {
             }, {
                 "eventId": "reasoning-reload-completed",
                 "eventName": "agent.message.completed",
-                "sequence": 7,
+                "sequence": 8,
                 "turnId": "run-reasoning-reload",
                 "payload": {
                     "content": "Done.",
@@ -9148,7 +9158,7 @@ fn dispatches_agent_run_store_round_trip_requests() {
             "run_id": "run-1",
             "event": {
                 "eventId": "invalid-reasoning",
-                "eventName": "agent.reasoning_delta",
+                "eventName": "agent.reasoning.completed",
                 "payload": {
                     "modelCallId": "provider-invalid",
                     "reasoningId": "reasoning-invalid"

--- a/src-tauri/src/worker_thread/store/runtime_projection.rs
+++ b/src-tauri/src/worker_thread/store/runtime_projection.rs
@@ -24,6 +24,39 @@ pub(super) fn trace_event_from_thread_item(item: &ThreadItem) -> Option<Value> {
             "payload": payload,
         }));
     }
+    if let ThreadItemKind::ToolCallStarted(value) = &item.kind {
+        if value.get("type").and_then(Value::as_str) == Some("custom_tool_call") {
+            return Some(serde_json::json!({
+                "eventName": "agent.tool_call.delta",
+                "payload": {
+                    "toolCallId": value
+                        .get("call_id")
+                        .or_else(|| value.get("callId"))
+                        .or_else(|| value.get("id"))
+                        .cloned()
+                        .unwrap_or(Value::Null),
+                    "toolName": value.get("name").cloned().unwrap_or(Value::Null),
+                    "argumentsDelta": value.get("input").cloned().unwrap_or(Value::Null),
+                },
+            }));
+        }
+    }
+    if let ThreadItemKind::ToolCallOutput(value) = &item.kind {
+        if value.get("type").and_then(Value::as_str) == Some("custom_tool_call_output") {
+            return Some(serde_json::json!({
+                "eventName": "agent.tool.result",
+                "payload": {
+                    "toolCallId": value
+                        .get("call_id")
+                        .or_else(|| value.get("callId"))
+                        .or_else(|| value.get("id"))
+                        .cloned()
+                        .unwrap_or(Value::Null),
+                    "content": value.get("output").cloned().unwrap_or(Value::Null),
+                },
+            }));
+        }
+    }
     let (payload, fallback_event_name) = match &item.kind {
         ThreadItemKind::UserMessage(value) => (value, Some("agent.turn.started")),
         ThreadItemKind::AssistantMessageDelta(value) => (value, Some("agent.delta")),

--- a/src-tauri/src/worker_thread_log/README.md
+++ b/src-tauri/src/worker_thread_log/README.md
@@ -15,8 +15,9 @@ turn double write.
 | `.tinybot/threads/<year>/<month>/<day>/thread-*.jsonl` | Canonical per-thread append-only log |
 | `.tinybot/state/state.sqlite` | Queryable index of thread/session metadata |
 
-A log begins with `ThreadMeta` and can contain event messages, response items,
-  turn context, world state, compaction records, and inter-agent communication.
+A log begins with `ThreadMeta` and can contain event messages, strongly typed
+response items, turn context, world state, compaction records, and inter-agent
+communication.
 Canonical reconstruction produces Thread items, session history, model
 context, agent runs, checkpoints, and token usage.
 
@@ -56,6 +57,11 @@ context, agent runs, checkpoints, and token usage.
   must be derivable from canonical logs.
 - Unknown or malformed persisted semantics return structured errors rather
   than being silently discarded when they affect replay correctness.
+- Diagnostic agent trace may be bounded, but canonical messages, completed
+  reasoning, tool calls, and tool outputs are materialized from the lossless
+  runtime event first and never reconstructed from truncated text.
+- Streaming reasoning deltas remain presentation events. One completed
+  reasoning ResponseItem is persisted per model call.
 
 See [`worker_thread`](../worker_thread/README.md) for the typed Thread domain and
 [`worker_session`](../worker_session/README.md) for session-shaped projections.

--- a/src-tauri/src/worker_thread_log/agent_run.rs
+++ b/src-tauri/src/worker_thread_log/agent_run.rs
@@ -10,9 +10,103 @@ use crate::worker_protocol::{
 use crate::worker_session::{
     AgentRunCheckpoint, AgentRunRecord, AgentRunRuntimeState, AgentRunStatus, AgentRunTracePage,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedAgentRunSeed {
+    session_id: String,
+    run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    parent_thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    child_thread_ids: Vec<String>,
+    started_at: String,
+    model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    max_iterations: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    instruction_provenance: Option<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    instruction_diagnostics: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    trace_context: Option<crate::agent_loop_runtime_protocol::AgentTraceContext>,
+}
+
+impl PersistedAgentRunSeed {
+    fn from_record(record: &AgentRunRecord) -> Self {
+        Self {
+            session_id: record.session_id.clone(),
+            run_id: record.run_id.clone(),
+            thread_id: record.thread_id.clone(),
+            turn_id: record.turn_id.clone(),
+            parent_thread_id: record.parent_thread_id.clone(),
+            child_thread_ids: record.child_thread_ids.clone(),
+            started_at: record.started_at.clone(),
+            model: record.model.clone(),
+            provider: record.provider.clone(),
+            max_iterations: record.max_iterations,
+            instruction_provenance: record.instruction_provenance.clone(),
+            instruction_diagnostics: record.instruction_diagnostics.clone(),
+            trace_context: record.trace_context.clone(),
+        }
+    }
+
+    fn into_record(self) -> AgentRunRecord {
+        AgentRunRecord {
+            session_id: self.session_id,
+            run_id: self.run_id,
+            thread_id: self.thread_id,
+            turn_id: self.turn_id,
+            parent_thread_id: self.parent_thread_id,
+            child_thread_ids: self.child_thread_ids,
+            status: AgentRunStatus::Running,
+            phase: "planning".to_string(),
+            started_at: self.started_at.clone(),
+            updated_at: self.started_at,
+            completed_at: None,
+            stop_reason: None,
+            model: self.model,
+            provider: self.provider,
+            max_iterations: self.max_iterations,
+            current_iteration: 0,
+            conversation_message_ids: Vec::new(),
+            trace_messages: Vec::new(),
+            trace_events: Vec::new(),
+            completed_tool_results: Vec::new(),
+            pending_tool_calls: Vec::new(),
+            checkpoint: None,
+            artifacts: Vec::new(),
+            usage: Vec::new(),
+            token_usage_info: None,
+            instruction_provenance: self.instruction_provenance,
+            instruction_diagnostics: self.instruction_diagnostics,
+            trace_context: self.trace_context,
+            error: None,
+        }
+    }
+
+    fn apply_metadata_to(self, record: &mut AgentRunRecord) {
+        record.thread_id = self.thread_id;
+        record.turn_id = self.turn_id;
+        record.parent_thread_id = self.parent_thread_id;
+        record.child_thread_ids = self.child_thread_ids;
+        record.model = self.model;
+        record.provider = self.provider;
+        record.max_iterations = self.max_iterations;
+        record.instruction_provenance = self.instruction_provenance;
+        record.instruction_diagnostics = self.instruction_diagnostics;
+        record.trace_context = self.trace_context;
+    }
+}
 
 impl WorkerThreadLogRpc {
     pub fn upsert_agent_run(
@@ -44,16 +138,12 @@ impl WorkerThreadLogRpc {
         let mut state = self.ensure_agent_run_thread(&record.session_id, &timestamp)?;
         let path = PathBuf::from(state.thread_path.clone());
         self.recorder.validate_thread_path(&path)?;
-        let mut items = vec![value_event(
+        let items = vec![value_event(
             super::EventKind::AgentRunUpsert,
-            serde_json::json!({ "record": persisted_record.clone() }),
+            serde_json::json!({
+                "record": PersistedAgentRunSeed::from_record(&persisted_record)
+            }),
         )];
-        if let Some(info) = record.token_usage_info.as_ref() {
-            items.push(value_event(
-                super::EventKind::TokenCount,
-                serde_json::json!({ "info": info }),
-            ));
-        }
         self.recorder
             .append_items(&path, timestamp.clone(), items)?;
         let log_head = self.recorder.thread_log_head(&path)?;
@@ -62,9 +152,6 @@ impl WorkerThreadLogRpc {
             state.model = Some(record.model.clone());
         }
         state.model_provider = record.provider.clone();
-        if let Some(info) = record.token_usage_info.as_ref() {
-            state.tokens_used = info.total_token_usage.total_tokens;
-        }
         self.state.upsert_thread_projection(&state, &log_head)?;
         Ok(persisted_record)
     }
@@ -490,7 +577,7 @@ impl WorkerThreadLogRpc {
         stop_reason: &str,
         final_content: Option<String>,
     ) -> Result<AgentRunRecord, WorkerProtocolError> {
-        let mut record = self.mark_agent_run_terminal(
+        self.mark_agent_run_terminal(
             session_id,
             run_id,
             AgentRunStatus::Completed,
@@ -498,15 +585,7 @@ impl WorkerThreadLogRpc {
             Some(stop_reason.to_string()),
             final_content,
             None,
-        )?;
-        if let Some(info) = record.token_usage_info.clone() {
-            let info_value = serde_json::to_value(info).map_err(thread_log_serialization_error)?;
-            let info = serde_json::from_value::<super::TokenUsageInfo>(info_value)
-                .map_err(thread_log_serialization_error)?;
-            self.append_token_count(session_id, info)?;
-            record.checkpoint = None;
-        }
-        Ok(record)
+        )
     }
 
     pub fn mark_agent_run_failed(
@@ -572,6 +651,15 @@ impl WorkerThreadLogRpc {
                 }
             }),
         )?;
+        self.mark_agent_run_interrupted_terminal(session_id, run_id, reason)
+    }
+
+    pub fn mark_agent_run_interrupted_terminal(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        reason: &str,
+    ) -> Result<AgentRunRecord, WorkerProtocolError> {
         self.mark_agent_run_terminal(
             session_id,
             run_id,
@@ -932,8 +1020,8 @@ pub(super) fn agent_run_records_from_lines(
                         payload,
                     )
                 })?;
-                let record =
-                    serde_json::from_value::<AgentRunRecord>(record_value).map_err(|error| {
+                let seed = serde_json::from_value::<PersistedAgentRunSeed>(record_value).map_err(
+                    |error| {
                         agent_run_replay_error(
                             "agent_run_upsert event contains an invalid record",
                             line,
@@ -942,19 +1030,10 @@ pub(super) fn agent_run_records_from_lines(
                                 "error": error.to_string(),
                             }),
                         )
-                    })?;
-                if !record.trace_events.is_empty() {
-                    return Err(agent_run_replay_error(
-                        "canonical agent_run_upsert record must not embed trace events",
-                        line,
-                        &serde_json::json!({
-                            "runId": &record.run_id,
-                            "traceEventCount": record.trace_events.len(),
-                        }),
-                    ));
-                }
-                let belongs_to_session = record.session_id == session_id;
-                let belongs_to_thread = record.session_id == thread_id;
+                    },
+                )?;
+                let belongs_to_session = seed.session_id == session_id;
+                let belongs_to_thread = seed.session_id == thread_id;
                 if !belongs_to_session && !belongs_to_thread {
                     return Err(agent_run_replay_error(
                         "agent_run_upsert record belongs to a different session",
@@ -962,22 +1041,19 @@ pub(super) fn agent_run_records_from_lines(
                         &serde_json::json!({
                             "expectedSessionId": session_id,
                             "expectedThreadId": thread_id,
-                            "actualSessionId": record.session_id,
-                            "runId": record.run_id,
+                            "actualSessionId": seed.session_id,
+                            "runId": seed.run_id,
                         }),
                     ));
                 }
-                runs.entry(record.run_id.clone())
-                    .and_modify(|existing| {
-                        let started_at = existing.started_at.clone();
-                        let trace_messages = existing.trace_messages.clone();
-                        let trace_events = existing.trace_events.clone();
-                        *existing = record.clone();
-                        existing.started_at = started_at;
-                        existing.trace_messages = trace_messages;
-                        existing.trace_events = trace_events;
-                    })
-                    .or_insert(record);
+                match runs.entry(seed.run_id.clone()) {
+                    std::collections::hash_map::Entry::Occupied(mut entry) => {
+                        seed.apply_metadata_to(entry.get_mut());
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(seed.into_record());
+                    }
+                }
             }
             super::EventKind::AgentRunTrace => {
                 let run_id = payload_run_id(payload).ok_or_else(|| {
@@ -1128,14 +1204,29 @@ fn apply_response_item_to_agent_runs(
     else {
         return Ok(());
     };
+    let Some(record) = runs.get_mut(run_id) else {
+        return Ok(());
+    };
+    if item.get("type").and_then(Value::as_str) == Some("custom_tool_call_output") {
+        let completed_result = completed_tool_result_from_response_item(item);
+        let call_id = completed_result
+            .get("toolCallId")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if let Some(index) = record.completed_tool_results.iter().position(|candidate| {
+            candidate.get("toolCallId").and_then(Value::as_str) == Some(call_id)
+        }) {
+            record.completed_tool_results[index] = completed_result;
+        } else {
+            record.completed_tool_results.push(completed_result);
+        }
+        return Ok(());
+    }
     if item.get("type").and_then(Value::as_str) != Some("message")
         || item.get("role").and_then(Value::as_str) != Some("assistant")
     {
         return Ok(());
     }
-    let Some(record) = runs.get_mut(run_id) else {
-        return Ok(());
-    };
     let content = response_message_text(item);
     let message_id = item
         .get("id")
@@ -1163,6 +1254,43 @@ fn apply_response_item_to_agent_runs(
         record.trace_messages.push(message);
     }
     Ok(())
+}
+
+fn completed_tool_result_from_response_item(item: &Value) -> Value {
+    let payload = item
+        .get("threadItemPayload")
+        .or_else(|| item.get("thread_item_payload"))
+        .and_then(|event| event.get("payload"))
+        .unwrap_or(&Value::Null);
+    let envelope = payload.get("envelope").cloned().unwrap_or(Value::Null);
+    let status = envelope
+        .get("status")
+        .or_else(|| payload.get("resultStatus"))
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!("ok"));
+    let summary = envelope
+        .get("summary")
+        .or_else(|| payload.get("summary"))
+        .or_else(|| item.get("output"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    serde_json::json!({
+        "toolCallId": payload
+            .get("toolCallId")
+            .or_else(|| payload.get("tool_call_id"))
+            .or_else(|| item.get("call_id"))
+            .cloned()
+            .unwrap_or(Value::Null),
+        "toolName": payload
+            .get("toolName")
+            .or_else(|| payload.get("tool_name"))
+            .or_else(|| payload.get("name"))
+            .cloned()
+            .unwrap_or(Value::Null),
+        "status": status,
+        "summary": summary,
+        "envelope": envelope,
+    })
 }
 
 fn response_message_text(item: &Value) -> String {
@@ -1569,16 +1697,6 @@ fn empty_agent_run_trace_batch_error(session_id: &str, run_id: &str) -> WorkerPr
             "session_id": session_id,
             "run_id": run_id,
         }),
-        false,
-        WorkerProtocolErrorSource::RustCore,
-    )
-}
-
-fn thread_log_serialization_error(error: serde_json::Error) -> WorkerProtocolError {
-    WorkerProtocolError::new(
-        WorkerProtocolErrorCode::WorkerError,
-        format!("thread log agent run serialization error: {error}"),
-        serde_json::json!({ "method": "agent_run" }),
         false,
         WorkerProtocolErrorSource::RustCore,
     )

--- a/src-tauri/src/worker_thread_log/agent_run.rs
+++ b/src-tauri/src/worker_thread_log/agent_run.rs
@@ -124,27 +124,8 @@ impl WorkerThreadLogRpc {
                 .is_some_and(agent_run_trace_event_is_response_backed)
         });
         let mut items = Vec::new();
-        let mut pending_reasoning = None::<ReasoningResponseAccumulator>;
+        let mut persisted_events = Vec::with_capacity(events.len());
         for event in events.iter().cloned() {
-            if let Some(fragment) = ReasoningResponseFragment::from_runtime_event(&event) {
-                if pending_reasoning
-                    .as_ref()
-                    .is_some_and(|pending| !pending.matches(&fragment))
-                {
-                    push_reasoning_response_item(
-                        &mut items,
-                        pending_reasoning
-                            .take()
-                            .expect("pending reasoning should exist"),
-                        run_id,
-                    )?;
-                }
-                pending_reasoning
-                    .get_or_insert_with(|| ReasoningResponseAccumulator::from_fragment(&fragment))
-                    .push(fragment);
-            } else if let Some(pending) = pending_reasoning.take() {
-                push_reasoning_response_item(&mut items, pending, run_id)?;
-            }
             let response_item = response_item_from_runtime_event(&event)
                 .map(|mut item| {
                     item["runId"] = Value::String(run_id.to_string());
@@ -169,12 +150,13 @@ impl WorkerThreadLogRpc {
                     .cloned()
             })
             .flatten();
+            let persisted_event = crate::worker_rollout::bound_persisted_trace_value(event.clone());
             items.push(value_event(
                 super::EventKind::AgentRunTrace,
                 serde_json::json!({
                     "sessionId": session_id,
                     "runId": run_id,
-                    "event": event,
+                    "event": persisted_event.clone(),
                 }),
             ));
             if let Some(info) = token_info {
@@ -186,14 +168,12 @@ impl WorkerThreadLogRpc {
             if let Some(response_item) = response_item {
                 items.push(ThreadLogItem::ResponseItem(response_item));
             }
-        }
-        if let Some(pending) = pending_reasoning {
-            push_reasoning_response_item(&mut items, pending, run_id)?;
+            persisted_events.push(persisted_event);
         }
         self.recorder
             .append_items(&path, timestamp.clone(), items)?;
         let log_head = self.recorder.thread_log_head(&path)?;
-        for event in events {
+        for event in persisted_events {
             upsert_trace_event(&mut record.trace_events, event.clone());
             apply_agent_status_snapshot(&mut record, &event);
         }
@@ -760,51 +740,107 @@ fn response_item_from_runtime_event(event: &Value) -> Option<Value> {
     match event.get("eventName").and_then(Value::as_str)? {
         "agent.turn.started" => {
             let mut message = payload.get("userMessage")?.clone();
+            let content = message.get("content").cloned().unwrap_or(Value::Null);
+            message["type"] = Value::String("message".to_string());
             message["role"] = Value::String("user".to_string());
+            message["content"] = canonical_message_content(content, "input_text");
+            if message.get("id").is_none() {
+                message["id"] = message
+                    .get("messageId")
+                    .or_else(|| message.get("message_id"))
+                    .or_else(|| payload.get("userMessageId"))
+                    .cloned()
+                    .unwrap_or(Value::Null);
+            }
+            if message.get("messageId").is_none() {
+                message["messageId"] = message.get("id").cloned().unwrap_or(Value::Null);
+            }
             Some(message)
         }
         "agent.message.completed" => {
             let content = payload.get("content")?.as_str()?;
+            let message_id = payload.get("messageId").cloned().unwrap_or(Value::Null);
             Some(serde_json::json!({
+                "type": "message",
+                "id": message_id,
                 "role": "assistant",
-                "content": content,
-                "messageId": payload.get("messageId").cloned().unwrap_or(Value::Null),
+                "content": canonical_message_content(Value::String(content.to_string()), "output_text"),
+                "messageId": message_id,
+                "phase": payload
+                    .get("messagePhase")
+                    .cloned()
+                    .unwrap_or_else(|| Value::String("final_answer".to_string())),
             }))
         }
-        "agent.message.classified" => Some(serde_json::json!({
-            "role": "assistant",
-            "content": payload.get("content").cloned().unwrap_or(Value::Null),
-            "messageId": payload.get("messageId").cloned().unwrap_or(Value::Null),
-        })),
+        "agent.message.classified" => {
+            let message_id = payload.get("messageId").cloned().unwrap_or(Value::Null);
+            Some(serde_json::json!({
+                "type": "message",
+                "id": message_id,
+                "role": "assistant",
+                "content": canonical_message_content(
+                    payload.get("content").cloned().unwrap_or(Value::Null),
+                    "output_text",
+                ),
+                "messageId": message_id,
+                "phase": payload
+                    .get("messagePhase")
+                    .cloned()
+                    .unwrap_or_else(|| Value::String("commentary".to_string())),
+            }))
+        }
+        "agent.reasoning.completed" => {
+            let summary = payload.get("summary")?.as_str()?;
+            Some(serde_json::json!({
+                "type": "reasoning",
+                "id": payload
+                    .get("reasoningId")
+                    .cloned()
+                    .unwrap_or_else(|| payload.get("modelCallId").cloned().unwrap_or(Value::Null)),
+                "summary": [{
+                    "type": "summary_text",
+                    "text": summary,
+                }],
+                "content": null,
+                "encrypted_content": null,
+                "modelCallId": payload.get("modelCallId").cloned().unwrap_or(Value::Null),
+                "reasoningId": payload.get("reasoningId").cloned().unwrap_or(Value::Null),
+            }))
+        }
         "agent.tool_call.delta" => Some(serde_json::json!({
-            "role": "assistant",
-            "content": serde_json::Value::Null,
-            "tool_calls": [{
-                "id": payload.get("toolCallId")?.clone(),
-                "type": "function",
-                "function": {
-                    "name": payload
-                        .get("toolName")
-                        .or_else(|| payload.get("name"))?
-                        .clone(),
-                    "arguments": payload
-                        .get("argumentsDelta")
-                        .cloned()
-                        .unwrap_or_else(|| serde_json::json!("{}")),
-                }
-            }]
-        })),
-        "agent.tool.result" => Some(serde_json::json!({
-            "role": "tool",
-            "tool_call_id": payload.get("toolCallId")?.clone(),
+            "type": "custom_tool_call",
+            "id": payload.get("toolCallId")?.clone(),
+            "call_id": payload.get("toolCallId")?.clone(),
             "name": payload
                 .get("toolName")
-                .or_else(|| payload.get("name"))
+                .or_else(|| payload.get("name"))?
+                .clone(),
+            "input": payload
+                .get("argumentsDelta")
                 .cloned()
-                .unwrap_or(Value::Null),
-            "content": payload.get("content").cloned().unwrap_or(Value::Null),
+                .unwrap_or_else(|| serde_json::json!("{}")),
+        })),
+        "agent.tool.result" => Some(serde_json::json!({
+            "type": "custom_tool_call_output",
+            "call_id": payload.get("toolCallId")?.clone(),
+            "output": payload.get("content").cloned().unwrap_or(Value::Null),
         })),
         _ => None,
+    }
+}
+
+fn canonical_message_content(content: Value, part_type: &str) -> Value {
+    match content {
+        Value::Array(_) => content,
+        Value::String(text) => serde_json::json!([{
+            "type": part_type,
+            "text": text,
+        }]),
+        Value::Null => Value::Array(Vec::new()),
+        value => serde_json::json!([{
+            "type": part_type,
+            "text": value.to_string(),
+        }]),
     }
 }
 
@@ -812,7 +848,7 @@ fn agent_run_trace_event_is_response_backed(event_name: &str) -> bool {
     matches!(
         event_name,
         "agent.turn.started"
-            | "agent.reasoning_delta"
+            | "agent.reasoning.completed"
             | "agent.message.classified"
             | "agent.message.completed"
             | "agent.tool_call.delta"
@@ -855,11 +891,7 @@ fn validate_agent_run_trace_event(
     if !agent_run_trace_event_is_response_backed(event_name) {
         return Ok(());
     }
-    let materializes_response = if event_name == "agent.reasoning_delta" {
-        ReasoningResponseFragment::from_runtime_event(event).is_some()
-    } else {
-        response_item_from_runtime_event(event).is_some()
-    };
+    let materializes_response = response_item_from_runtime_event(event).is_some();
     if !materializes_response {
         return Err(invalid_agent_run_trace_event_error(
             "response-backed agent run trace event cannot be materialized",
@@ -869,97 +901,6 @@ fn validate_agent_run_trace_event(
             Some(event_name),
         ));
     }
-    Ok(())
-}
-
-struct ReasoningResponseFragment {
-    event_id: String,
-    turn_id: String,
-    model_call_id: Option<String>,
-    reasoning_id: Option<String>,
-    text: String,
-}
-
-impl ReasoningResponseFragment {
-    fn from_runtime_event(event: &Value) -> Option<Self> {
-        if event.get("eventName").and_then(Value::as_str) != Some("agent.reasoning_delta") {
-            return None;
-        }
-        let payload = event.get("payload")?;
-        let text = payload.get("delta").and_then(Value::as_str)?;
-        Some(Self {
-            event_id: event.get("eventId").and_then(Value::as_str)?.to_string(),
-            turn_id: event
-                .get("turnId")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string(),
-            model_call_id: payload
-                .get("modelCallId")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            reasoning_id: payload
-                .get("reasoningId")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            text: text.to_string(),
-        })
-    }
-}
-
-struct ReasoningResponseAccumulator {
-    event_id: String,
-    turn_id: String,
-    model_call_id: Option<String>,
-    reasoning_id: Option<String>,
-    text: String,
-}
-
-impl ReasoningResponseAccumulator {
-    fn from_fragment(fragment: &ReasoningResponseFragment) -> Self {
-        Self {
-            event_id: fragment.event_id.clone(),
-            turn_id: fragment.turn_id.clone(),
-            model_call_id: fragment.model_call_id.clone(),
-            reasoning_id: fragment.reasoning_id.clone(),
-            text: String::new(),
-        }
-    }
-
-    fn matches(&self, fragment: &ReasoningResponseFragment) -> bool {
-        self.turn_id == fragment.turn_id
-            && self.model_call_id == fragment.model_call_id
-            && self.reasoning_id == fragment.reasoning_id
-    }
-
-    fn push(&mut self, fragment: ReasoningResponseFragment) {
-        self.text.push_str(&fragment.text);
-    }
-}
-
-fn push_reasoning_response_item(
-    items: &mut Vec<ThreadLogItem>,
-    reasoning: ReasoningResponseAccumulator,
-    run_id: &str,
-) -> Result<(), WorkerProtocolError> {
-    let response_item = super::typed_response_item(
-        serde_json::json!({
-            "type": "reasoning",
-            "id": reasoning.event_id,
-            "summary": [{
-                "type": "summary_text",
-                "text": reasoning.text,
-            }],
-            "content": null,
-            "encrypted_content": null,
-            "runId": run_id,
-            "turnId": reasoning.turn_id,
-            "modelCallId": reasoning.model_call_id,
-            "reasoningId": reasoning.reasoning_id,
-        }),
-        "agent reasoning",
-    )?;
-    items.push(ThreadLogItem::ResponseItem(response_item));
     Ok(())
 }
 
@@ -974,6 +915,10 @@ pub(super) fn agent_run_records_from_lines(
 ) -> Result<Vec<AgentRunRecord>, WorkerProtocolError> {
     let mut runs: HashMap<String, AgentRunRecord> = HashMap::new();
     for line in lines {
+        if let super::ThreadLogItem::ResponseItem(item) = &line.item {
+            apply_response_item_to_agent_runs(&mut runs, item.as_value(), line)?;
+            continue;
+        }
         let super::ThreadLogItem::EventMsg(event) = &line.item else {
             continue;
         };
@@ -1025,9 +970,11 @@ pub(super) fn agent_run_records_from_lines(
                 runs.entry(record.run_id.clone())
                     .and_modify(|existing| {
                         let started_at = existing.started_at.clone();
+                        let trace_messages = existing.trace_messages.clone();
                         let trace_events = existing.trace_events.clone();
                         *existing = record.clone();
                         existing.started_at = started_at;
+                        existing.trace_messages = trace_messages;
                         existing.trace_events = trace_events;
                     })
                     .or_insert(record);
@@ -1169,6 +1116,70 @@ pub(super) fn agent_run_records_from_lines(
     Ok(runs.into_values().collect())
 }
 
+fn apply_response_item_to_agent_runs(
+    runs: &mut HashMap<String, AgentRunRecord>,
+    item: &Value,
+    _line: &super::ThreadLogLine,
+) -> Result<(), WorkerProtocolError> {
+    let Some(run_id) = item
+        .get("runId")
+        .or_else(|| item.get("run_id"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(());
+    };
+    if item.get("type").and_then(Value::as_str) != Some("message")
+        || item.get("role").and_then(Value::as_str) != Some("assistant")
+    {
+        return Ok(());
+    }
+    let Some(record) = runs.get_mut(run_id) else {
+        return Ok(());
+    };
+    let content = response_message_text(item);
+    let message_id = item
+        .get("id")
+        .or_else(|| item.get("messageId"))
+        .or_else(|| item.get("message_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let mut message = serde_json::json!({
+        "role": "assistant",
+        "content": content,
+    });
+    if let Some(message_id) = message_id.as_ref() {
+        message["messageId"] = Value::String(message_id.clone());
+    }
+    if let Some(index) = message_id.as_ref().and_then(|message_id| {
+        record.trace_messages.iter().position(|candidate| {
+            candidate
+                .get("messageId")
+                .and_then(Value::as_str)
+                .is_some_and(|candidate_id| candidate_id == message_id)
+        })
+    }) {
+        record.trace_messages[index] = message;
+    } else {
+        record.trace_messages.push(message);
+    }
+    Ok(())
+}
+
+fn response_message_text(item: &Value) -> String {
+    match item.get("content") {
+        Some(Value::String(content)) => content.clone(),
+        Some(Value::Array(parts)) => parts
+            .iter()
+            .filter_map(|part| {
+                part.as_str()
+                    .or_else(|| part.get("text").and_then(Value::as_str))
+            })
+            .collect(),
+        Some(Value::Null) | None => String::new(),
+        Some(content) => content.to_string(),
+    }
+}
+
 fn agent_run_replay_error(
     message: &str,
     line: &super::ThreadLogLine,
@@ -1246,16 +1257,10 @@ fn apply_terminal_to_record(
     status: AgentRunStatus,
     phase: &str,
     stop_reason: Option<String>,
-    final_content: Option<String>,
+    _final_content: Option<String>,
     error: Option<Value>,
     timestamp: &str,
 ) {
-    if let Some(final_content) = final_content.filter(|content| !content.trim().is_empty()) {
-        record.trace_messages.push(serde_json::json!({
-            "role": "assistant",
-            "content": final_content,
-        }));
-    }
     record.status = status;
     record.phase = phase.to_string();
     record.stop_reason = stop_reason;
@@ -1547,13 +1552,12 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(call["tool_calls"][0]["id"], "call-1");
-        assert_eq!(
-            call["tool_calls"][0]["function"]["arguments"],
-            "{\"path\":\"README.md\"}"
-        );
-        assert_eq!(result["tool_call_id"], "call-1");
-        assert_eq!(result["content"], "contents");
+        assert_eq!(call["type"], "custom_tool_call");
+        assert_eq!(call["call_id"], "call-1");
+        assert_eq!(call["input"], "{\"path\":\"README.md\"}");
+        assert_eq!(result["type"], "custom_tool_call_output");
+        assert_eq!(result["call_id"], "call-1");
+        assert_eq!(result["output"], "contents");
     }
 }
 

--- a/src-tauri/src/worker_thread_log/mod.rs
+++ b/src-tauri/src/worker_thread_log/mod.rs
@@ -3745,6 +3745,7 @@ fn thread_item_from_agent_run_trace(
             | "agent.context.compacted"
             | "agent.delta"
             | "agent.reasoning_delta"
+            | "agent.reasoning.completed"
             | "agent.message.phase"
             | "agent.message.classified"
             | "agent.message.completed"
@@ -3928,23 +3929,44 @@ fn rollout_thread_item_id(item: &Value, thread_id: &str, sequence: u64) -> Strin
 }
 
 fn response_item_thread_kind(item: &Value) -> ThreadItemKind {
-    let payload = item
-        .get("threadItemPayload")
-        .cloned()
-        .unwrap_or_else(|| item.clone());
     match item.get("role").and_then(Value::as_str) {
-        Some("user") => ThreadItemKind::UserMessage(payload),
-        Some("assistant") => ThreadItemKind::AssistantMessageCompleted(payload),
-        Some("tool") => ThreadItemKind::ToolCallOutput(payload),
+        Some("user") => ThreadItemKind::UserMessage(response_item_thread_message_payload(item)),
+        Some("assistant") => {
+            ThreadItemKind::AssistantMessageCompleted(response_item_thread_message_payload(item))
+        }
+        Some("tool") => ThreadItemKind::ToolCallOutput(item.clone()),
         _ => match item.get("type").and_then(Value::as_str) {
             Some("reasoning") => ThreadItemKind::Reasoning(item.clone()),
-            Some("function_call" | "tool_call") => ThreadItemKind::ToolCallStarted(item.clone()),
-            Some("function_call_output" | "tool_result") => {
+            Some("function_call" | "tool_call" | "custom_tool_call") => {
+                ThreadItemKind::ToolCallStarted(item.clone())
+            }
+            Some("function_call_output" | "tool_result" | "custom_tool_call_output") => {
                 ThreadItemKind::ToolCallOutput(item.clone())
             }
             _ => ThreadItemKind::Event(item.clone()),
         },
     }
+}
+
+fn response_item_thread_message_payload(item: &Value) -> Value {
+    let mut payload = item.clone();
+    let content = match item.get("content") {
+        Some(Value::String(content)) => content.clone(),
+        Some(Value::Array(parts)) => parts
+            .iter()
+            .filter_map(|part| {
+                part.as_str()
+                    .or_else(|| part.get("text").and_then(Value::as_str))
+            })
+            .collect(),
+        Some(Value::Null) | None => String::new(),
+        Some(content) => content.to_string(),
+    };
+    payload["content"] = Value::String(content);
+    if let Some(object) = payload.as_object_mut() {
+        object.remove("threadItemPayload");
+    }
+    payload
 }
 
 fn thread_run_summary_from_agent_run(
@@ -4385,7 +4407,11 @@ fn thread_log_consistency_error(message: impl Into<String>, details: Value) -> W
     )
 }
 
-fn typed_response_item(value: Value, context: &str) -> Result<ResponseItem, WorkerProtocolError> {
+fn typed_response_item(
+    mut value: Value,
+    context: &str,
+) -> Result<ResponseItem, WorkerProtocolError> {
+    normalize_response_item_for_rollout(&mut value);
     let diagnostic_value = value.clone();
     ResponseItem::from_value(value).map_err(|error| {
         WorkerProtocolError::new(
@@ -4400,6 +4426,43 @@ fn typed_response_item(value: Value, context: &str) -> Result<ResponseItem, Work
             WorkerProtocolErrorSource::RustCore,
         )
     })
+}
+
+fn normalize_response_item_for_rollout(value: &mut Value) {
+    let Some(item) = value.as_object_mut() else {
+        return;
+    };
+    let role = item.get("role").and_then(Value::as_str).map(str::to_string);
+    if role.is_some() && !item.contains_key("type") {
+        item.insert("type".to_string(), Value::String("message".to_string()));
+    }
+    if item.get("type").and_then(Value::as_str) != Some("message") {
+        return;
+    }
+    if !item.contains_key("id") {
+        if let Some(message_id) = item
+            .get("messageId")
+            .or_else(|| item.get("message_id"))
+            .cloned()
+        {
+            item.insert("id".to_string(), message_id);
+        }
+    }
+    let Some(Value::String(content)) = item.get("content").cloned() else {
+        return;
+    };
+    let part_type = if role.as_deref() == Some("user") {
+        "input_text"
+    } else {
+        "output_text"
+    };
+    item.insert(
+        "content".to_string(),
+        serde_json::json!([{
+            "type": part_type,
+            "text": content,
+        }]),
+    );
 }
 
 fn typed_compacted_item(value: Value, context: &str) -> Result<CompactedItem, WorkerProtocolError> {

--- a/src-tauri/src/worker_thread_log/mod.rs
+++ b/src-tauri/src/worker_thread_log/mod.rs
@@ -1376,6 +1376,17 @@ impl WorkerThreadLogRpc {
         let replay = replay_thread_transcript(&replay_lines)?;
         let updated_at = state_projection_updated_at(&meta.created_at, &scan.lines);
         let archived = self.recorder.is_archived_path(path);
+        let model_provider = replay
+            .previous_turn_settings
+            .as_ref()
+            .and_then(|settings| settings.provider.clone())
+            .or(meta.model_provider);
+        let model = replay
+            .previous_turn_settings
+            .as_ref()
+            .map(|settings| settings.model.clone())
+            .filter(|model| !model.trim().is_empty())
+            .or(meta.model);
         let title = if is_default_session_title(&replay.title) {
             title_from_messages(&replay.messages).unwrap_or(replay.title)
         } else {
@@ -1391,8 +1402,8 @@ impl WorkerThreadLogRpc {
             title,
             preview: preview_from_messages(&replay.messages),
             cwd: meta.cwd,
-            model_provider: meta.model_provider,
-            model: meta.model,
+            model_provider,
+            model,
             tokens_used: 0,
             archived,
             archived_at: None,
@@ -1438,6 +1449,17 @@ impl WorkerThreadLogRpc {
         let log_head = self.recorder.thread_log_head(path)?;
         let updated_at = state_projection_updated_at(&meta.created_at, &lines);
         let archived = self.recorder.is_archived_path(path);
+        let model_provider = replay
+            .previous_turn_settings
+            .as_ref()
+            .and_then(|settings| settings.provider.clone())
+            .or(meta.model_provider);
+        let model = replay
+            .previous_turn_settings
+            .as_ref()
+            .map(|settings| settings.model.clone())
+            .filter(|model| !model.trim().is_empty())
+            .or(meta.model);
         let title = if is_default_session_title(&replay.title) {
             title_from_messages(&replay.messages).unwrap_or(replay.title)
         } else {
@@ -1453,8 +1475,8 @@ impl WorkerThreadLogRpc {
             title,
             preview: preview_from_messages(&replay.messages),
             cwd: meta.cwd,
-            model_provider: meta.model_provider,
-            model: meta.model,
+            model_provider,
+            model,
             tokens_used: replay
                 .token_usage_info
                 .as_ref()

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -346,13 +346,6 @@ export function ClaudeStyleAiInput({
           <span>{disabledReason}</span>
         </div>
       ) : null}
-      {!error && !disabled && responding ? (
-        <div className="claude-ai-input__notice" role="status">
-          <AlertCircle aria-hidden="true" size={15} />
-          <span>任务执行中；此时发送的新消息会排队，并在当前步骤结束后送达。</span>
-        </div>
-      ) : null}
-
       {files.length || pastedContent.length || contextReferences.length ? (
         <div className="claude-ai-input__attachments" aria-label="Composer attachments">
           {contextReferences.map((reference) => (

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -2828,8 +2828,7 @@ describe("ChatPage", () => {
     }));
   });
 
-  it("dispatches pause from Chat through the correlated run controller", async () => {
-    const user = userEvent.setup();
+  it("hides run controls and the queue notice from the Chat surface", async () => {
     const stores = createStores({
       sessions: [{
         id: "s1",
@@ -2850,12 +2849,11 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
-    await user.click(await screen.findByRole("button", { name: "Pause" }));
-    expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
-      kind: "agent.pause",
-      source: { control: "chat-pause", surface: "chat" },
-      target: expect.objectContaining({ runId: run.id, sessionId: "s1" }),
-    }));
+    expect(await screen.findByRole("button", { name: "Stop generation" })).toBeTruthy();
+    expect(screen.queryByLabelText("Agent run controls")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Pause" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
+    expect(screen.queryByText("任务执行中；此时发送的新消息会排队，并在当前步骤结束后送达。")).toBeNull();
   });
 
   it("disables cancellation with the backend-authored unavailable reason", async () => {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -16,7 +16,6 @@ import {
   MoreHorizontal,
   PanelRightClose,
   PanelRightOpen,
-  Pause,
   Plus,
   Search,
   Settings,
@@ -1749,13 +1748,6 @@ export function ChatPage({
           />
         ) : null}
         {queueMessage ? <p className="react-queued-inputs__message">{queueMessage}</p> : null}
-        {activeSession && activeRun ? (
-          <div aria-label="Agent run controls" className="react-agent-run-controls">
-            <span>Run {activeRun.id}</span>
-            <button disabled={!canPauseRun || cancelInFlight} title={canPauseRun ? "Pause at the next safe runtime boundary" : pauseUnavailableReason} type="button" onClick={() => void handleAgentRunControl("agent.pause", "chat")}><Pause aria-hidden="true" size={13} />Pause</button>
-            <button disabled={!canResumeRun || cancelInFlight} title={canResumeRun ? "Resume the same Agent run" : resumeUnavailableReason} type="button" onClick={() => void handleAgentRunControl("agent.resume", "chat")}><Play aria-hidden="true" size={13} />Resume</button>
-          </div>
-        ) : null}
         {commandLifecycle.stage !== "idle" ? (
           <p
             aria-live="polite"

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -6050,20 +6050,6 @@ button.tinyos-overlay-backdrop:focus-visible {
   font-size: 12px;
 }
 
-.react-agent-run-controls {
-  display: flex;
-  width: min(760px, calc(100% - 32px));
-  align-items: center;
-  justify-content: flex-end;
-  gap: 6px;
-  margin: 0 auto 6px;
-  color: var(--color-muted);
-  font-size: 11px;
-}
-
-.react-agent-run-controls > span { overflow: hidden; margin-right: auto; text-overflow: ellipsis; white-space: nowrap; }
-.react-agent-run-controls > button { display: inline-flex; align-items: center; gap: 4px; border: 1px solid var(--color-hairline); border-radius: 6px; padding: 4px 7px; background: var(--color-surface); color: var(--color-ink); font-size: 10px; }
-
 .react-agent-command-status[data-stage="rejected"],
 .react-agent-command-status[data-stage="timed_out"] {
   color: var(--color-danger);


### PR DESCRIPTION
## Summary
- align canonical rollout persistence and reconstruction with the native worker runtime
- keep agent-run events traceable across the native bridge, worker rollout, and thread log projections
- simplify active chat run controls and remove obsolete UI handling

## Testing
- not run in this merge flow; merged immediately as requested without waiting for CI