### PR TITLE
fix: reduce rollout persistence write amplification

### DIFF
--- a/src-tauri/src/native_agent_bridge/result_projection.rs
+++ b/src-tauri/src/native_agent_bridge/result_projection.rs
@@ -219,8 +219,15 @@ pub(crate) fn native_agent_canonical_trace_values(
     values
         .iter()
         .filter(|value| {
-            value.get("eventName").and_then(serde_json::Value::as_str)
-                != Some("agent.provider.requested")
+            value
+                .get("eventName")
+                .and_then(serde_json::Value::as_str)
+                .is_none_or(|event_name| {
+                    crate::worker_rollout::should_persist_agent_runtime_event(
+                        event_name,
+                        value.get("payload").unwrap_or(value),
+                    )
+                })
         })
         .cloned()
         .collect()

--- a/src-tauri/src/native_agent_bridge/trace_sink.rs
+++ b/src-tauri/src/native_agent_bridge/trace_sink.rs
@@ -3,6 +3,7 @@ use crate::agent_loop_runtime_protocol::{AgentRuntimeEventEnvelope, AgentTimelin
 use crate::worker_agent_runtime::NativeAgentTraceSink;
 use crate::worker_protocol::WorkerRequest;
 use crate::worker_request_id::next_worker_request_correlation;
+use crate::worker_rollout::should_persist_agent_runtime_event;
 use crate::{call_rust_state_service, tauri_safe_event_name};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -137,7 +138,6 @@ enum TracePersistenceCommand {
         session_id: String,
         run_id: String,
         event: AgentRuntimeEventEnvelope,
-        flush_after: bool,
     },
     Flush(mpsc::SyncSender<Result<(), String>>),
     Shutdown,
@@ -222,10 +222,6 @@ impl BufferedNativeAgentTraceSink {
             session_id: session_id.to_string(),
             run_id: run_id.to_string(),
             event: event.clone(),
-            flush_after: !matches!(
-                event.event_name.as_str(),
-                "agent.delta" | "agent.reasoning_delta"
-            ),
         };
         if self.worker.sender.send(command).is_err() {
             self.worker.queued_events.fetch_sub(1, Ordering::Relaxed);
@@ -253,12 +249,14 @@ impl NativeAgentTraceSink for BufferedNativeAgentTraceSink {
         event: &AgentRuntimeEventEnvelope,
     ) -> Result<(), String> {
         let live_result = self.live_sink.append_trace_event(session_id, run_id, event);
+        if !should_persist_agent_runtime_event(&event.event_name, &event.payload) {
+            crate::runtime::observability::global_agent_runtime_metrics()
+                .increment("persistence.events.filtered");
+            return live_result;
+        }
         let enqueue_result = self.enqueue_event(session_id, run_id, event);
         live_result.and(enqueue_result)?;
-        if !matches!(
-            event.event_name.as_str(),
-            "agent.delta" | "agent.reasoning_delta"
-        ) {
+        if agent_runtime_event_requires_durable_boundary(event) {
             self.flush()?;
         }
         Ok(())
@@ -342,7 +340,6 @@ fn run_trace_persistence_worker(
                 session_id,
                 run_id,
                 event,
-                flush_after,
             } => {
                 if !pending_events.is_empty()
                     && (pending_session_id != session_id || pending_run_id != run_id)
@@ -363,7 +360,7 @@ fn run_trace_persistence_worker(
                     pending_started_at = Some(Instant::now());
                 }
                 pending_events.push(event);
-                if flush_after || pending_events.len() >= TRACE_PERSISTENCE_BATCH_SIZE {
+                if pending_events.len() >= TRACE_PERSISTENCE_BATCH_SIZE {
                     persist_pending_trace_events(
                         durable_sink.as_ref(),
                         &pending_session_id,
@@ -401,6 +398,15 @@ fn run_trace_persistence_worker(
             }
         }
     }
+}
+
+fn agent_runtime_event_requires_durable_boundary(event: &AgentRuntimeEventEnvelope) -> bool {
+    event.event_name == "agent.status"
+        && event
+            .payload
+            .get("isBlocking")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(true)
 }
 
 fn persist_pending_trace_events(
@@ -518,7 +524,10 @@ pub(crate) fn native_agent_trace_sink(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent_loop_runtime_protocol::AgentRunEmitter;
+    use crate::agent_loop_runtime_protocol::{
+        AgentRunEmitter, AgentRuntimeEventAppendInput, AgentRuntimeEventSource,
+        AgentRuntimeEventVisibility, AgentRuntimePhase,
+    };
 
     #[derive(Default)]
     struct RecordingTraceSink {
@@ -581,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn buffered_trace_sink_emits_live_event_before_slow_persistence_finishes() {
+    fn buffered_trace_sink_keeps_delta_live_without_durable_persistence() {
         let durable = Arc::new(RecordingTraceSink::with_delay(Duration::from_millis(200)));
         let live = Arc::new(RecordingTraceSink::default());
         let sink = BufferedNativeAgentTraceSink::new(durable.clone(), live.clone());
@@ -599,11 +608,11 @@ mod tests {
         assert_eq!(live.event_count(), 1);
         assert_eq!(durable.event_count(), 0);
         sink.flush().expect("durable trace should flush");
-        assert_eq!(durable.event_count(), 1);
+        assert_eq!(durable.event_count(), 0);
     }
 
     #[test]
-    fn buffered_trace_sink_batches_adjacent_delta_events_in_order() {
+    fn buffered_trace_sink_does_not_queue_adjacent_delta_events_for_persistence() {
         let durable = Arc::new(RecordingTraceSink::default());
         let live = Arc::new(RecordingTraceSink::default());
         let sink = BufferedNativeAgentTraceSink::new(durable.clone(), live.clone());
@@ -618,7 +627,104 @@ mod tests {
         sink.flush().expect("durable trace should flush");
 
         assert_eq!(live.event_count(), 2);
+        assert!(durable.batch_sizes().is_empty());
+        assert_eq!(durable.event_count(), 0);
+    }
+
+    #[test]
+    fn buffered_trace_sink_batches_adjacent_canonical_events_until_explicit_flush() {
+        let durable = Arc::new(RecordingTraceSink::default());
+        let live = Arc::new(RecordingTraceSink::default());
+        let sink = BufferedNativeAgentTraceSink::new(durable.clone(), live.clone());
+        let mut emitter = AgentRunEmitter::new("session-1", "run-1");
+        let first = emitter.tool_start(
+            "unix-ms:1",
+            "tool-1",
+            "workspace.read_file",
+            serde_json::json!({ "path": "first.md" }),
+        );
+        let second = emitter.tool_result(
+            "unix-ms:2",
+            "tool-1",
+            "workspace.read_file",
+            serde_json::json!({ "content": "done" }),
+        );
+
+        sink.append_trace_event("session-1", "run-1", &first)
+            .expect("first event should enqueue");
+        sink.append_trace_event("session-1", "run-1", &second)
+            .expect("second event should enqueue");
+        sink.flush().expect("durable trace should flush");
+
+        assert_eq!(live.event_count(), 2);
         assert_eq!(durable.batch_sizes(), vec![2]);
-        assert_eq!(durable.event_count(), 2);
+    }
+
+    #[test]
+    fn buffered_trace_sink_persists_only_blocking_status_progress() {
+        let durable = Arc::new(RecordingTraceSink::default());
+        let live = Arc::new(RecordingTraceSink::default());
+        let sink = BufferedNativeAgentTraceSink::new(durable.clone(), live.clone());
+        let mut emitter = AgentRunEmitter::new("session-1", "run-1");
+        let phase = emitter.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.phase.changed".to_string(),
+            phase: AgentRuntimePhase::Planning,
+            timestamp: "unix-ms:1".to_string(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::Debug,
+            payload: serde_json::json!({
+                "previousPhase": "queued",
+                "nextPhase": "planning",
+                "iteration": 1,
+            }),
+        });
+        let status = emitter.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.status".to_string(),
+            phase: AgentRuntimePhase::Planning,
+            timestamp: "unix-ms:2".to_string(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({
+                "phase": "planning",
+                "label": "Planning",
+                "iteration": 1,
+                "isBlocking": false,
+            }),
+        });
+        let blocking_status = emitter.emit(AgentRuntimeEventAppendInput {
+            parent_turn_id: None,
+            item_id: None,
+            event_name: "agent.status".to_string(),
+            phase: AgentRuntimePhase::AwaitingApproval,
+            timestamp: "unix-ms:3".to_string(),
+            source: AgentRuntimeEventSource::RustBackend,
+            visibility: AgentRuntimeEventVisibility::User,
+            payload: serde_json::json!({
+                "phase": "awaiting_approval",
+                "label": "Waiting for approval",
+                "iteration": 1,
+                "isBlocking": true,
+            }),
+        });
+
+        sink.append_trace_event("session-1", "run-1", &phase)
+            .expect("phase event should remain live");
+        sink.append_trace_event("session-1", "run-1", &status)
+            .expect("status event should remain live");
+        sink.append_trace_event("session-1", "run-1", &blocking_status)
+            .expect("blocking status should persist");
+        assert_eq!(
+            durable.event_count(),
+            1,
+            "blocking status must cross a durable barrier before append returns"
+        );
+        sink.flush().expect("trace sink should flush");
+
+        assert_eq!(live.event_count(), 3);
+        assert_eq!(durable.event_count(), 1);
     }
 }

--- a/src-tauri/src/native_agent_bridge/webui_continuation.rs
+++ b/src-tauri/src/native_agent_bridge/webui_continuation.rs
@@ -74,7 +74,10 @@ pub(crate) fn pending_approvals_from_checkpoint(
 
 #[cfg(test)]
 mod tests {
-    use super::{native_approval_continuation_spec, pending_approvals_from_checkpoint};
+    use super::{
+        finish_native_agent_run, native_approval_continuation_spec,
+        pending_approvals_from_checkpoint,
+    };
 
     #[test]
     fn pending_approvals_preserve_runtime_tool_approval_id() {
@@ -128,6 +131,37 @@ mod tests {
 
         assert_eq!(continuation["traceContext"], checkpoint["traceContext"]);
         assert_eq!(continuation["metadata"]["commandId"], "command-approval-1");
+    }
+
+    #[test]
+    fn continuation_run_reports_both_runtime_and_flush_failures() {
+        let error = finish_native_agent_run::<()>(
+            Err("runtime failed".to_string()),
+            Err("flush failed".to_string()),
+            "native agent continuation",
+        )
+        .expect_err("both failures should be reported");
+
+        assert_eq!(
+            error,
+            "native agent continuation failed: runtime failed; trace persistence flush failed: \
+             flush failed"
+        );
+    }
+}
+
+fn finish_native_agent_run<T>(
+    run_result: Result<T, String>,
+    flush_result: Result<(), String>,
+    label: &str,
+) -> Result<T, String> {
+    match (run_result, flush_result) {
+        (Ok(result), Ok(())) => Ok(result),
+        (Err(run_error), Ok(())) => Err(run_error),
+        (Ok(_), Err(flush_error)) => Err(flush_error),
+        (Err(run_error), Err(flush_error)) => Err(format!(
+            "{label} failed: {run_error}; trace persistence flush failed: {flush_error}"
+        )),
     }
 }
 
@@ -333,14 +367,18 @@ pub(crate) async fn resolve_approval_continuation_with_services(
         config_snapshot.clone(),
         None,
     ));
-    let mut continuation = run_native_agent_turn_with_workspace_async(
+    let run_result = run_native_agent_turn_with_workspace_async(
         &services,
         continuation_spec.clone(),
         config_snapshot.clone(),
         &workspace_root,
     )
-    .await?;
-    services.flush_trace_sink()?;
+    .await;
+    let mut continuation = finish_native_agent_run(
+        run_result,
+        services.flush_trace_sink(),
+        "native approval continuation",
+    )?;
     persist_native_agent_run_terminal_if_present(
         continuation_spec.clone(),
         &mut continuation,
@@ -655,14 +693,18 @@ pub(crate) async fn resolve_agent_ui_form_with_services(
         config_snapshot.clone(),
         None,
     ));
-    let mut continuation = run_native_agent_turn_with_workspace_async(
+    let run_result = run_native_agent_turn_with_workspace_async(
         &services,
         continuation_spec.clone(),
         config_snapshot.clone(),
         &workspace_root,
     )
-    .await?;
-    services.flush_trace_sink()?;
+    .await;
+    let mut continuation = finish_native_agent_run(
+        run_result,
+        services.flush_trace_sink(),
+        "native Agent UI form continuation",
+    )?;
     persist_native_agent_run_terminal_if_present(
         continuation_spec.clone(),
         &mut continuation,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2156,21 +2156,37 @@ fn worker_run_agent_persists_agent_run_record_and_keeps_history_compact() {
         .expect("runtime events should be returned");
     let durable_runtime_events = result_runtime_events
         .iter()
-        .filter(|event| event["eventName"] != "agent.provider.requested")
+        .filter(|event| {
+            event["eventName"].as_str().is_none_or(|event_name| {
+                crate::worker_rollout::should_persist_agent_runtime_event(
+                    event_name,
+                    event.get("payload").unwrap_or(event),
+                )
+            })
+        })
         .collect::<Vec<_>>();
     assert!(result_runtime_events
         .iter()
         .any(|event| event["eventName"] == "agent.provider.requested"));
     assert_eq!(trace_events.len(), durable_runtime_events.len());
+    assert!(
+        trace_events.len() < result_runtime_events.len(),
+        "live-only progress must not be copied into the canonical Rollout"
+    );
     for (persisted, emitted) in trace_events.iter().zip(durable_runtime_events) {
         assert_eq!(persisted["eventId"], emitted["eventId"]);
     }
     assert_eq!(trace_events[0]["schemaVersion"], "tinybot.agent_event.v1");
-    assert_eq!(trace_events[0]["eventName"], "agent.phase.changed");
-    assert_eq!(trace_events[0]["sequence"], 1);
-    assert_eq!(trace_events[0]["payload"]["nextPhase"], "hydrating_history");
-    assert_eq!(trace_events[1]["eventName"], "agent.phase.changed");
-    assert_eq!(trace_events[1]["payload"]["nextPhase"], "planning");
+    assert!(trace_events.iter().all(|event| {
+        event["eventName"] != "agent.delta"
+            && event["eventName"] != "agent.reasoning_delta"
+            && event["eventName"] != "agent.phase.changed"
+            && event["eventName"] != "agent.provider.requested"
+    }));
+    assert!(trace_events.iter().all(|event| {
+        event["eventName"] != "agent.status"
+            || event["payload"]["isBlocking"].as_bool() != Some(false)
+    }));
     let turn_started = trace_events
         .iter()
         .find(|event| event["eventName"] == "agent.turn.started")
@@ -2180,17 +2196,9 @@ fn worker_run_agent_persists_agent_run_record_and_keeps_history_compact() {
         turn_started["payload"]["userMessage"]["content"],
         "read and answer"
     );
-    assert!(trace_events.iter().any(|event| {
-        event["eventName"] == "agent.phase.changed"
-            && event["payload"]["nextPhase"] == "calling_model"
-    }));
     assert!(trace_events
         .iter()
         .any(|event| event["eventName"] == "agent.tool.result"));
-    assert!(trace_events.iter().any(|event| {
-        event["eventName"] == "agent.phase.changed"
-            && event["payload"]["nextPhase"] == "tool_calling"
-    }));
     let tool_result = trace_events
         .iter()
         .find(|event| event["eventName"] == "agent.tool.result")
@@ -2201,9 +2209,6 @@ fn worker_run_agent_persists_agent_run_record_and_keeps_history_compact() {
     assert!(tool_result["sequence"]
         .as_u64()
         .is_some_and(|value| value > 1));
-    assert!(trace_events.iter().any(|event| {
-        event["eventName"] == "agent.phase.changed" && event["payload"]["nextPhase"] == "finalizing"
-    }));
     assert_eq!(history["messages"].as_array().unwrap().len(), 2);
     assert!(history["messages"]
         .as_array()

--- a/src-tauri/src/worker_rollout/mod.rs
+++ b/src-tauri/src/worker_rollout/mod.rs
@@ -3,7 +3,8 @@ mod reconstruction;
 mod types;
 
 pub use self::policy::{
-    bound_persisted_trace_value, should_persist_rollout_item, ROLLOUT_TRACE_STRING_LIMIT,
+    bound_persisted_trace_value, should_persist_agent_runtime_event, should_persist_rollout_item,
+    ROLLOUT_TRACE_STRING_LIMIT,
 };
 pub use self::reconstruction::{
     effective_rollout_line_indexes, latest_effective_compaction_index, reconstruct_rollout,

--- a/src-tauri/src/worker_rollout/policy.rs
+++ b/src-tauri/src/worker_rollout/policy.rs
@@ -6,6 +6,21 @@ use serde_json::Value;
 
 pub const ROLLOUT_TRACE_STRING_LIMIT: usize = 256;
 
+pub fn should_persist_agent_runtime_event(event_name: &str, payload: &Value) -> bool {
+    match event_name {
+        "agent.delta"
+        | "agent.reasoning_delta"
+        | "agent.timeline.patch"
+        | "agent.phase.changed"
+        | "agent.provider.requested" => false,
+        "agent.status" => payload
+            .get("isBlocking")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        _ => true,
+    }
+}
+
 pub fn should_persist_rollout_item(item: &RolloutItem) -> Result<bool, WorkerProtocolError> {
     match item {
         RolloutItem::SessionMeta(_)
@@ -130,13 +145,15 @@ fn persisted_event_needs_trace_context(event_name: &str) -> bool {
 }
 
 fn is_transient_agent_trace(payload: &Value) -> bool {
-    matches!(
-        payload
-            .get("event")
-            .and_then(|event| event.get("eventName"))
-            .and_then(Value::as_str),
-        Some("agent.delta" | "agent.reasoning_delta" | "agent.timeline.patch")
-    )
+    let Some(event) = payload.get("event") else {
+        return false;
+    };
+    event
+        .get("eventName")
+        .and_then(Value::as_str)
+        .is_some_and(|event_name| {
+            !should_persist_agent_runtime_event(event_name, event.get("payload").unwrap_or(event))
+        })
 }
 
 fn persistence_policy_error(message: &str, detail: Value) -> WorkerProtocolError {
@@ -159,14 +176,23 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn policy_drops_streaming_trace_but_keeps_durable_trace() {
-        let transient = RolloutItem::EventMsg(EventMsg::new(
-            EventKind::AgentRunTrace,
-            json!({
-                "runId": "run-1",
-                "event": {"eventName": "agent.delta", "payload": {"delta": "x"}}
-            }),
-        ));
+    fn policy_drops_live_only_trace_but_keeps_durable_trace() {
+        for event_name in [
+            "agent.delta",
+            "agent.reasoning_delta",
+            "agent.timeline.patch",
+            "agent.phase.changed",
+            "agent.provider.requested",
+        ] {
+            let transient = RolloutItem::EventMsg(EventMsg::new(
+                EventKind::AgentRunTrace,
+                json!({
+                    "runId": "run-1",
+                    "event": {"eventName": event_name, "payload": {"delta": "x"}}
+                }),
+            ));
+            assert!(!should_persist_rollout_item(&transient).unwrap());
+        }
         let durable = RolloutItem::EventMsg(EventMsg::new(
             EventKind::AgentRunTrace,
             json!({
@@ -175,8 +201,29 @@ mod tests {
             }),
         ));
 
-        assert!(!should_persist_rollout_item(&transient).unwrap());
         assert!(should_persist_rollout_item(&durable).unwrap());
+        let progress_status = RolloutItem::EventMsg(EventMsg::new(
+            EventKind::AgentRunTrace,
+            json!({
+                "runId": "run-1",
+                "event": {
+                    "eventName": "agent.status",
+                    "payload": {"phase": "planning", "isBlocking": false}
+                }
+            }),
+        ));
+        assert!(!should_persist_rollout_item(&progress_status).unwrap());
+        let blocking_status = RolloutItem::EventMsg(EventMsg::new(
+            EventKind::AgentRunTrace,
+            json!({
+                "runId": "run-1",
+                "event": {
+                    "eventName": "agent.status",
+                    "payload": {"phase": "awaiting_approval", "isBlocking": true}
+                }
+            }),
+        ));
+        assert!(should_persist_rollout_item(&blocking_status).unwrap());
     }
 
     #[test]

--- a/src-tauri/src/worker_thread_log/README.md
+++ b/src-tauri/src/worker_thread_log/README.md
@@ -60,8 +60,19 @@ context, agent runs, checkpoints, and token usage.
 - Diagnostic agent trace may be bounded, but canonical messages, completed
   reasoning, tool calls, and tool outputs are materialized from the lossless
   runtime event first and never reconstructed from truncated text.
-- Streaming reasoning deltas remain presentation events. One completed
-  reasoning ResponseItem is persisted per model call.
+- Streaming deltas, phase changes, and non-blocking status updates remain live
+  presentation events. Blocking status boundaries remain persisted for
+  recovery. One completed reasoning ResponseItem is persisted per model call.
+- Ordinary canonical runtime events are durably appended in batches of up to
+  64 events or 50 milliseconds. Blocking status and run/continuation exit
+  remain explicit synchronous durability barriers.
+- A trace batch is appended as one recorder transaction and response-backed
+  projection replays the Rollout at most once for the whole batch.
+- `AddItems` only stages ordered lines in the writer. `Persist`, `Flush`, or
+  `Shutdown` owns the file write/flush barrier; an append must not auto-flush
+  and then immediately flush again through `Persist`.
+- Repeating an identical full Thread record is a metadata no-op and must not
+  append another snapshot.
 
 See [`worker_thread`](../worker_thread/README.md) for the typed Thread domain and
 [`worker_session`](../worker_session/README.md) for session-shaped projections.

--- a/src-tauri/src/worker_thread_log/mod.rs
+++ b/src-tauri/src/worker_thread_log/mod.rs
@@ -25,9 +25,11 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 static CONTEXT_CHECKPOINT_COMMIT_LOCK: Mutex<()> = Mutex::new(());
+static THREAD_RECORD_CACHE: OnceLock<Mutex<HashMap<PathBuf, CachedThreadRecord>>> = OnceLock::new();
+const THREAD_RECORD_CACHE_CAPACITY: usize = 64;
 pub use self::reader::read_thread_lines;
 use self::reader::read_thread_lines_for_discovery;
 use self::recorder::ThreadLogHead;
@@ -113,6 +115,12 @@ struct CanonicalThreadState {
 struct CachedRolloutReconstruction {
     head: ThreadLogHead,
     reconstruction: reconstruction::CanonicalRolloutReconstruction,
+}
+
+#[derive(Clone, Debug)]
+struct CachedThreadRecord {
+    head: ThreadLogHead,
+    record: ThreadRecord,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -376,7 +384,9 @@ impl WorkerThreadLogRpc {
                 archived_at: None,
             };
             let log_head = self.recorder.thread_log_head(&path)?;
-            self.state.upsert_thread_projection(&record, &log_head)
+            self.state.upsert_thread_projection(&record, &log_head)?;
+            cache_thread_record(&path, log_head, thread.clone());
+            Ok(())
         })();
         if let Err(error) = result {
             if let Err(cleanup_error) = self.recorder.delete_rollout(&path) {
@@ -395,6 +405,13 @@ impl WorkerThreadLogRpc {
         existing: &ThreadStateRecord,
         thread: &ThreadRecord,
     ) -> Result<(), WorkerProtocolError> {
+        let path = PathBuf::from(&existing.thread_path);
+        self.recorder.validate_thread_path(&path)?;
+        if self.latest_persisted_thread_record(&path)? == *thread {
+            crate::runtime::observability::global_agent_runtime_metrics()
+                .increment("persistence.metadata.noop");
+            return Ok(());
+        }
         let target_preview = thread.metadata.preview.clone().unwrap_or_default();
         let target_cwd = thread
             .metadata
@@ -441,8 +458,6 @@ impl WorkerThreadLogRpc {
                 .as_deref()
                 .unwrap_or(&thread.updated_at),
         )?;
-        let path = PathBuf::from(&existing.thread_path);
-        self.recorder.validate_thread_path(&path)?;
         self.recorder.append_item(
             &path,
             timestamp,
@@ -460,9 +475,64 @@ impl WorkerThreadLogRpc {
             canonical.latest_checkpoint.as_ref(),
             &ThreadLogHead {
                 byte_length: canonical.log_head.byte_length,
+                tail_hash: canonical.log_head.tail_hash.clone(),
+            },
+        )?;
+        cache_thread_record(
+            &path,
+            ThreadLogHead {
+                byte_length: canonical.log_head.byte_length,
                 tail_hash: canonical.log_head.tail_hash,
             },
-        )
+            thread.clone(),
+        );
+        Ok(())
+    }
+
+    fn latest_persisted_thread_record(
+        &self,
+        path: &Path,
+    ) -> Result<ThreadRecord, WorkerProtocolError> {
+        let head = self.recorder.thread_log_head(path)?;
+        {
+            let cache = thread_record_cache().lock().map_err(|_| {
+                thread_log_consistency_error(
+                    "thread record cache lock was poisoned",
+                    serde_json::json!({ "threadPath": path.display().to_string() }),
+                )
+            })?;
+            if let Some(cached) = cache.get(path) {
+                if cached.head == head {
+                    return Ok(cached.record.clone());
+                }
+            }
+        }
+        let lines = read_thread_lines(path)?;
+        let value = lines
+            .iter()
+            .rev()
+            .filter_map(|line| match &line.item {
+                ThreadLogItem::EventMsg(event) => event.payload().get("threadRecord"),
+                _ => None,
+            })
+            .next()
+            .ok_or_else(|| {
+                thread_log_consistency_error(
+                    "canonical Rollout is missing its thread record snapshot",
+                    serde_json::json!({ "threadPath": path.display().to_string() }),
+                )
+            })?;
+        let record = serde_json::from_value::<ThreadRecord>(value.clone()).map_err(|error| {
+            thread_log_consistency_error(
+                "canonical Rollout contains an invalid thread record snapshot",
+                serde_json::json!({
+                    "threadPath": path.display().to_string(),
+                    "error": error.to_string(),
+                }),
+            )
+        })?;
+        cache_thread_record_checked(path, head, record.clone())?;
+        Ok(record)
     }
 
     pub fn append_thread_items(
@@ -4429,6 +4499,35 @@ fn thread_log_consistency_error(message: impl Into<String>, details: Value) -> W
     )
 }
 
+fn thread_record_cache() -> &'static Mutex<HashMap<PathBuf, CachedThreadRecord>> {
+    THREAD_RECORD_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cache_thread_record(path: &Path, head: ThreadLogHead, record: ThreadRecord) {
+    cache_thread_record_checked(path, head, record)
+        .expect("thread record cache lock should not be poisoned");
+}
+
+fn cache_thread_record_checked(
+    path: &Path,
+    head: ThreadLogHead,
+    record: ThreadRecord,
+) -> Result<(), WorkerProtocolError> {
+    let mut cache = thread_record_cache().lock().map_err(|_| {
+        thread_log_consistency_error(
+            "thread record cache lock was poisoned",
+            serde_json::json!({ "threadPath": path.display().to_string() }),
+        )
+    })?;
+    if cache.len() >= THREAD_RECORD_CACHE_CAPACITY && !cache.contains_key(path) {
+        if let Some(evicted) = cache.keys().next().cloned() {
+            cache.remove(&evicted);
+        }
+    }
+    cache.insert(path.to_path_buf(), CachedThreadRecord { head, record });
+    Ok(())
+}
+
 fn typed_response_item(
     mut value: Value,
     context: &str,
@@ -4595,5 +4694,88 @@ mod schema_tests {
             .message
             .contains("unsupported thread log schema version"));
         assert_eq!(error.details["supportedSchemaVersion"], 1);
+    }
+
+    #[test]
+    fn repeated_identical_thread_record_does_not_append_metadata_snapshot() {
+        let root = std::env::temp_dir().join(format!(
+            "tinybot-thread-metadata-noop-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock should be after unix epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).expect("test workspace should create");
+        let rpc = WorkerThreadLogRpc::new(
+            root.clone(),
+            CapabilityPolicy::new([WorkerCapability::SessionWrite]),
+        );
+        let mut thread = ThreadRecord {
+            thread_id: "thread-metadata-noop".to_string(),
+            title: "Metadata no-op".to_string(),
+            status: ThreadStatus::Idle,
+            session_key: Some("session-metadata-noop".to_string()),
+            root_run_id: None,
+            active_run_id: None,
+            parent_thread_id: None,
+            source: "test".to_string(),
+            created_at: "2026-07-20T00:00:00Z".to_string(),
+            updated_at: "2026-07-20T00:00:00Z".to_string(),
+            archived_at: None,
+            metadata: ThreadMetadata {
+                preview: Some("first preview".to_string()),
+                last_activity_at: Some("2026-07-20T00:00:00Z".to_string()),
+                extra: serde_json::json!({"clientThreadId": "client-thread-1"}),
+                ..Default::default()
+            },
+        };
+
+        rpc.create_from_thread_record(&thread)
+            .expect("initial thread record should persist");
+        let record = rpc
+            .state
+            .find_by_session_or_thread_id(&thread.thread_id)
+            .expect("thread lookup should succeed")
+            .expect("thread should be indexed");
+        let path = PathBuf::from(record.thread_path);
+        let initial_line_count = read_thread_lines(&path)
+            .expect("initial Rollout should read")
+            .len();
+        thread_record_cache()
+            .lock()
+            .expect("thread record cache should lock")
+            .remove(&path);
+        drop(rpc);
+        let rpc = WorkerThreadLogRpc::new(
+            root.clone(),
+            CapabilityPolicy::new([WorkerCapability::SessionWrite]),
+        );
+
+        rpc.create_from_thread_record(&thread)
+            .expect("identical thread record should be accepted after cache reset");
+        assert_eq!(
+            read_thread_lines(&path)
+                .expect("Rollout after no-op should read")
+                .len(),
+            initial_line_count,
+            "an identical thread record must not append another metadata snapshot"
+        );
+
+        thread.updated_at = "2026-07-20T00:00:01Z".to_string();
+        thread.metadata.last_activity_at = Some("2026-07-20T00:00:01Z".to_string());
+        thread.metadata.extra = serde_json::json!({"clientThreadId": "client-thread-2"});
+        rpc.create_from_thread_record(&thread)
+            .expect("changed thread record should persist");
+        assert_eq!(
+            read_thread_lines(&path)
+                .expect("Rollout after metadata change should read")
+                .len(),
+            initial_line_count + 1,
+            "a changed thread record should append exactly one metadata snapshot"
+        );
+
+        drop(rpc);
+        std::fs::remove_dir_all(root).expect("test workspace should clean up");
     }
 }

--- a/src-tauri/src/worker_thread_log/recorder.rs
+++ b/src-tauri/src/worker_thread_log/recorder.rs
@@ -910,6 +910,47 @@ mod tests {
     }
 
     #[test]
+    fn recorder_add_items_waits_for_an_explicit_durable_barrier() {
+        let root = temp_root("add-items-buffered");
+        let _ = fs::remove_dir_all(&root);
+        let recorder = ThreadRecorder::new(root.clone());
+        let path = recorder
+            .create_thread(thread_meta(
+                &root,
+                "thread-add-items-buffered",
+                "2026-07-08T10:12:30Z",
+            ))
+            .unwrap();
+
+        recorder
+            .add_items(
+                &path,
+                "2026-07-08T10:13:30Z".to_string(),
+                vec![value_event(
+                    EventKind::UserMessage,
+                    serde_json::json!({ "barrier": "persist" }),
+                )],
+            )
+            .unwrap();
+
+        assert_eq!(
+            recorder
+                .writer(&path)
+                .unwrap()
+                .pending_item_count()
+                .unwrap(),
+            1,
+            "AddItems must stay buffered until Persist, Flush, or Shutdown"
+        );
+        assert_eq!(read_thread_lines(&path).unwrap().len(), 1);
+
+        recorder.persist(&path).unwrap();
+        assert_eq!(read_thread_lines(&path).unwrap().len(), 2);
+        recorder.shutdown(&path).unwrap();
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn recorder_fails_fast_on_corrupt_canonical_ordinal() {
         let root = temp_root("corrupt-ordinal");
         let _ = fs::remove_dir_all(&root);

--- a/src-tauri/src/worker_thread_log/rollout_writer.rs
+++ b/src-tauri/src/worker_thread_log/rollout_writer.rs
@@ -14,6 +14,10 @@ static ROLLOUT_PATH_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>> = 
 
 enum RolloutWriterCommand {
     AddItems(Vec<RolloutLine>),
+    #[cfg(test)]
+    PendingItemCount {
+        ack: mpsc::Sender<usize>,
+    },
     Persist {
         ack: mpsc::Sender<Result<(), WorkerProtocolError>>,
     },
@@ -162,6 +166,18 @@ impl RolloutWriter {
 
     pub(super) fn flush(&self) -> Result<(), WorkerProtocolError> {
         self.barrier("flush", |ack| RolloutWriterCommand::Flush { ack })
+    }
+
+    #[cfg(test)]
+    pub(super) fn pending_item_count(&self) -> Result<usize, WorkerProtocolError> {
+        let (ack_tx, ack_rx) = mpsc::channel();
+        self.send_command(
+            "pending_item_count",
+            RolloutWriterCommand::PendingItemCount { ack: ack_tx },
+        )?;
+        ack_rx
+            .recv()
+            .map_err(|_| self.command_channel_error("pending_item_count"))
     }
 
     pub(super) fn shutdown(&self) -> Result<(), WorkerProtocolError> {
@@ -322,15 +338,6 @@ impl RolloutWriterState {
 
     fn add_items(&mut self, items: Vec<RolloutLine>) {
         self.pending_items.extend(items);
-    }
-
-    fn flush_if_materialized(&mut self) {
-        if self.file.is_none() {
-            return;
-        }
-        if let Err(error) = self.flush() {
-            self.enter_recovery_mode(&error);
-        }
     }
 
     fn persist(&mut self) -> Result<(), WorkerProtocolError> {
@@ -575,7 +582,10 @@ fn run_rollout_writer(
         match command {
             RolloutWriterCommand::AddItems(items) => {
                 state.add_items(items);
-                state.flush_if_materialized();
+            }
+            #[cfg(test)]
+            RolloutWriterCommand::PendingItemCount { ack } => {
+                let _ = ack.send(state.pending_items.len());
             }
             RolloutWriterCommand::Persist { ack } => {
                 let _ = ack.send(state.persist());


### PR DESCRIPTION
## Summary
- reduce redundant rollout persistence writes
- centralize rollout append behavior and preserve ordering
- update focused persistence coverage

## Verification
- branch changes were previously exercised by the Rust library test suite
- merge requested without waiting for CI