### PR TITLE
Prepare Tinybot Desktop v0.1.1 release

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -3,7 +3,7 @@ name: Release Windows x64
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
 
 permissions:
   contents: write
@@ -20,6 +20,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release source
+        shell: pwsh
+        run: |
+          git merge-base --is-ancestor "${{ github.sha }}" origin/master
+          if ($LASTEXITCODE -ne 0) {
+            throw "Release tags must point to a commit on master"
+          }
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -63,7 +73,10 @@ jobs:
           tagName: v__VERSION__
           releaseName: Tinybot Desktop v__VERSION__
           releaseBody: |
-            Initial Windows x64 release of Tinybot Desktop.
+            Tinybot Desktop for Windows x64.
+
+            > [!WARNING]
+            > Tinybot's Rust backend is under active development. This release may contain breaking changes, and data created by earlier versions may not remain compatible. Back up important `.tinybot` data before upgrading.
 
             The installer is not Authenticode-signed yet, so Windows SmartScreen may show an unknown publisher warning.
           releaseDraft: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinybot-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinybot-desktop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/code": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinybot-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "tinybot-desktop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinybot-desktop"
-version = "0.1.0"
+version = "0.1.1"
 description = "Tinybot lightweight desktop host"
 authors = ["Tinybot contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tinybot Desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.sudojacky.tinybot.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- bump the desktop application version to 0.1.1 across npm, Cargo, and Tauri metadata
- require release tags to point to commits on master
- use reusable release warnings together with GitHub-generated release notes

## Why

Prepare the signed Windows x64 release while keeping release documentation simple and preventing tags from publishing unmerged commits.

## Validation

- node .github/scripts/check-release-version.mjs v0.1.1
- npm test (77 files, 573 tests passed)
- npm run build
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo test --manifest-path src-tauri/Cargo.toml --lib desktop_update::tests -j 4 -- --test-threads=1 (3 passed)
- cargo metadata --manifest-path src-tauri/Cargo.toml --locked --no-deps --format-version 1
- git diff --check