### PR TITLE
Stabilize browser navigation test for v0.1.1 release

### DIFF
--- a/src/react-workbench/chat/LiveCanvas.test.tsx
+++ b/src/react-workbench/chat/LiveCanvas.test.tsx
@@ -858,6 +858,7 @@ describe("LiveCanvas TinyOS", () => {
     const address = within(browser).getByRole("textbox", { name: "Browser address" });
     await user.clear(address);
     await user.type(address, "example.net/path");
+    await waitFor(() => expect((address as HTMLInputElement).value).toBe("example.net/path"));
     await user.click(within(browser).getByRole("button", { name: "Go" }));
     expect(runtime.navigate).toHaveBeenCalledWith("browser-session-1", "tab-1", "https://example.net/path");
 


### PR DESCRIPTION
## Summary

- wait for the controlled browser address input to contain the complete typed value before submitting navigation
- keep the existing full URL assertion unchanged

## Root cause

The LiveCanvas navigation test submitted immediately after simulated typing. Under the Windows release runner load, the controlled React input occasionally had only committed `example.net` when Go was clicked, so the test observed a truncated navigation call. The product URL normalization path was not involved.

## Validation

- targeted browser navigation test passed 10 consecutive runs
- npm test (77 files, 573 tests passed)
- git diff --check