### PR TITLE
test: stabilize browser address navigation

### DIFF
--- a/src/react-workbench/chat/LiveCanvas.test.tsx
+++ b/src/react-workbench/chat/LiveCanvas.test.tsx
@@ -856,9 +856,8 @@ describe("LiveCanvas TinyOS", () => {
     expect(runtime.back).toHaveBeenCalledWith("browser-session-1", "tab-1");
 
     const address = within(browser).getByRole("textbox", { name: "Browser address" });
-    await user.clear(address);
-    await user.type(address, "example.net/path");
-    await waitFor(() => expect((address as HTMLInputElement).value).toBe("example.net/path"));
+    fireEvent.change(address, { target: { value: "example.net/path" } });
+    expect((address as HTMLInputElement).value).toBe("example.net/path");
     await user.click(within(browser).getByRole("button", { name: "Go" }));
     expect(runtime.navigate).toHaveBeenCalledWith("browser-session-1", "tab-1", "https://example.net/path");
 


### PR DESCRIPTION
## Summary
- replace per-keystroke address-bar input in the LiveCanvas navigation test with a deterministic change event
- keep the assertion focused on the browser navigation behavior exercised by the test

## Root cause
The Windows release runner intermittently stopped the synthetic per-character input at example.net before the Go action. The keystroke sequence is not part of the behavior under test, so runner load could fail the setup without exercising navigation.

## Verification
- Node.js 22 targeted LiveCanvas test
- Node.js 22 full frontend suite: 573/573 tests
- Node.js 22 production build
- targeted test repeated 10 times