### PR TITLE
Prepare Tinybot Desktop v0.1.2

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run updater tests
         working-directory: src-tauri
-        run: cargo test --lib desktop_update::tests -- --test-threads=1
+        run: cargo test --lib desktop::update::tests -- --test-threads=1
 
       - name: Build and upload signed updater artifacts
         uses: tauri-apps/tauri-action@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinybot-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinybot-desktop",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/code": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinybot-desktop",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "tinybot-desktop"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinybot-desktop"
-version = "0.1.1"
+version = "0.1.2"
 description = "Tinybot lightweight desktop host"
 authors = ["Tinybot contributors"]
 edition = "2021"

--- a/src-tauri/src/agent/runtime/instructions.rs
+++ b/src-tauri/src/agent/runtime/instructions.rs
@@ -508,30 +508,10 @@ fn instruction_working_directory(spec: &Value, workspace_root: &Path) -> Result<
         })
         .map(PathBuf::from)
         .unwrap_or_else(|| workspace_root.to_path_buf());
-    let working_directory = if candidate.is_absolute() {
-        candidate
-    } else {
-        workspace_root.join(candidate)
-    };
-    let metadata = fs::metadata(&working_directory).map_err(|error| {
-        format!(
-            "failed to inspect agent working directory `{}`: {error}",
-            working_directory.display()
-        )
-    })?;
-    if !metadata.is_dir() {
-        return Err(format!(
-            "agent working directory is not a directory: `{}`",
-            working_directory.display()
-        ));
-    }
-    fs::canonicalize(&working_directory).map_err(|error| {
-        format!(
-            "failed to resolve agent working directory `{}`: {error}",
-            working_directory.display()
-        )
-    })?;
-    Ok(working_directory)
+    crate::runtime::working_directory::resolve_existing_working_directory(
+        workspace_root,
+        &candidate,
+    )
 }
 
 fn project_instruction_paths(

--- a/src-tauri/src/desktop/bootstrap.rs
+++ b/src-tauri/src/desktop/bootstrap.rs
@@ -242,6 +242,7 @@ pub(crate) fn run() {
             crate::desktop_commands::config::apply_config_patch_result,
             crate::desktop_commands::config::apply_config_operations,
             crate::desktop::files::pick_chat_files,
+            crate::desktop::files::pick_workspace_directory,
             crate::desktop::files::pick_upload_file,
             crate::desktop::files::reveal_workspace_file,
             crate::desktop::files::save_export_file,

--- a/src-tauri/src/desktop/files.rs
+++ b/src-tauri/src/desktop/files.rs
@@ -103,6 +103,23 @@ pub(crate) fn pick_chat_files(
 }
 
 #[tauri::command]
+pub(crate) fn pick_workspace_directory(
+    options: UploadFilePickerOptions,
+) -> Result<Option<String>, String> {
+    let mut dialog = rfd::FileDialog::new();
+    if let Some(title) = options.title {
+        dialog = dialog.set_title(&title);
+    }
+    let Some(path) = dialog.pick_folder() else {
+        return Ok(None);
+    };
+    path.into_os_string()
+        .into_string()
+        .map(Some)
+        .map_err(|_| "selected workspace directory path is not valid UTF-8".to_string())
+}
+
+#[tauri::command]
 pub(crate) fn reveal_workspace_file(path: String) -> Result<(), String> {
     let target_path = reveal_workspace_file_path(&path)?;
     reveal_file_in_folder(&target_path)

--- a/src-tauri/src/rpc/tests/threads_and_tools.rs
+++ b/src-tauri/src/rpc/tests/threads_and_tools.rs
@@ -4348,6 +4348,31 @@ fn dispatches_agent_turn_store_round_trip_requests() {
         clear_checkpoint.result.as_ref().unwrap()["checkpoint"],
         json!(null)
     );
+    let fork = router.dispatch(&WorkerRequest::new(
+        "req-agent-turn-fork",
+        "trace-agent-turn",
+        "thread.fork",
+        json!({
+            "threadId": "session-1",
+            "clientEventId": "fork:session-1:turn-1"
+        }),
+    ));
+    assert_eq!(fork.error, None);
+    let fork_thread_id = fork.result.as_ref().unwrap()["threadId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let fork_turns = router.dispatch(&WorkerRequest::new(
+        "req-agent-turn-fork-list",
+        "trace-agent-turn",
+        "thread.turn.list",
+        json!({ "threadId": fork_thread_id }),
+    ));
+    assert_eq!(fork_turns.error, None);
+    assert_eq!(
+        fork_turns.result.as_ref().unwrap()["turns"][0]["sessionId"],
+        fork_thread_id
+    );
 
     assert_removed_persistence_paths_absent(&fixture.root);
 

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod lifecycle;
 pub(crate) mod mcp;
 pub(crate) mod observability;
 pub(crate) mod turn_execution;
+pub(crate) mod working_directory;

--- a/src-tauri/src/runtime/working_directory.rs
+++ b/src-tauri/src/runtime/working_directory.rs
@@ -1,0 +1,32 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn resolve_existing_working_directory(
+    workspace_root: &Path,
+    requested: &Path,
+) -> Result<PathBuf, String> {
+    let working_directory = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        workspace_root.join(requested)
+    };
+    let metadata = fs::metadata(&working_directory).map_err(|error| {
+        format!(
+            "failed to inspect working directory `{}`: {error}",
+            working_directory.display()
+        )
+    })?;
+    if !metadata.is_dir() {
+        return Err(format!(
+            "working directory is not a directory: `{}`",
+            working_directory.display()
+        ));
+    }
+    fs::canonicalize(&working_directory).map_err(|error| {
+        format!(
+            "failed to resolve working directory `{}`: {error}",
+            working_directory.display()
+        )
+    })?;
+    Ok(working_directory)
+}

--- a/src-tauri/src/threads/domain/mod.rs
+++ b/src-tauri/src/threads/domain/mod.rs
@@ -8,6 +8,7 @@ pub(crate) use self::store::{runtime_events_from_thread_items, turn_summaries_fr
 pub use self::store::{
     MemoryThreadStore, ThreadPersistenceRepairMode, ThreadPersistenceRepairRequest, ThreadStore,
 };
+use self::types::ThreadMetadataPatch;
 pub use self::types::{
     AppendThreadItemsRequest, AppendThreadItemsResult, ArchiveThreadRequest,
     ContinueThreadTurnRequest, CreateThreadRequest, DeleteThreadRequest, DeleteThreadResult,
@@ -31,16 +32,18 @@ use std::path::PathBuf;
 pub struct WorkerThreadRpc {
     store: MemoryThreadStore,
     runtime: ThreadRuntime<MemoryThreadStore>,
+    workspace_root: PathBuf,
     policy: CapabilityPolicy,
 }
 
 impl WorkerThreadRpc {
-    pub fn new(_workspace_root: PathBuf, policy: CapabilityPolicy) -> Self {
+    pub fn new(workspace_root: PathBuf, policy: CapabilityPolicy) -> Self {
         let store = MemoryThreadStore::default();
         let runtime = ThreadRuntime::new(store.clone());
         Self {
             store,
             runtime,
+            workspace_root,
             policy,
         }
     }
@@ -63,9 +66,10 @@ impl WorkerThreadRpc {
 
     pub fn create_thread(
         &self,
-        request: CreateThreadRequest,
+        mut request: CreateThreadRequest,
     ) -> Result<ThreadRecord, WorkerProtocolError> {
         self.require(WorkerCapability::SessionWrite)?;
+        self.resolve_metadata_working_directory("thread.create", &mut request.metadata)?;
         self.store.create_thread(request)
     }
 
@@ -111,9 +115,10 @@ impl WorkerThreadRpc {
 
     pub fn update_thread_metadata(
         &self,
-        request: UpdateThreadMetadataRequest,
+        mut request: UpdateThreadMetadataRequest,
     ) -> Result<ThreadRecord, WorkerProtocolError> {
         self.require(WorkerCapability::SessionWrite)?;
+        self.resolve_metadata_working_directory("thread.update_metadata", &mut request.metadata)?;
         let mut updated = self
             .store
             .update_thread_metadata(&request.thread_id, request.metadata)?;
@@ -123,6 +128,32 @@ impl WorkerThreadRpc {
                 .update_thread_session_key(&request.thread_id, session_key)?;
         }
         Ok(updated)
+    }
+
+    fn resolve_metadata_working_directory(
+        &self,
+        method: &str,
+        metadata: &mut ThreadMetadataPatch,
+    ) -> Result<(), WorkerProtocolError> {
+        let Some(requested) = metadata.working_directory.as_deref() else {
+            return Ok(());
+        };
+        let requested = requested.trim();
+        if requested.is_empty() {
+            return Err(thread_working_directory_error(
+                method,
+                requested,
+                "thread working directory must be a non-empty path".to_string(),
+            ));
+        }
+        let working_directory =
+            crate::runtime::working_directory::resolve_existing_working_directory(
+                &self.workspace_root,
+                std::path::Path::new(requested),
+            )
+            .map_err(|error| thread_working_directory_error(method, requested, error))?;
+        metadata.working_directory = Some(working_directory.display().to_string());
+        Ok(())
     }
 
     pub fn archive_thread(
@@ -288,4 +319,21 @@ impl WorkerThreadRpc {
             WorkerProtocolErrorSource::RustCore,
         ))
     }
+}
+
+fn thread_working_directory_error(
+    method: &str,
+    working_directory: &str,
+    message: String,
+) -> WorkerProtocolError {
+    WorkerProtocolError::new(
+        WorkerProtocolErrorCode::InvalidProtocol,
+        message,
+        serde_json::json!({
+            "method": method,
+            "workingDirectory": working_directory,
+        }),
+        false,
+        WorkerProtocolErrorSource::RustCore,
+    )
 }

--- a/src-tauri/src/threads/rollout/store/mod.rs
+++ b/src-tauri/src/threads/rollout/store/mod.rs
@@ -703,6 +703,7 @@ impl WorkerThreadLogRpc {
             fork_after_sequence,
             &fork.thread_id,
         )?;
+        let fork_session_id = fork.session_key.as_deref().unwrap_or(&fork.thread_id);
         let inherited_lines = inherited_indexes
             .into_iter()
             .filter_map(|index| {
@@ -710,7 +711,7 @@ impl WorkerThreadLogRpc {
                 fork_inherits_rollout_item(&line.item, include_checkpoints).then(|| ThreadLogLine {
                     timestamp: line.timestamp.clone(),
                     ordinal: None,
-                    item: line.item.clone(),
+                    item: forked_rollout_item(&line.item, fork_session_id, &fork.thread_id),
                 })
             })
             .collect::<Vec<_>>();
@@ -2465,6 +2466,38 @@ fn fork_inherits_rollout_item(item: &ThreadLogItem, include_checkpoints: bool) -
         Some(value) if value.starts_with("turn_") => false,
         Some("checkpoint_created") if !include_checkpoints => false,
         _ => true,
+    }
+}
+
+fn forked_rollout_item(
+    item: &ThreadLogItem,
+    fork_session_id: &str,
+    fork_thread_id: &str,
+) -> ThreadLogItem {
+    let ThreadLogItem::EventMsg(event) = item else {
+        return item.clone();
+    };
+    let mut payload = event.payload().clone();
+    let mut rebound = false;
+    if let Some(payload) = payload.as_object_mut() {
+        let identities = [("sessionId", fork_session_id), ("threadId", fork_thread_id)];
+        let mut rebind = |object: &mut serde_json::Map<String, Value>| {
+            for (field, value) in identities.iter().copied() {
+                if let Some(existing) = object.get_mut(field) {
+                    *existing = Value::String(value.to_string());
+                    rebound = true;
+                }
+            }
+        };
+        rebind(payload);
+        if let Some(turn) = payload.get_mut("turn").and_then(Value::as_object_mut) {
+            rebind(turn);
+        }
+    }
+    if rebound {
+        value_event(event.kind().clone(), payload)
+    } else {
+        item.clone()
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tinybot Desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.sudojacky.tinybot.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tests/crate/threads.rs
+++ b/src-tauri/tests/crate/threads.rs
@@ -541,6 +541,145 @@ fn worker_submit_thread_turn_uses_thread_id_as_rollout_id() {
 }
 
 #[test]
+fn thread_create_resolves_relative_working_directory_before_persistence() {
+    let fixture = WorkspaceFixture::new();
+    let working_directory = fixture.root.join("relative-thread-project");
+    std::fs::create_dir_all(&working_directory)
+        .expect("relative thread working directory should create");
+    let create_request = next_worker_request_correlation();
+
+    let created = call_rust_state_service(
+        &fixture.thread_store,
+        serde_json::json!({}),
+        WorkerRequest::new(
+            create_request.id("relative-thread-working-directory-create"),
+            create_request.trace_id("relative-thread-working-directory-create"),
+            "thread.create",
+            serde_json::json!({
+                "threadId": "thread-relative-working-directory",
+                "metadata": {
+                    "workingDirectory": "relative-thread-project"
+                }
+            }),
+        ),
+        "relative thread working directory create",
+    )
+    .expect("relative thread working directory should resolve");
+
+    assert_eq!(
+        created["metadata"]["workingDirectory"],
+        working_directory.display().to_string()
+    );
+    let read_request = next_worker_request_correlation();
+    let persisted = call_rust_state_service(
+        &fixture.thread_store,
+        serde_json::json!({}),
+        WorkerRequest::new(
+            read_request.id("relative-thread-working-directory-read"),
+            read_request.trace_id("relative-thread-working-directory-read"),
+            "thread.read",
+            serde_json::json!({
+                "threadId": "thread-relative-working-directory"
+            }),
+        ),
+        "relative thread working directory read",
+    )
+    .expect("resolved thread working directory should persist");
+    assert_eq!(
+        persisted["thread"]["metadata"]["workingDirectory"],
+        working_directory.display().to_string()
+    );
+}
+
+#[test]
+fn thread_working_directory_mutations_fail_before_persisting_invalid_paths() {
+    let fixture = WorkspaceFixture::new();
+    let valid_working_directory = fixture.root.join("valid-thread-project");
+    std::fs::create_dir_all(&valid_working_directory)
+        .expect("valid thread working directory should create");
+    let missing_working_directory = fixture.root.join("missing-thread-project");
+    let invalid_create_request = next_worker_request_correlation();
+
+    let create_error = call_rust_state_service(
+        &fixture.thread_store,
+        serde_json::json!({}),
+        WorkerRequest::new(
+            invalid_create_request.id("invalid-thread-working-directory-create"),
+            invalid_create_request.trace_id("invalid-thread-working-directory-create"),
+            "thread.create",
+            serde_json::json!({
+                "threadId": "thread-invalid-working-directory",
+                "metadata": {
+                    "workingDirectory": missing_working_directory
+                }
+            }),
+        ),
+        "invalid thread working directory create",
+    )
+    .expect_err("missing thread working directory must fail during create");
+    assert!(create_error.contains("failed to inspect working directory"));
+
+    let valid_create_request = next_worker_request_correlation();
+    call_rust_state_service(
+        &fixture.thread_store,
+        serde_json::json!({}),
+        WorkerRequest::new(
+            valid_create_request.id("valid-thread-working-directory-create"),
+            valid_create_request.trace_id("valid-thread-working-directory-create"),
+            "thread.create",
+            serde_json::json!({
+                "threadId": "thread-valid-working-directory",
+                "metadata": {
+                    "workingDirectory": valid_working_directory
+                }
+            }),
+        ),
+        "valid thread working directory create",
+    )
+    .expect("valid thread working directory should create");
+
+    let invalid_update_request = next_worker_request_correlation();
+    let update_error = call_rust_state_service(
+        &fixture.thread_store,
+        serde_json::json!({}),
+        WorkerRequest::new(
+            invalid_update_request.id("invalid-thread-working-directory-update"),
+            invalid_update_request.trace_id("invalid-thread-working-directory-update"),
+            "thread.update_metadata",
+            serde_json::json!({
+                "threadId": "thread-valid-working-directory",
+                "metadata": {
+                    "workingDirectory": missing_working_directory
+                }
+            }),
+        ),
+        "invalid thread working directory update",
+    )
+    .expect_err("missing thread working directory must fail during metadata update");
+    assert!(update_error.contains("failed to inspect working directory"));
+
+    let read_request = next_worker_request_correlation();
+    let persisted = call_rust_state_service(
+        &fixture.thread_store,
+        serde_json::json!({}),
+        WorkerRequest::new(
+            read_request.id("valid-thread-working-directory-read"),
+            read_request.trace_id("valid-thread-working-directory-read"),
+            "thread.read",
+            serde_json::json!({
+                "threadId": "thread-valid-working-directory"
+            }),
+        ),
+        "valid thread working directory read",
+    )
+    .expect("valid thread should remain readable after rejected update");
+    assert_eq!(
+        persisted["thread"]["metadata"]["workingDirectory"],
+        valid_working_directory.display().to_string()
+    );
+}
+
+#[test]
 fn worker_submit_thread_turn_does_not_require_a_session_key() {
     let fixture = WorkspaceFixture::new();
     let shared = Arc::new(Mutex::new(GatewayRuntime::with_thread_store(

--- a/src/app-core/chat/nativeChat.test.ts
+++ b/src/app-core/chat/nativeChat.test.ts
@@ -127,6 +127,25 @@ describe("native chat state", () => {
     ]);
   });
 
+  test("preserves canonical Thread working directories for workspace grouping", () => {
+    expect(
+      normalizeSessionsPayload({
+        threads: [
+          {
+            threadId: "thread-workspace",
+            title: "Workspace session",
+            metadata: {
+              workingDirectory: "D:\\Code\\py\\tinybot",
+            },
+          },
+        ],
+      })[0],
+    ).toMatchObject({
+      key: "thread-workspace",
+      workingDirectory: "D:\\Code\\py\\tinybot",
+    });
+  });
+
   test("canonicalizes legacy WebSocket session keys to the native backend key", () => {
     expect(
       normalizeSessionsPayload({

--- a/src/app-core/chat/nativeChat.ts
+++ b/src/app-core/chat/nativeChat.ts
@@ -20,6 +20,7 @@ export type NativeChatSession = {
   pinned?: boolean;
   archived?: boolean;
   status?: string;
+  workingDirectory?: string;
 };
 
 export type NativeChatMessage = {
@@ -142,6 +143,7 @@ export function normalizeSessionsPayload(payload: unknown): NativeChatSession[] 
     const key = isThreadList && threadId ? threadId : canonicalSessionKey(sourceKey, chatId) || chatId;
     const metadata = isRecord(item.metadata) ? item.metadata : {};
     const extra = isRecord(metadata.extra) ? metadata.extra : isRecord(item.extra) && isRecord(item.extra.metadata) ? item.extra.metadata : {};
+    const workingDirectory = stringValue(metadata.workingDirectory ?? metadata.working_directory);
     return {
       key,
       chatId,
@@ -150,6 +152,7 @@ export function normalizeSessionsPayload(payload: unknown): NativeChatSession[] 
       createdAt: stringValue(item.createdAt ?? item.created_at),
       updatedAt: stringValue(item.updatedAt ?? item.updated_at),
       ...(booleanValue(extra.pinned) ? { pinned: true } : {}),
+      ...(workingDirectory ? { workingDirectory } : {}),
       ...(stringValue(item.status) ? { status: stringValue(item.status) } : {}),
       ...(Boolean(item.archivedAt ?? item.archived_at) || stringValue(item.status) === "archived" ? { archived: true } : {}),
     };

--- a/src/app-core/native/desktopNativeThreads.ts
+++ b/src/app-core/native/desktopNativeThreads.ts
@@ -23,6 +23,7 @@ export type NativeThreadRecord = {
   archivedAt?: string;
   metadata?: {
     extra?: Record<string, unknown>;
+    workingDirectory?: string;
     [key: string]: unknown;
   };
   [key: string]: unknown;

--- a/src/app-core/native/desktopNativeWorkspacePicker.test.ts
+++ b/src/app-core/native/desktopNativeWorkspacePicker.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDesktopNativeWorkspacePicker } from "./desktopNativeWorkspacePicker";
+
+describe("desktop native workspace picker", () => {
+  it("invokes the native folder picker with the workspace title", async () => {
+    const invoke = vi.fn(async () => "D:\\Code\\py\\tinybot");
+    const pickWorkspaceDirectory = createDesktopNativeWorkspacePicker({ invoke });
+
+    await expect(pickWorkspaceDirectory()).resolves.toBe("D:\\Code\\py\\tinybot");
+    expect(invoke).toHaveBeenCalledWith("pick_workspace_directory", {
+      options: { title: "Select workspace folder" },
+    });
+  });
+});

--- a/src/app-core/native/desktopNativeWorkspacePicker.ts
+++ b/src/app-core/native/desktopNativeWorkspacePicker.ts
@@ -1,0 +1,12 @@
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+
+type TauriInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+export function createDesktopNativeWorkspacePicker(options: { invoke?: TauriInvoke } = {}) {
+  const invoke = options.invoke ?? tauriInvoke;
+  return () => invoke("pick_workspace_directory", {
+    options: { title: "Select workspace folder" },
+  }) as Promise<string | null>;
+}
+
+export const pickDesktopWorkspaceDirectory = createDesktopNativeWorkspacePicker();

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -17,12 +17,22 @@ const nativeFilePickerMocks = vi.hoisted(() => ({
   pickDesktopChatFiles: vi.fn(),
 }));
 
+const nativeWorkspacePickerMocks = vi.hoisted(() => ({
+  pickDesktopWorkspaceDirectory: vi.fn(),
+}));
+
 vi.mock("../../app-core/native/desktopNativeFilePicker", () => ({
   pickDesktopChatFiles: nativeFilePickerMocks.pickDesktopChatFiles,
 }));
 
+vi.mock("../../app-core/native/desktopNativeWorkspacePicker", () => ({
+  pickDesktopWorkspaceDirectory: nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory,
+}));
+
 afterEach(() => {
   cleanup();
+  nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory.mockReset();
+  window.localStorage.clear();
   document.head.querySelectorAll("[data-test-style='workbench']").forEach((element) => element.remove());
   vi.useRealTimers();
 });
@@ -640,6 +650,234 @@ describe("ChatPage", () => {
 
     expect(sidebar.getAttribute("data-collapsed")).toBe("false");
     expect(screen.getByRole("heading", { name: "会话" })).toBeTruthy();
+  });
+
+  it("groups sessions by workspace and creates another session in that directory", async () => {
+    const user = userEvent.setup();
+    const workingDirectory = "D:\\Code\\py\\tinybot";
+    const stores = createStores({
+      sessions: [
+        {
+          id: "s1",
+          chatId: "chat-1",
+          title: "Planning notes",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+          status: "idle",
+          workingDirectory,
+        },
+        {
+          id: "s2",
+          chatId: "chat-2",
+          title: "Knowledge review",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 50, 0),
+          status: "idle",
+          workingDirectory: "d:/code/py/tinybot/",
+        },
+        {
+          id: "s3",
+          chatId: "chat-3",
+          title: "General question",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 40, 0),
+          status: "idle",
+        },
+      ],
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const sidebar = await screen.findByLabelText("Sessions");
+    const workspace = within(sidebar).getByRole("group", { name: "Workspace tinybot" });
+    expect(within(workspace).getByRole("button", { name: "Planning notes" })).toBeTruthy();
+    expect(within(workspace).getByRole("button", { name: "Knowledge review" })).toBeTruthy();
+    expect(within(sidebar).getByRole("group", { name: "Workspace 常规会话" })).toBeTruthy();
+
+    await user.click(within(workspace).getByRole("button", { name: "New session in tinybot" }));
+
+    expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory });
+  });
+
+  it("inherits the active workspace when creating a session from the global action", async () => {
+    const user = userEvent.setup();
+    const workingDirectory = "D:\\Code\\py\\tinybot";
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Planning notes",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "idle",
+        workingDirectory,
+      }],
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const sidebar = await screen.findByLabelText("Sessions");
+    await user.click(within(sidebar).getByRole("button", { name: "New Chat" }));
+
+    expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory });
+  });
+
+  it("creates and opens the first session for a selected workspace folder", async () => {
+    const user = userEvent.setup();
+    const workingDirectory = "D:\\Code\\VirtualHome";
+    const stores = createStores();
+    nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory.mockResolvedValueOnce(workingDirectory);
+    vi.mocked(stores.sessionStore.create).mockResolvedValueOnce({
+      id: "workspace-session",
+      title: "New session",
+      updatedAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      workingDirectory,
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const sidebar = await screen.findByLabelText("Sessions");
+    await user.click(within(sidebar).getByRole("button", { name: "Add workspace folder" }));
+
+    expect(await within(sidebar).findByRole("group", { name: "Workspace VirtualHome" })).toBeTruthy();
+    expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory });
+    await waitFor(() => expect(stores.chatStore.load).toHaveBeenLastCalledWith("workspace-session"));
+  });
+
+  it("selects a workspace folder and exposes native creation failures", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory.mockResolvedValueOnce("Z:\\missing");
+    vi.mocked(stores.sessionStore.create).mockRejectedValueOnce(
+      new Error("failed to inspect working directory `Z:\\missing`"),
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const sidebar = await screen.findByLabelText("Sessions");
+    await user.click(within(sidebar).getByRole("button", { name: "Add workspace folder" }));
+
+    expect(nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory).toHaveBeenCalledTimes(1);
+    expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory: "Z:\\missing" });
+    expect((await within(sidebar).findByRole("alert")).textContent).toContain(
+      "failed to inspect working directory `Z:\\missing`",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "[session-workspaces] session.create.failed",
+      expect.objectContaining({
+        error: "failed to inspect working directory `Z:\\missing`",
+        workingDirectory: "Z:\\missing",
+      }),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("opens sidebar sessions as an accessible multi-session tab set", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [
+        {
+          id: "s1",
+          chatId: "chat-1",
+          title: "Planning notes",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+          status: "idle",
+        },
+        {
+          id: "s2",
+          chatId: "chat-2",
+          title: "Knowledge review",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 50, 0),
+          status: "running",
+        },
+      ],
+    });
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const sidebar = await screen.findByLabelText("Sessions");
+    const tablist = screen.getByRole("tablist", { name: "Open conversations" });
+    expect(within(tablist).getAllByRole("tab")).toHaveLength(1);
+
+    await user.click(within(sidebar).getByRole("button", { name: "Knowledge review" }));
+
+    expect(within(tablist).getAllByRole("tab")).toHaveLength(2);
+    expect(within(tablist).getByRole("tab", { name: "Knowledge review, running" }).getAttribute("aria-selected")).toBe("true");
+    await waitFor(() => expect(stores.chatStore.load).toHaveBeenLastCalledWith("s2"));
+  });
+
+  it("preserves per-session drafts and closing a tab does not delete the session", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [
+        {
+          id: "s1",
+          chatId: "chat-1",
+          title: "Planning notes",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+          status: "idle",
+        },
+        {
+          id: "s2",
+          chatId: "chat-2",
+          title: "Knowledge review",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 50, 0),
+          status: "idle",
+        },
+      ],
+    });
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const sidebar = await screen.findByLabelText("Sessions");
+    const tablist = screen.getByRole("tablist", { name: "Open conversations" });
+    const input = screen.getByRole("textbox", { name: /message/i }) as HTMLTextAreaElement;
+    await user.type(input, "draft for planning");
+    await user.click(within(sidebar).getByRole("button", { name: "Knowledge review" }));
+    await user.type(input, "draft for knowledge");
+
+    await user.click(within(tablist).getByRole("tab", { name: "Planning notes" }));
+    expect(input.value).toBe("draft for planning");
+    await user.click(screen.getByRole("button", { name: "Close Planning notes tab" }));
+
+    expect(stores.sessionStore.delete).not.toHaveBeenCalled();
+    expect(within(tablist).queryByRole("tab", { name: "Planning notes" })).toBeNull();
+    expect(input.value).toBe("draft for knowledge");
+  });
+
+  it("marks background completion unread without interrupting the active tab", async () => {
+    const user = userEvent.setup();
+    const listeners = new Map<string, (event: ChatEvent) => void>();
+    const stores = createStores({
+      sessions: [
+        {
+          id: "s1",
+          chatId: "chat-1",
+          title: "Planning notes",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+          status: "running",
+        },
+        {
+          id: "s2",
+          chatId: "chat-2",
+          title: "Knowledge review",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 50, 0),
+          status: "idle",
+        },
+      ],
+    });
+    stores.chatStore.subscribe = vi.fn((sessionId, listener) => {
+      listeners.set(sessionId, listener);
+      return () => {
+        if (listeners.get(sessionId) === listener) listeners.delete(sessionId);
+      };
+    });
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const sidebar = await screen.findByLabelText("Sessions");
+    await user.click(within(sidebar).getByRole("button", { name: "Knowledge review" }));
+    await waitFor(() => expect(listeners.has("s1")).toBe(true));
+
+    act(() => listeners.get("s1")?.({ type: "agent.event", eventType: "agent.turn.completed" }));
+
+    const backgroundTab = screen.getByRole("tab", { name: "Planning notes, running" }).closest(".react-session-tab");
+    expect(backgroundTab?.getAttribute("data-unread")).toBe("true");
+    expect(screen.getByRole("tab", { name: "Knowledge review" }).getAttribute("aria-selected")).toBe("true");
   });
 
   it("hides the session-list empty copy when the sidebar is collapsed", async () => {

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -649,7 +649,7 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: "Expand session sidebar" }));
 
     expect(sidebar.getAttribute("data-collapsed")).toBe("false");
-    expect(screen.getByRole("heading", { name: "会话" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Tinybot" })).toBeTruthy();
   });
 
   it("groups sessions by workspace and creates another session in that directory", async () => {

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -655,6 +655,7 @@ describe("ChatPage", () => {
   it("groups sessions by workspace and creates another session in that directory", async () => {
     const user = userEvent.setup();
     const workingDirectory = "D:\\Code\\py\\tinybot";
+    mountWorkbenchCss();
     const stores = createStores({
       sessions: [
         {
@@ -687,10 +688,23 @@ describe("ChatPage", () => {
 
     const sidebar = await screen.findByLabelText("Sessions");
     const workspace = within(sidebar).getByRole("group", { name: "Workspace tinybot" });
+    const workspaceSummary = workspace.querySelector("summary");
+    const collapsedFolder = workspaceSummary?.querySelector(".react-session-workspace__folder-icon--collapsed");
+    const expandedFolder = workspaceSummary?.querySelector(".react-session-workspace__folder-icon--expanded");
+    expect(collapsedFolder).toBeTruthy();
+    expect(expandedFolder).toBeTruthy();
+    expect(getComputedStyle(collapsedFolder as Element).display).toBe("none");
+    expect(getComputedStyle(expandedFolder as Element).display).not.toBe("none");
     expect(within(workspace).getByRole("button", { name: "Planning notes" })).toBeTruthy();
     expect(within(workspace).getByRole("button", { name: "Knowledge review" })).toBeTruthy();
     expect(within(sidebar).getByRole("group", { name: "Workspace 常规会话" })).toBeTruthy();
 
+    await user.click(workspaceSummary as HTMLElement);
+    expect(workspace.hasAttribute("open")).toBe(false);
+    expect(getComputedStyle(collapsedFolder as Element).display).not.toBe("none");
+    expect(getComputedStyle(expandedFolder as Element).display).toBe("none");
+
+    await user.click(workspaceSummary as HTMLElement);
     await user.click(within(workspace).getByRole("button", { name: "New session in tinybot" }));
 
     expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory });

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -7,7 +7,9 @@ import {
   ChevronRight,
   Circle,
   Copy,
+  Folder,
   FolderOpen,
+  FolderPlus,
   GitBranch,
   Loader2,
   Play,
@@ -45,12 +47,25 @@ import { formatRelativeUpdatedTime } from "../lib/relativeTime";
 import type { ApprovalAction, ChatEvent, ChatInput, ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore, WorkspaceStore } from "../services";
 import { createDesktopTurnSubmitCommand } from "../../app-core/chat/desktopCommand";
 import { pickDesktopChatFiles } from "../../app-core/native/desktopNativeFilePicker";
+import { pickDesktopWorkspaceDirectory } from "../../app-core/native/desktopNativeWorkspacePicker";
 import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
 import { canBranchFromMessage, canCopyMessage, type ContextReferenceSummary, type ReactChatMessage, type ToolCallSummary } from "./messageActions";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { AgentUiFormCard } from "./AgentUiFormCard";
 import { AssistantMarkdown } from "./AssistantMarkdown";
 import { clampTinyOsWidth, LiveCanvas, type LiveCanvasEntry, type LiveCanvasMode } from "./LiveCanvas";
+import { SessionTabStrip, type SessionTabItem } from "./SessionTabStrip";
+import {
+  INITIAL_SESSION_TAB_WORKSPACE,
+  readPersistedSessionTabWorkspace,
+  reduceSessionTabWorkspace,
+  sessionTabDraft,
+  writePersistedSessionTabWorkspace,
+} from "./sessionTabWorkspace";
+import {
+  groupSessionsByWorkspace,
+  sessionWorkspaceName,
+} from "./sessionWorkspaces";
 import {
   applyLoadedDelegatedAgentTrace,
   projectLoadedArtifactDetail,
@@ -117,6 +132,11 @@ type DrawerState =
   | { kind: "artifact"; title: string; artifact: ArtifactRef; detail?: LoadedArtifactDetail; loading: boolean; error?: string }
   | { kind: "error"; title: string; step: ChatStep; turn: ChatTurn }
   | null;
+
+type ConversationViewState = {
+  scrollTop: number;
+  stickToLatest: boolean;
+};
 
 type LiveCanvasState = {
   mode: LiveCanvasMode;
@@ -200,6 +220,7 @@ const EMPTY_CHAT_PROMPTS = [
 const SESSION_DELETE_DISSOLVE_MS = 760;
 const SESSION_DELETE_PARTICLE_COUNT = 220;
 const TINYOS_WIDTH_STORAGE_KEY = "tinybot.ui.tinyos.width";
+const EMPTY_OPTIMISTIC_MESSAGES: ReactChatMessage[] = [];
 
 type SessionDeleteParticle = {
   id: number;
@@ -245,9 +266,14 @@ export function ChatPage({
   const tinyOsUiScope = useId();
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [sessionsLoaded, setSessionsLoaded] = useState(false);
-  const [activeSessionId, setActiveSessionId] = useState("");
+  const [sessionTabs, dispatchSessionTabs] = useReducer(
+    reduceSessionTabWorkspace,
+    INITIAL_SESSION_TAB_WORKSPACE,
+  );
   const [timeline, setTimeline] = useState<ChatTimelineSnapshot | null>(null);
-  const [optimisticMessages, setOptimisticMessages] = useState<ReactChatMessage[]>([]);
+  const [optimisticMessagesBySession, setOptimisticMessagesBySession] = useState<Map<string, ReactChatMessage[]>>(
+    () => new Map(),
+  );
   const [timelineError, setTimelineError] = useState("");
   const [browserSnapshot, setBrowserSnapshot] = useState<TinyOsNativeSnapshot<TinyOsNativeBrowserSession>>();
   const [browserRuntimeError, setBrowserRuntimeError] = useState("");
@@ -258,6 +284,9 @@ export function ChatPage({
   const [defaultComposerModel, setDefaultComposerModel] = useState("");
   const [headerMenuOpen, setHeaderMenuOpen] = useState(false);
   const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
+  const [sessionWorkspaceError, setSessionWorkspaceError] = useState("");
+  const [sessionCreatePending, setSessionCreatePending] = useState(false);
+  const [workspacePickerPending, setWorkspacePickerPending] = useState(false);
   const [localSessionSidebarCollapsed, setLocalSessionSidebarCollapsed] = useState(false);
   const [drawer, setDrawer] = useState<DrawerState>(null);
   const [liveCanvas, dispatchLiveCanvas] = useReducer(reduceLiveCanvasState, INITIAL_LIVE_CANVAS_STATE);
@@ -270,7 +299,6 @@ export function ChatPage({
   const [agentUiForms, setAgentUiForms] = useState<AgentUiForm[]>([]);
   const [queuedInputsBySession, setQueuedInputsBySession] = useState<Map<string, QueuedComposerInput[]>>(() => new Map());
   const [queueMessage, setQueueMessage] = useState("");
-  const [composerDraft, setComposerDraft] = useState("");
   const [tinyOsContextReferences, setTinyOsContextReferences] = useState<TinyOsContextReference[]>([]);
   const [tinyOsDropError, setTinyOsDropError] = useState("");
   const [recoveringTurnId, setRecoveringTurnId] = useState("");
@@ -286,10 +314,16 @@ export function ChatPage({
   const optimisticSessionTitlesRef = useRef<Map<string, string>>(new Map());
   const conversationRef = useRef<HTMLDivElement | null>(null);
   const conversationEndRef = useRef<HTMLDivElement | null>(null);
+  const conversationViewBySessionRef = useRef<Map<string, ConversationViewState>>(new Map());
+  const pendingConversationRestoreRef = useRef("");
+  const hasActivatedSessionRef = useRef(false);
   const liveCanvasHeadingRef = useRef<HTMLHeadingElement | null>(null);
   const liveCanvasToggleRef = useRef<HTMLButtonElement | null>(null);
   const liveCanvasWasOpenRef = useRef(false);
   const stickToLatestRef = useRef(true);
+  const activeSessionId = sessionTabs.activeSessionId;
+  const composerDraft = sessionTabDraft(sessionTabs, activeSessionId);
+  const optimisticMessages = optimisticMessagesBySession.get(activeSessionId) ?? EMPTY_OPTIMISTIC_MESSAGES;
 
   useEffect(() => {
     const clampWidthToViewport = () => setTinyOsWidth((current) => clampTinyOsWidth(current));
@@ -299,13 +333,25 @@ export function ChatPage({
 
   const resolvedSessionSidebarCollapsed = sessionSidebarCollapsed ?? localSessionSidebarCollapsed;
   const activeSession = useMemo(
-    () => sessions.find((session) => session.id === activeSessionId) ?? sessions[0],
+    () => sessions.find((session) => session.id === activeSessionId),
     [activeSessionId, sessions],
   );
+  const openSessionTabs = useMemo<SessionTabItem[]>(() => (
+    sessionTabs.openSessionIds.flatMap((sessionId) => {
+      const session = sessions.find((candidate) => candidate.id === sessionId);
+      return session ? [{
+        id: session.id,
+        status: session.status,
+        title: displaySessionTitle(session.title),
+        unread: sessionTabs.unreadSessionIds.includes(session.id),
+      }] : [];
+    })
+  ), [sessionTabs.openSessionIds, sessionTabs.unreadSessionIds, sessions]);
+  const sessionWorkspaces = useMemo(() => groupSessionsByWorkspace(sessions), [sessions]);
   const tinyOsFiles = useTinyOsFilesController(activeSession?.id ?? "draft", workspaceStore, liveCanvas.visibility === "open");
   const draftNewSession = sessionsLoaded && !activeSession;
   const timelineLoaded = Boolean(activeSession) && timeline?.sessionId === activeSession?.id;
-  const emptyActiveSession = draftNewSession || (timelineLoaded && timeline.turns.length === 0 && optimisticMessages.length === 0);
+  const emptyActiveSession = draftNewSession || (timelineLoaded && timeline?.turns.length === 0 && optimisticMessages.length === 0);
   const sessionRunning = activeSession?.status === "running" || activeSession?.status === "waiting_approval";
   const sessionResponding = sessionRunning && !emptyActiveSession;
   const activeTurn = useMemo(() => [...(timeline?.turns ?? [])].reverse().find((turn) => (
@@ -730,12 +776,26 @@ export function ChatPage({
       sessionsRef.current = nextSessions;
       setSessions(nextSessions);
       setSessionsLoaded(true);
-      setActiveSessionId((current) => current || nextSessions[0]?.id || "");
+      dispatchSessionTabs({
+        type: "hydrate",
+        availableSessionIds: nextSessions.map((session) => session.id),
+        persisted: readPersistedSessionTabWorkspace(window.localStorage),
+      });
     });
     return () => {
       cancelled = true;
     };
   }, [sessionStore]);
+
+  useEffect(() => {
+    if (!sessionsLoaded) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      writePersistedSessionTabWorkspace(window.localStorage, sessionTabs);
+    }, 180);
+    return () => window.clearTimeout(timer);
+  }, [sessionTabs, sessionsLoaded]);
 
   useEffect(() => {
     if (createSessionSignal === lastCreateSessionSignal.current) {
@@ -748,12 +808,10 @@ export function ChatPage({
   useEffect(() => {
     if (!activeSessionId) {
       setTimeline(null);
-      setOptimisticMessages([]);
       setTimelineError("");
       return;
     }
     setTimeline(null);
-    setOptimisticMessages([]);
     setTimelineError("");
     setAgentUiForms([]);
     setBrowserSnapshot(undefined);
@@ -778,9 +836,13 @@ export function ChatPage({
     const applyTimeline = (nextTimeline: ChatTimelineSnapshot) => {
       setTimeline(nextTimeline);
       setTimelineError("");
-      setOptimisticMessages((current) => current.filter((message) => !nextTimeline.turns.some((turn) => (
-        turn.userMessage.clientEventId === message.id
-      ))));
+      setOptimisticMessagesBySession((current) => updateSessionMessages(
+        current,
+        activeSessionId,
+        (messages) => messages.filter((message) => !nextTimeline.turns.some((turn) => (
+          turn.userMessage.clientEventId === message.id
+        ))),
+      ));
     };
     const scheduleStreamingTimeline = (nextTimeline: ChatTimelineSnapshot) => {
       pendingStreamingTimeline = nextTimeline;
@@ -851,12 +913,16 @@ export function ChatPage({
       }
       if (event.message) {
         const nextMessage = event.message;
-        setOptimisticMessages((current) => (
-          current.some((message) => message.id === nextMessage.id)
-            ? current.map((message) => (
-              message.id === nextMessage.id ? { ...message, ...nextMessage } : message
-            ))
-            : [...current, nextMessage]
+        setOptimisticMessagesBySession((current) => updateSessionMessages(
+          current,
+          activeSessionId,
+          (messages) => (
+            messages.some((message) => message.id === nextMessage.id)
+              ? messages.map((message) => (
+                message.id === nextMessage.id ? { ...message, ...nextMessage } : message
+              ))
+              : [...messages, nextMessage]
+          ),
         ));
         return;
       }
@@ -878,6 +944,33 @@ export function ChatPage({
       unsubscribe();
     };
   }, [activeSessionId, chatStore, now]);
+
+  useEffect(() => {
+    const unsubscribes = sessionTabs.openSessionIds
+      .filter((sessionId) => sessionId !== activeSessionId)
+      .map((sessionId) => chatStore.subscribe(sessionId, (event) => {
+        if (event.timeline) {
+          const status = sessionStatusFromTimeline(event.timeline);
+          if (status) {
+            setSessions((current) => {
+              const next = current.map((session) => (
+                session.id === sessionId ? { ...session, status } : session
+              ));
+              sessionsRef.current = next;
+              return next;
+            });
+          }
+          dispatchSessionTabs({ type: "activity", sessionId });
+        }
+        if (isBackgroundTabActivityEvent(event)) {
+          dispatchSessionTabs({ type: "activity", sessionId });
+        }
+        if (shouldReloadSessionsForChatEvent(event)) {
+          void handleQueueStateAfterChatEvent(sessionId, event);
+        }
+      }));
+    return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
+  }, [activeSessionId, chatStore, sessionTabs.openSessionIds]);
 
   useEffect(() => {
     if (!settingsStore?.loadChatModels) {
@@ -909,19 +1002,89 @@ export function ChatPage({
   }, [activeSession?.id, onStopGenerationTargetChange, sessionResponding]);
 
   useEffect(() => {
+    const view = conversationViewBySessionRef.current.get(activeSessionId);
+    if (activeSessionId && !hasActivatedSessionRef.current) {
+      hasActivatedSessionRef.current = true;
+      pendingConversationRestoreRef.current = "";
+    } else {
+      pendingConversationRestoreRef.current = activeSessionId;
+    }
+    stickToLatestRef.current = view?.stickToLatest ?? true;
+    setShowBackToLatest(view ? !view.stickToLatest : false);
+  }, [activeSessionId]);
+
+  useEffect(() => {
+    const element = conversationRef.current;
+    const view = conversationViewBySessionRef.current.get(activeSessionId);
+    const shouldRestore = Boolean(
+      activeSessionId
+      && pendingConversationRestoreRef.current === activeSessionId
+      && timeline?.sessionId === activeSessionId,
+    );
+    if (element && view && !view.stickToLatest && shouldRestore) {
+      element.scrollTo?.({
+        behavior: "instant",
+        top: Math.min(view.scrollTop, Math.max(0, element.scrollHeight - element.clientHeight)),
+      });
+      pendingConversationRestoreRef.current = "";
+      return;
+    }
+    if (shouldRestore) {
+      pendingConversationRestoreRef.current = "";
+    }
     if (stickToLatestRef.current) {
       conversationEndRef.current?.scrollIntoView({ block: "end" });
     }
-  }, [timeline, optimisticMessages, agentUiForms.length]);
+  }, [activeSessionId, timeline, optimisticMessages, agentUiForms.length]);
 
-  async function handleCreateSession() {
-    const created = await sessionStore.create();
-    activateCreatedSession(created);
+  async function handleCreateSession(workingDirectory = activeSession?.workingDirectory): Promise<SessionSummary | null> {
+    if (sessionCreatePending) {
+      return null;
+    }
+    setSessionCreatePending(true);
+    setSessionWorkspaceError("");
+    try {
+      const created = await sessionStore.create(workingDirectory ? { workingDirectory } : undefined);
+      activateCreatedSession(created);
+      return created;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setSessionWorkspaceError(message);
+      console.error("[session-workspaces] session.create.failed", {
+        error: message,
+        workingDirectory: workingDirectory ?? "",
+      });
+      return null;
+    } finally {
+      setSessionCreatePending(false);
+    }
   }
 
   async function handleCreateSessionFromSearch() {
-    await handleCreateSession();
-    setSessionSearchOpen(false);
+    const created = await handleCreateSession();
+    if (created) {
+      setSessionSearchOpen(false);
+    }
+  }
+
+  async function handleAddWorkspace() {
+    if (workspacePickerPending || sessionCreatePending) {
+      return;
+    }
+    setWorkspacePickerPending(true);
+    setSessionWorkspaceError("");
+    try {
+      const workingDirectory = await pickDesktopWorkspaceDirectory();
+      if (workingDirectory) {
+        await handleCreateSession(workingDirectory);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setSessionWorkspaceError(message);
+      console.error("[session-workspaces] workspace.pick.failed", { error: message });
+    } finally {
+      setWorkspacePickerPending(false);
+    }
   }
 
   async function handleDeleteSession(session: SessionSummary) {
@@ -935,7 +1098,14 @@ export function ChatPage({
         const remaining = sessionsRef.current.filter((item) => item.id !== session.id);
         sessionsRef.current = remaining;
         setSessions(remaining);
-        setActiveSessionId((current) => current === session.id ? remaining[0]?.id ?? "" : current);
+        dispatchSessionTabs({ type: "remove", sessionId: session.id });
+        conversationViewBySessionRef.current.delete(session.id);
+        setOptimisticMessagesBySession((current) => {
+          if (!current.has(session.id)) return current;
+          const next = new Map(current);
+          next.delete(session.id);
+          return next;
+        });
         setDissolvingSessionIds((current) => {
           const nextIds = new Set(current);
           nextIds.delete(session.id);
@@ -962,9 +1132,14 @@ export function ChatPage({
       optimisticSessionTitlesRef.current.has(session.id) && !listedSessionIdsBeforeReconciliation.has(session.id)
     ));
     const replacementCandidates = titledSessions.filter((session) => !knownSessionIds.has(session.id));
+    let sessionIdReplacement: { previousSessionId: string; sessionId: string } | undefined;
     if (missingOptimisticSessions.length === 1 && replacementCandidates.length === 1) {
       const pendingSession = missingOptimisticSessions[0];
       const replacementSession = replacementCandidates[0];
+      sessionIdReplacement = {
+        previousSessionId: pendingSession.id,
+        sessionId: replacementSession.id,
+      };
       const optimisticTitle = optimisticSessionTitlesRef.current.get(pendingSession.id);
       optimisticSessionTitlesRef.current.delete(pendingSession.id);
       if (optimisticTitle && isDefaultSessionTitle(replacementSession.title)) {
@@ -992,14 +1167,27 @@ export function ChatPage({
       ));
     sessionsRef.current = nextSessions;
     setSessions(nextSessions);
-    setActiveSessionId((current) => {
-      if (preserveSession && current === preserveSession.id) {
-        return preserveSession.id;
-      }
-      if (!nextSessions.length) {
-        return "";
-      }
-      return nextSessions.some((session) => session.id === current) ? current : nextSessions[0]?.id ?? "";
+    if (sessionIdReplacement) {
+      dispatchSessionTabs({ type: "replace", ...sessionIdReplacement });
+      moveMapValue(
+        conversationViewBySessionRef.current,
+        sessionIdReplacement.previousSessionId,
+        sessionIdReplacement.sessionId,
+      );
+      setOptimisticMessagesBySession((current) => replaceMapKey(
+        current,
+        sessionIdReplacement.previousSessionId,
+        sessionIdReplacement.sessionId,
+      ));
+      updateQueuedInputsBySession((current) => replaceMapKey(
+        current,
+        sessionIdReplacement.previousSessionId,
+        sessionIdReplacement.sessionId,
+      ));
+    }
+    dispatchSessionTabs({
+      type: "reconcile",
+      availableSessionIds: nextSessions.map((session) => session.id),
     });
     return nextSessions;
   }
@@ -1036,17 +1224,19 @@ export function ChatPage({
   async function handleArchiveConversation(session: SessionSummary) {
     await sessionStore.archive(session.id);
     const remaining = sessions.filter((item) => item.id !== session.id);
+    sessionsRef.current = remaining;
     setSessions(remaining);
-    if (activeSessionId === session.id) {
-      setActiveSessionId(remaining[0]?.id ?? "");
-    }
+    dispatchSessionTabs({ type: "remove", sessionId: session.id });
+    conversationViewBySessionRef.current.delete(session.id);
     setHeaderMenuOpen(false);
   }
 
   async function handleBranchFromMessage(session: SessionSummary, messageId: string) {
     const branched = await chatStore.branchFromMessage(session.id, messageId);
-    setSessions((current) => [branched, ...current.filter((item) => item.id !== branched.id)]);
-    setActiveSessionId(branched.id);
+    const nextSessions = [branched, ...sessionsRef.current.filter((item) => item.id !== branched.id)];
+    sessionsRef.current = nextSessions;
+    setSessions(nextSessions);
+    dispatchSessionTabs({ type: "open", sessionId: branched.id });
   }
 
   function dispatchTurn(sessionId: string, input: ChatInput, control: string): Promise<void> {
@@ -1166,12 +1356,22 @@ export function ChatPage({
       return;
     }
     const nearBottom = element.scrollHeight - element.scrollTop - element.clientHeight < 96;
+    pendingConversationRestoreRef.current = "";
     stickToLatestRef.current = nearBottom;
+    conversationViewBySessionRef.current.set(activeSessionId, {
+      scrollTop: element.scrollTop,
+      stickToLatest: nearBottom,
+    });
     setShowBackToLatest(!nearBottom);
   }
 
   function handleBackToLatest(): void {
     stickToLatestRef.current = true;
+    const element = conversationRef.current;
+    conversationViewBySessionRef.current.set(activeSessionId, {
+      scrollTop: element ? Math.max(0, element.scrollHeight - element.clientHeight) : 0,
+      stickToLatest: true,
+    });
     setShowBackToLatest(false);
     conversationEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }
@@ -1221,7 +1421,7 @@ export function ChatPage({
   function activateCreatedSession(created: SessionSummary): void {
     sessionsRef.current = [created, ...sessionsRef.current.filter((session) => session.id !== created.id)];
     setSessions((current) => [created, ...current.filter((session) => session.id !== created.id)]);
-    setActiveSessionId(created.id);
+    dispatchSessionTabs({ type: "open", sessionId: created.id });
   }
 
   function handleDeleteQueuedInput(sessionId: string, inputId: string) {
@@ -1532,8 +1732,24 @@ export function ChatPage({
 
   function handleSessionSearchSelect(session: SessionSummary) {
     dispatchDelete({ type: "session-selected", sessionId: session.id });
-    setActiveSessionId(session.id);
+    dispatchSessionTabs({ type: "open", sessionId: session.id });
     setSessionSearchOpen(false);
+  }
+
+  function handleActivateSessionTab(sessionId: string) {
+    dispatchDelete({ type: "session-selected", sessionId });
+    dispatchSessionTabs({ type: "activate", sessionId });
+  }
+
+  function handleCloseSessionTab(sessionId: string) {
+    dispatchSessionTabs({ type: "close", sessionId });
+    if (sessionId === activeSessionId) {
+      setHeaderMenuOpen(false);
+    }
+  }
+
+  function handleComposerDraftChange(value: string) {
+    dispatchSessionTabs({ type: "draft.changed", sessionId: activeSessionId, value });
   }
 
   const visibleAgentUiForms = agentUiForms.filter(isVisibleAgentUiForm);
@@ -1555,6 +1771,16 @@ export function ChatPage({
             <h2>会话</h2>
             <div className="react-session-list__title-actions">
               <button
+                aria-label="Add workspace folder"
+                className="react-session-list__add-workspace"
+                disabled={workspacePickerPending || sessionCreatePending}
+                title="Add workspace folder"
+                type="button"
+                onClick={() => void handleAddWorkspace()}
+              >
+                <FolderPlus aria-hidden="true" size={15} />
+              </button>
+              <button
                 aria-label="Search chats"
                 className="react-session-list__search"
                 title="Search chats"
@@ -1574,76 +1800,123 @@ export function ChatPage({
               </button>
             </div>
           </div>
-          <button aria-label="New Chat" className="react-session-list__new" type="button" onClick={handleCreateSession}>
-            <Plus aria-hidden="true" size={15} />
+          <button
+            aria-label="New Chat"
+            className="react-session-list__new"
+            disabled={sessionCreatePending}
+            type="button"
+            onClick={() => void handleCreateSession()}
+          >
+            {sessionCreatePending ? <Loader2 aria-hidden="true" className="react-session-list__pending" size={15} /> : <Plus aria-hidden="true" size={15} />}
             <span>新会话</span>
           </button>
+          {sessionWorkspaceError ? (
+            <p className="react-session-list__error" role="alert">{sessionWorkspaceError}</p>
+          ) : null}
         </div>
         <div className="react-session-list__rows" aria-label="Session list rows" data-motion="animated-list">
-          {sessions.length ? sessions.map((session, index) => {
-            const confirming = deleteState.confirmingSessionId === session.id;
-            const dissolving = dissolvingSessionIds.has(session.id);
-            return (
-              <div
-                className="react-session-row"
-                data-active={session.id === activeSession?.id}
-                data-confirming={confirming}
-                data-dissolving={dissolving ? "true" : undefined}
-                data-motion-role="item"
-                key={session.id}
-                onMouseLeave={() => dispatchDelete({ type: "row-left", sessionId: session.id })}
-                style={{ "--react-session-row-index": String(index) } as CSSProperties}
+          {sessionWorkspaces.length ? sessionWorkspaces.map((workspace) => (
+            <details
+              aria-label={`Workspace ${workspace.label}`}
+              className="react-session-workspace"
+              data-active={workspace.sessions.some((session) => session.id === activeSession?.id) ? "true" : undefined}
+              key={workspace.key}
+              open
+              role="group"
+            >
+              <summary title={workspace.workingDirectory ?? workspace.label}>
+                <ChevronRight aria-hidden="true" className="react-session-workspace__chevron" size={14} />
+                <Folder aria-hidden="true" className="react-session-workspace__folder" size={15} />
+                <span className="react-session-workspace__copy">
+                  <strong>{workspace.label}</strong>
+                  {workspace.workingDirectory ? <small>{workspace.workingDirectory}</small> : null}
+                </span>
+              </summary>
+              <button
+                aria-label={`New session in ${workspace.label}`}
+                className="react-session-workspace__new"
+                disabled={sessionCreatePending}
+                title={`New session in ${workspace.label}`}
+                type="button"
+                onClick={() => void handleCreateSession(workspace.workingDirectory)}
               >
-                <button
-                  aria-label={session.title}
-                  className="react-session-row__select"
-                  type="button"
-                  disabled={dissolving}
-                  onClick={() => {
-                    dispatchDelete({ type: "session-selected", sessionId: session.id });
-                    setActiveSessionId(session.id);
-                  }}
-                >
-                  <span className="react-session-row__title">{displaySessionTitle(session.title)}</span>
-                  <small>{formatRelativeUpdatedTime(session.updatedAtMs, now())}</small>
-                </button>
-                <button
-                  aria-label={`${confirming ? "Confirm delete" : "Delete"} ${session.title}`}
-                  className="react-session-row__delete"
-                  data-confirming={confirming}
-                  type="button"
-                  disabled={dissolving}
-                  onClick={() => void handleDeleteSession(session)}
-                >
-                  <Trash2 aria-hidden="true" size={15} />
-                </button>
-                {dissolving ? (
-                  <span className="react-session-row__particles" aria-hidden="true">
-                    {SESSION_DELETE_PARTICLES.map((particle) => (
-                      <span
-                        className="react-session-row__particle"
-                        key={particle.id}
-                        style={{
-                          "--particle-delay": `${particle.delay}ms`,
-                          "--particle-origin-x": `${particle.originX}%`,
-                          "--particle-origin-y": `${particle.originY}%`,
-                          "--particle-size": `${particle.size}px`,
-                          "--particle-x": `${particle.x}px`,
-                          "--particle-y": `${particle.y}px`,
-                        } as CSSProperties}
-                      />
-                    ))}
-                  </span>
-                ) : null}
+                <Plus aria-hidden="true" size={15} />
+              </button>
+              <div className="react-session-workspace__sessions">
+                {workspace.sessions.map((session, index) => {
+                  const confirming = deleteState.confirmingSessionId === session.id;
+                  const dissolving = dissolvingSessionIds.has(session.id);
+                  return (
+                    <div
+                      className="react-session-row"
+                      data-active={session.id === activeSession?.id}
+                      data-confirming={confirming}
+                      data-dissolving={dissolving ? "true" : undefined}
+                      data-motion-role="item"
+                      key={session.id}
+                      onMouseLeave={() => dispatchDelete({ type: "row-left", sessionId: session.id })}
+                      style={{ "--react-session-row-index": String(index) } as CSSProperties}
+                    >
+                      <button
+                        aria-label={session.title}
+                        className="react-session-row__select"
+                        type="button"
+                        disabled={dissolving}
+                        onClick={() => {
+                          dispatchDelete({ type: "session-selected", sessionId: session.id });
+                          dispatchSessionTabs({ type: "open", sessionId: session.id });
+                        }}
+                      >
+                        <span className="react-session-row__title">{displaySessionTitle(session.title)}</span>
+                        <small>{formatRelativeUpdatedTime(session.updatedAtMs, now())}</small>
+                      </button>
+                      <button
+                        aria-label={`${confirming ? "Confirm delete" : "Delete"} ${session.title}`}
+                        className="react-session-row__delete"
+                        data-confirming={confirming}
+                        type="button"
+                        disabled={dissolving}
+                        onClick={() => void handleDeleteSession(session)}
+                      >
+                        <Trash2 aria-hidden="true" size={15} />
+                      </button>
+                      {dissolving ? (
+                        <span className="react-session-row__particles" aria-hidden="true">
+                          {SESSION_DELETE_PARTICLES.map((particle) => (
+                            <span
+                              className="react-session-row__particle"
+                              key={particle.id}
+                              style={{
+                                "--particle-delay": `${particle.delay}ms`,
+                                "--particle-origin-x": `${particle.originX}%`,
+                                "--particle-origin-y": `${particle.originY}%`,
+                                "--particle-size": `${particle.size}px`,
+                                "--particle-x": `${particle.x}px`,
+                                "--particle-y": `${particle.y}px`,
+                              } as CSSProperties}
+                            />
+                          ))}
+                        </span>
+                      ) : null}
+                    </div>
+                  );
+                })}
               </div>
-            );
-          }) : resolvedSessionSidebarCollapsed ? null : <EmptyStateText text="No sessions yet." />}
+            </details>
+          )) : resolvedSessionSidebarCollapsed ? null : <EmptyStateText text="No sessions yet." />}
         </div>
       </aside>
 
       <main className="react-chat-surface" data-empty-session={emptyActiveSession ? "true" : undefined}>
         <header className="react-chat-header">
-          <h1>{headerTitle}</h1>
+          <h1 className="react-chat-header__title">{headerTitle}</h1>
+          <SessionTabStrip
+            activeSessionId={activeSessionId}
+            tabs={openSessionTabs}
+            onActivate={handleActivateSessionTab}
+            onClose={handleCloseSessionTab}
+            onCreate={() => void handleCreateSession()}
+          />
           <div className="react-chat-header__actions">
             <button
               ref={liveCanvasToggleRef}
@@ -1692,7 +1965,15 @@ export function ChatPage({
           </div>
         </header>
 
-        <div ref={conversationRef} className="react-conversation-view" aria-label="Conversation" aria-live="polite" onScroll={handleConversationScroll}>
+        <div
+          ref={conversationRef}
+          aria-label="Conversation"
+          aria-live="polite"
+          className="react-conversation-view"
+          id="tinybot-chat-conversation"
+          role="tabpanel"
+          onScroll={handleConversationScroll}
+        >
           {timelineError ? <p aria-live="assertive" className="react-timeline-error">{timelineError}</p> : null}
           {activeSession && timeline?.turns.length ? timeline.turns.map((turn) => (
             <CanonicalChatTurn
@@ -1709,7 +1990,7 @@ export function ChatPage({
               onOpenError={(step) => setDrawer({ kind: "error", title: "错误详情", step, turn })}
               onRecover={(action) => void handleRecoverTurn(turn, action)}
             />
-          )) : emptyActiveSession ? <EmptyChatStart onSelectPrompt={setComposerDraft} /> : activeSession ? null : <EmptyStateText text="Select or create a session." />}
+          )) : emptyActiveSession ? <EmptyChatStart onSelectPrompt={handleComposerDraftChange} /> : activeSession ? null : <EmptyStateText text="Select or create a session." />}
           {optimisticMessages.map((message) => (
             <MessageBubble
               key={message.id}
@@ -1783,7 +2064,7 @@ export function ChatPage({
           onClearContextReferences={() => setTinyOsContextReferences([])}
           onRemoveContextReference={(id) => setTinyOsContextReferences((current) => current.filter((reference) => tinyOsContextReferenceId(reference) !== id))}
           onSelectFiles={pickDesktopChatFiles}
-          onValueChange={setComposerDraft}
+          onValueChange={handleComposerDraftChange}
           onSendMessage={(message, files, pastedContent, options) => handleComposerSend(message, files, pastedContent, options)}
             onStopResponding={() => activeSession && handleStopGeneration(activeSession, "chat")}
           />
@@ -1923,7 +2204,7 @@ function SessionSearchDialog({
   const [query, setQuery] = useState("");
   const normalizedQuery = query.trim().toLowerCase();
   const filteredSessions = normalizedQuery
-    ? sessions.filter((session) => [session.title, session.chatId ?? "", session.id]
+    ? sessions.filter((session) => [session.title, session.chatId ?? "", session.id, session.workingDirectory ?? ""]
       .some((value) => value.toLowerCase().includes(normalizedQuery)))
     : sessions;
   const recommendations = [
@@ -2000,7 +2281,9 @@ function SessionSearchDialog({
               >
                 <span className="react-session-search__rank">{index + 1}</span>
                 <span className="react-session-search__title">{session.title}</span>
-                <span className="react-session-search__meta">tinybot</span>
+                <span className="react-session-search__meta">
+                  {session.workingDirectory ? sessionWorkspaceName(session.workingDirectory) : "常规会话"}
+                </span>
                 <kbd>{`Ctrl+${index + 1}`}</kbd>
                 <small>{formatRelativeUpdatedTime(session.updatedAtMs, now())}</small>
               </button>
@@ -2075,6 +2358,31 @@ function shouldReloadSessionsForChatEvent(event: ChatEvent): boolean {
 
 function shouldReloadAgentUiFormsForChatEvent(type: string): boolean {
   return type === "agent-ui.form" || type === "agent-ui.event";
+}
+
+function isBackgroundTabActivityEvent(event: ChatEvent): boolean {
+  return Boolean(
+    event.error
+    || event.timeline
+    || (event.type === "agent.event" && event.eventType && TERMINAL_AGENT_EVENT_TYPES.has(event.eventType)),
+  );
+}
+
+function sessionStatusFromTimeline(timeline: ChatTimelineSnapshot): SessionSummary["status"] | undefined {
+  const status = timeline.turns[timeline.turns.length - 1]?.status;
+  if (status === "pending" || status === "running" || status === "awaiting_user") {
+    return "running";
+  }
+  if (status === "awaiting_approval") {
+    return "waiting_approval";
+  }
+  if (status === "failed" || status === "interrupted") {
+    return "failed";
+  }
+  if (status === "completed") {
+    return "idle";
+  }
+  return undefined;
 }
 
 function shouldDispatchQueuedInputForChatEvent(event: ChatEvent): boolean {
@@ -2237,6 +2545,49 @@ function isVisibleAgentUiForm(form: AgentUiForm): boolean {
 
 async function writeClipboardText(value: string): Promise<void> {
   await navigator.clipboard?.writeText(value);
+}
+
+function updateSessionMessages(
+  current: Map<string, ReactChatMessage[]>,
+  sessionId: string,
+  update: (messages: ReactChatMessage[]) => ReactChatMessage[],
+): Map<string, ReactChatMessage[]> {
+  const nextMessages = update(current.get(sessionId) ?? EMPTY_OPTIMISTIC_MESSAGES);
+  const next = new Map(current);
+  if (nextMessages.length) {
+    next.set(sessionId, nextMessages);
+  } else {
+    next.delete(sessionId);
+  }
+  return next;
+}
+
+function replaceMapKey<T>(
+  current: Map<string, T>,
+  previousSessionId: string,
+  sessionId: string,
+): Map<string, T> {
+  if (!current.has(previousSessionId) || previousSessionId === sessionId) {
+    return current;
+  }
+  const next = new Map(current);
+  const value = next.get(previousSessionId) as T;
+  next.delete(previousSessionId);
+  next.set(sessionId, value);
+  return next;
+}
+
+function moveMapValue<T>(
+  map: Map<string, T>,
+  previousSessionId: string,
+  sessionId: string,
+): void {
+  if (!map.has(previousSessionId) || previousSessionId === sessionId) {
+    return;
+  }
+  const value = map.get(previousSessionId) as T;
+  map.delete(previousSessionId);
+  map.set(sessionId, value);
 }
 
 function formatComposerMessage(message: string, pastedContent: PastedContent[]): string {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1826,7 +1826,10 @@ export function ChatPage({
             >
               <summary title={workspace.workingDirectory ?? workspace.label}>
                 <ChevronRight aria-hidden="true" className="react-session-workspace__chevron" size={14} />
-                <Folder aria-hidden="true" className="react-session-workspace__folder" size={15} />
+                <span aria-hidden="true" className="react-session-workspace__folder">
+                  <Folder className="react-session-workspace__folder-icon--collapsed" size={15} />
+                  <FolderOpen className="react-session-workspace__folder-icon--expanded" size={15} />
+                </span>
                 <span className="react-session-workspace__copy">
                   <strong>{workspace.label}</strong>
                   {workspace.workingDirectory ? <small>{workspace.workingDirectory}</small> : null}

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1768,7 +1768,7 @@ export function ChatPage({
       <aside className="react-session-list" aria-label="Sessions" data-collapsed={resolvedSessionSidebarCollapsed}>
         <div className="react-session-list__header">
           <div className="react-session-list__title-row">
-            <h2>会话</h2>
+            <h2>Tinybot</h2>
             <div className="react-session-list__title-actions">
               <button
                 aria-label="Add workspace folder"

--- a/src/react-workbench/chat/SessionTabStrip.tsx
+++ b/src/react-workbench/chat/SessionTabStrip.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { AlertTriangle, Circle, List, Loader2, Plus, X } from "lucide-react";
+import type { SessionSummary } from "../services";
+
+export type SessionTabItem = Pick<SessionSummary, "id" | "status"> & {
+  title: string;
+  unread: boolean;
+};
+
+export type SessionTabStripProps = {
+  activeSessionId: string;
+  tabs: SessionTabItem[];
+  onActivate: (sessionId: string) => void;
+  onClose: (sessionId: string) => void;
+  onCreate: () => void;
+};
+
+export function SessionTabStrip({
+  activeSessionId,
+  onActivate,
+  onClose,
+  onCreate,
+  tabs,
+}: SessionTabStripProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [activeSessionId]);
+
+  const focusTab = (sessionId: string) => {
+    onActivate(sessionId);
+    window.requestAnimationFrame(() => tabRefs.current.get(sessionId)?.focus());
+  };
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, sessionId: string) => {
+    const index = tabs.findIndex((tab) => tab.id === sessionId);
+    if (index < 0) {
+      return;
+    }
+    let target: SessionTabItem | undefined;
+    if (event.key === "ArrowRight") {
+      target = tabs[(index + 1) % tabs.length];
+    } else if (event.key === "ArrowLeft") {
+      target = tabs[(index - 1 + tabs.length) % tabs.length];
+    } else if (event.key === "Home") {
+      target = tabs[0];
+    } else if (event.key === "End") {
+      target = tabs[tabs.length - 1];
+    } else if (event.key === "Delete") {
+      event.preventDefault();
+      onClose(sessionId);
+      return;
+    }
+    if (!target) {
+      return;
+    }
+    event.preventDefault();
+    focusTab(target.id);
+  };
+
+  return (
+    <div className="react-session-tabs">
+      <div className="react-session-tabs__scroller" aria-label="Open conversations" role="tablist">
+        {tabs.length ? tabs.map((tab) => {
+          const active = tab.id === activeSessionId;
+          const statusLabel = sessionTabStatusLabel(tab);
+          return (
+            <div
+              className="react-session-tab"
+              data-active={active ? "true" : undefined}
+              data-status={tab.status ?? "idle"}
+              data-unread={tab.unread ? "true" : undefined}
+              key={tab.id}
+            >
+              <button
+                aria-controls="tinybot-chat-conversation"
+                aria-label={`${tab.title}${statusLabel ? `, ${statusLabel}` : ""}`}
+                aria-selected={active}
+                className="react-session-tab__select"
+                id={`tinybot-session-tab-${tab.id}`}
+                ref={(element) => {
+                  if (element) {
+                    tabRefs.current.set(tab.id, element);
+                  } else {
+                    tabRefs.current.delete(tab.id);
+                  }
+                }}
+                role="tab"
+                tabIndex={active ? 0 : -1}
+                title={tab.title}
+                type="button"
+                onClick={() => onActivate(tab.id)}
+                onKeyDown={(event) => handleTabKeyDown(event, tab.id)}
+              >
+                <SessionTabStatus tab={tab} />
+                <span>{tab.title}</span>
+              </button>
+              <button
+                aria-label={`Close ${tab.title} tab`}
+                className="react-session-tab__close"
+                title={`Close ${tab.title}`}
+                type="button"
+                onClick={() => onClose(tab.id)}
+              >
+                <X aria-hidden="true" size={13} strokeWidth={2} />
+              </button>
+            </div>
+          );
+        }) : (
+          <div className="react-session-tab react-session-tab--draft" data-active="true">
+            <button
+              aria-controls="tinybot-chat-conversation"
+              aria-label="新会话"
+              aria-selected="true"
+              className="react-session-tab__select"
+              role="tab"
+              tabIndex={0}
+              type="button"
+            >
+              <span>新会话</span>
+            </button>
+          </div>
+        )}
+      </div>
+      <div className="react-session-tabs__controls">
+        <button aria-label="New conversation tab" title="New conversation" type="button" onClick={onCreate}>
+          <Plus aria-hidden="true" size={16} />
+        </button>
+        {tabs.length > 1 ? (
+          <div className="react-session-tabs__overflow">
+            <button
+              aria-expanded={menuOpen}
+              aria-haspopup="menu"
+              aria-label="Open tabs menu"
+              title="Open tabs"
+              type="button"
+              onClick={() => setMenuOpen((open) => !open)}
+            >
+              <List aria-hidden="true" size={15} />
+            </button>
+            {menuOpen ? (
+              <div className="react-session-tabs__menu" role="menu">
+                {tabs.map((tab) => (
+                  <button
+                    aria-current={tab.id === activeSessionId ? "page" : undefined}
+                    key={tab.id}
+                    role="menuitem"
+                    type="button"
+                    onClick={() => onActivate(tab.id)}
+                  >
+                    <SessionTabStatus tab={tab} />
+                    <span className="react-session-tabs__menu-title">{tab.title}</span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SessionTabStatus({ tab }: { tab: SessionTabItem }) {
+  if (tab.status === "running") {
+    return <Loader2 aria-hidden="true" className="react-session-tab__status" data-kind="running" size={11} />;
+  }
+  if (tab.status === "waiting_approval") {
+    return <AlertTriangle aria-hidden="true" className="react-session-tab__status" data-kind="waiting" size={11} />;
+  }
+  if (tab.status === "failed") {
+    return <AlertTriangle aria-hidden="true" className="react-session-tab__status" data-kind="failed" size={11} />;
+  }
+  if (tab.unread) {
+    return <Circle aria-hidden="true" className="react-session-tab__status" data-kind="unread" fill="currentColor" size={8} />;
+  }
+  return null;
+}
+
+function sessionTabStatusLabel(tab: SessionTabItem): string {
+  if (tab.status === "running") return "running";
+  if (tab.status === "waiting_approval") return "waiting for approval";
+  if (tab.status === "failed") return "failed";
+  if (tab.unread) return "unread activity";
+  return "";
+}

--- a/src/react-workbench/chat/sessionTabWorkspace.test.ts
+++ b/src/react-workbench/chat/sessionTabWorkspace.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  DRAFT_SESSION_KEY,
+  INITIAL_SESSION_TAB_WORKSPACE,
+  reduceSessionTabWorkspace,
+  sessionTabDraft,
+} from "./sessionTabWorkspace";
+
+describe("sessionTabWorkspace", () => {
+  it("hydrates only available tabs and falls back to the first session", () => {
+    const state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "hydrate",
+      availableSessionIds: ["s1", "s2"],
+      persisted: {
+        activeSessionId: "missing",
+        draftsBySession: { missing: "drop", s2: "keep", [DRAFT_SESSION_KEY]: "new" },
+        openSessionIds: ["missing", "s2"],
+      },
+    });
+
+    expect(state).toEqual({
+      activeSessionId: "s2",
+      draftsBySession: { s2: "keep", [DRAFT_SESSION_KEY]: "new" },
+      openSessionIds: ["s2"],
+      unreadSessionIds: [],
+    });
+  });
+
+  it("preserves an intentionally empty saved tab set", () => {
+    const state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "hydrate",
+      availableSessionIds: ["s1", "s2"],
+      persisted: {
+        activeSessionId: "",
+        draftsBySession: { [DRAFT_SESSION_KEY]: "new" },
+        openSessionIds: [],
+      },
+    });
+
+    expect(state.activeSessionId).toBe("");
+    expect(state.openSessionIds).toEqual([]);
+    expect(sessionTabDraft(state, "")).toBe("new");
+  });
+
+  it("opens, activates, and closes tabs without deleting their drafts", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "hydrate",
+      availableSessionIds: ["s1", "s2", "s3"],
+    });
+    state = reduceSessionTabWorkspace(state, { type: "draft.changed", sessionId: "s1", value: "draft one" });
+    state = reduceSessionTabWorkspace(state, { type: "open", sessionId: "s2" });
+    state = reduceSessionTabWorkspace(state, { type: "open", sessionId: "s3" });
+    state = reduceSessionTabWorkspace(state, { type: "activate", sessionId: "s2" });
+    state = reduceSessionTabWorkspace(state, { type: "close", sessionId: "s2" });
+
+    expect(state.openSessionIds).toEqual(["s1", "s3"]);
+    expect(state.activeSessionId).toBe("s3");
+    expect(sessionTabDraft(state, "s1")).toBe("draft one");
+  });
+
+  it("removes deleted sessions and their saved view state", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "hydrate",
+      availableSessionIds: ["s1", "s2"],
+    });
+    state = reduceSessionTabWorkspace(state, { type: "draft.changed", sessionId: "s1", value: "discard me" });
+    state = reduceSessionTabWorkspace(state, { type: "open", sessionId: "s2" });
+    state = reduceSessionTabWorkspace(state, { type: "remove", sessionId: "s1" });
+
+    expect(state.openSessionIds).toEqual(["s2"]);
+    expect(state.draftsBySession.s1).toBeUndefined();
+  });
+
+  it("marks only inactive open tabs unread and clears unread on activation", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "hydrate",
+      availableSessionIds: ["s1", "s2"],
+    });
+    state = reduceSessionTabWorkspace(state, { type: "open", sessionId: "s2" });
+    state = reduceSessionTabWorkspace(state, { type: "activity", sessionId: "s1" });
+    state = reduceSessionTabWorkspace(state, { type: "activity", sessionId: "s2" });
+
+    expect(state.unreadSessionIds).toEqual(["s1"]);
+
+    state = reduceSessionTabWorkspace(state, { type: "activate", sessionId: "s1" });
+    expect(state.unreadSessionIds).toEqual([]);
+  });
+
+  it("moves the active tab and draft when a pending session receives its canonical id", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "open",
+      sessionId: "pending:1",
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "draft.changed",
+      sessionId: "pending:1",
+      value: "keep this",
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "replace",
+      previousSessionId: "pending:1",
+      sessionId: "WebSocket:chat-2",
+    });
+
+    expect(state.activeSessionId).toBe("WebSocket:chat-2");
+    expect(state.openSessionIds).toEqual(["WebSocket:chat-2"]);
+    expect(sessionTabDraft(state, "WebSocket:chat-2")).toBe("keep this");
+  });
+});

--- a/src/react-workbench/chat/sessionTabWorkspace.ts
+++ b/src/react-workbench/chat/sessionTabWorkspace.ts
@@ -1,0 +1,229 @@
+export const CHAT_SESSION_TABS_STORAGE_KEY = "tinybot.ui.chat.session-tabs.v1";
+export const DRAFT_SESSION_KEY = "__tinybot_draft_session__";
+
+export type SessionTabWorkspaceState = {
+  activeSessionId: string;
+  draftsBySession: Record<string, string>;
+  openSessionIds: string[];
+  unreadSessionIds: string[];
+};
+
+export type PersistedSessionTabWorkspace = Pick<
+  SessionTabWorkspaceState,
+  "activeSessionId" | "draftsBySession" | "openSessionIds"
+>;
+
+export type SessionTabWorkspaceEvent =
+  | { type: "hydrate"; availableSessionIds: string[]; persisted?: PersistedSessionTabWorkspace }
+  | { type: "open"; sessionId: string }
+  | { type: "activate"; sessionId: string }
+  | { type: "close"; sessionId: string }
+  | { type: "remove"; sessionId: string }
+  | { type: "activity"; sessionId: string }
+  | { type: "draft.changed"; sessionId: string; value: string }
+  | { type: "replace"; previousSessionId: string; sessionId: string }
+  | { type: "reconcile"; availableSessionIds: string[] };
+
+export const INITIAL_SESSION_TAB_WORKSPACE: SessionTabWorkspaceState = {
+  activeSessionId: "",
+  draftsBySession: {},
+  openSessionIds: [],
+  unreadSessionIds: [],
+};
+
+export function reduceSessionTabWorkspace(
+  state: SessionTabWorkspaceState,
+  event: SessionTabWorkspaceEvent,
+): SessionTabWorkspaceState {
+  switch (event.type) {
+    case "hydrate":
+      return hydrateWorkspace(event.availableSessionIds, event.persisted);
+    case "open":
+    case "activate": {
+      const openSessionIds = state.openSessionIds.includes(event.sessionId)
+        ? state.openSessionIds
+        : [...state.openSessionIds, event.sessionId];
+      return {
+        ...state,
+        activeSessionId: event.sessionId,
+        openSessionIds,
+        unreadSessionIds: withoutValue(state.unreadSessionIds, event.sessionId),
+      };
+    }
+    case "close": {
+      const index = state.openSessionIds.indexOf(event.sessionId);
+      if (index < 0) {
+        return state;
+      }
+      const openSessionIds = withoutValue(state.openSessionIds, event.sessionId);
+      const activeSessionId = state.activeSessionId === event.sessionId
+        ? openSessionIds[index] ?? openSessionIds[index - 1] ?? ""
+        : state.activeSessionId;
+      return {
+        ...state,
+        activeSessionId,
+        openSessionIds,
+        unreadSessionIds: withoutValue(state.unreadSessionIds, event.sessionId),
+      };
+    }
+    case "remove": {
+      const closed = reduceSessionTabWorkspace(state, { type: "close", sessionId: event.sessionId });
+      const draftsBySession = { ...closed.draftsBySession };
+      delete draftsBySession[event.sessionId];
+      return { ...closed, draftsBySession };
+    }
+    case "activity":
+      if (event.sessionId === state.activeSessionId
+        || !state.openSessionIds.includes(event.sessionId)
+        || state.unreadSessionIds.includes(event.sessionId)) {
+        return state;
+      }
+      return { ...state, unreadSessionIds: [...state.unreadSessionIds, event.sessionId] };
+    case "draft.changed": {
+      const key = event.sessionId || DRAFT_SESSION_KEY;
+      if (!event.value && !(key in state.draftsBySession)) {
+        return state;
+      }
+      const draftsBySession = { ...state.draftsBySession };
+      if (event.value) {
+        draftsBySession[key] = event.value;
+      } else {
+        delete draftsBySession[key];
+      }
+      return { ...state, draftsBySession };
+    }
+    case "replace": {
+      if (event.previousSessionId === event.sessionId) {
+        return state;
+      }
+      const openSessionIds = unique(state.openSessionIds.map((sessionId) => (
+        sessionId === event.previousSessionId ? event.sessionId : sessionId
+      )));
+      const draftsBySession = { ...state.draftsBySession };
+      if (event.previousSessionId in draftsBySession) {
+        draftsBySession[event.sessionId] = draftsBySession[event.previousSessionId];
+        delete draftsBySession[event.previousSessionId];
+      }
+      return {
+        activeSessionId: state.activeSessionId === event.previousSessionId
+          ? event.sessionId
+          : state.activeSessionId,
+        draftsBySession,
+        openSessionIds,
+        unreadSessionIds: unique(state.unreadSessionIds.map((sessionId) => (
+          sessionId === event.previousSessionId ? event.sessionId : sessionId
+        ))),
+      };
+    }
+    case "reconcile": {
+      const available = new Set(event.availableSessionIds);
+      const openSessionIds = state.openSessionIds.filter((sessionId) => available.has(sessionId));
+      const activeSessionId = openSessionIds.includes(state.activeSessionId)
+        ? state.activeSessionId
+        : openSessionIds[0] ?? "";
+      const draftsBySession = Object.fromEntries(
+        Object.entries(state.draftsBySession).filter(([sessionId]) => (
+          sessionId === DRAFT_SESSION_KEY || available.has(sessionId)
+        )),
+      );
+      return {
+        activeSessionId,
+        draftsBySession,
+        openSessionIds,
+        unreadSessionIds: state.unreadSessionIds.filter((sessionId) => (
+          sessionId !== activeSessionId && openSessionIds.includes(sessionId)
+        )),
+      };
+    }
+  }
+}
+
+export function sessionTabDraft(state: SessionTabWorkspaceState, sessionId: string): string {
+  return state.draftsBySession[sessionId || DRAFT_SESSION_KEY] ?? "";
+}
+
+export function persistedSessionTabWorkspace(
+  state: SessionTabWorkspaceState,
+): PersistedSessionTabWorkspace {
+  return {
+    activeSessionId: state.activeSessionId,
+    draftsBySession: state.draftsBySession,
+    openSessionIds: state.openSessionIds,
+  };
+}
+
+export function readPersistedSessionTabWorkspace(
+  storage: Pick<Storage, "getItem">,
+): PersistedSessionTabWorkspace | undefined {
+  const serialized = storage.getItem(CHAT_SESSION_TABS_STORAGE_KEY);
+  if (!serialized) {
+    return undefined;
+  }
+  try {
+    const value = JSON.parse(serialized) as unknown;
+    if (!isRecord(value)
+      || !Array.isArray(value.openSessionIds)
+      || !value.openSessionIds.every((sessionId) => typeof sessionId === "string")
+      || typeof value.activeSessionId !== "string"
+      || !isStringRecord(value.draftsBySession)) {
+      throw new Error("Stored session tab workspace has an invalid shape.");
+    }
+    return {
+      activeSessionId: value.activeSessionId,
+      draftsBySession: value.draftsBySession,
+      openSessionIds: unique(value.openSessionIds),
+    };
+  } catch (error) {
+    console.warn("[session-tabs] Failed to restore the saved workspace.", error);
+    return undefined;
+  }
+}
+
+export function writePersistedSessionTabWorkspace(
+  storage: Pick<Storage, "setItem">,
+  state: SessionTabWorkspaceState,
+): void {
+  storage.setItem(CHAT_SESSION_TABS_STORAGE_KEY, JSON.stringify(persistedSessionTabWorkspace(state)));
+}
+
+function hydrateWorkspace(
+  availableSessionIds: string[],
+  persisted?: PersistedSessionTabWorkspace,
+): SessionTabWorkspaceState {
+  const available = new Set(availableSessionIds);
+  let openSessionIds = unique(persisted?.openSessionIds ?? []).filter((sessionId) => available.has(sessionId));
+  if (!persisted && !openSessionIds.length && availableSessionIds[0]) {
+    openSessionIds = [availableSessionIds[0]];
+  }
+  const activeSessionId = persisted?.activeSessionId
+    && openSessionIds.includes(persisted.activeSessionId)
+    ? persisted.activeSessionId
+    : openSessionIds[0] ?? "";
+  const draftsBySession = Object.fromEntries(
+    Object.entries(persisted?.draftsBySession ?? {}).filter(([sessionId]) => (
+      sessionId === DRAFT_SESSION_KEY || available.has(sessionId)
+    )),
+  );
+  return {
+    activeSessionId,
+    draftsBySession,
+    openSessionIds,
+    unreadSessionIds: [],
+  };
+}
+
+function withoutValue(values: string[], value: string): string[] {
+  return values.filter((candidate) => candidate !== value);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}

--- a/src/react-workbench/chat/sessionWorkspaces.test.ts
+++ b/src/react-workbench/chat/sessionWorkspaces.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { SessionSummary } from "../services";
+import {
+  GENERAL_SESSION_WORKSPACE_KEY,
+  groupSessionsByWorkspace,
+  sessionWorkspaceName,
+} from "./sessionWorkspaces";
+
+function session(
+  id: string,
+  updatedAtMs: number,
+  workingDirectory?: string,
+): SessionSummary {
+  return {
+    id,
+    title: id,
+    updatedAtMs,
+    ...(workingDirectory ? { workingDirectory } : {}),
+  };
+}
+
+describe("session workspace projection", () => {
+  it("groups equivalent Windows directories without changing the session order", () => {
+    const groups = groupSessionsByWorkspace([
+      session("tinybot-new", 30, "D:\\Code\\py\\tinybot\\"),
+      session("general", 25),
+      session("tinybot-old", 20, "d:/code/py/tinybot"),
+      session("virtual-home", 10, "D:\\Code\\VirtualHome"),
+    ]);
+
+    expect(groups).toEqual([
+      expect.objectContaining({
+        label: "tinybot",
+        sessions: [
+          expect.objectContaining({ id: "tinybot-new" }),
+          expect.objectContaining({ id: "tinybot-old" }),
+        ],
+        workingDirectory: "D:\\Code\\py\\tinybot",
+      }),
+      expect.objectContaining({
+        key: GENERAL_SESSION_WORKSPACE_KEY,
+        label: "常规会话",
+        sessions: [expect.objectContaining({ id: "general" })],
+      }),
+      expect.objectContaining({
+        label: "VirtualHome",
+        sessions: [expect.objectContaining({ id: "virtual-home" })],
+      }),
+    ]);
+  });
+
+  it("derives a useful label for Windows, Unix, and root directories", () => {
+    expect(sessionWorkspaceName("D:\\Code\\py\\tinybot\\")).toBe("tinybot");
+    expect(sessionWorkspaceName("/work/projects/tinybot/")).toBe("tinybot");
+    expect(sessionWorkspaceName("D:\\")).toBe("D:");
+  });
+});

--- a/src/react-workbench/chat/sessionWorkspaces.ts
+++ b/src/react-workbench/chat/sessionWorkspaces.ts
@@ -1,0 +1,58 @@
+import type { SessionSummary } from "../services";
+
+export const GENERAL_SESSION_WORKSPACE_KEY = "session-workspace:general";
+
+export type SessionWorkspaceGroup = {
+  key: string;
+  label: string;
+  sessions: SessionSummary[];
+  updatedAtMs: number;
+  workingDirectory?: string;
+};
+
+export function groupSessionsByWorkspace(sessions: SessionSummary[]): SessionWorkspaceGroup[] {
+  const groups = new Map<string, SessionWorkspaceGroup>();
+  for (const session of sessions) {
+    const workingDirectory = normalizedDisplayPath(session.workingDirectory);
+    const pathKey = workingDirectory ? normalizedWorkspacePathKey(workingDirectory) : "";
+    const key = pathKey ? `session-workspace:${pathKey}` : GENERAL_SESSION_WORKSPACE_KEY;
+    const current = groups.get(key);
+    if (current) {
+      current.sessions.push(session);
+      current.updatedAtMs = Math.max(current.updatedAtMs, session.updatedAtMs);
+      continue;
+    }
+    groups.set(key, {
+      key,
+      label: workingDirectory ? sessionWorkspaceName(workingDirectory) : "常规会话",
+      sessions: [session],
+      updatedAtMs: session.updatedAtMs,
+      ...(workingDirectory ? { workingDirectory } : {}),
+    });
+  }
+  return [...groups.values()].sort((left, right) => right.updatedAtMs - left.updatedAtMs);
+}
+
+export function sessionWorkspaceName(workingDirectory: string): string {
+  const path = normalizedDisplayPath(workingDirectory);
+  if (!path) {
+    return "常规会话";
+  }
+  const parts = path.split(/[\\/]+/).filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+function normalizedDisplayPath(value: string | undefined): string {
+  const path = value?.trim() ?? "";
+  if (!path) {
+    return "";
+  }
+  const withoutTrailingSeparators = path.replace(/[\\/]+$/, "");
+  return withoutTrailingSeparators || path;
+}
+
+function normalizedWorkspacePathKey(path: string): string {
+  const slashPath = path.replace(/\\/g, "/");
+  const windowsPath = /^[a-zA-Z]:\//.test(slashPath) || slashPath.startsWith("//");
+  return windowsPath ? slashPath.toLocaleLowerCase("en-US") : slashPath;
+}

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -27,7 +27,10 @@ const thread = {
   status: "idle",
   createdAt: "2026-07-14T00:00:00.000Z",
   updatedAt: "2026-07-14T00:00:00.000Z",
-  metadata: { extra: {} },
+  metadata: {
+    workingDirectory: "D:\\Code\\py\\tinybot",
+    extra: {},
+  },
 };
 
 function canonicalRuntimeState(turnId: string, status = "running") {
@@ -100,14 +103,29 @@ describe("desktop native app services", () => {
     const services = createDesktopAppServices();
 
     await expect(services.sessionStore.list()).resolves.toEqual([
-      expect.objectContaining({ id: "thread-1", title: "Native thread" }),
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Native thread",
+        workingDirectory: "D:\\Code\\py\\tinybot",
+      }),
     ]);
-    await expect(services.sessionStore.create({ title: "New Thread" })).resolves.toEqual(
+    await expect(services.sessionStore.create({
+      title: "New Thread",
+      workingDirectory: "D:\\Code\\py\\tinybot",
+    })).resolves.toEqual(
       expect.objectContaining({ id: "thread-1" }),
     );
 
     expect(mocks.invoke).toHaveBeenCalledWith("worker_thread_create", {
-      input: { body: { title: "New Thread", source: "desktop" } },
+      input: {
+        body: {
+          title: "New Thread",
+          source: "desktop",
+          metadata: {
+            workingDirectory: "D:\\Code\\py\\tinybot",
+          },
+        },
+      },
     });
   });
 

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -430,6 +430,11 @@ export function createDesktopAppServices(): AppServices {
         const thread = await requireNative(nativeThreads, "Thread").create({
           title: input?.title || "New session",
           source: "desktop",
+          ...(input?.workingDirectory ? {
+            metadata: {
+              workingDirectory: input.workingDirectory,
+            },
+          } : {}),
         });
         await controller.loadSessions();
         const sessionId = thread.threadId;
@@ -718,6 +723,7 @@ function mapSession(session: NativeChatSession, responding: boolean, fallbackPay
     updatedAtMs: timestampMs(session.updatedAt) ?? timestampFromPayload(fallbackPayload) ?? Date.now(),
     ...(session.pinned ? { pinned: true } : {}),
     ...(session.archived ? { archived: true } : {}),
+    ...(session.workingDirectory ? { workingDirectory: session.workingDirectory } : {}),
     status: responding || threadStatus === "running" || threadStatus === "cancelling"
       ? "running"
       : threadStatus === "waiting_for_approval"

--- a/src/react-workbench/services.ts
+++ b/src/react-workbench/services.ts
@@ -39,6 +39,7 @@ export type SessionSummary = {
   pinned?: boolean;
   archived?: boolean;
   status?: "idle" | "running" | "waiting_approval" | "failed";
+  workingDirectory?: string;
 };
 
 export type ChatInput = DesktopChatInput;
@@ -60,7 +61,7 @@ export type ApprovalAction = "approveOnce" | "approveSession" | "deny";
 
 export type SessionStore = {
   list(): Promise<SessionSummary[]>;
-  create(input?: { title?: string }): Promise<SessionSummary>;
+  create(input?: { title?: string; workingDirectory?: string }): Promise<SessionSummary>;
   rename(id: string, title: string): Promise<void>;
   delete(id: string): Promise<void>;
   pin(id: string, pinned: boolean): Promise<void>;

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -3,7 +3,7 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { readFileSync } from "node:fs";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopShell } from "./DesktopShell";
 import { buildAgentDefaultsSettings } from "../../app-core/settings/agentDefaultsSettings";
 import { buildProviderModelsSettings } from "../../app-core/settings/providerModelsSettings";
@@ -12,6 +12,7 @@ import type { ReactChatMessage } from "../chat/messageActions";
 import { timelineFromReactMessages } from "../chat/testTimelineFixtures";
 import { unavailableTinyOsEffectiveCapabilities } from "../../app-core/chat/tinyOsCapabilities";
 
+beforeEach(() => window.localStorage.clear());
 afterEach(() => cleanup());
 
 function createServices(options: { messages?: ReactChatMessage[]; sessions?: SessionSummary[] } = {}): AppServices & {
@@ -150,10 +151,9 @@ describe("DesktopShell", () => {
     expect(css).toMatch(/\.react-window-frame__brand\s*{[^}]*font-size:\s*13px;/s);
     expect(css).toMatch(/\.react-top-menu__trigger\s*{[^}]*font-size:\s*12px;/s);
     expect(css).toMatch(/\.react-top-menu__menu-item\s*{[^}]*font-size:\s*13px;/s);
-    expect(css).toMatch(/\.react-activity-rail button\s*{[^}]*font-size:\s*10px;/s);
-    expect(css).toMatch(/\.react-workbench-layout\s*{[^}]*grid-template-columns:\s*58px minmax\(0,\s*1fr\);/s);
-    expect(css).toMatch(/\.react-activity-rail button span\s*{[^}]*display:\s*none;/s);
-    expect(css).toMatch(/\.react-activity-rail button::after\s*{[^}]*content:\s*attr\(data-label\);/s);
+    expect(css).toMatch(/\.react-workbench-layout\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\);/s);
+    expect(css).toMatch(/\.react-top-menu__menu-item\[aria-current="page"\]\s*{[^}]*background:/s);
+    expect(css).not.toMatch(/\.react-activity-rail/);
     expect(css).toMatch(/\.react-session-list\s*{[^}]*transition:\s*width 260ms var\(--motion-ease-standard\);/s);
     expect(css).toMatch(/\.react-session-list\[data-collapsed="true"\]\s*{[^}]*width:\s*64px;/s);
     expect(css).toMatch(/\.react-session-list__new\s*{[^}]*font-size:\s*12px;/s);
@@ -184,7 +184,10 @@ describe("DesktopShell", () => {
 
     await user.click(screen.getByRole("button", { name: "Resources" }));
     const resourcesMenu = screen.getByRole("menu", { name: "Resources menu" });
-    expect(within(resourcesMenu).getByRole("menuitem", { name: "Chat" })).toBeTruthy();
+    for (const item of ["Chat", "Workspace Files", "Cowork", "GitHub", "Tools & Skills"]) {
+      expect(within(resourcesMenu).getByRole("menuitem", { name: item })).toBeTruthy();
+    }
+    expect(within(resourcesMenu).getByRole("menuitem", { name: "Chat" }).getAttribute("aria-current")).toBe("page");
 
     await user.click(screen.getByRole("button", { name: "System" }));
     const systemMenu = screen.getByRole("menu", { name: "System menu" });
@@ -230,7 +233,7 @@ describe("DesktopShell", () => {
     fireEvent.pointerDown(appMenu);
     expect(screen.getByRole("menu", { name: "Application menu" })).toBeTruthy();
 
-    await user.click(screen.getByRole("button", { name: "Files" }));
+    await user.click(screen.getByText("Tinybot", { selector: ".react-window-frame__brand" }));
     expect(screen.queryByRole("menu", { name: "Application menu" })).toBeNull();
   });
 
@@ -242,22 +245,45 @@ describe("DesktopShell", () => {
     for (const menu of ["App", "Resources", "System", "Help"]) {
       expect(screen.getByRole("button", { name: menu })).toBeTruthy();
     }
+    expect(screen.queryByRole("navigation", { name: "Primary" })).toBeNull();
 
-    await user.click(screen.getByRole("button", { name: "Files" }));
+    await user.click(screen.getByRole("button", { name: "Resources" }));
+    let resourcesMenu = screen.getByRole("menu", { name: "Resources menu" });
+    await user.click(within(resourcesMenu).getByRole("menuitem", { name: "Workspace Files" }));
     expect(await screen.findByRole("heading", { name: "Workspace Files" })).toBeTruthy();
     expect(screen.getByText("src/main.ts")).toBeTruthy();
     expect(services.workspaceStore.listFiles).toHaveBeenCalled();
 
-    await user.click(screen.getByRole("button", { name: "Tools" }));
+    await user.click(screen.getByRole("button", { name: "Resources" }));
+    resourcesMenu = screen.getByRole("menu", { name: "Resources menu" });
+    expect(within(resourcesMenu).getByRole("menuitem", { name: "Workspace Files" }).getAttribute("aria-current")).toBe("page");
+    await user.click(within(resourcesMenu).getByRole("menuitem", { name: "Cowork" }));
+    expect(await screen.findByRole("heading", { name: "Cowork" })).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Resources" }));
+    resourcesMenu = screen.getByRole("menu", { name: "Resources menu" });
+    await user.click(within(resourcesMenu).getByRole("menuitem", { name: "GitHub" }));
+    expect(await screen.findByRole("heading", { name: "GitHub" })).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Resources" }));
+    resourcesMenu = screen.getByRole("menu", { name: "Resources menu" });
+    await user.click(within(resourcesMenu).getByRole("menuitem", { name: "Tools & Skills" }));
     expect(await screen.findByRole("heading", { name: "Tools & Skills" })).toBeTruthy();
     expect(screen.getByText("Read file")).toBeTruthy();
     expect(screen.getByText("review-code")).toBeTruthy();
 
-    await user.click(screen.getByRole("button", { name: "Settings" }));
+    await user.click(screen.getByRole("button", { name: "System" }));
+    const systemMenu = screen.getByRole("menu", { name: "System menu" });
+    await user.click(within(systemMenu).getByRole("menuitem", { name: "Settings (Ctrl+,)" }));
     expect(await screen.findByRole("heading", { name: "Settings" })).toBeTruthy();
     expect(screen.getByText("Default model")).toBeTruthy();
-
     expect(screen.queryByText(/placeholder/i)).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Help" }));
+    const helpMenu = screen.getByRole("menu", { name: "Help menu" });
+    await user.click(within(helpMenu).getByRole("menuitem", { name: "Documentation (F1)" }));
+    expect(await screen.findByRole("heading", { name: "Docs" })).toBeTruthy();
+
     expect(screen.queryByText(/Vue/i)).toBeNull();
   });
 
@@ -318,7 +344,9 @@ describe("DesktopShell", () => {
     services.settingsStore.fetchProviderModels = fetchProviderModels;
     render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={services} />);
 
-    await user.click(screen.getByRole("button", { name: "Settings" }));
+    await user.click(screen.getByRole("button", { name: "System" }));
+    await user.click(within(screen.getByRole("menu", { name: "System menu" }))
+      .getByRole("menuitem", { name: "Settings (Ctrl+,)" }));
 
     expect(await screen.findByRole("heading", { name: "Provider & Models" })).toBeTruthy();
     expect(screen.getByRole("navigation", { name: "Settings categories" })).toBeTruthy();
@@ -420,7 +448,9 @@ describe("DesktopShell", () => {
     services.settingsStore.saveProviderSettings = saveProviderSettings;
     render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={services} />);
 
-    await user.click(screen.getByRole("button", { name: "Settings" }));
+    await user.click(screen.getByRole("button", { name: "System" }));
+    await user.click(within(screen.getByRole("menu", { name: "System menu" }))
+      .getByRole("menuitem", { name: "Settings (Ctrl+,)" }));
     await user.click(await screen.findByRole("button", { name: "Add provider" }));
     const dialog = screen.getByRole("dialog", { name: "Add provider" });
     await user.type(within(dialog).getByLabelText("Provider ID"), "local-openai");
@@ -488,7 +518,9 @@ describe("DesktopShell", () => {
     services.settingsStore.saveAgentDefaultsSettings = saveAgentDefaultsSettings;
     render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={services} />);
 
-    await user.click(screen.getByRole("button", { name: "Settings" }));
+    await user.click(screen.getByRole("button", { name: "System" }));
+    await user.click(within(screen.getByRole("menu", { name: "System menu" }))
+      .getByRole("menuitem", { name: "Settings (Ctrl+,)" }));
     await user.click(await screen.findByRole("button", { name: "Agent Defaults" }));
 
     expect(await screen.findByRole("heading", { name: "Agent Defaults" })).toBeTruthy();

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -114,6 +114,9 @@ describe("DesktopShell", () => {
     const appMenuButton = screen.getByRole("button", { name: "App" });
     expect(appMenuButton.querySelector(".react-top-menu__icon")).toBeTruthy();
     expect(appMenuButton.querySelector(".react-top-menu__label")?.textContent).toBe("App");
+    expect(screen.getByRole("button", { name: "Go back" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Go forward" }).hasAttribute("disabled")).toBe(true);
+    expect(document.querySelector(".react-window-frame__brand")).toBeNull();
 
     fireEvent.pointerDown(appMenuButton);
 
@@ -148,10 +151,11 @@ describe("DesktopShell", () => {
   it("keeps shell navigation typography compact", () => {
     const css = readFileSync("src/react-workbench/styles/workbench.css", "utf8");
 
-    expect(css).toMatch(/\.react-window-frame__brand\s*{[^}]*font-size:\s*13px;/s);
+    expect(css).toMatch(/\.react-window-frame__history button\s*{[^}]*width:\s*32px;[^}]*height:\s*32px;/s);
     expect(css).toMatch(/\.react-top-menu__trigger\s*{[^}]*font-size:\s*12px;/s);
     expect(css).toMatch(/\.react-top-menu__menu-item\s*{[^}]*font-size:\s*13px;/s);
     expect(css).toMatch(/\.react-workbench-layout\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\);/s);
+    expect(css).toMatch(/\.react-chat-surface\s*{[^}]*grid-template-rows:\s*45px minmax\(0,\s*1fr\) auto;/s);
     expect(css).toMatch(/\.react-top-menu__menu-item\[aria-current="page"\]\s*{[^}]*background:/s);
     expect(css).not.toMatch(/\.react-activity-rail/);
     expect(css).toMatch(/\.react-session-list\s*{[^}]*transition:\s*width 260ms var\(--motion-ease-standard\);/s);
@@ -233,8 +237,38 @@ describe("DesktopShell", () => {
     fireEvent.pointerDown(appMenu);
     expect(screen.getByRole("menu", { name: "Application menu" })).toBeTruthy();
 
-    await user.click(screen.getByText("Tinybot", { selector: ".react-window-frame__brand" }));
+    fireEvent.pointerDown(screen.getByRole("banner", { name: "Tinybot desktop window frame" }));
     expect(screen.queryByRole("menu", { name: "Application menu" })).toBeNull();
+  });
+
+  it("navigates backward and forward through shell routes", async () => {
+    const user = userEvent.setup();
+    render(<DesktopShell now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} services={createServices()} />);
+
+    const backButton = screen.getByRole("button", { name: "Go back" });
+    const forwardButton = screen.getByRole("button", { name: "Go forward" });
+    expect(backButton.hasAttribute("disabled")).toBe(true);
+    expect(forwardButton.hasAttribute("disabled")).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "Resources" }));
+    await user.click(within(screen.getByRole("menu", { name: "Resources menu" })).getByRole("menuitem", { name: "Workspace Files" }));
+    expect(await screen.findByRole("heading", { name: "Workspace Files" })).toBeTruthy();
+    expect(backButton.hasAttribute("disabled")).toBe(false);
+    expect(forwardButton.hasAttribute("disabled")).toBe(true);
+
+    await user.click(backButton);
+    expect(await screen.findByRole("heading", { name: "Tinybot" })).toBeTruthy();
+    expect(backButton.hasAttribute("disabled")).toBe(true);
+    expect(forwardButton.hasAttribute("disabled")).toBe(false);
+
+    await user.click(forwardButton);
+    expect(await screen.findByRole("heading", { name: "Workspace Files" })).toBeTruthy();
+
+    await user.click(backButton);
+    await user.click(screen.getByRole("button", { name: "System" }));
+    await user.click(within(screen.getByRole("menu", { name: "System menu" })).getByRole("menuitem", { name: "Settings (Ctrl+,)" }));
+    expect(await screen.findByRole("heading", { name: "Settings" })).toBeTruthy();
+    expect(forwardButton.hasAttribute("disabled")).toBe(true);
   });
 
   it("renders native-style top menus and functional secondary pages", async () => {

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -9,7 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
-import { BookOpen, Check, ChevronRight, Command, Folder, Minus, Settings, Square, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, BookOpen, Check, ChevronRight, Command, Folder, Minus, Settings, Square, X } from "lucide-react";
 import { createDesktopStopCommand } from "../../app-core/chat/desktopCommand";
 import { ChatPage } from "../chat/ChatPage";
 import { AgentDefaultsSettingsPage } from "../settings/AgentDefaultsSettingsPage";
@@ -18,6 +18,12 @@ import { ProviderModelsSettingsPage } from "../settings/ProviderModelsSettingsPa
 import type { AppServices, ToolCatalogSummary, WorkspaceFileSummary } from "../services";
 
 type AppRoute = "chat" | "files" | "cowork" | "github" | "docs" | "tools" | "settings";
+
+type RouteHistory = {
+  back: AppRoute[];
+  current: AppRoute;
+  forward: AppRoute[];
+};
 
 export type DesktopShellProps = {
   services: AppServices;
@@ -148,7 +154,12 @@ const topMenuItems: TopMenuItem[] = [
 ];
 
 export function DesktopShell({ now, services, windowControls }: DesktopShellProps) {
-  const [route, setRoute] = useState<AppRoute>("chat");
+  const [routeHistory, setRouteHistory] = useState<RouteHistory>({
+    back: [],
+    current: "chat",
+    forward: [],
+  });
+  const route = routeHistory.current;
   const [activeTopMenu, setActiveTopMenu] = useState<TopMenuLabel | null>(null);
   const [activeTopSubmenu, setActiveTopSubmenu] = useState<string | null>(null);
   const [sessionSidebarCollapsed, setSessionSidebarCollapsed] = useState(false);
@@ -224,6 +235,47 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
     setActiveTopMenu((current) => current === label ? null : label);
   }
 
+  function navigateToRoute(nextRoute: AppRoute) {
+    setRouteHistory((current) => {
+      if (nextRoute === current.current) {
+        return current;
+      }
+      return {
+        back: [...current.back, current.current],
+        current: nextRoute,
+        forward: [],
+      };
+    });
+  }
+
+  function goBack() {
+    setRouteHistory((current) => {
+      const previous = current.back[current.back.length - 1];
+      if (!previous) {
+        return current;
+      }
+      return {
+        back: current.back.slice(0, -1),
+        current: previous,
+        forward: [current.current, ...current.forward],
+      };
+    });
+  }
+
+  function goForward() {
+    setRouteHistory((current) => {
+      const [next, ...remaining] = current.forward;
+      if (!next) {
+        return current;
+      }
+      return {
+        back: [...current.back, current.current],
+        current: next,
+        forward: remaining,
+      };
+    });
+  }
+
   function runTopMenuCommand(command: TopMenuCommand) {
     if (command.enabled === false) {
       return;
@@ -231,12 +283,12 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
     setActiveTopMenu(null);
     setActiveTopSubmenu(null);
     if (command.route) {
-      setRoute(command.route);
+      navigateToRoute(command.route);
       return;
     }
     switch (command.id) {
       case "new-chat":
-        setRoute("chat");
+        navigateToRoute("chat");
         setCreateChatSignal((current) => current + 1);
         return;
       case "stop-generation":
@@ -336,7 +388,26 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
         role="banner"
         onDoubleClick={handleFrameDoubleClick}
       >
-        <div className="react-window-frame__brand" data-tauri-drag-region="">Tinybot</div>
+        <nav aria-label="Page history" className="react-window-frame__history" data-no-window-drag="">
+          <button
+            aria-label="Go back"
+            disabled={routeHistory.back.length === 0}
+            title="Back"
+            type="button"
+            onClick={goBack}
+          >
+            <ArrowLeft aria-hidden="true" size={17} />
+          </button>
+          <button
+            aria-label="Go forward"
+            disabled={routeHistory.forward.length === 0}
+            title="Forward"
+            type="button"
+            onClick={goForward}
+          >
+            <ArrowRight aria-hidden="true" size={17} />
+          </button>
+        </nav>
         <nav className="react-top-menu" aria-label="Application menu">
           {topMenuItems.map(({ entries, icon: Icon, label, menuLabel }) => (
             <div className="react-top-menu__group" key={label}>
@@ -417,7 +488,7 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
           route={route}
           services={services}
           sessionSidebarCollapsed={sessionSidebarCollapsed}
-          onNavigate={setRoute}
+          onNavigate={navigateToRoute}
           onSessionSidebarCollapsedChange={setSessionSidebarCollapsed}
           onStopGenerationTargetChange={handleStopGenerationTargetChange}
         />

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -9,7 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
-import { BookOpen, Bot, ChevronRight, Code2, Command, FileText, Folder, MessageSquare, Minus, Settings, Square, Wrench, X } from "lucide-react";
+import { BookOpen, Check, ChevronRight, Command, Folder, Minus, Settings, Square, X } from "lucide-react";
 import { createDesktopStopCommand } from "../../app-core/chat/desktopCommand";
 import { ChatPage } from "../chat/ChatPage";
 import { AgentDefaultsSettingsPage } from "../settings/AgentDefaultsSettingsPage";
@@ -25,15 +25,15 @@ export type DesktopShellProps = {
   windowControls?: WindowFrameControls;
 };
 
-const routeItems: Array<{ id: AppRoute; label: string; icon: typeof MessageSquare }> = [
-  { id: "chat", label: "Chat", icon: MessageSquare },
-  { id: "files", label: "Files", icon: Folder },
-  { id: "cowork", label: "Cowork", icon: Bot },
-  { id: "github", label: "GitHub", icon: Code2 },
-  { id: "docs", label: "Docs", icon: FileText },
-  { id: "tools", label: "Tools", icon: Wrench },
-  { id: "settings", label: "Settings", icon: Settings },
-];
+const routeLabels: Record<AppRoute, string> = {
+  chat: "Chat",
+  files: "Workspace Files",
+  cowork: "Cowork",
+  github: "GitHub",
+  docs: "Docs",
+  tools: "Tools & Skills",
+  settings: "Settings",
+};
 
 type WindowFrameControls = {
   close(): Promise<void>;
@@ -48,6 +48,10 @@ type TopMenuCommandId =
   | "stop-generation"
   | "search-sessions"
   | "open-chat"
+  | "open-files"
+  | "open-cowork"
+  | "open-github"
+  | "open-tools"
   | "open-tinybot-repo"
   | "open-settings"
   | "open-docs"
@@ -64,6 +68,7 @@ type TopMenuCommand = {
   label: string;
   shortcut?: string;
   enabled?: boolean;
+  route?: AppRoute;
 };
 
 type TopMenuEntry =
@@ -74,7 +79,7 @@ type TopMenuEntry =
 type TopMenuItem = {
   label: TopMenuLabel;
   menuLabel: string;
-  icon: typeof MessageSquare;
+  icon: typeof Command;
   entries: TopMenuEntry[];
 };
 
@@ -101,7 +106,11 @@ const topMenuItems: TopMenuItem[] = [
     menuLabel: "Resources menu",
     icon: Folder,
     entries: [
-      menuCommand({ id: "open-chat", label: "Chat" }),
+      menuCommand({ id: "open-chat", label: routeLabels.chat, route: "chat" }),
+      menuCommand({ id: "open-files", label: routeLabels.files, route: "files" }),
+      menuCommand({ id: "open-cowork", label: routeLabels.cowork, route: "cowork" }),
+      menuCommand({ id: "open-github", label: routeLabels.github, route: "github" }),
+      menuCommand({ id: "open-tools", label: routeLabels.tools, route: "tools" }),
     ],
   },
   {
@@ -109,7 +118,7 @@ const topMenuItems: TopMenuItem[] = [
     menuLabel: "System menu",
     icon: Settings,
     entries: [
-      menuCommand({ id: "open-settings", label: "Settings", shortcut: "Ctrl+," }),
+      menuCommand({ id: "open-settings", label: routeLabels.settings, route: "settings", shortcut: "Ctrl+," }),
       menuSeparator("system-status-separator"),
       menuCommand({ id: "refresh-gateway-status", label: "Gateway Status", shortcut: "Ctrl+Shift+G", enabled: false }),
     ],
@@ -119,7 +128,7 @@ const topMenuItems: TopMenuItem[] = [
     menuLabel: "Help menu",
     icon: BookOpen,
     entries: [
-      menuCommand({ id: "open-docs", label: "Documentation", shortcut: "F1" }),
+      menuCommand({ id: "open-docs", label: "Documentation", route: "docs", shortcut: "F1" }),
       menuSeparator("help-more-separator"),
       {
         kind: "submenu",
@@ -221,19 +230,14 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
     }
     setActiveTopMenu(null);
     setActiveTopSubmenu(null);
+    if (command.route) {
+      setRoute(command.route);
+      return;
+    }
     switch (command.id) {
       case "new-chat":
         setRoute("chat");
         setCreateChatSignal((current) => current + 1);
-        return;
-      case "open-chat":
-        setRoute("chat");
-        return;
-      case "open-settings":
-        setRoute("settings");
-        return;
-      case "open-docs":
-        setRoute("docs");
         return;
       case "stop-generation":
         stopActiveGeneration();
@@ -255,6 +259,7 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
       : command;
     return (
       <button
+        aria-current={resolvedCommand.route === route ? "page" : undefined}
         aria-label={menuCommandAccessibleLabel(resolvedCommand)}
         className="react-top-menu__menu-item"
         disabled={resolvedCommand.enabled === false}
@@ -265,7 +270,14 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
         onClick={() => runTopMenuCommand(resolvedCommand)}
       >
         <span className="react-top-menu__menu-label">{resolvedCommand.label}</span>
-        {resolvedCommand.shortcut ? <span className="react-top-menu__shortcut">{resolvedCommand.shortcut}</span> : null}
+        {resolvedCommand.route === route || resolvedCommand.shortcut ? (
+          <span className="react-top-menu__menu-meta">
+            {resolvedCommand.route === route ? (
+              <Check aria-hidden="true" className="react-top-menu__current" size={15} />
+            ) : null}
+            {resolvedCommand.shortcut ? <span className="react-top-menu__shortcut">{resolvedCommand.shortcut}</span> : null}
+          </span>
+        ) : null}
       </button>
     );
   }
@@ -398,25 +410,6 @@ export function DesktopShell({ now, services, windowControls }: DesktopShellProp
       </header>
 
       <div className="react-workbench-layout">
-        <nav className="react-activity-rail" aria-label="Primary">
-          {routeItems.map((item) => {
-            const Icon = item.icon;
-            return (
-              <button
-                aria-label={item.label}
-                data-active={route === item.id}
-                data-label={item.label}
-                key={item.id}
-                title={item.label}
-                type="button"
-                onClick={() => setRoute(item.id)}
-              >
-                <Icon aria-hidden="true" size={18} />
-                <span>{item.label}</span>
-              </button>
-            );
-          })}
-        </nav>
         <section className="react-route-surface">
           <RouteSurface
             createChatSignal={createChatSignal}
@@ -510,7 +503,7 @@ function RouteSurface({
     case "cowork":
     case "github":
     case "docs":
-      return <PlaceholderPage title={routeItems.find((item) => item.id === route)?.label ?? "Page"} />;
+      return <PlaceholderPage title={routeLabels[route]} />;
   }
 }
 

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -122,10 +122,41 @@ button:disabled {
   -webkit-user-select: none;
 }
 
-.react-window-frame__brand {
+.react-window-frame__history {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.react-window-frame__history button {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-muted);
+}
+
+.react-window-frame__history button:hover:not(:disabled),
+.react-window-frame__history button:focus-visible {
+  background: var(--color-surface-soft);
   color: var(--color-ink);
-  font-size: 13px;
-  font-weight: 650;
+}
+
+.react-window-frame__history button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 55%, transparent);
+  outline-offset: -2px;
+}
+
+.react-window-frame__history button:disabled {
+  color: var(--color-muted-soft);
+  cursor: default;
+  opacity: 0.48;
 }
 
 .react-top-menu {
@@ -928,7 +959,7 @@ button:disabled {
 .react-chat-surface {
   position: relative;
   display: grid;
-  grid-template-rows: 56px minmax(0, 1fr) auto;
+  grid-template-rows: 45px minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
   background: var(--color-canvas);

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -137,7 +137,6 @@ button:disabled {
 
 .react-top-menu__trigger,
 .react-window-frame > button,
-.react-activity-rail button,
 .react-chat-header__actions > button,
 .react-message__actions button,
 .react-session-row__delete {
@@ -285,6 +284,10 @@ button:disabled {
   background: var(--color-surface-soft);
 }
 
+.react-top-menu__menu-item[aria-current="page"] {
+  background: var(--color-surface-card);
+}
+
 .react-top-menu__menu-item:focus-visible {
   border-color: var(--color-primary);
 }
@@ -334,6 +337,17 @@ button:disabled {
   white-space: nowrap;
 }
 
+.react-top-menu__menu-meta {
+  display: inline-flex;
+  align-items: center;
+  justify-self: end;
+  gap: 7px;
+}
+
+.react-top-menu__current {
+  color: var(--color-primary);
+}
+
 .react-top-menu__shortcut {
   display: inline-flex;
   align-items: center;
@@ -355,67 +369,8 @@ button:disabled {
 
 .react-workbench-layout {
   display: grid;
-  grid-template-columns: 58px minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   min-height: 0;
-}
-
-.react-activity-rail {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  overflow: visible;
-  padding: 10px 7px;
-  border-right: 1px solid var(--color-hairline);
-  background: var(--color-surface-soft);
-}
-
-.react-activity-rail button {
-  position: relative;
-  width: 42px;
-  min-width: 42px;
-  min-height: 42px;
-  padding: 0;
-  color: var(--color-muted);
-  font-size: 10px;
-}
-
-.react-activity-rail button span {
-  display: none;
-}
-
-.react-activity-rail button::after {
-  position: absolute;
-  top: 50%;
-  left: calc(100% + 9px);
-  z-index: 50;
-  min-width: max-content;
-  border: 1px solid var(--color-hairline);
-  border-radius: 7px;
-  background: #fff;
-  box-shadow: 0 12px 28px rgb(20 20 19 / 12%);
-  color: var(--color-ink);
-  content: attr(data-label);
-  font-size: 12px;
-  font-weight: 650;
-  line-height: 1;
-  opacity: 0;
-  padding: 7px 9px;
-  pointer-events: none;
-  transform: translate(-4px, -50%);
-  transition: opacity 160ms ease, transform 220ms ease;
-  white-space: nowrap;
-}
-
-.react-activity-rail button:hover::after,
-.react-activity-rail button:focus-visible::after {
-  opacity: 1;
-  transform: translate(0, -50%);
-}
-
-.react-activity-rail button[data-active="true"] {
-  background: var(--color-cream-strong);
-  color: var(--color-ink);
 }
 
 .react-route-surface {
@@ -480,6 +435,7 @@ button:disabled {
 }
 
 .react-session-list__header h2,
+.react-session-list__add-workspace,
 .react-session-list__search,
 .react-session-list__new span,
 .react-session-row__title,
@@ -533,6 +489,7 @@ button:disabled {
   color: var(--color-muted);
 }
 
+.react-session-list__add-workspace,
 .react-session-list__search {
   display: inline-grid;
   place-items: center;
@@ -549,9 +506,15 @@ button:disabled {
     min-width 240ms var(--motion-ease-standard);
 }
 
+.react-session-list__add-workspace:hover,
+.react-session-list__add-workspace:focus-visible,
 .react-session-list__search:hover,
 .react-session-list__search:focus-visible {
   color: var(--color-ink);
+}
+
+.react-session-list__add-workspace:disabled {
+  color: var(--color-muted-soft);
 }
 
 .react-session-list__collapse svg {
@@ -572,6 +535,7 @@ button:disabled {
 }
 
 .react-session-list[data-collapsed="true"] .react-session-list__header h2,
+.react-session-list[data-collapsed="true"] .react-session-list__add-workspace,
 .react-session-list[data-collapsed="true"] .react-session-list__search,
 .react-session-list[data-collapsed="true"] .react-session-list__new span {
   max-width: 0;
@@ -580,6 +544,7 @@ button:disabled {
   transform: translateX(-6px);
 }
 
+.react-session-list[data-collapsed="true"] .react-session-list__add-workspace,
 .react-session-list[data-collapsed="true"] .react-session-list__search {
   width: 0;
   min-width: 0;
@@ -598,6 +563,126 @@ button:disabled {
   min-height: 0;
   overflow: auto;
   padding: 0 8px 12px;
+}
+
+.react-session-list__error {
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--color-error) 28%, transparent);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--color-error) 7%, #fff);
+  padding: 7px 8px;
+  color: var(--color-error);
+  font-size: 10px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.react-session-list__pending {
+  animation: react-session-tab-spin 1.2s linear infinite;
+}
+
+.react-session-workspace {
+  position: relative;
+  margin-top: 5px;
+}
+
+.react-session-workspace > summary {
+  display: grid;
+  grid-template-columns: 14px 16px minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+  min-height: 44px;
+  padding: 5px 36px 5px 5px;
+  border-radius: 8px;
+  color: var(--color-muted);
+  cursor: pointer;
+  list-style: none;
+  transition:
+    background-color var(--motion-duration-fast) ease,
+    color var(--motion-duration-fast) ease;
+}
+
+.react-session-workspace > summary::-webkit-details-marker {
+  display: none;
+}
+
+.react-session-workspace > summary:hover,
+.react-session-workspace > summary:focus-visible,
+.react-session-workspace[data-active="true"] > summary {
+  background: color-mix(in srgb, var(--color-cream-strong) 58%, transparent);
+  color: var(--color-ink);
+}
+
+.react-session-workspace > summary:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 74%, transparent);
+  outline-offset: -2px;
+}
+
+.react-session-workspace__chevron {
+  transition: transform var(--motion-duration-fast) ease;
+}
+
+.react-session-workspace[open] > summary .react-session-workspace__chevron {
+  transform: rotate(90deg);
+}
+
+.react-session-workspace__folder {
+  color: var(--color-primary);
+}
+
+.react-session-workspace__copy {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+
+.react-session-workspace__copy strong,
+.react-session-workspace__copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-session-workspace__copy strong {
+  color: inherit;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-session-workspace__copy small {
+  color: var(--color-muted-soft);
+  font-size: 9px;
+  font-weight: 450;
+}
+
+.react-session-workspace__new {
+  position: absolute;
+  top: 6px;
+  right: 1px;
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0;
+  color: var(--color-muted);
+  opacity: .7;
+}
+
+.react-session-workspace__new:hover,
+.react-session-workspace__new:focus-visible {
+  background: color-mix(in srgb, #fff 72%, transparent);
+  color: var(--color-ink);
+  opacity: 1;
+}
+
+.react-session-workspace:not([open]) > .react-session-workspace__sessions {
+  display: none;
+}
+
+.react-session-workspace__sessions {
+  padding-left: 13px;
 }
 
 .react-session-row {
@@ -853,14 +938,241 @@ button:disabled {
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 0 20px;
+  min-width: 0;
+  gap: 0;
+  padding: 0 8px 0 0;
   border-bottom: 1px solid var(--color-hairline);
+  background: color-mix(in srgb, var(--color-canvas) 92%, #fff);
 }
 
 .react-chat-surface[data-empty-session="true"] .react-chat-header {
-  border-bottom-color: transparent;
+  border-bottom-color: var(--color-hairline);
+}
+
+.react-chat-header__title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.react-session-tabs {
+  display: flex;
+  align-items: stretch;
+  align-self: stretch;
+  min-width: 0;
+  flex: 1;
+}
+
+.react-session-tabs__scroller {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+
+.react-session-tabs__scroller::-webkit-scrollbar {
+  display: none;
+}
+
+.react-session-tab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 150px;
+  max-width: 230px;
+  flex: 1 1 190px;
+  border-right: 1px solid color-mix(in srgb, var(--color-hairline) 76%, transparent);
+  color: var(--color-muted);
+  transition:
+    background-color var(--motion-duration-fast) ease,
+    box-shadow var(--motion-duration-fast) ease,
+    color var(--motion-duration-fast) ease;
+}
+
+.react-session-tab:hover,
+.react-session-tab:focus-within {
+  background: color-mix(in srgb, var(--color-surface-soft) 72%, transparent);
+  color: var(--color-body);
+}
+
+.react-session-tab[data-active="true"] {
+  background: color-mix(in srgb, var(--color-cream-strong) 54%, var(--color-canvas));
+  box-shadow: inset 0 -2px var(--color-primary);
+  color: var(--color-ink);
+}
+
+.react-session-tab--draft {
+  max-width: 210px;
+}
+
+.react-session-tab__select {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  min-height: 44px;
+  flex: 1;
+  overflow: hidden;
+  border-radius: 0;
+  padding: 0 4px 0 16px;
+  color: inherit;
+  text-align: left;
+}
+
+.react-session-tab__select:hover,
+.react-session-tab__select:focus-visible {
+  background: transparent;
+}
+
+.react-session-tab__select:focus-visible {
+  border-color: transparent;
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 74%, transparent);
+  outline-offset: -3px;
+}
+
+.react-session-tab__select > span {
+  overflow: hidden;
+  color: inherit;
+  font-size: 12px;
+  font-weight: 560;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-session-tab[data-active="true"] .react-session-tab__select > span {
+  font-weight: 650;
+}
+
+.react-session-tab__status {
+  min-width: 11px;
+  flex: 0 0 auto;
+}
+
+.react-session-tab__status[data-kind="running"] {
+  color: #5f806c;
+  animation: react-session-tab-spin 1.2s linear infinite;
+}
+
+.react-session-tab__status[data-kind="waiting"] {
+  color: #a97821;
+}
+
+.react-session-tab__status[data-kind="failed"] {
+  color: var(--color-error);
+}
+
+.react-session-tab__status[data-kind="unread"] {
+  color: var(--color-primary);
+}
+
+.react-session-tab__close {
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  min-width: 40px;
+  height: 44px;
+  min-height: 44px;
+  border-radius: 0;
+  padding: 0;
+  color: var(--color-muted-soft);
+  opacity: .64;
+}
+
+.react-session-tab__close:hover,
+.react-session-tab__close:focus-visible {
+  background: color-mix(in srgb, var(--color-surface-card) 72%, transparent);
+  color: var(--color-ink);
+  opacity: 1;
+}
+
+.react-session-tab__close:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 74%, transparent);
+  outline-offset: -3px;
+}
+
+.react-session-tabs__controls {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  padding: 0 4px;
+  border-left: 1px solid color-mix(in srgb, var(--color-hairline) 76%, transparent);
+}
+
+.react-session-tabs__controls > button,
+.react-session-tabs__overflow > button {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  min-width: 44px;
+  height: 44px;
+  min-height: 44px;
+  padding: 0;
+  color: var(--color-muted);
+}
+
+.react-session-tabs__controls > button:hover,
+.react-session-tabs__controls > button:focus-visible,
+.react-session-tabs__overflow > button:hover,
+.react-session-tabs__overflow > button:focus-visible {
+  color: var(--color-ink);
+}
+
+.react-session-tabs__overflow {
+  position: relative;
+}
+
+.react-session-tabs__menu {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  z-index: 20;
+  display: grid;
+  width: min(280px, 42vw);
+  max-height: min(360px, 60vh);
+  overflow: auto;
+  padding: 6px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 10px;
+  background: color-mix(in srgb, #fff 94%, var(--color-canvas));
+  box-shadow: 0 18px 44px rgb(61 50 39 / 13%);
+}
+
+.react-session-tabs__menu button {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.react-session-tabs__menu button[aria-current="page"] {
+  background: var(--color-cream-strong);
+}
+
+.react-session-tabs__menu button span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-session-tabs__menu-title {
+  grid-column: 2;
+}
+
+@keyframes react-session-tab-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .react-chat-header__actions {
@@ -868,6 +1180,16 @@ button:disabled {
   display: flex;
   align-items: center;
   gap: 4px;
+  flex: 0 0 auto;
+  padding-left: 8px;
+  border-left: 1px solid color-mix(in srgb, var(--color-hairline) 76%, transparent);
+}
+
+.react-chat-header__actions > button {
+  width: 44px;
+  min-width: 44px;
+  height: 44px;
+  min-height: 44px;
 }
 
 .react-chat-header__actions > button.react-live-canvas-toggle {
@@ -7952,11 +8274,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   }
 
   .react-workbench-layout {
-    grid-template-columns: 58px minmax(0, 1fr);
-  }
-
-  .react-activity-rail button span {
-    display: none;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .react-chat-page {

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -658,7 +658,22 @@ button:disabled {
 }
 
 .react-session-workspace__folder {
+  display: grid;
+  place-items: center;
   color: var(--color-primary);
+}
+
+.react-session-workspace__folder > svg {
+  grid-area: 1 / 1;
+}
+
+.react-session-workspace__folder-icon--expanded,
+.react-session-workspace[open] > summary .react-session-workspace__folder-icon--collapsed {
+  display: none;
+}
+
+.react-session-workspace[open] > summary .react-session-workspace__folder-icon--expanded {
+  display: block;
 }
 
 .react-session-workspace__copy {


### PR DESCRIPTION
## Summary

- add workspace-scoped session navigation and working-directory support
- refine the desktop shell navigation, session tabs, and workspace folder states
- bump the npm, Cargo, and Tauri versions to `0.1.2`
- fix the Windows release workflow so its updater test filter runs the real updater tests

## Why

Tinybot Desktop v0.1.2 groups conversations by working directory and streamlines the desktop navigation model. The release metadata must stay aligned across the frontend, Rust crate, and Tauri package before the release tag is created.

The updater test gate previously used the obsolete `desktop_update::tests` module path, which returned success while running zero tests. The workflow now targets `desktop::update::tests` and executes all three updater tests.

## Validation

- `node .github/scripts/check-release-version.mjs v0.1.2`
- `npm test` — 580 tests passed
- `npm run build`
- `cargo fmt --check`
- `cargo test --lib desktop::update::tests -- --test-threads=1` — 3 tests passed
- pre-commit `cargo check`