### PR TITLE
Stabilize the v0.1.2 session delete animation test

### DIFF
--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -1279,24 +1279,30 @@ describe("ChatPage", () => {
   });
 
   it("dissolves a confirmed deleted session before removing it from the list", async () => {
-    const user = userEvent.setup();
     const stores = createStores();
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const sessionButton = await screen.findByRole("button", { name: "Planning notes" });
+    vi.useFakeTimers();
     const row = sessionButton.closest(".react-session-row") as HTMLElement | null;
-    await user.hover(sessionButton);
-    await user.click(screen.getByRole("button", { name: /delete Planning notes/i }));
-    await user.click(screen.getByRole("button", { name: /confirm delete Planning notes/i }));
+    fireEvent.mouseEnter(sessionButton);
+    fireEvent.click(screen.getByRole("button", { name: /delete Planning notes/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm delete Planning notes/i }));
+    await act(async () => {
+      await Promise.resolve();
+    });
     mountWorkbenchCss();
 
     expect(stores.sessionStore.delete).toHaveBeenCalledWith("s1");
     expect(row?.dataset.dissolving).toBe("true");
     expect(screen.getByRole("button", { name: "Planning notes" })).toBeTruthy();
     expect(getComputedStyle(row?.querySelector(".react-session-row__delete") as Element).position).toBe("absolute");
-    expect(row?.querySelectorAll(".react-session-row__particle").length).toBeGreaterThanOrEqual(200);
+    expect(row?.querySelectorAll(".react-session-row__particle").length).toBeGreaterThanOrEqual(90);
 
-    await waitFor(() => expect(screen.queryByRole("button", { name: "Planning notes" })).toBeNull(), { timeout: 1000 });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(760);
+    });
+    expect(screen.queryByRole("button", { name: "Planning notes" })).toBeNull();
   });
 
   it("shows branch on a completed tool-backed final answer but not on user or commentary messages", async () => {
@@ -3397,7 +3403,7 @@ describe("ChatPage", () => {
     const source = readFileSync("src/react-workbench/chat/ChatPage.tsx", "utf8");
 
     expect(source).toContain("const SESSION_DELETE_DISSOLVE_MS = 760;");
-    expect(source).toContain("const SESSION_DELETE_PARTICLE_COUNT = 220;");
+    expect(source).toContain("const SESSION_DELETE_PARTICLE_COUNT = 96;");
     expect(css).toContain(".react-session-row__particle");
     expect(css).toContain("--react-session-particle-color: rgb(255 255 255 / 96%)");
     expect(css).toContain("--react-session-particle-glow: rgb(255 255 255 / 72%)");

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -218,7 +218,7 @@ const EMPTY_CHAT_PROMPTS = [
 ] as const;
 
 const SESSION_DELETE_DISSOLVE_MS = 760;
-const SESSION_DELETE_PARTICLE_COUNT = 220;
+const SESSION_DELETE_PARTICLE_COUNT = 96;
 const TINYOS_WIDTH_STORAGE_KEY = "tinybot.ui.tinyos.width";
 const EMPTY_OPTIMISTIC_MESSAGES: ReactChatMessage[] = [];
 


### PR DESCRIPTION
## Summary
- reduce the session-delete dissolve particles from 220 to 96
- keep the existing 760 ms visual duration
- drive the animation lifecycle test with deterministic fake timers instead of wall-clock timing

## Root cause
The v0.1.2 release workflow timed out in the delete-animation test under shared Windows runner load. The test combined 220 particle DOM nodes with a real 760 ms timer and asynchronous React work, which made the default 5-second Vitest timeout flaky in CI.

## Validation
- focused delete-animation tests passed
- full frontend suite passed: 580 tests
- production frontend build passed
- pre-commit checks passed