### PR TITLE
Remove remaining frontend release test races

### DIFF
--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -1283,7 +1283,7 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const sessionButton = await screen.findByRole("button", { name: "Planning notes" });
-    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
     const row = sessionButton.closest(".react-session-row") as HTMLElement | null;
     fireEvent.mouseEnter(sessionButton);
     fireEvent.click(screen.getByRole("button", { name: /delete Planning notes/i }));
@@ -1291,6 +1291,11 @@ describe("ChatPage", () => {
     await act(async () => {
       await Promise.resolve();
     });
+    const dissolveTimerIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === 760);
+    expect(dissolveTimerIndex).toBeGreaterThanOrEqual(0);
+    const dissolveTimer = setTimeoutSpy.mock.calls[dissolveTimerIndex]?.[0];
+    window.clearTimeout(setTimeoutSpy.mock.results[dissolveTimerIndex]?.value);
+    setTimeoutSpy.mockRestore();
     mountWorkbenchCss();
 
     expect(stores.sessionStore.delete).toHaveBeenCalledWith("s1");
@@ -1300,7 +1305,8 @@ describe("ChatPage", () => {
     expect(row?.querySelectorAll(".react-session-row__particle").length).toBeGreaterThanOrEqual(90);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(760);
+      expect(dissolveTimer).toEqual(expect.any(Function));
+      (dissolveTimer as () => void)();
     });
     expect(screen.queryByRole("button", { name: "Planning notes" })).toBeNull();
   });
@@ -1671,8 +1677,14 @@ describe("ChatPage", () => {
     expect(within(card).getByRole("alert").textContent).toBe("Required");
     expect(within(card).getByLabelText("Destination").getAttribute("aria-invalid")).toBe("true");
 
-    fireEvent.change(within(card).getByLabelText("Destination"), { target: { value: "Singapore" } });
-    fireEvent.change(within(card).getByLabelText("Nights"), { target: { value: "4" } });
+    const destination = within(card).getByLabelText("Destination") as HTMLInputElement;
+    const nights = within(card).getByLabelText("Nights") as HTMLInputElement;
+    await user.clear(destination);
+    await user.type(destination, "Singapore");
+    await user.clear(nights);
+    await user.type(nights, "4");
+    expect(destination.value).toBe("Singapore");
+    expect(nights.value).toBe("4");
     await user.click(within(card).getByRole("button", { name: "Save preferences" }));
 
     expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({


### PR DESCRIPTION
## Summary
- capture and invoke the session-delete dissolve callback directly instead of replacing React's clock with Vitest fake timers
- update the agent form test through real user input and assert the controlled values before submission

## Root cause
The first hotfix reduced rendering work, but the release runner showed that `advanceTimersByTimeAsync` could still stall while React had pending asynchronous work. That timeout also left the test file in a bad state, and a later form test could submit before its controlled values were settled.

## Validation
- both affected tests passed together
- full frontend suite passed: 580 tests
- production frontend build passed
- pre-commit tests and build passed