### PR TITLE
Reduce delete particles and bound the heavy UI test

### DIFF
--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -1302,14 +1302,14 @@ describe("ChatPage", () => {
     expect(row?.dataset.dissolving).toBe("true");
     expect(screen.getByRole("button", { name: "Planning notes" })).toBeTruthy();
     expect(getComputedStyle(row?.querySelector(".react-session-row__delete") as Element).position).toBe("absolute");
-    expect(row?.querySelectorAll(".react-session-row__particle").length).toBeGreaterThanOrEqual(90);
+    expect(row?.querySelectorAll(".react-session-row__particle").length).toBeGreaterThanOrEqual(60);
 
     await act(async () => {
       expect(dissolveTimer).toEqual(expect.any(Function));
       (dissolveTimer as () => void)();
     });
     expect(screen.queryByRole("button", { name: "Planning notes" })).toBeNull();
-  });
+  }, 15_000);
 
   it("shows branch on a completed tool-backed final answer but not on user or commentary messages", async () => {
     const user = userEvent.setup();
@@ -3415,7 +3415,7 @@ describe("ChatPage", () => {
     const source = readFileSync("src/react-workbench/chat/ChatPage.tsx", "utf8");
 
     expect(source).toContain("const SESSION_DELETE_DISSOLVE_MS = 760;");
-    expect(source).toContain("const SESSION_DELETE_PARTICLE_COUNT = 96;");
+    expect(source).toContain("const SESSION_DELETE_PARTICLE_COUNT = 64;");
     expect(css).toContain(".react-session-row__particle");
     expect(css).toContain("--react-session-particle-color: rgb(255 255 255 / 96%)");
     expect(css).toContain("--react-session-particle-glow: rgb(255 255 255 / 72%)");

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -218,7 +218,7 @@ const EMPTY_CHAT_PROMPTS = [
 ] as const;
 
 const SESSION_DELETE_DISSOLVE_MS = 760;
-const SESSION_DELETE_PARTICLE_COUNT = 96;
+const SESSION_DELETE_PARTICLE_COUNT = 64;
 const TINYOS_WIDTH_STORAGE_KEY = "tinybot.ui.tinyos.width";
 const EMPTY_OPTIMISTIC_MESSAGES: ReactChatMessage[] = [];
 


### PR DESCRIPTION
## Summary
- reduce the session-delete particle count from 96 to 64 (220 to 64 across the full hotfix)
- keep the production dissolve duration unchanged
- give the deterministic full-ChatPage animation test a 15-second runner budget

## Root cause
After removing wall-clock and fake-timer dependencies, the Windows release runner still exceeded Vitest's default 5-second per-test limit while running the large ChatPage integration suite under shared CPU load. The test is deterministic now; this change reduces its render work further and gives this one heavy integration test an explicit upper bound while preserving failure on a real hang.

## Validation
- full frontend suite passed: 580 tests
- production frontend build passed
- pre-commit tests and build passed