### PR TITLE
Prepare v0.1.3 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinybot-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinybot-desktop",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/code": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinybot-desktop",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "tinybot-desktop"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinybot-desktop"
-version = "0.1.2"
+version = "0.1.3"
 description = "Tinybot lightweight desktop host"
 authors = ["Tinybot contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tinybot Desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.sudojacky.tinybot.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Summary: bump the desktop application version to 0.1.3 across npm, Cargo, and Tauri metadata. Validation: release version check, 449 frontend tests, frontend production build, cargo fmt --check, updater tests, and cargo check.