### PR TITLE
Improve agent web tools and TinyOS browser lifecycle

### DIFF
--- a/src-tauri/src/agent/bridge/mod.rs
+++ b/src-tauri/src/agent/bridge/mod.rs
@@ -32,8 +32,6 @@ pub(crate) use thread_flow::{
 };
 pub(crate) use tool_dispatcher::native_agent_services_with_tool_executor;
 #[cfg(test)]
-pub(crate) use tool_dispatcher::{dispatch_agent_browser_interact, dispatch_agent_browser_observe};
-#[cfg(test)]
 pub(crate) use trace_sink::AgentTurnSemanticSink;
 pub(crate) use trace_sink::{desktop_agent_event_sink, native_agent_trace_sink};
 pub(crate) use webui_continuation::resolve_agent_ui_form_body_with_services;

--- a/src-tauri/src/agent/bridge/tool_dispatcher.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher.rs
@@ -1,6 +1,6 @@
 use crate::agent::runtime::{
-    AgentTurnContext, NativeAgentRuntimeServices, NativeAgentToolDispatcher, NativeAgentToolResult,
-    PreparedToolCall,
+    AgentTurnContext, NativeAgentCancellationContext, NativeAgentRuntimeServices,
+    NativeAgentToolDispatcher, NativeAgentToolResult, PreparedToolCall,
 };
 use crate::collaboration::subagents::SubagentThreadManager;
 use crate::protocol::{WorkerRequest, WorkerRequestCancellation};
@@ -9,6 +9,7 @@ use crate::runtime::mcp::{configured_mcp_servers, mcp_tool_is_enabled, McpRuntim
 use crate::threads::workspace_store::WorkspaceThreadStore;
 use crate::tools::registry::ToolExecutionTarget;
 use crate::tools::shell::WorkerShellRuntime;
+use crate::tools::web::{self, WebToolCancellation};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -24,16 +25,23 @@ struct NativeAgentToolExecutorDispatcher {
     browser_runtime: Option<crate::native_browser::SharedBrowserRuntime>,
 }
 
+impl WebToolCancellation for NativeAgentCancellationContext {
+    fn is_cancelled(&self) -> bool {
+        NativeAgentCancellationContext::is_cancelled(self)
+    }
+
+    fn cancelled(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(NativeAgentCancellationContext::cancelled(self))
+    }
+}
+
 impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
     fn dispatch(
         &self,
         context: &AgentTurnContext,
         tool_call: &PreparedToolCall,
     ) -> Result<NativeAgentToolResult, String> {
-        if matches!(
-            tool_call.name.as_str(),
-            "browser.observe" | "browser.interact"
-        ) {
+        if web::is_web_tool(&tool_call.name) {
             return Err(format!(
                 "native tool `{}` requires asynchronous shared-browser dispatch",
                 tool_call.name
@@ -135,7 +143,7 @@ impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
         Box<dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send>,
     > {
         Box::pin(async move {
-            if let Some(result) = self.dispatch_browser_if_needed(&context, &tool_call).await {
+            if let Some(result) = self.dispatch_web_if_needed(&context, &tool_call).await {
                 return result;
             }
             if let Some(result) = self.dispatch_mcp_if_needed(&context, &tool_call).await {
@@ -184,15 +192,12 @@ fn apply_turn_working_directory(
 mod tests;
 
 impl NativeAgentToolExecutorDispatcher {
-    async fn dispatch_browser_if_needed(
+    async fn dispatch_web_if_needed(
         &self,
         context: &AgentTurnContext,
         tool_call: &PreparedToolCall,
     ) -> Option<Result<NativeAgentToolResult, String>> {
-        if !matches!(
-            tool_call.name.as_str(),
-            "browser.observe" | "browser.interact"
-        ) {
+        if !web::is_web_tool(&tool_call.name) {
             return None;
         }
         let runtime = match self.browser_runtime.clone() {
@@ -206,26 +211,40 @@ impl NativeAgentToolExecutorDispatcher {
         };
         let mut arguments = tool_call.arguments_value();
         let result = match tool_call.name.as_str() {
-            "browser.observe" => {
-                dispatch_agent_browser_observe(&runtime, &context.session_id, arguments).await
-            }
-            "browser.interact" => {
+            "web.open" => {
                 arguments["commandId"] = serde_json::Value::String(tool_call.id.clone());
-                dispatch_agent_browser_interact(
+                web::dispatch_web_open(
                     &runtime,
                     &context.session_id,
-                    context.cancellation.clone(),
+                    context
+                        .cancellation
+                        .as_ref()
+                        .map(|cancellation| cancellation as &dyn WebToolCancellation),
                     arguments,
                 )
                 .await
             }
-            _ => unreachable!("browser tool dispatch should be exhaustive"),
+            "web.read" => web::dispatch_web_read(&runtime, &context.session_id, arguments).await,
+            "web.act" => {
+                arguments["commandId"] = serde_json::Value::String(tool_call.id.clone());
+                web::dispatch_web_act(
+                    &runtime,
+                    &context.session_id,
+                    context
+                        .cancellation
+                        .as_ref()
+                        .map(|cancellation| cancellation as &dyn WebToolCancellation),
+                    arguments,
+                )
+                .await
+            }
+            _ => unreachable!("web tool dispatch should be exhaustive"),
         };
         Some(result.and_then(|raw| {
             let mut raw = serde_json::to_value(raw).map_err(|error| {
                 format!("native browser tool result serialization failed: {error}")
             })?;
-            strip_browser_capture_data(&mut raw);
+            web::strip_browser_capture_data(&mut raw);
             Ok(NativeAgentToolResult::generic_success(tool_call, raw))
         }))
     }
@@ -339,184 +358,6 @@ pub(crate) fn native_agent_services_with_tool_executor(
             browser_runtime,
         })),
     )
-}
-
-pub(crate) async fn dispatch_agent_browser_observe(
-    runtime: &crate::native_browser::SharedBrowserRuntime,
-    owner_session_id: &str,
-    arguments: serde_json::Value,
-) -> Result<serde_json::Value, String> {
-    let capabilities = runtime.capabilities();
-    if !capabilities.session_snapshot.available {
-        return Err(capabilities
-            .session_snapshot
-            .reason
-            .unwrap_or_else(|| "TinyOS browser sessions are unavailable".to_string()));
-    }
-    let capture = arguments
-        .get("capture")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(true);
-    let semantic = arguments
-        .get("semantic")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(true);
-    if capture && !capabilities.real_capture.available {
-        return Err(capabilities
-            .real_capture
-            .reason
-            .unwrap_or_else(|| "TinyOS browser capture is unavailable".to_string()));
-    }
-    if semantic && !capabilities.semantic_observation.available {
-        return Err(capabilities
-            .semantic_observation
-            .reason
-            .unwrap_or_else(|| "TinyOS browser semantic observation is unavailable".to_string()));
-    }
-    let requested_session_id = optional_text(&arguments, "browserSessionId")?;
-    let snapshot = match runtime.snapshot_for_owner(owner_session_id) {
-        Some(snapshot) => snapshot,
-        None if requested_session_id.is_some() => {
-            return Err(
-                "The requested TinyOS browser session is not owned by this chat".to_string(),
-            );
-        }
-        None => {
-            runtime
-                .create_session(
-                    serde_json::from_value::<crate::native_browser::BrowserCreateSessionInput>(
-                        serde_json::json!({ "ownerSessionId": owner_session_id }),
-                    )
-                    .map_err(|error| {
-                        format!("failed to create TinyOS browser session input: {error}")
-                    })?,
-                )
-                .await?
-        }
-    };
-    ensure_agent_browser_owner(&snapshot, requested_session_id.as_deref())?;
-    let requested_tab_id = optional_text(&arguments, "tabId")?;
-    let tab_id = requested_tab_id
-        .as_deref()
-        .unwrap_or_else(|| snapshot.data.active_tab_id.as_str());
-    ensure_agent_browser_tab(&snapshot, tab_id)?;
-    let input =
-        serde_json::from_value::<crate::native_browser::BrowserObserveInput>(serde_json::json!({
-            "browserSessionId": snapshot.data.browser_session_id.as_str(),
-            "tabId": tab_id,
-            "capture": capture,
-            "semantic": semantic,
-        }))
-        .map_err(|error| format!("browser.observe payload is invalid: {error}"))?;
-    serde_json::to_value(runtime.observe(input).await?)
-        .map_err(|error| format!("browser.observe result serialization failed: {error}"))
-}
-
-pub(crate) async fn dispatch_agent_browser_interact(
-    runtime: &crate::native_browser::SharedBrowserRuntime,
-    owner_session_id: &str,
-    cancellation: Option<crate::agent::runtime::NativeAgentCancellationContext>,
-    arguments: serde_json::Value,
-) -> Result<serde_json::Value, String> {
-    let capabilities = runtime.capabilities();
-    if !capabilities.agent_interaction.available {
-        return Err(capabilities
-            .agent_interaction
-            .reason
-            .unwrap_or_else(|| "TinyOS Agent browser interaction is unavailable".to_string()));
-    }
-    let input = serde_json::from_value::<crate::native_browser::BrowserInteractionInput>(arguments)
-        .map_err(|error| format!("browser.interact payload is invalid: {error}"))?;
-    let snapshot = runtime
-        .snapshot_for_owner(owner_session_id)
-        .ok_or_else(|| {
-            "Open or observe the TinyOS browser before interacting with it".to_string()
-        })?;
-    ensure_agent_browser_owner(&snapshot, Some(input.browser_session_id.as_str()))?;
-    ensure_agent_browser_tab(&snapshot, input.tab_id.as_str())?;
-    let tab_id = input.tab_id.clone();
-    let command_id = input.command_id.clone();
-    if cancellation
-        .as_ref()
-        .is_some_and(|cancellation| cancellation.is_cancelled())
-    {
-        return Err("Agent browser command was cancelled before dispatch".to_string());
-    }
-    let interaction = runtime.interact(input);
-    tokio::pin!(interaction);
-    let result = if let Some(cancellation) = cancellation {
-        tokio::select! {
-            result = &mut interaction => result,
-            _ = cancellation.cancelled() => {
-                if runtime.cancel_agent_command(&tab_id, &command_id) {
-                    interaction.await
-                } else {
-                    return Err("Agent browser command was cancelled before dispatch".to_string());
-                }
-            }
-        }
-    } else {
-        interaction.await
-    }?;
-    serde_json::to_value(result)
-        .map_err(|error| format!("browser.interact result serialization failed: {error}"))
-}
-
-fn ensure_agent_browser_owner(
-    snapshot: &crate::native_browser::BrowserNativeSnapshot,
-    requested_session_id: Option<&str>,
-) -> Result<(), String> {
-    if snapshot.data.session_id.is_empty() {
-        return Err("TinyOS browser snapshot has no owning chat session".to_string());
-    }
-    if requested_session_id
-        .is_some_and(|requested| requested != snapshot.data.browser_session_id.as_str())
-    {
-        return Err("The requested TinyOS browser session is not owned by this chat".to_string());
-    }
-    Ok(())
-}
-
-fn ensure_agent_browser_tab(
-    snapshot: &crate::native_browser::BrowserNativeSnapshot,
-    tab_id: &str,
-) -> Result<(), String> {
-    snapshot
-        .data
-        .tabs
-        .iter()
-        .any(|tab| tab.tab_id.as_str() == tab_id)
-        .then_some(())
-        .ok_or_else(|| {
-            "The requested TinyOS browser tab is not part of this chat session".to_string()
-        })
-}
-
-fn optional_text(value: &serde_json::Value, key: &str) -> Result<Option<String>, String> {
-    match value.get(key) {
-        None | Some(serde_json::Value::Null) => Ok(None),
-        Some(serde_json::Value::String(text)) if !text.trim().is_empty() => {
-            Ok(Some(text.trim().to_string()))
-        }
-        Some(_) => Err(format!("{key} must be a non-empty string")),
-    }
-}
-
-fn strip_browser_capture_data(value: &mut serde_json::Value) {
-    match value {
-        serde_json::Value::Object(object) => {
-            object.remove("dataUrl");
-            for child in object.values_mut() {
-                strip_browser_capture_data(child);
-            }
-        }
-        serde_json::Value::Array(values) => {
-            for child in values {
-                strip_browser_capture_data(child);
-            }
-        }
-        _ => {}
-    }
 }
 
 fn normalize_subagent_arguments(

--- a/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
@@ -1,4 +1,4 @@
-use super::{apply_turn_working_directory, strip_browser_capture_data};
+use super::apply_turn_working_directory;
 
 #[test]
 fn turn_working_directory_becomes_shell_default_without_overriding_tool_input() {
@@ -42,24 +42,4 @@ fn turn_working_directory_preserves_an_absolute_path_outside_the_workspace() {
     .expect("outside turn working directory should reach shell dispatch");
 
     assert_eq!(arguments["workingDir"], "D:/outside");
-}
-
-#[test]
-fn browser_capture_bytes_are_not_returned_to_the_model_context() {
-    let mut result = serde_json::json!({
-        "capture": { "captureId": "capture-1", "dataUrl": "data:image/png;base64,AAAA" },
-        "snapshot": {
-            "data": {
-                "tabs": [{ "captures": [{ "captureId": "capture-1", "dataUrl": "data:image/png;base64,BBBB" }] }]
-            }
-        }
-    });
-
-    strip_browser_capture_data(&mut result);
-
-    assert_eq!(result["capture"]["captureId"], "capture-1");
-    assert!(result["capture"].get("dataUrl").is_none());
-    assert!(result["snapshot"]["data"]["tabs"][0]["captures"][0]
-        .get("dataUrl")
-        .is_none());
 }

--- a/src-tauri/src/agent/runtime/instructions.rs
+++ b/src-tauri/src/agent/runtime/instructions.rs
@@ -124,6 +124,7 @@ impl InstructionComposer {
                 workspace_root,
                 &working_directory,
             )?;
+        crate::tool_notes::create_default_tool_notes_if_missing(workspace_root)?;
         if system_content.len() > WORKSPACE_SYSTEM_MAX_BYTES {
             return Err(format!(
                 "workspace system instructions exceed the {WORKSPACE_SYSTEM_MAX_BYTES}-byte limit: `{}`",
@@ -194,7 +195,7 @@ impl InstructionComposer {
                 WORKSPACE_USER_PRECEDENCE,
             ),
             (
-                "TOOLS.md",
+                crate::tool_notes::TOOL_NOTES_FILE_NAME,
                 InstructionSourceKind::WorkspaceTools,
                 WORKSPACE_TOOLS_PRECEDENCE,
             ),

--- a/src-tauri/src/agent/runtime/tests/configuration.rs
+++ b/src-tauri/src/agent/runtime/tests/configuration.rs
@@ -326,9 +326,10 @@ fn composed_workspace_instructions_reach_provider_and_reload_user_edits() {
             .expect("instruction provenance sources should be visible");
         assert_eq!(sources[0]["kind"], "built_in_identity");
         assert_eq!(sources[1]["kind"], "workspace_system");
-        assert_eq!(sources[2]["kind"], "project_agents");
-        assert_eq!(sources[3]["kind"], "project_override");
-        assert_eq!(sources[4]["kind"], "runtime_environment");
+        assert_eq!(sources[2]["kind"], "workspace_tools");
+        assert_eq!(sources[3]["kind"], "project_agents");
+        assert_eq!(sources[4]["kind"], "project_override");
+        assert_eq!(sources[5]["kind"], "runtime_environment");
         assert!(sources.iter().all(|source| source["contentHash"]
             .as_str()
             .is_some_and(|hash| hash.len() == 64)));

--- a/src-tauri/src/agent/runtime/tests/configuration.rs
+++ b/src-tauri/src/agent/runtime/tests/configuration.rs
@@ -436,7 +436,7 @@ fn chat_completion_request_exposes_only_foundational_model_tools() {
 
 #[cfg(all(windows, feature = "native-browser-runtime"))]
 #[test]
-fn feature_build_defers_browser_tools_until_searched() {
+fn feature_build_always_exposes_high_level_web_tools() {
     let context = AgentTurnContext::from_spec(
         json!({
             "runtime": "rust",
@@ -459,6 +459,9 @@ fn feature_build_defers_browser_tools_until_searched() {
 
     assert!(!names.contains(&"browser_observe"));
     assert!(!names.contains(&"browser_interact"));
+    assert!(names.contains(&"web_open"));
+    assert!(names.contains(&"web_read"));
+    assert!(names.contains(&"web_act"));
     assert!(names.contains(&"tool_search"));
 }
 

--- a/src-tauri/src/agent/runtime/tests/interactions.rs
+++ b/src-tauri/src/agent/runtime/tests/interactions.rs
@@ -823,10 +823,11 @@ fn direct_calls_to_unactivated_deferred_tools_are_rejected() {
             if self.calls.fetch_add(1, Ordering::SeqCst) > 0 {
                 assert!(context.messages.iter().any(|message| {
                     message["role"] == "tool"
-                        && message["tool_call_id"] == "unactivated-shell"
-                        && message["content"]
-                            .as_str()
-                            .is_some_and(|content| content.contains("not permitted"))
+                        && message["tool_call_id"] == "unactivated-deferred"
+                        && message["content"].as_str().is_some_and(|content| {
+                            content.contains("not active for this turn")
+                                && content.contains("tool_search")
+                        })
                 }));
                 return Ok(NativeAgentProviderResponse {
                     final_content: "deferred tool rejection handled".to_string(),
@@ -840,9 +841,9 @@ fn direct_calls_to_unactivated_deferred_tools_are_rejected() {
                 reasoning_delta: None,
                 usage: None,
                 tool_calls: vec![NativeAgentToolCall {
-                    id: "unactivated-shell".to_string(),
-                    name: "shell.execute".to_string(),
-                    arguments_json: r#"{"command":"echo should-not-run"}"#.to_string(),
+                    id: "unactivated-deferred".to_string(),
+                    name: "test.deferred_echo".to_string(),
+                    arguments_json: r#"{"query":"should-not-run"}"#.to_string(),
                     result: Value::Null,
                 }],
             })
@@ -861,15 +862,20 @@ fn direct_calls_to_unactivated_deferred_tools_are_rejected() {
         }
     }
 
+    let services = NativeAgentRuntimeServices::new(
+        Arc::new(DeferredToolProvider {
+            calls: AtomicUsize::new(0),
+        }),
+        Arc::new(PanickingDeferredDispatcher),
+        Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+        Arc::new(InMemoryNativeAgentCancellation::default()),
+    )
+    .with_test_tool_registry_entries(vec![test_read_only_tool(
+        "test.deferred_echo",
+        ToolExposure::Deferred,
+    )]);
     let result = run_native_agent_turn_with_config(
-        &NativeAgentRuntimeServices::new(
-            Arc::new(DeferredToolProvider {
-                calls: AtomicUsize::new(0),
-            }),
-            Arc::new(PanickingDeferredDispatcher),
-            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
-            Arc::new(InMemoryNativeAgentCancellation::default()),
-        ),
+        &services,
         json!({
             "turnId": "turn-unactivated-deferred",
             "sessionId": "session-unactivated-deferred",
@@ -888,7 +894,24 @@ fn direct_calls_to_unactivated_deferred_tools_are_rejected() {
         .iter()
         .find(|event| event["eventName"] == "agent.tool.result")
         .expect("tool result should be present");
-    assert_eq!(tool_result["payload"]["toolName"], "shell.execute");
+    assert_eq!(tool_result["payload"]["toolName"], "test.deferred_echo");
+}
+
+#[test]
+fn inactive_deferred_provider_names_still_resolve_to_the_registered_method() {
+    let router = NativeToolRouter::new(vec![test_read_only_tool(
+        "test.deferred_echo",
+        ToolExposure::Deferred,
+    )]);
+
+    assert_eq!(
+        router.resolve_provider_name("test_deferred_echo").unwrap(),
+        "test.deferred_echo"
+    );
+    assert!(!router.is_permitted("test.deferred_echo"));
+    assert!(router
+        .rejection_reason("test.deferred_echo")
+        .contains("tool_search"));
 }
 
 #[test]

--- a/src-tauri/src/agent/runtime/tool_dispatcher.rs
+++ b/src-tauri/src/agent/runtime/tool_dispatcher.rs
@@ -15,10 +15,7 @@ impl NativeAgentToolDispatcher for FakeNativeAgentToolDispatcher {
         tool_call: &PreparedToolCall,
     ) -> Result<NativeAgentToolResult, String> {
         if !native_tool_is_permitted(_context, &tool_call.name) {
-            return Err(format!(
-                "native tool `{}` is not permitted by Rust capability policy",
-                tool_call.name
-            ));
+            return Err(native_tool_rejection_reason(_context, &tool_call.name));
         }
         Ok(NativeAgentToolResult::generic_success(
             tool_call,
@@ -51,10 +48,7 @@ impl NativeAgentToolDispatcher for SubagentNativeAgentToolDispatcher {
             return self.fallback.dispatch(context, tool_call);
         }
         if !native_tool_is_permitted(context, &tool_call.name) {
-            return Err(format!(
-                "native tool `{}` is not permitted by Rust capability policy",
-                tool_call.name
-            ));
+            return Err(native_tool_rejection_reason(context, &tool_call.name));
         }
         let args = tool_call.arguments_value();
         let raw = match tool_call.name.as_str() {
@@ -227,6 +221,11 @@ impl NativeAgentToolDispatcher for SubagentNativeAgentToolDispatcher {
 
 pub(super) fn native_tool_is_permitted(context: &AgentTurnContext, name: &str) -> bool {
     registry_tool_available(context, name) || legacy_native_tool_alias_is_permitted(context, name)
+}
+
+pub(super) fn native_tool_rejection_reason(context: &AgentTurnContext, name: &str) -> String {
+    let policy_method = legacy_native_tool_alias_policy_method(name).unwrap_or(name);
+    context.tool_router.rejection_reason(policy_method)
 }
 
 pub(super) fn native_tool_supports_parallel(context: &AgentTurnContext, name: &str) -> bool {

--- a/src-tauri/src/agent/runtime/tool_router.rs
+++ b/src-tauri/src/agent/runtime/tool_router.rs
@@ -91,12 +91,31 @@ impl NativeToolRouter {
         {
             return Ok(entry.method.clone());
         }
-        Ok(self
+        if let Some(method) = self
             .provider_name_map(&self.activated_tool_ids)?
             .get(provider_name)
             .copied()
-            .unwrap_or(provider_name)
-            .to_string())
+        {
+            return Ok(method.to_string());
+        }
+
+        let mut registered_matches = self.entries.iter().filter(|entry| {
+            matches!(entry.exposure, ToolExposure::Model | ToolExposure::Deferred)
+                && (entry.method == provider_name
+                    || provider_tool_name(&entry.method) == provider_name)
+        });
+        let Some(first) = registered_matches.next() else {
+            return Ok(provider_name.to_string());
+        };
+        if let Some(conflict) =
+            registered_matches.find(|entry| entry.method.as_str() != first.method.as_str())
+        {
+            return Err(format!(
+                "provider tool name `{provider_name}` is ambiguous between {} and {}",
+                first.method, conflict.method
+            ));
+        }
+        Ok(first.method.clone())
     }
 
     pub(super) fn search_and_activate(
@@ -233,6 +252,25 @@ impl NativeToolRouter {
     pub(super) fn is_permitted(&self, method: &str) -> bool {
         self.visible_entries(&self.activated_tool_ids)
             .any(|entry| entry.method == method)
+    }
+
+    pub(super) fn rejection_reason(&self, method: &str) -> String {
+        let Some(entry) = self.entries.iter().find(|entry| entry.method == method) else {
+            return format!("native tool `{method}` is unknown or unavailable");
+        };
+        if !entry.available {
+            return format!(
+                "native tool `{method}` is unavailable because its required capabilities are not permitted"
+            );
+        }
+        if entry.exposure == ToolExposure::Deferred
+            && !self.activated_tool_ids.contains(entry.tool_id.as_str())
+        {
+            return format!(
+                "native tool `{method}` is not active for this turn; call `tool_search` to activate it before retrying"
+            );
+        }
+        format!("native tool `{method}` is not exposed to the model")
     }
 
     pub(super) fn supports_parallel(&self, method: &str) -> bool {

--- a/src-tauri/src/agent/runtime/tool_runtime.rs
+++ b/src-tauri/src/agent/runtime/tool_runtime.rs
@@ -4,7 +4,8 @@ use super::state::AgentTurnState;
 use super::tool_dispatcher::{
     native_tool_call_supports_parallel, native_tool_cancellation_mode,
     native_tool_cleanup_timeout_ms, native_tool_is_permitted, native_tool_mutates_session,
-    native_tool_mutates_workspace, native_tool_waits_for_runtime_cancellation,
+    native_tool_mutates_workspace, native_tool_rejection_reason,
+    native_tool_waits_for_runtime_cancellation,
 };
 use super::tool_projection::{assistant_tool_calls_message, commit_tool_observation};
 use super::{
@@ -982,10 +983,7 @@ fn policy_denied_tool_result(
     iteration: i64,
     tool_call: &NativeAgentToolCall,
 ) -> Result<NativeAgentToolExecutionOutcome, String> {
-    let error = format!(
-        "native tool `{}` is not permitted by Rust capability policy",
-        tool_call.name
-    );
+    let error = native_tool_rejection_reason(context, &tool_call.name);
     tool_error_result(services, context, state, iteration, tool_call, error)
 }
 

--- a/src-tauri/src/desktop/bootstrap.rs
+++ b/src-tauri/src/desktop/bootstrap.rs
@@ -13,6 +13,7 @@ use crate::desktop_commands::runtime::{
 };
 use crate::native_browser;
 use crate::system_prompt::{load_or_create_system_prompt, SYSTEM_PROMPT_FILE_NAME};
+use crate::tool_notes::{create_default_tool_notes_if_missing, TOOL_NOTES_FILE_NAME};
 
 use super::logging::append_native_backend_log_line;
 use super::menu::{
@@ -120,6 +121,18 @@ pub(crate) fn run() {
                 Err(error) => push_log(
                     &setup_state,
                     &format!("failed to initialize system prompt: {error}"),
+                ),
+            }
+            let tool_notes_path = workspace_root.join(TOOL_NOTES_FILE_NAME);
+            match create_default_tool_notes_if_missing(&workspace_root) {
+                Ok(true) => push_log(
+                    &setup_state,
+                    &format!("default tool notes created at {}", tool_notes_path.display()),
+                ),
+                Ok(false) => {}
+                Err(error) => push_log(
+                    &setup_state,
+                    &format!("failed to initialize tool notes: {error}"),
                 ),
             }
             if let Err(error) =

--- a/src-tauri/src/desktop_commands/thread.rs
+++ b/src-tauri/src/desktop_commands/thread.rs
@@ -81,7 +81,6 @@ thread_command!(
     "thread-unarchive",
     "thread.unarchive"
 );
-thread_command!(worker_thread_delete, "thread-delete", "thread.delete");
 thread_command!(worker_thread_fork, "thread-fork", "thread.fork");
 thread_command!(worker_thread_events, "thread-events", "thread.events");
 thread_command!(
@@ -95,6 +94,36 @@ thread_command!(
     "thread-turn-runtime-state",
     "thread.turn.runtime_state"
 );
+
+#[tauri::command]
+pub(crate) async fn worker_thread_delete(
+    input: WorkerThreadRequestInput,
+    state: State<'_, SharedNativeRuntime>,
+    browser_runtime: State<'_, SharedBrowserRuntime>,
+) -> Result<serde_json::Value, String> {
+    let thread_id = input
+        .body
+        .get("threadId")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "thread delete requires threadId".to_string())?
+        .to_string();
+    if let Some(snapshot) = browser_runtime.snapshot_for_owner(&thread_id) {
+        browser_runtime
+            .close_session(&snapshot.data.browser_session_id)
+            .await?;
+    }
+    worker_thread_request_with_options(
+        state.inner(),
+        "thread-delete",
+        "thread.delete",
+        input.body,
+        native_backend_workspace_root(),
+        native_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
 
 #[tauri::command]
 pub(crate) fn thread_get_effective_capabilities(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod skills;
 mod storage;
 mod system_prompt;
 mod threads;
+mod tool_notes;
 mod tools;
 mod transport;
 mod workspace;

--- a/src-tauri/src/native_browser/integration.rs
+++ b/src-tauri/src/native_browser/integration.rs
@@ -432,6 +432,7 @@ async fn exercise_agent_interactions(
             tab_id: tab_id.clone(),
             command_id: BrowserCommandId::new("stale-observation")?,
             control_epoch: stale_context.0,
+            snapshot_id: None,
             capture_id: stale_context.2,
             observation_revision: Some(stale_context.1),
             action: BrowserAction::Wait {
@@ -497,6 +498,7 @@ async fn run_interaction(
             tab_id: tab_id.clone(),
             command_id: BrowserCommandId::new(command_id)?,
             control_epoch,
+            snapshot_id: None,
             capture_id,
             observation_revision: action
                 .requires_observation()

--- a/src-tauri/src/native_browser/manager.rs
+++ b/src-tauri/src/native_browser/manager.rs
@@ -1794,6 +1794,24 @@ impl BrowserSessionManager {
     }
 
     pub(crate) async fn close_session(&self, session_id: &BrowserSessionId) -> Result<(), String> {
+        let owner_session_id = {
+            let state = self.lock_state();
+            state
+                .sessions
+                .get(session_id)
+                .ok_or_else(|| "Browser session is unavailable".to_string())?
+                .owner_session_id
+                .clone()
+        };
+        let creation_lock = self.owner_creation_lock(&owner_session_id);
+        let _creation_guard = creation_lock.lock().await;
+        self.close_session_after_creation(session_id).await
+    }
+
+    async fn close_session_after_creation(
+        &self,
+        session_id: &BrowserSessionId,
+    ) -> Result<(), String> {
         let started = Instant::now();
         let (tab_ids, profile, owner_session_id) = {
             let mut state = self.lock_state();
@@ -2596,6 +2614,12 @@ fn plan_browser_interaction(
     tab: &BrowserTabRecord,
     input: &BrowserInteractionInput,
 ) -> Result<BrowserPlatformAction, BrowserInteractionRejection> {
+    if input.snapshot_id.is_some() && session.active_tab_id != input.tab_id {
+        return Err(BrowserInteractionRejection {
+            metric: Some("browser.command.rejected.inactive_agent_tab"),
+            reason: AGENT_SNAPSHOT_STALE.to_string(),
+        });
+    }
     if let Some(snapshot_id) = input.snapshot_id.as_deref() {
         if tab.agent_snapshot_dirty || snapshot_id != agent_snapshot_id(tab) {
             return Err(BrowserInteractionRejection {

--- a/src-tauri/src/native_browser/manager.rs
+++ b/src-tauri/src/native_browser/manager.rs
@@ -1191,11 +1191,12 @@ impl BrowserSessionManager {
                                 .map(|(index, node)| {
                                     let target_ref =
                                         format!("target-{observation_revision}-{index}");
+                                    let protected_reason = semantic_protected_reason(&node);
                                     tab.semantic_targets.insert(
                                         target_ref.clone(),
                                         BrowserSemanticTarget {
                                             selector: node.selector,
-                                            protected_reason: node.protected_reason.clone(),
+                                            protected_reason: protected_reason.clone(),
                                         },
                                     );
                                     BrowserSemanticNode {
@@ -1210,7 +1211,7 @@ impl BrowserSessionManager {
                                         disabled: node.disabled,
                                         focused: node.focused,
                                         sensitive: node.sensitive,
-                                        protected_reason: node.protected_reason,
+                                        protected_reason,
                                     }
                                 })
                                 .collect();
@@ -1228,11 +1229,12 @@ impl BrowserSessionManager {
                                 for (current_node, node) in
                                     current.nodes.iter().zip(&platform.semantic_nodes)
                                 {
+                                    let protected_reason = semantic_protected_reason(node);
                                     tab.semantic_targets.insert(
                                         current_node.target_ref.clone(),
                                         BrowserSemanticTarget {
                                             selector: node.selector.clone(),
-                                            protected_reason: node.protected_reason.clone(),
+                                            protected_reason,
                                         },
                                     );
                                 }
@@ -1402,7 +1404,7 @@ impl BrowserSessionManager {
                         &input,
                         BrowserCommandStatus::UserRequired,
                         Some("user_required"),
-                        Some("Direct user interaction is required"),
+                        Some(reason),
                     )?;
                     self.diagnostic_command_result(&input, &result, started.elapsed());
                     return Ok(result);
@@ -2097,26 +2099,40 @@ impl BrowserSessionManager {
                     }
                 }
                 BrowserPlatformEvent::UserInput { tab_id } => {
+                    let user_handoff_active =
+                        state.sessions.get(&session_id).is_some_and(|session| {
+                            session.control.state == BrowserControlState::UserRequired
+                        });
                     self.diagnostic(
-                        "browser.user_input.interrupted",
+                        if user_handoff_active {
+                            "browser.user_input.handoff"
+                        } else {
+                            "browser.user_input.interrupted"
+                        },
                         Some(session_id.clone()),
                         Some(tab_id.clone()),
                         None,
-                        Some("user_interrupted"),
+                        Some(if user_handoff_active {
+                            "user_required"
+                        } else {
+                            "user_interrupted"
+                        }),
                         None,
                         BTreeMap::new(),
                     );
-                    self.cancel_tab_command(
-                        &tab_id,
-                        BrowserCommandStatus::Cancelled,
-                        "user_interrupted",
-                        "Direct user input interrupted the Agent browser action",
-                    );
+                    if !user_handoff_active {
+                        self.cancel_tab_command(
+                            &tab_id,
+                            BrowserCommandStatus::Cancelled,
+                            "user_interrupted",
+                            "Direct user input interrupted the Agent browser action",
+                        );
+                    }
                     if let Some(session) = state.sessions.get_mut(&session_id) {
                         session.control.control_epoch =
                             session.control.control_epoch.saturating_add(1);
                         session.control.active_command_id = None;
-                        if session.pending_policy_request.is_none() {
+                        if !user_handoff_active && session.pending_policy_request.is_none() {
                             session.control.state = BrowserControlState::Interrupted;
                             session.control.reason = Some(
                                 "Direct user input invalidated pending Agent browser work"
@@ -2127,7 +2143,14 @@ impl BrowserSessionManager {
                             mark_agent_snapshot_dirty(tab, true);
                         }
                     }
-                    increment_counter(&mut state, "browser.user_input.interrupted");
+                    increment_counter(
+                        &mut state,
+                        if user_handoff_active {
+                            "browser.user_input.handoff"
+                        } else {
+                            "browser.user_input.interrupted"
+                        },
+                    );
                 }
                 BrowserPlatformEvent::ContentDirty { tab_id } => {
                     if let Some(session) = state.sessions.get_mut(&session_id) {
@@ -2371,7 +2394,9 @@ fn snapshot_from_state(
     }
     let capabilities = adapter.capabilities();
     let ready = session.lifecycle == BrowserSessionLifecycle::Ready;
-    let interaction = ready && capabilities.agent_interaction.available;
+    let interaction = ready
+        && capabilities.agent_interaction.available
+        && session.control.state != BrowserControlState::UserRequired;
     let source_id = format!("native-browser:{}", session.id);
     Some(BrowserNativeSnapshot {
         schema_version: "tinybot.tinyos_native_snapshot.v1",
@@ -2538,6 +2563,23 @@ fn plan_browser_interaction(
             ),
         });
     }
+    if session.control.state == BrowserControlState::UserRequired
+        && !matches!(&input.action, BrowserAction::Resume)
+    {
+        return Err(BrowserInteractionRejection {
+            metric: Some("browser.command.rejected.user_handoff"),
+            reason:
+                "Browser control is handed to the user; wait until the user resumes Agent control"
+                    .to_string(),
+        });
+    }
+    if matches!(&input.action, BrowserAction::Resume) && session.pending_policy_request.is_some() {
+        return Err(BrowserInteractionRejection {
+            metric: Some("browser.command.rejected.policy_pending"),
+            reason: "Resolve the pending browser policy request before resuming Agent control"
+                .to_string(),
+        });
+    }
     if input.action.requires_observation() {
         let expected_revision =
             input
@@ -2599,6 +2641,12 @@ fn plan_browser_interaction(
                     ),
                 });
             }
+            if let Some(reason_code) = protected_reason_at(tab, *x, *y) {
+                return Ok(BrowserPlatformAction::UserRequired {
+                    reason: protected_operation_reason(reason_code),
+                    reason_code: reason_code.to_string(),
+                });
+            }
             Ok(BrowserPlatformAction::Browser(input.action.clone()))
         }
         BrowserAction::ClickTarget { target_ref } => {
@@ -2636,6 +2684,16 @@ fn plan_browser_interaction(
                     selector: target.selector.clone(),
                     text: text.clone(),
                 })
+            }
+        }
+        BrowserAction::Type { .. } | BrowserAction::Key { .. } => {
+            if let Some(reason_code) = focused_protected_reason(tab) {
+                Ok(BrowserPlatformAction::UserRequired {
+                    reason: protected_operation_reason(reason_code),
+                    reason_code: reason_code.to_string(),
+                })
+            } else {
+                Ok(BrowserPlatformAction::Browser(input.action.clone()))
             }
         }
         BrowserAction::UserHandoff { reason } => {
@@ -2866,8 +2924,34 @@ fn protected_operation_reason(reason_code: &str) -> String {
         "captcha" => {
             "CAPTCHA requires direct user completion before Agent work can resume".to_string()
         }
+        "sensitive_input" => {
+            "A password, verification code, or payment field requires direct user input before Agent work can resume"
+                .to_string()
+        }
         _ => "This protected browser operation requires direct user completion".to_string(),
     }
+}
+
+fn semantic_protected_reason(node: &BrowserPlatformSemanticNode) -> Option<String> {
+    node.protected_reason
+        .clone()
+        .or_else(|| node.sensitive.then(|| "sensitive_input".to_string()))
+}
+
+fn protected_reason_at(tab: &BrowserTabRecord, x: f64, y: f64) -> Option<&str> {
+    tab.semantic.as_ref()?.nodes.iter().find_map(|node| {
+        let reason = node.protected_reason.as_deref()?;
+        (x >= node.x && x <= node.x + node.width && y >= node.y && y <= node.y + node.height)
+            .then_some(reason)
+    })
+}
+
+fn focused_protected_reason(tab: &BrowserTabRecord) -> Option<&str> {
+    tab.semantic.as_ref()?.nodes.iter().find_map(|node| {
+        node.focused
+            .then(|| node.protected_reason.as_deref())
+            .flatten()
+    })
 }
 
 fn hidden_surface_reason(input: &BrowserSurfaceUpdate) -> String {

--- a/src-tauri/src/native_browser/manager.rs
+++ b/src-tauri/src/native_browser/manager.rs
@@ -134,6 +134,7 @@ pub(crate) struct BrowserSessionManager {
     profile_root: PathBuf,
     state: Mutex<BrowserRuntimeState>,
     command_locks: Mutex<HashMap<BrowserTabId, Arc<tokio::sync::Mutex<()>>>>,
+    owner_creation_locks: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     active_cancellations: Mutex<HashMap<BrowserTabId, BrowserActiveCancellation>>,
     surface_lock: tokio::sync::Mutex<()>,
     snapshot_sink: BrowserSnapshotSink,
@@ -152,6 +153,7 @@ impl BrowserSessionManager {
             profile_root,
             state: Mutex::new(BrowserRuntimeState::default()),
             command_locks: Mutex::new(HashMap::new()),
+            owner_creation_locks: Mutex::new(HashMap::new()),
             active_cancellations: Mutex::new(HashMap::new()),
             surface_lock: tokio::sync::Mutex::new(()),
             snapshot_sink,
@@ -285,6 +287,34 @@ impl BrowserSessionManager {
     ) -> Result<BrowserNativeSnapshot, String> {
         let owner_session_id = required_text(input.owner_session_id, "Browser owner session id")?;
         if let Some(snapshot) = self.snapshot_for_owner(&owner_session_id) {
+            if snapshot.data.lifecycle != BrowserSessionLifecycle::Creating {
+                return Ok(snapshot);
+            }
+        }
+        let creation_lock = self.owner_creation_lock(&owner_session_id);
+        let wait_started = Instant::now();
+        let _creation_guard = creation_lock.lock().await;
+        if let Some(snapshot) = self.snapshot_for_owner(&owner_session_id) {
+            let mut state = self.lock_state();
+            increment_counter(&mut state, "browser.session.create.coalesced");
+            record_duration(
+                &mut state,
+                "browser.session.create.wait",
+                wait_started.elapsed(),
+            );
+            drop(state);
+            self.diagnostic(
+                "browser.session.create.coalesced",
+                Some(snapshot.data.browser_session_id.clone()),
+                Some(snapshot.data.active_tab_id.clone()),
+                None,
+                None,
+                None,
+                diagnostic_details([(
+                    "waitMs",
+                    serde_json::Value::from(wait_started.elapsed().as_millis() as u64),
+                )]),
+            );
             return Ok(snapshot);
         }
         let initial_url = safe_browser_url(input.initial_url.as_deref().unwrap_or("about:blank"))?;
@@ -583,6 +613,7 @@ impl BrowserSessionManager {
                     tab_id: tab_id.clone(),
                     rect,
                     visible: true,
+                    focus: true,
                 })
                 .await?;
         }
@@ -856,6 +887,7 @@ impl BrowserSessionManager {
                         tab_id: tab_id.clone(),
                         rect,
                         visible: true,
+                        focus: true,
                     })
                     .await?;
             }
@@ -903,27 +935,12 @@ impl BrowserSessionManager {
         let _surface_guard = self.surface_lock.lock().await;
         input.rect.validate()?;
         let show = input.should_show();
-        let capture_before_hide = {
-            let state = self.lock_state();
-            let session = state
-                .sessions
-                .get(&input.browser_session_id)
-                .ok_or_else(|| "Browser session is unavailable".to_string())?;
-            require_tab(session, &input.tab_id)?;
-            input.layout_revision >= session.surface.layout_revision
-                && !show
-                && session.surface.lifecycle == BrowserSurfaceLifecycle::Visible
+        let next_lifecycle = if show {
+            BrowserSurfaceLifecycle::Visible
+        } else {
+            BrowserSurfaceLifecycle::Hidden
         };
-        if capture_before_hide {
-            let _ = self
-                .observe(BrowserObserveInput {
-                    browser_session_id: input.browser_session_id.clone(),
-                    tab_id: input.tab_id.clone(),
-                    capture: true,
-                    semantic: false,
-                })
-                .await;
-        }
+        let hidden_reason = (!show).then(|| hidden_surface_reason(&input));
         let previous_surface = {
             let mut state = self.lock_state();
             let session = ready_session_mut(&mut state, &input.browser_session_id)?;
@@ -933,22 +950,40 @@ impl BrowserSessionManager {
                     input.layout_revision, session.surface.layout_revision
                 ));
             }
-            let previous_surface = session.surface.clone();
-            session.surface = BrowserSurfaceSnapshot {
-                lifecycle: session
-                    .surface
-                    .lifecycle
-                    .transition_to(BrowserSurfaceLifecycle::Attaching)?,
-                surface_id: Some(input.surface_id.clone()),
-                tab_id: Some(input.tab_id.clone()),
-                rect: Some(input.rect.clone()),
-                layout_revision: input.layout_revision,
-                reason: (!show).then(|| hidden_surface_reason(&input)),
-            };
-            bump_revision(&mut state);
-            previous_surface
+            let unchanged = session.surface.lifecycle == next_lifecycle
+                && session.surface.surface_id.as_ref() == Some(&input.surface_id)
+                && session.surface.tab_id.as_ref() == Some(&input.tab_id)
+                && session.surface.rect.as_ref() == Some(&input.rect)
+                && session.surface.reason.as_ref() == hidden_reason.as_ref();
+            if unchanged {
+                increment_counter(&mut state, "browser.surface.unchanged");
+                None
+            } else {
+                let previous_surface = session.surface.clone();
+                session.surface = BrowserSurfaceSnapshot {
+                    lifecycle: session
+                        .surface
+                        .lifecycle
+                        .transition_to(BrowserSurfaceLifecycle::Attaching)?,
+                    surface_id: Some(input.surface_id.clone()),
+                    tab_id: Some(input.tab_id.clone()),
+                    rect: Some(input.rect.clone()),
+                    layout_revision: input.layout_revision,
+                    reason: hidden_reason,
+                };
+                bump_revision(&mut state);
+                Some(previous_surface)
+            }
+        };
+        let Some(previous_surface) = previous_surface else {
+            return self.snapshot(&input.browser_session_id).ok_or_else(|| {
+                "Browser session disappeared after unchanged surface update".to_string()
+            });
         };
         self.publish_snapshot(&input.browser_session_id);
+        let became_visible = show
+            && (previous_surface.lifecycle != BrowserSurfaceLifecycle::Visible
+                || previous_surface.tab_id.as_ref() != Some(&input.tab_id));
         if previous_surface.lifecycle == BrowserSurfaceLifecycle::Visible
             && previous_surface.tab_id.as_ref() != Some(&input.tab_id)
         {
@@ -960,6 +995,7 @@ impl BrowserSessionManager {
                         tab_id: previous_tab_id,
                         rect: previous_rect,
                         visible: false,
+                        focus: false,
                     })
                     .await?;
             }
@@ -970,6 +1006,7 @@ impl BrowserSessionManager {
                 tab_id: input.tab_id.clone(),
                 rect: input.rect.clone(),
                 visible: show,
+                focus: became_visible,
             })
             .await;
         let superseded = {
@@ -1058,7 +1095,7 @@ impl BrowserSessionManager {
             ]),
         );
         result?;
-        if show {
+        if became_visible {
             let manager = self.clone();
             let observe_input = BrowserObserveInput {
                 browser_session_id: input.browser_session_id.clone(),
@@ -1874,6 +1911,15 @@ impl BrowserSessionManager {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(tab_id, Arc::new(tokio::sync::Mutex::new(())));
+    }
+
+    fn owner_creation_lock(&self, owner_session_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+        self.owner_creation_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entry(owner_session_id.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     fn remove_command_lock(&self, tab_id: &BrowserTabId) {

--- a/src-tauri/src/native_browser/manager.rs
+++ b/src-tauri/src/native_browser/manager.rs
@@ -1624,9 +1624,12 @@ impl BrowserSessionManager {
             session.control.state = if input.approved {
                 BrowserControlState::Recovering
             } else {
-                BrowserControlState::Idle
+                BrowserControlState::UserRequired
             };
-            session.control.reason = None;
+            session.control.reason = (!input.approved).then(|| {
+                "Continue using the browser, then hand control back to the Agent when ready"
+                    .to_string()
+            });
             increment_counter(
                 &mut state,
                 if input.approved {
@@ -1683,12 +1686,13 @@ impl BrowserSessionManager {
                 .sessions
                 .get_mut(&input.browser_session_id)
                 .ok_or_else(|| "Browser session closed during policy decision".to_string())?;
-            session.control.state = if operation.is_ok() {
-                BrowserControlState::Idle
-            } else {
-                BrowserControlState::Failed
-            };
-            session.control.reason = operation.as_ref().err().cloned();
+            session.control.state = BrowserControlState::UserRequired;
+            session.control.reason = operation.as_ref().err().cloned().or_else(|| {
+                Some(
+                    "Continue using the browser, then hand control back to the Agent when ready"
+                        .to_string(),
+                )
+            });
             increment_counter(
                 &mut state,
                 if operation.is_ok() {

--- a/src-tauri/src/native_browser/manager.rs
+++ b/src-tauri/src/native_browser/manager.rs
@@ -16,7 +16,8 @@ use super::{
     platform::{
         diagnostic_details, external_protocol_url, redact_browser_url, safe_browser_url,
         BrowserPlatformAction, BrowserPlatformCreateTab, BrowserPlatformEvent,
-        BrowserPlatformProfile, BrowserPlatformSurface, BrowserRuntimeAdapter,
+        BrowserPlatformProfile, BrowserPlatformSemanticNode, BrowserPlatformSurface,
+        BrowserRuntimeAdapter,
     },
 };
 use chrono::{SecondsFormat, Utc};
@@ -31,6 +32,7 @@ use std::{
 const CAPTURE_RETENTION: usize = 12;
 const MAX_CAPTURE_BASE64_BYTES: usize = 12 * 1024 * 1024;
 const DEFAULT_AGENT_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const AGENT_SNAPSHOT_STALE: &str = "Browser page snapshot is stale";
 
 pub(crate) type BrowserSnapshotSink = Arc<dyn Fn(BrowserNativeSnapshot) + Send + Sync>;
 pub(crate) type BrowserDiagnosticSink = Arc<dyn Fn(BrowserRuntimeDiagnostic) + Send + Sync>;
@@ -73,6 +75,13 @@ struct BrowserSessionRecord {
 }
 
 #[derive(Clone)]
+pub(crate) struct BrowserAgentPageState {
+    pub(crate) snapshot_id: String,
+    pub(crate) dirty: bool,
+    pub(crate) observation: BrowserObserveResult,
+}
+
+#[derive(Clone)]
 struct BrowserPendingPolicyRequest {
     snapshot: BrowserPolicyRequestSnapshot,
     url: String,
@@ -110,6 +119,9 @@ struct BrowserTabRecord {
     captures: VecDeque<BrowserCaptureSnapshot>,
     semantic: Option<BrowserSemanticObservation>,
     semantic_targets: HashMap<String, BrowserSemanticTarget>,
+    agent_snapshot_generation: String,
+    agent_snapshot_revision: u64,
+    agent_snapshot_dirty: bool,
 }
 
 struct BrowserSemanticTarget {
@@ -200,6 +212,42 @@ impl BrowserSessionManager {
         snapshot_from_state(&self.lock_state(), session_id, self.adapter.as_ref())
     }
 
+    pub(crate) fn agent_page_state_for_owner(
+        &self,
+        owner_session_id: &str,
+    ) -> Option<BrowserAgentPageState> {
+        let state = self.lock_state();
+        let session_id = state.owner_sessions.get(owner_session_id)?;
+        let session = state.sessions.get(session_id)?;
+        let tab = session.tabs.get(&session.active_tab_id)?;
+        Some(BrowserAgentPageState {
+            snapshot_id: agent_snapshot_id(tab),
+            dirty: tab.agent_snapshot_dirty,
+            observation: BrowserObserveResult {
+                snapshot: snapshot_from_state(&state, session_id, self.adapter.as_ref())?,
+                capture: tab.captures.back().cloned(),
+                semantic: tab.semantic.clone(),
+            },
+        })
+    }
+
+    pub(crate) fn advance_agent_snapshot_for_owner(
+        &self,
+        owner_session_id: &str,
+    ) -> Result<(), String> {
+        let mut state = self.lock_state();
+        let session_id = state
+            .owner_sessions
+            .get(owner_session_id)
+            .cloned()
+            .ok_or_else(|| "TinyOS browser session is unavailable for this chat".to_string())?;
+        let session = ready_session_mut(&mut state, &session_id)?;
+        let active_tab_id = session.active_tab_id.clone();
+        advance_agent_snapshot(require_tab_mut(session, &active_tab_id)?);
+        bump_revision(&mut state);
+        Ok(())
+    }
+
     pub(crate) fn cancel_agent_command(
         &self,
         tab_id: &BrowserTabId,
@@ -259,6 +307,10 @@ impl BrowserSessionManager {
             let navigation_id = BrowserNavigationId(next_id(&mut state, "browser-navigation"));
             let observed_at = now_timestamp();
             let url = initial_url.to_string();
+            let agent_snapshot_generation = format!(
+                "b{}",
+                &stable_short_hash(&format!("{owner_session_id}:{session_id}:{observed_at}"))[..7]
+            );
             let tab = BrowserTabRecord {
                 id: tab_id.clone(),
                 lifecycle: BrowserTabLifecycle::Creating,
@@ -283,6 +335,9 @@ impl BrowserSessionManager {
                 captures: VecDeque::new(),
                 semantic: None,
                 semantic_targets: HashMap::new(),
+                agent_snapshot_generation,
+                agent_snapshot_revision: 0,
+                agent_snapshot_dirty: true,
             };
             let session = BrowserSessionRecord {
                 id: session_id.clone(),
@@ -411,8 +466,21 @@ impl BrowserSessionManager {
             ensure_accepting(&state)?;
             let tab_id = BrowserTabId(next_id(&mut state, "browser-tab"));
             let navigation_id = BrowserNavigationId(next_id(&mut state, "browser-navigation"));
+            let agent_snapshot_generation = format!(
+                "b{}",
+                &stable_short_hash(&format!(
+                    "{}:{tab_id}:{}",
+                    input.browser_session_id,
+                    now_timestamp()
+                ))[..7]
+            );
             let session = ready_session_mut(&mut state, &input.browser_session_id)?;
-            let tab = new_tab_record(tab_id.clone(), navigation_id, url.as_str());
+            let tab = new_tab_record(
+                tab_id.clone(),
+                navigation_id,
+                url.as_str(),
+                agent_snapshot_generation,
+            );
             session.tabs.insert(tab_id.clone(), tab);
             session.tab_order.push(tab_id.clone());
             session.active_tab_id = tab_id.clone();
@@ -499,7 +567,9 @@ impl BrowserSessionManager {
             let mut state = self.lock_state();
             let session = ready_session_mut(&mut state, session_id)?;
             require_tab(session, tab_id)?;
-            session.active_tab_id = tab_id.clone();
+            if session.active_tab_id != *tab_id {
+                session.active_tab_id = tab_id.clone();
+            }
             let surface = session.surface.clone();
             bump_revision(&mut state);
             surface
@@ -1010,6 +1080,14 @@ impl BrowserSessionManager {
         self: &Arc<Self>,
         input: BrowserObserveInput,
     ) -> Result<BrowserObserveResult, String> {
+        self.observe_internal(input, false).await
+    }
+
+    async fn observe_internal(
+        self: &Arc<Self>,
+        input: BrowserObserveInput,
+        force_new_observation: bool,
+    ) -> Result<BrowserObserveResult, String> {
         self.require_ready_tab(&input.browser_session_id, &input.tab_id)?;
         let started = Instant::now();
         let platform = self
@@ -1046,96 +1124,133 @@ impl BrowserSessionManager {
                 .capture
                 .then(|| BrowserCaptureId(next_id(&mut state, "browser-capture")));
             let observed_at = now_timestamp();
-            let (capture, semantic, retention_truncated) = {
+            let (capture, semantic, retention_truncated, semantic_changed) = {
                 let session = ready_session_mut(&mut state, &input.browser_session_id)?;
-                let tab = require_tab_mut(session, &input.tab_id)?;
-                tab.observation_revision = tab.observation_revision.saturating_add(1);
-                let observation_revision = tab.observation_revision;
+                let (capture, semantic, retention_truncated, semantic_changed) = {
+                    let tab = require_tab_mut(session, &input.tab_id)?;
+                    let semantic_changed = input.semantic
+                        && (force_new_observation
+                            || !semantic_content_matches(
+                                tab.semantic.as_ref(),
+                                &platform.semantic_nodes,
+                                platform.semantic_truncated,
+                            ));
+                    if semantic_changed {
+                        tab.observation_revision = tab.observation_revision.saturating_add(1);
+                    }
+                    let observation_revision = tab.observation_revision;
 
-                let capture = if let Some(capture_id) = capture_id {
-                    let data_url = platform
-                        .capture_base64
-                        .map(|base64| {
-                            if base64.len() > MAX_CAPTURE_BASE64_BYTES {
-                                return Err(format!(
-                                    "Browser capture exceeds the {} byte retention limit",
-                                    MAX_CAPTURE_BASE64_BYTES
-                                ));
-                            }
-                            Ok(format!("data:image/png;base64,{base64}"))
-                        })
-                        .transpose()?;
-                    for retained in &mut tab.captures {
-                        retained.stale = true;
-                    }
-                    let capture = BrowserCaptureSnapshot {
-                        capture_id: capture_id.clone(),
-                        observed_at: observed_at.clone(),
-                        stale: false,
-                        observation_revision,
-                        navigation_id: navigation_id.clone(),
-                        viewport_width: platform.viewport_width,
-                        viewport_height: platform.viewport_height,
-                        device_scale: platform.device_scale,
-                        data_url,
+                    let capture = if let Some(capture_id) = capture_id {
+                        let data_url = platform
+                            .capture_base64
+                            .map(|base64| {
+                                if base64.len() > MAX_CAPTURE_BASE64_BYTES {
+                                    return Err(format!(
+                                        "Browser capture exceeds the {} byte retention limit",
+                                        MAX_CAPTURE_BASE64_BYTES
+                                    ));
+                                }
+                                Ok(format!("data:image/png;base64,{base64}"))
+                            })
+                            .transpose()?;
+                        for retained in &mut tab.captures {
+                            retained.stale = true;
+                        }
+                        let capture = BrowserCaptureSnapshot {
+                            capture_id: capture_id.clone(),
+                            observed_at: observed_at.clone(),
+                            stale: false,
+                            observation_revision,
+                            navigation_id: navigation_id.clone(),
+                            viewport_width: platform.viewport_width,
+                            viewport_height: platform.viewport_height,
+                            device_scale: platform.device_scale,
+                            data_url,
+                        };
+                        tab.captures.push_back(capture.clone());
+                        let mut retention_truncated = 0;
+                        while tab.captures.len() > CAPTURE_RETENTION {
+                            tab.captures.pop_front();
+                            retention_truncated += 1;
+                        }
+                        if let Some(history) = tab.history.get_mut(tab.active_history_index) {
+                            history.capture_id = Some(capture_id);
+                        }
+                        (Some(capture), retention_truncated)
+                    } else {
+                        (None, 0)
                     };
-                    tab.captures.push_back(capture.clone());
-                    let mut retention_truncated = 0;
-                    while tab.captures.len() > CAPTURE_RETENTION {
-                        tab.captures.pop_front();
-                        retention_truncated += 1;
-                    }
-                    if let Some(history) = tab.history.get_mut(tab.active_history_index) {
-                        history.capture_id = Some(capture_id);
-                    }
-                    (Some(capture), retention_truncated)
-                } else {
-                    (None, 0)
-                };
 
-                tab.semantic_targets.clear();
-                let semantic = if input.semantic {
-                    let nodes = platform
-                        .semantic_nodes
-                        .into_iter()
-                        .enumerate()
-                        .map(|(index, node)| {
-                            let target_ref = format!("target-{observation_revision}-{index}");
-                            tab.semantic_targets.insert(
-                                target_ref.clone(),
-                                BrowserSemanticTarget {
-                                    selector: node.selector,
-                                    protected_reason: node.protected_reason.clone(),
-                                },
-                            );
-                            BrowserSemanticNode {
-                                target_ref,
-                                role: node.role,
-                                name: node.name,
-                                frame: node.frame,
-                                x: node.x,
-                                y: node.y,
-                                width: node.width,
-                                height: node.height,
-                                disabled: node.disabled,
-                                focused: node.focused,
-                                sensitive: node.sensitive,
-                                protected_reason: node.protected_reason,
+                    let semantic = if input.semantic {
+                        if semantic_changed {
+                            tab.semantic_targets.clear();
+                            let nodes = platform
+                                .semantic_nodes
+                                .into_iter()
+                                .enumerate()
+                                .map(|(index, node)| {
+                                    let target_ref =
+                                        format!("target-{observation_revision}-{index}");
+                                    tab.semantic_targets.insert(
+                                        target_ref.clone(),
+                                        BrowserSemanticTarget {
+                                            selector: node.selector,
+                                            protected_reason: node.protected_reason.clone(),
+                                        },
+                                    );
+                                    BrowserSemanticNode {
+                                        target_ref,
+                                        role: node.role,
+                                        name: node.name,
+                                        frame: node.frame,
+                                        x: node.x,
+                                        y: node.y,
+                                        width: node.width,
+                                        height: node.height,
+                                        disabled: node.disabled,
+                                        focused: node.focused,
+                                        sensitive: node.sensitive,
+                                        protected_reason: node.protected_reason,
+                                    }
+                                })
+                                .collect();
+                            let observation = BrowserSemanticObservation {
+                                observation_revision,
+                                observed_at,
+                                truncated: platform.semantic_truncated,
+                                nodes,
+                            };
+                            tab.semantic = Some(observation.clone());
+                            Some(observation)
+                        } else {
+                            tab.semantic_targets.clear();
+                            if let Some(current) = tab.semantic.as_ref() {
+                                for (current_node, node) in
+                                    current.nodes.iter().zip(&platform.semantic_nodes)
+                                {
+                                    tab.semantic_targets.insert(
+                                        current_node.target_ref.clone(),
+                                        BrowserSemanticTarget {
+                                            selector: node.selector.clone(),
+                                            protected_reason: node.protected_reason.clone(),
+                                        },
+                                    );
+                                }
                             }
-                        })
-                        .collect();
-                    let observation = BrowserSemanticObservation {
-                        observation_revision,
-                        observed_at,
-                        truncated: platform.semantic_truncated,
-                        nodes,
+                            tab.semantic.clone()
+                        }
+                    } else {
+                        None
                     };
-                    tab.semantic = Some(observation.clone());
-                    Some(observation)
-                } else {
-                    None
+                    if input.semantic {
+                        if semantic_changed {
+                            advance_agent_snapshot(tab);
+                        }
+                        tab.agent_snapshot_dirty = false;
+                    }
+                    (capture.0, semantic, capture.1, semantic_changed)
                 };
-                (capture.0, semantic, capture.1)
+                (capture, semantic, retention_truncated, semantic_changed)
             };
             for _ in 0..retention_truncated {
                 increment_counter(&mut state, "browser.capture.retention_truncated");
@@ -1146,6 +1261,9 @@ impl BrowserSessionManager {
                 record_duration(&mut state, "browser.capture", started.elapsed());
             }
             record_duration(&mut state, "browser.observe", started.elapsed());
+            if semantic_changed {
+                increment_counter(&mut state, "browser.agent_snapshot.refreshed");
+            }
             bump_revision(&mut state);
             (capture, semantic)
         };
@@ -1418,12 +1536,15 @@ impl BrowserSessionManager {
         self.publish_snapshot(&input.browser_session_id);
         if final_status == BrowserCommandStatus::Completed {
             let _ = self
-                .observe(BrowserObserveInput {
-                    browser_session_id: input.browser_session_id.clone(),
-                    tab_id: input.tab_id.clone(),
-                    capture: true,
-                    semantic: true,
-                })
+                .observe_internal(
+                    BrowserObserveInput {
+                        browser_session_id: input.browser_session_id.clone(),
+                        tab_id: input.tab_id.clone(),
+                        capture: true,
+                        semantic: true,
+                    },
+                    true,
+                )
                 .await;
         }
         let (code, message) =
@@ -1863,12 +1984,13 @@ impl BrowserSessionManager {
     }
 
     fn handle_platform_event(self: &Arc<Self>, event: BrowserPlatformEvent) {
-        let (session_id, recapture_tab_id) = {
+        let (session_id, recapture_tab_id, publish_snapshot) = {
             let mut state = self.lock_state();
             let Some(session_id) = find_session_for_tab(&state, event_tab_id(&event)) else {
                 return;
             };
             let mut recapture_tab_id = None;
+            let mut publish_snapshot = true;
             match event {
                 BrowserPlatformEvent::NavigationStarted { tab_id, url } => {
                     self.diagnostic(
@@ -1882,21 +2004,20 @@ impl BrowserSessionManager {
                     );
                     let next_navigation =
                         BrowserNavigationId(next_id(&mut state, "browser-navigation"));
-                    if let Some(tab) = state
-                        .sessions
-                        .get_mut(&session_id)
-                        .and_then(|session| session.tabs.get_mut(&tab_id))
-                    {
-                        tab.lifecycle = BrowserTabLifecycle::Loading;
-                        tab.loading = true;
-                        tab.url = url;
-                        tab.navigation_sequence = tab.navigation_sequence.saturating_add(1);
-                        tab.navigation_started_at = Some(Instant::now());
-                        tab.navigation_id = next_navigation;
-                        tab.semantic = None;
-                        tab.semantic_targets.clear();
-                        for capture in &mut tab.captures {
-                            capture.stale = true;
+                    if let Some(session) = state.sessions.get_mut(&session_id) {
+                        if let Some(tab) = session.tabs.get_mut(&tab_id) {
+                            tab.lifecycle = BrowserTabLifecycle::Loading;
+                            tab.loading = true;
+                            tab.url = url;
+                            tab.navigation_sequence = tab.navigation_sequence.saturating_add(1);
+                            tab.navigation_started_at = Some(Instant::now());
+                            tab.navigation_id = next_navigation;
+                            tab.semantic = None;
+                            tab.semantic_targets.clear();
+                            for capture in &mut tab.captures {
+                                capture.stale = true;
+                            }
+                            mark_agent_snapshot_dirty(tab, true);
                         }
                     }
                     increment_counter(&mut state, "browser.navigation.started");
@@ -1916,55 +2037,62 @@ impl BrowserSessionManager {
                         Some(&url),
                         BTreeMap::new(),
                     );
-                    let navigation_duration = if let Some(tab) = state
-                        .sessions
-                        .get_mut(&session_id)
-                        .and_then(|session| session.tabs.get_mut(&tab_id))
-                    {
-                        tab.lifecycle = BrowserTabLifecycle::Ready;
-                        tab.loading = false;
-                        tab.url = url.clone();
-                        tab.can_go_back = can_go_back;
-                        tab.can_go_forward = can_go_forward;
-                        let observed_at = now_timestamp();
-                        if tab
-                            .history
-                            .get(tab.active_history_index)
-                            .map(|entry| entry.url.as_str())
-                            != Some(url.as_str())
-                        {
-                            tab.history
-                                .truncate(tab.active_history_index.saturating_add(1));
-                            tab.history.push(BrowserNavigationEntry {
-                                url,
-                                title: tab.title.clone(),
-                                observed_at,
-                                navigation_id: tab.navigation_id.clone(),
-                                capture_id: None,
-                            });
-                            tab.active_history_index = tab.history.len().saturating_sub(1);
-                        }
-                        recapture_tab_id = Some(tab_id.clone());
-                        tab.navigation_started_at
-                            .take()
-                            .map(|started| started.elapsed())
-                    } else {
-                        None
-                    };
+                    let navigation_duration =
+                        if let Some(session) = state.sessions.get_mut(&session_id) {
+                            let duration = if let Some(tab) = session.tabs.get_mut(&tab_id) {
+                                tab.lifecycle = BrowserTabLifecycle::Ready;
+                                tab.loading = false;
+                                tab.url = url.clone();
+                                tab.can_go_back = can_go_back;
+                                tab.can_go_forward = can_go_forward;
+                                let observed_at = now_timestamp();
+                                if tab
+                                    .history
+                                    .get(tab.active_history_index)
+                                    .map(|entry| entry.url.as_str())
+                                    != Some(url.as_str())
+                                {
+                                    tab.history
+                                        .truncate(tab.active_history_index.saturating_add(1));
+                                    tab.history.push(BrowserNavigationEntry {
+                                        url,
+                                        title: tab.title.clone(),
+                                        observed_at,
+                                        navigation_id: tab.navigation_id.clone(),
+                                        capture_id: None,
+                                    });
+                                    tab.active_history_index = tab.history.len().saturating_sub(1);
+                                }
+                                recapture_tab_id = Some(tab_id.clone());
+                                let duration = tab
+                                    .navigation_started_at
+                                    .take()
+                                    .map(|started| started.elapsed());
+                                mark_agent_snapshot_dirty(tab, false);
+                                duration
+                            } else {
+                                None
+                            };
+                            duration
+                        } else {
+                            None
+                        };
                     increment_counter(&mut state, "browser.navigation.completed");
                     if let Some(duration) = navigation_duration {
                         record_duration(&mut state, "browser.navigation", duration);
                     }
                 }
                 BrowserPlatformEvent::TitleChanged { tab_id, title } => {
-                    if let Some(tab) = state
-                        .sessions
-                        .get_mut(&session_id)
-                        .and_then(|session| session.tabs.get_mut(&tab_id))
-                    {
-                        tab.title = title.clone();
-                        if let Some(history) = tab.history.get_mut(tab.active_history_index) {
-                            history.title = title;
+                    if let Some(session) = state.sessions.get_mut(&session_id) {
+                        if let Some(tab) = session.tabs.get_mut(&tab_id) {
+                            let changed = tab.title != title;
+                            tab.title = title.clone();
+                            if let Some(history) = tab.history.get_mut(tab.active_history_index) {
+                                history.title = title;
+                            }
+                            if changed {
+                                mark_agent_snapshot_dirty(tab, true);
+                            }
                         }
                     }
                 }
@@ -1995,8 +2123,19 @@ impl BrowserSessionManager {
                                     .to_string(),
                             );
                         }
+                        if let Some(tab) = session.tabs.get_mut(&tab_id) {
+                            mark_agent_snapshot_dirty(tab, true);
+                        }
                     }
                     increment_counter(&mut state, "browser.user_input.interrupted");
+                }
+                BrowserPlatformEvent::ContentDirty { tab_id } => {
+                    if let Some(session) = state.sessions.get_mut(&session_id) {
+                        if let Some(tab) = session.tabs.get_mut(&tab_id) {
+                            mark_agent_snapshot_dirty(tab, false);
+                        }
+                    }
+                    publish_snapshot = false;
                 }
                 BrowserPlatformEvent::PopupRequested { tab_id, url } => {
                     self.diagnostic(
@@ -2136,6 +2275,7 @@ impl BrowserSessionManager {
                             tab.lifecycle = BrowserTabLifecycle::Crashed;
                             tab.renderer_lifecycle = BrowserRendererLifecycle::Failed;
                             tab.loading = false;
+                            mark_agent_snapshot_dirty(tab, true);
                         }
                     }
                     increment_counter(&mut state, "browser.renderer.crashed");
@@ -2153,10 +2293,14 @@ impl BrowserSessionManager {
                     );
                 }
             }
-            bump_revision(&mut state);
-            (session_id, recapture_tab_id)
+            if publish_snapshot {
+                bump_revision(&mut state);
+            }
+            (session_id, recapture_tab_id, publish_snapshot)
         };
-        self.publish_snapshot(&session_id);
+        if publish_snapshot {
+            self.publish_snapshot(&session_id);
+        }
         if let Some(tab_id) = recapture_tab_id {
             let manager = self.clone();
             tauri::async_runtime::spawn(async move {
@@ -2309,6 +2453,7 @@ fn new_tab_record(
     tab_id: BrowserTabId,
     navigation_id: BrowserNavigationId,
     url: &str,
+    agent_snapshot_generation: String,
 ) -> BrowserTabRecord {
     BrowserTabRecord {
         id: tab_id,
@@ -2334,6 +2479,9 @@ fn new_tab_record(
         captures: VecDeque::new(),
         semantic: None,
         semantic_targets: HashMap::new(),
+        agent_snapshot_generation,
+        agent_snapshot_revision: 0,
+        agent_snapshot_dirty: true,
     }
 }
 
@@ -2373,6 +2521,14 @@ fn plan_browser_interaction(
     tab: &BrowserTabRecord,
     input: &BrowserInteractionInput,
 ) -> Result<BrowserPlatformAction, BrowserInteractionRejection> {
+    if let Some(snapshot_id) = input.snapshot_id.as_deref() {
+        if tab.agent_snapshot_dirty || snapshot_id != agent_snapshot_id(tab) {
+            return Err(BrowserInteractionRejection {
+                metric: Some("browser.command.rejected.stale_agent_snapshot"),
+                reason: AGENT_SNAPSHOT_STALE.to_string(),
+            });
+        }
+    }
     if session.control.control_epoch != input.control_epoch {
         return Err(BrowserInteractionRejection {
             metric: Some("browser.command.rejected.stale_epoch"),
@@ -2561,6 +2717,49 @@ fn bump_revision(state: &mut BrowserRuntimeState) {
     state.revision = state.revision.saturating_add(1);
 }
 
+fn agent_snapshot_id(tab: &BrowserTabRecord) -> String {
+    format!(
+        "{}.{}",
+        tab.agent_snapshot_generation, tab.agent_snapshot_revision
+    )
+}
+
+fn advance_agent_snapshot(tab: &mut BrowserTabRecord) {
+    tab.agent_snapshot_revision = tab.agent_snapshot_revision.saturating_add(1);
+}
+
+fn mark_agent_snapshot_dirty(tab: &mut BrowserTabRecord, advance_revision: bool) {
+    tab.agent_snapshot_dirty = true;
+    if advance_revision {
+        advance_agent_snapshot(tab);
+    }
+}
+
+fn semantic_content_matches(
+    current: Option<&BrowserSemanticObservation>,
+    nodes: &[BrowserPlatformSemanticNode],
+    truncated: bool,
+) -> bool {
+    let Some(current) = current else {
+        return false;
+    };
+    current.truncated == truncated
+        && current.nodes.len() == nodes.len()
+        && current.nodes.iter().zip(nodes).all(|(current, node)| {
+            current.role == node.role
+                && current.name == node.name
+                && current.frame == node.frame
+                && current.x == node.x
+                && current.y == node.y
+                && current.width == node.width
+                && current.height == node.height
+                && current.disabled == node.disabled
+                && current.focused == node.focused
+                && current.sensitive == node.sensitive
+                && current.protected_reason == node.protected_reason
+        })
+}
+
 fn increment_counter(state: &mut BrowserRuntimeState, name: &str) {
     let counter = state.metrics.counters.entry(name.to_string()).or_default();
     *counter = counter.saturating_add(1);
@@ -2599,6 +2798,7 @@ fn event_tab_id(event: &BrowserPlatformEvent) -> &BrowserTabId {
         | BrowserPlatformEvent::NavigationFinished { tab_id, .. }
         | BrowserPlatformEvent::TitleChanged { tab_id, .. }
         | BrowserPlatformEvent::UserInput { tab_id }
+        | BrowserPlatformEvent::ContentDirty { tab_id }
         | BrowserPlatformEvent::PopupRequested { tab_id, .. }
         | BrowserPlatformEvent::ExternalProtocolRequested { tab_id, .. }
         | BrowserPlatformEvent::DownloadBlocked { tab_id, .. }

--- a/src-tauri/src/native_browser/manager_tests.rs
+++ b/src-tauri/src/native_browser/manager_tests.rs
@@ -108,23 +108,53 @@ impl BrowserRuntimeAdapter for FakeAdapter {
             viewport_height: 600,
             device_scale: 1.0,
             semantic_nodes: if semantic {
-                vec![BrowserPlatformSemanticNode {
-                    selector: "#submit".to_string(),
-                    role: "button".to_string(),
-                    name: "Submit".to_string(),
-                    frame: "top".to_string(),
-                    x: 10.0,
-                    y: 20.0,
-                    width: 80.0,
-                    height: 30.0,
-                    disabled: false,
-                    focused: false,
-                    sensitive: false,
-                    protected_reason: self
-                        .protected_semantic
-                        .load(std::sync::atomic::Ordering::Relaxed)
-                        .then(|| "native_file_picker".to_string()),
-                }]
+                vec![
+                    BrowserPlatformSemanticNode {
+                        selector: "#submit".to_string(),
+                        role: "button".to_string(),
+                        name: "Submit".to_string(),
+                        frame: "top".to_string(),
+                        x: 10.0,
+                        y: 20.0,
+                        width: 80.0,
+                        height: 30.0,
+                        disabled: false,
+                        focused: false,
+                        sensitive: false,
+                        protected_reason: self
+                            .protected_semantic
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                            .then(|| "native_file_picker".to_string()),
+                    },
+                    BrowserPlatformSemanticNode {
+                        selector: "#offscreen".to_string(),
+                        role: "button".to_string(),
+                        name: "Offscreen".to_string(),
+                        frame: "top".to_string(),
+                        x: 900.0,
+                        y: 20.0,
+                        width: 80.0,
+                        height: 30.0,
+                        disabled: false,
+                        focused: false,
+                        sensitive: false,
+                        protected_reason: None,
+                    },
+                    BrowserPlatformSemanticNode {
+                        selector: "#unnamed".to_string(),
+                        role: "button".to_string(),
+                        name: String::new(),
+                        frame: "top".to_string(),
+                        x: 100.0,
+                        y: 20.0,
+                        width: 30.0,
+                        height: 30.0,
+                        disabled: false,
+                        focused: false,
+                        sensitive: false,
+                        protected_reason: None,
+                    },
+                ]
             } else {
                 vec![]
             },
@@ -303,6 +333,7 @@ async fn high_level_web_tools_refresh_and_reject_stale_actions() {
             .unwrap();
     assert_eq!(first["status"], "completed");
     assert!(first["snapshot"].get("browserSessionId").is_none());
+    assert_eq!(first["snapshot"]["targets"].as_array().unwrap().len(), 1);
     let first_snapshot_id = first["snapshotId"].as_str().unwrap().to_string();
     let first_target_ref = first["snapshot"]["targets"][0]["targetRef"]
         .as_str()

--- a/src-tauri/src/native_browser/manager_tests.rs
+++ b/src-tauri/src/native_browser/manager_tests.rs
@@ -544,6 +544,29 @@ async fn high_level_web_tools_refresh_and_reject_stale_actions() {
 }
 
 #[tokio::test]
+async fn high_level_web_tools_do_not_allow_the_agent_to_resume_user_control() {
+    let manager = manager(Arc::new(FakeAdapter::default()));
+    let page =
+        crate::tools::web::dispatch_web_read(&manager, "chat-agent-resume", serde_json::json!({}))
+            .await
+            .unwrap();
+    let error = crate::tools::web::dispatch_web_act(
+        &manager,
+        "chat-agent-resume",
+        None,
+        serde_json::json!({
+            "commandId": "agent-resume",
+            "snapshotId": page["snapshotId"],
+            "action": { "type": "resume" }
+        }),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.contains("Only the user can hand browser control back to the Agent"));
+}
+
+#[tokio::test]
 async fn diagnostics_correlate_commands_and_redact_navigation_urls() {
     let diagnostics = Arc::new(Mutex::new(Vec::new()));
     let manager = manager_with_diagnostics(Arc::new(FakeAdapter::default()), diagnostics.clone());
@@ -1670,6 +1693,10 @@ async fn confirmed_popup_becomes_a_managed_tab() {
         url: "https://example.com/popup?secret=value".to_string(),
     });
     let pending = manager.snapshot(&snapshot.data.browser_session_id).unwrap();
+    assert_eq!(
+        pending.data.control.state,
+        BrowserControlState::UserRequired
+    );
     let request = pending.data.pending_policy_request.unwrap();
     assert_eq!(request.kind, BrowserPolicyRequestKind::Popup);
     assert_eq!(request.safe_url, "https://example.com/popup");
@@ -1687,6 +1714,46 @@ async fn confirmed_popup_becomes_a_managed_tab() {
         "https://example.com/popup?secret=value"
     );
     assert!(resolved.data.pending_policy_request.is_none());
+    assert_eq!(
+        resolved.data.control.state,
+        BrowserControlState::UserRequired
+    );
+}
+
+#[tokio::test]
+async fn denied_popup_keeps_browser_control_with_the_user() {
+    let adapter = Arc::new(FakeAdapter::default());
+    let manager = manager(adapter.clone());
+    let snapshot = manager
+        .create_session(BrowserCreateSessionInput {
+            owner_session_id: "thread-popup-denied".to_string(),
+            profile_id: None,
+            persistence: BrowserProfilePersistence::Persistent,
+            initial_url: None,
+        })
+        .await
+        .unwrap();
+    adapter.sink.read().unwrap().as_ref().unwrap()(BrowserPlatformEvent::PopupRequested {
+        tab_id: snapshot.data.active_tab_id,
+        url: "https://example.com/popup".to_string(),
+    });
+    let pending = manager.snapshot(&snapshot.data.browser_session_id).unwrap();
+    let request = pending.data.pending_policy_request.unwrap();
+    let resolved = manager
+        .resolve_policy_request(BrowserResolvePolicyRequestInput {
+            browser_session_id: snapshot.data.browser_session_id,
+            request_id: request.request_id,
+            approved: false,
+        })
+        .await
+        .unwrap();
+
+    assert!(resolved.data.pending_policy_request.is_none());
+    assert_eq!(
+        resolved.data.control.state,
+        BrowserControlState::UserRequired
+    );
+    assert_eq!(resolved.data.tabs.len(), 1);
 }
 
 #[tokio::test]

--- a/src-tauri/src/native_browser/manager_tests.rs
+++ b/src-tauri/src/native_browser/manager_tests.rs
@@ -26,6 +26,27 @@ struct FakeAdapter {
     fail_create: std::sync::atomic::AtomicBool,
 }
 
+#[derive(Default)]
+struct TestWebCancellation {
+    token: tokio_util::sync::CancellationToken,
+}
+
+impl TestWebCancellation {
+    fn cancel(&self) {
+        self.token.cancel();
+    }
+}
+
+impl crate::tools::web::WebToolCancellation for TestWebCancellation {
+    fn is_cancelled(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    fn cancelled(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(self.token.cancelled())
+    }
+}
+
 #[async_trait]
 impl BrowserRuntimeAdapter for FakeAdapter {
     fn runtime_kind(&self) -> &'static str {
@@ -344,6 +365,54 @@ async fn concurrent_session_creation_waits_for_the_owner_session_to_be_ready() {
 }
 
 #[tokio::test]
+async fn closing_a_session_waits_for_initial_creation_before_releasing_it() {
+    let adapter = Arc::new(FakeAdapter::default());
+    adapter
+        .create_delay_ms
+        .store(100, std::sync::atomic::Ordering::Relaxed);
+    let manager = manager(adapter.clone());
+    let create_manager = manager.clone();
+    let creating = tokio::spawn(async move {
+        create_manager
+            .create_session(BrowserCreateSessionInput {
+                owner_session_id: "thread-close-during-create".to_string(),
+                profile_id: None,
+                persistence: BrowserProfilePersistence::Persistent,
+                initial_url: None,
+            })
+            .await
+    });
+
+    let creating_snapshot = loop {
+        if let Some(snapshot) = manager.snapshot_for_owner("thread-close-during-create") {
+            break snapshot;
+        }
+        tokio::task::yield_now().await;
+    };
+    let close_manager = manager.clone();
+    let browser_session_id = creating_snapshot.data.browser_session_id;
+    let mut closing =
+        tokio::spawn(async move { close_manager.close_session(&browser_session_id).await });
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut closing)
+            .await
+            .is_err(),
+        "browser cleanup must wait for the initial native tab creation"
+    );
+    let created = creating.await.unwrap().unwrap();
+    closing.await.unwrap().unwrap();
+
+    assert!(manager
+        .snapshot_for_owner("thread-close-during-create")
+        .is_none());
+    assert_eq!(
+        adapter.closed.lock().unwrap().as_slice(),
+        &[created.data.active_tab_id]
+    );
+}
+
+#[tokio::test]
 async fn web_tools_wait_for_a_preheated_session_to_be_ready() {
     let adapter = Arc::new(FakeAdapter::default());
     adapter
@@ -541,6 +610,142 @@ async fn high_level_web_tools_refresh_and_reject_stale_actions() {
         .unwrap_err();
     assert_eq!(rejected, AGENT_SNAPSHOT_STALE);
     assert_eq!(adapter.interactions.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn cancelled_initial_web_open_finishes_session_creation_in_the_background() {
+    let adapter = Arc::new(FakeAdapter::default());
+    adapter
+        .create_delay_ms
+        .store(200, std::sync::atomic::Ordering::Relaxed);
+    let manager = manager(adapter.clone());
+    let cancellation = Arc::new(TestWebCancellation::default());
+    let open_manager = manager.clone();
+    let open_cancellation = cancellation.clone();
+    let opening = tokio::spawn(async move {
+        crate::tools::web::dispatch_web_open(
+            &open_manager,
+            "chat-cancel-initial-open",
+            Some(open_cancellation.as_ref()),
+            serde_json::json!({ "url": "https://example.com" }),
+        )
+        .await
+    });
+
+    loop {
+        if manager
+            .snapshot_for_owner("chat-cancel-initial-open")
+            .is_some()
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    cancellation.cancel();
+    let error = tokio::time::timeout(Duration::from_millis(500), opening)
+        .await
+        .expect("cancelled web.open should finish promptly")
+        .unwrap()
+        .unwrap_err();
+
+    assert!(error.contains("cancelled"));
+    let creating_session = manager
+        .snapshot_for_owner("chat-cancel-initial-open")
+        .expect("the cancelled caller leaves managed creation running");
+    assert_eq!(
+        creating_session.data.lifecycle,
+        BrowserSessionLifecycle::Creating
+    );
+
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if manager
+                .snapshot_for_owner("chat-cancel-initial-open")
+                .is_some_and(|snapshot| snapshot.data.lifecycle == BrowserSessionLifecycle::Ready)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("managed session creation should survive caller cancellation");
+
+    let retried = crate::tools::web::dispatch_web_open(
+        &manager,
+        "chat-cancel-initial-open",
+        None,
+        serde_json::json!({
+            "commandId": "retry-after-cancelled-create",
+            "url": "https://example.org"
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(retried["status"], "completed");
+    assert_eq!(
+        manager
+            .snapshot_for_owner("chat-cancel-initial-open")
+            .unwrap()
+            .data
+            .browser_session_id,
+        creating_session.data.browser_session_id
+    );
+    assert_eq!(adapter.created.lock().unwrap().len(), 1);
+    assert!(adapter.closed.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn agent_snapshot_action_rejects_a_tab_that_is_no_longer_active() {
+    let adapter = Arc::new(FakeAdapter::default());
+    let manager = manager(adapter.clone());
+    crate::tools::web::dispatch_web_read(&manager, "chat-switch-active-tab", serde_json::json!({}))
+        .await
+        .unwrap();
+    let page = manager
+        .agent_page_state_for_owner("chat-switch-active-tab")
+        .unwrap();
+    let native = &page.observation.snapshot.data;
+    let old_tab = native
+        .tabs
+        .iter()
+        .find(|tab| tab.tab_id == native.active_tab_id)
+        .unwrap();
+    let browser_session_id = native.browser_session_id.clone();
+    let old_tab_id = old_tab.tab_id.clone();
+    let control_epoch = native.control.control_epoch;
+    let snapshot_id = page.snapshot_id;
+    let capture_id = old_tab.current_capture_id.clone();
+    let observation_revision = old_tab.observation_revision;
+
+    let switched = manager
+        .create_tab(BrowserCreateTabInput {
+            browser_session_id: browser_session_id.clone(),
+            url: None,
+        })
+        .await
+        .unwrap();
+    assert_ne!(switched.data.active_tab_id, old_tab_id);
+
+    let error = manager
+        .interact(BrowserInteractionInput {
+            browser_session_id,
+            tab_id: old_tab_id,
+            command_id: BrowserCommandId::new("inactive-tab-action").unwrap(),
+            control_epoch,
+            snapshot_id: Some(snapshot_id),
+            capture_id,
+            observation_revision: Some(observation_revision),
+            action: BrowserAction::Scroll {
+                delta_x: 0.0,
+                delta_y: 120.0,
+            },
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error, AGENT_SNAPSHOT_STALE);
+    assert!(adapter.interactions.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/src-tauri/src/native_browser/manager_tests.rs
+++ b/src-tauri/src/native_browser/manager_tests.rs
@@ -199,6 +199,7 @@ fn creation_completion_accepts_a_navigation_event_that_already_made_the_tab_read
         BrowserTabId("tab-race".to_string()),
         BrowserNavigationId("navigation-race".to_string()),
         "http://127.0.0.1/",
+        "btest".to_string(),
     );
     tab.lifecycle = BrowserTabLifecycle::Ready;
 
@@ -243,7 +244,7 @@ async fn session_lifecycle_and_observation_are_revisioned() {
 #[tokio::test]
 async fn agent_browser_tools_reuse_the_chat_owned_session() {
     let manager = manager(Arc::new(FakeAdapter::default()));
-    let observed = crate::agent::bridge::dispatch_agent_browser_observe(
+    let observed = crate::tools::web::dispatch_browser_observe(
         &manager,
         "chat-shared-browser",
         serde_json::json!({}),
@@ -256,7 +257,7 @@ async fn agent_browser_tools_reuse_the_chat_owned_session() {
     let control_epoch = snapshot["control"]["controlEpoch"].as_u64().unwrap();
     let observation_revision = snapshot["tabs"][0]["observationRevision"].as_u64().unwrap();
 
-    let result = crate::agent::bridge::dispatch_agent_browser_interact(
+    let result = crate::tools::web::dispatch_browser_interact(
         &manager,
         "chat-shared-browser",
         None,
@@ -282,7 +283,7 @@ async fn agent_browser_tools_reuse_the_chat_owned_session() {
             .as_str(),
         browser_session_id
     );
-    let ownership_error = crate::agent::bridge::dispatch_agent_browser_observe(
+    let ownership_error = crate::tools::web::dispatch_browser_observe(
         &manager,
         "other-chat",
         serde_json::json!({ "browserSessionId": browser_session_id }),
@@ -290,6 +291,109 @@ async fn agent_browser_tools_reuse_the_chat_owned_session() {
     .await
     .expect_err("another chat must not attach to the shared browser session");
     assert!(ownership_error.contains("not owned by this chat"));
+}
+
+#[tokio::test]
+async fn high_level_web_tools_refresh_and_reject_stale_actions() {
+    let adapter = Arc::new(FakeAdapter::default());
+    let manager = manager(adapter.clone());
+    let first =
+        crate::tools::web::dispatch_web_read(&manager, "chat-web-snapshot", serde_json::json!({}))
+            .await
+            .unwrap();
+    assert_eq!(first["status"], "completed");
+    assert!(first["snapshot"].get("browserSessionId").is_none());
+    let first_snapshot_id = first["snapshotId"].as_str().unwrap().to_string();
+    let first_target_ref = first["snapshot"]["targets"][0]["targetRef"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let tab_id = manager
+        .snapshot_for_owner("chat-web-snapshot")
+        .unwrap()
+        .data
+        .active_tab_id;
+
+    adapter.sink.read().unwrap().as_ref().unwrap()(BrowserPlatformEvent::ContentDirty {
+        tab_id: tab_id.clone(),
+    });
+    let unchanged = crate::tools::web::dispatch_web_read(
+        &manager,
+        "chat-web-snapshot",
+        serde_json::json!({ "snapshotId": first_snapshot_id }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(unchanged["status"], "unchanged");
+    assert_eq!(unchanged["snapshotId"], first_snapshot_id);
+
+    adapter.sink.read().unwrap().as_ref().unwrap()(BrowserPlatformEvent::UserInput { tab_id });
+    let stale = crate::tools::web::dispatch_web_act(
+        &manager,
+        "chat-web-snapshot",
+        None,
+        serde_json::json!({
+            "commandId": "stale-web-action",
+            "snapshotId": first_snapshot_id,
+            "action": { "type": "scroll", "deltaX": 0, "deltaY": 120 }
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(stale["status"], "stale_snapshot");
+    assert_eq!(stale["actionExecuted"], false);
+    assert_ne!(stale["snapshotId"], first_snapshot_id);
+    assert_eq!(
+        stale["snapshot"]["targets"][0]["targetRef"],
+        first_target_ref
+    );
+    assert!(adapter.interactions.lock().unwrap().is_empty());
+
+    let current_snapshot_id = stale["snapshotId"].as_str().unwrap();
+    let completed = crate::tools::web::dispatch_web_act(
+        &manager,
+        "chat-web-snapshot",
+        None,
+        serde_json::json!({
+            "commandId": "current-web-action",
+            "snapshotId": current_snapshot_id,
+            "action": { "type": "scroll", "deltaX": 0, "deltaY": 120 }
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(completed["status"], "completed");
+    assert_eq!(completed["actionExecuted"], true);
+    assert_ne!(completed["snapshotId"], current_snapshot_id);
+    assert_eq!(adapter.interactions.lock().unwrap().len(), 1);
+
+    let page = manager
+        .agent_page_state_for_owner("chat-web-snapshot")
+        .unwrap();
+    let native = &page.observation.snapshot.data;
+    let tab = native
+        .tabs
+        .iter()
+        .find(|tab| tab.tab_id == native.active_tab_id)
+        .unwrap();
+    adapter.sink.read().unwrap().as_ref().unwrap()(BrowserPlatformEvent::ContentDirty {
+        tab_id: native.active_tab_id.clone(),
+    });
+    let rejected = manager
+        .interact(BrowserInteractionInput {
+            browser_session_id: native.browser_session_id.clone(),
+            tab_id: native.active_tab_id.clone(),
+            command_id: BrowserCommandId::new("racing-web-action").unwrap(),
+            control_epoch: native.control.control_epoch,
+            snapshot_id: Some(page.snapshot_id.clone()),
+            capture_id: tab.current_capture_id.clone(),
+            observation_revision: Some(tab.observation_revision),
+            action: BrowserAction::Back,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(rejected, AGENT_SNAPSHOT_STALE);
+    assert_eq!(adapter.interactions.lock().unwrap().len(), 1);
 }
 
 #[tokio::test]
@@ -312,6 +416,7 @@ async fn diagnostics_correlate_commands_and_redact_navigation_urls() {
             tab_id: snapshot.data.active_tab_id,
             command_id: command_id.clone(),
             control_epoch: snapshot.data.control.control_epoch,
+            snapshot_id: None,
             capture_id: None,
             observation_revision: None,
             action: BrowserAction::Navigate {
@@ -412,6 +517,7 @@ async fn stale_control_epoch_is_rejected_and_user_input_advances_epoch() {
             tab_id,
             command_id: BrowserCommandId::new("command-1").unwrap(),
             control_epoch: 0,
+            snapshot_id: None,
             capture_id: None,
             observation_revision: None,
             action: BrowserAction::Navigate {
@@ -455,6 +561,7 @@ async fn resume_returns_interrupted_control_to_idle_without_platform_dispatch() 
             tab_id,
             command_id: command_id.clone(),
             control_epoch: interrupted_epoch,
+            snapshot_id: None,
             capture_id: None,
             observation_revision: None,
             action: BrowserAction::Resume,
@@ -751,6 +858,7 @@ async fn coordinate_actions_require_current_capture_bounds() {
             tab_id: tab.tab_id.clone(),
             command_id: BrowserCommandId::new("coordinate-outside").unwrap(),
             control_epoch: observed.snapshot.data.control.control_epoch,
+            snapshot_id: None,
             capture_id: tab.current_capture_id.clone(),
             observation_revision: Some(tab.observation_revision),
             action: BrowserAction::Click { x: 900.0, y: 10.0 },
@@ -794,6 +902,7 @@ async fn semantic_action_is_normalized_and_post_action_observed() {
             tab_id: snapshot.data.active_tab_id,
             command_id: BrowserCommandId::new("semantic-click").unwrap(),
             control_epoch: observed.snapshot.data.control.control_epoch,
+            snapshot_id: None,
             capture_id: observed.capture.map(|capture| capture.capture_id),
             observation_revision: Some(before_revision),
             action: BrowserAction::ClickTarget { target_ref },
@@ -845,6 +954,7 @@ async fn direct_user_input_cancels_an_in_flight_agent_wait() {
         tab_id: tab.tab_id.clone(),
         command_id: command_id.clone(),
         control_epoch: observed.snapshot.data.control.control_epoch,
+        snapshot_id: None,
         capture_id: tab.current_capture_id.clone(),
         observation_revision: Some(tab.observation_revision),
         action: BrowserAction::Wait {
@@ -924,6 +1034,7 @@ async fn protected_semantic_target_requires_user_without_platform_dispatch() {
             tab_id: snapshot.data.active_tab_id,
             command_id: command_id.clone(),
             control_epoch: observed.snapshot.data.control.control_epoch,
+            snapshot_id: None,
             capture_id: observed.capture.map(|capture| capture.capture_id),
             observation_revision: Some(observation_revision),
             action: BrowserAction::ClickTarget {

--- a/src-tauri/src/native_browser/manager_tests.rs
+++ b/src-tauri/src/native_browser/manager_tests.rs
@@ -19,6 +19,7 @@ struct FakeAdapter {
     opened_external: Mutex<Vec<String>>,
     interaction_delay_ms: std::sync::atomic::AtomicU64,
     protected_semantic: std::sync::atomic::AtomicBool,
+    sensitive_semantic: std::sync::atomic::AtomicBool,
     fail_create: std::sync::atomic::AtomicBool,
 }
 
@@ -119,8 +120,12 @@ impl BrowserRuntimeAdapter for FakeAdapter {
                         width: 80.0,
                         height: 30.0,
                         disabled: false,
-                        focused: false,
-                        sensitive: false,
+                        focused: self
+                            .sensitive_semantic
+                            .load(std::sync::atomic::Ordering::Relaxed),
+                        sensitive: self
+                            .sensitive_semantic
+                            .load(std::sync::atomic::Ordering::Relaxed),
                         protected_reason: self
                             .protected_semantic
                             .load(std::sync::atomic::Ordering::Relaxed)
@@ -1092,6 +1097,151 @@ async fn protected_semantic_target_requires_user_without_platform_dispatch() {
             && diagnostic.command_id.as_ref() == Some(&command_id)
             && diagnostic.reason_code.as_deref() == Some("native_file_picker")
     }));
+}
+
+#[tokio::test]
+async fn explicit_user_handoff_stays_active_during_user_input_until_resume() {
+    let adapter = Arc::new(FakeAdapter::default());
+    let manager = manager(adapter.clone());
+    let snapshot = manager
+        .create_session(BrowserCreateSessionInput {
+            owner_session_id: "thread-user-handoff".to_string(),
+            profile_id: None,
+            persistence: BrowserProfilePersistence::Persistent,
+            initial_url: None,
+        })
+        .await
+        .unwrap();
+    let session_id = snapshot.data.browser_session_id.clone();
+    let tab_id = snapshot.data.active_tab_id.clone();
+    let handoff_reason = "Complete the login verification";
+    let handoff = manager
+        .interact(BrowserInteractionInput {
+            browser_session_id: session_id.clone(),
+            tab_id: tab_id.clone(),
+            command_id: BrowserCommandId::new("user-handoff").unwrap(),
+            control_epoch: snapshot.data.control.control_epoch,
+            snapshot_id: None,
+            capture_id: None,
+            observation_revision: None,
+            action: BrowserAction::UserHandoff {
+                reason: handoff_reason.to_string(),
+            },
+        })
+        .await
+        .unwrap();
+    assert_eq!(handoff.status, BrowserCommandStatus::UserRequired);
+    assert_eq!(handoff.reason.as_deref(), Some(handoff_reason));
+    let awaiting_user = manager.snapshot(&session_id).unwrap();
+    assert_eq!(
+        awaiting_user.data.control.state,
+        BrowserControlState::UserRequired
+    );
+    assert_eq!(
+        awaiting_user.data.control.reason.as_deref(),
+        Some(handoff_reason)
+    );
+    assert!(!awaiting_user.data.interaction.click);
+    assert!(!awaiting_user.data.interaction.navigate);
+    assert!(!awaiting_user.data.interaction.type_text);
+
+    adapter.sink.read().unwrap().as_ref().unwrap()(BrowserPlatformEvent::UserInput {
+        tab_id: tab_id.clone(),
+    });
+    let after_input = manager.snapshot(&session_id).unwrap();
+    assert_eq!(
+        after_input.data.control.state,
+        BrowserControlState::UserRequired
+    );
+    assert_eq!(
+        after_input.data.control.reason.as_deref(),
+        Some(handoff_reason)
+    );
+    assert!(after_input.data.control.control_epoch > awaiting_user.data.control.control_epoch);
+
+    let rejected = manager
+        .interact(BrowserInteractionInput {
+            browser_session_id: session_id.clone(),
+            tab_id: tab_id.clone(),
+            command_id: BrowserCommandId::new("handoff-back").unwrap(),
+            control_epoch: after_input.data.control.control_epoch,
+            snapshot_id: None,
+            capture_id: None,
+            observation_revision: None,
+            action: BrowserAction::Back,
+        })
+        .await
+        .unwrap_err();
+    assert!(rejected.contains("handed to the user"));
+
+    let resumed = manager
+        .interact(BrowserInteractionInput {
+            browser_session_id: session_id.clone(),
+            tab_id,
+            command_id: BrowserCommandId::new("handoff-resume").unwrap(),
+            control_epoch: after_input.data.control.control_epoch,
+            snapshot_id: None,
+            capture_id: None,
+            observation_revision: None,
+            action: BrowserAction::Resume,
+        })
+        .await
+        .unwrap();
+    assert_eq!(resumed.status, BrowserCommandStatus::Completed);
+    let idle = manager.snapshot(&session_id).unwrap();
+    assert_eq!(idle.data.control.state, BrowserControlState::Idle);
+    assert!(idle.data.interaction.click);
+}
+
+#[tokio::test]
+async fn sensitive_focused_field_requires_direct_user_input() {
+    let adapter = Arc::new(FakeAdapter::default());
+    adapter
+        .sensitive_semantic
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let manager = manager(adapter.clone());
+    let snapshot = manager
+        .create_session(BrowserCreateSessionInput {
+            owner_session_id: "thread-sensitive-input".to_string(),
+            profile_id: None,
+            persistence: BrowserProfilePersistence::Persistent,
+            initial_url: None,
+        })
+        .await
+        .unwrap();
+    let observed = manager
+        .observe(BrowserObserveInput {
+            browser_session_id: snapshot.data.browser_session_id.clone(),
+            tab_id: snapshot.data.active_tab_id.clone(),
+            capture: true,
+            semantic: true,
+        })
+        .await
+        .unwrap();
+    let semantic = observed.semantic.as_ref().unwrap();
+    let observation_revision = semantic.observation_revision;
+    let node = &semantic.nodes[0];
+    assert!(node.sensitive);
+    assert_eq!(node.protected_reason.as_deref(), Some("sensitive_input"));
+
+    let result = manager
+        .interact(BrowserInteractionInput {
+            browser_session_id: snapshot.data.browser_session_id,
+            tab_id: snapshot.data.active_tab_id,
+            command_id: BrowserCommandId::new("sensitive-type").unwrap(),
+            control_epoch: observed.snapshot.data.control.control_epoch,
+            snapshot_id: None,
+            capture_id: observed.capture.map(|capture| capture.capture_id),
+            observation_revision: Some(observation_revision),
+            action: BrowserAction::Type {
+                text: "secret".to_string(),
+            },
+        })
+        .await
+        .unwrap();
+    assert_eq!(result.status, BrowserCommandStatus::UserRequired);
+    assert_eq!(result.reason_code.as_deref(), Some("sensitive_input"));
+    assert!(adapter.interactions.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/src-tauri/src/native_browser/manager_tests.rs
+++ b/src-tauri/src/native_browser/manager_tests.rs
@@ -17,7 +17,10 @@ struct FakeAdapter {
     deleted_profiles: Mutex<Vec<BrowserProfileId>>,
     interactions: Mutex<Vec<BrowserPlatformAction>>,
     opened_external: Mutex<Vec<String>>,
+    create_delay_ms: std::sync::atomic::AtomicU64,
     interaction_delay_ms: std::sync::atomic::AtomicU64,
+    observe_delay_ms: std::sync::atomic::AtomicU64,
+    observe_completed: std::sync::atomic::AtomicU64,
     protected_semantic: std::sync::atomic::AtomicBool,
     sensitive_semantic: std::sync::atomic::AtomicBool,
     fail_create: std::sync::atomic::AtomicBool,
@@ -41,6 +44,12 @@ impl BrowserRuntimeAdapter for FakeAdapter {
         &self,
         request: BrowserPlatformCreateTab,
     ) -> Result<BrowserPlatformTabState, String> {
+        let delay_ms = self
+            .create_delay_ms
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        }
         if self.fail_create.load(std::sync::atomic::Ordering::Relaxed) {
             return Err("fixture WebView initialization failed".to_string());
         }
@@ -103,6 +112,14 @@ impl BrowserRuntimeAdapter for FakeAdapter {
         capture: bool,
         semantic: bool,
     ) -> Result<BrowserPlatformObservation, String> {
+        let delay_ms = self
+            .observe_delay_ms
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        }
+        self.observe_completed
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(BrowserPlatformObservation {
             capture_base64: capture.then(|| "cG5n".to_string()),
             viewport_width: 800,
@@ -274,6 +291,100 @@ async fn session_lifecycle_and_observation_are_revisioned() {
         .unwrap()
         .starts_with("data:image/png;base64,"));
     assert_eq!(observed.semantic.unwrap().nodes[0].name, "Submit");
+}
+
+#[tokio::test]
+async fn concurrent_session_creation_waits_for_the_owner_session_to_be_ready() {
+    let adapter = Arc::new(FakeAdapter::default());
+    adapter
+        .create_delay_ms
+        .store(100, std::sync::atomic::Ordering::Relaxed);
+    let manager = manager(adapter.clone());
+    let first_manager = manager.clone();
+    let first = tokio::spawn(async move {
+        first_manager
+            .create_session(BrowserCreateSessionInput {
+                owner_session_id: "thread-concurrent-create".to_string(),
+                profile_id: None,
+                persistence: BrowserProfilePersistence::Persistent,
+                initial_url: None,
+            })
+            .await
+            .unwrap()
+    });
+
+    loop {
+        if manager
+            .snapshot_for_owner("thread-concurrent-create")
+            .is_some()
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let second = manager
+        .create_session(BrowserCreateSessionInput {
+            owner_session_id: "thread-concurrent-create".to_string(),
+            profile_id: None,
+            persistence: BrowserProfilePersistence::Persistent,
+            initial_url: None,
+        })
+        .await
+        .unwrap();
+    let first = first.await.unwrap();
+
+    assert_eq!(first.data.lifecycle, BrowserSessionLifecycle::Ready);
+    assert_eq!(second.data.lifecycle, BrowserSessionLifecycle::Ready);
+    assert_eq!(
+        second.data.browser_session_id,
+        first.data.browser_session_id
+    );
+    assert_eq!(adapter.created.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn web_tools_wait_for_a_preheated_session_to_be_ready() {
+    let adapter = Arc::new(FakeAdapter::default());
+    adapter
+        .create_delay_ms
+        .store(100, std::sync::atomic::Ordering::Relaxed);
+    let manager = manager(adapter.clone());
+    let preheat_manager = manager.clone();
+    let preheat = tokio::spawn(async move {
+        preheat_manager
+            .create_session(BrowserCreateSessionInput {
+                owner_session_id: "thread-preheated-web-tool".to_string(),
+                profile_id: None,
+                persistence: BrowserProfilePersistence::Persistent,
+                initial_url: None,
+            })
+            .await
+            .unwrap()
+    });
+
+    loop {
+        if manager
+            .snapshot_for_owner("thread-preheated-web-tool")
+            .is_some()
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let observed = crate::tools::web::dispatch_browser_observe(
+        &manager,
+        "thread-preheated-web-tool",
+        serde_json::json!({}),
+    )
+    .await
+    .unwrap();
+    let preheated = preheat.await.unwrap();
+
+    assert_eq!(preheated.data.lifecycle, BrowserSessionLifecycle::Ready);
+    assert_eq!(observed["snapshot"]["data"]["lifecycle"], "ready");
+    assert_eq!(adapter.created.lock().unwrap().len(), 1);
 }
 
 #[tokio::test]
@@ -827,6 +938,239 @@ async fn closing_the_visible_tab_clears_its_surface_before_showing_the_replaceme
             .last()
             .map(|surface| &surface.tab_id),
         Some(&first_tab)
+    );
+}
+
+#[tokio::test]
+async fn hiding_a_visible_surface_does_not_wait_for_capture() {
+    let adapter = Arc::new(FakeAdapter::default());
+    let manager = manager(adapter.clone());
+    let snapshot = manager
+        .create_session(BrowserCreateSessionInput {
+            owner_session_id: "thread-surface-hide".to_string(),
+            profile_id: None,
+            persistence: BrowserProfilePersistence::Persistent,
+            initial_url: None,
+        })
+        .await
+        .unwrap();
+    let session_id = snapshot.data.browser_session_id;
+    let tab_id = snapshot.data.active_tab_id;
+    let surface_id = BrowserSurfaceId::new("surface-hide").unwrap();
+    let rect = BrowserSurfaceRect {
+        x: 0.0,
+        y: 0.0,
+        width: 800.0,
+        height: 600.0,
+        device_scale: 1.0,
+    };
+    manager
+        .update_surface(BrowserSurfaceUpdate {
+            browser_session_id: session_id.clone(),
+            tab_id: tab_id.clone(),
+            surface_id: surface_id.clone(),
+            layout_revision: 1,
+            rect: rect.clone(),
+            visible: true,
+            live: true,
+            topmost: true,
+            unobscured: true,
+        })
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while adapter
+            .observe_completed
+            .load(std::sync::atomic::Ordering::Relaxed)
+            == 0
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("visible-surface observation should complete");
+    adapter
+        .observe_delay_ms
+        .store(5_000, std::sync::atomic::Ordering::Relaxed);
+
+    let hidden = tokio::time::timeout(
+        Duration::from_millis(100),
+        manager.update_surface(BrowserSurfaceUpdate {
+            browser_session_id: session_id,
+            tab_id,
+            surface_id,
+            layout_revision: 2,
+            rect,
+            visible: false,
+            live: true,
+            topmost: false,
+            unobscured: false,
+        }),
+    )
+    .await
+    .expect("hiding the native surface must not wait for capture")
+    .unwrap();
+
+    assert_eq!(
+        hidden.data.surface.lifecycle,
+        BrowserSurfaceLifecycle::Hidden
+    );
+    assert_eq!(
+        adapter
+            .surfaces
+            .lock()
+            .unwrap()
+            .last()
+            .map(|surface| surface.visible),
+        Some(false)
+    );
+}
+
+#[tokio::test]
+async fn moving_a_visible_surface_does_not_recapture_the_page() {
+    let adapter = Arc::new(FakeAdapter::default());
+    let manager = manager(adapter.clone());
+    let snapshot = manager
+        .create_session(BrowserCreateSessionInput {
+            owner_session_id: "thread-surface-move".to_string(),
+            profile_id: None,
+            persistence: BrowserProfilePersistence::Persistent,
+            initial_url: None,
+        })
+        .await
+        .unwrap();
+    let session_id = snapshot.data.browser_session_id;
+    let tab_id = snapshot.data.active_tab_id;
+    let surface_id = BrowserSurfaceId::new("surface-move").unwrap();
+
+    manager
+        .update_surface(BrowserSurfaceUpdate {
+            browser_session_id: session_id.clone(),
+            tab_id: tab_id.clone(),
+            surface_id: surface_id.clone(),
+            layout_revision: 1,
+            rect: BrowserSurfaceRect {
+                x: 0.0,
+                y: 0.0,
+                width: 800.0,
+                height: 600.0,
+                device_scale: 1.0,
+            },
+            visible: true,
+            live: true,
+            topmost: true,
+            unobscured: true,
+        })
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while adapter
+            .observe_completed
+            .load(std::sync::atomic::Ordering::Relaxed)
+            == 0
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    let captures_after_attach = adapter
+        .observe_completed
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    manager
+        .update_surface(BrowserSurfaceUpdate {
+            browser_session_id: session_id,
+            tab_id,
+            surface_id,
+            layout_revision: 2,
+            rect: BrowserSurfaceRect {
+                x: 120.0,
+                y: 80.0,
+                width: 800.0,
+                height: 600.0,
+                device_scale: 1.0,
+            },
+            visible: true,
+            live: true,
+            topmost: true,
+            unobscured: true,
+        })
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    assert_eq!(
+        adapter
+            .observe_completed
+            .load(std::sync::atomic::Ordering::Relaxed),
+        captures_after_attach
+    );
+    let surfaces = adapter.surfaces.lock().unwrap();
+    assert!(surfaces[surfaces.len() - 2].focus);
+    assert!(!surfaces[surfaces.len() - 1].focus);
+}
+
+#[tokio::test]
+async fn unchanged_visible_surface_does_not_reach_the_platform_adapter() {
+    let adapter = Arc::new(FakeAdapter::default());
+    let manager = manager(adapter.clone());
+    let snapshot = manager
+        .create_session(BrowserCreateSessionInput {
+            owner_session_id: "thread-surface-unchanged".to_string(),
+            profile_id: None,
+            persistence: BrowserProfilePersistence::Persistent,
+            initial_url: None,
+        })
+        .await
+        .unwrap();
+    let session_id = snapshot.data.browser_session_id;
+    let tab_id = snapshot.data.active_tab_id;
+    let surface_id = BrowserSurfaceId::new("surface-unchanged").unwrap();
+    let rect = BrowserSurfaceRect {
+        x: 12.0,
+        y: 24.0,
+        width: 800.0,
+        height: 600.0,
+        device_scale: 1.0,
+    };
+
+    manager
+        .update_surface(BrowserSurfaceUpdate {
+            browser_session_id: session_id.clone(),
+            tab_id: tab_id.clone(),
+            surface_id: surface_id.clone(),
+            layout_revision: 1,
+            rect: rect.clone(),
+            visible: true,
+            live: true,
+            topmost: true,
+            unobscured: true,
+        })
+        .await
+        .unwrap();
+    adapter.surfaces.lock().unwrap().clear();
+
+    let unchanged = manager
+        .update_surface(BrowserSurfaceUpdate {
+            browser_session_id: session_id,
+            tab_id,
+            surface_id,
+            layout_revision: 2,
+            rect,
+            visible: true,
+            live: true,
+            topmost: true,
+            unobscured: true,
+        })
+        .await
+        .unwrap();
+
+    assert!(adapter.surfaces.lock().unwrap().is_empty());
+    assert_eq!(unchanged.data.surface.layout_revision, 1);
+    assert_eq!(
+        unchanged.data.surface.lifecycle,
+        BrowserSurfaceLifecycle::Visible
     );
 }
 

--- a/src-tauri/src/native_browser/mod.rs
+++ b/src-tauri/src/native_browser/mod.rs
@@ -17,7 +17,7 @@ mod unsupported;
 mod windows;
 
 use crate::desktop_commands::runtime::native_backend_log_path;
-pub(crate) use manager::SharedBrowserRuntime;
+pub(crate) use manager::{BrowserAgentPageState, SharedBrowserRuntime, AGENT_SNAPSHOT_STALE};
 use manager::{BrowserDiagnosticSink, BrowserSessionManager, BrowserSnapshotSink};
 pub(crate) use model::{
     BrowserCreateSessionInput, BrowserInteractionInput, BrowserNativeSnapshot, BrowserObserveInput,

--- a/src-tauri/src/native_browser/mod.rs
+++ b/src-tauri/src/native_browser/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use manager::{BrowserAgentPageState, SharedBrowserRuntime, AGENT_SNAP
 use manager::{BrowserDiagnosticSink, BrowserSessionManager, BrowserSnapshotSink};
 pub(crate) use model::{
     BrowserCreateSessionInput, BrowserInteractionInput, BrowserNativeSnapshot, BrowserObserveInput,
+    BrowserSessionLifecycle,
 };
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager};

--- a/src-tauri/src/native_browser/model.rs
+++ b/src-tauri/src/native_browser/model.rs
@@ -348,6 +348,8 @@ pub struct BrowserInteractionInput {
     pub command_id: BrowserCommandId,
     pub control_epoch: u64,
     #[serde(default)]
+    pub snapshot_id: Option<String>,
+    #[serde(default)]
     pub capture_id: Option<BrowserCaptureId>,
     #[serde(default)]
     pub observation_revision: Option<u64>,

--- a/src-tauri/src/native_browser/platform.rs
+++ b/src-tauri/src/native_browser/platform.rs
@@ -92,6 +92,7 @@ pub(crate) struct BrowserPlatformSurface {
     pub tab_id: BrowserTabId,
     pub rect: BrowserSurfaceRect,
     pub visible: bool,
+    pub focus: bool,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src-tauri/src/native_browser/platform.rs
+++ b/src-tauri/src/native_browser/platform.rs
@@ -31,6 +31,9 @@ pub(crate) enum BrowserPlatformEvent {
     UserInput {
         tab_id: BrowserTabId,
     },
+    ContentDirty {
+        tab_id: BrowserTabId,
+    },
     PopupRequested {
         tab_id: BrowserTabId,
         url: String,

--- a/src-tauri/src/native_browser/windows.rs
+++ b/src-tauri/src/native_browser/windows.rs
@@ -22,7 +22,7 @@ use std::{
 };
 use tauri::{
     webview::{DownloadEvent, NewWindowResponse, PageLoadEvent, WebviewBuilder},
-    AppHandle, LogicalPosition, LogicalSize, Manager, Webview, WebviewUrl, Wry,
+    AppHandle, LogicalPosition, LogicalSize, Manager, Rect, Webview, WebviewUrl, Wry,
 };
 use tokio::sync::{mpsc, oneshot};
 use webview2_com::{
@@ -51,12 +51,13 @@ const DIRECT_INPUT_SCRIPT: &str = r#"
   if (window.__tinybotBrowserDirectInputInstalled) return;
   Object.defineProperty(window, '__tinybotBrowserDirectInputInstalled', { value: true });
   const notify = (event) => {
-    if (event.isTrusted && window.chrome?.webview) {
-      window.chrome.webview.postMessage('tinybot-browser-direct-input-v1');
-    }
+    if (!event.isTrusted) return;
+    setTimeout(() => {
+      window.chrome?.webview?.postMessage('tinybot-browser-direct-input-v1');
+    }, 0);
   };
-  addEventListener('pointerdown', notify, true);
-  addEventListener('keydown', notify, true);
+  addEventListener('click', notify, true);
+  addEventListener('keyup', notify, true);
   addEventListener('input', notify, true);
 
   const installContentObserver = () => {
@@ -525,27 +526,28 @@ impl BrowserRuntimeAdapter for WindowsBrowserRuntime {
         if surface.visible {
             handle
                 .webview
-                .set_position(LogicalPosition::new(surface.rect.x, surface.rect.y))
-                .map_err(|error| format!("Failed to position native browser surface: {error}"))?;
-            handle
-                .webview
-                .set_size(LogicalSize::new(surface.rect.width, surface.rect.height))
-                .map_err(|error| format!("Failed to size native browser surface: {error}"))?;
+                .set_bounds(Rect {
+                    position: LogicalPosition::new(surface.rect.x, surface.rect.y).into(),
+                    size: LogicalSize::new(surface.rect.width, surface.rect.height).into(),
+                })
+                .map_err(|error| format!("Failed to place native browser surface: {error}"))?;
             handle
                 .webview
                 .show()
                 .map_err(|error| format!("Failed to show native browser surface: {error}"))?;
-            handle
-                .webview
-                .set_focus()
-                .map_err(|error| format!("Failed to focus native browser surface: {error}"))?;
+            if surface.focus {
+                handle
+                    .webview
+                    .set_focus()
+                    .map_err(|error| format!("Failed to focus native browser surface: {error}"))?;
+            }
         } else {
             handle
                 .webview
                 .hide()
                 .map_err(|error| format!("Failed to hide native browser surface: {error}"))?;
         }
-        Ok(())
+        wait_for_webview_dispatch(&handle.webview, "surface update").await
     }
 
     async fn navigate(&self, tab_id: &BrowserTabId, url: &str) -> Result<(), String> {
@@ -1085,6 +1087,19 @@ async fn register_webview2_events(
         .await
         .map_err(|_| "WebView2 event registration timed out".to_string())?
         .map_err(|_| "WebView2 event registration result channel closed".to_string())?
+}
+
+async fn wait_for_webview_dispatch(webview: &Webview<Wry>, operation: &str) -> Result<(), String> {
+    let (tx, rx) = oneshot::channel();
+    webview
+        .with_webview(move |_| {
+            let _ = tx.send(());
+        })
+        .map_err(|error| format!("Failed to enqueue native browser {operation}: {error}"))?;
+    tokio::time::timeout(Duration::from_secs(5), rx)
+        .await
+        .map_err(|_| format!("Native browser {operation} timed out"))?
+        .map_err(|_| format!("Native browser {operation} completion channel closed"))
 }
 
 fn ensure_profile_path(root: &Path, candidate: &Path) -> Result<(), String> {

--- a/src-tauri/src/native_browser/windows.rs
+++ b/src-tauri/src/native_browser/windows.rs
@@ -39,6 +39,8 @@ use windows_sys::Win32::{
 const DIRECT_INPUT_MESSAGE: &str = "tinybot-browser-direct-input-v1";
 const CONTENT_DIRTY_MESSAGE: &str = "tinybot-browser-content-dirty-v1";
 const MAX_SEMANTIC_NODES: usize = 500;
+const BACKGROUND_VIEWPORT_WIDTH: u32 = 1024;
+const BACKGROUND_VIEWPORT_HEIGHT: u32 = 768;
 const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(15);
 const BROWSER_PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(30);
 const PROFILE_DELETE_RETRY_DELAY: Duration = Duration::from_millis(50);
@@ -452,7 +454,10 @@ impl BrowserRuntimeAdapter for WindowsBrowserRuntime {
             .add_child(
                 builder,
                 LogicalPosition::new(0.0, 0.0),
-                LogicalSize::new(1.0, 1.0),
+                LogicalSize::new(
+                    f64::from(BACKGROUND_VIEWPORT_WIDTH),
+                    f64::from(BACKGROUND_VIEWPORT_HEIGHT),
+                ),
             )
             .map_err(|error| format!("Failed to create native browser WebView2 child: {error}"))?;
         webview
@@ -486,8 +491,8 @@ impl BrowserRuntimeAdapter for WindowsBrowserRuntime {
             title: "New tab".to_string(),
             can_go_back: false,
             can_go_forward: false,
-            viewport_width: 1,
-            viewport_height: 1,
+            viewport_width: BACKGROUND_VIEWPORT_WIDTH,
+            viewport_height: BACKGROUND_VIEWPORT_HEIGHT,
             device_scale: 1.0,
         })
     }

--- a/src-tauri/src/native_browser/windows.rs
+++ b/src-tauri/src/native_browser/windows.rs
@@ -37,6 +37,7 @@ use windows_sys::Win32::{
 };
 
 const DIRECT_INPUT_MESSAGE: &str = "tinybot-browser-direct-input-v1";
+const CONTENT_DIRTY_MESSAGE: &str = "tinybot-browser-content-dirty-v1";
 const MAX_SEMANTIC_NODES: usize = 500;
 const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(15);
 const BROWSER_PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -55,6 +56,32 @@ const DIRECT_INPUT_SCRIPT: &str = r#"
   addEventListener('pointerdown', notify, true);
   addEventListener('keydown', notify, true);
   addEventListener('input', notify, true);
+
+  const installContentObserver = () => {
+    if (!document.documentElement || window.__tinybotBrowserContentObserverInstalled) return;
+    Object.defineProperty(window, '__tinybotBrowserContentObserverInstalled', { value: true });
+    let scheduled = false;
+    const notifyContentDirty = () => {
+      if (scheduled || !window.chrome?.webview) return;
+      scheduled = true;
+      setTimeout(() => {
+        scheduled = false;
+        window.chrome.webview.postMessage('tinybot-browser-content-dirty-v1');
+      }, 50);
+    };
+    new MutationObserver(notifyContentDirty).observe(document.documentElement, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: [
+        'aria-label', 'aria-expanded', 'aria-disabled', 'disabled', 'hidden',
+        'href', 'value', 'role', 'tabindex'
+      ]
+    });
+  };
+  if (document.documentElement) installContentObserver();
+  else addEventListener('DOMContentLoaded', installContentObserver, { once: true });
 })();
 "#;
 
@@ -987,13 +1014,22 @@ async fn register_webview2_events(
                             return Ok(());
                         };
                         let mut raw = PWSTR::null();
-                        if unsafe { args.TryGetWebMessageAsString(&mut raw) }.is_ok()
-                            && webview2_com::take_pwstr(raw) == DIRECT_INPUT_MESSAGE
-                        {
+                        if unsafe { args.TryGetWebMessageAsString(&mut raw) }.is_ok() {
+                            let message = webview2_com::take_pwstr(raw);
                             if let Some(sink) = message_sink.as_ref() {
-                                sink(BrowserPlatformEvent::UserInput {
-                                    tab_id: message_tab.clone(),
-                                });
+                                match message.as_str() {
+                                    DIRECT_INPUT_MESSAGE => {
+                                        sink(BrowserPlatformEvent::UserInput {
+                                            tab_id: message_tab.clone(),
+                                        });
+                                    }
+                                    CONTENT_DIRTY_MESSAGE => {
+                                        sink(BrowserPlatformEvent::ContentDirty {
+                                            tab_id: message_tab.clone(),
+                                        });
+                                    }
+                                    _ => {}
+                                }
                             }
                         }
                         Ok(())

--- a/src-tauri/src/native_browser/windows_tests.rs
+++ b/src-tauri/src/native_browser/windows_tests.rs
@@ -50,6 +50,11 @@ fn injected_scripts_are_narrow_and_privacy_bounded() {
     assert!(DIRECT_INPUT_SCRIPT.contains("event.isTrusted"));
     assert!(DIRECT_INPUT_SCRIPT.contains(DIRECT_INPUT_MESSAGE));
     assert!(DIRECT_INPUT_SCRIPT.contains(CONTENT_DIRTY_MESSAGE));
+    assert!(DIRECT_INPUT_SCRIPT.contains("setTimeout"));
+    assert!(DIRECT_INPUT_SCRIPT.contains("addEventListener('click'"));
+    assert!(DIRECT_INPUT_SCRIPT.contains("addEventListener('keyup'"));
+    assert!(!DIRECT_INPUT_SCRIPT.contains("addEventListener('pointerdown'"));
+    assert!(!DIRECT_INPUT_SCRIPT.contains("addEventListener('keydown'"));
     assert!(DIRECT_INPUT_SCRIPT.contains("MutationObserver"));
     assert!(!DIRECT_INPUT_SCRIPT.contains("__TAURI__"));
     assert!(OBSERVE_SCRIPT.contains("const limit = 500"));

--- a/src-tauri/src/native_browser/windows_tests.rs
+++ b/src-tauri/src/native_browser/windows_tests.rs
@@ -49,6 +49,8 @@ fn child_webview_labels_are_capability_isolated() {
 fn injected_scripts_are_narrow_and_privacy_bounded() {
     assert!(DIRECT_INPUT_SCRIPT.contains("event.isTrusted"));
     assert!(DIRECT_INPUT_SCRIPT.contains(DIRECT_INPUT_MESSAGE));
+    assert!(DIRECT_INPUT_SCRIPT.contains(CONTENT_DIRTY_MESSAGE));
+    assert!(DIRECT_INPUT_SCRIPT.contains("MutationObserver"));
     assert!(!DIRECT_INPUT_SCRIPT.contains("__TAURI__"));
     assert!(OBSERVE_SCRIPT.contains("const limit = 500"));
     assert!(OBSERVE_SCRIPT.contains("parts.length < 8"));

--- a/src-tauri/src/tool_notes.rs
+++ b/src-tauri/src/tool_notes.rs
@@ -1,0 +1,55 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::Path,
+};
+
+pub(crate) const TOOL_NOTES_FILE_NAME: &str = "TOOLS.md";
+
+const DEFAULT_TOOL_NOTES: &str = r#"# Tool Usage Notes
+
+Tool names, descriptions, and input schemas are supplied automatically. Use this file for non-obvious usage scenarios, tool combinations, and practical tips rather than repeating complete tool signatures.
+
+## Web browser
+
+- Use the web tools when a task depends on current website content or requires interaction with a page.
+- `web.open` opens a URL and automatically creates or reuses this chat's browser session.
+- `web.read` reads the current page. Pass the previous `snapshotId` to get a compact unchanged response when possible.
+- `web.act` changes the current page and requires the latest `snapshotId`. If an action is rejected as stale, use the returned snapshot and retry only if the action is still appropriate.
+- Prefer semantic `targetRef` values from the latest snapshot over screen coordinates, and treat both `snapshotId` and `targetRef` as opaque values.
+- Use `web.open` for URL navigation instead of inventing a navigation action for `web.act`.
+- Hand control to the user when login credentials, verification codes, CAPTCHA, payment details, file pickers, or another protected step requires human input.
+"#;
+
+pub(crate) fn create_default_tool_notes_if_missing(workspace_root: &Path) -> Result<bool, String> {
+    fs::create_dir_all(workspace_root).map_err(|error| {
+        format!(
+            "failed to create tool notes directory `{}`: {error}",
+            workspace_root.display()
+        )
+    })?;
+    let path = workspace_root.join(TOOL_NOTES_FILE_NAME);
+    let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "failed to create tool notes file `{}`: {error}",
+                path.display()
+            ));
+        }
+    };
+    if let Err(error) = file.write_all(DEFAULT_TOOL_NOTES.as_bytes()) {
+        drop(file);
+        let _ = fs::remove_file(&path);
+        return Err(format!(
+            "failed to write default tool notes file `{}`: {error}",
+            path.display()
+        ));
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+#[path = "tool_notes_tests.rs"]
+mod tests;

--- a/src-tauri/src/tool_notes.rs
+++ b/src-tauri/src/tool_notes.rs
@@ -18,7 +18,7 @@ Tool names, descriptions, and input schemas are supplied automatically. Use this
 - `web.act` changes the current page and requires the latest `snapshotId`. If an action is rejected as stale, use the returned snapshot and retry only if the action is still appropriate.
 - Prefer semantic `targetRef` values from the latest snapshot over screen coordinates, and treat both `snapshotId` and `targetRef` as opaque values.
 - Use `web.open` for URL navigation instead of inventing a navigation action for `web.act`.
-- Hand control to the user when login credentials, verification codes, CAPTCHA, payment details, file pickers, or another protected step requires human input.
+- Hand control to the user when login credentials, verification codes, CAPTCHA, payment details, file pickers, or another protected step requires human input. Only the user can hand browser control back to the Agent.
 "#;
 
 pub(crate) fn create_default_tool_notes_if_missing(workspace_root: &Path) -> Result<bool, String> {

--- a/src-tauri/src/tool_notes_tests.rs
+++ b/src-tauri/src/tool_notes_tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+use std::path::PathBuf;
+
+#[test]
+fn creates_default_tool_notes_with_usage_guidance() {
+    let fixture = ToolNotesFixture::new("default");
+
+    assert!(create_default_tool_notes_if_missing(&fixture.root)
+        .expect("default tool notes should be created"));
+    let saved = std::fs::read_to_string(fixture.root.join(TOOL_NOTES_FILE_NAME))
+        .expect("default tool notes should be readable");
+
+    assert!(saved.contains("usage scenarios"));
+    assert!(saved.contains("`web.open`"));
+    assert!(saved.contains("latest `snapshotId`"));
+    assert!(saved.contains("Hand control to the user"));
+}
+
+#[test]
+fn preserves_existing_tool_notes() {
+    let fixture = ToolNotesFixture::new("existing");
+    let path = fixture.root.join(TOOL_NOTES_FILE_NAME);
+    let custom = "# Local tool guidance\n\nPrefer the internal search service.\n";
+    std::fs::write(&path, custom).expect("custom tool notes should write");
+
+    assert!(!create_default_tool_notes_if_missing(&fixture.root)
+        .expect("existing tool notes should be preserved"));
+    assert_eq!(
+        std::fs::read_to_string(path).expect("custom tool notes should remain readable"),
+        custom
+    );
+}
+
+struct ToolNotesFixture {
+    root: PathBuf,
+}
+
+impl ToolNotesFixture {
+    fn new(label: &str) -> Self {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should be monotonic")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "tinybot-tool-notes-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("tool notes fixture should create");
+        Self { root }
+    }
+}
+
+impl Drop for ToolNotesFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}

--- a/src-tauri/src/tools/mod.rs
+++ b/src-tauri/src/tools/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod executor;
 pub(crate) mod permissions;
 pub(crate) mod registry;
 pub(crate) mod shell;
+pub(crate) mod web;

--- a/src-tauri/src/tools/registry/contributors.rs
+++ b/src-tauri/src/tools/registry/contributors.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::tools::web::WebToolContributor;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -105,7 +106,7 @@ pub(super) fn default_tool_contributors() -> Vec<Arc<dyn ToolContributor>> {
     for entry in core_tool_entries() {
         match entry.namespace.as_str() {
             "tool_registry" | "interaction" | "planning" => control_tools.push(entry),
-            "browser" | "shell" | "subagent" => runtime_tools.push(entry),
+            "shell" | "subagent" => runtime_tools.push(entry),
             namespace => panic!(
                 "core tool `{}` has no contributor for namespace `{namespace}`",
                 entry.tool_id
@@ -119,6 +120,7 @@ pub(super) fn default_tool_contributors() -> Vec<Arc<dyn ToolContributor>> {
         }),
         Arc::new(WorkspaceToolContributor),
         Arc::new(BuiltinMcpToolContributor),
+        Arc::new(WebToolContributor),
         Arc::new(CoreToolContributor {
             id: "builtin.runtime_tools",
             entries: runtime_tools,

--- a/src-tauri/src/tools/registry/mod.rs
+++ b/src-tauri/src/tools/registry/mod.rs
@@ -445,69 +445,6 @@ fn core_tool_entries() -> Vec<ToolRegistryEntry> {
             }),
         ),
         tool(
-            "browser.observe",
-            "browser",
-            "Observe TinyOS browser",
-            "Create or inspect the browser session owned by this chat. Returns the active session, tab, control epoch, capture, and bounded semantic targets. Use this before browser.interact.",
-            ToolExposure::Deferred,
-            false,
-            runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),
-            vec![WorkerCapability::BrowserObserve],
-            json!({
-                "type": "object",
-                "properties": {
-                    "browserSessionId": { "type": "string" },
-                    "tabId": { "type": "string" },
-                    "capture": { "type": "boolean", "default": true },
-                    "semantic": { "type": "boolean", "default": true }
-                },
-                "additionalProperties": false
-            }),
-        ),
-        tool(
-            "browser.interact",
-            "browser",
-            "Interact with TinyOS browser",
-            "Operate the current chat's shared TinyOS browser session. Call browser.observe first and pass its current session, tab, control epoch, and observation or capture identity. Never opens a detached browser.",
-            ToolExposure::Deferred,
-            false,
-            runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),
-            vec![WorkerCapability::BrowserInteract],
-            json!({
-                "type": "object",
-                "required": ["browserSessionId", "tabId", "controlEpoch", "action"],
-                "properties": {
-                    "browserSessionId": { "type": "string" },
-                    "tabId": { "type": "string" },
-                    "controlEpoch": { "type": "integer", "minimum": 0 },
-                    "captureId": { "type": "string" },
-                    "observationRevision": { "type": "integer", "minimum": 0 },
-                    "action": {
-                        "type": "object",
-                        "required": ["type"],
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "enum": ["navigate", "back", "forward", "reload", "stop", "click", "clickTarget", "type", "fill", "key", "scroll", "wait", "userHandoff", "resume"]
-                            },
-                            "url": { "type": "string" },
-                            "x": { "type": "number" },
-                            "y": { "type": "number" },
-                            "targetRef": { "type": "string" },
-                            "text": { "type": "string" },
-                            "key": { "type": "string" },
-                            "deltaX": { "type": "number" },
-                            "deltaY": { "type": "number" },
-                            "timeoutMs": { "type": "integer", "minimum": 0, "maximum": 15000 },
-                            "reason": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                    }
-                },
-                "additionalProperties": false
-            }),
-        ),
-        tool(
             "shell.execute",
             "shell",
             "Execute shell command",
@@ -698,7 +635,7 @@ fn core_tool_entries() -> Vec<ToolRegistryEntry> {
     ]
 }
 
-fn tool(
+pub(super) fn tool(
     method: &'static str,
     namespace: &'static str,
     title: &'static str,
@@ -787,7 +724,7 @@ fn runtime_control_tool(
     }
 }
 
-fn runtime_policy(
+pub(super) fn runtime_policy(
     supports_parallel_tool_calls: bool,
     cancellation_mode: ToolCancellationMode,
     mutates_workspace: bool,

--- a/src-tauri/src/tools/registry/registry_tests.rs
+++ b/src-tauri/src/tools/registry/registry_tests.rs
@@ -84,7 +84,7 @@ fn canonical_apply_patch_is_model_visible_and_legacy_name_is_hidden() {
 }
 
 #[test]
-fn browser_tools_are_deferred() {
+fn browser_tools_are_always_exposed_to_the_model() {
     let registry = WorkerToolRegistryRpc::new(CapabilityPolicy::new([
         WorkerCapability::BrowserObserve,
         WorkerCapability::BrowserInteract,
@@ -99,12 +99,12 @@ fn browser_tools_are_deferred() {
         .get_tool("web.act")
         .expect("web.act should be registered");
 
-    assert_eq!(open.exposure, ToolExposure::Deferred);
+    assert_eq!(open.exposure, ToolExposure::Model);
     assert!(open.available);
     assert!(open.runtime_policy.mutates_session);
-    assert_eq!(read.exposure, ToolExposure::Deferred);
+    assert_eq!(read.exposure, ToolExposure::Model);
     assert!(read.available);
-    assert_eq!(act.exposure, ToolExposure::Deferred);
+    assert_eq!(act.exposure, ToolExposure::Model);
     assert!(act.available);
     assert_eq!(
         registry.contributor_id_for_tool("web.open"),

--- a/src-tauri/src/tools/registry/registry_tests.rs
+++ b/src-tauri/src/tools/registry/registry_tests.rs
@@ -126,6 +126,13 @@ fn browser_tools_are_always_exposed_to_the_model() {
         act.input_schema["required"],
         json!(["snapshotId", "action"])
     );
+    assert!(
+        !act.input_schema["properties"]["action"]["properties"]["type"]["enum"]
+            .as_array()
+            .expect("web.act action types should be an array")
+            .iter()
+            .any(|action| action.as_str() == Some("resume"))
+    );
     assert!(registry.get_tool("browser.observe").is_none());
     assert!(registry.get_tool("browser.interact").is_none());
 }

--- a/src-tauri/src/tools/registry/registry_tests.rs
+++ b/src-tauri/src/tools/registry/registry_tests.rs
@@ -89,26 +89,45 @@ fn browser_tools_are_deferred() {
         WorkerCapability::BrowserObserve,
         WorkerCapability::BrowserInteract,
     ]));
-    let observe = registry
-        .get_tool("browser.observe")
-        .expect("browser.observe should be registered");
-    let interact = registry
-        .get_tool("browser.interact")
-        .expect("browser.interact should be registered");
+    let open = registry
+        .get_tool("web.open")
+        .expect("web.open should be registered");
+    let read = registry
+        .get_tool("web.read")
+        .expect("web.read should be registered");
+    let act = registry
+        .get_tool("web.act")
+        .expect("web.act should be registered");
 
-    assert_eq!(observe.exposure, ToolExposure::Deferred);
-    assert!(observe.available);
-    assert!(observe.runtime_policy.mutates_session);
-    assert_eq!(interact.exposure, ToolExposure::Deferred);
-    assert!(interact.available);
+    assert_eq!(open.exposure, ToolExposure::Deferred);
+    assert!(open.available);
+    assert!(open.runtime_policy.mutates_session);
+    assert_eq!(read.exposure, ToolExposure::Deferred);
+    assert!(read.available);
+    assert_eq!(act.exposure, ToolExposure::Deferred);
+    assert!(act.available);
     assert_eq!(
-        interact.runtime_policy.cancellation_mode,
+        registry.contributor_id_for_tool("web.open"),
+        Some("builtin.web".to_string())
+    );
+    assert_eq!(
+        registry.contributor_id_for_tool("web.read"),
+        Some("builtin.web".to_string())
+    );
+    assert_eq!(
+        registry.contributor_id_for_tool("web.act"),
+        Some("builtin.web".to_string())
+    );
+    assert_eq!(
+        act.runtime_policy.cancellation_mode,
         ToolCancellationMode::DetachForbidden
     );
     assert_eq!(
-        interact.input_schema["required"],
-        json!(["browserSessionId", "tabId", "controlEpoch", "action"])
+        act.input_schema["required"],
+        json!(["snapshotId", "action"])
     );
+    assert!(registry.get_tool("browser.observe").is_none());
+    assert!(registry.get_tool("browser.interact").is_none());
 }
 
 #[test]

--- a/src-tauri/src/tools/web/README.md
+++ b/src-tauri/src/tools/web/README.md
@@ -123,9 +123,9 @@ URL 跳转使用 `web.open`，不作为 `web.act` 动作。
 }
 ```
 
-浏览器进入 `user_required`，前端展示当前页面和原因。用户操作期间仍保持这个状态，但每次直接输入都会让旧快照失效。用户点击 “Done and continue” 后，前端读取最新 control epoch、执行 `resume`，并在同一会话发起一个简短续接回合。agent 随后通过 `web.read` 获取新的 `snapshotId`。
+浏览器进入 `user_required`，前端展示当前页面和原因。用户操作、切换标签页以及处理 popup 或外部协议期间都保持这个状态，但每次直接输入都会让旧快照失效。只有用户点击 “Hand control back to Agent” 后，前端才读取最新 control epoch、执行内部 `resume`，并在同一会话发起一个简短续接回合。agent 随后通过 `web.read` 获取新的 `snapshotId`。
 
-`user_required` 期间只允许观察和 `resume`，其他 agent 页面修改会被拒绝。弹窗和外部协议仍使用各自的 Allow/Deny 确认，不使用通用完成按钮。
+`user_required` 期间 agent 只允许观察；`resume` 不对 agent 开放。弹窗和外部协议仍使用各自的 Allow/Deny 确认，处理完后继续保持用户控制，直到用户明确交回。
 
 ## 保持简单
 

--- a/src-tauri/src/tools/web/README.md
+++ b/src-tauri/src/tools/web/README.md
@@ -1,0 +1,91 @@
+# Agent Web 工具
+
+这里放置提供给 agent 的网络和浏览器工具。
+
+## 对外工具
+
+- `web.open`：打开 URL，后端自动创建或复用 browser session。
+- `web.read`：读取当前页面；携带上一次的 `snapshotId` 时，可返回精简的 `unchanged`。
+- `web.act`：在当前页面执行一个动作，必须携带 `snapshotId`。
+
+agent 不需要处理 browser session、tab、control epoch、capture ID 或 observation revision。这些底层参数由本目录中的适配层自动补齐。
+
+原有的 `browser.observe` 和 `browser.interact` 仍作为内部能力使用，不直接暴露给 agent。
+
+## 分层
+
+- `registry.rs`：定义 agent 可以看到的工具和输入 schema。
+- `agent.rs`：实现 `web.open`、`web.read`、`web.act` 的高层流程。
+- `browser.rs`：封装底层 browser observe/interact 调用和所有权检查。
+- 浏览器 session、tab、事件和快照状态仍由 `native_browser` 管理。
+
+## 快照状态
+
+每个 tab 只维护当前状态：
+
+```text
+generation
+revision
+dirty
+current observation
+```
+
+对 agent 暴露的 ID 为：
+
+```text
+<generation>.<revision>
+```
+
+例如 `b13ac72.4`。它只是一个不透明版本号。
+
+不保存历史快照，也不在每个 targetRef 中重复携带页面版本。
+
+## dirty 与刷新
+
+页面 DOM 变化时，WebView 只发送 dirty 信号：
+
+1. 后端把当前 tab 标记为 dirty。
+2. 此时不生成或广播完整快照。
+3. 下一次读取或动作前再执行 observe。
+4. 如果语义内容确实变化，递增 revision。
+5. 如果内容相同，只清除 dirty，保留原 snapshotId 和 targetRef。
+
+用户直接输入和导航开始会立即推进 revision，避免 agent 在旧页面状态上继续操作。
+
+## 动作校验
+
+`web.act` 的基本流程：
+
+```text
+刷新 dirty 页面
+→ 比较请求 snapshotId
+→ 在浏览器命令锁内再次校验
+→ 执行动作
+→ observe 最新页面
+→ 返回最新 snapshotId
+```
+
+如果 ID 已过期，动作不会执行：
+
+```json
+{
+  "status": "stale_snapshot",
+  "actionExecuted": false,
+  "requestedSnapshotId": "b13ac72.3",
+  "snapshotId": "b13ac72.4",
+  "snapshot": {}
+}
+```
+
+锁内二次校验用于处理“第一次比较后、真正点击前，用户又操作了页面”的竞态。
+
+## 保持简单
+
+当前设计刻意不做：
+
+- 快照历史和回滚。
+- 后台持续生成完整快照。
+- agent 手动管理浏览器内部 ID。
+- 额外的缓存、同步协议或全局静态状态表。
+
+需要扩展时，优先保持 `web.*` 接口稳定，把浏览器实现细节留在后端。

--- a/src-tauri/src/tools/web/README.md
+++ b/src-tauri/src/tools/web/README.md
@@ -8,6 +8,8 @@
 - `web.read`：读取当前页面；携带上一次的 `snapshotId` 时，可返回精简的 `unchanged`。
 - `web.act`：在当前页面执行一个动作，必须携带 `snapshotId`。
 
+这三个工具始终提供给 agent，不需要先通过 `tool_search` 激活。浏览器操作通常会跨越多个用户回合，保持常驻可以避免新回合丢失工具 schema 和名称映射。
+
 agent 不需要处理 browser session、tab、control epoch、capture ID 或 observation revision。这些底层参数由本目录中的适配层自动补齐。
 
 原有的 `browser.observe` 和 `browser.interact` 仍作为内部能力使用，不直接暴露给 agent。
@@ -38,7 +40,17 @@ current observation
 
 例如 `b13ac72.4`。它只是一个不透明版本号。
 
-不保存历史快照，也不在每个 targetRef 中重复携带页面版本。
+不保存历史快照，也不在每个 `targetRef` 中重复携带 `snapshotId`。
+
+`targetRef` 是不透明的语义节点引用，当前内部格式为：
+
+```text
+target-<observation revision>-<index>
+```
+
+其中 observation revision 只标识语义目标集合，不等同于页面级 `snapshotId`。agent 不应解析或拼接 `targetRef`。
+
+返回给 agent 的 targets 只保留当前 viewport 中有名称或受保护含义的节点，并限制为最多 100 个。底层仍保留本次 observation 的完整目标映射。
 
 ## dirty 与刷新
 
@@ -78,6 +90,20 @@ current observation
 ```
 
 锁内二次校验用于处理“第一次比较后、真正点击前，用户又操作了页面”的竞态。
+
+目标动作需要把字段放在 `action` 对象内：
+
+```json
+{
+  "snapshotId": "b13ac72.4",
+  "action": {
+    "type": "clickTarget",
+    "targetRef": "target-2-7"
+  }
+}
+```
+
+URL 跳转使用 `web.open`，不作为 `web.act` 动作。
 
 ## 保持简单
 

--- a/src-tauri/src/tools/web/README.md
+++ b/src-tauri/src/tools/web/README.md
@@ -105,6 +105,24 @@ target-<observation revision>-<index>
 
 URL 跳转使用 `web.open`，不作为 `web.act` 动作。
 
+## 转交给用户
+
+密码、一次性验证码、CAPTCHA、支付信息、文件选择器等步骤不应由 agent 代替用户完成。agent 调用：
+
+```json
+{
+  "snapshotId": "b13ac72.4",
+  "action": {
+    "type": "userHandoff",
+    "reason": "请完成登录验证"
+  }
+}
+```
+
+浏览器进入 `user_required`，前端展示当前页面和原因。用户操作期间仍保持这个状态，但每次直接输入都会让旧快照失效。用户点击 “Done and continue” 后，前端读取最新 control epoch、执行 `resume`，并在同一会话发起一个简短续接回合。agent 随后通过 `web.read` 获取新的 `snapshotId`。
+
+`user_required` 期间只允许观察和 `resume`，其他 agent 页面修改会被拒绝。弹窗和外部协议仍使用各自的 Allow/Deny 确认，不使用通用完成按钮。
+
 ## 保持简单
 
 当前设计刻意不做：

--- a/src-tauri/src/tools/web/README.md
+++ b/src-tauri/src/tools/web/README.md
@@ -14,6 +14,10 @@ agent 不需要处理 browser session、tab、control epoch、capture ID 或 obs
 
 原有的 `browser.observe` 和 `browser.interact` 仍作为内部能力使用，不直接暴露给 agent。
 
+## 浏览器生命周期
+
+关闭 TinyOS 面板只会隐藏界面，保留 browser session，方便稍后继续。用户选择“Exit TinyOS and release browser”或删除所属聊天线程时，后端会关闭该 session 的所有 tab；Windows 上会调用 WebView 的 `close()` 并释放句柄。再次打开 TinyOS 时会按需新建 session。
+
 ## 分层
 
 - `registry.rs`：定义 agent 可以看到的工具和输入 schema。

--- a/src-tauri/src/tools/web/agent.rs
+++ b/src-tauri/src/tools/web/agent.rs
@@ -1,6 +1,7 @@
 use super::browser::{dispatch_browser_interact, dispatch_browser_observe, WebToolCancellation};
 use crate::native_browser::{
-    BrowserAgentPageState, BrowserCreateSessionInput, SharedBrowserRuntime, AGENT_SNAPSHOT_STALE,
+    BrowserAgentPageState, BrowserCreateSessionInput, BrowserNativeSnapshot, SharedBrowserRuntime,
+    AGENT_SNAPSHOT_STALE,
 };
 use serde_json::{json, Value};
 
@@ -14,15 +15,16 @@ pub(crate) async fn dispatch_web_open(
 ) -> Result<Value, String> {
     let url = required_text(&arguments, "url")?;
     if runtime.snapshot_for_owner(owner_session_id).is_none() {
-        runtime
-            .create_session(
-                serde_json::from_value::<BrowserCreateSessionInput>(json!({
-                    "ownerSessionId": owner_session_id,
-                    "initialUrl": url,
-                }))
-                .map_err(|error| format!("web.open payload is invalid: {error}"))?,
-            )
-            .await?;
+        create_session_with_cancellation(
+            runtime,
+            cancellation,
+            serde_json::from_value::<BrowserCreateSessionInput>(json!({
+                "ownerSessionId": owner_session_id,
+                "initialUrl": url,
+            }))
+            .map_err(|error| format!("web.open payload is invalid: {error}"))?,
+        )
+        .await?;
         let page = refresh_page(runtime, owner_session_id).await?;
         return Ok(completed_response(&page, None));
     }
@@ -88,6 +90,36 @@ pub(crate) async fn dispatch_web_act(
         action,
     )
     .await
+}
+
+async fn create_session_with_cancellation(
+    runtime: &SharedBrowserRuntime,
+    cancellation: Option<&dyn WebToolCancellation>,
+    input: BrowserCreateSessionInput,
+) -> Result<BrowserNativeSnapshot, String> {
+    if cancellation.is_some_and(WebToolCancellation::is_cancelled) {
+        return Err("Agent browser session creation was cancelled".to_string());
+    }
+    let runtime = runtime.clone();
+    let mut creation =
+        tauri::async_runtime::spawn(async move { runtime.create_session(input).await });
+    if let Some(cancellation) = cancellation {
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                Err("Agent browser session creation was cancelled".to_string())
+            }
+            result = &mut creation => {
+                result.map_err(|error| {
+                    format!("Agent browser session creation task failed: {error}")
+                })?
+            },
+        }
+    } else {
+        creation
+            .await
+            .map_err(|error| format!("Agent browser session creation task failed: {error}"))?
+    }
 }
 
 async fn ensure_session(

--- a/src-tauri/src/tools/web/agent.rs
+++ b/src-tauri/src/tools/web/agent.rs
@@ -71,6 +71,9 @@ pub(crate) async fn dispatch_web_act(
         .get("action")
         .cloned()
         .ok_or_else(|| "web.act requires an action".to_string())?;
+    if action.get("type").and_then(Value::as_str) == Some("resume") {
+        return Err("Only the user can hand browser control back to the Agent".to_string());
+    }
     ensure_session(runtime, owner_session_id).await?;
     let page = refresh_page(runtime, owner_session_id).await?;
     if requested_snapshot_id != page.snapshot_id {

--- a/src-tauri/src/tools/web/agent.rs
+++ b/src-tauri/src/tools/web/agent.rs
@@ -1,0 +1,266 @@
+use super::browser::{dispatch_browser_interact, dispatch_browser_observe, WebToolCancellation};
+use crate::native_browser::{
+    BrowserAgentPageState, BrowserCreateSessionInput, SharedBrowserRuntime, AGENT_SNAPSHOT_STALE,
+};
+use serde_json::{json, Value};
+
+pub(crate) async fn dispatch_web_open(
+    runtime: &SharedBrowserRuntime,
+    owner_session_id: &str,
+    cancellation: Option<&dyn WebToolCancellation>,
+    arguments: Value,
+) -> Result<Value, String> {
+    let url = required_text(&arguments, "url")?;
+    if runtime.snapshot_for_owner(owner_session_id).is_none() {
+        runtime
+            .create_session(
+                serde_json::from_value::<BrowserCreateSessionInput>(json!({
+                    "ownerSessionId": owner_session_id,
+                    "initialUrl": url,
+                }))
+                .map_err(|error| format!("web.open payload is invalid: {error}"))?,
+            )
+            .await?;
+        let page = refresh_page(runtime, owner_session_id).await?;
+        return Ok(completed_response(&page, None));
+    }
+
+    let page = refresh_page(runtime, owner_session_id).await?;
+    execute_action(
+        runtime,
+        owner_session_id,
+        cancellation,
+        &page,
+        arguments
+            .get("commandId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "web.open command id is missing".to_string())?,
+        json!({ "type": "navigate", "url": url }),
+    )
+    .await
+}
+
+pub(crate) async fn dispatch_web_read(
+    runtime: &SharedBrowserRuntime,
+    owner_session_id: &str,
+    arguments: Value,
+) -> Result<Value, String> {
+    ensure_session(runtime, owner_session_id).await?;
+    let requested_snapshot_id = optional_text(&arguments, "snapshotId")?;
+    let page = refresh_page(runtime, owner_session_id).await?;
+    if requested_snapshot_id.as_deref() == Some(page.snapshot_id.as_str()) {
+        return Ok(json!({
+            "status": "unchanged",
+            "snapshotId": page.snapshot_id,
+        }));
+    }
+    Ok(completed_response(&page, None))
+}
+
+pub(crate) async fn dispatch_web_act(
+    runtime: &SharedBrowserRuntime,
+    owner_session_id: &str,
+    cancellation: Option<&dyn WebToolCancellation>,
+    arguments: Value,
+) -> Result<Value, String> {
+    let requested_snapshot_id = required_text(&arguments, "snapshotId")?;
+    let command_id = required_text(&arguments, "commandId")?;
+    let action = arguments
+        .get("action")
+        .cloned()
+        .ok_or_else(|| "web.act requires an action".to_string())?;
+    ensure_session(runtime, owner_session_id).await?;
+    let page = refresh_page(runtime, owner_session_id).await?;
+    if requested_snapshot_id != page.snapshot_id {
+        return Ok(stale_response(&requested_snapshot_id, &page));
+    }
+    execute_action(
+        runtime,
+        owner_session_id,
+        cancellation,
+        &page,
+        &command_id,
+        action,
+    )
+    .await
+}
+
+async fn ensure_session(
+    runtime: &SharedBrowserRuntime,
+    owner_session_id: &str,
+) -> Result<(), String> {
+    if runtime.snapshot_for_owner(owner_session_id).is_none() {
+        dispatch_browser_observe(runtime, owner_session_id, json!({})).await?;
+    }
+    Ok(())
+}
+
+async fn refresh_page(
+    runtime: &SharedBrowserRuntime,
+    owner_session_id: &str,
+) -> Result<BrowserAgentPageState, String> {
+    let page = runtime
+        .agent_page_state_for_owner(owner_session_id)
+        .ok_or_else(|| "TinyOS browser session is unavailable for this chat".to_string())?;
+    if page.dirty || page.observation.capture.is_none() || page.observation.semantic.is_none() {
+        dispatch_browser_observe(
+            runtime,
+            owner_session_id,
+            json!({
+                "browserSessionId": page.observation.snapshot.data.browser_session_id,
+                "tabId": page.observation.snapshot.data.active_tab_id,
+                "capture": true,
+                "semantic": true,
+            }),
+        )
+        .await?;
+        return runtime
+            .agent_page_state_for_owner(owner_session_id)
+            .ok_or_else(|| "TinyOS browser session disappeared after refresh".to_string());
+    }
+    Ok(page)
+}
+
+async fn execute_action(
+    runtime: &SharedBrowserRuntime,
+    owner_session_id: &str,
+    cancellation: Option<&dyn WebToolCancellation>,
+    page: &BrowserAgentPageState,
+    command_id: &str,
+    action: Value,
+) -> Result<Value, String> {
+    let native = &page.observation.snapshot.data;
+    let tab = native
+        .tabs
+        .iter()
+        .find(|tab| tab.tab_id == native.active_tab_id)
+        .ok_or_else(|| "TinyOS browser active tab is unavailable".to_string())?;
+    let result = dispatch_browser_interact(
+        runtime,
+        owner_session_id,
+        cancellation,
+        json!({
+            "browserSessionId": native.browser_session_id,
+            "tabId": native.active_tab_id,
+            "commandId": command_id,
+            "controlEpoch": native.control.control_epoch,
+            "snapshotId": page.snapshot_id,
+            "captureId": tab.current_capture_id,
+            "observationRevision": tab.observation_revision,
+            "action": action,
+        }),
+    )
+    .await;
+
+    let command = match result {
+        Ok(command) => command,
+        Err(error) if error == AGENT_SNAPSHOT_STALE => {
+            let latest = refresh_page(runtime, owner_session_id).await?;
+            return Ok(stale_response(&page.snapshot_id, &latest));
+        }
+        Err(error) => return Err(error),
+    };
+    let status = command
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("failed");
+    let mut latest = refresh_page(runtime, owner_session_id).await?;
+    if status == "completed" && latest.snapshot_id == page.snapshot_id {
+        runtime.advance_agent_snapshot_for_owner(owner_session_id)?;
+        latest = runtime
+            .agent_page_state_for_owner(owner_session_id)
+            .ok_or_else(|| "TinyOS browser session disappeared after interaction".to_string())?;
+    }
+    Ok(completed_response(&latest, Some(&command)))
+}
+
+fn completed_response(page: &BrowserAgentPageState, command: Option<&Value>) -> Value {
+    let status = command
+        .and_then(|command| command.get("status"))
+        .and_then(Value::as_str)
+        .unwrap_or("completed");
+    let mut response = json!({
+        "status": status,
+        "snapshotId": page.snapshot_id,
+        "snapshot": snapshot_payload(page),
+    });
+    if let Some(command) = command {
+        response["actionExecuted"] = Value::Bool(status == "completed");
+        if let Some(reason_code) = command.get("reasonCode") {
+            response["reasonCode"] = reason_code.clone();
+        }
+        if let Some(reason) = command.get("reason") {
+            response["reason"] = reason.clone();
+        }
+    }
+    response
+}
+
+fn stale_response(requested_snapshot_id: &str, page: &BrowserAgentPageState) -> Value {
+    json!({
+        "status": "stale_snapshot",
+        "actionExecuted": false,
+        "requestedSnapshotId": requested_snapshot_id,
+        "snapshotId": page.snapshot_id,
+        "snapshot": snapshot_payload(page),
+    })
+}
+
+fn snapshot_payload(page: &BrowserAgentPageState) -> Value {
+    let native = &page.observation.snapshot.data;
+    let Some(tab) = native
+        .tabs
+        .iter()
+        .find(|tab| tab.tab_id == native.active_tab_id)
+    else {
+        return json!({});
+    };
+    let viewport = page.observation.capture.as_ref().map(|capture| {
+        json!({
+            "width": capture.viewport_width,
+            "height": capture.viewport_height,
+            "deviceScale": capture.device_scale,
+        })
+    });
+    let targets = page
+        .observation
+        .semantic
+        .as_ref()
+        .map(|semantic| &semantic.nodes);
+    let targets_truncated = page
+        .observation
+        .semantic
+        .as_ref()
+        .is_some_and(|semantic| semantic.truncated);
+    json!({
+        "url": tab.url,
+        "title": tab.title,
+        "loading": tab.loading,
+        "canGoBack": tab.can_go_back,
+        "canGoForward": tab.can_go_forward,
+        "viewport": viewport,
+        "targets": targets,
+        "targetsTruncated": targets_truncated,
+        "interaction": native.interaction,
+        "control": {
+            "state": native.control.state,
+            "reason": native.control.reason,
+        },
+        "pendingPolicyRequest": native.pending_policy_request.as_ref().map(|request| json!({
+            "kind": request.kind,
+            "safeUrl": request.safe_url,
+        })),
+    })
+}
+
+fn required_text(value: &Value, key: &str) -> Result<String, String> {
+    optional_text(value, key)?.ok_or_else(|| format!("{key} is required"))
+}
+
+fn optional_text(value: &Value, key: &str) -> Result<Option<String>, String> {
+    match value.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(text)) if !text.trim().is_empty() => Ok(Some(text.trim().to_string())),
+        Some(_) => Err(format!("{key} must be a non-empty string")),
+    }
+}

--- a/src-tauri/src/tools/web/agent.rs
+++ b/src-tauri/src/tools/web/agent.rs
@@ -4,6 +4,8 @@ use crate::native_browser::{
 };
 use serde_json::{json, Value};
 
+const MAX_AGENT_SNAPSHOT_TARGETS: usize = 100;
+
 pub(crate) async fn dispatch_web_open(
     runtime: &SharedBrowserRuntime,
     owner_session_id: &str,
@@ -222,16 +224,39 @@ fn snapshot_payload(page: &BrowserAgentPageState) -> Value {
             "deviceScale": capture.device_scale,
         })
     });
+    let mut targets_truncated = false;
     let targets = page
         .observation
         .semantic
         .as_ref()
-        .map(|semantic| &semantic.nodes);
-    let targets_truncated = page
-        .observation
-        .semantic
-        .as_ref()
-        .is_some_and(|semantic| semantic.truncated);
+        .map(|semantic| {
+            targets_truncated = semantic.truncated;
+            let mut targets = semantic
+                .nodes
+                .iter()
+                .filter(|target| {
+                    let meaningful = !target.name.trim().is_empty()
+                        || target.sensitive
+                        || target.protected_reason.is_some();
+                    meaningful
+                        && page.observation.capture.as_ref().is_none_or(|capture| {
+                            capture.viewport_width <= 1
+                                || capture.viewport_height <= 1
+                                || (target.x + target.width > 0.0
+                                    && target.y + target.height > 0.0
+                                    && target.x < f64::from(capture.viewport_width)
+                                    && target.y < f64::from(capture.viewport_height))
+                        })
+                })
+                .take(MAX_AGENT_SNAPSHOT_TARGETS + 1)
+                .collect::<Vec<_>>();
+            if targets.len() > MAX_AGENT_SNAPSHOT_TARGETS {
+                targets.truncate(MAX_AGENT_SNAPSHOT_TARGETS);
+                targets_truncated = true;
+            }
+            targets
+        })
+        .unwrap_or_default();
     json!({
         "url": tab.url,
         "title": tab.title,

--- a/src-tauri/src/tools/web/browser.rs
+++ b/src-tauri/src/tools/web/browser.rs
@@ -1,0 +1,187 @@
+use crate::native_browser::{
+    BrowserCreateSessionInput, BrowserInteractionInput, BrowserNativeSnapshot, BrowserObserveInput,
+    SharedBrowserRuntime,
+};
+use std::future::Future;
+use std::pin::Pin;
+
+pub(crate) trait WebToolCancellation: Send + Sync {
+    fn is_cancelled(&self) -> bool;
+
+    fn cancelled(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+}
+
+pub(crate) async fn dispatch_browser_observe(
+    runtime: &SharedBrowserRuntime,
+    owner_session_id: &str,
+    arguments: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let capabilities = runtime.capabilities();
+    if !capabilities.session_snapshot.available {
+        return Err(capabilities
+            .session_snapshot
+            .reason
+            .unwrap_or_else(|| "TinyOS browser sessions are unavailable".to_string()));
+    }
+    let capture = arguments
+        .get("capture")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    let semantic = arguments
+        .get("semantic")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    if capture && !capabilities.real_capture.available {
+        return Err(capabilities
+            .real_capture
+            .reason
+            .unwrap_or_else(|| "TinyOS browser capture is unavailable".to_string()));
+    }
+    if semantic && !capabilities.semantic_observation.available {
+        return Err(capabilities
+            .semantic_observation
+            .reason
+            .unwrap_or_else(|| "TinyOS browser semantic observation is unavailable".to_string()));
+    }
+    let requested_session_id = optional_text(&arguments, "browserSessionId")?;
+    let snapshot = match runtime.snapshot_for_owner(owner_session_id) {
+        Some(snapshot) => snapshot,
+        None if requested_session_id.is_some() => {
+            return Err(
+                "The requested TinyOS browser session is not owned by this chat".to_string(),
+            );
+        }
+        None => {
+            runtime
+                .create_session(
+                    serde_json::from_value::<BrowserCreateSessionInput>(serde_json::json!({
+                        "ownerSessionId": owner_session_id
+                    }))
+                    .map_err(|error| {
+                        format!("failed to create TinyOS browser session input: {error}")
+                    })?,
+                )
+                .await?
+        }
+    };
+    ensure_browser_owner(&snapshot, requested_session_id.as_deref())?;
+    let requested_tab_id = optional_text(&arguments, "tabId")?;
+    let tab_id = requested_tab_id
+        .as_deref()
+        .unwrap_or_else(|| snapshot.data.active_tab_id.as_str());
+    ensure_browser_tab(&snapshot, tab_id)?;
+    let input = serde_json::from_value::<BrowserObserveInput>(serde_json::json!({
+        "browserSessionId": snapshot.data.browser_session_id.as_str(),
+        "tabId": tab_id,
+        "capture": capture,
+        "semantic": semantic,
+    }))
+    .map_err(|error| format!("browser.observe payload is invalid: {error}"))?;
+    serde_json::to_value(runtime.observe(input).await?)
+        .map_err(|error| format!("browser.observe result serialization failed: {error}"))
+}
+
+pub(crate) async fn dispatch_browser_interact(
+    runtime: &SharedBrowserRuntime,
+    owner_session_id: &str,
+    cancellation: Option<&dyn WebToolCancellation>,
+    arguments: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let capabilities = runtime.capabilities();
+    if !capabilities.agent_interaction.available {
+        return Err(capabilities
+            .agent_interaction
+            .reason
+            .unwrap_or_else(|| "TinyOS Agent browser interaction is unavailable".to_string()));
+    }
+    let input = serde_json::from_value::<BrowserInteractionInput>(arguments)
+        .map_err(|error| format!("browser.interact payload is invalid: {error}"))?;
+    let snapshot = runtime
+        .snapshot_for_owner(owner_session_id)
+        .ok_or_else(|| {
+            "Open or observe the TinyOS browser before interacting with it".to_string()
+        })?;
+    ensure_browser_owner(&snapshot, Some(input.browser_session_id.as_str()))?;
+    ensure_browser_tab(&snapshot, input.tab_id.as_str())?;
+    let tab_id = input.tab_id.clone();
+    let command_id = input.command_id.clone();
+    if cancellation.is_some_and(|cancellation| cancellation.is_cancelled()) {
+        return Err("Agent browser command was cancelled before dispatch".to_string());
+    }
+    let interaction = runtime.interact(input);
+    tokio::pin!(interaction);
+    let result = if let Some(cancellation) = cancellation {
+        tokio::select! {
+            result = &mut interaction => result,
+            _ = cancellation.cancelled() => {
+                if runtime.cancel_agent_command(&tab_id, &command_id) {
+                    interaction.await
+                } else {
+                    return Err("Agent browser command was cancelled before dispatch".to_string());
+                }
+            }
+        }
+    } else {
+        interaction.await
+    }?;
+    serde_json::to_value(result)
+        .map_err(|error| format!("browser.interact result serialization failed: {error}"))
+}
+
+fn ensure_browser_owner(
+    snapshot: &BrowserNativeSnapshot,
+    requested_session_id: Option<&str>,
+) -> Result<(), String> {
+    if snapshot.data.session_id.is_empty() {
+        return Err("TinyOS browser snapshot has no owning chat session".to_string());
+    }
+    if requested_session_id
+        .is_some_and(|requested| requested != snapshot.data.browser_session_id.as_str())
+    {
+        return Err("The requested TinyOS browser session is not owned by this chat".to_string());
+    }
+    Ok(())
+}
+
+fn ensure_browser_tab(snapshot: &BrowserNativeSnapshot, tab_id: &str) -> Result<(), String> {
+    snapshot
+        .data
+        .tabs
+        .iter()
+        .any(|tab| tab.tab_id.as_str() == tab_id)
+        .then_some(())
+        .ok_or_else(|| {
+            "The requested TinyOS browser tab is not part of this chat session".to_string()
+        })
+}
+
+fn optional_text(value: &serde_json::Value, key: &str) -> Result<Option<String>, String> {
+    match value.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(text)) if !text.trim().is_empty() => {
+            Ok(Some(text.trim().to_string()))
+        }
+        Some(_) => Err(format!("{key} must be a non-empty string")),
+    }
+}
+
+pub(crate) fn strip_browser_capture_data(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            object.remove("dataUrl");
+            for child in object.values_mut() {
+                strip_browser_capture_data(child);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                strip_browser_capture_data(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+#[path = "browser_tests.rs"]
+mod tests;

--- a/src-tauri/src/tools/web/browser.rs
+++ b/src-tauri/src/tools/web/browser.rs
@@ -1,6 +1,6 @@
 use crate::native_browser::{
     BrowserCreateSessionInput, BrowserInteractionInput, BrowserNativeSnapshot, BrowserObserveInput,
-    SharedBrowserRuntime,
+    BrowserSessionLifecycle, SharedBrowserRuntime,
 };
 use std::future::Future;
 use std::pin::Pin;
@@ -45,6 +45,18 @@ pub(crate) async fn dispatch_browser_observe(
     }
     let requested_session_id = optional_text(&arguments, "browserSessionId")?;
     let snapshot = match runtime.snapshot_for_owner(owner_session_id) {
+        Some(snapshot) if snapshot.data.lifecycle == BrowserSessionLifecycle::Creating => {
+            runtime
+                .create_session(
+                    serde_json::from_value::<BrowserCreateSessionInput>(serde_json::json!({
+                        "ownerSessionId": owner_session_id
+                    }))
+                    .map_err(|error| {
+                        format!("failed to create TinyOS browser session input: {error}")
+                    })?,
+                )
+                .await?
+        }
         Some(snapshot) => snapshot,
         None if requested_session_id.is_some() => {
             return Err(

--- a/src-tauri/src/tools/web/browser_tests.rs
+++ b/src-tauri/src/tools/web/browser_tests.rs
@@ -1,0 +1,21 @@
+use super::strip_browser_capture_data;
+
+#[test]
+fn browser_capture_bytes_are_not_returned_to_the_model_context() {
+    let mut result = serde_json::json!({
+        "capture": { "captureId": "capture-1", "dataUrl": "data:image/png;base64,AAAA" },
+        "snapshot": {
+            "data": {
+                "tabs": [{ "captures": [{ "captureId": "capture-1", "dataUrl": "data:image/png;base64,BBBB" }] }]
+            }
+        }
+    });
+
+    strip_browser_capture_data(&mut result);
+
+    assert_eq!(result["capture"]["captureId"], "capture-1");
+    assert!(result["capture"].get("dataUrl").is_none());
+    assert!(result["snapshot"]["data"]["tabs"][0]["captures"][0]
+        .get("dataUrl")
+        .is_none());
+}

--- a/src-tauri/src/tools/web/mod.rs
+++ b/src-tauri/src/tools/web/mod.rs
@@ -1,0 +1,13 @@
+mod agent;
+mod browser;
+mod registry;
+
+pub(crate) use agent::{dispatch_web_act, dispatch_web_open, dispatch_web_read};
+#[cfg(test)]
+pub(crate) use browser::{dispatch_browser_interact, dispatch_browser_observe};
+pub(crate) use browser::{strip_browser_capture_data, WebToolCancellation};
+pub(crate) use registry::WebToolContributor;
+
+pub(crate) fn is_web_tool(method: &str) -> bool {
+    matches!(method, "web.open" | "web.read" | "web.act")
+}

--- a/src-tauri/src/tools/web/registry.rs
+++ b/src-tauri/src/tools/web/registry.rs
@@ -20,7 +20,7 @@ impl ToolContributor for WebToolContributor {
                 "type": {
                     "type": "string",
                     "description": "Use clickTarget with targetRef for semantic targets. Use click only with x and y coordinates. Use userHandoff when login credentials, verification codes, CAPTCHA, payment details, file pickers, or another protected step requires the user. URL navigation belongs in web.open.",
-                    "enum": ["back", "forward", "reload", "stop", "click", "clickTarget", "type", "fill", "key", "scroll", "wait", "userHandoff", "resume"]
+                    "enum": ["back", "forward", "reload", "stop", "click", "clickTarget", "type", "fill", "key", "scroll", "wait", "userHandoff"]
                 },
                 "x": { "type": "number" },
                 "y": { "type": "number" },

--- a/src-tauri/src/tools/web/registry.rs
+++ b/src-tauri/src/tools/web/registry.rs
@@ -19,7 +19,7 @@ impl ToolContributor for WebToolContributor {
             "properties": {
                 "type": {
                     "type": "string",
-                    "description": "Use clickTarget with targetRef for semantic targets. Use click only with x and y coordinates. URL navigation belongs in web.open.",
+                    "description": "Use clickTarget with targetRef for semantic targets. Use click only with x and y coordinates. Use userHandoff when login credentials, verification codes, CAPTCHA, payment details, file pickers, or another protected step requires the user. URL navigation belongs in web.open.",
                     "enum": ["back", "forward", "reload", "stop", "click", "clickTarget", "type", "fill", "key", "scroll", "wait", "userHandoff", "resume"]
                 },
                 "x": { "type": "number" },
@@ -30,7 +30,7 @@ impl ToolContributor for WebToolContributor {
                 "deltaX": { "type": "number" },
                 "deltaY": { "type": "number" },
                 "timeoutMs": { "type": "integer", "minimum": 0, "maximum": 15000 },
-                "reason": { "type": "string" }
+                "reason": { "type": "string", "description": "Required for userHandoff. Briefly tell the user what they need to complete." }
             },
             "additionalProperties": false
         });
@@ -77,7 +77,7 @@ impl ToolContributor for WebToolContributor {
                 "web.act",
                 "web",
                 "Act on the current web page",
-                "Perform one action against the current page. Put action fields inside the action object; use clickTarget with targetRef for semantic targets. Use web.open, not web.act, for URL navigation. Always pass the latest snapshotId. Stale actions are not executed and return the latest snapshot.",
+                "Perform one action against the current page. Put action fields inside the action object; use clickTarget with targetRef for semantic targets. For passwords, verification codes, CAPTCHA, payment details, file pickers, or another protected step, call userHandoff with a clear reason and stop changing the page until the user resumes control. Use web.open, not web.act, for URL navigation. Always pass the latest snapshotId. Stale actions are not executed and return the latest snapshot.",
                 ToolExposure::Model,
                 false,
                 runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),

--- a/src-tauri/src/tools/web/registry.rs
+++ b/src-tauri/src/tools/web/registry.rs
@@ -1,0 +1,99 @@
+use crate::protocol::capability::WorkerCapability;
+use crate::tools::registry::{
+    runtime_policy, tool, ToolCancellationMode, ToolContributor, ToolExposure, ToolRegistryEntry,
+};
+use serde_json::json;
+
+#[derive(Debug)]
+pub(crate) struct WebToolContributor;
+
+impl ToolContributor for WebToolContributor {
+    fn id(&self) -> &str {
+        "builtin.web"
+    }
+
+    fn contribute(&self) -> Vec<ToolRegistryEntry> {
+        let action_schema = json!({
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": ["back", "forward", "reload", "stop", "click", "clickTarget", "type", "fill", "key", "scroll", "wait", "userHandoff", "resume"]
+                },
+                "x": { "type": "number" },
+                "y": { "type": "number" },
+                "targetRef": { "type": "string" },
+                "text": { "type": "string" },
+                "key": { "type": "string" },
+                "deltaX": { "type": "number" },
+                "deltaY": { "type": "number" },
+                "timeoutMs": { "type": "integer", "minimum": 0, "maximum": 15000 },
+                "reason": { "type": "string" }
+            },
+            "additionalProperties": false
+        });
+        vec![
+            tool(
+                "web.open",
+                "web",
+                "Open a web page",
+                "Open a URL in this chat's shared browser and return the current page snapshot and snapshotId. Session and tab setup are handled automatically.",
+                ToolExposure::Deferred,
+                false,
+                runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),
+                vec![
+                    WorkerCapability::BrowserObserve,
+                    WorkerCapability::BrowserInteract,
+                ],
+                json!({
+                    "type": "object",
+                    "required": ["url"],
+                    "properties": {
+                        "url": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                }),
+            ),
+            tool(
+                "web.read",
+                "web",
+                "Read the current web page",
+                "Return the latest page snapshot and snapshotId. Pass the last snapshotId for a compact unchanged response when the page has not changed.",
+                ToolExposure::Deferred,
+                false,
+                runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),
+                vec![WorkerCapability::BrowserObserve],
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "snapshotId": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                }),
+            ),
+            tool(
+                "web.act",
+                "web",
+                "Act on the current web page",
+                "Perform one action against the current page. Always pass the snapshotId returned by web.open, web.read, or the previous web.act. Stale actions are not executed and return the latest snapshot.",
+                ToolExposure::Deferred,
+                false,
+                runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),
+                vec![
+                    WorkerCapability::BrowserObserve,
+                    WorkerCapability::BrowserInteract,
+                ],
+                json!({
+                    "type": "object",
+                    "required": ["snapshotId", "action"],
+                    "properties": {
+                        "snapshotId": { "type": "string" },
+                        "action": action_schema
+                    },
+                    "additionalProperties": false
+                }),
+            ),
+        ]
+    }
+}

--- a/src-tauri/src/tools/web/registry.rs
+++ b/src-tauri/src/tools/web/registry.rs
@@ -19,11 +19,12 @@ impl ToolContributor for WebToolContributor {
             "properties": {
                 "type": {
                     "type": "string",
+                    "description": "Use clickTarget with targetRef for semantic targets. Use click only with x and y coordinates. URL navigation belongs in web.open.",
                     "enum": ["back", "forward", "reload", "stop", "click", "clickTarget", "type", "fill", "key", "scroll", "wait", "userHandoff", "resume"]
                 },
                 "x": { "type": "number" },
                 "y": { "type": "number" },
-                "targetRef": { "type": "string" },
+                "targetRef": { "type": "string", "description": "Opaque targetRef from the latest returned snapshot." },
                 "text": { "type": "string" },
                 "key": { "type": "string" },
                 "deltaX": { "type": "number" },
@@ -39,7 +40,7 @@ impl ToolContributor for WebToolContributor {
                 "web",
                 "Open a web page",
                 "Open a URL in this chat's shared browser and return the current page snapshot and snapshotId. Session and tab setup are handled automatically.",
-                ToolExposure::Deferred,
+                ToolExposure::Model,
                 false,
                 runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),
                 vec![
@@ -60,7 +61,7 @@ impl ToolContributor for WebToolContributor {
                 "web",
                 "Read the current web page",
                 "Return the latest page snapshot and snapshotId. Pass the last snapshotId for a compact unchanged response when the page has not changed.",
-                ToolExposure::Deferred,
+                ToolExposure::Model,
                 false,
                 runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),
                 vec![WorkerCapability::BrowserObserve],
@@ -76,8 +77,8 @@ impl ToolContributor for WebToolContributor {
                 "web.act",
                 "web",
                 "Act on the current web page",
-                "Perform one action against the current page. Always pass the snapshotId returned by web.open, web.read, or the previous web.act. Stale actions are not executed and return the latest snapshot.",
-                ToolExposure::Deferred,
+                "Perform one action against the current page. Put action fields inside the action object; use clickTarget with targetRef for semantic targets. Use web.open, not web.act, for URL navigation. Always pass the latest snapshotId. Stale actions are not executed and return the latest snapshot.",
+                ToolExposure::Model,
                 false,
                 runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),
                 vec![

--- a/src/app-core/chat/tinyOsShellCommandRegistry.ts
+++ b/src/app-core/chat/tinyOsShellCommandRegistry.ts
@@ -9,6 +9,7 @@ export type TinyOsShellCommandId =
   | "browser.type"
   | "history.return_live"
   | "shell.close"
+  | "shell.exit"
   | "shell.expanded_toggle"
   | "shell.notification_center"
   | "shell.overview"

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -440,7 +440,7 @@ describe("ChatPage", () => {
     const canvas = await screen.findByLabelText("TinyOS shared desktop");
     const browser = await within(canvas).findByLabelText("Browser window");
     expect(browser.getAttribute("data-active")).toBe("true");
-    await userEvent.click(within(browser).getByRole("button", { name: "Done and continue" }));
+    await userEvent.click(within(browser).getByRole("button", { name: "Hand control back to Agent" }));
 
     expect(interact).toHaveBeenCalledWith(expect.objectContaining({
       action: { type: "resume" },
@@ -451,6 +451,29 @@ describe("ChatPage", () => {
     await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
       text: "我已完成浏览器中的必要操作。请重新读取当前页面，并从转交前的位置继续。",
     }));
+  });
+
+  it("does not continue the Agent from an idle snapshot without explicit user hand-back", async () => {
+    const stores = createStores();
+    const handoff = handoffBrowserSnapshot("user_required", 7);
+    const idle = handoffBrowserSnapshot("idle", 8);
+    let listener: ((event: ChatEvent) => void) | undefined;
+    stores.chatStore.subscribe = vi.fn((_sessionId, nextListener) => {
+      listener = nextListener;
+      return () => undefined;
+    });
+    stores.chatStore.browserRuntime = {
+      createSession: vi.fn(async () => handoff),
+      updateSurface: vi.fn(async () => handoff),
+    } as unknown as NativeBrowserRuntimeApi;
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 29, 0, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await waitFor(() => expect(listener).toBeTruthy());
+    act(() => listener?.({ browserSnapshot: handoff, type: "browser.snapshot" }));
+    act(() => listener?.({ browserSnapshot: idle, type: "browser.snapshot" }));
+
+    await waitFor(() => expect(screen.getByLabelText("TinyOS shared desktop")).toBeTruthy());
+    expect(turnSubmitCommands(stores.chatStore)).toEqual([]);
   });
 
   it("attaches a TinyOS file range as a visible composer chip and structured chat reference", async () => {

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -388,6 +388,30 @@ describe("ChatPage", () => {
     expect(screen.queryByLabelText("TinyOS shared desktop")).toBeNull();
   });
 
+  it("releases the TinyOS browser session on explicit exit and recreates it when reopened", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const snapshot = handoffBrowserSnapshot("idle", 0);
+    const createSession = vi.fn(async () => snapshot);
+    const closeSession = vi.fn(async () => undefined);
+    stores.chatStore.browserRuntime = {
+      closeSession,
+      createSession,
+      updateSurface: vi.fn(async () => snapshot),
+    } as unknown as NativeBrowserRuntimeApi;
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 29, 0, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole("button", { name: /^Open TinyOS/ }));
+    await user.click(await screen.findByRole("button", { name: "Exit TinyOS and release browser" }));
+
+    await waitFor(() => expect(closeSession).toHaveBeenCalledWith("browser-handoff"));
+    await waitFor(() => expect(screen.queryByLabelText("TinyOS shared desktop")).toBeNull());
+    await user.click(screen.getByRole("button", { name: /^Open TinyOS/ }));
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(2));
+  });
+
   it("opens the handed-off browser and continues the Agent after explicit completion", async () => {
     const stores = createStores();
     const handoff = handoffBrowserSnapshot("user_required", 7);

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -375,6 +375,19 @@ describe("ChatPage", () => {
     expect(document.activeElement).toBe(openButton);
   }, 10_000);
 
+  it("prepares the active chat browser session before TinyOS is opened", async () => {
+    const stores = createStores();
+    const createSession = vi.fn(async () => handoffBrowserSnapshot("idle", 0));
+    stores.chatStore.browserRuntime = {
+      createSession,
+    } as unknown as NativeBrowserRuntimeApi;
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 29, 0, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ ownerSessionId: "s1" }));
+    expect(screen.queryByLabelText("TinyOS shared desktop")).toBeNull();
+  });
+
   it("opens the handed-off browser and continues the Agent after explicit completion", async () => {
     const stores = createStores();
     const handoff = handoffBrowserSnapshot("user_required", 7);

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -11,6 +11,8 @@ import type { ReactChatMessage } from "./messageActions";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { createTinyOsAgentCancelCommand } from "../../app-core/chat/tinyOsCommand";
 import type { TinyOsEffectiveCapabilities } from "../../app-core/chat/tinyOsCapabilities";
+import { createTinyOsBrowserSessionSnapshot } from "../../app-core/chat/tinyOsNativeSnapshot";
+import type { NativeBrowserRuntimeApi } from "../../app-core/native/desktopNativeBrowser";
 import { timelineFromReactMessages } from "./testTimelineFixtures";
 
 const nativeFilePickerMocks = vi.hoisted(() => ({
@@ -172,6 +174,53 @@ function mockTurnSubmit(
   });
 }
 
+function handoffBrowserSnapshot(state: "idle" | "user_required", controlEpoch: number) {
+  return createTinyOsBrowserSessionSnapshot({
+    activeTabId: "tab-handoff",
+    browserSessionId: "browser-handoff",
+    contract: "browser_session_v1",
+    control: {
+      controlEpoch,
+      ...(state === "user_required" ? { reason: "Complete the login verification" } : {}),
+      state,
+    },
+    interaction: {
+      click: state === "idle",
+      key: state === "idle",
+      navigate: state === "idle",
+      scroll: state === "idle",
+      semantic: true,
+      type: state === "idle",
+      wait: state === "idle",
+    },
+    kind: "browser_session",
+    lifecycle: "ready",
+    operationId: "operation-browser-handoff",
+    profileId: "profile-browser-handoff",
+    profilePersistence: "persistent",
+    runtimeKind: "windows_webview2",
+    runtimeVersion: "test-webview2",
+    sessionId: "s1",
+    state: "running",
+    tabs: [{
+      activeHistoryIndex: 0,
+      captures: [{ captureId: "capture-handoff", observedAt: "2026-07-29T00:00:00Z", stale: false }],
+      currentCaptureId: "capture-handoff",
+      history: [{ captureId: "capture-handoff", title: "Login", url: "https://example.com/login" }],
+      loading: false,
+      observationRevision: 4,
+      rendererLifecycle: "running",
+      tabId: "tab-handoff",
+      title: "Login",
+      url: "https://example.com/login",
+    }],
+  }, {
+    observedAt: "2026-07-29T00:00:00Z",
+    revision: controlEpoch,
+    sourceId: "browser.handoff",
+  });
+}
+
 function failedPlanTimeline(sessionId = "s1") {
   const timeline = timelineFromReactMessages(sessionId, [{
     id: "u-failed-plan",
@@ -325,6 +374,47 @@ describe("ChatPage", () => {
     expect(openButton.getAttribute("aria-label")).toMatch(/^Open TinyOS/);
     expect(document.activeElement).toBe(openButton);
   }, 10_000);
+
+  it("opens the handed-off browser and continues the Agent after explicit completion", async () => {
+    const stores = createStores();
+    const handoff = handoffBrowserSnapshot("user_required", 7);
+    const idle = handoffBrowserSnapshot("idle", 8);
+    let currentSnapshot = handoff;
+    let listener: ((event: ChatEvent) => void) | undefined;
+    stores.chatStore.subscribe = vi.fn((_sessionId, nextListener) => {
+      listener = nextListener;
+      return () => undefined;
+    });
+    const interact = vi.fn(async () => {
+      currentSnapshot = idle;
+      listener?.({ browserSnapshot: idle, type: "browser.snapshot" });
+    });
+    stores.chatStore.browserRuntime = {
+      createSession: vi.fn(async () => currentSnapshot),
+      interact,
+      snapshot: vi.fn(async () => currentSnapshot),
+      updateSurface: vi.fn(async () => currentSnapshot),
+    } as unknown as NativeBrowserRuntimeApi;
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 29, 0, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await waitFor(() => expect(listener).toBeTruthy());
+    act(() => listener?.({ browserSnapshot: handoff, type: "browser.snapshot" }));
+
+    const canvas = await screen.findByLabelText("TinyOS shared desktop");
+    const browser = await within(canvas).findByLabelText("Browser window");
+    expect(browser.getAttribute("data-active")).toBe("true");
+    await userEvent.click(within(browser).getByRole("button", { name: "Done and continue" }));
+
+    expect(interact).toHaveBeenCalledWith(expect.objectContaining({
+      action: { type: "resume" },
+      browserSessionId: "browser-handoff",
+      controlEpoch: 7,
+      tabId: "tab-handoff",
+    }));
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
+      text: "我已完成浏览器中的必要操作。请重新读取当前页面，并从转交前的位置继续。",
+    }));
+  });
 
   it("attaches a TinyOS file range as a visible composer chip and structured chat reference", async () => {
     const user = userEvent.setup();

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -459,7 +459,7 @@ export function ChatPage({
   useEffect(() => {
     setBrowserSnapshot(undefined);
     setBrowserRuntimeError("");
-    if (!liveCanvasOpen || !activeSession?.id || !chatStore.browserRuntime) return;
+    if (!activeSession?.id || !chatStore.browserRuntime) return;
     let cancelled = false;
     void chatStore.browserRuntime.createSession({ ownerSessionId: activeSession.id }).then((snapshot) => {
       if (!cancelled) setBrowserSnapshot(snapshot);
@@ -469,7 +469,7 @@ export function ChatPage({
     return () => {
       cancelled = true;
     };
-  }, [activeSession?.id, chatStore, liveCanvasOpen]);
+  }, [activeSession?.id, chatStore]);
   const liveCanvasEntries = useMemo<LiveCanvasEntry[]>(() => (
     (timelineLoaded ? timeline?.turns ?? [] : []).flatMap((turn) => (
       (turn.executionItems ?? turn.steps).map((step) => ({ step, turnId: turn.id }))

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -158,6 +158,8 @@ const INITIAL_LIVE_CANVAS_STATE: LiveCanvasState = {
   visibility: "closed",
 };
 
+const BROWSER_HANDOFF_CONTINUE_MESSAGE = "我已完成浏览器中的必要操作。请重新读取当前页面，并从转交前的位置继续。";
+
 function reduceLiveCanvasState(state: LiveCanvasState, action: LiveCanvasAction): LiveCanvasState {
   switch (action.type) {
     case "close":
@@ -264,6 +266,7 @@ export function ChatPage({
   const [localSessionSidebarCollapsed, setLocalSessionSidebarCollapsed] = useState(false);
   const [drawer, setDrawer] = useState<DrawerState>(null);
   const [liveCanvas, dispatchLiveCanvas] = useReducer(reduceLiveCanvasState, INITIAL_LIVE_CANVAS_STATE);
+  const browserHandoffRef = useRef<{ browserSessionId: string; ownerSessionId: string } | undefined>(undefined);
   const [commandLifecycle, dispatchCommandLifecycle] = useReducer(
     reduceTinyOsCommandLifecycle,
     { stage: "idle" } as TinyOsCommandLifecycle,
@@ -431,6 +434,27 @@ export function ChatPage({
     );
     return () => window.clearTimeout(timer);
   }, [liveCanvas.visibility]);
+
+  useEffect(() => {
+    const browserSession = browserSnapshot?.data;
+    if (!browserSession || !activeSession?.id) return;
+    if (browserSession.control?.state === "user_required") {
+      browserHandoffRef.current = {
+        browserSessionId: browserSession.browserSessionId,
+        ownerSessionId: activeSession.id,
+      };
+      dispatchLiveCanvas({ type: "return_live" });
+      return;
+    }
+    const handoff = browserHandoffRef.current;
+    if (browserSession.control?.state !== "idle"
+      || handoff?.browserSessionId !== browserSession.browserSessionId
+      || handoff.ownerSessionId !== activeSession.id) {
+      return;
+    }
+    browserHandoffRef.current = undefined;
+    void handleBrowserHandoffComplete(activeSession);
+  }, [activeSession?.id, browserSnapshot?.data.browserSessionId, browserSnapshot?.data.control?.state]);
 
   useEffect(() => {
     setBrowserSnapshot(undefined);
@@ -1213,6 +1237,15 @@ export function ChatPage({
       sessionId,
       source: { control, surface: "chat" },
     }));
+  }
+
+  async function handleBrowserHandoffComplete(session: SessionSummary): Promise<void> {
+    try {
+      await dispatchTurn(session.id, { text: BROWSER_HANDOFF_CONTINUE_MESSAGE }, "browser-handoff-complete");
+      await handleSessionStoreRefresh(session);
+    } catch (error) {
+      setTimelineError(`Browser handoff could not continue the Agent: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   async function handleComposerSend(

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -470,6 +470,27 @@ export function ChatPage({
       cancelled = true;
     };
   }, [activeSession?.id, chatStore]);
+
+  useEffect(() => {
+    if (liveCanvas.visibility !== "open"
+      || browserSnapshot
+      || !activeSession?.id
+      || !chatStore.browserRuntime) {
+      return;
+    }
+    let cancelled = false;
+    void chatStore.browserRuntime.createSession({ ownerSessionId: activeSession.id }).then((snapshot) => {
+      if (!cancelled) {
+        setBrowserSnapshot(snapshot);
+        setBrowserRuntimeError("");
+      }
+    }).catch((error) => {
+      if (!cancelled) setBrowserRuntimeError(error instanceof Error ? error.message : String(error));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSession?.id, browserSnapshot, chatStore, liveCanvas.visibility]);
   const liveCanvasEntries = useMemo<LiveCanvasEntry[]>(() => (
     (timelineLoaded ? timeline?.turns ?? [] : []).flatMap((turn) => (
       (turn.executionItems ?? turn.steps).map((step) => ({ step, turnId: turn.id }))
@@ -1246,6 +1267,34 @@ export function ChatPage({
     } catch (error) {
       setTimelineError(`Browser handoff could not continue the Agent: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  async function handleExitTinyOs(): Promise<void> {
+    const browserSession = browserSnapshot?.data;
+    const browserRuntime = chatStore.browserRuntime;
+    if (browserSession && browserRuntime && browserSession.sessionId === activeSession?.id) {
+      try {
+        await browserRuntime.closeSession(browserSession.browserSessionId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setBrowserRuntimeError(message);
+        setTimelineError(`TinyOS browser could not be released: ${message}`);
+        console.error("[tinyos] browser.session.close.failed", {
+          browserSessionId: browserSession.browserSessionId,
+          error: message,
+          ownerSessionId: browserSession.sessionId,
+        });
+        return;
+      }
+      setBrowserSnapshot((current) => (
+        current?.data.browserSessionId === browserSession.browserSessionId ? undefined : current
+      ));
+      setBrowserRuntimeError("");
+      if (browserHandoffRef.current?.browserSessionId === browserSession.browserSessionId) {
+        browserHandoffRef.current = undefined;
+      }
+    }
+    dispatchLiveCanvas({ type: "close" });
   }
 
   async function handleComposerSend(
@@ -2058,6 +2107,7 @@ export function ChatPage({
           onCancelTurn={() => activeSession && void handleStopGeneration(activeSession, "tinyos")}
           onPauseTurn={() => void handleAgentTurnControl("agent.pause", "tinyos")}
           onClose={() => dispatchLiveCanvas({ type: "close" })}
+          onExit={handleExitTinyOs}
           onExpandedChange={() => dispatchLiveCanvas({ type: "expand_toggle" })}
           onOpenArtifact={(artifact) => void handleOpenArtifact(artifact)}
           onAgentRequest={(reference, intent, fromHistory) => void handleTinyOsAgentRequest(reference, intent, fromHistory)}

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -266,7 +266,6 @@ export function ChatPage({
   const [localSessionSidebarCollapsed, setLocalSessionSidebarCollapsed] = useState(false);
   const [drawer, setDrawer] = useState<DrawerState>(null);
   const [liveCanvas, dispatchLiveCanvas] = useReducer(reduceLiveCanvasState, INITIAL_LIVE_CANVAS_STATE);
-  const browserHandoffRef = useRef<{ browserSessionId: string; ownerSessionId: string } | undefined>(undefined);
   const [commandLifecycle, dispatchCommandLifecycle] = useReducer(
     reduceTinyOsCommandLifecycle,
     { stage: "idle" } as TinyOsCommandLifecycle,
@@ -437,24 +436,11 @@ export function ChatPage({
 
   useEffect(() => {
     const browserSession = browserSnapshot?.data;
-    if (!browserSession || !activeSession?.id) return;
+    if (!browserSession) return;
     if (browserSession.control?.state === "user_required") {
-      browserHandoffRef.current = {
-        browserSessionId: browserSession.browserSessionId,
-        ownerSessionId: activeSession.id,
-      };
       dispatchLiveCanvas({ type: "return_live" });
-      return;
     }
-    const handoff = browserHandoffRef.current;
-    if (browserSession.control?.state !== "idle"
-      || handoff?.browserSessionId !== browserSession.browserSessionId
-      || handoff.ownerSessionId !== activeSession.id) {
-      return;
-    }
-    browserHandoffRef.current = undefined;
-    void handleBrowserHandoffComplete(activeSession);
-  }, [activeSession?.id, browserSnapshot?.data.browserSessionId, browserSnapshot?.data.control?.state]);
+  }, [browserSnapshot?.data.browserSessionId, browserSnapshot?.data.control?.state]);
 
   useEffect(() => {
     setBrowserSnapshot(undefined);
@@ -1290,9 +1276,6 @@ export function ChatPage({
         current?.data.browserSessionId === browserSession.browserSessionId ? undefined : current
       ));
       setBrowserRuntimeError("");
-      if (browserHandoffRef.current?.browserSessionId === browserSession.browserSessionId) {
-        browserHandoffRef.current = undefined;
-      }
     }
     dispatchLiveCanvas({ type: "close" });
   }
@@ -2112,6 +2095,10 @@ export function ChatPage({
           onOpenArtifact={(artifact) => void handleOpenArtifact(artifact)}
           onAgentRequest={(reference, intent, fromHistory) => void handleTinyOsAgentRequest(reference, intent, fromHistory)}
           onCancelTerminal={handleCancelTinyOsTerminal}
+          onBrowserHandoffComplete={({ browserSessionId, ownerSessionId }) => {
+            if (activeSession?.id !== ownerSessionId || browserSnapshot?.data.browserSessionId !== browserSessionId) return;
+            void handleBrowserHandoffComplete(activeSession);
+          }}
           onBrowserInteract={handleInteractTinyOsBrowser}
           onDeleteFile={handleDeleteTinyOsFile}
           onExecuteTerminal={handleExecuteTinyOsTerminal}

--- a/src/react-workbench/chat/LiveCanvas.test.tsx
+++ b/src/react-workbench/chat/LiveCanvas.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { createRef } from "react";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
@@ -909,6 +909,76 @@ describe("LiveCanvas TinyOS", () => {
       layoutRevision: 42,
       tabId: "tab-1",
     });
+  });
+
+  it("does not resend an unchanged native browser surface", async () => {
+    const runtime = browserRuntimeMock();
+    const browserEntry = entry(step({ id: "browser-native-stable", kind: "browser" }));
+    render(<LiveCanvas {...canvasProps([browserEntry], {
+      browserRuntime: runtime.api,
+      nativeSnapshots: [browserSessionSnapshot()],
+    })} />);
+
+    await waitFor(() => expect(runtime.updateSurface).toHaveBeenCalledTimes(1));
+    runtime.updateSurface.mockClear();
+    fireEvent(window, new Event("resize"));
+    await act(async () => {
+      await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    });
+
+    expect(runtime.updateSurface).not.toHaveBeenCalled();
+  });
+
+  it("keeps the native browser surface attached while its TinyOS window is dragged", async () => {
+    const snapshot = browserSessionSnapshot();
+    const runtime = browserRuntimeMock(snapshot);
+    const browserEntry = entry(step({ id: "browser-native-drag", kind: "browser" }));
+    render(<LiveCanvas {...canvasProps([browserEntry], {
+      browserRuntime: runtime.api,
+      nativeSnapshots: [snapshot],
+      widthPx: 900,
+    })} />);
+
+    await waitFor(() => expect(runtime.updateSurface).toHaveBeenCalledWith(expect.objectContaining({ visible: true })));
+    runtime.updateSurface.mockClear();
+    let releaseFirstUpdate: (() => void) | undefined;
+    runtime.updateSurface.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseFirstUpdate = () => resolve(snapshot);
+    }));
+
+    const browserSurface = screen.getByLabelText("Browser page");
+    let browserSurfaceX = 0;
+    vi.spyOn(browserSurface, "getBoundingClientRect").mockImplementation(() => ({
+      bottom: 600,
+      height: 600,
+      left: browserSurfaceX,
+      right: browserSurfaceX + 800,
+      top: 0,
+      width: 800,
+      x: browserSurfaceX,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+    const titlebar = screen.getByLabelText("Move Browser window");
+    fireEvent.pointerDown(titlebar, { button: 0, clientX: 120, clientY: 80, pointerId: 7 });
+    browserSurfaceX = 120;
+    fireEvent.pointerMove(titlebar, { clientX: 240, clientY: 180, pointerId: 7 });
+
+    await waitFor(() => expect(runtime.updateSurface).toHaveBeenCalledTimes(1));
+    browserSurfaceX = 160;
+    fireEvent.pointerMove(titlebar, { clientX: 280, clientY: 210, pointerId: 7 });
+    browserSurfaceX = 200;
+    fireEvent.pointerMove(titlebar, { clientX: 320, clientY: 240, pointerId: 7 });
+    fireEvent(window, new Event("resize"));
+    await act(async () => {
+      await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    });
+
+    expect(runtime.updateSurface).toHaveBeenCalledTimes(1);
+    await act(async () => releaseFirstUpdate?.());
+    await waitFor(() => expect(runtime.updateSurface).toHaveBeenCalledTimes(2));
+    expect(runtime.updateSurface.mock.calls.every(([input]) => input.visible)).toBe(true);
+    expect(runtime.updateSurface).toHaveBeenCalledWith(expect.objectContaining({ visible: true }));
   });
 
   it("switches applications with keyboard shortcuts and restores session UI state", async () => {

--- a/src/react-workbench/chat/LiveCanvas.test.tsx
+++ b/src/react-workbench/chat/LiveCanvas.test.tsx
@@ -151,8 +151,7 @@ function browserSessionSnapshot() {
   });
 }
 
-function browserRuntimeMock() {
-  const snapshot = browserSessionSnapshot();
+function browserRuntimeMock(snapshot = browserSessionSnapshot()) {
   const activateTab = vi.fn(async () => snapshot);
   const back = vi.fn(async () => undefined);
   const closeSession = vi.fn(async () => undefined);
@@ -161,7 +160,9 @@ function browserRuntimeMock() {
   const createTab = vi.fn(async () => snapshot);
   const forward = vi.fn(async () => undefined);
   const navigate = vi.fn(async () => snapshot);
+  const interact = vi.fn(async () => undefined);
   const reload = vi.fn(async () => undefined);
+  const snapshotQuery = vi.fn(async () => snapshot);
   const stop = vi.fn(async () => undefined);
   const updateSurface = vi.fn(async (_input: Parameters<NativeBrowserRuntimeApi["updateSurface"]>[0]) => snapshot);
   const api = {
@@ -174,17 +175,17 @@ function browserRuntimeMock() {
     createTab,
     deleteProfile: vi.fn(),
     forward,
-    interact: vi.fn(),
+    interact,
     navigate,
     observe: vi.fn(),
     reload,
     resolvePolicyRequest: vi.fn(async () => snapshot),
     restartTab: vi.fn(async () => snapshot),
-    snapshot: vi.fn(async () => snapshot),
+    snapshot: snapshotQuery,
     stop,
     updateSurface,
   } as unknown as NativeBrowserRuntimeApi;
-  return { activateTab, api, back, closeSession, closeTab, createSession, createTab, forward, navigate, reload, stop, updateSurface };
+  return { activateTab, api, back, closeSession, closeTab, createSession, createTab, forward, interact, navigate, reload, snapshotQuery, stop, updateSurface };
 }
 
 describe("LiveCanvas TinyOS", () => {
@@ -855,6 +856,35 @@ describe("LiveCanvas TinyOS", () => {
     expect(runtime.stop).toHaveBeenCalledWith("browser-session-1", "tab-2");
     await user.click(within(browser).getByRole("button", { name: "Close Second tab" }));
     expect(runtime.closeTab).toHaveBeenCalledWith("browser-session-1", "tab-2");
+  });
+
+  it("lets the user explicitly return a handed-off browser to the Agent", async () => {
+    const handoff = browserSessionSnapshot();
+    handoff.data.control = {
+      controlEpoch: 7,
+      reason: "Complete the login verification",
+      state: "user_required",
+    };
+    const runtime = browserRuntimeMock(handoff);
+    render(<LiveCanvas {...canvasProps([], {
+      browserRuntime: runtime.api,
+      nativeSnapshots: [handoff],
+    })} />);
+
+    const browser = screen.getByLabelText("Browser window");
+    expect(browser.getAttribute("data-active")).toBe("true");
+    const prompt = within(browser).getByRole("alert", { name: "Browser user handoff" });
+    expect(within(prompt).getByText("Complete the login verification")).toBeTruthy();
+
+    await userEvent.click(within(prompt).getByRole("button", { name: "Done and continue" }));
+
+    expect(runtime.snapshotQuery).toHaveBeenCalledWith("browser-session-1");
+    expect(runtime.interact).toHaveBeenCalledWith(expect.objectContaining({
+      action: { type: "resume" },
+      browserSessionId: "browser-session-1",
+      controlEpoch: 7,
+      tabId: "tab-1",
+    }));
   });
 
   it("continues native browser surface revisions after the host remounts", async () => {

--- a/src/react-workbench/chat/LiveCanvas.test.tsx
+++ b/src/react-workbench/chat/LiveCanvas.test.tsx
@@ -79,6 +79,7 @@ function canvasProps(entries: LiveCanvasEntry[], overrides: Record<string, unkno
     onAgentRequest: vi.fn(),
     onAttachContext: vi.fn(),
     onClose: vi.fn(),
+    onExit: vi.fn(async () => undefined),
     onOpenArtifact: vi.fn(),
     onRetryOperation: vi.fn(),
     onReturnToLive: vi.fn(),
@@ -929,7 +930,7 @@ describe("LiveCanvas TinyOS", () => {
     expect(runtime.updateSurface).not.toHaveBeenCalled();
   });
 
-  it("keeps the native browser surface attached while its TinyOS window is dragged", async () => {
+  it("suspends the native browser surface during drag and applies only the final bounds", async () => {
     const snapshot = browserSessionSnapshot();
     const runtime = browserRuntimeMock(snapshot);
     const browserEntry = entry(step({ id: "browser-native-drag", kind: "browser" }));
@@ -941,9 +942,9 @@ describe("LiveCanvas TinyOS", () => {
 
     await waitFor(() => expect(runtime.updateSurface).toHaveBeenCalledWith(expect.objectContaining({ visible: true })));
     runtime.updateSurface.mockClear();
-    let releaseFirstUpdate: (() => void) | undefined;
+    let releaseHiddenUpdate: (() => void) | undefined;
     runtime.updateSurface.mockImplementationOnce(() => new Promise((resolve) => {
-      releaseFirstUpdate = () => resolve(snapshot);
+      releaseHiddenUpdate = () => resolve(snapshot);
     }));
 
     const browserSurface = screen.getByLabelText("Browser page");
@@ -961,24 +962,27 @@ describe("LiveCanvas TinyOS", () => {
     }));
     const titlebar = screen.getByLabelText("Move Browser window");
     fireEvent.pointerDown(titlebar, { button: 0, clientX: 120, clientY: 80, pointerId: 7 });
+    await waitFor(() => expect(runtime.updateSurface).toHaveBeenCalledWith(expect.objectContaining({ visible: false })));
     browserSurfaceX = 120;
     fireEvent.pointerMove(titlebar, { clientX: 240, clientY: 180, pointerId: 7 });
-
-    await waitFor(() => expect(runtime.updateSurface).toHaveBeenCalledTimes(1));
     browserSurfaceX = 160;
     fireEvent.pointerMove(titlebar, { clientX: 280, clientY: 210, pointerId: 7 });
     browserSurfaceX = 200;
     fireEvent.pointerMove(titlebar, { clientX: 320, clientY: 240, pointerId: 7 });
     fireEvent(window, new Event("resize"));
+    fireEvent.pointerUp(titlebar, { clientX: 320, clientY: 240, pointerId: 7 });
     await act(async () => {
-      await new Promise((resolve) => window.requestAnimationFrame(resolve));
+      await new Promise((resolve) => window.setTimeout(resolve, 120));
     });
 
     expect(runtime.updateSurface).toHaveBeenCalledTimes(1);
-    await act(async () => releaseFirstUpdate?.());
+    await act(async () => releaseHiddenUpdate?.());
     await waitFor(() => expect(runtime.updateSurface).toHaveBeenCalledTimes(2));
-    expect(runtime.updateSurface.mock.calls.every(([input]) => input.visible)).toBe(true);
-    expect(runtime.updateSurface).toHaveBeenCalledWith(expect.objectContaining({ visible: true }));
+    expect(runtime.updateSurface.mock.calls[0]?.[0]).toMatchObject({ visible: false });
+    expect(runtime.updateSurface.mock.calls[1]?.[0]).toMatchObject({
+      rect: { x: 200 },
+      visible: true,
+    });
   });
 
   it("switches applications with keyboard shortcuts and restores session UI state", async () => {
@@ -1183,5 +1187,19 @@ describe("LiveCanvas TinyOS", () => {
     rerender(<LiveCanvas {...canvasProps([form], { onClose })} />);
     expect(screen.queryByRole("button", { name: "Close TinyOS overlay" })).toBeNull();
     expect(screen.getByRole("dialog", { name: "TinyOS input request" })).toBeTruthy();
+  });
+
+  it("keeps hiding separate from exiting and releasing the browser", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onExit = vi.fn(async () => undefined);
+    render(<LiveCanvas {...canvasProps([], { onClose, onExit })} />);
+
+    await user.click(screen.getByRole("button", { name: "Close TinyOS desktop" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onExit).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Exit TinyOS and release browser" }));
+    expect(onExit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/react-workbench/chat/LiveCanvas.test.tsx
+++ b/src/react-workbench/chat/LiveCanvas.test.tsx
@@ -867,9 +867,11 @@ describe("LiveCanvas TinyOS", () => {
       state: "user_required",
     };
     const runtime = browserRuntimeMock(handoff);
+    const onBrowserHandoffComplete = vi.fn();
     render(<LiveCanvas {...canvasProps([], {
       browserRuntime: runtime.api,
       nativeSnapshots: [handoff],
+      onBrowserHandoffComplete,
     })} />);
 
     const browser = screen.getByLabelText("Browser window");
@@ -877,7 +879,7 @@ describe("LiveCanvas TinyOS", () => {
     const prompt = within(browser).getByRole("alert", { name: "Browser user handoff" });
     expect(within(prompt).getByText("Complete the login verification")).toBeTruthy();
 
-    await userEvent.click(within(prompt).getByRole("button", { name: "Done and continue" }));
+    await userEvent.click(within(prompt).getByRole("button", { name: "Hand control back to Agent" }));
 
     expect(runtime.snapshotQuery).toHaveBeenCalledWith("browser-session-1");
     expect(runtime.interact).toHaveBeenCalledWith(expect.objectContaining({
@@ -886,6 +888,10 @@ describe("LiveCanvas TinyOS", () => {
       controlEpoch: 7,
       tabId: "tab-1",
     }));
+    expect(onBrowserHandoffComplete).toHaveBeenCalledWith({
+      browserSessionId: "browser-session-1",
+      ownerSessionId: "session-1",
+    });
   });
 
   it("continues native browser surface revisions after the host remounts", async () => {

--- a/src/react-workbench/chat/LiveCanvas.tsx
+++ b/src/react-workbench/chat/LiveCanvas.tsx
@@ -6,7 +6,7 @@ import { tinyOsLayoutModeForWidth, type TinyOsAgentRequestIntent, type TinyOsAge
 import type { ArtifactRef, BackendAgentTurnItem, ChatStep } from "../../app-core/chat/chatTurnModel";
 import type { TinyOsBrowserAction } from "../../app-core/chat/tinyOsCommand";
 import type { TinyOsNativeSnapshot } from "../../app-core/chat/tinyOsNativeSnapshot";
-import { TinyOsShell } from "./TinyOsShell";
+import { TinyOsShell, type TinyOsBrowserHandoff } from "./TinyOsShell";
 import type { TinyOsFilesController } from "./useTinyOsFilesController";
 import { isTinyOsCommandInFlight, type TinyOsCommandLifecycle } from "../../app-core/chat/tinyOsCommand";
 import { createTinyOsShellCommandRegistry, defineTinyOsShellCommand, type TinyOsShellCommandAvailability } from "../../app-core/chat/tinyOsShellCommandRegistry";
@@ -56,6 +56,7 @@ export function LiveCanvas({
   onOpenArtifact,
   onAgentRequest,
   onCancelTerminal = async () => undefined,
+  onBrowserHandoffComplete = () => undefined,
   onBrowserInteract = async () => undefined,
   onDeleteFile = async () => undefined,
   onExecuteTerminal = async () => undefined,
@@ -117,6 +118,7 @@ export function LiveCanvas({
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent, fromHistory: boolean) => void;
   onCancelTerminal?: () => Promise<void>;
+  onBrowserHandoffComplete?: (input: TinyOsBrowserHandoff) => void;
   onBrowserInteract?: (input: { action: TinyOsBrowserAction; browserSessionId: string; captureId: string; controlEpoch: number; observationRevision: number; tabId: string }) => Promise<void>;
   onDeleteFile?: (input: { baseRevision: string; path: string }) => Promise<void>;
   onExecuteTerminal?: (input: { command: string; cwd?: string }) => Promise<void>;
@@ -394,6 +396,7 @@ export function LiveCanvas({
         onOpenArtifact={onOpenArtifact}
         onAgentRequest={(reference, intent) => onAgentRequest(reference, intent, mode === "history")}
         onCancelTerminal={onCancelTerminal}
+        onBrowserHandoffComplete={onBrowserHandoffComplete}
         onBrowserInteract={onBrowserInteract}
         onDeleteFile={onDeleteFile}
         onExecuteTerminal={onExecuteTerminal}

--- a/src/react-workbench/chat/LiveCanvas.tsx
+++ b/src/react-workbench/chat/LiveCanvas.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent, type RefObject } from "react";
-import { Maximize2, Minimize2, MonitorDot, Play, X } from "lucide-react";
+import { Maximize2, Minimize2, MonitorDot, Play, Power, X } from "lucide-react";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { projectKernelBackedTinyOsDesktop, projectTinyOsDesktop, type TinyOsTimelineEntry } from "../../app-core/chat/tinyOsDesktopModel";
 import { tinyOsLayoutModeForWidth, type TinyOsAgentRequestIntent, type TinyOsAgentRequestReference, type TinyOsContextReference } from "../../app-core/chat/tinyOsUiState";
@@ -51,6 +51,7 @@ export function LiveCanvas({
   onPauseTurn,
   onAttachContext,
   onClose,
+  onExit,
   onExpandedChange,
   onOpenArtifact,
   onAgentRequest,
@@ -111,6 +112,7 @@ export function LiveCanvas({
   onPauseTurn: () => void;
   onAttachContext: (reference: TinyOsContextReference) => void;
   onClose: () => void;
+  onExit: () => Promise<void>;
   onExpandedChange?: () => void;
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent, fromHistory: boolean) => void;
@@ -260,6 +262,17 @@ export function LiveCanvas({
       scope: "local_presentation",
       target: { kind: "shell" },
     }),
+    defineTinyOsShellCommand({
+      availability: { available: true },
+      category: "system",
+      dispatch: onExit,
+      id: "shell.exit",
+      input: { kind: "none" },
+      keywords: ["exit", "release", "browser", "tinyos"],
+      label: "Exit TinyOS and release browser",
+      scope: "runtime",
+      target: { kind: "shell" },
+    }),
   ], { simulationMode: mode === "history" ? "history" : "live" });
 
   useEffect(() => {
@@ -346,6 +359,9 @@ export function LiveCanvas({
             </button>
           ) : null}
           {onExpandedChange ? <button aria-label={expanded ? "Exit expanded TinyOS" : "Expand TinyOS to Chat surface"} title={expanded ? "Exit expanded mode" : "Expanded mode"} type="button" onClick={() => void canvasCommandRegistry.execute("shell.expanded_toggle")}>{expanded ? <Minimize2 aria-hidden="true" size={15} /> : <Maximize2 aria-hidden="true" size={15} />}</button> : null}
+          <button aria-label="Exit TinyOS and release browser" title="Exit TinyOS and release browser" type="button" onClick={() => void canvasCommandRegistry.execute("shell.exit")}>
+            <Power aria-hidden="true" size={16} />
+          </button>
           <button aria-label="Close TinyOS desktop" title="Close TinyOS" type="button" onClick={() => void canvasCommandRegistry.execute("shell.close")}>
             <X aria-hidden="true" size={16} />
           </button>

--- a/src/react-workbench/chat/TinyOsShell.tsx
+++ b/src/react-workbench/chat/TinyOsShell.tsx
@@ -108,6 +108,11 @@ type TinyOsPinnedEvidence = {
   resources: TinyOsResource[];
 };
 
+export type TinyOsBrowserHandoff = {
+  browserSessionId: string;
+  ownerSessionId: string;
+};
+
 export function TinyOsShell({
   agentUiForms,
   canCancelTerminal = false,
@@ -125,6 +130,7 @@ export function TinyOsShell({
   onOpenArtifact,
   onAgentRequest,
   onCancelTerminal = async () => undefined,
+  onBrowserHandoffComplete = () => undefined,
   onBrowserInteract = async () => undefined,
   onDeleteFile = async () => undefined,
   onExecuteTerminal = async () => undefined,
@@ -166,6 +172,7 @@ export function TinyOsShell({
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void;
   onCancelTerminal?: () => Promise<void>;
+  onBrowserHandoffComplete?: (input: TinyOsBrowserHandoff) => void;
   onBrowserInteract?: (input: { action: TinyOsBrowserAction; browserSessionId: string; captureId: string; controlEpoch: number; observationRevision: number; tabId: string }) => Promise<void>;
   onDeleteFile?: (input: TinyOsFileDeleteInput) => Promise<void>;
   onExecuteTerminal?: (input: TinyOsTerminalExecuteInput) => Promise<void>;
@@ -1069,6 +1076,7 @@ export function TinyOsShell({
             ])}
             onOpenArtifact={onOpenArtifact}
             onAgentRequest={onAgentRequest}
+            onBrowserHandoffComplete={onBrowserHandoffComplete}
             onDeleteFile={onDeleteFile}
             onMoveFile={onMoveFile}
             onSaveFile={onSaveFile}
@@ -1411,6 +1419,7 @@ function TinyOsAppWindow({
   onOpenContextMenu,
   onOpenArtifact,
   onAgentRequest,
+  onBrowserHandoffComplete,
   onDeleteFile,
   onMoveFile,
   onSaveFile,
@@ -1446,6 +1455,7 @@ function TinyOsAppWindow({
   onOpenContextMenu: (event: MouseEvent<HTMLElement>) => void;
   onOpenArtifact: (artifact: ArtifactRef) => void;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void;
+  onBrowserHandoffComplete: (input: TinyOsBrowserHandoff) => void;
   onDeleteFile: (input: TinyOsFileDeleteInput) => Promise<void>;
   onMoveFile: (input: TinyOsFileMoveInput) => Promise<void>;
   onSaveFile: (input: TinyOsFileSaveInput) => Promise<void>;
@@ -1624,6 +1634,7 @@ function TinyOsAppWindow({
           onAttachContext={onAttachContext}
           onOpenArtifact={onOpenArtifact}
           onAgentRequest={onAgentRequest}
+          onBrowserHandoffComplete={onBrowserHandoffComplete}
           onDeleteFile={onDeleteFile}
           onMoveFile={onMoveFile}
           onSaveFile={onSaveFile}
@@ -1648,7 +1659,7 @@ function TinyOsAppWindow({
   );
 }
 
-function TinyOsAppContent({ activeTabId, browserRuntime, browserSurfaceLayout, browserSurfaceVisible, canDirectEdit, canRequestChange, canSaveFile, commandLifecycle, commandRegistry, directEditUnavailableReason, filesController, kernel, layoutMode, window, onAgentRequest, onAttachContext, onDeleteFile, onMoveFile, onOpenArtifact, onSaveFile, onTabChange, requestChangeUnavailableReason, runningTerminalOperationId, saveFileUnavailableReason, systemMonitorControls }: {
+function TinyOsAppContent({ activeTabId, browserRuntime, browserSurfaceLayout, browserSurfaceVisible, canDirectEdit, canRequestChange, canSaveFile, commandLifecycle, commandRegistry, directEditUnavailableReason, filesController, kernel, layoutMode, window, onAgentRequest, onAttachContext, onBrowserHandoffComplete, onDeleteFile, onMoveFile, onOpenArtifact, onSaveFile, onTabChange, requestChangeUnavailableReason, runningTerminalOperationId, saveFileUnavailableReason, systemMonitorControls }: {
   activeTabId?: string;
   browserRuntime?: NativeBrowserRuntimeApi;
   browserSurfaceLayout?: TinyOsWindowRect;
@@ -1664,6 +1675,7 @@ function TinyOsAppContent({ activeTabId, browserRuntime, browserSurfaceLayout, b
   layoutMode: TinyOsLayoutMode;
   onAgentRequest: (reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent) => void;
   onAttachContext: (reference: TinyOsContextReference) => void;
+  onBrowserHandoffComplete: (input: TinyOsBrowserHandoff) => void;
   onDeleteFile: (input: TinyOsFileDeleteInput) => Promise<void>;
   onMoveFile: (input: TinyOsFileMoveInput) => Promise<void>;
   onOpenArtifact: (artifact: ArtifactRef) => void;
@@ -1682,7 +1694,7 @@ function TinyOsAppContent({ activeTabId, browserRuntime, browserSurfaceLayout, b
         : <EmptyCopy text="Workspace Explorer is unavailable." />
       : <TinyOsFiles activeTabId={activeTabId} canRequestChange={canRequestChange} window={window} onAgentRequest={onAgentRequest} onAttachContext={onAttachContext} onTabChange={onTabChange} requestChangeUnavailableReason={requestChangeUnavailableReason} />;
     case "terminal": return <div className="tinyos-terminal-host"><TinyOsTerminalHostControls commandLifecycle={commandLifecycle} commandRegistry={commandRegistry} runningOperationId={runningTerminalOperationId} />{window.entries.length ? <TinyOsTerminal activeTabId={activeTabId} canRequestChange={canRequestChange} kernel={kernel} window={window} onAgentRequest={onAgentRequest} onAttachContext={onAttachContext} onTabChange={onTabChange} requestChangeUnavailableReason={requestChangeUnavailableReason} /> : <EmptyCopy text="Run a reviewed command to create a retained canonical execution. TinyOS does not present this as a persistent PTY session." />}</div>;
-    case "browser": return <TinyOsBrowser browserRuntime={browserRuntime} kernel={kernel} surfaceLayout={browserSurfaceLayout} surfaceVisible={browserSurfaceVisible} />;
+    case "browser": return <TinyOsBrowser browserRuntime={browserRuntime} kernel={kernel} onHandoffComplete={onBrowserHandoffComplete} surfaceLayout={browserSurfaceLayout} surfaceVisible={browserSurfaceVisible} />;
     case "plan": return <TinyOsPlan canRequestChange={canRequestChange} entry={[...window.entries].reverse().find(({ step }) => Boolean(step.plan)) ?? window.entries[window.entries.length - 1]} onAgentRequest={onAgentRequest} requestChangeUnavailableReason={requestChangeUnavailableReason} />;
     case "subagents": return <TinyOsSubagents window={window} />;
     case "artifacts": return <TinyOsArtifacts window={window} onOpenArtifact={onOpenArtifact} />;
@@ -1898,9 +1910,10 @@ function TinyOsTerminal({ activeTabId, canRequestChange, kernel, onAgentRequest,
   );
 }
 
-function TinyOsBrowser({ browserRuntime, kernel, surfaceLayout, surfaceVisible }: {
+function TinyOsBrowser({ browserRuntime, kernel, onHandoffComplete, surfaceLayout, surfaceVisible }: {
   browserRuntime?: NativeBrowserRuntimeApi;
   kernel?: TinyOsKernelSnapshot;
+  onHandoffComplete: (input: TinyOsBrowserHandoff) => void;
   surfaceLayout?: TinyOsWindowRect;
   surfaceVisible: boolean;
 }) {
@@ -1989,6 +2002,10 @@ function TinyOsBrowser({ browserRuntime, kernel, surfaceLayout, surfaceVisible }
         controlEpoch: latest.data.control.controlEpoch,
         tabId: latest.data.activeTabId,
       });
+      onHandoffComplete({
+        browserSessionId: latest.data.browserSessionId,
+        ownerSessionId: latest.data.sessionId,
+      });
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : String(reason));
     } finally {
@@ -2039,8 +2056,8 @@ function TinyOsBrowser({ browserRuntime, kernel, surfaceLayout, surfaceVisible }
       <div><button type="button" onClick={() => void execute(() => browserRuntime.resolvePolicyRequest(session.browserSessionId, session.pendingPolicyRequest!.requestId, false))}>Deny</button><button type="button" onClick={() => void execute(() => browserRuntime.resolvePolicyRequest(session.browserSessionId, session.pendingPolicyRequest!.requestId, true))}>Allow once</button></div>
     </section> : null}
     {session.control?.state === "user_required" && !session.pendingPolicyRequest ? <section aria-label="Browser user handoff" className="tinyos-browser__handoff" role="alert">
-      <div><ShieldCheck aria-hidden="true" size={14} /><span><strong>Finish this step in the browser</strong><span>{session.control.reason || "Complete the requested browser interaction, then return control to the Agent."}</span></span></div>
-      <button disabled={handoffCompleting} type="button" onClick={() => void completeUserHandoff()}>{handoffCompleting ? "Continuing…" : "Done and continue"}</button>
+      <div><ShieldCheck aria-hidden="true" size={14} /><span><strong>You have browser control</strong><span>{session.control.reason || "Continue in the browser until you want the Agent to take over."}</span></span></div>
+      <button disabled={handoffCompleting} type="button" onClick={() => void completeUserHandoff()}>{handoffCompleting ? "Handing back…" : "Hand control back to Agent"}</button>
     </section> : null}
     {tab.rendererLifecycle === "failed"
       ? <div className="tinyos-browser__unavailable" role="alert"><AlertTriangle aria-hidden="true" size={22} /><strong>{session.lifecycle === "failed" ? "Browser failed to start" : "This tab stopped responding"}</strong><span>{session.control?.reason || (session.lifecycle === "failed" ? "Retry the shared browser session." : "Restart it to continue in the same shared browser session.")}</span><button type="button" onClick={() => void (session.lifecycle === "failed" ? retryFailedSession() : execute(() => browserRuntime.restartTab(session.browserSessionId, tab.tabId)))}>{session.lifecycle === "failed" ? "Retry browser" : "Restart tab"}</button></div>

--- a/src/react-workbench/chat/TinyOsShell.tsx
+++ b/src/react-workbench/chat/TinyOsShell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type DragEvent, type KeyboardEvent, type MouseEvent, type PointerEvent } from "react";
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type DragEvent, type KeyboardEvent, type MouseEvent, type PointerEvent } from "react";
 import { gsap } from "gsap";
 import {
   Activity,
@@ -1462,7 +1462,6 @@ function TinyOsAppWindow({
   const Icon = APP_ICONS[window.appId];
   const latest = window.entries[window.entries.length - 1];
   const windowRef = useRef<HTMLElement>(null);
-  const [pointerActive, setPointerActive] = useState(false);
   const pointerState = useRef<{
     kind: "move" | "resize";
     pointerId: number;
@@ -1503,7 +1502,6 @@ function TinyOsAppWindow({
     if (kind === "move" && (event.target as Element).closest("button")) return;
     event.preventDefault();
     onFocus();
-    setPointerActive(true);
     pointerState.current = {
       kind,
       pointerId: event.pointerId,
@@ -1533,7 +1531,6 @@ function TinyOsAppWindow({
   function endPointer(event: PointerEvent<HTMLElement>) {
     if (pointerState.current?.pointerId !== event.pointerId) return;
     pointerState.current = undefined;
-    setPointerActive(false);
     if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
   }
 
@@ -1611,7 +1608,8 @@ function TinyOsAppWindow({
           canRequestChange={canRequestChange}
           canSaveFile={canSaveFile}
           browserRuntime={browserRuntime}
-          browserSurfaceVisible={active && browserSurfaceAllowed && !pointerActive}
+          browserSurfaceLayout={layout}
+          browserSurfaceVisible={active && browserSurfaceAllowed}
           commandLifecycle={systemMonitorControls.commandLifecycle}
           commandRegistry={commandRegistry}
           directEditUnavailableReason={directEditUnavailableReason}
@@ -1645,9 +1643,10 @@ function TinyOsAppWindow({
   );
 }
 
-function TinyOsAppContent({ activeTabId, browserRuntime, browserSurfaceVisible, canDirectEdit, canRequestChange, canSaveFile, commandLifecycle, commandRegistry, directEditUnavailableReason, filesController, kernel, layoutMode, window, onAgentRequest, onAttachContext, onDeleteFile, onMoveFile, onOpenArtifact, onSaveFile, onTabChange, requestChangeUnavailableReason, runningTerminalOperationId, saveFileUnavailableReason, systemMonitorControls }: {
+function TinyOsAppContent({ activeTabId, browserRuntime, browserSurfaceLayout, browserSurfaceVisible, canDirectEdit, canRequestChange, canSaveFile, commandLifecycle, commandRegistry, directEditUnavailableReason, filesController, kernel, layoutMode, window, onAgentRequest, onAttachContext, onDeleteFile, onMoveFile, onOpenArtifact, onSaveFile, onTabChange, requestChangeUnavailableReason, runningTerminalOperationId, saveFileUnavailableReason, systemMonitorControls }: {
   activeTabId?: string;
   browserRuntime?: NativeBrowserRuntimeApi;
+  browserSurfaceLayout?: TinyOsWindowRect;
   browserSurfaceVisible: boolean;
   canDirectEdit: boolean;
   canRequestChange: boolean;
@@ -1678,7 +1677,7 @@ function TinyOsAppContent({ activeTabId, browserRuntime, browserSurfaceVisible, 
         : <EmptyCopy text="Workspace Explorer is unavailable." />
       : <TinyOsFiles activeTabId={activeTabId} canRequestChange={canRequestChange} window={window} onAgentRequest={onAgentRequest} onAttachContext={onAttachContext} onTabChange={onTabChange} requestChangeUnavailableReason={requestChangeUnavailableReason} />;
     case "terminal": return <div className="tinyos-terminal-host"><TinyOsTerminalHostControls commandLifecycle={commandLifecycle} commandRegistry={commandRegistry} runningOperationId={runningTerminalOperationId} />{window.entries.length ? <TinyOsTerminal activeTabId={activeTabId} canRequestChange={canRequestChange} kernel={kernel} window={window} onAgentRequest={onAgentRequest} onAttachContext={onAttachContext} onTabChange={onTabChange} requestChangeUnavailableReason={requestChangeUnavailableReason} /> : <EmptyCopy text="Run a reviewed command to create a retained canonical execution. TinyOS does not present this as a persistent PTY session." />}</div>;
-    case "browser": return <TinyOsBrowser browserRuntime={browserRuntime} kernel={kernel} surfaceVisible={browserSurfaceVisible} />;
+    case "browser": return <TinyOsBrowser browserRuntime={browserRuntime} kernel={kernel} surfaceLayout={browserSurfaceLayout} surfaceVisible={browserSurfaceVisible} />;
     case "plan": return <TinyOsPlan canRequestChange={canRequestChange} entry={[...window.entries].reverse().find(({ step }) => Boolean(step.plan)) ?? window.entries[window.entries.length - 1]} onAgentRequest={onAgentRequest} requestChangeUnavailableReason={requestChangeUnavailableReason} />;
     case "subagents": return <TinyOsSubagents window={window} />;
     case "artifacts": return <TinyOsArtifacts window={window} onOpenArtifact={onOpenArtifact} />;
@@ -1894,9 +1893,10 @@ function TinyOsTerminal({ activeTabId, canRequestChange, kernel, onAgentRequest,
   );
 }
 
-function TinyOsBrowser({ browserRuntime, kernel, surfaceVisible }: {
+function TinyOsBrowser({ browserRuntime, kernel, surfaceLayout, surfaceVisible }: {
   browserRuntime?: NativeBrowserRuntimeApi;
   kernel?: TinyOsKernelSnapshot;
+  surfaceLayout?: TinyOsWindowRect;
   surfaceVisible: boolean;
 }) {
   const session = kernel?.browserSessions[0];
@@ -2039,7 +2039,7 @@ function TinyOsBrowser({ browserRuntime, kernel, surfaceVisible }: {
     </section> : null}
     {tab.rendererLifecycle === "failed"
       ? <div className="tinyos-browser__unavailable" role="alert"><AlertTriangle aria-hidden="true" size={22} /><strong>{session.lifecycle === "failed" ? "Browser failed to start" : "This tab stopped responding"}</strong><span>{session.control?.reason || (session.lifecycle === "failed" ? "Retry the shared browser session." : "Restart it to continue in the same shared browser session.")}</span><button type="button" onClick={() => void (session.lifecycle === "failed" ? retryFailedSession() : execute(() => browserRuntime.restartTab(session.browserSessionId, tab.tabId)))}>{session.lifecycle === "failed" ? "Retry browser" : "Restart tab"}</button></div>
-      : <BrowserSurfaceHost browserRuntime={browserRuntime} onError={setError} session={session} tabId={tab.tabId} visible={liveSurfaceVisible} />}
+      : <BrowserSurfaceHost browserRuntime={browserRuntime} onError={setError} session={session} surfaceLayout={surfaceLayout} tabId={tab.tabId} visible={liveSurfaceVisible} />}
     {error ? <p className="tinyos-browser__error" role="alert">{error}</p> : null}
   </div>;
 }
@@ -2078,10 +2078,29 @@ function browserControlCopy(state?: "idle" | "agent_active" | "user_required" | 
   }
 }
 
-function BrowserSurfaceHost({ browserRuntime, onError, session, tabId, visible }: {
+type BrowserSurfaceUpdateInput = Parameters<NativeBrowserRuntimeApi["updateSurface"]>[0];
+
+function sameBrowserSurfaceUpdate(left: BrowserSurfaceUpdateInput | undefined, right: BrowserSurfaceUpdateInput): boolean {
+  if (!left) return false;
+  return left.browserSessionId === right.browserSessionId
+    && left.live === right.live
+    && left.rect.deviceScale === right.rect.deviceScale
+    && left.rect.height === right.rect.height
+    && left.rect.width === right.rect.width
+    && left.rect.x === right.rect.x
+    && left.rect.y === right.rect.y
+    && left.surfaceId === right.surfaceId
+    && left.tabId === right.tabId
+    && left.topmost === right.topmost
+    && left.unobscured === right.unobscured
+    && left.visible === right.visible;
+}
+
+function BrowserSurfaceHost({ browserRuntime, onError, session, surfaceLayout, tabId, visible }: {
   browserRuntime?: NativeBrowserRuntimeApi;
   onError: (message: string) => void;
   session: TinyOsKernelSnapshot["browserSessions"][number];
+  surfaceLayout?: TinyOsWindowRect;
   tabId: string;
   visible: boolean;
 }) {
@@ -2089,57 +2108,83 @@ function BrowserSurfaceHost({ browserRuntime, onError, session, tabId, visible }
   const nativeLayoutRevision = session.surface?.layoutRevision ?? 0;
   const layoutRevision = useRef(nativeLayoutRevision);
   layoutRevision.current = Math.max(layoutRevision.current, nativeLayoutRevision);
-  const pendingUpdates = useRef<Promise<void>>(Promise.resolve());
+  const lastReportedUpdate = useRef<BrowserSurfaceUpdateInput | undefined>(undefined);
+  const pendingUpdate = useRef<BrowserSurfaceUpdateInput | undefined>(undefined);
+  const updateInFlight = useRef(false);
+  const frame = useRef(0);
+  const scheduledVisible = useRef(visible);
   const surfaceId = useMemo(() => `tinyos-browser-surface-${session.browserSessionId}`, [session.browserSessionId]);
+
+  const flushUpdate = useCallback(function flushPendingSurfaceUpdate() {
+    const input = pendingUpdate.current;
+    if (!browserRuntime || updateInFlight.current || !input) return;
+    pendingUpdate.current = undefined;
+    updateInFlight.current = true;
+    void browserRuntime.updateSurface(input).catch((reason) => {
+      if (sameBrowserSurfaceUpdate(lastReportedUpdate.current, input)) {
+        lastReportedUpdate.current = undefined;
+      }
+      onError(reason instanceof Error ? reason.message : String(reason));
+    }).finally(() => {
+      updateInFlight.current = false;
+      flushPendingSurfaceUpdate();
+    });
+  }, [browserRuntime, onError]);
+
+  const report = useCallback((nextVisible: boolean) => {
+    const host = hostRef.current;
+    if (!host || !browserRuntime) return;
+    const bounds = host.getBoundingClientRect();
+    const nextUpdate: BrowserSurfaceUpdateInput = {
+      browserSessionId: session.browserSessionId,
+      layoutRevision: layoutRevision.current + 1,
+      live: true,
+      rect: {
+        deviceScale: window.devicePixelRatio || 1,
+        height: Math.max(1, bounds.height),
+        width: Math.max(1, bounds.width),
+        x: Math.max(0, bounds.x),
+        y: Math.max(0, bounds.y),
+      },
+      surfaceId,
+      tabId,
+      topmost: nextVisible,
+      unobscured: nextVisible,
+      visible: nextVisible,
+    };
+    if (sameBrowserSurfaceUpdate(lastReportedUpdate.current, nextUpdate)) return;
+    layoutRevision.current = nextUpdate.layoutRevision;
+    lastReportedUpdate.current = nextUpdate;
+    pendingUpdate.current = nextUpdate;
+    flushUpdate();
+  }, [browserRuntime, flushUpdate, session.browserSessionId, surfaceId, tabId]);
+
+  const schedule = useCallback((nextVisible: boolean) => {
+    scheduledVisible.current = nextVisible;
+    window.cancelAnimationFrame(frame.current);
+    frame.current = window.requestAnimationFrame(() => report(scheduledVisible.current));
+  }, [report]);
 
   useLayoutEffect(() => {
     const host = hostRef.current;
     if (!host || !browserRuntime) return;
-    let disposed = false;
-    let frame = 0;
-    const report = (nextVisible: boolean) => {
-      if (disposed && nextVisible) return;
-      const bounds = host.getBoundingClientRect();
-      layoutRevision.current += 1;
-      const input = {
-        browserSessionId: session.browserSessionId,
-        layoutRevision: layoutRevision.current,
-        live: true,
-        rect: {
-          deviceScale: window.devicePixelRatio || 1,
-          height: Math.max(1, bounds.height),
-          width: Math.max(1, bounds.width),
-          x: Math.max(0, bounds.x),
-          y: Math.max(0, bounds.y),
-        },
-        surfaceId,
-        tabId,
-        topmost: nextVisible,
-        unobscured: nextVisible,
-        visible: nextVisible,
-      };
-      pendingUpdates.current = pendingUpdates.current.then(() => browserRuntime.updateSurface(input)).then(() => undefined).catch((reason) => {
-        onError(reason instanceof Error ? reason.message : String(reason));
-      });
-    };
-    const schedule = () => {
-      window.cancelAnimationFrame(frame);
-      frame = window.requestAnimationFrame(() => report(visible));
-    };
-    const observer = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(schedule);
+    const scheduleCurrent = () => schedule(visible);
+    const observer = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(scheduleCurrent);
     observer?.observe(host);
-    window.addEventListener("resize", schedule);
-    window.addEventListener("scroll", schedule, true);
-    report(visible);
+    window.addEventListener("resize", scheduleCurrent);
+    window.addEventListener("scroll", scheduleCurrent, true);
     return () => {
-      disposed = true;
-      window.cancelAnimationFrame(frame);
+      window.cancelAnimationFrame(frame.current);
       observer?.disconnect();
-      window.removeEventListener("resize", schedule);
-      window.removeEventListener("scroll", schedule, true);
+      window.removeEventListener("resize", scheduleCurrent);
+      window.removeEventListener("scroll", scheduleCurrent, true);
       report(false);
     };
-  }, [browserRuntime, onError, session.browserSessionId, surfaceId, tabId, visible]);
+  }, [browserRuntime, report, schedule, visible]);
+
+  useLayoutEffect(() => {
+    schedule(visible);
+  }, [schedule, surfaceLayout?.height, surfaceLayout?.width, surfaceLayout?.x, surfaceLayout?.y, visible]);
 
   return <div aria-label="Browser page" aria-labelledby={`tinyos-browser-tab-${tabId}`} className="tinyos-browser__surface-host" data-live={visible ? "true" : undefined} id="tinyos-browser-page" ref={hostRef} role="tabpanel"><span aria-live="polite">{visible ? "Loading live page…" : "Browser temporarily hidden"}</span></div>;
 }

--- a/src/react-workbench/chat/TinyOsShell.tsx
+++ b/src/react-workbench/chat/TinyOsShell.tsx
@@ -1462,6 +1462,7 @@ function TinyOsAppWindow({
   const Icon = APP_ICONS[window.appId];
   const latest = window.entries[window.entries.length - 1];
   const windowRef = useRef<HTMLElement>(null);
+  const [pointerActive, setPointerActive] = useState(false);
   const pointerState = useRef<{
     kind: "move" | "resize";
     pointerId: number;
@@ -1502,6 +1503,7 @@ function TinyOsAppWindow({
     if (kind === "move" && (event.target as Element).closest("button")) return;
     event.preventDefault();
     onFocus();
+    setPointerActive(true);
     pointerState.current = {
       kind,
       pointerId: event.pointerId,
@@ -1531,6 +1533,7 @@ function TinyOsAppWindow({
   function endPointer(event: PointerEvent<HTMLElement>) {
     if (pointerState.current?.pointerId !== event.pointerId) return;
     pointerState.current = undefined;
+    setPointerActive(false);
     if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
   }
 
@@ -1592,6 +1595,7 @@ function TinyOsAppWindow({
         onKeyDown={handleWindowKeyDown}
         onPointerDown={(event) => startPointer(event, "move")}
         onPointerMove={movePointer}
+        onPointerCancel={endPointer}
         onPointerUp={endPointer}
       >
         <span><Icon aria-hidden="true" size={15} /><strong>{window.title}</strong></span>
@@ -1609,7 +1613,7 @@ function TinyOsAppWindow({
           canSaveFile={canSaveFile}
           browserRuntime={browserRuntime}
           browserSurfaceLayout={layout}
-          browserSurfaceVisible={active && browserSurfaceAllowed}
+          browserSurfaceVisible={active && browserSurfaceAllowed && !pointerActive}
           commandLifecycle={systemMonitorControls.commandLifecycle}
           commandRegistry={commandRegistry}
           directEditUnavailableReason={directEditUnavailableReason}
@@ -1637,6 +1641,7 @@ function TinyOsAppWindow({
         tabIndex={-1}
         onPointerDown={(event) => startPointer(event, "resize")}
         onPointerMove={movePointer}
+        onPointerCancel={endPointer}
         onPointerUp={endPointer}
       />
     </article>
@@ -2079,6 +2084,7 @@ function browserControlCopy(state?: "idle" | "agent_active" | "user_required" | 
 }
 
 type BrowserSurfaceUpdateInput = Parameters<NativeBrowserRuntimeApi["updateSurface"]>[0];
+const BROWSER_SURFACE_SETTLE_MS = 80;
 
 function sameBrowserSurfaceUpdate(left: BrowserSurfaceUpdateInput | undefined, right: BrowserSurfaceUpdateInput): boolean {
   if (!left) return false;
@@ -2094,6 +2100,16 @@ function sameBrowserSurfaceUpdate(left: BrowserSurfaceUpdateInput | undefined, r
     && left.topmost === right.topmost
     && left.unobscured === right.unobscured
     && left.visible === right.visible;
+}
+
+function sameHiddenBrowserSurfaceTarget(left: BrowserSurfaceUpdateInput | undefined, right: BrowserSurfaceUpdateInput): boolean {
+  return Boolean(left
+    && !left.visible
+    && !right.visible
+    && left.browserSessionId === right.browserSessionId
+    && left.live === right.live
+    && left.surfaceId === right.surfaceId
+    && left.tabId === right.tabId);
 }
 
 function BrowserSurfaceHost({ browserRuntime, onError, session, surfaceLayout, tabId, visible }: {
@@ -2112,6 +2128,7 @@ function BrowserSurfaceHost({ browserRuntime, onError, session, surfaceLayout, t
   const pendingUpdate = useRef<BrowserSurfaceUpdateInput | undefined>(undefined);
   const updateInFlight = useRef(false);
   const frame = useRef(0);
+  const settleTimer = useRef(0);
   const scheduledVisible = useRef(visible);
   const surfaceId = useMemo(() => `tinyos-browser-surface-${session.browserSessionId}`, [session.browserSessionId]);
 
@@ -2152,7 +2169,8 @@ function BrowserSurfaceHost({ browserRuntime, onError, session, surfaceLayout, t
       unobscured: nextVisible,
       visible: nextVisible,
     };
-    if (sameBrowserSurfaceUpdate(lastReportedUpdate.current, nextUpdate)) return;
+    if (sameBrowserSurfaceUpdate(lastReportedUpdate.current, nextUpdate)
+      || sameHiddenBrowserSurfaceTarget(lastReportedUpdate.current, nextUpdate)) return;
     layoutRevision.current = nextUpdate.layoutRevision;
     lastReportedUpdate.current = nextUpdate;
     pendingUpdate.current = nextUpdate;
@@ -2162,7 +2180,16 @@ function BrowserSurfaceHost({ browserRuntime, onError, session, surfaceLayout, t
   const schedule = useCallback((nextVisible: boolean) => {
     scheduledVisible.current = nextVisible;
     window.cancelAnimationFrame(frame.current);
-    frame.current = window.requestAnimationFrame(() => report(scheduledVisible.current));
+    window.clearTimeout(settleTimer.current);
+    const enqueue = () => {
+      settleTimer.current = 0;
+      frame.current = window.requestAnimationFrame(() => report(scheduledVisible.current));
+    };
+    if (nextVisible) {
+      settleTimer.current = window.setTimeout(enqueue, BROWSER_SURFACE_SETTLE_MS);
+    } else {
+      enqueue();
+    }
   }, [report]);
 
   useLayoutEffect(() => {
@@ -2175,6 +2202,7 @@ function BrowserSurfaceHost({ browserRuntime, onError, session, surfaceLayout, t
     window.addEventListener("scroll", scheduleCurrent, true);
     return () => {
       window.cancelAnimationFrame(frame.current);
+      window.clearTimeout(settleTimer.current);
       observer?.disconnect();
       window.removeEventListener("resize", scheduleCurrent);
       window.removeEventListener("scroll", scheduleCurrent, true);

--- a/src/react-workbench/chat/TinyOsShell.tsx
+++ b/src/react-workbench/chat/TinyOsShell.tsx
@@ -232,7 +232,11 @@ export function TinyOsShell({
   const initialWindowIds = useRef(new Set(appWindows.map((window) => window.id)));
   const initialAppIds = appWindows.map((window) => window.appId);
   const browserSessionAvailable = Boolean(snapshot.kernel?.browserSessions.length);
+  const browserNeedsUser = snapshot.kernel?.browserSessions.some(
+    (session) => session.control?.state === "user_required",
+  ) ?? false;
   const browserSessionWasAvailable = useRef(browserSessionAvailable);
+  const browserNeededUser = useRef(false);
   const seenFileOperations = useRef(new Set<string>());
   const revealedCursorItemId = useRef<string | undefined>(undefined);
   const previousHistoryMode = useRef(history);
@@ -353,18 +357,20 @@ export function TinyOsShell({
   useEffect(() => {
     const returningToLive = previousHistoryMode.current && !history;
     const browserBecameAvailable = !browserSessionWasAvailable.current && browserSessionAvailable;
+    const browserBeganNeedingUser = !browserNeededUser.current && browserNeedsUser;
     previousHistoryMode.current = history;
     browserSessionWasAvailable.current = browserSessionAvailable;
+    browserNeededUser.current = browserNeedsUser;
     dispatchUi({
       appIds: appWindows.map((window) => window.appId),
       bounds: uiState.bounds,
       layoutMode,
-      preferredActiveAppId: browserBecameAvailable
+      preferredActiveAppId: browserBecameAvailable || browserBeganNeedingUser
         ? "browser"
         : history || returningToLive ? snapshot.activeAppId : uiState.focusedAppId,
       type: "sync",
     });
-  }, [appWindows.length, browserSessionAvailable, history, layoutMode, snapshot.activeAppId, snapshot.cursorItemId, snapshot.cursorTurnId]);
+  }, [appWindows.length, browserNeedsUser, browserSessionAvailable, history, layoutMode, snapshot.activeAppId, snapshot.cursorItemId, snapshot.cursorTurnId]);
 
   useEffect(() => {
     const desktop = desktopRef.current;
@@ -1899,6 +1905,7 @@ function TinyOsBrowser({ browserRuntime, kernel, surfaceVisible }: {
   const tab = session?.tabs.find(({ tabId }) => tabId === activeTabId);
   const [address, setAddress] = useState(tab?.url ?? "");
   const [error, setError] = useState("");
+  const [handoffCompleting, setHandoffCompleting] = useState(false);
   const liveRuntimeAvailable = Boolean(browserRuntime && session && tab && session.runtimeKind === "windows_webview2");
   const liveSurfaceVisible = liveRuntimeAvailable && surfaceVisible && tab?.rendererLifecycle !== "failed";
 
@@ -1961,6 +1968,29 @@ function TinyOsBrowser({ browserRuntime, kernel, surfaceVisible }: {
     });
   }
 
+  async function completeUserHandoff() {
+    if (!browserRuntime || !session) return;
+    setError("");
+    setHandoffCompleting(true);
+    try {
+      const latest = await browserRuntime.snapshot(session.browserSessionId);
+      if (latest.data.control?.state !== "user_required") {
+        throw new Error("Browser control is no longer waiting for user completion.");
+      }
+      await browserRuntime.interact({
+        action: { type: "resume" },
+        browserSessionId: latest.data.browserSessionId,
+        commandId: `browser-handoff-resume-${Date.now().toString(36)}`,
+        controlEpoch: latest.data.control.controlEpoch,
+        tabId: latest.data.activeTabId,
+      });
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      setHandoffCompleting(false);
+    }
+  }
+
   if (!browserRuntime) {
     return <BrowserUnavailable message="The live browser is unavailable in this desktop build." />;
   }
@@ -2002,6 +2032,10 @@ function TinyOsBrowser({ browserRuntime, kernel, surfaceVisible }: {
     {session.pendingPolicyRequest ? <section aria-label="Browser policy confirmation" className="tinyos-browser__policy" role="alert">
       <div><ShieldCheck aria-hidden="true" size={14} /><span><strong>{session.pendingPolicyRequest.kind === "popup" ? "Open popup as a managed tab?" : "Open external application?"}</strong><code>{session.pendingPolicyRequest.safeUrl}</code></span></div>
       <div><button type="button" onClick={() => void execute(() => browserRuntime.resolvePolicyRequest(session.browserSessionId, session.pendingPolicyRequest!.requestId, false))}>Deny</button><button type="button" onClick={() => void execute(() => browserRuntime.resolvePolicyRequest(session.browserSessionId, session.pendingPolicyRequest!.requestId, true))}>Allow once</button></div>
+    </section> : null}
+    {session.control?.state === "user_required" && !session.pendingPolicyRequest ? <section aria-label="Browser user handoff" className="tinyos-browser__handoff" role="alert">
+      <div><ShieldCheck aria-hidden="true" size={14} /><span><strong>Finish this step in the browser</strong><span>{session.control.reason || "Complete the requested browser interaction, then return control to the Agent."}</span></span></div>
+      <button disabled={handoffCompleting} type="button" onClick={() => void completeUserHandoff()}>{handoffCompleting ? "Continuing…" : "Done and continue"}</button>
     </section> : null}
     {tab.rendererLifecycle === "failed"
       ? <div className="tinyos-browser__unavailable" role="alert"><AlertTriangle aria-hidden="true" size={22} /><strong>{session.lifecycle === "failed" ? "Browser failed to start" : "This tab stopped responding"}</strong><span>{session.control?.reason || (session.lifecycle === "failed" ? "Retry the shared browser session." : "Restart it to continue in the same shared browser session.")}</span><button type="button" onClick={() => void (session.lifecycle === "failed" ? retryFailedSession() : execute(() => browserRuntime.restartTab(session.browserSessionId, tab.tabId)))}>{session.lifecycle === "failed" ? "Retry browser" : "Restart tab"}</button></div>

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -3502,7 +3502,8 @@ button.tinyos-overlay-backdrop:focus-visible {
   color: var(--color-error);
 }
 
-.tinyos-browser__policy {
+.tinyos-browser__policy,
+.tinyos-browser__handoff {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -3514,10 +3515,13 @@ button.tinyos-overlay-backdrop:focus-visible {
   font-size: 9px;
 }
 
-.tinyos-browser__policy > div { display: flex; align-items: center; gap: 6px; }
-.tinyos-browser__policy span { display: grid; gap: 2px; min-width: 0; }
+.tinyos-browser__policy > div,
+.tinyos-browser__handoff > div { display: flex; align-items: center; gap: 6px; }
+.tinyos-browser__policy span,
+.tinyos-browser__handoff span { display: grid; gap: 2px; min-width: 0; }
 .tinyos-browser__policy code { max-width: 320px; overflow: hidden; text-overflow: ellipsis; }
-.tinyos-browser__policy button { border-radius: 6px; background: #fff; padding: 4px 7px; }
+.tinyos-browser__policy button,
+.tinyos-browser__handoff button { border-radius: 6px; background: #fff; padding: 4px 7px; }
 
 .tinyos-browser__error {
   display: flex;


### PR DESCRIPTION
## Summary

- add snapshot-aware `web.open`, `web.read`, and `web.act` tools with automatic native browser session handling and stale-action protection
- keep browser tools available throughout Agent turns and create focused default `TOOLS.md` guidance when it is missing
- add protected-step handoff so login, CAPTCHA, payment, and similar interactions stay under user control until the user explicitly hands control back
- coalesce TinyOS browser surface updates, ignore unchanged geometry, and release native browser resources when TinyOS exits
- add regression coverage for popup policy state, explicit handoff completion, stale snapshots, surface movement, and browser lifecycle cleanup

## Why

Agents previously had to coordinate lower-level browser session state themselves, and browser handoff completion could be inferred from unrelated `idle` snapshots. Rapid TinyOS browser movement could also submit obsolete WebView2 geometry work faster than it was applied, while closed TinyOS sessions retained native browser resources.

This change makes the Agent-facing web flow smaller and snapshot-safe, makes user control explicit, and bounds the native browser surface lifecycle.

## Validation

- `npm test -- src/react-workbench/chat/LiveCanvas.test.tsx src/react-workbench/chat/ChatPage.test.tsx` (141 tests passed)
- `npx tsc --noEmit`
- `cargo test --manifest-path src-tauri/Cargo.toml -j 4 popup`
- `cargo test --manifest-path src-tauri/Cargo.toml -j 4 high_level_web_tools_do_not_allow_the_agent_to_resume_user_control`
- `cargo test --manifest-path src-tauri/Cargo.toml -j 4 browser_tools_are_always_exposed_to_the_model`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`

Manual two-minute WebView2 memory profiling was not run.

Closes #380