### PR TITLE
Refine the settings control center

### DIFF
--- a/src/react-workbench/settings/AgentDefaultsSettingsPage.tsx
+++ b/src/react-workbench/settings/AgentDefaultsSettingsPage.tsx
@@ -115,7 +115,12 @@ export function AgentDefaultsSettingsPage({ onNavigateToProviderModels, settings
             <dd>{data.defaultModel ?? "Not configured"}</dd>
           </div>
         </dl>
-        <button type="button" aria-label="Change default model in Provider & Models" onClick={onNavigateToProviderModels}>
+        <button
+          data-press-feedback="true"
+          type="button"
+          aria-label="Change default model in Provider & Models"
+          onClick={onNavigateToProviderModels}
+        >
           <span>Provider & Models</span>
           <ArrowUpRight aria-hidden="true" size={15} />
         </button>

--- a/src/react-workbench/settings/ConfigSettingsPage.tsx
+++ b/src/react-workbench/settings/ConfigSettingsPage.tsx
@@ -218,7 +218,7 @@ export function ConfigSettingsPage({ groupId, settingsStore }: ConfigSettingsPag
             {dirty ? <small>Unsaved changes</small> : <small>Up to date</small>}
           </div>
           <div>
-            <button type="button" disabled={!dirty || saving} onClick={resetDraft}>
+            <button data-press-feedback="true" type="button" disabled={!dirty || saving} onClick={resetDraft}>
               <RotateCcw aria-hidden="true" size={14} />
               Reset
             </button>

--- a/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
+++ b/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
@@ -81,8 +81,9 @@ export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSett
     <section className="react-provider-settings" aria-labelledby="provider-models-title">
       <div className="react-provider-settings__header">
         <div>
+          <span className="react-settings-eyebrow">AI connections</span>
           <h2 id="provider-models-title">Provider & Models</h2>
-          <p>Built-in providers use backend config profiles for credentials, endpoints, and model defaults.</p>
+          <p>Choose the model Tinybot uses by default, then manage the connections that make it available.</p>
         </div>
       </div>
 
@@ -95,16 +96,20 @@ export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSett
 
       <section className="react-provider-directory" aria-labelledby="providers-title">
         <header>
-          <h3 id="providers-title">Providers</h3>
-          <p>Manage provider connections, credentials, and available models.</p>
+          <div>
+            <h3 id="providers-title">Connections</h3>
+            <p>Credentials, endpoints, and models for each provider.</p>
+          </div>
+          <button
+            className="react-provider-add"
+            data-press-feedback="true"
+            type="button"
+            onClick={() => setCreatingProvider(true)}
+          >
+            <Plus aria-hidden="true" size={16} />
+            Add provider
+          </button>
         </header>
-        <div className="react-provider-directory__columns" aria-hidden="true">
-          <span>Provider</span>
-          <span>Base URL</span>
-          <span>Status</span>
-          <span>Models</span>
-          <span>Action</span>
-        </div>
         <div className="react-provider-grid">
         {data.providers.map((provider) => (
           <ProviderPresetRow
@@ -123,15 +128,6 @@ export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSett
           />
         ))}
         </div>
-        <button
-          className="react-provider-add"
-          data-press-feedback="true"
-          type="button"
-          onClick={() => setCreatingProvider(true)}
-        >
-          <Plus aria-hidden="true" size={16} />
-          Add provider
-        </button>
       </section>
 
       {creatingProvider ? (
@@ -235,22 +231,23 @@ function DefaultLlmPanel({
     <section className="react-default-llm-panel" aria-labelledby="default-llm-title">
       <header>
         <div>
+          <span className="react-settings-eyebrow">Current default</span>
           <h3 id="default-llm-title">Default model</h3>
-          <p>This model is used for new chats and agent turns unless overridden.</p>
+          <p>Used for new chats and agent turns unless a conversation overrides it.</p>
         </div>
       </header>
       <div className="react-default-llm-summary">
         {selectedProvider ? <ProviderBrandIcon provider={selectedProvider} /> : null}
+        <div className="react-default-llm-summary__model">
+          <strong>{model || "No model configured"}</strong>
+          <span>{selectedProvider?.label ?? "No provider"}</span>
+        </div>
         <div className="react-default-llm-summary__provider">
-          <strong>{selectedProvider?.label ?? "No provider"}</strong>
           <span className="react-provider-status" data-status={selectedProvider?.status}>
             <span aria-hidden="true" />
             {selectedProvider ? providerStatusLabel(selectedProvider.status) : "Not configured"}
           </span>
-        </div>
-        <div className="react-default-llm-summary__model">
-          <strong>{model || "No model configured"}</strong>
-          {model ? <span>Default</span> : null}
+          <small>{selectedProvider?.useResponsesApi ? "Responses API" : "Chat Completions"}</small>
         </div>
         <span className="react-default-llm-summary__count">
           {selectedProvider?.modelCount ? `${selectedProvider.modelCount} models` : "No models"}
@@ -379,25 +376,39 @@ function ProviderPresetRow({
   const primaryAction = provider.status === "available" ? "models" : "configure";
 
   return (
-    <article className="react-provider-card" aria-label={`${provider.label} provider`} data-status={provider.status}>
+    <article
+      className="react-provider-card"
+      aria-label={`${provider.label} provider`}
+      data-active={provider.active || undefined}
+      data-status={provider.status}
+    >
       <div className="react-provider-card__identity">
         <ProviderBrandIcon provider={provider} />
-        <strong>{provider.label}</strong>
+        <div>
+          <span>
+            <strong>{provider.label}</strong>
+            {provider.active ? <small>Active</small> : null}
+          </span>
+          <span className="react-provider-card__url" title={provider.baseUrl}>{provider.baseUrl}</span>
+        </div>
       </div>
-      <span className="react-provider-card__url" title={provider.baseUrl}>{provider.baseUrl}</span>
+      <div className="react-provider-card__model">
+        <small>Default model</small>
+        <strong>{provider.defaultModel ?? "Not selected"}</strong>
+        <span className="react-provider-card__models">{provider.modelCount ? `${provider.modelCount} models` : "No models"}</span>
+      </div>
       <div className="react-provider-card__state">
         <span className="react-provider-status" data-status={provider.status}>
           <span aria-hidden="true" />
           {providerStatusLabel(provider.status)}
         </span>
-        {provider.active ? <small>Active</small> : !provider.apiKeyConfigured ? <small>API key not set</small> : null}
+        <small>{provider.apiKeyConfigured ? (provider.useResponsesApi ? "Responses API" : "Chat Completions") : "API key not set"}</small>
       </div>
-      <span className="react-provider-card__models">{provider.modelCount ? `${provider.modelCount} models` : "—"}</span>
       <div className="react-provider-card__actions">
         {primaryAction === "models" ? (
-          <button type="button" aria-label={`Manage ${provider.label} models`} onClick={onModels}>Models</button>
+          <button type="button" aria-label={`Manage ${provider.label} models`} onClick={onModels}>Manage</button>
         ) : (
-          <button type="button" aria-label={`Configure ${provider.label}`} onClick={onConfigure}>Configure</button>
+          <button type="button" aria-label={`Configure ${provider.label}`} onClick={onConfigure}>Set up</button>
         )}
         <button
           className="react-provider-card__more"
@@ -502,7 +513,7 @@ function ProviderConfigureDialog({
 
   return (
     <div className="react-settings-dialog-backdrop">
-      <form className="react-settings-dialog" aria-label={`Configure ${provider.label}`} role="dialog" onSubmit={submit}>
+      <form aria-modal="true" className="react-settings-dialog" aria-label={`Configure ${provider.label}`} role="dialog" onSubmit={submit}>
         <header>
           <h2>Configure {provider.label}</h2>
           <button type="button" aria-label={`Close ${provider.label} configuration`} onClick={onClose}>
@@ -611,7 +622,7 @@ function CustomProviderDialog({
 
   return (
     <div className="react-settings-dialog-backdrop">
-      <form className="react-settings-dialog" aria-label="Add provider" role="dialog" onSubmit={submit}>
+      <form aria-modal="true" className="react-settings-dialog" aria-label="Add provider" role="dialog" onSubmit={submit}>
         <header>
           <div>
             <h2>Add provider</h2>
@@ -765,7 +776,7 @@ function ProviderModelsDialog({
 
   return (
     <div className="react-settings-dialog-backdrop">
-      <section className="react-settings-dialog react-settings-dialog--wide" aria-label={`${provider.label} models`} role="dialog">
+      <section aria-modal="true" className="react-settings-dialog react-settings-dialog--wide" aria-label={`${provider.label} models`} role="dialog">
         <header>
           <h2>{provider.label} models</h2>
           <button type="button" aria-label="Close models" onClick={onClose}>

--- a/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
+++ b/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronRight, EllipsisVertical, KeyRound, Loader2, Plus, RefreshCw, Search, Settings, Trash2, X } from "lucide-react";
+import { Check, ChevronRight, EllipsisVertical, Loader2, Plus, RefreshCw, Search, Settings, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   buildCustomProviderPatch,
@@ -14,6 +14,7 @@ import {
 } from "../../app-core/settings/providerModelsSettings";
 import type { SettingsStore } from "../services";
 import { SettingsSaveStatus, type SettingsSaveState } from "./SettingsSaveStatus";
+import { SettingsSheet } from "./SettingsSheet";
 
 type ProviderModelsSettingsPageProps = {
   settingsStore: SettingsStore;
@@ -134,10 +135,7 @@ export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSett
         <CustomProviderDialog
           existingProviders={data.providers}
           onClose={() => setCreatingProvider(false)}
-          onSave={async (patch) => {
-            await savePatch(patch);
-            setCreatingProvider(false);
-          }}
+          onSave={savePatch}
         />
       ) : null}
 
@@ -145,10 +143,7 @@ export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSett
         <ProviderConfigureDialog
           provider={configureProvider}
           onClose={() => setConfigureProvider(null)}
-          onSave={async (patch) => {
-            await savePatch(patch);
-            setConfigureProvider(null);
-          }}
+          onSave={savePatch}
         />
       ) : null}
 
@@ -159,10 +154,7 @@ export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSett
           onRefresh={fetchProviderModels
             ? (input) => fetchProviderModels(input)
             : undefined}
-          onSave={async (patch) => {
-            await savePatch(patch);
-            setModelsProvider(null);
-          }}
+          onSave={savePatch}
         />
       ) : null}
     </section>
@@ -214,17 +206,24 @@ function DefaultLlmPanel({
     ? modelOptions.filter((option) => `${option.label} ${option.id}`.toLocaleLowerCase().includes(normalizedModelSearch))
     : modelOptions, [modelOptions, normalizedModelSearch]);
 
-  async function saveDefaultLlm() {
+  async function saveDefaultLlm(onSaved: () => void) {
     if (!canSave) {
       return;
     }
     setSaving(true);
     try {
       await onSave(buildProviderDefaultLlmPatch({ profileId, model }));
-      setEditing(false);
+      onSaved();
     } finally {
       setSaving(false);
     }
+  }
+
+  function closeEditor() {
+    setProfileId(initialProfileId);
+    setModel(initialModel);
+    setModelSearch("");
+    setEditing(false);
   }
 
   return (
@@ -254,6 +253,7 @@ function DefaultLlmPanel({
         </span>
         <button
           aria-expanded={editing}
+          data-press-feedback="true"
           type="button"
           onClick={() => setEditing((current) => !current)}
         >
@@ -261,100 +261,110 @@ function DefaultLlmPanel({
         </button>
       </div>
       {editing ? (
-        <div className="react-default-llm-editor">
-          <div className="react-default-model-picker">
-            <nav className="react-default-model-picker__providers" aria-label="Provider selection">
-              {data.providers.map((provider) => {
-                const selected = provider.profileId === profileId;
-                return (
-                  <button
-                    aria-label={`Select ${provider.label} provider`}
-                    aria-pressed={selected}
-                    key={provider.profileId}
-                    type="button"
-                    onClick={() => {
-                      setProfileId(provider.profileId);
-                      setModel(provider.defaultModel ?? provider.models[0]?.id ?? "");
-                      setModelSearch("");
-                    }}
-                  >
-                    <ProviderBrandIcon provider={provider} />
-                    <span>
-                      <strong>{provider.label}</strong>
-                      <small>{provider.modelCount ? `${provider.modelCount} models` : providerStatusLabel(provider.status)}</small>
-                    </span>
-                    <ChevronRight aria-hidden="true" size={16} />
-                  </button>
-                );
-              })}
-            </nav>
-            <section className="react-default-model-picker__models" aria-label={`${selectedProvider?.label ?? "Provider"} models`}>
-              <header>
-                <h4>Models from {selectedProvider?.label ?? "provider"}</h4>
-              </header>
-              <label className="react-default-model-picker__search">
-                <Search aria-hidden="true" size={16} />
-                <span className="react-sr-only">Search models</span>
-                <input
-                  type="search"
-                  placeholder="Search models"
-                  value={modelSearch}
-                  onChange={(event) => setModelSearch(event.target.value)}
-                />
-              </label>
-              <p className="react-default-model-picker__count">
-                {normalizedModelSearch
-                  ? `Showing ${filteredModelOptions.length} of ${modelOptions.length}`
-                  : `${modelOptions.length} ${modelOptions.length === 1 ? "model" : "models"}`}
-              </p>
-              <div className="react-default-model-picker__models-list" role="radiogroup" aria-label="Model selection">
-                {filteredModelOptions.length ? filteredModelOptions.map((option) => {
-                  const selected = option.id === model;
-                  return (
-                    <button
-                      aria-checked={selected}
-                      aria-label={`Select ${option.label} model`}
-                      key={option.id}
-                      role="radio"
-                      type="button"
-                      onClick={() => setModel(option.id)}
-                    >
-                      <strong>{option.label}</strong>
-                      <small>{modelSourceLabel(option.source)}</small>
-                      {selected ? <Check aria-hidden="true" size={16} /> : <span aria-hidden="true" />}
-                    </button>
-                  );
-                }) : (
-                  <p className="react-default-model-picker__empty">
-                    {modelOptions.length ? "No models match your search." : "No models configured."}
+        <SettingsSheet
+          ariaLabel="Change default model"
+          closeLabel="Close model selection"
+          description="Choose a provider and model for new chats and agent turns."
+          onClose={closeEditor}
+          title="Change default model"
+          wide
+        >
+          {(requestClose) => (
+            <div className="react-settings-sheet__content react-default-llm-editor">
+              <div className="react-default-model-picker">
+                <nav className="react-default-model-picker__providers" aria-label="Provider selection">
+                  {data.providers.map((provider) => {
+                    const selected = provider.profileId === profileId;
+                    return (
+                      <button
+                        aria-label={`Select ${provider.label} provider`}
+                        aria-pressed={selected}
+                        data-press-feedback="true"
+                        key={provider.profileId}
+                        type="button"
+                        onClick={() => {
+                          setProfileId(provider.profileId);
+                          setModel(provider.defaultModel ?? provider.models[0]?.id ?? "");
+                          setModelSearch("");
+                        }}
+                      >
+                        <ProviderBrandIcon provider={provider} />
+                        <span>
+                          <strong>{provider.label}</strong>
+                          <small>{provider.modelCount ? `${provider.modelCount} models` : providerStatusLabel(provider.status)}</small>
+                        </span>
+                        <ChevronRight aria-hidden="true" size={16} />
+                      </button>
+                    );
+                  })}
+                </nav>
+                <section className="react-default-model-picker__models" aria-label={`${selectedProvider?.label ?? "Provider"} models`}>
+                  <header>
+                    <h4>Models from {selectedProvider?.label ?? "provider"}</h4>
+                  </header>
+                  <label className="react-default-model-picker__search">
+                    <Search aria-hidden="true" size={16} />
+                    <span className="react-sr-only">Search models</span>
+                    <input
+                      data-settings-sheet-focus
+                      type="search"
+                      placeholder="Search models"
+                      value={modelSearch}
+                      onChange={(event) => setModelSearch(event.target.value)}
+                    />
+                  </label>
+                  <p className="react-default-model-picker__count">
+                    {normalizedModelSearch
+                      ? `Showing ${filteredModelOptions.length} of ${modelOptions.length}`
+                      : `${modelOptions.length} ${modelOptions.length === 1 ? "model" : "models"}`}
                   </p>
-                )}
+                  <div className="react-default-model-picker__models-list" role="radiogroup" aria-label="Model selection">
+                    {filteredModelOptions.length ? filteredModelOptions.map((option) => {
+                      const selected = option.id === model;
+                      return (
+                        <button
+                          aria-checked={selected}
+                          aria-label={`Select ${option.label} model`}
+                          data-press-feedback="true"
+                          key={option.id}
+                          role="radio"
+                          type="button"
+                          onClick={() => setModel(option.id)}
+                        >
+                          <strong>{option.label}</strong>
+                          <small>{modelSourceLabel(option.source)}</small>
+                          {selected ? <Check aria-hidden="true" size={16} /> : <span aria-hidden="true" />}
+                        </button>
+                      );
+                    }) : (
+                      <p className="react-default-model-picker__empty">
+                        {modelOptions.length ? "No models match your search." : "No models configured."}
+                      </p>
+                    )}
+                  </div>
+                </section>
               </div>
-            </section>
-          </div>
-          <footer>
-            <span>{data.revision ? `Config revision ${data.revision}` : "Changes apply to new agent turns."}</span>
-            <div>
-              <button
-                type="button"
-                onClick={() => {
-                  setProfileId(initialProfileId);
-                  setModel(initialModel);
-                  setModelSearch("");
-                  setEditing(false);
-                }}
-              >
-                Cancel
-              </button>
-              <button type="button" aria-label="Save default LLM" data-press-feedback="true" disabled={!canSave} onClick={saveDefaultLlm}>
-                {saving
-                  ? <Loader2 aria-hidden="true" className="react-settings-spinner" size={15} />
-                  : <Check aria-hidden="true" size={15} />}
-                {saving ? "Saving" : dirty ? "Save" : "Saved"}
-              </button>
+              <footer>
+                <span>{data.revision ? `Config revision ${data.revision}` : "Changes apply to new agent turns."}</span>
+                <div>
+                  <button data-press-feedback="true" type="button" onClick={requestClose}>Cancel</button>
+                  <button
+                    type="button"
+                    aria-label="Save default LLM"
+                    data-press-feedback="true"
+                    disabled={!canSave}
+                    onClick={() => saveDefaultLlm(requestClose)}
+                  >
+                    {saving
+                      ? <Loader2 aria-hidden="true" className="react-settings-spinner" size={15} />
+                      : <Check aria-hidden="true" size={15} />}
+                    {saving ? "Saving" : dirty ? "Save" : "Saved"}
+                  </button>
+                </div>
+              </footer>
             </div>
-          </footer>
-        </div>
+          )}
+        </SettingsSheet>
       ) : null}
     </section>
   );
@@ -406,12 +416,13 @@ function ProviderPresetRow({
       </div>
       <div className="react-provider-card__actions">
         {primaryAction === "models" ? (
-          <button type="button" aria-label={`Manage ${provider.label} models`} onClick={onModels}>Manage</button>
+          <button data-press-feedback="true" type="button" aria-label={`Manage ${provider.label} models`} onClick={onModels}>Manage</button>
         ) : (
-          <button type="button" aria-label={`Configure ${provider.label}`} onClick={onConfigure}>Set up</button>
+          <button data-press-feedback="true" type="button" aria-label={`Configure ${provider.label}`} onClick={onConfigure}>Set up</button>
         )}
         <button
           className="react-provider-card__more"
+          data-press-feedback="true"
           type="button"
           aria-expanded={menuOpen}
           aria-haspopup="menu"
@@ -489,10 +500,15 @@ function ProviderConfigureDialog({
   const [apiBase, setApiBase] = useState(provider.baseUrl);
   const [apiKey, setApiKey] = useState("");
   const [useResponsesApi, setUseResponsesApi] = useState(provider.useResponsesApi);
-  const [activate, setActivate] = useState(false);
+  const [activate, setActivate] = useState(provider.active);
   const [saving, setSaving] = useState(false);
+  const dirty = apiBase.trim() !== provider.baseUrl
+    || Boolean(apiKey.trim())
+    || useResponsesApi !== provider.useResponsesApi
+    || activate !== provider.active;
+  const canSave = Boolean(apiBase.trim()) && dirty && !saving;
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
+  async function submit(event: FormEvent<HTMLFormElement>, onSaved: () => void) {
     event.preventDefault();
     setSaving(true);
     try {
@@ -504,64 +520,116 @@ function ProviderConfigureDialog({
         apiKey,
         useResponsesApi,
         enabled: true,
-        activate,
+        activate: !provider.active && activate,
       }));
+      onSaved();
     } finally {
       setSaving(false);
     }
   }
 
   return (
-    <div className="react-settings-dialog-backdrop">
-      <form aria-modal="true" className="react-settings-dialog" aria-label={`Configure ${provider.label}`} role="dialog" onSubmit={submit}>
-        <header>
-          <h2>Configure {provider.label}</h2>
-          <button type="button" aria-label={`Close ${provider.label} configuration`} onClick={onClose}>
-            <X aria-hidden="true" size={17} />
-          </button>
-        </header>
-        <label>
-          <span>API base</span>
-          <input aria-label="API base" value={apiBase} onChange={(event) => setApiBase(event.currentTarget.value)} />
-        </label>
-        <label>
-          <span>API key</span>
-          <input
-            aria-label="API key"
-            autoComplete="off"
-            placeholder={provider.apiKeyConfigured ? "Leave blank to keep current key" : "Enter API key"}
-            type="password"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.currentTarget.value)}
-          />
-        </label>
-        <label className="react-settings-checkbox">
-          <input checked={activate} type="checkbox" onChange={(event) => setActivate(event.currentTarget.checked)} />
-          <span>Set as active profile</span>
-        </label>
-        <section className="react-settings-dialog__advanced">
-          <h3>Advanced</h3>
-          <label className="react-settings-checkbox">
-            <input
-              checked={useResponsesApi}
-              type="checkbox"
-              onChange={(event) => setUseResponsesApi(event.currentTarget.checked)}
-            />
-            <span>Use Responses API</span>
-          </label>
-          <p>Enable only when this endpoint supports <code>/responses</code>.</p>
-        </section>
-        <footer>
-          <button type="button" onClick={onClose}>Cancel</button>
-          <button data-press-feedback="true" type="submit" disabled={saving || !apiBase.trim()}>
-            {saving
-              ? <Loader2 aria-hidden="true" className="react-settings-spinner" size={15} />
-              : <KeyRound aria-hidden="true" size={15} />}
-            {saving ? "Saving" : "Save"}
-          </button>
-        </footer>
-      </form>
-    </div>
+    <SettingsSheet
+      ariaLabel={`Configure ${provider.label}`}
+      closeLabel={`Close ${provider.label} configuration`}
+      compact
+      description="Update the connection used by this provider."
+      onClose={onClose}
+      title={`Configure ${provider.label}`}
+    >
+      {(requestClose) => (
+        <form className="react-settings-sheet__content react-provider-config" onSubmit={(event) => submit(event, requestClose)}>
+          <section className="react-provider-config__section" aria-labelledby="provider-connection-title">
+            <h3 id="provider-connection-title">Connection</h3>
+            <label>
+              <span>API base</span>
+              <input
+                aria-label="API base"
+                data-settings-sheet-focus
+                value={apiBase}
+                onChange={(event) => setApiBase(event.currentTarget.value)}
+              />
+            </label>
+            <label>
+              <span className="react-provider-config__field-heading">
+                <span>API key</span>
+                <small data-status={provider.apiKeyConfigured ? "configured" : "missing"}>
+                  {provider.apiKeyConfigured ? "Configured" : "Not configured"}
+                </small>
+              </span>
+              <input
+                aria-describedby="provider-api-key-help"
+                aria-label="API key"
+                autoComplete="off"
+                placeholder="Enter a new API key"
+                type="password"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.currentTarget.value)}
+              />
+              <small id="provider-api-key-help" className="react-provider-config__help">
+                {provider.apiKeyConfigured
+                  ? "Entering a new key replaces the current key."
+                  : "Enter a key if this endpoint requires one."}
+              </small>
+            </label>
+          </section>
+
+          <section className="react-provider-config__section" aria-labelledby="provider-profile-title">
+            <h3 id="provider-profile-title">Profile</h3>
+            <label className="react-provider-config__switch" data-disabled={provider.active || undefined}>
+              <span>
+                <strong>{provider.active ? "Active profile" : "Set as active profile"}</strong>
+                <small>{provider.active ? "This provider is currently used for new turns." : "Use this provider for new agent turns after saving."}</small>
+              </span>
+              <input
+                aria-label="Set as active profile"
+                checked={activate}
+                disabled={provider.active}
+                type="checkbox"
+                onChange={(event) => setActivate(event.currentTarget.checked)}
+              />
+              <i aria-hidden="true" />
+            </label>
+          </section>
+
+          <fieldset className="react-provider-config__section react-provider-config__mode">
+            <legend>API mode</legend>
+            <div>
+              <label data-selected={useResponsesApi || undefined}>
+                <input
+                  checked={useResponsesApi}
+                  name="provider-api-mode"
+                  type="radio"
+                  value="responses"
+                  onChange={() => setUseResponsesApi(true)}
+                />
+                <span>Responses API</span>
+              </label>
+              <label data-selected={!useResponsesApi || undefined}>
+                <input
+                  checked={!useResponsesApi}
+                  name="provider-api-mode"
+                  type="radio"
+                  value="chat_completions"
+                  onChange={() => setUseResponsesApi(false)}
+                />
+                <span>Chat Completions</span>
+              </label>
+            </div>
+            <small>Use Responses API only when the endpoint supports <code>/responses</code>.</small>
+          </fieldset>
+          <footer>
+            <button className="react-provider-config__cancel" data-press-feedback="true" type="button" onClick={requestClose}>Cancel</button>
+            <button className="react-provider-config__save" data-press-feedback="true" type="submit" disabled={!canSave}>
+              {saving
+                ? <Loader2 aria-hidden="true" className="react-settings-spinner" size={15} />
+                : <Check aria-hidden="true" size={15} />}
+              {saving ? "Saving…" : "Save changes"}
+            </button>
+          </footer>
+        </form>
+      )}
+    </SettingsSheet>
   );
 }
 
@@ -597,7 +665,7 @@ function CustomProviderDialog({
     && Boolean(model.trim())
     && !saving;
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
+  async function submit(event: FormEvent<HTMLFormElement>, onSaved: () => void) {
     event.preventDefault();
     if (!canSave) {
       return;
@@ -615,75 +683,76 @@ function CustomProviderDialog({
         useResponsesApi,
         activate,
       }));
+      onSaved();
     } finally {
       setSaving(false);
     }
   }
 
   return (
-    <div className="react-settings-dialog-backdrop">
-      <form aria-modal="true" className="react-settings-dialog" aria-label="Add provider" role="dialog" onSubmit={submit}>
-        <header>
-          <div>
-            <h2>Add provider</h2>
-            <p>Configure an OpenAI-compatible endpoint.</p>
-          </div>
-          <button type="button" aria-label="Close add provider" onClick={onClose}>
-            <X aria-hidden="true" size={17} />
-          </button>
-        </header>
-        <label>
-          <span>Provider ID</span>
-          <input
-            aria-label="Provider ID"
-            autoComplete="off"
-            placeholder="local-openai"
-            value={providerId}
-            onChange={(event) => setProviderId(event.currentTarget.value)}
-          />
-          {providerId && !idValid ? <small>Use lowercase letters, numbers, hyphens, or underscores.</small> : null}
-          {duplicate ? <small role="alert">This provider ID already exists.</small> : null}
-        </label>
-        <label>
-          <span>Display name</span>
-          <input aria-label="Display name" placeholder="Local OpenAI" value={displayName} onChange={(event) => setDisplayName(event.currentTarget.value)} />
-        </label>
-        <label>
-          <span>API base</span>
-          <input aria-label="Custom API base" placeholder="http://127.0.0.1:11434/v1" value={apiBase} onChange={(event) => setApiBase(event.currentTarget.value)} />
-          {apiBase && !apiBaseValid ? <small role="alert">Enter a valid HTTP or HTTPS URL.</small> : null}
-        </label>
-        <label>
-          <span>API key <small>Optional for local endpoints</small></span>
-          <input aria-label="Custom API key" autoComplete="off" type="password" value={apiKey} onChange={(event) => setApiKey(event.currentTarget.value)} />
-        </label>
-        <label>
-          <span>Default model</span>
-          <input aria-label="Default model" placeholder="model-id" value={model} onChange={(event) => setModel(event.currentTarget.value)} />
-        </label>
-        <label className="react-settings-checkbox">
-          <input checked={supportsModelDiscovery} type="checkbox" onChange={(event) => setSupportsModelDiscovery(event.currentTarget.checked)} />
-          <span>Discover models from the /models endpoint</span>
-        </label>
-        <label className="react-settings-checkbox">
-          <input checked={useResponsesApi} type="checkbox" onChange={(event) => setUseResponsesApi(event.currentTarget.checked)} />
-          <span>Use Responses API <small>Requires a compatible /responses endpoint</small></span>
-        </label>
-        <label className="react-settings-checkbox">
-          <input checked={activate} type="checkbox" onChange={(event) => setActivate(event.currentTarget.checked)} />
-          <span>Set as active provider and default model</span>
-        </label>
-        <footer>
-          <button type="button" onClick={onClose}>Cancel</button>
-          <button data-press-feedback="true" type="submit" disabled={!canSave}>
-            {saving
-              ? <Loader2 aria-hidden="true" className="react-settings-spinner" size={15} />
-              : <Plus aria-hidden="true" size={15} />}
-            {saving ? "Adding" : "Add provider"}
-          </button>
-        </footer>
-      </form>
-    </div>
+    <SettingsSheet
+      ariaLabel="Add provider"
+      closeLabel="Close add provider"
+      description="Configure an OpenAI-compatible endpoint."
+      onClose={onClose}
+      title="Add provider"
+    >
+      {(requestClose) => (
+        <form className="react-settings-sheet__content" onSubmit={(event) => submit(event, requestClose)}>
+          <label>
+            <span>Provider ID</span>
+            <input
+              aria-label="Provider ID"
+              autoComplete="off"
+              data-settings-sheet-focus
+              placeholder="local-openai"
+              value={providerId}
+              onChange={(event) => setProviderId(event.currentTarget.value)}
+            />
+            {providerId && !idValid ? <small>Use lowercase letters, numbers, hyphens, or underscores.</small> : null}
+            {duplicate ? <small role="alert">This provider ID already exists.</small> : null}
+          </label>
+          <label>
+            <span>Display name</span>
+            <input aria-label="Display name" placeholder="Local OpenAI" value={displayName} onChange={(event) => setDisplayName(event.currentTarget.value)} />
+          </label>
+          <label>
+            <span>API base</span>
+            <input aria-label="Custom API base" placeholder="http://127.0.0.1:11434/v1" value={apiBase} onChange={(event) => setApiBase(event.currentTarget.value)} />
+            {apiBase && !apiBaseValid ? <small role="alert">Enter a valid HTTP or HTTPS URL.</small> : null}
+          </label>
+          <label>
+            <span>API key <small>Optional for local endpoints</small></span>
+            <input aria-label="Custom API key" autoComplete="off" type="password" value={apiKey} onChange={(event) => setApiKey(event.currentTarget.value)} />
+          </label>
+          <label>
+            <span>Default model</span>
+            <input aria-label="Default model" placeholder="model-id" value={model} onChange={(event) => setModel(event.currentTarget.value)} />
+          </label>
+          <label className="react-settings-checkbox">
+            <input checked={supportsModelDiscovery} type="checkbox" onChange={(event) => setSupportsModelDiscovery(event.currentTarget.checked)} />
+            <span>Discover models from the /models endpoint</span>
+          </label>
+          <label className="react-settings-checkbox">
+            <input checked={useResponsesApi} type="checkbox" onChange={(event) => setUseResponsesApi(event.currentTarget.checked)} />
+            <span>Use Responses API <small>Requires a compatible /responses endpoint</small></span>
+          </label>
+          <label className="react-settings-checkbox">
+            <input checked={activate} type="checkbox" onChange={(event) => setActivate(event.currentTarget.checked)} />
+            <span>Set as active provider and default model</span>
+          </label>
+          <footer>
+            <button data-press-feedback="true" type="button" onClick={requestClose}>Cancel</button>
+            <button data-press-feedback="true" type="submit" disabled={!canSave}>
+              {saving
+                ? <Loader2 aria-hidden="true" className="react-settings-spinner" size={15} />
+                : <Plus aria-hidden="true" size={15} />}
+              {saving ? "Adding" : "Add provider"}
+            </button>
+          </footer>
+        </form>
+      )}
+    </SettingsSheet>
   );
 }
 
@@ -774,77 +843,86 @@ function ProviderModelsDialog({
 
   const canRefresh = Boolean(onRefresh) && provider.modelDiscovery.status === "openai-compatible";
 
+  async function saveModels(onSaved: () => void) {
+    await onSave(buildProviderModelsPatch({
+      providerId: provider.id,
+      profileId: provider.profileId,
+      models: models.map((model) => model.id),
+      defaultModel,
+      setAgentDefault,
+    }));
+    onSaved();
+  }
+
   return (
-    <div className="react-settings-dialog-backdrop">
-      <section aria-modal="true" className="react-settings-dialog react-settings-dialog--wide" aria-label={`${provider.label} models`} role="dialog">
-        <header>
-          <h2>{provider.label} models</h2>
-          <button type="button" aria-label="Close models" onClick={onClose}>
-            <X aria-hidden="true" size={17} />
-          </button>
-        </header>
-        <label>
-          <span>Search models</span>
-          <input aria-label="Search models" placeholder="Search models" value={query} onChange={(event) => setQuery(event.currentTarget.value)} />
-        </label>
-        <div className="react-provider-model-list">
-          {filteredModels.map((model) => (
-            <div className="react-provider-model-row" key={model.id}>
-              <div>
-                <strong>{model.label}</strong>
-                <small>{model.id}</small>
+    <SettingsSheet
+      ariaLabel={`${provider.label} models`}
+      closeLabel="Close models"
+      description="Manage the models available from this connection."
+      onClose={onClose}
+      title={`${provider.label} models`}
+      wide
+    >
+      {(requestClose) => (
+        <div className="react-settings-sheet__content">
+          <label>
+            <span>Search models</span>
+            <input
+              aria-label="Search models"
+              data-settings-sheet-focus
+              placeholder="Search models"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+            />
+          </label>
+          <div className="react-provider-model-list">
+            {filteredModels.map((model) => (
+              <div className="react-provider-model-row" key={model.id}>
+                <div>
+                  <strong>{model.label}</strong>
+                  <small>{model.id}</small>
+                </div>
+                <span>{modelSourceLabel(model.source)}</span>
+                <button data-press-feedback="true" type="button" onClick={() => setDefaultModel(model.id)}>
+                  {defaultModel === model.id ? <Check aria-hidden="true" size={15} /> : null}
+                  Default
+                </button>
+                <button
+                  data-press-feedback="true"
+                  type="button"
+                  aria-label={`Remove ${model.id}`}
+                  disabled={model.source !== "user"}
+                  onClick={() => removeModel(model)}
+                >
+                  <Trash2 aria-hidden="true" size={15} />
+                </button>
               </div>
-              <span>{modelSourceLabel(model.source)}</span>
-              <button type="button" onClick={() => setDefaultModel(model.id)}>
-                {defaultModel === model.id ? <Check aria-hidden="true" size={15} /> : null}
-                Default
-              </button>
-              <button
-                type="button"
-                aria-label={`Remove ${model.id}`}
-                disabled={model.source !== "user"}
-                onClick={() => removeModel(model)}
-              >
-                <Trash2 aria-hidden="true" size={15} />
-              </button>
-            </div>
-          ))}
-          {!filteredModels.length ? <p className="react-empty-state">No models match the search.</p> : null}
+            ))}
+            {!filteredModels.length ? <p className="react-empty-state">No models match the search.</p> : null}
+          </div>
+          <div className="react-provider-model-add">
+            <input aria-label="Add model ID" placeholder="model-id" value={newModel} onChange={(event) => setNewModel(event.currentTarget.value)} />
+            <button data-press-feedback="true" type="button" onClick={addModel}>
+              <Plus aria-hidden="true" size={15} />
+              Add model
+            </button>
+          </div>
+          <label className="react-settings-checkbox">
+            <input checked={setAgentDefault} type="checkbox" onChange={(event) => setSetAgentDefault(event.currentTarget.checked)} />
+            <span>Use selected model as agent default</span>
+          </label>
+          {refreshMessage ? <p className="react-settings-save-status" role="status">{refreshMessage}</p> : null}
+          <footer>
+            <button data-press-feedback="true" type="button" disabled={!canRefresh || refreshing} onClick={refreshModels}>
+              <RefreshCw aria-hidden="true" size={15} />
+              {provider.modelDiscovery.status === "static" ? "Static list" : refreshing ? "Refreshing" : "Refresh models"}
+            </button>
+            <button data-press-feedback="true" type="button" onClick={requestClose}>Cancel</button>
+            <button data-press-feedback="true" type="button" onClick={() => saveModels(requestClose)}>Save</button>
+          </footer>
         </div>
-        <div className="react-provider-model-add">
-          <input aria-label="Add model ID" placeholder="model-id" value={newModel} onChange={(event) => setNewModel(event.currentTarget.value)} />
-          <button type="button" onClick={addModel}>
-            <Plus aria-hidden="true" size={15} />
-            Add model
-          </button>
-        </div>
-        <label className="react-settings-checkbox">
-          <input checked={setAgentDefault} type="checkbox" onChange={(event) => setSetAgentDefault(event.currentTarget.checked)} />
-          <span>Use selected model as agent default</span>
-        </label>
-        {refreshMessage ? <p className="react-settings-save-status" role="status">{refreshMessage}</p> : null}
-        <footer>
-          <button type="button" disabled={!canRefresh || refreshing} onClick={refreshModels}>
-            <RefreshCw aria-hidden="true" size={15} />
-            {provider.modelDiscovery.status === "static" ? "Static list" : refreshing ? "Refreshing" : "Refresh models"}
-          </button>
-          <button type="button" onClick={onClose}>Cancel</button>
-          <button
-            data-press-feedback="true"
-            type="button"
-            onClick={() => onSave(buildProviderModelsPatch({
-              providerId: provider.id,
-              profileId: provider.profileId,
-              models: models.map((model) => model.id),
-              defaultModel,
-              setAgentDefault,
-            }))}
-          >
-            Save
-          </button>
-        </footer>
-      </section>
-    </div>
+      )}
+    </SettingsSheet>
   );
 }
 

--- a/src/react-workbench/settings/SettingsChoiceList.tsx
+++ b/src/react-workbench/settings/SettingsChoiceList.tsx
@@ -62,6 +62,7 @@ export function SettingsChoiceList({
         aria-haspopup="menu"
         aria-label={`${label}: ${selectedOption?.label ?? "Not configured"}`}
         className="react-settings-choice-trigger"
+        data-press-feedback="true"
         type="button"
         onClick={() => setOpen((current) => !current)}
       >
@@ -83,6 +84,7 @@ export function SettingsChoiceList({
             <button
               aria-checked={selected}
               className="react-top-menu__menu-item react-settings-choice-item"
+              data-press-feedback="true"
               disabled={option.disabled}
               key={option.value}
               role="menuitemradio"

--- a/src/react-workbench/settings/SettingsSheet.test.tsx
+++ b/src/react-workbench/settings/SettingsSheet.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { useState } from "react";
+import { SettingsSheet } from "./SettingsSheet";
+
+afterEach(() => cleanup());
+
+describe("SettingsSheet", () => {
+  it("traps focus, closes with Escape, and restores focus to its trigger", async () => {
+    const user = userEvent.setup();
+    render(<SettingsSheetHarness />);
+
+    const trigger = screen.getByRole("button", { name: "Open settings sheet" });
+    await user.click(trigger);
+
+    const dialog = screen.getByRole("dialog", { name: "Example settings" });
+    const initialInput = screen.getByRole("textbox", { name: "Display name" });
+    await waitFor(() => expect(document.activeElement).toBe(initialInput));
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    cancel.focus();
+    await user.tab();
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Close example settings" }));
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(dialog.getAttribute("data-state")).toBe("closing"));
+    fireEvent.transitionEnd(dialog, { propertyName: "transform" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Example settings" })).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+
+function SettingsSheetHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>Open settings sheet</button>
+      {open ? (
+        <SettingsSheet
+          ariaLabel="Example settings"
+          closeLabel="Close example settings"
+          description="A short explanation."
+          onClose={() => setOpen(false)}
+          title="Example"
+        >
+          {(requestClose) => (
+            <div className="react-settings-sheet__content">
+              <label>
+                Display name
+                <input data-settings-sheet-focus />
+              </label>
+              <button type="button">Secondary action</button>
+              <button type="button" onClick={requestClose}>Cancel</button>
+            </div>
+          )}
+        </SettingsSheet>
+      ) : null}
+    </>
+  );
+}

--- a/src/react-workbench/settings/SettingsSheet.tsx
+++ b/src/react-workbench/settings/SettingsSheet.tsx
@@ -1,0 +1,189 @@
+import { X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  type TransitionEvent as ReactTransitionEvent,
+} from "react";
+
+const CLOSE_FALLBACK_MS = 340;
+const REDUCED_MOTION_CLOSE_FALLBACK_MS = 180;
+const FOCUSABLE_SELECTOR = [
+  "button:not(:disabled)",
+  "input:not(:disabled)",
+  "select:not(:disabled)",
+  "textarea:not(:disabled)",
+  "[href]",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+type SettingsSheetProps = {
+  ariaLabel: string;
+  children: (requestClose: () => void) => ReactNode;
+  closeLabel: string;
+  compact?: boolean;
+  description?: string;
+  onClose: () => void;
+  title: string;
+  wide?: boolean;
+};
+
+export function SettingsSheet({
+  ariaLabel,
+  children,
+  closeLabel,
+  compact = false,
+  description,
+  onClose,
+  title,
+  wide = false,
+}: SettingsSheetProps) {
+  const panelRef = useRef<HTMLElement>(null);
+  const closeTimerRef = useRef<number | null>(null);
+  const closingRef = useRef(false);
+  const finishedRef = useRef(false);
+  const onCloseRef = useRef(onClose);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  const finishClose = useCallback(() => {
+    if (finishedRef.current) {
+      return;
+    }
+    finishedRef.current = true;
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    onCloseRef.current();
+  }, []);
+
+  const requestClose = useCallback(() => {
+    if (closingRef.current) {
+      return;
+    }
+    closingRef.current = true;
+    setClosing(true);
+    const closeFallback = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+      ? REDUCED_MOTION_CLOSE_FALLBACK_MS
+      : CLOSE_FALLBACK_MS;
+    closeTimerRef.current = window.setTimeout(finishClose, closeFallback);
+  }, [finishClose]);
+
+  useEffect(() => {
+    restoreFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const frame = window.requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      const target = panel?.querySelector<HTMLElement>("[data-settings-sheet-focus]")
+        ?? focusableElements(panel)[0];
+      target?.focus({ preventScroll: true });
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.body.style.overflow = previousBodyOverflow;
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+      }
+      const target = restoreFocusRef.current;
+      if (target?.isConnected) {
+        target.focus({ preventScroll: true });
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        requestClose();
+        return;
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      const focusable = focusableElements(panelRef.current);
+      if (!focusable.length) {
+        event.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (!panelRef.current?.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [requestClose]);
+
+  function onBackdropPointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.target === event.currentTarget) {
+      requestClose();
+    }
+  }
+
+  function onPanelTransitionEnd(event: ReactTransitionEvent<HTMLElement>) {
+    if (closing && event.target === panelRef.current && event.propertyName === "transform") {
+      finishClose();
+    }
+  }
+
+  return (
+    <div
+      className="react-settings-dialog-backdrop"
+      data-state={closing ? "closing" : "open"}
+      onPointerDown={onBackdropPointerDown}
+    >
+      <section
+        aria-label={ariaLabel}
+        aria-modal="true"
+        className={wide
+          ? "react-settings-dialog react-settings-dialog--wide"
+          : compact
+            ? "react-settings-dialog react-settings-dialog--compact"
+            : "react-settings-dialog"}
+        data-state={closing ? "closing" : "open"}
+        onTransitionEnd={onPanelTransitionEnd}
+        ref={panelRef}
+        role="dialog"
+      >
+        <header>
+          <div>
+            <h2>{title}</h2>
+            {description ? <p>{description}</p> : null}
+          </div>
+          <button data-press-feedback="true" type="button" aria-label={closeLabel} onClick={requestClose}>
+            <X aria-hidden="true" size={17} />
+          </button>
+        </header>
+        {children(requestClose)}
+      </section>
+    </div>
+  );
+}
+
+function focusableElements(root: HTMLElement | null): HTMLElement[] {
+  if (!root) {
+    return [];
+  }
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => element.tabIndex >= 0 && element.getAttribute("aria-hidden") !== "true");
+}

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -475,8 +475,16 @@ describe("DesktopShell", () => {
     await user.click(within(providerActions).getByRole("menuitem", { name: "Configure" }));
     const dialog = screen.getByRole("dialog", { name: "Configure OpenAI" });
     expect((within(dialog).getByLabelText("API base") as HTMLInputElement).value).toBe("https://api.openai.com/v1");
+    expect(within(dialog).getByText("Configured")).toBeTruthy();
+    expect((within(dialog).getByRole("radio", { name: "Chat Completions" }) as HTMLInputElement).checked).toBe(true);
+    const activeProfile = within(dialog).getByRole("checkbox", { name: "Set as active profile" }) as HTMLInputElement;
+    expect(activeProfile.checked).toBe(true);
+    expect(activeProfile.disabled).toBe(true);
+    const saveChanges = within(dialog).getByRole("button", { name: "Save changes" }) as HTMLButtonElement;
+    expect(saveChanges.disabled).toBe(true);
     await user.type(within(dialog).getByLabelText("API key"), "sk-test");
-    await user.click(within(dialog).getByRole("button", { name: "Save" }));
+    expect(saveChanges.disabled).toBe(false);
+    await user.click(saveChanges);
 
     await waitFor(() => expect(saveProviderSettings).toHaveBeenCalledTimes(2));
     expect(saveProviderSettings.mock.calls[1][1]).toEqual({

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -173,7 +173,7 @@ describe("DesktopShell", () => {
     expect(controls.toggleMaximize).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps shell navigation typography compact", () => {
+  it("keeps shell navigation and settings layouts compact", () => {
     const css = readFileSync("src/react-workbench/styles/workbench.css", "utf8");
 
     expect(css).toMatch(/\.react-window-frame__history button\s*{[^}]*width:\s*32px;[^}]*height:\s*32px;/s);
@@ -189,8 +189,12 @@ describe("DesktopShell", () => {
     expect(css).toMatch(/\.react-session-row__title\s*{[^}]*font-size:\s*12px;/s);
     expect(css).toMatch(/\.react-default-model-picker\s*{[^}]*grid-template-columns:\s*minmax\(170px,\s*0\.72fr\) minmax\(300px,\s*1\.45fr\);/s);
     expect(css).toMatch(/\.react-default-model-picker__models-list\s*{[^}]*max-height:\s*220px;[^}]*overflow-y:\s*auto;/s);
-    expect(css).toMatch(/\.react-default-llm-summary\s*{[^}]*grid-template-columns:\s*42px minmax\(145px,\s*0\.85fr\) minmax\(180px,\s*1\.15fr\) 88px auto;/s);
-    expect(css).toMatch(/\.react-provider-directory__columns,\s*\.react-provider-card\s*{[^}]*grid-template-columns:/s);
+    expect(css).toMatch(/\.react-settings-sidebar button\s*{[^}]*grid-template-columns:\s*18px minmax\(0,\s*1fr\) 15px;/s);
+    expect(css).toMatch(/\.react-default-llm-summary\s*{[^}]*grid-template-columns:\s*44px minmax\(180px,\s*1fr\) minmax\(132px,\s*0\.6fr\) auto auto;/s);
+    expect(css).toMatch(/\.react-default-llm-panel\s*{[^}]*border-radius:\s*0;[^}]*background:\s*transparent;/s);
+    expect(css).toMatch(/\.react-provider-grid\s*{[^}]*border-top:\s*1px solid var\(--color-hairline\);[^}]*border-bottom:\s*1px solid var\(--color-hairline\);/s);
+    expect(css).toMatch(/\.react-provider-card\s*{[^}]*grid-template-columns:\s*minmax\(250px,\s*1\.35fr\) minmax\(150px,\s*0\.8fr\) minmax\(130px,\s*0\.6fr\) auto;/s);
+    expect(css).toMatch(/\.react-settings-dialog-backdrop\s*{[^}]*place-items:\s*stretch end;/s);
     expect(css).toMatch(/\.react-settings-choice-item \.react-top-menu__menu-label\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\) max-content;/s);
   });
 

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -9,7 +9,24 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
-import { ArrowLeft, ArrowRight, BookOpen, Check, ChevronRight, Command, Folder, Minus, Settings, Square, X } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Bot,
+  BookOpen,
+  Cable,
+  Check,
+  ChevronRight,
+  Cloud,
+  Command,
+  Folder,
+  Minus,
+  Radio,
+  Settings,
+  Square,
+  X,
+  type LucideIcon,
+} from "lucide-react";
 import { createDesktopStopCommand } from "../../app-core/chat/desktopCommand";
 import { ChatPage } from "../chat/ChatPage";
 import { AgentDefaultsSettingsPage } from "../settings/AgentDefaultsSettingsPage";
@@ -771,11 +788,19 @@ function SettingsPage({ services }: { services: AppServices }) {
 
 type SettingsModuleId = "provider-models" | "agent-defaults" | ConfigSettingsGroupId;
 
-const settingsModules: Array<{ id: SettingsModuleId; label: string; description: string; groupId?: ConfigSettingsGroupId }> = [
-  { id: "provider-models", label: "Provider & Models", description: "Providers, API keys, and model defaults" },
-  { id: "agent-defaults", label: "Agent Defaults", description: "Runtime behavior for new agent turns" },
-  { id: "tools-mcp", label: "Tools & MCP", description: "Tool access and MCP server configuration", groupId: "tools-mcp" },
-  { id: "channels", label: "Channels", description: "Progress signals and delivery retries", groupId: "channels" },
+type SettingsModule = {
+  id: SettingsModuleId;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  groupId?: ConfigSettingsGroupId;
+};
+
+const settingsModules: SettingsModule[] = [
+  { id: "provider-models", label: "Provider & Models", description: "Providers, API keys, and model defaults", icon: Cloud },
+  { id: "agent-defaults", label: "Agent Defaults", description: "Runtime behavior for new agent turns", icon: Bot },
+  { id: "tools-mcp", label: "Tools & MCP", description: "Tool access and MCP server configuration", icon: Cable, groupId: "tools-mcp" },
+  { id: "channels", label: "Channels", description: "Progress signals and delivery retries", icon: Radio, groupId: "channels" },
 ];
 
 function SettingsLayout({
@@ -786,25 +811,34 @@ function SettingsLayout({
 }: {
   activeModuleId: SettingsModuleId;
   children: ReactNode;
-  modules: Array<{ id: SettingsModuleId; label: string; description: string }>;
+  modules: SettingsModule[];
   onSelectModule: (moduleId: SettingsModuleId) => void;
 }) {
   return (
     <div className="react-settings-layout">
       <aside className="react-settings-sidebar">
+        <div className="react-settings-sidebar__intro">
+          <span>Preferences</span>
+          <small>Configure Tinybot for your workflow.</small>
+        </div>
         <nav aria-label="Settings categories">
-          {modules.map((module) => (
-            <button
-              key={module.id}
-              aria-current={module.id === activeModuleId ? "page" : undefined}
-              aria-label={module.label}
-              onClick={() => onSelectModule(module.id)}
-              type="button"
-            >
-              <span>{module.label}</span>
-              <small>{module.description}</small>
-            </button>
-          ))}
+          {modules.map((module) => {
+            const Icon = module.icon;
+            return (
+              <button
+                key={module.id}
+                aria-current={module.id === activeModuleId ? "page" : undefined}
+                aria-label={module.label}
+                onClick={() => onSelectModule(module.id)}
+                title={module.description}
+                type="button"
+              >
+                <Icon aria-hidden="true" size={17} />
+                <span>{module.label}</span>
+                <ChevronRight aria-hidden="true" className="react-settings-sidebar__chevron" size={15} />
+              </button>
+            );
+          })}
         </nav>
       </aside>
       <div className="react-settings-detail">

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -18,6 +18,7 @@
   --motion-duration-medium: 220ms;
   --motion-duration-text: 720ms;
   --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --motion-ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--color-ink);
   background: var(--color-canvas);
@@ -7417,17 +7418,13 @@ button.tinyos-overlay-backdrop:focus-visible {
 .react-settings-sidebar__chevron {
   color: var(--color-muted-soft);
   opacity: 0;
-  transform: translateX(-3px);
-  transition:
-    opacity var(--motion-duration-fast) var(--motion-ease-standard),
-    transform var(--motion-duration-fast) var(--motion-ease-standard);
+  transition: opacity var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
 .react-settings-sidebar button:hover .react-settings-sidebar__chevron,
 .react-settings-sidebar button:focus-visible .react-settings-sidebar__chevron,
 .react-settings-sidebar button[aria-current="page"] .react-settings-sidebar__chevron {
   opacity: 1;
-  transform: translateX(0);
 }
 
 .react-settings-detail {
@@ -7444,12 +7441,9 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-config-settings__persistence {
   flex: 0 0 auto;
-  border-radius: 999px;
-  background: var(--color-surface-soft);
-  padding: 5px 9px;
   color: var(--color-muted);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   white-space: nowrap;
 }
 
@@ -7460,27 +7454,45 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-config-settings__fields {
   display: grid;
-  grid-template-columns: repeat(2, minmax(190px, 1fr));
-  gap: 12px;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline);
+  border-bottom: 1px solid var(--color-hairline);
 }
 
 .react-config-settings__field,
 .react-config-settings__toggle {
   min-width: 0;
-  border: 1px solid var(--color-hairline);
-  border-radius: 9px;
-  background: #fff;
-  padding: 15px 16px;
+  border: 0;
+  border-bottom: 1px solid var(--color-hairline);
+  border-radius: 0;
+  background: transparent;
+  padding: 14px 0;
+}
+
+.react-config-settings__field:last-child,
+.react-config-settings__toggle:last-child {
+  border-bottom: 0;
 }
 
 .react-config-settings__field {
   display: grid;
-  align-content: start;
-  gap: 8px;
+  grid-template-areas:
+    "label control"
+    "description control"
+    ". error";
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+  align-items: center;
+  gap: 4px 28px;
 }
 
 .react-config-settings__field--wide {
-  grid-column: 1 / -1;
+  grid-template-areas:
+    "label"
+    "description"
+    "control"
+    "error";
+  grid-template-columns: minmax(0, 1fr);
+  gap: 7px;
 }
 
 .react-config-settings__field > span,
@@ -7490,6 +7502,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-config-settings__field > span {
   display: flex;
+  grid-area: label;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
@@ -7569,6 +7582,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-config-settings__input-wrap {
   position: relative;
+  min-width: 0;
 }
 
 .react-config-settings__input-wrap > span {
@@ -7607,7 +7621,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   height: 20px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--color-muted) 28%, #fff);
-  transition: background-color 140ms ease;
+  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
 .react-config-settings__toggle i::after {
@@ -7620,7 +7634,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   background: #fff;
   box-shadow: 0 1px 3px rgb(20 20 19 / 22%);
   content: "";
-  transition: transform 140ms ease;
+  transition: transform var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
 .react-config-settings__toggle input:checked + i {
@@ -7632,8 +7646,8 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .react-config-settings__toggle:focus-within {
-  border-color: color-mix(in srgb, var(--color-primary) 52%, var(--color-hairline));
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--color-surface-soft) 46%, transparent);
+  box-shadow: none;
 }
 
 .react-config-settings__notice {
@@ -7641,6 +7655,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .react-config-settings__error {
+  grid-area: error;
   color: #b42318 !important;
 }
 
@@ -7712,6 +7727,17 @@ button.tinyos-overlay-backdrop:focus-visible {
   font-size: 27px;
   line-height: 1.15;
   letter-spacing: -0.025em;
+}
+
+.react-config-settings__field > small:not(.react-config-settings__error) {
+  grid-area: description;
+}
+
+.react-config-settings__field > input,
+.react-config-settings__field > select,
+.react-config-settings__field > textarea,
+.react-config-settings__field > .react-config-settings__input-wrap {
+  grid-area: control;
 }
 
 .react-provider-settings__header p {
@@ -7937,17 +7963,15 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .react-default-llm-editor {
-  display: grid;
+  display: flex;
+  min-height: 0;
   overflow: hidden;
-  border: 1px solid var(--color-hairline);
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 18px 42px rgb(20 20 19 / 7%);
 }
 
 .react-default-model-picker {
   display: grid;
   grid-template-columns: minmax(170px, 0.72fr) minmax(300px, 1.45fr);
+  flex: 1 1 auto;
   min-height: 310px;
 }
 
@@ -8218,7 +8242,9 @@ button.tinyos-overlay-backdrop:focus-visible {
 .react-settings-choice-trigger svg {
   justify-self: end;
   color: var(--color-muted);
-  transition: transform 160ms ease, color 160ms ease;
+  transition:
+    transform var(--motion-duration-fast) var(--motion-ease-standard),
+    color var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
 .react-settings-choice-trigger[aria-expanded="true"] svg {
@@ -8329,15 +8355,14 @@ button.tinyos-overlay-backdrop:focus-visible {
 .react-agent-defaults-form {
   display: grid;
   gap: 14px;
-  border: 1px solid var(--color-hairline);
-  border-radius: 8px;
-  background: #fff;
-  padding: 18px 20px;
 }
 
 .react-settings-linked-summary {
   grid-template-columns: minmax(180px, 1fr) minmax(220px, 1.2fr) auto;
   align-items: center;
+  border-top: 1px solid var(--color-hairline);
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 16px 0;
 }
 
 .react-settings-linked-summary h3,
@@ -8386,7 +8411,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   gap: 6px;
   min-height: 34px;
   border: 1px solid var(--color-hairline);
-  border-radius: 8px;
+  border-radius: 6px;
   background: #fff;
   color: var(--color-ink);
   font-size: 12px;
@@ -8404,16 +8429,51 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-agent-defaults-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(180px, 1fr));
-  gap: 12px;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline);
+  border-bottom: 1px solid var(--color-hairline);
 }
 
-.react-agent-defaults-grid label {
+.react-agent-defaults-grid > label,
+.react-agent-defaults-grid > .react-settings-choice {
   display: grid;
-  gap: 7px;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+  align-items: center;
+  gap: 4px 28px;
+  min-height: 68px;
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 12px 0;
   color: var(--color-body);
   font-size: 13px;
   font-weight: 650;
+}
+
+.react-agent-defaults-grid > :last-child {
+  border-bottom: 0;
+}
+
+.react-agent-defaults-grid > label > span,
+.react-agent-defaults-grid > .react-settings-choice > .react-settings-choice__label {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.react-agent-defaults-grid > label > input,
+.react-agent-defaults-grid > .react-settings-choice > .react-settings-choice-trigger {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.react-agent-defaults-grid > label > small,
+.react-agent-defaults-grid > .react-settings-choice > small {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.react-agent-defaults-grid .react-settings-choice-popover {
+  right: 0;
+  left: auto;
+  width: min(320px, 100%);
 }
 
 .react-agent-defaults-grid input,
@@ -8428,7 +8488,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   font-size: 13px;
 }
 
-.react-agent-defaults-grid small {
+.react-agent-defaults-grid > label > small {
   color: #b42318;
   font-size: 12px;
   font-weight: 500;
@@ -8757,6 +8817,8 @@ button.tinyos-overlay-backdrop:focus-visible {
   place-items: stretch end;
   background: rgb(20 20 19 / 34%);
   padding: 0;
+  opacity: 1;
+  transition: opacity 180ms var(--motion-ease-standard);
 }
 
 .react-settings-dialog {
@@ -8773,10 +8835,35 @@ button.tinyos-overlay-backdrop:focus-visible {
   background: #fff;
   padding: 24px;
   box-shadow: -24px 0 80px rgb(20 20 19 / 15%);
+  transform: translateX(0);
+  transition: transform 280ms var(--motion-ease-drawer);
+  will-change: transform;
+}
+
+.react-settings-dialog-backdrop[data-state="closing"] {
+  opacity: 0;
+}
+
+.react-settings-dialog-backdrop[data-state="closing"] .react-settings-dialog {
+  transform: translateX(100%);
+}
+
+@starting-style {
+  .react-settings-dialog-backdrop {
+    opacity: 0;
+  }
+
+  .react-settings-dialog {
+    transform: translateX(100%);
+  }
 }
 
 .react-settings-dialog--wide {
   width: min(680px, 100%);
+}
+
+.react-settings-dialog--compact {
+  width: min(460px, 100%);
 }
 
 .react-settings-dialog header,
@@ -8791,6 +8878,26 @@ button.tinyos-overlay-backdrop:focus-visible {
   margin: 0;
   color: var(--color-ink);
   font-size: 16px;
+}
+
+.react-settings-dialog header > div {
+  display: grid;
+  gap: 3px;
+}
+
+.react-settings-dialog header p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.react-settings-sheet__content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  gap: 16px;
 }
 
 .react-settings-dialog header button {
@@ -8821,6 +8928,12 @@ button.tinyos-overlay-backdrop:focus-visible {
   font-size: 13px;
 }
 
+.react-settings-dialog input:focus-visible {
+  outline: 0;
+  border-color: color-mix(in srgb, var(--color-primary) 56%, var(--color-hairline));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 16%, transparent);
+}
+
 .react-settings-checkbox {
   display: flex !important;
   grid-template-columns: unset;
@@ -8836,25 +8949,202 @@ button.tinyos-overlay-backdrop:focus-visible {
   padding: 0;
 }
 
-.react-settings-dialog__advanced {
-  border-top: 1px solid var(--color-hairline);
-  padding-top: 14px;
+.react-provider-config {
+  gap: 0;
 }
 
-.react-settings-dialog__advanced h3,
-.react-settings-dialog__advanced p {
+.react-provider-config__section {
+  display: grid;
+  gap: 14px;
   margin: 0;
+  border: 0;
+  border-top: 1px solid var(--color-hairline);
+  padding: 20px 0;
 }
 
-.react-settings-dialog__advanced h3 {
+.react-provider-config__section:first-child {
+  border-top: 0;
+  padding-top: 4px;
+}
+
+.react-provider-config__section h3,
+.react-provider-config__section legend {
+  margin: 0;
+  padding: 0;
+  color: var(--color-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.react-provider-config__field-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.react-provider-config__field-heading small {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.react-provider-config__field-heading small::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-muted-soft);
+  content: "";
+}
+
+.react-provider-config__field-heading small[data-status="configured"] {
+  color: color-mix(in srgb, var(--color-success) 74%, var(--color-ink));
+}
+
+.react-provider-config__field-heading small[data-status="configured"]::before {
+  background: var(--color-success);
+}
+
+.react-provider-config__help,
+.react-provider-config__mode > small {
+  color: var(--color-muted);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.react-provider-config__switch {
+  position: relative;
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  align-items: center;
+  gap: 16px !important;
+  cursor: pointer;
+}
+
+.react-provider-config__switch > span {
+  display: grid;
+  gap: 4px;
+}
+
+.react-provider-config__switch strong {
   color: var(--color-ink);
   font-size: 13px;
+  font-weight: 650;
 }
 
-.react-settings-dialog__advanced p {
-  margin-top: 4px;
+.react-provider-config__switch small {
   color: var(--color-muted);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.react-provider-config__switch input,
+.react-provider-config__mode input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  min-height: 0;
+  padding: 0;
+  opacity: 0;
+}
+
+.react-provider-config__switch i {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-muted) 28%, #fff);
+  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.react-provider-config__switch i::after {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgb(20 20 19 / 22%);
+  content: "";
+  transition: transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.react-provider-config__switch input:checked + i {
+  background: var(--color-primary);
+}
+
+.react-provider-config__switch input:checked + i::after {
+  transform: translateX(16px);
+}
+
+.react-provider-config__switch:has(input:focus-visible) i {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+.react-provider-config__switch[data-disabled="true"] {
+  cursor: default;
+}
+
+.react-provider-config__mode > div {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  background: var(--color-surface-soft);
+  padding: 3px;
+}
+
+.react-provider-config__mode label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  border-radius: 6px;
+  color: var(--color-muted);
+  cursor: pointer;
   font-size: 12px;
+  font-weight: 600;
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    color var(--motion-duration-fast) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.react-provider-config__mode label[data-selected="true"] {
+  background: #fff;
+  color: var(--color-ink);
+  box-shadow: 0 1px 4px rgb(20 20 19 / 11%);
+}
+
+.react-provider-config__mode label:has(input:focus-visible) {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 35%, transparent);
+}
+
+.react-provider-config__cancel {
+  border-color: transparent;
+  background: transparent;
+}
+
+.react-provider-config__save {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.react-provider-config__save:hover,
+.react-provider-config__save:focus-visible {
+  border-color: var(--color-primary-active);
+  background: var(--color-primary-active);
+  color: #fff;
 }
 
 .react-provider-model-list {
@@ -9369,8 +9659,24 @@ button.tinyos-overlay-backdrop:focus-visible {
 
   .react-chat-page,
   .react-session-list,
-  .react-session-list__collapse svg {
+  .react-session-list__collapse svg,
+  .react-settings-choice-trigger svg,
+  .react-config-settings__toggle i,
+  .react-config-settings__toggle i::after,
+  .react-provider-config__switch i,
+  .react-provider-config__switch i::after,
+  .react-provider-config__mode label {
     transition-duration: 0ms;
+  }
+
+  .react-settings-dialog {
+    transform: none !important;
+    transition: none;
+    will-change: auto;
+  }
+
+  .react-settings-dialog-backdrop {
+    transition-duration: 140ms;
   }
 
   .react-session-list__header h2,

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -7308,9 +7308,25 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-settings-layout {
   display: grid;
-  grid-template-columns: 196px minmax(0, 1fr);
-  gap: 34px;
+  grid-template-columns: 204px minmax(0, 860px);
+  justify-content: start;
+  gap: 46px;
   align-items: start;
+}
+
+.react-workbench-page--settings {
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 0;
+  padding: 0;
+  background: color-mix(in srgb, var(--color-canvas) 86%, #fff);
+}
+
+.react-workbench-page--settings > header {
+  padding: 20px 30px 17px;
+}
+
+.react-workbench-page--settings > .react-settings-layout {
+  padding: 28px 30px 48px;
 }
 
 .react-data-row__content {
@@ -7321,53 +7337,102 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-settings-sidebar {
   position: sticky;
-  top: 16px;
-  min-height: calc(100vh - 138px);
-  border-right: 1px solid var(--color-hairline);
-  padding-right: 20px;
+  top: 0;
+  min-height: calc(100vh - 154px);
+  padding-right: 8px;
 }
 
 .react-settings-sidebar nav {
   display: grid;
-  gap: 6px;
+  gap: 4px;
+}
+
+.react-settings-sidebar__intro {
+  display: grid;
+  gap: 4px;
+  padding: 2px 10px 16px;
+}
+
+.react-settings-sidebar__intro span {
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.react-settings-sidebar__intro small {
+  color: var(--color-muted);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: normal;
 }
 
 .react-settings-sidebar button {
+  position: relative;
   display: grid;
-  gap: 2px;
+  grid-template-columns: 18px minmax(0, 1fr) 15px;
+  align-items: center;
+  gap: 10px;
   width: 100%;
-  min-height: 44px;
-  border-radius: 8px;
-  padding: 8px 10px;
+  min-height: 42px;
+  border: 0;
+  border-radius: 4px;
+  padding: 0 10px;
+  color: var(--color-muted);
   text-align: left;
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    color var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
 .react-settings-sidebar button[aria-current="page"] {
-  background: var(--color-surface-soft);
+  background: color-mix(in srgb, var(--color-surface-soft) 82%, transparent);
   color: var(--color-ink);
+  box-shadow: none;
 }
 
-.react-settings-sidebar span,
-.react-settings-sidebar small {
+.react-settings-sidebar button[aria-current="page"]::before {
+  position: absolute;
+  top: 9px;
+  bottom: 9px;
+  left: 0;
+  width: 2px;
+  background: var(--color-primary);
+  content: "";
+}
+
+.react-settings-sidebar button span {
   min-width: 0;
   overflow: hidden;
+  font-size: 13px;
+  font-weight: 650;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.react-settings-sidebar span {
-  color: var(--color-ink);
-  font-size: 13px;
-  font-weight: 650;
+.react-settings-sidebar button[aria-current="page"] > svg:first-child {
+  color: var(--color-primary-active);
 }
 
-.react-settings-sidebar small {
-  color: var(--color-muted);
-  font-size: 11px;
+.react-settings-sidebar__chevron {
+  color: var(--color-muted-soft);
+  opacity: 0;
+  transform: translateX(-3px);
+  transition:
+    opacity var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.react-settings-sidebar button:hover .react-settings-sidebar__chevron,
+.react-settings-sidebar button:focus-visible .react-settings-sidebar__chevron,
+.react-settings-sidebar button[aria-current="page"] .react-settings-sidebar__chevron {
+  opacity: 1;
+  transform: translateX(0);
 }
 
 .react-settings-detail {
   min-width: 0;
+  width: 100%;
 }
 
 .react-provider-settings,
@@ -7644,7 +7709,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 .react-provider-settings__header h2 {
   margin: 0;
   color: var(--color-ink);
-  font-size: 28px;
+  font-size: 27px;
   line-height: 1.15;
   letter-spacing: -0.025em;
 }
@@ -7655,6 +7720,16 @@ button.tinyos-overlay-backdrop:focus-visible {
   color: var(--color-muted);
   font-size: 14px;
   line-height: 1.45;
+}
+
+.react-settings-eyebrow {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--color-primary-active);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
 }
 
 .react-provider-settings__summary {
@@ -7778,7 +7853,12 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-default-llm-panel {
   display: grid;
-  gap: 14px;
+  gap: 16px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 4px 0 0;
+  box-shadow: none;
 }
 
 .react-default-llm-panel > header {
@@ -7791,7 +7871,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 .react-default-llm-panel h3 {
   margin: 0;
   color: var(--color-ink);
-  font-size: 18px;
+  font-size: 17px;
   letter-spacing: -0.01em;
 }
 
@@ -7802,20 +7882,23 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-default-llm-summary {
   display: grid;
-  grid-template-columns: 42px minmax(145px, 0.85fr) minmax(180px, 1.15fr) 88px auto;
+  grid-template-columns: 44px minmax(180px, 1fr) minmax(132px, 0.6fr) auto auto;
   align-items: center;
   gap: 16px;
-  min-height: 88px;
+  min-height: 78px;
+  border: 0;
   border-top: 1px solid var(--color-hairline);
   border-bottom: 1px solid var(--color-hairline);
-  padding: 14px 10px;
+  border-radius: 0;
+  background: transparent;
+  padding: 14px 0;
 }
 
 .react-default-llm-summary__provider,
 .react-default-llm-summary__model {
   display: grid;
   min-width: 0;
-  gap: 5px;
+  gap: 4px;
 }
 
 .react-default-llm-summary__provider strong,
@@ -7830,23 +7913,26 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .react-default-llm-summary__model {
-  border-left: 1px solid var(--color-hairline);
-  padding-left: 22px;
+  padding-left: 2px;
 }
 
 .react-default-llm-summary__model span {
   justify-self: start;
-  border-radius: 5px;
-  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
-  padding: 2px 6px;
-  color: var(--color-primary-active);
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.react-default-llm-summary__provider small {
+  color: var(--color-muted);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 500;
 }
 
 .react-default-llm-summary__count {
   color: var(--color-muted);
-  font-size: 13px;
+  font-size: 11px;
+  font-weight: 600;
   white-space: nowrap;
 }
 
@@ -8196,11 +8282,17 @@ button.tinyos-overlay-backdrop:focus-visible {
   min-height: 38px;
   gap: 6px;
   border: 1px solid var(--color-hairline);
-  border-radius: 8px;
+  border-radius: 6px;
   background: #fff;
   color: var(--color-ink);
   font-size: 12px;
   font-weight: 650;
+}
+
+.react-default-llm-summary > button {
+  border-color: var(--color-hairline);
+  background: transparent;
+  color: var(--color-primary-active);
 }
 
 .react-default-llm-summary > button:disabled,
@@ -8361,15 +8453,21 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-provider-grid {
   display: grid;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline);
+  border-bottom: 1px solid var(--color-hairline);
 }
 
 .react-provider-directory {
   display: grid;
-  gap: 0;
+  gap: 14px;
 }
 
 .react-provider-directory > header {
-  margin-bottom: 18px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
 }
 
 .react-provider-directory > header h3 {
@@ -8385,33 +8483,29 @@ button.tinyos-overlay-backdrop:focus-visible {
   font-size: 13px;
 }
 
-.react-provider-directory__columns,
 .react-provider-card {
   display: grid;
-  grid-template-columns: minmax(145px, 1fr) minmax(160px, 1.25fr) minmax(132px, 0.95fr) 88px 118px;
+  grid-template-columns: minmax(250px, 1.35fr) minmax(150px, 0.8fr) minmax(130px, 0.6fr) auto;
   align-items: center;
   gap: 16px;
-}
-
-.react-provider-directory__columns {
-  min-height: 38px;
+  min-height: 88px;
+  border: 0;
   border-bottom: 1px solid var(--color-hairline);
-  color: var(--color-muted);
-  font-size: 11px;
-  font-weight: 650;
-  letter-spacing: 0.02em;
-}
-
-.react-provider-card {
-  min-height: 92px;
-  border-bottom: 1px solid var(--color-hairline);
+  border-radius: 0;
+  background: transparent;
   padding: 14px 0;
-  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard);
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.react-provider-card:last-child {
+  border-bottom: 0;
 }
 
 .react-provider-card:hover,
 .react-provider-card:focus-within {
-  background: color-mix(in srgb, var(--color-surface-soft) 56%, transparent);
+  background: color-mix(in srgb, var(--color-surface-soft) 46%, transparent);
+  box-shadow: none;
 }
 
 .react-provider-card__identity,
@@ -8425,6 +8519,19 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .react-provider-card__identity {
   min-width: 0;
+}
+
+.react-provider-card__identity > div {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.react-provider-card__identity > div > span:first-child {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 7px;
 }
 
 .react-provider-brand-icon {
@@ -8460,6 +8567,20 @@ button.tinyos-overlay-backdrop:focus-visible {
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.react-default-llm-summary > .react-provider-brand-icon,
+.react-provider-card .react-provider-brand-icon {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.react-provider-card__identity small {
+  flex: 0 0 auto;
+  color: var(--color-primary-active);
+  font-size: 10px;
+  font-weight: 700;
 }
 
 .react-provider-status {
@@ -8499,9 +8620,6 @@ button.tinyos-overlay-backdrop:focus-visible {
 .react-provider-card__state small,
 .react-provider-model-row > span {
   justify-self: start;
-  border-radius: 6px;
-  background: var(--color-surface-soft);
-  padding: 3px 6px;
   color: var(--color-muted);
   font-size: 11px;
   font-weight: 650;
@@ -8514,17 +8632,42 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 .react-provider-card__url,
-.react-provider-card__models {
+.react-provider-card__models,
+.react-provider-card__model strong {
   min-width: 0;
   overflow: hidden;
-  color: var(--color-muted);
-  font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .react-provider-card__url {
+  color: var(--color-muted);
   font: 12px/1.35 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.react-provider-card__model {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.react-provider-card__model > small {
+  color: var(--color-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.react-provider-card__model strong {
+  color: var(--color-ink);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.react-provider-card__models {
+  color: var(--color-muted);
+  font-size: 11px;
 }
 
 .react-provider-card__actions {
@@ -8542,7 +8685,7 @@ button.tinyos-overlay-backdrop:focus-visible {
   min-height: 32px;
   gap: 6px;
   border: 1px solid var(--color-hairline);
-  border-radius: 8px;
+  border-radius: 6px;
   background: #fff;
   padding: 0 10px;
   color: var(--color-ink);
@@ -8591,8 +8734,10 @@ button.tinyos-overlay-backdrop:focus-visible {
   justify-self: start;
   min-height: 38px;
   gap: 7px;
-  margin-top: 16px;
+  margin: 0;
   border: 0;
+  border-radius: 4px;
+  background: transparent;
   padding: 0 4px;
   color: var(--color-primary-active);
   font-size: 13px;
@@ -8609,26 +8754,29 @@ button.tinyos-overlay-backdrop:focus-visible {
   inset: 0;
   z-index: 40;
   display: grid;
-  place-items: center;
+  place-items: stretch end;
   background: rgb(20 20 19 / 34%);
-  padding: 24px;
+  padding: 0;
 }
 
 .react-settings-dialog {
-  display: grid;
-  width: min(760px, 100%);
-  max-height: min(720px, calc(100vh - 48px));
+  display: flex;
+  flex-direction: column;
+  width: min(500px, 100%);
+  height: 100%;
+  max-height: 100vh;
   gap: 16px;
   overflow: auto;
   border: 1px solid var(--color-hairline);
-  border-radius: 8px;
+  border-width: 0 0 0 1px;
+  border-radius: 18px 0 0 18px;
   background: #fff;
-  padding: 20px;
-  box-shadow: 0 24px 80px rgb(20 20 19 / 18%);
+  padding: 24px;
+  box-shadow: -24px 0 80px rgb(20 20 19 / 15%);
 }
 
 .react-settings-dialog--wide {
-  width: min(820px, 100%);
+  width: min(680px, 100%);
 }
 
 .react-settings-dialog header,
@@ -8950,37 +9098,44 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 @media (max-width: 1080px) {
   .react-settings-layout {
-    grid-template-columns: 176px minmax(0, 1fr);
-    gap: 24px;
+    grid-template-columns: 184px minmax(0, 1fr);
+    gap: 28px;
   }
 
   .react-settings-sidebar {
-    padding-right: 14px;
+    padding-right: 4px;
   }
 
   .react-default-llm-summary {
-    grid-template-columns: 40px minmax(120px, 1fr) minmax(160px, 1.15fr) auto;
+    grid-template-columns: 40px minmax(160px, 1fr) minmax(132px, 0.6fr) auto;
   }
 
   .react-default-llm-summary__count {
     display: none;
   }
 
-  .react-provider-directory__columns,
   .react-provider-card {
-    grid-template-columns: minmax(135px, 1fr) minmax(132px, 0.9fr) 76px 110px;
+    grid-template-columns: minmax(210px, 1.2fr) minmax(135px, 0.8fr) minmax(120px, 0.65fr) auto;
   }
 
-  .react-provider-directory__columns > span:nth-child(2),
   .react-provider-card__url {
     display: none;
   }
 }
 
+.react-settings-dialog footer {
+  position: sticky;
+  bottom: -24px;
+  margin-top: auto;
+  border-top: 1px solid var(--color-hairline);
+  background: #fff;
+  padding: 16px 0 2px;
+}
+
 @media (max-width: 780px) {
   .react-settings-layout {
     grid-template-columns: minmax(0, 1fr);
-    gap: 24px;
+    gap: 22px;
   }
 
   .react-settings-sidebar {
@@ -8988,11 +9143,28 @@ button.tinyos-overlay-backdrop:focus-visible {
     min-height: 0;
     border-right: 0;
     border-bottom: 1px solid var(--color-hairline);
-    padding: 0 0 16px;
+    overflow-x: auto;
+    padding: 0 0 14px;
   }
 
   .react-settings-sidebar nav {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    display: flex;
+    gap: 6px;
+    min-width: max-content;
+  }
+
+  .react-settings-sidebar__intro {
+    display: none;
+  }
+
+  .react-settings-sidebar button {
+    grid-template-columns: 17px auto;
+    width: auto;
+    padding-inline: 11px;
+  }
+
+  .react-settings-sidebar__chevron {
+    display: none;
   }
 
   .react-provider-settings__header h2 {
@@ -9014,8 +9186,8 @@ button.tinyos-overlay-backdrop:focus-visible {
 
   .react-default-llm-summary {
     grid-template-areas:
-      "icon provider action"
-      "model model model";
+      "icon model action"
+      "provider provider provider";
     grid-template-columns: 40px minmax(0, 1fr) auto;
   }
 
@@ -9025,13 +9197,15 @@ button.tinyos-overlay-backdrop:focus-visible {
 
   .react-default-llm-summary__provider {
     grid-area: provider;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    border-top: 1px solid var(--color-hairline);
+    padding-top: 12px;
   }
 
   .react-default-llm-summary__model {
     grid-area: model;
-    border-top: 1px solid var(--color-hairline);
-    border-left: 0;
-    padding: 12px 0 0;
+    padding: 0;
   }
 
   .react-default-llm-summary > button {
@@ -9052,39 +9226,39 @@ button.tinyos-overlay-backdrop:focus-visible {
     padding-inline: 7px;
   }
 
-  .react-provider-directory__columns {
-    display: none;
+  .react-provider-directory > header {
+    align-items: center;
   }
 
   .react-provider-card {
     grid-template-areas:
       "identity actions"
-      "url actions"
-      "state models";
+      "model state";
     grid-template-columns: minmax(0, 1fr) auto;
-    gap: 8px 14px;
+    gap: 12px 16px;
   }
 
   .react-provider-card__identity {
     grid-area: identity;
   }
 
-  .react-provider-card__url {
-    display: block;
-    grid-area: url;
+  .react-provider-card__model {
+    grid-area: model;
   }
 
   .react-provider-card__state {
     grid-area: state;
   }
 
-  .react-provider-card__models {
-    grid-area: models;
-    justify-self: end;
-  }
-
   .react-provider-card__actions {
     grid-area: actions;
+    align-self: start;
+  }
+
+  .react-settings-dialog,
+  .react-settings-dialog--wide {
+    width: 100%;
+    border-radius: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

- simplify the settings control center with flatter provider, agent-default, and configuration rows
- add a shared accessible settings sheet with focus trapping, focus restoration, Escape handling, and reduced-motion support
- move model and provider workflows into the shared sheet and refine the provider configuration hierarchy, API key status, active-profile control, and API mode selector
- normalize press feedback and motion timing across settings interactions

## User impact

The settings area now has less nested card chrome, clearer information hierarchy, more consistent side-sheet workflows, and improved keyboard and motion accessibility.

## Validation

- `npm run build`
- `npx vitest run src/react-workbench/settings/SettingsSheet.test.tsx src/react-workbench/shell/DesktopShell.test.tsx` (17 passed)
- `npm test -- --reporter=dot` (493 passed; one existing ChatPage text-animation timing test failed in the full run and passed when rerun in isolation)
- `git diff --check`
