### PR TITLE
Unify context compaction behavior

### DIFF
--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -1599,8 +1599,8 @@ context-window budget fields:
 
 Rust agent context-window controls are read from `agents.defaults` or the turn specification:
 
-- `contextWindowTokens` / `context_window_tokens`: effective context window. The fallback is
-  `128000`.
+- `contextWindowTokens` / `context_window_tokens`: effective context window. When unset,
+  `deepseek-v4-flash` and `deepseek-v4-pro` use `1000000`; other models fall back to `128000`.
 - `contextWindowStrategy` / `context_window_strategy`: `discard` or `compact`. The fallback is
   `discard`.
 - `compactTriggerPercent` / `compact_trigger_percent`: percentage threshold for `compact`; default

--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -703,6 +703,15 @@ items without that field fall back to the most recent known usage budget, then t
 loaded Agent Defaults context-window budget. Canonical compaction data also preserves `strategy` so
 the restored indicator matches the live context policy.
 
+Manual and automatic compaction share one replacement-history policy. Current system/developer
+instructions and recent user messages are retained within the context budget; assistant messages,
+tool calls, tool results, and any previous compaction summary are replaced by exactly one marked
+assistant summary (`contextCompaction: true`). Provider adapters project that internal summary as a
+continuation user message without exposing the marker. `agent.context.compacted` reports
+`preservedUserMessageCount`, `droppedUserMessageCount`, `droppedAssistantMessageCount`,
+`droppedToolMessageCount`, and `mergedCompactionSummaryCount` alongside the existing token and
+message counts.
+
 The desktop loads Subagent traces and artifact content through
 `worker_background_trace_get_delegate_trace` and `worker_background_trace_get_artifact`. Timeline
 paths are metadata only and are never used directly as browser image URLs. Raster previews accept

--- a/src-tauri/src/agent/runtime/chat_completions_adapter.rs
+++ b/src-tauri/src/agent/runtime/chat_completions_adapter.rs
@@ -118,6 +118,7 @@ impl ChatCompletionsAdapter {
                     .as_ref()
                     .map(|reasoning| reasoning.summary.clone()),
                 tool_calls,
+                context_compaction: false,
             },
             reasoning,
             usage,

--- a/src-tauri/src/agent/runtime/context_manager_tests.rs
+++ b/src-tauri/src/agent/runtime/context_manager_tests.rs
@@ -55,6 +55,27 @@ fn prompt_accepts_complete_tool_pairs() {
 }
 
 #[test]
+fn compaction_summary_round_trips_as_internal_assistant_and_provider_user_message() {
+    let history = ContextManager::from_legacy_messages(&[json!({
+        "role": "assistant",
+        "content": "Conversation summary so far:\nfinished the first task",
+        "contextCompaction": true
+    })])
+    .unwrap();
+
+    let stored = history.messages();
+    assert_eq!(stored[0]["role"], "assistant");
+    assert_eq!(stored[0]["contextCompaction"], true);
+
+    let prompt = history.for_prompt().unwrap();
+    assert_eq!(prompt[0]["role"], "user");
+    assert!(prompt[0].get("contextCompaction").is_none());
+    assert!(prompt[0]["content"]
+        .as_str()
+        .is_some_and(|content| content.starts_with("Conversation summary so far:")));
+}
+
+#[test]
 fn token_info_tracks_total_and_last_model_call_usage() {
     let mut history = ContextManager::from_legacy_messages(&[]).unwrap();
 

--- a/src-tauri/src/agent/runtime/items.rs
+++ b/src-tauri/src/agent/runtime/items.rs
@@ -60,6 +60,12 @@ pub struct AgentAssistantMessage {
     pub reasoning: Option<String>,
     #[serde(default)]
     pub tool_calls: Vec<AgentToolCallItem>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub context_compaction: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -349,6 +355,11 @@ impl AgentItem {
                     "assistant reasoning content",
                 )?,
                 tool_calls: parse_legacy_tool_calls(object.get("tool_calls"))?,
+                context_compaction: object
+                    .get("contextCompaction")
+                    .or_else(|| object.get("context_compaction"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
             })),
             "tool" => Ok(Self::ToolResult(AgentToolResultItem {
                 id,
@@ -396,6 +407,28 @@ impl AgentItem {
                 "content": message.content.to_value(),
             })),
             Self::AssistantMessage(message) => {
+                if message.context_compaction {
+                    if message.reasoning.is_some() || !message.tool_calls.is_empty() {
+                        return Err(
+                            "context compaction summary cannot contain reasoning or tool calls"
+                                .to_string(),
+                        );
+                    }
+                    let content = message.content.as_ref().ok_or_else(|| {
+                        "context compaction summary requires message content".to_string()
+                    })?;
+                    if provider_names {
+                        return Ok(serde_json::json!({
+                            "role": "user",
+                            "content": content.to_value(),
+                        }));
+                    }
+                    return Ok(serde_json::json!({
+                        "role": "assistant",
+                        "content": content.to_value(),
+                        "contextCompaction": true,
+                    }));
+                }
                 let tool_calls = message
                     .tool_calls
                     .iter()

--- a/src-tauri/src/agent/runtime/responses_adapter.rs
+++ b/src-tauri/src/agent/runtime/responses_adapter.rs
@@ -230,6 +230,7 @@ impl ResponsesAdapter {
                     .as_ref()
                     .map(|reasoning| reasoning.summary.clone()),
                 tool_calls,
+                context_compaction: false,
             },
             reasoning,
             usage,

--- a/src-tauri/src/agent/runtime/tests/context.rs
+++ b/src-tauri/src/agent/runtime/tests/context.rs
@@ -1,3 +1,4 @@
+use super::super::usage::{context_window_action_payload, context_window_projection};
 use super::*;
 
 #[test]
@@ -423,12 +424,14 @@ fn agent_chat_request_compacts_old_messages_when_strategy_is_compact() {
         .expect("messages should be an array");
 
     assert_eq!(messages.len(), 2);
-    assert_eq!(messages[0]["role"], "system");
-    assert!(messages[0]["content"]
+    assert_eq!(messages[0]["role"], "user");
+    assert_eq!(messages[0]["content"], "current question");
+    assert_eq!(messages[1]["role"], "user");
+    assert!(messages[1]["content"]
         .as_str()
         .expect("summary content should be text")
         .contains("summary of earlier turns"));
-    assert_eq!(messages[1]["content"], "current question");
+    assert!(messages[1].get("contextCompaction").is_none());
 }
 
 #[test]
@@ -568,6 +571,10 @@ fn agent_turn_emits_context_compaction_event_when_old_messages_are_summarized() 
     assert_eq!(compact_event["payload"]["droppedMessageCount"], 2);
     assert_eq!(compact_event["payload"]["retainedMessageCount"], 1);
     assert_eq!(compact_event["payload"]["replacementMessageCount"], 2);
+    assert_eq!(compact_event["payload"]["preservedUserMessageCount"], 1);
+    assert_eq!(compact_event["payload"]["droppedUserMessageCount"], 1);
+    assert_eq!(compact_event["payload"]["droppedAssistantMessageCount"], 1);
+    assert_eq!(compact_event["payload"]["droppedToolMessageCount"], 0);
     assert_eq!(compact_event["payload"]["contextWindowTokens"], 800);
     assert_eq!(
         compact_event["payload"]["agentItem"]["type"],
@@ -665,11 +672,183 @@ fn manual_context_compaction_bypasses_threshold_and_finishes_without_a_normal_re
         .as_u64()
         .is_some_and(|count| count > 0));
     assert_eq!(result["contextCheckpoint"]["checkpointStage"], "finalized");
+    let replacement = result["contextCheckpoint"]["replacementHistory"]
+        .as_array()
+        .expect("manual compaction should persist replacement history");
+    assert_eq!(replacement.len(), 3);
+    assert_eq!(replacement[0]["role"], "user");
+    assert_eq!(replacement[1]["role"], "user");
+    assert_eq!(replacement[2]["role"], "assistant");
+    assert_eq!(replacement[2]["contextCompaction"], true);
     assert!(result["runtimeEvents"]
         .as_array()
         .is_some_and(|events| !events
             .iter()
             .any(|event| event["eventName"] == "agent.message.completed")));
+}
+
+#[test]
+fn manual_and_auto_compaction_install_the_same_role_aware_history() {
+    let messages = json!([
+        { "role": "system", "content": "historical system instruction" },
+        { "role": "user", "content": "The login page returns 401; investigate it." },
+        { "role": "assistant", "content": "I will inspect authentication. ".repeat(100) },
+        {
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "compact-call-1",
+                "type": "function",
+                "function": { "name": "workspace.search", "arguments": "{}" }
+            }]
+        },
+        { "role": "tool", "tool_call_id": "compact-call-1", "content": "search results" },
+        { "role": "assistant", "content": "The token validation is wrong." },
+        { "role": "user", "content": "Keep the old Session API compatible." },
+        { "role": "assistant", "content": "I will preserve that constraint." },
+        {
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "compact-call-2",
+                "type": "function",
+                "function": { "name": "workspace.read_file", "arguments": "{}" }
+            }]
+        },
+        { "role": "tool", "tool_call_id": "compact-call-2", "content": "auth.ts contents" },
+        { "role": "assistant", "content": "I changed the middleware." },
+        {
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "compact-call-3",
+                "type": "function",
+                "function": { "name": "workspace.run_tests", "arguments": "{}" }
+            }]
+        },
+        { "role": "tool", "tool_call_id": "compact-call-3", "content": "all tests passed" },
+        { "role": "assistant", "content": "The fix is complete." }
+    ]);
+    let config = json!({
+        "agents": { "defaults": {
+            "provider": "fixture",
+            "model": "fixture-model",
+            "contextWindowTokens": 10_000,
+            "contextWindowStrategy": "compact",
+            "compactTriggerPercent": 1,
+            "compactSummaryMaxTokens": 64
+        }},
+        "providers": { "fixture": { "responses": [
+            { "content": "fixed token validation, preserved Session compatibility, and passed tests" }
+        ]}}
+    });
+    let base_spec = json!({
+        "runtime": "rust",
+        "turnId": "turn-unified-compaction",
+        "sessionId": "session-unified-compaction",
+        "messages": messages
+    });
+    let auto_context = AgentTurnContext::from_spec(base_spec.clone(), config.clone());
+    let mut manual_spec = base_spec;
+    manual_spec["contextCompaction"] = json!({
+        "trigger": "manual",
+        "reason": "user_requested",
+        "phase": "standalone_turn"
+    });
+    let manual_context = AgentTurnContext::from_spec(manual_spec, config);
+
+    let auto = context_window_projection(&auto_context).expect("auto compaction should project");
+    let manual =
+        context_window_projection(&manual_context).expect("manual compaction should project");
+
+    assert_eq!(manual.messages, auto.messages);
+    assert_eq!(manual.messages.len(), 4);
+    assert_eq!(manual.messages[0]["role"], "system");
+    assert_eq!(manual.messages[1]["role"], "user");
+    assert_eq!(manual.messages[2]["role"], "user");
+    assert_eq!(manual.messages[3]["role"], "assistant");
+    assert_eq!(manual.messages[3]["contextCompaction"], true);
+    assert!(manual.messages[3]["content"]
+        .as_str()
+        .is_some_and(|content| content.contains("fixed token validation")));
+    assert!(!manual
+        .messages
+        .iter()
+        .any(|message| message["role"] == "tool" || message.get("tool_calls").is_some()));
+
+    let auto_payload = context_window_action_payload(
+        &auto_context,
+        0,
+        auto.action.as_ref().expect("auto action should exist"),
+    );
+    let manual_payload = context_window_action_payload(
+        &manual_context,
+        0,
+        manual.action.as_ref().expect("manual action should exist"),
+    );
+    assert_eq!(auto_payload["trigger"], "auto");
+    assert_eq!(manual_payload["trigger"], "manual");
+    assert_eq!(auto_payload["preservedUserMessageCount"], 2);
+    assert_eq!(auto_payload["droppedAssistantMessageCount"], 8);
+    assert_eq!(auto_payload["droppedToolMessageCount"], 3);
+}
+
+#[test]
+fn repeated_compaction_replaces_the_previous_summary() {
+    let context = AgentTurnContext::from_spec(
+        json!({
+            "runtime": "rust",
+            "turnId": "turn-repeat-compaction",
+            "sessionId": "session-repeat-compaction",
+            "contextCompaction": { "trigger": "manual" },
+            "messages": [
+                { "role": "system", "content": "historical system instruction" },
+                { "role": "user", "content": "first request" },
+                { "role": "user", "content": "second request" },
+                {
+                    "role": "assistant",
+                    "content": "Conversation summary so far:\nOLD SUMMARY MUST BE REPLACED",
+                    "contextCompaction": true
+                },
+                { "role": "user", "content": "third request" },
+                { "role": "assistant", "content": "new work after the first compaction" }
+            ]
+        }),
+        json!({
+            "agents": { "defaults": {
+                "provider": "fixture",
+                "model": "fixture-model",
+                "contextWindowTokens": 10_000,
+                "contextWindowStrategy": "compact",
+                "compactSummaryMaxTokens": 64
+            }},
+            "providers": { "fixture": { "responses": [
+                { "content": "NEW MERGED SUMMARY" }
+            ]}}
+        }),
+    );
+
+    let projection = context_window_projection(&context).expect("repeat compaction should project");
+
+    assert_eq!(projection.messages.len(), 5);
+    assert_eq!(
+        projection
+            .messages
+            .iter()
+            .filter(|message| message["contextCompaction"] == true)
+            .count(),
+        1
+    );
+    assert!(!projection
+        .messages
+        .iter()
+        .any(|message| message.to_string().contains("OLD SUMMARY MUST BE REPLACED")));
+    assert!(projection.messages.last().is_some_and(|message| {
+        message["role"] == "assistant"
+            && message["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("NEW MERGED SUMMARY"))
+    }));
 }
 
 #[test]
@@ -909,24 +1088,20 @@ fn context_compaction_masks_large_tool_output_without_splitting_its_call() {
     let replacement = result["contextCheckpoint"]["replacementHistory"]
         .as_array()
         .expect("replacement history should be present");
-    assert!(replacement.iter().any(|message| {
-        message["role"] == "assistant"
-            && message["tool_calls"].as_array().is_some_and(|tool_calls| {
-                tool_calls
-                    .iter()
-                    .any(|call| call["id"] == "context-tool-mask-1")
-            })
+    assert!(!replacement.iter().any(|message| message["role"] == "tool"));
+    assert!(!replacement.iter().any(|message| {
+        message["tool_calls"].as_array().is_some_and(|tool_calls| {
+            tool_calls
+                .iter()
+                .any(|call| call["id"] == "context-tool-mask-1")
+        })
     }));
-    let tool_message = replacement
-        .iter()
-        .find(|message| message["role"] == "tool")
-        .expect("tool call unit should be retained together");
-    let content = tool_message["content"]
-        .as_str()
-        .expect("masked tool content should be text");
-    assert!(content.starts_with("HEAD-"));
-    assert!(content.contains("tool output compacted"));
-    assert!(content.ends_with("-TAIL"));
+    assert!(replacement.iter().any(|message| {
+        message["contextCompaction"] == true
+            && message["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("summary before the tool call"))
+    }));
 }
 
 #[test]

--- a/src-tauri/src/agent/runtime/tests/context.rs
+++ b/src-tauri/src/agent/runtime/tests/context.rs
@@ -1264,6 +1264,44 @@ fn agent_usage_event_includes_context_window_budget() {
 }
 
 #[test]
+fn context_window_uses_whitelisted_model_default_when_unconfigured() {
+    for model in ["deepseek-v4-flash", "deepseek-v4-pro"] {
+        let context = AgentTurnContext::from_spec(json!({ "model": model }), json!({}));
+
+        let usage = enrich_usage_with_context_window(&context, json!({}), 10, 0);
+
+        assert_eq!(usage["contextWindowTokens"], 1_000_000, "model: {model}");
+    }
+}
+
+#[test]
+fn context_window_keeps_generic_default_for_unlisted_models() {
+    let context = AgentTurnContext::from_spec(json!({ "model": "custom-model" }), json!({}));
+
+    let usage = enrich_usage_with_context_window(&context, json!({}), 10, 0);
+
+    assert_eq!(usage["contextWindowTokens"], 128_000);
+}
+
+#[test]
+fn configured_context_window_overrides_whitelisted_model_default() {
+    let context = AgentTurnContext::from_spec(
+        json!({ "model": "deepseek-v4-pro" }),
+        json!({
+            "agents": {
+                "defaults": {
+                    "contextWindowTokens": 64_000
+                }
+            }
+        }),
+    );
+
+    let usage = enrich_usage_with_context_window(&context, json!({}), 10, 0);
+
+    assert_eq!(usage["contextWindowTokens"], 64_000);
+}
+
+#[test]
 fn user_file_and_image_parts_emit_typed_reference_items() {
     let result = run_native_agent_turn_with_services(
         &NativeAgentRuntimeServices::default(),

--- a/src-tauri/src/agent/runtime/tool_projection.rs
+++ b/src-tauri/src/agent/runtime/tool_projection.rs
@@ -23,6 +23,7 @@ pub(super) fn assistant_tool_calls_message(
                 arguments_json: tool_call.arguments_json.clone(),
             })
             .collect(),
+        context_compaction: false,
     })
     .to_legacy_message()
     .expect("constructed assistant tool-call item must serialize")

--- a/src-tauri/src/agent/runtime/usage.rs
+++ b/src-tauri/src/agent/runtime/usage.rs
@@ -9,12 +9,15 @@ use std::sync::Arc;
 const DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS: i64 = 128_000;
 const DEFAULT_COMPACT_TRIGGER_PERCENT: i64 = 90;
 const DEFAULT_COMPACT_SUMMARY_MAX_TOKENS: i64 = 1024;
+const COMPACT_USER_MESSAGE_MAX_TOKENS: i64 = 20_000;
+const COMPACT_USER_MESSAGE_BUDGET_PERCENT: i64 = 25;
 const APPROX_BYTES_PER_TOKEN: usize = 4;
 const MAX_COMPACT_TOOL_OUTPUT_CHARS: usize = 16_000;
 const MIN_COMPACT_TOOL_OUTPUT_CHARS: usize = 64;
 const MAX_COMPACTION_SUMMARY_LAYERS: usize = 8;
 const COMPACTION_REQUEST_LIMIT_PERCENT: i64 = 95;
-const SOURCE_SUMMARY_INSTRUCTION: &str = "Summarize earlier conversation context for a coding agent. Preserve user goals, decisions, constraints, file paths, commands, tool results, and unresolved tasks. Be concise and factual.";
+const COMPACTION_SUMMARY_PREFIX: &str = "Conversation summary so far:\n";
+const SOURCE_SUMMARY_INSTRUCTION: &str = "User messages are retained separately. Summarize assistant and tool work: decisions, constraints, files, commands, results, errors, tests, and next steps. Be concise and factual.";
 const MERGE_SUMMARY_INSTRUCTION: &str = "Merge partial coding-agent conversation summaries into one concise, factual continuation summary. Preserve goals, decisions, constraints, paths, tool results, progress, and unresolved tasks without duplicating facts.";
 
 #[derive(Clone, Debug)]
@@ -38,15 +41,25 @@ pub(super) struct ContextWindowAction {
     estimated_tokens_after: i64,
     masked_tool_output_count: usize,
     summary_request_count: usize,
+    preserved_user_message_count: usize,
+    dropped_user_message_count: usize,
+    dropped_assistant_message_count: usize,
+    dropped_tool_message_count: usize,
+    merged_compaction_summary_count: usize,
 }
 
 #[derive(Clone, Debug)]
 struct CompactedContextMessages {
     messages: Vec<Value>,
-    old_count: usize,
-    recent_count: usize,
+    dropped_count: usize,
+    retained_count: usize,
     masked_tool_output_count: usize,
     summary_request_count: usize,
+    preserved_user_message_count: usize,
+    dropped_user_message_count: usize,
+    dropped_assistant_message_count: usize,
+    dropped_tool_message_count: usize,
+    merged_compaction_summary_count: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -97,8 +110,7 @@ pub(super) async fn context_window_projection_async(
         && compact_threshold_reached(context, full_estimate, context_window_tokens);
     if manual_compaction || automatic_compaction {
         if let Some(compacted) =
-            compact_messages_to_context_window_async(context, message_budget, manual_compaction)
-                .await?
+            compact_messages_to_context_window_async(context, message_budget).await?
         {
             let estimated_tokens_after =
                 estimate_messages_tokens(&compacted.messages).saturating_add(system_prompt_tokens);
@@ -119,14 +131,19 @@ pub(super) async fn context_window_projection_async(
                     } else {
                         "pre_turn"
                     },
-                    dropped_message_count: compacted.old_count,
-                    retained_message_count: compacted.recent_count,
+                    dropped_message_count: compacted.dropped_count,
+                    retained_message_count: compacted.retained_count,
                     replacement_message_count,
                     context_window_tokens,
                     estimated_tokens_before: full_estimate,
                     estimated_tokens_after,
                     masked_tool_output_count: compacted.masked_tool_output_count,
                     summary_request_count: compacted.summary_request_count,
+                    preserved_user_message_count: compacted.preserved_user_message_count,
+                    dropped_user_message_count: compacted.dropped_user_message_count,
+                    dropped_assistant_message_count: compacted.dropped_assistant_message_count,
+                    dropped_tool_message_count: compacted.dropped_tool_message_count,
+                    merged_compaction_summary_count: compacted.merged_compaction_summary_count,
                 }),
             });
         }
@@ -170,6 +187,11 @@ pub(super) async fn context_window_projection_async(
             estimated_tokens_after,
             masked_tool_output_count,
             summary_request_count: 0,
+            preserved_user_message_count: 0,
+            dropped_user_message_count: 0,
+            dropped_assistant_message_count: 0,
+            dropped_tool_message_count: 0,
+            merged_compaction_summary_count: 0,
         }),
     })
 }
@@ -204,6 +226,11 @@ pub(super) fn context_window_action_payload(
         "estimatedTokensAfter": action.estimated_tokens_after,
         "maskedToolOutputCount": action.masked_tool_output_count,
         "summaryRequestCount": action.summary_request_count,
+        "preservedUserMessageCount": action.preserved_user_message_count,
+        "droppedUserMessageCount": action.dropped_user_message_count,
+        "droppedAssistantMessageCount": action.dropped_assistant_message_count,
+        "droppedToolMessageCount": action.dropped_tool_message_count,
+        "mergedCompactionSummaryCount": action.merged_compaction_summary_count,
     })
 }
 
@@ -509,41 +536,142 @@ fn mask_tool_output(content: &str, max_chars: usize) -> String {
 async fn compact_messages_to_context_window_async(
     context: &AgentTurnContext,
     context_window_tokens: i64,
-    manual: bool,
 ) -> Result<Option<CompactedContextMessages>, NativeAgentProviderFailure> {
     let (bounded_messages, masked_tool_output_count) = mask_oversized_tool_outputs(
         &context.messages,
         compact_tool_output_char_limit(context_window_tokens),
     );
-    let recent_budget = if manual {
-        (estimate_messages_tokens(&bounded_messages).saturating_mul(2) / 3).max(1)
-    } else {
-        (context_window_tokens.saturating_mul(2) / 3).max(1)
-    };
-    let recent_messages = trim_messages_to_context_window(&bounded_messages, recent_budget);
-    let recent_count = recent_messages.len();
-    let old_count = bounded_messages.len().saturating_sub(recent_messages.len());
-    if old_count == 0 {
-        return Ok(None);
-    }
-    let old_messages = &bounded_messages[..old_count];
-    let summary = compact_old_messages_async(context, old_messages).await?;
-    if summary.content.trim().is_empty() {
+    if bounded_messages.is_empty() {
         return Ok(None);
     }
 
-    let mut compacted = vec![serde_json::json!({
-        "role": "system",
-        "content": format!("Conversation summary so far:\n{}", summary.content.trim()),
-    })];
-    compacted.extend(recent_messages);
+    let instruction_messages = bounded_messages
+        .iter()
+        .filter(|message| {
+            matches!(message_role(message), Some("system") | Some("developer"))
+                && !is_context_compaction_summary(message)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let user_messages = bounded_messages
+        .iter()
+        .filter(|message| {
+            message_role(message) == Some("user") && !is_context_compaction_summary(message)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let instruction_tokens = estimate_messages_tokens(&instruction_messages);
+    let summary_reserve = effective_compact_summary_max_tokens(context).saturating_add(32);
+    let user_budget = context_window_tokens
+        .saturating_sub(instruction_tokens)
+        .saturating_sub(summary_reserve)
+        .min(
+            context_window_tokens
+                .saturating_mul(COMPACT_USER_MESSAGE_BUDGET_PERCENT)
+                .saturating_div(100),
+        )
+        .min(COMPACT_USER_MESSAGE_MAX_TOKENS)
+        .max(1);
+    let selected_user_messages = trim_messages_to_context_window(&user_messages, user_budget);
+    let compactable_message_count = bounded_messages
+        .len()
+        .saturating_sub(instruction_messages.len())
+        .saturating_sub(user_messages.len());
+    if compactable_message_count == 0 && selected_user_messages.len() == user_messages.len() {
+        return Ok(None);
+    }
+
+    let dropped_user_source_count = user_messages
+        .len()
+        .saturating_sub(selected_user_messages.len());
+    let mut seen_user_messages = 0usize;
+    let summary_source_messages = bounded_messages
+        .iter()
+        .filter_map(|message| {
+            if message_role(message) == Some("user") && !is_context_compaction_summary(message) {
+                let include = seen_user_messages < dropped_user_source_count;
+                seen_user_messages = seen_user_messages.saturating_add(1);
+                return include.then(|| message.clone());
+            }
+            if matches!(message_role(message), Some("system") | Some("developer"))
+                && !is_context_compaction_summary(message)
+            {
+                return None;
+            }
+            Some(message.clone())
+        })
+        .collect::<Vec<_>>();
+    if summary_source_messages.is_empty() {
+        return Ok(None);
+    }
+    let summary = compact_old_messages_async(context, &summary_source_messages).await?;
+    if summary.content.trim().is_empty() {
+        return Err(NativeAgentProviderFailure::provider(
+            "context compaction produced an empty summary",
+        ));
+    }
+
+    let merged_compaction_summary_count = bounded_messages
+        .iter()
+        .filter(|message| is_context_compaction_summary(message))
+        .count();
+    let dropped_assistant_message_count = bounded_messages
+        .iter()
+        .filter(|message| message_role(message) == Some("assistant"))
+        .count();
+    let dropped_tool_message_count = bounded_messages
+        .iter()
+        .filter(|message| message_role(message) == Some("tool"))
+        .count();
+    let mut compacted = instruction_messages;
+    compacted.extend(selected_user_messages);
+    compacted.push(serde_json::json!({
+        "role": "assistant",
+        "content": format!("{COMPACTION_SUMMARY_PREFIX}{}", summary.content.trim()),
+        "contextCompaction": true,
+    }));
+    let messages = trim_messages_to_context_window(&compacted, context_window_tokens);
+    let preserved_user_message_count = messages
+        .iter()
+        .filter(|message| {
+            message_role(message) == Some("user") && !is_context_compaction_summary(message)
+        })
+        .count();
+    let retained_instruction_count = messages
+        .iter()
+        .filter(|message| {
+            matches!(message_role(message), Some("system") | Some("developer"))
+                && !is_context_compaction_summary(message)
+        })
+        .count();
+    let retained_count = retained_instruction_count.saturating_add(preserved_user_message_count);
+    let dropped_count = bounded_messages.len().saturating_sub(retained_count);
     Ok(Some(CompactedContextMessages {
-        messages: trim_messages_to_context_window(&compacted, context_window_tokens),
-        old_count,
-        recent_count,
+        messages,
+        dropped_count,
+        retained_count,
         masked_tool_output_count,
         summary_request_count: summary.request_count,
+        preserved_user_message_count,
+        dropped_user_message_count: user_messages
+            .len()
+            .saturating_sub(preserved_user_message_count),
+        dropped_assistant_message_count,
+        dropped_tool_message_count,
+        merged_compaction_summary_count,
     }))
+}
+
+fn is_context_compaction_summary(message: &Value) -> bool {
+    message
+        .get("contextCompaction")
+        .or_else(|| message.get("context_compaction"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || message
+            .get("content")
+            .and_then(Value::as_str)
+            .is_some_and(|content| content.starts_with(COMPACTION_SUMMARY_PREFIX))
 }
 
 async fn compact_old_messages_async(

--- a/src-tauri/src/agent/runtime/usage.rs
+++ b/src-tauri/src/agent/runtime/usage.rs
@@ -7,6 +7,10 @@ use serde_json::Value;
 use std::sync::Arc;
 
 const DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS: i64 = 128_000;
+const DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS: &[(&str, i64)] = &[
+    ("deepseek-v4-flash", 1_000_000),
+    ("deepseek-v4-pro", 1_000_000),
+];
 const DEFAULT_COMPACT_TRIGGER_PERCENT: i64 = 90;
 const DEFAULT_COMPACT_SUMMARY_MAX_TOKENS: i64 = 1024;
 const COMPACT_USER_MESSAGE_MAX_TOKENS: i64 = 20_000;
@@ -348,7 +352,14 @@ fn effective_context_window_tokens(context: &AgentTurnContext) -> i64 {
                         .or_else(|| positive_i64_field(defaults, "context_window_tokens"))
                 })
         })
+        .or_else(|| default_context_window_tokens_for_model(&context.model))
         .unwrap_or(DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS)
+}
+
+fn default_context_window_tokens_for_model(model: &str) -> Option<i64> {
+    DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS
+        .iter()
+        .find_map(|(model_id, tokens)| (*model_id == model).then_some(*tokens))
 }
 
 fn context_window_strategy(context: &AgentTurnContext) -> String {

--- a/src-tauri/src/native_browser/README.md
+++ b/src-tauri/src/native_browser/README.md
@@ -31,6 +31,12 @@ Agent cancellation is forwarded to the matching in-flight browser command.
 Capture bytes remain available for native Agent observation but are not
 returned in model tool results or rendered as a TinyOS fallback.
 
+Agent observation does not require the TinyOS surface to be open. On Windows,
+detached tabs are rendered offscreen only for the duration of a serialized
+observation and return to the hidden state before the tool call continues.
+Surface updates and background observations share the same presentation lock,
+so opening or closing TinyOS cannot race screenshot capture.
+
 See [`tools::web`](../tools/web/README.md) for the model-facing snapshot and
 action contract.
 
@@ -41,6 +47,10 @@ capture, and surface identities; monotonically increasing snapshot and
 observation revisions; ordered tabs and history; lifecycle state; control
 epoch; profile persistence; bounded semantic targets; and at most one pending
 popup or external-protocol policy request.
+
+Opening or switching to a Chat does not preheat a native browser session. The
+session is created lazily when the Agent first invokes a `web.*` tool or the
+user opens TinyOS, so chats that never browse do not retain WebView2 processes.
 
 Calling `browser_create_session` again with the same owner identity rehydrates
 the existing session. Agent actions include navigation, coordinate or semantic

--- a/src-tauri/src/native_browser/integration.rs
+++ b/src-tauri/src/native_browser/integration.rs
@@ -106,6 +106,8 @@ async fn exercise_public_commands(
         ));
     }
 
+    exercise_lazy_agent_open(app, fixture).await?;
+
     let created = browser_create_session(
         runtime_state(app),
         BrowserCreateSessionInput {
@@ -174,6 +176,39 @@ async fn exercise_public_commands(
     Ok(())
 }
 
+async fn exercise_lazy_agent_open(
+    app: &tauri::AppHandle,
+    fixture: &NativeBrowserFixture,
+) -> Result<(), String> {
+    let runtime = runtime_state(app).inner().clone();
+    let owner_session_id = "native-browser-lazy-agent-open";
+    let opened = crate::tools::web::dispatch_web_open(
+        &runtime,
+        owner_session_id,
+        None,
+        json!({ "url": fixture.url("/") }),
+    )
+    .await
+    .map_err(|error| format!("Lazy Agent web.open failed: {error}"))?;
+    let snapshot = runtime
+        .snapshot_for_owner(owner_session_id)
+        .ok_or_else(|| "Lazy Agent web.open did not create an owned session".to_string())?;
+    let browser_session_id = snapshot.data.browser_session_id.clone();
+    let valid = opened["status"] == "completed"
+        && opened["snapshot"]["url"] == fixture.url("/")
+        && opened["snapshot"]["targets"]
+            .as_array()
+            .is_some_and(|targets| !targets.is_empty());
+    let close_result = runtime.close_session(&browser_session_id).await;
+    close_result?;
+    if !valid {
+        return Err(format!(
+            "Lazy Agent web.open returned incomplete evidence: {opened}"
+        ));
+    }
+    Ok(())
+}
+
 async fn exercise_open_session(
     app: &tauri::AppHandle,
     fixture: &NativeBrowserFixture,
@@ -190,15 +225,28 @@ async fn exercise_open_session(
         return Err("Public create/snapshot commands returned unexpected tab state".to_string());
     }
 
-    browser_navigate(
-        runtime_state(app),
-        BrowserNavigateInput {
-            browser_session_id: browser_session_id.clone(),
-            tab_id: tab_id.clone(),
-            url: fixture.url("/"),
-        },
+    let runtime = runtime_state(app).inner().clone();
+    let background_open = crate::tools::web::dispatch_web_open(
+        &runtime,
+        "native-browser-integration",
+        None,
+        json!({
+            "commandId": "native-browser-background-open",
+            "url": fixture.url("/"),
+        }),
     )
-    .await?;
+    .await
+    .map_err(|error| format!("Detached Agent web.open failed: {error}"))?;
+    if background_open["status"] != "completed"
+        || background_open["snapshot"]["url"] != fixture.url("/")
+        || background_open["snapshot"]["targets"]
+            .as_array()
+            .is_none_or(Vec::is_empty)
+    {
+        return Err(format!(
+            "Detached Agent web.open returned incomplete evidence: {background_open}"
+        ));
+    }
 
     browser_update_surface(
         runtime_state(app),

--- a/src-tauri/src/native_browser/windows.rs
+++ b/src-tauri/src/native_browser/windows.rs
@@ -159,6 +159,13 @@ struct BrowserTabHandle {
     webview: Webview<Wry>,
     profile: BrowserPlatformProfile,
     navigation: Arc<NavigationCompletion>,
+    presentation: Arc<BrowserTabPresentation>,
+}
+
+#[derive(Default)]
+struct BrowserTabPresentation {
+    lock: tokio::sync::Mutex<()>,
+    surface_visible: AtomicBool,
 }
 
 #[derive(Default)]
@@ -485,6 +492,7 @@ impl BrowserRuntimeAdapter for WindowsBrowserRuntime {
                 webview,
                 profile: request.profile,
                 navigation: navigation_completion,
+                presentation: Arc::new(BrowserTabPresentation::default()),
             },
         );
         Ok(BrowserPlatformTabState {
@@ -523,6 +531,7 @@ impl BrowserRuntimeAdapter for WindowsBrowserRuntime {
 
     async fn set_surface(&self, surface: BrowserPlatformSurface) -> Result<(), String> {
         let handle = self.tab(&surface.tab_id)?;
+        let _presentation_guard = handle.presentation.lock.lock().await;
         if surface.visible {
             handle
                 .webview
@@ -547,7 +556,12 @@ impl BrowserRuntimeAdapter for WindowsBrowserRuntime {
                 .hide()
                 .map_err(|error| format!("Failed to hide native browser surface: {error}"))?;
         }
-        wait_for_webview_dispatch(&handle.webview, "surface update").await
+        wait_for_webview_dispatch(&handle.webview, "surface update").await?;
+        handle
+            .presentation
+            .surface_visible
+            .store(surface.visible, Ordering::Release);
+        Ok(())
     }
 
     async fn navigate(&self, tab_id: &BrowserTabId, url: &str) -> Result<(), String> {
@@ -605,41 +619,26 @@ impl BrowserRuntimeAdapter for WindowsBrowserRuntime {
         semantic: bool,
     ) -> Result<BrowserPlatformObservation, String> {
         let handle = self.tab(tab_id)?;
-        let observed: ObservedDocument = eval_json(&handle.webview, OBSERVE_SCRIPT).await?;
-        let capture_base64 = if capture {
-            let result = call_cdp(
-                &handle.webview,
-                "Page.captureScreenshot",
-                json!({ "format": "png", "fromSurface": true, "captureBeyondViewport": false }),
-            )
-            .await?;
-            Some(
-                result
-                    .get("data")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| "WebView2 screenshot response omitted image data".to_string())?
-                    .to_string(),
-            )
+        let _presentation_guard = handle.presentation.lock.lock().await;
+        let background_observation = !handle.presentation.surface_visible.load(Ordering::Acquire);
+        if background_observation {
+            prepare_background_observation(&handle.webview).await?;
+        }
+
+        let observation = observe_webview(&handle.webview, capture, semantic).await;
+        let restore = if background_observation {
+            restore_hidden_surface(&handle.webview).await
         } else {
-            None
+            Ok(())
         };
-        Ok(BrowserPlatformObservation {
-            capture_base64,
-            viewport_width: observed.viewport_width,
-            viewport_height: observed.viewport_height,
-            device_scale: observed.device_scale,
-            semantic_nodes: if semantic {
-                observed
-                    .nodes
-                    .into_iter()
-                    .take(MAX_SEMANTIC_NODES)
-                    .map(Into::into)
-                    .collect()
-            } else {
-                Vec::new()
-            },
-            semantic_truncated: semantic && observed.truncated,
-        })
+        match (observation, restore) {
+            (Ok(observation), Ok(())) => Ok(observation),
+            (Err(error), Ok(())) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Err(observe_error), Err(restore_error)) => Err(format!(
+                "{observe_error}; restoring the hidden browser surface also failed: {restore_error}"
+            )),
+        }
     }
 
     async fn interact(
@@ -883,6 +882,77 @@ fn selector_action(selector: &str, kind: &str, text: Option<&str>) -> Result<Str
         }
         _ => Err("Unsupported normalized browser selector action".to_string()),
     }
+}
+
+async fn prepare_background_observation(webview: &Webview<Wry>) -> Result<(), String> {
+    webview
+        .set_bounds(Rect {
+            position: LogicalPosition::new(-(f64::from(BACKGROUND_VIEWPORT_WIDTH) + 16.0), 0.0)
+                .into(),
+            size: LogicalSize::new(
+                f64::from(BACKGROUND_VIEWPORT_WIDTH),
+                f64::from(BACKGROUND_VIEWPORT_HEIGHT),
+            )
+            .into(),
+        })
+        .map_err(|error| format!("Failed to place background browser surface: {error}"))?;
+    webview
+        .show()
+        .map_err(|error| format!("Failed to enable background browser rendering: {error}"))?;
+    if let Err(error) = wait_for_webview_dispatch(webview, "background observation").await {
+        let _ = webview.hide();
+        return Err(error);
+    }
+    Ok(())
+}
+
+async fn restore_hidden_surface(webview: &Webview<Wry>) -> Result<(), String> {
+    webview
+        .hide()
+        .map_err(|error| format!("Failed to restore hidden browser surface: {error}"))?;
+    wait_for_webview_dispatch(webview, "background observation cleanup").await
+}
+
+async fn observe_webview(
+    webview: &Webview<Wry>,
+    capture: bool,
+    semantic: bool,
+) -> Result<BrowserPlatformObservation, String> {
+    let observed: ObservedDocument = eval_json(webview, OBSERVE_SCRIPT).await?;
+    let capture_base64 = if capture {
+        let result = call_cdp(
+            webview,
+            "Page.captureScreenshot",
+            json!({ "format": "png", "fromSurface": true, "captureBeyondViewport": false }),
+        )
+        .await?;
+        Some(
+            result
+                .get("data")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "WebView2 screenshot response omitted image data".to_string())?
+                .to_string(),
+        )
+    } else {
+        None
+    };
+    Ok(BrowserPlatformObservation {
+        capture_base64,
+        viewport_width: observed.viewport_width,
+        viewport_height: observed.viewport_height,
+        device_scale: observed.device_scale,
+        semantic_nodes: if semantic {
+            observed
+                .nodes
+                .into_iter()
+                .take(MAX_SEMANTIC_NODES)
+                .map(Into::into)
+                .collect()
+        } else {
+            Vec::new()
+        },
+        semantic_truncated: semantic && observed.truncated,
+    })
 }
 
 async fn eval_unit(webview: &Webview<Wry>, script: &str) -> Result<(), String> {

--- a/src-tauri/src/threads/rollout/format/reconstruction_tests.rs
+++ b/src-tauri/src/threads/rollout/format/reconstruction_tests.rs
@@ -232,6 +232,7 @@ fn replay_compacted_replacement_history_wins() {
                         "role": "assistant",
                         "messageId": "compact-summary",
                         "content": "Summary of earlier context",
+                        "contextCompaction": true,
                         "timestamp": "2026-07-08T10:02:00Z"
                     }
                 ]
@@ -242,6 +243,7 @@ fn replay_compacted_replacement_history_wins() {
 
     assert_eq!(replay.messages.len(), 1);
     assert_eq!(replay.messages[0]["messageId"], "compact-summary");
+    assert_eq!(replay.messages[0]["contextCompaction"], true);
 }
 
 #[test]

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -376,17 +376,22 @@ describe("ChatPage", () => {
     expect(document.activeElement).toBe(openButton);
   }, 10_000);
 
-  it("prepares the active chat browser session before TinyOS is opened", async () => {
+  it("does not create a browser session until TinyOS or an Agent web tool needs it", async () => {
+    const user = userEvent.setup();
     const stores = createStores();
     const createSession = vi.fn(async () => handoffBrowserSnapshot("idle", 0));
     stores.chatStore.browserRuntime = {
       createSession,
+      updateSurface: vi.fn(async () => handoffBrowserSnapshot("idle", 0)),
     } as unknown as NativeBrowserRuntimeApi;
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 29, 0, 0, 0)} sessionStore={stores.sessionStore} />);
 
-    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ ownerSessionId: "s1" }));
+    await screen.findByText("Can you help?");
+    expect(createSession).not.toHaveBeenCalled();
     expect(screen.queryByLabelText("TinyOS shared desktop")).toBeNull();
+    await user.click(screen.getByRole("button", { name: /^Open TinyOS/ }));
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ ownerSessionId: "s1" }));
   });
 
   it("releases the TinyOS browser session on explicit exit and recreates it when reopened", async () => {
@@ -403,8 +408,10 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 29, 0, 0, 0)} sessionStore={stores.sessionStore} />);
 
-    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1));
+    await screen.findByText("Can you help?");
+    expect(createSession).not.toHaveBeenCalled();
     await user.click(screen.getByRole("button", { name: /^Open TinyOS/ }));
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1));
     await user.click(await screen.findByRole("button", { name: "Exit TinyOS and release browser" }));
 
     await waitFor(() => expect(closeSession).toHaveBeenCalledWith("browser-handoff"));

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -539,17 +539,7 @@ export function ChatPage({
   useEffect(() => {
     setBrowserSnapshot(undefined);
     setBrowserRuntimeError("");
-    if (!activeSession?.id || !chatStore.browserRuntime) return;
-    let cancelled = false;
-    void chatStore.browserRuntime.createSession({ ownerSessionId: activeSession.id }).then((snapshot) => {
-      if (!cancelled) setBrowserSnapshot(snapshot);
-    }).catch((error) => {
-      if (!cancelled) setBrowserRuntimeError(error instanceof Error ? error.message : String(error));
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [activeSession?.id, chatStore]);
+  }, [activeSession?.id]);
 
   useEffect(() => {
     if (liveCanvas.visibility !== "open"


### PR DESCRIPTION
## Summary

- unify automatic and manual context compaction around the same role-aware history and checkpoint behavior
- preserve context-window usage, tool-call pairing, and persisted reconstruction across Chat Completions and Responses API turns
- lazy-load native browser sessions so hidden browser UI does not eagerly initialize a session
- use a 1,000,000-token default context window for `deepseek-v4-flash` and `deepseek-v4-pro` while preserving explicit configuration and the generic 128,000-token fallback
- update backend API and native browser documentation for the new behavior

## Why

The previous compaction paths could diverge in how they installed summaries, tracked context usage, and reconstructed persisted turns. Native browser sessions were also initialized more eagerly than the UI required. This change consolidates those behaviors and makes model-specific context budgets explicit.

## User impact

Long DeepSeek v4 conversations receive the intended default context budget, manual and automatic compaction behave consistently, and native browser resources are initialized only when needed.

## Validation

- `cargo test context_window_ -j 4` (9 passed)
- `npx vitest run src/react-workbench/chat/ChatPage.test.tsx` (109 passed)
- `cargo test -j 4` (868 passed; two Windows child-process termination tests failed inside the restricted sandbox)
- `cargo test termination -j 4` outside the restricted sandbox (2 passed)
- `git diff --check`
