### PR TITLE
Hide composer file paths from chat messages

### DIFF
--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -441,7 +441,7 @@ export function ClaudeStyleAiInput({
           ))}
           {files.map((item) => (
             <AttachmentChip
-              detail={`${getFileTypeLabel(item.mimeType)} - ${formatFileSize(item.sizeBytes)}`}
+              detail={formatFileMetadata(item.mimeType, item.sizeBytes)}
               icon={getFileIcon(item.mimeType)}
               key={item.id}
               label={item.name}
@@ -793,6 +793,10 @@ function getFileTypeLabel(type: string): string {
     label = `${label.substring(0, 10)}...`;
   }
   return label;
+}
+
+export function formatFileMetadata(mimeType: string, sizeBytes: number): string {
+  return `${getFileTypeLabel(mimeType)} - ${formatFileSize(sizeBytes)}`;
 }
 
 function countWords(text: string): number {

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -2858,7 +2858,7 @@ describe("ChatPage", () => {
     expect((input as HTMLTextAreaElement).value).toBe("");
   });
 
-  it("sends native file paths inside the final user text", async () => {
+  it("sends native files as structured references without exposing paths in user text", async () => {
     const user = userEvent.setup();
     const stores = createStores();
     nativeFilePickerMocks.pickDesktopChatFiles.mockResolvedValueOnce([{
@@ -2877,8 +2877,44 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
     expectTurnSubmit(stores.chatStore, "s1", {
-      text: "# Files mentioned by the user:\n\n## notes.md: C:\\Users\\tester\\notes.md\n\n## My request for Tinybot:\nReview this file",
+      references: [{
+        detail: "MARKDOWN - 16 Bytes",
+        kind: "reference",
+        rawPath: "C:\\Users\\tester\\notes.md",
+        title: "notes.md",
+        type: "tinyos.file",
+      }],
+      text: "Review this file",
     });
+  });
+
+  it("renders native file metadata without exposing its absolute path", async () => {
+    const stores = createStores();
+    const timeline = timelineFromReactMessages("s1", [{
+      id: "u-native-file",
+      role: "user",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      text: "文件中的内容是什么",
+      status: "complete",
+    }]);
+    timeline.turns[0].userMessage.references = [{
+      detail: "MARKDOWN - 1.67 KB",
+      kind: "reference",
+      rawPath: "D:\\code\\tinybot\\test\\AI_Agent_第一性原理_文档.md",
+      title: "AI_Agent_第一性原理_文档.md",
+      type: "tinyos.file",
+    }];
+    stores.chatStore.load = vi.fn(async () => timeline);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    const message = await screen.findByTestId("message-u-native-file");
+    const attachments = within(message).getByLabelText("Attachments");
+    expect(message.textContent).toContain("文件中的内容是什么");
+    expect(attachments.textContent).toContain("AI_Agent_第一性原理_文档.md");
+    expect(attachments.textContent).toContain("MARKDOWN - 1.67 KB");
+    expect(message.textContent).not.toContain("D:\\code\\tinybot\\test");
+    expect(message.textContent).not.toContain("Files mentioned by the user");
   });
 
   it("queues composer text while the active session is running", async () => {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   Circle,
   Copy,
+  FileText,
   Folder,
   FolderOpen,
   FolderPlus,
@@ -38,6 +39,7 @@ import {
 import type { QueuedInput } from "../../app-core/chat/chatUiProjection";
 import {
   ClaudeStyleAiInput,
+  formatFileMetadata,
   type ComposerFileReference,
   type ComposerContextReference,
   type ComposerSendOptions,
@@ -1401,7 +1403,10 @@ export function ChatPage({
     pastedContent: PastedContent[],
     options: ComposerSendOptions,
   ) {
-    const references = tinyOsContextReferences.map(nativeReferenceFromTinyOs);
+    const references = [
+      ...files.map(nativeReferenceFromComposerFile),
+      ...tinyOsContextReferences.map(nativeReferenceFromTinyOs),
+    ];
     if (message.trim() === "/compact") {
       if (files.length || pastedContent.length || references.length) {
         throw new Error("/compact 不能与附件或上下文引用一起使用。");
@@ -1433,13 +1438,12 @@ export function ChatPage({
       message || (files.length ? "Review the attached files." : references.length ? "Use the attached TinyOS context." : ""),
       pastedContent,
     );
-    const text = formatComposerFileReferences(visibleText, files);
     const sendSession = activeSession ?? await createSessionForDraft();
-    if (!text || !sendSession) {
+    if (!visibleText || !sendSession) {
       return;
     }
     const queuedResult = submitComposerText({
-      content: text,
+      content: visibleText,
       isRunning: isQueueableRunningSession(sendSession, emptyActiveSession),
       now: nextQueuedInputTimestamp(),
       queuedInputs: activeQueuedInputs,
@@ -2711,6 +2715,16 @@ function nativeReferenceFromTinyOs(reference: TinyOsAgentRequestReference): Agen
   };
 }
 
+function nativeReferenceFromComposerFile(file: ComposerFileReference): AgentInputReference {
+  return {
+    detail: formatFileMetadata(file.mimeType, file.sizeBytes),
+    kind: "reference",
+    rawPath: file.path,
+    title: file.name,
+    type: "tinyos.file",
+  };
+}
+
 function tinyOsAgentRequestControl(reference: TinyOsAgentRequestReference, intent: TinyOsAgentRequestIntent): string {
   return `${reference.kind}-${intent.replace(/_/g, "-")}`;
 }
@@ -2790,14 +2804,6 @@ function formatComposerMessage(message: string, pastedContent: PastedContent[]):
     segments.push(`Pasted content:\n${pasted.content}`);
   }
   return segments.join("\n\n");
-}
-
-function formatComposerFileReferences(message: string, files: ComposerFileReference[]): string {
-  if (!files.length) {
-    return message;
-  }
-  const mentionedFiles = files.map((file) => `## ${file.name}: ${file.path}`).join("\n\n");
-  return `# Files mentioned by the user:\n\n${mentionedFiles}\n\n## My request for Tinybot:\n${message}`;
 }
 
 function toComposerModelOption(model: ChatModelOption): ModelOption {
@@ -3555,6 +3561,9 @@ function canonicalReferenceSummary(reference: AgentInputReference, index: number
   return {
     id: reference.noteId || reference.evidenceId || `${reference.kind}:${index}`,
     kind: reference.kind,
+    presentation: reference.type === "tinyos.file" && Boolean(reference.rawPath) && !reference.sourcePath
+      ? "attachment"
+      : "context",
     title: reference.title,
     detail: reference.detail,
     sourcePath: reference.sourcePath,
@@ -3669,19 +3678,29 @@ function MessageReasoning({ durationMs, streaming, text }: { durationMs?: number
 }
 
 function MessageContext({ references }: { references: ContextReferenceSummary[] }) {
+  const attachmentsOnly = references.every((reference) => reference.presentation === "attachment");
   return (
-    <section className="react-message-context" aria-label="Context">
-      <h3>Context</h3>
+    <section
+      aria-label={attachmentsOnly ? "Attachments" : "Context"}
+      className="react-message-context"
+      data-presentation={attachmentsOnly ? "attachment" : "context"}
+    >
+      <h3>{attachmentsOnly ? "Attachments" : "Context"}</h3>
       <ul>
         {references.map((reference) => (
-          <li key={reference.id}>
-            <span>{reference.title}</span>
-            {reference.detail ? <small>{reference.detail}</small> : null}
-            {reference.sourcePath ? (
-              <small>
-                {reference.sourcePath}{typeof reference.sourceLine === "number" ? `:${reference.sourceLine}` : ""}
-              </small>
+          <li data-presentation={reference.presentation ?? "context"} key={reference.id}>
+            {reference.presentation === "attachment" ? (
+              <span className="react-message-context__icon"><FileText aria-hidden="true" size={16} /></span>
             ) : null}
+            <span className="react-message-context__text">
+              <strong>{reference.title}</strong>
+              {reference.detail ? <small>{reference.detail}</small> : null}
+              {reference.sourcePath ? (
+                <small>
+                  {reference.sourcePath}{typeof reference.sourceLine === "number" ? `:${reference.sourceLine}` : ""}
+                </small>
+              ) : null}
+            </span>
           </li>
         ))}
       </ul>

--- a/src/react-workbench/chat/messageActions.ts
+++ b/src/react-workbench/chat/messageActions.ts
@@ -23,6 +23,7 @@ export type ContextReferenceSummary = {
   kind: string;
   title: string;
   detail?: string;
+  presentation?: "attachment" | "context";
   sourcePath?: string;
   sourceLine?: number;
 };

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -221,6 +221,41 @@ describe("desktop native app services", () => {
     expect(events).toContainEqual(expect.objectContaining({ type: "message-sent" }));
   });
 
+  test("projects native file references as optimistic attachment metadata", async () => {
+    const services = createDesktopAppServices();
+    await services.sessionStore.list();
+    const events: ChatEvent[] = [];
+    services.chatStore.subscribe("thread-1", (event) => events.push(event));
+
+    await services.chatStore.dispatch(createDesktopTurnSubmitCommand({
+      commandId: "command-file-1",
+      message: {
+        references: [{
+          detail: "MARKDOWN - 16 Bytes",
+          kind: "reference",
+          rawPath: "C:\\Users\\tester\\notes.md",
+          title: "notes.md",
+          type: "tinyos.file",
+        }],
+        text: "Review this file",
+      },
+      sessionId: "thread-1",
+      source: { control: "test", surface: "chat" },
+    }));
+
+    expect(events).toContainEqual(expect.objectContaining({
+      message: expect.objectContaining({
+        contextReferences: [expect.objectContaining({
+          detail: "MARKDOWN - 16 Bytes",
+          presentation: "attachment",
+          title: "notes.md",
+        })],
+        text: "Review this file",
+      }),
+      type: "message-sent",
+    }));
+  });
+
   test("preserves live reasoning after the completed Thread result arrives", async () => {
     let completedTurnId = "";
     let resolveSubmit!: (value: unknown) => void;

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -747,6 +747,9 @@ function createOptimisticUserMessage(clientEventId: string, text: string, refere
         detail: reference.detail,
         id: reference.evidenceId || `reference-${index}`,
         kind: reference.kind,
+        presentation: reference.type === "tinyos.file" && Boolean(reference.rawPath) && !reference.sourcePath
+          ? "attachment"
+          : "context",
         sourceLine: reference.sourceLine,
         sourcePath: reference.sourcePath,
         title: reference.title,

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -4936,6 +4936,48 @@ button.tinyos-overlay-backdrop:focus-visible {
   gap: 2px;
 }
 
+.react-message-context li[data-presentation="attachment"] {
+  display: flex;
+  align-items: center;
+  width: fit-content;
+  max-width: min(280px, 100%);
+  gap: 8px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 10px;
+  background: var(--color-surface-soft);
+  padding: 7px 9px;
+}
+
+.react-message-context__icon {
+  display: inline-grid;
+  flex: 0 0 28px;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-muted);
+}
+
+.react-message-context__text {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+
+.react-message-context li[data-presentation="attachment"] .react-message-context__text strong,
+.react-message-context li[data-presentation="attachment"] .react-message-context__text small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-message-context__text strong {
+  color: var(--color-ink);
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .react-message-context small {
   color: var(--color-muted);
 }


### PR DESCRIPTION
## Summary

- Keep the user-visible message text separate from composer file attachment context.
- Send selected file paths as structured references so providers can still access them without exposing absolute paths in chat.
- Render selected files as attachment cards with the file name, type, and size.
- Preserve the existing Context presentation for TinyOS selections and other references.

## Root cause

The composer serialized selected file paths into a prebuilt Markdown prompt and used that prompt as the canonical user message. Because the same text was persisted and rendered, internal prompt scaffolding and absolute paths appeared in the conversation.

## Impact

New file attachment messages show only the user's original request. File paths remain available to the model through provider-only structured context, while the UI displays limited attachment metadata.

Existing historical messages that were already persisted in the legacy format are not rewritten.

## Validation

- `npm test -- src/react-workbench/chat/ChatPage.test.tsx src/react-workbench/defaultServices.test.ts src/components/ui/claude-style-ai-input.test.tsx` (127 passed)
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib provider_history_injects_tinyos_references_without_mutating_visible_message --jobs 4` (1 passed)
- `git diff --check`