### PR TITLE
Prepare v0.2.1 with custom updater notes

### DIFF
--- a/.github/scripts/customize-updater-manifest.mjs
+++ b/.github/scripts/customize-updater-manifest.mjs
@@ -1,0 +1,34 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+function optionalText(value) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function fail(message) {
+  console.error(`updater manifest customization failed: ${message}`);
+  process.exit(1);
+}
+
+const manifestPath = process.argv[2];
+if (!manifestPath) {
+  fail("pass the latest.json path as the first argument");
+}
+
+try {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const releaseNotes = optionalText(process.env.UPDATE_RELEASE_NOTES);
+  const displayNotes = optionalText(process.env.UPDATE_DISPLAY_NOTES);
+
+  if (releaseNotes) {
+    manifest.notes = releaseNotes;
+  }
+  if (displayNotes) {
+    manifest.display_notes = displayNotes;
+  }
+
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  console.log(`customized updater manifest: ${manifestPath}`);
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}

--- a/.github/scripts/customize-updater-manifest.test.mjs
+++ b/.github/scripts/customize-updater-manifest.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(new URL("./customize-updater-manifest.mjs", import.meta.url));
+
+function customize(manifest, environment = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "tinybot-updater-manifest-"));
+  const manifestPath = join(directory, "latest.json");
+  writeFileSync(manifestPath, JSON.stringify(manifest), "utf8");
+
+  const result = spawnSync(process.execPath, [scriptPath, manifestPath], {
+    encoding: "utf8",
+    env: { ...process.env, ...environment },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(readFileSync(manifestPath, "utf8"));
+}
+
+test("writes custom release and display notes without changing updater artifacts", () => {
+  const manifest = customize(
+    {
+      version: "0.3.0",
+      notes: "Generated notes",
+      platforms: { "windows-x86_64": { url: "https://example.com/update.zip", signature: "signed" } },
+    },
+    {
+      UPDATE_RELEASE_NOTES: "  Added a custom workflow.\n\nFixed update prompts.  ",
+      UPDATE_DISPLAY_NOTES: "  Save active work before installing.  ",
+    },
+  );
+
+  assert.equal(manifest.notes, "Added a custom workflow.\n\nFixed update prompts.");
+  assert.equal(manifest.display_notes, "Save active work before installing.");
+  assert.equal(manifest.platforms["windows-x86_64"].signature, "signed");
+});
+
+test("keeps generated notes when custom inputs are blank", () => {
+  const manifest = customize(
+    { version: "0.3.0", notes: "Generated notes" },
+    { UPDATE_RELEASE_NOTES: "  ", UPDATE_DISPLAY_NOTES: "" },
+  );
+
+  assert.equal(manifest.notes, "Generated notes");
+  assert.equal("display_notes" in manifest, false);
+});

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -4,6 +4,20 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "v<semver> tag to create or reuse at the current master commit"
+        required: true
+        type: string
+      release_notes:
+        description: "Custom What's new notes; leave blank to generate them from GitHub"
+        required: false
+        type: string
+      display_notes:
+        description: "Optional highlighted Before you update notice"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -16,17 +30,19 @@ jobs:
       CARGO_HTTP_TIMEOUT: "120"
       CARGO_NET_RETRY: "10"
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'master' || github.ref }}
 
       - name: Verify release source
         shell: pwsh
         run: |
-          git merge-base --is-ancestor "${{ github.sha }}" origin/master
+          git merge-base --is-ancestor HEAD origin/master
           if ($LASTEXITCODE -ne 0) {
             throw "Release tags must point to a commit on master"
           }
@@ -47,7 +63,10 @@ jobs:
         run: npm ci
 
       - name: Verify release version
-        run: node .github/scripts/check-release-version.mjs "${{ github.ref_name }}"
+        run: node .github/scripts/check-release-version.mjs "$env:RELEASE_TAG"
+
+      - name: Test updater manifest customization
+        run: node --test .github/scripts/customize-updater-manifest.test.mjs
 
       - name: Run frontend tests
         run: npm test
@@ -63,6 +82,22 @@ jobs:
         working-directory: src-tauri
         run: cargo test --lib desktop::update::tests -- --test-threads=1
 
+      - name: Ensure manual release tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: pwsh
+        run: |
+          $headCommit = git rev-parse HEAD
+          $tagCommit = git rev-list -n 1 "$env:RELEASE_TAG" 2>$null
+          if ($LASTEXITCODE -eq 0) {
+            if ($tagCommit -ne $headCommit) {
+              throw "Release tag $env:RELEASE_TAG already points to a different commit"
+            }
+            Write-Host "Release tag $env:RELEASE_TAG already points to $headCommit"
+          } else {
+            git tag "$env:RELEASE_TAG" HEAD
+            git push origin "refs/tags/$env:RELEASE_TAG"
+          }
+
       - name: Build and upload signed updater artifacts
         uses: tauri-apps/tauri-action@v1
         env:
@@ -72,25 +107,28 @@ jobs:
         with:
           tagName: v__VERSION__
           releaseName: Tinybot Desktop v__VERSION__
-          releaseBody: |
-            Highlights
-
-            • Added OpenAI Responses API support and persistent Responses sessions.
-            • Added workspace apply_patch support with visible code diffs.
-            • Improved tool activity, composer slash commands, and agent workflows.
-            • Stabilized the TinyOS browser lifecycle and fixed drag-time memory growth.
-            • Added About Tinybot with manual update review and installation.
-
-            Before updating, save active work. Tinybot closes its runtime before launching the installer.
-
-            The installer is not Authenticode-signed yet, so Windows SmartScreen may show an unknown publisher warning.
+          releaseBody: ${{ inputs.release_notes || '' }}
           releaseDraft: true
           prerelease: false
-          generateReleaseNotes: true
+          generateReleaseNotes: ${{ inputs.release_notes == '' }}
           updaterJsonPreferNsis: true
           args: --bundles nsis --target x86_64-pc-windows-msvc
+
+      - name: Apply custom updater notes
+        if: ${{ inputs.release_notes != '' || inputs.display_notes != '' }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_DISPLAY_NOTES: ${{ inputs.display_notes }}
+          UPDATE_RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          $manifestDirectory = Join-Path $env:RUNNER_TEMP "tinybot-updater-manifest"
+          New-Item -ItemType Directory -Force -Path $manifestDirectory | Out-Null
+          gh release download "$env:RELEASE_TAG" --pattern "latest.json" --dir $manifestDirectory --clobber
+          node .github/scripts/customize-updater-manifest.mjs (Join-Path $manifestDirectory "latest.json")
+          gh release upload "$env:RELEASE_TAG" (Join-Path $manifestDirectory "latest.json") --clobber
 
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false --latest
+        run: gh release edit "$env:RELEASE_TAG" --draft=false --latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinybot-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinybot-desktop",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/code": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinybot-desktop",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "tinybot-desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinybot-desktop"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tinybot lightweight desktop host"
 authors = ["Tinybot contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tinybot Desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.sudojacky.tinybot.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -482,7 +482,7 @@ describe("DesktopShell", () => {
     expect(activeProfile.disabled).toBe(true);
     const saveChanges = within(dialog).getByRole("button", { name: "Save changes" }) as HTMLButtonElement;
     expect(saveChanges.disabled).toBe(true);
-    await user.type(within(dialog).getByLabelText("API key"), "sk-test");
+    fireEvent.change(within(dialog).getByLabelText("API key"), { target: { value: "sk-test" } });
     expect(saveChanges.disabled).toBe(false);
     await user.click(saveChanges);
 


### PR DESCRIPTION
## Summary

- add a manual Windows release path with custom release notes and an optional highlighted update notice
- patch and re-upload `latest.json` while preserving updater artifact URLs and signatures
- bump the desktop version consistently to 0.2.1

## Validation

- `node .github/scripts/check-release-version.mjs v0.2.1`
- `node --test .github/scripts/customize-updater-manifest.test.mjs`
- `npm test` (496 tests)
- `npm run build`
- `cargo fmt --check`
- `cargo test -j 4 --lib desktop::update::tests -- --test-threads=1` (5 tests)