### PR TITLE
Add interrupt and queue actions for running turns

### DIFF
--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -184,6 +184,17 @@ work. Duplicate active Turn IDs are rejected. A form continuation starts a new
 generation only after the previous execution reaches a non-terminal waiting
 state.
 
+User-authored conversation messages never continue an active Turn. The desktop
+"insert" action cancels the active Turn, waits for both native cancellation
+confirmation and its interrupted terminal event, then submits the message through
+the normal Turn-start path with a new Turn ID. Its complete input envelope,
+including the selected model and references, is preserved exactly as it is for a
+normal or queued message. Queued messages use the same Turn-start path after the
+active Turn completes normally. Once either pending input is successfully
+submitted, it is removed from the pending-input queue. Protocol-level guidance
+remains reserved for internal controls and is not used as a desktop
+conversation-message transport.
+
 Cancellation is idempotent and has one terminal owner. The Turn remains in
 `cancelling` while owned children perform bounded cleanup, and a late result
 cannot replace the published terminal result.

--- a/src/app-core/chat/chatInputState.test.ts
+++ b/src/app-core/chat/chatInputState.test.ts
@@ -6,6 +6,7 @@ import {
   pauseQueuedInputs,
   resumeNextQueuedInput,
   submitComposerText,
+  updateInterruptStatus,
 } from "./chatInputState";
 import type { QueuedInput } from "./chatUiProjection";
 
@@ -28,7 +29,26 @@ describe("chat input state", () => {
     });
   });
 
-  test("enforces five queued inputs and does not expose guide input creation", () => {
+  test("creates an interrupt-and-new-turn input explicitly", () => {
+    expect(submitComposerText({
+      content: "Use the new API instead.",
+      isRunning: true,
+      runningAction: "interrupt",
+      queuedInputs: [],
+      now: "2026-07-01T10:11:00Z",
+    })).toEqual({
+      kind: "interrupt_input",
+      input: {
+        id: "interrupt-2026-07-01T10:11:00Z",
+        mode: "interrupt",
+        content: "Use the new API instead.",
+        createdAt: "2026-07-01T10:11:00Z",
+        status: "queued",
+      },
+    });
+  });
+
+  test("enforces five pending inputs", () => {
     const queuedInputs = Array.from({ length: MAX_QUEUED_INPUTS }, (_, index): QueuedInput => ({
       id: `queued-${index}`,
       mode: "queued",
@@ -47,6 +67,19 @@ describe("chat input state", () => {
       maxQueuedInputs: 5,
       message: "已有 5 条排队消息，请等待处理或删除一条后再发送。",
     });
+  });
+
+  test("tracks interrupt handoff before the input is submitted", () => {
+    const input: QueuedInput = {
+      id: "interrupt-1",
+      mode: "interrupt",
+      content: "Correct course",
+      createdAt: "2026-07-01T10:12:00Z",
+      status: "queued",
+    };
+
+    expect(updateInterruptStatus([input], input.id, "sent")[0].status).toBe("sent");
+    expect(updateInterruptStatus([input], input.id, "failed")[0].status).toBe("failed");
   });
 
   test("pauses queued input on stop or failure and resumes one item", () => {

--- a/src/app-core/chat/chatInputState.ts
+++ b/src/app-core/chat/chatInputState.ts
@@ -4,6 +4,7 @@ export const MAX_QUEUED_INPUTS = 5;
 
 export type SubmitComposerTextInput = {
   isRunning: boolean;
+  runningAction?: "interrupt" | "queue";
   content: string;
   queuedInputs: QueuedInput[];
   now: string;
@@ -12,6 +13,10 @@ export type SubmitComposerTextInput = {
 export type SubmitComposerTextResult =
   | {
       kind: "queue_input";
+      input: QueuedInput;
+    }
+  | {
+      kind: "interrupt_input";
       input: QueuedInput;
     }
   | {
@@ -27,11 +32,26 @@ export type SubmitComposerTextResult =
 export function submitComposerText(input: SubmitComposerTextInput): SubmitComposerTextResult {
   const content = input.content.trim();
   if (input.isRunning) {
-    if (input.queuedInputs.length >= MAX_QUEUED_INPUTS) {
+    const pendingCount = input.queuedInputs.filter((queued) => (
+      queued.status === "queued" || queued.status === "paused"
+    )).length;
+    if (pendingCount >= MAX_QUEUED_INPUTS) {
       return {
         kind: "queue_limit_reached",
         maxQueuedInputs: MAX_QUEUED_INPUTS,
         message: "已有 5 条排队消息，请等待处理或删除一条后再发送。",
+      };
+    }
+    if (input.runningAction === "interrupt") {
+      return {
+        kind: "interrupt_input",
+        input: {
+          id: `interrupt-${input.now}`,
+          mode: "interrupt",
+          content,
+          createdAt: input.now,
+          status: "queued",
+        },
       };
     }
     return {
@@ -52,7 +72,13 @@ export function submitComposerText(input: SubmitComposerTextInput): SubmitCompos
 }
 
 export function pauseQueuedInputs(inputs: QueuedInput[]): QueuedInput[] {
-  return inputs.map((input) => input.status === "sent" || input.status === "guided" ? input : { ...input, status: "paused" });
+  return inputs.map((input) => (
+    input.mode === "interrupt"
+      || input.status === "sent"
+      || input.status === "failed"
+      ? input
+      : { ...input, status: "paused" }
+  ));
 }
 
 export function resumeNextQueuedInput(inputs: QueuedInput[]): { nextInput?: QueuedInput; remainingInputs: QueuedInput[] } {
@@ -78,5 +104,17 @@ export function dispatchNextQueuedInput(inputs: QueuedInput[]): { nextInput?: Qu
 }
 
 export function deleteQueuedInput(inputs: QueuedInput[], inputId: string): QueuedInput[] {
-  return inputs.filter((input) => input.id !== inputId || input.status === "sent" || input.status === "guided");
+  return inputs.filter((input) => input.id !== inputId || (input.mode === "queued" && input.status === "sent"));
+}
+
+export function updateInterruptStatus(
+  inputs: QueuedInput[],
+  inputId: string,
+  status: "sent" | "failed",
+): QueuedInput[] {
+  return inputs.map((input) => {
+    if (input.id !== inputId || input.mode !== "interrupt") return input;
+    if (status === "sent" && input.status !== "queued") return input;
+    return { ...input, status };
+  });
 }

--- a/src/app-core/chat/chatUiProjection.ts
+++ b/src/app-core/chat/chatUiProjection.ts
@@ -54,10 +54,10 @@ export type LiveSubagent = {
 
 export type QueuedInput = {
   id: string;
-  mode: "queued" | "guide";
+  mode: "queued" | "interrupt";
   content: string;
   createdAt: string;
-  status: "queued" | "paused" | "sent" | "guided";
+  status: "queued" | "paused" | "sent" | "failed";
 };
 
 export type DetailPanelState = {

--- a/src/components/ui/claude-style-ai-input.test.tsx
+++ b/src/components/ui/claude-style-ai-input.test.tsx
@@ -42,6 +42,27 @@ describe("ClaudeStyleAiInput slash commands", () => {
     expect(onSendMessage).not.toHaveBeenCalled();
   });
 
+  it("offers explicit interrupt and next-turn actions while responding", async () => {
+    const user = userEvent.setup();
+    const onInterruptMessage = vi.fn();
+    const onSendMessage = vi.fn();
+    render(<ClaudeStyleAiInput
+      onInterruptMessage={onInterruptMessage}
+      onSendMessage={onSendMessage}
+      responding
+    />);
+
+    const input = screen.getByRole("textbox", { name: "Message" });
+    await user.type(input, "Change direction");
+    await user.click(screen.getByRole("button", { name: "插入当前任务" }));
+    expect(onInterruptMessage).toHaveBeenCalledWith("Change direction", [], [], {});
+    expect(onSendMessage).not.toHaveBeenCalled();
+
+    await user.type(input, "Do this afterward");
+    await user.click(screen.getByRole("button", { name: "排队为下一轮" }));
+    expect(onSendMessage).toHaveBeenCalledWith("Do this afterward", [], [], {});
+  });
+
   it("dismisses the menu with Escape without changing the draft", async () => {
     const user = userEvent.setup();
     render(<ClaudeStyleAiInput slashCommands={slashCommands} />);

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -82,6 +82,12 @@ export interface ClaudeStyleAiInputProps {
     pastedContent: PastedContent[],
     options: ComposerSendOptions,
   ) => void | Promise<void>;
+  onInterruptMessage?: (
+    message: string,
+    files: ComposerFileReference[],
+    pastedContent: PastedContent[],
+    options: ComposerSendOptions,
+  ) => void | Promise<void>;
   disabled?: boolean;
   disabledReason?: string;
   placeholder?: string;
@@ -128,6 +134,7 @@ export function ClaudeStyleAiInput({
   models = EMPTY_MODELS,
   onModelChange,
   onClearContextReferences,
+  onInterruptMessage,
   onRemoveContextReference,
   onSelectFiles,
   onSendMessage,
@@ -236,15 +243,15 @@ export function ClaudeStyleAiInput({
     return () => document.removeEventListener("pointerdown", closeMenus, true);
   }, [modelMenuOpen, slashMenuOpen, toolMenuOpen]);
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
+  async function sendMessage(mode: "interrupt" | "queue") {
     if (!canSend) {
       return;
     }
     setSending(true);
     setError("");
     try {
-      await onSendMessage?.(currentMessage.trim(), files, pastedContent, {
+      const handler = mode === "interrupt" ? onInterruptMessage : onSendMessage;
+      await handler?.(currentMessage.trim(), files, pastedContent, {
         ...(selectedModel?.id ? { model: selectedModel.id } : {}),
       });
       updateMessage("");
@@ -256,6 +263,11 @@ export function ClaudeStyleAiInput({
     } finally {
       setSending(false);
     }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await sendMessage("queue");
   }
 
   async function handleStopResponding() {
@@ -606,16 +618,35 @@ export function ClaudeStyleAiInput({
           </div>
 
           {responding ? (
-            <button
-              aria-label={canStopResponding ? "Stop generation" : `Stop generation unavailable: ${stopUnavailableReason || "unsupported"}`}
-              className="claude-ai-input__send"
-              disabled={disabled || !canStopResponding}
-              title={canStopResponding ? "Stop generation" : stopUnavailableReason || "Stopping is unavailable"}
-              type="button"
-              onClick={() => void handleStopResponding()}
-            >
-              <Square aria-hidden="true" size={15} />
-            </button>
+            <div className="claude-ai-input__running-actions">
+              <button
+                className="claude-ai-input__running-action claude-ai-input__running-action--primary"
+                disabled={!canSend || !onInterruptMessage}
+                title={canSend ? "中断当前回复并作为新一轮发送" : "输入内容后插入当前任务"}
+                type="button"
+                onClick={() => void sendMessage("interrupt")}
+              >
+                插入当前任务
+              </button>
+              <button
+                className="claude-ai-input__running-action"
+                disabled={!canSend}
+                title={canSend ? "当前任务完成后作为下一轮发送" : "输入内容后排队"}
+                type="submit"
+              >
+                排队为下一轮
+              </button>
+              <button
+                aria-label={canStopResponding ? "Stop generation" : `Stop generation unavailable: ${stopUnavailableReason || "unsupported"}`}
+                className="claude-ai-input__send"
+                disabled={disabled || !canStopResponding}
+                title={canStopResponding ? "Stop generation" : stopUnavailableReason || "Stopping is unavailable"}
+                type="button"
+                onClick={() => void handleStopResponding()}
+              >
+                <Square aria-hidden="true" size={15} />
+              </button>
+            </div>
           ) : (
             <button
               aria-label="Send message"

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -34,6 +34,7 @@ vi.mock("../../app-core/native/desktopNativeWorkspacePicker", () => ({
 
 afterEach(() => {
   cleanup();
+  nativeFilePickerMocks.pickDesktopChatFiles.mockReset();
   nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory.mockReset();
   window.localStorage.clear();
   document.head.querySelectorAll("[data-test-style='workbench']").forEach((element) => element.remove());
@@ -159,6 +160,16 @@ function expectTurnSubmit(chatStore: ChatStore, sessionId: string, input: unknow
     kind: "turn.submit",
     target: { sessionId },
   }));
+}
+
+async function mockLatestTurnStatus(
+  chatStore: ChatStore,
+  status: "pending" | "running" | "awaiting_user" | "completed" | "failed" | "interrupted",
+): Promise<void> {
+  const timeline = await chatStore.load("s1");
+  timeline.turns[timeline.turns.length - 1].status = status;
+  vi.mocked(chatStore.load).mockReset();
+  vi.mocked(chatStore.load).mockResolvedValue(timeline);
 }
 
 function mockTurnSubmit(
@@ -2928,6 +2939,9 @@ describe("ChatPage", () => {
         status: "running",
       }],
     });
+    const runningTimeline = await stores.chatStore.load("s1");
+    runningTimeline.turns[runningTimeline.turns.length - 1].status = "running";
+    vi.mocked(stores.chatStore.load).mockResolvedValue(runningTimeline);
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const input = await screen.findByRole("textbox", { name: /message/i });
@@ -2938,6 +2952,129 @@ describe("ChatPage", () => {
     expect(queuedInputs.textContent).toContain("Summarize after this run");
     expect(queuedInputs.textContent).toContain("Waiting");
     expect((input as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("restores the normal send action when the canonical timeline is terminal", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Planning notes",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "running",
+      }],
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+
+    await screen.findByText("I ran a tool.");
+    const input = screen.getByRole("textbox", { name: /message/i });
+    await user.type(input, "Start another turn");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expectTurnSubmit(stores.chatStore, "s1", { text: "Start another turn" });
+    expect(screen.queryByRole("button", { name: "插入当前任务" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "排队为下一轮" })).toBeNull();
+  });
+
+  it("interrupts the canonical active turn even when the session summary is stale", async () => {
+    const user = userEvent.setup();
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    nativeFilePickerMocks.pickDesktopChatFiles.mockResolvedValueOnce([{
+      name: "new-api.md",
+      path: "C:\\Users\\tester\\new-api.md",
+      mimeType: "text/markdown",
+      sizeBytes: 32,
+    }]);
+    const staleIdleSession = {
+      id: "s1",
+      chatId: "chat-1",
+      title: "Planning notes",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+      status: "idle" as const,
+    };
+    const stores = createStores({ sessions: [staleIdleSession] });
+    const settingsStore: SettingsStore = {
+      load: vi.fn(async () => []),
+      loadChatModels: vi.fn(async () => [{
+        id: "deepseek-v4-flash",
+        label: "deepseek-v4-flash",
+        description: "DeepSeek",
+        default: true,
+      }, {
+        id: "deepseek-v4-pro",
+        label: "deepseek-v4-pro",
+        description: "DeepSeek",
+      }]),
+    };
+    const runningTimeline = await stores.chatStore.load("s1");
+    const active = runningTimeline.turns[runningTimeline.turns.length - 1];
+    active.status = "running";
+    vi.mocked(stores.chatStore.load).mockResolvedValue(runningTimeline);
+    let confirmCancellation: (() => void) | undefined;
+    stores.chatStore.dispatch = vi.fn(async (command) => {
+      if (command.kind === "agent.cancel") {
+        await new Promise<void>((resolve) => {
+          confirmCancellation = resolve;
+        });
+      }
+    });
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+    render(
+      <ChatPage
+        chatStore={stores.chatStore}
+        now={() => Date.UTC(2026, 6, 4, 12, 0, 0)}
+        sessionStore={stores.sessionStore}
+        settingsStore={settingsStore}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Select model" }).textContent).toContain("deepseek-v4-flash"));
+    const input = await screen.findByRole("textbox", { name: /message/i });
+    await user.click(screen.getByRole("button", { name: "Attach files" }));
+    await waitFor(() => expect(nativeFilePickerMocks.pickDesktopChatFiles).toHaveBeenCalledTimes(1));
+    await user.type(input, "Use the new API instead");
+    await user.click(screen.getByRole("button", { name: "插入当前任务" }));
+
+    const cancelCommand = vi.mocked(stores.chatStore.dispatch).mock.calls
+      .map(([command]) => command)
+      .find((command) => command.kind === "agent.cancel");
+    expect(cancelCommand).toEqual(expect.objectContaining({
+      target: expect.objectContaining({ sessionId: "s1", turnId: active.id }),
+    }));
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
+    expect(screen.getByLabelText("Queued inputs").textContent).toContain("正在中断当前回复");
+
+    act(() => subscribed?.({
+      eventType: "agent.turn.interrupted",
+      type: "agent.event",
+    }));
+    act(() => subscribed?.({
+      eventType: "agent.turn.interrupted",
+      type: "agent.event",
+    }));
+    await waitFor(() => expect(vi.mocked(stores.sessionStore.list).mock.calls.length).toBeGreaterThanOrEqual(3));
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
+
+    act(() => confirmCancellation?.());
+
+    await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
+      model: "deepseek-v4-flash",
+      references: [{
+        detail: "MARKDOWN - 32 Bytes",
+        kind: "reference",
+        rawPath: "C:\\Users\\tester\\new-api.md",
+        title: "new-api.md",
+        type: "tinyos.file",
+      }],
+      text: "Use the new API instead",
+    }));
+    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(1);
+    await waitFor(() => expect(screen.queryByLabelText("Queued inputs")).toBeNull());
   });
 
   it("deletes queued composer text before it is sent", async () => {
@@ -2951,6 +3088,7 @@ describe("ChatPage", () => {
         status: "running",
       }],
     });
+    await mockLatestTurnStatus(stores.chatStore, "running");
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const input = await screen.findByRole("textbox", { name: /message/i });
@@ -2972,6 +3110,7 @@ describe("ChatPage", () => {
         status: "running",
       }],
     });
+    await mockLatestTurnStatus(stores.chatStore, "running");
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const input = await screen.findByRole("textbox", { name: /message/i });
@@ -2997,6 +3136,7 @@ describe("ChatPage", () => {
     };
     const idleSession = { ...runningSession, status: "idle" as const };
     const stores = createStores({ sessions: [runningSession] });
+    await mockLatestTurnStatus(stores.chatStore, "running");
     stores.sessionStore.list = vi.fn()
       .mockResolvedValueOnce([runningSession])
       .mockResolvedValueOnce([idleSession])
@@ -3044,6 +3184,7 @@ describe("ChatPage", () => {
     };
     const idleSession = { ...runningSession, status: "idle" as const };
     const stores = createStores({ sessions: [runningSession] });
+    await mockLatestTurnStatus(stores.chatStore, "running");
     stores.sessionStore.list = vi.fn()
       .mockResolvedValueOnce([runningSession])
       .mockResolvedValueOnce([idleSession])
@@ -3082,6 +3223,7 @@ describe("ChatPage", () => {
       status: "running" as const,
     };
     const stores = createStores({ sessions: [runningSession] });
+    await mockLatestTurnStatus(stores.chatStore, "running");
     stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
       subscribed = listener;
       return () => undefined;
@@ -3110,6 +3252,7 @@ describe("ChatPage", () => {
       status: "running" as const,
     };
     const stores = createStores({ sessions: [runningSession] });
+    await mockLatestTurnStatus(stores.chatStore, "running");
     stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
       subscribed = listener;
       return () => undefined;
@@ -3141,9 +3284,11 @@ describe("ChatPage", () => {
     };
     const failedSession = { ...runningSession, status: "failed" as const };
     const stores = createStores({ sessions: [runningSession] });
+    await mockLatestTurnStatus(stores.chatStore, "running");
     stores.sessionStore.list = vi.fn()
       .mockResolvedValueOnce([runningSession])
-      .mockResolvedValueOnce([failedSession]);
+      .mockResolvedValueOnce([failedSession])
+      .mockResolvedValue([failedSession]);
     stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
       subscribed = listener;
       return () => undefined;
@@ -3216,6 +3361,7 @@ describe("ChatPage", () => {
       status: "running" as const,
     };
     const stores = createStores({ sessions: [runningSession] });
+    await mockLatestTurnStatus(stores.chatStore, "running");
     stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
       subscribed = listener;
       return () => undefined;

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -34,7 +34,7 @@ import {
   pauseQueuedInputs,
   resumeNextQueuedInput,
   submitComposerText,
-  type SubmitComposerTextResult,
+  updateInterruptStatus,
 } from "../../app-core/chat/chatInputState";
 import type { QueuedInput } from "../../app-core/chat/chatUiProjection";
 import {
@@ -202,7 +202,7 @@ function reduceLiveCanvasState(state: LiveCanvasState, action: LiveCanvasAction)
 
 type RecoveryAction = "continue" | "retry" | "restart";
 
-type QueuedComposerInput = QueuedInput & Pick<ChatInput, "model" | "references">;
+type QueuedComposerInput = QueuedInput & { turnInput: ChatInput };
 
 function shouldFrameBatchTimeline(timeline: ChatTimelineSnapshot): boolean {
   return timeline.turns[timeline.turns.length - 1]?.status === "running";
@@ -371,6 +371,9 @@ export function ChatPage({
   const sessionsRef = useRef<SessionSummary[]>([]);
   const queuedInputsRef = useRef<Map<string, QueuedComposerInput[]>>(new Map());
   const queuedInputSequence = useRef(0);
+  const interruptCancellationConfirmedInputIdsRef = useRef(new Set<string>());
+  const interruptDispatchingInputIdsRef = useRef(new Set<string>());
+  const interruptTerminalInputIdsRef = useRef(new Set<string>());
   const deleteDissolveTimers = useRef<number[]>([]);
   const lastCreateSessionSignal = useRef(createSessionSignal);
   const draftSessionCreatePromise = useRef<Promise<SessionSummary> | null>(null);
@@ -423,7 +426,9 @@ export function ChatPage({
       || turn.status === "awaiting_user"
     ))
     : undefined, [timeline, timelineLoaded]);
-  const sessionResponding = Boolean(activeTurn) || (sessionRunning && !emptyActiveSession);
+  const sessionResponding = timelineLoaded
+    ? Boolean(activeTurn) || (sessionRunning && optimisticMessages.length > 0)
+    : sessionRunning && !emptyActiveSession;
   const cancelCapability = tinyOsCapabilities.capabilities.agent.cancel;
   const capabilityTargetsActiveTurn = !tinyOsCapabilities.evaluatedTurnId
     || tinyOsCapabilities.evaluatedTurnId === activeTurn?.id;
@@ -1402,6 +1407,7 @@ export function ChatPage({
     files: ComposerFileReference[],
     pastedContent: PastedContent[],
     options: ComposerSendOptions,
+    runningAction: "interrupt" | "queue" = "queue",
   ) {
     const references = [
       ...files.map(nativeReferenceFromComposerFile),
@@ -1444,12 +1450,39 @@ export function ChatPage({
     }
     const queuedResult = submitComposerText({
       content: visibleText,
-      isRunning: isQueueableRunningSession(sendSession, emptyActiveSession),
+      isRunning: sendSession.id === activeSession?.id
+        ? sessionResponding
+        : isQueueableRunningSession(sendSession, emptyActiveSession),
       now: nextQueuedInputTimestamp(),
       queuedInputs: activeQueuedInputs,
+      runningAction,
     });
-    if (queuedResult.kind !== "send_message") {
-      handleQueuedComposerResult(sendSession.id, queuedResult, options, references);
+    if (queuedResult.kind === "queue_limit_reached") {
+      setQueueMessage("Already have 5 queued messages. Wait for processing or delete one before sending more.");
+      return;
+    }
+    const turnInput = createComposerChatInput(
+      queuedResult.kind === "send_message" ? queuedResult.content : queuedResult.input.content,
+      options,
+      references,
+    );
+    if (queuedResult.kind === "interrupt_input") {
+      if (!activeTurn || activeTurn.status === "awaiting_user") {
+        throw new Error("当前没有可以中断的 Agent Turn，请改用“排队为下一轮”。");
+      }
+      if (activeQueuedInputs.some((input) => (
+        input.mode === "interrupt" && (input.status === "queued" || input.status === "sent")
+      ))) {
+        throw new Error("已有一条插入消息正在等待新一轮开始。");
+      }
+      await handleInterruptComposerResult(sendSession.id, activeTurn.id, {
+        ...queuedResult.input,
+        turnInput,
+      });
+      return;
+    }
+    if (queuedResult.kind === "queue_input") {
+      handleQueuedComposerResult(sendSession.id, queuedResult.input, turnInput);
       return;
     }
     const optimisticSession = isDefaultSessionTitle(sendSession.title)
@@ -1460,11 +1493,7 @@ export function ChatPage({
       setSessions((current) => current.map((session) => session.id === sendSession.id ? optimisticSession : session));
       await sessionStore.rename(sendSession.id, optimisticSession.title);
     }
-    await dispatchTurn(sendSession.id, {
-      text: queuedResult.content,
-      ...(options.model ? { model: options.model } : {}),
-      ...(references.length ? { references } : {}),
-    }, "composer-send");
+    await dispatchTurn(sendSession.id, turnInput, "composer-send");
     await handleSessionStoreRefresh(optimisticSession);
   }
 
@@ -1556,22 +1585,58 @@ export function ChatPage({
 
   function handleQueuedComposerResult(
     sessionId: string,
-    result: Exclude<SubmitComposerTextResult, { kind: "send_message" }>,
-    options: ComposerSendOptions,
-    references: AgentInputReference[],
+    input: QueuedInput,
+    turnInput: ChatInput,
   ) {
-    if (result.kind === "queue_limit_reached") {
-      setQueueMessage("Already have 5 queued messages. Wait for processing or delete one before sending more.");
-      return;
-    }
     setQueueMessage("");
     updateQueuedInputsBySession((current) => {
       const next = new Map(current);
       next.set(sessionId, [...(next.get(sessionId) ?? []), {
-        ...result.input,
-        ...(options.model ? { model: options.model } : {}),
-        ...(references.length ? { references } : {}),
+        ...input,
+        turnInput,
       }]);
+      return next;
+    });
+  }
+
+  async function handleInterruptComposerResult(
+    sessionId: string,
+    turnId: string,
+    input: QueuedComposerInput,
+  ) {
+    setQueueMessage("");
+    updateQueuedInputsBySession((current) => {
+      const next = new Map(current);
+      next.set(sessionId, [...(next.get(sessionId) ?? []), input]);
+      return next;
+    });
+    const command = createTinyOsAgentCancelCommand({
+      sessionId,
+      source: { control: "composer-interrupt", surface: "chat" },
+      turnId,
+    });
+    try {
+      await chatStore.dispatch(command);
+      interruptCancellationConfirmedInputIdsRef.current.add(input.id);
+      await sendPendingInterruptInput(sessionId);
+    } catch (error) {
+      interruptCancellationConfirmedInputIdsRef.current.delete(input.id);
+      interruptTerminalInputIdsRef.current.delete(input.id);
+      updateInterruptForSession(sessionId, input.id, "failed");
+      throw error;
+    }
+  }
+
+  function updateInterruptForSession(
+    sessionId: string,
+    inputId: string,
+    status: "sent" | "failed",
+  ) {
+    updateQueuedInputsBySession((current) => {
+      const inputs = current.get(sessionId) ?? [];
+      if (!inputs.some((input) => input.id === inputId && input.mode === "interrupt")) return current;
+      const next = new Map(current);
+      next.set(sessionId, updateInterruptStatus(inputs, inputId, status) as QueuedComposerInput[]);
       return next;
     });
   }
@@ -1601,11 +1666,15 @@ export function ChatPage({
 
   function handleDeleteQueuedInput(sessionId: string, inputId: string) {
     setQueueMessage("");
+    removeQueuedInputForSession(sessionId, inputId);
+  }
+
+  function removeQueuedInputForSession(sessionId: string, inputId: string) {
     updateQueuedInputsBySession((current) => {
       const next = new Map(current);
       const remaining = deleteQueuedInput(next.get(sessionId) ?? [], inputId);
       if (remaining.length) {
-        next.set(sessionId, remaining);
+        next.set(sessionId, remaining as QueuedComposerInput[]);
       } else {
         next.delete(sessionId);
       }
@@ -1660,6 +1729,9 @@ export function ChatPage({
 
   async function handleQueueStateAfterChatEvent(sessionId: string, event: ChatEvent) {
     const nextSessions = await handleSessionStoreRefresh();
+    if (isTerminalAgentEvent(event) && await sendPendingInterruptInput(sessionId, true)) {
+      return;
+    }
     if (shouldPauseQueuedInputsForChatEvent(event)) {
       pauseQueuedInputsForSession(sessionId);
       return;
@@ -1672,6 +1744,39 @@ export function ChatPage({
       return;
     }
     await sendNextQueuedInput(sessionId, "normal_completion");
+  }
+
+  async function sendPendingInterruptInput(
+    sessionId: string,
+    terminalEventReceived = false,
+  ): Promise<boolean> {
+    const input = (queuedInputsRef.current.get(sessionId) ?? []).find((candidate) => (
+      candidate.mode === "interrupt" && (candidate.status === "queued" || candidate.status === "sent")
+    ));
+    if (!input) return false;
+    if (terminalEventReceived) {
+      interruptTerminalInputIdsRef.current.add(input.id);
+    }
+    if (!interruptCancellationConfirmedInputIdsRef.current.has(input.id)
+      || !interruptTerminalInputIdsRef.current.has(input.id)) {
+      return true;
+    }
+    if (interruptDispatchingInputIdsRef.current.has(input.id)) return true;
+    interruptDispatchingInputIdsRef.current.add(input.id);
+    updateInterruptForSession(sessionId, input.id, "sent");
+    try {
+      await dispatchTurn(sessionId, toChatInput(input), "interrupt-new-turn");
+      removeQueuedInputForSession(sessionId, input.id);
+      await handleSessionStoreRefresh();
+    } catch (error) {
+      updateInterruptForSession(sessionId, input.id, "failed");
+      setQueueMessage(`插入消息发送失败：${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      interruptCancellationConfirmedInputIdsRef.current.delete(input.id);
+      interruptDispatchingInputIdsRef.current.delete(input.id);
+      interruptTerminalInputIdsRef.current.delete(input.id);
+    }
+    return true;
   }
 
   async function handleResumeQueuedInputs(sessionId: string) {
@@ -2213,7 +2318,8 @@ export function ChatPage({
           onSelectFiles={pickDesktopChatFiles}
           onValueChange={handleComposerDraftChange}
           onSendMessage={(message, files, pastedContent, options) => handleComposerSend(message, files, pastedContent, options)}
-            onStopResponding={() => activeSession && handleStopGeneration(activeSession, "chat")}
+          onInterruptMessage={(message, files, pastedContent, options) => handleComposerSend(message, files, pastedContent, options, "interrupt")}
+          onStopResponding={() => activeSession && handleStopGeneration(activeSession, "chat")}
           />
           {tinyOsDropError ? <p className="tinyos-composer-drop-error" role="alert">{tinyOsDropError}</p> : null}
         </div>
@@ -2533,6 +2639,10 @@ function shouldDispatchQueuedInputForChatEvent(event: ChatEvent): boolean {
   return event.type === "agent.event" && event.eventType === "agent.turn.completed";
 }
 
+function isTerminalAgentEvent(event: ChatEvent): boolean {
+  return event.type === "agent.event" && Boolean(event.eventType && TERMINAL_AGENT_EVENT_TYPES.has(event.eventType));
+}
+
 function shouldPauseQueuedInputsForChatEvent(event: ChatEvent): boolean {
   return event.type === "interrupted"
     || (event.type === "agent.event" && (
@@ -2608,10 +2718,18 @@ function isQueueableRunningSession(session: SessionSummary, emptyActiveSession: 
 }
 
 function toChatInput(input: QueuedComposerInput): ChatInput {
+  return input.turnInput;
+}
+
+function createComposerChatInput(
+  text: string,
+  options: ComposerSendOptions,
+  references: AgentInputReference[],
+): ChatInput {
   return {
-    text: input.content,
-    ...(input.model ? { model: input.model } : {}),
-    ...(input.references?.length ? { references: input.references } : {}),
+    text,
+    ...(options.model ? { model: options.model } : {}),
+    ...(references.length ? { references } : {}),
   };
 }
 
@@ -2825,12 +2943,13 @@ function QueuedInputsPanel({
   onResume: () => void;
 }) {
   const hasPausedInput = inputs.some((input) => input.status === "paused");
+  const pendingCount = inputs.filter((input) => input.status === "queued" || input.status === "paused").length;
   return (
-    <section aria-label="Queued inputs" className="react-queued-inputs">
+    <section aria-label="Queued inputs" aria-live="polite" className="react-queued-inputs">
       <div className="react-queued-inputs__header">
-        <h2>Queued inputs</h2>
+        <h2>运行中输入</h2>
         <div>
-          <span>{inputs.length}/{MAX_QUEUED_INPUTS}</span>
+          <span>待处理 {pendingCount}/{MAX_QUEUED_INPUTS}</span>
           {hasPausedInput ? <button type="button" onClick={onResume}>Resume queue</button> : null}
         </div>
       </div>
@@ -2839,8 +2958,8 @@ function QueuedInputsPanel({
           <li className="react-queued-input" data-status={input.status} key={input.id}>
             <span>{queuedInputStatusLabel(input)}</span>
             <p>{input.content}</p>
-            {input.status === "queued" || input.status === "paused" ? (
-              <button type="button" onClick={() => onDelete(input.id)}>Delete queued input</button>
+            {(input.mode === "queued" && (input.status === "queued" || input.status === "paused")) || (input.mode === "interrupt" && input.status !== "queued") ? (
+              <button type="button" onClick={() => onDelete(input.id)}>{input.mode === "interrupt" ? "清除插入状态" : "Delete queued input"}</button>
             ) : null}
           </li>
         ))}
@@ -2850,13 +2969,23 @@ function QueuedInputsPanel({
 }
 
 function queuedInputStatusLabel(input: QueuedInput): string {
+  if (input.mode === "interrupt") {
+    switch (input.status) {
+      case "sent":
+        return "正在发送为新一轮";
+      case "failed":
+        return "插入失败";
+      default:
+        return "正在中断当前回复";
+    }
+  }
   switch (input.status) {
-    case "guided":
-      return "Guided";
     case "paused":
       return "Paused";
     case "sent":
       return "Sent";
+    case "failed":
+      return "Failed";
     default:
       return "Waiting";
   }

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -5582,6 +5582,43 @@ button.tinyos-overlay-backdrop:focus-visible {
   gap: 6px;
 }
 
+.claude-ai-input__running-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.claude-ai-input__running-action {
+  min-height: 34px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 999px;
+  background: var(--color-surface-card);
+  padding: 0 12px;
+  color: var(--color-body);
+  font-size: 12px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.claude-ai-input__running-action:hover,
+.claude-ai-input__running-action:focus-visible {
+  border-color: var(--color-primary);
+  outline: none;
+}
+
+.claude-ai-input__running-action--primary {
+  border-color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 10%, var(--color-surface-card));
+  color: var(--color-primary-active);
+}
+
+.claude-ai-input__running-action:disabled {
+  border-color: var(--color-hairline);
+  background: var(--color-surface-card);
+  color: var(--color-muted-soft);
+}
+
 .claude-ai-input__icon-button,
 .claude-ai-input__send {
   display: inline-grid;
@@ -9595,6 +9632,19 @@ button.tinyos-overlay-backdrop:focus-visible {
 }
 
 @media (max-width: 680px) {
+  .claude-ai-input__toolbar {
+    align-items: flex-end;
+  }
+
+  .claude-ai-input__running-actions {
+    flex-wrap: wrap;
+  }
+
+  .claude-ai-input__running-action {
+    padding: 0 9px;
+    font-size: 11px;
+  }
+
   .react-chat-surface[data-empty-session="true"] .react-conversation-view {
     padding: 24px 18px;
   }


### PR DESCRIPTION
## Summary

- add explicit **Insert into current task** and **Queue for next turn** actions while an agent turn is running
- make insert cancel the active turn and wait for both cancellation acknowledgement and the terminal interruption event before starting a new turn
- preserve the selected model, attachments, and context references across normal, queued, and interrupt sends
- restore the normal send action after the canonical turn becomes terminal
- remove successfully submitted inputs from the pending-input queue

## Root cause

The composer UI and submission path used different sources of truth for running state, and each send mode assembled its input independently. This allowed an insert to bypass cancellation when session summary state was stale, lose the selected model or references, and retain a submitted item in the pending queue.

## User impact

Users can now correct a running agent without overlapping turns or restarting the conversation. Queued input remains non-disruptive, and both paths use the same complete turn input as a normal send.

## Validation

- `npm test` — 75 files, 501 tests passed
- `npx tsc --noEmit`
- `git diff --check`