### PR TITLE
Prepare v0.2.2 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinybot-desktop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinybot-desktop",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/code": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinybot-desktop",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "tinybot-desktop"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinybot-desktop"
-version = "0.2.1"
+version = "0.2.2"
 description = "Tinybot lightweight desktop host"
 authors = ["Tinybot contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tinybot Desktop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.sudojacky.tinybot.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- bump the desktop application version from 0.2.1 to 0.2.2
- keep npm, Cargo, and Tauri version sources aligned
- prepare `master` for the custom Windows release workflow

## Release scope

This patch release ships the running-turn composer controls from PR #389, including interrupt-to-new-turn behavior, next-turn queueing, selected-model and reference preservation, and pending-input cleanup.

## Validation

- `node .github/scripts/check-release-version.mjs v0.2.2`
- `node --test .github/scripts/customize-updater-manifest.test.mjs`
- `npm test` — 75 files, 501 tests passed
- `npx tsc --noEmit`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib desktop::update::tests -j 4 -- --test-threads=1` — 5 tests passed
- `git diff --check`