### PR TITLE
Improve native tool outcomes and prevent no-progress loops

### DIFF
--- a/src-tauri/src/agent/bridge/tool_dispatcher.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher.rs
@@ -333,10 +333,10 @@ fn native_web_tool_result(
     tool_call: &PreparedToolCall,
     raw: serde_json::Value,
 ) -> NativeAgentToolResult {
-    let summary = web::result_summary(&tool_call.name, &raw);
     if let Some(outcome) = native_web_tool_outcome(&tool_call.name, &raw) {
-        return NativeAgentToolResult::success_with_outcome(tool_call, summary, raw, outcome);
+        return NativeAgentToolResult::success_with_outcome(tool_call, raw, outcome);
     }
+    let summary = web::result_summary(&tool_call.name, &raw);
     let model_content = raw.to_string();
     NativeAgentToolResult::generic_success_with_model_content(
         tool_call,
@@ -370,23 +370,20 @@ fn native_web_tool_outcome(tool_name: &str, raw: &serde_json::Value) -> Option<N
             reason_code: "page_unchanged".to_string(),
             reason: "The page has not changed since the supplied snapshot.".to_string(),
             retry: NativeToolRetry::DoNotRetry,
-            guidance: "Reuse the prior snapshot. Do not call web.read again with the same snapshotId until the page may have changed.".to_string(),
             next_action: None,
         },
         "stale_snapshot" => {
-            let guidance = if tool_name == "web.read" {
-                "The page changed while paginated text was being read. Use the returned content from offset 0 and continue with the returned snapshotId; do not reuse requestedSnapshotId."
+            let reason = if tool_name == "web.read" {
+                "The page changed while paginated text was being read. The returned content restarted at offset 0 with a new snapshot."
             } else {
-                "The action was not executed because the page snapshot is stale. Reassess the target in the returned snapshot before issuing a new web.act."
+                "The page changed after the supplied snapshot was captured, so the requested action was not executed."
             };
             NativeToolOutcome {
                 effect: "stale_state".to_string(),
                 action_executed: Some(false),
                 reason_code: "snapshot_stale".to_string(),
-                reason: "The browser page changed after the supplied snapshot was captured."
-                    .to_string(),
+                reason: reason.to_string(),
                 retry: NativeToolRetry::RetryWithUpdatedState,
-                guidance: guidance.to_string(),
                 next_action: None,
             }
         }
@@ -408,8 +405,6 @@ fn native_web_tool_outcome(tool_name: &str, raw: &serde_json::Value) -> Option<N
                         .to_string()
                 }),
                 retry: NativeToolRetry::DoNotRetry,
-                guidance: "Do not repeat the click. Use web.open with suggestedUrl instead."
-                    .to_string(),
                 next_action,
             }
         }
@@ -422,7 +417,6 @@ fn native_web_tool_outcome(tool_name: &str, raw: &serde_json::Value) -> Option<N
                     .to_string()
             }),
             retry: NativeToolRetry::AfterUserAction,
-            guidance: "Stop automated browser actions and ask the user to complete the required interaction. Resume only after the user confirms it is complete.".to_string(),
             next_action: None,
         },
         "failed" | "cancelled" | "timed_out" => NativeToolOutcome {
@@ -432,7 +426,6 @@ fn native_web_tool_outcome(tool_name: &str, raw: &serde_json::Value) -> Option<N
             reason: result_reason()
                 .unwrap_or_else(|| format!("The browser action returned {status}.")),
             retry: NativeToolRetry::Replan,
-            guidance: "Do not assume the page changed and do not retry automatically. Inspect the reason and current snapshot, then choose a new action.".to_string(),
             next_action: None,
         },
         other => NativeToolOutcome {
@@ -442,7 +435,6 @@ fn native_web_tool_outcome(tool_name: &str, raw: &serde_json::Value) -> Option<N
             reason: result_reason()
                 .unwrap_or_else(|| format!("The web tool returned the special status `{other}`.")),
             retry: NativeToolRetry::Replan,
-            guidance: "Treat this result as no confirmed progress. Inspect the result and replan before issuing another browser action.".to_string(),
             next_action: None,
         },
     };

--- a/src-tauri/src/agent/bridge/tool_dispatcher.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher.rs
@@ -1,6 +1,7 @@
 use crate::agent::runtime::{
     AgentTurnContext, NativeAgentCancellationContext, NativeAgentRuntimeServices,
-    NativeAgentToolDispatcher, NativeAgentToolResult, PreparedToolCall,
+    NativeAgentToolDispatcher, NativeAgentToolResult, NativeToolNextAction, NativeToolOutcome,
+    NativeToolRetry, PreparedToolCall,
 };
 use crate::collaboration::subagents::SubagentThreadManager;
 use crate::protocol::{WorkerRequest, WorkerRequestCancellation};
@@ -238,14 +239,7 @@ impl NativeAgentToolExecutorDispatcher {
                 format!("native browser tool result serialization failed: {error}")
             })?;
             web::strip_browser_capture_data(&mut raw);
-            let summary = web::result_summary(&tool_call.name, &raw);
-            let model_content = raw.to_string();
-            Ok(NativeAgentToolResult::generic_success_with_model_content(
-                tool_call,
-                summary,
-                model_content,
-                raw,
-            ))
+            Ok(native_web_tool_result(tool_call, raw))
         }))
     }
 
@@ -333,6 +327,126 @@ impl NativeAgentToolExecutorDispatcher {
             )
         }))
     }
+}
+
+fn native_web_tool_result(
+    tool_call: &PreparedToolCall,
+    raw: serde_json::Value,
+) -> NativeAgentToolResult {
+    let summary = web::result_summary(&tool_call.name, &raw);
+    if let Some(outcome) = native_web_tool_outcome(&tool_call.name, &raw) {
+        return NativeAgentToolResult::success_with_outcome(tool_call, summary, raw, outcome);
+    }
+    let model_content = raw.to_string();
+    NativeAgentToolResult::generic_success_with_model_content(
+        tool_call,
+        summary,
+        model_content,
+        raw,
+    )
+}
+
+fn native_web_tool_outcome(tool_name: &str, raw: &serde_json::Value) -> Option<NativeToolOutcome> {
+    let status = raw.get("status").and_then(serde_json::Value::as_str)?;
+    let action_executed = raw
+        .get("actionExecuted")
+        .and_then(serde_json::Value::as_bool);
+    let result_reason_code = || {
+        raw.get("reasonCode")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    };
+    let result_reason = || {
+        raw.get("reason")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    };
+
+    let outcome = match status {
+        "completed" => return None,
+        "unchanged" => NativeToolOutcome {
+            effect: "unchanged".to_string(),
+            action_executed,
+            reason_code: "page_unchanged".to_string(),
+            reason: "The page has not changed since the supplied snapshot.".to_string(),
+            retry: NativeToolRetry::DoNotRetry,
+            guidance: "Reuse the prior snapshot. Do not call web.read again with the same snapshotId until the page may have changed.".to_string(),
+            next_action: None,
+        },
+        "stale_snapshot" => {
+            let guidance = if tool_name == "web.read" {
+                "The page changed while paginated text was being read. Use the returned content from offset 0 and continue with the returned snapshotId; do not reuse requestedSnapshotId."
+            } else {
+                "The action was not executed because the page snapshot is stale. Reassess the target in the returned snapshot before issuing a new web.act."
+            };
+            NativeToolOutcome {
+                effect: "stale_state".to_string(),
+                action_executed: Some(false),
+                reason_code: "snapshot_stale".to_string(),
+                reason: "The browser page changed after the supplied snapshot was captured."
+                    .to_string(),
+                retry: NativeToolRetry::RetryWithUpdatedState,
+                guidance: guidance.to_string(),
+                next_action: None,
+            }
+        }
+        "navigation_required" => {
+            let next_action = raw
+                .get("suggestedUrl")
+                .and_then(serde_json::Value::as_str)
+                .map(|url| NativeToolNextAction {
+                    tool: "web.open".to_string(),
+                    arguments: serde_json::json!({ "url": url }),
+                });
+            NativeToolOutcome {
+                effect: "alternative_required".to_string(),
+                action_executed: Some(false),
+                reason_code: result_reason_code()
+                    .unwrap_or_else(|| "navigation_required".to_string()),
+                reason: result_reason().unwrap_or_else(|| {
+                    "The requested target cannot be activated in the current browser tab."
+                        .to_string()
+                }),
+                retry: NativeToolRetry::DoNotRetry,
+                guidance: "Do not repeat the click. Use web.open with suggestedUrl instead."
+                    .to_string(),
+                next_action,
+            }
+        }
+        "user_required" => NativeToolOutcome {
+            effect: "user_action_required".to_string(),
+            action_executed: Some(false),
+            reason_code: result_reason_code().unwrap_or_else(|| "user_required".to_string()),
+            reason: result_reason().unwrap_or_else(|| {
+                "The browser requires direct user interaction before Agent work can continue."
+                    .to_string()
+            }),
+            retry: NativeToolRetry::AfterUserAction,
+            guidance: "Stop automated browser actions and ask the user to complete the required interaction. Resume only after the user confirms it is complete.".to_string(),
+            next_action: None,
+        },
+        "failed" | "cancelled" | "timed_out" => NativeToolOutcome {
+            effect: status.to_string(),
+            action_executed: Some(false),
+            reason_code: result_reason_code().unwrap_or_else(|| status.to_string()),
+            reason: result_reason()
+                .unwrap_or_else(|| format!("The browser action returned {status}.")),
+            retry: NativeToolRetry::Replan,
+            guidance: "Do not assume the page changed and do not retry automatically. Inspect the reason and current snapshot, then choose a new action.".to_string(),
+            next_action: None,
+        },
+        other => NativeToolOutcome {
+            effect: "unrecognized".to_string(),
+            action_executed,
+            reason_code: result_reason_code().unwrap_or_else(|| other.to_string()),
+            reason: result_reason()
+                .unwrap_or_else(|| format!("The web tool returned the special status `{other}`.")),
+            retry: NativeToolRetry::Replan,
+            guidance: "Treat this result as no confirmed progress. Inspect the result and replan before issuing another browser action.".to_string(),
+            next_action: None,
+        },
+    };
+    Some(outcome)
 }
 
 pub(crate) fn native_agent_services_with_tool_executor(

--- a/src-tauri/src/agent/bridge/tool_dispatcher.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher.rs
@@ -6,7 +6,9 @@ use crate::agent::runtime::{
 use crate::collaboration::subagents::SubagentThreadManager;
 use crate::protocol::{WorkerRequest, WorkerRequestCancellation};
 use crate::rpc::call_rust_state_service_with_mcp_runtime;
-use crate::runtime::mcp::{configured_mcp_servers, mcp_tool_is_enabled, McpRuntime};
+use crate::runtime::mcp::{
+    configured_mcp_servers, mcp_tool_is_enabled, McpRuntime, McpRuntimeError, McpRuntimeErrorKind,
+};
 use crate::threads::workspace_store::WorkspaceThreadStore;
 use crate::tools::registry::ToolExecutionTarget;
 use crate::tools::shell::WorkerShellRuntime;
@@ -124,6 +126,9 @@ impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
         match executor_result {
             Ok(executor_result) => {
                 native_tool_result_from_executor_response(tool_call, executor_result)
+            }
+            Err(error) if is_shell_agent_tool(&tool_call.name) => {
+                Ok(native_shell_dispatch_error_result(tool_call, error))
             }
             Err(error) => Err(error),
         }
@@ -265,10 +270,19 @@ impl NativeAgentToolExecutorDispatcher {
                     .map(str::trim)
                     .filter(|value| !value.is_empty())
                     .map(str::to_string);
-                let (Some(server), Some(tool)) = (server, tool) else {
-                    return Some(Err(
-                        "mcp.call_tool requires non-empty server and tool fields".to_string(),
-                    ));
+                let (server, tool) = match (server, tool) {
+                    (Some(server), Some(tool)) => (server, tool),
+                    (server, tool) => {
+                        return Some(Ok(native_mcp_failure_result(
+                            tool_call,
+                            server.as_deref(),
+                            tool.as_deref(),
+                            "invalid_request",
+                            "mcp_request_invalid",
+                            "mcp.call_tool requires non-empty server and tool fields".to_string(),
+                            NativeToolRetry::Replan,
+                        )));
+                    }
                 };
                 let tool_arguments = arguments
                     .get("arguments")
@@ -279,23 +293,53 @@ impl NativeAgentToolExecutorDispatcher {
             _ => return None,
         };
         if !tool_arguments.is_object() {
-            return Some(Err("MCP tool arguments must be a JSON object".to_string()));
+            return Some(Ok(native_mcp_failure_result(
+                tool_call,
+                Some(&server_name),
+                Some(&tool_name),
+                "invalid_request",
+                "mcp_arguments_invalid",
+                "MCP tool arguments must be a JSON object".to_string(),
+                NativeToolRetry::Replan,
+            )));
         }
         let Some(server_config) = configured_mcp_servers(&context.config_snapshot)
             .and_then(|servers| servers.get(&server_name))
         else {
-            return Some(Err(format!("MCP server is not configured: {server_name}")));
+            return Some(Ok(native_mcp_failure_result(
+                tool_call,
+                Some(&server_name),
+                Some(&tool_name),
+                "user_action_required",
+                "mcp_server_not_configured",
+                format!("MCP server is not configured: {server_name}"),
+                NativeToolRetry::AfterUserAction,
+            )));
         };
         if server_config
             .get("enabled")
             .and_then(serde_json::Value::as_bool)
             == Some(false)
         {
-            return Some(Err(format!("MCP server is disabled: {server_name}")));
+            return Some(Ok(native_mcp_failure_result(
+                tool_call,
+                Some(&server_name),
+                Some(&tool_name),
+                "user_action_required",
+                "mcp_server_disabled",
+                format!("MCP server is disabled: {server_name}"),
+                NativeToolRetry::AfterUserAction,
+            )));
         }
         if !mcp_tool_is_enabled(&server_name, &tool_name, server_config) {
-            return Some(Err(format!(
-                "MCP tool is not allowlisted: {server_name}.{tool_name}"
+            return Some(Ok(native_mcp_failure_result(
+                tool_call,
+                Some(&server_name),
+                Some(&tool_name),
+                "user_action_required",
+                "mcp_tool_not_allowlisted",
+                format!("MCP tool is not allowlisted: {server_name}.{tool_name}"),
+                NativeToolRetry::AfterUserAction,
             )));
         }
         let cancellation = context
@@ -312,20 +356,24 @@ impl NativeAgentToolExecutorDispatcher {
                 Some(tool_arguments),
                 cancellation,
             )
-            .await
-            .map_err(|error| error.message);
-        Some(result.map(|result| {
-            let model_content = native_tool_executor_model_content(&result);
-            NativeAgentToolResult::generic_success(
-                tool_call,
-                serde_json::json!({
+            .await;
+        Some(result.map_or_else(
+            |error| {
+                Ok(native_mcp_runtime_error_result(
+                    tool_call, &tool_name, error,
+                ))
+            },
+            |result| {
+                let model_content = native_tool_executor_model_content(&result);
+                let raw = serde_json::json!({
                     "content": model_content,
                     "result": result,
                     "server": server_name,
                     "tool": tool_name,
-                }),
-            )
-        }))
+                });
+                Ok(native_mcp_tool_result(tool_call, raw))
+            },
+        ))
     }
 }
 
@@ -580,6 +628,11 @@ fn native_tool_result_from_executor_response(
             tool_call, raw_result,
         ));
     }
+    if let Some(outcome) = native_shell_tool_outcome(&tool_call.name, &raw_result) {
+        return Ok(NativeAgentToolResult::success_with_outcome(
+            tool_call, raw_result, outcome,
+        ));
+    }
     let model_content = native_tool_executor_model_content(&raw_result);
     let summary = native_tool_executor_summary(&raw_result, &model_content);
     Ok(NativeAgentToolResult::generic_success_with_model_content(
@@ -588,6 +641,316 @@ fn native_tool_result_from_executor_response(
         model_content,
         raw_result,
     ))
+}
+
+fn is_shell_agent_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "exec_command" | "write_stdin" | "shell.start" | "shell.execute"
+    )
+}
+
+fn native_shell_tool_outcome(
+    tool_name: &str,
+    raw: &serde_json::Value,
+) -> Option<NativeToolOutcome> {
+    if !is_shell_agent_tool(tool_name) {
+        return None;
+    }
+
+    let cancelled = bool_field(raw, "cancelled", "cancelled").unwrap_or(false)
+        || string_field(raw, "status", "status") == Some("cancelled");
+    if cancelled {
+        return Some(NativeToolOutcome {
+            effect: "cancelled".to_string(),
+            action_executed: None,
+            reason_code: "shell_cancelled".to_string(),
+            reason: "The shell command was cancelled before a complete result was available."
+                .to_string(),
+            retry: NativeToolRetry::DoNotRetry,
+            next_action: None,
+        });
+    }
+
+    let timed_out = bool_field(raw, "timedOut", "timed_out").unwrap_or(false)
+        || string_field(raw, "status", "status") == Some("timed_out");
+    if timed_out {
+        return Some(NativeToolOutcome {
+            effect: "timed_out".to_string(),
+            action_executed: None,
+            reason_code: "shell_timed_out".to_string(),
+            reason:
+                "The shell command exceeded its time limit and did not produce a complete result."
+                    .to_string(),
+            retry: NativeToolRetry::Replan,
+            next_action: None,
+        });
+    }
+
+    let status = string_field(raw, "status", "status");
+    let running = bool_field(raw, "running", "running").unwrap_or(false)
+        || matches!(status, Some("running" | "terminating"));
+    if running {
+        let process_id = string_field(raw, "processId", "process_id");
+        let truncated = bool_field(raw, "truncated", "truncated").unwrap_or(false);
+        let reason = match (process_id, truncated) {
+            (Some(process_id), true) => format!(
+                "Shell process `{process_id}` is still running; earlier output was truncated."
+            ),
+            (Some(process_id), false) => {
+                format!("Shell process `{process_id}` is still running.")
+            }
+            (None, true) => {
+                "The shell command is still running; earlier output was truncated.".to_string()
+            }
+            (None, false) => "The shell command is still running.".to_string(),
+        };
+        let next_action = process_id.map(|process_id| {
+            let mut arguments = serde_json::json!({
+                "processId": process_id,
+                "input": "",
+                "yieldTimeMs": 1000,
+            });
+            if let Some(cursor) = integer_field(raw, "cursor", "cursor") {
+                arguments["cursor"] = serde_json::json!(cursor);
+            }
+            NativeToolNextAction {
+                tool: "write_stdin".to_string(),
+                arguments,
+            }
+        });
+        return Some(NativeToolOutcome {
+            effect: "in_progress".to_string(),
+            action_executed: Some(true),
+            reason_code: if truncated {
+                "shell_running_output_truncated".to_string()
+            } else {
+                "shell_process_running".to_string()
+            },
+            reason,
+            retry: NativeToolRetry::RetryWithUpdatedState,
+            next_action,
+        });
+    }
+
+    if matches!(status, Some("failed" | "terminated"))
+        || raw.get("failure").is_some_and(|failure| !failure.is_null())
+    {
+        let reason = raw
+            .get("failure")
+            .and_then(serde_json::Value::as_str)
+            .filter(|reason| !reason.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| match status {
+                Some("terminated") => "The shell process was terminated.".to_string(),
+                _ => "The shell process failed before completing.".to_string(),
+            });
+        return Some(NativeToolOutcome {
+            effect: "failed".to_string(),
+            action_executed: None,
+            reason_code: match status {
+                Some("terminated") => "shell_terminated".to_string(),
+                _ => "shell_process_failed".to_string(),
+            },
+            reason,
+            retry: NativeToolRetry::Replan,
+            next_action: None,
+        });
+    }
+
+    if let Some(exit_code) = integer_field(raw, "exitCode", "exit_code") {
+        if exit_code != 0 {
+            return Some(NativeToolOutcome {
+                effect: "failed".to_string(),
+                action_executed: Some(true),
+                reason_code: "shell_nonzero_exit".to_string(),
+                reason: format!("The shell command exited with code {exit_code}."),
+                retry: NativeToolRetry::Replan,
+                next_action: None,
+            });
+        }
+    }
+
+    if bool_field(raw, "truncated", "truncated").unwrap_or(false) {
+        let dropped_bytes = integer_field(raw, "droppedBytes", "dropped_bytes").unwrap_or(0);
+        let reason = if dropped_bytes > 0 {
+            format!("The shell command completed, but {dropped_bytes} output bytes were discarded.")
+        } else {
+            "The shell command completed, but its output was truncated.".to_string()
+        };
+        return Some(NativeToolOutcome {
+            effect: "partial_result".to_string(),
+            action_executed: Some(true),
+            reason_code: "shell_output_truncated".to_string(),
+            reason,
+            retry: NativeToolRetry::DoNotRetry,
+            next_action: None,
+        });
+    }
+
+    None
+}
+
+fn native_shell_dispatch_error_result(
+    tool_call: &PreparedToolCall,
+    error: String,
+) -> NativeAgentToolResult {
+    let raw = serde_json::json!({
+        "status": "failed",
+        "error": {
+            "message": error,
+        },
+    });
+    let outcome = NativeToolOutcome {
+        effect: "failed".to_string(),
+        action_executed: Some(false),
+        reason_code: "shell_dispatch_failed".to_string(),
+        reason: raw["error"]["message"]
+            .as_str()
+            .unwrap_or("Shell dispatch failed")
+            .to_string(),
+        retry: NativeToolRetry::Replan,
+        next_action: None,
+    };
+    NativeAgentToolResult::success_with_outcome(tool_call, raw, outcome)
+}
+
+fn native_mcp_tool_result(
+    tool_call: &PreparedToolCall,
+    raw: serde_json::Value,
+) -> NativeAgentToolResult {
+    let is_error = raw
+        .get("result")
+        .and_then(|result| {
+            bool_field(result, "isError", "is_error")
+                .or_else(|| bool_field(result, "is_error", "isError"))
+        })
+        .unwrap_or(false);
+    if !is_error {
+        return NativeAgentToolResult::generic_success(tool_call, raw);
+    }
+    let server = raw
+        .get("server")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let tool = raw
+        .get("tool")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let outcome = NativeToolOutcome {
+        effect: "failed".to_string(),
+        action_executed: Some(true),
+        reason_code: "mcp_tool_error".to_string(),
+        reason: format!("MCP tool `{server}.{tool}` returned an error result."),
+        retry: NativeToolRetry::Replan,
+        next_action: None,
+    };
+    NativeAgentToolResult::success_with_outcome(tool_call, raw, outcome)
+}
+
+fn native_mcp_runtime_error_result(
+    tool_call: &PreparedToolCall,
+    tool_name: &str,
+    error: McpRuntimeError,
+) -> NativeAgentToolResult {
+    let effect = match error.kind {
+        McpRuntimeErrorKind::Configuration => "user_action_required",
+        McpRuntimeErrorKind::Timeout => "timed_out",
+        McpRuntimeErrorKind::Cancelled => "cancelled",
+        McpRuntimeErrorKind::InvalidArguments
+        | McpRuntimeErrorKind::ServerStarting
+        | McpRuntimeErrorKind::Operation
+        | McpRuntimeErrorKind::Shutdown => "failed",
+    };
+    let reason_code = error.kind.reason_code();
+    let retry = match error.kind {
+        McpRuntimeErrorKind::Configuration => NativeToolRetry::AfterUserAction,
+        McpRuntimeErrorKind::Cancelled => NativeToolRetry::DoNotRetry,
+        McpRuntimeErrorKind::InvalidArguments
+        | McpRuntimeErrorKind::ServerStarting
+        | McpRuntimeErrorKind::Timeout
+        | McpRuntimeErrorKind::Operation
+        | McpRuntimeErrorKind::Shutdown => NativeToolRetry::Replan,
+    };
+    let reason = error.message.clone();
+    let raw = serde_json::json!({
+        "status": effect,
+        "server": error.server,
+        "tool": tool_name,
+        "error": {
+            "reasonCode": reason_code,
+            "message": error.message,
+            "transport": error.transport,
+            "retryable": error.retryable,
+            "cancelled": error.cancelled,
+        },
+    });
+    NativeAgentToolResult::success_with_outcome(
+        tool_call,
+        raw,
+        NativeToolOutcome {
+            effect: effect.to_string(),
+            action_executed: None,
+            reason_code: reason_code.to_string(),
+            reason,
+            retry,
+            next_action: None,
+        },
+    )
+}
+
+fn native_mcp_failure_result(
+    tool_call: &PreparedToolCall,
+    server: Option<&str>,
+    tool: Option<&str>,
+    effect: &str,
+    reason_code: &str,
+    reason: String,
+    retry: NativeToolRetry,
+) -> NativeAgentToolResult {
+    let outcome_reason = reason.clone();
+    let raw = serde_json::json!({
+        "status": "failed",
+        "server": server,
+        "tool": tool,
+        "error": {
+            "reasonCode": reason_code,
+            "message": reason,
+        },
+    });
+    NativeAgentToolResult::success_with_outcome(
+        tool_call,
+        raw,
+        NativeToolOutcome {
+            effect: effect.to_string(),
+            action_executed: Some(false),
+            reason_code: reason_code.to_string(),
+            reason: outcome_reason,
+            retry,
+            next_action: None,
+        },
+    )
+}
+
+fn bool_field(value: &serde_json::Value, primary: &str, alias: &str) -> Option<bool> {
+    value
+        .get(primary)
+        .or_else(|| value.get(alias))
+        .and_then(serde_json::Value::as_bool)
+}
+
+fn string_field<'a>(value: &'a serde_json::Value, primary: &str, alias: &str) -> Option<&'a str> {
+    value
+        .get(primary)
+        .or_else(|| value.get(alias))
+        .and_then(serde_json::Value::as_str)
+}
+
+fn integer_field(value: &serde_json::Value, primary: &str, alias: &str) -> Option<i64> {
+    value
+        .get(primary)
+        .or_else(|| value.get(alias))
+        .and_then(serde_json::Value::as_i64)
 }
 
 fn native_tool_executor_summary(value: &serde_json::Value, model_content: &str) -> String {

--- a/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
@@ -1,6 +1,6 @@
 use super::{
     apply_turn_working_directory, native_tool_executor_model_content,
-    native_tool_result_from_executor_response,
+    native_tool_result_from_executor_response, native_web_tool_result,
 };
 use crate::agent::runtime::{NativeAgentToolCall, PreparedToolCall};
 
@@ -123,4 +123,119 @@ fn turn_working_directory_preserves_an_absolute_path_outside_the_workspace() {
     .expect("outside turn working directory should reach shell dispatch");
 
     assert_eq!(arguments["workingDir"], "D:/outside");
+}
+
+#[test]
+fn special_web_result_exposes_recovery_guidance_in_the_tool_envelope() {
+    let tool_call = PreparedToolCall::prepare(NativeAgentToolCall {
+        id: "call-navigation-required".to_string(),
+        name: "web.act".to_string(),
+        arguments_json: r#"{"snapshotId":"snapshot-1","action":{"type":"clickTarget"}}"#
+            .to_string(),
+        result: serde_json::Value::Null,
+    })
+    .expect("tool call should prepare");
+    let raw = serde_json::json!({
+        "status": "navigation_required",
+        "actionExecuted": false,
+        "reasonCode": "target_opens_new_window",
+        "reason": "This target opens a new browser window.",
+        "suggestedUrl": "https://agentskills.io/specification",
+        "snapshotId": "snapshot-1"
+    });
+
+    let result = native_web_tool_result(&tool_call, raw.clone());
+    let outcome = &result.envelope["structured"]["outcome"];
+    let model_content: serde_json::Value = serde_json::from_str(
+        result.envelope["modelContent"]
+            .as_str()
+            .expect("model content should be JSON"),
+    )
+    .expect("model content should parse");
+
+    assert_eq!(result.envelope["status"], "ok");
+    assert_eq!(result.envelope["structured"]["kind"], "tool_outcome");
+    assert_eq!(outcome["effect"], "alternative_required");
+    assert_eq!(outcome["actionExecuted"], false);
+    assert_eq!(outcome["retry"], "do_not_retry");
+    assert_eq!(outcome["nextAction"]["tool"], "web.open");
+    assert_eq!(
+        outcome["nextAction"]["arguments"]["url"],
+        "https://agentskills.io/specification"
+    );
+    assert!(model_content["toolOutcome"]["guidance"]
+        .as_str()
+        .is_some_and(|guidance| guidance.contains("Do not repeat the click")));
+    assert_eq!(model_content["result"], raw);
+}
+
+#[test]
+fn completed_web_result_keeps_the_existing_generic_projection() {
+    let tool_call = PreparedToolCall::prepare(NativeAgentToolCall {
+        id: "call-web-completed".to_string(),
+        name: "web.read".to_string(),
+        arguments_json: "{}".to_string(),
+        result: serde_json::Value::Null,
+    })
+    .expect("tool call should prepare");
+    let raw = serde_json::json!({
+        "status": "completed",
+        "snapshotId": "snapshot-1"
+    });
+
+    let result = native_web_tool_result(&tool_call, raw.clone());
+
+    assert_eq!(result.envelope["structured"]["kind"], "generic_result");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(
+            result.envelope["modelContent"]
+                .as_str()
+                .expect("model content should be JSON")
+        )
+        .expect("model content should parse"),
+        raw
+    );
+}
+
+#[test]
+fn web_special_statuses_have_explicit_effects_and_retry_dispositions() {
+    for (tool_name, status, effect, retry) in [
+        ("web.read", "unchanged", "unchanged", "do_not_retry"),
+        (
+            "web.act",
+            "stale_snapshot",
+            "stale_state",
+            "retry_with_updated_state",
+        ),
+        (
+            "web.act",
+            "user_required",
+            "user_action_required",
+            "after_user_action",
+        ),
+        ("web.act", "timed_out", "timed_out", "replan"),
+    ] {
+        let tool_call = PreparedToolCall::prepare(NativeAgentToolCall {
+            id: format!("call-{status}"),
+            name: tool_name.to_string(),
+            arguments_json: "{}".to_string(),
+            result: serde_json::Value::Null,
+        })
+        .expect("tool call should prepare");
+        let result = native_web_tool_result(
+            &tool_call,
+            serde_json::json!({
+                "status": status,
+                "reasonCode": status,
+                "reason": format!("Browser returned {status}")
+            }),
+        );
+        let outcome = &result.envelope["structured"]["outcome"];
+
+        assert_eq!(outcome["effect"], effect, "status {status}");
+        assert_eq!(outcome["retry"], retry, "status {status}");
+        assert!(outcome["guidance"]
+            .as_str()
+            .is_some_and(|guidance| !guidance.trim().is_empty()));
+    }
 }

--- a/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
@@ -163,9 +163,16 @@ fn special_web_result_exposes_recovery_guidance_in_the_tool_envelope() {
         outcome["nextAction"]["arguments"]["url"],
         "https://agentskills.io/specification"
     );
+    assert!(outcome.get("guidance").is_none());
     assert!(model_content["toolOutcome"]["guidance"]
         .as_str()
-        .is_some_and(|guidance| guidance.contains("Do not repeat the click")));
+        .is_some_and(|guidance| guidance.contains("Do not repeat the same tool call")));
+    assert_eq!(
+        result.envelope["summary"],
+        "Alternative action required: This target opens a new browser window."
+    );
+    assert_eq!(result.envelope["ui"]["summary"], result.envelope["summary"]);
+    assert_eq!(result.envelope["ui"]["actions"][0]["tool"], "web.open");
     assert_eq!(model_content["result"], raw);
 }
 
@@ -231,11 +238,19 @@ fn web_special_statuses_have_explicit_effects_and_retry_dispositions() {
             }),
         );
         let outcome = &result.envelope["structured"]["outcome"];
+        let model_content: serde_json::Value = serde_json::from_str(
+            result.envelope["modelContent"]
+                .as_str()
+                .expect("model content should be JSON"),
+        )
+        .expect("model content should parse");
 
         assert_eq!(outcome["effect"], effect, "status {status}");
         assert_eq!(outcome["retry"], retry, "status {status}");
-        assert!(outcome["guidance"]
+        assert!(outcome.get("guidance").is_none());
+        assert!(model_content["toolOutcome"]["guidance"]
             .as_str()
             .is_some_and(|guidance| !guidance.trim().is_empty()));
+        assert_eq!(result.envelope["ui"]["summary"], result.envelope["summary"]);
     }
 }

--- a/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
@@ -1,8 +1,10 @@
 use super::{
-    apply_turn_working_directory, native_tool_executor_model_content,
+    apply_turn_working_directory, native_mcp_failure_result, native_mcp_runtime_error_result,
+    native_mcp_tool_result, native_tool_executor_model_content,
     native_tool_result_from_executor_response, native_web_tool_result,
 };
-use crate::agent::runtime::{NativeAgentToolCall, PreparedToolCall};
+use crate::agent::runtime::{NativeAgentToolCall, NativeToolRetry, PreparedToolCall};
+use crate::runtime::mcp::{McpRuntimeError, McpRuntimeErrorKind};
 
 #[test]
 fn shell_process_output_uses_terminal_output_as_model_content() {
@@ -79,6 +81,191 @@ fn executor_response_keeps_only_the_native_shell_result() {
     assert_eq!(serialized.matches("\"stdout\"").count(), 3);
     assert!(!serialized.contains("permission"));
     assert!(!serialized.contains("executor"));
+}
+
+#[test]
+fn running_shell_result_exposes_poll_action_and_retry_semantics() {
+    let tool_call = PreparedToolCall::prepare(NativeAgentToolCall {
+        id: "call-running".to_string(),
+        name: "exec_command".to_string(),
+        arguments_json: r#"{"command":"long-task"}"#.to_string(),
+        result: serde_json::Value::Null,
+    })
+    .expect("tool call should prepare");
+    let executor_response = serde_json::json!({
+        "result": {
+            "processId": "process-1",
+            "status": "running",
+            "running": true,
+            "exitCode": null,
+            "output": "working",
+            "cursor": 7,
+            "truncated": false
+        }
+    });
+
+    let result = native_tool_result_from_executor_response(&tool_call, executor_response)
+        .expect("running shell result should be projected");
+    let outcome = &result.envelope["structured"]["outcome"];
+    let model_content: serde_json::Value = serde_json::from_str(
+        result.envelope["modelContent"]
+            .as_str()
+            .expect("model content should be JSON"),
+    )
+    .expect("model content should parse");
+
+    assert_eq!(outcome["effect"], "in_progress");
+    assert_eq!(outcome["reasonCode"], "shell_process_running");
+    assert_eq!(outcome["retry"], "retry_with_updated_state");
+    assert_eq!(outcome["nextAction"]["tool"], "write_stdin");
+    assert_eq!(outcome["nextAction"]["arguments"]["processId"], "process-1");
+    assert_eq!(outcome["nextAction"]["arguments"]["cursor"], 7);
+    assert!(model_content["toolOutcome"]["guidance"]
+        .as_str()
+        .is_some_and(|guidance| guidance.contains("Follow nextAction")));
+}
+
+#[test]
+fn shell_terminal_special_states_use_structured_outcomes() {
+    for (name, raw, effect, reason_code, retry) in [
+        (
+            "exec_command",
+            serde_json::json!({
+                "processId": "process-failed",
+                "status": "exited",
+                "running": false,
+                "exitCode": 7,
+                "output": "failure"
+            }),
+            "failed",
+            "shell_nonzero_exit",
+            "replan",
+        ),
+        (
+            "shell.execute",
+            serde_json::json!({
+                "exit_code": -1,
+                "timed_out": true,
+                "cancelled": false,
+                "truncated": false,
+                "content": "timed out"
+            }),
+            "timed_out",
+            "shell_timed_out",
+            "replan",
+        ),
+        (
+            "exec_command",
+            serde_json::json!({
+                "processId": "process-truncated",
+                "status": "exited",
+                "running": false,
+                "exitCode": 0,
+                "output": "partial",
+                "truncated": true,
+                "droppedBytes": 512
+            }),
+            "partial_result",
+            "shell_output_truncated",
+            "do_not_retry",
+        ),
+    ] {
+        let tool_call = PreparedToolCall::prepare(NativeAgentToolCall {
+            id: format!("call-{reason_code}"),
+            name: name.to_string(),
+            arguments_json: r#"{"command":"task"}"#.to_string(),
+            result: serde_json::Value::Null,
+        })
+        .expect("tool call should prepare");
+        let result = native_tool_result_from_executor_response(
+            &tool_call,
+            serde_json::json!({ "result": raw }),
+        )
+        .expect("special shell result should be projected");
+        let outcome = &result.envelope["structured"]["outcome"];
+
+        assert_eq!(outcome["effect"], effect, "reason {reason_code}");
+        assert_eq!(outcome["reasonCode"], reason_code, "reason {reason_code}");
+        assert_eq!(outcome["retry"], retry, "reason {reason_code}");
+    }
+}
+
+#[test]
+fn mcp_error_result_and_configuration_failure_share_outcome_projection() {
+    let tool_call = PreparedToolCall::prepare(NativeAgentToolCall {
+        id: "call-mcp".to_string(),
+        name: "mcp.docs.search".to_string(),
+        arguments_json: r#"{"query":"Tinybot"}"#.to_string(),
+        result: serde_json::Value::Null,
+    })
+    .expect("tool call should prepare");
+    let domain_error = native_mcp_tool_result(
+        &tool_call,
+        serde_json::json!({
+            "server": "docs",
+            "tool": "search",
+            "result": {
+                "isError": true,
+                "content": [{ "type": "text", "text": "query rejected" }]
+            }
+        }),
+    );
+    let configuration_error = native_mcp_failure_result(
+        &tool_call,
+        Some("docs"),
+        Some("search"),
+        "user_action_required",
+        "mcp_server_disabled",
+        "MCP server is disabled: docs".to_string(),
+        NativeToolRetry::AfterUserAction,
+    );
+
+    assert_eq!(
+        domain_error.envelope["structured"]["outcome"]["reasonCode"],
+        "mcp_tool_error"
+    );
+    assert_eq!(
+        domain_error.envelope["structured"]["outcome"]["retry"],
+        "replan"
+    );
+    assert_eq!(
+        configuration_error.envelope["structured"]["outcome"]["effect"],
+        "user_action_required"
+    );
+    assert_eq!(
+        configuration_error.envelope["structured"]["outcome"]["retry"],
+        "after_user_action"
+    );
+    assert_eq!(configuration_error.envelope["raw"]["server"], "docs");
+}
+
+#[test]
+fn mcp_runtime_error_kind_drives_effect_and_reason_code() {
+    let tool_call = PreparedToolCall::prepare(NativeAgentToolCall {
+        id: "call-mcp-timeout".to_string(),
+        name: "mcp.docs.search".to_string(),
+        arguments_json: r#"{"query":"Tinybot"}"#.to_string(),
+        result: serde_json::Value::Null,
+    })
+    .expect("tool call should prepare");
+    let result = native_mcp_runtime_error_result(
+        &tool_call,
+        "search",
+        McpRuntimeError {
+            kind: McpRuntimeErrorKind::Timeout,
+            server: "docs".to_string(),
+            transport: "http".to_string(),
+            message: "MCP server `docs` timed out during tools/call".to_string(),
+            retryable: true,
+            cancelled: false,
+        },
+    );
+    let outcome = &result.envelope["structured"]["outcome"];
+
+    assert_eq!(outcome["effect"], "timed_out");
+    assert_eq!(outcome["reasonCode"], "mcp_timed_out");
+    assert_eq!(outcome["retry"], "replan");
+    assert_eq!(result.envelope["raw"]["error"]["transport"], "http");
 }
 
 #[test]

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -181,6 +181,16 @@ effects; Shell adapters report retained processes, cancellation, timeout,
 non-zero exit, failure, and truncated output; MCP adapters report configuration,
 allowlist, transport, and MCP `isError` results through the same projection.
 
+The runtime also guards against equivalent external tool calls that repeat a
+no-progress outcome. Tool names and recursively canonicalized arguments are
+hashed in memory and are not added to diagnostics. The first no-progress result
+reaches the model with replanning guidance; an equivalent call made before a
+successful tool declared to mutate workspace or session state is not dispatched
+and receives a `repeated_no_progress` outcome instead. Changed arguments and
+explicitly recommended same-call continuations remain allowed. Runtime-control
+tools such as plan updates, tool search, and user-input requests are outside
+this guard.
+
 `runtime.metrics` exposes bounded process-local counters, duration aggregates,
 and gauges for turns, providers, tools, persistence, cancellation, MCP,
 processes, recovery, and memory. Metric names come from fixed runtime enums.

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -169,6 +169,14 @@ add `providerAttemptId`, tool events retain `itemId` and `toolCallId`, and
 internal Worker RPC operations derive request IDs under the same root trace.
 Persisted tool envelopes use the configured secret-redaction path.
 
+Special tool results use the shared `tool_outcome` envelope projection instead
+of relying on tool-specific prose hidden in raw JSON. The outer envelope status
+continues to report whether dispatch completed, while the outcome records the
+observed effect, whether an action ran, the reason, retry disposition, recovery
+guidance, and an optional next tool call. The same outcome is included in
+`modelContent`; malformed outcomes without actionable guidance fail projection.
+Ordinary successful results retain the existing generic projection.
+
 `runtime.metrics` exposes bounded process-local counters, duration aggregates,
 and gauges for turns, providers, tools, persistence, cancellation, MCP,
 processes, recovery, and memory. Metric names come from fixed runtime enums.

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -176,7 +176,10 @@ observed effect, whether an action ran, the reason, retry disposition, and an
 optional next tool call. A central projection derives model recovery guidance,
 the envelope summary, and UI metadata from those facts. Malformed outcomes fail
 projection rather than reaching the model. Ordinary successful results retain
-the existing generic projection.
+the existing generic projection. Web adapters report navigation and page-state
+effects; Shell adapters report retained processes, cancellation, timeout,
+non-zero exit, failure, and truncated output; MCP adapters report configuration,
+allowlist, transport, and MCP `isError` results through the same projection.
 
 `runtime.metrics` exposes bounded process-local counters, duration aggregates,
 and gauges for turns, providers, tools, persistence, cancellation, MCP,

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -172,10 +172,11 @@ Persisted tool envelopes use the configured secret-redaction path.
 Special tool results use the shared `tool_outcome` envelope projection instead
 of relying on tool-specific prose hidden in raw JSON. The outer envelope status
 continues to report whether dispatch completed, while the outcome records the
-observed effect, whether an action ran, the reason, retry disposition, recovery
-guidance, and an optional next tool call. The same outcome is included in
-`modelContent`; malformed outcomes without actionable guidance fail projection.
-Ordinary successful results retain the existing generic projection.
+observed effect, whether an action ran, the reason, retry disposition, and an
+optional next tool call. A central projection derives model recovery guidance,
+the envelope summary, and UI metadata from those facts. Malformed outcomes fail
+projection rather than reaching the model. Ordinary successful results retain
+the existing generic projection.
 
 `runtime.metrics` exposes bounded process-local counters, duration aggregates,
 and gauges for turns, providers, tools, persistence, cancellation, MCP,

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -337,6 +337,36 @@ pub struct NativeAgentToolResult {
     pub envelope: NativeToolResultEnvelope,
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NativeToolOutcome {
+    pub effect: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_executed: Option<bool>,
+    pub reason_code: String,
+    pub reason: String,
+    pub retry: NativeToolRetry,
+    pub guidance: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<NativeToolNextAction>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NativeToolNextAction {
+    pub tool: String,
+    pub arguments: Value,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativeToolRetry {
+    DoNotRetry,
+    RetryWithUpdatedState,
+    AfterUserAction,
+    Replan,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct NativeToolResultEnvelope {

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -36,6 +36,7 @@ mod state;
 mod stores;
 mod subagent_projection;
 mod tool_dispatcher;
+mod tool_outcome_projection;
 mod tool_projection;
 mod tool_result;
 mod tool_router;
@@ -346,7 +347,6 @@ pub(crate) struct NativeToolOutcome {
     pub reason_code: String,
     pub reason: String,
     pub retry: NativeToolRetry,
-    pub guidance: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<NativeToolNextAction>,
 }

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -36,6 +36,7 @@ mod state;
 mod stores;
 mod subagent_projection;
 mod tool_dispatcher;
+mod tool_loop_guard;
 mod tool_outcome_projection;
 mod tool_projection;
 mod tool_result;

--- a/src-tauri/src/agent/runtime/state.rs
+++ b/src-tauri/src/agent/runtime/state.rs
@@ -2,6 +2,7 @@ use super::context_manager::ContextManager;
 use super::continuations::guidance_continuation_message;
 use super::events::{prepare_runtime_event_input, runtime_event_timestamp, runtime_status_label};
 use super::hooks::AgentHookEvaluation;
+use super::tool_loop_guard::ToolLoopGuard;
 use super::trace_commit::TraceCommitter;
 use super::usage::{
     enrich_usage_with_context_window, latest_cumulative_usage_tokens, usage_context_used_tokens,
@@ -35,6 +36,7 @@ pub(super) struct AgentTurnState {
     context_checkpoint: Option<Value>,
     source_context_checkpoint: Option<Value>,
     pending_guidance_message: Option<Value>,
+    pub(super) tool_loop_guard: ToolLoopGuard,
 }
 
 impl AgentTurnState {
@@ -72,6 +74,7 @@ impl AgentTurnState {
                         .map(|context_id| serde_json::json!({ "contextId": context_id }))
                 }),
             pending_guidance_message: guidance_continuation_message(&context.metadata),
+            tool_loop_guard: ToolLoopGuard::default(),
         })
     }
 

--- a/src-tauri/src/agent/runtime/tests/tools.rs
+++ b/src-tauri/src/agent/runtime/tests/tools.rs
@@ -500,6 +500,128 @@ fn tool_runtime_dispatches_through_async_dispatch_seam() {
 }
 
 #[test]
+fn repeated_no_progress_call_is_returned_to_model_without_redispatch() {
+    struct RepeatingProvider {
+        calls: AtomicUsize,
+    }
+
+    impl NativeAgentProvider for RepeatingProvider {
+        fn complete(
+            &self,
+            context: &AgentTurnContext,
+        ) -> Result<NativeAgentProviderResponse, String> {
+            let call_index = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call_index < 2 {
+                if call_index == 1 {
+                    assert!(context.messages.iter().any(|message| {
+                        message["role"] == "tool"
+                            && message["tool_call_id"] == "call-no-progress-1"
+                            && message["content"].as_str().is_some_and(|content| {
+                                content.contains("equivalent call against unchanged state")
+                            })
+                    }));
+                }
+                return Ok(NativeAgentProviderResponse {
+                    final_content: String::new(),
+                    reasoning_delta: None,
+                    usage: None,
+                    response_items: Vec::new(),
+                    tool_calls: vec![NativeAgentToolCall {
+                        id: format!("call-no-progress-{}", call_index + 1),
+                        name: "test.lookup".to_string(),
+                        arguments_json: if call_index == 0 {
+                            r#"{"limit":5,"query":"same"}"#.to_string()
+                        } else {
+                            r#"{"query":"same","limit":5}"#.to_string()
+                        },
+                        result: Value::Null,
+                    }],
+                });
+            }
+            assert!(context.messages.iter().any(|message| {
+                message["role"] == "tool"
+                    && message["tool_call_id"] == "call-no-progress-2"
+                    && message["content"]
+                        .as_str()
+                        .is_some_and(|content| content.contains("repeated_no_progress"))
+            }));
+            Ok(NativeAgentProviderResponse {
+                final_content: "used another approach".to_string(),
+                reasoning_delta: None,
+                usage: None,
+                response_items: Vec::new(),
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    struct NoProgressDispatcher {
+        dispatches: AtomicUsize,
+    }
+
+    impl NativeAgentToolDispatcher for NoProgressDispatcher {
+        fn dispatch(
+            &self,
+            _context: &AgentTurnContext,
+            tool_call: &PreparedToolCall,
+        ) -> Result<NativeAgentToolResult, String> {
+            self.dispatches.fetch_add(1, Ordering::SeqCst);
+            Ok(NativeAgentToolResult::success_with_outcome(
+                tool_call,
+                json!({ "status": "unchanged" }),
+                NativeToolOutcome {
+                    effect: "unchanged".to_string(),
+                    action_executed: Some(true),
+                    reason_code: "lookup_unchanged".to_string(),
+                    reason: "The lookup returned no new evidence.".to_string(),
+                    retry: NativeToolRetry::DoNotRetry,
+                    next_action: None,
+                },
+            ))
+        }
+    }
+
+    let dispatcher = Arc::new(NoProgressDispatcher {
+        dispatches: AtomicUsize::new(0),
+    });
+    let result = run_native_agent_turn_with_services(
+        &NativeAgentRuntimeServices::new(
+            Arc::new(RepeatingProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            dispatcher.clone(),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        )
+        .with_test_tool_registry_entries(test_registry_with_model_tools(&["test.lookup"])),
+        json!({
+            "runtime": "rust",
+            "turnId": "turn-no-progress-loop",
+            "sessionId": "session-no-progress-loop",
+            "maxIterations": 3,
+            "messages": [{ "role": "user", "content": "keep looking" }]
+        }),
+    )
+    .expect("loop guard should return the blocked call to the model");
+
+    assert_eq!(dispatcher.dispatches.load(Ordering::SeqCst), 1);
+    assert_eq!(result["stopReason"], "final_response");
+    assert_eq!(result["finalContent"], "used another approach");
+    assert_eq!(result["toolsUsed"], json!(["test.lookup"]));
+    assert_eq!(
+        result["completedToolResults"][1]["envelope"]["structured"]["outcome"]["reasonCode"],
+        "repeated_no_progress"
+    );
+    assert!(result["runtimeEvents"]
+        .as_array()
+        .expect("runtime events should be present")
+        .iter()
+        .any(|event| event["eventName"] == "agent.tool.start"
+            && event["payload"]["toolCallId"] == "call-no-progress-2"
+            && event["payload"]["status"] == "blocked"));
+}
+
+#[test]
 fn registry_has_no_parallel_safe_builtin_tools() {
     let registry = WorkerToolRegistryRpc::new(CapabilityPolicy::new([
         WorkerCapability::FsWorkspaceRead,

--- a/src-tauri/src/agent/runtime/tool_loop_guard.rs
+++ b/src-tauri/src/agent/runtime/tool_loop_guard.rs
@@ -1,0 +1,237 @@
+use super::{NativeAgentToolCall, NativeToolResultEnvelope};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct ToolLoopBlock {
+    pub(super) previous_effect: String,
+    pub(super) previous_reason_code: String,
+}
+
+#[derive(Clone, Default)]
+pub(super) struct ToolLoopGuard {
+    no_progress_calls: HashMap<String, NoProgressObservation>,
+}
+
+#[derive(Clone)]
+struct NoProgressObservation {
+    effect: String,
+    reason_code: String,
+}
+
+impl ToolLoopGuard {
+    pub(super) fn block_for(&self, tool_call: &NativeAgentToolCall) -> Option<ToolLoopBlock> {
+        let call_fingerprint = tool_call_fingerprint(tool_call);
+        let previous = self.no_progress_calls.get(&call_fingerprint)?;
+        Some(ToolLoopBlock {
+            previous_effect: previous.effect.clone(),
+            previous_reason_code: previous.reason_code.clone(),
+        })
+    }
+
+    pub(super) fn observe(
+        &mut self,
+        tool_call: &NativeAgentToolCall,
+        envelope: &NativeToolResultEnvelope,
+        state_changed: bool,
+    ) {
+        match no_progress_observation(tool_call, envelope) {
+            Some(observation) => {
+                self.no_progress_calls
+                    .insert(tool_call_fingerprint(tool_call), observation);
+            }
+            None if state_changed && !is_tool_outcome(envelope) => {
+                self.no_progress_calls.clear();
+            }
+            None => {}
+        }
+    }
+}
+
+fn no_progress_observation(
+    tool_call: &NativeAgentToolCall,
+    envelope: &NativeToolResultEnvelope,
+) -> Option<NoProgressObservation> {
+    if let Some(outcome) = envelope
+        .pointer("/structured/outcome")
+        .filter(|_| is_tool_outcome(envelope))
+    {
+        if next_action_repeats_call(tool_call, outcome) {
+            return None;
+        }
+        return Some(NoProgressObservation {
+            effect: outcome
+                .get("effect")
+                .and_then(Value::as_str)
+                .unwrap_or("no_progress")
+                .to_string(),
+            reason_code: outcome
+                .get("reasonCode")
+                .and_then(Value::as_str)
+                .unwrap_or("tool_outcome")
+                .to_string(),
+        });
+    }
+
+    match envelope.get("status").and_then(Value::as_str) {
+        Some("error" | "denied") => Some(NoProgressObservation {
+            effect: "failed".to_string(),
+            reason_code: "tool_result_error".to_string(),
+        }),
+        _ => None,
+    }
+}
+
+fn is_tool_outcome(envelope: &NativeToolResultEnvelope) -> bool {
+    envelope.pointer("/structured/kind").and_then(Value::as_str) == Some("tool_outcome")
+}
+
+fn next_action_repeats_call(tool_call: &NativeAgentToolCall, outcome: &Value) -> bool {
+    let Some(next_action) = outcome.get("nextAction") else {
+        return false;
+    };
+    if next_action.get("tool").and_then(Value::as_str) != Some(tool_call.name.as_str()) {
+        return false;
+    }
+    let Some(arguments) = next_action.get("arguments") else {
+        return false;
+    };
+    canonical_json(arguments)
+        == serde_json::from_str::<Value>(&tool_call.arguments_json)
+            .map(|arguments| canonical_json(&arguments))
+            .unwrap_or_else(|_| tool_call.arguments_json.clone())
+}
+
+fn tool_call_fingerprint(tool_call: &NativeAgentToolCall) -> String {
+    let canonical_arguments = serde_json::from_str::<Value>(&tool_call.arguments_json)
+        .map(|arguments| canonical_json(&arguments))
+        .unwrap_or_else(|_| tool_call.arguments_json.clone());
+    let encoded = format!("{}\0{canonical_arguments}", tool_call.name);
+    format!("sha256:{:x}", Sha256::digest(encoded.as_bytes()))
+}
+
+fn canonical_json(value: &Value) -> String {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => value.to_string(),
+        Value::Array(values) => format!(
+            "[{}]",
+            values
+                .iter()
+                .map(canonical_json)
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        Value::Object(values) => {
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            let fields = keys
+                .into_iter()
+                .map(|key| {
+                    format!(
+                        "{}:{}",
+                        Value::String(key.clone()),
+                        canonical_json(&values[key])
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{{{fields}}}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::runtime::{
+        NativeAgentToolResult, NativeToolNextAction, NativeToolOutcome, NativeToolRetry,
+    };
+    use serde_json::json;
+
+    fn call(arguments_json: &str) -> NativeAgentToolCall {
+        NativeAgentToolCall {
+            id: "call-1".to_string(),
+            name: "web.act".to_string(),
+            arguments_json: arguments_json.to_string(),
+            result: Value::Null,
+        }
+    }
+
+    fn unchanged_result(tool_call: &NativeAgentToolCall) -> NativeAgentToolResult {
+        NativeAgentToolResult::success_with_outcome(
+            tool_call,
+            json!({ "status": "unchanged" }),
+            NativeToolOutcome {
+                effect: "unchanged".to_string(),
+                action_executed: Some(true),
+                reason_code: "page_unchanged".to_string(),
+                reason: "The page did not change.".to_string(),
+                retry: NativeToolRetry::DoNotRetry,
+                next_action: None,
+            },
+        )
+    }
+
+    #[test]
+    fn blocks_equivalent_arguments_after_no_progress() {
+        let first = call(r#"{"snapshotId":"one","action":{"type":"clickTarget","targetRef":"a"}}"#);
+        let reordered =
+            call(r#"{"action":{"targetRef":"a","type":"clickTarget"},"snapshotId":"one"}"#);
+        let mut guard = ToolLoopGuard::default();
+        let result = unchanged_result(&first);
+
+        guard.observe(&first, &result.envelope, false);
+
+        let blocked = guard
+            .block_for(&reordered)
+            .expect("canonical equivalent call should be blocked");
+        assert_eq!(blocked.previous_effect, "unchanged");
+        assert_eq!(blocked.previous_reason_code, "page_unchanged");
+    }
+
+    #[test]
+    fn changed_arguments_or_successful_state_mutation_allow_the_call() {
+        let first = call(r#"{"snapshotId":"one","action":{"type":"clickTarget"}}"#);
+        let changed = call(r#"{"snapshotId":"two","action":{"type":"clickTarget"}}"#);
+        let mut guard = ToolLoopGuard::default();
+        let result = unchanged_result(&first);
+        guard.observe(&first, &result.envelope, false);
+
+        assert!(guard.block_for(&changed).is_none());
+
+        let mutation = NativeAgentToolResult::generic_success(&changed, json!({ "saved": true }));
+        guard.observe(&changed, &mutation.envelope, true);
+        assert!(guard.block_for(&first).is_none());
+    }
+
+    #[test]
+    fn explicitly_recommended_same_call_is_not_recorded_as_a_loop() {
+        let poll = NativeAgentToolCall {
+            id: "call-poll".to_string(),
+            name: "write_stdin".to_string(),
+            arguments_json: r#"{"cursor":4,"input":"","processId":"p-1"}"#.to_string(),
+            result: Value::Null,
+        };
+        let result = NativeAgentToolResult::success_with_outcome(
+            &poll,
+            json!({ "status": "running" }),
+            NativeToolOutcome {
+                effect: "in_progress".to_string(),
+                action_executed: Some(true),
+                reason_code: "shell_process_running".to_string(),
+                reason: "The process is still running.".to_string(),
+                retry: NativeToolRetry::RetryWithUpdatedState,
+                next_action: Some(NativeToolNextAction {
+                    tool: "write_stdin".to_string(),
+                    arguments: json!({ "processId": "p-1", "input": "", "cursor": 4 }),
+                }),
+            },
+        );
+        let mut guard = ToolLoopGuard::default();
+
+        guard.observe(&poll, &result.envelope, false);
+
+        assert!(guard.block_for(&poll).is_none());
+    }
+}

--- a/src-tauri/src/agent/runtime/tool_outcome_projection.rs
+++ b/src-tauri/src/agent/runtime/tool_outcome_projection.rs
@@ -49,6 +49,8 @@ fn outcome_summary(outcome: &NativeToolOutcome) -> String {
     let label = match outcome.effect.as_str() {
         "unchanged" => "No change",
         "stale_state" => "State changed",
+        "in_progress" => "Still running",
+        "partial_result" => "Partial result",
         "alternative_required" => "Alternative action required",
         "user_action_required" => "User action required",
         "failed" => "Tool failed",

--- a/src-tauri/src/agent/runtime/tool_outcome_projection.rs
+++ b/src-tauri/src/agent/runtime/tool_outcome_projection.rs
@@ -1,0 +1,147 @@
+use super::{NativeAgentToolCall, NativeToolNextAction, NativeToolOutcome, NativeToolRetry};
+use serde_json::Value;
+
+pub(super) struct NativeToolOutcomeProjection {
+    pub summary: String,
+    pub model_content: String,
+    pub structured: Value,
+    pub ui: Value,
+}
+
+pub(super) fn project_tool_outcome(
+    tool_call: &NativeAgentToolCall,
+    raw_content: &Value,
+    outcome: &NativeToolOutcome,
+) -> NativeToolOutcomeProjection {
+    let structured_outcome =
+        serde_json::to_value(outcome).expect("native tool outcome must serialize to JSON");
+    let guidance = outcome_guidance(outcome);
+    let mut model_outcome = structured_outcome.clone();
+    model_outcome["guidance"] = Value::String(guidance);
+    let summary = outcome_summary(outcome);
+    let actions = outcome
+        .next_action
+        .as_ref()
+        .map(project_ui_action)
+        .into_iter()
+        .collect::<Vec<_>>();
+    NativeToolOutcomeProjection {
+        summary: summary.clone(),
+        model_content: serde_json::json!({
+            "toolOutcome": model_outcome,
+            "result": raw_content,
+        })
+        .to_string(),
+        structured: serde_json::json!({
+            "kind": "tool_outcome",
+            "outcome": structured_outcome,
+        }),
+        ui: serde_json::json!({
+            "type": "tool_outcome",
+            "title": tool_call.name,
+            "summary": summary,
+            "actions": actions,
+        }),
+    }
+}
+
+fn outcome_summary(outcome: &NativeToolOutcome) -> String {
+    let label = match outcome.effect.as_str() {
+        "unchanged" => "No change",
+        "stale_state" => "State changed",
+        "alternative_required" => "Alternative action required",
+        "user_action_required" => "User action required",
+        "failed" => "Tool failed",
+        "cancelled" => "Tool cancelled",
+        "timed_out" => "Tool timed out",
+        _ => "Special tool result",
+    };
+    format!("{label}: {}", compact_text(&outcome.reason, 160))
+}
+
+fn outcome_guidance(outcome: &NativeToolOutcome) -> String {
+    let retry_guidance = match outcome.retry {
+        NativeToolRetry::DoNotRetry => "Do not repeat the same tool call.",
+        NativeToolRetry::RetryWithUpdatedState => {
+            "Use the returned updated state to reassess before issuing a new tool call."
+        }
+        NativeToolRetry::AfterUserAction => {
+            "Pause automated work until the required user action is complete, then reassess the current state."
+        }
+        NativeToolRetry::Replan => {
+            "Do not retry automatically. Inspect the reason and current evidence, then replan."
+        }
+    };
+    match outcome.next_action.as_ref() {
+        Some(next_action) => format!(
+            "{retry_guidance} Follow nextAction by calling `{}` with its provided arguments.",
+            next_action.tool
+        ),
+        None => retry_guidance.to_string(),
+    }
+}
+
+fn project_ui_action(next_action: &NativeToolNextAction) -> Value {
+    serde_json::json!({
+        "type": "tool_call",
+        "label": format!("Use {}", next_action.tool),
+        "tool": next_action.tool,
+        "arguments": next_action.arguments,
+    })
+}
+
+fn compact_text(text: &str, max_chars: usize) -> String {
+    let mut characters = text.trim().chars();
+    let compact = characters.by_ref().take(max_chars).collect::<String>();
+    if characters.next().is_some() {
+        format!("{compact}…")
+    } else {
+        compact
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn projection_generates_model_guidance_and_ui_from_structured_facts() {
+        let tool_call = NativeAgentToolCall {
+            id: "call-navigation".to_string(),
+            name: "web.act".to_string(),
+            arguments_json: "{}".to_string(),
+            result: Value::Null,
+        };
+        let outcome = NativeToolOutcome {
+            effect: "alternative_required".to_string(),
+            action_executed: Some(false),
+            reason_code: "target_opens_new_window".to_string(),
+            reason: "The target opens a new browser window.".to_string(),
+            retry: NativeToolRetry::DoNotRetry,
+            next_action: Some(NativeToolNextAction {
+                tool: "web.open".to_string(),
+                arguments: serde_json::json!({ "url": "https://example.com/docs" }),
+            }),
+        };
+
+        let projection = project_tool_outcome(
+            &tool_call,
+            &serde_json::json!({ "status": "navigation_required" }),
+            &outcome,
+        );
+        let model_content: Value =
+            serde_json::from_str(&projection.model_content).expect("model content should be JSON");
+
+        assert_eq!(
+            projection.summary,
+            "Alternative action required: The target opens a new browser window."
+        );
+        assert_eq!(projection.structured["outcome"]["retry"], "do_not_retry");
+        assert!(projection.structured["outcome"].get("guidance").is_none());
+        assert!(model_content["toolOutcome"]["guidance"]
+            .as_str()
+            .is_some_and(|guidance| guidance.contains("Follow nextAction")));
+        assert_eq!(projection.ui["summary"], projection.summary);
+        assert_eq!(projection.ui["actions"][0]["tool"], "web.open");
+    }
+}

--- a/src-tauri/src/agent/runtime/tool_outcome_projection.rs
+++ b/src-tauri/src/agent/runtime/tool_outcome_projection.rs
@@ -51,6 +51,7 @@ fn outcome_summary(outcome: &NativeToolOutcome) -> String {
         "stale_state" => "State changed",
         "in_progress" => "Still running",
         "partial_result" => "Partial result",
+        "blocked" => "Loop prevented",
         "alternative_required" => "Alternative action required",
         "user_action_required" => "User action required",
         "failed" => "Tool failed",
@@ -74,13 +75,14 @@ fn outcome_guidance(outcome: &NativeToolOutcome) -> String {
             "Do not retry automatically. Inspect the reason and current evidence, then replan."
         }
     };
-    match outcome.next_action.as_ref() {
+    let guidance = match outcome.next_action.as_ref() {
         Some(next_action) => format!(
             "{retry_guidance} Follow nextAction by calling `{}` with its provided arguments.",
             next_action.tool
         ),
         None => retry_guidance.to_string(),
-    }
+    };
+    format!("{guidance} An equivalent call against unchanged state may be blocked by the runtime.")
 }
 
 fn project_ui_action(next_action: &NativeToolNextAction) -> Value {

--- a/src-tauri/src/agent/runtime/tool_projection.rs
+++ b/src-tauri/src/agent/runtime/tool_projection.rs
@@ -1,5 +1,6 @@
 use super::state::AgentTurnState;
 use super::subagent_projection::project_subagent_tool_result;
+use super::tool_dispatcher::{native_tool_mutates_session, native_tool_mutates_workspace};
 use super::{
     AgentAssistantMessage, AgentItem, AgentMessageContent, AgentToolCallItem, AgentToolResultItem,
     AgentTurnContext, NativeAgentToolCall, NativeAgentToolResult, NativeToolResultEnvelope,
@@ -158,6 +159,12 @@ pub(super) fn commit_tool_observation(
     state
         .completed_tool_results
         .push(completed_tool_result_entry(&tool_call, &result, &status));
+    let state_changed = status == "ok"
+        && (native_tool_mutates_workspace(context, &tool_call.name)
+            || native_tool_mutates_session(context, &tool_call.name));
+    state
+        .tool_loop_guard
+        .observe(&tool_call, &result.envelope, state_changed);
     Ok(())
 }
 

--- a/src-tauri/src/agent/runtime/tool_projection.rs
+++ b/src-tauri/src/agent/runtime/tool_projection.rs
@@ -205,6 +205,9 @@ fn normalize_tool_result_for_context(
     if let Some(structured) = envelope.get_mut("structured") {
         redact_sensitive_value(structured, &secrets, &mut redactions);
     }
+    if let Some(ui) = envelope.get_mut("ui") {
+        redact_sensitive_value(ui, &secrets, &mut redactions);
+    }
     if let Some(raw) = envelope.get_mut("raw") {
         redact_sensitive_value(raw, &secrets, &mut redactions);
     }
@@ -254,7 +257,7 @@ fn validate_tool_outcome(envelope: &NativeToolResultEnvelope) -> Result<(), Stri
         .get("outcome")
         .and_then(Value::as_object)
         .ok_or_else(|| "field `structured.outcome` must be an object".to_string())?;
-    for field in ["effect", "reasonCode", "reason", "retry", "guidance"] {
+    for field in ["effect", "reasonCode", "reason", "retry"] {
         if outcome
             .get(field)
             .and_then(Value::as_str)
@@ -500,7 +503,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_tool_observation_rejects_tool_outcome_without_guidance() {
+    fn commit_tool_observation_rejects_tool_outcome_with_unsupported_retry() {
         let context = AgentTurnContext::from_spec(
             json!({
                 "turnId": "turn-malformed-tool-outcome",
@@ -522,25 +525,86 @@ mod tests {
             reason_code: "page_unchanged".to_string(),
             reason: "The page did not change.".to_string(),
             retry: super::super::NativeToolRetry::DoNotRetry,
-            guidance: "Use another action.".to_string(),
             next_action: None,
         };
         let mut result = NativeAgentToolResult::success_with_outcome(
             &tool_call,
-            "Page unchanged".to_string(),
             json!({ "status": "unchanged" }),
             outcome,
         );
-        result.envelope["structured"]["outcome"]
-            .as_object_mut()
-            .expect("test outcome should be an object")
-            .remove("guidance");
+        result.envelope["structured"]["outcome"]["retry"] =
+            Value::String("retry_forever".to_string());
 
         let error = commit_tool_observation(&context, &mut state, 0, tool_call, result)
-            .expect_err("tool outcomes without guidance must fail fast");
+            .expect_err("tool outcomes with unsupported retry must fail fast");
 
-        assert!(error.contains("structured.outcome.guidance"));
+        assert!(error.contains("unsupported value `retry_forever`"));
         assert_eq!(state.history.messages().len(), 1);
         assert!(state.completed_tool_results.is_empty());
+    }
+
+    #[test]
+    fn tool_outcome_projection_redacts_model_and_ui_content() {
+        let context = AgentTurnContext::from_spec(
+            json!({
+                "turnId": "turn-redacted-tool-outcome",
+                "sessionId": "session-redacted-tool-outcome",
+                "messages": [{ "role": "user", "content": "use the browser" }]
+            }),
+            json!({
+                "providers": {
+                    "fixture": { "api_key": "secret-token" }
+                }
+            }),
+        );
+        let mut state = AgentTurnState::new(&context, None).expect("state should initialize");
+        let tool_call = NativeAgentToolCall {
+            id: "call-redacted-outcome".to_string(),
+            name: "web.act".to_string(),
+            arguments_json: "{}".to_string(),
+            result: Value::Null,
+        };
+        let outcome = super::super::NativeToolOutcome {
+            effect: "alternative_required".to_string(),
+            action_executed: Some(false),
+            reason_code: "secret_redirect".to_string(),
+            reason: "Open secret-token in another tool.".to_string(),
+            retry: super::super::NativeToolRetry::DoNotRetry,
+            next_action: Some(super::super::NativeToolNextAction {
+                tool: "web.open".to_string(),
+                arguments: json!({ "url": "https://example.com/secret-token" }),
+            }),
+        };
+        let result = NativeAgentToolResult::success_with_outcome(
+            &tool_call,
+            json!({ "status": "navigation_required", "secret": "secret-token" }),
+            outcome,
+        );
+
+        commit_tool_observation(&context, &mut state, 0, tool_call, result)
+            .expect("valid outcome should be committed");
+
+        let envelope = &state.completed_tool_results[0]["envelope"];
+        assert!(!envelope.to_string().contains("secret-token"));
+        assert!(envelope["ui"]["summary"]
+            .as_str()
+            .is_some_and(|summary| summary.contains("[REDACTED]")));
+        assert_eq!(
+            envelope["ui"]["actions"][0]["arguments"]["url"],
+            "https://example.com/[REDACTED]"
+        );
+        assert!(envelope["modelContent"]
+            .as_str()
+            .is_some_and(|content| content.contains("[REDACTED]")));
+        let event = state
+            .runtime_events()
+            .into_iter()
+            .find(|event| event.event_name == AgentEventKind::ToolResult.wire_name())
+            .expect("tool result event should be emitted");
+        assert_eq!(event.payload["summary"], envelope["summary"]);
+        assert_eq!(
+            event.payload["envelope"]["ui"]["summary"],
+            envelope["summary"]
+        );
     }
 }

--- a/src-tauri/src/agent/runtime/tool_projection.rs
+++ b/src-tauri/src/agent/runtime/tool_projection.rs
@@ -174,6 +174,7 @@ fn normalize_tool_result_for_context(
             "tool result envelope has unsupported status `{status}`"
         ));
     }
+    validate_tool_outcome(&result.envelope)?;
     let summary = required_envelope_string(&result.envelope, "summary")?.to_string();
     let mut model_content = required_envelope_string(&result.envelope, "modelContent")?.to_string();
     let secrets = config_redaction_values(&context.config_snapshot);
@@ -240,6 +241,71 @@ fn normalize_tool_result_for_context(
     }
     result.content = Value::String(model_content);
     Ok(result)
+}
+
+fn validate_tool_outcome(envelope: &NativeToolResultEnvelope) -> Result<(), String> {
+    let Some(structured) = envelope.get("structured") else {
+        return Ok(());
+    };
+    if structured.get("kind").and_then(Value::as_str) != Some("tool_outcome") {
+        return Ok(());
+    }
+    let outcome = structured
+        .get("outcome")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "field `structured.outcome` must be an object".to_string())?;
+    for field in ["effect", "reasonCode", "reason", "retry", "guidance"] {
+        if outcome
+            .get(field)
+            .and_then(Value::as_str)
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            return Err(format!(
+                "field `structured.outcome.{field}` must be a non-empty string"
+            ));
+        }
+    }
+    let retry = outcome
+        .get("retry")
+        .and_then(Value::as_str)
+        .expect("validated tool outcome retry must be a string");
+    if !matches!(
+        retry,
+        "do_not_retry" | "retry_with_updated_state" | "after_user_action" | "replan"
+    ) {
+        return Err(format!(
+            "field `structured.outcome.retry` has unsupported value `{retry}`"
+        ));
+    }
+    if outcome
+        .get("actionExecuted")
+        .is_some_and(|value| !value.is_boolean())
+    {
+        return Err("field `structured.outcome.actionExecuted` must be a boolean".to_string());
+    }
+    if let Some(next_action) = outcome.get("nextAction") {
+        let next_action = next_action
+            .as_object()
+            .ok_or_else(|| "field `structured.outcome.nextAction` must be an object".to_string())?;
+        if next_action
+            .get("tool")
+            .and_then(Value::as_str)
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            return Err(
+                "field `structured.outcome.nextAction.tool` must be a non-empty string".to_string(),
+            );
+        }
+        if next_action
+            .get("arguments")
+            .is_none_or(|value| !value.is_object())
+        {
+            return Err(
+                "field `structured.outcome.nextAction.arguments` must be an object".to_string(),
+            );
+        }
+    }
+    Ok(())
 }
 
 fn required_envelope_string<'a>(
@@ -431,5 +497,50 @@ mod tests {
         let completed = &state.completed_tool_results[0];
         assert!(completed.get("summary").is_none());
         assert_eq!(completed["envelope"]["summary"], "README");
+    }
+
+    #[test]
+    fn commit_tool_observation_rejects_tool_outcome_without_guidance() {
+        let context = AgentTurnContext::from_spec(
+            json!({
+                "turnId": "turn-malformed-tool-outcome",
+                "sessionId": "session-malformed-tool-outcome",
+                "messages": [{ "role": "user", "content": "use the browser" }]
+            }),
+            json!({}),
+        );
+        let mut state = AgentTurnState::new(&context, None).expect("state should initialize");
+        let tool_call = NativeAgentToolCall {
+            id: "call-malformed-outcome".to_string(),
+            name: "web.act".to_string(),
+            arguments_json: r#"{"snapshotId":"snapshot-1"}"#.to_string(),
+            result: Value::Null,
+        };
+        let outcome = super::super::NativeToolOutcome {
+            effect: "unchanged".to_string(),
+            action_executed: Some(false),
+            reason_code: "page_unchanged".to_string(),
+            reason: "The page did not change.".to_string(),
+            retry: super::super::NativeToolRetry::DoNotRetry,
+            guidance: "Use another action.".to_string(),
+            next_action: None,
+        };
+        let mut result = NativeAgentToolResult::success_with_outcome(
+            &tool_call,
+            "Page unchanged".to_string(),
+            json!({ "status": "unchanged" }),
+            outcome,
+        );
+        result.envelope["structured"]["outcome"]
+            .as_object_mut()
+            .expect("test outcome should be an object")
+            .remove("guidance");
+
+        let error = commit_tool_observation(&context, &mut state, 0, tool_call, result)
+            .expect_err("tool outcomes without guidance must fail fast");
+
+        assert!(error.contains("structured.outcome.guidance"));
+        assert_eq!(state.history.messages().len(), 1);
+        assert!(state.completed_tool_results.is_empty());
     }
 }

--- a/src-tauri/src/agent/runtime/tool_result.rs
+++ b/src-tauri/src/agent/runtime/tool_result.rs
@@ -268,10 +268,12 @@ mod tests {
             result.envelope["structured"]["outcome"]["retry"],
             "do_not_retry"
         );
-        assert_eq!(
-            model_content["toolOutcome"]["guidance"],
-            "Do not repeat the same tool call. Follow nextAction by calling `web.open` with its provided arguments."
-        );
+        let guidance = model_content["toolOutcome"]["guidance"]
+            .as_str()
+            .expect("tool outcome guidance should be text");
+        assert!(guidance.contains("Do not repeat the same tool call"));
+        assert!(guidance.contains("Follow nextAction by calling `web.open`"));
+        assert!(guidance.contains("unchanged state may be blocked"));
         assert_eq!(
             result.envelope["summary"],
             "Alternative action required: The target opens a new window."

--- a/src-tauri/src/agent/runtime/tool_result.rs
+++ b/src-tauri/src/agent/runtime/tool_result.rs
@@ -1,3 +1,4 @@
+use super::tool_outcome_projection::project_tool_outcome;
 use super::tool_projection::legacy_tool_content;
 use super::{
     NativeAgentToolCall, NativeAgentToolResult, NativeToolOutcome, NativeToolResultEnvelope,
@@ -26,8 +27,7 @@ impl NativeToolResultEnvelope {
             "ok",
             summary,
             model_content,
-            "generic_result",
-            tool_call.name.clone(),
+            generic_ui("generic_result", tool_call.name.clone()),
             serde_json::json!({
                 "kind": "generic_result",
             }),
@@ -41,27 +41,16 @@ impl NativeToolResultEnvelope {
 
     fn success_with_outcome(
         tool_call: &NativeAgentToolCall,
-        summary: String,
         raw_content: Value,
         outcome: NativeToolOutcome,
     ) -> Self {
-        let outcome =
-            serde_json::to_value(outcome).expect("native tool outcome must serialize to JSON");
-        let model_content = serde_json::json!({
-            "toolOutcome": outcome,
-            "result": raw_content,
-        })
-        .to_string();
+        let projection = project_tool_outcome(tool_call, &raw_content, &outcome);
         Self::from_parts(
             "ok",
-            summary,
-            model_content,
-            "generic_result",
-            tool_call.name.clone(),
-            serde_json::json!({
-                "kind": "tool_outcome",
-                "outcome": outcome,
-            }),
+            projection.summary,
+            projection.model_content,
+            projection.ui,
+            projection.structured,
             serde_json::json!([]),
             serde_json::json!([]),
             serde_json::json!([]),
@@ -79,8 +68,7 @@ impl NativeToolResultEnvelope {
             "error",
             summary.clone(),
             summary,
-            "generic_error",
-            tool_call.name.clone(),
+            generic_ui("generic_error", tool_call.name.clone()),
             serde_json::json!({
                 "kind": "generic_error",
             }),
@@ -96,8 +84,7 @@ impl NativeToolResultEnvelope {
         status: &str,
         summary: String,
         model_content: String,
-        ui_type: &str,
-        title: String,
+        ui: Value,
         structured: Value,
         references: Value,
         artifacts: Value,
@@ -111,11 +98,7 @@ impl NativeToolResultEnvelope {
                 "summary": summary,
                 "modelContent": model_content,
                 "structured": structured,
-                "ui": {
-                    "type": ui_type,
-                    "title": title,
-                    "actions": [],
-                },
+                "ui": ui,
                 "references": references,
                 "artifacts": artifacts,
                 "sideEffects": side_effects,
@@ -199,16 +182,11 @@ impl NativeAgentToolResult {
 
     pub(crate) fn success_with_outcome(
         tool_call: &NativeAgentToolCall,
-        summary: String,
         raw_content: Value,
         outcome: NativeToolOutcome,
     ) -> Self {
-        let envelope = NativeToolResultEnvelope::success_with_outcome(
-            tool_call,
-            summary,
-            raw_content,
-            outcome,
-        );
+        let envelope =
+            NativeToolResultEnvelope::success_with_outcome(tool_call, raw_content, outcome);
         let model_content = envelope
             .get("modelContent")
             .and_then(Value::as_str)
@@ -219,6 +197,14 @@ impl NativeAgentToolResult {
             envelope,
         }
     }
+}
+
+fn generic_ui(ui_type: &str, title: String) -> Value {
+    serde_json::json!({
+        "type": ui_type,
+        "title": title,
+        "actions": [],
+    })
 }
 
 #[cfg(test)]
@@ -262,19 +248,13 @@ mod tests {
             reason_code: "target_opens_new_window".to_string(),
             reason: "The target opens a new window.".to_string(),
             retry: super::super::NativeToolRetry::DoNotRetry,
-            guidance: "Use web.open instead.".to_string(),
             next_action: Some(super::super::NativeToolNextAction {
                 tool: "web.open".to_string(),
                 arguments: json!({ "url": "https://example.com/docs" }),
             }),
         };
 
-        let result = NativeAgentToolResult::success_with_outcome(
-            &tool_call,
-            "Use web.open".to_string(),
-            raw.clone(),
-            outcome,
-        );
+        let result = NativeAgentToolResult::success_with_outcome(&tool_call, raw.clone(), outcome);
         let model_content: Value = serde_json::from_str(
             result.envelope["modelContent"]
                 .as_str()
@@ -290,8 +270,14 @@ mod tests {
         );
         assert_eq!(
             model_content["toolOutcome"]["guidance"],
-            "Use web.open instead."
+            "Do not repeat the same tool call. Follow nextAction by calling `web.open` with its provided arguments."
         );
+        assert_eq!(
+            result.envelope["summary"],
+            "Alternative action required: The target opens a new window."
+        );
+        assert_eq!(result.envelope["ui"]["summary"], result.envelope["summary"]);
+        assert_eq!(result.envelope["ui"]["actions"][0]["tool"], "web.open");
         assert_eq!(model_content["result"], raw);
         assert_eq!(result.envelope["raw"], raw);
     }

--- a/src-tauri/src/agent/runtime/tool_result.rs
+++ b/src-tauri/src/agent/runtime/tool_result.rs
@@ -1,5 +1,7 @@
 use super::tool_projection::legacy_tool_content;
-use super::{NativeAgentToolCall, NativeAgentToolResult, NativeToolResultEnvelope};
+use super::{
+    NativeAgentToolCall, NativeAgentToolResult, NativeToolOutcome, NativeToolResultEnvelope,
+};
 use serde_json::Value;
 use std::ops::{Deref, DerefMut};
 
@@ -28,6 +30,37 @@ impl NativeToolResultEnvelope {
             tool_call.name.clone(),
             serde_json::json!({
                 "kind": "generic_result",
+            }),
+            serde_json::json!([]),
+            serde_json::json!([]),
+            serde_json::json!([]),
+            tool_call,
+            raw_content,
+        )
+    }
+
+    fn success_with_outcome(
+        tool_call: &NativeAgentToolCall,
+        summary: String,
+        raw_content: Value,
+        outcome: NativeToolOutcome,
+    ) -> Self {
+        let outcome =
+            serde_json::to_value(outcome).expect("native tool outcome must serialize to JSON");
+        let model_content = serde_json::json!({
+            "toolOutcome": outcome,
+            "result": raw_content,
+        })
+        .to_string();
+        Self::from_parts(
+            "ok",
+            summary,
+            model_content,
+            "generic_result",
+            tool_call.name.clone(),
+            serde_json::json!({
+                "kind": "tool_outcome",
+                "outcome": outcome,
             }),
             serde_json::json!([]),
             serde_json::json!([]),
@@ -163,6 +196,29 @@ impl NativeAgentToolResult {
             envelope,
         }
     }
+
+    pub(crate) fn success_with_outcome(
+        tool_call: &NativeAgentToolCall,
+        summary: String,
+        raw_content: Value,
+        outcome: NativeToolOutcome,
+    ) -> Self {
+        let envelope = NativeToolResultEnvelope::success_with_outcome(
+            tool_call,
+            summary,
+            raw_content,
+            outcome,
+        );
+        let model_content = envelope
+            .get("modelContent")
+            .and_then(Value::as_str)
+            .expect("native tool outcome must include model content")
+            .to_string();
+        Self {
+            content: Value::String(model_content),
+            envelope,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -185,5 +241,58 @@ mod tests {
         assert_eq!(result.envelope["raw"], raw);
         assert_eq!(result.envelope["structured"]["kind"], "generic_result");
         assert!(result.envelope["structured"].get("value").is_none());
+    }
+
+    #[test]
+    fn outcome_envelope_exposes_guidance_to_the_model_and_keeps_raw_evidence() {
+        let tool_call = NativeAgentToolCall {
+            id: "call-web-navigation".to_string(),
+            name: "web.act".to_string(),
+            arguments_json: r#"{"snapshotId":"snapshot-1"}"#.to_string(),
+            result: Value::Null,
+        };
+        let raw = json!({
+            "status": "navigation_required",
+            "actionExecuted": false,
+            "suggestedUrl": "https://example.com/docs"
+        });
+        let outcome = NativeToolOutcome {
+            effect: "alternative_required".to_string(),
+            action_executed: Some(false),
+            reason_code: "target_opens_new_window".to_string(),
+            reason: "The target opens a new window.".to_string(),
+            retry: super::super::NativeToolRetry::DoNotRetry,
+            guidance: "Use web.open instead.".to_string(),
+            next_action: Some(super::super::NativeToolNextAction {
+                tool: "web.open".to_string(),
+                arguments: json!({ "url": "https://example.com/docs" }),
+            }),
+        };
+
+        let result = NativeAgentToolResult::success_with_outcome(
+            &tool_call,
+            "Use web.open".to_string(),
+            raw.clone(),
+            outcome,
+        );
+        let model_content: Value = serde_json::from_str(
+            result.envelope["modelContent"]
+                .as_str()
+                .expect("model content should be JSON"),
+        )
+        .expect("model content should parse");
+
+        assert_eq!(result.envelope["status"], "ok");
+        assert_eq!(result.envelope["structured"]["kind"], "tool_outcome");
+        assert_eq!(
+            result.envelope["structured"]["outcome"]["retry"],
+            "do_not_retry"
+        );
+        assert_eq!(
+            model_content["toolOutcome"]["guidance"],
+            "Use web.open instead."
+        );
+        assert_eq!(model_content["result"], raw);
+        assert_eq!(result.envelope["raw"], raw);
     }
 }

--- a/src-tauri/src/agent/runtime/tool_runtime.rs
+++ b/src-tauri/src/agent/runtime/tool_runtime.rs
@@ -7,10 +7,11 @@ use super::tool_dispatcher::{
     native_tool_mutates_workspace, native_tool_rejection_reason,
     native_tool_waits_for_runtime_cancellation,
 };
+use super::tool_loop_guard::ToolLoopBlock;
 use super::tool_projection::{assistant_tool_calls_message, commit_tool_observation};
 use super::{
     AgentTurnContext, NativeAgentRuntimeServices, NativeAgentToolCall, NativeAgentToolDispatcher,
-    PreparedToolCall,
+    NativeToolOutcome, NativeToolRetry, PreparedToolCall,
 };
 use crate::agent::runtime_protocol::{
     AgentEventKind, AgentRuntimePhase, PendingAgentEvent, TerminalEvent, ToolLifecycleEvent,
@@ -657,6 +658,23 @@ async fn execute_tool_batch(
     iteration: i64,
     tool_calls: Vec<PreparedToolCall>,
 ) -> Result<NativeAgentToolExecutionOutcome, String> {
+    let (tool_calls, blocked_calls) = partition_repeated_no_progress_calls(state, tool_calls);
+    commit_loop_blocked_calls(context, state, iteration, blocked_calls)?;
+    if tool_calls.is_empty() {
+        state.clear_pending_tool_calls();
+        state.transition_phase(
+            AgentRuntimePhase::Planning,
+            iteration,
+            AgentEventKind::ToolResult.wire_name(),
+        )?;
+        save_phase_checkpoint(
+            services,
+            context,
+            state.phase.as_str(),
+            state.active_checkpoint_payload("tool_loop_blocked"),
+        );
+        return Ok(NativeAgentToolExecutionOutcome::Continue);
+    }
     let is_multi_call = tool_calls.len() > 1;
     if !is_multi_call && context_is_cancelled(context) {
         return cancelled_result(services, context, state, iteration);
@@ -734,6 +752,75 @@ async fn execute_tool_batch(
         state.active_checkpoint_payload("tool_completed"),
     );
     Ok(NativeAgentToolExecutionOutcome::Continue)
+}
+
+fn partition_repeated_no_progress_calls(
+    state: &AgentTurnState,
+    tool_calls: Vec<PreparedToolCall>,
+) -> (
+    Vec<PreparedToolCall>,
+    Vec<(PreparedToolCall, ToolLoopBlock)>,
+) {
+    let mut allowed = Vec::new();
+    let mut blocked = Vec::new();
+    for tool_call in tool_calls {
+        match state.tool_loop_guard.block_for(&tool_call) {
+            Some(reason) => blocked.push((tool_call, reason)),
+            None => allowed.push(tool_call),
+        }
+    }
+    (allowed, blocked)
+}
+
+fn commit_loop_blocked_calls(
+    context: &AgentTurnContext,
+    state: &mut AgentTurnState,
+    iteration: i64,
+    blocked_calls: Vec<(PreparedToolCall, ToolLoopBlock)>,
+) -> Result<(), String> {
+    if blocked_calls.is_empty() {
+        return Ok(());
+    }
+    state.transition_phase(
+        AgentRuntimePhase::ToolRunning,
+        iteration,
+        AgentEventKind::ToolStarted.wire_name(),
+    )?;
+    for (tool_call, blocked) in blocked_calls {
+        state.emit(ToolLifecycleEvent::Started(serde_json::json!({
+            "iteration": iteration,
+            "toolCallId": tool_call.id,
+            "toolName": tool_call.name,
+            "name": tool_call.name,
+            "detailId": format!("tool:{}", tool_call.id),
+            "status": "blocked",
+            "reasonCode": "repeated_no_progress",
+        })))?;
+        let reason = format!(
+            "An equivalent `{}` call already returned `{}` (`{}`), and no relevant state-changing tool has completed since then.",
+            tool_call.name, blocked.previous_effect, blocked.previous_reason_code
+        );
+        let raw = serde_json::json!({
+            "status": "blocked",
+            "reasonCode": "repeated_no_progress",
+            "previousEffect": blocked.previous_effect,
+            "previousReasonCode": blocked.previous_reason_code,
+        });
+        let result = super::NativeAgentToolResult::success_with_outcome(
+            &tool_call,
+            raw,
+            NativeToolOutcome {
+                effect: "blocked".to_string(),
+                action_executed: Some(false),
+                reason_code: "repeated_no_progress".to_string(),
+                reason,
+                retry: NativeToolRetry::Replan,
+                next_action: None,
+            },
+        );
+        commit_tool_observation(context, state, iteration, tool_call.into_original(), result)?;
+    }
+    Ok(())
 }
 
 fn queue_tool_batch(

--- a/src-tauri/src/native_browser/manager.rs
+++ b/src-tauri/src/native_browser/manager.rs
@@ -1339,6 +1339,8 @@ impl BrowserSessionManager {
                                         target_ref,
                                         role: node.role,
                                         name: node.name,
+                                        href: node.href,
+                                        opens_new_window: node.opens_new_window,
                                         frame: node.frame,
                                         x: node.x,
                                         y: node.y,
@@ -2992,6 +2994,8 @@ fn semantic_content_matches(
         && current.nodes.iter().zip(nodes).all(|(current, node)| {
             current.role == node.role
                 && current.name == node.name
+                && current.href == node.href
+                && current.opens_new_window == node.opens_new_window
                 && current.frame == node.frame
                 && current.x == node.x
                 && current.y == node.y

--- a/src-tauri/src/native_browser/manager_tests.rs
+++ b/src-tauri/src/native_browser/manager_tests.rs
@@ -24,6 +24,7 @@ struct FakeAdapter {
     observe_completed: std::sync::atomic::AtomicU64,
     protected_semantic: std::sync::atomic::AtomicBool,
     sensitive_semantic: std::sync::atomic::AtomicBool,
+    new_window_semantic: std::sync::atomic::AtomicBool,
     page_text: Mutex<Option<String>>,
     page_text_revision: std::sync::atomic::AtomicU64,
     fail_create: std::sync::atomic::AtomicBool,
@@ -177,11 +178,22 @@ impl BrowserRuntimeAdapter for FakeAdapter {
                 .then(|| self.page_text_revision())
                 .unwrap_or_default(),
             semantic_nodes: if semantic {
+                let new_window_semantic = self
+                    .new_window_semantic
+                    .load(std::sync::atomic::Ordering::Relaxed);
                 vec![
                     BrowserPlatformSemanticNode {
                         selector: "#submit".to_string(),
-                        role: "button".to_string(),
-                        name: "Submit".to_string(),
+                        role: if new_window_semantic { "a" } else { "button" }.to_string(),
+                        name: if new_window_semantic {
+                            "Agent Skills specification"
+                        } else {
+                            "Submit"
+                        }
+                        .to_string(),
+                        href: new_window_semantic
+                            .then(|| "https://agentskills.io/specification".to_string()),
+                        opens_new_window: new_window_semantic,
                         frame: "top".to_string(),
                         x: 10.0,
                         y: 20.0,
@@ -203,6 +215,8 @@ impl BrowserRuntimeAdapter for FakeAdapter {
                         selector: "#offscreen".to_string(),
                         role: "button".to_string(),
                         name: "Offscreen".to_string(),
+                        href: None,
+                        opens_new_window: false,
                         frame: "top".to_string(),
                         x: 900.0,
                         y: 20.0,
@@ -217,6 +231,8 @@ impl BrowserRuntimeAdapter for FakeAdapter {
                         selector: "#unnamed".to_string(),
                         role: "button".to_string(),
                         name: String::new(),
+                        href: None,
+                        opens_new_window: false,
                         frame: "top".to_string(),
                         x: 100.0,
                         y: 20.0,
@@ -690,6 +706,53 @@ async fn high_level_web_tools_refresh_and_reject_stale_actions() {
         .unwrap_err();
     assert_eq!(rejected, AGENT_SNAPSHOT_STALE);
     assert_eq!(adapter.interactions.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn high_level_web_act_redirects_new_window_links_to_web_open() {
+    let adapter = Arc::new(FakeAdapter::default());
+    adapter
+        .new_window_semantic
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let manager = manager(adapter.clone());
+    let first = crate::tools::web::dispatch_web_read(
+        &manager,
+        "chat-new-window-link",
+        serde_json::json!({}),
+    )
+    .await
+    .unwrap();
+    let snapshot_id = first["snapshotId"].as_str().unwrap();
+    let target = &first["snapshot"]["targets"][0];
+
+    assert_eq!(target["href"], "https://agentskills.io/specification");
+    assert_eq!(target["opensNewWindow"], true);
+
+    let result = crate::tools::web::dispatch_web_act(
+        &manager,
+        "chat-new-window-link",
+        None,
+        serde_json::json!({
+            "commandId": "open-new-window-link",
+            "snapshotId": snapshot_id,
+            "action": {
+                "type": "clickTarget",
+                "targetRef": target["targetRef"]
+            }
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result["status"], "navigation_required");
+    assert_eq!(result["actionExecuted"], false);
+    assert_eq!(result["reasonCode"], "target_opens_new_window");
+    assert_eq!(
+        result["suggestedUrl"],
+        "https://agentskills.io/specification"
+    );
+    assert_eq!(result["snapshotId"], snapshot_id);
+    assert!(adapter.interactions.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/src-tauri/src/native_browser/model.rs
+++ b/src-tauri/src/native_browser/model.rs
@@ -475,6 +475,9 @@ pub struct BrowserSemanticNode {
     pub target_ref: String,
     pub role: String,
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub href: Option<String>,
+    pub opens_new_window: bool,
     pub frame: String,
     pub x: f64,
     pub y: f64,

--- a/src-tauri/src/native_browser/platform.rs
+++ b/src-tauri/src/native_browser/platform.rs
@@ -123,6 +123,8 @@ pub(crate) struct BrowserPlatformSemanticNode {
     pub selector: String,
     pub role: String,
     pub name: String,
+    pub href: Option<String>,
+    pub opens_new_window: bool,
     pub frame: String,
     pub x: f64,
     pub y: f64,

--- a/src-tauri/src/native_browser/windows.rs
+++ b/src-tauri/src/native_browser/windows.rs
@@ -131,10 +131,15 @@ const OBSERVE_SCRIPT: &str = r#"
     const protectedReason = inputType === 'file' ? 'native_file_picker' : captchaSignal ? 'captcha' : null;
     const explicitName = element.getAttribute('aria-label') || element.getAttribute('title') || '';
     const textName = sensitive ? '' : String(element.innerText || element.getAttribute('placeholder') || '').trim();
+    const anchor = element.closest?.('a[href]') || null;
+    const href = anchor ? String(anchor.href || '') : '';
+    const opensNewWindow = Boolean(anchor && String(anchor.target || '').toLowerCase() === '_blank');
     nodes.push({
       selector: cssPath(element),
       role: element.getAttribute('role') || element.localName || 'element',
       name: String(explicitName || textName).slice(0, 160),
+      href: href || null,
+      opensNewWindow,
       frame: window === window.top ? 'top' : 'child',
       x: rect.x,
       y: rect.y,
@@ -1320,6 +1325,8 @@ struct ObservedNode {
     selector: String,
     role: String,
     name: String,
+    href: Option<String>,
+    opens_new_window: bool,
     frame: String,
     x: f64,
     y: f64,
@@ -1333,10 +1340,13 @@ struct ObservedNode {
 
 impl From<ObservedNode> for BrowserPlatformSemanticNode {
     fn from(value: ObservedNode) -> Self {
+        let href = safe_observed_href(value.href);
         Self {
             selector: value.selector,
             role: value.role,
             name: value.name,
+            opens_new_window: value.opens_new_window && href.is_some(),
+            href,
             frame: value.frame,
             x: value.x,
             y: value.y,
@@ -1348,6 +1358,13 @@ impl From<ObservedNode> for BrowserPlatformSemanticNode {
             protected_reason: value.protected_reason,
         }
     }
+}
+
+fn safe_observed_href(value: Option<String>) -> Option<String> {
+    value
+        .and_then(|href| url::Url::parse(&href).ok())
+        .filter(|href| navigation_policy(href) == BrowserNavigationPolicy::Embedded)
+        .map(|href| href.to_string())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/native_browser/windows_tests.rs
+++ b/src-tauri/src/native_browser/windows_tests.rs
@@ -67,6 +67,9 @@ fn injected_scripts_are_narrow_and_privacy_bounded() {
     assert!(OBSERVE_SCRIPT.contains("inputType === 'password'"));
     assert!(OBSERVE_SCRIPT.contains("cc-|one-time-code"));
     assert!(OBSERVE_SCRIPT.contains("sensitive ? ''"));
+    assert!(OBSERVE_SCRIPT.contains("element.closest?.('a[href]')"));
+    assert!(OBSERVE_SCRIPT.contains("anchor.target"));
+    assert!(OBSERVE_SCRIPT.contains("opensNewWindow"));
 }
 
 #[test]
@@ -79,4 +82,20 @@ fn page_text_script_returns_only_the_requested_bounded_chunk() {
     assert!(script.contains("nextTextOffset"));
     assert!(script.contains("sourceTruncated"));
     assert!(script.contains("pageTextHash"));
+}
+
+#[test]
+fn observed_link_urls_are_absolute_and_embeddable() {
+    assert_eq!(
+        safe_observed_href(Some("https://agentskills.io/specification".to_string())),
+        Some("https://agentskills.io/specification".to_string())
+    );
+    assert_eq!(
+        safe_observed_href(Some("javascript:alert(1)".to_string())),
+        None
+    );
+    assert_eq!(
+        safe_observed_href(Some("mailto:test@example.com".to_string())),
+        None
+    );
 }

--- a/src-tauri/src/rpc/mcp.rs
+++ b/src-tauri/src/rpc/mcp.rs
@@ -252,6 +252,7 @@ struct McpServerStatusParams {
 }
 
 fn mcp_runtime_error(method: &str, error: McpRuntimeError) -> WorkerProtocolError {
+    let reason_code = error.kind.reason_code();
     WorkerProtocolError::new(
         if error.cancelled {
             WorkerProtocolErrorCode::WorkerError
@@ -263,6 +264,7 @@ fn mcp_runtime_error(method: &str, error: McpRuntimeError) -> WorkerProtocolErro
         error.message,
         serde_json::json!({
             "method": method,
+            "reasonCode": reason_code,
             "server": error.server,
             "transport": error.transport,
             "retryable": error.retryable,

--- a/src-tauri/src/runtime/mcp.rs
+++ b/src-tauri/src/runtime/mcp.rs
@@ -30,11 +30,37 @@ pub(crate) struct McpRuntime {
 
 #[derive(Clone, Debug)]
 pub(crate) struct McpRuntimeError {
+    pub(crate) kind: McpRuntimeErrorKind,
     pub(crate) server: String,
     pub(crate) transport: String,
     pub(crate) message: String,
     pub(crate) retryable: bool,
     pub(crate) cancelled: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum McpRuntimeErrorKind {
+    Configuration,
+    InvalidArguments,
+    ServerStarting,
+    Timeout,
+    Operation,
+    Cancelled,
+    Shutdown,
+}
+
+impl McpRuntimeErrorKind {
+    pub(crate) fn reason_code(self) -> &'static str {
+        match self {
+            Self::Configuration => "mcp_configuration_invalid",
+            Self::InvalidArguments => "mcp_arguments_invalid",
+            Self::ServerStarting => "mcp_server_starting",
+            Self::Timeout => "mcp_timed_out",
+            Self::Operation => "mcp_operation_failed",
+            Self::Cancelled => "mcp_call_cancelled",
+            Self::Shutdown => "mcp_shutdown_failed",
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -236,6 +262,7 @@ impl McpRuntime {
             Some(Value::Object(arguments)) => Some(arguments),
             Some(_) => {
                 return Err(McpRuntimeError {
+                    kind: McpRuntimeErrorKind::InvalidArguments,
                     server: server_name.to_string(),
                     transport: config.transport().to_string(),
                     message: "MCP tool arguments must be a JSON object".to_string(),
@@ -469,6 +496,7 @@ impl McpRuntime {
                 Some(server) => {
                     let fingerprint =
                         serde_json::to_string(server).map_err(|error| McpRuntimeError {
+                            kind: McpRuntimeErrorKind::Configuration,
                             server: key.server_name.clone(),
                             transport: server
                                 .get("transport")
@@ -508,6 +536,7 @@ impl McpRuntime {
             "stdio" => parse_stdio_server_config(server_name, server_config, workspace_root)
                 .map(McpServerConfig::Stdio)
                 .map_err(|error| McpRuntimeError {
+                    kind: McpRuntimeErrorKind::Configuration,
                     server: server_name.to_string(),
                     transport: error.transport,
                     message: error.message,
@@ -518,6 +547,7 @@ impl McpRuntime {
                 parse_http_server_config(server_name, server_config)
                     .map(McpServerConfig::Http)
                     .map_err(|error| McpRuntimeError {
+                        kind: McpRuntimeErrorKind::Configuration,
                         server: server_name.to_string(),
                         transport: error.transport,
                         message: error.message,
@@ -526,6 +556,7 @@ impl McpRuntime {
                     })
             }
             unsupported => Err(McpRuntimeError {
+                kind: McpRuntimeErrorKind::Configuration,
                 server: server_name.to_string(),
                 transport: unsupported.to_string(),
                 message: format!(
@@ -586,6 +617,7 @@ impl McpRuntime {
                     && server.fingerprint == config.fingerprint()
                 {
                     return Err(McpRuntimeError {
+                        kind: McpRuntimeErrorKind::ServerStarting,
                         server: server_name.to_string(),
                         transport: config.transport().to_string(),
                         message: format!("MCP server `{server_name}` is still starting"),
@@ -723,6 +755,7 @@ impl McpRuntime {
         config: &StdioServerConfig,
     ) -> Result<ClientService, McpRuntimeError> {
         let command = stdio_command(config).map_err(|error| McpRuntimeError {
+            kind: McpRuntimeErrorKind::Operation,
             server: server_name.to_string(),
             transport: "stdio".to_string(),
             message: format!(
@@ -736,6 +769,7 @@ impl McpRuntime {
             .stderr(Stdio::null())
             .spawn()
             .map_err(|error| McpRuntimeError {
+                kind: McpRuntimeErrorKind::Operation,
                 server: server_name.to_string(),
                 transport: "stdio".to_string(),
                 message: sanitize_error(&format!("failed to start MCP stdio server: {error}")),
@@ -901,6 +935,7 @@ impl McpRuntime {
         timeout: Duration,
     ) -> McpRuntimeError {
         McpRuntimeError {
+            kind: McpRuntimeErrorKind::Timeout,
             server: server_name.to_string(),
             transport: transport.to_string(),
             message: format!(
@@ -920,6 +955,7 @@ impl McpRuntime {
         message: String,
     ) -> McpRuntimeError {
         McpRuntimeError {
+            kind: McpRuntimeErrorKind::Operation,
             server: server_name.to_string(),
             transport: transport.to_string(),
             message: sanitize_error(&format!(
@@ -932,6 +968,7 @@ impl McpRuntime {
 
     fn cancelled_error(&self, server_name: &str, transport: &str) -> McpRuntimeError {
         McpRuntimeError {
+            kind: McpRuntimeErrorKind::Cancelled,
             server: server_name.to_string(),
             transport: transport.to_string(),
             message: "MCP tool call cancelled".to_string(),
@@ -947,6 +984,7 @@ impl McpRuntime {
         message: String,
     ) -> McpRuntimeError {
         McpRuntimeError {
+            kind: McpRuntimeErrorKind::Shutdown,
             server: server_name.to_string(),
             transport: transport.to_string(),
             message: sanitize_error(&message),

--- a/src-tauri/src/tool_notes.rs
+++ b/src-tauri/src/tool_notes.rs
@@ -17,6 +17,7 @@ Tool names, descriptions, and input schemas are supplied automatically. Use this
 - `web.read` reads bounded, untrusted page text and the current interaction targets. Pass the previous `snapshotId` to get a compact unchanged response when possible. If the result includes `nextTextOffset`, pass both that `snapshotId` and `nextTextOffset` as `textOffset` to continue reading without repeating targets. A changed page resets the offset and returns its new first chunk.
 - `web.act` changes the current page and requires the latest `snapshotId`. If an action is rejected as stale, use the returned snapshot and retry only if the action is still appropriate.
 - Prefer semantic `targetRef` values from the latest snapshot over screen coordinates, and treat both `snapshotId` and `targetRef` as opaque values.
+- Link targets may include `href` and `opensNewWindow`. If `web.act` returns `navigation_required`, call `web.open` once with `suggestedUrl` instead of clicking the target again.
 - Use `web.open` for URL navigation instead of inventing a navigation action for `web.act`.
 - Hand control to the user when login credentials, verification codes, CAPTCHA, payment details, file pickers, or another protected step requires human input. Only the user can hand browser control back to the Agent.
 "#;

--- a/src-tauri/src/tool_notes.rs
+++ b/src-tauri/src/tool_notes.rs
@@ -17,7 +17,7 @@ Tool names, descriptions, and input schemas are supplied automatically. Use this
 - `web.read` reads bounded, untrusted page text and the current interaction targets. Pass the previous `snapshotId` to get a compact unchanged response when possible. If the result includes `nextTextOffset`, pass both that `snapshotId` and `nextTextOffset` as `textOffset` to continue reading without repeating targets. A changed page resets the offset and returns its new first chunk.
 - `web.act` changes the current page and requires the latest `snapshotId`. If an action is rejected as stale, use the returned snapshot and retry only if the action is still appropriate.
 - Prefer semantic `targetRef` values from the latest snapshot over screen coordinates, and treat both `snapshotId` and `targetRef` as opaque values.
-- Link targets may include `href` and `opensNewWindow`. If `web.act` returns `navigation_required`, call `web.open` once with `suggestedUrl` instead of clicking the target again.
+- Link targets may include `href` and `opensNewWindow`. Open those `href` values with `web.open` instead of clicking the target.
 - Use `web.open` for URL navigation instead of inventing a navigation action for `web.act`.
 - Hand control to the user when login credentials, verification codes, CAPTCHA, payment details, file pickers, or another protected step requires human input. Only the user can hand browser control back to the Agent.
 "#;

--- a/src-tauri/src/tools/shell/README.md
+++ b/src-tauri/src/tools/shell/README.md
@@ -4,4 +4,10 @@
 capabilities and working directories, then manages process input, output,
 resize, polling, cancellation, and cleanup.
 
+Agent-facing Shell results use the shared tool-outcome projection for states
+that require a different next step. A retained process includes a structured
+`write_stdin` continuation, while cancellation, timeout, non-zero exit,
+process failure, and truncated output carry explicit retry guidance. Ordinary
+successful commands keep the generic result projection.
+
 Platform-specific process containment is implemented separately where needed.

--- a/src-tauri/src/tools/web/README.md
+++ b/src-tauri/src/tools/web/README.md
@@ -115,7 +115,7 @@ URL 跳转使用 `web.open`，不作为 `web.act` 动作。
 
 语义链接目标可附带经过安全 URL 校验的 `href`，使用 `opensNewWindow: true` 标识会创建新窗口的链接。对这类目标调用 `clickTarget` 时，Tinybot 不执行点击，而是返回 `navigation_required`、`actionExecuted: false` 和 `suggestedUrl`；agent 应只调用一次 `web.open` 打开该 URL，不能继续重复点击。
 
-`unchanged`、`stale_snapshot`、`navigation_required`、`user_required` 以及浏览器失败状态会通过统一的 `toolOutcome` 投影进入模型上下文。该投影明确说明动作是否执行、原因、是否应重试、恢复指导和可选的下一工具调用；原始 Web 结果仍保留在 `result` 和运行时 Envelope 的 `raw` 中。普通 `completed` 结果保持原有格式。
+`unchanged`、`stale_snapshot`、`navigation_required`、`user_required` 以及浏览器失败状态会先映射为只包含事实的结构化 Outcome，再由 Agent Runtime 的统一 Projection 生成模型恢复指导、Envelope/UI 摘要和可选 UI 动作。原始 Web 结果仍保留在 `result` 和运行时 Envelope 的 `raw` 中。普通 `completed` 结果保持原有格式。
 
 ## 转交给用户
 

--- a/src-tauri/src/tools/web/README.md
+++ b/src-tauri/src/tools/web/README.md
@@ -113,6 +113,10 @@ target-<observation revision>-<index>
 
 URL 跳转使用 `web.open`，不作为 `web.act` 动作。
 
+语义链接目标可附带经过安全 URL 校验的 `href`，使用 `opensNewWindow: true` 标识会创建新窗口的链接。对这类目标调用 `clickTarget` 时，Tinybot 不执行点击，而是返回 `navigation_required`、`actionExecuted: false` 和 `suggestedUrl`；agent 应只调用一次 `web.open` 打开该 URL，不能继续重复点击。
+
+`unchanged`、`stale_snapshot`、`navigation_required`、`user_required` 以及浏览器失败状态会通过统一的 `toolOutcome` 投影进入模型上下文。该投影明确说明动作是否执行、原因、是否应重试、恢复指导和可选的下一工具调用；原始 Web 结果仍保留在 `result` 和运行时 Envelope 的 `raw` 中。普通 `completed` 结果保持原有格式。
+
 ## 转交给用户
 
 密码、一次性验证码、CAPTCHA、支付信息、文件选择器等步骤不应由 agent 代替用户完成。agent 调用：

--- a/src-tauri/src/tools/web/agent.rs
+++ b/src-tauri/src/tools/web/agent.rs
@@ -163,6 +163,9 @@ pub(crate) async fn dispatch_web_act(
             SnapshotProjection::interaction(),
         ));
     }
+    if let Some(response) = new_window_navigation_response(&page, &action) {
+        return Ok(response);
+    }
     execute_action(
         runtime,
         owner_session_id,
@@ -173,6 +176,33 @@ pub(crate) async fn dispatch_web_act(
         SnapshotProjection::interaction(),
     )
     .await
+}
+
+fn new_window_navigation_response(page: &BrowserAgentPageState, action: &Value) -> Option<Value> {
+    if action.get("type").and_then(Value::as_str) != Some("clickTarget") {
+        return None;
+    }
+    let target_ref = action.get("targetRef").and_then(Value::as_str)?;
+    let target = page
+        .observation
+        .semantic
+        .as_ref()?
+        .nodes
+        .iter()
+        .find(|target| target.target_ref == target_ref)?;
+    if !target.opens_new_window {
+        return None;
+    }
+    let href = target.href.as_ref()?;
+    Some(json!({
+        "status": "navigation_required",
+        "actionExecuted": false,
+        "reasonCode": "target_opens_new_window",
+        "reason": "This target opens a new browser window. Use web.open with suggestedUrl instead of clicking it again.",
+        "suggestedUrl": href,
+        "snapshotId": page.snapshot_id,
+        "snapshot": snapshot_payload(page, SnapshotProjection::interaction(), None),
+    }))
 }
 
 async fn create_session_with_cancellation(
@@ -522,6 +552,12 @@ fn snapshot_target_payload(target: &BrowserSemanticNode) -> Value {
     );
     payload.insert("role".to_string(), Value::String(target.role.clone()));
     payload.insert("name".to_string(), Value::String(target.name.clone()));
+    if let Some(href) = target.href.as_ref() {
+        payload.insert("href".to_string(), Value::String(href.clone()));
+    }
+    if target.opens_new_window {
+        payload.insert("opensNewWindow".to_string(), Value::Bool(true));
+    }
     if target.frame != "top" {
         payload.insert("frame".to_string(), Value::String(target.frame.clone()));
     }
@@ -565,6 +601,16 @@ pub(crate) fn result_summary(method: &str, result: &Value) -> String {
             format!("Page changed while reading; text offset reset: {page}")
         }
         "stale_snapshot" => format!("Page changed before the action: {page}"),
+        "navigation_required" => result
+            .get("suggestedUrl")
+            .and_then(Value::as_str)
+            .map(|url| {
+                format!(
+                    "Target opens a new window; use web.open for {}",
+                    compact_label(url, 80)
+                )
+            })
+            .unwrap_or_else(|| "Target opens a new window; use web.open instead".to_string()),
         "completed" => match method {
             "web.open" => format!("Opened {page} with {target_count} visible targets"),
             "web.read" => format!("Read {page} with {target_count} visible targets"),
@@ -581,7 +627,19 @@ pub(crate) fn project_web_result_history(model_content: &mut String, retain_targ
     let Ok(mut result) = serde_json::from_str::<Value>(model_content) else {
         return false;
     };
-    let Some(snapshot) = result.get_mut("snapshot").and_then(Value::as_object_mut) else {
+    let has_tool_outcome = result.get("toolOutcome").is_some();
+    let result_payload = if has_tool_outcome {
+        let Some(result_payload) = result.get_mut("result") else {
+            return false;
+        };
+        result_payload
+    } else {
+        &mut result
+    };
+    let Some(snapshot) = result_payload
+        .get_mut("snapshot")
+        .and_then(Value::as_object_mut)
+    else {
         return false;
     };
     if !snapshot.contains_key("targets") {
@@ -639,6 +697,8 @@ mod tests {
             target_ref: format!("target-4-{index}"),
             role: "button".to_string(),
             name: "Open account settings".to_string(),
+            href: None,
+            opens_new_window: false,
             frame: "top".to_string(),
             x: 10.0,
             y: index as f64 * 30.0,
@@ -668,12 +728,28 @@ mod tests {
             "focused",
             "sensitive",
             "protectedReason",
+            "href",
+            "opensNewWindow",
         ] {
             assert!(
                 payload.get(omitted).is_none(),
                 "unexpected field: {omitted}"
             );
         }
+    }
+
+    #[test]
+    fn agent_target_payload_preserves_safe_link_navigation() {
+        let mut target = semantic_node(3);
+        target.role = "a".to_string();
+        target.name = "Agent Skills specification".to_string();
+        target.href = Some("https://agentskills.io/specification".to_string());
+        target.opens_new_window = true;
+
+        let payload = snapshot_target_payload(&target);
+
+        assert_eq!(payload["href"], "https://agentskills.io/specification");
+        assert_eq!(payload["opensNewWindow"], true);
     }
 
     #[test]
@@ -777,6 +853,11 @@ mod tests {
             "status": "stale_snapshot",
             "snapshot": { "title": "Updated article" }
         });
+        let navigation_required = json!({
+            "status": "navigation_required",
+            "suggestedUrl": "https://agentskills.io/specification",
+            "snapshot": { "title": "Agent Plugins" }
+        });
 
         assert_eq!(
             result_summary("web.open", &opened),
@@ -789,6 +870,10 @@ mod tests {
         assert_eq!(
             result_summary("web.read", &reset),
             "Page changed while reading; text offset reset: Updated article"
+        );
+        assert_eq!(
+            result_summary("web.act", &navigation_required),
+            "Target opens a new window; use web.open for https://agentskills.io/specification"
         );
     }
 
@@ -814,5 +899,35 @@ mod tests {
             projected["snapshot"]["content"]["text"],
             "Important page text"
         );
+    }
+
+    #[test]
+    fn superseded_history_projection_supports_structured_tool_outcomes() {
+        let mut content = json!({
+            "toolOutcome": {
+                "effect": "stale_state",
+                "reasonCode": "snapshot_stale",
+                "reason": "The page changed.",
+                "retry": "retry_with_updated_state",
+                "guidance": "Reassess the returned snapshot."
+            },
+            "result": {
+                "status": "stale_snapshot",
+                "snapshot": {
+                    "url": "https://example.com",
+                    "targets": [
+                        { "targetRef": "target-1", "role": "button", "name": "Save" }
+                    ],
+                    "content": { "trust": "untrusted", "text": "Updated page" }
+                }
+            }
+        })
+        .to_string();
+
+        assert!(project_web_result_history(&mut content, false));
+        let projected: Value = serde_json::from_str(&content).unwrap();
+        assert!(projected["result"]["snapshot"].get("targets").is_none());
+        assert_eq!(projected["result"]["snapshot"]["targetsSuperseded"], true);
+        assert_eq!(projected["toolOutcome"]["effect"], "stale_state");
     }
 }

--- a/src-tauri/src/tools/web/agent.rs
+++ b/src-tauri/src/tools/web/agent.rs
@@ -198,7 +198,7 @@ fn new_window_navigation_response(page: &BrowserAgentPageState, action: &Value) 
         "status": "navigation_required",
         "actionExecuted": false,
         "reasonCode": "target_opens_new_window",
-        "reason": "This target opens a new browser window. Use web.open with suggestedUrl instead of clicking it again.",
+        "reason": "This target opens a new browser window, which cannot be activated in the current browser tab.",
         "suggestedUrl": href,
         "snapshotId": page.snapshot_id,
         "snapshot": snapshot_payload(page, SnapshotProjection::interaction(), None),
@@ -596,21 +596,6 @@ pub(crate) fn result_summary(method: &str, result: &Value) -> String {
         .unwrap_or_default();
 
     match status {
-        "unchanged" => format!("Page unchanged: {page}"),
-        "stale_snapshot" if method == "web.read" => {
-            format!("Page changed while reading; text offset reset: {page}")
-        }
-        "stale_snapshot" => format!("Page changed before the action: {page}"),
-        "navigation_required" => result
-            .get("suggestedUrl")
-            .and_then(Value::as_str)
-            .map(|url| {
-                format!(
-                    "Target opens a new window; use web.open for {}",
-                    compact_label(url, 80)
-                )
-            })
-            .unwrap_or_else(|| "Target opens a new window; use web.open instead".to_string()),
         "completed" => match method {
             "web.open" => format!("Opened {page} with {target_count} visible targets"),
             "web.read" => format!("Read {page} with {target_count} visible targets"),
@@ -840,7 +825,7 @@ mod tests {
     }
 
     #[test]
-    fn web_result_summary_is_short_and_status_specific() {
+    fn completed_web_result_summary_is_short_and_method_specific() {
         let opened = json!({
             "status": "completed",
             "snapshot": {
@@ -848,32 +833,9 @@ mod tests {
                 "targets": [{}, {}, {}]
             }
         });
-        let unchanged = json!({ "status": "unchanged" });
-        let reset = json!({
-            "status": "stale_snapshot",
-            "snapshot": { "title": "Updated article" }
-        });
-        let navigation_required = json!({
-            "status": "navigation_required",
-            "suggestedUrl": "https://agentskills.io/specification",
-            "snapshot": { "title": "Agent Plugins" }
-        });
-
         assert_eq!(
             result_summary("web.open", &opened),
             "Opened Account settings with 3 visible targets"
-        );
-        assert_eq!(
-            result_summary("web.read", &unchanged),
-            "Page unchanged: current page"
-        );
-        assert_eq!(
-            result_summary("web.read", &reset),
-            "Page changed while reading; text offset reset: Updated article"
-        );
-        assert_eq!(
-            result_summary("web.act", &navigation_required),
-            "Target opens a new window; use web.open for https://agentskills.io/specification"
         );
     }
 

--- a/src-tauri/src/tools/web/registry.rs
+++ b/src-tauri/src/tools/web/registry.rs
@@ -82,7 +82,7 @@ impl ToolContributor for WebToolContributor {
                 "web.act",
                 "web",
                 "Act on the current web page",
-                "Perform one action against the current page. Put action fields inside the action object; use clickTarget with targetRef for semantic targets. Link targets may include href and opensNewWindow; a new-window target returns navigation_required with suggestedUrl and is not clicked, so call web.open once with that URL instead. For passwords, verification codes, CAPTCHA, payment details, file pickers, or another protected step, call userHandoff with a clear reason and stop changing the page until the user resumes control. Use web.open, not web.act, for URL navigation. Always pass the latest snapshotId. Stale actions are not executed and return the latest snapshot.",
+                "Perform one action against the current page. Put action fields inside the action object; use clickTarget with targetRef for semantic targets. Link targets may include href and opensNewWindow; open those href values with web.open instead of clicking the target. For passwords, verification codes, CAPTCHA, payment details, file pickers, or another protected step, call userHandoff with a clear reason and stop changing the page until the user resumes control. Use web.open, not web.act, for URL navigation. Always pass the latest snapshotId. Stale actions are not executed and return the latest snapshot.",
                 ToolExposure::Model,
                 false,
                 runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),

--- a/src-tauri/src/tools/web/registry.rs
+++ b/src-tauri/src/tools/web/registry.rs
@@ -82,7 +82,7 @@ impl ToolContributor for WebToolContributor {
                 "web.act",
                 "web",
                 "Act on the current web page",
-                "Perform one action against the current page. Put action fields inside the action object; use clickTarget with targetRef for semantic targets. For passwords, verification codes, CAPTCHA, payment details, file pickers, or another protected step, call userHandoff with a clear reason and stop changing the page until the user resumes control. Use web.open, not web.act, for URL navigation. Always pass the latest snapshotId. Stale actions are not executed and return the latest snapshot.",
+                "Perform one action against the current page. Put action fields inside the action object; use clickTarget with targetRef for semantic targets. Link targets may include href and opensNewWindow; a new-window target returns navigation_required with suggestedUrl and is not clicked, so call web.open once with that URL instead. For passwords, verification codes, CAPTCHA, payment details, file pickers, or another protected step, call userHandoff with a clear reason and stop changing the page until the user resumes control. Use web.open, not web.act, for URL navigation. Always pass the latest snapshotId. Stale actions are not executed and return the latest snapshot.",
                 ToolExposure::Model,
                 false,
                 runtime_policy(false, ToolCancellationMode::DetachForbidden, false, true),


### PR DESCRIPTION
## Summary

- expose structured domain outcomes for web, shell, and MCP tool results
- centralize model guidance and UI summaries from the structured result envelope
- detect browser actions that execute without changing page state
- prevent equivalent external tool calls from repeating after a no-progress result until relevant state changes
- preserve explicit same-call continuations such as shell polling

## Why

Browser actions that produced no observable change could previously look successful to the agent. With limited result semantics, the model could repeat the same click indefinitely. Other native tools also returned inconsistent failure and continuation information.

## Impact

The model now receives consistent execution status and domain-effect guidance. Repeated calls against unchanged state are returned as a structured `repeated_no_progress` result and the agent is asked to replan instead of redispatching the tool.

## Validation

- `cargo test tool_loop_guard --jobs 4`
- `cargo test agent::runtime::tests::tools --jobs 4`
- `cargo test agent::runtime::tool_projection::tests --jobs 4`
- `cargo test agent::runtime::tool_result::tests --jobs 4`
- `cargo fmt --all -- --check`
- `git diff --check`
