### PR TITLE
Move reasoning effort control to composer

### DIFF
--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -301,6 +301,9 @@ configuration for a separate backend process. Secret fields
 return `value: null` with `secret` metadata and must remain redacted in exported/public config.
 Provider selection is profile-based. New config should use `agents.defaults.activeProfile` and
 `providers.profiles.<profileId>.provider`; `agents.defaults.provider: "auto"` is a legacy value only.
+Reasoning effort is not an Agent Defaults setting. A legacy `agents.defaults.reasoningEffort` value
+may remain in raw config for read compatibility, but the settings registry does not expose it and the
+agent runtime does not apply it to model requests.
 The built-in provider catalog currently exposes only `deepseek`, `dashscope`, and `openai`.
 Profiles are not limited to that catalog: a profile with a custom provider ID, explicit `apiBase`,
 and at least one model is resolved as an OpenAI-compatible provider. Its optional API key remains on
@@ -418,7 +421,8 @@ content.
 Each Turn owns an immutable settings snapshot parsed from the Turn specification, metadata, and
 agent defaults. It includes model, provider, iteration and streaming limits,
 temperature, maximum completion tokens, context-window strategy, reasoning options, service tier, output schema,
-working directory, permission profile, selected tools, and parallel-tool policy.
+working directory, permission profile, selected tools, and parallel-tool policy. Reasoning options are
+request-specific: they are read only from the Turn specification or metadata, never from agent defaults.
 Invalid values fail request construction rather than being reread differently by later stages.
 
 Optional provider features must be declared explicitly on the selected provider profile:
@@ -444,9 +448,10 @@ Optional provider features must be declared explicitly on the selected provider 
 `structured_output` (camel-case spellings are also accepted). A requested undeclared feature fails
 with the resolved provider ID and missing capability. Built-in profile capabilities fall back to the
 provider catalog when the profile omits the field; an explicit profile value overrides that default.
-Declared settings map to Chat Completions fields as
-follows: service tier to `service_tier`, reasoning effort to `reasoning_effort`, reasoning summary
-configuration to `reasoning`, and output schemas to `response_format.type = "json_schema"`.
+Declared settings map to Chat Completions fields as follows: service tier to `service_tier`, reasoning
+effort to `reasoning_effort`, reasoning summary configuration to `reasoning`, and output schemas to
+`response_format.type = "json_schema"`. For Responses requests, effort and summary map to
+`reasoning.effort` and `reasoning.summary`, while output schemas map to `text.format`.
 
 Turn-level runtime controls are also typed and validated before MCP discovery or provider dispatch:
 
@@ -860,6 +865,11 @@ message verbatim and does not copy attachment files. The agent reads a mentioned
   "content": "# Files mentioned by the user:\n\n## notes.md: C:\\work\\notes.md\n\n## My request for Tinybot:\nReview the file."
 }
 ```
+
+The renderer sends the composer's effort choice as `spec.reasoningEffort`. Composer values are `low`,
+`medium`, `high`, `xhigh`, and `max`; a missing or invalid local preference starts at `medium`. Model
+support varies, and an unsupported explicit value remains a provider request error rather than being
+silently downgraded.
 
 `ThreadRecord`:
 

--- a/src-tauri/src/agent/bridge/persistence.rs
+++ b/src-tauri/src/agent/bridge/persistence.rs
@@ -199,6 +199,7 @@ fn native_agent_turn_context(
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default();
     let trace_context = agent_trace_context_from_value(spec);
+    let reasoning = spec.get("reasoning").and_then(serde_json::Value::as_object);
     let api_mode = spec
         .get("apiMode")
         .or_else(|| spec.get("api_mode"))
@@ -258,12 +259,14 @@ fn native_agent_turn_context(
             .unwrap_or(serde_json::Value::Null),
         "effort": spec
             .get("reasoningEffort")
-            .or_else(|| defaults.get("reasoningEffort"))
+            .or_else(|| spec.get("reasoning_effort"))
+            .or_else(|| reasoning.and_then(|value| value.get("effort")))
             .cloned()
             .unwrap_or(serde_json::Value::Null),
         "summary": spec
             .get("reasoningSummary")
-            .or_else(|| defaults.get("reasoningSummary"))
+            .or_else(|| spec.get("reasoning_summary"))
+            .or_else(|| reasoning.and_then(|value| value.get("summary")))
             .cloned()
             .unwrap_or_else(|| serde_json::json!("auto")),
     })

--- a/src-tauri/src/agent/bridge/persistence_tests.rs
+++ b/src-tauri/src/agent/bridge/persistence_tests.rs
@@ -1,4 +1,4 @@
-use super::materialized_turn_messages;
+use super::{materialized_turn_messages, native_agent_turn_context};
 
 #[test]
 fn materialized_turn_messages_preserve_frontend_user_content_verbatim() {
@@ -36,4 +36,29 @@ fn manual_compaction_does_not_materialize_historical_user_messages() {
     );
 
     assert!(messages.is_empty());
+}
+
+#[test]
+fn persisted_turn_context_uses_only_explicit_reasoning_settings() {
+    let explicit = native_agent_turn_context(
+        &serde_json::json!({
+            "reasoning": { "effort": "high", "summary": "detailed" }
+        }),
+        &serde_json::json!({
+            "agents": { "defaults": { "reasoningEffort": "low" } }
+        }),
+        "turn-explicit",
+    );
+    assert_eq!(explicit["effort"], "high");
+    assert_eq!(explicit["summary"], "detailed");
+
+    let omitted = native_agent_turn_context(
+        &serde_json::json!({}),
+        &serde_json::json!({
+            "agents": { "defaults": { "reasoningEffort": "low" } }
+        }),
+        "turn-omitted",
+    );
+    assert!(omitted["effort"].is_null());
+    assert_eq!(omitted["summary"], "auto");
 }

--- a/src-tauri/src/agent/runtime/settings.rs
+++ b/src-tauri/src/agent/runtime/settings.rs
@@ -108,7 +108,7 @@ impl AgentTurnSettings {
             }
         })
         .unwrap_or(ContextWindowStrategy::Discard);
-        let reasoning = reasoning_settings(spec, metadata, defaults, &mut validation_errors);
+        let reasoning = reasoning_settings(spec, metadata, &mut validation_errors);
         let service_tier = optional_string_setting(
             spec,
             metadata,
@@ -211,10 +211,12 @@ fn normalize_permission_profile(
 fn reasoning_settings(
     spec: &Value,
     metadata: &Value,
-    defaults: &Value,
     validation_errors: &mut Vec<String>,
 ) -> Option<AgentReasoningSettings> {
-    if let Some(value) = setting_value(spec, metadata, defaults, &["reasoning"]) {
+    // Reasoning support and accepted effort levels are model-specific, so this
+    // setting must be explicit on the turn rather than inherited globally.
+    let no_defaults = Value::Null;
+    if let Some(value) = setting_value(spec, metadata, &no_defaults, &["reasoning"]) {
         let Some(object) = value.as_object() else {
             validation_errors.push("reasoning must be an object".to_string());
             return None;
@@ -232,7 +234,7 @@ fn reasoning_settings(
     optional_string_setting(
         spec,
         metadata,
-        defaults,
+        &no_defaults,
         &["reasoningEffort", "reasoning_effort"],
         "reasoning_effort",
         validation_errors,

--- a/src-tauri/src/agent/runtime/tests/configuration.rs
+++ b/src-tauri/src/agent/runtime/tests/configuration.rs
@@ -65,14 +65,14 @@ fn resolves_profile_based_provider_for_reasoning_turns() {
     let context = AgentTurnContext::from_spec(
         json!({
             "runtime": "rust",
+            "reasoningEffort": "medium",
             "messages": [{ "role": "user", "content": "hello" }]
         }),
         json!({
             "agents": {
                 "defaults": {
                     "activeProfile": "deepseek-default",
-                    "model": "deepseek-v4-pro",
-                    "reasoningEffort": "medium"
+                    "model": "deepseek-v4-pro"
                 }
             },
             "providers": {
@@ -101,14 +101,14 @@ fn profile_capabilities_override_built_in_provider_defaults() {
     let context = AgentTurnContext::from_spec(
         json!({
             "runtime": "rust",
+            "reasoningEffort": "medium",
             "messages": [{ "role": "user", "content": "hello" }]
         }),
         json!({
             "agents": {
                 "defaults": {
                     "activeProfile": "deepseek-default",
-                    "model": "deepseek-v4-pro",
-                    "reasoningEffort": "medium"
+                    "model": "deepseek-v4-pro"
                 }
             },
             "providers": {
@@ -127,6 +127,31 @@ fn profile_capabilities_override_built_in_provider_defaults() {
 
     assert!(error.contains("deepseek"));
     assert!(error.contains("reasoning"));
+}
+
+#[test]
+fn legacy_agent_default_reasoning_effort_is_not_applied_to_requests() {
+    let context = AgentTurnContext::from_spec(
+        json!({
+            "runtime": "rust",
+            "messages": [{ "role": "user", "content": "hello" }]
+        }),
+        json!({
+            "agents": {
+                "defaults": {
+                    "provider": "openai",
+                    "model": "gpt-test",
+                    "reasoningEffort": "high"
+                }
+            }
+        }),
+    );
+
+    let request = agent_chat_completion_request(&context)
+        .expect("legacy reasoning defaults should not require provider capability");
+
+    assert!(context.settings.reasoning.is_none());
+    assert!(request.get("reasoning_effort").is_none());
 }
 
 #[test]
@@ -167,6 +192,7 @@ fn builds_internal_responses_api_request_without_changing_chat_defaults() {
     let context = AgentTurnContext::from_spec(
         json!({
             "runtime": "rust",
+            "reasoning": { "effort": "high" },
             "messages": [{ "role": "user", "content": "hello" }]
         }),
         json!({
@@ -180,7 +206,8 @@ fn builds_internal_responses_api_request_without_changing_chat_defaults() {
             "providers": {
                 "openai": {
                     "api_key": "sk-test",
-                    "api_mode": "responses"
+                    "api_mode": "responses",
+                    "capabilities": ["reasoning"]
                 }
             }
         }),
@@ -194,8 +221,10 @@ fn builds_internal_responses_api_request_without_changing_chat_defaults() {
     assert_eq!(responses_request["input"][0]["role"], "user");
     assert_eq!(responses_request["store"], false);
     assert_eq!(responses_request["max_output_tokens"], 512);
+    assert_eq!(responses_request["reasoning"]["effort"], "high");
     assert!(responses_request.get("messages").is_none());
     assert!(chat_request.get("messages").is_some());
+    assert_eq!(chat_request["reasoning_effort"], "high");
     assert!(chat_request.get("input").is_none());
 }
 

--- a/src-tauri/src/config/registry.rs
+++ b/src-tauri/src/config/registry.rs
@@ -249,21 +249,6 @@ pub fn build_settings_snapshot(input: SettingsSnapshotInput) -> SettingsSnapshot
                         ],
                     ),
                 ),
-                config_field(
-                    "reasoning-effort",
-                    "Reasoning effort",
-                    "agents.defaults.reasoningEffort",
-                    SettingScope::RunDefault,
-                    SettingValueType::String,
-                    true,
-                    pick_path(
-                        config,
-                        &[
-                            &["agents", "defaults", "reasoningEffort"],
-                            &["agents", "defaults", "reasoning_effort"],
-                        ],
-                    ),
-                ),
             ],
         ),
         provider_models_group(config),

--- a/src-tauri/src/config/registry_tests.rs
+++ b/src-tauri/src/config/registry_tests.rs
@@ -226,6 +226,20 @@ fn max_tool_iterations_projects_runtime_key_with_legacy_aliases() {
 }
 
 #[test]
+fn agent_defaults_do_not_expose_legacy_reasoning_effort() {
+    let snapshot = build_settings_snapshot(SettingsSnapshotInput {
+        config: json!({
+            "agents": { "defaults": { "reasoningEffort": "medium" } }
+        }),
+        config_path: PathBuf::from("C:/Users/example/.tinybot/config.json"),
+        revision: "rev-1".to_string(),
+        diagnostics: Vec::new(),
+    });
+
+    assert!(snapshot.field("agents.defaults.reasoningEffort").is_none());
+}
+
+#[test]
 fn expert_config_exposes_redacted_effective_config() {
     let snapshot = build_settings_snapshot(SettingsSnapshotInput {
         config: config_fixture(),

--- a/src/app-core/chat/desktopChatSessionController.test.ts
+++ b/src/app-core/chat/desktopChatSessionController.test.ts
@@ -85,6 +85,7 @@ describe("desktop native chat session controller", () => {
     const result = await controller.submitMessage("hello", {
       model: "model-1",
       provider: "openai",
+      reasoningEffort: "xhigh",
       references: [{
         kind: "reference",
         title: "README",
@@ -121,6 +122,7 @@ describe("desktop native chat session controller", () => {
         stream: true,
         model: "model-1",
         provider: "openai",
+        reasoningEffort: "xhigh",
         metadata: {
           clientEventId: "client-1",
           references: [{ kind: "reference", title: "README", detail: "selected file" }],

--- a/src/app-core/chat/desktopChatSessionController.ts
+++ b/src/app-core/chat/desktopChatSessionController.ts
@@ -1,4 +1,5 @@
 import type { AgentInputReference } from "./agentInputReference";
+import type { ReasoningEffort } from "./reasoningEffort";
 import {
   createAgentTimelineModel,
   TimelineRevisionGapError,
@@ -49,6 +50,7 @@ export type ChatDeleteSessionResult =
 export type ChatSubmitOptions = {
   model?: string;
   provider?: string;
+  reasoningEffort?: ReasoningEffort;
   references?: AgentInputReference[];
   selectedSkills?: string[];
   clientEventId?: string;
@@ -288,7 +290,7 @@ export function createDesktopChatSessionController({
       throw new Error("Cannot submit a turn without an active Thread");
     }
     const clientEventId = options.clientEventId || createClientEventId();
-    const { model, provider, references, selectedSkills } = options;
+    const { model, provider, reasoningEffort, references, selectedSkills } = options;
     const turnId = createTurnId();
     const threadId = state.activeThreadId;
     const request: NativeThreadTurnInput = {
@@ -305,6 +307,7 @@ export function createDesktopChatSessionController({
         stream: true,
         ...(model ? { model } : {}),
         ...(provider ? { provider } : {}),
+        ...(reasoningEffort ? { reasoningEffort } : {}),
         metadata: {
           clientEventId,
           ...(references?.length ? { references } : {}),

--- a/src/app-core/chat/desktopCommand.test.ts
+++ b/src/app-core/chat/desktopCommand.test.ts
@@ -7,7 +7,7 @@ describe("desktop command", () => {
     expect(createDesktopTurnSubmitCommand({
       commandId: "command-1",
       issuedAt: "2026-07-15T00:00:00.000Z",
-      message: { text: "hello", model: "model-1" },
+      message: { text: "hello", model: "model-1", reasoningEffort: "high" },
       sessionId: "thread-1",
       source: { control: "composer-send", surface: "chat" },
     })).toEqual({
@@ -17,7 +17,7 @@ describe("desktop command", () => {
       kind: "turn.submit",
       source: { control: "composer-send", surface: "chat" },
       target: { sessionId: "thread-1" },
-      input: { text: "hello", model: "model-1" },
+      input: { text: "hello", model: "model-1", reasoningEffort: "high" },
     });
   });
 

--- a/src/app-core/chat/desktopCommand.ts
+++ b/src/app-core/chat/desktopCommand.ts
@@ -1,10 +1,12 @@
 import type { AgentInputReference } from "./agentInputReference";
+import type { ReasoningEffort } from "./reasoningEffort";
 import type { TinyOsCommand, TinyOsCommandSource } from "./tinyOsCommand";
 
 export type DesktopChatInput = {
   text: string;
   model?: string;
   provider?: string;
+  reasoningEffort?: ReasoningEffort;
   references?: AgentInputReference[];
   selectedSkills?: string[];
 };

--- a/src/app-core/chat/reasoningEffort.test.ts
+++ b/src/app-core/chat/reasoningEffort.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, test } from "vitest";
+
+import {
+  CHAT_REASONING_EFFORT_STORAGE_KEY,
+  readCurrentChatReasoningEffort,
+  writeCurrentChatReasoningEffort,
+} from "./reasoningEffort";
+
+describe("chat reasoning effort preference", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  test("persists supported explicit effort values", () => {
+    writeCurrentChatReasoningEffort("xhigh");
+
+    expect(readCurrentChatReasoningEffort()).toBe("xhigh");
+  });
+
+  test.each(["none", "ultra"])("removes unsupported effort value %s and falls back to medium", (effort) => {
+    window.localStorage.setItem(CHAT_REASONING_EFFORT_STORAGE_KEY, effort);
+
+    expect(readCurrentChatReasoningEffort()).toBe("medium");
+    expect(window.localStorage.getItem(CHAT_REASONING_EFFORT_STORAGE_KEY)).toBeNull();
+  });
+
+  test("uses medium when no preference has been saved", () => {
+    expect(readCurrentChatReasoningEffort()).toBe("medium");
+  });
+});

--- a/src/app-core/chat/reasoningEffort.ts
+++ b/src/app-core/chat/reasoningEffort.ts
@@ -1,0 +1,33 @@
+export const REASONING_EFFORT_VALUES = ["low", "medium", "high", "xhigh", "max"] as const;
+
+export type ReasoningEffort = typeof REASONING_EFFORT_VALUES[number];
+
+export const CHAT_REASONING_EFFORT_STORAGE_KEY = "tinybot.ui.chat.composer-reasoning-effort";
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
+
+export function isReasoningEffort(value: string): value is ReasoningEffort {
+  return REASONING_EFFORT_VALUES.some((effort) => effort === value);
+}
+
+export function readCurrentChatReasoningEffort(): ReasoningEffort {
+  if (typeof window === "undefined") return DEFAULT_REASONING_EFFORT;
+  try {
+    const effort = window.localStorage.getItem(CHAT_REASONING_EFFORT_STORAGE_KEY)?.trim() ?? "";
+    if (!effort) return DEFAULT_REASONING_EFFORT;
+    if (isReasoningEffort(effort)) return effort;
+    window.localStorage.removeItem(CHAT_REASONING_EFFORT_STORAGE_KEY);
+    return DEFAULT_REASONING_EFFORT;
+  } catch (error) {
+    console.warn("Unable to read the current chat reasoning effort.", error);
+    return DEFAULT_REASONING_EFFORT;
+  }
+}
+
+export function writeCurrentChatReasoningEffort(effort: ReasoningEffort): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CHAT_REASONING_EFFORT_STORAGE_KEY, effort);
+  } catch (error) {
+    console.warn("Unable to save the current chat reasoning effort.", error);
+  }
+}

--- a/src/app-core/native/desktopNativeThreads.ts
+++ b/src/app-core/native/desktopNativeThreads.ts
@@ -1,4 +1,5 @@
 import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import type { ReasoningEffort } from "../chat/reasoningEffort";
 
 type TauriInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
 
@@ -49,6 +50,7 @@ export type NativeThreadTurnInput = {
     stream: true;
     model?: string;
     provider?: string;
+    reasoningEffort?: ReasoningEffort;
     metadata: Record<string, unknown>;
   };
 };

--- a/src/app-core/settings/agentDefaultsSettings.test.ts
+++ b/src/app-core/settings/agentDefaultsSettings.test.ts
@@ -19,7 +19,6 @@ describe("agent defaults settings", () => {
           contextWindowTokens: 128000,
           contextWindowStrategy: "compact",
           maxIterations: 12,
-          reasoningEffort: "medium",
         },
       },
     });
@@ -35,7 +34,6 @@ describe("agent defaults settings", () => {
         contextWindowTokens: "128000",
         contextWindowStrategy: "compact",
         maxToolIterations: "12",
-        reasoningEffort: "medium",
       },
     });
   });
@@ -55,7 +53,6 @@ describe("agent defaults settings", () => {
       contextWindowTokens: "128000",
       contextWindowStrategy: "discard",
       maxToolIterations: "200",
-      reasoningEffort: "medium",
     });
   });
 
@@ -67,7 +64,6 @@ describe("agent defaults settings", () => {
       contextWindowTokens: "64000",
       contextWindowStrategy: "compact",
       maxToolIterations: "8",
-      reasoningEffort: "high",
     })).toEqual({
       agents: {
         defaults: {
@@ -77,7 +73,6 @@ describe("agent defaults settings", () => {
           contextWindowTokens: 64000,
           contextWindowStrategy: "compact",
           maxIterations: 8,
-          reasoningEffort: "high",
         },
       },
     });
@@ -91,7 +86,6 @@ describe("agent defaults settings", () => {
       contextWindowTokens: "64000",
       contextWindowStrategy: "compact",
       maxToolIterations: "8",
-      reasoningEffort: "high",
     })).toEqual({
       temperature: "Temperature must be a number between 0 and 2.",
     });
@@ -102,7 +96,6 @@ describe("agent defaults settings", () => {
       contextWindowTokens: "",
       contextWindowStrategy: "discard",
       maxToolIterations: "",
-      reasoningEffort: "",
     })).toEqual({
       agents: {
         defaults: {
@@ -121,7 +114,6 @@ describe("agent defaults settings", () => {
       contextWindowTokens: "1.5",
       contextWindowStrategy: "invalid",
       maxToolIterations: "-1",
-      reasoningEffort: "medium",
     })).toEqual({
       temperature: "Temperature must be between 0 and 2.",
       maxTokens: "Max output tokens must be a positive integer.",

--- a/src/app-core/settings/agentDefaultsSettings.ts
+++ b/src/app-core/settings/agentDefaultsSettings.ts
@@ -5,7 +5,6 @@ export type AgentDefaultsFormValues = {
   contextWindowTokens: string;
   contextWindowStrategy: string;
   maxToolIterations: string;
-  reasoningEffort: string;
 };
 
 export type AgentDefaultsSettingsData = {
@@ -24,7 +23,6 @@ const DEFAULT_AGENT_MAX_TOKENS = 8192;
 const DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS = 128000;
 const DEFAULT_AGENT_CONTEXT_WINDOW_STRATEGY = "discard";
 const DEFAULT_AGENT_MAX_TOOL_ITERATIONS = 200;
-const DEFAULT_AGENT_REASONING_EFFORT = "medium";
 
 export function buildAgentDefaultsSettings(config: unknown): AgentDefaultsSettingsData {
   const root = asRecord(config);
@@ -49,7 +47,6 @@ export function buildAgentDefaultsSettings(config: unknown): AgentDefaultsSettin
         pick(defaults, "maxIterations", "max_iterations", "maxToolIterations", "max_tool_iterations"),
         DEFAULT_AGENT_MAX_TOOL_ITERATIONS,
       ),
-      reasoningEffort: stringValue(pick(defaults, "reasoningEffort", "reasoning_effort")) || DEFAULT_AGENT_REASONING_EFFORT,
     },
   };
 }
@@ -95,10 +92,6 @@ export function buildAgentDefaultsPatch(values: AgentDefaultsFormValues): JsonRe
     defaults.contextWindowStrategy = contextWindowStrategy;
   }
   setOptionalInteger(defaults, "maxIterations", values.maxToolIterations);
-  const reasoningEffort = values.reasoningEffort.trim();
-  if (reasoningEffort) {
-    defaults.reasoningEffort = reasoningEffort;
-  }
   return { agents: { defaults } };
 }
 

--- a/src/app-core/settings/desktopSettingsProviders.test.ts
+++ b/src/app-core/settings/desktopSettingsProviders.test.ts
@@ -637,7 +637,6 @@ describe("desktop settings and provider helpers", () => {
           active_profile: "deepseek",
           temperature: 0.2,
           max_tokens: 4096,
-          reasoning_effort: "medium",
         },
       },
       providers: {
@@ -672,7 +671,7 @@ describe("desktop settings and provider helpers", () => {
     });
     expect(fields["general.temperature"]).toMatchObject({ control: "number", requirement: "optional", configurationMode: "numeric", advanced: true });
     expect(fields["general.contextWindowStrategy"]).toMatchObject({ control: "select", requirement: "optional", configurationMode: "fixed", advanced: true });
-    expect(fields["general.reasoningEffort"]).toMatchObject({ control: "select", requirement: "optional", configurationMode: "fixed", advanced: true });
+    expect(fields["general.reasoningEffort"]).toBeUndefined();
     expect(fields["tools-mcp.mcpServers"]).toMatchObject({ control: "textarea", requirement: "optional", configurationMode: "json", advanced: true });
     expect(fields["tools-mcp.searchProvider"]).toMatchObject({ control: "select", requirement: "optional", configurationMode: "fixed", advanced: true });
   });

--- a/src/app-core/settings/desktopSettingsProviders.ts
+++ b/src/app-core/settings/desktopSettingsProviders.ts
@@ -41,7 +41,6 @@ export interface DesktopSettingsFormState {
     contextWindowTokens: number | null;
     contextWindowStrategy: string | null;
     maxToolIterations: number | null;
-    reasoningEffort: string | null;
     timezone: string | null;
   };
   embedding: {
@@ -510,7 +509,6 @@ export function buildDesktopSettingsFormState(
       contextWindowTokens: numberOrDefault(pick(defaults, "contextWindowTokens", "context_window_tokens"), 128000),
       contextWindowStrategy: stringOrDefault(pick(defaults, "contextWindowStrategy", "context_window_strategy"), "discard"),
       maxToolIterations: numberOrDefault(pick(defaults, "maxIterations", "max_iterations", "maxToolIterations", "max_tool_iterations"), 200),
-      reasoningEffort: stringOrNull(pick(defaults, "reasoningEffort", "reasoning_effort")),
       timezone: stringOrDefault(pick(defaults, "timezone"), "UTC"),
     },
     embedding: {
@@ -765,7 +763,6 @@ function createDesktopSettingsFullPatch(
         context_window_tokens: state.agent.contextWindowTokens,
         context_window_strategy: state.agent.contextWindowStrategy,
         maxIterations: state.agent.maxToolIterations,
-        reasoning_effort: state.agent.reasoningEffort,
         timezone: state.agent.timezone,
         embedding: {
           provider: state.embedding.provider,
@@ -831,8 +828,6 @@ function getDesktopSettingsPatchPathValue(state: DesktopSettingsFormState, path:
       return state.agent.contextWindowStrategy;
     case "agents.defaults.maxIterations":
       return state.agent.maxToolIterations;
-    case "agents.defaults.reasoning_effort":
-      return state.agent.reasoningEffort;
     case "agents.defaults.timezone":
       return state.agent.timezone;
     case "agents.defaults.embedding.provider":
@@ -1144,10 +1139,6 @@ export function applyDesktopSettingsFieldEdit(
     case "maxToolIterations":
       nextState.agent.maxToolIterations = numberOrNullInput(text);
       markDesktopSettingsTouched(nextState, "agents.defaults.maxIterations");
-      break;
-    case "reasoningEffort":
-      nextState.agent.reasoningEffort = stringOrNullInput(text);
-      markDesktopSettingsTouched(nextState, "agents.defaults.reasoning_effort");
       break;
     case "timezone":
       nextState.agent.timezone = stringOrNullInput(text);
@@ -1779,13 +1770,6 @@ function buildDesktopSettingsPaneGroups(
           min: 1,
           step: 1,
         }),
-        field("reasoningEffort", "Reasoning effort", state.agent.reasoningEffort, {
-          control: "select",
-          options: fixedOptions(["", "low", "medium", "high"]),
-          requirement: "optional",
-          configurationMode: "fixed",
-          advanced: true,
-        }),
       ],
     },
     {
@@ -2067,7 +2051,6 @@ function getDesktopSettingsPaneFieldPersistentPath(
     "general.contextWindowTokens": "agents.defaults.contextWindowTokens",
     "general.contextWindowStrategy": "agents.defaults.contextWindowStrategy",
     "general.maxToolIterations": "agents.defaults.maxIterations",
-    "general.reasoningEffort": "agents.defaults.reasoningEffort",
     "provider-models.selectedProvider": "desktop.ui.settings.providerEditor.selectedProvider",
     "provider-models.profileId": "agents.defaults.activeProfile",
     "tools-mcp.webEnable": "tools.web.enable",

--- a/src/app-core/settings/desktopSettingsSchemaCoverage.ts
+++ b/src/app-core/settings/desktopSettingsSchemaCoverage.ts
@@ -21,7 +21,7 @@ type DispositionRule = {
 };
 
 const DISPOSITION_RULES: DispositionRule[] = [
-  { pattern: /^agents\.defaults\.(model|provider|activeProfile|temperature|timezone|workspace|maxTokens|contextWindowTokens|contextWindowStrategy|maxIterations|reasoningEffort)$/, disposition: "essential" },
+  { pattern: /^agents\.defaults\.(model|provider|activeProfile|temperature|timezone|workspace|maxTokens|contextWindowTokens|contextWindowStrategy|maxIterations)$/, disposition: "essential" },
   { pattern: /^agents\.defaults\.(contextBlockLimit|maxToolResultChars|embedding\..+)$/, disposition: "advanced" },
   { pattern: /^providers\.[^.]+\.(api_key|api_base|enabled|models)$/, disposition: "essential" },
   { pattern: /^providers\.profiles\.[^.]+\.(provider|api_key|api_base|enabled|models)$/, disposition: "essential" },
@@ -40,7 +40,6 @@ export function canonicalizeDesktopSettingsPersistentPath(path: string): string 
   return path
     .replace(/^agents\.defaults\.active_profile$/, "agents.defaults.activeProfile")
     .replace(/^agents\.defaults\.max_tokens$/, "agents.defaults.maxTokens")
-    .replace(/^agents\.defaults\.reasoning_effort$/, "agents.defaults.reasoningEffort")
     .replace(/^agents\.defaults\.context_block_limit$/, "agents.defaults.contextBlockLimit")
     .replace(/^agents\.defaults\.context_window_tokens$/, "agents.defaults.contextWindowTokens")
     .replace(/^agents\.defaults\.context_window_strategy$/, "agents.defaults.contextWindowStrategy")

--- a/src/components/ui/claude-style-ai-input.test.tsx
+++ b/src/components/ui/claude-style-ai-input.test.tsx
@@ -42,6 +42,39 @@ describe("ClaudeStyleAiInput slash commands", () => {
     expect(onSendMessage).not.toHaveBeenCalled();
   });
 
+  it("selects reasoning effort from the model menu and sends the API value", async () => {
+    const user = userEvent.setup();
+    const onReasoningEffortChange = vi.fn();
+    const onSendMessage = vi.fn();
+    render(<ClaudeStyleAiInput
+      models={[{ id: "gpt-5.6", name: "GPT-5.6", description: "OpenAI" }]}
+      onReasoningEffortChange={onReasoningEffortChange}
+      onSendMessage={onSendMessage}
+    />);
+
+    await user.click(screen.getByRole("button", { name: "Select model" }));
+    const menu = screen.getByRole("dialog", { name: "Model and reasoning effort" });
+    expect(within(menu).getByRole("button", { name: /Model GPT-5\.6/ })).toBeTruthy();
+    expect(within(menu).queryByText("Speed")).toBeNull();
+
+    await user.click(within(menu).getByRole("button", { name: /Effort Medium/ }));
+    const effortList = screen.getByRole("listbox", { name: "Reasoning effort" });
+    expect(within(effortList).queryByRole("option", { name: /Default/ })).toBeNull();
+    expect(within(effortList).queryByRole("option", { name: /^None/ })).toBeNull();
+    expect(within(effortList).queryByRole("option", { name: /Ultra/ })).toBeNull();
+    await user.click(within(effortList).getByRole("option", { name: /Extra High/ }));
+
+    expect(onReasoningEffortChange).toHaveBeenCalledWith("xhigh");
+    expect(screen.getByRole("button", { name: "Select model" }).textContent).toContain("Extra High");
+
+    await user.type(screen.getByRole("textbox", { name: "Message" }), "Think carefully");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(onSendMessage).toHaveBeenCalledWith("Think carefully", [], [], {
+      model: "gpt-5.6",
+      reasoningEffort: "xhigh",
+    });
+  });
+
   it("offers explicit interrupt and next-turn actions while responding", async () => {
     const user = userEvent.setup();
     const onInterruptMessage = vi.fn();
@@ -55,12 +88,12 @@ describe("ClaudeStyleAiInput slash commands", () => {
     const input = screen.getByRole("textbox", { name: "Message" });
     await user.type(input, "Change direction");
     await user.click(screen.getByRole("button", { name: "插入当前任务" }));
-    expect(onInterruptMessage).toHaveBeenCalledWith("Change direction", [], [], {});
+    expect(onInterruptMessage).toHaveBeenCalledWith("Change direction", [], [], { reasoningEffort: "medium" });
     expect(onSendMessage).not.toHaveBeenCalled();
 
     await user.type(input, "Do this afterward");
     await user.click(screen.getByRole("button", { name: "排队为下一轮" }));
-    expect(onSendMessage).toHaveBeenCalledWith("Do this afterward", [], [], {});
+    expect(onSendMessage).toHaveBeenCalledWith("Do this afterward", [], [], { reasoningEffort: "medium" });
   });
 
   it("dismisses the menu with Escape without changing the draft", async () => {
@@ -98,7 +131,7 @@ describe("ClaudeStyleAiInput slash commands", () => {
       "/compact",
       [],
       [],
-      {},
+      { reasoningEffort: "medium" },
     ));
   });
 });

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -2,6 +2,7 @@
 
 import type { ClipboardEvent, FormEvent, KeyboardEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { DEFAULT_REASONING_EFFORT, type ReasoningEffort } from "../../app-core/chat/reasoningEffort";
 import type { TokenUsage } from "../../app-core/chat/chatTurnModel";
 import {
   AlertCircle,
@@ -9,6 +10,8 @@ import {
   ArrowUp,
   Check,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   Command,
   Copy,
   FileText,
@@ -67,6 +70,7 @@ export interface ComposerSlashCommand {
 export interface ComposerSendOptions {
   model?: string;
   provider?: string;
+  reasoningEffort?: ReasoningEffort;
 }
 
 export interface ComposerContextReference {
@@ -98,7 +102,9 @@ export interface ClaudeStyleAiInputProps {
   onSelectFiles?: () => Promise<ComposerFileSelection[]>;
   models?: ModelOption[];
   defaultModel?: string;
+  defaultReasoningEffort?: ReasoningEffort;
   onModelChange?: (modelId: string) => void;
+  onReasoningEffortChange?: (effort: ReasoningEffort) => void;
   onClearContextReferences?: () => void;
   onRemoveContextReference?: (id: string) => void;
   contextUsage?: TokenUsage;
@@ -117,6 +123,19 @@ const PASTE_THRESHOLD = 200;
 const EMPTY_MODELS: ModelOption[] = [];
 const EMPTY_TOOLS: ComposerToolOption[] = [];
 const EMPTY_SLASH_COMMANDS: readonly ComposerSlashCommand[] = [];
+const REASONING_EFFORT_OPTIONS: ReadonlyArray<{
+  description: string;
+  label: string;
+  value: ReasoningEffort;
+}> = [
+  { value: "low", label: "Light", description: "Prioritize speed and lower token use." },
+  { value: "medium", label: "Medium", description: "Use balanced reasoning depth." },
+  { value: "high", label: "High", description: "Use deeper reasoning." },
+  { value: "xhigh", label: "Extra High", description: "Use very deep reasoning." },
+  { value: "max", label: "Max", description: "Use the model's maximum reasoning depth." },
+];
+
+type ModelMenuView = "advanced" | "effort" | "models";
 
 let generatedId = 0;
 
@@ -131,11 +150,13 @@ export function ClaudeStyleAiInput({
   contextReferences = [],
   contextUsage,
   defaultModel,
+  defaultReasoningEffort,
   disabled = false,
   disabledReason,
   maxFiles = MAX_FILES,
   models = EMPTY_MODELS,
   onModelChange,
+  onReasoningEffortChange,
   onClearContextReferences,
   onInterruptMessage,
   onRemoveContextReference,
@@ -153,12 +174,17 @@ export function ClaudeStyleAiInput({
   const panelRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const modelMenuRef = useRef<HTMLDivElement | null>(null);
+  const modelTriggerRef = useRef<HTMLButtonElement | null>(null);
   const toolMenuRef = useRef<HTMLDivElement | null>(null);
   const [message, setMessage] = useState("");
   const [files, setFiles] = useState<ComposerFileReference[]>([]);
   const [pastedContent, setPastedContent] = useState<PastedContent[]>([]);
   const [selectedModelId, setSelectedModelId] = useState(defaultModel ?? models[0]?.id ?? "");
+  const [selectedReasoningEffort, setSelectedReasoningEffort] = useState<ReasoningEffort>(
+    defaultReasoningEffort ?? DEFAULT_REASONING_EFFORT,
+  );
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
+  const [modelMenuView, setModelMenuView] = useState<ModelMenuView>("advanced");
   const [toolMenuOpen, setToolMenuOpen] = useState(false);
   const [enabledToolIds, setEnabledToolIds] = useState<string[]>(() => tools.filter((tool) => tool.enabled).map((tool) => tool.id));
   const [error, setError] = useState("");
@@ -174,6 +200,7 @@ export function ClaudeStyleAiInput({
       ?? models[0],
     [defaultModel, models, selectedModelId],
   );
+  const selectedReasoningEffortLabel = reasoningEffortLabel(selectedReasoningEffort);
   const contextUsageView = useMemo(() => buildContextUsageView(contextUsage), [contextUsage]);
   const enabledToolIdSet = useMemo(() => new Set(enabledToolIds), [enabledToolIds]);
   const canSend = !disabled && !sending && Boolean(currentMessage.trim() || files.length || pastedContent.length || contextReferences.length);
@@ -207,6 +234,10 @@ export function ClaudeStyleAiInput({
   }, [defaultModel, models]);
 
   useEffect(() => {
+    setSelectedReasoningEffort(defaultReasoningEffort ?? DEFAULT_REASONING_EFFORT);
+  }, [defaultReasoningEffort]);
+
+  useEffect(() => {
     setEnabledToolIds(tools.filter((tool) => tool.enabled).map((tool) => tool.id));
   }, [tools]);
 
@@ -218,6 +249,7 @@ export function ClaudeStyleAiInput({
   useEffect(() => {
     if (!slashMenuOpen) return;
     setModelMenuOpen(false);
+    setModelMenuView("advanced");
     setToolMenuOpen(false);
   }, [slashMenuOpen]);
 
@@ -229,6 +261,7 @@ export function ClaudeStyleAiInput({
       const target = event.target as Node;
       if (!modelMenuRef.current?.contains(target)) {
         setModelMenuOpen(false);
+        setModelMenuView("advanced");
       }
       if (!toolMenuRef.current?.contains(target)) {
         setToolMenuOpen(false);
@@ -241,6 +274,19 @@ export function ClaudeStyleAiInput({
     return () => document.removeEventListener("pointerdown", closeMenus, true);
   }, [modelMenuOpen, slashMenuOpen, toolMenuOpen]);
 
+  useEffect(() => {
+    if (!modelMenuOpen) return;
+    function closeOnEscape(event: globalThis.KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      setModelMenuOpen(false);
+      setModelMenuView("advanced");
+      modelTriggerRef.current?.focus();
+    }
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [modelMenuOpen]);
+
   async function sendMessage(mode: "interrupt" | "queue") {
     if (!canSend) {
       return;
@@ -252,6 +298,7 @@ export function ClaudeStyleAiInput({
       await handler?.(currentMessage.trim(), files, pastedContent, {
         ...(selectedModel ? { model: selectedModel.modelId || selectedModel.id } : {}),
         ...(selectedModel?.providerId ? { provider: selectedModel.providerId } : {}),
+        reasoningEffort: selectedReasoningEffort,
       });
       updateMessage("");
       setFiles([]);
@@ -372,7 +419,17 @@ export function ClaudeStyleAiInput({
   function selectModel(modelId: string) {
     setSelectedModelId(modelId);
     setModelMenuOpen(false);
+    setModelMenuView("advanced");
+    modelTriggerRef.current?.focus();
     onModelChange?.(modelId);
+  }
+
+  function selectReasoningEffort(effort: ReasoningEffort) {
+    setSelectedReasoningEffort(effort);
+    setModelMenuOpen(false);
+    setModelMenuView("advanced");
+    modelTriggerRef.current?.focus();
+    onReasoningEffortChange?.(effort);
   }
 
   function toggleTool(tool: ComposerToolOption) {
@@ -576,40 +633,105 @@ export function ClaudeStyleAiInput({
             </div>
             <div ref={modelMenuRef} className="claude-ai-input__model">
               <button
+                ref={modelTriggerRef}
                 aria-expanded={modelMenuOpen}
-                aria-haspopup="listbox"
+                aria-haspopup="dialog"
                 aria-label="Select model"
                 className="claude-ai-input__model-trigger"
                 disabled={disabled || !models.length}
                 type="button"
                 onClick={() => {
                   setSlashMenuDismissed(true);
-                  setModelMenuOpen((open) => !open);
+                  setModelMenuOpen((open) => {
+                    if (!open) setModelMenuView("advanced");
+                    return !open;
+                  });
                   setToolMenuOpen(false);
                 }}
               >
-                <span>{selectedModel?.name ?? "Model"}</span>
+                <span className="claude-ai-input__model-trigger-name">{selectedModel?.name ?? "Model"}</span>
+                <span className="claude-ai-input__model-trigger-effort">{selectedReasoningEffortLabel}</span>
                 <ChevronDown aria-hidden="true" size={16} />
               </button>
               {modelMenuOpen ? (
-                <div className="claude-ai-input__model-menu" role="listbox" aria-label="Models">
-                  {models.map((model) => (
-                    <button
-                      aria-selected={model.id === selectedModelId}
-                      className="claude-ai-input__model-option"
-                      key={model.id}
-                      role="option"
-                      type="button"
-                      onClick={() => selectModel(model.id)}
-                    >
-                      <span>
-                        <strong>{model.name}</strong>
-                        <small>{model.description}</small>
-                      </span>
-                      {model.badge ? <em>{model.badge}</em> : null}
-                      {model.id === selectedModelId ? <Check aria-hidden="true" size={15} /> : null}
-                    </button>
-                  ))}
+                <div className="claude-ai-input__model-menu" role="dialog" aria-label="Model and reasoning effort">
+                  {modelMenuView === "advanced" ? (
+                    <>
+                      <div className="claude-ai-input__model-menu-title">Advanced</div>
+                      <button
+                        className="claude-ai-input__model-menu-row"
+                        type="button"
+                        onClick={() => setModelMenuView("models")}
+                      >
+                        <strong>Model</strong>
+                        <span>{selectedModel?.name ?? "Choose model"}</span>
+                        <ChevronRight aria-hidden="true" size={16} />
+                      </button>
+                      <button
+                        className="claude-ai-input__model-menu-row"
+                        type="button"
+                        onClick={() => setModelMenuView("effort")}
+                      >
+                        <strong>Effort</strong>
+                        <span>{selectedReasoningEffortLabel}</span>
+                        <ChevronRight aria-hidden="true" size={16} />
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <div className="claude-ai-input__model-menu-header">
+                        <button
+                          aria-label="Back to advanced options"
+                          className="claude-ai-input__model-menu-back"
+                          type="button"
+                          onClick={() => setModelMenuView("advanced")}
+                        >
+                          <ChevronLeft aria-hidden="true" size={16} />
+                        </button>
+                        <strong>{modelMenuView === "models" ? "Model" : "Effort"}</strong>
+                      </div>
+                      {modelMenuView === "models" ? (
+                        <div className="claude-ai-input__model-menu-list" role="listbox" aria-label="Models">
+                          {models.map((model) => (
+                            <button
+                              aria-selected={model.id === selectedModelId}
+                              className="claude-ai-input__model-option"
+                              key={model.id}
+                              role="option"
+                              type="button"
+                              onClick={() => selectModel(model.id)}
+                            >
+                              <span>
+                                <strong>{model.name}</strong>
+                                <small>{model.description}</small>
+                              </span>
+                              {model.badge ? <em>{model.badge}</em> : null}
+                              {model.id === selectedModelId ? <Check aria-hidden="true" size={15} /> : null}
+                            </button>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="claude-ai-input__model-menu-list" role="listbox" aria-label="Reasoning effort">
+                          {REASONING_EFFORT_OPTIONS.map((option) => (
+                            <button
+                              aria-selected={option.value === selectedReasoningEffort}
+                              className="claude-ai-input__model-option claude-ai-input__effort-option"
+                              key={option.value}
+                              role="option"
+                              type="button"
+                              onClick={() => selectReasoningEffort(option.value)}
+                            >
+                              <span>
+                                <strong>{option.label}</strong>
+                                <small>{option.description}</small>
+                              </span>
+                              {option.value === selectedReasoningEffort ? <Check aria-hidden="true" size={15} /> : null}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  )}
                 </div>
               ) : null}
             </div>
@@ -758,6 +880,10 @@ function formatTokenCount(value: number): string {
 
 function trimDecimal(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/, "");
+}
+
+function reasoningEffortLabel(effort: ReasoningEffort): string {
+  return REASONING_EFFORT_OPTIONS.find((option) => option.value === effort)?.label ?? "Medium";
 }
 
 function AttachmentChip({

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -1140,6 +1140,7 @@ describe("ChatPage", () => {
 
     await waitFor(() => expect(stores.sessionStore.create).toHaveBeenCalledTimes(1));
     await waitFor(() => expectTurnSubmit(stores.chatStore, "s-new", {
+      reasoningEffort: "medium",
       text: "Hello from an empty app",
     }));
   });
@@ -1166,6 +1167,7 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
     await waitFor(() => expectTurnSubmit(stores.chatStore, "s-new", {
+      reasoningEffort: "medium",
       text: "Hello from an empty app",
     }));
     expect(screen.getByRole("heading", { name: "Hello from an empty app" })).toBeTruthy();
@@ -2987,7 +2989,7 @@ describe("ChatPage", () => {
     await user.type(input, "Hello from React");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
-    expectTurnSubmit(stores.chatStore, "s1", { text: "Hello from React" });
+    expectTurnSubmit(stores.chatStore, "s1", { reasoningEffort: "medium", text: "Hello from React" });
     expect((input as HTMLTextAreaElement).value).toBe("");
   });
 
@@ -3010,6 +3012,7 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
     expectTurnSubmit(stores.chatStore, "s1", {
+      reasoningEffort: "medium",
       references: [{
         detail: "MARKDOWN - 16 Bytes",
         kind: "reference",
@@ -3095,7 +3098,7 @@ describe("ChatPage", () => {
     await user.type(input, "Start another turn");
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
-    expectTurnSubmit(stores.chatStore, "s1", { text: "Start another turn" });
+    expectTurnSubmit(stores.chatStore, "s1", { reasoningEffort: "medium", text: "Start another turn" });
     expect(screen.queryByRole("button", { name: "插入当前任务" })).toBeNull();
     expect(screen.queryByRole("button", { name: "排队为下一轮" })).toBeNull();
   });
@@ -3186,6 +3189,7 @@ describe("ChatPage", () => {
 
     await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
       model: "deepseek-v4-flash",
+      reasoningEffort: "medium",
       references: [{
         detail: "MARKDOWN - 32 Bytes",
         kind: "reference",
@@ -3278,6 +3282,7 @@ describe("ChatPage", () => {
     subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
     await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
+      reasoningEffort: "medium",
       text: "first queued",
     }));
     expect(turnSubmitCommands(stores.chatStore)).toHaveLength(1);
@@ -3288,6 +3293,7 @@ describe("ChatPage", () => {
     subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
     await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
+      reasoningEffort: "medium",
       text: "second queued",
     }));
     expect(turnSubmitCommands(stores.chatStore)).toHaveLength(2);
@@ -3330,6 +3336,7 @@ describe("ChatPage", () => {
     subscribed?.({ type: "agent.event", eventType: "agent.turn.completed" });
 
     await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
+      reasoningEffort: "medium",
       text: "queued after full turn",
     }));
   });
@@ -3464,6 +3471,7 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: "Resume queue" }));
 
     await waitFor(() => expectTurnSubmit(stores.chatStore, "s1", {
+      reasoningEffort: "medium",
       text: "resume first",
     }));
     const queuedInputs = screen.getByLabelText("Queued inputs");
@@ -3707,6 +3715,7 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
     await waitFor(() => expectTurnSubmit(stores.chatStore, "pending:1", {
+      reasoningEffort: "medium",
       text: "Summarize docs",
     }));
     expect(screen.queryByRole("heading", { name: "未选择会话" })).toBeNull();
@@ -3796,6 +3805,7 @@ describe("ChatPage", () => {
     const modelTrigger = await screen.findByRole("button", { name: "Select model" });
     expect(modelTrigger.textContent).toContain("deepseek-chat");
     await user.click(modelTrigger);
+    await user.click(screen.getByRole("button", { name: /Model deepseek-chat/ }));
 
     expect(screen.getByRole("option", { name: /deepseek-reasoner/i })).toBeTruthy();
     expect(screen.queryByText("Claude Sonnet 4")).toBeNull();
@@ -3809,7 +3819,44 @@ describe("ChatPage", () => {
 
     expectTurnSubmit(stores.chatStore, "s1", {
       model: "deepseek-reasoner",
+      reasoningEffort: "medium",
       text: "Use a specific model",
+    });
+  });
+
+  it("persists composer effort and submits it as an explicit turn setting", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const settingsStore: SettingsStore = {
+      load: vi.fn(async () => []),
+      loadChatModels: vi.fn(async () => [{
+        id: "gpt-5.6",
+        label: "gpt-5.6",
+        description: "OpenAI",
+        default: true,
+      }]),
+    };
+    render(
+      <ChatPage
+        chatStore={stores.chatStore}
+        now={() => Date.UTC(2026, 6, 4, 12, 0, 0)}
+        sessionStore={stores.sessionStore}
+        settingsStore={settingsStore}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Select model" }));
+    await user.click(screen.getByRole("button", { name: /Effort Medium/ }));
+    await user.click(screen.getByRole("option", { name: /Extra High/ }));
+
+    expect(window.localStorage.getItem("tinybot.ui.chat.composer-reasoning-effort")).toBe("xhigh");
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Solve this carefully");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
+    expectTurnSubmit(stores.chatStore, "s1", {
+      model: "gpt-5.6",
+      reasoningEffort: "xhigh",
+      text: "Solve this carefully",
     });
   });
 
@@ -4053,6 +4100,7 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
     expectTurnSubmit(stores.chatStore, "s1", {
+      reasoningEffort: "medium",
       text: `Summarize this\n\nPasted content:\n${pastedText}`,
     });
     expect(screen.queryByText("Pasted text")).toBeNull();

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -56,6 +56,10 @@ import {
   readCurrentChatModelPreference,
   writeCurrentChatModel,
 } from "../../app-core/chat/chatModelPreference";
+import {
+  readCurrentChatReasoningEffort,
+  writeCurrentChatReasoningEffort,
+} from "../../app-core/chat/reasoningEffort";
 import { pickDesktopChatFiles } from "../../app-core/native/desktopNativeFilePicker";
 import { pickDesktopWorkspaceDirectory } from "../../app-core/native/desktopNativeWorkspacePicker";
 import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
@@ -362,6 +366,7 @@ export function ChatPage({
   ));
   const [composerModels, setComposerModels] = useState<ModelOption[]>([]);
   const [defaultComposerModel, setDefaultComposerModel] = useState("");
+  const [composerReasoningEffort, setComposerReasoningEffort] = useState(readCurrentChatReasoningEffort);
   const [contextUsageDefaults, setContextUsageDefaults] = useState<ContextUsageDefaults>({});
   const [headerMenuOpen, setHeaderMenuOpen] = useState(false);
   const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
@@ -2428,6 +2433,7 @@ export function ChatPage({
           disabled={!activeSession && !draftNewSession}
           disabledReason={!sessionsLoaded ? "正在加载会话…" : !activeSession && !draftNewSession ? "请先创建或选择一个会话" : undefined}
           defaultModel={defaultComposerModel}
+          defaultReasoningEffort={composerReasoningEffort}
           contextUsage={activeContextUsage}
           models={composerModels}
           onModelChange={(modelId) => {
@@ -2453,6 +2459,10 @@ export function ChatPage({
                 setTimelineError(`Model selection could not be saved: ${error instanceof Error ? error.message : String(error)}`);
               });
             }
+          }}
+          onReasoningEffortChange={(effort) => {
+            setComposerReasoningEffort(effort);
+            writeCurrentChatReasoningEffort(effort);
           }}
           responding={sessionResponding}
           slashCommands={COMPOSER_SLASH_COMMANDS}
@@ -2877,6 +2887,7 @@ function createComposerChatInput(
     text,
     ...(options.model ? { model: options.model } : {}),
     ...(options.provider ? { provider: options.provider } : {}),
+    ...(options.reasoningEffort ? { reasoningEffort: options.reasoningEffort } : {}),
     ...(references.length ? { references } : {}),
   };
 }

--- a/src/react-workbench/defaultServices.test.ts
+++ b/src/react-workbench/defaultServices.test.ts
@@ -257,6 +257,7 @@ describe("desktop native app services", () => {
         text: "hello",
         model: "model-1",
         provider: "openai",
+        reasoningEffort: "xhigh",
         selectedSkills: ["create-agent-plugin:migrate-agent-plugin"],
       },
       sessionId: "thread-1",
@@ -272,6 +273,7 @@ describe("desktop native app services", () => {
           stream: true,
           model: "model-1",
           provider: "openai",
+          reasoningEffort: "xhigh",
           metadata: expect.objectContaining({
             clientEventId: "command-turn-1",
             selectedSkills: ["create-agent-plugin:migrate-agent-plugin"],

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -330,6 +330,7 @@ export function createDesktopAppServices(): AppServices {
     const result = await controller.submitMessage(input.text, {
       ...(model ? { model } : {}),
       ...(provider ? { provider } : {}),
+      ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
       ...(input.references?.length ? { references: input.references } : {}),
       ...(input.selectedSkills?.length ? { selectedSkills: input.selectedSkills } : {}),
       clientEventId: command.commandId,

--- a/src/react-workbench/settings/AgentDefaultsSettingsPage.tsx
+++ b/src/react-workbench/settings/AgentDefaultsSettingsPage.tsx
@@ -168,17 +168,6 @@ export function AgentDefaultsSettingsPage({ onNavigateToProviderModels, settings
               value={values.maxToolIterations}
               onChange={(value) => editValue("maxToolIterations", value)}
             />
-            <SettingsChoiceList
-              label="Reasoning effort"
-              options={[
-                { value: "", label: "Default", description: "Use the model provider default." },
-                { value: "low", label: "Low", description: "Faster, lighter reasoning." },
-                { value: "medium", label: "Medium", description: "Balanced reasoning depth." },
-                { value: "high", label: "High", description: "More deliberate reasoning." },
-              ]}
-              value={values.reasoningEffort}
-              onChange={(value) => editValue("reasoningEffort", value)}
-            />
           </div>
         </section>
         <footer>

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -727,7 +727,6 @@ describe("DesktopShell", () => {
           contextWindowTokens: 128000,
           contextWindowStrategy: "discard",
           maxToolIterations: 12,
-          reasoningEffort: "medium",
         },
       },
     };
@@ -768,7 +767,7 @@ describe("DesktopShell", () => {
     await user.click(screen.getByRole("button", { name: "Context window strategy: Discard old messages" }));
     const strategyMenu = screen.getByRole("menu", { name: "Context window strategy options" });
     expect(strategyMenu.classList.contains("react-settings-choice-popover")).toBe(true);
-    expect(screen.getByRole("button", { name: "Reasoning effort: Medium" }).classList.contains("react-settings-choice-trigger")).toBe(true);
+    expect(screen.queryByText("Reasoning effort")).toBeNull();
     await user.click(within(strategyMenu).getByRole("menuitemradio", { name: /Compact old messages/ }));
     await user.click(screen.getByRole("button", { name: "Save agent defaults" }));
 
@@ -782,7 +781,6 @@ describe("DesktopShell", () => {
           contextWindowTokens: 128000,
           contextWindowStrategy: "compact",
           maxIterations: 12,
-          reasoningEffort: "medium",
         },
       },
     });

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -5667,7 +5667,7 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .claude-ai-input__model-trigger {
   gap: 6px;
-  max-width: 210px;
+  max-width: 260px;
   height: 34px;
   border-radius: 999px;
   padding: 0 10px;
@@ -5675,11 +5675,22 @@ button.tinyos-overlay-backdrop:focus-visible {
   font-size: 13px;
 }
 
-.claude-ai-input__model-trigger span {
+.claude-ai-input__model-trigger-name {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.claude-ai-input__model-trigger-effort {
+  flex: 0 0 auto;
+  color: var(--color-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.claude-ai-input__model-trigger svg {
+  flex: 0 0 auto;
 }
 
 .claude-ai-input__context-usage {
@@ -5791,6 +5802,105 @@ button.tinyos-overlay-backdrop:focus-visible {
   width: min(300px, calc(100vw - 48px));
 }
 
+.claude-ai-input__model-menu {
+  overflow: hidden;
+}
+
+.claude-ai-input__model-menu-title {
+  min-height: 36px;
+  border-bottom: 1px solid var(--color-hairline);
+  color: var(--color-muted);
+  padding: 8px 10px 7px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.claude-ai-input__model-menu-row {
+  display: grid;
+  grid-template-columns: minmax(72px, auto) minmax(0, 1fr) 16px;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 46px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-ink);
+  padding: 7px 10px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.claude-ai-input__model-menu-row:hover,
+.claude-ai-input__model-menu-row:focus-visible {
+  border-color: var(--color-primary);
+  background: var(--color-surface-soft);
+  outline: none;
+}
+
+.claude-ai-input__model-menu-row strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.claude-ai-input__model-menu-row span {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-muted);
+  font-size: 13px;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.claude-ai-input__model-menu-row svg {
+  color: var(--color-muted);
+}
+
+.claude-ai-input__model-menu-header {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) 34px;
+  align-items: center;
+  min-height: 44px;
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 0 2px;
+}
+
+.claude-ai-input__model-menu-header strong {
+  grid-column: 2;
+  color: var(--color-ink);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.claude-ai-input__model-menu-back {
+  display: inline-grid;
+  grid-column: 1;
+  grid-row: 1;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+}
+
+.claude-ai-input__model-menu-back:hover,
+.claude-ai-input__model-menu-back:focus-visible {
+  border-color: var(--color-primary);
+  background: var(--color-surface-soft);
+  color: var(--color-body);
+  outline: none;
+}
+
+.claude-ai-input__model-menu-list {
+  max-height: 224px;
+  overflow: auto;
+}
+
 .claude-ai-input__tool-option,
 .claude-ai-input__model-option {
   display: grid;
@@ -5810,6 +5920,10 @@ button.tinyos-overlay-backdrop:focus-visible {
 
 .claude-ai-input__model-option {
   grid-template-columns: minmax(0, 1fr) max-content 16px;
+}
+
+.claude-ai-input__effort-option {
+  grid-template-columns: minmax(0, 1fr) 16px;
 }
 
 .claude-ai-input__tool-option:hover,


### PR DESCRIPTION
## Summary
- remove reasoning effort from global Agent Defaults and legacy default request inheritance
- add a nested Model / Effort composer control with Light, Medium, High, Extra High, and Max
- persist the composer effort locally and submit it as an explicit turn setting for Chat Completions and Responses

## Why
Reasoning effort is model- and request-specific. Keeping it in Agent Defaults could silently apply a stale global value to unrelated providers or models.

## User impact
Users choose effort next to the active model. Medium is the first-use fallback, and later choices are restored locally. Unsupported provider/model combinations fail explicitly rather than being silently downgraded.

## Validation
- `npm test` (78 files, 518 tests)
- `npm run build`
- `cargo check`
- focused Chat Completions and Responses reasoning request tests
- `git diff --check`