### PR TITLE
Fix canonical timeline reloads and live session status

### DIFF
--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -599,8 +599,11 @@ The renderer queries canonical Turn summaries and runtime state through the Thre
 documented below. These commands accept `threadId` directly.
 
 `thread_get_turn_runtime_state` returns runtime events projected from the Thread's canonical
-Rollout plus one canonical timeline snapshot for product rendering. Rollout ordinals define event
-order; embedded event sequence values and in-memory thread items are not reconstruction sources.
+Rollout plus one canonical timeline snapshot for product rendering. Rollout ordinals define replay
+order. Persisted canonical runtime event envelopes retain their original sequence and timestamp so
+live patches and reloaded snapshots keep the same item identity; the Rollout ordinal and timestamp
+are fallback values for older records that do not carry that identity. In-memory thread items are
+not reconstruction sources.
 
 ```json
 {
@@ -638,14 +641,28 @@ order; embedded event sequence values and in-memory thread items are not reconst
 `item.sequence` is the source runtime-event position and never changes for an existing item.
 `item.revision` advances for each mutation of that item. `snapshotRevision` counts canonical
 timeline mutations only; diagnostic runtime events that do not produce an item do not advance it.
-This makes live patch revisions contiguous while preserving source ordering.
+This makes live patch revisions contiguous while preserving source identity. Snapshot array order
+is the authoritative replay/render order and does not need to be monotonic by source sequence.
+
+For Responses turns, the provider-native `function_call` remains the model-history record, while
+its canonical `agent.tool_call.delta` supplies the persisted timeline sequence and timestamp. This
+keeps model replay deduplicated and makes a reloaded Tool item match its live identity. When an
+older Rollout lacks that identity metadata, the desktop resolves a live/persisted sequence conflict
+by reloading the already-flushed durable snapshot and requires it to reach the patch revision.
+Tool outputs use their Rollout ordinal for replay order while retaining runtime sequence and
+timestamp as identity metadata, so completion cannot be replayed before its matching call. The
+projected snapshot preserves application order instead of sorting again by source sequence.
 
 `assistant_message.data.phase` is `unknown`, `commentary`, or `final_answer`. A provider-supplied
 phase is used immediately. For providers without phases, a model response followed by Tool calls is
 classified as `commentary`; a terminal response without Tool calls is classified as
-`final_answer`. Only `unknown` may transition to a classified phase. Reclassifying commentary as a
+`final_answer`. A tool-only provider response with empty assistant content does not create a
+timeline item or advance `snapshotRevision`; its Tool calls remain canonical items. Only `unknown`
+may transition to a classified phase. Reclassifying commentary as a
 final answer, changing a classified phase, or emitting Tool, Plan, Reasoning, Form, or
-Subagent work after the final answer is a protocol error and fails visibly. Plan completion is not a
+Subagent work after the final answer is a protocol error and returns a structured projection error.
+These state-machine checks belong to the backend; the renderer validates schema, revision
+continuity, and item identity, then renders the backend-provided order. Plan completion is not a
 final-answer signal.
 
 Provider reasoning is retained in provider-native replay records and debug runtime events, but it is

--- a/src-tauri/src/agent/runtime_protocol/timeline_projection.rs
+++ b/src-tauri/src/agent/runtime_protocol/timeline_projection.rs
@@ -15,6 +15,7 @@ pub struct AgentTimelineProjector {
     turn_id: String,
     order: Vec<String>,
     items: HashMap<String, AgentTurnItem>,
+    assistant_phases: HashMap<String, AgentAssistantMessagePhase>,
     snapshot_revision: u64,
     final_answer: Option<String>,
 }
@@ -24,12 +25,19 @@ pub fn project_turn_items_from_trace_events(
 ) -> Vec<AgentTurnItem> {
     let mut order = Vec::new();
     let mut items = HashMap::<String, AgentTurnItem>::new();
+    let mut assistant_phases = HashMap::<String, AgentAssistantMessagePhase>::new();
 
     for event in events {
         match canonical_event_kind(event) {
             Ok(Some(kind)) => {
-                apply_trace_event_to_items(&mut order, &mut items, event, kind)
-                    .unwrap_or_else(|error| panic!("{error}"));
+                apply_trace_event_to_items(
+                    &mut order,
+                    &mut items,
+                    &mut assistant_phases,
+                    event,
+                    kind,
+                )
+                .unwrap_or_else(|error| panic!("{error}"));
             }
             Ok(None) => {}
             Err(error) => panic!("{error}"),
@@ -45,6 +53,7 @@ pub fn project_turn_items_from_trace_events(
 fn apply_trace_event_to_items(
     order: &mut Vec<String>,
     items: &mut HashMap<String, AgentTurnItem>,
+    assistant_phases: &mut HashMap<String, AgentAssistantMessagePhase>,
     event: &AgentRuntimeEventEnvelope,
     event_kind: AgentEventKind,
 ) -> Result<Option<String>, String> {
@@ -55,6 +64,18 @@ fn apply_trace_event_to_items(
         .item_id
         .clone()
         .unwrap_or_else(|| projected_item_id(event, &kind));
+    if kind == AgentTurnItemKind::AssistantMessage
+        && matches!(
+            event_kind,
+            AgentEventKind::MessageClassified | AgentEventKind::MessageCompleted
+        )
+    {
+        validate_and_record_assistant_phase(
+            assistant_phases,
+            &item_id,
+            assistant_message_phase(&event.payload, event_kind),
+        )?;
+    }
     if kind == AgentTurnItemKind::AssistantMessage
         && !items.contains_key(&item_id)
         && matches!(
@@ -144,6 +165,7 @@ impl AgentTimelineProjector {
             turn_id: turn_id.into(),
             order: Vec::new(),
             items: HashMap::new(),
+            assistant_phases: HashMap::new(),
             snapshot_revision: 0,
             final_answer: None,
         }
@@ -173,8 +195,13 @@ impl AgentTimelineProjector {
         let Some(event_kind) = canonical_event_kind(event)? else {
             return Ok(None);
         };
-        let Some(item_id) =
-            apply_trace_event_to_items(&mut self.order, &mut self.items, event, event_kind)?
+        let Some(item_id) = apply_trace_event_to_items(
+            &mut self.order,
+            &mut self.items,
+            &mut self.assistant_phases,
+            event,
+            event_kind,
+        )?
         else {
             return Ok(None);
         };
@@ -495,7 +522,31 @@ fn validate_assistant_phase_transition(
     else {
         return Ok(());
     };
-    if previous_phase == next_phase || *previous_phase == AgentAssistantMessagePhase::Unknown {
+    validate_assistant_phase_change(*previous_phase, *next_phase, item_id)
+}
+
+fn validate_and_record_assistant_phase(
+    phases: &mut HashMap<String, AgentAssistantMessagePhase>,
+    item_id: &str,
+    next_phase: AgentAssistantMessagePhase,
+) -> Result<(), String> {
+    let previous_phase = phases
+        .get(item_id)
+        .copied()
+        .unwrap_or(AgentAssistantMessagePhase::Unknown);
+    validate_assistant_phase_change(previous_phase, next_phase, item_id)?;
+    if previous_phase == AgentAssistantMessagePhase::Unknown {
+        phases.insert(item_id.to_string(), next_phase);
+    }
+    Ok(())
+}
+
+fn validate_assistant_phase_change(
+    previous_phase: AgentAssistantMessagePhase,
+    next_phase: AgentAssistantMessagePhase,
+    item_id: &str,
+) -> Result<(), String> {
+    if previous_phase == next_phase || previous_phase == AgentAssistantMessagePhase::Unknown {
         return Ok(());
     }
     Err(format!(

--- a/src-tauri/src/agent/runtime_protocol/timeline_projection.rs
+++ b/src-tauri/src/agent/runtime_protocol/timeline_projection.rs
@@ -16,7 +16,7 @@ pub struct AgentTimelineProjector {
     order: Vec<String>,
     items: HashMap<String, AgentTurnItem>,
     snapshot_revision: u64,
-    final_answer: Option<(u64, String)>,
+    final_answer: Option<String>,
 }
 
 pub fn project_turn_items_from_trace_events(
@@ -28,7 +28,8 @@ pub fn project_turn_items_from_trace_events(
     for event in events {
         match canonical_event_kind(event) {
             Ok(Some(kind)) => {
-                apply_trace_event_to_items(&mut order, &mut items, event, kind);
+                apply_trace_event_to_items(&mut order, &mut items, event, kind)
+                    .unwrap_or_else(|error| panic!("{error}"));
             }
             Ok(None) => {}
             Err(error) => panic!("{error}"),
@@ -46,12 +47,24 @@ fn apply_trace_event_to_items(
     items: &mut HashMap<String, AgentTurnItem>,
     event: &AgentRuntimeEventEnvelope,
     event_kind: AgentEventKind,
-) -> Option<String> {
-    let kind = projected_item_kind(event, event_kind)?;
+) -> Result<Option<String>, String> {
+    let Some(kind) = projected_item_kind(event, event_kind) else {
+        return Ok(None);
+    };
     let item_id = event
         .item_id
         .clone()
         .unwrap_or_else(|| projected_item_id(event, &kind));
+    if kind == AgentTurnItemKind::AssistantMessage
+        && !items.contains_key(&item_id)
+        && matches!(
+            event_kind,
+            AgentEventKind::MessageClassified | AgentEventKind::MessageCompleted
+        )
+        && !assistant_event_has_content(event)
+    {
+        return Ok(None);
+    }
     let status = projected_item_status(event, event_kind);
     let payload = projected_item_payload(
         items.get(&item_id).map(|item| &item.payload),
@@ -64,10 +77,10 @@ fn apply_trace_event_to_items(
 
     if let Some(item) = items.get_mut(&item_id) {
         if item.kind != kind {
-            panic!(
+            return Err(format!(
                 "canonical timeline item `{item_id}` changed kind from {:?} to {:?}",
                 item.kind, kind
-            );
+            ));
         }
         if matches!(
             item.status,
@@ -76,12 +89,12 @@ fn apply_trace_event_to_items(
                 | AgentTurnItemStatus::Cancelled
         ) && item.status != status
         {
-            panic!(
+            return Err(format!(
                 "canonical timeline item `{item_id}` cannot transition from {:?} to {:?}",
                 item.status, status
-            );
+            ));
         }
-        validate_assistant_phase_transition(&item.data, &data, &item_id);
+        validate_assistant_phase_transition(&item.data, &data, &item_id)?;
         item.status = status;
         item.updated_at = Some(event.timestamp.clone());
         item.revision += 1;
@@ -121,7 +134,7 @@ fn apply_trace_event_to_items(
             },
         );
     }
-    Some(item_id)
+    Ok(Some(item_id))
 }
 
 impl AgentTimelineProjector {
@@ -161,7 +174,7 @@ impl AgentTimelineProjector {
             return Ok(None);
         };
         let Some(item_id) =
-            apply_trace_event_to_items(&mut self.order, &mut self.items, event, event_kind)
+            apply_trace_event_to_items(&mut self.order, &mut self.items, event, event_kind)?
         else {
             return Ok(None);
         };
@@ -184,17 +197,11 @@ impl AgentTimelineProjector {
     }
 
     pub fn snapshot(&self) -> Result<AgentTimelineSnapshot, String> {
-        let mut items = self
+        let items = self
             .order
             .iter()
             .filter_map(|item_id| self.items.get(item_id).cloned())
             .collect::<Vec<_>>();
-        items.sort_by(|left, right| {
-            left.sequence
-                .cmp(&right.sequence)
-                .then_with(|| left.item_id.cmp(&right.item_id))
-        });
-        validate_final_answer_boundary(&items)?;
         Ok(AgentTimelineSnapshot {
             schema_version: AGENT_TIMELINE_SCHEMA_VERSION.to_string(),
             session_id: self.session_id.clone(),
@@ -209,8 +216,8 @@ impl AgentTimelineProjector {
             .items
             .get(item_id)
             .ok_or_else(|| format!("projected timeline item `{item_id}` is missing"))?;
-        if let Some((final_sequence, final_item_id)) = self.final_answer.as_ref() {
-            if item.sequence > *final_sequence && item_is_disallowed_after_final(item) {
+        if let Some(final_item_id) = self.final_answer.as_ref() {
+            if item.item_id != *final_item_id && item_is_disallowed_after_final(item) {
                 return Err(format!(
                     "canonical timeline item `{}` appears after final answer `{}`",
                     item.item_id, final_item_id
@@ -220,15 +227,7 @@ impl AgentTimelineProjector {
         if !item_is_final_answer(item) || self.final_answer.is_some() {
             return Ok(());
         }
-        if let Some(invalid) = self.items.values().find(|candidate| {
-            candidate.sequence > item.sequence && item_is_disallowed_after_final(candidate)
-        }) {
-            return Err(format!(
-                "canonical timeline item `{}` appears after final answer `{}`",
-                invalid.item_id, item.item_id
-            ));
-        }
-        self.final_answer = Some((item.sequence, item.item_id.clone()));
+        self.final_answer = Some(item.item_id.clone());
         Ok(())
     }
 }
@@ -483,7 +482,7 @@ fn validate_assistant_phase_transition(
     previous: &AgentTurnItemData,
     next: &AgentTurnItemData,
     item_id: &str,
-) {
+) -> Result<(), String> {
     let (
         AgentTurnItemData::AssistantMessage {
             phase: previous_phase,
@@ -494,30 +493,14 @@ fn validate_assistant_phase_transition(
         },
     ) = (previous, next)
     else {
-        return;
-    };
-    if previous_phase == next_phase || *previous_phase == AgentAssistantMessagePhase::Unknown {
-        return;
-    }
-    panic!(
-        "canonical assistant item `{item_id}` cannot transition phase from {previous_phase:?} to {next_phase:?}"
-    );
-}
-
-fn validate_final_answer_boundary(items: &[AgentTurnItem]) -> Result<(), String> {
-    let Some(final_item) = items.iter().find(|item| item_is_final_answer(item)) else {
         return Ok(());
     };
-    if let Some(invalid) = items
-        .iter()
-        .find(|item| item.sequence > final_item.sequence && item_is_disallowed_after_final(item))
-    {
-        return Err(format!(
-            "canonical timeline item `{}` appears after final answer `{}`",
-            invalid.item_id, final_item.item_id
-        ));
+    if previous_phase == next_phase || *previous_phase == AgentAssistantMessagePhase::Unknown {
+        return Ok(());
     }
-    Ok(())
+    Err(format!(
+        "canonical assistant item `{item_id}` cannot transition phase from {previous_phase:?} to {next_phase:?}"
+    ))
 }
 
 fn item_is_final_answer(item: &AgentTurnItem) -> bool {
@@ -1304,6 +1287,11 @@ fn payload_text_fragment(payload: &Value) -> Option<&str> {
     ["delta", "finalContent", "content", "text", "message"]
         .into_iter()
         .find_map(|key| payload.get(key).and_then(Value::as_str))
+}
+
+fn assistant_event_has_content(event: &AgentRuntimeEventEnvelope) -> bool {
+    let payload = event.payload.get("agentItem").unwrap_or(&event.payload);
+    payload_text_fragment(payload).is_some_and(|content| !content.trim().is_empty())
 }
 
 fn done_event_has_final_content(payload: &Value) -> bool {

--- a/src-tauri/src/agent/runtime_protocol_tests.rs
+++ b/src-tauri/src/agent/runtime_protocol_tests.rs
@@ -829,7 +829,6 @@ fn timeline_snapshot_and_patch_share_revision_and_item_projection() {
 }
 
 #[test]
-#[should_panic(expected = "cannot transition from Completed to Running")]
 fn canonical_projection_rejects_terminal_status_regression() {
     let events = vec![
         runtime_event(
@@ -850,7 +849,10 @@ fn canonical_projection_rejects_terminal_status_regression() {
         ),
     ];
 
-    let _ = project_timeline_snapshot("session-1", "turn-terminal", &events);
+    let error = project_timeline_snapshot("session-1", "turn-terminal", &events)
+        .expect_err("terminal status regression must be rejected without panicking");
+
+    assert!(error.contains("cannot transition from Completed to Running"));
 }
 
 #[test]
@@ -1073,7 +1075,6 @@ fn canonical_projection_omits_non_user_reasoning() {
 }
 
 #[test]
-#[should_panic(expected = "cannot transition phase from Commentary to FinalAnswer")]
 fn canonical_projection_rejects_reclassifying_commentary_as_final_answer() {
     let events = vec![
         runtime_event(
@@ -1098,7 +1099,10 @@ fn canonical_projection_rejects_reclassifying_commentary_as_final_answer() {
         ),
     ];
 
-    let _ = project_turn_items_from_trace_events(&events);
+    let error = project_timeline_snapshot("session-1", "turn-phase-regression", &events)
+        .expect_err("assistant phase reclassification must be rejected without panicking");
+
+    assert!(error.contains("cannot transition phase from Commentary to FinalAnswer"));
 }
 
 #[test]
@@ -1130,6 +1134,52 @@ fn canonical_timeline_rejects_work_after_final_answer() {
         .expect_err("post-final work must be rejected");
 
     assert!(error.contains("appears after final answer"));
+}
+
+#[test]
+fn canonical_timeline_uses_replay_order_for_final_answer_boundary() {
+    let events = vec![
+        runtime_event(
+            "turn-mixed-sequence",
+            "agent.tool.start",
+            AgentRuntimePhase::ToolRunning,
+            Some("tool-1"),
+            56,
+            json!({ "toolCallId": "tool-1", "toolName": "shell" }),
+        ),
+        runtime_event(
+            "turn-mixed-sequence",
+            "agent.tool.result",
+            AgentRuntimePhase::Completed,
+            Some("tool-1"),
+            67,
+            json!({ "toolCallId": "tool-1", "toolName": "shell" }),
+        ),
+        runtime_event(
+            "turn-mixed-sequence",
+            "agent.message.completed",
+            AgentRuntimePhase::Completed,
+            Some("message-1"),
+            55,
+            json!({
+                "content": "Done.",
+                "modelCallId": "call-0",
+                "messagePhase": "final_answer"
+            }),
+        ),
+    ];
+
+    let snapshot = project_timeline_snapshot("session-1", "turn-mixed-sequence", &events)
+        .expect("replay order, not source sequence, defines the final-answer boundary");
+
+    assert_eq!(
+        snapshot
+            .items
+            .iter()
+            .map(|item| (item.item_id.as_str(), item.sequence))
+            .collect::<Vec<_>>(),
+        vec![("tool-1", 56), ("message-1", 55)]
+    );
 }
 
 #[test]

--- a/src-tauri/src/threads/domain/store/runtime_projection.rs
+++ b/src-tauri/src/threads/domain/store/runtime_projection.rs
@@ -359,7 +359,7 @@ pub(crate) fn runtime_events_from_thread_items(
                     ))
             )
     });
-    items
+    let mut events = items
         .iter()
         .filter(|item| item.turn_id == turn_id)
         .filter(|item| {
@@ -374,7 +374,29 @@ pub(crate) fn runtime_events_from_thread_items(
                 )
         })
         .filter_map(|item| runtime_event_from_thread_item(item, session_id))
-        .collect()
+        .collect::<Vec<_>>();
+    let event_item_ids = events
+        .iter()
+        .filter_map(|event| event.item_id.clone())
+        .collect::<HashSet<_>>();
+    for item_id in event_item_ids {
+        let positions = events
+            .iter()
+            .enumerate()
+            .filter_map(|(index, event)| {
+                (event.item_id.as_deref() == Some(&item_id)).then_some(index)
+            })
+            .collect::<Vec<_>>();
+        let mut item_events = positions
+            .iter()
+            .map(|index| events[*index].clone())
+            .collect::<Vec<_>>();
+        item_events.sort_by_key(|event| event.sequence);
+        for (position, event) in positions.into_iter().zip(item_events) {
+            events[position] = event;
+        }
+    }
+    events
 }
 
 pub(super) fn turn_items_from_thread_items(

--- a/src-tauri/src/threads/domain/store/runtime_projection.rs
+++ b/src-tauri/src/threads/domain/store/runtime_projection.rs
@@ -5,6 +5,7 @@ use crate::agent::runtime_protocol::{
 };
 use crate::threads::domain::types::{ThreadItem, ThreadItemKind};
 use serde_json::Value;
+use std::collections::HashSet;
 
 fn semantic_event_from_thread_item(item: &ThreadItem) -> Option<(AgentEventKind, Value)> {
     match &item.kind {
@@ -18,6 +19,7 @@ fn semantic_event_from_thread_item(item: &ThreadItem) -> Option<(AgentEventKind,
                 "content": response_item_text(value),
                 "messageId": value.get("messageId").or_else(|| value.get("id")).cloned().unwrap_or_else(|| Value::String(item.item_id.clone())),
                 "messagePhase": value.get("phase").cloned().unwrap_or_else(|| Value::String("final_answer".to_string())),
+                "modelCallId": value.get("modelCallId").or_else(|| value.get("model_call_id")).cloned().unwrap_or(Value::Null),
             }),
         )),
         ThreadItemKind::Reasoning(value) => Some((
@@ -63,17 +65,15 @@ fn semantic_event_from_thread_item(item: &ThreadItem) -> Option<(AgentEventKind,
         }
         ThreadItemKind::Error(value) => Some((AgentEventKind::Error, value.clone())),
         ThreadItemKind::Cancelled(value) => Some((AgentEventKind::Cancelled, value.clone())),
-        ThreadItemKind::ContextCompaction(value) => {
-            persisted_context_state_event(value).or_else(|| {
-                Some((
-                    AgentEventKind::ContextCompacted,
-                    context_checkpoint(value).clone(),
-                ))
-            })
-        }
-        ThreadItemKind::ContextTrimmed(value) => persisted_context_state_event(value)
+        ThreadItemKind::ContextCompaction(value) => persisted_semantic_event(value).or_else(|| {
+            Some((
+                AgentEventKind::ContextCompacted,
+                context_checkpoint(value).clone(),
+            ))
+        }),
+        ThreadItemKind::ContextTrimmed(value) => persisted_semantic_event(value)
             .or_else(|| Some((AgentEventKind::ContextTrimmed, value.clone()))),
-        ThreadItemKind::Event(value) => persisted_context_state_event(value),
+        ThreadItemKind::Event(value) => persisted_semantic_event(value),
         ThreadItemKind::AssistantMessageDelta(_)
         | ThreadItemKind::TurnStarted(_)
         | ThreadItemKind::TurnStep(_)
@@ -96,7 +96,7 @@ fn persisted_tool_result_status(value: &Value, result: &Value) -> Option<String>
     }
 }
 
-fn persisted_context_state_event(value: &Value) -> Option<(AgentEventKind, Value)> {
+fn persisted_semantic_event(value: &Value) -> Option<(AgentEventKind, Value)> {
     let event = if value.get("eventName").is_some() {
         value
     } else {
@@ -109,7 +109,8 @@ fn persisted_context_state_event(value: &Value) -> Option<(AgentEventKind, Value
         EventNameResolution::Canonical(
             kind @ (AgentEventKind::ContextCompacted
             | AgentEventKind::ContextTrimmed
-            | AgentEventKind::Usage),
+            | AgentEventKind::Usage
+            | AgentEventKind::ToolCallDelta),
         ) => kind,
         EventNameResolution::Canonical(_)
         | EventNameResolution::DeprecatedIgnored(_)
@@ -197,6 +198,7 @@ fn runtime_event_from_thread_item(
 ) -> Option<AgentRuntimeEventEnvelope> {
     let (event_kind, payload) = semantic_event_from_thread_item(item)?;
     let item_id = semantic_item_id(item);
+    let (sequence, timestamp) = persisted_runtime_event_identity(item);
     let phase = event_kind
         .definition()
         .resolve_phase(&AgentRuntimePhase::Planning, &payload)
@@ -210,12 +212,37 @@ fn runtime_event_from_thread_item(
             item_id: Some(item_id),
             event_kind,
             phase,
-            sequence: item.sequence,
-            timestamp: item.created_at.clone(),
+            sequence,
+            timestamp,
             trace_context: None,
             payload,
         },
     ))
+}
+
+fn persisted_runtime_event_identity(item: &ThreadItem) -> (u64, String) {
+    let value = match &item.kind {
+        ThreadItemKind::Event(value)
+        | ThreadItemKind::AssistantMessageCompleted(value)
+        | ThreadItemKind::Reasoning(value)
+        | ThreadItemKind::ToolCallStarted(value)
+        | ThreadItemKind::ToolCallOutput(value) => value,
+        _ => return (item.sequence, item.created_at.clone()),
+    };
+    let sequence = value
+        .get("sequence")
+        .or_else(|| value.get("threadItemSequence"))
+        .or_else(|| value.get("thread_item_sequence"))
+        .and_then(Value::as_u64)
+        .unwrap_or(item.sequence);
+    let timestamp = value
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|timestamp| !timestamp.is_empty())
+        .unwrap_or(&item.created_at)
+        .to_string();
+    (sequence, timestamp)
 }
 
 fn semantic_item_id(item: &ThreadItem) -> String {
@@ -302,12 +329,31 @@ pub(crate) fn runtime_events_from_thread_items(
     session_id: &str,
     turn_id: &str,
 ) -> Vec<AgentRuntimeEventEnvelope> {
+    let persisted_tool_call_ids = items
+        .iter()
+        .filter(|item| item.turn_id == turn_id)
+        .filter_map(|item| match &item.kind {
+            ThreadItemKind::Event(value) => persisted_semantic_event(value),
+            _ => None,
+        })
+        .filter_map(|(kind, payload)| {
+            (kind == AgentEventKind::ToolCallDelta)
+                .then(|| {
+                    payload
+                        .get("toolCallId")
+                        .or_else(|| payload.get("tool_call_id"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .flatten()
+        })
+        .collect::<HashSet<_>>();
     let has_persisted_context_event = items.iter().any(|item| {
         item.turn_id == turn_id
             && matches!(
                 &item.kind,
                 ThreadItemKind::Event(value)
-                    if persisted_context_state_event(value).is_some_and(|(kind, _)| matches!(
+                    if persisted_semantic_event(value).is_some_and(|(kind, _)| matches!(
                         kind,
                         AgentEventKind::ContextCompacted | AgentEventKind::ContextTrimmed
                     ))
@@ -316,6 +362,10 @@ pub(crate) fn runtime_events_from_thread_items(
     items
         .iter()
         .filter(|item| item.turn_id == turn_id)
+        .filter(|item| {
+            !matches!(&item.kind, ThreadItemKind::ToolCallStarted(_))
+                || !persisted_tool_call_ids.contains(&semantic_item_id(item))
+        })
         .filter(|item| {
             !has_persisted_context_event
                 || !matches!(

--- a/src-tauri/src/threads/domain/store/runtime_projection_tests.rs
+++ b/src-tauri/src/threads/domain/store/runtime_projection_tests.rs
@@ -1,6 +1,6 @@
 use super::{runtime_events_from_thread_items, turn_items_from_thread_items};
 use crate::agent::runtime_protocol::{
-    AgentRuntimeEventVisibility, AgentTurnItemData, AgentTurnItemKind,
+    AgentRuntimeEventVisibility, AgentTurnItemData, AgentTurnItemKind, AgentTurnItemStatus,
 };
 use crate::threads::domain::types::{ThreadItem, ThreadItemKind};
 use serde_json::json;
@@ -30,6 +30,66 @@ fn typed_record_uses_rollout_identity_sequence_and_timestamp() {
     assert_eq!(events[0].session_id, "canonical-session");
     assert_eq!(events[0].thread_id.as_deref(), Some("canonical-thread"));
     assert_eq!(events[0].turn_id, "canonical-turn");
+}
+
+#[test]
+fn persisted_runtime_events_replay_in_canonical_sequence_order() {
+    let item = |item_id: &str, sequence: u64, kind: ThreadItemKind| ThreadItem {
+        item_id: item_id.to_string(),
+        thread_id: "thread-1".to_string(),
+        turn_id: "turn-1".to_string(),
+        parent_item_id: None,
+        sequence,
+        created_at: sequence.to_string(),
+        kind,
+    };
+    let items = vec![
+        item(
+            "tool-output:call-1",
+            1,
+            ThreadItemKind::ToolCallOutput(json!({
+                "type": "function_call_output",
+                "call_id": "call-1",
+                "status": "error",
+                "output": "invalid arguments",
+                "sequence": 9,
+                "timestamp": "2026-08-14T10:00:00.009Z",
+            })),
+        ),
+        item(
+            "event:call-1",
+            2,
+            ThreadItemKind::Event(json!({
+                "eventName": "agent.tool_call.delta",
+                "itemId": "call-1",
+                "sequence": 8,
+                "timestamp": "2026-08-14T10:00:00.008Z",
+                "payload": {
+                    "toolCallId": "call-1",
+                    "toolName": "workspace.write_file",
+                    "argumentsDelta": "{not json",
+                },
+            })),
+        ),
+    ];
+
+    let events = runtime_events_from_thread_items(&items, "thread-1", "turn-1");
+
+    assert_eq!(
+        events
+            .iter()
+            .map(|event| (event.event_name.as_str(), event.sequence))
+            .collect::<Vec<_>>(),
+        vec![("agent.tool_call.delta", 8), ("agent.tool.result", 9)],
+    );
+    let projected = turn_items_from_thread_items(&items, "thread-1", "turn-1");
+    assert_eq!(projected.len(), 1);
+    assert_eq!(projected[0].status, AgentTurnItemStatus::Completed);
+    assert!(matches!(
+        &projected[0].data,
+        AgentTurnItemData::ToolCall { result_status, .. }
+            if result_status.as_deref() == Some("error")
+    ));
 }
 
 #[test]

--- a/src-tauri/src/threads/domain/store/runtime_projection_tests.rs
+++ b/src-tauri/src/threads/domain/store/runtime_projection_tests.rs
@@ -433,13 +433,13 @@ fn persisted_usage_restores_context_window_after_session_reload() {
         thread_id: "thread-1".to_string(),
         turn_id: "turn-1".to_string(),
         parent_item_id: None,
-        sequence: 8,
+        sequence: 2,
         created_at: "2026-08-03T12:00:01Z".to_string(),
         kind: ThreadItemKind::Event(json!({
             "itemId": "usage-1",
             "eventId": "usage-event-1",
-            "sequence": 8,
-            "timestamp": "2026-08-03T12:00:01Z",
+            "sequence": 23,
+            "timestamp": "1786673534920",
             "eventName": "agent.usage",
             "turnId": "turn-1",
             "source": "provider",
@@ -459,10 +459,14 @@ fn persisted_usage_restores_context_window_after_session_reload() {
     let events = runtime_events_from_thread_items(&items, "thread-1", "turn-1");
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].event_name, "agent.usage");
+    assert_eq!(events[0].sequence, 23);
+    assert_eq!(events[0].timestamp, "1786673534920");
 
     let projected = turn_items_from_thread_items(&items, "thread-1", "turn-1");
     assert_eq!(projected.len(), 1);
     assert_eq!(projected[0].kind, AgentTurnItemKind::Usage);
+    assert_eq!(projected[0].sequence, 23);
+    assert_eq!(projected[0].created_at, "1786673534920");
     assert!(matches!(
         &projected[0].data,
         AgentTurnItemData::Usage { provider_payload, .. }

--- a/src-tauri/src/threads/rollout/store/README.md
+++ b/src-tauri/src/threads/rollout/store/README.md
@@ -118,17 +118,34 @@ successful append.
 
 ## Timeline projection and replay
 
-Rollout ordinals define runtime-event order. A projected timeline item keeps the
-source event position as `sequence`; updates advance `revision` without changing
-that sequence. `snapshotRevision` advances only for canonical timeline
-mutations, so live patches are contiguous even when diagnostic events occur
-between them.
+Rollout line order defines runtime-event replay order. A persisted canonical
+runtime event retains its source `sequence` and timestamp so live patches and
+reloaded snapshots project the same item identity; the Rollout ordinal and
+timestamp are fallbacks for older events that do not carry those fields. Updates
+advance `revision` without changing the source sequence. `snapshotRevision`
+advances only for canonical timeline mutations, so live patches are contiguous
+even when diagnostic events occur between them.
+
+In Responses mode, the provider-native `function_call` remains the model replay
+record. Its later `agent.tool_call.delta` is also persisted as a lightweight
+timeline-identity event so reconstruction uses the live Tool call's sequence
+and timestamp without duplicating the provider call in model history. Older
+Rollouts without that identity event continue to use their response-item
+ordinal.
+
+Tool outputs retain their source sequence and timestamp as runtime identity
+metadata, but their Rollout ordinal remains the replay position. This keeps a
+completion after its matching call identity even when runtime sequence values
+are numerically lower than later Rollout ordinals. Timeline snapshots preserve
+the resulting application order instead of sorting again by source sequence.
 
 Assistant-message identities are scoped to one provider/model call. Provider
 IDs are retained when available; otherwise the projector derives a stable ID
 from the provider attempt or iteration. Deltas coalesce only into that matching
-item. Reasoning identities remain available to replay and diagnostics but do
-not create product-facing timeline items.
+item. A tool-only provider response with no assistant content does not create a
+live-only empty item or advance `snapshotRevision`. Reasoning identities remain
+available to replay and diagnostics but do not create product-facing timeline
+items.
 
 Thread-owned runtime-event records persist the canonical item identity.
 Reconstruction of older records recovers assistant and reasoning identity from

--- a/src-tauri/src/threads/rollout/store/mod.rs
+++ b/src-tauri/src/threads/rollout/store/mod.rs
@@ -2996,6 +2996,15 @@ fn thread_items_from_effective_rollout(
                     .or_else(|| item.as_value().get("thread_item_sequence"))
                     .and_then(Value::as_u64)
                     .unwrap_or(sequence);
+                let kind = response_item_thread_kind(item.as_value());
+                // Tool output mutates an existing call, so its source sequence is identity
+                // metadata rather than replay order. Keep the Rollout position to ensure the
+                // persisted call identity is always reconstructed before its completion.
+                let replay_sequence = if matches!(&kind, ThreadItemKind::ToolCallOutput(_)) {
+                    sequence
+                } else {
+                    item_sequence
+                };
                 Some(ThreadItem {
                     item_id: rollout_thread_item_id(item.as_value(), thread_id, item_sequence),
                     thread_id: thread_id.to_string(),
@@ -3009,9 +3018,9 @@ fn thread_items_from_effective_rollout(
                     )?,
                     parent_item_id: string_value(item.as_value(), "parentItemId")
                         .or_else(|| string_value(item.as_value(), "parent_item_id")),
-                    sequence: item_sequence,
+                    sequence: replay_sequence,
                     created_at: line.timestamp.clone(),
-                    kind: response_item_thread_kind(item.as_value()),
+                    kind,
                 })
             }
             ThreadLogItem::EventMsg(event) if event.kind() == &EventKind::ThreadItem => {

--- a/src-tauri/src/threads/rollout/store/store_schema_tests.rs
+++ b/src-tauri/src/threads/rollout/store/store_schema_tests.rs
@@ -154,6 +154,112 @@ fn rollout_reconstruction_skips_historical_approval_items_without_losing_other_h
 }
 
 #[test]
+fn legacy_responses_history_uses_replay_order_across_mixed_source_sequences() {
+    let turn_id = "turn-mixed-sequence";
+    let thread_id = "thread-mixed-sequence";
+    let lines = vec![
+        ThreadLogLine {
+            timestamp: "2026-08-14T07:20:01Z".to_string(),
+            ordinal: Some(39),
+            item: value_event(
+                EventKind::ThreadItem,
+                serde_json::json!({
+                    "item": {
+                        "itemId": "semantic-tool-call",
+                        "threadId": thread_id,
+                        "turnId": turn_id,
+                        "sequence": 0,
+                        "createdAt": "2026-08-14T07:20:01Z",
+                        "kind": {
+                            "type": "event",
+                            "payload": {
+                                "schemaVersion": "tinybot.agent_event.v1",
+                                "eventId": "tool-call-event",
+                                "sequence": 56,
+                                "sessionId": thread_id,
+                                "threadId": thread_id,
+                                "turnId": turn_id,
+                                "itemId": "call-1",
+                                "eventName": "agent.tool_call.delta",
+                                "phase": "tool_calling",
+                                "timestamp": "1786692001743",
+                                "source": "tool",
+                                "visibility": "user",
+                                "payload": {
+                                    "toolCallId": "call-1",
+                                    "toolName": "exec_command",
+                                    "argumentsDelta": "{}"
+                                }
+                            }
+                        }
+                    }
+                }),
+            ),
+        },
+        ThreadLogLine {
+            timestamp: "2026-08-14T07:20:02Z".to_string(),
+            ordinal: Some(42),
+            item: ThreadLogItem::ResponseItem(
+                typed_response_item(
+                    serde_json::json!({
+                        "type": "function_call_output",
+                        "call_id": "call-1",
+                        "turnId": turn_id,
+                        "threadItemSequence": 67,
+                        "timestamp": "1786692002260",
+                        "status": "ok",
+                        "output": "done"
+                    }),
+                    "legacy mixed-sequence test output",
+                )
+                .unwrap(),
+            ),
+        },
+        ThreadLogLine {
+            timestamp: "2026-08-14T07:20:03Z".to_string(),
+            ordinal: Some(55),
+            item: ThreadLogItem::ResponseItem(
+                typed_response_item(
+                    serde_json::json!({
+                        "type": "message",
+                        "id": "final-1",
+                        "role": "assistant",
+                        "turnId": turn_id,
+                        "content": [{ "type": "output_text", "text": "Done." }]
+                    }),
+                    "legacy mixed-sequence test final answer",
+                )
+                .unwrap(),
+            ),
+        },
+    ];
+
+    let thread_items = thread_items_from_effective_rollout(&lines, &[0, 1, 2], thread_id)
+        .expect("legacy Rollout should reconstruct");
+    let events =
+        crate::threads::domain::runtime_events_from_thread_items(&thread_items, thread_id, turn_id);
+    assert_eq!(
+        events
+            .iter()
+            .map(|event| event.sequence)
+            .collect::<Vec<_>>(),
+        vec![56, 67, 55]
+    );
+
+    let snapshot =
+        crate::agent::runtime_protocol::project_timeline_snapshot(thread_id, turn_id, &events)
+            .expect("replay order should keep historical tools before the final answer");
+    assert_eq!(
+        snapshot
+            .items
+            .iter()
+            .map(|item| item.item_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["call-1", "final-1"]
+    );
+}
+
+#[test]
 fn repeated_identical_thread_record_does_not_append_metadata_snapshot() {
     let root = std::env::temp_dir().join(format!(
         "tinybot-thread-metadata-noop-{}-{}",

--- a/src-tauri/src/threads/rollout/store/turn.rs
+++ b/src-tauri/src/threads/rollout/store/turn.rs
@@ -12,6 +12,7 @@ use super::{
 use crate::agent::runtime_protocol::{resolve_event_name, AgentEventKind, EventNameResolution};
 use crate::protocol::capability::WorkerCapability;
 use crate::protocol::{WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource};
+use crate::threads::rollout::format::SessionApiMode;
 use crate::threads::turn::{
     AgentTurnCheckpoint, AgentTurnRecord, AgentTurnRuntimeState, AgentTurnStatus,
 };
@@ -272,6 +273,39 @@ impl WorkerThreadLogRpc {
                 represented_function_calls.insert(call_id);
             }
             appended_response_items |= !response_items.is_empty();
+            let response_items_preserve_event_identity = api_mode
+                == SessionApiMode::ChatCompletions
+                || matches!(
+                    runtime_event_kind(&event),
+                    Some(AgentEventKind::TurnStarted | AgentEventKind::ToolResult)
+                );
+            let response_items_contain_assistant_message = matches!(
+                runtime_event_kind(&event),
+                Some(AgentEventKind::MessageClassified | AgentEventKind::MessageCompleted)
+            );
+            let event_sequence = event.get("sequence").and_then(Value::as_u64);
+            let event_timestamp = event
+                .get("timestamp")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|timestamp| !timestamp.is_empty())
+                .map(str::to_string);
+            let event_model_call_id = event
+                .get("payload")
+                .and_then(|payload| {
+                    payload
+                        .get("modelCallId")
+                        .or_else(|| payload.get("model_call_id"))
+                })
+                .cloned();
+            let event_message_phase = event
+                .get("payload")
+                .and_then(|payload| {
+                    payload
+                        .get("messagePhase")
+                        .or_else(|| payload.get("message_phase"))
+                })
+                .cloned();
             let response_items = response_items
                 .into_iter()
                 .map(|mut item| {
@@ -286,6 +320,37 @@ impl WorkerThreadLogRpc {
                                     .to_string(),
                             ),
                         );
+                        let is_assistant_message = object.get("type").and_then(Value::as_str)
+                            == Some("message")
+                            && object.get("role").and_then(Value::as_str) == Some("assistant");
+                        if response_items_contain_assistant_message && is_assistant_message {
+                            if !object.contains_key("modelCallId") {
+                                if let Some(model_call_id) = event_model_call_id.as_ref() {
+                                    object.insert("modelCallId".to_string(), model_call_id.clone());
+                                }
+                            }
+                            if !object.contains_key("phase") {
+                                if let Some(message_phase) = event_message_phase.as_ref() {
+                                    object.insert("phase".to_string(), message_phase.clone());
+                                }
+                            }
+                        }
+                        if response_items_preserve_event_identity
+                            || (response_items_contain_assistant_message && is_assistant_message)
+                        {
+                            if let Some(sequence) = event_sequence {
+                                object.insert(
+                                    "threadItemSequence".to_string(),
+                                    Value::Number(sequence.into()),
+                                );
+                            }
+                            if let Some(timestamp) = event_timestamp.as_ref() {
+                                object.insert(
+                                    "timestamp".to_string(),
+                                    Value::String(timestamp.clone()),
+                                );
+                            }
+                        }
                     }
                     item
                 })
@@ -325,9 +390,9 @@ impl WorkerThreadLogRpc {
             for response_item in response_items {
                 items.push(ThreadLogItem::ResponseItem(response_item));
             }
-            if let Some(thread_item) =
-                semantic_thread_item_from_runtime_event(session_id, turn_id, &timestamp, &event)
-            {
+            if let Some(thread_item) = semantic_thread_item_from_runtime_event(
+                session_id, turn_id, &timestamp, &event, api_mode,
+            ) {
                 items.push(value_event(
                     super::EventKind::ThreadItem,
                     serde_json::json!({ "item": thread_item }),
@@ -1011,6 +1076,7 @@ fn semantic_thread_item_from_runtime_event(
     turn_id: &str,
     timestamp: &str,
     event: &Value,
+    api_mode: SessionApiMode,
 ) -> Option<crate::threads::domain::ThreadItem> {
     let payload = event.get("payload").cloned().unwrap_or(Value::Null);
     let kind = match runtime_event_kind(event)? {
@@ -1028,6 +1094,9 @@ fn semantic_thread_item_from_runtime_event(
         AgentEventKind::ContextCompacted
         | AgentEventKind::ContextTrimmed
         | AgentEventKind::Usage => crate::threads::domain::ThreadItemKind::Event(event.clone()),
+        AgentEventKind::ToolCallDelta if api_mode == SessionApiMode::Responses => {
+            crate::threads::domain::ThreadItemKind::Event(event.clone())
+        }
         _ => return None,
     };
     let event_id = event.get("eventId").and_then(Value::as_str)?;

--- a/src-tauri/src/threads/rollout/store/turn_tests.rs
+++ b/src-tauri/src/threads/rollout/store/turn_tests.rs
@@ -2,6 +2,7 @@ use super::{
     completed_tool_result_from_response_item, response_item_from_runtime_event,
     response_items_from_runtime_event,
 };
+use crate::agent::runtime_protocol::{project_timeline_snapshot, AgentRuntimeEventEnvelope};
 use crate::protocol::capability::{CapabilityPolicy, WorkerCapability};
 use crate::threads::rollout::format::SessionApiMode;
 use crate::threads::rollout::store::{
@@ -410,6 +411,347 @@ fn completed_standalone_compaction_runtime_state_keeps_the_turn_boundary() {
     assert_eq!(serialized["stopReason"], "context_compacted");
     assert_eq!(runtime_state.timeline.items.len(), 1);
     assert_eq!(serialized["timeline"]["items"][0]["status"], "running");
+
+    drop(rpc);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn persisted_usage_preserves_the_live_timeline_item_identity() {
+    let root = std::env::temp_dir().join(format!(
+        "tinybot-usage-timeline-identity-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    let rpc = WorkerThreadLogRpc::new(
+        root.clone(),
+        CapabilityPolicy::new([
+            WorkerCapability::SessionWrite,
+            WorkerCapability::SessionMetadataRead,
+        ]),
+    );
+    let session_id = "usage-timeline-session";
+    let turn_id = "turn-usage";
+    let started_at = "2026-08-14T02:12:10.469Z";
+    rpc.start_turn(
+        AgentTurnRecord {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            thread_id: None,
+            parent_thread_id: None,
+            child_thread_ids: Vec::new(),
+            status: AgentTurnStatus::Running,
+            phase: "calling_model".to_string(),
+            started_at: started_at.to_string(),
+            updated_at: started_at.to_string(),
+            completed_at: None,
+            stop_reason: None,
+            model: "gpt-test".to_string(),
+            provider: Some("openai".to_string()),
+            max_iterations: 1,
+            current_iteration: 0,
+            conversation_message_ids: Vec::new(),
+            trace_messages: Vec::new(),
+            completed_tool_results: Vec::new(),
+            pending_tool_calls: Vec::new(),
+            checkpoint: None,
+            artifacts: Vec::new(),
+            usage: Vec::new(),
+            token_usage_info: None,
+            instruction_provenance: None,
+            instruction_diagnostics: Vec::new(),
+            trace_context: None,
+            error: None,
+        },
+        None,
+        Vec::new(),
+    )
+    .unwrap();
+    let live_event: AgentRuntimeEventEnvelope = serde_json::from_value(json!({
+        "schemaVersion": "tinybot.agent_event.v1",
+        "eventId": "turn-usage:agent-usage:23",
+        "sequence": 23,
+        "sessionId": session_id,
+        "threadId": session_id,
+        "turnId": turn_id,
+        "itemId": "turn-usage:usage:0",
+        "eventName": "agent.usage",
+        "phase": "calling_model",
+        "timestamp": "1786673534920",
+        "source": "provider",
+        "visibility": "debug",
+        "payload": {
+            "iteration": 0,
+            "modelCallId": "turn-usage:provider:1",
+            "usage": {
+                "inputTokens": 4469,
+                "outputTokens": 219,
+                "totalTokens": 4688
+            }
+        }
+    }))
+    .unwrap();
+    let live_timeline =
+        project_timeline_snapshot(session_id, turn_id, std::slice::from_ref(&live_event)).unwrap();
+
+    rpc.append_turn_semantic_event(
+        session_id,
+        turn_id,
+        serde_json::to_value(&live_event).unwrap(),
+    )
+    .unwrap();
+    let reloaded = rpc
+        .get_turn_runtime_state(session_id, turn_id)
+        .unwrap()
+        .expect("persisted usage should reload");
+
+    assert_eq!(reloaded.timeline.items, live_timeline.items);
+    assert_eq!(
+        reloaded.timeline.snapshot_revision,
+        live_timeline.snapshot_revision
+    );
+
+    drop(rpc);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn persisted_responses_tool_call_preserves_the_live_timeline_item_identity() {
+    let root = std::env::temp_dir().join(format!(
+        "tinybot-tool-timeline-identity-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    let rpc = WorkerThreadLogRpc::new(
+        root.clone(),
+        CapabilityPolicy::new([
+            WorkerCapability::SessionWrite,
+            WorkerCapability::SessionMetadataRead,
+        ]),
+    );
+    let session_id = "tool-timeline-session";
+    let turn_id = "turn-tool";
+    let started_at = "2026-08-14T04:40:01.936Z";
+    rpc.ensure_turn_thread(
+        session_id,
+        started_at,
+        None,
+        Some(SessionApiMode::Responses),
+    )
+    .unwrap();
+    rpc.start_turn(
+        AgentTurnRecord {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            thread_id: None,
+            parent_thread_id: None,
+            child_thread_ids: Vec::new(),
+            status: AgentTurnStatus::Running,
+            phase: "calling_model".to_string(),
+            started_at: started_at.to_string(),
+            updated_at: started_at.to_string(),
+            completed_at: None,
+            stop_reason: None,
+            model: "gpt-test".to_string(),
+            provider: Some("openai".to_string()),
+            max_iterations: 1,
+            current_iteration: 0,
+            conversation_message_ids: Vec::new(),
+            trace_messages: Vec::new(),
+            completed_tool_results: Vec::new(),
+            pending_tool_calls: Vec::new(),
+            checkpoint: None,
+            artifacts: Vec::new(),
+            usage: Vec::new(),
+            token_usage_info: None,
+            instruction_provenance: None,
+            instruction_diagnostics: Vec::new(),
+            trace_context: None,
+            error: None,
+        },
+        None,
+        Vec::new(),
+    )
+    .unwrap();
+
+    let classified_event: AgentRuntimeEventEnvelope = serde_json::from_value(json!({
+        "schemaVersion": "tinybot.agent_event.v1",
+        "eventId": "message-classified-1",
+        "sequence": 0,
+        "sessionId": session_id,
+        "threadId": session_id,
+        "turnId": turn_id,
+        "itemId": "assistant-1",
+        "eventName": "agent.message.classified",
+        "phase": "completed",
+        "timestamp": "1786682410223",
+        "source": "provider",
+        "visibility": "user",
+        "payload": {
+            "content": "",
+            "messageId": "assistant-1",
+            "messagePhase": "commentary",
+            "responseItems": [{
+                "type": "function_call",
+                "id": "function-call-1",
+                "call_id": "call-1",
+                "name": "exec_command",
+                "arguments": "{\"command\":\"dir\"}"
+            }]
+        }
+    }))
+    .unwrap();
+    let call_event: AgentRuntimeEventEnvelope = serde_json::from_value(json!({
+        "schemaVersion": "tinybot.agent_event.v1",
+        "eventId": "tool-call-1",
+        "sequence": 1,
+        "sessionId": session_id,
+        "threadId": session_id,
+        "turnId": turn_id,
+        "itemId": "call-1",
+        "eventName": "agent.tool_call.delta",
+        "phase": "tool_calling",
+        "timestamp": "1786682410224",
+        "source": "tool",
+        "visibility": "user",
+        "payload": {
+            "toolCallId": "call-1",
+            "toolName": "exec_command",
+            "argumentsDelta": "{\"command\":\"dir\"}"
+        }
+    }))
+    .unwrap();
+    let result_event: AgentRuntimeEventEnvelope = serde_json::from_value(json!({
+        "schemaVersion": "tinybot.agent_event.v1",
+        "eventId": "tool-result-1",
+        "sequence": 2,
+        "sessionId": session_id,
+        "threadId": session_id,
+        "turnId": turn_id,
+        "itemId": "call-1",
+        "eventName": "agent.tool.result",
+        "phase": "tool_running",
+        "timestamp": "1786682412260",
+        "source": "tool",
+        "visibility": "user",
+        "payload": {
+            "toolCallId": "call-1",
+            "toolName": "exec_command",
+            "resultStatus": "ok",
+            "result": { "exitCode": 0 },
+            "summary": "completed"
+        }
+    }))
+    .unwrap();
+    let final_event: AgentRuntimeEventEnvelope = serde_json::from_value(json!({
+        "schemaVersion": "tinybot.agent_event.v1",
+        "eventId": "message-completed-1",
+        "sequence": 90,
+        "sessionId": session_id,
+        "threadId": session_id,
+        "turnId": turn_id,
+        "itemId": "assistant-final",
+        "eventName": "agent.message.completed",
+        "phase": "completed",
+        "timestamp": "1786682413260",
+        "source": "provider",
+        "visibility": "user",
+        "payload": {
+            "content": "Done.",
+            "messageId": "assistant-final",
+            "modelCallId": "call-final",
+            "messagePhase": "final_answer",
+            "responseItems": [{
+                "type": "message",
+                "id": "assistant-final",
+                "role": "assistant",
+                "modelCallId": "call-final",
+                "phase": "final_answer",
+                "content": [{ "type": "output_text", "text": "Done." }]
+            }]
+        }
+    }))
+    .unwrap();
+    let live_timeline = project_timeline_snapshot(
+        session_id,
+        turn_id,
+        &[
+            classified_event.clone(),
+            call_event.clone(),
+            result_event.clone(),
+            final_event.clone(),
+        ],
+    )
+    .unwrap();
+
+    for event in [&classified_event, &call_event, &result_event, &final_event] {
+        rpc.append_turn_semantic_event(session_id, turn_id, serde_json::to_value(event).unwrap())
+            .unwrap();
+    }
+    let reloaded = rpc
+        .get_turn_runtime_state(session_id, turn_id)
+        .unwrap()
+        .expect("persisted tool call should reload");
+    assert_eq!(
+        live_timeline.snapshot_revision, reloaded.timeline.snapshot_revision,
+        "tool-only provider responses must not create live-only assistant mutations"
+    );
+    assert_eq!(
+        live_timeline
+            .items
+            .iter()
+            .map(|item| item.item_id.as_str())
+            .collect::<Vec<_>>(),
+        reloaded
+            .timeline
+            .items
+            .iter()
+            .map(|item| item.item_id.as_str())
+            .collect::<Vec<_>>(),
+    );
+    let live_tool = live_timeline
+        .items
+        .iter()
+        .find(|item| item.item_id == "call-1")
+        .unwrap();
+    let reloaded_tool = reloaded
+        .timeline
+        .items
+        .iter()
+        .find(|item| item.item_id == "call-1")
+        .unwrap();
+
+    assert_eq!(reloaded_tool.item_id, live_tool.item_id);
+    assert_eq!(reloaded_tool.sequence, live_tool.sequence);
+    assert_eq!(reloaded_tool.revision, live_tool.revision);
+    assert_eq!(reloaded_tool.created_at, live_tool.created_at);
+    assert_eq!(reloaded_tool.updated_at, live_tool.updated_at);
+    assert_eq!(reloaded_tool.status, live_tool.status);
+    let live_final = live_timeline
+        .items
+        .iter()
+        .find(|item| item.item_id == "assistant-final")
+        .unwrap();
+    let reloaded_final = reloaded
+        .timeline
+        .items
+        .iter()
+        .find(|item| item.item_id == "assistant-final")
+        .unwrap();
+    assert_eq!(reloaded_final.item_id, live_final.item_id);
+    assert_eq!(reloaded_final.sequence, live_final.sequence);
+    assert_eq!(reloaded_final.revision, live_final.revision);
+    assert_eq!(reloaded_final.created_at, live_final.created_at);
+    assert_eq!(reloaded_final.status, live_final.status);
+    assert_eq!(reloaded_final.data, live_final.data);
 
     drop(rpc);
     std::fs::remove_dir_all(root).unwrap();

--- a/src-tauri/tests/crate/turns.rs
+++ b/src-tauri/tests/crate/turns.rs
@@ -828,6 +828,8 @@ fn worker_run_agent_combines_thread_history_with_current_tool_results() {
             "id",
             "output",
             "status",
+            "threadItemSequence",
+            "timestamp",
             "tinybot_result",
             "tool_name",
             "turnId",

--- a/src/app-core/chat/agentTimelineModel.test.ts
+++ b/src/app-core/chat/agentTimelineModel.test.ts
@@ -382,7 +382,7 @@ describe("canonical agent timeline model", () => {
     ]);
   });
 
-  test("rejects gaps, equal-revision conflicts, and terminal regressions", () => {
+  test("rejects transport conflicts but trusts backend status transitions", () => {
     const model = createAgentTimelineModel();
     model.load(sessionId, [runtimeState()]);
 
@@ -394,11 +394,11 @@ describe("canonical agent timeline model", () => {
     }))).toThrow("equal-revision conflict");
 
     model.applyPatch(sessionId, patch(2, { revision: 2, status: "completed" }));
-    expect(() => model.applyPatch(sessionId, patch(3, { revision: 3, status: "running" })))
-      .toThrow("cannot transition from completed to running");
+    const snapshot = model.applyPatch(sessionId, patch(3, { revision: 3, status: "running" }));
+    expect(snapshot.turnRevisions).toEqual({ [turnId]: 3 });
   });
 
-  test("allows unknown assistant phase classification once and rejects reclassification", () => {
+  test("trusts backend assistant phase transitions", () => {
     const model = createAgentTimelineModel();
     model.load(sessionId, [runtimeState()]);
 
@@ -414,7 +414,7 @@ describe("canonical agent timeline model", () => {
       },
     }));
 
-    expect(() => model.applyPatch(sessionId, patch(3, {
+    const snapshot = model.applyPatch(sessionId, patch(3, {
       revision: 3,
       status: "completed",
       data: {
@@ -424,7 +424,9 @@ describe("canonical agent timeline model", () => {
         phase: "final_answer",
         content: "Done.",
       },
-    }))).toThrow("cannot transition phase from commentary to final_answer");
+    }));
+
+    expect(snapshot.turns[0].finalAnswer?.text).toBe("Done.");
   });
 
   test("ignores a lower item revision but advances the turn cursor with a diagnostic", () => {

--- a/src/app-core/chat/agentTimelineModel.ts
+++ b/src/app-core/chat/agentTimelineModel.ts
@@ -6,7 +6,6 @@ import {
 import type {
   BackendAgentTurnRuntimeState,
   BackendAgentTimelinePatch,
-  BackendAgentTurnItem,
   ChatTurn,
 } from "./chatTurnModel";
 
@@ -46,12 +45,23 @@ export class TimelineRevisionGapError extends Error {
   }
 }
 
+export class TimelineItemIdentityConflictError extends Error {
+  constructor(
+    readonly turnId: string,
+    readonly itemId: string,
+    readonly currentSequence: number,
+    readonly receivedSequence: number,
+    readonly snapshotRevision: number,
+  ) {
+    super(`Canonical timeline item ${itemId} changed sequence from ${currentSequence} to ${receivedSequence}`);
+    this.name = "TimelineItemIdentityConflictError";
+  }
+}
+
 type SessionTimelineState = {
   diagnostics: TimelineDiagnostic[];
   turns: Map<string, BackendAgentTurnRuntimeState>;
 };
-
-const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 
 export function createAgentTimelineModel(): AgentTimelineModel {
   const sessions = new Map<string, SessionTimelineState>();
@@ -129,7 +139,7 @@ function applyPatchToSession(session: SessionTimelineState, patch: BackendAgentT
   if (patch.snapshotRevision === turn.snapshotRevision) {
     const current = turn.items.find((item) => item.itemId === patch.item.itemId);
     if (!current) {
-      turn.items = [...turn.items, patch.item].sort(compareCanonicalItems);
+      turn.items = [...turn.items, patch.item];
       return;
     }
     if (patch.item.revision < current.revision) {
@@ -142,10 +152,14 @@ function applyPatchToSession(session: SessionTimelineState, patch: BackendAgentT
       return;
     }
     if (patch.item.sequence !== current.sequence) {
-      throw new Error(`Canonical timeline item ${patch.item.itemId} changed sequence from ${current.sequence} to ${patch.item.sequence}`);
+      throw new TimelineItemIdentityConflictError(
+        patch.turnId,
+        patch.item.itemId,
+        current.sequence,
+        patch.item.sequence,
+        patch.snapshotRevision,
+      );
     }
-    assertMonotonicStatus(current, patch.item);
-    assertMonotonicAssistantPhase(current, patch.item);
     turn.items = turn.items.map((item) => item.itemId === patch.item.itemId ? patch.item : item);
     return;
   }
@@ -160,14 +174,20 @@ function applyPatchToSession(session: SessionTimelineState, patch: BackendAgentT
 
   const index = turn.items.findIndex((item) => item.itemId === patch.item.itemId);
   if (index < 0) {
-    turn.items = [...turn.items, patch.item].sort(compareCanonicalItems);
+    turn.items = [...turn.items, patch.item];
     turn.snapshotRevision = patch.snapshotRevision;
     return;
   }
 
   const current = turn.items[index];
   if (patch.item.sequence !== current.sequence) {
-    throw new Error(`Canonical timeline item ${patch.item.itemId} changed sequence from ${current.sequence} to ${patch.item.sequence}`);
+    throw new TimelineItemIdentityConflictError(
+      patch.turnId,
+      patch.item.itemId,
+      current.sequence,
+      patch.item.sequence,
+      patch.snapshotRevision,
+    );
   }
   if (patch.item.revision < current.revision) {
     session.diagnostics.push({
@@ -184,27 +204,8 @@ function applyPatchToSession(session: SessionTimelineState, patch: BackendAgentT
   if (patch.item.revision === current.revision) {
     throw new Error(`Canonical timeline mutation ${patch.snapshotRevision} did not advance item ${patch.item.itemId} revision ${current.revision}`);
   }
-  assertMonotonicStatus(current, patch.item);
-  assertMonotonicAssistantPhase(current, patch.item);
   turn.items = turn.items.map((item, itemIndex) => itemIndex === index ? patch.item : item);
   turn.snapshotRevision = patch.snapshotRevision;
-}
-
-function assertMonotonicAssistantPhase(current: BackendAgentTurnItem, incoming: BackendAgentTurnItem): void {
-  if (current.kind !== "assistant_message" || incoming.kind !== "assistant_message") {
-    return;
-  }
-  const currentPhase = String(current.data.phase);
-  const incomingPhase = String(incoming.data.phase);
-  if (currentPhase !== incomingPhase && currentPhase !== "unknown") {
-    throw new Error(`Canonical assistant item ${current.itemId} cannot transition phase from ${currentPhase} to ${incomingPhase}`);
-  }
-}
-
-function assertMonotonicStatus(current: BackendAgentTurnItem, incoming: BackendAgentTurnItem): void {
-  if (TERMINAL_STATUSES.has(current.status) && incoming.status !== current.status) {
-    throw new Error(`Canonical timeline item ${current.itemId} cannot transition from ${current.status} to ${incoming.status}`);
-  }
 }
 
 function projectSessionSnapshot(sessionId: string, state: SessionTimelineState): ChatTimelineSnapshot {
@@ -228,10 +229,6 @@ function emptyTimelineSnapshot(sessionId: string): ChatTimelineSnapshot {
     turns: [],
     diagnostics: [],
   };
-}
-
-function compareCanonicalItems(left: BackendAgentTurnItem, right: BackendAgentTurnItem): number {
-  return left.sequence - right.sequence || left.itemId.localeCompare(right.itemId);
 }
 
 function stableSerialize(value: unknown): string {

--- a/src/app-core/chat/chatTurnModel.test.ts
+++ b/src/app-core/chat/chatTurnModel.test.ts
@@ -217,6 +217,59 @@ describe("chat turn model", () => {
     });
   });
 
+  test("preserves backend replay order when persisted source sequences are mixed", () => {
+    const runtimeState = normalizeAgentTurnRuntimeStatePayload(canonicalRuntimeState("turn-mixed-sequence", [
+      {
+        itemId: "call-first",
+        sequence: 56,
+        kind: "tool_call",
+        status: "completed",
+        data: {
+          type: "tool_call",
+          toolCallId: "call-first",
+          name: "read_file",
+          status: "completed",
+          args: { path: "README.md" },
+          result: { summary: "first" },
+          timing: {},
+        },
+      },
+      {
+        itemId: "call-second",
+        sequence: 78,
+        kind: "tool_call",
+        status: "completed",
+        data: {
+          type: "tool_call",
+          toolCallId: "call-second",
+          name: "read_file",
+          status: "completed",
+          args: { path: "Cargo.toml" },
+          result: { summary: "second" },
+          timing: {},
+        },
+      },
+      {
+        itemId: "assistant-final",
+        sequence: 55,
+        kind: "assistant_message",
+        status: "completed",
+        data: {
+          type: "assistant_message",
+          messageId: "assistant-final",
+          modelCallId: "call-final",
+          phase: "final_answer",
+          content: "Done.",
+        },
+      },
+    ]));
+
+    const [turn] = backendRuntimeStatesToTurns("WebSocket:chat-1", [runtimeState]);
+
+    expect(turn.steps.map((step) => step.id)).toEqual(["call-first", "call-second"]);
+    expect(turn.finalAnswer?.text).toBe("Done.");
+  });
+
   test("preserves the context window budget from a restored compaction item", () => {
     const runtimeState = normalizeAgentTurnRuntimeStatePayload(canonicalRuntimeState("turn-compacted", [{
       itemId: "turn-compacted:context",

--- a/src/app-core/chat/chatTurnModel.ts
+++ b/src/app-core/chat/chatTurnModel.ts
@@ -376,7 +376,6 @@ export function normalizeAgentTimelineSnapshotPayload(payload: unknown): Backend
     throw new Error(`Canonical timeline ${turnId} is missing items`);
   }
   const seenItemIds = new Set<string>();
-  let previousSequence = -1;
   const items = timeline.items.map((raw, index) => {
     if (!isRecord(raw)) {
       throw new Error(`Canonical timeline ${turnId} item ${index} is not an object`);
@@ -385,14 +384,9 @@ export function normalizeAgentTimelineSnapshotPayload(payload: unknown): Backend
     if (seenItemIds.has(item.itemId)) {
       throw new Error(`Canonical timeline ${turnId} contains duplicate item ${item.itemId}`);
     }
-    if (item.sequence < previousSequence) {
-      throw new Error(`Canonical timeline ${turnId} item ${item.itemId} has non-monotonic sequence ${item.sequence}`);
-    }
     seenItemIds.add(item.itemId);
-    previousSequence = item.sequence;
     return item;
   });
-  validateCanonicalFinalAnswerBoundary(items, turnId);
   return {
     schemaVersion: "tinybot.timeline.v2",
     sessionId,
@@ -481,28 +475,6 @@ function assistantMessagePhase(value: unknown, itemId: string): AssistantMessage
     return phase;
   }
   throw new Error(`Canonical assistant item ${itemId} has invalid phase ${phase || "missing"}`);
-}
-
-function validateCanonicalFinalAnswerBoundary(items: BackendAgentTurnItem[], turnId: string): void {
-  const finalItem = items.find((item) => (
-    item.kind === "assistant_message" && stringValue(item.data.phase) === "final_answer"
-  ));
-  if (!finalItem) {
-    return;
-  }
-  const invalid = items.find((item) => item.sequence > finalItem.sequence && (
-    item.kind === "assistant_message"
-      || item.kind === "reasoning"
-      || item.kind === "tool_call"
-      || item.kind === "form"
-      || item.kind === "subagent_lifecycle"
-      || item.kind === "subagent_message"
-      || item.kind === "plan_progress"
-      || item.kind === "context_compaction"
-  ));
-  if (invalid) {
-    throw new Error(`Canonical timeline ${turnId} item ${invalid.itemId} appears after final answer ${finalItem.itemId}`);
-  }
 }
 
 function requiredCanonicalString(value: Record<string, unknown>, key: string): string {
@@ -876,7 +848,6 @@ function attachFileReferences(turn: ChatTurn, items: BackendAgentTurnItem[]): vo
       title: artifact.title,
     }));
   }
-  turn.steps.sort((left, right) => left.sequence - right.sequence || left.id.localeCompare(right.id));
 }
 
 function runtimeStep(

--- a/src/app-core/chat/desktopChatSessionController.test.ts
+++ b/src/app-core/chat/desktopChatSessionController.test.ts
@@ -36,6 +36,92 @@ function createController(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function usageItem(sequence: number, createdAt: string) {
+  return {
+    schemaVersion: "tinybot.turn_item.v2",
+    itemId: "turn-usage:usage:0",
+    sessionId: "thread-1",
+    threadId: "thread-1",
+    turnId: "turn-usage",
+    sequence,
+    revision: 1,
+    kind: "usage",
+    status: "completed",
+    createdAt,
+    data: {
+      type: "usage",
+      id: "turn-usage:usage:0",
+      inputTokens: 4_469,
+      outputTokens: 219,
+      totalTokens: 4_688,
+      providerPayload: {},
+    },
+  };
+}
+
+function usageRuntimeState(sequence: number, createdAt: string) {
+  return {
+    runtimeEvents: [],
+    status: "running",
+    timeline: {
+      schemaVersion: "tinybot.timeline.v2",
+      sessionId: "thread-1",
+      turnId: "turn-usage",
+      snapshotRevision: 1,
+      items: [usageItem(sequence, createdAt)],
+    },
+  };
+}
+
+function usagePatch(sequence: number, createdAt: string) {
+  return {
+    schemaVersion: "tinybot.timeline_patch.v2",
+    sessionId: "thread-1",
+    turnId: "turn-usage",
+    snapshotRevision: 1,
+    item: usageItem(sequence, createdAt),
+  };
+}
+
+function toolCallItem(sequence: number, revision: number, status: "running" | "completed") {
+  return {
+    schemaVersion: "tinybot.turn_item.v2",
+    itemId: "call-1",
+    sessionId: "thread-1",
+    threadId: "thread-1",
+    turnId: "turn-tool",
+    sequence,
+    revision,
+    kind: "tool_call",
+    status,
+    createdAt: "1786682410223",
+    ...(revision > 1 ? { updatedAt: "1786682412260" } : {}),
+    data: {
+      type: "tool_call",
+      toolCallId: "call-1",
+      name: "exec_command",
+      status,
+      args: { command: "dir" },
+      result: status === "completed" ? { exitCode: 0 } : null,
+      timing: {},
+    },
+  };
+}
+
+function toolRuntimeState(sequence: number, revision: number, status: "running" | "completed") {
+  return {
+    runtimeEvents: [],
+    status: "running",
+    timeline: {
+      schemaVersion: "tinybot.timeline.v2",
+      sessionId: "thread-1",
+      turnId: "turn-tool",
+      snapshotRevision: revision,
+      items: [toolCallItem(sequence, revision, status)],
+    },
+  };
+}
+
 describe("desktop native chat session controller", () => {
   test("loads and selects Thread records without a transport attach", async () => {
     const { controller } = createController();
@@ -187,5 +273,78 @@ describe("desktop native chat session controller", () => {
       source: "canonical",
       turns: [expect.objectContaining({ id: "turn-1" })],
     });
+  });
+
+  test("does not replay a buffered live patch already covered by the loaded snapshot", async () => {
+    let resolveRuntimeState: (value: unknown) => void = () => undefined;
+    const runtimeState = new Promise<unknown>((resolve) => {
+      resolveRuntimeState = resolve;
+    });
+    const getAgentTurnRuntimeState = vi.fn(() => runtimeState);
+    const { controller } = createController({
+      listTurns: vi.fn(async () => ({ turns: [{ turnId: "turn-usage" }] })),
+      getAgentTurnRuntimeState,
+    });
+
+    const loading = controller.loadTimeline("thread-1");
+    await vi.waitFor(() => expect(getAgentTurnRuntimeState).toHaveBeenCalledTimes(1));
+    await expect(controller.applyTimelinePatch("thread-1", usagePatch(23, "1786673534920")))
+      .resolves.toBeNull();
+    resolveRuntimeState(usageRuntimeState(16, "2026-08-14T02:12:14.921Z"));
+
+    await expect(loading).resolves.toMatchObject({
+      turnRevisions: { "turn-usage": 1 },
+      turns: [expect.objectContaining({
+        canonicalItems: [expect.objectContaining({ sequence: 16 })],
+      })],
+    });
+  });
+
+  test("coalesces concurrent reloads for the same session", async () => {
+    let resolveTurns: (value: unknown) => void = () => undefined;
+    const turns = new Promise<unknown>((resolve) => {
+      resolveTurns = resolve;
+    });
+    const listTurns = vi.fn(() => turns);
+    const { controller } = createController({ listTurns });
+
+    const first = controller.reloadTimeline("thread-1");
+    const second = controller.reloadTimeline("thread-1");
+
+    expect(listTurns).toHaveBeenCalledTimes(1);
+    resolveTurns({ turns: [] });
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+  });
+
+  test("reloads durable state when a legacy tool patch disagrees with its persisted sequence", async () => {
+    let durableRevision = 1;
+    const getAgentTurnRuntimeState = vi.fn(async () => (
+      toolRuntimeState(20, durableRevision, durableRevision === 1 ? "running" : "completed")
+    ));
+    const { controller } = createController({
+      listTurns: vi.fn(async () => ({ turns: [{ turnId: "turn-tool" }] })),
+      getAgentTurnRuntimeState,
+    });
+    await controller.loadTimeline("thread-1");
+    durableRevision = 2;
+
+    await expect(controller.applyTimelinePatch("thread-1", {
+      schemaVersion: "tinybot.timeline_patch.v2",
+      sessionId: "thread-1",
+      turnId: "turn-tool",
+      snapshotRevision: 2,
+      item: toolCallItem(33, 2, "completed"),
+    })).resolves.toMatchObject({
+      turnRevisions: { "turn-tool": 2 },
+      turns: [expect.objectContaining({
+        canonicalItems: [expect.objectContaining({
+          itemId: "call-1",
+          sequence: 20,
+          revision: 2,
+          status: "completed",
+        })],
+      })],
+    });
+    expect(getAgentTurnRuntimeState).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app-core/chat/desktopChatSessionController.test.ts
+++ b/src/app-core/chat/desktopChatSessionController.test.ts
@@ -275,6 +275,52 @@ describe("desktop native chat session controller", () => {
     });
   });
 
+  test("projects a completed timeline back onto the Thread status", async () => {
+    const { controller } = createController({
+      listThreads: vi.fn(async () => ({
+        threads: [{
+          threadId: "thread-1",
+          sessionKey: "thread-1",
+          title: "Native thread",
+          status: "running" as const,
+          createdAt: "2026-07-14T00:00:00.000Z",
+          updatedAt: "2026-07-14T00:00:00.000Z",
+        }],
+        total: 1,
+      })),
+    });
+    await controller.loadSessions();
+
+    await controller.applyTimelinePatch("thread-1", {
+      schemaVersion: "tinybot.timeline_patch.v2",
+      sessionId: "thread-1",
+      turnId: "turn-1",
+      snapshotRevision: 1,
+      item: {
+        schemaVersion: "tinybot.turn_item.v2",
+        itemId: "assistant-final-1",
+        sessionId: "thread-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        sequence: 1,
+        revision: 1,
+        kind: "assistant_message",
+        status: "completed",
+        createdAt: "2026-07-14T00:00:01.000Z",
+        data: {
+          type: "assistant_message",
+          messageId: "assistant-final-1",
+          modelCallId: "model-call-1",
+          content: "Done",
+          phase: "final_answer",
+        },
+      },
+    });
+
+    expect(controller.state.respondingThreadIds.has("thread-1")).toBe(false);
+    expect(controller.state.threads[0]?.status).toBe("idle");
+  });
+
   test("does not replay a buffered live patch already covered by the loaded snapshot", async () => {
     let resolveRuntimeState: (value: unknown) => void = () => undefined;
     const runtimeState = new Promise<unknown>((resolve) => {

--- a/src/app-core/chat/desktopChatSessionController.ts
+++ b/src/app-core/chat/desktopChatSessionController.ts
@@ -300,6 +300,20 @@ export function createDesktopChatSessionController({
     } else {
       state.respondingThreadIds.delete(threadId);
     }
+
+    const latestTurnStatus = snapshot.turns[snapshot.turns.length - 1]?.status;
+    const projectedThreadStatus = responding
+      ? "running"
+      : latestTurnStatus === "failed" || latestTurnStatus === "interrupted"
+        ? "failed"
+        : latestTurnStatus === "completed" ? "idle" : undefined;
+    if (projectedThreadStatus) {
+      state.threads = state.threads.map((thread) => (
+        thread.threadId === threadId && thread.status !== "archived"
+          ? { ...thread, status: projectedThreadStatus }
+          : thread
+      ));
+    }
   }
 
   async function patchSession(sessionKey: string, body: unknown): Promise<boolean> {

--- a/src/app-core/chat/desktopChatSessionController.ts
+++ b/src/app-core/chat/desktopChatSessionController.ts
@@ -2,9 +2,11 @@ import type { AgentInputReference } from "./agentInputReference";
 import type { ReasoningEffort } from "./reasoningEffort";
 import {
   createAgentTimelineModel,
+  TimelineItemIdentityConflictError,
   TimelineRevisionGapError,
   type ChatTimelineSnapshot,
 } from "./agentTimelineModel";
+import { normalizeAgentTimelinePatchPayload } from "./chatTurnModel";
 import { logDesktopNativeDebug, summarizeDebugText } from "../native/desktopNativeChatDebug";
 import type {
   NativeThreadListResult,
@@ -90,7 +92,7 @@ export function createDesktopChatSessionController({
   };
   const timelineModel = createAgentTimelineModel();
   const loadedTimelineSessions = new Set<string>();
-  const loadingTimelineSessions = new Set<string>();
+  const timelineLoads = new Map<string, Promise<ChatTimelineSnapshot>>();
   const bufferedTimelinePatches = new Map<string, unknown[]>();
 
   async function loadSessions(): Promise<number> {
@@ -178,6 +180,21 @@ export function createDesktopChatSessionController({
     if (loadedTimelineSessions.has(sessionKey)) {
       return timelineModel.snapshot(sessionKey);
     }
+    const existingLoad = timelineLoads.get(sessionKey);
+    if (existingLoad) {
+      return existingLoad;
+    }
+    let load: Promise<ChatTimelineSnapshot>;
+    load = loadTimelineFromRuntime(sessionKey).finally(() => {
+      if (timelineLoads.get(sessionKey) === load) {
+        timelineLoads.delete(sessionKey);
+      }
+    });
+    timelineLoads.set(sessionKey, load);
+    return load;
+  }
+
+  async function loadTimelineFromRuntime(sessionKey: string): Promise<ChatTimelineSnapshot> {
     if (!api.listTurns || !api.getAgentTurnRuntimeState) {
       throw new Error("Canonical agent timeline API is unavailable");
     }
@@ -185,13 +202,23 @@ export function createDesktopChatSessionController({
       ...summarizeSessionState(),
       sessionKey,
     });
-    loadingTimelineSessions.add(sessionKey);
     try {
       const turnsPayload = await api.listTurns(sessionKey);
       const turnIds = normalizeTurnIdsPayload(turnsPayload);
       const payloads = await Promise.all(turnIds.map((turnId) => api.getAgentTurnRuntimeState?.(sessionKey, turnId)));
       let snapshot = timelineModel.load(sessionKey, payloads.filter((payload) => payload !== null && payload !== undefined));
-      for (const patch of bufferedTimelinePatches.get(sessionKey) ?? []) {
+      for (const patchPayload of bufferedTimelinePatches.get(sessionKey) ?? []) {
+        const patch = normalizeAgentTimelinePatchPayload(patchPayload);
+        const loadedRevision = snapshot.turnRevisions[patch.turnId];
+        if (loadedRevision !== undefined && patch.snapshotRevision <= loadedRevision) {
+          logDesktopNativeDebug("session.agentTurnRuntime.patch.subsumed", {
+            loadedRevision,
+            patchRevision: patch.snapshotRevision,
+            turnId: patch.turnId,
+            sessionKey,
+          });
+          continue;
+        }
         snapshot = timelineModel.applyPatch(sessionKey, patch);
       }
       bufferedTimelinePatches.delete(sessionKey);
@@ -211,13 +238,11 @@ export function createDesktopChatSessionController({
         sessionKey,
       });
       throw error;
-    } finally {
-      loadingTimelineSessions.delete(sessionKey);
     }
   }
 
   async function applyTimelinePatch(sessionKey: string, payload: unknown): Promise<ChatTimelineSnapshot | null> {
-    if (loadingTimelineSessions.has(sessionKey) || !loadedTimelineSessions.has(sessionKey)) {
+    if (timelineLoads.has(sessionKey) || !loadedTimelineSessions.has(sessionKey)) {
       const patches = bufferedTimelinePatches.get(sessionKey) ?? [];
       patches.push(payload);
       bufferedTimelinePatches.set(sessionKey, patches);
@@ -228,6 +253,25 @@ export function createDesktopChatSessionController({
       syncRespondingState(sessionKey, snapshot);
       return snapshot;
     } catch (error) {
+      if (error instanceof TimelineItemIdentityConflictError) {
+        logDesktopNativeDebug("session.agentTurnRuntime.patch.identityConflict", {
+          currentSequence: error.currentSequence,
+          itemId: error.itemId,
+          receivedSequence: error.receivedSequence,
+          snapshotRevision: error.snapshotRevision,
+          turnId: error.turnId,
+          sessionKey,
+        });
+        loadedTimelineSessions.delete(sessionKey);
+        const snapshot = await loadTimeline(sessionKey);
+        const durableRevision = snapshot.turnRevisions[error.turnId];
+        if (durableRevision === undefined || durableRevision < error.snapshotRevision) {
+          throw new Error(
+            `Canonical timeline identity recovery for item ${error.itemId} loaded revision ${durableRevision ?? "missing"}, expected at least ${error.snapshotRevision}`,
+          );
+        }
+        return snapshot;
+      }
       if (!(error instanceof TimelineRevisionGapError)) {
         throw error;
       }

--- a/src/components/ui/claude-style-ai-input.test.tsx
+++ b/src/components/ui/claude-style-ai-input.test.tsx
@@ -112,20 +112,32 @@ describe("ClaudeStyleAiInput slash commands", () => {
     });
   });
 
-  it("queues the next turn without showing text actions while responding", async () => {
+  it("uses one primary action that switches between stop and send", async () => {
     const user = userEvent.setup();
     const onSendMessage = vi.fn();
-    render(<ClaudeStyleAiInput
+    const onStopResponding = vi.fn();
+    const view = render(<ClaudeStyleAiInput
       onSendMessage={onSendMessage}
+      onStopResponding={onStopResponding}
       responding
     />);
 
+    expect(document.querySelectorAll(".claude-ai-input__send")).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "Queue as next turn" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Stop generation" }));
+    expect(onStopResponding).toHaveBeenCalledTimes(1);
+
+    view.rerender(<ClaudeStyleAiInput
+      onSendMessage={onSendMessage}
+      onStopResponding={onStopResponding}
+    />);
     const input = screen.getByRole("textbox", { name: "Message" });
-    await user.type(input, "Do this afterward");
-    await user.click(screen.getByRole("button", { name: "Queue as next turn" }));
-    expect(onSendMessage).toHaveBeenCalledWith("Do this afterward", [], [], { reasoningEffort: "medium" });
-    expect(screen.queryByText("Interrupt current task")).toBeNull();
-    expect(screen.queryByText("Queue as next turn")).toBeNull();
+    await user.type(input, "Start the next turn");
+    expect(document.querySelectorAll(".claude-ai-input__send")).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "Stop generation" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(onSendMessage).toHaveBeenCalledWith("Start the next turn", [], [], { reasoningEffort: "medium" });
   });
 
   it("dismisses the menu with Escape without changing the draft", async () => {

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -863,39 +863,28 @@ export function ClaudeStyleAiInput({
             {contextUsageView ? <ContextUsageIndicator view={contextUsageView} /> : null}
           </div>
 
-          {responding ? (
-            <div className="claude-ai-input__running-actions">
-              <button
-                aria-label={t("composer.queue")}
-                className="claude-ai-input__send"
-                disabled={!canSend}
-                title={canSend ? t("composer.queueHelp") : t("composer.queueDisabled")}
-                type="submit"
-              >
-                <ArrowUp aria-hidden="true" size={18} />
-              </button>
-              <button
-                aria-label={canStopResponding ? t("composer.stop") : t("composer.stopUnavailable", { reason: stopUnavailableReason || t("composer.unsupported") })}
-                className="claude-ai-input__send"
-                disabled={disabled || !canStopResponding}
-                title={canStopResponding ? t("composer.stop") : stopUnavailableReason || t("composer.stoppingUnavailable")}
-                type="button"
-                onClick={() => void handleStopResponding()}
-              >
-                <Square aria-hidden="true" size={15} />
-              </button>
-            </div>
-          ) : (
-            <button
-              aria-label={t("composer.send")}
-              className="claude-ai-input__send"
-              disabled={!canSend}
-              title={canSend ? t("composer.send") : disabledReason || t("composer.sendDisabled")}
-              type="submit"
-            >
-              <ArrowUp aria-hidden="true" size={18} />
-            </button>
-          )}
+          <button
+            aria-label={responding
+              ? canStopResponding
+                ? t("composer.stop")
+                : t("composer.stopUnavailable", { reason: stopUnavailableReason || t("composer.unsupported") })
+              : t("composer.send")}
+            className="claude-ai-input__send"
+            disabled={responding ? disabled || !canStopResponding : !canSend}
+            title={responding
+              ? canStopResponding
+                ? t("composer.stop")
+                : stopUnavailableReason || t("composer.stoppingUnavailable")
+              : canSend
+                ? t("composer.send")
+                : disabledReason || t("composer.sendDisabled")}
+            type={responding ? "button" : "submit"}
+            onClick={responding ? () => void handleStopResponding() : undefined}
+          >
+            {responding
+              ? <Square aria-hidden="true" size={15} />
+              : <ArrowUp aria-hidden="true" size={18} />}
+          </button>
         </div>
       </div>
     </form>

--- a/src/react-workbench/chat/ChatPage.test.tsx
+++ b/src/react-workbench/chat/ChatPage.test.tsx
@@ -1078,6 +1078,42 @@ describe("ChatPage", () => {
     await waitFor(() => expect(stores.chatStore.load).toHaveBeenLastCalledWith("s2"));
   });
 
+  it("clears the active workspace child running indicator from its completed timeline", async () => {
+    let subscribed: ((event: ChatEvent) => void) | undefined;
+    const runningSession: SessionSummary = {
+      id: "workspace-child",
+      chatId: "workspace-child",
+      title: "Inspect workspace",
+      updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+      status: "running",
+      workingDirectory: "D:\\Code\\workspace",
+    };
+    const stores = createStores({ sessions: [runningSession] });
+    const runningTimeline = await stores.chatStore.load(runningSession.id);
+    runningTimeline.turns[runningTimeline.turns.length - 1].status = "running";
+    const completedTimeline = structuredClone(runningTimeline);
+    completedTimeline.turns[completedTimeline.turns.length - 1].status = "completed";
+    stores.chatStore.load = vi.fn(async () => runningTimeline);
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => {
+      subscribed = listener;
+      return () => undefined;
+    });
+
+    render(<ChatPage
+      chatStore={stores.chatStore}
+      now={() => Date.UTC(2026, 6, 4, 12, 0, 0)}
+      sessionStore={stores.sessionStore}
+    />);
+
+    await screen.findByRole("tab", { name: "Inspect workspace, running" });
+    act(() => subscribed?.({ type: "timeline.patch", timeline: completedTimeline }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tab", { name: "Inspect workspace, running" })).toBeNull();
+      expect(screen.getByRole("tab", { name: "Inspect workspace" })).toBeTruthy();
+    });
+  });
+
   it("preserves per-session drafts and closing a tab does not delete the session", async () => {
     const user = userEvent.setup();
     const stores = createStores({

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1010,6 +1010,7 @@ export function ChatPage({
     const applyTimeline = (nextTimeline: ChatTimelineSnapshot) => {
       setTimeline(nextTimeline);
       setTimelineError("");
+      updateSessionStatusFromTimeline(activeSessionId, nextTimeline);
       setOptimisticMessagesBySession((current) => updateSessionMessages(
         current,
         activeSessionId,
@@ -1124,16 +1125,7 @@ export function ChatPage({
       .filter((sessionId) => sessionId !== activeSessionId)
       .map((sessionId) => chatStore.subscribe(sessionId, (event) => {
         if (event.timeline) {
-          const status = sessionStatusFromTimeline(event.timeline);
-          if (status) {
-            setSessions((current) => {
-              const next = current.map((session) => (
-                session.id === sessionId ? { ...session, status } : session
-              ));
-              sessionsRef.current = next;
-              return next;
-            });
-          }
+          updateSessionStatusFromTimeline(sessionId, event.timeline);
           dispatchSessionTabs({ type: "activity", sessionId });
         }
         if (isBackgroundTabActivityEvent(event)) {
@@ -1986,6 +1978,18 @@ export function ChatPage({
       return;
     }
     await sendNextQueuedInput(sessionId, "normal_completion");
+  }
+
+  function updateSessionStatusFromTimeline(sessionId: string, nextTimeline: ChatTimelineSnapshot) {
+    const status = sessionStatusFromTimeline(nextTimeline);
+    if (!status) return;
+    setSessions((current) => {
+      const next = current.map((session) => (
+        session.id === sessionId ? { ...session, status } : session
+      ));
+      sessionsRef.current = next;
+      return next;
+    });
   }
 
   async function sendPendingInterruptInput(

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -617,7 +617,7 @@ export const en = {
         low: { label: "Light", description: "Prioritize speed and lower token use." }, medium: { label: "Medium", description: "Use balanced reasoning depth." },
         high: { label: "High", description: "Use deeper reasoning." }, xhigh: { label: "Extra High", description: "Use very deep reasoning." }, max: { label: "Max", description: "Use the model's maximum reasoning depth." },
       },
-      queueHelp: "Send as the next turn after the current task finishes", queueDisabled: "Enter content to queue", queue: "Queue as next turn", stop: "Stop generation", stopUnavailable: "Stop generation unavailable: {{reason}}",
+      stop: "Stop generation", stopUnavailable: "Stop generation unavailable: {{reason}}",
       unsupported: "unsupported", stoppingUnavailable: "Stopping is unavailable", send: "Send message", sendDisabled: "Enter content to send",
       context: { title: "Context window", used: "{{percent}}% used ({{left}}% left)", strategy: "Strategy: {{strategy}}", aria: "Context window {{percent}}% used, {{left}}% left", tokens: "{{used}} / {{window}} tokens used", zero: "0 tokens used", provider: "Token budget reported by provider" },
     },

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -317,7 +317,7 @@ export const zh = {
         low: { label: "轻量", description: "优先保证速度并降低 Token 消耗。" }, medium: { label: "中等", description: "使用均衡的推理深度。" },
         high: { label: "高", description: "使用更深度的推理。" }, xhigh: { label: "超高", description: "使用非常深入的推理。" }, max: { label: "最大", description: "使用模型支持的最大推理深度。" },
       },
-      queueHelp: "当前任务完成后作为下一轮发送", queueDisabled: "输入内容后排队", queue: "排队为下一轮", stop: "停止生成", stopUnavailable: "停止生成不可用：{{reason}}",
+      stop: "停止生成", stopUnavailable: "停止生成不可用：{{reason}}",
       unsupported: "不支持", stoppingUnavailable: "当前无法停止", send: "发送消息", sendDisabled: "输入内容后发送",
       context: { title: "上下文窗口", used: "已使用 {{percent}}%（剩余 {{left}}%）", strategy: "策略：{{strategy}}", aria: "上下文窗口已使用 {{percent}}%，剩余 {{left}}%", tokens: "已使用 {{used}} / {{window}} Token", zero: "已使用 0 Token", provider: "Provider 报告的 Token 预算" },
     },

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -6003,13 +6003,6 @@ button.tinyos-overlay-backdrop:focus-visible {
   gap: 6px;
 }
 
-.claude-ai-input__running-actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 6px;
-}
-
 .claude-ai-input__icon-button,
 .claude-ai-input__send {
   display: inline-grid;


### PR DESCRIPTION
## Summary

- make canonical timeline persistence, replay, and live patch application converge across reloads
- recover from stale or identity-conflicting timeline patches without crashing the renderer
- synchronize completed child-workspace timelines back to session and Thread status so finished sessions stop showing as running
- replace separate queue and stop composer controls with one accessible action that switches between Send and Stop while preserving Enter-to-queue behavior

## Root cause

Live timeline patches, durable runtime projections, and the cached Thread status could advance independently. Switching sessions during child-workspace execution could therefore combine incompatible revisions or leave a completed child marked as running. The composer also exposed queue and stop as two simultaneous primary actions while a turn was active.

## User impact

Coordinator-created child sessions now remain renderable during live updates, expose completion promptly, and use a single predictable composer action.

## Validation

- `npm test -- src/app-core/chat/desktopChatSessionController.test.ts src/components/ui/claude-style-ai-input.test.tsx src/react-workbench/chat/ChatPage.test.tsx` (138 tests)
- `npm run build`
- `git diff --check`
