### PR TITLE
feat: support desktop pet file drops and link source icons

### DIFF
--- a/docs/api/desktop.md
+++ b/docs/api/desktop.md
@@ -15,7 +15,7 @@ src/app-core/native/desktopNativePet.ts
 src/app-core/native/desktopNativePetQuickChat.ts
 src/app-core/native/nativeBackendContract.test.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:29aa71ff7e4bd723be9fd0caf9baf8e47f91f4cac58f80cff8c7b4c9541e0cbe -->
+<!-- tinybot-doc-fingerprint: sha256:71fcce8c46b56e033db235f644c47a2d3bf56543d908d203b24657c0d520a08e -->
 
 This document covers native desktop lifecycle and operating-system integration
 commands. It is part of the [Rust backend API reference](rust-backend-api.md),
@@ -52,12 +52,19 @@ the main window does not remove it from the desktop.
 
 The pet renderer is selected with `index.html?surface=desktop-pet`; it does not
 start another App service graph. Dropping external `text/plain` content on the
-pet, or clicking its chat affordance, sends a validated request through the
-typed `desktopNativePetQuickChat` event seam. The main renderer positions the
-quick-chat panel next to the pet within the current monitor work area, then the
-`?surface=desktop-pet-chat` renderer presents an editable draft and uses the
-canonical Thread stores for model selection, token usage, timeline updates,
-and first-send creation of a standard non-workspace Thread. Its title bar
+pet, dropping one to ten local `Files`, or clicking its chat affordance sends a
+validated `tinybot.desktop_pet_quick_chat.v2` request through the typed
+`desktopNativePetQuickChat` event seam. Text remains an editable draft. For
+files, the HTML5 drop supplies WebView2 additional objects; `pet_file_drop`
+validates the Tauri invoke key, extracts only local paths, and delegates to the
+same native attachment importer as `pick_chat_files`. Images therefore receive
+a managed path and content hash, ordinary files retain their path, directories
+fail explicitly, and no file bytes cross the renderer message boundary. The
+main renderer positions the quick-chat panel next to the pet within the current
+monitor work area, then the `?surface=desktop-pet-chat` renderer presents the
+editable draft and removable attachments and uses the canonical Thread stores
+for model selection, token usage, timeline updates, and first-send creation of
+a standard non-workspace Thread. File-only submission is valid. Its title bar
 starts native window dragging while leaving the window controls interactive.
 Opening a quick-chat Thread in Tinybot first shows, restores, and focuses
 `main`, then refreshes and activates the explicit Thread ID carried by the
@@ -75,10 +82,13 @@ Closing `desktop-pet` prevents destruction, hides the window, and notifies
 `main` to persist `visible: false`; closing `desktop-pet-chat` hides it without
 discarding canonical Thread state. Closing `main` performs the normal bounded
 runtime cleanup before destroying both auxiliary windows. The pet's
-Windows-only capability grants only event, position, scale-factor, and
-native-drag access. The quick-chat capability grants events, window hide,
-native dragging, and a least-privilege application-command subset for its chat
-workflow. The build-time application-command manifest prevents either
+Windows-only capability grants only event, position, scale-factor, native-drag,
+and the no-op `desktop_pet_drop_signal` used to authenticate the WebView2
+additional-object message. The command does not accept paths or file bytes and
+is not a general-purpose `invoke` API. The quick-chat capability grants events,
+window hide, native dragging, `pick_chat_files`, and the remaining
+least-privilege application-command subset for its chat workflow. The
+build-time application-command manifest prevents either
 auxiliary webview from inheriting the wider main-window command surface.
 
 ## Sidecar Terminal Commands
@@ -106,7 +116,7 @@ back to `~/.tinybot/workspace`.
 | Command | Args | Response |
 | --- | --- | --- |
 | `pick_upload_file` | `{ options: { title?: string, filters?: { name: string, extensions: string[] }[] } }` | `null` when cancelled, or `{ name, path, mime_type, size_bytes, bytes }` |
-| `pick_chat_files` | `{ options: { title?: string, filters?: { name: string, extensions: string[] }[] } }` | `[]` when cancelled, or `{ name, path, mimeType, sizeBytes, contentHash? }[]`; supported images are copied into Tinybot-managed storage and identified by `contentHash`, while other files keep their selected path; file bytes are not returned |
+| `pick_chat_files` | `{ options: { title?: string, filters?: { name: string, extensions: string[] }[] } }` | `[]` when cancelled, or `{ name, path, mimeType, sizeBytes, contentHash? }[]`; non-files fail, supported images are copied into Tinybot-managed storage and identified by `contentHash`, while other files keep their selected path; file bytes are not returned |
 | `pick_workspace_directory` | `{ options: { title?: string } }` | `null` when cancelled, or the selected absolute UTF-8 path |
 | `save_export_file` | `{ options: { title?: string, defaultPath?: string, filters?: Filter[], contents: string } }` | `null` when cancelled, or `{ path }` |
 | `reveal_workspace_file` | `{ path: string }` | `void` |

--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -10,7 +10,7 @@ src/app-core/native/desktopNativeUpdate.ts
 src/app-core/native/desktopNativeWebui.ts
 src/app-core/native/nativeBackendContract.test.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:d6d38b55d7408535717eb604ae51be768636ce8a75924c75fb579d28170fa283 -->
+<!-- tinybot-doc-fingerprint: sha256:6e6c3edf3ea3f39fecd16dc940273b9fe124f7026f0606c8dfcf8ff1db1b90c8 -->
 
 This document describes the API surfaces exposed by the Rust/Tauri backend in `src-tauri`.
 It is intended for frontend callers and integrators who need command names, invocation
@@ -128,7 +128,8 @@ Prefer these wrappers instead of direct command strings:
 | `createDesktopNativeAgentGraphRuntime` | `src/app-core/native/desktopNativeAgentGraphRuntime.ts` | Graph Run history and saved-revision execution |
 | `createDesktopNativeConfigApi` | `src/app-core/native/desktopNativeConfig.ts` | Config snapshot |
 | `createDesktopNativeHooksApi` | `src/app-core/native/desktopNativeHooks.ts` | Workspace hook catalog, managed-hook save/test/archive, constrained script editing, and exact-definition trust |
-| `createDesktopNativePetQuickChatHost` / quick-chat clients | `src/app-core/native/desktopNativePetQuickChat.ts` | Validated desktop-pet draft handoff, panel presentation, dismissal, and explicit Thread handoff to `main` through scoped Tauri events |
+| `createDesktopNativePetFileDropImporter` | `src/app-core/native/desktopNativePetFileDrop.ts` | Bounded Windows WebView2 file-drop result handshake, timeout, and strict attachment-metadata parsing |
+| `createDesktopNativePetQuickChatHost` / quick-chat clients | `src/app-core/native/desktopNativePetQuickChat.ts` | Validated desktop-pet draft-and-attachment handoff, panel presentation, dismissal, and explicit Thread handoff to `main` through scoped Tauri events |
 | `createDesktopNativeUpdateClient` | `src/app-core/native/desktopNativeUpdate.ts` | Desktop update status, check, install, and status events |
 | `createDesktopNativeThreadsApi` | `src/app-core/native/desktopNativeThreads.ts` | Thread, Turn timeline, and effective-capability commands |
 | `createDesktopNativeHostCommandApi` | `src/app-core/native/desktopNativeHostCommand.ts` | Transitional Chat `operation.retry` dispatch |

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:ce1ea4469cf906030a216de6b46f87f24bb35f68aa22b8a9f9f061a2c67807b0 -->
+<!-- tinybot-doc-fingerprint: sha256:b706237fb478e81f795251ee736d3c125db592898e826a1ac0666c0e76921d98 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -60,6 +60,7 @@ Desktop Commands / Desktop Host
 | `graph_runs` | Linear Graph preflight, Run status files, Agent node sequencing, and standard Thread creation | Renderer state, definition editing, or the Agent Loop implementation |
 | `app-core/native` | Typed renderer adapters for native commands and events | Product state or backend behavior |
 | `desktop_commands` | Thin Tauri input/output adaptation | Reusable domain behavior |
+| `desktop/pet_file_drop` and `desktop/files` | Windows WebView2 dropped-path extraction plus shared chat-attachment validation/import | Chat state, file-byte transport, or renderer presentation |
 | `desktop_terminal` | User-only Sidecar PTY lifecycle and resource ownership | Agent shell sessions or renderer presentation |
 | `chat_attachments` | Content-addressed managed image storage, validation, and request-local Data URL encoding | Conversation authority or provider protocol selection |
 | `agent::bridge` | Complete Turn orchestration and persistence coordination | Provider iteration or the Thread data model |
@@ -115,8 +116,12 @@ Desktop Commands / Desktop Host
   never becomes a second authority.
 - Desktop pet quick-chat state: canonical Threads and Rollouts remain
   authoritative. The `desktop-pet-chat` webview owns only its editable draft,
-  selected recent Thread, and shared composer/timeline projection; explicit
-  Tauri events carry draft presentation and main-window Thread activation.
+  removable attachment selection, selected recent Thread, and shared
+  composer/timeline projection. The native `pet_file_drop` Adapter extracts
+  local paths from WebView2 additional objects, while the shared attachment
+  importer owns validation and managed-image storage; explicit Tauri events
+  carry versioned draft-and-attachment presentation and main-window Thread
+  activation.
 
 An adapter may translate at a seam, but it must not become a second authority.
 
@@ -141,9 +146,10 @@ receives snapshots from `DesktopShell` through `app-core/native`, so showing a
 global desktop pet does not duplicate routes, stores, or native runtimes. The
 `?surface=desktop-pet-chat` path mounts `DesktopPetQuickChatWindow` with a
 bounded service composition and a least-privilege Tauri command permission so
-it can create and continue canonical Threads; the scoped native event seam
-positions it next to the pet and hands an explicit Thread ID back to
-`DesktopShell` when the user opens the conversation in the main Chat route.
+it can pick attachments and create and continue canonical Threads; the scoped
+native event seam positions it next to the pet and hands an explicit Thread ID
+back to `DesktopShell` when the user opens the conversation in the main Chat
+route.
 
 ## Cross-module flows
 

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:1f08a5450e4a2482e0ead3cfd418e20a33995d08eb07f4fe5386289b610c21da -->
+<!-- tinybot-doc-fingerprint: sha256:746e277974435fce3795c7d41e86be8c80e077617c14468a27fe72e076b10bbd -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:eee270ed1cb4ea9dab9bbd6ee463241ba40cfb1ddcc427d257761fe4c538582e -->
+<!-- tinybot-module-fingerprint: sha256:443d3e93d8154b016ea2526883dfd215b25f789d1df4b656c161aeeb1ed2d2f3 -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime
@@ -18,7 +18,8 @@ For desktop setup and launch behavior, see [the desktop guide](../docs/desktop.m
   `src/desktop/diagnostics.rs` owns bounded Performance Trace snapshots and
   local diagnostic ZIP export; `src/desktop/pet.rs` creates the Windows-only
   transparent desktop-pet window and its adjacent quick-chat panel without
-  making either an owned child of `main`.
+  making either an owned child of `main`; `src/desktop/pet_file_drop.rs` owns
+  the WebView2 local-file bridge used by the pet.
 
 Sidecar terminals with no explicit Thread working directory resolve through
 the same configured native backend workspace used by ordinary Agent turns.
@@ -34,12 +35,15 @@ local server.
 
 Tauri capabilities remain window-scoped. `capabilities/default.json` belongs
 to the main webview, while `capabilities/desktop-pet.json` grants the pet only
-event, position, and native drag operations on Windows. The separate
+event, position, native drag operations, and its no-op file-drop signal on
+Windows. The separate
 `capabilities/desktop-pet-chat.json` grants the quick-chat panel scoped events,
 window hiding, native dragging, and only the application commands required to
-list, create, configure, and run chat Threads. `app_commands.rs` is the
+pick attachments and list, create, configure, and run chat Threads.
+`app_commands.rs` is the
 build-time application-command manifest; `permissions/app-commands.toml`
-separates the complete main-window command surface from that quick-chat subset.
+separates the complete main-window command surface from the narrow pet and
+quick-chat subsets.
 The main capability also grants restore and focus operations so quick-chat
 handoff can bring a minimized main window to the foreground before routing to
 the selected Thread.

--- a/src-tauri/app_commands.rs
+++ b/src-tauri/app_commands.rs
@@ -90,6 +90,7 @@ pub const APP_COMMANDS: &[&str] = &[
     "apply_config_patch_result",
     "apply_config_operations",
     "pick_chat_files",
+    "desktop_pet_drop_signal",
     "pick_workspace_directory",
     "pick_upload_file",
     "reveal_workspace_file",

--- a/src-tauri/capabilities/desktop-pet.json
+++ b/src-tauri/capabilities/desktop-pet.json
@@ -9,6 +9,7 @@
     "core:window:allow-outer-position",
     "core:window:allow-scale-factor",
     "core:window:allow-set-position",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    "desktop-pet-drop-app-commands"
   ]
 }

--- a/src-tauri/permissions/app-commands.toml
+++ b/src-tauri/permissions/app-commands.toml
@@ -93,6 +93,7 @@ commands.allow = [
   "apply_config_patch_result",
   "apply_config_operations",
   "pick_chat_files",
+  "desktop_pet_drop_signal",
   "pick_workspace_directory",
   "pick_upload_file",
   "reveal_workspace_file",
@@ -124,6 +125,11 @@ commands.allow = [
 ]
 
 [[permission]]
+identifier = "desktop-pet-drop-app-commands"
+description = "Allows the desktop pet webview to signal a WebView2 file drop without broader application command access."
+commands.allow = ["desktop_pet_drop_signal"]
+
+[[permission]]
 identifier = "desktop-pet-quick-chat-app-commands"
 description = "Allows the desktop pet quick chat webview to load, create, configure, and run chat threads."
 commands.allow = [
@@ -131,6 +137,7 @@ commands.allow = [
   "record_renderer_log",
   "get_settings_snapshot",
   "get_config_editor_snapshot",
+  "pick_chat_files",
   "worker_webui_route",
   "worker_threads_list",
   "worker_thread_create",

--- a/src-tauri/src/desktop/README.md
+++ b/src-tauri/src/desktop/README.md
@@ -1,13 +1,14 @@
 # Desktop Runtime
-<!-- tinybot-module-fingerprint: sha256:9cb23caa1a81ad7dafb49223d0fcd5bd19938db0a58ae08a1fb3675fcfdeca46 -->
+<!-- tinybot-module-fingerprint: sha256:3e88ff3e34f1c96757629c846101f1c96adf03b746bcd9e51963bded76573629 -->
 
 `desktop` wires the Rust backend into the Tauri application. It owns startup,
 shared desktop state, logging, file helpers, menus, and application updates.
 
-`files` detects supported images by content when the chat picker returns them,
-copies them into content-addressed application storage, and returns their hash
-with the managed path. Other selected files retain their original path, and no
-file bytes cross the Tauri command boundary.
+`files` is the shared chat-attachment importer for picker and desktop-pet
+drops. It rejects non-files, detects supported images by content, copies images
+into content-addressed application storage, and returns their hash with the
+managed path. Other files retain their original path, and no file bytes cross
+the Tauri command boundary.
 
 `bootstrap` also creates the Windows-only `desktop-pet` and
 `desktop-pet-chat` transparent webview windows through `pet`. Both remain
@@ -15,9 +16,13 @@ independent from the main window and stay available while it is minimized. A
 pet close request hides the pet; a quick-chat close request hides only the
 panel. Both auxiliary windows own an explicit empty native menu and keep it
 hidden so later application-menu updates cannot attach menu labels or alter
-their transparent client area. The quick-chat webview disables Tauri's native
-drag-drop handler so the pet can receive external browser text through frontend
-HTML5 drag events.
+their transparent client area. The pet webview disables Tauri's native
+drag-drop handler so frontend HTML5 events continue to receive browser text and
+Explorer files. On Windows, `pet_file_drop` owns a narrow WebView2
+additional-object bridge: it validates the Tauri invoke key, extracts local
+file paths, delegates to the shared attachment importer, and emits a bounded
+result back to the pet. `pet` depends only on its initialization and
+registration Interface.
 Closing the main window still shuts down the Sidecar terminal and native
 runtimes first, then destroys both auxiliary windows and the main window.
 

--- a/src-tauri/src/desktop/bootstrap.rs
+++ b/src-tauri/src/desktop/bootstrap.rs
@@ -294,6 +294,7 @@ pub(crate) fn run() {
             crate::desktop_commands::config::apply_config_patch_result,
             crate::desktop_commands::config::apply_config_operations,
             crate::desktop::files::pick_chat_files,
+            crate::desktop::pet_file_drop::desktop_pet_drop_signal,
             crate::desktop::files::pick_workspace_directory,
             crate::desktop::files::pick_upload_file,
             crate::desktop::files::reveal_workspace_file,

--- a/src-tauri/src/desktop/files.rs
+++ b/src-tauri/src/desktop/files.rs
@@ -40,7 +40,7 @@ pub(crate) struct PickedUploadFile {
     pub(crate) bytes: Vec<u8>,
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PickedChatFile {
     pub(crate) name: String,
@@ -95,12 +95,10 @@ pub(crate) fn pick_chat_files(
         let extensions: Vec<&str> = filter.extensions.iter().map(String::as_str).collect();
         dialog = dialog.add_filter(&filter.name, &extensions);
     }
-    dialog
-        .pick_files()
-        .unwrap_or_default()
-        .iter()
-        .map(|path| chat_file_from_path(path, &crate::config::application::tinybot_data_root()))
-        .collect()
+    chat_files_from_paths(
+        &dialog.pick_files().unwrap_or_default(),
+        &crate::config::application::tinybot_data_root(),
+    )
 }
 
 #[tauri::command]
@@ -168,6 +166,16 @@ pub(crate) fn upload_file_from_path(path: &Path) -> Result<PickedUploadFile, Str
     })
 }
 
+pub(crate) fn chat_files_from_paths(
+    paths: &[PathBuf],
+    data_root: &Path,
+) -> Result<Vec<PickedChatFile>, String> {
+    paths
+        .iter()
+        .map(|path| chat_file_from_path(path, data_root))
+        .collect()
+}
+
 fn chat_file_from_path(path: &Path, data_root: &Path) -> Result<PickedChatFile, String> {
     let path = if path.is_absolute() {
         path.to_path_buf()
@@ -178,6 +186,12 @@ fn chat_file_from_path(path: &Path, data_root: &Path) -> Result<PickedChatFile, 
     };
     let metadata = std::fs::metadata(&path)
         .map_err(|error| format!("failed to inspect selected file: {error}"))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "selected attachment is not a regular file: {}",
+            path.display()
+        ));
+    }
     let managed_image = crate::chat_attachments::store_image_attachment(&path, data_root)?;
     let (stored_path, mime_type, size_bytes, content_hash) = match managed_image {
         Some(image) => (
@@ -328,4 +342,52 @@ fn safe_export_file_name(default_path: &str) -> String {
         .trim()
         .trim_matches('-')
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn chat_file_import_rejects_directories_before_attachment_storage() {
+        let directory = unique_temp_path("directory");
+        std::fs::create_dir_all(&directory).expect("create test directory");
+
+        let error = chat_file_from_path(&directory, &directory)
+            .expect_err("directories must not become chat attachments");
+
+        assert!(error.contains("not a regular file"), "{error}");
+        std::fs::remove_dir_all(directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn chat_file_import_preserves_non_image_metadata_without_copying_bytes() {
+        let directory = unique_temp_path("text-file");
+        std::fs::create_dir_all(&directory).expect("create test directory");
+        let path = directory.join("notes.md");
+        std::fs::write(&path, b"hello").expect("write test attachment");
+
+        let imported = chat_files_from_paths(std::slice::from_ref(&path), &directory)
+            .expect("import text attachment");
+
+        assert_eq!(imported.len(), 1);
+        assert_eq!(imported[0].name, "notes.md");
+        assert_eq!(imported[0].path, path.display().to_string());
+        assert_eq!(imported[0].mime_type, "text/markdown");
+        assert_eq!(imported[0].size_bytes, 5);
+        assert_eq!(imported[0].content_hash, None);
+        std::fs::remove_dir_all(directory).expect("remove test directory");
+    }
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "tinybot-chat-file-{label}-{}-{nonce}",
+            std::process::id()
+        ))
+    }
 }

--- a/src-tauri/src/desktop/mod.rs
+++ b/src-tauri/src/desktop/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod files;
 pub(crate) mod logging;
 pub(crate) mod menu;
 pub(crate) mod pet;
+pub(crate) mod pet_file_drop;
 pub(crate) mod state;
 mod update;
 

--- a/src-tauri/src/desktop/pet.rs
+++ b/src-tauri/src/desktop/pet.rs
@@ -33,6 +33,9 @@ fn isolated_desktop_window_menu<R: tauri::Runtime>(
 pub(crate) fn create_desktop_pet_window<R: tauri::Runtime>(
     app: &mut tauri::App<R>,
 ) -> tauri::Result<()> {
+    let drop_script = super::pet_file_drop::initialization_script(app.invoke_key());
+    let app_handle = app.handle().clone();
+    let invoke_key = app.invoke_key().to_string();
     let window = tauri::WebviewWindowBuilder::new(
         app,
         DESKTOP_PET_WINDOW_LABEL,
@@ -51,8 +54,10 @@ pub(crate) fn create_desktop_pet_window<R: tauri::Runtime>(
     .skip_taskbar(true)
     .visible(false)
     .disable_drag_drop_handler()
+    .initialization_script(drop_script)
     .build()?;
     window.hide_menu()?;
+    super::pet_file_drop::register_bridge(&window, app_handle, invoke_key)?;
     eprintln!("desktop_pet_window_created visible=false menu_scope=isolated");
     Ok(())
 }

--- a/src-tauri/src/desktop/pet_file_drop.rs
+++ b/src-tauri/src/desktop/pet_file_drop.rs
@@ -1,0 +1,303 @@
+#[cfg(windows)]
+use serde::{Deserialize, Serialize};
+#[cfg(windows)]
+use std::path::PathBuf;
+#[cfg(windows)]
+use tauri::Emitter;
+#[cfg(windows)]
+use webview2_com::{
+    Microsoft::Web::WebView2::Win32::{
+        ICoreWebView2File, ICoreWebView2WebMessageReceivedEventArgs2,
+    },
+    WebMessageReceivedEventHandler,
+};
+#[cfg(windows)]
+use windows::core::{Interface, PWSTR};
+
+#[cfg(windows)]
+const DROP_SIGNAL_COMMAND: &str = "desktop_pet_drop_signal";
+#[cfg(windows)]
+const FILE_DROP_RESULT_EVENT: &str = "desktop-pet-file-drop-result";
+#[cfg(windows)]
+const FILE_DROP_SCHEMA_VERSION: &str = "tinybot.desktop_pet_file_drop.v1";
+#[cfg(windows)]
+const MAX_DROPPED_FILES: u32 = 10;
+#[cfg(windows)]
+const INITIALIZATION_SCRIPT: &str = r#"
+;(() => {
+  const invokeKey = __TINYBOT_INVOKE_KEY__;
+  Object.defineProperty(window, '__TINYBOT_DESKTOP_PET_POST_DROPPED_FILES__', {
+    value: (requestId, files) => new Promise((resolve, reject) => {
+      const additionalObjects = Array.from(files || []);
+      if (!requestId || !additionalObjects.length || !additionalObjects.every((file) => file instanceof File)) {
+        reject(new Error('Desktop pet file-drop bridge received invalid input.'));
+        return;
+      }
+      const internals = window.__TAURI_INTERNALS__;
+      let callback;
+      let error;
+      callback = internals.transformCallback((value) => {
+        internals.unregisterCallback(error);
+        resolve(value);
+      }, true);
+      error = internals.transformCallback((value) => {
+        internals.unregisterCallback(callback);
+        const message = typeof value === 'string' ? value : JSON.stringify(value) || String(value);
+        reject(new Error(message));
+      }, true);
+      try {
+        window.chrome.webview.postMessageWithAdditionalObjects(JSON.stringify({
+          cmd: 'desktop_pet_drop_signal',
+          callback,
+          error,
+          payload: { requestId },
+          options: {},
+          __TAURI_INVOKE_KEY__: invokeKey,
+        }), additionalObjects);
+      } catch (postError) {
+        internals.unregisterCallback(callback);
+        internals.unregisterCallback(error);
+        reject(postError);
+      }
+    }),
+  });
+})();
+"#;
+
+#[cfg(windows)]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DropSignalPayload {
+    request_id: String,
+}
+
+#[cfg(windows)]
+#[derive(Deserialize)]
+struct DropIpcMessage {
+    cmd: String,
+    payload: DropSignalPayload,
+    #[serde(rename = "__TAURI_INVOKE_KEY__")]
+    invoke_key: String,
+}
+
+#[cfg(windows)]
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FileDropResult {
+    schema_version: &'static str,
+    request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    files: Option<Vec<crate::desktop::files::PickedChatFile>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[cfg(windows)]
+pub(crate) fn initialization_script(invoke_key: &str) -> String {
+    INITIALIZATION_SCRIPT.replace(
+        "__TINYBOT_INVOKE_KEY__",
+        &serde_json::to_string(invoke_key).expect("serialize Tauri invoke key"),
+    )
+}
+
+#[cfg(windows)]
+pub(crate) fn register_bridge<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    app: tauri::AppHandle<R>,
+    invoke_key: String,
+) -> tauri::Result<()> {
+    window.with_webview(move |platform| {
+        let result = (|| -> Result<(), String> {
+            let core = unsafe { platform.controller().CoreWebView2() }
+                .map_err(|error| format!("failed to access desktop pet WebView2: {error}"))?;
+            let handler = WebMessageReceivedEventHandler::create(Box::new(move |_sender, args| {
+                let Some(args) = args else {
+                    return Ok(());
+                };
+                let Some(signal) = drop_signal_from_message(&args, &invoke_key) else {
+                    return Ok(());
+                };
+                let request_id = signal.payload.request_id;
+                let paths = match dropped_paths(&args) {
+                    Ok(paths) => paths,
+                    Err(error) => {
+                        emit_result(&app, request_id, Err(error));
+                        return Ok(());
+                    }
+                };
+                let import_app = app.clone();
+                let import_request_id = request_id.clone();
+                if let Err(error) = std::thread::Builder::new()
+                    .name("desktop-pet-file-drop".to_string())
+                    .spawn(move || {
+                        eprintln!(
+                            "desktop_pet_file_drop_import_started request_id={} file_count={}",
+                            import_request_id,
+                            paths.len()
+                        );
+                        let result = crate::desktop::files::chat_files_from_paths(
+                            &paths,
+                            &crate::config::application::tinybot_data_root(),
+                        );
+                        emit_result(&import_app, import_request_id, result);
+                    })
+                {
+                    emit_result(
+                        &app,
+                        request_id,
+                        Err(format!("failed to start desktop pet file import: {error}")),
+                    );
+                }
+                Ok(())
+            }));
+            let mut token = 0;
+            unsafe { core.add_WebMessageReceived(&handler, &mut token) }.map_err(|error| {
+                format!("failed to register desktop pet file-drop bridge: {error}")
+            })?;
+            Ok(())
+        })();
+        if let Err(error) = result {
+            eprintln!("desktop_pet_file_drop_bridge_registration_failed error={error}");
+        }
+    })
+}
+
+#[tauri::command]
+pub(crate) fn desktop_pet_drop_signal(request_id: String) -> Result<(), String> {
+    #[cfg(not(windows))]
+    {
+        let _ = request_id;
+        return Err("desktop pet file drops require Windows WebView2".to_string());
+    }
+    #[cfg(windows)]
+    {
+        validate_request_id(&request_id)?;
+        eprintln!("desktop_pet_file_drop_signal_received request_id={request_id}");
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn drop_signal_from_message(
+    args: &webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2WebMessageReceivedEventArgs,
+    invoke_key: &str,
+) -> Option<DropIpcMessage> {
+    let mut raw = PWSTR::null();
+    unsafe { args.TryGetWebMessageAsString(&mut raw) }.ok()?;
+    let message = webview2_com::take_pwstr(raw);
+    let value = serde_json::from_str::<serde_json::Value>(&message).ok()?;
+    if value.get("cmd").and_then(serde_json::Value::as_str) != Some(DROP_SIGNAL_COMMAND) {
+        return None;
+    }
+    let signal = match serde_json::from_value::<DropIpcMessage>(value) {
+        Ok(signal) => signal,
+        Err(error) => {
+            eprintln!("desktop_pet_file_drop_signal_invalid error={error}");
+            return None;
+        }
+    };
+    if signal.cmd != DROP_SIGNAL_COMMAND || signal.invoke_key != invoke_key {
+        eprintln!("desktop_pet_file_drop_signal_rejected reason=invalid_command_or_invoke_key");
+        return None;
+    }
+    if let Err(error) = validate_request_id(&signal.payload.request_id) {
+        eprintln!("desktop_pet_file_drop_signal_rejected reason={error}");
+        return None;
+    }
+    Some(signal)
+}
+
+#[cfg(windows)]
+fn dropped_paths(
+    args: &webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2WebMessageReceivedEventArgs,
+) -> Result<Vec<PathBuf>, String> {
+    let args2: ICoreWebView2WebMessageReceivedEventArgs2 = args
+        .cast()
+        .map_err(|error| format!("desktop pet drop does not expose WebView2 files: {error}"))?;
+    let objects = unsafe { args2.AdditionalObjects() }
+        .map_err(|error| format!("failed to read desktop pet dropped files: {error}"))?;
+    let mut count = 0;
+    unsafe { objects.Count(&mut count) }
+        .map_err(|error| format!("failed to count desktop pet dropped files: {error}"))?;
+    if count == 0 || count > MAX_DROPPED_FILES {
+        return Err(format!(
+            "desktop pet file drops require 1 to {MAX_DROPPED_FILES} files"
+        ));
+    }
+    (0..count)
+        .map(|index| {
+            let object = unsafe { objects.GetValueAtIndex(index) }
+                .map_err(|error| format!("failed to read dropped object {index}: {error}"))?;
+            let file: ICoreWebView2File = object
+                .cast()
+                .map_err(|error| format!("dropped object {index} is not a local file: {error}"))?;
+            let mut raw_path = PWSTR::null();
+            unsafe { file.Path(&mut raw_path) }
+                .map_err(|error| format!("failed to read dropped file path {index}: {error}"))?;
+            let path = PathBuf::from(webview2_com::take_pwstr(raw_path));
+            if path.as_os_str().is_empty() {
+                return Err(format!("dropped file path {index} is empty"));
+            }
+            Ok(path)
+        })
+        .collect()
+}
+
+#[cfg(windows)]
+fn emit_result<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    request_id: String,
+    result: Result<Vec<crate::desktop::files::PickedChatFile>, String>,
+) {
+    let (files, error) = match result {
+        Ok(files) => {
+            eprintln!(
+                "desktop_pet_file_drop_import_completed request_id={} file_count={}",
+                request_id,
+                files.len()
+            );
+            (Some(files), None)
+        }
+        Err(error) => {
+            eprintln!(
+                "desktop_pet_file_drop_import_failed request_id={} error={}",
+                request_id, error
+            );
+            (None, Some(error))
+        }
+    };
+    let payload = FileDropResult {
+        schema_version: FILE_DROP_SCHEMA_VERSION,
+        request_id,
+        files,
+        error,
+    };
+    if let Err(error) = app.emit_to(
+        super::pet::DESKTOP_PET_WINDOW_LABEL,
+        FILE_DROP_RESULT_EVENT,
+        payload,
+    ) {
+        eprintln!("desktop_pet_file_drop_result_emit_failed error={error}");
+    }
+}
+
+fn validate_request_id(request_id: &str) -> Result<(), String> {
+    if request_id.starts_with("pet-file-drop-") && request_id.len() <= 128 {
+        Ok(())
+    } else {
+        Err("invalid desktop pet file-drop request ID".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_bounded_file_drop_request_ids() {
+        assert!(validate_request_id("pet-file-drop-abc123").is_ok());
+        assert!(validate_request_id("").is_err());
+        assert!(validate_request_id("chat-drop-abc123").is_err());
+        assert!(validate_request_id(&format!("pet-file-drop-{}", "x".repeat(128))).is_err());
+    }
+}

--- a/src/app-core/native/README.md
+++ b/src/app-core/native/README.md
@@ -1,5 +1,5 @@
 # Native Renderer Adapters
-<!-- tinybot-module-fingerprint: sha256:c71f977b65867c77c909b7365fe15cbc5753d0f2b9a33c3e7821213c6291a656 -->
+<!-- tinybot-module-fingerprint: sha256:0a5fa659edb446c00400e115fdaea4b6b6f50fff4c8844bddb50dd66abe91ee3 -->
 
 `native` contains typed adapters for Tauri commands and events used by the
 desktop renderer. Each file owns one native capability, such as Threads,
@@ -50,10 +50,12 @@ Neither side creates a second application service graph.
 `desktopNativePetQuickChat` owns the typed event handshake between the pet,
 main renderer, and independent `desktop-pet-chat` webview. The main host alone
 positions, presents, and focuses the native panel; the pet sends a bounded
-plain-text draft, and the quick-chat window can hand an explicit Thread ID back
-to the main Chat route or start native dragging from its title bar. Main-window
-handoff shows, restores, and focuses `main` before dispatching the route event.
-Invalid or oversized payloads fail at this adapter boundary.
+draft plus validated attachment metadata, and the quick-chat window can hand an
+explicit Thread ID back to the main Chat route or start native dragging from
+its title bar. `desktopNativePetFileDrop` owns the Windows WebView2 result
+handshake, request timeout, and strict metadata parsing. Main-window handoff
+shows, restores, and focuses `main` before dispatching the route event. Invalid
+or oversized payloads fail at these Adapter boundaries.
 
 `desktopNativeHostCommand` is a transitional retry adapter: it dispatches only
 Chat `operation.retry` frames. Browser sessions remain a separate native

--- a/src/app-core/native/desktopNativeCommandPermissions.test.ts
+++ b/src/app-core/native/desktopNativeCommandPermissions.test.ts
@@ -56,6 +56,7 @@ describe("desktop native command permissions", () => {
       "record_renderer_log",
       "get_settings_snapshot",
       "get_config_editor_snapshot",
+      "pick_chat_files",
       "worker_webui_route",
       "worker_threads_list",
       "worker_thread_create",
@@ -71,6 +72,12 @@ describe("desktop native command permissions", () => {
     expect(capabilityPermissions("desktop-pet.json")).not.toContain("main-app-commands");
     expect(capabilityPermissions("desktop-pet.json")).not.toContain(
       "desktop-pet-quick-chat-app-commands",
+    );
+    expect(permissionCommands("desktop-pet-drop-app-commands")).toEqual([
+      "desktop_pet_drop_signal",
+    ]);
+    expect(capabilityPermissions("desktop-pet.json")).toContain(
+      "desktop-pet-drop-app-commands",
     );
   });
 });

--- a/src/app-core/native/desktopNativePetFileDrop.test.ts
+++ b/src/app-core/native/desktopNativePetFileDrop.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDesktopNativePetFileDropImporter } from "./desktopNativePetFileDrop";
+
+describe("createDesktopNativePetFileDropImporter", () => {
+  it("listens before posting files and returns validated native metadata", async () => {
+    let listener: ((event: { payload: unknown }) => void) | undefined;
+    const calls: string[] = [];
+    const importer = createDesktopNativePetFileDropImporter({
+      listen: vi.fn(async (_event, nextListener) => {
+        calls.push("listen");
+        listener = nextListener;
+        return () => calls.push("unlisten");
+      }),
+      post: vi.fn(async (requestId) => {
+        calls.push("post");
+        listener?.({
+          payload: {
+            schemaVersion: "tinybot.desktop_pet_file_drop.v1",
+            requestId,
+            files: [{
+              contentHash: "abc123",
+              mimeType: "image/png",
+              name: "diagram.png",
+              path: "C:\\Tinybot\\diagram.png",
+              sizeBytes: 2048,
+            }],
+          },
+        });
+      }),
+      requestId: () => "drop-1",
+    });
+
+    const files = [new File(["image"], "diagram.png", { type: "image/png" })];
+    await expect(importer(files)).resolves.toEqual([{
+      contentHash: "abc123",
+      mimeType: "image/png",
+      name: "diagram.png",
+      path: "C:\\Tinybot\\diagram.png",
+      sizeBytes: 2048,
+    }]);
+    expect(calls).toEqual(["listen", "post", "unlisten"]);
+  });
+
+  it("surfaces native import failures without returning partial attachments", async () => {
+    let listener: ((event: { payload: unknown }) => void) | undefined;
+    const importer = createDesktopNativePetFileDropImporter({
+      listen: vi.fn(async (_event, nextListener) => {
+        listener = nextListener;
+        return () => undefined;
+      }),
+      post: vi.fn(async (requestId) => {
+        listener?.({
+          payload: {
+            schemaVersion: "tinybot.desktop_pet_file_drop.v1",
+            requestId,
+            error: "Dropped paths must point to regular files.",
+          },
+        });
+      }),
+      requestId: () => "drop-2",
+    });
+
+    await expect(importer([new File(["x"], "folder")])).rejects.toThrow(
+      "Dropped paths must point to regular files.",
+    );
+  });
+
+  it("times out even when the WebView2 signal callback never settles", async () => {
+    const importer = createDesktopNativePetFileDropImporter({
+      listen: vi.fn(async () => () => undefined),
+      post: vi.fn(() => new Promise<void>(() => undefined)),
+      requestId: () => "drop-3",
+      timeoutMs: 1,
+    });
+
+    await expect(importer([new File(["x"], "notes.txt")])).rejects.toThrow(
+      "Desktop pet file import timed out after 1 ms.",
+    );
+  });
+});

--- a/src/app-core/native/desktopNativePetFileDrop.ts
+++ b/src/app-core/native/desktopNativePetFileDrop.ts
@@ -1,0 +1,149 @@
+import { listen as tauriListen } from "@tauri-apps/api/event";
+import type { NativePickedFile } from "./desktopNativeFilePicker";
+
+const DESKTOP_PET_FILE_DROP_RESULT_EVENT = "desktop-pet-file-drop-result";
+const DESKTOP_PET_FILE_DROP_SCHEMA_VERSION = "tinybot.desktop_pet_file_drop.v1";
+const DEFAULT_IMPORT_TIMEOUT_MS = 15_000;
+export const MAX_DESKTOP_PET_DROPPED_FILES = 10;
+
+type FileDropEvent = { payload: unknown };
+type FileDropListener = (
+  event: string,
+  listener: (event: FileDropEvent) => void,
+) => Promise<() => void>;
+type FileDropPost = (requestId: string, files: readonly File[]) => Promise<void>;
+
+type DesktopPetFileDropResult = {
+  schemaVersion: typeof DESKTOP_PET_FILE_DROP_SCHEMA_VERSION;
+  requestId: string;
+  files?: NativePickedFile[];
+  error?: string;
+};
+
+declare global {
+  interface Window {
+    __TINYBOT_DESKTOP_PET_POST_DROPPED_FILES__?: FileDropPost;
+  }
+}
+
+export function createDesktopNativePetFileDropImporter(options: {
+  listen?: FileDropListener;
+  post?: FileDropPost;
+  requestId?: () => string;
+  timeoutMs?: number;
+} = {}) {
+  const listen = options.listen ?? ((event, listener) => tauriListen<unknown>(event, listener));
+  const post = options.post ?? postDroppedFiles;
+  const nextRequestId = options.requestId ?? (() => (
+    `pet-file-drop-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  ));
+  const timeoutMs = options.timeoutMs ?? DEFAULT_IMPORT_TIMEOUT_MS;
+
+  return async (files: readonly File[]): Promise<NativePickedFile[]> => {
+    if (!files.length) throw new Error("Cannot import an empty desktop pet file drop.");
+    if (files.length > MAX_DESKTOP_PET_DROPPED_FILES) {
+      throw new Error(`Desktop pet file drops support at most ${MAX_DESKTOP_PET_DROPPED_FILES} files.`);
+    }
+    const requestId = nextRequestId();
+    if (!requestId.trim()) throw new Error("Desktop pet file-drop request ID cannot be empty.");
+
+    let resolveResult: (files: NativePickedFile[]) => void = () => undefined;
+    let rejectResult: (error: Error) => void = () => undefined;
+    const result = new Promise<NativePickedFile[]>((resolve, reject) => {
+      resolveResult = resolve;
+      rejectResult = reject;
+    });
+    const unlisten = await listen(DESKTOP_PET_FILE_DROP_RESULT_EVENT, ({ payload }) => {
+      if (!isRecord(payload) || payload.requestId !== requestId) return;
+      try {
+        const parsed = parseDesktopPetFileDropResult(payload);
+        if (parsed.error) rejectResult(new Error(parsed.error));
+        else resolveResult(parsed.files ?? []);
+      } catch (error) {
+        rejectResult(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+    const timeout = globalThis.setTimeout(() => {
+      rejectResult(new Error(`Desktop pet file import timed out after ${timeoutMs} ms.`));
+    }, timeoutMs);
+    try {
+      const [, importedFiles] = await Promise.all([
+        post(requestId, files),
+        result,
+      ]);
+      return importedFiles;
+    } finally {
+      globalThis.clearTimeout(timeout);
+      unlisten();
+    }
+  };
+}
+
+export const importDesktopPetDroppedFiles = createDesktopNativePetFileDropImporter();
+
+export function parseNativePickedFiles(value: unknown): NativePickedFile[] {
+  if (!Array.isArray(value) || value.length > MAX_DESKTOP_PET_DROPPED_FILES) {
+    throw new Error("Received an invalid desktop pet attachment list.");
+  }
+  return value.map((item) => {
+    if (!isRecord(item)
+      || typeof item.name !== "string"
+      || !item.name.trim()
+      || typeof item.path !== "string"
+      || !item.path.trim()
+      || typeof item.mimeType !== "string"
+      || !item.mimeType.trim()
+      || !Number.isSafeInteger(item.sizeBytes)
+      || (item.sizeBytes as number) < 0
+      || (item.contentHash !== undefined
+        && (typeof item.contentHash !== "string" || !item.contentHash.trim()))) {
+      throw new Error("Received invalid desktop pet attachment metadata.");
+    }
+    return {
+      name: item.name,
+      path: item.path,
+      mimeType: item.mimeType,
+      sizeBytes: item.sizeBytes as number,
+      ...(typeof item.contentHash === "string" ? { contentHash: item.contentHash } : {}),
+    };
+  });
+}
+
+function parseDesktopPetFileDropResult(value: unknown): DesktopPetFileDropResult {
+  if (!isRecord(value)
+    || value.schemaVersion !== DESKTOP_PET_FILE_DROP_SCHEMA_VERSION
+    || typeof value.requestId !== "string"
+    || !value.requestId.trim()) {
+    throw new Error("Received an invalid desktop pet file-drop result.");
+  }
+  const hasFiles = value.files !== undefined;
+  const hasError = value.error !== undefined;
+  if (hasFiles === hasError) {
+    throw new Error("Desktop pet file-drop results must contain files or an error.");
+  }
+  if (hasError) {
+    if (typeof value.error !== "string" || !value.error.trim()) {
+      throw new Error("Received an invalid desktop pet file-drop error.");
+    }
+    return {
+      schemaVersion: DESKTOP_PET_FILE_DROP_SCHEMA_VERSION,
+      requestId: value.requestId,
+      error: value.error,
+    };
+  }
+  return {
+    schemaVersion: DESKTOP_PET_FILE_DROP_SCHEMA_VERSION,
+    requestId: value.requestId,
+    files: parseNativePickedFiles(value.files),
+  };
+}
+
+function postDroppedFiles(requestId: string, files: readonly File[]): Promise<void> {
+  const post = window.__TINYBOT_DESKTOP_PET_POST_DROPPED_FILES__;
+  if (!post) throw new Error("The Windows desktop pet file-drop bridge is unavailable.");
+  return post(requestId, files);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/app-core/native/desktopNativePetQuickChat.ts
+++ b/src/app-core/native/desktopNativePetQuickChat.ts
@@ -12,6 +12,11 @@ import {
 import { desktopPetWindowCenter } from "../desktop-pet/desktopPetWindowGeometry";
 import type { DesktopPetPosition } from "../desktop-pet/desktopPetState";
 import { DESKTOP_PET_WINDOW_LABEL } from "./desktopNativePet";
+import {
+  importDesktopPetDroppedFiles,
+  parseNativePickedFiles,
+} from "./desktopNativePetFileDrop";
+import type { NativePickedFile } from "./desktopNativeFilePicker";
 
 export const DESKTOP_PET_QUICK_CHAT_WINDOW_LABEL = "desktop-pet-chat";
 
@@ -20,13 +25,14 @@ const QUICK_CHAT_PRESENT_EVENT = "desktop-pet-quick-chat-present";
 const QUICK_CHAT_READY_EVENT = "desktop-pet-quick-chat-ready";
 const QUICK_CHAT_PROBE_EVENT = "desktop-pet-quick-chat-probe";
 const QUICK_CHAT_OPEN_MAIN_EVENT = "desktop-pet-quick-chat-open-main";
-const QUICK_CHAT_SCHEMA_VERSION = "tinybot.desktop_pet_quick_chat.v1";
+const QUICK_CHAT_SCHEMA_VERSION = "tinybot.desktop_pet_quick_chat.v2";
 const MAX_QUICK_CHAT_DRAFT_LENGTH = 512 * 1024;
 
 export type DesktopPetQuickChatRequest = {
   schemaVersion: typeof QUICK_CHAT_SCHEMA_VERSION;
   requestId: string;
   draft: string;
+  attachments: NativePickedFile[];
 };
 
 export type DesktopPetQuickChatHostEvent = {
@@ -39,6 +45,7 @@ export type DesktopPetQuickChatHost = {
 };
 
 export type DesktopPetQuickChatDropClient = {
+  openWithFiles(files: readonly File[]): Promise<void>;
   openWithDraft(draft: string): Promise<void>;
 };
 
@@ -156,6 +163,11 @@ class TauriDesktopPetQuickChatHost implements DesktopPetQuickChatHost {
 }
 
 class TauriDesktopPetQuickChatDropClient implements DesktopPetQuickChatDropClient {
+  async openWithFiles(files: readonly File[]): Promise<void> {
+    const attachments = await importDesktopPetDroppedFiles(files);
+    await emitTo("main", QUICK_CHAT_OPEN_REQUEST_EVENT, createQuickChatRequest("", attachments));
+  }
+
   openWithDraft(draft: string): Promise<void> {
     return emitTo("main", QUICK_CHAT_OPEN_REQUEST_EVENT, createQuickChatRequest(draft));
   }
@@ -194,7 +206,10 @@ class TauriDesktopPetQuickChatWindowClient implements DesktopPetQuickChatWindowC
   }
 }
 
-function createQuickChatRequest(draft: string): DesktopPetQuickChatRequest {
+function createQuickChatRequest(
+  draft: string,
+  attachments: NativePickedFile[] = [],
+): DesktopPetQuickChatRequest {
   if (draft.length > MAX_QUICK_CHAT_DRAFT_LENGTH) {
     throw new Error(`Dropped text exceeds the ${MAX_QUICK_CHAT_DRAFT_LENGTH} character limit.`);
   }
@@ -202,6 +217,7 @@ function createQuickChatRequest(draft: string): DesktopPetQuickChatRequest {
     schemaVersion: QUICK_CHAT_SCHEMA_VERSION,
     requestId: `pet-chat-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
     draft,
+    attachments: parseNativePickedFiles(attachments),
   };
 }
 
@@ -211,13 +227,15 @@ function parseDesktopPetQuickChatRequest(value: unknown): DesktopPetQuickChatReq
     || typeof value.requestId !== "string"
     || !value.requestId.trim()
     || typeof value.draft !== "string"
-    || value.draft.length > MAX_QUICK_CHAT_DRAFT_LENGTH) {
+    || value.draft.length > MAX_QUICK_CHAT_DRAFT_LENGTH
+    || value.attachments === undefined) {
     throw new Error("Received an invalid desktop pet quick chat request.");
   }
   return {
     schemaVersion: QUICK_CHAT_SCHEMA_VERSION,
     requestId: value.requestId,
     draft: value.draft,
+    attachments: parseNativePickedFiles(value.attachments),
   };
 }
 

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -1,11 +1,14 @@
 # Shared UI
-<!-- tinybot-module-fingerprint: sha256:f9b922f8812aa3411569cb12c9147ca96340937a3d4d683499c18cf7315f8772 -->
+<!-- tinybot-module-fingerprint: sha256:291d1a6f9095b049aaf772ebb31282f479ac09243dc11dcbf63a5fed81f2acc9 -->
 
 `components/ui` contains reusable renderer UI whose interface is not owned by
 a single route. It includes the shared chat composer, file metadata formatting,
 and desktop-level modal interaction behavior. Composer file references retain
 the optional managed-image content hash while keeping preview and removal
-interaction independent from native storage.
+interaction independent from native storage. The composer supports internal
+attachment state for ordinary Chat and controlled attachment state for native
+entry points such as desktop-pet quick chat; both paths share selection limits,
+removal, file-only submission, and successful-send clearing.
 
 Route orchestration and domain-specific state stay in `react-workbench` and
 `app-core`; shared UI receives data and actions through explicit props.

--- a/src/components/ui/claude-style-ai-input.test.tsx
+++ b/src/components/ui/claude-style-ai-input.test.tsx
@@ -140,6 +140,30 @@ describe("ClaudeStyleAiInput slash commands", () => {
     expect(onSendMessage).toHaveBeenCalledWith("Start the next turn", [], [], { reasoningEffort: "medium" });
   });
 
+  it("submits and clears externally controlled file attachments", async () => {
+    const user = userEvent.setup();
+    const files = [{
+      contentHash: "abc123",
+      id: "file-1",
+      mimeType: "image/png",
+      name: "diagram.png",
+      path: "C:\\Tinybot\\diagram.png",
+      sizeBytes: 2048,
+    }];
+    const onFilesChange = vi.fn();
+    const onSendMessage = vi.fn();
+    render(<ClaudeStyleAiInput
+      files={files}
+      onFilesChange={onFilesChange}
+      onSendMessage={onSendMessage}
+    />);
+
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(onSendMessage).toHaveBeenCalledWith("", files, [], { reasoningEffort: "medium" });
+    expect(onFilesChange).toHaveBeenCalledWith([]);
+  });
+
   it("dismisses the menu with Escape without changing the draft", async () => {
     const user = userEvent.setup();
     render(<ClaudeStyleAiInput slashCommands={slashCommands} />);

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -104,6 +104,8 @@ export interface ClaudeStyleAiInputProps {
   disabledReason?: string;
   placeholder?: string;
   maxFiles?: number;
+  files?: ComposerFileReference[];
+  onFilesChange?: (files: ComposerFileReference[]) => void;
   onSelectFiles?: () => Promise<ComposerFileSelection[]>;
   models?: ModelOption[];
   defaultModel?: string;
@@ -159,6 +161,7 @@ export function ClaudeStyleAiInput({
   defaultReasoningEffort,
   disabled = false,
   disabledReason,
+  files: controlledFiles,
   maxFiles = MAX_FILES,
   models = EMPTY_MODELS,
   onModelChange,
@@ -166,6 +169,7 @@ export function ClaudeStyleAiInput({
   onAddSessionMention,
   onClearContextReferences,
   onClearSessionMentions,
+  onFilesChange,
   onRemoveContextReference,
   onRemoveSessionMention,
   onSelectFiles,
@@ -188,7 +192,7 @@ export function ClaudeStyleAiInput({
   const modelTriggerRef = useRef<HTMLButtonElement | null>(null);
   const toolMenuRef = useRef<HTMLDivElement | null>(null);
   const [message, setMessage] = useState("");
-  const [files, setFiles] = useState<ComposerFileReference[]>([]);
+  const [uncontrolledFiles, setUncontrolledFiles] = useState<ComposerFileReference[]>([]);
   const [pastedContent, setPastedContent] = useState<PastedContent[]>([]);
   const [selectedModelId, setSelectedModelId] = useState(defaultModel ?? models[0]?.id ?? "");
   const [selectedReasoningEffort, setSelectedReasoningEffort] = useState<ReasoningEffort>(
@@ -208,6 +212,8 @@ export function ClaudeStyleAiInput({
   const slashListboxId = useId();
   const sessionMentionListboxId = useId();
   const currentMessage = value ?? message;
+  const files = controlledFiles ?? uncontrolledFiles;
+  const filesRef = useRef(files);
   const selectedModel = useMemo(
     () => models.find((model) => model.id === selectedModelId)
       ?? models.find((model) => model.id === defaultModel)
@@ -275,6 +281,17 @@ export function ClaudeStyleAiInput({
     setMessage(nextMessage);
     onValueChange?.(nextMessage);
   }
+
+  function updateFiles(update: (current: ComposerFileReference[]) => ComposerFileReference[]): void {
+    const nextFiles = update(filesRef.current);
+    filesRef.current = nextFiles;
+    if (controlledFiles === undefined) setUncontrolledFiles(nextFiles);
+    else onFilesChange?.(nextFiles);
+  }
+
+  useEffect(() => {
+    filesRef.current = files;
+  }, [files]);
 
   useEffect(() => {
     const nextModelId = defaultModel || models[0]?.id || "";
@@ -353,7 +370,7 @@ export function ClaudeStyleAiInput({
         reasoningEffort: selectedReasoningEffort,
       });
       updateMessage("");
-      setFiles([]);
+      updateFiles(() => []);
       setPastedContent([]);
       onClearContextReferences?.();
       onClearSessionMentions?.();
@@ -470,7 +487,7 @@ export function ClaudeStyleAiInput({
       if (!selectedFiles.length) {
         return;
       }
-      setFiles((current) => {
+      updateFiles((current) => {
         const remainingSlots = Math.max(0, maxFiles - current.length);
         if (selectedFiles.length > remainingSlots) {
           setError(t("composer.fileLimit", { count: maxFiles }));
@@ -491,7 +508,7 @@ export function ClaudeStyleAiInput({
   }
 
   function removeFile(id: string) {
-    setFiles((current) => current.filter((file) => file.id !== id));
+    updateFiles((current) => current.filter((file) => file.id !== id));
   }
 
   function removePastedContent(id: string) {

--- a/src/react-workbench/chat/AssistantMarkdown.test.tsx
+++ b/src/react-workbench/chat/AssistantMarkdown.test.tsx
@@ -75,4 +75,22 @@ describe("AssistantMarkdown", () => {
     expect(screen.queryByRole("link", { name: "Local file" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Relative" })).toBeNull();
   });
+
+  it("adds quiet source icons without changing link names", () => {
+    const { container } = render(
+      <AssistantMarkdown
+        streaming={false}
+        text={'https://github.com/SudoJacky/tinybot/releases [Web docs](https://example.com/docs) [Email us](mailto:hello@example.com)'}
+      />,
+    );
+
+    const githubLink = screen.getByRole("link", { name: "https://github.com/SudoJacky/tinybot/releases" });
+    expect(githubLink.querySelector(".react-message-markdown__link-label")?.textContent)
+      .toBe("https://github.com/SudoJacky/tinybot/releases");
+    expect(screen.getByRole("link", { name: "Web docs" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Email us" })).toBeTruthy();
+    expect(container.querySelector('[data-link-kind="github"] [data-link-icon="github"][aria-hidden="true"]')).toBeTruthy();
+    expect(container.querySelector('[data-link-kind="web"] [data-link-icon="web"][aria-hidden="true"]')).toBeTruthy();
+    expect(container.querySelector('[data-link-kind="email"] [data-link-icon="email"][aria-hidden="true"]')).toBeTruthy();
+  });
 });

--- a/src/react-workbench/chat/AssistantMarkdown.tsx
+++ b/src/react-workbench/chat/AssistantMarkdown.tsx
@@ -1,6 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
+import { Globe2, Mail } from "lucide-react";
 import { memo, type ComponentProps } from "react";
 import {
   Streamdown,
@@ -30,6 +31,36 @@ const ASSISTANT_MARKDOWN_PLUGINS = {
 const DISALLOWED_ASSISTANT_ELEMENTS = ["img"];
 const ALLOWED_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
 
+type AssistantMarkdownLinkKind = "email" | "github" | "web";
+
+const ASSISTANT_MARKDOWN_LINK_ICON_PROPS = {
+  "aria-hidden": true,
+  className: "react-message-markdown__link-icon",
+  height: 14,
+  width: 14,
+} as const;
+
+function assistantMarkdownLinkKind(href: string): AssistantMarkdownLinkKind {
+  const url = new URL(href);
+  if (url.protocol === "mailto:") {
+    return "email";
+  }
+  const hostname = url.hostname.toLowerCase();
+  return hostname === "github.com" || hostname.endsWith(".github.com") ? "github" : "web";
+}
+
+function AssistantMarkdownLinkIcon({ kind }: { kind: AssistantMarkdownLinkKind }) {
+  if (kind === "github") {
+    return (
+      <svg {...ASSISTANT_MARKDOWN_LINK_ICON_PROPS} data-link-icon="github" focusable="false" viewBox="0 0 16 16">
+        <path fill="currentColor" d="M8 0a8.16 8.16 0 0 0-2.53 15.84c.4.08.55-.18.55-.39 0-.19-.01-.83-.01-1.51-2.23.49-2.7-.96-2.7-.96-.36-.94-.89-1.19-.89-1.19-.73-.5.05-.49.05-.49.8.06 1.22.83 1.22.83.71 1.23 1.87.88 2.33.67.07-.52.28-.88.51-1.08-1.78-.21-3.65-.91-3.65-4.02 0-.89.31-1.61.82-2.18-.08-.2-.36-1.03.08-2.15 0 0 .67-.22 2.2.83A7.48 7.48 0 0 1 8 3.98c.68 0 1.36.09 2 .27 1.53-1.05 2.2-.83 2.2-.83.44 1.12.16 1.95.08 2.15.51.57.82 1.29.82 2.18 0 3.12-1.87 3.8-3.66 4.01.29.25.54.74.54 1.5 0 1.08-.01 1.95-.01 2.22 0 .22.15.47.55.39A8.16 8.16 0 0 0 8 0Z" />
+      </svg>
+    );
+  }
+  const LinkIcon = kind === "email" ? Mail : Globe2;
+  return <LinkIcon {...ASSISTANT_MARKDOWN_LINK_ICON_PROPS} data-link-icon={kind} />;
+}
+
 const transformAssistantMarkdownUrl: UrlTransform = (url, key) => {
   if (key === "src") {
     return null;
@@ -53,9 +84,11 @@ function AssistantMarkdownLink({ children, href, node: _node, onClick: _onClick,
   if (!href) {
     return <span>{children}</span>;
   }
+  const linkKind = assistantMarkdownLinkKind(href);
   return (
     <a
       {...props}
+      data-link-kind={linkKind}
       data-streamdown="link"
       href={href}
       rel="noreferrer noopener"
@@ -64,7 +97,8 @@ function AssistantMarkdownLink({ children, href, node: _node, onClick: _onClick,
         void openAssistantMarkdownUrl(href);
       }}
     >
-      {children}
+      <AssistantMarkdownLinkIcon kind={linkKind} />
+      <span className="react-message-markdown__link-label">{children}</span>
     </a>
   );
 }

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -286,10 +286,30 @@
 }
 
 .react-message-markdown [data-streamdown="link"] {
+  display: inline-flex;
+  align-items: baseline;
+  max-width: 100%;
   color: var(--color-primary-active);
+  cursor: pointer;
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, currentColor 35%, transparent);
   text-underline-offset: 3px;
+  transition:
+    color var(--motion-duration-fast) var(--motion-ease-standard),
+    text-decoration-color var(--motion-duration-fast) var(--motion-ease-standard);
+  vertical-align: baseline;
+}
+
+.react-message-markdown__link-icon {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  margin-inline-end: 4px;
+}
+
+.react-message-markdown__link-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .react-message-markdown [data-streamdown="link"]:hover,

--- a/src/react-workbench/chat/ChatPage.messages.test.tsx
+++ b/src/react-workbench/chat/ChatPage.messages.test.tsx
@@ -74,6 +74,15 @@ describe("ChatPage", () => {
     expect(css).toMatch(
       /\.react-message-markdown \[data-streamdown="code-block-body"\] pre,\s*\.react-message-markdown \[data-streamdown="code-block-body"\] code\s*{[^}]*font-family:\s*var\(--font-code\);/s,
     );
+    expect(css).toMatch(
+      /\.react-message-markdown__link-icon\s*{[^}]*flex:\s*0 0 auto;[^}]*width:\s*14px;[^}]*height:\s*14px;[^}]*margin-inline-end:\s*4px;/s,
+    );
+    expect(css).toMatch(
+      /\.react-message-markdown \[data-streamdown="link"\]\s*{[^}]*display:\s*inline-flex;[^}]*align-items:\s*baseline;[^}]*max-width:\s*100%;/s,
+    );
+    expect(css).toMatch(
+      /\.react-message-markdown__link-label\s*{[^}]*min-width:\s*0;[^}]*overflow-wrap:\s*anywhere;/s,
+    );
   });
 
   it("renders assistant Markdown tables instead of raw pipe text", async () => {

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:830b10af7d507d2b0acbbedf32cd697df4295b748ff68bcee2efb5e003a9fdc6 -->
+<!-- tinybot-module-fingerprint: sha256:6066cd49e88bbea1162462527ffe166b59e847781add5a55e9aef2325140c1eb -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -7,6 +7,11 @@ canonical timeline presentation, the composer, and detail drawers.
 `ChatTimeline.tsx` owns the reusable canonical message and execution rendering;
 its action callbacks are optional so read-only consumers can omit unavailable
 branch, recovery, artifact, delegate, and tool-detail controls.
+`AssistantMarkdown.tsx` owns assistant prose and external-link presentation.
+Allowed web and email links keep their existing safe opener path while adding
+an aria-hidden inline source icon: a GitHub mark for GitHub hosts, an envelope
+for email, and a globe for other websites. The anchor remains inline so long
+URLs can wrap with the surrounding Markdown text.
 
 The desktop pet quick-chat surface composes `ChatTimeline` and
 `ClaudeStyleAiInput` directly without mounting `ChatPage`. Its first submitted

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:c1f6add66262a0754592473cc3ce669130b75909ba4a48b71b6100df3277e405 -->
+<!-- tinybot-module-fingerprint: sha256:3b67e4ace8037fa49b9fd4951e638e65fc8a53f47e25050c5ffb193a547af469 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles.
@@ -34,6 +34,8 @@ Editor shortcut hints use the platform modifier label while persisted script
 content, event names, paths, and trust identifiers remain untranslated.
 
 Desktop pet quick-chat copy also lives in the common renderer bundle so the
-pet drop affordance and the independent panel use the same locale. Draft text,
-Thread IDs, model identifiers, and the `desktop-pet` entry-point value remain
-untranslated protocol or user content.
+pet drop affordance and the independent panel use the same locale. File chips
+and file-only prompts reuse the canonical Chat composer bundle instead of a
+pet-specific unsupported state. Draft text, filenames, Thread IDs, model
+identifiers, and the `desktop-pet` entry-point value remain untranslated
+protocol or user content.

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -74,7 +74,6 @@ export const en = {
         today: "Today",
         placeholder: "Message Tinybot",
         needsInput: "Continue in Tinybot to provide the requested input",
-        filesUnsupported: "Quick chat does not support file attachments yet.",
         commandUnsupported: "This command is not available in quick chat.",
       },
       sizes: { small: "Small", medium: "Medium", large: "Large" },

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -21,7 +21,7 @@ export const zh = {
         open: "打开快捷会话", release: "松开以聊天", emptyDrop: "拖入的内容中没有文字。", panel: "Tinybot 快捷会话", newChat: "新会话",
         windowControls: "快捷会话窗口控制", openInMain: "在 Tinybot 中打开", minimize: "收起快捷会话", loading: "正在加载会话",
         recent: "最近会话", seeAll: "查看全部", today: "今天", placeholder: "给 Tinybot 发消息",
-        needsInput: "在 Tinybot 中继续并提供所需信息", filesUnsupported: "快捷会话暂不支持文件附件。", commandUnsupported: "快捷会话暂不支持这个命令。",
+        needsInput: "在 Tinybot 中继续并提供所需信息", commandUnsupported: "快捷会话暂不支持这个命令。",
       },
       sizes: { small: "小", medium: "中", large: "大" },
       status: { calm: "Tinybot 很平静", curious: "Tinybot 正疑惑地等你", working: "Tinybot 正在努力", angry: "Tinybot 有点生气", pleased: "Tinybot 满意地完成了任务" },

--- a/src/react-workbench/shell/DesktopPetQuickChatWindow.test.tsx
+++ b/src/react-workbench/shell/DesktopPetQuickChatWindow.test.tsx
@@ -185,13 +185,21 @@ describe("DesktopPetQuickChatWindow", () => {
     await waitFor(() => expect(requestListener).toBeTypeOf("function"));
 
     act(() => requestListener?.({
-      schemaVersion: "tinybot.desktop_pet_quick_chat.v1",
+      schemaVersion: "tinybot.desktop_pet_quick_chat.v2",
       requestId: "drop-1",
       draft: "Selected browser text",
+      attachments: [{
+        contentHash: "abc123",
+        mimeType: "image/png",
+        name: "diagram.png",
+        path: "C:\\Tinybot\\diagram.png",
+        sizeBytes: 2048,
+      }],
     }));
 
     const composer = await screen.findByRole("textbox", { name: "Message" });
     expect((composer as HTMLTextAreaElement).value).toBe("Selected browser text");
+    expect(screen.getByText("diagram.png")).toBeTruthy();
     expect(screen.getByText("Regular")).toBeTruthy();
     expect(screen.queryByText("Workspace")).toBeNull();
     fireEvent.change(composer, { target: { value: "Selected browser text and a question" } });
@@ -205,8 +213,16 @@ describe("DesktopPetQuickChatWindow", () => {
       kind: "turn.submit",
       source: { control: "desktop-pet-quick-chat", surface: "chat" },
       target: { sessionId: "quick-1" },
-      input: expect.objectContaining({ text: "Selected browser text and a question" }),
+      input: expect.objectContaining({
+        references: [expect.objectContaining({
+          contentHash: "abc123",
+          rawPath: "C:\\Tinybot\\diagram.png",
+          type: "tinyos.image",
+        })],
+        text: "Selected browser text and a question",
+      }),
     }));
     await waitFor(() => expect((composer as HTMLTextAreaElement).value).toBe(""));
+    await waitFor(() => expect(screen.queryByText("diagram.png")).toBeNull());
   });
 });

--- a/src/react-workbench/shell/DesktopPetQuickChatWindow.tsx
+++ b/src/react-workbench/shell/DesktopPetQuickChatWindow.tsx
@@ -31,6 +31,7 @@ import {
   type ModelOption,
   type PastedContent,
 } from "../../components/ui/claude-style-ai-input";
+import { pickDesktopChatFiles } from "../../app-core/native/desktopNativeFilePicker";
 import type { ChatModelOption, ChatStore, SessionStore, SessionSummary, SettingsStore } from "../services";
 import { ChatTimeline } from "../chat/ChatTimeline";
 import {
@@ -69,6 +70,7 @@ export function DesktopPetQuickChatWindow({
   const conversationEndRef = useRef<HTMLDivElement | null>(null);
   const [activeRequestId, setActiveRequestId] = useState("");
   const [draft, setDraft] = useState("");
+  const [composerFiles, setComposerFiles] = useState<ComposerFileReference[]>([]);
   const [session, setSession] = useState<SessionSummary | null>(null);
   const [recentSessions, setRecentSessions] = useState<SessionSummary[]>([]);
   const [models, setModels] = useState<ModelOption[]>([]);
@@ -119,9 +121,14 @@ export function DesktopPetQuickChatWindow({
     console.info("[desktop-pet-quick-chat] request.received", {
       requestId: request.requestId,
       textLength: request.draft.length,
+      attachmentCount: request.attachments.length,
     });
     setActiveRequestId(request.requestId);
     setDraft(request.draft);
+    setComposerFiles(request.attachments.map((attachment, index) => ({
+      ...attachment,
+      id: `${request.requestId}-attachment-${index}`,
+    })));
     setSession(null);
     setOptimisticMessages([]);
     setLoadError("");
@@ -235,7 +242,6 @@ export function DesktopPetQuickChatWindow({
     pastedContent: PastedContent[],
     options: ComposerSendOptions,
   ) {
-    if (files.length) throw new Error(t("desktopPet.quickChat.filesUnsupported"));
     const prepared = await prepareChatSubmission({
       availableSessionIds: new Set(),
       files,
@@ -301,6 +307,7 @@ export function DesktopPetQuickChatWindow({
   function selectRecentSession(nextSession: SessionSummary) {
     setSession(nextSession);
     setDraft("");
+    setComposerFiles([]);
     setOptimisticMessages([]);
     setLoadError("");
   }
@@ -397,7 +404,9 @@ export function DesktopPetQuickChatWindow({
         contextUsage={activeContextUsage}
         defaultModel={composerModel}
         defaultReasoningEffort={reasoningEffort}
+        files={composerFiles}
         models={models}
+        onFilesChange={setComposerFiles}
         placeholder={t("desktopPet.quickChat.placeholder")}
         responding={sessionRunning}
         value={draft}
@@ -431,6 +440,7 @@ export function DesktopPetQuickChatWindow({
           setReasoningEffort(effort);
           writeCurrentChatReasoningEffort(effort);
         }}
+        onSelectFiles={pickDesktopChatFiles}
         onSendMessage={handleSend}
         onStopResponding={handleStop}
         onValueChange={setDraft}

--- a/src/react-workbench/shell/DesktopPetWindow.test.tsx
+++ b/src/react-workbench/shell/DesktopPetWindow.test.tsx
@@ -22,6 +22,7 @@ describe("DesktopPetWindow", () => {
       startDragging: vi.fn(async () => undefined),
     };
     const quickChatClient: DesktopPetQuickChatDropClient = {
+      openWithFiles: vi.fn(async () => undefined),
       openWithDraft: vi.fn(async () => undefined),
     };
     const user = userEvent.setup();
@@ -60,6 +61,7 @@ describe("DesktopPetWindow", () => {
       startDragging: vi.fn(async () => undefined),
     };
     const quickChatClient: DesktopPetQuickChatDropClient = {
+      openWithFiles: vi.fn(async () => undefined),
       openWithDraft: vi.fn(async () => undefined),
     };
     const view = render(<DesktopPetWindow client={client} quickChatClient={quickChatClient} />);
@@ -85,5 +87,49 @@ describe("DesktopPetWindow", () => {
 
     await waitFor(() => expect(quickChatClient.openWithDraft).toHaveBeenCalledWith("Selected browser text"));
     expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("opens quick chat with local files dropped from Explorer", async () => {
+    let stateListener: ((snapshot: DesktopPetWindowSnapshot) => void) | undefined;
+    const client: DesktopPetWindowClient = {
+      listen: vi.fn(async (listener) => {
+        stateListener = listener;
+        return () => undefined;
+      }),
+      moveBy: vi.fn(async () => undefined),
+      requestPreferences: vi.fn(async () => undefined),
+      startDragging: vi.fn(async () => undefined),
+    };
+    const quickChatClient: DesktopPetQuickChatDropClient = {
+      openWithFiles: vi.fn(async () => undefined),
+      openWithDraft: vi.fn(async () => undefined),
+    };
+    const view = render(<DesktopPetWindow client={client} quickChatClient={quickChatClient} />);
+    await waitFor(() => expect(stateListener).toBeTypeOf("function"));
+    stateListener?.({
+      label: "Tinybot is calm",
+      mood: "calm",
+      preferences: { visible: true, size: "medium", position: null },
+    });
+    const surface = await screen.findByRole("group", {
+      name: "Move Tinybot desktop pet. Drag it or use the arrow keys.",
+    });
+    const files = [
+      new File(["image"], "diagram.png", { type: "image/png" }),
+      new File(["notes"], "notes.md", { type: "text/markdown" }),
+    ];
+    const dataTransfer = {
+      dropEffect: "none",
+      files,
+      getData: vi.fn(() => "D:\\diagram.png"),
+      types: ["Files", "text/plain"],
+    };
+
+    fireEvent.dragEnter(view.container.firstElementChild as Element, { dataTransfer });
+    fireEvent.dragOver(surface, { dataTransfer });
+    fireEvent.drop(surface, { dataTransfer });
+
+    await waitFor(() => expect(quickChatClient.openWithFiles).toHaveBeenCalledWith(files));
+    expect(quickChatClient.openWithDraft).not.toHaveBeenCalled();
   });
 });

--- a/src/react-workbench/shell/DesktopPetWindow.tsx
+++ b/src/react-workbench/shell/DesktopPetWindow.tsx
@@ -96,7 +96,7 @@ export function DesktopPetWindow({
   }
 
   function handleDragEnter(event: DragEvent<HTMLDivElement>) {
-    if (!hasPlainText(event.dataTransfer.types)) return;
+    if (!hasSupportedDrop(event.dataTransfer.types)) return;
     event.preventDefault();
     dragDepth.current += 1;
     setDropError("");
@@ -104,22 +104,31 @@ export function DesktopPetWindow({
   }
 
   function handleDragOver(event: DragEvent<HTMLDivElement>) {
-    if (!hasPlainText(event.dataTransfer.types)) return;
+    if (!hasSupportedDrop(event.dataTransfer.types)) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = "copy";
   }
 
   function handleDragLeave(event: DragEvent<HTMLDivElement>) {
-    if (!hasPlainText(event.dataTransfer.types)) return;
+    if (!hasSupportedDrop(event.dataTransfer.types)) return;
     dragDepth.current = Math.max(0, dragDepth.current - 1);
     if (dragDepth.current === 0) setDropActive(false);
   }
 
   function handleDrop(event: DragEvent<HTMLDivElement>) {
-    if (!hasPlainText(event.dataTransfer.types)) return;
+    if (!hasSupportedDrop(event.dataTransfer.types)) return;
     event.preventDefault();
     dragDepth.current = 0;
     setDropActive(false);
+    const files = Array.from(event.dataTransfer.files ?? []);
+    if (files.length) {
+      void dropClient.openWithFiles(files).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        setDropError(message);
+        reportDesktopPetWindowError(error);
+      });
+      return;
+    }
     const draft = event.dataTransfer.getData("text/plain") || event.dataTransfer.getData("text");
     if (!draft.trim()) {
       setDropError(t("desktopPet.quickChat.emptyDrop"));
@@ -205,8 +214,8 @@ export function DesktopPetWindow({
   );
 }
 
-function hasPlainText(types: readonly string[] | DOMStringList): boolean {
-  return Array.from(types).some((type) => type === "text/plain" || type === "text");
+function hasSupportedDrop(types: readonly string[] | DOMStringList): boolean {
+  return Array.from(types).some((type) => type === "Files" || type === "text/plain" || type === "text");
 }
 
 function keyboardDirection(key: string): DesktopPetPosition | null {

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:b31e5338b56e1398b3e09aac4add605fa349ba318687e84fbc1079bad40ae2de -->
+<!-- tinybot-module-fingerprint: sha256:6b4d960646bcf934e7c5e1b7d2f382d0942dd38603672c621e8b5dab8f3a53d4 -->
 
 `shell` owns Tinybot's desktop chrome: the window frame, menus, route
 selection, deferred route loading, and update dialogs.
@@ -22,17 +22,19 @@ window interaction, while Chat only reports the current mascot mood. The pet
 can be hidden from its own controls and restored from the System menu without
 duplicating Agent lifecycle state or booting a second `App` service graph.
 
-The pet accepts external HTML5 `text/plain` drops and forwards the exact draft
-through `desktopNativePetQuickChat` to the independent `desktop-pet-chat`
-window. `DesktopPetQuickChatWindow.tsx` reuses Chat's canonical composer and
-timeline presentation, keeps the draft editable, exposes the same model picker
-and context-token usage, and persists model changes to the selected Thread. It
-lazily creates a standard Thread on first send without workspace or project
-metadata. Opening an existing recent chat or handing the new Thread to the main
-window always carries its explicit Thread ID; `DesktopShell` refreshes the main
-renderer's session list before activating it. Pointer-down on the panel title
-bar starts native window dragging, while the open and minimize controls remain
-ordinary buttons.
+The pet accepts external HTML5 `text/plain` and `Files` drops. It forwards text
+unchanged and asks the native Adapter to import local files before sending a
+versioned quick-chat request to the independent `desktop-pet-chat` window.
+`DesktopPetQuickChatWindow.tsx` reuses Chat's canonical composer, attachment
+submission, and timeline presentation; dropped attachments remain removable,
+and the composer file picker uses the same native importer. It keeps the draft
+editable, exposes the same model picker and context-token usage, and persists
+model changes to the selected Thread. It lazily creates a standard Thread on
+first send without workspace or project metadata. Opening an existing recent
+chat or handing the new Thread to the main window always carries its explicit
+Thread ID; `DesktopShell` refreshes the main renderer's session list before
+activating it. Pointer-down on the panel title bar starts native window
+dragging, while the open and minimize controls remain ordinary buttons.
 
 The bounded `react-route-surface` owns vertical overflow for document-like
 routes so long settings, tools, and diagnostics pages remain scrollable inside


### PR DESCRIPTION
## Summary

- support dropping files onto the desktop pet and forwarding them into quick chat
- add native command permissions, frontend integration, and coverage for desktop pet file drops
- show source favicons for links rendered in assistant messages
- update the related API, architecture, and component documentation

## Testing

- Not run (PR creation only)