### PR TITLE
Improve sidecar previews and chat execution feedback

### DIFF
--- a/docs/api/desktop.md
+++ b/docs/api/desktop.md
@@ -15,7 +15,7 @@ src/app-core/native/desktopNativePet.ts
 src/app-core/native/desktopNativePetQuickChat.ts
 src/app-core/native/nativeBackendContract.test.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:c78ea538607619f7b202bf334d39113386af396d5fae7227c591a5dff000ea42 -->
+<!-- tinybot-doc-fingerprint: sha256:558df943e791000d20fef5ed0a49ea073a5b3cbead954df0544d278103e9805a -->
 
 This document covers native desktop lifecycle and operating-system integration
 commands. It is part of the [Rust backend API reference](rust-backend-api.md),
@@ -110,6 +110,22 @@ Sidecar tab does not invoke termination; closing the resource terminates and
 releases its PTY record. When `workingDirectory` is omitted, the command uses
 the same configured native backend workspace as an ordinary Thread, falling
 back to `~/.tinybot/workspace`.
+
+## Sidecar Artifact File Preview
+
+Assistant Markdown file links open contextual Artifact tabs; Artifact is not an
+empty resource offered by the Sidecar add menu. The renderer recognizes
+workspace-relative paths, `file:` URLs, absolute paths inside the active
+workspace, and optional line suffixes. It sends the Thread ID and normalized
+path to `worker_thread_workspace_file_chunk`, never a renderer-selected
+workspace root.
+
+The backend resolves the canonical Thread projection and uses its recorded
+`workingDirectory`, falling back to the configured default workspace only when
+the Thread is unbound. It then delegates to the guarded workspace chunk reader,
+so traversal and symlink escapes fail explicitly. The Artifact surface shows
+loading, truncated-preview, binary-file, and read-failure states instead of an
+empty successful preview.
 
 ## File Dialog Commands
 

--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -10,7 +10,7 @@ src/app-core/native/desktopNativeUpdate.ts
 src/app-core/native/desktopNativeWebui.ts
 src/app-core/native/nativeBackendContract.test.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:344f596d5c858af16b9d52c79a1c2a3ce4296d6a725e190e8bcfdde7037ef26a -->
+<!-- tinybot-doc-fingerprint: sha256:af4c966fb04fad3a47389ac0ecbfcbe0bac8663bcfd5fe0b50ac62761ae59f13 -->
 
 This document describes the API surfaces exposed by the Rust/Tauri backend in `src-tauri`.
 It is intended for frontend callers and integrators who need command names, invocation
@@ -135,6 +135,7 @@ Prefer these wrappers instead of direct command strings:
 | `createDesktopNativeThreadsApi` | `src/app-core/native/desktopNativeThreads.ts` | Thread, Turn timeline, and effective-capability commands |
 | `createDesktopNativeHostCommandApi` | `src/app-core/native/desktopNativeHostCommand.ts` | Transitional Chat `operation.retry` dispatch |
 | `createDesktopNativeTerminalApi` | `src/app-core/native/desktopNativeTerminal.ts` | User-only Sidecar terminal lifecycle and PTY input/output |
+| `createDesktopNativeWorkspaceApi` | `src/app-core/native/desktopNativeWorkspace.ts` | Default-workspace browsing plus Thread-scoped file chunks for contextual Artifact previews |
 | `createDesktopNativeWebuiApi` | `src/app-core/native/desktopNativeWebui.ts` | `worker_webui_route` |
 
 ## Examples

--- a/docs/api/workspace-and-extensions.md
+++ b/docs/api/workspace-and-extensions.md
@@ -15,7 +15,7 @@ src-tauri/src/skills/definition.rs
 src-tauri/src/workspace/types.rs
 src-tauri/src/rpc/tests/workspace_and_shell.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:c14c191e846cb3d04be90c3e3dccf698865a8a84265999c47356361e55872791 -->
+<!-- tinybot-doc-fingerprint: sha256:7d81f627efe3963085d988be3a157b82c86578703bdfc94f01f6a648ad217e0a -->
 
 This document covers workspace operations and the extension catalogs available
 to Agents. It is part of the [Rust backend API reference](rust-backend-api.md),
@@ -116,6 +116,7 @@ node runs expose the selected route/edge, raw response, and provider usage.
 | `worker_workspace_put_file` | `{ input: { path, body } }` | `WorkspaceWriteResult` |
 | `worker_workspace_directory` | `{ input: { path, cursor?, nameQuery? } }` | Worker response containing `WorkspaceDirectoryPage` |
 | `worker_workspace_file_chunk` | `{ input: { path, cursor? } }` | Worker response containing `WorkspaceFileChunk` |
+| `worker_thread_workspace_file_chunk` | `{ input: { threadId, path, cursor? } }` | Worker response containing `WorkspaceFileChunk` |
 
 Lower-level workspace RPC also supports:
 
@@ -192,6 +193,15 @@ Binary files return `content_type: "binary"` without invented text content or li
 continuation cursors are bound to `revision`; using one after the file changes fails visibly with
 query code `source_changed`. Other workspace query failures retain their protocol error, path, and
 retryable metadata rather than returning an empty successful page.
+
+`worker_thread_workspace_file_chunk` is the Sidecar Artifact preview boundary.
+It resolves the Thread from the canonical rollout projection and selects that
+Thread's recorded `workingDirectory`; an unbound Thread uses the configured
+default workspace. Absolute paths are accepted only when their canonical target
+is below that root, then converted to workspace-relative paths before the same
+chunk reader handles them. The renderer cannot supply a workspace root, and
+relative traversal, symlink escape, binary content, stale cursors, and I/O
+errors retain the normal structured workspace failure behavior.
 
 `workspace.apply_patch` accepts:
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:c2f8044fd6ba65cddcfcad1c82a270ab3c7d96b476a4845bf30a005c12a5cc3a -->
+<!-- tinybot-doc-fingerprint: sha256:9bba20486a83a9226ceb16d12e02e21c4989e7cb1f4c435e2c9abeff99e7e5dc -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -52,14 +52,14 @@ Desktop Commands / Desktop Host
 | --- | --- | --- |
 | `react-workbench` | React routes, presentation, route state | Native transport or durable domain state |
 | `react-workbench/agent-graph` | Standalone Agent Graph library and unbounded spatial canvas, node configuration, Run history, and per-node inspection | Chat route state or native execution rules |
-| `react-workbench/sidecar` | Resource tabs, scope filtering, and Sidecar presentation | Native Browser or Terminal lifecycle |
+| `react-workbench/sidecar` | Resource tabs, scope filtering, and Browser, Terminal, or contextual Artifact presentation | Native Browser or Terminal lifecycle, Artifact domain state, or workspace file authorization |
 | `app-core` | Framework-independent contracts, validation, commands, and projections | React rendering or Tauri invocation |
 | `app-core/agent-graph` | Versioned Graph contracts, validation, edit operations, persistence Interface, and runtime Interface | React rendering, native filesystem I/O, or Agent execution |
 | `app-core/desktop-pet` | Pet preferences plus monitor-aware pet and quick-chat window geometry | React rendering or native window calls |
 | `agent_graphs` | Workspace Graph files, schema validation, atomic writes, and exact-byte revisions | Renderer state or Graph execution |
 | `graph_runs` | Linear Graph preflight, Run status files, Agent node sequencing, and standard Thread creation | Renderer state, definition editing, or the Agent Loop implementation |
 | `app-core/native` | Typed renderer adapters for native commands and events | Product state or backend behavior |
-| `desktop_commands` | Thin Tauri input/output adaptation | Reusable domain behavior |
+| `desktop_commands` | Thin Tauri input/output adaptation, including Thread-scoped workspace selection for Artifact file reads | Reusable workspace path validation or file-reading behavior |
 | `desktop/pet_file_drop` and `desktop/files` | Windows WebView2 dropped-path extraction plus shared chat-attachment validation/import | Chat state, file-byte transport, or renderer presentation |
 | `desktop_terminal` | User-only Sidecar PTY lifecycle and resource ownership | Agent shell sessions or renderer presentation |
 | `chat_attachments` | Content-addressed managed image storage, validation, and request-local Data URL encoding | Conversation authority or provider protocol selection |

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:240ff156e75d16e84b052c74c36ca6151472ae85341e3e3eb3ebd7fb88a71f63 -->
+<!-- tinybot-doc-fingerprint: sha256:4053272b21f971e83201994ce73bf20bbada7368b4c97db856187fc858a895a0 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:443d3e93d8154b016ea2526883dfd215b25f789d1df4b656c161aeeb1ed2d2f3 -->
+<!-- tinybot-module-fingerprint: sha256:00d6487518d75cfb80d3f7fc6e3bdebc60a39db1893691d2a9bda520ef5a57ad -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime
@@ -23,6 +23,9 @@ For desktop setup and launch behavior, see [the desktop guide](../docs/desktop.m
 
 Sidecar terminals with no explicit Thread working directory resolve through
 the same configured native backend workspace used by ordinary Agent turns.
+Contextual Artifact file previews instead resolve the canonical Thread's
+recorded working directory and pass only a guarded, bounded file-chunk result
+to the renderer; the renderer cannot select an arbitrary workspace root.
 - `src/desktop_commands/` adapts typed Tauri inputs to backend services.
 - `WorkerRpcRouter` handles versioned `WorkerRequest` values for internal and
   transport-backed callers.

--- a/src-tauri/app_commands.rs
+++ b/src-tauri/app_commands.rs
@@ -43,6 +43,7 @@ pub const APP_COMMANDS: &[&str] = &[
     "worker_workspace_put_file",
     "worker_workspace_directory",
     "worker_workspace_file_chunk",
+    "worker_thread_workspace_file_chunk",
     "worker_thread_create",
     "worker_thread_read",
     "worker_thread_resume",

--- a/src-tauri/permissions/app-commands.toml
+++ b/src-tauri/permissions/app-commands.toml
@@ -46,6 +46,7 @@ commands.allow = [
   "worker_workspace_put_file",
   "worker_workspace_directory",
   "worker_workspace_file_chunk",
+  "worker_thread_workspace_file_chunk",
   "worker_thread_create",
   "worker_thread_read",
   "worker_thread_resume",

--- a/src-tauri/src/desktop/README.md
+++ b/src-tauri/src/desktop/README.md
@@ -1,5 +1,5 @@
 # Desktop Runtime
-<!-- tinybot-module-fingerprint: sha256:4f8b2d07cb8e06a3bc987e986e1e751986258d431006b1d458216fca4bb80d7c -->
+<!-- tinybot-module-fingerprint: sha256:8cb12c43c72df9e9acce6f58f18bd680ee6bfca66516d38a773a7f388e227c7f -->
 
 `desktop` wires the Rust backend into the Tauri application. It owns startup,
 shared desktop state, logging, file helpers, menus, and application updates.
@@ -34,6 +34,11 @@ exact-definition trust commands. Graph definition storage remains owned by
 `agent_graphs`, while `graph_runs` owns Run status and delegates Agent nodes to
 the standard Thread/Agent path. Hook behavior remains owned by `command_hooks`
 and the Agent runtime.
+
+Bootstrap also registers the Thread-scoped workspace file-chunk command used
+by contextual Sidecar Artifact previews. The handler derives the workspace
+from canonical Thread state before routing through the ordinary guarded
+workspace reader; bootstrap owns registration only.
 
 `logging` owns the `tinybot.native_log.v1` record, severity levels, context
 redaction and bounds, the platform log path, and 5 MiB single-backup rotation.

--- a/src-tauri/src/desktop/bootstrap.rs
+++ b/src-tauri/src/desktop/bootstrap.rs
@@ -290,6 +290,7 @@ pub(crate) fn run() {
             crate::desktop_commands::workspace::worker_workspace_put_file,
             crate::desktop_commands::workspace::worker_workspace_directory,
             crate::desktop_commands::workspace::worker_workspace_file_chunk,
+            crate::desktop_commands::workspace::worker_thread_workspace_file_chunk,
             crate::desktop_commands::thread::worker_thread_create,
             crate::desktop_commands::thread::worker_thread_read,
             crate::desktop_commands::thread::worker_thread_resume,

--- a/src-tauri/src/desktop_commands/README.md
+++ b/src-tauri/src/desktop_commands/README.md
@@ -1,5 +1,5 @@
 # Desktop Commands
-<!-- tinybot-module-fingerprint: sha256:d502cc80c21d40bdb950220c78bf078234990bb4a645cb4ca0d7171c2b0cd159 -->
+<!-- tinybot-module-fingerprint: sha256:f5e97e385d209236c1c37903ca7f71ccd8327a260386f276629ecca3be9bc967 -->
 
 `desktop_commands` contains the Tauri command boundary used by the desktop
 frontend. Commands are grouped by agent, configuration, hooks, memory, runtime,
@@ -8,6 +8,12 @@ WebUI, and workspace operations.
 
 These handlers should stay thin and delegate domain behavior to the owning
 backend module.
+
+Workspace file queries normally use the configured default workspace. The
+Thread file-preview command is the scoped exception: it accepts a Thread ID,
+derives the recorded working directory from the canonical Thread projection,
+and then delegates to the same guarded workspace reader. It never accepts a
+renderer-supplied workspace root.
 
 Agent Graph commands pass workspace-scoped list, save, and delete requests to
 `agent_graphs`. Schema checks, path containment, atomic writes, and optimistic

--- a/src-tauri/src/desktop_commands/workspace.rs
+++ b/src-tauri/src/desktop_commands/workspace.rs
@@ -2,7 +2,9 @@ use crate::config::application::{native_backend_workspace_root, native_config_sn
 use crate::desktop::{lock_runtime, SharedNativeRuntime};
 use crate::protocol::request_id::next_worker_request_correlation;
 use crate::protocol::WorkerRequest;
-use crate::rpc::{call_rust_state_service, native_request_router};
+use crate::rpc::{
+    call_rust_state_service, native_request_router, native_request_router_with_workspace_root,
+};
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
 use tauri::State;
@@ -37,6 +39,14 @@ pub(crate) struct WorkerWorkspaceDirectoryInput {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct WorkerWorkspaceFileChunkInput {
+    path: String,
+    cursor: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkerThreadWorkspaceFileChunkInput {
+    thread_id: String,
     path: String,
     cursor: Option<String>,
 }
@@ -119,6 +129,22 @@ pub(crate) fn worker_workspace_file_chunk(
 ) -> Result<serde_json::Value, String> {
     worker_workspace_file_chunk_with_options(
         state.inner(),
+        input.path,
+        input.cursor,
+        native_backend_workspace_root(),
+        native_config_snapshot(),
+        Duration::from_secs(10),
+    )
+}
+
+#[tauri::command]
+pub(crate) fn worker_thread_workspace_file_chunk(
+    input: WorkerThreadWorkspaceFileChunkInput,
+    state: State<'_, SharedNativeRuntime>,
+) -> Result<serde_json::Value, String> {
+    worker_thread_workspace_file_chunk_with_options(
+        state.inner(),
+        input.thread_id,
         input.path,
         input.cursor,
         native_backend_workspace_root(),
@@ -290,3 +316,87 @@ pub(crate) fn worker_workspace_file_chunk_with_options(
     serde_json::to_value(response)
         .map_err(|error| format!("worker workspace file chunk failed: {error}"))
 }
+
+pub(crate) fn worker_thread_workspace_file_chunk_with_options(
+    shared: &SharedNativeRuntime,
+    thread_id: String,
+    path: String,
+    cursor: Option<String>,
+    default_workspace_root: PathBuf,
+    config_snapshot: serde_json::Value,
+    _timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let thread_store = { lock_runtime(shared).thread_store.clone() };
+    let workspace_root = {
+        let operation = thread_store.begin_operation().map_err(|error| {
+            format!(
+                "thread workspace file lookup failed: {}; details={}",
+                error.message, error.details
+            )
+        })?;
+        let (thread, _) = operation
+            .thread_log()
+            .thread_projection_for(&thread_id)
+            .map_err(|error| {
+                format!(
+                    "thread workspace file lookup failed: {}; details={}",
+                    error.message, error.details
+                )
+            })?;
+        thread
+            .metadata
+            .working_directory
+            .map(PathBuf::from)
+            .unwrap_or(default_workspace_root)
+    };
+    let path = thread_workspace_file_path(&workspace_root, &path)?;
+    let request_id = next_worker_request_correlation();
+    let response =
+        native_request_router_with_workspace_root(thread_store, workspace_root, config_snapshot)
+            .dispatch(&WorkerRequest::new(
+                request_id.id("thread-workspace-file-chunk"),
+                request_id.trace_id("thread-workspace-file-chunk"),
+                "workspace.read_file_chunk",
+                serde_json::json!({ "path": path, "cursor": cursor }),
+            ));
+    serde_json::to_value(response)
+        .map_err(|error| format!("thread workspace file chunk failed: {error}"))
+}
+
+fn thread_workspace_file_path(
+    workspace_root: &std::path::Path,
+    requested: &str,
+) -> Result<String, String> {
+    let requested_path = PathBuf::from(requested);
+    if !requested_path.is_absolute() {
+        return Ok(requested.to_string());
+    }
+    let canonical_root = workspace_root.canonicalize().map_err(|error| {
+        format!(
+            "thread workspace file lookup failed: workspace root is unavailable: {error}; workspaceRoot={}",
+            workspace_root.display()
+        )
+    })?;
+    let canonical_file = requested_path.canonicalize().map_err(|error| {
+        format!(
+            "thread workspace file lookup failed: file is unavailable: {error}; path={requested}"
+        )
+    })?;
+    let relative = canonical_file.strip_prefix(&canonical_root).map_err(|_| {
+        format!(
+            "thread workspace file lookup failed: file is outside the thread workspace; path={requested}; workspaceRoot={}",
+            canonical_root.display()
+        )
+    })?;
+    let relative = relative.to_string_lossy().replace('\\', "/");
+    if relative.is_empty() {
+        return Err(
+            "thread workspace file lookup failed: path identifies the workspace root".to_string(),
+        );
+    }
+    Ok(relative)
+}
+
+#[cfg(test)]
+#[path = "workspace_tests.rs"]
+mod tests;

--- a/src-tauri/src/desktop_commands/workspace_tests.rs
+++ b/src-tauri/src/desktop_commands/workspace_tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+use crate::desktop::state::NativeRuntimeState;
+use crate::protocol::capability::default_desktop_capability_policy;
+use crate::threads::workspace_store::WorkspaceThreadStore;
+use serde_json::json;
+use std::sync::{Arc, Mutex};
+
+fn test_root(label: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "tinybot-thread-workspace-preview-{}-{}-{label}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should follow the Unix epoch")
+            .as_nanos(),
+    ));
+    std::fs::create_dir_all(&root).expect("test root should create");
+    root
+}
+
+#[test]
+fn thread_file_preview_reads_from_the_recorded_workspace_and_rejects_escape() {
+    let root = test_root("guarded-read");
+    let default_workspace = root.join("default-workspace");
+    let thread_workspace = root.join("thread-workspace");
+    let data_root = root.join("data");
+    std::fs::create_dir_all(default_workspace.join("src"))
+        .expect("default workspace should create");
+    std::fs::create_dir_all(thread_workspace.join("src")).expect("thread workspace should create");
+    std::fs::write(default_workspace.join("src/main.ts"), "default root")
+        .expect("default file should write");
+    std::fs::write(thread_workspace.join("src/main.ts"), "thread root")
+        .expect("thread file should write");
+    std::fs::write(root.join("secret.txt"), "outside thread workspace")
+        .expect("outside file should write");
+
+    let store = WorkspaceThreadStore::new_with_data_root(
+        default_workspace.clone(),
+        data_root,
+        default_desktop_capability_policy(),
+    );
+    let mut router = native_request_router(store.clone(), json!({}));
+    let created = router.dispatch(&WorkerRequest::new(
+        "request-create-thread-workspace-preview",
+        "trace-create-thread-workspace-preview",
+        "thread.create",
+        json!({
+            "threadId": "thread-workspace-preview",
+            "sessionKey": "session-workspace-preview",
+            "title": "Workspace preview",
+            "metadata": {
+                "workingDirectory": thread_workspace.to_string_lossy(),
+            },
+        }),
+    ));
+    assert_eq!(created.error, None, "{created:?}");
+    let default_created = router.dispatch(&WorkerRequest::new(
+        "request-create-default-workspace-preview",
+        "trace-create-default-workspace-preview",
+        "thread.create",
+        json!({
+            "threadId": "thread-default-workspace-preview",
+            "sessionKey": "session-default-workspace-preview",
+            "title": "Default workspace preview",
+        }),
+    ));
+    assert_eq!(default_created.error, None, "{default_created:?}");
+    drop(router);
+
+    let shared = Arc::new(Mutex::new(NativeRuntimeState::with_thread_store(
+        store.clone(),
+    )));
+    let loaded = worker_thread_workspace_file_chunk_with_options(
+        &shared,
+        "session-workspace-preview".to_string(),
+        "src/main.ts".to_string(),
+        None,
+        default_workspace.clone(),
+        json!({}),
+        Duration::from_secs(1),
+    )
+    .expect("thread workspace file should load");
+    assert_eq!(loaded["result"]["content"], "thread root");
+
+    let default_loaded = worker_thread_workspace_file_chunk_with_options(
+        &shared,
+        "session-default-workspace-preview".to_string(),
+        default_workspace
+            .join("src/main.ts")
+            .to_string_lossy()
+            .to_string(),
+        None,
+        default_workspace.clone(),
+        json!({}),
+        Duration::from_secs(1),
+    )
+    .expect("absolute file in the default thread workspace should load");
+    assert_eq!(default_loaded["result"]["content"], "default root");
+
+    let escaped = worker_thread_workspace_file_chunk_with_options(
+        &shared,
+        "session-workspace-preview".to_string(),
+        "../secret.txt".to_string(),
+        None,
+        root.clone(),
+        json!({}),
+        Duration::from_secs(1),
+    )
+    .expect("guarded workspace errors should stay structured");
+    assert!(escaped["error"].is_object(), "{escaped}");
+    assert!(escaped["result"].is_null(), "{escaped}");
+
+    drop(shared);
+    drop(store);
+    std::fs::remove_dir_all(root).expect("test root should clean up");
+}

--- a/src-tauri/src/native_browser/README.md
+++ b/src-tauri/src/native_browser/README.md
@@ -1,5 +1,5 @@
 # Native Browser Runtime
-<!-- tinybot-module-fingerprint: sha256:23904818829f80cd1201ad38474e0af0ae8dd626109b951cafd05a79cc7cfa4a -->
+<!-- tinybot-module-fingerprint: sha256:baa288f30235abad5ee45c15bed9be1915f219e2d9064bcb40472b52163a255d -->
 
 `native_browser` owns the managed WebView2 session used by native Agent browser
 tools and attachable desktop browser surfaces. Direct user input and Agent
@@ -58,10 +58,14 @@ desktop surface explicitly requests one, so chats that never browse do not
 retain WebView2 processes.
 
 Calling `browser_create_session` again with the same owner identity rehydrates
-the existing session. Agent actions include navigation, coordinate or semantic
-click, focused type, semantic fill, key, scroll, bounded wait, user handoff, and
-resume. Accepted dispatch is not completion: the host records the eventual
-completed, failed, cancelled, timed-out, or user-required result.
+the existing ready session. A WebView initialization failure remains observable
+as a failed snapshot, is retried once after a short delay, and is replaced by a
+fresh session on a later create request instead of being returned as a
+successful rehydration. Retry and recovery attempts retain structured
+diagnostics and counters. Agent actions include navigation, coordinate or
+semantic click, focused type, semantic fill, key, scroll, bounded wait, user
+handoff, and resume. Accepted dispatch is not completion: the host records the
+eventual completed, failed, cancelled, timed-out, or user-required result.
 
 ## Navigation and protected handoff
 

--- a/src-tauri/src/native_browser/manager.rs
+++ b/src-tauri/src/native_browser/manager.rs
@@ -32,6 +32,7 @@ use std::{
 const CAPTURE_RETENTION: usize = 12;
 const MAX_CAPTURE_BASE64_BYTES: usize = 12 * 1024 * 1024;
 const DEFAULT_AGENT_TIMEOUT: Duration = Duration::from_secs(15);
+const SESSION_CREATE_RETRY_DELAY: Duration = Duration::from_millis(250);
 pub(crate) const AGENT_SNAPSHOT_STALE: &str = "Browser page snapshot is stale";
 
 pub(crate) type BrowserSnapshotSink = Arc<dyn Fn(BrowserNativeSnapshot) + Send + Sync>;
@@ -380,9 +381,66 @@ impl BrowserSessionManager {
         self: &Arc<Self>,
         input: BrowserCreateSessionInput,
     ) -> Result<BrowserNativeSnapshot, String> {
+        let owner_session_id = input.owner_session_id.trim().to_string();
+        let first_error = match self.create_session_attempt(input.clone()).await {
+            Ok(snapshot) => return Ok(snapshot),
+            Err(error) => error,
+        };
+        let Some(failed_snapshot) = self
+            .snapshot_for_owner(&owner_session_id)
+            .filter(|snapshot| {
+                snapshot.data.lifecycle == BrowserSessionLifecycle::Failed
+                    && snapshot.data.control.reason.as_deref() == Some(first_error.as_str())
+            })
+        else {
+            return Err(first_error);
+        };
+        {
+            let mut state = self.lock_state();
+            increment_counter(&mut state, "browser.session.create.retry.started");
+        }
+        self.diagnostic(
+            "browser.session.create_retry_started",
+            Some(failed_snapshot.data.browser_session_id),
+            Some(failed_snapshot.data.active_tab_id),
+            None,
+            Some("adapter_initialization_failed"),
+            None,
+            diagnostic_details([
+                (
+                    "delayMs",
+                    serde_json::Value::from(SESSION_CREATE_RETRY_DELAY.as_millis() as u64),
+                ),
+                ("message", serde_json::Value::String(first_error.clone())),
+            ]),
+        );
+        tokio::time::sleep(SESSION_CREATE_RETRY_DELAY).await;
+        match self.create_session_attempt(input).await {
+            Ok(snapshot) => {
+                let mut state = self.lock_state();
+                increment_counter(&mut state, "browser.session.create.retry.completed");
+                Ok(snapshot)
+            }
+            Err(retry_error) => {
+                let mut state = self.lock_state();
+                increment_counter(&mut state, "browser.session.create.retry.failed");
+                Err(format!(
+                    "Native browser session creation failed after one retry: {retry_error} (initial failure: {first_error})"
+                ))
+            }
+        }
+    }
+
+    async fn create_session_attempt(
+        self: &Arc<Self>,
+        input: BrowserCreateSessionInput,
+    ) -> Result<BrowserNativeSnapshot, String> {
         let owner_session_id = required_text(input.owner_session_id, "Browser owner session id")?;
         if let Some(snapshot) = self.snapshot_for_owner(&owner_session_id) {
-            if snapshot.data.lifecycle != BrowserSessionLifecycle::Creating {
+            if !matches!(
+                snapshot.data.lifecycle,
+                BrowserSessionLifecycle::Creating | BrowserSessionLifecycle::Failed
+            ) {
                 return Ok(snapshot);
             }
         }
@@ -390,27 +448,53 @@ impl BrowserSessionManager {
         let wait_started = Instant::now();
         let _creation_guard = creation_lock.lock().await;
         if let Some(snapshot) = self.snapshot_for_owner(&owner_session_id) {
-            let mut state = self.lock_state();
-            increment_counter(&mut state, "browser.session.create.coalesced");
-            record_duration(
-                &mut state,
-                "browser.session.create.wait",
-                wait_started.elapsed(),
-            );
-            drop(state);
-            self.diagnostic(
-                "browser.session.create.coalesced",
-                Some(snapshot.data.browser_session_id.clone()),
-                Some(snapshot.data.active_tab_id.clone()),
-                None,
-                None,
-                None,
-                diagnostic_details([(
-                    "waitMs",
-                    serde_json::Value::from(wait_started.elapsed().as_millis() as u64),
-                )]),
-            );
-            return Ok(snapshot);
+            if snapshot.data.lifecycle == BrowserSessionLifecycle::Failed {
+                {
+                    let mut state = self.lock_state();
+                    increment_counter(&mut state, "browser.session.recovery.started");
+                }
+                self.diagnostic(
+                    "browser.session.recovery_started",
+                    Some(snapshot.data.browser_session_id.clone()),
+                    Some(snapshot.data.active_tab_id.clone()),
+                    None,
+                    Some("failed_session_replaced"),
+                    None,
+                    diagnostic_details([(
+                        "message",
+                        serde_json::Value::String(
+                            snapshot.data.control.reason.clone().unwrap_or_default(),
+                        ),
+                    )]),
+                );
+                self.close_session_after_creation(&snapshot.data.browser_session_id)
+                    .await
+                    .map_err(|error| {
+                        format!("Failed to clean up the failed browser session: {error}")
+                    })?;
+            } else {
+                let mut state = self.lock_state();
+                increment_counter(&mut state, "browser.session.create.coalesced");
+                record_duration(
+                    &mut state,
+                    "browser.session.create.wait",
+                    wait_started.elapsed(),
+                );
+                drop(state);
+                self.diagnostic(
+                    "browser.session.create.coalesced",
+                    Some(snapshot.data.browser_session_id.clone()),
+                    Some(snapshot.data.active_tab_id.clone()),
+                    None,
+                    None,
+                    None,
+                    diagnostic_details([(
+                        "waitMs",
+                        serde_json::Value::from(wait_started.elapsed().as_millis() as u64),
+                    )]),
+                );
+                return Ok(snapshot);
+            }
         }
         let initial_url = safe_browser_url(input.initial_url.as_deref().unwrap_or("about:blank"))?;
         let profile_id = validated_profile_id(input.profile_id.as_deref(), &owner_session_id)?;

--- a/src-tauri/src/native_browser/manager_tests.rs
+++ b/src-tauri/src/native_browser/manager_tests.rs
@@ -28,6 +28,7 @@ struct FakeAdapter {
     page_text: Mutex<Option<String>>,
     page_text_revision: std::sync::atomic::AtomicU64,
     fail_create: std::sync::atomic::AtomicBool,
+    create_failures_remaining: std::sync::atomic::AtomicU64,
     fail_observe: std::sync::atomic::AtomicBool,
 }
 
@@ -100,7 +101,15 @@ impl BrowserRuntimeAdapter for FakeAdapter {
         if delay_ms > 0 {
             tokio::time::sleep(Duration::from_millis(delay_ms)).await;
         }
-        if self.fail_create.load(std::sync::atomic::Ordering::Relaxed) {
+        let transient_create_failure = self
+            .create_failures_remaining
+            .fetch_update(
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+                |remaining| remaining.checked_sub(1),
+            )
+            .is_ok();
+        if self.fail_create.load(std::sync::atomic::Ordering::Relaxed) || transient_create_failure {
             return Err("fixture WebView initialization failed".to_string());
         }
         self.created.lock().unwrap().push(request.tab_id.clone());
@@ -1199,6 +1208,82 @@ async fn failed_session_snapshot_never_advertises_interaction() {
     assert!(!snapshot.data.interaction.navigate);
     assert!(!snapshot.data.interaction.click);
     assert!(!snapshot.data.interaction.semantic);
+}
+
+#[tokio::test]
+async fn transient_session_creation_failure_is_retried() {
+    let adapter = Arc::new(FakeAdapter::default());
+    adapter
+        .create_failures_remaining
+        .store(1, std::sync::atomic::Ordering::Relaxed);
+    let manager = manager(adapter.clone());
+
+    let snapshot = manager
+        .create_session(BrowserCreateSessionInput {
+            owner_session_id: "thread-transient-create-failure".to_string(),
+            profile_id: None,
+            persistence: BrowserProfilePersistence::Persistent,
+            initial_url: None,
+        })
+        .await
+        .expect("a transient WebView initialization failure should be retried");
+
+    assert_eq!(snapshot.data.lifecycle, BrowserSessionLifecycle::Ready);
+    assert_eq!(adapter.created.lock().unwrap().len(), 1);
+    assert_eq!(adapter.closed.lock().unwrap().len(), 1);
+    let metrics = manager.metrics();
+    assert_eq!(
+        metrics.counters.get("browser.session.create.failed"),
+        Some(&1)
+    );
+    assert_eq!(
+        metrics.counters.get("browser.session.create.completed"),
+        Some(&1)
+    );
+}
+
+#[tokio::test]
+async fn failed_session_can_be_recreated_for_the_same_owner() {
+    let adapter = Arc::new(FakeAdapter::default());
+    adapter
+        .fail_create
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let manager = manager(adapter.clone());
+    let input = BrowserCreateSessionInput {
+        owner_session_id: "thread-recover-create-failure".to_string(),
+        profile_id: None,
+        persistence: BrowserProfilePersistence::Persistent,
+        initial_url: None,
+    };
+
+    manager
+        .create_session(input.clone())
+        .await
+        .expect_err("persistent fixture failure should remain visible");
+    let failed_session_id = manager
+        .snapshot_for_owner("thread-recover-create-failure")
+        .expect("failed session should remain observable")
+        .data
+        .browser_session_id;
+    adapter
+        .fail_create
+        .store(false, std::sync::atomic::Ordering::Relaxed);
+
+    let recovered = manager
+        .create_session(input)
+        .await
+        .expect("a later create request should replace the failed session");
+
+    assert_eq!(recovered.data.lifecycle, BrowserSessionLifecycle::Ready);
+    assert_ne!(recovered.data.browser_session_id, failed_session_id);
+    assert_eq!(
+        manager
+            .snapshot_for_owner("thread-recover-create-failure")
+            .unwrap()
+            .data
+            .browser_session_id,
+        recovered.data.browser_session_id
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/src/rpc/README.md
+++ b/src-tauri/src/rpc/README.md
@@ -1,5 +1,5 @@
 # Worker RPC Router
-<!-- tinybot-module-fingerprint: sha256:67ca26670914eb0e9c5d690bdb543409cf465059f130cced7234162eaa2038d4 -->
+<!-- tinybot-module-fingerprint: sha256:8f2f1d4b2846aef358a49d27ab934465a855fcf981abe129be28e72ab86e6613 -->
 
 `rpc` is the versioned method-routing boundary for native backend services.
 The module root is `mod.rs`; protocol envelopes and parameter validation live
@@ -18,6 +18,11 @@ in the sibling `protocol/` module.
 The router should coordinate services, not become the implementation of every
 service. `workspace/`, `tools/`, and `threads/` own their domain
 behavior.
+
+Desktop boundaries that already resolved an authoritative workspace may build
+a router with that explicit root. The Thread Artifact preview command uses
+this narrow constructor after loading the canonical Thread projection; path
+containment and file reads still belong to the workspace service.
 
 ## Dispatch flow
 

--- a/src-tauri/src/rpc/mod.rs
+++ b/src-tauri/src/rpc/mod.rs
@@ -903,7 +903,7 @@ pub(crate) fn native_request_router(
     .with_builtin_skills_root(crate::config::application::repo_root())
 }
 
-fn native_request_router_with_workspace_root(
+pub(crate) fn native_request_router_with_workspace_root(
     threads: WorkspaceThreadStore,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,

--- a/src/app-core/native/README.md
+++ b/src/app-core/native/README.md
@@ -1,5 +1,5 @@
 # Native Renderer Adapters
-<!-- tinybot-module-fingerprint: sha256:3be367fd616626dbd48190a43271c8f9c26be6528d1b889a3378071cc37c102f -->
+<!-- tinybot-module-fingerprint: sha256:00e76f734c9388d2fb3f71496f7770c45f490a786815b7247777201207e31a06 -->
 
 `native` contains typed adapters for Tauri commands and events used by the
 desktop renderer. Each file owns one native capability, such as Threads,
@@ -67,6 +67,11 @@ typed PowerShell or Command Prompt creation plus poll, input, resize, and
 terminate operations; callers cannot send an arbitrary process startup command
 or address Agent shell sessions. Its create contract leaves the working
 directory optional so a regular chat can use Rust's configured native default.
+
+`desktopNativeWorkspace` exposes both default-workspace browsing and a
+Thread-scoped file-chunk request for contextual Artifact previews. The latter
+sends only `threadId`, path, and optional cursor; Rust remains responsible for
+selecting the canonical Thread workspace and enforcing its filesystem bounds.
 
 `rendererLogger` is the renderer-wide observability entry point. It emits
 structured `debug`, `info`, `warn`, and `error` events to the console and a

--- a/src/app-core/native/desktopNativeWorkspace.test.ts
+++ b/src/app-core/native/desktopNativeWorkspace.test.ts
@@ -34,5 +34,9 @@ describe("desktop native workspace API", () => {
       command: "worker_workspace_file_chunk",
       args: { input: { path: "src/chat.ts", cursor: "next" } },
     });
+    await expect(api.threadFileChunk({ threadId: "thread-1", path: "src/chat.ts" })).resolves.toEqual({
+      command: "worker_thread_workspace_file_chunk",
+      args: { input: { threadId: "thread-1", path: "src/chat.ts" } },
+    });
   });
 });

--- a/src/app-core/native/desktopNativeWorkspace.ts
+++ b/src/app-core/native/desktopNativeWorkspace.ts
@@ -9,6 +9,7 @@ export type NativeWorkspaceApi = {
   putFile: (path: string, body: unknown) => Promise<unknown>;
   directory: (request: { cursor?: string; nameQuery?: string; path: string }) => Promise<unknown>;
   fileChunk: (request: { cursor?: string; path: string }) => Promise<unknown>;
+  threadFileChunk: (request: { cursor?: string; path: string; threadId: string }) => Promise<unknown>;
 };
 
 export function createDesktopNativeWorkspaceApi(options: { invoke?: TauriInvoke } = {}): NativeWorkspaceApi {
@@ -20,5 +21,6 @@ export function createDesktopNativeWorkspaceApi(options: { invoke?: TauriInvoke 
     putFile: (path: string, body: unknown) => invoke("worker_workspace_put_file", { input: { path, body } }),
     directory: (request) => invoke("worker_workspace_directory", { input: request }),
     fileChunk: (request) => invoke("worker_workspace_file_chunk", { input: request }),
+    threadFileChunk: (request) => invoke("worker_thread_workspace_file_chunk", { input: request }),
   };
 }

--- a/src/react-workbench/README.md
+++ b/src/react-workbench/README.md
@@ -1,5 +1,5 @@
 # React Workbench
-<!-- tinybot-module-fingerprint: sha256:30d07c1dc50628a1c845fa04c9bdb783ce669e1a83b3734a11c3be9f0764f74f -->
+<!-- tinybot-module-fingerprint: sha256:cd143fe6b7514b514808aa34218238c0c773fa5d14e7721324b30f84188d6408 -->
 
 `react-workbench` contains the React renderer for Tinybot's desktop application.
 `main.tsx` mounts `App` for the main window and selects lightweight
@@ -47,6 +47,9 @@ web tools. Terminal resources attach to a separate user-only PTY runtime;
 switching or hiding resources preserves the process, while closing the
 Terminal tab ends it. Regular chats share the native default-workspace Sidecar
 scope even though their Thread metadata has no explicit working directory.
+Assistant Markdown file links open contextual Artifact tabs backed by bounded,
+Thread-scoped workspace reads. Artifact remains absent from the empty-resource
+menu, while binary, truncated, and failed reads stay visible in the preview.
 Docked Sidecar widths are measured against the Chat workspace so persisted
 sizes and live resizing cannot displace the resource surface beyond its
 container; narrow windows retain the overlay gutter instead.

--- a/src/react-workbench/adapters/README.md
+++ b/src/react-workbench/adapters/README.md
@@ -1,5 +1,5 @@
 # Desktop Adapters
-<!-- tinybot-module-fingerprint: sha256:1c37c2db658cd39c6a67a88a96157aa4c5c6d290507315f6f0111751549be924 -->
+<!-- tinybot-module-fingerprint: sha256:a78ca49c13f167e89cb7a264e3a6a93eb2f4056f33701088d65f5610959e3ce3 -->
 
 `adapters` implements renderer store interfaces over Tinybot's native and
 app-core modules. It owns event projection and the Settings, Tools, and
@@ -8,6 +8,11 @@ Workspace store adapters used by `createDesktopAppServices()`.
 Adapters may translate transport data into renderer contracts, but they do not
 render React views or become a second authority for chat, settings, or
 workspace state.
+
+The workspace Adapter keeps default-workspace directory and chunk browsing
+separate from Thread-scoped file preview reads. For the latter it forwards only
+the Thread ID and file path to the native API, preserving Rust as the authority
+for workspace selection and path containment.
 
 The desktop Settings adapter projects the native Provider catalog into the
 shared Chat model catalog. Only enabled Providers whose runtime status is

--- a/src/react-workbench/adapters/desktopWorkspaceStore.test.ts
+++ b/src/react-workbench/adapters/desktopWorkspaceStore.test.ts
@@ -7,6 +7,7 @@ function createNativeWorkspace() {
     files: vi.fn<NativeWorkspaceApi["files"]>(async () => ({ files: [] })),
     directory: vi.fn<NativeWorkspaceApi["directory"]>(async () => ({ result: { entries: [], listing_revision: "revision-1", path: "." } })),
     fileChunk: vi.fn<NativeWorkspaceApi["fileChunk"]>(async () => ({ result: { content_type: "text", path: "README.md", revision: "revision-1", size_bytes: 0 } })),
+    threadFileChunk: vi.fn<NativeWorkspaceApi["threadFileChunk"]>(async () => ({ result: { content_type: "text", path: "README.md", revision: "revision-1", size_bytes: 0 } })),
   };
 }
 
@@ -58,6 +59,19 @@ describe("desktop workspace store", () => {
         updated_at: "2026-08-15T00:00:00.000Z",
       },
     });
+    nativeWorkspace.threadFileChunk.mockResolvedValue({
+      result: {
+        content: "hello",
+        content_type: "text",
+        line_end: 2,
+        line_start: 1,
+        next_cursor: "cursor-2",
+        path: "src/main.ts",
+        revision: "revision-3",
+        size_bytes: 5,
+        updated_at: "2026-08-15T00:00:00.000Z",
+      },
+    });
     const store = createDesktopWorkspaceStore({ initialize: async () => undefined, nativeWorkspace });
 
     await expect(store.listDirectory({ path: "src" })).resolves.toEqual({
@@ -81,6 +95,19 @@ describe("desktop workspace store", () => {
       sizeBytes: 5,
       updatedAt: "2026-08-15T00:00:00.000Z",
     });
+
+    await expect(store.readThreadFile({ threadId: "thread-1", path: "src/main.ts" })).resolves.toEqual({
+      content: "hello",
+      contentType: "text",
+      lineEnd: 2,
+      lineStart: 1,
+      nextCursor: "cursor-2",
+      path: "src/main.ts",
+      revision: "revision-3",
+      sizeBytes: 5,
+      updatedAt: "2026-08-15T00:00:00.000Z",
+    });
+    expect(nativeWorkspace.threadFileChunk).toHaveBeenCalledWith({ threadId: "thread-1", path: "src/main.ts" });
   });
 
   it("preserves structured workspace query failures", async () => {

--- a/src/react-workbench/adapters/desktopWorkspaceStore.ts
+++ b/src/react-workbench/adapters/desktopWorkspaceStore.ts
@@ -8,7 +8,7 @@ import type {
   WorkspaceStore,
 } from "../services";
 
-type NativeWorkspaceQueryApi = Pick<NativeWorkspaceApi, "directory" | "fileChunk" | "files">;
+type NativeWorkspaceQueryApi = Pick<NativeWorkspaceApi, "directory" | "fileChunk" | "files" | "threadFileChunk">;
 
 export function createDesktopWorkspaceStore({
   initialize,
@@ -29,6 +29,10 @@ export function createDesktopWorkspaceStore({
     async readFile(request) {
       await initialize();
       return normalizeWorkspaceFileChunk(await requireNativeWorkspace(nativeWorkspace).fileChunk(request));
+    },
+    async readThreadFile(request) {
+      await initialize();
+      return normalizeWorkspaceFileChunk(await requireNativeWorkspace(nativeWorkspace).threadFileChunk(request));
     },
   };
 }

--- a/src/react-workbench/agent-graph/AgentGraphNodeDrawer.tsx
+++ b/src/react-workbench/agent-graph/AgentGraphNodeDrawer.tsx
@@ -114,7 +114,6 @@ export function AgentGraphNodeDrawer({
         interactiveFormIds={EMPTY_INTERACTIVE_FORM_IDS}
         latestFailedTurnId=""
         optimisticMessages={[]}
-        recoveringTurnId=""
         sessionRunning={nodeRun?.status === "running"}
         turns={timeline.turns}
       />

--- a/src/react-workbench/agent-graph/README.md
+++ b/src/react-workbench/agent-graph/README.md
@@ -1,5 +1,5 @@
 # Agent Graph Workbench
-<!-- tinybot-module-fingerprint: sha256:3011942a085766f991ecde82e922a0925280be99cf01648966659d57bc4223b0 -->
+<!-- tinybot-module-fingerprint: sha256:731da7c61b01357edf598c8c36476f71eb6d11285632ab770afb0a55f6ba323d -->
 
 `agent-graph` owns the standalone Agent Graph route and its React presentation.
 The page creates one honest in-memory starter draft and exposes an unbounded

--- a/src/react-workbench/chat/AssistantMarkdown.test.tsx
+++ b/src/react-workbench/chat/AssistantMarkdown.test.tsx
@@ -76,6 +76,29 @@ describe("AssistantMarkdown", () => {
     expect(screen.queryByRole("link", { name: "Relative" })).toBeNull();
   });
 
+  it("opens local file links through the artifact handler without invoking the system opener", async () => {
+    const onOpenFileLink = vi.fn();
+    render(
+      <AssistantMarkdown
+        onOpenFileLink={onOpenFileLink}
+        streaming={false}
+        text={'[Workspace guide](./docs/guide.md) [Entry](src/main.ts:12) [Absolute file](file:///D:/Code/tinybot/src/main.ts) [Outside](C:/Users/private.txt)'}
+      />,
+    );
+
+    const relativeLink = screen.getByRole("link", { name: "Workspace guide" });
+    expect(relativeLink.getAttribute("data-link-kind")).toBe("file");
+    expect(relativeLink.getAttribute("href")).toBe("#");
+    expect(relativeLink.getAttribute("target")).toBeNull();
+    fireEvent.click(relativeLink);
+
+    expect(onOpenFileLink).toHaveBeenCalledWith({ href: "./docs/guide.md" });
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+    expect(screen.getByRole("link", { name: "Entry" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Absolute file" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Outside" })).toBeTruthy();
+  });
+
   it("adds quiet source icons without changing link names", () => {
     const { container } = render(
       <AssistantMarkdown

--- a/src/react-workbench/chat/AssistantMarkdown.tsx
+++ b/src/react-workbench/chat/AssistantMarkdown.tsx
@@ -1,17 +1,19 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
-import { Globe2, Mail } from "lucide-react";
-import { memo, type ComponentProps } from "react";
+import { FileText, Globe2, Mail } from "lucide-react";
+import { memo, type ComponentProps, useMemo } from "react";
 import {
   Streamdown,
   type Components,
   type ControlsConfig,
+  defaultRemarkPlugins,
   type LinkSafetyConfig,
   type PluginConfig,
   type UrlTransform,
 } from "streamdown";
 import "streamdown/styles.css";
+import { isAssistantFileHref, type AssistantFileLink } from "./assistantFileLinks";
 
 const ASSISTANT_MARKDOWN_CONTROLS = {
   code: { copy: true, download: false },
@@ -30,8 +32,10 @@ const ASSISTANT_MARKDOWN_PLUGINS = {
 
 const DISALLOWED_ASSISTANT_ELEMENTS = ["img"];
 const ALLOWED_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const ASSISTANT_FILE_LINK_ORIGIN = "https://tinybot.local";
+const ASSISTANT_FILE_LINK_PATH = "/artifact-file";
 
-type AssistantMarkdownLinkKind = "email" | "github" | "web";
+type AssistantMarkdownLinkKind = "email" | "file" | "github" | "web";
 
 const ASSISTANT_MARKDOWN_LINK_ICON_PROPS = {
   "aria-hidden": true,
@@ -41,6 +45,9 @@ const ASSISTANT_MARKDOWN_LINK_ICON_PROPS = {
 } as const;
 
 function assistantMarkdownLinkKind(href: string): AssistantMarkdownLinkKind {
+  if (decodeAssistantFileLink(href)) {
+    return "file";
+  }
   const url = new URL(href);
   if (url.protocol === "mailto:") {
     return "email";
@@ -56,6 +63,9 @@ function AssistantMarkdownLinkIcon({ kind }: { kind: AssistantMarkdownLinkKind }
         <path fill="currentColor" d="M8 0a8.16 8.16 0 0 0-2.53 15.84c.4.08.55-.18.55-.39 0-.19-.01-.83-.01-1.51-2.23.49-2.7-.96-2.7-.96-.36-.94-.89-1.19-.89-1.19-.73-.5.05-.49.05-.49.8.06 1.22.83 1.22.83.71 1.23 1.87.88 2.33.67.07-.52.28-.88.51-1.08-1.78-.21-3.65-.91-3.65-4.02 0-.89.31-1.61.82-2.18-.08-.2-.36-1.03.08-2.15 0 0 .67-.22 2.2.83A7.48 7.48 0 0 1 8 3.98c.68 0 1.36.09 2 .27 1.53-1.05 2.2-.83 2.2-.83.44 1.12.16 1.95.08 2.15.51.57.82 1.29.82 2.18 0 3.12-1.87 3.8-3.66 4.01.29.25.54.74.54 1.5 0 1.08-.01 1.95-.01 2.22 0 .22.15.47.55.39A8.16 8.16 0 0 0 8 0Z" />
       </svg>
     );
+  }
+  if (kind === "file") {
+    return <FileText {...ASSISTANT_MARKDOWN_LINK_ICON_PROPS} data-link-icon="file" />;
   }
   const LinkIcon = kind === "email" ? Mail : Globe2;
   return <LinkIcon {...ASSISTANT_MARKDOWN_LINK_ICON_PROPS} data-link-icon={kind} />;
@@ -80,20 +90,37 @@ async function openAssistantMarkdownUrl(url: string): Promise<void> {
   }
 }
 
-function AssistantMarkdownLink({ children, href, node: _node, onClick: _onClick, ...props }: ComponentProps<"a"> & { node?: unknown }) {
+function AssistantMarkdownLink({
+  children,
+  href,
+  node: _node,
+  onClick: _onClick,
+  onOpenFileLink,
+  target,
+  ...props
+}: ComponentProps<"a"> & { node?: unknown; onOpenFileLink?: (link: AssistantFileLink) => void }) {
   if (!href) {
     return <span>{children}</span>;
   }
   const linkKind = assistantMarkdownLinkKind(href);
+  const fileHref = linkKind === "file" ? decodeAssistantFileLink(href) : undefined;
+  if (linkKind === "file" && !onOpenFileLink) {
+    return <span>{children}</span>;
+  }
   return (
     <a
       {...props}
       data-link-kind={linkKind}
       data-streamdown="link"
-      href={href}
+      href={linkKind === "file" ? "#" : href}
       rel="noreferrer noopener"
+      target={linkKind === "file" ? undefined : target}
       onClick={(event) => {
         event.preventDefault();
+        if (fileHref) {
+          onOpenFileLink?.({ href: fileHref });
+          return;
+        }
         void openAssistantMarkdownUrl(href);
       }}
     >
@@ -107,18 +134,60 @@ function AssistantMarkdownStrong({ node: _node, ...props }: ComponentProps<"stro
   return <strong data-streamdown="strong" {...props} />;
 }
 
-const ASSISTANT_MARKDOWN_COMPONENTS = {
-  a: AssistantMarkdownLink,
-  strong: AssistantMarkdownStrong,
-} satisfies Components;
+type AssistantMarkdownNode = {
+  children?: AssistantMarkdownNode[];
+  type?: string;
+  url?: string;
+};
+
+function remarkAssistantFileLinks() {
+  return (tree: AssistantMarkdownNode) => {
+    const pending = [tree];
+    while (pending.length) {
+      const node = pending.pop()!;
+      if (node.type === "link" && node.url && isAssistantFileHref(node.url)) {
+        node.url = encodeAssistantFileLink(node.url);
+      }
+      if (node.children) {
+        pending.push(...node.children);
+      }
+    }
+  };
+}
+
+const ASSISTANT_MARKDOWN_REMARK_PLUGINS = [...Object.values(defaultRemarkPlugins), remarkAssistantFileLinks];
+
+function encodeAssistantFileLink(href: string): string {
+  return `${ASSISTANT_FILE_LINK_ORIGIN}${ASSISTANT_FILE_LINK_PATH}?href=${encodeURIComponent(href)}`;
+}
+
+function decodeAssistantFileLink(href: string): string | undefined {
+  try {
+    const url = new URL(href);
+    if (url.origin !== ASSISTANT_FILE_LINK_ORIGIN || url.pathname !== ASSISTANT_FILE_LINK_PATH) {
+      return undefined;
+    }
+    return url.searchParams.get("href") || undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export const AssistantMarkdown = memo(function AssistantMarkdown({
+  onOpenFileLink,
   streaming,
   text,
 }: {
+  onOpenFileLink?: (link: AssistantFileLink) => void;
   streaming: boolean;
   text: string;
 }) {
+  const components = useMemo(() => ({
+    a: (props: ComponentProps<typeof AssistantMarkdownLink>) => (
+      <AssistantMarkdownLink {...props} onOpenFileLink={onOpenFileLink} />
+    ),
+    strong: AssistantMarkdownStrong,
+  } satisfies Components), [onOpenFileLink]);
   if (!text.trim()) {
     return null;
   }
@@ -126,7 +195,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
     <Streamdown
       animated={false}
       className="react-message-markdown"
-      components={ASSISTANT_MARKDOWN_COMPONENTS}
+      components={components}
       controls={ASSISTANT_MARKDOWN_CONTROLS}
       disallowedElements={DISALLOWED_ASSISTANT_ELEMENTS}
       isAnimating={false}
@@ -135,6 +204,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
       linkSafety={ASSISTANT_MARKDOWN_LINK_SAFETY}
       mode="streaming"
       plugins={ASSISTANT_MARKDOWN_PLUGINS}
+      remarkPlugins={ASSISTANT_MARKDOWN_REMARK_PLUGINS}
       skipHtml
       unwrapDisallowed
       urlTransform={transformAssistantMarkdownUrl}

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -1729,7 +1729,7 @@
   margin: 4px 0;
   border: 0;
   background: transparent;
-  color: var(--color-ink);
+  color: var(--color-muted);
   overflow: visible;
 }
 
@@ -1738,15 +1738,15 @@
 }
 
 .react-execution-timeline__trigger {
-  display: grid;
-  grid-template-columns: 24px minmax(0, 1fr) 24px;
+  display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: flex-start;
+  gap: 6px;
   width: 100%;
-  min-height: 52px;
-  border-bottom: 1px solid var(--color-hairline);
+  min-height: 40px;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-hairline) 65%, transparent);
   border-radius: 0;
-  padding: 0 0 10px;
+  padding: 0 0 4px;
   color: inherit;
   text-align: left;
   cursor: pointer;
@@ -1754,7 +1754,7 @@
 }
 
 .react-execution-timeline__trigger:hover {
-  border-bottom-color: var(--color-hairline-strong);
+  border-bottom-color: var(--color-hairline);
   background: transparent;
   color: var(--color-body);
 }
@@ -1767,29 +1767,46 @@
 .react-execution-timeline__status {
   display: inline-grid;
   place-items: center;
-  color: var(--color-muted);
+  color: var(--color-muted-soft);
 }
 
 .react-execution-timeline__heading {
-  display: grid;
-  gap: 2px;
+  display: flex;
+  flex: 0 1 auto;
+  align-items: baseline;
+  gap: 6px;
   min-width: 0;
+}
+
+.react-execution-timeline__heading strong {
+  flex: none;
+  color: var(--color-body);
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .react-execution-timeline__heading small {
   overflow: hidden;
-  color: var(--color-muted);
-  font-size: 12px;
+  color: var(--color-muted-soft);
+  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .react-execution-timeline__chevron {
+  flex: none;
+  color: var(--color-muted-soft);
   transition: transform 180ms ease;
 }
 
+.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__status,
+.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__heading strong,
+.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__chevron {
+  color: var(--color-error);
+}
+
 .react-execution-timeline__trigger[aria-expanded="true"] .react-execution-timeline__chevron {
-  transform: rotate(180deg);
+  transform: rotate(90deg);
 }
 
 .react-execution-timeline__content {
@@ -1808,7 +1825,7 @@
 }
 
 .react-execution-timeline__item + .react-execution-timeline__item {
-  border-top: 1px solid var(--color-hairline);
+  border-top: 1px solid color-mix(in srgb, var(--color-hairline) 65%, transparent);
 }
 
 .react-execution-timeline__canvas-button {
@@ -1837,7 +1854,7 @@
 .react-execution-timeline__item:has(> .react-execution-timeline__canvas-button) > .react-message,
 .react-execution-timeline__item:has(> .react-execution-timeline__canvas-button) > .react-message-reasoning,
 .react-execution-timeline__item:has(> .react-execution-timeline__canvas-button) > .react-canonical-step,
-.react-execution-timeline__item:has(> .react-execution-timeline__canvas-button) > .react-error-recovery,
+.react-execution-timeline__item:has(> .react-execution-timeline__canvas-button) > .react-execution-error,
 .react-execution-timeline__item:has(> .react-execution-timeline__canvas-button) > .react-canonical-step-stack {
   padding-right: 40px;
 }
@@ -1858,7 +1875,7 @@
 .react-execution-timeline__item > .react-message-reasoning,
 .react-execution-timeline__item > .react-agent-steps,
 .react-execution-timeline__item > .react-canonical-step,
-.react-execution-timeline__item > .react-error-recovery,
+.react-execution-timeline__item > .react-execution-error,
 .react-execution-timeline__item > .react-canonical-step-stack,
 .react-execution-timeline__item > .react-patch-change {
   width: 100%;
@@ -1922,24 +1939,39 @@
 }
 
 .react-tool-activity__header {
-  display: grid;
-  grid-template-columns: 20px minmax(0, 1fr) auto 30px 30px;
+  display: flex;
   align-items: center;
-  gap: 6px;
+  justify-content: flex-start;
+  gap: 4px;
+  width: 100%;
   min-width: 0;
-  min-height: 44px;
-  padding: 6px 0;
+  min-height: 34px;
+  border: 0;
+  background: transparent;
+  padding: 2px 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   transition: background-color var(--motion-duration-fast) ease;
 }
 
-.react-tool-activity__header:hover {
-  background: color-mix(in srgb, var(--color-surface-soft) 58%, transparent);
+.react-tool-activity__header:is(button) {
+  cursor: pointer;
+}
+
+.react-tool-activity__header:is(button):hover {
+  background: color-mix(in srgb, var(--color-surface-soft) 42%, transparent);
+}
+
+.react-tool-activity__header:is(button):focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
 }
 
 .react-tool-activity__icon {
   display: inline-grid;
   place-items: center;
-  color: var(--color-body);
+  color: var(--color-muted-soft);
 }
 
 .react-tool-activity__icon svg {
@@ -1949,8 +1981,9 @@
 
 .react-tool-activity__copy {
   display: flex;
+  flex: 0 1 auto;
   align-items: baseline;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
 }
 
@@ -1963,33 +1996,30 @@
 }
 
 .react-tool-activity__copy strong {
-  color: var(--color-ink);
-  font-size: 13px;
-  font-weight: 650;
+  color: var(--color-body);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .react-tool-activity__copy small {
-  color: var(--color-muted);
-  font-size: 11px;
+  color: var(--color-muted-soft);
+  font-size: 10px;
 }
 
 .react-tool-activity__status {
   display: inline-flex;
+  flex: none;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   color: var(--color-muted);
-  font-size: 11px;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: 550;
   white-space: nowrap;
 }
 
 .react-tool-activity__status svg {
   width: 15px;
   height: 15px;
-}
-
-.react-tool-activity__status[data-status="success"] {
-  color: color-mix(in srgb, var(--color-success) 82%, #245b31);
 }
 
 .react-tool-activity__status[data-status="active"] {
@@ -2008,58 +2038,40 @@
   color: var(--color-error);
 }
 
-.react-tool-activity__open-details,
-.react-tool-activity__toggle,
 .react-patch-file__copy {
   display: inline-grid;
   width: 30px;
   height: 30px;
   place-items: center;
   border-radius: 7px;
-  color: var(--color-muted);
+  color: var(--color-muted-soft);
   transition: background-color var(--motion-duration-fast) ease, color var(--motion-duration-fast) ease, opacity var(--motion-duration-fast) ease;
 }
 
-.react-tool-activity__open-details {
-  opacity: 0;
-}
-
-.react-tool-activity__header:hover .react-tool-activity__open-details,
-.react-tool-activity__open-details:focus-visible {
-  opacity: 1;
-}
-
-.react-tool-activity__open-details:hover,
-.react-tool-activity__toggle:hover,
 .react-patch-file__copy:hover {
   background: var(--color-surface-soft);
   color: var(--color-ink);
 }
 
-.react-tool-activity__open-details:focus-visible,
-.react-tool-activity__toggle:focus-visible,
 .react-patch-file__copy:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 1px;
 }
 
-.react-tool-activity__toggle svg {
+.react-tool-activity__chevron {
+  flex: none;
+  color: var(--color-muted-soft);
   transition: transform var(--motion-duration-fast) ease;
 }
 
-.react-tool-activity__toggle[aria-expanded="true"] svg {
-  transform: rotate(180deg);
-}
-
-.react-tool-activity__action-spacer {
-  width: 30px;
-  height: 1px;
+.react-tool-activity[data-open="true"] .react-tool-activity__chevron {
+  transform: rotate(90deg);
 }
 
 .react-tool-activity__details {
   display: grid;
-  gap: 8px;
-  padding: 0 0 12px 26px;
+  gap: 4px;
+  padding: 0 0 6px 22px;
 }
 
 .react-tool-activity__details[hidden] {
@@ -2081,9 +2093,12 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: start;
-  gap: 10px;
-  min-height: 46px;
-  padding: 12px 14px;
+  gap: 6px;
+  min-height: 32px;
+  border-color: color-mix(in srgb, var(--color-hairline) 72%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--color-canvas) 62%, transparent);
+  padding: 6px 10px;
 }
 
 .react-tool-activity__preview[data-preview-kind="code"] {
@@ -2102,7 +2117,7 @@
   color: var(--color-body);
   font-family: var(--font-code);
   font-size: 11px;
-  line-height: 1.55;
+  line-height: 1.45;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
@@ -2111,14 +2126,14 @@
   margin: 0;
   color: var(--color-body);
   font-size: 12px;
-  line-height: 1.55;
+  line-height: 1.45;
 }
 
 .react-tool-activity__prompt {
   color: var(--color-muted);
   font-family: var(--font-code);
   font-size: 12px;
-  line-height: 1.55;
+  line-height: 1.45;
 }
 
 .react-tool-activity__preview-meta {
@@ -2134,7 +2149,7 @@
 .react-tool-activity__code-lines {
   display: grid;
   min-width: 0;
-  margin: -12px -14px;
+  margin: -6px -10px;
 }
 
 .react-tool-activity__code-lines > div {
@@ -2518,116 +2533,64 @@
   color: var(--color-muted);
 }
 
-.react-error-recovery {
+.react-execution-error {
   display: grid;
-  gap: 12px;
-  width: min(760px, 100%);
-  margin: 4px auto;
-  border: 1px solid color-mix(in srgb, var(--color-error) 34%, var(--color-hairline));
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--color-error) 5%, var(--color-panel));
-  padding: 14px 16px;
-  color: var(--color-body);
-}
-
-.react-error-recovery:focus {
-  outline: 2px solid color-mix(in srgb, var(--color-error) 60%, transparent);
-  outline-offset: 3px;
-}
-
-.react-error-recovery__heading {
-  display: grid;
-  grid-template-columns: 22px minmax(0, 1fr);
-  gap: 9px;
+  grid-template-columns: 18px minmax(0, auto) auto;
+  align-items: start;
+  justify-content: start;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 0;
   color: var(--color-error);
 }
 
-.react-error-recovery__heading p {
-  margin: 3px 0 0;
+.react-execution-error:focus {
+  outline: none;
+}
+
+.react-execution-error__icon {
+  margin-top: 1px;
+}
+
+.react-execution-error__message {
+  min-width: 0;
+}
+
+.react-execution-error__message strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.react-execution-error__message p {
+  margin: 1px 0 0;
   color: var(--color-body);
+  font-size: 12px;
+  line-height: 1.45;
 }
 
-.react-error-recovery__summary,
-.react-error-detail dl {
-  display: grid;
-  gap: 6px;
-  margin: 0;
-}
-
-.react-error-recovery__summary > div,
-.react-error-detail dl > div {
-  display: grid;
-  grid-template-columns: 84px minmax(0, 1fr);
-  gap: 10px;
-}
-
-.react-error-recovery dt,
-.react-error-recovery dd,
-.react-error-detail dt,
-.react-error-detail dd {
-  margin: 0;
-}
-
-.react-error-recovery dt,
-.react-error-detail dt {
-  color: var(--color-muted);
-}
-
-.react-error-recovery__valid-results {
-  display: grid;
-  gap: 5px;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--color-panel) 68%, transparent);
-  padding: 9px 10px;
-}
-
-.react-error-recovery__valid-results ul {
-  margin: 0;
-  padding-left: 20px;
-}
-
-.react-error-recovery__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-}
-
-.react-error-recovery__actions button {
+.react-execution-error__copy {
   display: inline-flex;
-  min-height: 36px;
+  min-height: 26px;
   align-items: center;
-  gap: 6px;
-  border: 1px solid var(--color-hairline);
-  border-radius: 8px;
-  background: var(--color-panel);
-  padding: 0 10px;
-  color: var(--color-body);
+  gap: 5px;
+  margin-top: -4px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  padding: 3px 6px;
+  color: var(--color-muted);
   cursor: pointer;
+  font-size: 11px;
 }
 
-.react-error-recovery__actions button:first-child {
-  border-color: var(--color-primary);
-  background: var(--color-primary);
-  color: var(--color-on-primary);
-}
-
-.react-error-recovery__actions button:disabled {
-  cursor: wait;
-  opacity: 0.55;
-}
-
-.react-error-detail {
-  display: grid;
-  gap: 16px;
-  margin-top: 14px;
-}
-
-.react-error-detail pre {
-  overflow: auto;
-  border-radius: 8px;
+.react-execution-error__copy:hover {
   background: var(--color-surface-soft);
-  padding: 10px;
-  white-space: pre-wrap;
+  color: var(--color-body);
+}
+
+.react-execution-error__copy:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
 }
 
 .react-canonical-step-stack {
@@ -3491,13 +3454,8 @@
     min-height: 138px;
   }
 
-  .react-tool-activity__header {
-    grid-template-columns: 20px minmax(0, 1fr) auto 30px 30px;
-    gap: 6px;
-  }
-
   .react-tool-activity__details {
-    padding-left: 26px;
+    padding-left: 22px;
   }
 
   .react-tool-activity__status > span {

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -2964,6 +2964,12 @@
   overflow-wrap: anywhere;
 }
 
+.react-artifact-detail__notice {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
 .react-canonical-step[data-kind="error"] {
   border-color: #e5b7ad;
   background: color-mix(in srgb, var(--color-error) 7%, var(--color-panel));

--- a/src/react-workbench/chat/ChatPage.messages.test.tsx
+++ b/src/react-workbench/chat/ChatPage.messages.test.tsx
@@ -48,10 +48,10 @@ describe("ChatPage", () => {
     );
   });
 
-  it("does not use colored left accent strips on error cards", () => {
+  it("renders execution errors without a card or colored accent strip", () => {
     const css = readWorkbenchCss();
 
-    expect(css).not.toMatch(/\.react-error-recovery\s*{[^}]*border-left:/s);
+    expect(css).not.toMatch(/\.react-execution-error\s*{[^}]*(?:border|background):/s);
     expect(css).not.toMatch(/\.react-canonical-scoped-errors\s*{[^}]*border-left:/s);
   });
 

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -10,10 +10,7 @@ import { timelineFromReactMessages } from "./test/timelineFixtures";
 import {
   ChatPageUnderTest as ChatPage,
   createStores,
-  effectiveCapabilities,
-  expectTurnSubmit,
   failedPlanTimeline,
-  turnSubmitCommands,
 } from "./test/ChatPageTestHarness";
 
 describe("ChatPage", () => {
@@ -596,7 +593,7 @@ describe("ChatPage", () => {
     requestFrame.mockRestore();
   });
 
-  it("renders Plan first, collapses execution details, and exposes failure recovery", async () => {
+  it("renders Plan first and shows failures as a lightweight inline error", async () => {
     const user = userEvent.setup();
     const stores = createStores();
     stores.chatStore.load = vi.fn(async () => failedPlanTimeline());
@@ -615,14 +612,10 @@ describe("ChatPage", () => {
     await user.click(planToggle);
     expect(details.getAttribute("aria-expanded")).toBe("false");
     expect(error.textContent).toContain("Execution reached the iteration limit");
-    expect(error.textContent).toContain("Read project files");
-    expect(error.textContent).toContain("1 steps completed");
-    expect(within(error).getByRole("button", { name: "Continue" })).toBeTruthy();
-    expect(within(error).getByRole("button", { name: "Retry current step" })).toBeTruthy();
-    expect(within(error).getByRole("button", { name: "Start over" })).toBeTruthy();
-
-    await user.click(within(error).getByRole("button", { name: "View details" }));
-    expect(screen.getByLabelText("Details drawer").textContent).toContain("max_iterations");
+    expect(error.textContent).not.toContain("Read project files");
+    expect(error.textContent).not.toContain("1 steps completed");
+    expect(within(error).getByRole("button", { name: "Copy error" })).toBeTruthy();
+    expect(within(error).queryByRole("button", { name: /Continue|Retry|Start over|View details/ })).toBeNull();
   });
 
   it("renders canonical execution items chronologically and restores completed turns folded", async () => {
@@ -694,7 +687,7 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
-    const toggle = await screen.findByRole("button", { name: /Work performed Completed · 4 actions/ });
+    const toggle = await screen.findByRole("button", { name: /Work performed 4 actions/ });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(screen.getByText("Verification passed.")).toBeTruthy();
     await user.click(toggle);
@@ -714,7 +707,6 @@ describe("ChatPage", () => {
   });
 
   it("renders apply_patch tool results as an inline file diff", async () => {
-    const user = userEvent.setup();
     const stores = createStores();
     const timeline = timelineFromReactMessages("s1", [{
       id: "u-patch-preview",
@@ -762,8 +754,7 @@ describe("ChatPage", () => {
     expect(screen.getByText("let marker = line.trim();")).toBeTruthy();
     expect(screen.getByText("let marker = line.trim_end();")).toBeTruthy();
 
-    await user.click(screen.getByRole("button", { name: "Open details for Edited parser.rs" }));
-    expect(screen.getByLabelText("Details drawer").textContent).toContain("apply_patch");
+    expect(screen.queryByRole("button", { name: "Open details for Edited parser.rs" })).toBeNull();
   });
 
   it("auto-folds untouched execution on final answer and preserves explicit user-open intent", async () => {
@@ -852,7 +843,7 @@ describe("ChatPage", () => {
       return 1;
     });
     act(() => listener?.({ type: "timeline.patch", timeline: timelineFor(true) }));
-    toggle = await screen.findByRole("button", { name: /Work performed Completed · 1 action/ });
+    toggle = await screen.findByRole("button", { name: /Work performed 1 action/ });
     await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("false"));
     act(() => animationFrame?.(0));
     expect(conversation.scrollTop).toBe(450);
@@ -911,7 +902,7 @@ describe("ChatPage", () => {
     await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("false"));
   });
 
-  it("keeps abnormal canonical execution expanded with recovery controls visible", async () => {
+  it("keeps abnormal canonical execution expanded with the inline error visible", async () => {
     const stores = createStores();
     const timeline = failedPlanTimeline();
     timeline.turns[0].executionItems = timeline.turns[0].steps;
@@ -922,7 +913,7 @@ describe("ChatPage", () => {
     const toggle = await screen.findByRole("button", { name: /Work performed Failed · 3 actions/ });
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     const error = screen.getByRole("alert", { name: "Task execution failed" });
-    expect(within(error).getByRole("button", { name: "Continue" })).toBeTruthy();
+    expect(within(error).getByRole("button", { name: "Copy error" })).toBeTruthy();
   });
 
   it("keeps interrupted work visible without rendering a failure recovery card", async () => {
@@ -939,56 +930,23 @@ describe("ChatPage", () => {
     expect(screen.queryByRole("alert", { name: "Task execution failed" })).toBeNull();
   });
 
-  it("sends a contextual recovery prompt for continue", async () => {
+  it("copies contextual failure details from the inline error", async () => {
     const user = userEvent.setup();
-    const stores = createStores();
-    stores.chatStore.load = vi.fn(async () => failedPlanTimeline());
-
-    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
-
-    const error = await screen.findByRole("alert", { name: "Task execution failed" });
-    await user.click(within(error).getByRole("button", { name: "Continue" }));
-
-    expectTurnSubmit(stores.chatStore, "s1", {
-      text: "Continue from where you were interrupted using the existing context and plan. Confirm the current progress first, then finish the remaining work.",
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
     });
-  });
-
-  it("dispatches retry as a correlated TinyOS command instead of a synthetic chat prompt", async () => {
-    const user = userEvent.setup();
-    const stores = createStores();
-    const timeline = failedPlanTimeline();
-    const capabilities = effectiveCapabilities("s1");
-    capabilities.evaluatedTurnId = timeline.turns[0].id;
-    capabilities.capabilities.agent.retry = { available: true };
-    stores.chatStore.load = vi.fn(async () => timeline);
-    stores.chatStore.loadTinyOsCapabilities = vi.fn(async () => capabilities);
-
-    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
-
-    const error = await screen.findByRole("alert", { name: "Task execution failed" });
-    await user.click(within(error).getByRole("button", { name: "Retry current step" }));
-
-    expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
-      kind: "operation.retry",
-      operation: { itemId: "error-failed-plan", turnId: timeline.turns[0].id },
-      target: expect.objectContaining({ sessionId: "s1" }),
-    }));
-    expect(turnSubmitCommands(stores.chatStore)).toHaveLength(0);
-  });
-
-  it("restarts a failed task in a new titled session", async () => {
-    const user = userEvent.setup();
     const stores = createStores();
     stores.chatStore.load = vi.fn(async () => failedPlanTimeline());
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
     const error = await screen.findByRole("alert", { name: "Task execution failed" });
-    await user.click(within(error).getByRole("button", { name: "Start over" }));
+    await user.click(within(error).getByRole("button", { name: "Copy error" }));
 
-    expect(stores.sessionStore.create).toHaveBeenCalledWith({ title: "Inspect the project and repo…" });
-    expectTurnSubmit(stores.chatStore, "s2", { text: "Inspect the project and report findings" });
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("Error code: max_iterations"));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("Interrupted at: Read project files"));
   });
 
   it("loads owner-associated image references through the artifact API before previewing", async () => {

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -1035,4 +1035,151 @@ describe("ChatPage", () => {
     const image = await within(sidecar).findByRole("img", { name: "chart.png" });
     expect(image.getAttribute("src")).toBe("data:image/png;base64,aGVsbG8=");
   });
+
+  it("opens assistant workspace file links as contextual artifact tabs", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Tinybot workspace",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "idle",
+        workingDirectory: "D:\\Code\\py\\tinybot",
+      }],
+    });
+    stores.chatStore.load = vi.fn(async (sessionId) => timelineFromReactMessages(sessionId, [{
+      id: "a-file-link",
+      role: "assistant",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      text: "See [the renderer entry](src/main.ts:12).",
+      status: "complete",
+    }]));
+    const readThreadFile = vi.fn(async () => ({
+      content: "import { mount } from './react-workbench/main';",
+      contentType: "text" as const,
+      lineEnd: 1,
+      lineStart: 1,
+      path: "src/main.ts",
+      revision: "rev-1",
+      sizeBytes: 48,
+    }));
+
+    render(
+      <ChatPage
+        chatStore={stores.chatStore}
+        now={() => Date.UTC(2026, 6, 4, 12, 2, 0)}
+        sessionStore={stores.sessionStore}
+        workspaceStore={{ readThreadFile }}
+      />,
+    );
+
+    await user.click(await screen.findByRole("link", { name: "the renderer entry" }));
+
+    expect(readThreadFile).toHaveBeenCalledWith({ path: "src/main.ts", threadId: "s1" });
+    const sidecar = await screen.findByLabelText("Sidecar");
+    expect(within(sidecar).getByRole("tab", { name: "main.ts" })).toBeTruthy();
+    expect(await within(sidecar).findByText("import { mount } from './react-workbench/main';")).toBeTruthy();
+  });
+
+  it("surfaces truncated and binary workspace file previews in the artifact tab", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Tinybot workspace",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "idle",
+        workingDirectory: "D:\\Code\\py\\tinybot",
+      }],
+    });
+    stores.chatStore.load = vi.fn(async (sessionId) => timelineFromReactMessages(sessionId, [{
+      id: "a-file-preview-boundaries",
+      role: "assistant",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      text: "Inspect [the full log](logs/full.log) or [the executable](dist/tinybot.exe).",
+      status: "complete",
+    }]));
+    const readThreadFile = vi.fn(async ({ path }: { path: string }) => path.endsWith(".exe")
+      ? {
+          contentType: "binary" as const,
+          path,
+          revision: "rev-binary",
+          sizeBytes: 1024,
+        }
+      : {
+          content: "first chunk",
+          contentType: "text" as const,
+          lineEnd: 1,
+          lineStart: 1,
+          nextCursor: "cursor-2",
+          path,
+          revision: "rev-log",
+          sizeBytes: 2048,
+        });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <ChatPage
+        chatStore={stores.chatStore}
+        now={() => Date.UTC(2026, 6, 4, 12, 2, 0)}
+        sessionStore={stores.sessionStore}
+        workspaceStore={{ readThreadFile }}
+      />,
+    );
+
+    await user.click(await screen.findByRole("link", { name: "the full log" }));
+    let sidecar = await screen.findByLabelText("Sidecar");
+    expect(await within(sidecar).findByText("first chunk")).toBeTruthy();
+    expect(within(sidecar).getByText(/Preview truncated/)).toBeTruthy();
+
+    await user.click(screen.getByRole("link", { name: "the executable" }));
+    sidecar = await screen.findByLabelText("Sidecar");
+    await waitFor(() => {
+      expect(within(sidecar).getByRole("alert").textContent).toContain("Binary files cannot be previewed");
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[artifact-preview] workspace file read failed",
+      expect.objectContaining({ path: "dist/tinybot.exe", sessionId: "s1" }),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("shows workspace file preview failures inside the artifact tab", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [{
+        id: "s1",
+        chatId: "chat-1",
+        title: "Tinybot workspace",
+        updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+        status: "idle",
+        workingDirectory: "D:\\Code\\py\\tinybot",
+      }],
+    });
+    stores.chatStore.load = vi.fn(async (sessionId) => timelineFromReactMessages(sessionId, [{
+      id: "a-bad-file-link",
+      role: "assistant",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      text: "See [private file](C:/Users/private.txt).",
+      status: "complete",
+    }]));
+    const readThreadFile = vi.fn();
+
+    render(
+      <ChatPage
+        chatStore={stores.chatStore}
+        now={() => Date.UTC(2026, 6, 4, 12, 2, 0)}
+        sessionStore={stores.sessionStore}
+        workspaceStore={{ readThreadFile }}
+      />,
+    );
+
+    await user.click(await screen.findByRole("link", { name: "private file" }));
+
+    const sidecar = await screen.findByLabelText("Sidecar");
+    expect(within(sidecar).getByRole("alert").textContent).toContain("outside the active workspace");
+    expect(readThreadFile).not.toHaveBeenCalled();
+  });
 });

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -75,8 +75,6 @@ import {
 } from "../../app-core/chat/chatProjection";
 import type {
   ArtifactRef,
-  ChatStep,
-  ChatTurn,
   DelegatedAgentState,
   LoadedArtifactDetail,
 } from "../../app-core/chat/chatTurnContracts";
@@ -92,7 +90,6 @@ import {
   createTinyOsAgentCancelCommand,
   createTinyOsFormCancelCommand,
   createTinyOsFormSubmitCommand,
-  createTinyOsOperationRetryCommand,
   isTinyOsCommandInFlight,
   reduceTinyOsCommandLifecycle,
   type TinyOsCommandLifecycle,
@@ -111,11 +108,7 @@ import {
   prepareChatSubmission,
   type QueuedComposerInput,
 } from "./chatSubmission";
-import {
-  ChatErrorDetails,
-  ChatTimeline,
-  type RecoveryAction,
-} from "./ChatTimeline";
+import { ChatTimeline } from "./ChatTimeline";
 import {
   AssistantFileLinkError,
   assistantFileArtifact,
@@ -173,7 +166,6 @@ export type ChatPageProps = {
 type DrawerState =
   | { kind: "tool"; title: string; toolCall: ToolCallSummary }
   | { kind: "subagent"; title: string; delegate: DelegatedAgentState; loading: boolean; error?: string }
-  | { kind: "error"; title: string; step: ChatStep; turn: ChatTurn }
   | null;
 
 type ArtifactSidecarContent = {
@@ -315,7 +307,6 @@ export function ChatPage({
   const [queuedInputsBySession, setQueuedInputsBySession] = useState<Map<string, QueuedComposerInput[]>>(() => new Map());
   const [queueMessage, setQueueMessage] = useState("");
   const [composerSessionMentionIds, setComposerSessionMentionIds] = useState<string[]>([]);
-  const [recoveringTurnId, setRecoveringTurnId] = useState("");
   const [installingMigrationJobId, setInstallingMigrationJobId] = useState("");
   const [migrationInstallError, setMigrationInstallError] = useState("");
   const [showBackToLatest, setShowBackToLatest] = useState(false);
@@ -1249,73 +1240,6 @@ export function ChatPage({
     await handleSessionStoreRefresh(optimisticSession);
   }
 
-  async function handleRecoverTurn(
-    turn: ChatTurn,
-    action: RecoveryAction,
-    retryItemId?: string,
-  ): Promise<void> {
-    if (!activeSession || recoveringTurnId || isTinyOsCommandInFlight(commandLifecycle)) {
-      return;
-    }
-    setRecoveringTurnId(turn.id);
-    try {
-      if (action === "retry") {
-        if (tinyOsCapabilities.threadId !== activeSession.id
-          || tinyOsCapabilities.evaluatedTurnId !== turn.id
-          || !tinyOsCapabilities.capabilities.agent.retry.available) {
-          reportTimelineError(tinyOsCapabilities.capabilities.agent.retry.reason || t("runtime.failedTurnRetryUnavailable"));
-          return;
-        }
-        const failedItem = retryItemId
-          ? (turn.executionItems ?? turn.steps).find((step) => step.id === retryItemId && step.status === "failed")
-          : [...(turn.executionItems ?? turn.steps)].reverse().find((step) => step.status === "failed");
-        if (!failedItem) {
-          reportTimelineError(t("runtime.failedItemUnavailable"));
-          return;
-        }
-        const command = createTinyOsOperationRetryCommand({
-          itemId: failedItem.id,
-          sessionId: activeSession.id,
-          source: { control: "error-recovery", surface: "chat" },
-          threadId: turn.canonicalItems?.find((item) => item.threadId)?.threadId,
-          turnId: turn.id,
-        });
-        clearTimelineError();
-        dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
-        try {
-          await chatStore.dispatch(command);
-        } catch (error) {
-          dispatchCommandLifecycle({
-            commandId: command.commandId,
-            error: error instanceof Error ? error.message : String(error),
-            type: "rejected",
-          });
-        }
-        return;
-      }
-      if (action === "restart") {
-        const created = await sessionStore.create({
-          title: deriveSessionTitle(turn.userMessage.text, t),
-          ...(activeSession.model
-            ? {
-                model: activeSession.model,
-                ...(activeSession.modelProvider ? { modelProvider: activeSession.modelProvider } : {}),
-              }
-            : composerSessionModelInput(composerModels, composerModel)),
-        });
-        activateCreatedSession(created);
-        await dispatchTurn(created.id, { text: turn.userMessage.text }, "recovery-restart");
-        await handleSessionStoreRefresh(created);
-        return;
-      }
-      const text = t("continuePrompt");
-      await dispatchTurn(activeSession.id, { text }, "recovery-continue");
-      await handleSessionStoreRefresh(activeSession);
-    } finally {
-      setRecoveringTurnId("");
-    }
-  }
-
   function handleConversationScroll(): void {
     const element = conversationRef.current;
     if (!element) {
@@ -2168,18 +2092,15 @@ export function ChatPage({
             actions={{
               onBranch: (messageId) => activeSession && void handleBranchFromMessage(activeSession, messageId),
               onOpenArtifact: (artifact) => void handleOpenArtifact(artifact),
-              onOpenError: (turn, step) => setDrawer({ kind: "error", title: t("shell.errorDetails"), step, turn }),
               onOpenFileLink: (link) => void handleOpenAssistantFileLink(link),
               onOpenSubagent: (delegate) => void handleOpenSubagent(delegate),
               onOpenTool: (toolCall) => setDrawer({ kind: "tool", title: toolCall.name, toolCall }),
-              onRecover: (turn, action) => void handleRecoverTurn(turn, action),
             }}
             error={timelineError}
             hookResults={hookResults}
             interactiveFormIds={interactiveFormIds}
             latestFailedTurnId={latestFailedTurnId}
             optimisticMessages={optimisticMessages}
-            recoveringTurnId={recoveringTurnId}
             sessionRunning={sessionRunning}
             turns={activeSession ? timeline?.turns ?? [] : []}
           />
@@ -2360,10 +2281,8 @@ export function ChatPage({
           <div className="react-right-drawer__content">
             {drawer.kind === "tool" ? (
               <ToolCallDetails toolCall={drawer.toolCall} />
-            ) : drawer.kind === "subagent" ? (
-              <SubagentDetails delegate={drawer.delegate} error={drawer.error} loading={drawer.loading} />
             ) : (
-              <ChatErrorDetails step={drawer.step} turn={drawer.turn} />
+              <SubagentDetails delegate={drawer.delegate} error={drawer.error} loading={drawer.loading} />
             )}
           </div>
         </aside>

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -117,6 +117,13 @@ import {
   type RecoveryAction,
 } from "./ChatTimeline";
 import {
+  AssistantFileLinkError,
+  assistantFileArtifact,
+  assistantFileLinkTitle,
+  resolveAssistantFileLink,
+  type AssistantFileLink,
+} from "./assistantFileLinks";
+import {
   ChatSessionWorkspace,
   type ProjectSessionContext,
 } from "./ChatSessionWorkspace";
@@ -149,7 +156,7 @@ export type ChatPageProps = {
   projectGroupStore?: ProjectGroupStore;
   settingsStore?: SettingsStore;
   toolsStore?: Pick<ToolsStore, "installPluginMigration">;
-  workspaceStore?: Pick<WorkspaceStore, "listDirectory" | "readFile">;
+  workspaceStore?: Pick<WorkspaceStore, "readThreadFile">;
   createSessionSignal?: number;
   activateSessionRequest?: { sessionId: string; signal: number } | null;
   sessionSidebarCollapsed?: boolean;
@@ -174,6 +181,7 @@ type ArtifactSidecarContent = {
   detail?: LoadedArtifactDetail;
   error?: string;
   loading: boolean;
+  notice?: string;
 };
 
 type BrowserSnapshot = TinyOsNativeSnapshot<TinyOsNativeBrowserSession>;
@@ -264,6 +272,7 @@ export function ChatPage({
   projectGroupStore,
   settingsStore,
   toolsStore,
+  workspaceStore,
 }: ChatPageProps) {
   const { i18n, t } = useTranslation("chat");
   const slashCommands = useMemo(() => composerSlashCommands(t), [t]);
@@ -1737,6 +1746,101 @@ export function ChatPage({
     }
   }
 
+  async function handleOpenAssistantFileLink(link: AssistantFileLink) {
+    if (!activeSession) {
+      return;
+    }
+
+    let artifact: ArtifactRef;
+    try {
+      artifact = assistantFileArtifact(resolveAssistantFileLink(link.href, activeSession.workingDirectory));
+    } catch (error) {
+      artifact = assistantFileArtifact({ path: link.href, title: assistantFileLinkTitle(link.href) });
+      const tabId = sidecarArtifactTabId(activeSession.id, artifact.id);
+      dispatchSidecar({
+        artifactId: artifact.id,
+        threadId: activeSession.id,
+        title: artifact.title,
+        type: "tab.openArtifact",
+      });
+      const message = error instanceof AssistantFileLinkError && error.code === "outside_workspace"
+        ? t("details.fileOutsideWorkspace")
+        : errorMessage(error);
+      console.error("[artifact-preview] workspace file link resolution failed", {
+        error,
+        href: link.href,
+        sessionId: activeSession.id,
+        workspaceRoot: activeSession.workingDirectory,
+      });
+      setArtifactSidecarContent((current) => ({
+        ...current,
+        [tabId]: { artifact, error: message, loading: false },
+      }));
+      return;
+    }
+
+    const tabId = sidecarArtifactTabId(activeSession.id, artifact.id);
+    dispatchSidecar({
+      artifactId: artifact.id,
+      threadId: activeSession.id,
+      title: artifact.title,
+      type: "tab.openArtifact",
+    });
+    if (!workspaceStore) {
+      const message = t("details.filePreviewUnavailable");
+      console.error("[artifact-preview] workspace file API unavailable", {
+        path: artifact.fetchPath,
+        sessionId: activeSession.id,
+      });
+      setArtifactSidecarContent((current) => ({
+        ...current,
+        [tabId]: { artifact, error: message, loading: false },
+      }));
+      return;
+    }
+
+    setArtifactSidecarContent((current) => ({
+      ...current,
+      [tabId]: { artifact, loading: true },
+    }));
+    try {
+      const file = await workspaceStore.readThreadFile({
+        path: artifact.fetchPath!,
+        threadId: activeSession.id,
+      });
+      if (file.contentType !== "text") {
+        throw new Error(t("details.binaryFilePreviewUnsupported"));
+      }
+      const detail: LoadedArtifactDetail = {
+        id: artifact.id,
+        mimeType: artifact.mimeType,
+        textContent: file.content ?? "",
+        title: artifact.title,
+      };
+      setArtifactSidecarContent((current) => current[tabId]
+        ? {
+            ...current,
+            [tabId]: {
+              ...current[tabId],
+              detail,
+              loading: false,
+              ...(file.nextCursor ? { notice: t("details.filePreviewTruncated") } : {}),
+            },
+          }
+        : current);
+    } catch (error) {
+      const message = errorMessage(error);
+      console.error("[artifact-preview] workspace file read failed", {
+        error,
+        path: artifact.fetchPath,
+        sessionId: activeSession.id,
+      });
+      setArtifactSidecarContent((current) => current[tabId]
+        ? { ...current, [tabId]: { ...current[tabId], error: message, loading: false } }
+        : current);
+    }
+  }
+
   async function handleCloseSidecarTab(tab: SidecarTab) {
     if (tab.kind === "browser") {
       setBrowserProvisionErrors((current) => omitRecordKey(current, tab.id));
@@ -1799,6 +1903,7 @@ export function ChatPage({
         detail={content.detail}
         error={content.error}
         loading={content.loading}
+        notice={content.notice}
       />
     );
   }
@@ -2064,6 +2169,7 @@ export function ChatPage({
               onBranch: (messageId) => activeSession && void handleBranchFromMessage(activeSession, messageId),
               onOpenArtifact: (artifact) => void handleOpenArtifact(artifact),
               onOpenError: (turn, step) => setDrawer({ kind: "error", title: t("shell.errorDetails"), step, turn }),
+              onOpenFileLink: (link) => void handleOpenAssistantFileLink(link),
               onOpenSubagent: (delegate) => void handleOpenSubagent(delegate),
               onOpenTool: (toolCall) => setDrawer({ kind: "tool", title: toolCall.name, toolCall }),
               onRecover: (turn, action) => void handleRecoverTurn(turn, action),
@@ -2524,11 +2630,13 @@ function ArtifactDetails({
   detail,
   error,
   loading,
+  notice,
 }: {
   artifact: ArtifactRef;
   detail?: LoadedArtifactDetail;
   error?: string;
   loading: boolean;
+  notice?: string;
 }) {
   const { t } = useTranslation("chat");
   return (
@@ -2539,6 +2647,7 @@ function ArtifactDetails({
       </dl>
       {loading ? <p aria-live="polite">{t("details.loadingArtifact")}</p> : null}
       {error ? <p role="alert">{error}</p> : null}
+      {notice ? <p className="react-artifact-detail__notice">{notice}</p> : null}
       {detail?.imageDataUrl ? <img alt={detail.title} src={detail.imageDataUrl} /> : null}
       {detail?.dataView ? <DataViewCard artifact={{ ...artifact, dataView: detail.dataView }} expanded /> : null}
       {detail?.textContent ? <pre>{detail.textContent}</pre> : null}

--- a/src/react-workbench/chat/ChatTimeline.test.tsx
+++ b/src/react-workbench/chat/ChatTimeline.test.tsx
@@ -21,7 +21,6 @@ describe("ChatTimeline", () => {
         interactiveFormIds={new Set()}
         latestFailedTurnId=""
         optimisticMessages={[optimisticMessage()]}
-        recoveringTurnId=""
         sessionRunning={false}
         turns={[turn]}
       />,
@@ -35,7 +34,12 @@ describe("ChatTimeline", () => {
     expect(actions.onBranch).toHaveBeenCalledWith("assistant-1");
   });
 
-  test("keeps failed-turn recovery and error details behind timeline actions", () => {
+  test("shows failed turns inline with copy as the only error action", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
     const actions = createActions();
     const turn = failedTurn();
     render(
@@ -45,20 +49,19 @@ describe("ChatTimeline", () => {
         interactiveFormIds={new Set()}
         latestFailedTurnId={turn.id}
         optimisticMessages={[]}
-        recoveringTurnId=""
         sessionRunning={false}
         turns={[turn]}
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
-    expect(actions.onRecover).toHaveBeenCalledWith(turn, "retry");
-
-    fireEvent.click(screen.getByRole("button", { name: /details/i }));
-    expect(actions.onOpenError).toHaveBeenCalledWith(turn, turn.steps[0]);
+    const error = screen.getByRole("alert", { name: "Task execution failed" });
+    fireEvent.click(screen.getByRole("button", { name: "Copy error" }));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("Error message: Execution failed"));
+    expect(error.querySelector(".react-execution-error__message")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /retry|continue|details/i })).toBeNull();
   });
 
-  test("omits unavailable actions when embedded as a read-only timeline", () => {
+  test("keeps inline errors available when embedded as a read-only timeline", () => {
     render(
       <ChatTimeline
         actions={{}}
@@ -66,7 +69,6 @@ describe("ChatTimeline", () => {
         interactiveFormIds={new Set()}
         latestFailedTurnId=""
         optimisticMessages={[]}
-        recoveringTurnId=""
         sessionRunning={false}
         turns={[completedTurn(), failedTurn()]}
       />,
@@ -75,6 +77,7 @@ describe("ChatTimeline", () => {
     expect(screen.queryByRole("button", { name: /branch/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /^details$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy error" })).toBeTruthy();
     expect(screen.getByText("Canonical answer")).toBeTruthy();
     expect(screen.getByText("Execution failed")).toBeTruthy();
   });
@@ -105,7 +108,6 @@ describe("ChatTimeline", () => {
         interactiveFormIds={new Set()}
         latestFailedTurnId=""
         optimisticMessages={[]}
-        recoveringTurnId=""
         sessionRunning={false}
         turns={[turn]}
       />,
@@ -124,10 +126,8 @@ function createActions(): ChatTimelineActions {
   return {
     onBranch: vi.fn(),
     onOpenArtifact: vi.fn(),
-    onOpenError: vi.fn(),
     onOpenSubagent: vi.fn(),
     onOpenTool: vi.fn(),
-    onRecover: vi.fn(),
   };
 }
 

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -15,9 +15,6 @@ import {
   ListCollapse,
   Loader2,
   PanelRightOpen,
-  Play,
-  RefreshCw,
-  RotateCcw,
   X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -43,16 +40,12 @@ import { isApplyPatchToolCall, PatchDiffCard, patchChangeSetFromToolResult } fro
 import { ToolActivityItem } from "./ToolActivityItem";
 import { DataViewCard } from "./DataViewCard";
 
-export type RecoveryAction = "continue" | "retry" | "restart";
-
 export type ChatTimelineActions = {
   onBranch?: (messageId: string) => void;
   onOpenArtifact?: (artifact: ArtifactRef) => void;
-  onOpenError?: (turn: ChatTurn, step: ChatStep) => void;
   onOpenFileLink?: (link: AssistantFileLink) => void;
   onOpenSubagent?: (delegate: DelegatedAgentState) => void;
   onOpenTool?: (toolCall: ToolCallSummary) => void;
-  onRecover?: (turn: ChatTurn, action: RecoveryAction) => void;
 };
 
 export function ChatTimeline({
@@ -62,7 +55,6 @@ export function ChatTimeline({
   interactiveFormIds,
   latestFailedTurnId,
   optimisticMessages,
-  recoveringTurnId,
   sessionRunning,
   turns,
 }: {
@@ -72,7 +64,6 @@ export function ChatTimeline({
   interactiveFormIds: ReadonlySet<string>;
   latestFailedTurnId: string;
   optimisticMessages: readonly ReactChatMessage[];
-  recoveringTurnId: string;
   sessionRunning: boolean;
   turns: readonly ChatTurn[];
 }) {
@@ -85,15 +76,12 @@ export function ChatTimeline({
           interactiveFormIds={interactiveFormIds}
           key={turn.id}
           hookResults={hookResults.filter((result) => result.turnId === turn.id)}
-          recovering={recoveringTurnId === turn.id}
           turn={turn}
           onBranch={actions.onBranch}
           onOpenArtifact={actions.onOpenArtifact}
-          onOpenError={actions.onOpenError ? (step) => actions.onOpenError?.(turn, step) : undefined}
           onOpenFileLink={actions.onOpenFileLink}
           onOpenSubagent={actions.onOpenSubagent}
           onOpenTool={actions.onOpenTool}
-          onRecover={actions.onRecover ? (action) => actions.onRecover?.(turn, action) : undefined}
         />
       ))}
       {optimisticMessages.map((message) => (
@@ -120,26 +108,20 @@ function CanonicalChatTurn({
   hookResults,
   interactiveFormIds,
   onBranch,
-  onOpenError,
   onOpenArtifact,
   onOpenFileLink,
-  onRecover,
   onOpenSubagent,
   onOpenTool,
-  recovering,
   turn,
 }: {
   focusError: boolean;
   hookResults: readonly HookExecutionResult[];
   interactiveFormIds: ReadonlySet<string>;
   onBranch?: (messageId: string) => void;
-  onOpenError?: (step: ChatStep) => void;
   onOpenArtifact?: (artifact: ArtifactRef) => void;
   onOpenFileLink?: (link: AssistantFileLink) => void;
-  onRecover?: (action: RecoveryAction) => void;
   onOpenSubagent?: (delegate: DelegatedAgentState) => void;
   onOpenTool?: (toolCall: ToolCallSummary) => void;
-  recovering: boolean;
   turn: ChatTurn;
 }) {
   const { t } = useTranslation("chat");
@@ -174,17 +156,13 @@ function CanonicalChatTurn({
           executionItems={executionItems}
           focusError={focusError}
           onOpenArtifact={onOpenArtifact}
-          onOpenError={onOpenError}
           onOpenSubagent={onOpenSubagent}
-          onOpenTool={onOpenTool}
-          onRecover={onRecover}
-          recovering={recovering}
           turn={turn}
         />
       ) : !turn.executionItems ? (
         <>
           {planSteps.map((step) => (
-            <CanonicalChatStep key={step.id} onOpenArtifact={onOpenArtifact} onOpenFileLink={onOpenFileLink} onOpenSubagent={onOpenSubagent} onOpenTool={onOpenTool} step={step} />
+            <CanonicalChatStep key={step.id} onOpenArtifact={onOpenArtifact} onOpenFileLink={onOpenFileLink} onOpenSubagent={onOpenSubagent} step={step} />
           ))}
           {groupCanonicalSteps(legacyProcessSteps).map((group) => (
             Array.isArray(group) ? (
@@ -194,18 +172,15 @@ function CanonicalChatTurn({
                 <CanonicalScopedErrors errors={group.flatMap((step) => step.scopedErrors ?? [])} />
               </div>
             ) : (
-              <CanonicalChatStep key={group.id} onOpenArtifact={onOpenArtifact} onOpenFileLink={onOpenFileLink} onOpenSubagent={onOpenSubagent} onOpenTool={onOpenTool} step={group} />
+              <CanonicalChatStep key={group.id} onOpenArtifact={onOpenArtifact} onOpenFileLink={onOpenFileLink} onOpenSubagent={onOpenSubagent} step={group} />
             )
           ))}
           {errorSteps.map((step, index) => (
-            <ErrorRecoveryCard
+            <InlineExecutionError
               focusOnMount={focusError && index === errorSteps.length - 1}
               key={step.id}
-              recovering={recovering}
               step={step}
               turn={turn}
-              onOpenDetails={onOpenError ? () => onOpenError(step) : undefined}
-              onRecover={onRecover}
             />
           ))}
         </>
@@ -314,21 +289,13 @@ function ExecutionTimeline({
   executionItems,
   focusError,
   onOpenArtifact,
-  onOpenError,
   onOpenSubagent,
-  onOpenTool,
-  onRecover,
-  recovering,
   turn,
 }: {
   executionItems: ChatStep[];
   focusError: boolean;
   onOpenArtifact?: (artifact: ArtifactRef) => void;
-  onOpenError?: (step: ChatStep) => void;
   onOpenSubagent?: (delegate: DelegatedAgentState) => void;
-  onOpenTool?: (toolCall: ToolCallSummary) => void;
-  onRecover?: (action: RecoveryAction) => void;
-  recovering: boolean;
   turn: ChatTurn;
 }) {
   const { t } = useTranslation("chat");
@@ -394,25 +361,21 @@ function ExecutionTimeline({
           <strong>{t("turn.workPerformed")}</strong>
           <small aria-live="polite">{summary}</small>
         </span>
-        <ChevronDown aria-hidden="true" className="react-execution-timeline__chevron" size={18} />
+        <ChevronRight aria-hidden="true" className="react-execution-timeline__chevron" size={16} />
       </button>
       <div className="react-execution-timeline__content" hidden={!open} id={contentId}>
         {visibleExecutionItems.map((step) => (
           <div className="react-execution-timeline__item" data-kind={step.kind} data-status={step.status} key={step.id}>
             {step.kind === "error" ? (
-              <ErrorRecoveryCard
+              <InlineExecutionError
                 focusOnMount={focusError && step.id === errorItems[errorItems.length - 1]?.id}
-                recovering={recovering}
                 step={step}
                 turn={turn}
-                onOpenDetails={onOpenError ? () => onOpenError(step) : undefined}
-                onRecover={onRecover}
               />
             ) : (
               <CanonicalChatStep
                 onOpenArtifact={onOpenArtifact}
                 onOpenSubagent={onOpenSubagent}
-                onOpenTool={onOpenTool}
                 step={step}
               />
             )}
@@ -428,7 +391,8 @@ function executionTimelineSummary(turn: ChatTurn, items: ChatStep[], abnormal: b
   const durationMs = turn.completedAt
     ? Math.max(0, Date.parse(turn.completedAt) - Date.parse(turn.startedAt))
     : undefined;
-  const parts = [executionStatusLabel(turn.status, t), t("execution.actionCount", { count: items.length })];
+  const parts = [executionStatusLabel(turn.status, t), t("execution.actionCount", { count: items.length })]
+    .filter((part): part is string => Boolean(part));
   if (plan) {
     parts.push(t("execution.plan", { completed: plan.completed, total: plan.total }));
   }
@@ -442,9 +406,9 @@ function executionTimelineSummary(turn: ChatTurn, items: ChatStep[], abnormal: b
   return parts.join(" · ");
 }
 
-function executionStatusLabel(status: ChatTurn["status"], t: TFunction<"chat">): string {
+function executionStatusLabel(status: ChatTurn["status"], t: TFunction<"chat">): string | undefined {
   switch (status) {
-    case "completed": return t("execution.status.completed");
+    case "completed": return undefined;
     case "failed": return t("execution.status.failed");
     case "interrupted": return t("execution.status.interrupted");
     case "awaiting_user": return t("execution.status.awaiting");
@@ -524,13 +488,11 @@ function CanonicalChatStep({
   onOpenArtifact,
   onOpenFileLink,
   onOpenSubagent,
-  onOpenTool,
   step,
 }: {
   onOpenArtifact?: (artifact: ArtifactRef) => void;
   onOpenFileLink?: (link: AssistantFileLink) => void;
   onOpenSubagent?: (delegate: DelegatedAgentState) => void;
-  onOpenTool?: (toolCall: ToolCallSummary) => void;
   step: ChatStep;
 }) {
   const { i18n, t } = useTranslation("chat");
@@ -555,7 +517,6 @@ function CanonicalChatStep({
         <PatchDiffCard
           status={step.status}
           toolCall={step.toolCall}
-          onOpenDetails={onOpenTool ? () => onOpenTool(toolCallSummaryFromStep(step, step.toolCall!, t)) : undefined}
         />
       );
     }
@@ -564,7 +525,6 @@ function CanonicalChatStep({
         fallbackSummary={step.summary}
         status={step.status}
         toolCall={step.toolCall}
-        onOpenDetails={onOpenTool ? () => onOpenTool(toolCallSummaryFromStep(step, step.toolCall!, t)) : undefined}
       />
     );
   }
@@ -675,26 +635,10 @@ function CanonicalChatStep({
   );
 }
 
-function ErrorRecoveryCard({
-  focusOnMount,
-  onOpenDetails,
-  onRecover,
-  recovering,
-  step,
-  turn,
-}: {
-  focusOnMount: boolean;
-  onOpenDetails?: () => void;
-  onRecover?: (action: RecoveryAction) => void;
-  recovering: boolean;
-  step: ChatStep;
-  turn: ChatTurn;
-}) {
+function InlineExecutionError({ focusOnMount, step, turn }: { focusOnMount: boolean; step: ChatStep; turn: ChatTurn }) {
   const { t } = useTranslation("chat");
   const cardRef = useRef<HTMLElement | null>(null);
   const error = canonicalErrorInfo(step, t);
-  const failedStep = failedPlanStep(turn);
-  const completedSteps = completedPlanStepCount(turn);
 
   useEffect(() => {
     if (focusOnMount) {
@@ -706,38 +650,19 @@ function ErrorRecoveryCard({
     <section
       ref={cardRef}
       aria-label={t("recovery.label")}
-      className="react-error-recovery"
+      className="react-execution-error"
       role="alert"
       tabIndex={-1}
     >
-      <div className="react-error-recovery__heading">
-        <AlertTriangle aria-hidden="true" size={18} />
-        <div>
-          <strong>{turn.status === "interrupted" ? t("recovery.cancelled") : t("recovery.interrupted")}</strong>
-          <p>{friendlyErrorMessage(error.code, error.message, t)}</p>
-        </div>
+      <AlertTriangle aria-hidden="true" className="react-execution-error__icon" size={16} />
+      <div className="react-execution-error__message">
+        <strong>{turn.status === "interrupted" ? t("recovery.cancelled") : t("recovery.interrupted")}</strong>
+        <p>{friendlyErrorMessage(error.code, error.message, t)}</p>
       </div>
-      <dl className="react-error-recovery__summary">
-        {failedStep ? <div><dt>{t("recovery.failedAt")}</dt><dd>{failedStep}</dd></div> : null}
-        <div><dt>{t("recovery.progress")}</dt><dd>{t("recovery.completedSteps", { count: completedSteps })}</dd></div>
-      </dl>
-      {completedPlanSteps(turn).length ? (
-        <div className="react-error-recovery__valid-results">
-          <strong>{t("recovery.validResults")}</strong>
-          <ul>{completedPlanSteps(turn).map((item) => <li key={item}>{item}</li>)}</ul>
-        </div>
-      ) : null}
-      <div className="react-error-recovery__actions" aria-label={t("recovery.actions")}>
-        {onRecover ? (
-          <>
-            <button disabled={recovering} type="button" onClick={() => onRecover("continue")}><Play aria-hidden="true" size={15} />{t("recovery.continue")}</button>
-            <button disabled={recovering} type="button" onClick={() => onRecover("retry")}><RotateCcw aria-hidden="true" size={15} />{t("recovery.retry")}</button>
-            <button disabled={recovering} type="button" onClick={() => onRecover("restart")}><RefreshCw aria-hidden="true" size={15} />{t("recovery.restart")}</button>
-          </>
-        ) : null}
-        {onOpenDetails ? <button type="button" onClick={onOpenDetails}>{t("recovery.details")}</button> : null}
-        <button type="button" onClick={() => void writeClipboardText(formatFailureDetails(step, turn, t))}><Copy aria-hidden="true" size={15} />{t("recovery.copyError")}</button>
-      </div>
+      <button className="react-execution-error__copy" type="button" onClick={() => void writeClipboardText(formatFailureDetails(step, turn, t))}>
+        <Copy aria-hidden="true" size={14} />
+        {t("recovery.copyError")}
+      </button>
     </section>
   );
 }
@@ -1324,18 +1249,6 @@ function failedPlanStep(turn: ChatTurn): string {
   return "";
 }
 
-function completedPlanStepCount(turn: ChatTurn): number {
-  return turn.steps.reduce((count, step) => (
-    count + (step.plan?.steps.filter((planStep) => planStep.status === "completed").length ?? 0)
-  ), 0);
-}
-
-function completedPlanSteps(turn: ChatTurn): string[] {
-  return turn.steps.flatMap((step) => (
-    step.plan?.steps.filter((planStep) => planStep.status === "completed").map((planStep) => planStep.step) ?? []
-  ));
-}
-
 function canonicalErrorInfo(step: ChatStep, t: TFunction<"chat">): { code: string; message: string } {
   const error = step.error && typeof step.error === "object" ? step.error as Record<string, unknown> : {};
   return {
@@ -1367,24 +1280,4 @@ function formatFailureDetails(step: ChatStep, turn: ChatTurn, t: TFunction<"chat
     `${t("details.errorMessage")}: ${error.message}`,
     failedPlanStep(turn) ? `${t("details.interruptedAt")}: ${failedPlanStep(turn)}` : "",
   ].filter(Boolean).join("\n");
-}
-
-export function ChatErrorDetails({ step, turn }: { step: ChatStep; turn: ChatTurn }) {
-  const { t } = useTranslation("chat");
-  const error = canonicalErrorInfo(step, t);
-  return (
-    <div className="react-error-detail">
-      <dl>
-        <div><dt>{t("details.turnId")}</dt><dd><code>{turn.id}</code></dd></div>
-        <div><dt>{t("details.status")}</dt><dd>{turn.status}</dd></div>
-        <div><dt>{t("details.stopReason")}</dt><dd><code>{error.code}</code></dd></div>
-        {failedPlanStep(turn) ? <div><dt>{t("details.interruptedAt")}</dt><dd>{failedPlanStep(turn)}</dd></div> : null}
-        <div><dt>{t("details.originalTask")}</dt><dd>{turn.userMessage.text}</dd></div>
-      </dl>
-      <section>
-        <h3>{t("details.originalError")}</h3>
-        <pre>{error.message}</pre>
-      </section>
-    </div>
-  );
 }

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -38,6 +38,7 @@ import {
   type ToolCallSummary,
 } from "./messageActions";
 import { AssistantMarkdown } from "./AssistantMarkdown";
+import type { AssistantFileLink } from "./assistantFileLinks";
 import { isApplyPatchToolCall, PatchDiffCard, patchChangeSetFromToolResult } from "./PatchDiffCard";
 import { ToolActivityItem } from "./ToolActivityItem";
 import { DataViewCard } from "./DataViewCard";
@@ -48,6 +49,7 @@ export type ChatTimelineActions = {
   onBranch?: (messageId: string) => void;
   onOpenArtifact?: (artifact: ArtifactRef) => void;
   onOpenError?: (turn: ChatTurn, step: ChatStep) => void;
+  onOpenFileLink?: (link: AssistantFileLink) => void;
   onOpenSubagent?: (delegate: DelegatedAgentState) => void;
   onOpenTool?: (toolCall: ToolCallSummary) => void;
   onRecover?: (turn: ChatTurn, action: RecoveryAction) => void;
@@ -88,6 +90,7 @@ export function ChatTimeline({
           onBranch={actions.onBranch}
           onOpenArtifact={actions.onOpenArtifact}
           onOpenError={actions.onOpenError ? (step) => actions.onOpenError?.(turn, step) : undefined}
+          onOpenFileLink={actions.onOpenFileLink}
           onOpenSubagent={actions.onOpenSubagent}
           onOpenTool={actions.onOpenTool}
           onRecover={actions.onRecover ? (action) => actions.onRecover?.(turn, action) : undefined}
@@ -99,6 +102,7 @@ export function ChatTimeline({
           message={message}
           onBranch={() => undefined}
           onCopy={() => void writeClipboardText(formatMessageForCopy(message))}
+          onOpenFileLink={actions.onOpenFileLink}
           onOpenTool={() => undefined}
           sessionRunning={sessionRunning}
         />
@@ -118,6 +122,7 @@ function CanonicalChatTurn({
   onBranch,
   onOpenError,
   onOpenArtifact,
+  onOpenFileLink,
   onRecover,
   onOpenSubagent,
   onOpenTool,
@@ -130,6 +135,7 @@ function CanonicalChatTurn({
   onBranch?: (messageId: string) => void;
   onOpenError?: (step: ChatStep) => void;
   onOpenArtifact?: (artifact: ArtifactRef) => void;
+  onOpenFileLink?: (link: AssistantFileLink) => void;
   onRecover?: (action: RecoveryAction) => void;
   onOpenSubagent?: (delegate: DelegatedAgentState) => void;
   onOpenTool?: (toolCall: ToolCallSummary) => void;
@@ -178,7 +184,7 @@ function CanonicalChatTurn({
       ) : !turn.executionItems ? (
         <>
           {planSteps.map((step) => (
-            <CanonicalChatStep key={step.id} onOpenArtifact={onOpenArtifact} onOpenSubagent={onOpenSubagent} onOpenTool={onOpenTool} step={step} />
+            <CanonicalChatStep key={step.id} onOpenArtifact={onOpenArtifact} onOpenFileLink={onOpenFileLink} onOpenSubagent={onOpenSubagent} onOpenTool={onOpenTool} step={step} />
           ))}
           {groupCanonicalSteps(legacyProcessSteps).map((group) => (
             Array.isArray(group) ? (
@@ -188,7 +194,7 @@ function CanonicalChatTurn({
                 <CanonicalScopedErrors errors={group.flatMap((step) => step.scopedErrors ?? [])} />
               </div>
             ) : (
-              <CanonicalChatStep key={group.id} onOpenArtifact={onOpenArtifact} onOpenSubagent={onOpenSubagent} onOpenTool={onOpenTool} step={group} />
+              <CanonicalChatStep key={group.id} onOpenArtifact={onOpenArtifact} onOpenFileLink={onOpenFileLink} onOpenSubagent={onOpenSubagent} onOpenTool={onOpenTool} step={group} />
             )
           ))}
           {errorSteps.map((step, index) => (
@@ -214,6 +220,7 @@ function CanonicalChatTurn({
           role="assistant"
           streaming={turn.status === "running"}
           text={finalAnswer.text}
+          onOpenFileLink={onOpenFileLink}
           onBranch={turn.status === "completed" && onBranch ? () => onBranch(finalAnswer.id) : undefined}
         />
       ) : !turn.executionItems && reasoningSteps.length ? (
@@ -224,6 +231,7 @@ function CanonicalChatTurn({
           role="assistant"
           streaming={turn.status === "running"}
           text=""
+          onOpenFileLink={onOpenFileLink}
         />
       ) : null}
       {dataViewArtifacts.map((artifact) => (
@@ -460,6 +468,7 @@ function CanonicalMessage({
   allowActions = true,
   messageId,
   onBranch,
+  onOpenFileLink,
   reasoning = [],
   references = [],
   role,
@@ -469,6 +478,7 @@ function CanonicalMessage({
   allowActions?: boolean;
   messageId: string;
   onBranch?: () => void;
+  onOpenFileLink?: (link: AssistantFileLink) => void;
   reasoning?: ChatStep[];
   references?: AgentInputReference[];
   role: "user" | "assistant";
@@ -490,7 +500,7 @@ function CanonicalMessage({
         {reasoning.map((step) => (
           <MessageReasoning durationMs={reasoningDurationMs(step)} key={step.id} streaming={step.status === "running"} text={step.summary ?? ""} />
         ))}
-        {role === "assistant" ? <AssistantMarkdown streaming={streaming} text={text} /> : <PlainMessageText text={text} />}
+        {role === "assistant" ? <AssistantMarkdown onOpenFileLink={onOpenFileLink} streaming={streaming} text={text} /> : <PlainMessageText text={text} />}
         {inlineReferences.length ? <MessageContext references={inlineReferences} /> : null}
         {streaming ? <span aria-label={t("turn.agentResponding")} className="react-message__streaming" /> : null}
       </div>
@@ -512,11 +522,13 @@ function CanonicalMessage({
 
 function CanonicalChatStep({
   onOpenArtifact,
+  onOpenFileLink,
   onOpenSubagent,
   onOpenTool,
   step,
 }: {
   onOpenArtifact?: (artifact: ArtifactRef) => void;
+  onOpenFileLink?: (link: AssistantFileLink) => void;
   onOpenSubagent?: (delegate: DelegatedAgentState) => void;
   onOpenTool?: (toolCall: ToolCallSummary) => void;
   step: ChatStep;
@@ -533,6 +545,7 @@ function CanonicalChatStep({
         role="assistant"
         streaming={step.status === "running"}
         text={step.summary ?? ""}
+        onOpenFileLink={onOpenFileLink}
       />
     );
   }
@@ -922,12 +935,14 @@ function MessageBubble({
   message,
   onBranch,
   onCopy,
+  onOpenFileLink,
   onOpenTool,
   sessionRunning,
 }: {
   message: ReactChatMessage;
   onBranch: () => void;
   onCopy: () => void;
+  onOpenFileLink?: (link: AssistantFileLink) => void;
   onOpenTool: (toolCall: ToolCallSummary) => void;
   sessionRunning: boolean;
 }) {
@@ -954,7 +969,7 @@ function MessageBubble({
           <MessageReasoning streaming={message.status === "streaming"} text={message.reasoningText} />
         ) : null}
         {message.role === "assistant" ? (
-          <AssistantMarkdown streaming={message.status === "streaming"} text={message.text} />
+          <AssistantMarkdown onOpenFileLink={onOpenFileLink} streaming={message.status === "streaming"} text={message.text} />
         ) : (
           <PlainMessageText text={message.text} />
         )}

--- a/src/react-workbench/chat/PatchDiffCard.test.tsx
+++ b/src/react-workbench/chat/PatchDiffCard.test.tsx
@@ -44,7 +44,7 @@ describe("PatchDiffCard", () => {
     expect(screen.getByRole("button", { name: "Toggle details for Edited lib.rs" })
       .getAttribute("aria-expanded"))
       .toBe("true");
-    expect(screen.getByText("Completed")).toBeTruthy();
+    expect(screen.queryByText("Completed")).toBeNull();
     const file = screen.getByRole("article", { name: "Diff for src/lib.rs" });
     expect(within(file).getByText("fn before() {}").closest("[data-diff-kind='remove']"))
       .not.toBeNull();

--- a/src/react-workbench/chat/PatchDiffCard.tsx
+++ b/src/react-workbench/chat/PatchDiffCard.tsx
@@ -55,11 +55,9 @@ export function patchChangeSetFromToolResult(value: unknown): PatchChangeSet | u
 }
 
 export function PatchDiffCard({
-  onOpenDetails,
   status,
   toolCall,
 }: {
-  onOpenDetails?: () => void;
   status: ChatStepStatus;
   toolCall: ToolCallState;
 }) {
@@ -83,7 +81,6 @@ export function PatchDiffCard({
         category={t("patch.category")}
         durationMs={toolCall.durationMs}
         icon={<FileDiff size={17} />}
-        onOpenDetails={onOpenDetails}
         status={status}
         title={title}
       >

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:dac3e81ef01d3376719819ef3f40e3ce3c03e79c8b90a08ad83a9e39ead7c168 -->
+<!-- tinybot-module-fingerprint: sha256:d064c3848b58eb2b74e7bd49664670a91af6f4e49d53b8e5af3bb42c678105f5 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -7,11 +7,16 @@ canonical timeline presentation, the composer, and detail drawers.
 `ChatTimeline.tsx` owns the reusable canonical message and execution rendering;
 its action callbacks are optional so read-only consumers can omit unavailable
 branch, recovery, artifact, delegate, and tool-detail controls.
-`AssistantMarkdown.tsx` owns assistant prose and external-link presentation.
+`AssistantMarkdown.tsx` owns assistant prose and link presentation.
 Allowed web and email links keep their existing safe opener path while adding
 an aria-hidden inline source icon: a GitHub mark for GitHub hosts, an envelope
 for email, and a globe for other websites. The anchor remains inline so long
 URLs can wrap with the surrounding Markdown text.
+Local Markdown links are encoded before Streamdown's URL hardening and decoded
+only by the file-link renderer. Clicking one asks Chat to open a contextual
+Artifact resource; it never sends a local path through the external URL opener.
+Chat normalizes relative paths, `file:` URLs, workspace absolute paths, and
+optional line suffixes before requesting a Thread-scoped workspace read.
 
 The desktop pet quick-chat surface composes `ChatTimeline` and
 `ClaudeStyleAiInput` directly without mounting `ChatPage`. Its first submitted
@@ -50,6 +55,12 @@ resource while native snapshots synchronize tab identity and content; the select
 resource then drives native activation without a reverse activation feedback loop.
 Returning to a Thread with retained Browser resources reloads the authoritative
 native snapshot before rendering its existing tabs.
+Artifact file previews use the Thread ID rather than accepting a renderer-owned
+workspace root. Rust resolves the recorded Thread working directory, falls back
+to the configured default only for unbound conversations, and applies the
+existing workspace traversal and symlink guards before reading one bounded text
+chunk. Unsupported binary files, truncated previews, and read failures remain
+visible in the Artifact surface.
 Creating sessions stay in the preparation state until WebView2 is ready, and
 monotonic snapshot revisions prevent stale surface responses from hiding a newer
 visible surface.

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:d064c3848b58eb2b74e7bd49664670a91af6f4e49d53b8e5af3bb42c678105f5 -->
+<!-- tinybot-module-fingerprint: sha256:68006b04ca3bc371385ea2400de05e829cacf96b0a8547e6aec662ba23cc2af6 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.

--- a/src/react-workbench/chat/ToolActivityItem.test.tsx
+++ b/src/react-workbench/chat/ToolActivityItem.test.tsx
@@ -23,12 +23,13 @@ describe("ToolActivityItem", () => {
 
     expect(screen.getByText("Ran npm test")).toBeTruthy();
     expect(screen.getByText("Terminal · 2.4s")).toBeTruthy();
-    expect(screen.getByText("Completed")).toBeTruthy();
+    expect(screen.queryByText("Completed")).toBeNull();
     expect(screen.getByText("$", { selector: ".react-tool-activity__prompt" })).toBeTruthy();
     expect(screen.getByText(/248 tests passed/)).toBeTruthy();
     expect(document.querySelectorAll(".react-tool-activity__preview")).toHaveLength(2);
 
     const toggle = screen.getByRole("button", { name: "Toggle details for Ran npm test" });
+    expect(screen.getByText("Ran npm test").closest("button")).toBe(toggle);
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     await user.click(toggle);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");

--- a/src/react-workbench/chat/ToolActivityItem.tsx
+++ b/src/react-workbench/chat/ToolActivityItem.tsx
@@ -4,14 +4,12 @@ import { useTranslation } from "react-i18next";
 import {
   AlertTriangle,
   Bot,
-  CheckCircle2,
-  ChevronDown,
+  ChevronRight,
   Circle,
   FileText,
   Globe2,
   ListChecks,
   Loader2,
-  PanelRightOpen,
   SquareTerminal,
   Wrench,
   XCircle,
@@ -37,12 +35,10 @@ type ToolActivityPreview = {
 
 export function ToolActivityItem({
   fallbackSummary,
-  onOpenDetails,
   status,
   toolCall,
 }: {
   fallbackSummary?: string;
-  onOpenDetails?: () => void;
   status: ChatStepStatus;
   toolCall: ToolCallState;
 }) {
@@ -58,7 +54,6 @@ export function ToolActivityItem({
       defaultOpen={descriptor.kind !== "web" && previews.length > 0}
       durationMs={toolCall.durationMs}
       icon={<ToolActivityIcon kind={descriptor.kind} />}
-      onOpenDetails={onOpenDetails}
       status={status}
       title={descriptor.title}
     >
@@ -75,7 +70,6 @@ export function ToolActivityFrame({
   defaultOpen = true,
   durationMs,
   icon,
-  onOpenDetails,
   status,
   title,
 }: {
@@ -84,7 +78,6 @@ export function ToolActivityFrame({
   defaultOpen?: boolean;
   durationMs?: number;
   icon: ReactNode;
-  onOpenDetails?: () => void;
   status: ChatStepStatus;
   title: string;
 }) {
@@ -93,40 +86,32 @@ export function ToolActivityFrame({
   const hasContent = Children.count(children) > 0;
   const [open, setOpen] = useState(defaultOpen && hasContent);
   const meta = [category, durationMs === undefined ? "" : formatToolDuration(durationMs)].filter(Boolean).join(" · ");
+  const headerContent = (
+    <>
+      <span aria-hidden="true" className="react-tool-activity__icon">{icon}</span>
+      <span className="react-tool-activity__copy">
+        <strong>{title}</strong>
+        {meta ? <small>{meta}</small> : null}
+      </span>
+      <ToolActivityStatus status={status} />
+      {hasContent ? <ChevronRight aria-hidden="true" className="react-tool-activity__chevron" size={15} /> : null}
+    </>
+  );
 
   return (
     <section className="react-tool-activity" data-open={open ? "true" : undefined} data-status={status}>
-      <header className="react-tool-activity__header">
-        <span aria-hidden="true" className="react-tool-activity__icon">{icon}</span>
-        <span className="react-tool-activity__copy">
-          <strong>{title}</strong>
-          {meta ? <small>{meta}</small> : null}
-        </span>
-        <ToolActivityStatus status={status} />
-        {onOpenDetails ? (
-          <button
-            aria-label={t("toolActivity.openDetails", { title })}
-            className="react-tool-activity__open-details"
-            title={t("toolActivity.viewDetails")}
-            type="button"
-            onClick={onOpenDetails}
-          >
-            <PanelRightOpen aria-hidden="true" size={15} />
-          </button>
-        ) : <span aria-hidden="true" className="react-tool-activity__action-spacer" />}
-        {hasContent ? (
-          <button
-            aria-controls={contentId}
-            aria-expanded={open}
-            aria-label={t("toolActivity.toggleDetails", { title })}
-            className="react-tool-activity__toggle"
-            type="button"
-            onClick={() => setOpen((current) => !current)}
-          >
-            <ChevronDown aria-hidden="true" size={17} />
-          </button>
-        ) : <span aria-hidden="true" className="react-tool-activity__action-spacer" />}
-      </header>
+      {hasContent ? (
+        <button
+          aria-controls={contentId}
+          aria-expanded={open}
+          aria-label={t("toolActivity.toggleDetails", { title })}
+          className="react-tool-activity__header"
+          type="button"
+          onClick={() => setOpen((current) => !current)}
+        >
+          {headerContent}
+        </button>
+      ) : <div className="react-tool-activity__header">{headerContent}</div>}
       {hasContent ? (
         <div className="react-tool-activity__details" data-testid="tool-activity-details" hidden={!open} id={contentId}>
           {children}
@@ -171,6 +156,9 @@ function PreviewMeta({ meta, truncated }: { meta?: string; truncated: boolean })
 function ToolActivityStatus({ status }: { status: ChatStepStatus }) {
   const { t } = useTranslation("chat");
   const normalized = toolActivityStatus(status, t);
+  if (!normalized) {
+    return null;
+  }
   return (
     <span className="react-tool-activity__status" data-status={normalized.kind}>
       {normalized.icon}
@@ -417,9 +405,9 @@ function clippedPreview(value: string): { lines: string[]; text: string; truncat
   return { lines: text.split("\n"), text, truncated };
 }
 
-function toolActivityStatus(status: ChatStepStatus, t: TFunction<"chat">): { icon: ReactNode; kind: string; label: string } {
+function toolActivityStatus(status: ChatStepStatus, t: TFunction<"chat">): { icon: ReactNode; kind: string; label: string } | undefined {
   switch (status) {
-    case "completed": return { icon: <CheckCircle2 aria-hidden="true" size={16} />, kind: "success", label: t("toolActivity.status.completed") };
+    case "completed": return undefined;
     case "running": return { icon: <Loader2 aria-hidden="true" size={16} />, kind: "active", label: t("toolActivity.status.running") };
     case "blocked": return { icon: <AlertTriangle aria-hidden="true" size={16} />, kind: "waiting", label: t("toolActivity.status.waiting") };
     case "failed": return { icon: <XCircle aria-hidden="true" size={16} />, kind: "error", label: t("toolActivity.status.failed") };

--- a/src/react-workbench/chat/assistantFileLinks.test.ts
+++ b/src/react-workbench/chat/assistantFileLinks.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  assistantFileArtifact,
+  isAssistantFileHref,
+  resolveAssistantFileLink,
+} from "./assistantFileLinks";
+
+describe("assistant file links", () => {
+  it("recognizes workspace-relative, absolute, and file URL targets without treating web URLs as files", () => {
+    expect(isAssistantFileHref("./docs/guide.md")).toBe(true);
+    expect(isAssistantFileHref("D:/Code/tinybot/src/main.ts")).toBe(true);
+    expect(isAssistantFileHref("file:///D:/Code/tinybot/src/main.ts")).toBe(true);
+    expect(isAssistantFileHref("https://example.com/guide.md")).toBe(false);
+    expect(isAssistantFileHref("javascript:alert(1)")).toBe(false);
+  });
+
+  it("resolves file URLs and workspace absolute paths to guarded relative paths", () => {
+    expect(resolveAssistantFileLink(
+      "file:///D:/Code/tinybot/docs/Hello%20World.md#L12",
+      "D:\\Code\\tinybot",
+    )).toEqual({ line: 12, path: "docs/Hello World.md", title: "Hello World.md" });
+
+    expect(resolveAssistantFileLink(
+      "D:/Code/tinybot/src/main.ts:27:4",
+      "D:\\Code\\tinybot",
+    )).toEqual({ line: 27, path: "src/main.ts", title: "main.ts" });
+
+    expect(resolveAssistantFileLink("D:/Code/tinybot/src/main.ts:27"))
+      .toEqual({ line: 27, path: "D:/Code/tinybot/src/main.ts", title: "main.ts" });
+  });
+
+  it("rejects traversal and absolute files outside the active workspace", () => {
+    expect(() => resolveAssistantFileLink("../secret.txt", "D:\\Code\\tinybot"))
+      .toThrowError(expect.objectContaining({ code: "outside_workspace" }));
+    expect(() => resolveAssistantFileLink("C:/Users/private.txt", "D:\\Code\\tinybot"))
+      .toThrowError(expect.objectContaining({ code: "outside_workspace" }));
+  });
+
+  it("projects a deterministic text artifact from the resolved file", () => {
+    expect(assistantFileArtifact({ path: "docs/guide.md", title: "guide.md" })).toEqual({
+      fetchPath: "docs/guide.md",
+      id: "workspace-file:docs/guide.md",
+      kind: "markdown",
+      mimeType: "text/markdown",
+      status: "completed",
+      title: "guide.md",
+    });
+    expect(assistantFileArtifact({ path: "src/main.ts", title: "main.ts" }).mimeType).toBe("text/typescript");
+  });
+});

--- a/src/react-workbench/chat/assistantFileLinks.ts
+++ b/src/react-workbench/chat/assistantFileLinks.ts
@@ -1,0 +1,192 @@
+import type { ArtifactRef } from "../../app-core/chat/chatTurnContracts";
+
+export type AssistantFileLink = {
+  href: string;
+};
+
+export type ResolvedAssistantFileLink = {
+  line?: number;
+  path: string;
+  title: string;
+};
+
+export type AssistantFileLinkErrorCode = "invalid_link" | "outside_workspace";
+
+export class AssistantFileLinkError extends Error {
+  readonly code: AssistantFileLinkErrorCode;
+
+  constructor(code: AssistantFileLinkErrorCode, message: string) {
+    super(message);
+    this.name = "AssistantFileLinkError";
+    this.code = code;
+  }
+}
+
+const EXTERNAL_PROTOCOL = /^[a-z][a-z\d+.-]*:/i;
+const WINDOWS_ABSOLUTE_PATH = /^[a-z]:[\\/]/i;
+
+export function isAssistantFileHref(href: string): boolean {
+  const value = href.trim();
+  if (!value || value.startsWith("#") || value.startsWith("//")) {
+    return false;
+  }
+  if (/^file:/i.test(value) || WINDOWS_ABSOLUTE_PATH.test(value)) {
+    return true;
+  }
+  return !EXTERNAL_PROTOCOL.test(value);
+}
+
+export function resolveAssistantFileLink(href: string, workspaceRoot = ""): ResolvedAssistantFileLink {
+  const decoded = decodeAssistantFileHref(href);
+  const fragmentLine = lineFromFragment(decoded.fragment);
+  const suffix = stripLineSuffix(decoded.path);
+  const line = fragmentLine ?? suffix.line;
+  const candidate = normalizeSlashes(suffix.path);
+  const normalizedRoot = normalizeSlashes(workspaceRoot).replace(/\/+$/, "");
+  let relativePath = candidate;
+
+  if (isAbsolutePath(candidate)) {
+    if (!normalizedRoot) {
+      const title = candidate.split("/").pop() || candidate;
+      return { ...(line ? { line } : {}), path: candidate, title };
+    }
+    const comparablePath = comparableWorkspacePath(candidate);
+    const comparableRoot = comparableWorkspacePath(normalizedRoot);
+    if (!comparablePath.startsWith(`${comparableRoot}/`)) {
+      throw new AssistantFileLinkError("outside_workspace", "The file is outside the active workspace.");
+    }
+    relativePath = candidate.slice(normalizedRoot.length + 1);
+  }
+
+  const path = normalizeRelativePath(relativePath);
+  const title = path.split("/").pop() || path;
+  return { ...(line ? { line } : {}), path, title };
+}
+
+export function assistantFileLinkTitle(href: string): string {
+  try {
+    const decoded = decodeAssistantFileHref(href);
+    const path = normalizeSlashes(stripLineSuffix(decoded.path).path).replace(/\/+$/, "");
+    return path.split("/").pop() || "File";
+  } catch {
+    return "File";
+  }
+}
+
+export function assistantFileArtifact(file: Pick<ResolvedAssistantFileLink, "path" | "title">): ArtifactRef {
+  const mimeType = assistantFileMimeType(file.path);
+  return {
+    fetchPath: file.path,
+    id: `workspace-file:${file.path}`,
+    kind: mimeType === "text/markdown" ? "markdown" : mimeType === "application/json" ? "json" : "text",
+    mimeType,
+    status: "completed",
+    title: file.title,
+  };
+}
+
+function decodeAssistantFileHref(href: string): { fragment: string; path: string } {
+  const value = href.trim();
+  if (!isAssistantFileHref(value)) {
+    throw new AssistantFileLinkError("invalid_link", "The link is not a local file link.");
+  }
+  if (/^file:/i.test(value)) {
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      throw new AssistantFileLinkError("invalid_link", "The file URL is invalid.");
+    }
+    if (url.hostname && url.hostname !== "localhost") {
+      throw new AssistantFileLinkError("outside_workspace", "Network file URLs are outside the active workspace.");
+    }
+    const decodedPath = decodePath(url.pathname);
+    return {
+      fragment: url.hash,
+      path: /^\/[a-z]:\//i.test(decodedPath) ? decodedPath.slice(1) : decodedPath,
+    };
+  }
+
+  const hashIndex = value.indexOf("#");
+  const queryIndex = value.indexOf("?");
+  const pathEnd = [hashIndex, queryIndex].filter((index) => index >= 0).reduce((minimum, index) => Math.min(minimum, index), value.length);
+  return {
+    fragment: hashIndex >= 0 ? value.slice(hashIndex) : "",
+    path: decodePath(value.slice(0, pathEnd)),
+  };
+}
+
+function decodePath(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new AssistantFileLinkError("invalid_link", "The file link contains invalid URL encoding.");
+  }
+}
+
+function normalizeSlashes(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function isAbsolutePath(value: string): boolean {
+  return WINDOWS_ABSOLUTE_PATH.test(value) || value.startsWith("/");
+}
+
+function comparableWorkspacePath(value: string): string {
+  const normalized = normalizeSlashes(value).replace(/\/+$/, "");
+  return WINDOWS_ABSOLUTE_PATH.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function normalizeRelativePath(value: string): string {
+  const segments = normalizeSlashes(value).split("/").filter((segment) => segment && segment !== ".");
+  if (!segments.length) {
+    throw new AssistantFileLinkError("invalid_link", "The file link does not identify a file.");
+  }
+  if (segments.includes("..")) {
+    throw new AssistantFileLinkError("outside_workspace", "The file is outside the active workspace.");
+  }
+  return segments.join("/");
+}
+
+function lineFromFragment(fragment: string): number | undefined {
+  const match = /^#L(\d+)(?:C\d+)?$/i.exec(fragment);
+  if (!match) return undefined;
+  const line = Number(match[1]);
+  return Number.isSafeInteger(line) && line > 0 ? line : undefined;
+}
+
+function stripLineSuffix(value: string): { line?: number; path: string } {
+  const match = /:(\d+)(?::\d+)?$/.exec(value);
+  if (!match) return { path: value };
+  const line = Number(match[1]);
+  return {
+    ...(Number.isSafeInteger(line) && line > 0 ? { line } : {}),
+    path: value.slice(0, match.index),
+  };
+}
+
+function assistantFileMimeType(path: string): string {
+  const extension = /(?:^|\/)\.?(?:[^./]+)(\.[^./]+)$/.exec(path.toLowerCase())?.[1] ?? "";
+  switch (extension) {
+    case ".md":
+    case ".mdx": return "text/markdown";
+    case ".json": return "application/json";
+    case ".ts":
+    case ".tsx": return "text/typescript";
+    case ".js":
+    case ".jsx":
+    case ".mjs":
+    case ".cjs": return "text/javascript";
+    case ".css": return "text/css";
+    case ".html":
+    case ".htm": return "text/html";
+    case ".xml": return "application/xml";
+    case ".yaml":
+    case ".yml": return "application/yaml";
+    case ".toml": return "application/toml";
+    case ".rs": return "text/x-rust";
+    case ".py": return "text/x-python";
+    case ".sh": return "text/x-shellscript";
+    default: return "text/plain";
+  }
+}

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:66cf11197a94e1b70847cf69253bcb9ca28a5a0a2c1cbf88766c143f7e2d5839 -->
+<!-- tinybot-module-fingerprint: sha256:f4015daaaa6f60dec52710478dd71ac955ac3200c60646672c508bd6e97b559a -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles.

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:1aec781718c1d1a5cdea5aa31648f63ca1315446a06a221339aef61fcce6b809 -->
+<!-- tinybot-module-fingerprint: sha256:66cf11197a94e1b70847cf69253bcb9ca28a5a0a2c1cbf88766c143f7e2d5839 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles.
@@ -26,7 +26,8 @@ Language-picker option names and descriptions use each target language's own
 copy (endonyms) instead of following the currently active interface language.
 The retired TinyOS application namespace is intentionally absent. Sidecar copy
 lives under the owning `chat` route namespace, including Terminal shell
-selection, process state, availability, and user-only ownership labels.
+selection, process state, availability, user-only ownership labels, and
+Artifact file-preview boundary, binary, truncation, and failure states.
 The Performance Trace route, diagnostic-mode controls, local-export status, and
 privacy warning follow the same English and Simplified Chinese resource
 boundary; metric and event identifiers remain untranslated.

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -895,10 +895,9 @@ export const en = {
     },
     runtime: {
       loadingCapabilities: "Loading effective capabilities.", staleCapabilities: "Effective capabilities are stale for the current Agent turn.", cancelUnavailable: "Cancellation is unavailable for this Agent turn.", noSessionSelected: "No session is selected.", commandRejected: "Command rejected",
-      failedTurnRetryUnavailable: "Retry is unavailable for this failed Agent turn.", failedItemUnavailable: "Cannot retry: the failed canonical item is not available.", cancelActiveTurnUnavailable: "Cannot cancel: canonical active turn is not available.",
+      cancelActiveTurnUnavailable: "Cannot cancel: canonical active turn is not available.",
       submitFormTurnUnavailable: "Cannot submit form: canonical active turn is not available.", submitFormStaleTurn: "Cannot submit form: request targets stale turn {{turnId}}.", cancelFormTurnUnavailable: "Cannot cancel form: canonical active turn is not available.", cancelFormStaleTurn: "Cannot cancel form: request targets stale turn {{turnId}}.",
     },
-    continuePrompt: "Continue from where you were interrupted using the existing context and plan. Confirm the current progress first, then finish the remaining work.",
     lifecycle: {
       operation: { cancel: "Cancel", cancellation: "Cancellation", formCancellation: "Form cancellation", formSubmission: "Form submission", retry: "Retry" },
       sending: "Sending {{operation}} command…", waiting: "{{operation}} delivered. Waiting for runtime confirmation…", acknowledged: "{{operation}} acknowledged by canonical item {{itemId}}. Waiting for completion.", completed: "{{operation}} {{status}} at canonical item {{itemId}}.",
@@ -909,7 +908,7 @@ export const en = {
       newSessionIn: "New session in {{name}}", confirmDelete: "Confirm delete {{name}}", delete: "Delete {{name}}", noSessions: "No sessions yet.",
       noSelection: "No conversation selected", conversationMenu: "Open conversation menu", unpin: "Unpin conversation", pin: "Pin conversation",
       rename: "Rename conversation", copyId: "Copy ID", copyMarkdown: "Copy Markdown", archive: "Archive conversation", sideChat: "Open side chat",
-      branch: "Branch", newWindow: "Open in new window", conversation: "Conversation", errorDetails: "Error details", selectSession: "Select or create a conversation.",
+      branch: "Branch", newWindow: "Open in new window", conversation: "Conversation", selectSession: "Select or create a conversation.",
       backToLatest: "Back to latest", compacting: "Compacting context", loadingSessions: "Loading conversations…", createOrSelect: "Create or select a conversation first",
       taskPlaceholder: "Enter a task, or paste/drop files", messagePlaceholder: "Message Tinybot", detailsDrawer: "Details drawer", closeDetails: "Close details drawer",
     },
@@ -965,14 +964,12 @@ export const en = {
     },
     execution: {
       actionCount: "{{count}} actions", plan: "plan {{completed}}/{{total}}", attention: "attention required",
-      status: { completed: "Completed", failed: "Failed", interrupted: "Interrupted", awaiting: "Awaiting input", running: "Running" },
+      status: { failed: "Failed", interrupted: "Interrupted", awaiting: "Awaiting input", running: "Running" },
     },
     form: { submitted: "Submitted", cancelled: "Cancelled", resolved: "Resolved", waiting: "Waiting for input" },
     compaction: { before: "Before: {{value}} tokens", after: "After: {{value}} tokens", dropped: "Dropped items: {{value}}" },
     recovery: {
-      label: "Task execution failed", cancelled: "Task cancelled", interrupted: "Task interrupted", failedAt: "Interrupted at", progress: "Plan progress",
-      completedSteps: "{{count}} steps completed", validResults: "Results that remain valid", actions: "Error recovery actions", continue: "Continue",
-      retry: "Retry current step", restart: "Start over", details: "View details", copyError: "Copy error",
+      label: "Task execution failed", cancelled: "Task cancelled", interrupted: "Task interrupted", copyError: "Copy error",
     },
     plan: {
       label: "Execution plan", completed: "{{completed}} of {{total}} completed", status: { completed: "Completed", inProgress: "In progress", failed: "Failed", cancelled: "Cancelled", pending: "Pending" },
@@ -989,7 +986,7 @@ export const en = {
     context: { attachments: "Attachments", context: "Context" },
     steps: { count: "{{count}} steps", title: "Execution details", label: "Agent steps", openDetails: "Open details for {{name}}", status: { active: "In progress", success: "Completed", waiting: "Waiting for confirmation", cancelled: "Cancelled", error: "Failed", pending: "Pending" } },
     details: {
-      turnId: "Turn ID", status: "Status", stopReason: "Stop reason", interruptedAt: "Interrupted at", originalTask: "Original task", originalError: "Original error",
+      status: "Status", interruptedAt: "Interrupted at",
       unavailable: "Details unavailable.", id: "ID", trace: "Trace", childTurn: "Child turn", loadingTrace: "Loading trace…", finalOutput: "Final output",
       type: "Type", loadingArtifact: "Loading artifact…", noPreview: "No preview content is available.", subagentTrace: "Subagent trace",
       fileOutsideWorkspace: "This file is outside the active workspace.", filePreviewUnavailable: "Workspace file preview is unavailable in this runtime.",
@@ -1005,8 +1002,8 @@ export const en = {
       editedFiles: "Edited {{count}} files", moved: "Moved {{name}}", created: "Created {{name}}", deleted: "Deleted {{name}}", edited: "Edited {{name}}",
     },
     toolActivity: {
-      openDetails: "Open details for {{title}}", viewDetails: "View full tool details", toggleDetails: "Toggle details for {{title}}", truncated: "preview truncated",
-      status: { completed: "Completed", running: "Running", waiting: "Waiting", failed: "Failed", cancelled: "Cancelled", pending: "Pending" },
+      toggleDetails: "Toggle details for {{title}}", truncated: "preview truncated",
+      status: { running: "Running", waiting: "Waiting", failed: "Failed", cancelled: "Cancelled", pending: "Pending" },
       category: { terminal: "Terminal", fileRead: "File read", web: "Web", planning: "Planning", presentation: "Data view", subagent: "Subagent", interaction: "Interaction", tool: "Tool" },
       command: "command", workspaceFile: "workspace file", currentPage: "current page", usedTool: "Used a tool",
       updatedPlan: "Updated execution plan", preparingDataView: "Preparing data view…", publishedDataView: "Published data view", dataViewFailed: "Data view publication failed", dataViewCancelled: "Data view publication cancelled", delegated: "Delegated a task", waitedSubagents: "Waited for subagents", updatedSubagent: "Updated a subagent", requestedInput: "Requested user input",

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -992,6 +992,8 @@ export const en = {
       turnId: "Turn ID", status: "Status", stopReason: "Stop reason", interruptedAt: "Interrupted at", originalTask: "Original task", originalError: "Original error",
       unavailable: "Details unavailable.", id: "ID", trace: "Trace", childTurn: "Child turn", loadingTrace: "Loading trace…", finalOutput: "Final output",
       type: "Type", loadingArtifact: "Loading artifact…", noPreview: "No preview content is available.", subagentTrace: "Subagent trace",
+      fileOutsideWorkspace: "This file is outside the active workspace.", filePreviewUnavailable: "Workspace file preview is unavailable in this runtime.",
+      binaryFilePreviewUnsupported: "Binary files cannot be previewed here yet.", filePreviewTruncated: "Preview truncated. Open the file directly to inspect the remaining content.",
       task: "Task", errorCode: "Error code", errorMessage: "Error message", summary: "Summary", arguments: "Arguments", response: "Response",
       delegate: "Delegate", title: "Title", parentTurn: "Parent turn", session: "Session",
     },

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -391,10 +391,9 @@ export const zh = {
     },
     runtime: {
       loadingCapabilities: "正在加载有效能力。", staleCapabilities: "有效能力与当前 Agent 轮次不一致。", cancelUnavailable: "当前 Agent 轮次不可取消。", noSessionSelected: "未选择会话。", commandRejected: "命令被拒绝",
-      failedTurnRetryUnavailable: "这个失败的 Agent 轮次不可重试。", failedItemUnavailable: "无法重试：找不到失败的规范项目。", cancelActiveTurnUnavailable: "无法取消：找不到当前规范轮次。",
+      cancelActiveTurnUnavailable: "无法取消：找不到当前规范轮次。",
       submitFormTurnUnavailable: "无法提交表单：找不到当前规范轮次。", submitFormStaleTurn: "无法提交表单：请求指向已过期的轮次 {{turnId}}。", cancelFormTurnUnavailable: "无法取消表单：找不到当前规范轮次。", cancelFormStaleTurn: "无法取消表单：请求指向已过期的轮次 {{turnId}}。",
     },
-    continuePrompt: "请从刚才中断的位置继续，沿用现有上下文和计划；先确认当前进度，再完成剩余任务。",
     lifecycle: {
       operation: { cancel: "取消", cancellation: "取消操作", formCancellation: "表单取消", formSubmission: "表单提交", retry: "重试" },
       sending: "正在发送{{operation}}命令…", waiting: "{{operation}}已送达，正在等待运行时确认…", acknowledged: "{{operation}}已由规范项目 {{itemId}} 确认，正在等待完成。", completed: "{{operation}}已于规范项目 {{itemId}} 结束，状态：{{status}}。",
@@ -404,7 +403,7 @@ export const zh = {
       newChat: "新会话", sessionRows: "会话列表", workspace: "工作区 {{name}}", generalSessions: "常规会话", newSessionIn: "在 {{name}} 中新建会话", confirmDelete: "确认删除 {{name}}",
       delete: "删除 {{name}}", noSessions: "还没有会话。", noSelection: "未选择会话", conversationMenu: "打开会话菜单",
       unpin: "取消置顶", pin: "置顶会话", rename: "重命名会话", copyId: "复制 ID", copyMarkdown: "复制 Markdown", archive: "归档会话",
-      sideChat: "打开侧边会话", branch: "创建分支", newWindow: "在新窗口中打开", conversation: "会话", errorDetails: "错误详情",
+      sideChat: "打开侧边会话", branch: "创建分支", newWindow: "在新窗口中打开", conversation: "会话",
       selectSession: "请选择或新建一个会话。", backToLatest: "回到最新消息", compacting: "正在压缩上下文", loadingSessions: "正在加载会话…",
       createOrSelect: "请先创建或选择一个会话", taskPlaceholder: "输入任务，或粘贴/拖入文件", messagePlaceholder: "输入消息给 Tinybot",
       detailsDrawer: "详情抽屉", closeDetails: "关闭详情抽屉",
@@ -460,14 +459,12 @@ export const zh = {
     },
     execution: {
       actionCount: "{{count}} 个操作", plan: "计划 {{completed}}/{{total}}", attention: "需要处理",
-      status: { completed: "已完成", failed: "失败", interrupted: "已中断", awaiting: "等待输入", running: "执行中" },
+      status: { failed: "失败", interrupted: "已中断", awaiting: "等待输入", running: "执行中" },
     },
     form: { submitted: "已提交", cancelled: "已取消", resolved: "已解决", waiting: "等待输入" },
     compaction: { before: "压缩前：{{value}} Token", after: "压缩后：{{value}} Token", dropped: "已丢弃项目：{{value}}" },
     recovery: {
-      label: "任务执行失败", cancelled: "任务已取消", interrupted: "任务已中断", failedAt: "中断位置", progress: "计划进度",
-      completedSteps: "已完成 {{count}} 个步骤", validResults: "仍然有效的结果", actions: "错误恢复操作", continue: "继续执行",
-      retry: "重试当前步骤", restart: "重新开始", details: "查看详情", copyError: "复制错误",
+      label: "任务执行失败", cancelled: "任务已取消", interrupted: "任务已中断", copyError: "复制错误",
     },
     plan: {
       label: "执行计划", completed: "已完成 {{completed}}/{{total}}", status: { completed: "已完成", inProgress: "执行中", failed: "失败", cancelled: "已取消", pending: "待执行" },
@@ -484,7 +481,7 @@ export const zh = {
     context: { attachments: "附件", context: "上下文" },
     steps: { count: "{{count}} 个步骤", title: "执行详情", label: "Agent 步骤", openDetails: "打开 {{name}} 的详情", status: { active: "执行中", success: "已完成", waiting: "等待确认", cancelled: "已取消", error: "失败", pending: "待执行" } },
     details: {
-      turnId: "Turn ID", status: "状态", stopReason: "停止原因", interruptedAt: "中断位置", originalTask: "原始任务", originalError: "原始错误信息",
+      status: "状态", interruptedAt: "中断位置",
       unavailable: "详情不可用。", id: "ID", trace: "Trace", childTurn: "子任务轮次", loadingTrace: "正在加载 Trace…", finalOutput: "最终输出",
       type: "类型", loadingArtifact: "正在加载产物…", noPreview: "没有可预览的内容。", subagentTrace: "子 Agent Trace",
       fileOutsideWorkspace: "该文件位于当前工作区之外。", filePreviewUnavailable: "当前运行环境无法预览工作区文件。",
@@ -500,8 +497,8 @@ export const zh = {
       editedFiles: "编辑了 {{count}} 个文件", moved: "移动了 {{name}}", created: "创建了 {{name}}", deleted: "删除了 {{name}}", edited: "编辑了 {{name}}",
     },
     toolActivity: {
-      openDetails: "打开 {{title}} 的详情", viewDetails: "查看完整工具详情", toggleDetails: "展开或收起 {{title}} 的详情", truncated: "预览已截断",
-      status: { completed: "已完成", running: "执行中", waiting: "等待中", failed: "失败", cancelled: "已取消", pending: "待执行" },
+      toggleDetails: "展开或收起 {{title}} 的详情", truncated: "预览已截断",
+      status: { running: "执行中", waiting: "等待中", failed: "失败", cancelled: "已取消", pending: "待执行" },
       category: { terminal: "终端", fileRead: "读取文件", web: "网页", planning: "计划", presentation: "数据视图", subagent: "子 Agent", interaction: "交互", tool: "工具" },
       command: "命令", workspaceFile: "工作区文件", currentPage: "当前页面", usedTool: "使用了工具",
       updatedPlan: "更新了执行计划", preparingDataView: "正在准备数据视图…", publishedDataView: "已发布数据视图", dataViewFailed: "数据视图发布失败", dataViewCancelled: "已取消发布数据视图", delegated: "委派了任务", waitedSubagents: "等待子 Agent", updatedSubagent: "更新了子 Agent", requestedInput: "请求用户输入",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -487,6 +487,8 @@ export const zh = {
       turnId: "Turn ID", status: "状态", stopReason: "停止原因", interruptedAt: "中断位置", originalTask: "原始任务", originalError: "原始错误信息",
       unavailable: "详情不可用。", id: "ID", trace: "Trace", childTurn: "子任务轮次", loadingTrace: "正在加载 Trace…", finalOutput: "最终输出",
       type: "类型", loadingArtifact: "正在加载产物…", noPreview: "没有可预览的内容。", subagentTrace: "子 Agent Trace",
+      fileOutsideWorkspace: "该文件位于当前工作区之外。", filePreviewUnavailable: "当前运行环境无法预览工作区文件。",
+      binaryFilePreviewUnsupported: "暂不支持在此处预览二进制文件。", filePreviewTruncated: "预览已截断，请直接打开文件查看剩余内容。",
       task: "任务", errorCode: "错误代码", errorMessage: "错误信息", summary: "摘要", arguments: "参数", response: "响应",
       delegate: "委派任务", title: "标题", parentTurn: "父任务轮次", session: "会话",
     },

--- a/src/react-workbench/services.ts
+++ b/src/react-workbench/services.ts
@@ -140,6 +140,7 @@ export type WorkspaceStore = {
   listFiles(): Promise<WorkspaceFileSummary[]>;
   listDirectory(request: WorkspaceDirectoryRequest): Promise<WorkspaceDirectoryPage>;
   readFile(request: { cursor?: string; path: string }): Promise<WorkspaceFileChunk>;
+  readThreadFile(request: { cursor?: string; path: string; threadId: string }): Promise<WorkspaceFileChunk>;
 };
 
 export type MemoryWorkspace = {

--- a/src/react-workbench/shell/DesktopPetQuickChatWindow.tsx
+++ b/src/react-workbench/shell/DesktopPetQuickChatWindow.tsx
@@ -366,7 +366,6 @@ export function DesktopPetQuickChatWindow({
               interactiveFormIds={EMPTY_INTERACTIVE_FORM_IDS}
               latestFailedTurnId={latestFailedTurnId}
               optimisticMessages={optimisticMessages}
-              recoveringTurnId=""
               sessionRunning={sessionRunning}
               turns={timeline?.turns ?? []}
             />

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -39,6 +39,7 @@ function createServices(options: { messages?: ReactChatMessage[]; sessions?: Ses
     listFiles: ReturnType<typeof vi.fn>;
     listDirectory: ReturnType<typeof vi.fn>;
     readFile: ReturnType<typeof vi.fn>;
+    readThreadFile: ReturnType<typeof vi.fn>;
   };
   toolsStore: {
     loadCatalog: ReturnType<typeof vi.fn>;
@@ -124,6 +125,13 @@ function createServices(options: { messages?: ReactChatMessage[]; sessions?: Ses
         workspaceKey: "test-workspace",
       })),
       readFile: vi.fn(async ({ path }) => ({
+        content: "",
+        contentType: "text" as const,
+        path,
+        revision: "test",
+        sizeBytes: 0,
+      })),
+      readThreadFile: vi.fn(async ({ path }) => ({
         content: "",
         contentType: "text" as const,
         path,

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:e5b3d1726896778c0e275a01d10eb713c86741ba99877caffdcf277ca32759be -->
+<!-- tinybot-module-fingerprint: sha256:334e22d7b200c0a448608663e9c80729858b021fd327299be2b5acd3b5aaa371 -->
 
 `shell` owns Tinybot's desktop chrome: the window frame, menus, route
 selection, deferred route loading, and update dialogs.

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:334e22d7b200c0a448608663e9c80729858b021fd327299be2b5acd3b5aaa371 -->
+<!-- tinybot-module-fingerprint: sha256:de49d55aba07b2ada6a6370e24deddc2e2b718326644d53336a2cb67ca4cd481 -->
 
 `shell` owns Tinybot's desktop chrome: the window frame, menus, route
 selection, deferred route loading, and update dialogs.

--- a/src/react-workbench/sidecar/README.md
+++ b/src/react-workbench/sidecar/README.md
@@ -54,7 +54,10 @@ resource invokes termination through Chat. Terminal input is serialized with
 polling so cursor-based output cannot be reordered.
 
 Artifact presentation is supplied by Chat through the Sidecar render contract;
-Artifact domain state does not live in this module.
+Artifact domain state does not live in this module. Artifact tabs may come from
+canonical Agent artifacts or from local file links in assistant Markdown. File
+links are contextual only, so the resource menu does not create an empty
+Artifact tab.
 
 ## Invariants
 
@@ -71,6 +74,8 @@ Artifact domain state does not live in this module.
   current workspace bounds.
 - Resource provisioning failures remain visible and retryable rather than
   being represented as an empty successful surface.
+- Local file Artifact reads use the recorded Thread workspace and retain the
+  native workspace path guard; the renderer cannot nominate an arbitrary root.
 
 ## Verification
 
@@ -84,6 +89,8 @@ Artifact domain state does not live in this module.
   reattachment, resize, and renderer disposal without termination.
 - `../chat/ChatPage.sidecar.test.tsx` covers Chat-owned provisioning, Browser
   activation, session reattachment, workspace fallback, and close-time cleanup.
+- `../chat/ChatPage.timeline.test.tsx` covers assistant file-link Artifact
+  previews and visible path-boundary failures.
 - Run the [Windows desktop smoke test](../../../docs/guides/desktop-smoke-test.md)
   for real WebView2, PTY, process cleanup, and native geometry behavior.
 

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:12234348f39cb4d54c32d6231b221193b0e27125b81cd8292663996d90ea80c3 -->
+<!-- tinybot-module-fingerprint: sha256:e5b97809d3eb1a37bf07b7778119a3b0070dfcacd23bdf4640bbff348860ec13 -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.

--- a/src/react-workbench/styles/workbench.test.ts
+++ b/src/react-workbench/styles/workbench.test.ts
@@ -39,18 +39,36 @@ describe("workbench CSS interaction contracts", () => {
     expect(queueListRule?.[1]).toContain("overflow-y: auto");
   });
 
-  test("keeps tool activity rows compact without shrinking their action controls", () => {
+  test("keeps execution summaries and tool activity compact without shrinking action controls", () => {
+    const timelineTriggerRule = chatStylesheet.match(/\.react-execution-timeline__trigger\s*\{([^}]+)\}/);
+    const timelineHeadingRule = chatStylesheet.match(/\.react-execution-timeline__heading\s*\{([^}]+)\}/);
+    const timelineTitleRule = chatStylesheet.match(/\.react-execution-timeline__heading strong\s*\{([^}]+)\}/);
     const headerRule = chatStylesheet.match(/\.react-tool-activity__header\s*\{([^}]+)\}/);
-    const actionRule = chatStylesheet.match(
-      /\.react-tool-activity__open-details,\s*\.react-tool-activity__toggle,\s*\.react-patch-file__copy\s*\{([^}]+)\}/,
-    );
+    const actionRule = chatStylesheet.match(/\.react-patch-file__copy\s*\{([^}]+)\}/);
     const detailsRule = chatStylesheet.match(/\.react-tool-activity__details\s*\{([^}]+)\}/);
+    const previewRule = chatStylesheet.match(/\.react-tool-activity__preview\s*\{([^}]+)\}/);
+    const toolTitleRule = chatStylesheet.match(/\.react-tool-activity__copy strong\s*\{([^}]+)\}/);
+    const toolChevronRule = chatStylesheet.match(/\.react-tool-activity\[data-open="true"\] \.react-tool-activity__chevron\s*\{([^}]+)\}/);
 
-    expect(headerRule?.[1]).toContain("min-height: 44px");
-    expect(headerRule?.[1]).toContain("padding: 6px 0");
+    expect(timelineTriggerRule?.[1]).toContain("min-height: 40px");
+    expect(timelineTriggerRule?.[1]).toContain("padding: 0 0 4px");
+    expect(timelineTriggerRule?.[1]).toContain("justify-content: flex-start");
+    expect(timelineHeadingRule?.[1]).toContain("display: flex");
+    expect(timelineTitleRule?.[1]).toContain("color: var(--color-body)");
+    expect(timelineTitleRule?.[1]).toContain("font-weight: 600");
+    expect(headerRule?.[1]).toContain("min-height: 34px");
+    expect(headerRule?.[1]).toContain("padding: 2px 0");
+    expect(headerRule?.[1]).toContain("display: flex");
+    expect(headerRule?.[1]).toContain("justify-content: flex-start");
     expect(actionRule?.[1]).toContain("width: 30px");
     expect(actionRule?.[1]).toContain("height: 30px");
-    expect(detailsRule?.[1]).toContain("padding: 0 0 12px 26px");
+    expect(detailsRule?.[1]).toContain("gap: 4px");
+    expect(detailsRule?.[1]).toContain("padding: 0 0 6px 22px");
+    expect(previewRule?.[1]).toContain("min-height: 32px");
+    expect(previewRule?.[1]).toContain("padding: 6px 10px");
+    expect(toolTitleRule?.[1]).toContain("font-size: 12px");
+    expect(toolTitleRule?.[1]).toContain("font-weight: 600");
+    expect(toolChevronRule?.[1]).toContain("transform: rotate(90deg)");
   });
 
   test("routes appearance controls through shared theme tokens", () => {


### PR DESCRIPTION
## Summary

- preview assistant workspace file links in the sidecar with native file reads and clear unsupported-file handling
- recover from intermittent WebView2 session creation failures with a bounded retry, failed-session replacement, and diagnostics
- simplify ChatPage execution feedback with compact left-aligned disclosure rows and lightweight inline errors

## Testing

- npm test (117 test files, 639 tests passed)
- npm run build
- TypeScript typecheck
- native browser unit suite (60 tests passed)
- real WebView2 integration coverage with the Sidecar unopened