### PR TITLE
Support controlled loops in Agent Graph runs

### DIFF
--- a/docs/api/workspace-and-extensions.md
+++ b/docs/api/workspace-and-extensions.md
@@ -15,7 +15,7 @@ src-tauri/src/skills/definition.rs
 src-tauri/src/workspace/types.rs
 src-tauri/src/rpc/tests/workspace_and_shell.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:d6a8ce95d2f1f3ebcf27417e360353ed482e0c41192c4e7e7af35b69d1ee48b2 -->
+<!-- tinybot-doc-fingerprint: sha256:18d5bb241a039b9935798aae303605ab37886e56650eabb26ffa7bc0fa29e4df -->
 
 This document covers workspace operations and the extension catalogs available
 to Agents. It is part of the [Rust backend API reference](rust-backend-api.md),
@@ -88,13 +88,16 @@ outgoing edge.
 Runs live at `~/.tinybot/graph-runs/<graph-id>/<run-id>.json` and are atomically
 updated as nodes transition. Start requires a non-empty runtime `input`,
 reloads the requested saved revision, and copies that runtime value into the
-Run so the Input node can be inspected later. It then
-canonicalizes every Agent workspace and validates an acyclic Input-to-Output
-graph. Router branches may reconverge, while non-Router branching, cycles,
-disconnected nodes, incomplete route connections, and missing workspaces fail
-preflight. Each visited Agent node creates a fresh standard
-parentless Thread with `source: "agent_graph"`; final output becomes the next
-Agent input and the Output value. Node instructions enter the existing
+Run so the Input node can be inspected later. It then canonicalizes every Agent
+workspace and validates the Input-to-Output graph. Router branches may
+reconverge or form controlled loops when the loop contains a Router route that
+exits it. Non-Router cycles, loops without an exit, disconnected nodes,
+incomplete route connections, and missing workspaces fail preflight. A Run is
+also limited to 64 Agent or Router executions so a model cannot loop forever.
+The first visit to an Agent node creates a standard parentless Thread with
+`source: "agent_graph"`; later visits to that node in the same Run continue the
+same Thread. Final output becomes the next Agent input and the Output value.
+Node instructions enter the existing
 turn-scoped agent-role instruction source, while an optional node model tuple
 sets the Turn's model, provider, and reasoning effort. A Router performs one
 non-streaming provider request with a dedicated system prompt and no Agent
@@ -115,10 +118,11 @@ management listing, Chat tool discovery skips invalid Graph files, logs and
 returns path-specific diagnostics, and continues with the valid definitions.
 
 The Graph renderer selects a durable Run before inspecting a node. Input and
-Output use the Run's boundary values. Agent nodes use the node invocation's
-`threadId` with the normal Thread timeline APIs and the shared read-only Chat
-timeline renderer; they remain excluded from Chat session discovery. Router
-node runs expose the selected route/edge, raw response, and provider usage.
+Output use the Run's boundary values. Agent nodes use the latest node
+invocation's `threadId` with the normal Thread timeline APIs and the shared
+read-only Chat timeline renderer; a reused Thread contains every visit to that
+Agent. They remain excluded from Chat session discovery. Router node details
+show the latest selected route/edge, raw response, and provider usage.
 
 ## Workspace Commands
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:b70a6d19025a633691dff21819befa9f045c2543232adc0b1da801167259755e -->
+<!-- tinybot-doc-fingerprint: sha256:da8f2fda8518c70289866519ab19f624f8b0997eb1ee7f2de4d172f3f2bcb59d -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -101,9 +101,10 @@ Desktop Commands / Desktop Host
   behavior remain renderer presentation state rather than persistence constraints.
 - Agent Graph Runs: application-owned status files under
   `~/.tinybot/graph-runs/<graph-id>/`. The runtime follows one model-selected
-  path through an acyclic Router graph, receives the initial task at Run time,
-  and delegates every visited Agent node to a fresh canonical
-  Thread. Per-node role
+  path through a Router graph, receives the initial task at Run time, and
+  permits Router-controlled loops with an exit route under a 64-node-execution
+  budget. The first visit to an Agent node creates a canonical Thread; later
+  visits in the same Run continue it. Per-node role
   instructions and optional Provider, model, and reasoning-effort settings use
   the existing Turn interfaces; the renderer only offers models from available
   Provider connections, while absent settings inherit application defaults.

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:9861aa7bf9150bfa7ce2925e12e0e67ee499a2dd64618cdfbae47e2ef19f011c -->
+<!-- tinybot-doc-fingerprint: sha256:e1492d919540dcb3bed3b280f90c0c8b8880b527a61c636d1e9b4cd4435af8d9 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the

--- a/docs/decisions/0001-agent-graph-definitions-runs-and-threads.md
+++ b/docs/decisions/0001-agent-graph-definitions-runs-and-threads.md
@@ -16,7 +16,7 @@ Keeping all of this state in one record would mix three different lifecycles:
 - one execution creates short-lived orchestration state;
 - every Agent Loop invocation creates durable conversation history.
 
-The standalone editor, definition store, and acyclic routing runtime implement
+The standalone editor, definition store, and bounded routing runtime implement
 these separate lifecycles through explicit interfaces.
 
 ## Decision
@@ -169,9 +169,11 @@ type AgentGraphRun = {
 };
 ```
 
-Input, Router, and Output nodes execute in the Graph runtime and do not
-create Threads. Every Agent node invocation creates a fresh standard Thread
-with no synthetic parent and with enough origin metadata to trace it back:
+Input, Router, and Output nodes execute in the Graph runtime and do not create
+Threads. The first visit to an Agent node creates a standard Thread with no
+synthetic parent and enough origin metadata to trace it back. Re-entering that
+node during the same Run appends another Turn to the existing Thread while
+recording a distinct node-run:
 
 ```json
 {
@@ -204,10 +206,14 @@ The complete response is trimmed and must exactly equal one generated route
 token. Prose, code fences, unknown tokens, and ambiguous output fail the node;
 the runtime does not search substrings, guess a default, or retry.
 
-Runtime preflight accepts acyclic graphs whose Router branches may reconverge.
-Every node must be reachable from Input and able to reach Output. Input and
-Agent nodes have one outgoing edge, each Router route has one outgoing edge,
-and non-Router branching and cycles remain unsupported.
+Runtime preflight accepts Router branches that reconverge or form controlled
+loops. Every cyclic strongly connected component must contain a Router with a
+route that exits the component; non-Router cycles and loops without an exit are
+rejected. Every node must be reachable from Input and able to reach Output.
+Input and Agent nodes have one outgoing edge, and each Router route has one
+outgoing edge. A Run may execute at most 64 Agent or Router node-runs, after
+which it fails explicitly rather than allowing a model-selected route to loop
+forever.
 
 The Graph revision identifies the definition loaded at run start and detects
 later divergence. The first version does not retain historical definition

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:44ce574f76afd1a41e5dfbc790bcb714213154dc3a816c34cfdd35e39e31b3b5 -->
+<!-- tinybot-module-fingerprint: sha256:f0234c0ac343498e90b562fde405a766cdd876c627777a841c6859909beeebb9 -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime
@@ -206,12 +206,14 @@ interfaces, while omitted overrides inherit application defaults. The Input
 node has no saved configuration; Run start requires a non-empty transient input
 and records that exact value on the Run. Legacy Input prompts are ignored and
 removed on the next save.
-Graph Runs use separate atomically replaced status files. Every Agent node
-invocation creates a canonical parentless Thread with `source: "agent_graph"`;
-its Rollout remains under the standard Thread root. Router nodes instead make
-one non-streaming, tool-free model request with a dedicated routing prompt,
+Graph Runs use separate atomically replaced status files. The first visit to an
+Agent node creates a canonical parentless Thread with `source: "agent_graph"`;
+later visits in the same Run continue that Thread with the preceding node's
+output. Its Rollout remains under the standard Thread root. Router nodes instead
+make one non-streaming, tool-free model request with a dedicated routing prompt,
 strictly parse an exact generated route token, and persist the selected stable
-route ID without creating a Thread.
+route ID without creating a Thread. Router-controlled loops require an exit
+route and are bounded to 64 Agent or Router executions per Run.
 
 For a Chat Thread with an explicitly declared working directory, the tool
 registry adds only Graphs stored in that same definition workspace. The global

--- a/src-tauri/src/graph_runs.rs
+++ b/src-tauri/src/graph_runs.rs
@@ -22,6 +22,7 @@ use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const AGENT_GRAPH_RUN_SCHEMA_VERSION: &str = "tinybot.agent_graph_run.v1";
+const MAX_AGENT_GRAPH_NODE_RUNS: usize = 64;
 static RUN_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static STORE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
@@ -237,17 +238,24 @@ pub(crate) async fn start(
         match node {
             PlannedNode::Output => break,
             PlannedNode::Agent(step) => {
+                if let Err(error) = ensure_node_run_budget(&run) {
+                    return finish_failed_run_without_node(data_root, run, error);
+                }
+                let existing_thread_id = latest_agent_thread(&run, &step.node_id);
                 let index = begin_node_run(data_root, &mut run, &step.node_id)?;
-                let thread_id = match create_agent_graph_thread(
-                    &thread_store,
-                    &config_snapshot,
-                    &stored.definition.name,
-                    &step,
-                    &run,
-                    index,
-                ) {
-                    Ok(thread_id) => thread_id,
-                    Err(error) => return finish_failed_run(data_root, run, index, error),
+                let thread_id = match existing_thread_id {
+                    Some(thread_id) => thread_id,
+                    None => match create_agent_graph_thread(
+                        &thread_store,
+                        &config_snapshot,
+                        &stored.definition.name,
+                        &step,
+                        &run,
+                        index,
+                    ) {
+                        Ok(thread_id) => thread_id,
+                        Err(error) => return finish_failed_run(data_root, run, index, error),
+                    },
                 };
                 run.node_runs[index].thread_id = Some(thread_id.clone());
                 write_run(data_root, &run)?;
@@ -323,6 +331,9 @@ pub(crate) async fn start(
                 cursor = single_outgoing_edge(&plan, &step.node_id)?.target.clone();
             }
             PlannedNode::Router(router_config) => {
+                if let Err(error) = ensure_node_run_budget(&run) {
+                    return finish_failed_run_without_node(data_root, run, error);
+                }
                 let index = begin_node_run(data_root, &mut run, &cursor)?;
                 let decision = router::route(&config_snapshot, &current_input, &router_config);
                 tokio::pin!(decision);
@@ -489,6 +500,7 @@ fn agent_graph_plan(definition: &AgentGraphDefinition) -> Result<AgentGraphPlan,
     if reachable_from_input.len() != nodes.len() {
         return Err("Agent Graph Run does not support disconnected nodes".to_string());
     }
+    validate_controlled_cycles(&nodes, &outgoing)?;
     let output = definition
         .nodes
         .iter()
@@ -513,7 +525,6 @@ fn agent_graph_plan(definition: &AgentGraphDefinition) -> Result<AgentGraphPlan,
     if reachable_nodes(&output.id, &reverse).len() != nodes.len() {
         return Err("Every Agent Graph path must reach the Output node".to_string());
     }
-    ensure_acyclic(&nodes, &outgoing, &incoming)?;
 
     Ok(AgentGraphPlan {
         input_node_id: input.id.clone(),
@@ -536,38 +547,148 @@ fn reachable_nodes(start: &str, outgoing: &HashMap<String, Vec<PlannedEdge>>) ->
     visited
 }
 
-fn ensure_acyclic(
+fn validate_controlled_cycles(
     nodes: &HashMap<String, PlannedNode>,
     outgoing: &HashMap<String, Vec<PlannedEdge>>,
-    incoming: &HashMap<String, Vec<String>>,
 ) -> Result<(), String> {
-    let mut incoming_counts = nodes
-        .keys()
-        .map(|node_id| (node_id.clone(), incoming.get(node_id).map_or(0, Vec::len)))
-        .collect::<HashMap<_, _>>();
-    let mut pending = incoming_counts
-        .iter()
-        .filter_map(|(node_id, count)| (*count == 0).then_some(node_id.clone()))
-        .collect::<Vec<_>>();
-    let mut visited_count = 0;
-    while let Some(node_id) = pending.pop() {
-        visited_count += 1;
-        if let Some(edges) = outgoing.get(&node_id) {
-            for edge in edges {
-                let count = incoming_counts
-                    .get_mut(&edge.target)
-                    .expect("edge target must be a planned node");
-                *count -= 1;
-                if *count == 0 {
-                    pending.push(edge.target.clone());
-                }
-            }
+    for component in strongly_connected_components(nodes, outgoing) {
+        let has_cycle = component.len() > 1
+            || component.first().is_some_and(|node_id| {
+                outgoing
+                    .get(node_id)
+                    .into_iter()
+                    .flatten()
+                    .any(|edge| edge.target == *node_id)
+            });
+        if !has_cycle {
+            continue;
+        }
+        let routers = component
+            .iter()
+            .filter(|node_id| matches!(nodes.get(*node_id), Some(PlannedNode::Router(_))))
+            .collect::<Vec<_>>();
+        if routers.is_empty() {
+            return Err(format!(
+                "Agent Graph cycle `{}` must include a Router",
+                component.join(" -> ")
+            ));
+        }
+        if !routers.iter().any(|node_id| {
+            outgoing
+                .get(*node_id)
+                .into_iter()
+                .flatten()
+                .any(|edge| !component.contains(&edge.target))
+        }) {
+            return Err(format!(
+                "Agent Graph cycle `{}` requires a Router route that exits the loop",
+                component.join(" -> ")
+            ));
         }
     }
-    if visited_count != nodes.len() {
-        return Err("Agent Graph Run does not support cycles".to_string());
+    Ok(())
+}
+
+fn strongly_connected_components(
+    nodes: &HashMap<String, PlannedNode>,
+    outgoing: &HashMap<String, Vec<PlannedEdge>>,
+) -> Vec<Vec<String>> {
+    let mut visited = HashSet::new();
+    let mut order = Vec::new();
+    for node_id in nodes.keys() {
+        visit_component_order(node_id, outgoing, &mut visited, &mut order);
+    }
+
+    let mut reverse = HashMap::<String, Vec<String>>::new();
+    for (source, edges) in outgoing {
+        for edge in edges {
+            reverse
+                .entry(edge.target.clone())
+                .or_default()
+                .push(source.clone());
+        }
+    }
+
+    visited.clear();
+    let mut components = Vec::new();
+    while let Some(node_id) = order.pop() {
+        if visited.contains(&node_id) {
+            continue;
+        }
+        let mut component = Vec::new();
+        collect_component(&node_id, &reverse, &mut visited, &mut component);
+        component.sort();
+        components.push(component);
+    }
+    components
+}
+
+fn visit_component_order(
+    node_id: &str,
+    outgoing: &HashMap<String, Vec<PlannedEdge>>,
+    visited: &mut HashSet<String>,
+    order: &mut Vec<String>,
+) {
+    if !visited.insert(node_id.to_string()) {
+        return;
+    }
+    if let Some(edges) = outgoing.get(node_id) {
+        for edge in edges {
+            visit_component_order(&edge.target, outgoing, visited, order);
+        }
+    }
+    order.push(node_id.to_string());
+}
+
+fn collect_component(
+    node_id: &str,
+    reverse: &HashMap<String, Vec<String>>,
+    visited: &mut HashSet<String>,
+    component: &mut Vec<String>,
+) {
+    if !visited.insert(node_id.to_string()) {
+        return;
+    }
+    component.push(node_id.to_string());
+    if let Some(sources) = reverse.get(node_id) {
+        for source in sources {
+            collect_component(source, reverse, visited, component);
+        }
+    }
+}
+
+fn ensure_node_run_budget(run: &AgentGraphRun) -> Result<(), String> {
+    if run.node_runs.len() >= MAX_AGENT_GRAPH_NODE_RUNS {
+        return Err(format!(
+            "Agent Graph Run exceeded the limit of {MAX_AGENT_GRAPH_NODE_RUNS} node executions"
+        ));
     }
     Ok(())
+}
+
+fn latest_agent_thread(run: &AgentGraphRun, node_id: &str) -> Option<String> {
+    run.node_runs.iter().rev().find_map(|node_run| {
+        if node_run.node_id == node_id {
+            node_run.thread_id.clone()
+        } else {
+            None
+        }
+    })
+}
+
+fn finish_failed_run_without_node(
+    data_root: &Path,
+    mut run: AgentGraphRun,
+    error: String,
+) -> Result<AgentGraphRun, String> {
+    run.status = AgentGraphRunStatus::Failed;
+    run.error = Some(error);
+    write_run(data_root, &run)?;
+    eprintln!(
+        "agent_graph_run_failed graph_id={} run_id={} reason=node_execution_limit",
+        run.graph_id, run.id
+    );
+    Ok(run)
 }
 
 fn single_outgoing_edge<'a>(
@@ -948,6 +1069,168 @@ mod tests {
     }
 
     #[test]
+    fn reentered_agent_uses_its_latest_existing_thread() {
+        let run = AgentGraphRun {
+            schema_version: AGENT_GRAPH_RUN_SCHEMA_VERSION.to_string(),
+            id: "run-loop".to_string(),
+            graph_id: "graph-loop".to_string(),
+            graph_revision: "sha256:test".to_string(),
+            definition_workspace_path: "workspace".to_string(),
+            status: AgentGraphRunStatus::Running,
+            input: "start".to_string(),
+            node_runs: vec![
+                AgentGraphNodeRun {
+                    id: "node-1".to_string(),
+                    node_id: "agent-a".to_string(),
+                    thread_id: Some("thread-a-1".to_string()),
+                    status: AgentGraphNodeRunStatus::Completed,
+                    router: None,
+                    error: None,
+                },
+                AgentGraphNodeRun {
+                    id: "node-2".to_string(),
+                    node_id: "agent-b".to_string(),
+                    thread_id: Some("thread-b".to_string()),
+                    status: AgentGraphNodeRunStatus::Completed,
+                    router: None,
+                    error: None,
+                },
+                AgentGraphNodeRun {
+                    id: "node-3".to_string(),
+                    node_id: "agent-a".to_string(),
+                    thread_id: Some("thread-a-2".to_string()),
+                    status: AgentGraphNodeRunStatus::Completed,
+                    router: None,
+                    error: None,
+                },
+            ],
+            output: None,
+            error: None,
+        };
+
+        assert_eq!(
+            latest_agent_thread(&run, "agent-a").as_deref(),
+            Some("thread-a-2")
+        );
+        assert_eq!(latest_agent_thread(&run, "missing"), None);
+    }
+
+    #[test]
+    fn node_execution_budget_stops_unbounded_router_loops() {
+        let node_runs = (0..MAX_AGENT_GRAPH_NODE_RUNS)
+            .map(|index| AgentGraphNodeRun {
+                id: format!("node-{index}"),
+                node_id: "router".to_string(),
+                thread_id: None,
+                status: AgentGraphNodeRunStatus::Completed,
+                router: None,
+                error: None,
+            })
+            .collect::<Vec<_>>();
+        let mut run = AgentGraphRun {
+            schema_version: AGENT_GRAPH_RUN_SCHEMA_VERSION.to_string(),
+            id: "run-budget".to_string(),
+            graph_id: "graph-loop".to_string(),
+            graph_revision: "sha256:test".to_string(),
+            definition_workspace_path: "workspace".to_string(),
+            status: AgentGraphRunStatus::Running,
+            input: "start".to_string(),
+            node_runs,
+            output: None,
+            error: None,
+        };
+
+        assert!(ensure_node_run_budget(&run)
+            .unwrap_err()
+            .contains("64 node executions"));
+        run.node_runs.pop();
+        ensure_node_run_budget(&run).unwrap();
+    }
+
+    #[test]
+    fn rejects_cycles_that_are_not_controlled_by_a_router() {
+        let agent = |node_id: &str| {
+            PlannedNode::Agent(AgentStep {
+                node_id: node_id.to_string(),
+                workspace_path: "workspace".to_string(),
+                instructions: String::new(),
+                model: None,
+            })
+        };
+        let nodes = HashMap::from([
+            ("agent-a".to_string(), agent("agent-a")),
+            ("agent-b".to_string(), agent("agent-b")),
+        ]);
+        let outgoing = HashMap::from([
+            (
+                "agent-a".to_string(),
+                vec![PlannedEdge {
+                    id: "edge-a-b".to_string(),
+                    target: "agent-b".to_string(),
+                    source_route_id: None,
+                }],
+            ),
+            (
+                "agent-b".to_string(),
+                vec![PlannedEdge {
+                    id: "edge-b-a".to_string(),
+                    target: "agent-a".to_string(),
+                    source_route_id: None,
+                }],
+            ),
+        ]);
+
+        assert!(validate_controlled_cycles(&nodes, &outgoing)
+            .unwrap_err()
+            .contains("must include a Router"));
+    }
+
+    #[test]
+    fn rejects_router_cycles_without_an_exit_route() {
+        let nodes = HashMap::from([
+            (
+                "router".to_string(),
+                PlannedNode::Router(AgentGraphRouterNodeConfig {
+                    task: None,
+                    routes: Vec::new(),
+                    model: None,
+                }),
+            ),
+            (
+                "agent".to_string(),
+                PlannedNode::Agent(AgentStep {
+                    node_id: "agent".to_string(),
+                    workspace_path: "workspace".to_string(),
+                    instructions: String::new(),
+                    model: None,
+                }),
+            ),
+        ]);
+        let outgoing = HashMap::from([
+            (
+                "router".to_string(),
+                vec![PlannedEdge {
+                    id: "edge-router-agent".to_string(),
+                    target: "agent".to_string(),
+                    source_route_id: Some("again".to_string()),
+                }],
+            ),
+            (
+                "agent".to_string(),
+                vec![PlannedEdge {
+                    id: "edge-agent-router".to_string(),
+                    target: "router".to_string(),
+                    source_route_id: None,
+                }],
+            ),
+        ]);
+
+        assert!(validate_controlled_cycles(&nodes, &outgoing)
+            .unwrap_err()
+            .contains("requires a Router route that exits the loop"));
+    }
+
+    #[test]
     fn rejects_a_branch_from_a_non_router_node() {
         let fixture = Fixture::new();
         let mut definition = fixture.definition();
@@ -1006,33 +1289,39 @@ mod tests {
     }
 
     #[test]
-    fn rejects_cycles_even_when_a_router_can_reach_output() {
+    fn plans_router_controlled_rework_loops() {
         let fixture = Fixture::new();
         let definition: AgentGraphDefinition = serde_json::from_value(serde_json::json!({
             "schemaVersion": "tinybot.agent_graph.v1",
             "id": "graph-cycle",
-            "name": "Cycle",
+            "name": "Evidence review loop",
             "nodes": [
                 { "id": "input", "kind": "input", "position": { "x": 0, "y": 0 } },
-                { "id": "router", "kind": "condition", "position": { "x": 100, "y": 0 }, "config": { "routes": [
-                    { "id": "again", "label": "Again", "description": "Repeat." },
-                    { "id": "done", "label": "Done", "description": "Finish." }
+                { "id": "agent-a", "kind": "agent", "position": { "x": 100, "y": 0 }, "config": { "workspacePath": fixture.first_workspace, "instructions": "Investigate the alert." } },
+                { "id": "router", "kind": "condition", "position": { "x": 200, "y": 0 }, "config": { "routes": [
+                    { "id": "more-evidence", "label": "More evidence", "description": "The conclusion needs more evidence." },
+                    { "id": "done", "label": "Done", "description": "The conclusion is supported." }
                 ] } },
-                { "id": "agent", "kind": "agent", "position": { "x": 200, "y": 0 }, "config": { "workspacePath": fixture.first_workspace, "instructions": "" } },
-                { "id": "output", "kind": "output", "position": { "x": 300, "y": 0 } }
+                { "id": "agent-b", "kind": "agent", "position": { "x": 300, "y": 100 }, "config": { "workspacePath": fixture.second_workspace, "instructions": "Request the missing evidence." } },
+                { "id": "output", "kind": "output", "position": { "x": 300, "y": -100 } }
             ],
             "edges": [
-                { "id": "edge-input", "source": "input", "target": "router" },
-                { "id": "edge-again", "source": "router", "target": "agent", "sourceRouteId": "again" },
+                { "id": "edge-input", "source": "input", "target": "agent-a" },
+                { "id": "edge-review", "source": "agent-a", "target": "router" },
+                { "id": "edge-more-evidence", "source": "router", "target": "agent-b", "sourceRouteId": "more-evidence" },
                 { "id": "edge-done", "source": "router", "target": "output", "sourceRouteId": "done" },
-                { "id": "edge-cycle", "source": "agent", "target": "router" }
+                { "id": "edge-rework", "source": "agent-b", "target": "agent-a" }
             ]
         }))
         .unwrap();
 
-        let error = agent_graph_plan(&definition).unwrap_err();
+        let plan = agent_graph_plan(&definition).expect("Router-controlled loops should plan");
 
-        assert!(error.contains("cycles"));
+        assert_eq!(
+            single_outgoing_edge(&plan, "agent-b").unwrap().target,
+            "agent-a"
+        );
+        assert_eq!(plan.outgoing["router"].len(), 2);
     }
 
     #[test]

--- a/src/app-core/agent-graph/README.md
+++ b/src/app-core/agent-graph/README.md
@@ -32,13 +32,17 @@ workspace instructions remain intact. Nodes without a model override inherit
 application defaults. `AgentGraphRuntime.start` requires a non-empty input for
 each execution and copies that runtime value into the Run record; it is never
 part of the saved definition. Legacy persisted Input prompts are discarded when
-definitions are loaded or saved. The runtime accepts an acyclic Input-to-Output graph with model-driven Router
-branches and reconvergence. Router definitions contain an optional routing
+definitions are loaded or saved. The runtime accepts an Input-to-Output graph
+with model-driven Router branches, reconvergence, and controlled loops. Every
+loop must contain a Router route that exits it, and a Run is bounded to 64 Agent
+or Router executions. Router definitions contain an optional routing
 task, at least two stable route IDs with required labels and descriptions, and
 an optional provider/model/reasoning override. Every route owns exactly one
 outgoing edge through `sourceRouteId`; removing a route prunes its edge. Runtime
-preflight rejects cycles, disconnected nodes, incomplete routes, unsupported
-non-Router branching, or missing execution workspaces before creating a Run.
+preflight rejects non-Router cycles, loops without an exit, disconnected nodes,
+incomplete routes, unsupported non-Router branching, or missing execution
+workspaces before creating a Run. Re-entering an Agent node in one Run continues
+that node's existing Thread.
 See
 [ADR 0001](../../../docs/decisions/0001-agent-graph-definitions-runs-and-threads.md)
 for the store Interface, revision rules, and runtime boundary.

--- a/src/react-workbench/agent-graph/AgentGraphNodeDrawer.tsx
+++ b/src/react-workbench/agent-graph/AgentGraphNodeDrawer.tsx
@@ -30,7 +30,7 @@ export function AgentGraphNodeDrawer({
 }) {
   const { t } = useTranslation("common");
   const nodeRun = node.kind === "agent" || node.kind === "condition"
-    ? run?.nodeRuns.find((candidate) => candidate.nodeId === node.id)
+    ? [...(run?.nodeRuns ?? [])].reverse().find((candidate) => candidate.nodeId === node.id)
     : undefined;
   const [timeline, setTimeline] = useState<ChatTimelineSnapshot | null>(null);
   const [timelineError, setTimelineError] = useState<string | null>(null);

--- a/src/react-workbench/agent-graph/AgentGraphsRoute.test.tsx
+++ b/src/react-workbench/agent-graph/AgentGraphsRoute.test.tsx
@@ -473,6 +473,15 @@ describe("AgentGraphsRoute", () => {
         nodeId: "router",
         status: "completed",
         router: {
+          rawResponse: "ROUTE_A",
+          selectedEdgeId: "edge-code",
+          selectedRouteId: "code",
+        },
+      }, {
+        id: "run-router-node-2",
+        nodeId: "router",
+        status: "completed",
+        router: {
           rawResponse: "ROUTE_B",
           selectedEdgeId: "edge-answer",
           selectedRouteId: "answer",

--- a/src/react-workbench/agent-graph/README.md
+++ b/src/react-workbench/agent-graph/README.md
@@ -1,5 +1,5 @@
 # Agent Graph Workbench
-<!-- tinybot-module-fingerprint: sha256:792a2f851855c19ae5395e06518c96a422acc883af2fb27bb2ba7a7b8b9f0208 -->
+<!-- tinybot-module-fingerprint: sha256:7cfbd908279ca5b0aed7abe506327321d400b08eeed3c20131e21fada69449e7 -->
 
 `agent-graph` owns the standalone Agent Graph route and its React presentation.
 The page creates one honest in-memory starter draft and exposes an unbounded
@@ -48,14 +48,16 @@ Graph as a Chat mode. It reuses only Chat's timeline presentation for standard
 Graph-owned Threads. It consumes the framework-independent definition in
 `app-core/agent-graph`; persistence and execution arrive through
 dedicated Graph interfaces. Execution follows one selected path through an
-acyclic graph, permits Router branches to reconverge, and creates Run entries
-only for nodes actually visited. Backend preflight rejects non-Router
-branching, cycles, disconnected nodes, incomplete route connections, and
-missing Agent workspaces.
+Graph, permits Router branches to reconverge or form bounded controlled loops,
+and creates one Run entry per node visit. Node status and Router details use the
+latest visit; an Agent re-entry continues its existing Thread so its timeline
+contains the complete loop history. Backend preflight rejects non-Router
+branching, uncontrolled cycles, disconnected nodes, incomplete route
+connections, and missing Agent workspaces.
 
 The page may reuse the workspaces already known to Chat and project groups as
 choices, but the selected definition workspace and each Agent node's execution
 workspace belong to Graph state. Graph definitions and Runs use distinct stores,
-and each Agent node creates a parentless standard Thread identified by
-`source: "agent_graph"` without routing execution through Chat. See
+and each Agent node's first visit creates a parentless standard Thread identified
+by `source: "agent_graph"` without routing execution through Chat. See
 [ADR 0001](../../../docs/decisions/0001-agent-graph-definitions-runs-and-threads.md).


### PR DESCRIPTION
## Summary
- allow Router-controlled rework loops in Agent Graph execution
- resume an Agent node's existing thread when the graph re-enters it
- cap Agent and Router executions at 64 to prevent unbounded loops
- show the latest repeated node execution in the run drawer

## Verification
- cargo test -j 4 graph_runs::tests
- cargo test -j 4 agent_graph
- cargo check -j 4
- cargo fmt --all -- --check
- npm test -- src/react-workbench/agent-graph/AgentGraphsRoute.test.tsx
- npm run typecheck
- npm run lint
- npm run readme:check
- npm run docs:check