### PR TITLE
Add persistent sidebar drag ordering

### DIFF
--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:f6edec760272f9c250271058c20f83e9115e2ae56c71ed27436995705494868e -->
+<!-- tinybot-doc-fingerprint: sha256:703f7c0745a79d90c144dd769971c79478584a5617dc1cceae0d70cdefa0668f -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -94,7 +94,9 @@ Desktop Commands / Desktop Host
 - Chat startup selection: `DesktopShell` marks only the first Chat mount in a
   desktop app lifetime as an uncreated conversation. Persisted tab state may be
   reused by later route remounts in that same lifetime, but it is not the app
-  launch selection authority.
+  launch selection authority. User new-chat commands create renderer-owned draft
+  sessions; only drafts with composer text survive navigation, and the first
+  send replaces the draft with a canonical Thread before dispatching its Turn.
 - Agent Graph definitions: versioned `app-core/agent-graph` values stored under
   `<workspace>/.tinybot/graphs/` through the native `agent_graphs` Adapter.
   Node positions are signed world coordinates; viewport pan, zoom, and fit-to-view

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:da8f2fda8518c70289866519ab19f624f8b0997eb1ee7f2de4d172f3f2bcb59d -->
+<!-- tinybot-doc-fingerprint: sha256:f6edec760272f9c250271058c20f83e9115e2ae56c71ed27436995705494868e -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -1,5 +1,5 @@
 # Agent
-<!-- tinybot-module-fingerprint: sha256:089c63d6b22bea282820511f2c2f1a9203f0b883fbd2a9f973b776f27d01ee8c -->
+<!-- tinybot-module-fingerprint: sha256:32806ec7b14ffd7ee442119d2d5c3118143e5a26a9b84a4186c48ba225c15889 -->
 
 `agent` contains the native agent stack. It connects provider configuration,
 the turn runtime, durable runtime events, and the desktop integration bridge.
@@ -9,4 +9,5 @@ and event projection live in `runtime/` and `runtime_protocol/`.
 `router.rs` is the deliberately smaller Agent Graph routing seam: it builds one
 dedicated, non-streaming, tool-free provider request, strictly maps the complete
 `ROUTE_*` response to a stable definition route ID, and does not enter the
-Agent Loop or create a Thread.
+Agent Loop or create a Thread. Router requests preserve explicit node provider
+overrides and otherwise use the active application provider profile.

--- a/src-tauri/src/agent/provider/README.md
+++ b/src-tauri/src/agent/provider/README.md
@@ -1,5 +1,5 @@
 # Agent Providers
-<!-- tinybot-module-fingerprint: sha256:8aff12bd90b2dcc07e1188699307cde57e816e9a5e953ffdabd25998d39997a7 -->
+<!-- tinybot-module-fingerprint: sha256:72debde400ecf2083f327787a4d790df4f173eb4c701821225c54c9ff82daa59 -->
 
 This module resolves provider and model configuration and performs streaming
 Chat Completions or Responses API requests.
@@ -10,5 +10,7 @@ Chat Completions or Responses API requests.
   providers default `supportsReasoningEffort` to `true`; an explicit `false`
   keeps effort out of provider requests. Profile `modelContextWindows` entries
   are normalized into positive per-model context-window overrides.
-- `completion.rs` performs provider requests.
+- `completion.rs` performs provider requests. Provider selection preserves an
+  explicit request override, then uses the active profile, and only infers from
+  the model when neither is configured.
 - `streaming.rs` normalizes streamed provider events.

--- a/src-tauri/src/agent/provider/catalog.rs
+++ b/src-tauri/src/agent/provider/catalog.rs
@@ -589,7 +589,7 @@ fn default_provider_id(config: &Value) -> Option<String> {
         .filter(|value| !value.is_empty() && value != "auto")
 }
 
-fn active_profile_name(config: &Value) -> Option<String> {
+pub(super) fn active_profile_name(config: &Value) -> Option<String> {
     config
         .get("agents")
         .and_then(|agents| agents.get("defaults"))

--- a/src-tauri/src/agent/provider/completion.rs
+++ b/src-tauri/src/agent/provider/completion.rs
@@ -1,6 +1,6 @@
 use super::catalog::{
-    catalog_entry_by_id, configured_model, infer_provider_from_model, normalize_provider_id,
-    resolve_provider_profile, string_field, NativeProviderProfile,
+    active_profile_name, catalog_entry_by_id, configured_model, infer_provider_from_model,
+    normalize_provider_id, resolve_provider_profile, string_field, NativeProviderProfile,
 };
 use super::streaming::{
     chat_completion_body, responses_body, NativeProviderStreamEvent, StreamingChatCompletion,
@@ -510,14 +510,18 @@ fn openai_client(profile: NativeProviderProfile) -> Result<Client<OpenAIConfig>,
 }
 
 fn resolve_chat_provider_profile(config: &Value, model: &str) -> Option<NativeProviderProfile> {
-    let default_provider = config
+    let provider_id = config
         .get("agents")
         .and_then(|agents| agents.get("defaults"))
-        .and_then(|defaults| string_field(defaults, "provider"));
-    let provider_id = default_provider
-        .as_deref()
-        .map(normalize_provider_id)
+        .and_then(|defaults| string_field(defaults, "provider"))
+        .map(|provider| normalize_provider_id(&provider))
         .filter(|provider| !provider.is_empty() && provider != "auto")
+        .or_else(|| {
+            active_profile_name(config).and_then(|profile_name| {
+                resolve_provider_profile(config, None, Some(&profile_name))
+                    .map(|profile| profile.provider_id)
+            })
+        })
         .unwrap_or_else(|| infer_provider_from_model(model));
     resolve_provider_profile(config, Some(&provider_id), None)
 }

--- a/src-tauri/src/agent/router.rs
+++ b/src-tauri/src/agent/router.rs
@@ -330,6 +330,32 @@ mod tests {
     }
 
     #[test]
+    fn inherited_router_uses_active_custom_profile_for_a_custom_model() {
+        let decision = tauri::async_runtime::block_on(route(
+            &serde_json::json!({
+                "agents": {
+                    "defaults": {
+                        "activeProfile": "fixture-default",
+                        "model": "custom-routing-model"
+                    }
+                },
+                "providers": {
+                    "profiles": {
+                        "fixture-default": { "provider": "fixture" }
+                    },
+                    "fixture": { "responses": [{ "content": "ROUTE_B" }] }
+                }
+            }),
+            "Review found an actionable issue.",
+            &router_config(),
+        ))
+        .expect("the inherited active profile should handle the Router request");
+
+        assert_eq!(decision.route_id, "changes");
+        assert_eq!(decision.raw_response, "ROUTE_B");
+    }
+
+    #[test]
     fn generates_route_tokens_beyond_z() {
         assert_eq!(route_token(0), "ROUTE_A");
         assert_eq!(route_token(25), "ROUTE_Z");

--- a/src/react-workbench/agent-graph/AgentGraphsRoute.css
+++ b/src/react-workbench/agent-graph/AgentGraphsRoute.css
@@ -993,6 +993,20 @@
   margin-top: 6px;
 }
 
+.react-agent-graph-node-config .react-settings-choice-item .react-top-menu__menu-label {
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 2px;
+}
+
+.react-agent-graph-node-config .react-settings-choice-item small {
+  justify-self: start;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 .react-agent-graph-node-config__textarea-field {
   display: grid;
   gap: 7px;
@@ -1118,7 +1132,8 @@
 }
 
 .react-agent-graph-router-route input,
-.react-agent-graph-router-route textarea {
+.react-agent-graph-router-route textarea,
+.react-agent-graph-run__input input {
   width: 100%;
   padding: 8px 9px;
   resize: vertical;
@@ -1136,7 +1151,8 @@
 }
 
 .react-agent-graph-router-route input:focus-visible,
-.react-agent-graph-router-route textarea:focus-visible {
+.react-agent-graph-router-route textarea:focus-visible,
+.react-agent-graph-run__input input:focus-visible {
   border-color: var(--color-primary);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 20%, transparent);
   outline: none;
@@ -2062,15 +2078,6 @@
 .react-agent-graphs-page[data-editor-open="true"] .react-agent-graph-run__status-dot {
   flex: 0 0 auto;
   color: var(--color-muted-soft);
-}
-
-.react-agent-graphs-page[data-editor-open="true"] .react-agent-graph-run__input input {
-  width: 100%;
-  min-height: 38px;
-  border-color: var(--graph-border);
-  background: var(--graph-panel-deep);
-  color: var(--color-ink);
-  font-size: 11px;
 }
 
 .react-agent-graphs-page[data-editor-open="true"] .react-agent-graph-run[data-status="running"] .react-agent-graph-run__status-dot {

--- a/src/react-workbench/agent-graph/AgentGraphsRoute.test.tsx
+++ b/src/react-workbench/agent-graph/AgentGraphsRoute.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { readFileSync } from "node:fs";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -17,6 +18,20 @@ import AgentGraphsRoute from "./AgentGraphsRoute";
 afterEach(cleanup);
 
 describe("AgentGraphsRoute", () => {
+  it("stacks choice copy inside the narrow node configuration popover", () => {
+    const css = readFileSync("src/react-workbench/agent-graph/AgentGraphsRoute.css", "utf8");
+
+    expect(css).toMatch(/\.react-agent-graph-node-config \.react-settings-choice-item \.react-top-menu__menu-label\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\);/s);
+    expect(css).toMatch(/\.react-agent-graph-node-config \.react-settings-choice-item small\s*{[^}]*white-space:\s*normal;[^}]*overflow-wrap:\s*anywhere;/s);
+  });
+
+  it("reuses the configured field appearance for the run input", () => {
+    const css = readFileSync("src/react-workbench/agent-graph/AgentGraphsRoute.css", "utf8");
+
+    expect(css).toMatch(/\.react-agent-graph-router-route input,\s*\.react-agent-graph-router-route textarea,\s*\.react-agent-graph-run__input input\s*{[^}]*border:\s*1px solid var\(--graph-border\);[^}]*border-radius:\s*7px;[^}]*background:\s*var\(--graph-panel-solid\);/s);
+    expect(css).toMatch(/\.react-agent-graph-router-route input:focus-visible,\s*\.react-agent-graph-router-route textarea:focus-visible,\s*\.react-agent-graph-run__input input:focus-visible\s*{[^}]*box-shadow:/s);
+  });
+
   it("creates and discards an isolated in-memory graph draft", async () => {
     const user = userEvent.setup();
     render(<AgentGraphsRoute services={createServices()} />);

--- a/src/react-workbench/agent-graph/README.md
+++ b/src/react-workbench/agent-graph/README.md
@@ -1,5 +1,5 @@
 # Agent Graph Workbench
-<!-- tinybot-module-fingerprint: sha256:7cfbd908279ca5b0aed7abe506327321d400b08eeed3c20131e21fada69449e7 -->
+<!-- tinybot-module-fingerprint: sha256:bdce3621e62aa933519df83bffdfdb29eb8b4c5f2186de931f95dfbe7a73df34 -->
 
 `agent-graph` owns the standalone Agent Graph route and its React presentation.
 The page creates one honest in-memory starter draft and exposes an unbounded
@@ -32,7 +32,10 @@ selection descriptions. Each route renders its own accessible source handle,
 while generated `ROUTE_A`, `ROUTE_B`, and later tokens stay runtime-only.
 Definition workspace, execution workspace, Provider, model, and reasoning
 controls reuse the workbench's canonical `SettingsChoiceList` appearance and
-interaction; Graph only owns their placement.
+interaction; Graph only owns their placement. Option titles and descriptions
+stack inside the narrow node configuration popover so localized copy cannot
+collide with the selected-state indicator. The compact Run input reuses the
+same field treatment as Router route inputs.
 The route lists, explicitly saves, opens, and deletes
 workspace definitions through `AgentGraphStore`; dirty state and revision
 conflicts stay visible. A separate Run panel accepts the required transient

--- a/src/react-workbench/chat/ChatPage.composer.test.tsx
+++ b/src/react-workbench/chat/ChatPage.composer.test.tsx
@@ -1026,6 +1026,10 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
     await user.click(screen.getByRole("button", { name: "New conversation tab" }));
 
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Use the saved model");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
     expect(stores.sessionStore.create).toHaveBeenCalledWith({
       model: "deepseek-v4-flash-vision-exp",
     });

--- a/src/react-workbench/chat/ChatPage.composer.test.tsx
+++ b/src/react-workbench/chat/ChatPage.composer.test.tsx
@@ -1022,8 +1022,9 @@ describe("ChatPage", () => {
     expect(window.localStorage.getItem("tinybot.ui.chat.composer-model"))
       .toBe("deepseek-v4-flash-vision-exp");
 
-    const sidebar = await screen.findByLabelText("Sessions");
-    await user.click(within(sidebar).getByRole("button", { name: "New chat" }));
+    await screen.findByLabelText("Sessions");
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
 
     expect(stores.sessionStore.create).toHaveBeenCalledWith({
       model: "deepseek-v4-flash-vision-exp",

--- a/src/react-workbench/chat/ChatPage.messages.test.tsx
+++ b/src/react-workbench/chat/ChatPage.messages.test.tsx
@@ -375,7 +375,9 @@ describe("ChatPage", () => {
     await user.type(input, "Summarize this pending chat");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
-    expect((await screen.findByTestId("message-local-user")).textContent).toContain("Summarize this pending chat");
+    await waitFor(() => expect(screen.getAllByText("Summarize this pending chat").some((element) => (
+      Boolean(element.closest('[data-testid^="message-"]'))
+    ))).toBe(true));
     expect(screen.queryByText("No sessions yet.")).toBeNull();
   });
 

--- a/src/react-workbench/chat/ChatPage.messages.test.tsx
+++ b/src/react-workbench/chat/ChatPage.messages.test.tsx
@@ -369,7 +369,8 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     await screen.findByText("No sessions yet.");
-    await user.click(screen.getByRole("button", { name: "New chat" }));
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
     const input = await screen.findByRole("textbox", { name: /message/i });
     await user.type(input, "Summarize this pending chat");
     await user.click(screen.getByRole("button", { name: /send message/i }));

--- a/src/react-workbench/chat/ChatPage.sessions.test.tsx
+++ b/src/react-workbench/chat/ChatPage.sessions.test.tsx
@@ -230,7 +230,12 @@ describe("ChatPage", () => {
     await user.click(workspaceSummary as HTMLElement);
     await user.click(within(workspace).getByRole("button", { name: "New session in tinybot" }));
 
-    expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory });
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "Continue in this workspace" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+    await waitFor(() => expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory }));
   });
 
   it("localizes the group for sessions without a working directory", async () => {
@@ -280,7 +285,68 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
     await user.click(screen.getByRole("button", { name: "New conversation tab" }));
 
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Continue here");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
     expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory });
+  });
+
+  it("discards an untouched local session draft when another session is selected", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+
+    render(<ChatPage chatStore={stores.chatStore} sessionStore={stores.sessionStore} />);
+
+    await screen.findByLabelText("Sessions");
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
+    expect(screen.getByRole("tab", { name: "New chat" })).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Planning notes" }));
+
+    expect(screen.queryByRole("tab", { name: "New chat" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Planning notes" })).toBeTruthy();
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+  });
+
+  it("keeps a non-empty local session draft when another session is selected", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+
+    render(<ChatPage chatStore={stores.chatStore} sessionStore={stores.sessionStore} />);
+
+    await screen.findByLabelText("Sessions");
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Keep this draft");
+
+    await user.click(screen.getByRole("button", { name: "Planning notes" }));
+    const draftTab = screen.getByRole("tab", { name: "New chat" });
+    expect(draftTab).toBeTruthy();
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+
+    await user.click(draftTab);
+    expect((screen.getByRole("textbox", { name: /message/i }) as HTMLTextAreaElement).value)
+      .toBe("Keep this draft");
+  });
+
+  it("restores a non-empty local session draft after leaving and returning to Chat", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const view = render(<ChatPage chatStore={stores.chatStore} sessionStore={stores.sessionStore} />);
+
+    await screen.findByLabelText("Sessions");
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Restore this draft");
+    view.unmount();
+
+    render(<ChatPage chatStore={stores.chatStore} sessionStore={stores.sessionStore} />);
+
+    expect((await screen.findByRole("textbox", { name: /message/i }) as HTMLTextAreaElement).value)
+      .toBe("Restore this draft");
+    expect(screen.getByRole("tab", { name: "New chat" })).toBeTruthy();
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
   });
 
   it("does not inherit an active coordinator when creating from the global action", async () => {
@@ -303,6 +369,9 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
     await user.click(screen.getByRole("button", { name: "New conversation tab" }));
 
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Start independently");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
     expect(stores.sessionStore.create).toHaveBeenCalledWith({});
   });
 
@@ -335,10 +404,13 @@ describe("ChatPage", () => {
     await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
     await user.click(screen.getByRole("button", { name: "New conversation tab" }));
 
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Start cleanly");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
     expect(stores.sessionStore.create).toHaveBeenCalledWith({});
   });
 
-  it("creates and opens the first session for a selected workspace folder", async () => {
+  it("shows a selected workspace as a local draft and creates it on first send", async () => {
     const user = userEvent.setup();
     const workingDirectory = "D:\\Code\\VirtualHome";
     const stores = createStores();
@@ -357,11 +429,17 @@ describe("ChatPage", () => {
     await user.click(within(sidebar).getByRole("menuitem", { name: "Add workspace folder" }));
 
     expect(await within(sidebar).findByRole("group", { name: "Workspace VirtualHome" })).toBeTruthy();
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    expect(stores.chatStore.load).not.toHaveBeenCalledWith("workspace-session");
+
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Inspect this workspace");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
     expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory });
     await waitFor(() => expect(stores.chatStore.load).toHaveBeenLastCalledWith("workspace-session"));
   });
 
-  it("selects a workspace folder and exposes native creation failures", async () => {
+  it("defers workspace creation failures until the first send and exposes them", async () => {
     const user = userEvent.setup();
     const stores = createStores();
     nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory.mockResolvedValueOnce("Z:\\missing");
@@ -377,6 +455,11 @@ describe("ChatPage", () => {
     await user.click(within(sidebar).getByRole("menuitem", { name: "Add workspace folder" }));
 
     expect(nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory).toHaveBeenCalledTimes(1);
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Inspect this workspace");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
     expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory: "Z:\\missing" });
     expect((await within(sidebar).findByRole("alert")).textContent).toContain(
       "failed to inspect working directory `Z:\\missing`",
@@ -438,6 +521,11 @@ describe("ChatPage", () => {
     });
     const project = await within(sidebar).findByRole("group", { name: "Project Commerce" });
     await user.click(within(project).getByRole("button", { name: "New coordination chat in Commerce" }));
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Coordinate the project");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
     expect(stores.sessionStore.create).toHaveBeenLastCalledWith({
       projectCoordinator: true,
       projectGroupId: "commerce",
@@ -502,12 +590,16 @@ describe("ChatPage", () => {
     const project = await within(sidebar).findByRole("group", { name: "Project group-1" });
     await user.click(within(project).getByRole("button", { name: "New session in tbtest" }));
 
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Work in tbtest");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+
     expect(stores.sessionStore.create).toHaveBeenLastCalledWith({
       workingDirectory,
       projectGroupId: "group-1",
     });
     await waitFor(() => expect(stores.chatStore.load).toHaveBeenLastCalledWith("created-workspace-session"));
-    const createdRow = within(project).getByRole("button", { name: "New session" })
+    const createdRow = within(project).getByRole("button", { name: "Work in tbtest" })
       .closest<HTMLElement>(".react-session-row");
     expect(createdRow?.dataset.active).toBe("true");
   });
@@ -573,6 +665,10 @@ describe("ChatPage", () => {
     />);
 
     await screen.findByRole("tab", { name: "Inspect workspace, running" });
+    await waitFor(() => expect(stores.chatStore.subscribe).toHaveBeenCalledWith(
+      runningSession.id,
+      expect.any(Function),
+    ));
     act(() => subscribed?.({ type: "timeline.patch", timeline: completedTimeline }));
 
     await waitFor(() => {
@@ -835,9 +931,13 @@ describe("ChatPage", () => {
     const dialog = screen.getByRole("dialog", { name: "Chat search" });
     await user.click(within(dialog).getByRole("button", { name: /New chat/ }));
 
-    await waitFor(() => expect(stores.sessionStore.create).toHaveBeenCalledTimes(1));
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog", { name: "Chat search" })).toBeNull();
     expect(screen.getByRole("heading", { name: "New chat" })).toBeTruthy();
+
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Start from search");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+    await waitFor(() => expect(stores.sessionStore.create).toHaveBeenCalledTimes(1));
   });
 
   it("uses a two-click delete confirmation in the session list", async () => {

--- a/src/react-workbench/chat/ChatPage.sessions.test.tsx
+++ b/src/react-workbench/chat/ChatPage.sessions.test.tsx
@@ -330,6 +330,33 @@ describe("ChatPage", () => {
       .toBe("Keep this draft");
   });
 
+  it("materializes the startup draft before opening another local draft", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+
+    render(
+      <ChatPage
+        chatStore={stores.chatStore}
+        now={() => Date.UTC(2026, 6, 4, 12, 0, 0)}
+        sessionStore={stores.sessionStore}
+        startInNewSession
+      />,
+    );
+
+    await screen.findByLabelText("Sessions");
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    const input = screen.getByRole("textbox", { name: /message/i }) as HTMLTextAreaElement;
+    await user.type(input, "Keep the startup draft");
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
+
+    const draftTabs = screen.getAllByRole("tab", { name: "New chat" });
+    expect(draftTabs).toHaveLength(2);
+    expect(input.value).toBe("");
+    await user.click(draftTabs[0]);
+    expect(input.value).toBe("Keep the startup draft");
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+  });
+
   it("restores a non-empty local session draft after leaving and returning to Chat", async () => {
     const user = userEvent.setup();
     const stores = createStores();
@@ -457,7 +484,8 @@ describe("ChatPage", () => {
     expect(nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory).toHaveBeenCalledTimes(1);
     expect(stores.sessionStore.create).not.toHaveBeenCalled();
 
-    await user.type(screen.getByRole("textbox", { name: /message/i }), "Inspect this workspace");
+    const input = screen.getByRole("textbox", { name: /message/i }) as HTMLTextAreaElement;
+    await user.type(input, "Inspect this workspace");
     await user.click(screen.getByRole("button", { name: /send message/i }));
 
     expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory: "Z:\\missing" });
@@ -471,6 +499,7 @@ describe("ChatPage", () => {
         workingDirectory: "Z:\\missing",
       }),
     );
+    expect(input.value).toBe("Inspect this workspace");
     consoleError.mockRestore();
   });
 

--- a/src/react-workbench/chat/ChatPage.sessions.test.tsx
+++ b/src/react-workbench/chat/ChatPage.sessions.test.tsx
@@ -158,17 +158,21 @@ describe("ChatPage", () => {
     const sidebar = await screen.findByLabelText("Sessions");
     expect(sidebar.getAttribute("data-collapsed")).toBe("false");
     expect(screen.getByRole("button", { name: "Planning notes" })).toBeTruthy();
+    expect(within(sidebar).queryByRole("button", { name: "New chat" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "New conversation tab" })).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
 
     expect(sidebar.getAttribute("data-collapsed")).toBe("true");
     expect(screen.getByRole("button", { name: "Planning notes" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Expand session sidebar" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "New conversation tab" })).toBeTruthy();
 
     await user.click(screen.getByRole("button", { name: "Expand session sidebar" }));
 
     expect(sidebar.getAttribute("data-collapsed")).toBe("false");
     expect(screen.getByRole("heading", { name: "Tinybot" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "New conversation tab" })).toBeNull();
   });
 
   it("groups sessions by workspace and creates another session in that directory", async () => {
@@ -272,8 +276,9 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
-    const sidebar = await screen.findByLabelText("Sessions");
-    await user.click(within(sidebar).getByRole("button", { name: "New chat" }));
+    await screen.findByLabelText("Sessions");
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
 
     expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory });
   });
@@ -294,8 +299,9 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
-    const sidebar = await screen.findByLabelText("Sessions");
-    await user.click(within(sidebar).getByRole("button", { name: "New chat" }));
+    await screen.findByLabelText("Sessions");
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
 
     expect(stores.sessionStore.create).toHaveBeenCalledWith({});
   });
@@ -325,8 +331,9 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
-    const sidebar = await screen.findByLabelText("Sessions");
-    await user.click(within(sidebar).getByRole("button", { name: "New chat" }));
+    await screen.findByLabelText("Sessions");
+    await user.click(screen.getByRole("button", { name: "Collapse session sidebar" }));
+    await user.click(screen.getByRole("button", { name: "New conversation tab" }));
 
     expect(stores.sessionStore.create).toHaveBeenCalledWith({});
   });
@@ -913,7 +920,6 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     await screen.findByText("No sessions yet.");
-    await user.click(screen.getByRole("button", { name: "New chat" }));
     expect(await screen.findByRole("heading", { name: "New chat" })).toBeTruthy();
 
     const input = screen.getByRole("textbox", { name: /message/i });

--- a/src/react-workbench/chat/ChatPage.styles.test.tsx
+++ b/src/react-workbench/chat/ChatPage.styles.test.tsx
@@ -88,6 +88,8 @@ describe("ChatPage", () => {
     expect(css).toMatch(
       /\.react-session-row__select\s*{[^}]*height:\s*34px;[^}]*padding:\s*0 10px;/s,
     );
+    expect(css).toContain('.react-session-row[draggable="true"]');
+    expect(css).not.toContain(".react-sidebar-reorder-handle");
   });
 
   it("defines reduced-motion fallbacks for chat motion primitives", () => {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1045,11 +1045,21 @@ export function ChatPage({
       ...(resolvedProjectContext?.projectCoordinator ? { projectCoordinator: true } : {}),
       ...(resolvedProjectContext?.title ? { title: resolvedProjectContext.title } : {}),
     };
-    const draft: DraftSession = {
-      id: `draft:${now()}:${++draftSessionSequence.current}`,
-      createdAtMs: now(),
-      createInput,
+    const createLocalDraft = (input: DraftSessionCreateInput): DraftSession => {
+      const createdAtMs = now();
+      return {
+        id: `draft:${createdAtMs}:${++draftSessionSequence.current}`,
+        createdAtMs,
+        createInput: input,
+      };
     };
+    if (!activeSessionId && composerDraft.trim()) {
+      dispatchSessionTabs({
+        type: "startup-draft.materialize",
+        draft: createLocalDraft({}),
+      });
+    }
+    const draft = createLocalDraft(createInput);
     dispatchDelete({ type: "session-selected", sessionId: draft.id });
     dispatchSessionTabs({ type: "session-draft.open", draft });
     return projectDraftSessionSummary(draft);
@@ -1489,11 +1499,7 @@ export function ChatPage({
           setSessionCreatePending(false);
         });
     }
-    try {
-      return await draftSessionCreatePromise.current;
-    } catch {
-      return null;
-    }
+    return draftSessionCreatePromise.current;
   }
 
   function activateCreatedSession(created: SessionSummary, previousSessionId = ""): void {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -66,6 +66,8 @@ import {
   reduceSessionTabWorkspace,
   sessionTabDraft,
   writePersistedSessionTabWorkspace,
+  type DraftSession,
+  type DraftSessionCreateInput,
 } from "./sessionTabWorkspace";
 import {
   groupSessionsByWorkspace,
@@ -354,6 +356,9 @@ export function ChatPage({
   const lastCreateSessionSignal = useRef(createSessionSignal);
   const lastActivateSessionSignal = useRef<number | null>(null);
   const draftSessionCreatePromise = useRef<Promise<SessionSummary> | null>(null);
+  const draftSessionSequence = useRef(0);
+  const sessionTabsRef = useRef(sessionTabs);
+  const sessionsLoadedRef = useRef(sessionsLoaded);
   const optimisticSessionTitlesRef = useRef<Map<string, string>>(new Map());
   const conversationRef = useRef<HTMLDivElement | null>(null);
   const conversationEndRef = useRef<HTMLDivElement | null>(null);
@@ -365,11 +370,30 @@ export function ChatPage({
   const browserProvisioningResourceIdRef = useRef("");
   const browserActivationTargetRef = useRef("");
   sidecarRef.current = sidecar;
+  sessionTabsRef.current = sessionTabs;
+  sessionsLoadedRef.current = sessionsLoaded;
   const activeSessionId = sessionTabs.activeSessionId;
+  const activeSession = useMemo(
+    () => sessions.find((session) => session.id === activeSessionId),
+    [activeSessionId, sessions],
+  );
+  const draftSessions = useMemo<SessionSummary[]>(() => (
+    Object.values(sessionTabs.draftSessionsById).map(projectDraftSessionSummary)
+  ), [sessionTabs.draftSessionsById]);
+  const activeDraftSession = useMemo(
+    () => draftSessions.find((session) => session.id === activeSessionId),
+    [activeSessionId, draftSessions],
+  );
+  const displayedSessions = useMemo(
+    () => [...draftSessions, ...sessions],
+    [draftSessions, sessions],
+  );
+  const activeDisplaySession = activeSession ?? activeDraftSession;
+  const activePersistedSessionId = activeSession?.id ?? "";
   const sessionRuntime = useChatSessionRuntime({
     chatStore,
     onEffect: handleChatSessionRuntimeEffect,
-    sessionId: activeSessionId,
+    sessionId: activePersistedSessionId,
   });
   const {
     agentUiForms,
@@ -391,10 +415,6 @@ export function ChatPage({
   const optimisticMessages = optimisticMessagesBySession.get(activeSessionId) ?? EMPTY_OPTIMISTIC_MESSAGES;
 
   const resolvedSessionSidebarCollapsed = sessionSidebarCollapsed ?? localSessionSidebarCollapsed;
-  const activeSession = useMemo(
-    () => sessions.find((session) => session.id === activeSessionId),
-    [activeSessionId, sessions],
-  );
   const composerSkillOptions = useMemo(
     () => buildComposerSkillOptions(composerSkills, t),
     [composerSkills, t],
@@ -405,13 +425,13 @@ export function ChatPage({
   );
   const sidecarTabs = useMemo(() => visibleSidecarTabs(sidecar), [sidecar]);
   const sidecarActiveTab = useMemo(() => activeSidecarTab(sidecar), [sidecar]);
-  const explicitWorkspaceId = activeSession?.workingDirectory?.trim() ?? "";
-  const activeWorkspaceId = activeSession
+  const explicitWorkspaceId = activeDisplaySession?.workingDirectory?.trim() ?? "";
+  const activeWorkspaceId = activeDisplaySession
     ? explicitWorkspaceId || DEFAULT_SIDECAR_WORKSPACE_ID
     : "";
   const activeWorkspaceLabel = explicitWorkspaceId
     ? sessionWorkspaceName(explicitWorkspaceId)
-    : activeSession ? t("shell.generalSessions") : "";
+    : activeDisplaySession ? t("shell.generalSessions") : "";
 
   useEffect(() => {
     if (!toolsStore?.loadCatalog) {
@@ -420,9 +440,9 @@ export function ChatPage({
       return;
     }
     let cancelled = false;
-    const workingDirectory = activeSession?.pluginMigration
+    const workingDirectory = activeDisplaySession?.pluginMigration
       ? undefined
-      : activeSession?.workingDirectory?.trim() || undefined;
+      : activeDisplaySession?.workingDirectory?.trim() || undefined;
     setComposerSkills([]);
     setComposerTools([]);
     void toolsStore.loadCatalog({ workingDirectory }).then((catalog) => {
@@ -442,7 +462,7 @@ export function ChatPage({
     return () => {
       cancelled = true;
     };
-  }, [activeSession?.pluginMigration, activeSession?.workingDirectory, toolsStore]);
+  }, [activeDisplaySession?.pluginMigration, activeDisplaySession?.workingDirectory, toolsStore]);
   const unboundBrowserResource = useMemo(() => sidecar.tabs.find((tab): tab is SidecarBrowserTab => (
     tab.kind === "browser"
       && tab.threadId === activeSession?.id
@@ -608,7 +628,7 @@ export function ChatPage({
   }, [activeSessionId]);
   const openSessionTabs = useMemo<SessionTabItem[]>(() => (
     sessionTabs.openSessionIds.flatMap((sessionId) => {
-      const session = sessions.find((candidate) => candidate.id === sessionId);
+      const session = displayedSessions.find((candidate) => candidate.id === sessionId);
       return session ? [{
         id: session.id,
         status: session.status,
@@ -616,7 +636,7 @@ export function ChatPage({
         unread: sessionTabs.unreadSessionIds.includes(session.id),
       }] : [];
     })
-  ), [sessionTabs.openSessionIds, sessionTabs.unreadSessionIds, sessions, t]);
+  ), [displayedSessions, sessionTabs.openSessionIds, sessionTabs.unreadSessionIds, t]);
   const allSessionWorkspaces = useMemo(() => groupSessionsByWorkspace(sessions).map((workspace) => ({
     ...workspace,
     label: workspace.label ?? t("shell.generalSessions"),
@@ -635,7 +655,9 @@ export function ChatPage({
         label: displaySessionTitle(session.title, t),
       }));
   }, [activeSession, allSessionWorkspaces, i18n.language, now, t]);
-  const draftNewSession = sessionsLoaded && !activeSession;
+  const draftNewSession = sessionsLoaded && !activeSession && (
+    Boolean(activeDraftSession) || !activeSessionId
+  );
   const timelineLoaded = Boolean(activeSession) && timeline?.sessionId === activeSession?.id;
   const emptyActiveSession = draftNewSession || (timelineLoaded && timeline?.turns.length === 0 && optimisticMessages.length === 0);
   const sessionRunning = activeSession?.status === "running";
@@ -700,22 +722,22 @@ export function ChatPage({
   }, [sessions]);
 
   useEffect(() => {
-    if (!activeSessionId) {
+    if (!activePersistedSessionId) {
       setTinyOsCapabilities(unavailableTinyOsEffectiveCapabilities("", "no_session", t("runtime.noSessionSelected")));
       return;
     }
     let cancelled = false;
     setTinyOsCapabilities(unavailableTinyOsEffectiveCapabilities(
-      activeSessionId,
+      activePersistedSessionId,
       "loading",
       t("runtime.loadingCapabilities"),
     ));
-    void chatStore.loadTinyOsCapabilities(activeSessionId).then((capabilities) => {
+    void chatStore.loadTinyOsCapabilities(activePersistedSessionId).then((capabilities) => {
       if (!cancelled) setTinyOsCapabilities(capabilities);
     }).catch((error) => {
       if (!cancelled) {
         setTinyOsCapabilities(unavailableTinyOsEffectiveCapabilities(
-          activeSessionId,
+          activePersistedSessionId,
           "capability_query_failed",
           error instanceof Error ? error.message : String(error),
         ));
@@ -724,13 +746,13 @@ export function ChatPage({
     return () => {
       cancelled = true;
     };
-  }, [activeTurn?.id, activeTurn?.status, activeSessionId, chatStore, t]);
+  }, [activeTurn?.id, activeTurn?.status, activePersistedSessionId, chatStore, t]);
 
   useEffect(() => {
     setComposerSessionMentionIds([]);
     setComposerSelectedSkillIds([]);
     dispatchCommandLifecycle({ type: "reset" });
-  }, [activeSession?.id]);
+  }, [activeSessionId]);
 
   useEffect(() => {
     if (!timeline || commandLifecycle.stage === "idle" || commandLifecycle.stage === "completed") return;
@@ -826,6 +848,12 @@ export function ChatPage({
     return () => window.clearTimeout(timer);
   }, [sessionTabs, sessionsLoaded]);
 
+  useEffect(() => () => {
+    if (sessionsLoadedRef.current) {
+      writePersistedSessionTabWorkspace(window.localStorage, sessionTabsRef.current);
+    }
+  }, []);
+
   const createSessionFromSignal = useEffectEvent(() => {
     void handleCreateSession();
   });
@@ -879,12 +907,14 @@ export function ChatPage({
   });
   useEffect(() => {
     const unsubscribes = sessionTabs.openSessionIds
-      .filter((sessionId) => sessionId !== activeSessionId)
+      .filter((sessionId) => (
+        sessionId !== activeSessionId && !(sessionId in sessionTabs.draftSessionsById)
+      ))
       .map((sessionId) => chatStore.subscribe(sessionId, (event) => {
         handleBackgroundChatEvent(sessionId, event);
       }));
     return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
-  }, [activeSessionId, chatStore, sessionTabs.openSessionIds]);
+  }, [activeSessionId, chatStore, sessionTabs.draftSessionsById, sessionTabs.openSessionIds]);
 
   useEffect(() => {
     if (!settingsStore?.loadChatModels) {
@@ -996,46 +1026,33 @@ export function ChatPage({
     workingDirectory?: string,
     projectContext?: ProjectSessionContext,
   ): Promise<SessionSummary | null> {
-    if (sessionCreatePending) {
-      return null;
-    }
-    setSessionCreatePending(true);
     setSessionWorkspaceError("");
     const inheritedProjectContext: ProjectSessionContext | undefined = workingDirectory === undefined
-      && activeSession?.projectGroupId
-      && !activeSession.projectCoordinator
+      && activeDisplaySession?.projectGroupId
+      && !activeDisplaySession.projectCoordinator
       ? {
-          projectCoordinator: activeSession.projectCoordinator,
-          projectGroupId: activeSession.projectGroupId,
+          projectCoordinator: activeDisplaySession.projectCoordinator,
+          projectGroupId: activeDisplaySession.projectGroupId,
         }
       : undefined;
     const resolvedProjectContext = projectContext ?? inheritedProjectContext;
     const resolvedWorkingDirectory = resolvedProjectContext?.projectCoordinator
       ? undefined
-      : workingDirectory ?? (activeSession?.pluginMigration ? undefined : activeSession?.workingDirectory);
-    const newSessionModel = resolveComposerModel(composerModels);
-    try {
-      const created = await sessionStore.create({
-        ...(resolvedWorkingDirectory ? { workingDirectory: resolvedWorkingDirectory } : {}),
-        ...(resolvedProjectContext?.projectGroupId ? { projectGroupId: resolvedProjectContext.projectGroupId } : {}),
-        ...(resolvedProjectContext?.projectCoordinator ? { projectCoordinator: true } : {}),
-        ...(resolvedProjectContext?.title ? { title: resolvedProjectContext.title } : {}),
-        ...composerSessionModelInput(composerModels, newSessionModel),
-      });
-      activateCreatedSession(created);
-      return created;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setSessionWorkspaceError(message);
-      console.error("[session-workspaces] session.create.failed", {
-        error: message,
-        workingDirectory: resolvedWorkingDirectory ?? "",
-        projectGroupId: resolvedProjectContext?.projectGroupId ?? "",
-      });
-      return null;
-    } finally {
-      setSessionCreatePending(false);
-    }
+      : workingDirectory ?? (activeDisplaySession?.pluginMigration ? undefined : activeDisplaySession?.workingDirectory);
+    const createInput: DraftSessionCreateInput = {
+      ...(resolvedWorkingDirectory ? { workingDirectory: resolvedWorkingDirectory } : {}),
+      ...(resolvedProjectContext?.projectGroupId ? { projectGroupId: resolvedProjectContext.projectGroupId } : {}),
+      ...(resolvedProjectContext?.projectCoordinator ? { projectCoordinator: true } : {}),
+      ...(resolvedProjectContext?.title ? { title: resolvedProjectContext.title } : {}),
+    };
+    const draft: DraftSession = {
+      id: `draft:${now()}:${++draftSessionSequence.current}`,
+      createdAtMs: now(),
+      createInput,
+    };
+    dispatchDelete({ type: "session-selected", sessionId: draft.id });
+    dispatchSessionTabs({ type: "session-draft.open", draft });
+    return projectDraftSessionSummary(draft);
   }
 
   async function handleInstallPluginMigration(session: SessionSummary): Promise<void> {
@@ -1078,6 +1095,10 @@ export function ChatPage({
     const next = reduceSessionDeleteState(deleteState, { type: "delete-clicked", sessionId: session.id });
     dispatchDelete({ type: "delete-clicked", sessionId: session.id });
     if (next.confirmedSessionId) {
+      if (session.id in sessionTabs.draftSessionsById) {
+        dispatchSessionTabs({ type: "remove", sessionId: session.id });
+        return;
+      }
       await sessionStore.delete(session.id);
       optimisticSessionTitlesRef.current.delete(session.id);
       setDissolvingSessionIds((current) => new Set(current).add(session.id));
@@ -1226,12 +1247,42 @@ export function ChatPage({
     dispatchSessionTabs({ type: "open", sessionId: branched.id });
   }
 
-  function dispatchTurn(sessionId: string, input: ChatInput, control: string): Promise<void> {
-    return chatStore.dispatch(createDesktopTurnSubmitCommand({
+  async function dispatchTurn(
+    sessionId: string,
+    input: ChatInput,
+    control: string,
+    optimisticText?: string,
+  ): Promise<void> {
+    const command = createDesktopTurnSubmitCommand({
       message: input,
       sessionId,
       source: { control, surface: "chat" },
-    }));
+    });
+    if (optimisticText) {
+      setOptimisticMessagesBySession((current) => updateSessionMessages(
+        current,
+        sessionId,
+        (messages) => [...messages, {
+          createdAtMs: now(),
+          id: command.commandId,
+          role: "user",
+          status: "complete",
+          text: optimisticText,
+        }],
+      ));
+    }
+    try {
+      await chatStore.dispatch(command);
+    } catch (error) {
+      if (optimisticText) {
+        setOptimisticMessagesBySession((current) => updateSessionMessages(
+          current,
+          sessionId,
+          (messages) => messages.filter((message) => message.id !== command.commandId),
+        ));
+      }
+      throw error;
+    }
   }
 
   async function handleComposerSend(
@@ -1292,6 +1343,7 @@ export function ChatPage({
       setQueueMessage(t("queue.limit", { count: MAX_QUEUED_INPUTS }));
       return;
     }
+    const materializingDraft = !activeSession;
     const sendSession = activeSession ?? await createSessionForDraft();
     if (!sendSession) {
       return;
@@ -1309,7 +1361,12 @@ export function ChatPage({
       setSessions((current) => current.map((session) => session.id === sendSession.id ? optimisticSession : session));
       await sessionStore.rename(sendSession.id, optimisticSession.title);
     }
-    await dispatchTurn(sendSession.id, prepared.turnInput, "composer-send");
+    await dispatchTurn(
+      sendSession.id,
+      prepared.turnInput,
+      "composer-send",
+      materializingDraft ? visibleText : undefined,
+    );
     await handleSessionStoreRefresh(optimisticSession);
   }
 
@@ -1400,23 +1457,51 @@ export function ChatPage({
       return null;
     }
     if (!draftSessionCreatePromise.current) {
+      const draftSession = sessionTabs.draftSessionsById[activeSessionId];
       const modelInput = composerSessionModelInput(composerModels, composerModel);
-      draftSessionCreatePromise.current = sessionStore.create(Object.keys(modelInput).length ? modelInput : undefined)
+      const createInput = {
+        ...draftSession?.createInput,
+        ...modelInput,
+      };
+      const createArgument = draftSession || Object.keys(createInput).length
+        ? createInput
+        : undefined;
+      const materializingSessionId = activeSessionId;
+      setSessionCreatePending(true);
+      setSessionWorkspaceError("");
+      draftSessionCreatePromise.current = sessionStore.create(createArgument)
         .then((created) => {
-          activateCreatedSession(created);
+          activateCreatedSession(created, materializingSessionId);
           return created;
+        })
+        .catch((error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          setSessionWorkspaceError(message);
+          console.error("[session-workspaces] session.create.failed", {
+            error: message,
+            workingDirectory: draftSession?.createInput.workingDirectory ?? "",
+            projectGroupId: draftSession?.createInput.projectGroupId ?? "",
+          });
+          return Promise.reject(error);
         })
         .finally(() => {
           draftSessionCreatePromise.current = null;
+          setSessionCreatePending(false);
         });
     }
-    return draftSessionCreatePromise.current;
+    try {
+      return await draftSessionCreatePromise.current;
+    } catch {
+      return null;
+    }
   }
 
-  function activateCreatedSession(created: SessionSummary): void {
+  function activateCreatedSession(created: SessionSummary, previousSessionId = ""): void {
     sessionsRef.current = [created, ...sessionsRef.current.filter((session) => session.id !== created.id)];
     setSessions((current) => [created, ...current.filter((session) => session.id !== created.id)]);
-    dispatchSessionTabs({ type: "open", sessionId: created.id });
+    dispatchSessionTabs(previousSessionId !== created.id
+      ? { type: "replace", previousSessionId, sessionId: created.id }
+      : { type: "open", sessionId: created.id });
   }
 
   function handleDeleteQueuedInput(sessionId: string, inputId: string) {
@@ -2062,7 +2147,9 @@ export function ChatPage({
 
   const visibleAgentUiForms = agentUiForms.filter(isVisibleAgentUiForm);
   const interactiveFormIds = new Set(visibleAgentUiForms.map((form) => form.form_id));
-  const headerTitle = activeSession ? displaySessionTitle(activeSession.title, t) : draftNewSession ? t("shell.newChat") : t("shell.noSelection");
+  const headerTitle = activeDisplaySession
+    ? displaySessionTitle(activeDisplaySession.title, t)
+    : draftNewSession ? t("shell.newChat") : t("shell.noSelection");
   const mascotMood = projectTinybotMascotMood({
     responding: sessionResponding,
     sessionStatus: activeSession?.status,
@@ -2096,7 +2183,7 @@ export function ChatPage({
         error={sessionWorkspaceError}
         now={now}
         projectGroupStore={projectGroupStore}
-        sessions={sessions}
+        sessions={displayedSessions}
       >
       <div
         className="react-chat-workspace"
@@ -2697,6 +2784,18 @@ function browserResourceTitle(title: string, url: string, fallback: string): str
   } catch {
     return url;
   }
+}
+
+function projectDraftSessionSummary(draft: DraftSession): SessionSummary {
+  return {
+    id: draft.id,
+    projectCoordinator: draft.createInput.projectCoordinator,
+    projectGroupId: draft.createInput.projectGroupId,
+    status: "idle",
+    title: draft.createInput.title ?? "New chat",
+    updatedAtMs: draft.createdAtMs,
+    workingDirectory: draft.createInput.workingDirectory,
+  };
 }
 
 function omitRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -2112,6 +2112,7 @@ export function ChatPage({
             onActivate={handleActivateSessionTab}
             onClose={handleCloseSessionTab}
             onCreate={() => void handleCreateSession()}
+            showCreate={resolvedSessionSidebarCollapsed}
           />
           <div className="react-chat-header__actions">
             <button

--- a/src/react-workbench/chat/ChatSessionWorkspace.test.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, createEvent, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { ProjectGroupStore, SessionSummary } from "../services";
 import {
@@ -10,6 +10,7 @@ import {
 
 afterEach(() => {
   cleanup();
+  window.localStorage.clear();
   vi.restoreAllMocks();
 });
 
@@ -52,7 +53,203 @@ describe("ChatSessionWorkspace", () => {
       { error: "Project catalog unavailable" },
     );
   });
+
+  test("uses the workspace and session rows themselves as drag sources", () => {
+    renderWorkspace();
+    const workspace = screen.getByRole("group", { name: "Workspace tinybot" });
+    const sessionRow = within(workspace).getByRole("button", { name: "Planning notes" })
+      .closest(".react-session-row")!;
+
+    expect(workspace.querySelector("summary")?.getAttribute("draggable")).toBe("true");
+    expect(sessionRow.getAttribute("draggable")).toBe("true");
+    expect(document.querySelector(".react-sidebar-reorder-handle")).toBeNull();
+  });
+
+  test("drags workspace groups into a persisted user order", () => {
+    const sessions = [
+      planningSession(),
+      {
+        ...planningSession(),
+        id: "session-2",
+        title: "Release notes",
+        updatedAtMs: Date.UTC(2026, 7, 13),
+        workingDirectory: "D:\\Code\\release",
+      },
+    ];
+    const rendered = renderWorkspace({ sessions });
+    const rows = screen.getByLabelText("Session list rows");
+    expect(sidebarGroupLabels(rows)).toEqual(["Workspace tinybot", "Workspace release"]);
+
+    const source = screen.getByRole("group", { name: "Workspace release" }).querySelector("summary")!;
+    const target = screen.getByRole("group", { name: "Workspace tinybot" }).querySelector("summary")!;
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue(rect(0, 44));
+    const dataTransfer = dragDataTransfer();
+    fireEvent.dragStart(source, { dataTransfer });
+    fireDragOverAt(target, 1, dataTransfer);
+    fireEvent.drop(target, { clientY: 1, dataTransfer });
+
+    expect(sidebarGroupLabels(rows)).toEqual(["Workspace release", "Workspace tinybot"]);
+
+    rendered.unmount();
+    renderWorkspace({ sessions });
+    expect(sidebarGroupLabels(screen.getByLabelText("Session list rows")))
+      .toEqual(["Workspace release", "Workspace tinybot"]);
+  });
+
+  test("drags member workspaces only within their project group", async () => {
+    const projectGroupStore: ProjectGroupStore = {
+      delete: vi.fn(async () => undefined),
+      list: vi.fn(async () => [{
+        name: "group-1",
+        projectGroupId: "project-1",
+        workspaceIds: ["D:\\Code\\tinybot", "D:\\Code\\release"],
+      }]),
+      save: vi.fn(async (input) => ({
+        name: input.name,
+        projectGroupId: input.projectGroupId ?? "project-1",
+        workspaceIds: input.workspaceIds,
+      })),
+    };
+    renderWorkspace({
+      projectGroupStore,
+      sessions: [
+        { ...planningSession(), projectGroupId: "project-1" },
+        {
+          ...planningSession(),
+          id: "session-2",
+          projectGroupId: "project-1",
+          title: "Release notes",
+          updatedAtMs: Date.UTC(2026, 7, 13),
+          workingDirectory: "D:\\Code\\release",
+        },
+      ],
+    });
+    const project = await screen.findByRole("group", { name: "Project group-1" });
+    expect(projectWorkspaceLabels(project)).toEqual(["Workspace tinybot", "Workspace release"]);
+
+    const source = within(project).getByRole("group", { name: "Workspace release" })
+      .querySelector(".react-project-group__member-title")!;
+    const target = within(project).getByRole("group", { name: "Workspace tinybot" })
+      .querySelector(".react-project-group__member-title")!;
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue(rect(0, 34));
+    const dataTransfer = dragDataTransfer();
+    fireEvent.dragStart(source, { dataTransfer });
+    fireDragOverAt(target, 1, dataTransfer);
+    fireEvent.drop(target, { dataTransfer });
+
+    expect(projectWorkspaceLabels(project)).toEqual(["Workspace release", "Workspace tinybot"]);
+  });
+
+  test("drags sessions only within their current workspace", () => {
+    const sessions = [
+      planningSession(),
+      {
+        ...planningSession(),
+        id: "session-2",
+        title: "Knowledge review",
+        updatedAtMs: Date.UTC(2026, 7, 13),
+      },
+      {
+        ...planningSession(),
+        id: "session-3",
+        title: "Release notes",
+        updatedAtMs: Date.UTC(2026, 7, 12),
+        workingDirectory: "D:\\Code\\release",
+      },
+    ];
+    renderWorkspace({ sessions });
+    const tinybot = screen.getByRole("group", { name: "Workspace tinybot" });
+    expect(sessionTitles(tinybot)).toEqual(["Planning notes", "Knowledge review"]);
+
+    const source = within(tinybot).getByRole("button", { name: "Knowledge review" })
+      .closest(".react-session-row")!;
+    const target = within(tinybot).getByRole("button", { name: "Planning notes" }).closest(".react-session-row")!;
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue(rect(0, 34));
+    const dataTransfer = dragDataTransfer();
+    fireEvent.dragStart(source, { dataTransfer });
+    fireDragOverAt(target, 1, dataTransfer);
+    fireEvent.drop(target, { clientY: 1, dataTransfer });
+
+    expect(sessionTitles(tinybot)).toEqual(["Knowledge review", "Planning notes"]);
+    const release = screen.getByRole("group", { name: "Workspace release" });
+    expect(sessionTitles(release)).toEqual(["Release notes"]);
+
+    const crossWorkspaceTarget = within(release).getByRole("button", { name: "Release notes" })
+      .closest(".react-session-row")!;
+    fireEvent.dragStart(source, { dataTransfer });
+    fireDragOverAt(crossWorkspaceTarget, 1, dataTransfer);
+    fireEvent.drop(crossWorkspaceTarget, { dataTransfer });
+
+    expect(sessionTitles(tinybot)).toEqual(["Knowledge review", "Planning notes"]);
+    expect(sessionTitles(release)).toEqual(["Release notes"]);
+  });
+
+  test("reorders with Alt+Arrow keys and announces the result", () => {
+    renderWorkspace({
+      sessions: [
+        planningSession(),
+        {
+          ...planningSession(),
+          id: "session-2",
+          title: "Knowledge review",
+          updatedAtMs: Date.UTC(2026, 7, 13),
+        },
+      ],
+    });
+    const workspace = screen.getByRole("group", { name: "Workspace tinybot" });
+    const row = within(workspace).getByRole("button", { name: "Planning notes" });
+
+    fireEvent.keyDown(row, { altKey: true, key: "ArrowDown" });
+
+    expect(sessionTitles(workspace)).toEqual(["Knowledge review", "Planning notes"]);
+    expect(screen.getByText("Moved Planning notes after Knowledge review.")).toBeTruthy();
+  });
 });
+
+function sidebarGroupLabels(rows: HTMLElement): string[] {
+  return Array.from(rows.children)
+    .filter((element): element is HTMLElement => element instanceof HTMLElement && element.matches("details[role='group']"))
+    .sort((left, right) => Number(left.style.order) - Number(right.style.order))
+    .map((element) => element.getAttribute("aria-label") ?? "");
+}
+
+function sessionTitles(group: HTMLElement): string[] {
+  return Array.from(group.querySelectorAll<HTMLElement>(".react-session-row__title"))
+    .map((element) => element.textContent ?? "");
+}
+
+function projectWorkspaceLabels(project: HTMLElement): string[] {
+  return Array.from(project.querySelectorAll<HTMLElement>(".react-project-workspace"))
+    .map((element) => element.getAttribute("aria-label") ?? "");
+}
+
+function dragDataTransfer(): DataTransfer {
+  return {
+    effectAllowed: "none",
+    dropEffect: "none",
+    setData: vi.fn(),
+  } as unknown as DataTransfer;
+}
+
+function fireDragOverAt(target: Element, clientY: number, dataTransfer: DataTransfer): void {
+  const event = createEvent.dragOver(target, { dataTransfer });
+  Object.defineProperty(event, "clientY", { value: clientY });
+  fireEvent(target, event);
+}
+
+function rect(top: number, height: number): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 240,
+    top,
+    width: 240,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
 
 function renderWorkspace({
   actions = createActions(),

--- a/src/react-workbench/chat/ChatSessionWorkspace.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.tsx
@@ -4,6 +4,8 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type DragEvent as ReactDragEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
 import {
@@ -30,8 +32,35 @@ import type {
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
 import { ProjectGroupDialog } from "./ProjectGroupDialog";
 import { projectSessionGroups } from "./projectSessionGroups";
+import {
+  INITIAL_SESSION_SIDEBAR_ORDER,
+  orderSidebarItems,
+  readSessionSidebarOrder,
+  reorderSidebarItems,
+  writeSessionSidebarOrder,
+  type SessionSidebarOrder,
+} from "./sessionSidebarOrder";
 import { displaySessionTitle } from "./sessionTitle";
-import { groupSessionsByWorkspace, sessionWorkspaceName } from "./sessionWorkspaces";
+import {
+  groupSessionsByWorkspace,
+  normalizedWorkspacePathKey,
+  sessionWorkspaceName,
+} from "./sessionWorkspaces";
+
+const SIDEBAR_ROOT_CONTAINER_ID = "sidebar:root";
+
+type SidebarOrderItem = {
+  itemId: string;
+  label: string;
+};
+
+type SidebarDragItem = SidebarOrderItem & {
+  containerId: string;
+};
+
+type SidebarDropTarget = SidebarDragItem & {
+  placement: "after" | "before";
+};
 
 export type ProjectSessionContext = {
   projectCoordinator?: boolean;
@@ -84,7 +113,16 @@ export function ChatSessionWorkspace({
   const [workspaceActionMenuOpen, setWorkspaceActionMenuOpen] = useState(false);
   const [workspaceError, setWorkspaceError] = useState("");
   const [workspacePickerPending, setWorkspacePickerPending] = useState(false);
+  const [sidebarOrder, setSidebarOrder] = useState<SessionSidebarOrder>(() => (
+    typeof window === "undefined"
+      ? INITIAL_SESSION_SIDEBAR_ORDER
+      : readSessionSidebarOrder(window.localStorage)
+  ));
+  const [draggedSidebarItem, setDraggedSidebarItem] = useState<SidebarDragItem>();
+  const [sidebarDropTarget, setSidebarDropTarget] = useState<SidebarDropTarget>();
+  const [reorderAnnouncement, setReorderAnnouncement] = useState("");
   const workspaceActionMenuRef = useRef<HTMLDivElement | null>(null);
+  const draggedSidebarItemRef = useRef<SidebarDragItem | undefined>(undefined);
 
   useEffect(() => {
     if (!projectGroupStore) {
@@ -119,6 +157,12 @@ export function ChatSessionWorkspace({
     return () => window.removeEventListener("pointerdown", closeOnOutsidePointer);
   }, [workspaceActionMenuOpen]);
 
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      writeSessionSidebarOrder(window.localStorage, sidebarOrder);
+    }
+  }, [sidebarOrder]);
+
   const projectProjection = useMemo(
     () => projectSessionGroups(projectGroups, [...sessions]),
     [projectGroups, sessions],
@@ -130,6 +174,28 @@ export function ChatSessionWorkspace({
     })),
     [projectProjection.ungroupedSessions, t],
   );
+  const rootGroups = useMemo(() => orderSidebarItems([
+    ...projectProjection.groups.map((group) => ({
+      group,
+      itemId: sidebarProjectGroupId(group.project.projectGroupId),
+      kind: "project" as const,
+      label: group.project.name,
+    })),
+    ...sessionWorkspaces.map((workspace) => ({
+      itemId: sidebarWorkspaceGroupId(workspace.key),
+      kind: "workspace" as const,
+      label: workspace.label,
+      workspace,
+    })),
+  ], sidebarOrder, SIDEBAR_ROOT_CONTAINER_ID, (item) => item.itemId), [
+    projectProjection.groups,
+    sessionWorkspaces,
+    sidebarOrder,
+  ]);
+  const rootOrderItems = useMemo<SidebarOrderItem[]>(() => rootGroups.map((group) => ({
+    itemId: group.itemId,
+    label: group.label,
+  })), [rootGroups]);
   const availableProjectWorkspaceIds = useMemo(() => Array.from(new Set([
     ...sessions.flatMap((session) => session.workingDirectory ? [session.workingDirectory] : []),
     ...projectGroups.flatMap((group) => group.workspaceIds),
@@ -139,34 +205,169 @@ export function ChatSessionWorkspace({
     : undefined;
   const displayError = error || workspaceError;
 
-  function renderSidebarSessionRow(session: SessionSummary, index: number) {
+  function beginSidebarDrag(
+    event: ReactDragEvent<HTMLElement>,
+    item: SidebarDragItem,
+  ): void {
+    draggedSidebarItemRef.current = item;
+    setDraggedSidebarItem(item);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", item.itemId);
+  }
+
+  function finishSidebarDrag(): void {
+    draggedSidebarItemRef.current = undefined;
+    setDraggedSidebarItem(undefined);
+    setSidebarDropTarget(undefined);
+  }
+
+  function updateSidebarDropTarget(
+    event: ReactDragEvent<HTMLElement>,
+    target: SidebarDragItem,
+  ): void {
+    const dragged = draggedSidebarItemRef.current;
+    if (!dragged || dragged.containerId !== target.containerId || dragged.itemId === target.itemId) {
+      setSidebarDropTarget(undefined);
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const placement = event.clientY < bounds.top + (bounds.height / 2) ? "before" : "after";
+    setSidebarDropTarget({ ...target, placement });
+  }
+
+  function moveSidebarItem(
+    dragged: SidebarDragItem,
+    target: SidebarOrderItem,
+    placement: "after" | "before",
+    currentItems: readonly SidebarOrderItem[],
+  ): void {
+    const nextOrder = reorderSidebarItems(sidebarOrder, {
+      containerId: dragged.containerId,
+      currentItemIds: currentItems.map((item) => item.itemId),
+      draggedItemId: dragged.itemId,
+      placement,
+      targetItemId: target.itemId,
+    });
+    if (nextOrder === sidebarOrder) return;
+    setSidebarOrder(nextOrder);
+    setReorderAnnouncement(t(
+      placement === "before" ? "shell.reorderedBefore" : "shell.reorderedAfter",
+      { item: dragged.label, target: target.label },
+    ));
+  }
+
+  function dropSidebarItem(
+    event: ReactDragEvent<HTMLElement>,
+    target: SidebarDragItem,
+    currentItems: readonly SidebarOrderItem[],
+  ): void {
+    const dragged = draggedSidebarItemRef.current;
+    if (!dragged || dragged.containerId !== target.containerId || dragged.itemId === target.itemId) {
+      finishSidebarDrag();
+      return;
+    }
+    event.preventDefault();
+    const placement = sidebarDropTarget?.containerId === target.containerId
+      && sidebarDropTarget.itemId === target.itemId
+      ? sidebarDropTarget.placement
+      : "before";
+    moveSidebarItem(dragged, target, placement, currentItems);
+    finishSidebarDrag();
+  }
+
+  function moveSidebarItemWithKeyboard(
+    event: ReactKeyboardEvent<HTMLElement>,
+    item: SidebarDragItem,
+    currentItems: readonly SidebarOrderItem[],
+  ): void {
+    if (!event.altKey || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const currentIndex = currentItems.findIndex((candidate) => candidate.itemId === item.itemId);
+    const targetIndex = currentIndex + (event.key === "ArrowUp" ? -1 : 1);
+    const target = currentItems[targetIndex];
+    if (!target) return;
+    moveSidebarItem(item, target, event.key === "ArrowUp" ? "before" : "after", currentItems);
+  }
+
+  function sidebarDropPosition(containerId: string, itemId: string): "after" | "before" | undefined {
+    return sidebarDropTarget?.containerId === containerId && sidebarDropTarget.itemId === itemId
+      ? sidebarDropTarget.placement
+      : undefined;
+  }
+
+  function renderSidebarSessionRows(
+    sessionsToRender: readonly SessionSummary[],
+    containerId: string,
+  ) {
+    const orderedSessions = orderSidebarItems(
+      sessionsToRender,
+      sidebarOrder,
+      containerId,
+      (session) => session.id,
+    );
+    const currentItems = orderedSessions.map((session) => ({
+      itemId: session.id,
+      label: displaySessionTitle(session.title, t),
+    }));
+    return orderedSessions.map((session, index) => renderSidebarSessionRow(
+      session,
+      index,
+      containerId,
+      currentItems,
+    ));
+  }
+
+  function renderSidebarSessionRow(
+    session: SessionSummary,
+    index: number,
+    containerId: string,
+    currentItems: readonly SidebarOrderItem[],
+  ) {
     const confirming = confirmingDeleteSessionId === session.id;
     const dissolving = dissolvingSessionIds.has(session.id);
+    const sessionLabel = displaySessionTitle(session.title, t);
+    const reorderItem = { containerId, itemId: session.id, label: sessionLabel };
     return (
       <div
         className="react-session-row"
         data-active={session.id === activeSessionId}
         data-confirming={confirming}
+        data-dragging={draggedSidebarItem?.containerId === containerId && draggedSidebarItem.itemId === session.id
+          ? "true"
+          : undefined}
+        data-drop-position={sidebarDropPosition(containerId, session.id)}
         data-dissolving={dissolving ? "true" : undefined}
         data-motion-role="item"
+        draggable={!dissolving}
         key={session.id}
+        onDragEnd={finishSidebarDrag}
+        onDragOver={(event) => updateSidebarDropTarget(event, reorderItem)}
+        onDragStart={(event) => beginSidebarDrag(event, reorderItem)}
+        onDrop={(event) => dropSidebarItem(event, reorderItem, currentItems)}
         onMouseLeave={() => actions.onCancelDeleteConfirmation(session.id)}
         style={{ "--react-session-row-index": String(index) } as CSSProperties}
       >
         <button
+          aria-description={t("shell.reorderSession", { name: sessionLabel })}
+          aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
           aria-label={session.title}
           className="react-session-row__select"
           type="button"
           disabled={dissolving}
           onClick={() => actions.onSelectSession(session)}
+          onKeyDown={(event) => moveSidebarItemWithKeyboard(event, reorderItem, currentItems)}
         >
-          <span className="react-session-row__title">{displaySessionTitle(session.title, t)}</span>
+          <span className="react-session-row__title">{sessionLabel}</span>
           <small>{formatRelativeUpdatedTime(session.updatedAtMs, now())}</small>
         </button>
         <button
           aria-label={t(confirming ? "shell.confirmDelete" : "shell.delete", { name: session.title })}
           className="react-session-row__delete"
           data-confirming={confirming}
+          draggable={false}
           type="button"
           disabled={dissolving}
           onClick={() => void actions.onDeleteSession(session)}
@@ -322,21 +523,109 @@ export function ChatSessionWorkspace({
           ) : null}
         </div>
         <div className="react-session-list__rows" aria-label={t("shell.sessionRows")} data-motion="animated-list">
-          {projectProjection.groups.map((projectGroup) => {
+          {rootGroups.map((rootGroup) => {
+            if (rootGroup.kind === "workspace") {
+              const { workspace } = rootGroup;
+              const reorderItem = {
+                containerId: SIDEBAR_ROOT_CONTAINER_ID,
+                itemId: rootGroup.itemId,
+                label: rootGroup.label,
+              };
+              return (
+                <details
+                  aria-label={t("shell.workspace", { name: workspace.label })}
+                  className="react-session-workspace"
+                  data-active={workspace.sessions.some((session) => session.id === activeSessionId) ? "true" : undefined}
+                  data-dragging={draggedSidebarItem?.containerId === SIDEBAR_ROOT_CONTAINER_ID
+                    && draggedSidebarItem.itemId === rootGroup.itemId ? "true" : undefined}
+                  data-drop-position={sidebarDropPosition(SIDEBAR_ROOT_CONTAINER_ID, rootGroup.itemId)}
+                  key={workspace.key}
+                  open
+                  role="group"
+                >
+                  <summary
+                    aria-description={t("shell.reorderWorkspace", { name: workspace.label })}
+                    aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
+                    draggable
+                    title={workspace.workingDirectory ?? workspace.label}
+                    onDragEnd={finishSidebarDrag}
+                    onDragOver={(event) => updateSidebarDropTarget(event, reorderItem)}
+                    onDragStart={(event) => beginSidebarDrag(event, reorderItem)}
+                    onDrop={(event) => dropSidebarItem(event, reorderItem, rootOrderItems)}
+                    onKeyDown={(event) => moveSidebarItemWithKeyboard(event, reorderItem, rootOrderItems)}
+                  >
+                    <ChevronRight aria-hidden="true" className="react-session-workspace__chevron" size={14} />
+                    <span aria-hidden="true" className="react-session-workspace__folder">
+                      <Folder className="react-session-workspace__folder-icon--collapsed" size={15} />
+                      <FolderOpen className="react-session-workspace__folder-icon--expanded" size={15} />
+                    </span>
+                    <span className="react-session-workspace__copy">
+                      <strong>{workspace.label}</strong>
+                      {workspace.workingDirectory ? <small>{workspace.workingDirectory}</small> : null}
+                    </span>
+                  </summary>
+                  <button
+                    aria-label={t("shell.newSessionIn", { name: workspace.label })}
+                    className="react-session-workspace__new"
+                    disabled={createPending}
+                    title={t("shell.newSessionIn", { name: workspace.label })}
+                    type="button"
+                    onClick={() => void actions.onCreateSession(workspace.workingDirectory)}
+                  >
+                    <Plus aria-hidden="true" size={15} />
+                  </button>
+                  <div className="react-session-workspace__sessions">
+                    {renderSidebarSessionRows(workspace.sessions, sidebarWorkspaceSessionsId(workspace.key))}
+                  </div>
+                </details>
+              );
+            }
+            const projectGroup = rootGroup.group;
             const projectSessions = [
               ...projectGroup.coordinatorSessions,
               ...projectGroup.workspaces.flatMap((workspace) => workspace.sessions),
             ];
+            const projectWorkspacesContainerId = sidebarProjectWorkspacesId(
+              projectGroup.project.projectGroupId,
+            );
+            const orderedProjectWorkspaces = orderSidebarItems(
+              projectGroup.workspaces,
+              sidebarOrder,
+              projectWorkspacesContainerId,
+              (workspace) => sidebarProjectWorkspaceItemId(workspace.workspaceId),
+            );
+            const projectWorkspaceOrderItems = orderedProjectWorkspaces.map((workspace) => ({
+              itemId: sidebarProjectWorkspaceItemId(workspace.workspaceId),
+              label: workspace.label,
+            }));
+            const reorderItem = {
+              containerId: SIDEBAR_ROOT_CONTAINER_ID,
+              itemId: rootGroup.itemId,
+              label: rootGroup.label,
+            };
             return (
               <details
                 aria-label={t("projectGroups.groupLabel", { name: projectGroup.project.name })}
                 className="react-project-group"
                 data-active={projectSessions.some((session) => session.id === activeSessionId) ? "true" : undefined}
+                data-dragging={draggedSidebarItem?.containerId === SIDEBAR_ROOT_CONTAINER_ID
+                  && draggedSidebarItem.itemId === rootGroup.itemId ? "true" : undefined}
+                data-drop-position={sidebarDropPosition(SIDEBAR_ROOT_CONTAINER_ID, rootGroup.itemId)}
                 key={projectGroup.project.projectGroupId}
                 open
                 role="group"
               >
-                <summary title={projectGroup.project.name}>
+                <summary
+                  aria-description={t("shell.reorderProject", { name: projectGroup.project.name })}
+                  aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
+                  draggable
+                  title={projectGroup.project.name}
+                  onDragEnd={finishSidebarDrag}
+                  onDragOver={(event) => updateSidebarDropTarget(event, reorderItem)}
+                  onDragStart={(event) => beginSidebarDrag(event, reorderItem)}
+                  onDrop={(event) => dropSidebarItem(event, reorderItem, rootOrderItems)}
+                  onKeyDown={(event) => moveSidebarItemWithKeyboard(event, reorderItem, rootOrderItems)}
+                >
                   <ChevronRight aria-hidden="true" className="react-project-group__chevron" size={14} />
                   <GitBranch aria-hidden="true" className="react-project-group__icon" size={15} />
                   <strong>{projectGroup.project.name}</strong>
@@ -367,12 +656,52 @@ export function ChatSessionWorkspace({
                         <GitBranch aria-hidden="true" size={13} />
                         <span>{t("projectGroups.coordination")}</span>
                       </div>
-                      {projectGroup.coordinatorSessions.map(renderSidebarSessionRow)}
+                      {renderSidebarSessionRows(
+                        projectGroup.coordinatorSessions,
+                        sidebarProjectCoordinatorSessionsId(projectGroup.project.projectGroupId),
+                      )}
                     </section>
                   ) : null}
-                  {projectGroup.workspaces.map((workspace) => (
-                    <section className="react-project-workspace" key={workspace.workspaceId}>
-                      <div className="react-project-group__member-title" title={workspace.workspaceId}>
+                  {orderedProjectWorkspaces.map((workspace) => {
+                    const workspaceReorderItem = {
+                      containerId: projectWorkspacesContainerId,
+                      itemId: sidebarProjectWorkspaceItemId(workspace.workspaceId),
+                      label: workspace.label,
+                    };
+                    return (
+                    <section
+                      aria-label={t("shell.workspace", { name: workspace.label })}
+                      className="react-project-workspace"
+                      data-dragging={draggedSidebarItem?.containerId === projectWorkspacesContainerId
+                        && draggedSidebarItem.itemId === workspaceReorderItem.itemId ? "true" : undefined}
+                      data-drop-position={sidebarDropPosition(
+                        projectWorkspacesContainerId,
+                        workspaceReorderItem.itemId,
+                      )}
+                      key={workspace.workspaceId}
+                      role="group"
+                    >
+                      <div
+                        aria-description={t("shell.reorderWorkspace", { name: workspace.label })}
+                        aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
+                        className="react-project-group__member-title"
+                        draggable
+                        tabIndex={0}
+                        title={workspace.workspaceId}
+                        onDragEnd={finishSidebarDrag}
+                        onDragOver={(event) => updateSidebarDropTarget(event, workspaceReorderItem)}
+                        onDragStart={(event) => beginSidebarDrag(event, workspaceReorderItem)}
+                        onDrop={(event) => dropSidebarItem(event, workspaceReorderItem, projectWorkspaceOrderItems)}
+                        onKeyDown={(event) => {
+                          if (event.target === event.currentTarget) {
+                            moveSidebarItemWithKeyboard(
+                              event,
+                              workspaceReorderItem,
+                              projectWorkspaceOrderItems,
+                            );
+                          }
+                        }}
+                      >
                         <Folder aria-hidden="true" size={13} />
                         <span>
                           <strong>{workspace.label}</strong>
@@ -381,6 +710,7 @@ export function ChatSessionWorkspace({
                         <button
                           aria-label={t("projectGroups.newWorkspaceSession", { name: workspace.label })}
                           disabled={createPending}
+                          draggable={false}
                           onClick={() => void actions.onCreateSession(workspace.workspaceId, {
                             projectGroupId: projectGroup.project.projectGroupId,
                           })}
@@ -391,52 +721,25 @@ export function ChatSessionWorkspace({
                         </button>
                       </div>
                       <div className="react-project-workspace__sessions">
-                        {workspace.sessions.map(renderSidebarSessionRow)}
+                        {renderSidebarSessionRows(
+                          workspace.sessions,
+                          sidebarProjectWorkspaceSessionsId(
+                            projectGroup.project.projectGroupId,
+                            workspace.workspaceId,
+                          ),
+                        )}
                       </div>
                     </section>
-                  ))}
+                    );
+                  })}
                 </div>
               </details>
             );
           })}
-          {sessionWorkspaces.length ? sessionWorkspaces.map((workspace) => (
-            <details
-              aria-label={t("shell.workspace", { name: workspace.label })}
-              className="react-session-workspace"
-              data-active={workspace.sessions.some((session) => session.id === activeSessionId) ? "true" : undefined}
-              key={workspace.key}
-              open
-              role="group"
-            >
-              <summary title={workspace.workingDirectory ?? workspace.label}>
-                <ChevronRight aria-hidden="true" className="react-session-workspace__chevron" size={14} />
-                <span aria-hidden="true" className="react-session-workspace__folder">
-                  <Folder className="react-session-workspace__folder-icon--collapsed" size={15} />
-                  <FolderOpen className="react-session-workspace__folder-icon--expanded" size={15} />
-                </span>
-                <span className="react-session-workspace__copy">
-                  <strong>{workspace.label}</strong>
-                  {workspace.workingDirectory ? <small>{workspace.workingDirectory}</small> : null}
-                </span>
-              </summary>
-              <button
-                aria-label={t("shell.newSessionIn", { name: workspace.label })}
-                className="react-session-workspace__new"
-                disabled={createPending}
-                title={t("shell.newSessionIn", { name: workspace.label })}
-                type="button"
-                onClick={() => void actions.onCreateSession(workspace.workingDirectory)}
-              >
-                <Plus aria-hidden="true" size={15} />
-              </button>
-              <div className="react-session-workspace__sessions">
-                {workspace.sessions.map(renderSidebarSessionRow)}
-              </div>
-            </details>
-          )) : null}
           {!projectProjection.groups.length && !sessionWorkspaces.length && !collapsed
             ? <EmptyStateText text={t("shell.noSessions")} />
             : null}
+          <p aria-live="polite" className="react-sr-only">{reorderAnnouncement}</p>
         </div>
       </aside>
       {children}
@@ -468,6 +771,39 @@ export function ChatSessionWorkspace({
 
 function EmptyStateText({ text }: { text: string }) {
   return <p className="react-empty-state">{text}</p>;
+}
+
+function sidebarProjectGroupId(projectGroupId: string): string {
+  return `project:${encodeURIComponent(projectGroupId)}`;
+}
+
+function sidebarWorkspaceGroupId(workspaceKey: string): string {
+  return `workspace:${encodeURIComponent(workspaceKey)}`;
+}
+
+function sidebarWorkspaceSessionsId(workspaceKey: string): string {
+  return `sessions:workspace:${encodeURIComponent(workspaceKey)}`;
+}
+
+function sidebarProjectCoordinatorSessionsId(projectGroupId: string): string {
+  return `sessions:project:${encodeURIComponent(projectGroupId)}:coordination`;
+}
+
+function sidebarProjectWorkspacesId(projectGroupId: string): string {
+  return `workspaces:project:${encodeURIComponent(projectGroupId)}`;
+}
+
+function sidebarProjectWorkspaceItemId(workspaceId: string): string {
+  return normalizedWorkspacePathKey(workspaceId);
+}
+
+function sidebarProjectWorkspaceSessionsId(projectGroupId: string, workspaceId: string): string {
+  return [
+    "sessions:project",
+    encodeURIComponent(projectGroupId),
+    "workspace",
+    encodeURIComponent(normalizedWorkspacePathKey(workspaceId)),
+  ].join(":");
 }
 
 function SessionSearchDialog({

--- a/src/react-workbench/chat/ChatSessionWorkspace.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.tsx
@@ -13,7 +13,6 @@ import {
   FolderOpen,
   FolderPlus,
   GitBranch,
-  Loader2,
   MoreHorizontal,
   Plus,
   Search,
@@ -318,16 +317,6 @@ export function ChatSessionWorkspace({
               </button>
             </div>
           </div>
-          <button
-            aria-label={t("shell.newChat")}
-            className="react-session-list__new"
-            disabled={createPending}
-            type="button"
-            onClick={() => void actions.onCreateSession()}
-          >
-            {createPending ? <Loader2 aria-hidden="true" className="react-session-list__pending" size={15} /> : <Plus aria-hidden="true" size={15} />}
-            <span>{t("shell.newChat")}</span>
-          </button>
           {displayError ? (
             <p className="react-session-list__error" role="alert">{displayError}</p>
           ) : null}

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:4d389cd321b9106778ecee74b4283e08bcb7f2406e62c09b5acbb6f67930ebb8 -->
+<!-- tinybot-module-fingerprint: sha256:854fac18ba759aec457cbca875764dc1fc0b1161fa742ed7e988cb85ffa03139 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -53,9 +53,14 @@ becomes authoritative.
 While the initial session list is loading, the composer keeps its draft editor
 available but disables sending. The first Chat mount in each desktop app
 lifetime ignores the persisted tab workspace and starts with an uncreated empty
-conversation. Later route remounts may restore tabs opened during that same app
-lifetime. The empty conversation continues to use the persisted composer model
-preference, and changing its model updates that preference for future chats.
+conversation. User-facing new-chat actions also open a local draft session
+without creating a native Thread. A pristine draft is removed when another
+conversation is selected or Chat is left; a draft with composer text remains in
+the local tab workspace and is restored on a later route mount. The first send
+materializes that draft with its captured workspace or project context, replaces
+the local tab with the returned Thread ID, and only then dispatches the Turn.
+The empty conversation continues to use the persisted composer model preference,
+and changing its model updates that preference for future chats.
 Browser runtime snapshots are retained by the
 session runtime and projected into Sidecar Browser resources. Each resource tab
 maps to one native WebView2 tab in the Chat-owned shared Browser Session, so user
@@ -96,12 +101,14 @@ this module while delegating modal focus, keyboard, dismissal, and scroll-lock
 behavior to `components/ui/useModalDialog`.
 
 Session creation follows the entry point's target. Workspace and project
-actions pass their workspace and project context explicitly. With the session
-sidebar expanded, those contextual actions and the draft's first submission are
-the primary creation paths; the tab-strip create action appears only while the
-sidebar is collapsed. Collapsed-tab, search, menu, and keyboard actions may
-inherit an ordinary active workspace, but never an active project coordinator;
-coordinator sessions are created only by the project's coordinator action.
+actions capture their workspace and project context on the local draft. With the
+session sidebar expanded, those contextual actions and the draft's first
+submission are the primary creation paths; the tab-strip create action appears
+only while the sidebar is collapsed. Collapsed-tab, search, menu, and keyboard
+actions may inherit an ordinary active workspace, but never an active project
+coordinator; coordinator sessions are created only by the project's coordinator
+action. System-owned flows such as plugin migration continue to create their
+required Thread immediately rather than entering the user draft lifecycle.
 
 Composer model selection has two scopes. Selecting a model in a draft or an
 empty Thread updates the default used by future chats as well as that Thread.

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:b6bc4b8645e3070fb6708adbead57ad19023301d4074e15c0137a4c8fa3cc8db -->
+<!-- tinybot-module-fingerprint: sha256:a2c919cdb0430a8cb4a1e2e4774656553c4f276b1e9550c56cff5d6beff47685 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -56,9 +56,12 @@ lifetime ignores the persisted tab workspace and starts with an uncreated empty
 conversation. User-facing new-chat actions also open a local draft session
 without creating a native Thread. A pristine draft is removed when another
 conversation is selected or Chat is left; a draft with composer text remains in
-the local tab workspace and is restored on a later route mount. The first send
-materializes that draft with its captured workspace or project context, replaces
-the local tab with the returned Thread ID, and only then dispatches the Turn.
+the local tab workspace and is restored on a later route mount. Opening another
+draft materializes non-empty startup text as its own navigable local tab. The
+first send materializes that draft with its captured workspace or project
+context, replaces the local tab with the returned Thread ID, and only then
+dispatches the Turn. Creation failures remain visible and reject the submission
+so the controlled composer keeps the user's input.
 The empty conversation continues to use the persisted composer model preference,
 and changing its model updates that preference for future chats.
 Browser runtime snapshots are retained by the

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:854fac18ba759aec457cbca875764dc1fc0b1161fa742ed7e988cb85ffa03139 -->
+<!-- tinybot-module-fingerprint: sha256:b6bc4b8645e3070fb6708adbead57ad19023301d4074e15c0137a4c8fa3cc8db -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -99,6 +99,18 @@ native default used by Agent turns.
 Desktop-level project and session-search dialogs keep their domain actions in
 this module while delegating modal focus, keyboard, dismissal, and scroll-lock
 behavior to `components/ui/useModalDialog`.
+
+The expanded session sidebar keeps a renderer-local, versioned user order for
+its top-level workspace/project blocks, each project's member workspaces, and
+each block's own session list.
+Dragging a session never changes its workspace or project membership. Workspace
+headers and complete session rows are the drag sources; there is no separate
+grip control. Their existing focus targets also support `Alt+ArrowUp` and
+`Alt+ArrowDown`, and announce the result through a polite live region. Newly
+discovered blocks and sessions appear ahead of a saved manual order; stale saved
+IDs are ignored. Invalid persisted state is reported through the
+`session-sidebar-order` diagnostic boundary before the sidebar returns to its
+natural recency order.
 
 Session creation follows the entry point's target. Workspace and project
 actions capture their workspace and project context on the local draft. With the

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:abdaa063ff9d1c2602ac0558558f9d9e5a6660afab32ccbae52cdbf3499ed872 -->
+<!-- tinybot-module-fingerprint: sha256:4d389cd321b9106778ecee74b4283e08bcb7f2406e62c09b5acbb6f67930ebb8 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -96,10 +96,12 @@ this module while delegating modal focus, keyboard, dismissal, and scroll-lock
 behavior to `components/ui/useModalDialog`.
 
 Session creation follows the entry point's target. Workspace and project
-actions pass their workspace and project context explicitly. Global, tab, and
-search actions may inherit an ordinary active workspace, but never an active
-project coordinator; coordinator sessions are created only by the project's
-coordinator action.
+actions pass their workspace and project context explicitly. With the session
+sidebar expanded, those contextual actions and the draft's first submission are
+the primary creation paths; the tab-strip create action appears only while the
+sidebar is collapsed. Collapsed-tab, search, menu, and keyboard actions may
+inherit an ordinary active workspace, but never an active project coordinator;
+coordinator sessions are created only by the project's coordinator action.
 
 Composer model selection has two scopes. Selecting a model in a draft or an
 empty Thread updates the default used by future chats as well as that Thread.

--- a/src/react-workbench/chat/SessionTabStrip.test.tsx
+++ b/src/react-workbench/chat/SessionTabStrip.test.tsx
@@ -24,6 +24,7 @@ function tabStrip(activeSessionId = tabs[0].id) {
       onActivate={vi.fn()}
       onClose={vi.fn()}
       onCreate={vi.fn()}
+      showCreate
     />
   );
 }

--- a/src/react-workbench/chat/SessionTabStrip.tsx
+++ b/src/react-workbench/chat/SessionTabStrip.tsx
@@ -15,6 +15,7 @@ export type SessionTabStripProps = {
   onActivate: (sessionId: string) => void;
   onClose: (sessionId: string) => void;
   onCreate: () => void;
+  showCreate: boolean;
 };
 
 export function SessionTabStrip({
@@ -22,6 +23,7 @@ export function SessionTabStrip({
   onActivate,
   onClose,
   onCreate,
+  showCreate,
   tabs,
 }: SessionTabStripProps) {
   const { t } = useTranslation("chat");
@@ -163,41 +165,45 @@ export function SessionTabStrip({
           </div>
         )}
       </div>
-      <div className="react-session-tabs__controls">
-        <button aria-label={t("tabs.newTab")} title={t("tabs.newConversation")} type="button" onClick={onCreate}>
-          <Plus aria-hidden="true" size={16} />
-        </button>
-        {tabs.length > 1 ? (
-          <div className="react-session-tabs__overflow">
-            <button
-              aria-expanded={menuOpen}
-              aria-haspopup="menu"
-              aria-label={t("tabs.menu")}
-              title={t("tabs.openTabs")}
-              type="button"
-              onClick={() => setMenuOpen((open) => !open)}
-            >
-              <List aria-hidden="true" size={15} />
+      {showCreate || tabs.length > 1 ? (
+        <div className="react-session-tabs__controls">
+          {showCreate ? (
+            <button aria-label={t("tabs.newTab")} title={t("tabs.newConversation")} type="button" onClick={onCreate}>
+              <Plus aria-hidden="true" size={16} />
             </button>
-            {menuOpen ? (
-              <div className="react-session-tabs__menu" role="menu">
-                {tabs.map((tab) => (
-                  <button
-                    aria-current={tab.id === activeSessionId ? "page" : undefined}
-                    key={tab.id}
-                    role="menuitem"
-                    type="button"
-                    onClick={() => onActivate(tab.id)}
-                  >
-                    <SessionTabStatus tab={tab} />
-                    <span className="react-session-tabs__menu-title">{tab.title}</span>
-                  </button>
-                ))}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
+          ) : null}
+          {tabs.length > 1 ? (
+            <div className="react-session-tabs__overflow">
+              <button
+                aria-expanded={menuOpen}
+                aria-haspopup="menu"
+                aria-label={t("tabs.menu")}
+                title={t("tabs.openTabs")}
+                type="button"
+                onClick={() => setMenuOpen((open) => !open)}
+              >
+                <List aria-hidden="true" size={15} />
+              </button>
+              {menuOpen ? (
+                <div className="react-session-tabs__menu" role="menu">
+                  {tabs.map((tab) => (
+                    <button
+                      aria-current={tab.id === activeSessionId ? "page" : undefined}
+                      key={tab.id}
+                      role="menuitem"
+                      type="button"
+                      onClick={() => onActivate(tab.id)}
+                    >
+                      <SessionTabStatus tab={tab} />
+                      <span className="react-session-tabs__menu-title">{tab.title}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/react-workbench/chat/sessionSidebarOrder.test.ts
+++ b/src/react-workbench/chat/sessionSidebarOrder.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  INITIAL_SESSION_SIDEBAR_ORDER,
+  SESSION_SIDEBAR_ORDER_STORAGE_KEY,
+  orderSidebarItems,
+  readSessionSidebarOrder,
+  reorderSidebarItems,
+  writeSessionSidebarOrder,
+} from "./sessionSidebarOrder";
+
+describe("sessionSidebarOrder", () => {
+  it("reorders items inside one container without changing another container", () => {
+    const reordered = reorderSidebarItems(INITIAL_SESSION_SIDEBAR_ORDER, {
+      containerId: "workspace:tinybot",
+      currentItemIds: ["one", "two", "three"],
+      draggedItemId: "three",
+      placement: "before",
+      targetItemId: "one",
+    });
+
+    expect(reordered.itemIdsByContainer).toEqual({
+      "workspace:tinybot": ["three", "one", "two"],
+    });
+    expect(orderSidebarItems(
+      [{ id: "one" }, { id: "two" }],
+      reordered,
+      "workspace:other",
+      (item) => item.id,
+    )).toEqual([{ id: "one" }, { id: "two" }]);
+  });
+
+  it("puts newly discovered items before a saved manual order and ignores removed ids", () => {
+    const items = [{ id: "new" }, { id: "two" }, { id: "one" }];
+    const ordered = orderSidebarItems(
+      items,
+      { itemIdsByContainer: { root: ["missing", "one", "two"] } },
+      "root",
+      (item) => item.id,
+    );
+
+    expect(ordered.map((item) => item.id)).toEqual(["new", "one", "two"]);
+  });
+
+  it("round-trips versioned storage and diagnoses invalid saved state", () => {
+    const storage = new Map<string, string>();
+    const adapter = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+    };
+    const order = { itemIdsByContainer: { root: ["workspace:b", "workspace:a"] } };
+
+    writeSessionSidebarOrder(adapter, order);
+    expect(readSessionSidebarOrder(adapter)).toEqual(order);
+
+    storage.set(SESSION_SIDEBAR_ORDER_STORAGE_KEY, JSON.stringify({ version: 2 }));
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    expect(readSessionSidebarOrder(adapter)).toBe(INITIAL_SESSION_SIDEBAR_ORDER);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "[session-sidebar-order] Failed to restore the saved order.",
+      expect.any(Error),
+    );
+  });
+});

--- a/src/react-workbench/chat/sessionSidebarOrder.ts
+++ b/src/react-workbench/chat/sessionSidebarOrder.ts
@@ -1,0 +1,128 @@
+export const SESSION_SIDEBAR_ORDER_STORAGE_KEY = "tinybot.ui.chat.sidebar-order.v1";
+
+export type SessionSidebarOrder = {
+  itemIdsByContainer: Record<string, string[]>;
+};
+
+export const INITIAL_SESSION_SIDEBAR_ORDER: SessionSidebarOrder = {
+  itemIdsByContainer: {},
+};
+
+type StoredSessionSidebarOrder = SessionSidebarOrder & {
+  version: 1;
+};
+
+export function orderSidebarItems<T>(
+  items: readonly T[],
+  order: SessionSidebarOrder,
+  containerId: string,
+  itemId: (item: T) => string,
+): T[] {
+  const byId = new Map(items.map((item) => [itemId(item), item]));
+  return reconcileSidebarItemIds(
+    items.map(itemId),
+    order.itemIdsByContainer[containerId] ?? [],
+  ).flatMap((id) => {
+    const item = byId.get(id);
+    return item === undefined ? [] : [item];
+  });
+}
+
+export function reorderSidebarItems(
+  order: SessionSidebarOrder,
+  input: {
+    containerId: string;
+    currentItemIds: readonly string[];
+    draggedItemId: string;
+    placement: "after" | "before";
+    targetItemId: string;
+  },
+): SessionSidebarOrder {
+  const reconciled = reconcileSidebarItemIds(
+    input.currentItemIds,
+    order.itemIdsByContainer[input.containerId] ?? [],
+  );
+  if (
+    input.draggedItemId === input.targetItemId
+    || !reconciled.includes(input.draggedItemId)
+    || !reconciled.includes(input.targetItemId)
+  ) {
+    return order;
+  }
+
+  const withoutDragged = reconciled.filter((id) => id !== input.draggedItemId);
+  const targetIndex = withoutDragged.indexOf(input.targetItemId);
+  const insertionIndex = targetIndex + (input.placement === "after" ? 1 : 0);
+  const nextItemIds = [...withoutDragged];
+  nextItemIds.splice(insertionIndex, 0, input.draggedItemId);
+  if (nextItemIds.every((id, index) => id === reconciled[index])) {
+    return order;
+  }
+  return {
+    itemIdsByContainer: {
+      ...order.itemIdsByContainer,
+      [input.containerId]: nextItemIds,
+    },
+  };
+}
+
+export function readSessionSidebarOrder(
+  storage: Pick<Storage, "getItem">,
+): SessionSidebarOrder {
+  try {
+    const serialized = storage.getItem(SESSION_SIDEBAR_ORDER_STORAGE_KEY);
+    if (!serialized) return INITIAL_SESSION_SIDEBAR_ORDER;
+    const value = JSON.parse(serialized) as unknown;
+    if (!isStoredSessionSidebarOrder(value)) {
+      throw new Error("Stored session sidebar order has an invalid shape.");
+    }
+    return { itemIdsByContainer: value.itemIdsByContainer };
+  } catch (error) {
+    console.warn("[session-sidebar-order] Failed to restore the saved order.", error);
+    return INITIAL_SESSION_SIDEBAR_ORDER;
+  }
+}
+
+export function writeSessionSidebarOrder(
+  storage: Pick<Storage, "setItem">,
+  order: SessionSidebarOrder,
+): void {
+  const stored: StoredSessionSidebarOrder = {
+    version: 1,
+    itemIdsByContainer: order.itemIdsByContainer,
+  };
+  storage.setItem(SESSION_SIDEBAR_ORDER_STORAGE_KEY, JSON.stringify(stored));
+}
+
+function reconcileSidebarItemIds(
+  currentItemIds: readonly string[],
+  preferredItemIds: readonly string[],
+): string[] {
+  const current = new Set(currentItemIds);
+  const preferredSet = new Set<string>();
+  const preferred = preferredItemIds.filter((id) => {
+    if (!current.has(id) || preferredSet.has(id)) return false;
+    preferredSet.add(id);
+    return true;
+  });
+  const newItemSet = new Set<string>();
+  const newItems = currentItemIds.filter((id) => {
+    if (preferredSet.has(id) || newItemSet.has(id)) return false;
+    newItemSet.add(id);
+    return true;
+  });
+  return [...newItems, ...preferred];
+}
+
+function isStoredSessionSidebarOrder(value: unknown): value is StoredSessionSidebarOrder {
+  return isRecord(value)
+    && value.version === 1
+    && isRecord(value.itemIdsByContainer)
+    && Object.values(value.itemIdsByContainer).every((ids) => (
+      Array.isArray(ids) && ids.every((id) => typeof id === "string")
+    ));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/react-workbench/chat/sessionTabWorkspace.test.ts
+++ b/src/react-workbench/chat/sessionTabWorkspace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DRAFT_SESSION_KEY,
   INITIAL_SESSION_TAB_WORKSPACE,
+  persistedSessionTabWorkspace,
   reduceSessionTabWorkspace,
   sessionTabDraft,
 } from "./sessionTabWorkspace";
@@ -20,6 +21,7 @@ describe("sessionTabWorkspace", () => {
 
     expect(state).toEqual({
       activeSessionId: "s2",
+      draftSessionsById: {},
       draftsBySession: { s2: "keep", [DRAFT_SESSION_KEY]: "new" },
       openSessionIds: ["s2"],
       unreadSessionIds: [],
@@ -121,5 +123,113 @@ describe("sessionTabWorkspace", () => {
     expect(state.activeSessionId).toBe("WebSocket:chat-2");
     expect(state.openSessionIds).toEqual(["WebSocket:chat-2"]);
     expect(sessionTabDraft(state, "WebSocket:chat-2")).toBe("keep this");
+  });
+
+  it("discards a pristine local session draft when another session is opened", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "hydrate",
+      availableSessionIds: ["s1"],
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "session-draft.open",
+      draft: {
+        id: "draft:1",
+        createdAtMs: 10,
+        createInput: { workingDirectory: "D:\\Code\\tinybot" },
+      },
+    });
+    state = reduceSessionTabWorkspace(state, { type: "open", sessionId: "s1" });
+
+    expect(state.activeSessionId).toBe("s1");
+    expect(state.openSessionIds).toEqual(["s1"]);
+    expect(state.draftSessionsById).toEqual({});
+  });
+
+  it("keeps a non-empty local session draft when another session is opened", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "hydrate",
+      availableSessionIds: ["s1"],
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "session-draft.open",
+      draft: {
+        id: "draft:1",
+        createdAtMs: 10,
+        createInput: { projectGroupId: "group-1", workingDirectory: "D:\\Code\\tinybot" },
+      },
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "draft.changed",
+      sessionId: "draft:1",
+      value: "Keep this locally",
+    });
+    state = reduceSessionTabWorkspace(state, { type: "open", sessionId: "s1" });
+
+    expect(state.activeSessionId).toBe("s1");
+    expect(state.openSessionIds).toEqual(["s1", "draft:1"]);
+    expect(state.draftSessionsById["draft:1"]?.createInput).toEqual({
+      projectGroupId: "group-1",
+      workingDirectory: "D:\\Code\\tinybot",
+    });
+    expect(sessionTabDraft(state, "draft:1")).toBe("Keep this locally");
+  });
+
+  it("replaces a local session draft with the created Thread without losing composer text", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "session-draft.open",
+      draft: {
+        id: "draft:1",
+        createdAtMs: 10,
+        createInput: { workingDirectory: "D:\\Code\\tinybot" },
+      },
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "draft.changed",
+      sessionId: "draft:1",
+      value: "Create me",
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "replace",
+      previousSessionId: "draft:1",
+      sessionId: "thread:1",
+    });
+
+    expect(state.activeSessionId).toBe("thread:1");
+    expect(state.openSessionIds).toEqual(["thread:1"]);
+    expect(state.draftSessionsById).toEqual({});
+    expect(sessionTabDraft(state, "thread:1")).toBe("Create me");
+  });
+
+  it("persists only local session drafts that contain composer text", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "hydrate",
+      availableSessionIds: ["s1"],
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "session-draft.open",
+      draft: { id: "draft:dirty", createdAtMs: 10, createInput: { workingDirectory: "D:\\Code\\one" } },
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "draft.changed",
+      sessionId: "draft:dirty",
+      value: "Keep me",
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "session-draft.open",
+      draft: { id: "draft:pristine", createdAtMs: 20, createInput: { workingDirectory: "D:\\Code\\two" } },
+    });
+
+    expect(persistedSessionTabWorkspace(state)).toEqual({
+      activeSessionId: "s1",
+      draftSessionsById: {
+        "draft:dirty": {
+          id: "draft:dirty",
+          createdAtMs: 10,
+          createInput: { workingDirectory: "D:\\Code\\one" },
+        },
+      },
+      draftsBySession: { "draft:dirty": "Keep me" },
+      openSessionIds: ["s1", "draft:dirty"],
+    });
   });
 });

--- a/src/react-workbench/chat/sessionTabWorkspace.test.ts
+++ b/src/react-workbench/chat/sessionTabWorkspace.test.ts
@@ -60,6 +60,28 @@ describe("sessionTabWorkspace", () => {
     expect(sessionTabDraft(state, "")).toBe("Draft while loading");
   });
 
+  it("materializes startup text as a navigable local draft", () => {
+    let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
+      type: "draft.changed",
+      sessionId: "",
+      value: "Keep the startup draft",
+    });
+    state = reduceSessionTabWorkspace(state, {
+      type: "startup-draft.materialize",
+      draft: {
+        id: "draft:startup",
+        createdAtMs: 10,
+        createInput: {},
+      },
+    });
+
+    expect(state.activeSessionId).toBe("draft:startup");
+    expect(state.openSessionIds).toEqual(["draft:startup"]);
+    expect(state.draftSessionsById["draft:startup"]?.createInput).toEqual({});
+    expect(sessionTabDraft(state, "draft:startup")).toBe("Keep the startup draft");
+    expect(state.draftsBySession[DRAFT_SESSION_KEY]).toBeUndefined();
+  });
+
   it("opens, activates, and closes tabs without deleting their drafts", () => {
     let state = reduceSessionTabWorkspace(INITIAL_SESSION_TAB_WORKSPACE, {
       type: "hydrate",

--- a/src/react-workbench/chat/sessionTabWorkspace.ts
+++ b/src/react-workbench/chat/sessionTabWorkspace.ts
@@ -1,8 +1,22 @@
 export const CHAT_SESSION_TABS_STORAGE_KEY = "tinybot.ui.chat.session-tabs.v1";
 export const DRAFT_SESSION_KEY = "__tinybot_draft_session__";
 
+export type DraftSessionCreateInput = {
+  projectCoordinator?: boolean;
+  projectGroupId?: string;
+  title?: string;
+  workingDirectory?: string;
+};
+
+export type DraftSession = {
+  id: string;
+  createdAtMs: number;
+  createInput: DraftSessionCreateInput;
+};
+
 export type SessionTabWorkspaceState = {
   activeSessionId: string;
+  draftSessionsById: Record<string, DraftSession>;
   draftsBySession: Record<string, string>;
   openSessionIds: string[];
   unreadSessionIds: string[];
@@ -11,7 +25,9 @@ export type SessionTabWorkspaceState = {
 export type PersistedSessionTabWorkspace = Pick<
   SessionTabWorkspaceState,
   "activeSessionId" | "draftsBySession" | "openSessionIds"
->;
+> & {
+  draftSessionsById?: Record<string, DraftSession>;
+};
 
 export type SessionTabWorkspaceEvent =
   | { type: "hydrate"; availableSessionIds: string[]; persisted?: PersistedSessionTabWorkspace }
@@ -21,11 +37,13 @@ export type SessionTabWorkspaceEvent =
   | { type: "remove"; sessionId: string }
   | { type: "activity"; sessionId: string }
   | { type: "draft.changed"; sessionId: string; value: string }
+  | { type: "session-draft.open"; draft: DraftSession }
   | { type: "replace"; previousSessionId: string; sessionId: string }
   | { type: "reconcile"; availableSessionIds: string[] };
 
 export const INITIAL_SESSION_TAB_WORKSPACE: SessionTabWorkspaceState = {
   activeSessionId: "",
+  draftSessionsById: {},
   draftsBySession: {},
   openSessionIds: [],
   unreadSessionIds: [],
@@ -51,16 +69,32 @@ export function reduceSessionTabWorkspace(
         },
       };
     }
+    case "session-draft.open": {
+      const navigable = discardActivePristineDraft(state);
+      return {
+        ...navigable,
+        activeSessionId: event.draft.id,
+        draftSessionsById: {
+          ...navigable.draftSessionsById,
+          [event.draft.id]: event.draft,
+        },
+        openSessionIds: unique([...navigable.openSessionIds, event.draft.id]),
+        unreadSessionIds: withoutValue(navigable.unreadSessionIds, event.draft.id),
+      };
+    }
     case "open":
     case "activate": {
-      const openSessionIds = state.openSessionIds.includes(event.sessionId)
-        ? state.openSessionIds
-        : [...state.openSessionIds, event.sessionId];
+      const navigable = event.sessionId === state.activeSessionId
+        ? state
+        : discardActivePristineDraft(state);
+      const openSessionIds = navigable.openSessionIds.includes(event.sessionId)
+        ? navigable.openSessionIds
+        : [...navigable.openSessionIds, event.sessionId];
       return {
-        ...state,
+        ...navigable,
         activeSessionId: event.sessionId,
         openSessionIds,
-        unreadSessionIds: withoutValue(state.unreadSessionIds, event.sessionId),
+        unreadSessionIds: withoutValue(navigable.unreadSessionIds, event.sessionId),
       };
     }
     case "close": {
@@ -72,12 +106,15 @@ export function reduceSessionTabWorkspace(
       const activeSessionId = state.activeSessionId === event.sessionId
         ? openSessionIds[index] ?? openSessionIds[index - 1] ?? ""
         : state.activeSessionId;
-      return {
+      const closed = {
         ...state,
         activeSessionId,
         openSessionIds,
         unreadSessionIds: withoutValue(state.unreadSessionIds, event.sessionId),
       };
+      return event.sessionId in state.draftSessionsById
+        ? removeDraftSession(closed, event.sessionId)
+        : closed;
     }
     case "remove": {
       const closed = reduceSessionTabWorkspace(state, { type: "close", sessionId: event.sessionId });
@@ -93,7 +130,7 @@ export function reduceSessionTabWorkspace(
       }
       return { ...state, unreadSessionIds: [...state.unreadSessionIds, event.sessionId] };
     case "draft.changed": {
-      const key = event.sessionId || DRAFT_SESSION_KEY;
+      const key = composerDraftKey(event.sessionId);
       if (!event.value && !(key in state.draftsBySession)) {
         return state;
       }
@@ -109,18 +146,25 @@ export function reduceSessionTabWorkspace(
       if (event.previousSessionId === event.sessionId) {
         return state;
       }
-      const openSessionIds = unique(state.openSessionIds.map((sessionId) => (
+      let openSessionIds = unique(state.openSessionIds.map((sessionId) => (
         sessionId === event.previousSessionId ? event.sessionId : sessionId
       )));
-      const draftsBySession = { ...state.draftsBySession };
-      if (event.previousSessionId in draftsBySession) {
-        draftsBySession[event.sessionId] = draftsBySession[event.previousSessionId];
-        delete draftsBySession[event.previousSessionId];
+      if (state.activeSessionId === event.previousSessionId && !openSessionIds.includes(event.sessionId)) {
+        openSessionIds = [...openSessionIds, event.sessionId];
       }
+      const draftsBySession = { ...state.draftsBySession };
+      const previousDraftKey = composerDraftKey(event.previousSessionId);
+      if (previousDraftKey in draftsBySession) {
+        draftsBySession[event.sessionId] = draftsBySession[previousDraftKey];
+        delete draftsBySession[previousDraftKey];
+      }
+      const draftSessionsById = { ...state.draftSessionsById };
+      delete draftSessionsById[event.previousSessionId];
       return {
         activeSessionId: state.activeSessionId === event.previousSessionId
           ? event.sessionId
           : state.activeSessionId,
+        draftSessionsById,
         draftsBySession,
         openSessionIds,
         unreadSessionIds: unique(state.unreadSessionIds.map((sessionId) => (
@@ -129,7 +173,10 @@ export function reduceSessionTabWorkspace(
       };
     }
     case "reconcile": {
-      const available = new Set(event.availableSessionIds);
+      const available = new Set([
+        ...event.availableSessionIds,
+        ...Object.keys(state.draftSessionsById),
+      ]);
       const openSessionIds = state.openSessionIds.filter((sessionId) => available.has(sessionId));
       const activeSessionId = openSessionIds.includes(state.activeSessionId)
         ? state.activeSessionId
@@ -141,6 +188,7 @@ export function reduceSessionTabWorkspace(
       );
       return {
         activeSessionId,
+        draftSessionsById: state.draftSessionsById,
         draftsBySession,
         openSessionIds,
         unreadSessionIds: state.unreadSessionIds.filter((sessionId) => (
@@ -152,16 +200,30 @@ export function reduceSessionTabWorkspace(
 }
 
 export function sessionTabDraft(state: SessionTabWorkspaceState, sessionId: string): string {
-  return state.draftsBySession[sessionId || DRAFT_SESSION_KEY] ?? "";
+  return state.draftsBySession[composerDraftKey(sessionId)] ?? "";
 }
 
 export function persistedSessionTabWorkspace(
   state: SessionTabWorkspaceState,
 ): PersistedSessionTabWorkspace {
+  const dirtyDraftSessionIds = new Set(Object.keys(state.draftSessionsById).filter((sessionId) => (
+    Boolean(sessionTabDraft(state, sessionId).trim())
+  )));
+  const draftSessionsById = Object.fromEntries(
+    Object.entries(state.draftSessionsById).filter(([sessionId]) => dirtyDraftSessionIds.has(sessionId)),
+  );
+  const openSessionIds = state.openSessionIds.filter((sessionId) => (
+    !(sessionId in state.draftSessionsById) || dirtyDraftSessionIds.has(sessionId)
+  ));
+  const activeSessionId = state.activeSessionId in state.draftSessionsById
+    && !dirtyDraftSessionIds.has(state.activeSessionId)
+      ? openSessionIds[0] ?? ""
+      : state.activeSessionId;
   return {
-    activeSessionId: state.activeSessionId,
+    activeSessionId,
+    draftSessionsById,
     draftsBySession: state.draftsBySession,
-    openSessionIds: state.openSessionIds,
+    openSessionIds,
   };
 }
 
@@ -178,11 +240,13 @@ export function readPersistedSessionTabWorkspace(
       || !Array.isArray(value.openSessionIds)
       || !value.openSessionIds.every((sessionId) => typeof sessionId === "string")
       || typeof value.activeSessionId !== "string"
-      || !isStringRecord(value.draftsBySession)) {
+      || !isStringRecord(value.draftsBySession)
+      || (value.draftSessionsById !== undefined && !isDraftSessionRecord(value.draftSessionsById))) {
       throw new Error("Stored session tab workspace has an invalid shape.");
     }
     return {
       activeSessionId: value.activeSessionId,
+      draftSessionsById: value.draftSessionsById ?? {},
       draftsBySession: value.draftsBySession,
       openSessionIds: unique(value.openSessionIds),
     };
@@ -203,7 +267,12 @@ function hydrateWorkspace(
   availableSessionIds: string[],
   persisted?: PersistedSessionTabWorkspace,
 ): SessionTabWorkspaceState {
-  const available = new Set(availableSessionIds);
+  const draftSessionsById = Object.fromEntries(
+    Object.entries(persisted?.draftSessionsById ?? {}).filter(([sessionId]) => (
+      Boolean(persisted?.draftsBySession[sessionId]?.trim())
+    )),
+  );
+  const available = new Set([...availableSessionIds, ...Object.keys(draftSessionsById)]);
   let openSessionIds = unique(persisted?.openSessionIds ?? []).filter((sessionId) => available.has(sessionId));
   if (!persisted && !openSessionIds.length && availableSessionIds[0]) {
     openSessionIds = [availableSessionIds[0]];
@@ -219,10 +288,44 @@ function hydrateWorkspace(
   );
   return {
     activeSessionId,
+    draftSessionsById,
     draftsBySession,
     openSessionIds,
     unreadSessionIds: [],
   };
+}
+
+function discardActivePristineDraft(state: SessionTabWorkspaceState): SessionTabWorkspaceState {
+  const draft = state.draftSessionsById[state.activeSessionId];
+  if (!draft || sessionTabDraft(state, draft.id).trim()) {
+    return state;
+  }
+  return removeDraftSession(state, draft.id);
+}
+
+function removeDraftSession(
+  state: SessionTabWorkspaceState,
+  sessionId: string,
+): SessionTabWorkspaceState {
+  const draftSessionsById = { ...state.draftSessionsById };
+  delete draftSessionsById[sessionId];
+  const draftsBySession = { ...state.draftsBySession };
+  delete draftsBySession[sessionId];
+  const openSessionIds = withoutValue(state.openSessionIds, sessionId);
+  return {
+    ...state,
+    activeSessionId: state.activeSessionId === sessionId
+      ? openSessionIds[0] ?? ""
+      : state.activeSessionId,
+    draftSessionsById,
+    draftsBySession,
+    openSessionIds,
+    unreadSessionIds: withoutValue(state.unreadSessionIds, sessionId),
+  };
+}
+
+function composerDraftKey(sessionId: string): string {
+  return sessionId || DRAFT_SESSION_KEY;
 }
 
 function withoutValue(values: string[], value: string): string[] {
@@ -239,4 +342,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isStringRecord(value: unknown): value is Record<string, string> {
   return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isDraftSessionRecord(value: unknown): value is Record<string, DraftSession> {
+  return isRecord(value) && Object.entries(value).every(([sessionId, entry]) => (
+    isRecord(entry)
+    && entry.id === sessionId
+    && typeof entry.createdAtMs === "number"
+    && isDraftSessionCreateInput(entry.createInput)
+  ));
+}
+
+function isDraftSessionCreateInput(value: unknown): value is DraftSessionCreateInput {
+  if (!isRecord(value)) return false;
+  return Object.entries(value).every(([key, entry]) => {
+    if (key === "projectCoordinator") return typeof entry === "boolean";
+    if (key === "projectGroupId" || key === "title" || key === "workingDirectory") {
+      return typeof entry === "string";
+    }
+    return false;
+  });
 }

--- a/src/react-workbench/chat/sessionTabWorkspace.ts
+++ b/src/react-workbench/chat/sessionTabWorkspace.ts
@@ -37,6 +37,7 @@ export type SessionTabWorkspaceEvent =
   | { type: "remove"; sessionId: string }
   | { type: "activity"; sessionId: string }
   | { type: "draft.changed"; sessionId: string; value: string }
+  | { type: "startup-draft.materialize"; draft: DraftSession }
   | { type: "session-draft.open"; draft: DraftSession }
   | { type: "replace"; previousSessionId: string; sessionId: string }
   | { type: "reconcile"; availableSessionIds: string[] };
@@ -67,6 +68,26 @@ export function reduceSessionTabWorkspace(
           ...hydrated.draftsBySession,
           [DRAFT_SESSION_KEY]: startupDraft,
         },
+      };
+    }
+    case "startup-draft.materialize": {
+      const startupText = sessionTabDraft(state, "");
+      if (state.activeSessionId || !startupText.trim()) {
+        return state;
+      }
+      const draftsBySession = { ...state.draftsBySession };
+      delete draftsBySession[DRAFT_SESSION_KEY];
+      draftsBySession[event.draft.id] = startupText;
+      return {
+        ...state,
+        activeSessionId: event.draft.id,
+        draftSessionsById: {
+          ...state.draftSessionsById,
+          [event.draft.id]: event.draft,
+        },
+        draftsBySession,
+        openSessionIds: unique([...state.openSessionIds, event.draft.id]),
+        unreadSessionIds: withoutValue(state.unreadSessionIds, event.draft.id),
       };
     }
     case "session-draft.open": {

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:db326e6644e577cc1d1ae965573982dc8b1797f5832984b244b438a0f134d526 -->
+<!-- tinybot-module-fingerprint: sha256:676072a382ba29660c27ee92f6340ec4c92eaaa3c9de17b76c218b8ac7ea79f1 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles.
@@ -48,3 +48,7 @@ and file-only prompts reuse the canonical Chat composer bundle instead of a
 pet-specific unsupported state. Draft text, filenames, Thread IDs, model
 identifiers, and the `desktop-pet` entry-point value remain untranslated
 protocol or user content.
+
+Session-sidebar whole-row keyboard instructions and live-region move
+announcements are localized here. Persisted container and item IDs remain
+language-neutral so changing the interface language cannot reset user order.

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -916,6 +916,8 @@ export const en = {
       label: "Chat", sessions: "Sessions", addWorkspace: "Add workspace folder", workspaceActions: "Workspace and project actions", searchChats: "Search chats", expandSidebar: "Expand session sidebar",
       collapseSidebar: "Collapse session sidebar", newChat: "New chat", sessionRows: "Session list rows", workspace: "Workspace {{name}}", generalSessions: "General chats",
       newSessionIn: "New session in {{name}}", confirmDelete: "Confirm delete {{name}}", delete: "Delete {{name}}", noSessions: "No sessions yet.",
+      reorderWorkspace: "Reorder workspace {{name}}. Drag or press Alt+Arrow Up or Down.", reorderProject: "Reorder project {{name}}. Drag or press Alt+Arrow Up or Down.",
+      reorderSession: "Reorder session {{name}}. Drag or press Alt+Arrow Up or Down.", reorderedBefore: "Moved {{item}} before {{target}}.", reorderedAfter: "Moved {{item}} after {{target}}.",
       noSelection: "No conversation selected", conversationMenu: "Open conversation menu", unpin: "Unpin conversation", pin: "Pin conversation",
       rename: "Rename conversation", copyId: "Copy ID", copyMarkdown: "Copy Markdown", archive: "Archive conversation", sideChat: "Open side chat",
       branch: "Branch", newWindow: "Open in new window", conversation: "Conversation", selectSession: "Select or create a conversation.",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -401,6 +401,8 @@ export const zh = {
       label: "聊天", sessions: "会话", addWorkspace: "添加工作区文件夹", workspaceActions: "工作区和项目操作", searchChats: "搜索会话", expandSidebar: "展开会话侧栏", collapseSidebar: "收起会话侧栏",
       newChat: "新会话", sessionRows: "会话列表", workspace: "工作区 {{name}}", generalSessions: "常规会话", newSessionIn: "在 {{name}} 中新建会话", confirmDelete: "确认删除 {{name}}",
       delete: "删除 {{name}}", noSessions: "还没有会话。", noSelection: "未选择会话", conversationMenu: "打开会话菜单",
+      reorderWorkspace: "调整工作区 {{name}} 的顺序。拖动，或按 Alt+上/下方向键。", reorderProject: "调整项目 {{name}} 的顺序。拖动，或按 Alt+上/下方向键。",
+      reorderSession: "调整会话 {{name}} 的顺序。拖动，或按 Alt+上/下方向键。", reorderedBefore: "已将 {{item}} 移到 {{target}} 前面。", reorderedAfter: "已将 {{item}} 移到 {{target}} 后面。",
       unpin: "取消置顶", pin: "置顶会话", rename: "重命名会话", copyId: "复制 ID", copyMarkdown: "复制 Markdown", archive: "归档会话",
       sideChat: "打开侧边会话", branch: "创建分支", newWindow: "在新窗口中打开", conversation: "会话",
       selectSession: "请选择或新建一个会话。", backToLatest: "回到最新消息", compacting: "正在压缩上下文", loadingSessions: "正在加载会话…",

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -361,7 +361,7 @@ describe("DesktopShell", () => {
     expect(css).not.toMatch(/\.react-activity-rail/);
     expect(css).toMatch(/\.react-session-list\s*{[^}]*transition:\s*width var\(--motion-duration-medium\) var\(--motion-ease-standard\);/s);
     expect(css).toMatch(/\.react-session-list\[data-collapsed="true"\]\s*{[^}]*width:\s*64px;/s);
-    expect(css).toMatch(/\.react-session-list__new\s*{[^}]*font-size:\s*12px;/s);
+    expect(css).not.toMatch(/\.react-session-list__new/);
     expect(css).toMatch(/\.react-session-row__title\s*{[^}]*font-size:\s*12px;/s);
     expect(css).toMatch(/\.react-default-model-picker\s*{[^}]*grid-template-columns:\s*minmax\(170px,\s*0\.72fr\) minmax\(300px,\s*1\.45fr\);/s);
     expect(css).toMatch(/\.react-default-model-picker__models-list\s*{[^}]*max-height:\s*220px;[^}]*overflow-y:\s*auto;/s);

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -389,7 +389,8 @@ describe("DesktopShell", () => {
     expect(within(appMenu).getByText("Ctrl+N").classList.contains("react-top-menu__shortcut")).toBe(true);
 
     await user.click(within(appMenu).getByRole("menuitem", { name: /New Chat/ }));
-    await waitFor(() => expect(services.sessionStore.create).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole("heading", { name: "New chat" })).toBeTruthy();
+    expect(services.sessionStore.create).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Resources" }));
     const resourcesMenu = screen.getByRole("menu", { name: "Resources menu" });

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:05ffe76f142428f3af11efe04c90287ac49646b8bce66309e84a5af3f1e8fba1 -->
+<!-- tinybot-module-fingerprint: sha256:dc969a5c817b56f14a5a7d73212331016482dc532d2e2f5c6a92a6098c68fe47 -->
 
 `shell` owns Tinybot's desktop chrome: the window frame, menus, route
 selection, deferred route loading, and update dialogs.

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:dc969a5c817b56f14a5a7d73212331016482dc532d2e2f5c6a92a6098c68fe47 -->
+<!-- tinybot-module-fingerprint: sha256:9c010eb04ef42cbab9bd13c32ac8b70beacfee7e3514db342124793e1e28203b -->
 
 `shell` owns Tinybot's desktop chrome: the window frame, menus, route
 selection, deferred route loading, and update dialogs.
@@ -10,6 +10,8 @@ behavior remains in the route module rather than moving into the shell.
 The shell also marks only the first Chat mount in an app lifetime as a fresh,
 uncreated conversation. Once Chat finishes session hydration, later route
 remounts can restore the tabs opened during that same app lifetime.
+Shell menu and keyboard new-chat commands only signal Chat to open a local
+draft; they do not create a native Thread before the draft's first send.
 
 Resources > Agent Graphs opens a dedicated lazy route. The shell knows only the
 route label, loader, and shared renderer stores passed to it; workspace catalog

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:e5b97809d3eb1a37bf07b7778119a3b0070dfcacd23bdf4640bbff348860ec13 -->
+<!-- tinybot-module-fingerprint: sha256:b8ef95011a65d898fc481b3ca72d37cac206d3b00528b3ba18c70325c689196d -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:b8ef95011a65d898fc481b3ca72d37cac206d3b00528b3ba18c70325c689196d -->
+<!-- tinybot-module-fingerprint: sha256:e1be426badee7563916238861d4c5f54d9a05acbae55bc579200e72f1289cbc0 -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.
@@ -7,3 +7,15 @@ defaults, shared primitives, and desktop-shell styles.
 Route-specific CSS is imported by its owning TypeScript module. Do not collect
 Chat, Settings, Memory, or Tools styles here through `@import`, because
 that would collapse their loading seams back into the startup bundle.
+
+The desktop session sidebar uses workspace headers and complete session rows as
+drag sources, with a grab cursor and high-contrast insertion line but no
+separate grip control. Dragging lowers the source opacity while keeping its
+footprint stable; reduced-motion mode retains these static state cues.
+
+The desktop document root is fixed to the WebView viewport and never owns page
+scrolling. `html`, `body`, and `#root` contain the `100%` shell while route,
+conversation, sidebar, and fatal-error surfaces own any required overflow. The
+native window configuration remains the only minimum-size boundary; duplicating
+its outer-window minimum on `body` would overflow the smaller inner WebView once
+window chrome is subtracted.

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -828,7 +828,6 @@ button:disabled {
 .react-session-list__header h2,
 .react-session-list__add-workspace,
 .react-session-list__search,
-.react-session-list__new span,
 .react-session-row__title,
 .react-session-row__select small,
 .react-session-row__delete {
@@ -843,30 +842,6 @@ button:disabled {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.react-session-list__new {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  min-height: 34px;
-  background: var(--color-primary);
-  color: var(--color-on-primary);
-  padding: 0 10px;
-  font-size: 12px;
-}
-
-.react-session-list__new span {
-  max-width: 180px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.react-session-list__new:hover,
-.react-session-list__new:focus-visible {
-  background: var(--color-primary-active);
 }
 
 .react-session-list__collapse {
@@ -920,7 +895,6 @@ button:disabled {
 .react-desktop-shell[data-sidebar-motion="keyboard"] .react-session-list__header h2,
 .react-desktop-shell[data-sidebar-motion="keyboard"] .react-session-list__add-workspace,
 .react-desktop-shell[data-sidebar-motion="keyboard"] .react-session-list__search,
-.react-desktop-shell[data-sidebar-motion="keyboard"] .react-session-list__new span,
 .react-desktop-shell[data-sidebar-motion="keyboard"] .react-session-row__title,
 .react-desktop-shell[data-sidebar-motion="keyboard"] .react-session-row__select small,
 .react-desktop-shell[data-sidebar-motion="keyboard"] .react-session-row__delete,
@@ -939,8 +913,7 @@ button:disabled {
 
 .react-session-list[data-collapsed="true"] .react-session-list__header h2,
 .react-session-list[data-collapsed="true"] .react-session-list__add-workspace,
-.react-session-list[data-collapsed="true"] .react-session-list__search,
-.react-session-list[data-collapsed="true"] .react-session-list__new span {
+.react-session-list[data-collapsed="true"] .react-session-list__search {
   max-width: 0;
   opacity: 0;
   pointer-events: none;
@@ -953,7 +926,6 @@ button:disabled {
   min-width: 0;
 }
 
-.react-session-list[data-collapsed="true"] .react-session-list__new,
 .react-session-list[data-collapsed="true"] .react-session-list__collapse {
   width: 40px;
   min-width: 40px;
@@ -1916,12 +1888,10 @@ button:disabled {
   gap: 3px;
 }
 
-.react-session-list__new,
 [data-press-feedback="true"] {
   transition: transform var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
-.react-session-list__new:active:not(:disabled),
 [data-press-feedback="true"]:active:not(:disabled) {
   transform: scale(.97);
 }
@@ -2108,7 +2078,6 @@ button:disabled {
   .react-session-list__header h2,
 .react-session-list__add-workspace,
 .react-session-list__search,
-.react-session-list__new span,
 .react-session-row__title,
 .react-session-row__select small,
 .react-session-row__delete {
@@ -2117,8 +2086,7 @@ button:disabled {
 
   .react-session-list[data-collapsed="true"] .react-session-list__header h2,
 .react-session-list[data-collapsed="true"] .react-session-list__add-workspace,
-.react-session-list[data-collapsed="true"] .react-session-list__search,
-.react-session-list[data-collapsed="true"] .react-session-list__new span {
+.react-session-list[data-collapsed="true"] .react-session-list__search {
     transform: none;
   }
 
@@ -2129,7 +2097,6 @@ button:disabled {
     transition-duration: 140ms;
   }
 
-  .react-session-list__new:active:not(:disabled),
 [data-press-feedback="true"]:active:not(:disabled) {
     transform: none;
   }

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -36,10 +36,18 @@
   box-sizing: border-box;
 }
 
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
 body {
   margin: 0;
-  min-width: 720px;
-  min-height: 520px;
   background: var(--color-canvas);
   color: var(--color-body);
 }
@@ -79,6 +87,7 @@ button:disabled {
   align-content: center;
   justify-items: start;
   min-height: 100vh;
+  overflow: auto;
   gap: 12px;
   padding: 40px;
   background: var(--color-panel);
@@ -114,8 +123,8 @@ button:disabled {
 .react-desktop-shell {
   display: grid;
   grid-template-rows: 42px minmax(0, 1fr);
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
 }
 
@@ -1173,6 +1182,10 @@ button:disabled {
   min-width: 0;
 }
 
+.react-project-workspace {
+  position: relative;
+}
+
 .react-project-group__member-title {
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr) 30px;
@@ -1428,6 +1441,68 @@ button:disabled {
     transform 180ms var(--motion-ease-standard);
 }
 
+.react-session-workspace > summary[draggable="true"],
+.react-project-group > summary[draggable="true"],
+.react-project-group__member-title[draggable="true"],
+.react-session-row[draggable="true"] {
+  cursor: grab;
+  user-select: none;
+}
+
+.react-project-group__member-title[draggable="true"]:focus-visible {
+  border-radius: 7px;
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 72%, transparent);
+  outline-offset: -2px;
+}
+
+.react-session-workspace[data-dragging="true"],
+.react-project-group[data-dragging="true"],
+.react-project-workspace[data-dragging="true"],
+.react-session-row[data-dragging="true"] {
+  cursor: grabbing;
+  opacity: .52;
+}
+
+.react-session-workspace[data-dragging="true"] > summary,
+.react-project-group[data-dragging="true"] > summary,
+.react-project-workspace[data-dragging="true"] > .react-project-group__member-title {
+  cursor: grabbing;
+}
+
+.react-session-workspace[data-drop-position="before"]::before,
+.react-project-group[data-drop-position="before"]::before,
+.react-project-workspace[data-drop-position="before"]::before,
+.react-session-row[data-drop-position="before"]::before,
+.react-session-workspace[data-drop-position="after"]::after,
+.react-project-group[data-drop-position="after"]::after,
+.react-project-workspace[data-drop-position="after"]::after,
+.react-session-row[data-drop-position="after"]::after {
+  position: absolute;
+  z-index: 4;
+  right: 4px;
+  left: 4px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--color-primary-active);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 12%, transparent);
+  content: "";
+  pointer-events: none;
+}
+
+.react-session-workspace[data-drop-position="before"]::before,
+.react-project-group[data-drop-position="before"]::before,
+.react-project-workspace[data-drop-position="before"]::before,
+.react-session-row[data-drop-position="before"]::before {
+  top: -3px;
+}
+
+.react-session-workspace[data-drop-position="after"]::after,
+.react-project-group[data-drop-position="after"]::after,
+.react-project-workspace[data-drop-position="after"]::after,
+.react-session-row[data-drop-position="after"]::after {
+  bottom: -3px;
+}
+
 .react-session-list__rows[data-motion="animated-list"] .react-session-row {
   animation: react-list-enter var(--motion-duration-medium) var(--motion-ease-standard) both;
   animation-delay: calc(var(--react-session-row-index, 0) * 22ms);
@@ -1450,6 +1525,7 @@ button:disabled {
   overflow: hidden;
   border-radius: inherit;
   padding: 0 10px;
+  cursor: inherit;
   text-align: left;
 }
 

--- a/src/react-workbench/styles/workbench.test.ts
+++ b/src/react-workbench/styles/workbench.test.ts
@@ -7,6 +7,21 @@ const settingsStylesheet = readFileSync(new URL("../settings/SettingsRoute.css",
 const memoryStylesheet = readFileSync(new URL("../memory/MemoryRoute.css", import.meta.url), "utf8");
 
 describe("workbench CSS interaction contracts", () => {
+  test("keeps document scrolling disabled while desktop surfaces own overflow", () => {
+    const documentRule = shellStylesheet.match(/html,\s*body,\s*#root\s*\{([^}]+)\}/);
+    const shellRule = shellStylesheet.match(/\.react-desktop-shell\s*\{([^}]+)\}/);
+    const sessionRowsRule = shellStylesheet.match(/\.react-session-list__rows\s*\{([^}]+)\}/);
+    const conversationRule = chatStylesheet.match(/\.react-conversation-view\s*\{([^}]+)\}/);
+
+    expect(documentRule?.[1]).toContain("width: 100%");
+    expect(documentRule?.[1]).toContain("height: 100%");
+    expect(documentRule?.[1]).toContain("overflow: hidden");
+    expect(shellRule?.[1]).toContain("width: 100%");
+    expect(shellRule?.[1]).toContain("height: 100%");
+    expect(sessionRowsRule?.[1]).toContain("overflow: auto");
+    expect(conversationRule?.[1]).toContain("overflow: auto");
+  });
+
   test("keeps conversation rows intrinsic and scopes drawer header layout", () => {
     const conversationRule = chatStylesheet.match(/\.react-conversation-view\s*\{([^}]+)\}/);
     const drawerHeaderRule = chatStylesheet.match(


### PR DESCRIPTION
## Summary

- Preserve active provider routing, refine chat creation controls, and defer draft session persistence until the first send.
- Let users reorder project, workspace, and session rows by dragging the full row, persist the order locally, and provide Alt+Arrow keyboard parity with localized announcements.
- Keep the document root fixed to the WebView viewport so narrow windows avoid outer scrollbars while sidebar and conversation surfaces retain owned scrolling.

## Scope note

This branch was created from fix/router-active-profile-resolution. Because that remote branch has no pull request, this PR targets master and transparently includes its three preceding commits.

## Validation

- npm test (667 tests)
- npm run typecheck
- npm run lint
- npm run build
- npm run readme:check
- npm run docs:check