### PR TITLE
Refactor provider policies into static plugins

### DIFF
--- a/docs/api/threads-and-memory.md
+++ b/docs/api/threads-and-memory.md
@@ -13,7 +13,7 @@ src-tauri/src/threads/domain/types/requests.rs
 src-tauri/tests/crate/threads.rs
 src/app-core/chat/agentInputReference.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:0f9f6cb86f7dd148bfec017a160aed0bbc5086ab6f4c9913b4b5c97fad258244 -->
+<!-- tinybot-doc-fingerprint: sha256:313bea46f54f1237dfa7af10cd9474d24fe719c50795f6b6e7fc03c1e81f0dab -->
 
 This document covers Thread queries, memory, persistence, and project grouping.
 It is part of the [Rust backend API reference](rust-backend-api.md), which

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -1,5 +1,5 @@
 # Agent
-<!-- tinybot-module-fingerprint: sha256:f9a5b3e1707f01cb77872e754fbbbcbe14329736f75f55dc55aaa7c808df90b7 -->
+<!-- tinybot-module-fingerprint: sha256:20a48e87e5a0202f1a042ea84972db7a006586d183ca90fb15564083bbecccde -->
 
 `agent` contains the native agent stack. It connects provider configuration,
 the turn runtime, durable runtime events, and the desktop integration bridge.

--- a/src-tauri/src/agent/provider.rs
+++ b/src-tauri/src/agent/provider.rs
@@ -1,5 +1,6 @@
 mod catalog;
 mod completion;
+mod plugins;
 mod streaming;
 
 // Preserve the existing provider interface while implementation stays in focused modules.
@@ -14,6 +15,7 @@ pub use completion::{
     complete_chat_for_agent_with_observer_async, complete_responses_for_agent_with_observer_async,
     NativeProviderFailure, NativeProviderFailureKind,
 };
+pub(crate) use plugins::adapt_provider_request;
 pub use streaming::NativeProviderStreamEvent;
 
 #[cfg(test)]

--- a/src-tauri/src/agent/provider/README.md
+++ b/src-tauri/src/agent/provider/README.md
@@ -1,9 +1,14 @@
 # Agent Providers
-<!-- tinybot-module-fingerprint: sha256:cb7b3d424410b438efd60ea80e5962ab0a6249e8e618145c320dcd4cd9406740 -->
+<!-- tinybot-module-fingerprint: sha256:34e9d3757cbd927cd18ed52038070e88c594eeeca47c9dd00fc14c223f51db7c -->
 
 This module resolves provider and model configuration and performs streaming
 Chat Completions or Responses API requests.
 
+- `plugins/` contains the statically registered Provider adapters. Every
+  built-in Provider implements the shared `ProviderPlugin` interface and owns
+  its catalog manifest, reasoning-effort policy, and wire-request adaptations.
+  The shared protocol and transport flow remains outside individual adapters;
+  custom OpenAI-compatible Providers use the default pass-through policy.
 - `catalog.rs` resolves configured providers and models. Live discovery stays
   async end to end, calls the authenticated OpenAI-compatible `GET /models`
   endpoint, and requires only `data[].id` from each provider response. Custom

--- a/src-tauri/src/agent/provider/README.md
+++ b/src-tauri/src/agent/provider/README.md
@@ -1,5 +1,5 @@
 # Agent Providers
-<!-- tinybot-module-fingerprint: sha256:34e9d3757cbd927cd18ed52038070e88c594eeeca47c9dd00fc14c223f51db7c -->
+<!-- tinybot-module-fingerprint: sha256:1a61ca5b3c0e34bb4fe3368457a842d8f134951b1b5875c061b515f0a868ec6a -->
 
 This module resolves provider and model configuration and performs streaming
 Chat Completions or Responses API requests.

--- a/src-tauri/src/agent/provider/catalog.rs
+++ b/src-tauri/src/agent/provider/catalog.rs
@@ -4,10 +4,10 @@ use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
+use super::plugins::{provider_plugin_by_id, registered_provider_plugins, OPENAI_API_MODES};
+
 const DEFAULT_AGENT_MODEL: &str = "deepseek-v4-pro";
 const DEFAULT_PROVIDER_TIMEOUT_MS: u64 = 120_000;
-const OPENAI_API_MODES: &[&str] = &["chat_completions", "responses"];
-const CHAT_COMPLETIONS_ONLY: &[&str] = &["chat_completions"];
 const BUILT_IN_IMAGE_INPUT_MODELS: &[&str] = &["deepseek-v4-flash-vision-exp", "glm-5.3-flash"];
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -159,152 +159,10 @@ struct ProviderModelDiscoveryItem {
     id: String,
 }
 
-const PROVIDER_CATALOG: &[NativeProviderCatalogEntry] = &[
-    catalog_entry(
-        "openai",
-        "OpenAI",
-        &["gpt", "chatgpt"],
-        &["built_in"],
-        Some("https://api.openai.com/v1"),
-        &["OPENAI_API_KEY"],
-        &["OPENAI_BASE_URL"],
-        &["gpt-4.1"],
-        &["gpt", "o1", "o3", "o4"],
-        &[],
-    ),
-    catalog_entry(
-        "deepseek",
-        "DeepSeek",
-        &["deep seek"],
-        &["built_in"],
-        Some("https://api.deepseek.com"),
-        &["DEEPSEEK_API_KEY"],
-        &["DEEPSEEK_BASE_URL"],
-        &["deepseek-v4-pro", "deepseek-v4-flash"],
-        &["deepseek"],
-        &["reasoning"],
-    ),
-    catalog_entry_with_discovery(
-        "dashscope",
-        "DashScope",
-        &["dash scope", "model studio", "qwen"],
-        &["built_in"],
-        Some("https://dashscope.aliyuncs.com/compatible-mode/v1"),
-        &["DASHSCOPE_API_KEY"],
-        &["DASHSCOPE_BASE_URL"],
-        true,
-        &["qwen-plus", "qwen-max", "qwen-turbo"],
-        &["qwen"],
-        &[],
-    ),
-    catalog_entry_with_options(
-        "zai",
-        "Z.ai",
-        &["z.ai", "zhipu", "bigmodel"],
-        &["built_in"],
-        Some("https://open.bigmodel.cn/api/paas/v4"),
-        &["ZAI_API_KEY"],
-        &["ZAI_BASE_URL"],
-        false,
-        &["glm-5.3", "glm-5.3-flash", "glm-5.2"],
-        &["glm"],
-        &[],
-        CHAT_COMPLETIONS_ONLY,
-    ),
-];
-
-const fn catalog_entry(
-    id: &'static str,
-    display_name: &'static str,
-    aliases: &'static [&'static str],
-    categories: &'static [&'static str],
-    default_api_base: Option<&'static str>,
-    api_key_env_vars: &'static [&'static str],
-    api_base_env_vars: &'static [&'static str],
-    curated_model_ids: &'static [&'static str],
-    model_prefixes: &'static [&'static str],
-    capabilities: &'static [&'static str],
-) -> NativeProviderCatalogEntry {
-    catalog_entry_with_discovery(
-        id,
-        display_name,
-        aliases,
-        categories,
-        default_api_base,
-        api_key_env_vars,
-        api_base_env_vars,
-        true,
-        curated_model_ids,
-        model_prefixes,
-        capabilities,
-    )
-}
-
-const fn catalog_entry_with_discovery(
-    id: &'static str,
-    display_name: &'static str,
-    aliases: &'static [&'static str],
-    categories: &'static [&'static str],
-    default_api_base: Option<&'static str>,
-    api_key_env_vars: &'static [&'static str],
-    api_base_env_vars: &'static [&'static str],
-    supports_model_discovery: bool,
-    curated_model_ids: &'static [&'static str],
-    model_prefixes: &'static [&'static str],
-    capabilities: &'static [&'static str],
-) -> NativeProviderCatalogEntry {
-    catalog_entry_with_options(
-        id,
-        display_name,
-        aliases,
-        categories,
-        default_api_base,
-        api_key_env_vars,
-        api_base_env_vars,
-        supports_model_discovery,
-        curated_model_ids,
-        model_prefixes,
-        capabilities,
-        OPENAI_API_MODES,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-const fn catalog_entry_with_options(
-    id: &'static str,
-    display_name: &'static str,
-    aliases: &'static [&'static str],
-    categories: &'static [&'static str],
-    default_api_base: Option<&'static str>,
-    api_key_env_vars: &'static [&'static str],
-    api_base_env_vars: &'static [&'static str],
-    supports_model_discovery: bool,
-    curated_model_ids: &'static [&'static str],
-    model_prefixes: &'static [&'static str],
-    capabilities: &'static [&'static str],
-    supported_api_modes: &'static [&'static str],
-) -> NativeProviderCatalogEntry {
-    NativeProviderCatalogEntry {
-        id,
-        display_name,
-        aliases,
-        categories,
-        default_api_base,
-        api_key_env_vars,
-        api_base_env_vars,
-        supports_model_discovery,
-        curated_model_ids,
-        model_prefixes,
-        capabilities,
-        supported_api_modes,
-        backend: "openai",
-    }
-}
-
 pub fn provider_catalog_body(config: &Value) -> Value {
-    let providers = PROVIDER_CATALOG
-        .iter()
-        .map(|entry| {
+    let providers = registered_provider_plugins()
+        .map(|plugin| {
+            let entry = plugin.catalog_entry();
             let profile = resolve_provider_profile(config, Some(entry.id), None);
             serde_json::json!({
                 "id": entry.id,
@@ -727,19 +585,13 @@ fn profile_matches_provider(profile: &Value, provider_id: &str) -> bool {
 pub(super) fn catalog_entry_by_id(
     provider_id: &str,
 ) -> Option<&'static NativeProviderCatalogEntry> {
-    PROVIDER_CATALOG.iter().find(|entry| {
-        entry.id == provider_id
-            || entry
-                .aliases
-                .iter()
-                .any(|alias| normalize_provider_id(alias) == provider_id)
-    })
+    provider_plugin_by_id(provider_id).map(|plugin| plugin.catalog_entry())
 }
 
 pub(super) fn infer_provider_from_model(model: &str) -> String {
     let normalized = model.trim().to_ascii_lowercase();
-    PROVIDER_CATALOG
-        .iter()
+    registered_provider_plugins()
+        .map(|plugin| plugin.catalog_entry())
         .find(|entry| {
             entry
                 .curated_model_ids

--- a/src-tauri/src/agent/provider/plugins/README.md
+++ b/src-tauri/src/agent/provider/plugins/README.md
@@ -1,0 +1,178 @@
+# Provider Plugins
+<!-- tinybot-module-fingerprint: sha256:9ca613631a8051fb46595bf2980c21177412c60ab20996a2ffcdad3b7eb01d32 -->
+
+This module contains the statically registered adapters for built-in
+Providers. A Provider plugin owns vendor-specific catalog metadata, reasoning
+effort policy, and request-shape adaptations while the shared Chat Completions
+and Responses flows remain in the runtime protocol adapters.
+
+Plugins are compiled into Tinybot. They are not dynamically loaded libraries.
+
+## When a Provider Plugin Is Enough
+
+Add a Provider plugin when the Provider uses an OpenAI-compatible transport and
+its differences are limited to matters such as:
+
+- supported Chat Completions or Responses modes;
+- model discovery and curated model metadata;
+- supported or renamed reasoning effort values;
+- ignored, renamed, rejected, or vendor-specific request fields.
+
+Do not copy protocol-wide history, tool, streaming, or response decoding into a
+Provider plugin. If a Provider changes authentication, endpoint construction,
+stream events, or response shapes, extend the corresponding transport or
+protocol Adapter at that seam instead.
+
+## Integration Steps
+
+### 1. Add a Provider module
+
+Create one file per Provider, for example `acme.rs`. Define one stateless
+Adapter and its catalog entry:
+
+```rust
+use super::{
+    ProviderPlugin, ProviderRequestContext, ReasoningEffortPolicy,
+    OPENAI_API_MODES,
+};
+use crate::agent::provider::{NativeProviderApiMode, NativeProviderCatalogEntry};
+use serde_json::Value;
+
+pub(super) struct AcmeProvider;
+
+pub(super) static PLUGIN: AcmeProvider = AcmeProvider;
+
+static CATALOG_ENTRY: NativeProviderCatalogEntry = NativeProviderCatalogEntry {
+    id: "acme",
+    display_name: "Acme",
+    aliases: &["acme-ai"],
+    categories: &["built_in"],
+    default_api_base: Some("https://api.acme.example/v1"),
+    api_key_env_vars: &["ACME_API_KEY"],
+    api_base_env_vars: &["ACME_BASE_URL"],
+    supports_model_discovery: true,
+    curated_model_ids: &["acme-1"],
+    model_prefixes: &["acme-"],
+    capabilities: &[],
+    supported_api_modes: OPENAI_API_MODES,
+    backend: "openai",
+};
+
+impl ProviderPlugin for AcmeProvider {
+    fn catalog_entry(&self) -> &'static NativeProviderCatalogEntry {
+        &CATALOG_ENTRY
+    }
+
+    fn reasoning_effort_policy(&self, _model: &str) -> ReasoningEffortPolicy {
+        ReasoningEffortPolicy::AllowList(&["low", "medium", "high"])
+    }
+
+    fn adapt_request(
+        &self,
+        context: ProviderRequestContext<'_>,
+        request: &mut Value,
+    ) -> Result<(), String> {
+        if context.protocol == NativeProviderApiMode::Responses {
+            request
+                .as_object_mut()
+                .ok_or_else(|| "provider request must be a JSON object".to_string())?
+                .remove("store");
+        }
+        Ok(())
+    }
+}
+```
+
+Use `CHAT_COMPLETIONS_ONLY` instead of `OPENAI_API_MODES` when Responses is not
+supported. Provider IDs and normalized aliases must be unique across the
+registry.
+
+### 2. Choose an effort policy
+
+`reasoning_effort_policy` may return:
+
+- `PassThrough`: send the frontend value unchanged;
+- `Omit`: remove effort from the request;
+- `AllowList`: accept only the listed values and fail visibly otherwise;
+- `Map`: translate Tinybot values to Provider-native values and fail when a
+  mapping is missing.
+
+The method receives the model ID, so one Provider can select different policies
+for different model families. A configured profile with
+`supportsReasoningEffort: false` overrides the plugin and omits effort.
+
+The shared normalizer writes the result to the correct protocol field:
+
+| Protocol | Effort field |
+| --- | --- |
+| Chat Completions | `reasoning_effort` |
+| Responses | `reasoning.effort` |
+
+### 3. Adapt only vendor-specific request fields
+
+The runtime constructs the standard request, applies common settings and tools,
+then calls `adapt_request`. Match on `context.protocol` when a transformation
+applies to only Chat Completions or Responses.
+
+Return an actionable error for unsupported values or field combinations. Do
+not silently downgrade an explicit user choice, and do not log credentials or
+request payloads.
+
+### 4. Register the plugin
+
+Declare the module and add its singleton to `PROVIDER_PLUGINS` in `mod.rs`:
+
+```rust
+mod acme;
+
+static PROVIDER_PLUGINS: [&dyn ProviderPlugin; 5] = [
+    &openai::PLUGIN,
+    &deepseek::PLUGIN,
+    &dashscope::PLUGIN,
+    &zai::PLUGIN,
+    &acme::PLUGIN,
+];
+```
+
+Registration makes the manifest available to catalog lookup, alias lookup, and
+model-based Provider inference. Unregistered custom OpenAI-compatible profiles
+continue to use the default pass-through request policy.
+
+### 5. Add focused tests
+
+At minimum, cover every non-default policy or request transformation:
+
+- accepted, rejected, omitted, or mapped effort values;
+- Chat Completions and Responses request shapes when both are supported;
+- invalid field combinations and their error messages;
+- manifest lookup through the Provider ID and aliases.
+
+Keep tests at the plugin seam by asserting the final request shape or returned
+error. Do not duplicate the shared protocol Adapter test suite in every plugin.
+
+Run the focused checks with HDD-friendly Cargo concurrency:
+
+```text
+cargo test --manifest-path src-tauri/Cargo.toml --lib --jobs 4 agent::provider::plugins
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+```
+
+## Frontend Exposure
+
+Registering a backend plugin does not currently add a built-in Provider preset
+to the settings UI. Existing custom Provider configuration can use the backend
+adapter without frontend changes. If a new Provider must appear as a built-in
+preset, update the frontend preset list as a separate product-facing change.
+
+## Review Checklist
+
+- The Provider is OpenAI-compatible at the transport and response levels.
+- The manifest declares only protocols and capabilities the Provider supports.
+- Provider IDs, aliases, model prefixes, and environment variables do not
+  conflict with an existing plugin.
+- Effort differences live in `reasoning_effort_policy`.
+- Other wire-request differences live in `adapt_request` and are scoped by
+  protocol where necessary.
+- Unsupported explicit settings fail with clear errors.
+- Focused request-shape and error-path tests pass.
+- This README and the parent Provider README pass freshness checks.

--- a/src-tauri/src/agent/provider/plugins/dashscope.rs
+++ b/src-tauri/src/agent/provider/plugins/dashscope.rs
@@ -1,0 +1,28 @@
+use super::{ProviderPlugin, OPENAI_API_MODES};
+use crate::agent::provider::NativeProviderCatalogEntry;
+
+pub(super) struct DashScopeProvider;
+
+pub(super) static PLUGIN: DashScopeProvider = DashScopeProvider;
+
+static CATALOG_ENTRY: NativeProviderCatalogEntry = NativeProviderCatalogEntry {
+    id: "dashscope",
+    display_name: "DashScope",
+    aliases: &["dash scope", "model studio", "qwen"],
+    categories: &["built_in"],
+    default_api_base: Some("https://dashscope.aliyuncs.com/compatible-mode/v1"),
+    api_key_env_vars: &["DASHSCOPE_API_KEY"],
+    api_base_env_vars: &["DASHSCOPE_BASE_URL"],
+    supports_model_discovery: true,
+    curated_model_ids: &["qwen-plus", "qwen-max", "qwen-turbo"],
+    model_prefixes: &["qwen"],
+    capabilities: &[],
+    supported_api_modes: OPENAI_API_MODES,
+    backend: "openai",
+};
+
+impl ProviderPlugin for DashScopeProvider {
+    fn catalog_entry(&self) -> &'static NativeProviderCatalogEntry {
+        &CATALOG_ENTRY
+    }
+}

--- a/src-tauri/src/agent/provider/plugins/deepseek.rs
+++ b/src-tauri/src/agent/provider/plugins/deepseek.rs
@@ -1,0 +1,28 @@
+use super::{ProviderPlugin, OPENAI_API_MODES};
+use crate::agent::provider::NativeProviderCatalogEntry;
+
+pub(super) struct DeepSeekProvider;
+
+pub(super) static PLUGIN: DeepSeekProvider = DeepSeekProvider;
+
+static CATALOG_ENTRY: NativeProviderCatalogEntry = NativeProviderCatalogEntry {
+    id: "deepseek",
+    display_name: "DeepSeek",
+    aliases: &["deep seek"],
+    categories: &["built_in"],
+    default_api_base: Some("https://api.deepseek.com"),
+    api_key_env_vars: &["DEEPSEEK_API_KEY"],
+    api_base_env_vars: &["DEEPSEEK_BASE_URL"],
+    supports_model_discovery: true,
+    curated_model_ids: &["deepseek-v4-pro", "deepseek-v4-flash"],
+    model_prefixes: &["deepseek"],
+    capabilities: &["reasoning"],
+    supported_api_modes: OPENAI_API_MODES,
+    backend: "openai",
+};
+
+impl ProviderPlugin for DeepSeekProvider {
+    fn catalog_entry(&self) -> &'static NativeProviderCatalogEntry {
+        &CATALOG_ENTRY
+    }
+}

--- a/src-tauri/src/agent/provider/plugins/mod.rs
+++ b/src-tauri/src/agent/provider/plugins/mod.rs
@@ -1,0 +1,229 @@
+mod dashscope;
+mod deepseek;
+mod openai;
+mod zai;
+
+use super::catalog::{
+    normalize_provider_id, NativeProviderApiMode, NativeProviderCatalogEntry, NativeProviderProfile,
+};
+use serde_json::Value;
+
+pub(super) const OPENAI_API_MODES: &[&str] = &["chat_completions", "responses"];
+pub(super) const CHAT_COMPLETIONS_ONLY: &[&str] = &["chat_completions"];
+
+pub(super) trait ProviderPlugin: Sync {
+    fn catalog_entry(&self) -> &'static NativeProviderCatalogEntry;
+
+    fn reasoning_effort_policy(&self, _model: &str) -> ReasoningEffortPolicy {
+        ReasoningEffortPolicy::PassThrough
+    }
+
+    fn adapt_request(
+        &self,
+        _context: ProviderRequestContext<'_>,
+        _request: &mut Value,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ProviderRequestContext<'a> {
+    pub provider_id: &'a str,
+    pub protocol: NativeProviderApiMode,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum ReasoningEffortPolicy {
+    PassThrough,
+    Omit,
+    AllowList(&'static [&'static str]),
+    Map(&'static [(&'static str, &'static str)]),
+}
+
+impl ReasoningEffortPolicy {
+    fn normalize(self, provider_id: &str, effort: &str) -> Result<Option<String>, String> {
+        match self {
+            Self::PassThrough => Ok(Some(effort.to_string())),
+            Self::Omit => Ok(None),
+            Self::AllowList(allowed) if allowed.contains(&effort) => Ok(Some(effort.to_string())),
+            Self::AllowList(allowed) => Err(format!(
+                "provider `{provider_id}` does not support reasoning effort `{effort}`; supported efforts: {}",
+                allowed.join(", ")
+            )),
+            Self::Map(mappings) => mappings
+                .iter()
+                .find_map(|(source, target)| (*source == effort).then_some((*target).to_string()))
+                .map(Some)
+                .ok_or_else(|| {
+                    format!(
+                        "provider `{provider_id}` does not define a reasoning effort mapping for `{effort}`"
+                    )
+                }),
+        }
+    }
+}
+
+static PROVIDER_PLUGINS: [&dyn ProviderPlugin; 4] = [
+    &openai::PLUGIN,
+    &deepseek::PLUGIN,
+    &dashscope::PLUGIN,
+    &zai::PLUGIN,
+];
+
+pub(super) fn registered_provider_plugins() -> impl Iterator<Item = &'static dyn ProviderPlugin> {
+    PROVIDER_PLUGINS.iter().copied()
+}
+
+pub(super) fn provider_plugin_by_id(provider_id: &str) -> Option<&'static dyn ProviderPlugin> {
+    let provider_id = normalize_provider_id(provider_id);
+    registered_provider_plugins().find(|plugin| {
+        let entry = plugin.catalog_entry();
+        entry.id == provider_id
+            || entry
+                .aliases
+                .iter()
+                .any(|alias| normalize_provider_id(alias) == provider_id)
+    })
+}
+
+pub(crate) fn adapt_provider_request(
+    profile: &NativeProviderProfile,
+    model: &str,
+    protocol: NativeProviderApiMode,
+    request: &mut Value,
+) -> Result<(), String> {
+    let plugin = provider_plugin_by_id(&profile.provider_id);
+    let effort_policy = if profile.supports_reasoning_effort {
+        plugin
+            .map(|plugin| plugin.reasoning_effort_policy(model))
+            .unwrap_or(ReasoningEffortPolicy::PassThrough)
+    } else {
+        ReasoningEffortPolicy::Omit
+    };
+    normalize_reasoning_effort(&profile.provider_id, protocol, request, effort_policy)?;
+
+    if let Some(plugin) = plugin {
+        plugin.adapt_request(
+            ProviderRequestContext {
+                provider_id: &profile.provider_id,
+                protocol,
+            },
+            request,
+        )?;
+    }
+    Ok(())
+}
+
+fn normalize_reasoning_effort(
+    provider_id: &str,
+    protocol: NativeProviderApiMode,
+    request: &mut Value,
+    policy: ReasoningEffortPolicy,
+) -> Result<(), String> {
+    let effort = match protocol {
+        NativeProviderApiMode::ChatCompletions => request
+            .get("reasoning_effort")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        NativeProviderApiMode::Responses => request
+            .pointer("/reasoning/effort")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    };
+    let Some(effort) = effort else {
+        return Ok(());
+    };
+    let normalized = policy.normalize(provider_id, &effort)?;
+
+    match protocol {
+        NativeProviderApiMode::ChatCompletions => {
+            let request = request
+                .as_object_mut()
+                .ok_or_else(|| "provider request must be a JSON object".to_string())?;
+            if let Some(effort) = normalized {
+                request.insert("reasoning_effort".to_string(), Value::String(effort));
+            } else {
+                request.remove("reasoning_effort");
+            }
+        }
+        NativeProviderApiMode::Responses => {
+            let reasoning = request
+                .get_mut("reasoning")
+                .and_then(Value::as_object_mut)
+                .ok_or_else(|| "Responses reasoning settings must be a JSON object".to_string())?;
+            if let Some(effort) = normalized {
+                reasoning.insert("effort".to_string(), Value::String(effort));
+            } else {
+                reasoning.remove("effort");
+            }
+            if reasoning.is_empty() {
+                request
+                    .as_object_mut()
+                    .expect("provider request should remain a JSON object")
+                    .remove("reasoning");
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn registry_has_unique_provider_ids_and_aliases() {
+        let mut owner_by_id = BTreeMap::new();
+        for plugin in registered_provider_plugins() {
+            let entry = plugin.catalog_entry();
+            for candidate in std::iter::once(entry.id).chain(entry.aliases.iter().copied()) {
+                let candidate = normalize_provider_id(candidate);
+                assert_eq!(
+                    owner_by_id.insert(candidate.clone(), entry.id),
+                    None,
+                    "provider registry key `{candidate}` is declared more than once"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn effort_policies_support_allow_lists_and_explicit_mappings() {
+        assert_eq!(
+            ReasoningEffortPolicy::AllowList(&["low", "high"])
+                .normalize("fixture", "high")
+                .unwrap()
+                .as_deref(),
+            Some("high")
+        );
+        assert!(ReasoningEffortPolicy::AllowList(&["low", "high"])
+            .normalize("fixture", "medium")
+            .unwrap_err()
+            .contains("supported efforts"));
+        assert_eq!(
+            ReasoningEffortPolicy::Map(&[("xhigh", "high")])
+                .normalize("fixture", "xhigh")
+                .unwrap()
+                .as_deref(),
+            Some("high")
+        );
+    }
+
+    #[test]
+    fn omitting_responses_effort_preserves_other_reasoning_fields() {
+        let mut request = json!({ "reasoning": { "effort": "high", "summary": "auto" } });
+        normalize_reasoning_effort(
+            "fixture",
+            NativeProviderApiMode::Responses,
+            &mut request,
+            ReasoningEffortPolicy::Omit,
+        )
+        .unwrap();
+
+        assert_eq!(request["reasoning"]["summary"], "auto");
+        assert!(request["reasoning"].get("effort").is_none());
+    }
+}

--- a/src-tauri/src/agent/provider/plugins/openai.rs
+++ b/src-tauri/src/agent/provider/plugins/openai.rs
@@ -1,0 +1,28 @@
+use super::{ProviderPlugin, OPENAI_API_MODES};
+use crate::agent::provider::NativeProviderCatalogEntry;
+
+pub(super) struct OpenAiProvider;
+
+pub(super) static PLUGIN: OpenAiProvider = OpenAiProvider;
+
+static CATALOG_ENTRY: NativeProviderCatalogEntry = NativeProviderCatalogEntry {
+    id: "openai",
+    display_name: "OpenAI",
+    aliases: &["gpt", "chatgpt"],
+    categories: &["built_in"],
+    default_api_base: Some("https://api.openai.com/v1"),
+    api_key_env_vars: &["OPENAI_API_KEY"],
+    api_base_env_vars: &["OPENAI_BASE_URL"],
+    supports_model_discovery: true,
+    curated_model_ids: &["gpt-4.1"],
+    model_prefixes: &["gpt", "o1", "o3", "o4"],
+    capabilities: &[],
+    supported_api_modes: OPENAI_API_MODES,
+    backend: "openai",
+};
+
+impl ProviderPlugin for OpenAiProvider {
+    fn catalog_entry(&self) -> &'static NativeProviderCatalogEntry {
+        &CATALOG_ENTRY
+    }
+}

--- a/src-tauri/src/agent/provider/plugins/zai.rs
+++ b/src-tauri/src/agent/provider/plugins/zai.rs
@@ -1,0 +1,61 @@
+use super::{ProviderPlugin, ProviderRequestContext, CHAT_COMPLETIONS_ONLY};
+use crate::agent::provider::{NativeProviderApiMode, NativeProviderCatalogEntry};
+use serde_json::Value;
+
+pub(super) struct ZaiProvider;
+
+pub(super) static PLUGIN: ZaiProvider = ZaiProvider;
+
+static CATALOG_ENTRY: NativeProviderCatalogEntry = NativeProviderCatalogEntry {
+    id: "zai",
+    display_name: "Z.ai",
+    aliases: &["z.ai", "zhipu", "bigmodel"],
+    categories: &["built_in"],
+    default_api_base: Some("https://open.bigmodel.cn/api/paas/v4"),
+    api_key_env_vars: &["ZAI_API_KEY"],
+    api_base_env_vars: &["ZAI_BASE_URL"],
+    supports_model_discovery: false,
+    curated_model_ids: &["glm-5.3", "glm-5.3-flash", "glm-5.2"],
+    model_prefixes: &["glm"],
+    capabilities: &[],
+    supported_api_modes: CHAT_COMPLETIONS_ONLY,
+    backend: "openai",
+};
+
+impl ProviderPlugin for ZaiProvider {
+    fn catalog_entry(&self) -> &'static NativeProviderCatalogEntry {
+        &CATALOG_ENTRY
+    }
+
+    fn adapt_request(
+        &self,
+        context: ProviderRequestContext<'_>,
+        request: &mut Value,
+    ) -> Result<(), String> {
+        if context.protocol != NativeProviderApiMode::ChatCompletions {
+            return Ok(());
+        }
+        let request = request
+            .as_object_mut()
+            .ok_or_else(|| "provider request must be a JSON object".to_string())?;
+        if let Some(temperature) = request.get("temperature").and_then(Value::as_f64) {
+            if !(temperature > 0.0 && temperature <= 1.0) {
+                return Err(format!(
+                    "provider `{}` temperature must be greater than 0 and at most 1, got {temperature}",
+                    context.provider_id
+                ));
+            }
+        }
+        if request.get("parallel_tool_calls").and_then(Value::as_bool) == Some(true) {
+            return Err(format!(
+                "provider `{}` does not declare support for `parallel_tool_calls`",
+                context.provider_id
+            ));
+        }
+        request.remove("stream_options");
+        if let Some(max_tokens) = request.remove("max_completion_tokens") {
+            request.insert("max_tokens".to_string(), max_tokens);
+        }
+        Ok(())
+    }
+}

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:7fadd26361ddc74a2a564a8096e31c4bd99fbce86ef637812d18e0201ab0a122 -->
+<!-- tinybot-module-fingerprint: sha256:88d917539b7c8cf442f87517d0d715006ab9c5d09027ed351fbd876df5812cb7 -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed

--- a/src-tauri/src/agent/runtime/chat_completions_adapter.rs
+++ b/src-tauri/src/agent/runtime/chat_completions_adapter.rs
@@ -1,8 +1,8 @@
 use super::items::{parse_tool_call, AgentUsageItem};
 use super::provider_adapter::{
-    attach_provider_tools, provider_message_with_user_context_and_images,
-    provider_reasoning_effort_enabled, require_model_image_input, require_provider_capability,
-    DecodedProviderTurn,
+    apply_provider_request_adaptation, attach_provider_tools,
+    provider_message_with_user_context_and_images, require_model_image_input,
+    require_provider_capability, DecodedProviderTurn,
 };
 use super::tool_router::AgentToolDefinition;
 use super::{
@@ -14,58 +14,6 @@ use serde_json::Value;
 
 pub(super) struct ChatCompletionsAdapter;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ChatCompletionsDialect {
-    OpenAi,
-    Zai,
-}
-
-impl ChatCompletionsDialect {
-    fn resolve(settings: &AgentTurnSettings, config_snapshot: &Value) -> Self {
-        let provider_id = crate::agent::provider::resolve_provider_profile(
-            config_snapshot,
-            settings.provider.as_deref(),
-            None,
-        )
-        .map(|profile| profile.provider_id)
-        .or_else(|| settings.provider.clone())
-        .unwrap_or_default();
-        match provider_id.as_str() {
-            "zai" | "z_ai" | "zhipu" | "bigmodel" => Self::Zai,
-            _ => Self::OpenAi,
-        }
-    }
-
-    fn include_stream_usage(self) -> bool {
-        self == Self::OpenAi
-    }
-
-    fn max_tokens_field(self) -> &'static str {
-        match self {
-            Self::OpenAi => "max_completion_tokens",
-            Self::Zai => "max_tokens",
-        }
-    }
-
-    fn validate_temperature(self, temperature: f64) -> Result<(), String> {
-        if self == Self::Zai && !(temperature > 0.0 && temperature <= 1.0) {
-            return Err(format!(
-                "provider `zai` temperature must be greater than 0 and at most 1, got {temperature}"
-            ));
-        }
-        Ok(())
-    }
-
-    fn require_parallel_tool_calls(self, enabled: bool) -> Result<(), String> {
-        if self == Self::Zai && enabled {
-            return Err(
-                "provider `zai` does not declare support for `parallel_tool_calls`".to_string(),
-            );
-        }
-        Ok(())
-    }
-}
-
 impl ChatCompletionsAdapter {
     pub fn build_request(
         legacy_messages: &[Value],
@@ -75,23 +23,27 @@ impl ChatCompletionsAdapter {
         config_snapshot: &Value,
         enable_parallel_tool_calls: bool,
     ) -> Result<Value, String> {
-        let dialect = ChatCompletionsDialect::resolve(settings, config_snapshot);
-        dialect.require_parallel_tool_calls(enable_parallel_tool_calls)?;
         require_model_image_input(settings, config_snapshot, legacy_messages)?;
         let mut request = serde_json::json!({
             "model": settings.model.clone(),
             "messages": Self::encode_history(legacy_messages, system_prompt)?,
             "stream": settings.stream,
         });
-        if settings.stream && dialect.include_stream_usage() {
+        if settings.stream {
             request["stream_options"] = serde_json::json!({ "include_usage": true });
         }
-        Self::apply_turn_settings(&mut request, settings, config_snapshot, dialect)?;
+        Self::apply_turn_settings(&mut request, settings, config_snapshot)?;
         attach_provider_tools(
             &mut request,
             Self::encode_tools(tools),
             enable_parallel_tool_calls,
         );
+        apply_provider_request_adaptation(
+            settings,
+            config_snapshot,
+            crate::agent::provider::NativeProviderApiMode::ChatCompletions,
+            &mut request,
+        )?;
         Ok(request)
     }
 
@@ -201,15 +153,13 @@ impl ChatCompletionsAdapter {
         request: &mut Value,
         settings: &AgentTurnSettings,
         config_snapshot: &Value,
-        dialect: ChatCompletionsDialect,
     ) -> Result<(), String> {
         settings.validate()?;
         if let Some(temperature) = settings.temperature {
-            dialect.validate_temperature(temperature)?;
             request["temperature"] = serde_json::json!(temperature);
         }
         if let Some(max_completion_tokens) = settings.max_completion_tokens {
-            request[dialect.max_tokens_field()] = serde_json::json!(max_completion_tokens);
+            request["max_completion_tokens"] = serde_json::json!(max_completion_tokens);
         }
         if let Some(service_tier) = settings.service_tier.as_deref() {
             require_provider_capability(settings, config_snapshot, "service_tier")?;
@@ -217,9 +167,7 @@ impl ChatCompletionsAdapter {
         }
         if let Some(reasoning) = settings.reasoning.as_ref() {
             if let Some(effort) = reasoning.effort.as_deref() {
-                if provider_reasoning_effort_enabled(settings, config_snapshot)? {
-                    request["reasoning_effort"] = Value::String(effort.to_string());
-                }
+                request["reasoning_effort"] = Value::String(effort.to_string());
             }
             if let Some(summary) = reasoning.summary.as_deref() {
                 require_provider_capability(settings, config_snapshot, "reasoning")?;

--- a/src-tauri/src/agent/runtime/provider_adapter.rs
+++ b/src-tauri/src/agent/runtime/provider_adapter.rs
@@ -369,12 +369,28 @@ pub(super) fn require_provider_capability(
     require_profile_capability(&profile, capability)
 }
 
-pub(super) fn provider_reasoning_effort_enabled(
+pub(super) fn apply_provider_request_adaptation(
     settings: &AgentTurnSettings,
     config_snapshot: &Value,
-) -> Result<bool, String> {
-    let profile = resolve_provider_profile(settings, config_snapshot)?;
-    Ok(profile.supports_reasoning_effort)
+    protocol: crate::agent::provider::NativeProviderApiMode,
+    request: &mut Value,
+) -> Result<(), String> {
+    let Some(profile) = crate::agent::provider::resolve_provider_profile(
+        config_snapshot,
+        settings.provider.as_deref(),
+        None,
+    ) else {
+        if settings
+            .reasoning
+            .as_ref()
+            .and_then(|reasoning| reasoning.effort.as_deref())
+            .is_some()
+        {
+            return resolve_provider_profile(settings, config_snapshot).map(|_| ());
+        }
+        return Ok(());
+    };
+    crate::agent::provider::adapt_provider_request(&profile, &settings.model, protocol, request)
 }
 
 fn resolve_provider_profile(

--- a/src-tauri/src/agent/runtime/responses_adapter.rs
+++ b/src-tauri/src/agent/runtime/responses_adapter.rs
@@ -1,8 +1,8 @@
 use super::items::{AgentContentPart, AgentUsageItem};
 use super::provider_adapter::{
-    attach_provider_tools, provider_message_with_user_context_and_images,
-    provider_reasoning_effort_enabled, require_model_image_input, require_provider_capability,
-    DecodedProviderTurn,
+    apply_provider_request_adaptation, attach_provider_tools,
+    provider_message_with_user_context_and_images, require_model_image_input,
+    require_provider_capability, DecodedProviderTurn,
 };
 use super::tool_router::{provider_tool_name, AgentToolDefinition};
 use super::{
@@ -48,6 +48,12 @@ impl ResponsesAdapter {
             Self::encode_tools(tools),
             enable_parallel_tool_calls,
         );
+        apply_provider_request_adaptation(
+            settings,
+            config_snapshot,
+            crate::agent::provider::NativeProviderApiMode::Responses,
+            &mut request,
+        )?;
         Ok(request)
     }
 
@@ -149,10 +155,7 @@ impl ResponsesAdapter {
         if let Some(reasoning) = settings.reasoning.as_ref() {
             let mut response_reasoning = Map::new();
             if let Some(effort) = reasoning.effort.as_deref() {
-                if provider_reasoning_effort_enabled(settings, config_snapshot)? {
-                    response_reasoning
-                        .insert("effort".to_string(), Value::String(effort.to_string()));
-                }
+                response_reasoning.insert("effort".to_string(), Value::String(effort.to_string()));
             }
             if let Some(summary) = reasoning.summary.as_deref() {
                 require_provider_capability(settings, config_snapshot, "reasoning")?;


### PR DESCRIPTION
## Summary

- Add a statically registered Provider plugin seam for catalog metadata, reasoning-effort policies, and vendor-specific request adaptation.
- Route both Chat Completions and Responses requests through the Provider adaptation seam while keeping shared protocol flows centralized.
- Move built-in OpenAI, DeepSeek, DashScope, and Z.ai behavior into focused Provider adapters.
- Document the integration workflow, supported extension scope, and verification checklist for future Providers.

## Testing

- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo test --manifest-path src-tauri/Cargo.toml --lib --jobs 4 provider
- cargo test --manifest-path src-tauri/Cargo.toml --lib --jobs 4 agent::provider::plugins
- cargo check --manifest-path src-tauri/Cargo.toml (pre-commit hook)
- Documentation and module README freshness checks (pre-commit hook)