### PR TITLE
feat: keep plan progress visible

### DIFF
--- a/docs/api/agent-runtime.md
+++ b/docs/api/agent-runtime.md
@@ -6,7 +6,7 @@ src-tauri/src/agent/runtime_protocol_tests.rs
 src-tauri/src/desktop_commands/runtime.rs
 src-tauri/src/desktop_commands/runtime_tests.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:f8f8058b31cd800c68e0bfb88bf532170a01174c93cadce7424e9e37715d8c62 -->
+<!-- tinybot-doc-fingerprint: sha256:235818abc2ad9e0dde6ce3eb00873aaa5146ecb92997dc9b8114175c1dce587c -->
 
 This document covers native Agent turn execution and provider-facing behavior.
 It is part of the [Rust backend API reference](rust-backend-api.md), which
@@ -168,6 +168,10 @@ Other extension tools may remain deferred until selected explicitly for the curr
 browser and subagent lifecycle tools are model-visible by default. Calls to inactive deferred tools fail with
 `stopReason: "policy_denied"`. Form continuations revalidate the persisted activation set against
 the current registry and capability policy.
+
+`update_plan` replaces the complete Turn plan and emits durable `agent.plan.progress`. Reloading a
+Thread reconstructs the last reported step states; a final assistant response does not implicitly
+mark unfinished plan steps completed or cancelled.
 
 ### Project-coordinator Thread tools
 

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -8,7 +8,7 @@ src/app-core/native/desktopNativeTauriEvents.ts
 src/app-core/native/desktopNativeTauriEvents.test.ts
 src/react-workbench/adapters/desktopNativeEventBridge.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:e4bfdb0bf6a7034c3d8fe7b582d139645bd6e008c0444b0de48caf4d175c3909 -->
+<!-- tinybot-doc-fingerprint: sha256:c7ba1dbba1af6aa82087b90f28a10533161b5e45d4b28d8ab596e14e798c05ac -->
 
 This document lists frontend-visible events emitted by the native runtime. It
 is part of the [Rust backend API reference](rust-backend-api.md), which defines
@@ -47,6 +47,10 @@ context compaction/trimming, errors/cancellation, usage updates, and user file/i
 Runtime event `itemId` is derived from the same typed item ID, so live delivery, trace persistence,
 and replay refer to one semantic item. Unknown or malformed internally constructed semantic events
 fail at the projection boundary instead of being persisted as an incomplete item.
+
+`agent.plan.progress` is durable and carries the complete current plan snapshot. Repeated updates
+revise the same Turn-local plan item, and an authoritative timeline reload restores the latest
+reported step states.
 
 `agent.timeline.patch` is the product-facing live update and is produced by the same projector as
 the runtime-state snapshot:

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -11,7 +11,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:f4848df56fc3d229e09ba7582bfe9507360ebe7572ec98e5f2206094d26b1b8f -->
+<!-- tinybot-doc-fingerprint: sha256:a98f74f59684cef86c011eec74ff37f1a5de6cbadfbfcd1fb197396125b6d6be -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal
@@ -138,6 +138,9 @@ calls, and tool results are materialized before diagnostic truncation. Reloaded
 timeline state is reconstructed from the Rollout rather than from renderer
 state. Legacy response records without an explicit Item ID derive one from the
 Thread, Turn, and sequence so Turn-local sequence reuse remains distinct.
+Plan-progress events are durable full snapshots. Normal Turn completion leaves
+their last reported step states unchanged; failure and interruption still
+project unfinished work to the corresponding terminal outcome.
 
 Startup recovery shares one Rollout-head-keyed cache of source lines and
 canonical reconstruction across index, Thread projection, and persisted Turn

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -11,7 +11,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:88287db6445c9da8ed2655090eeabf0581e616618849586d7895908b8b956ef6 -->
+<!-- tinybot-doc-fingerprint: sha256:2fb6aa1147f5f892b6572893859908355982b734d1f4d6373515d74bb88c903f -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:cddd2400b3501a8e6bdfb12c65206768885af34b397e5f354becfa81ec211b15 -->
+<!-- tinybot-doc-fingerprint: sha256:21464cc02e24520bb909b4132291c4b4c1c5f5e15d624249dbb95636aba8111a -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -11,7 +11,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:73c5b020cb1b8a0019042a61ebc6cd267a5493e7de25586679638e06f9ba77dc -->
+<!-- tinybot-doc-fingerprint: sha256:a507a1591cef35a0355f425ed189a4ebc476164832abebd1cad5d25a73154534 -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -365,7 +365,8 @@ lasts only for the current Turn; inactive calls fail before dispatch.
 `update_plan` replaces the complete Turn plan. States are `pending`,
 `in_progress`, and `completed`; an incomplete plan has exactly one active step.
 Valid updates revise one `<turnId>:plan` timeline item and emit
-`agent.plan.progress`.
+durable `agent.plan.progress`, so Thread reload reconstructs the last reported
+plan after session changes.
 
 Resumable form checkpoints persist the activated tool set. Continuation
 revalidates it against the current registry and capability policy. Stale IDs,

--- a/src-tauri/src/agent/runtime_protocol/README.md
+++ b/src-tauri/src/agent/runtime_protocol/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Protocol
-<!-- tinybot-module-fingerprint: sha256:86df6b4e634a997f8e96692ee34ecb0b8b9249f7cfc5287882c764ac936583af -->
+<!-- tinybot-module-fingerprint: sha256:1ded71978f34bf8dce54b7d473321600ff443a0ecd3caf8681d950c1de14cad3 -->
 
 `runtime_protocol` defines the durable events exchanged by the agent runtime
 and the projections built from them.

--- a/src-tauri/src/agent/runtime_protocol/event_catalog.rs
+++ b/src-tauri/src/agent/runtime_protocol/event_catalog.rs
@@ -550,7 +550,7 @@ impl AgentEventKind {
                 UserVisibility,
                 Some(PlanProgress),
                 AgentItem,
-                Ephemeral,
+                Durable,
             ),
             Self::TaskProgress => definition(
                 "agent.task_progress",

--- a/src-tauri/src/threads/domain/store/README.md
+++ b/src-tauri/src/threads/domain/store/README.md
@@ -1,5 +1,5 @@
 # Thread Stores
-<!-- tinybot-module-fingerprint: sha256:a41130f6b713eb02ed62bff93750770b7986c2d3cc9bd339ffa871b41cc8b289 -->
+<!-- tinybot-module-fingerprint: sha256:768ce860cd70a32db935d5a22fa7e2393d654d9714dcb4c112aa491be8e36ed8 -->
 
 This module implements thread storage operations and projections used by the
 thread domain.

--- a/src-tauri/src/threads/domain/store/runtime_projection.rs
+++ b/src-tauri/src/threads/domain/store/runtime_projection.rs
@@ -109,6 +109,7 @@ fn persisted_semantic_event(value: &Value) -> Option<(AgentEventKind, Value)> {
         EventNameResolution::Canonical(
             kind @ (AgentEventKind::ContextCompacted
             | AgentEventKind::ContextTrimmed
+            | AgentEventKind::PlanProgress
             | AgentEventKind::Usage
             | AgentEventKind::ToolCallDelta),
         ) => kind,

--- a/src-tauri/src/threads/rollout/store/README.md
+++ b/src-tauri/src/threads/rollout/store/README.md
@@ -1,5 +1,5 @@
 # Worker Thread Log
-<!-- tinybot-module-fingerprint: sha256:a780b52b8d0d1876a9113073bf933b3c7759b823d30fdbe3ff87c02db9e1a4a7 -->
+<!-- tinybot-module-fingerprint: sha256:a2180c42390a2cd4fc84aacd753b404a38fd1bd41a0169dcdb475b5f720c87e8 -->
 
 `threads::rollout::store` owns Tinybot's canonical append-only Rollout. It validates
 paths, records typed lines, reconstructs Thread and runtime projections,

--- a/src-tauri/src/threads/rollout/store/protocol_projection.rs
+++ b/src-tauri/src/threads/rollout/store/protocol_projection.rs
@@ -583,6 +583,9 @@ pub(super) fn semantic_thread_item_from_runtime_event(
         AgentEventKind::ContextCompacted | AgentEventKind::ContextTrimmed => {
             crate::threads::domain::ThreadItemKind::Event(event.clone())
         }
+        AgentEventKind::PlanProgress => {
+            crate::threads::domain::ThreadItemKind::Event(event.clone())
+        }
         AgentEventKind::Usage => {
             crate::threads::domain::ThreadItemKind::Event(compact_persisted_usage_event(event))
         }

--- a/src-tauri/src/threads/rollout/store/turn_tests.rs
+++ b/src-tauri/src/threads/rollout/store/turn_tests.rs
@@ -576,6 +576,114 @@ fn persisted_usage_preserves_the_live_timeline_item_identity() {
 }
 
 #[test]
+fn persisted_plan_progress_restores_the_live_timeline_after_session_reload() {
+    let root = std::env::temp_dir().join(format!(
+        "tinybot-plan-timeline-reload-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    let rpc = WorkerThreadLogRpc::new(
+        root.clone(),
+        CapabilityPolicy::new([
+            WorkerCapability::SessionWrite,
+            WorkerCapability::SessionMetadataRead,
+        ]),
+    );
+    let session_id = "plan-timeline-session";
+    let turn_id = "turn-plan";
+    let started_at = "2026-08-31T01:00:00.000Z";
+    rpc.start_turn(
+        AgentTurnRecord {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            thread_id: None,
+            parent_thread_id: None,
+            child_thread_ids: Vec::new(),
+            status: AgentTurnStatus::Running,
+            phase: "tool_running".to_string(),
+            started_at: started_at.to_string(),
+            updated_at: started_at.to_string(),
+            completed_at: None,
+            stop_reason: None,
+            model: "gpt-test".to_string(),
+            provider: Some("openai".to_string()),
+            max_iterations: 1,
+            current_iteration: 0,
+            conversation_message_ids: Vec::new(),
+            trace_messages: Vec::new(),
+            completed_tool_results: Vec::new(),
+            pending_tool_calls: Vec::new(),
+            checkpoint: None,
+            artifacts: Vec::new(),
+            usage: Vec::new(),
+            token_usage_info: None,
+            instruction_provenance: None,
+            instruction_diagnostics: Vec::new(),
+            trace_context: None,
+            error: None,
+        },
+        None,
+        Vec::new(),
+    )
+    .unwrap();
+    let live_event: AgentRuntimeEventEnvelope = serde_json::from_value(json!({
+        "schemaVersion": "tinybot.agent_event.v1",
+        "eventId": "turn-plan:plan:1",
+        "sequence": 1,
+        "sessionId": session_id,
+        "threadId": session_id,
+        "turnId": turn_id,
+        "itemId": "turn-plan:plan",
+        "eventName": "agent.plan.progress",
+        "phase": "tool_running",
+        "timestamp": "1788147600000",
+        "source": "tool",
+        "visibility": "user",
+        "payload": {
+            "agentItem": {
+                "type": "plan_progress",
+                "id": "turn-plan:plan",
+                "summary": "Inspect repository",
+                "completed": 0,
+                "total": 2,
+                "currentStep": "Inspect repository",
+                "steps": [
+                    { "step": "Inspect repository", "status": "in_progress" },
+                    { "step": "Report findings", "status": "pending" }
+                ]
+            }
+        }
+    }))
+    .unwrap();
+    let live_timeline =
+        project_timeline_snapshot(session_id, turn_id, std::slice::from_ref(&live_event)).unwrap();
+
+    rpc.append_turn_semantic_event(
+        session_id,
+        turn_id,
+        serde_json::to_value(&live_event).unwrap(),
+    )
+    .expect("plan progress must be durable before the session can be reloaded");
+    let reloaded = rpc
+        .get_turn_runtime_state(session_id, turn_id)
+        .unwrap()
+        .expect("persisted plan progress should reload");
+
+    assert_eq!(reloaded.timeline.items, live_timeline.items);
+    assert_eq!(
+        reloaded.timeline.snapshot_revision,
+        live_timeline.snapshot_revision
+    );
+
+    drop(rpc);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn persisted_responses_tool_call_preserves_the_live_timeline_item_identity() {
     let root = std::env::temp_dir().join(format!(
         "tinybot-tool-timeline-identity-{}-{}",

--- a/src/app-core/chat/README.md
+++ b/src/app-core/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Application Core
-<!-- tinybot-module-fingerprint: sha256:4d56dfa55829fdd22fba0343ea3b9ce55464f7684fcf6fe88b4360ba92584235 -->
+<!-- tinybot-module-fingerprint: sha256:0e69220e26caa28a25baee0e519a0e0046b2f43b7466d3909aedfbe18ef14f6d -->
 
 `chat` contains framework-independent chat and Thread contracts, command
 construction, canonical timeline validation, UI projection, input state, and

--- a/src/app-core/chat/chatProjection.test.ts
+++ b/src/app-core/chat/chatProjection.test.ts
@@ -459,6 +459,61 @@ describe("chat projection", () => {
     expect(turn.steps.some((step) => step.status === "running" || step.status === "pending")).toBe(false);
   });
 
+  test("preserves the last canonical plan state when a turn completes", () => {
+    const runtimeState = normalizeAgentTurnRuntimeStatePayload(canonicalRuntimeState("turn-completed-plan", [
+      {
+        itemId: "turn-completed-plan:user",
+        kind: "user_message",
+        status: "completed",
+        data: { type: "user_message", messageId: "user-completed-plan", content: "Run the plan" },
+      },
+      {
+        itemId: "turn-completed-plan:plan",
+        kind: "plan_progress",
+        status: "running",
+        data: {
+          type: "plan_progress",
+          completed: 0,
+          total: 2,
+          currentStep: "Inspect inputs",
+          steps: [
+            { step: "Inspect inputs", status: "in_progress" },
+            { step: "Report findings", status: "pending" },
+          ],
+        },
+      },
+      {
+        itemId: "turn-completed-plan:assistant",
+        kind: "assistant_message",
+        status: "completed",
+        data: {
+          type: "assistant_message",
+          messageId: "assistant-completed-plan",
+          modelCallId: "call-completed-plan",
+          content: "Done",
+          phase: "final_answer",
+        },
+      },
+    ], "WebSocket:chat-1", {
+      status: "completed",
+      completedAt: "2026-08-31T01:00:00Z",
+    }));
+
+    const [turn] = projectBackendTimeline("WebSocket:chat-1", [runtimeState]);
+
+    expect(turn.status).toBe("completed");
+    expect(turn.steps.find((step) => step.kind === "plan")).toMatchObject({
+      status: "running",
+      plan: {
+        currentStep: "Inspect inputs",
+        steps: [
+          { step: "Inspect inputs", status: "in_progress" },
+          { step: "Report findings", status: "pending" },
+        ],
+      },
+    });
+  });
+
   test("orders restored turns by their canonical timestamps", () => {
     const early = normalizeAgentTurnRuntimeStatePayload(canonicalRuntimeState("z-turn-early", [{
       itemId: "z-turn-early:user",

--- a/src/app-core/chat/chatProjection.ts
+++ b/src/app-core/chat/chatProjection.ts
@@ -564,6 +564,9 @@ function reconcileTerminalStepStatuses(turn: ChatTurn): void {
   }
 
   for (const step of turn.steps) {
+    if (step.plan && turn.status === "completed") {
+      continue;
+    }
     if (step.plan) {
       step.plan.steps = step.plan.steps.map((planStep) => {
         if (planStep.status === "completed" || planStep.status === "failed" || planStep.status === "cancelled") {

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -179,6 +179,151 @@
   cursor: pointer;
 }
 
+.react-floating-plan {
+  position: absolute;
+  z-index: 12;
+  top: 59px;
+  right: 16px;
+  display: grid;
+  width: min(360px, calc(100% - 32px));
+  justify-items: end;
+  pointer-events: none;
+  animation: react-floating-plan-enter 260ms var(--motion-ease-standard) both;
+}
+
+.react-floating-plan__note,
+.react-floating-plan__capsule {
+  grid-area: 1 / 1;
+  border: 1px solid color-mix(in srgb, var(--color-text) 13%, var(--color-hairline));
+  background: color-mix(in srgb, var(--color-panel) 96%, transparent);
+  box-shadow: 0 14px 38px rgb(20 20 19 / 14%);
+  backdrop-filter: blur(18px) saturate(135%);
+  transition:
+    opacity 220ms var(--motion-ease-standard),
+    transform 280ms var(--motion-ease-standard),
+    visibility 0ms linear 280ms;
+  will-change: opacity, transform;
+}
+
+.react-floating-plan__note {
+  width: 100%;
+  max-height: min(420px, calc(100vh - 190px));
+  overflow: auto;
+  border-radius: 14px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(20px) scale(.97);
+  transform-origin: top right;
+  visibility: hidden;
+}
+
+.react-floating-plan[data-expanded="true"] .react-floating-plan__note {
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+  visibility: visible;
+  transition-delay: 0ms;
+}
+
+.react-floating-plan__heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 18px;
+  width: 100%;
+  min-height: 44px;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  border-radius: 14px 14px 0 0;
+  background: transparent;
+  color: var(--color-text);
+  padding: 9px 11px 8px 13px;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.react-floating-plan__heading:hover {
+  background: color-mix(in srgb, var(--color-text) 4%, transparent);
+}
+
+.react-floating-plan__heading:focus-visible,
+.react-floating-plan__capsule:focus-visible {
+  outline: 2px solid var(--color-primary-active);
+  outline-offset: 2px;
+}
+
+.react-floating-plan__title {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.react-floating-plan__title strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-floating-plan__count {
+  color: var(--color-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.react-floating-plan__content {
+  display: grid;
+  gap: 9px;
+  padding: 0 13px 13px;
+}
+
+.react-floating-plan__content progress {
+  width: 100%;
+  height: 3px;
+  accent-color: var(--color-primary-active);
+}
+
+.react-floating-plan__capsule {
+  display: inline-flex;
+  align-self: start;
+  min-width: 82px;
+  height: 44px;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border-radius: 999px;
+  color: var(--color-text);
+  padding: 0 12px;
+  font: inherit;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+  transform-origin: top right;
+  visibility: visible;
+  cursor: pointer;
+}
+
+.react-floating-plan__capsule:hover {
+  background: color-mix(in srgb, var(--color-text) 5%, var(--color-panel));
+}
+
+.react-floating-plan[data-expanded="true"] .react-floating-plan__capsule {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(10px) scale(.88);
+  visibility: hidden;
+}
+
+@keyframes react-floating-plan-enter {
+  from { opacity: 0; transform: translateX(24px); }
+  to { opacity: 1; transform: none; }
+}
+
 
 .react-prompt-cycle {
   display: grid;
@@ -4290,6 +4435,12 @@
 }
 
 @media (max-width: 680px) {
+  .react-floating-plan {
+    top: 55px;
+    right: 12px;
+    width: min(340px, calc(100% - 24px));
+  }
+
   .react-message-attachments {
     width: min(320px, 100%);
   }
@@ -4390,6 +4541,27 @@
 
   .react-chat-page {
     transition-duration: 0ms;
+  }
+
+  .react-floating-plan {
+    animation: none;
+  }
+
+  .react-floating-plan__note,
+  .react-floating-plan__capsule,
+  .react-floating-plan[data-expanded="true"] .react-floating-plan__note,
+  .react-floating-plan[data-expanded="true"] .react-floating-plan__capsule {
+    transform: none;
+    transition: opacity 120ms ease, visibility 0ms linear 120ms;
+  }
+
+  .react-floating-plan[data-expanded="true"] .react-floating-plan__note,
+  .react-floating-plan:not([data-expanded="true"]) .react-floating-plan__capsule {
+    transition-delay: 0ms;
+  }
+
+  .react-floating-plan .react-canonical-plan__steps li[data-status="in_progress"] .react-canonical-plan__step-icon svg {
+    animation: none;
   }
 
 

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -634,6 +634,65 @@ describe("ChatPage", () => {
     expect(await screen.findByRole("region", { name: "Task progress" })).toBeTruthy();
   });
 
+  it("keeps the latest plan visible when a newer turn has not created a plan", async () => {
+    const stores = createStores();
+    let listener: ((event: ChatEvent) => void) | undefined;
+    const firstUserMessage: ReactChatMessage = {
+      id: "u-plan-first-turn",
+      role: "user",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      text: "Create a plan",
+      status: "complete",
+    };
+    const addPlan = (timeline: ReturnType<typeof timelineFromReactMessages>) => {
+      timeline.turns[0].steps.push({
+        agentContext: { id: "main", title: "Tinybot", type: "main" },
+        id: "plan-first-turn",
+        kind: "plan",
+        plan: {
+          completed: 1,
+          currentStep: "Implement fix",
+          steps: [
+            { status: "completed", step: "Inspect state" },
+            { status: "in_progress", step: "Implement fix" },
+          ],
+          total: 2,
+        },
+        sequence: 1,
+        status: "running",
+        title: "Plan",
+      });
+      return timeline;
+    };
+    const planningTimeline = addPlan(timelineFromReactMessages("s1", [firstUserMessage]));
+    stores.chatStore.load = vi.fn(async () => structuredClone(planningTimeline));
+    stores.chatStore.subscribe = vi.fn((_sessionId, callback) => {
+      listener = callback;
+      return () => undefined;
+    });
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
+
+    let floatingPlan = await screen.findByRole("region", { name: "Task progress" });
+    expect(within(floatingPlan).getByText("Implement fix")).toBeTruthy();
+
+    const timelineWithNewTurn = addPlan(timelineFromReactMessages("s1", [
+      firstUserMessage,
+      {
+        id: "u-plan-second-turn",
+        role: "user",
+        createdAtMs: Date.UTC(2026, 6, 4, 12, 3, 0),
+        text: "Continue with another request",
+        status: "complete",
+      },
+    ]));
+    act(() => listener?.({ type: "timeline.patch", timeline: timelineWithNewTurn }));
+
+    expect(await screen.findByText("Continue with another request")).toBeTruthy();
+    floatingPlan = screen.getByRole("region", { name: "Task progress" });
+    expect(within(floatingPlan).getByText("Implement fix")).toBeTruthy();
+  });
+
   it("coalesces multiple running timeline patches into one animation-frame commit", async () => {
     const stores = createStores();
     let listener: ((event: ChatEvent) => void) | undefined;

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -556,16 +556,82 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
     const progress = await screen.findByRole("progressbar", { name: "Plan 1/3" });
+    const inlinePlan = screen.getByRole("region", { name: "Execution plan" });
+    const floatingPlan = screen.getByRole("region", { name: "Task progress" });
     expect(progress.getAttribute("aria-valuenow")).toBe("1");
     expect(progress.getAttribute("aria-valuemax")).toBe("3");
-    expect(screen.getByText("Implementation order updated")).toBeTruthy();
-    expect(screen.getByText("Inspect model").closest("li")?.getAttribute("data-status")).toBe("completed");
-    expect(screen.getByText("Render progress")).toBeTruthy();
-    expect(screen.getByText("Run tests").closest("li")?.getAttribute("data-status")).toBe("pending");
+    expect(within(inlinePlan).getByText("Implementation order updated")).toBeTruthy();
+    expect(within(inlinePlan).getByText("Inspect model").closest("li")?.getAttribute("data-status")).toBe("completed");
+    expect(within(inlinePlan).getByText("Render progress")).toBeTruthy();
+    expect(within(inlinePlan).getByText("Run tests").closest("li")?.getAttribute("data-status")).toBe("pending");
+    expect(within(floatingPlan).getByText("Implementation order updated")).toBeTruthy();
+    expect(within(floatingPlan).getByText("Render progress")).toBeTruthy();
     await user.click(screen.getByText("Context compacted"));
     const compaction = screen.getByText("Before: 12,000 tokens").closest("details");
     expect(compaction?.textContent).toContain("After: 4,200 tokens");
     expect(compaction?.textContent).toContain("Dropped items: 12");
+  });
+
+  it("restores floating plan progress after switching away and back", async () => {
+    const user = userEvent.setup();
+    const stores = createStores({
+      sessions: [
+        {
+          id: "s1",
+          chatId: "chat-1",
+          title: "Planning notes",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 56, 0),
+          status: "running",
+        },
+        {
+          id: "s2",
+          chatId: "chat-2",
+          title: "Knowledge review",
+          updatedAtMs: Date.UTC(2026, 6, 4, 11, 50, 0),
+          status: "idle",
+        },
+      ],
+    });
+    const planningTimeline = timelineFromReactMessages("s1", [{
+      id: "u-plan-switch",
+      role: "user",
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 0, 0),
+      text: "Keep this plan visible",
+      status: "complete",
+    }]);
+    planningTimeline.turns[0].status = "running";
+    planningTimeline.turns[0].steps.push({
+      agentContext: { id: "main", title: "Tinybot", type: "main" },
+      id: "plan-switch",
+      kind: "plan",
+      plan: {
+        completed: 0,
+        currentStep: "Inspect state",
+        steps: [
+          { status: "in_progress", step: "Inspect state" },
+          { status: "pending", step: "Report findings" },
+        ],
+        total: 2,
+      },
+      sequence: 1,
+      status: "running",
+      title: "Plan",
+    });
+    stores.chatStore.load = vi.fn(async (sessionId) => structuredClone(
+      sessionId === "s1" ? planningTimeline : timelineFromReactMessages("s2", []),
+    ));
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
+
+    expect(await screen.findByRole("region", { name: "Task progress" })).toBeTruthy();
+    const sidebar = screen.getByLabelText("Sessions");
+    await user.click(within(sidebar).getByRole("button", { name: "Knowledge review" }));
+    await waitFor(() => expect(stores.chatStore.load).toHaveBeenLastCalledWith("s2"));
+    expect(screen.queryByRole("region", { name: "Task progress" })).toBeNull();
+
+    await user.click(within(sidebar).getByRole("button", { name: "Planning notes" }));
+    await waitFor(() => expect(stores.chatStore.load).toHaveBeenLastCalledWith("s1"));
+    expect(await screen.findByRole("region", { name: "Task progress" })).toBeTruthy();
   });
 
   it("coalesces multiple running timeline patches into one animation-frame commit", async () => {
@@ -943,7 +1009,7 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
     expect(await screen.findByRole("button", { name: /Work performed Interrupted/ })).toBeTruthy();
-    expect(screen.getByText("Read project files")).toBeTruthy();
+    expect(within(screen.getByRole("region", { name: "Execution plan" })).getByText("Read project files")).toBeTruthy();
     expect(screen.queryByRole("alert", { name: "Task execution failed" })).toBeNull();
   });
 

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -120,6 +120,7 @@ import {
   type SpreadsheetComposerAnnotation,
 } from "./chatSubmission";
 import { ChatTimeline } from "./ChatTimeline";
+import { FloatingPlanStatus } from "./FloatingPlanStatus";
 import { AssistantMarkdown } from "./AssistantMarkdown";
 import {
   AssistantFileLinkError,
@@ -287,6 +288,18 @@ function buildComposerToolOptions(tools: readonly ToolSummary[]): ComposerToolOp
 
 const SESSION_DELETE_DISSOLVE_MS = 180;
 const EMPTY_OPTIMISTIC_MESSAGES: ReactChatMessage[] = [];
+
+function latestTurnPlan(timeline: ChatTimelineSnapshot | null | undefined) {
+  const turn = timeline?.turns[timeline.turns.length - 1];
+  if (!turn) return undefined;
+  const step = [...turn.steps].reverse().find((candidate) => candidate.kind === "plan" && candidate.plan);
+  if (!step?.plan) return undefined;
+  return {
+    identityKey: `${turn.id}:${step.id}`,
+    plan: step.plan,
+    revisionKey: JSON.stringify({ plan: step.plan, status: step.status }),
+  };
+}
 
 export function ChatPage({
   activateSessionRequest = null,
@@ -745,6 +758,10 @@ export function ChatPage({
   const latestFailedTurnId = useMemo(() => (
     [...(timeline?.turns ?? [])].reverse().find((turn) => turn.status === "failed" || turn.status === "interrupted")?.id ?? ""
   ), [timeline]);
+  const floatingPlan = useMemo(
+    () => activeSession && timelineLoaded ? latestTurnPlan(timeline) : undefined,
+    [activeSession, timeline, timelineLoaded],
+  );
   useEffect(() => {
     sessionsRef.current = sessions;
   }, [sessions]);
@@ -2346,6 +2363,14 @@ export function ChatPage({
             ) : null}
           </div>
         </header>
+
+        {floatingPlan ? (
+          <FloatingPlanStatus
+            identityKey={floatingPlan.identityKey}
+            plan={floatingPlan.plan}
+            revisionKey={floatingPlan.revisionKey}
+          />
+        ) : null}
 
         <div
           ref={conversationRef}

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -290,15 +290,18 @@ const SESSION_DELETE_DISSOLVE_MS = 180;
 const EMPTY_OPTIMISTIC_MESSAGES: ReactChatMessage[] = [];
 
 function latestTurnPlan(timeline: ChatTimelineSnapshot | null | undefined) {
-  const turn = timeline?.turns[timeline.turns.length - 1];
-  if (!turn) return undefined;
-  const step = [...turn.steps].reverse().find((candidate) => candidate.kind === "plan" && candidate.plan);
-  if (!step?.plan) return undefined;
-  return {
-    identityKey: `${turn.id}:${step.id}`,
-    plan: step.plan,
-    revisionKey: JSON.stringify({ plan: step.plan, status: step.status }),
-  };
+  const turns = timeline?.turns ?? [];
+  for (let turnIndex = turns.length - 1; turnIndex >= 0; turnIndex -= 1) {
+    const turn = turns[turnIndex];
+    const step = [...turn.steps].reverse().find((candidate) => candidate.kind === "plan" && candidate.plan);
+    if (!step?.plan) continue;
+    return {
+      identityKey: `${turn.id}:${step.id}`,
+      plan: step.plan,
+      revisionKey: JSON.stringify({ plan: step.plan, status: step.status }),
+    };
+  }
+  return undefined;
 }
 
 export function ChatPage({

--- a/src/react-workbench/chat/FloatingPlanStatus.test.tsx
+++ b/src/react-workbench/chat/FloatingPlanStatus.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PlanState } from "../../app-core/chat/chatTurnContracts";
+import { FLOATING_PLAN_AUTO_COLLAPSE_MS, FloatingPlanStatus } from "./FloatingPlanStatus";
+
+const plan: PlanState = {
+  completed: 1,
+  currentStep: "Implement the floating note",
+  explanation: "Keep task progress visible while the conversation continues.",
+  steps: [
+    { status: "completed", step: "Inspect the canonical plan" },
+    { status: "in_progress", step: "Implement the floating note" },
+    { status: "pending", step: "Verify the interaction" },
+  ],
+  total: 3,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("FloatingPlanStatus", () => {
+  it("auto-collapses, then lets the user toggle the capsule", () => {
+    vi.useFakeTimers();
+    render(<FloatingPlanStatus identityKey="turn-1:plan-1" plan={plan} revisionKey="revision-1" />);
+
+    expect(screen.getByRole("region", { name: "Task progress" }).getAttribute("aria-live")).toBe("polite");
+    act(() => vi.advanceTimersByTime(FLOATING_PLAN_AUTO_COLLAPSE_MS));
+
+    const capsule = screen.getByRole("button", { name: /Expand task progress/ });
+    expect(capsule.textContent).toContain("1/3");
+    fireEvent.click(capsule);
+
+    const note = screen.getByRole("region", { name: "Task progress" });
+    expect(within(note).getByText("Implement the floating note")).toBeTruthy();
+    fireEvent.click(within(note).getByRole("button", { name: /Collapse task progress/ }));
+    expect(screen.getByRole("button", { name: /Expand task progress/ })).toBeTruthy();
+  });
+
+  it("reopens a collapsed note on updates but preserves a manual expansion", () => {
+    vi.useFakeTimers();
+    const view = render(
+      <FloatingPlanStatus identityKey="turn-1:plan-1" plan={plan} revisionKey="revision-1" />,
+    );
+    act(() => vi.advanceTimersByTime(FLOATING_PLAN_AUTO_COLLAPSE_MS));
+
+    const updatedPlan: PlanState = {
+      ...plan,
+      completed: 2,
+      currentStep: "Verify the interaction",
+      steps: [
+        { status: "completed", step: "Inspect the canonical plan" },
+        { status: "completed", step: "Implement the floating note" },
+        { status: "in_progress", step: "Verify the interaction" },
+      ],
+    };
+    view.rerender(
+      <FloatingPlanStatus identityKey="turn-1:plan-1" plan={updatedPlan} revisionKey="revision-2" />,
+    );
+
+    expect(screen.getByRole("region", { name: "Task progress" })).toBeTruthy();
+    act(() => vi.advanceTimersByTime(FLOATING_PLAN_AUTO_COLLAPSE_MS));
+    fireEvent.click(screen.getByRole("button", { name: /Expand task progress/ }));
+
+    view.rerender(
+      <FloatingPlanStatus identityKey="turn-1:plan-1" plan={{ ...updatedPlan, explanation: "Updated again." }} revisionKey="revision-3" />,
+    );
+    act(() => vi.advanceTimersByTime(FLOATING_PLAN_AUTO_COLLAPSE_MS * 2));
+
+    expect(screen.getByRole("region", { name: "Task progress" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Expand task progress/ })).toBeNull();
+  });
+});

--- a/src/react-workbench/chat/FloatingPlanStatus.tsx
+++ b/src/react-workbench/chat/FloatingPlanStatus.tsx
@@ -1,0 +1,136 @@
+import type { TFunction } from "i18next";
+import { AlertTriangle, Check, ChevronDown, ChevronUp, Circle, ListChecks, Loader2, X } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { PlanState } from "../../app-core/chat/chatTurnContracts";
+
+export const FLOATING_PLAN_AUTO_COLLAPSE_MS = 5_000;
+
+type FloatingPlanStatusProps = {
+  identityKey: string;
+  plan: PlanState;
+  revisionKey: string;
+};
+
+type DisplayMode = "auto" | "expanded" | "collapsed";
+type PlanStepStatus = PlanState["steps"][number]["status"];
+
+export function FloatingPlanStatus({ identityKey, plan, revisionKey }: FloatingPlanStatusProps) {
+  const { t } = useTranslation("chat");
+  const contentId = useId();
+  const [displayMode, setDisplayMode] = useState<DisplayMode>("auto");
+  const previousIdentityRef = useRef(identityKey);
+  const previousRevisionRef = useRef(revisionKey);
+  const expanded = displayMode !== "collapsed";
+
+  useEffect(() => {
+    const identityChanged = previousIdentityRef.current !== identityKey;
+    const revisionChanged = previousRevisionRef.current !== revisionKey;
+    previousIdentityRef.current = identityKey;
+    previousRevisionRef.current = revisionKey;
+
+    if (identityChanged) {
+      setDisplayMode("auto");
+      return;
+    }
+    if (revisionChanged) {
+      setDisplayMode((current) => current === "expanded" ? current : "auto");
+    }
+  }, [identityKey, revisionKey]);
+
+  useEffect(() => {
+    if (displayMode !== "auto") return;
+    const timer = window.setTimeout(() => {
+      setDisplayMode("collapsed");
+    }, FLOATING_PLAN_AUTO_COLLAPSE_MS);
+    return () => window.clearTimeout(timer);
+  }, [displayMode, revisionKey]);
+
+  const progressLabel = t("plan.completed", {
+    completed: plan.completed,
+    total: plan.total,
+  });
+
+  return (
+    <div className="react-floating-plan" data-expanded={expanded ? "true" : "false"}>
+      <section
+        aria-hidden={!expanded}
+        aria-label={t("plan.floatingLabel")}
+        aria-live="polite"
+        className="react-floating-plan__note"
+      >
+        <button
+          aria-controls={contentId}
+          aria-expanded={expanded}
+          aria-label={`${t("plan.floatingCollapse")}. ${progressLabel}`}
+          className="react-floating-plan__heading"
+          tabIndex={expanded ? 0 : -1}
+          type="button"
+          onClick={() => setDisplayMode("collapsed")}
+        >
+          <span className="react-floating-plan__title">
+            <ListChecks aria-hidden="true" size={16} />
+            <strong>{t("plan.label")}</strong>
+          </span>
+          <span className="react-floating-plan__count">{progressLabel}</span>
+          <ChevronUp aria-hidden="true" size={15} />
+        </button>
+        <div className="react-floating-plan__content" id={contentId}>
+          <progress
+            aria-label={progressLabel}
+            aria-valuemax={plan.total}
+            aria-valuemin={0}
+            aria-valuenow={plan.completed}
+            max={Math.max(plan.total, 1)}
+            value={plan.completed}
+          />
+          {plan.explanation ? <p className="react-canonical-plan__explanation">{plan.explanation}</p> : null}
+          <ol className="react-canonical-plan__steps">
+            {plan.steps.map((step, index) => (
+              <li data-status={step.status} key={`${index}:${step.step}`}>
+                <span aria-hidden="true" className="react-canonical-plan__step-icon">
+                  <FloatingPlanStepIcon status={step.status} />
+                </span>
+                <span>{step.step}</span>
+                <small>{planStepStatusLabel(step.status, t)}</small>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <button
+        aria-hidden={expanded}
+        aria-label={`${t("plan.floatingExpand")}. ${progressLabel}`}
+        className="react-floating-plan__capsule"
+        tabIndex={expanded ? -1 : 0}
+        type="button"
+        onClick={() => setDisplayMode("expanded")}
+      >
+        <ListChecks aria-hidden="true" size={15} />
+        <span>{plan.completed}/{plan.total}</span>
+        <ChevronDown aria-hidden="true" size={14} />
+      </button>
+    </div>
+  );
+}
+
+function FloatingPlanStepIcon({ status }: { status: PlanStepStatus }) {
+  switch (status) {
+    case "completed": return <Check size={13} />;
+    case "in_progress": return <Loader2 size={13} />;
+    case "failed": return <AlertTriangle size={13} />;
+    case "cancelled": return <X size={13} />;
+    default: return <Circle size={10} />;
+  }
+}
+
+function planStepStatusLabel(status: PlanStepStatus, t: TFunction<"chat">): string {
+  switch (status) {
+    case "completed": return t("plan.status.completed");
+    case "in_progress": return t("plan.status.inProgress");
+    case "failed": return t("plan.status.failed");
+    case "cancelled": return t("plan.status.cancelled");
+    default: return t("plan.status.pending");
+  }
+}

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:3d2e7ead6e2510761437018cfa2fc84bcc6064058d6fc81c0f6dfeec6aa37680 -->
+<!-- tinybot-module-fingerprint: sha256:d0f1a44ef14338ba91906fddc5d855131404ec4bd11b8a057a2d57bde07e820d -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -7,13 +7,14 @@ canonical timeline presentation, the composer, and detail drawers.
 `ChatTimeline.tsx` owns the reusable canonical message and execution rendering;
 its action callbacks are optional so read-only consumers can omit unavailable
 branch, recovery, artifact, delegate, and tool-detail controls.
-`FloatingPlanStatus.tsx` mirrors the latest Turn's canonical plan in a fixed
-top-right note without introducing another plan store. New plans and status
-revisions open the note briefly before it contracts to a progress capsule;
-manual expansion stays open until the user closes it, and reduced-motion mode
-replaces the slide with a short opacity transition. Normal Turn completion
-keeps the last canonical plan state; failed or interrupted Turns still reconcile
-unfinished steps to their terminal outcome.
+`FloatingPlanStatus.tsx` mirrors the most recent canonical plan across Turns in
+a fixed top-right note without introducing another plan store. A newer Turn
+without a plan keeps the previous plan visible; the next plan replaces it. New
+plans and status revisions open the note briefly before it contracts to a
+progress capsule; manual expansion stays open until the user closes it, and
+reduced-motion mode replaces the slide with a short opacity transition. Normal
+Turn completion keeps the last canonical plan state; failed or interrupted
+Turns still reconcile unfinished steps to their terminal outcome.
 `AssistantMarkdown.tsx` owns assistant prose and link presentation.
 Allowed web and email links keep their existing safe opener path while adding
 an aria-hidden inline source icon: a GitHub mark for GitHub hosts, an envelope

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:656010e729657fa76f4e6d98d2117f446417b34c5588219cc0a9633262409d41 -->
+<!-- tinybot-module-fingerprint: sha256:3d2e7ead6e2510761437018cfa2fc84bcc6064058d6fc81c0f6dfeec6aa37680 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -7,6 +7,13 @@ canonical timeline presentation, the composer, and detail drawers.
 `ChatTimeline.tsx` owns the reusable canonical message and execution rendering;
 its action callbacks are optional so read-only consumers can omit unavailable
 branch, recovery, artifact, delegate, and tool-detail controls.
+`FloatingPlanStatus.tsx` mirrors the latest Turn's canonical plan in a fixed
+top-right note without introducing another plan store. New plans and status
+revisions open the note briefly before it contracts to a progress capsule;
+manual expansion stays open until the user closes it, and reduced-motion mode
+replaces the slide with a short opacity transition. Normal Turn completion
+keeps the last canonical plan state; failed or interrupted Turns still reconcile
+unfinished steps to their terminal outcome.
 `AssistantMarkdown.tsx` owns assistant prose and link presentation.
 Allowed web and email links keep their existing safe opener path while adding
 an aria-hidden inline source icon: a GitHub mark for GitHub hosts, an envelope

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:44ee2e3e4478ac065b3a55c183d407b67a4021ccce5a1b0f205547732cbbbfc7 -->
+<!-- tinybot-module-fingerprint: sha256:62af7594155fa91579169b95744ce61bab65d954bedd51a6f97869ed0c5e13ac -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles.
@@ -24,6 +24,8 @@ language-neutral. Chat also localizes the slash-menu Skills heading, workspace
 source label, inline Skill removal label, and Skill-only fallback prompt.
 Context-window usage and latest-call cache-hit labels are localized here while
 their Token counts and computed percentage remain language-neutral values.
+Chat's floating plan-note label and expand/collapse actions are localized here;
+canonical step text and progress counts remain Agent-authored and numeric data.
 Provider model settings also localize automatic, fallback, and custom
 context-window modes, enabled-model counts, image-input controls, and the
 unsupported-image composer message while model IDs and numeric limits stay

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1076,7 +1076,7 @@ export const en = {
     },
     plan: {
       label: "Execution plan", completed: "{{completed}} of {{total}} completed", status: { completed: "Completed", inProgress: "In progress", failed: "Failed", cancelled: "Cancelled", pending: "Pending" },
-      collapse: "Collapse", expand: "Expand",
+      collapse: "Collapse", expand: "Expand", floatingLabel: "Task progress", floatingExpand: "Expand task progress", floatingCollapse: "Collapse task progress",
     },
     artifacts: { label: "Artifacts", preview: "Preview {{name}}" },
     dataView: {

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -547,7 +547,7 @@ export const zh = {
     },
     plan: {
       label: "执行计划", completed: "已完成 {{completed}}/{{total}}", status: { completed: "已完成", inProgress: "执行中", failed: "失败", cancelled: "已取消", pending: "待执行" },
-      collapse: "收起", expand: "展开",
+      collapse: "收起", expand: "展开", floatingLabel: "任务进度", floatingExpand: "展开任务进度", floatingCollapse: "收起任务进度",
     },
     artifacts: { label: "产物", preview: "预览 {{name}}" },
     dataView: {


### PR DESCRIPTION
## Summary
- add a floating Plan note that contracts into a progress capsule
- preserve canonical Plan state after turn completion, session switching, and new user turns
- persist Plan progress through timeline reloads

## Validation
- npm test (728 tests)
- npm run build
- npm run typecheck
- npm run readme:check
- npm run docs:check