### PR TITLE
Refine Chat execution activity timeline

### DIFF
--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -2006,37 +2006,38 @@
 
 .react-execution-timeline__heading {
   display: flex;
-  flex: 0 1 auto;
-  align-items: baseline;
-  gap: 6px;
+  flex: 1 1 auto;
+  align-items: center;
   min-width: 0;
 }
 
-.react-execution-timeline__heading strong {
-  flex: none;
+.react-execution-timeline__summary {
+  min-width: 0;
+  overflow: hidden;
   color: var(--color-body);
   font-size: 13px;
-  font-weight: 600;
-}
-
-.react-execution-timeline__heading small {
-  overflow: hidden;
-  color: var(--color-muted-soft);
-  font-size: 11px;
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .react-execution-timeline__chevron {
   flex: none;
+  margin-left: auto;
   color: var(--color-muted-soft);
   transition: transform 180ms ease;
 }
 
 .react-execution-timeline[data-abnormal="true"] .react-execution-timeline__status,
-.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__heading strong,
+.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__summary,
 .react-execution-timeline[data-abnormal="true"] .react-execution-timeline__chevron {
   color: var(--color-error);
+}
+
+.react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__status,
+.react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__summary,
+.react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__chevron {
+  color: var(--color-warning);
 }
 
 .react-execution-timeline__trigger[aria-expanded="true"] .react-execution-timeline__chevron {
@@ -2044,9 +2045,20 @@
 }
 
 .react-execution-timeline__content {
+  position: relative;
   display: grid;
   gap: 0;
-  padding: 2px 0 0;
+  padding: 4px 0 4px 28px;
+}
+
+.react-execution-timeline__content::before {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 8px;
+  width: 1px;
+  background: color-mix(in srgb, var(--color-hairline) 76%, transparent);
+  content: "";
 }
 
 .react-execution-timeline__content[hidden] {
@@ -2059,7 +2071,7 @@
 }
 
 .react-execution-timeline__item + .react-execution-timeline__item {
-  border-top: 1px solid color-mix(in srgb, var(--color-hairline) 65%, transparent);
+  border-top: 0;
 }
 
 .react-execution-timeline__canvas-button {
@@ -2132,6 +2144,21 @@
   background: transparent;
   box-shadow: none;
   overflow: visible;
+}
+
+.react-execution-reasoning {
+  display: flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-body);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.react-execution-reasoning svg {
+  flex: none;
+  color: var(--color-muted-soft);
 }
 
 .react-execution-timeline__item > .react-agent-steps > .react-agent-steps__header {

--- a/src/react-workbench/chat/ChatPage.styles.test.tsx
+++ b/src/react-workbench/chat/ChatPage.styles.test.tsx
@@ -48,14 +48,15 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
-    await screen.findByRole("button", { name: /Work performed Running · 1 action/ });
+    const toggle = await screen.findByRole("button", { name: /Work performed: Running/ });
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     mountWorkbenchCss();
     const executionTimeline = document.querySelector<HTMLElement>(".react-execution-timeline")!;
     const executionContent = document.querySelector<HTMLElement>(".react-execution-timeline__content")!;
     expect(getComputedStyle(executionTimeline).height).toBe("max-content");
     expect(getComputedStyle(executionTimeline).borderTopWidth).toBe("0px");
     expect(getComputedStyle(executionTimeline).marginLeft).toBe("0px");
-    expect(getComputedStyle(executionContent).paddingLeft).toBe("0px");
+    expect(getComputedStyle(executionContent).paddingLeft).toBe("28px");
   });
 
   it("renders the React chat layout without legacy header actions", async () => {

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -4,6 +4,7 @@ import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
+import type { ChatStep } from "../../app-core/chat/chatTurnContracts";
 import type { ChatEvent } from "../services";
 import type { ReactChatMessage } from "./messageActions";
 import { timelineFromReactMessages } from "./test/timelineFixtures";
@@ -29,6 +30,18 @@ vi.mock("../sidecar/OfficeArtifactPreview", () => ({
     </div>
   ),
 }));
+
+function executionToolStep(id: string, sequence: number, name: string): ChatStep {
+  return {
+    agentContext: { id: "main", title: "Tinybot", type: "main" },
+    id,
+    kind: "tool_call",
+    sequence,
+    status: "completed",
+    title: name,
+    toolCall: { id, name },
+  };
+}
 
 describe("ChatPage", () => {
   it("shows branch on a completed tool-backed final answer but not on user or commentary messages", async () => {
@@ -760,7 +773,7 @@ describe("ChatPage", () => {
     expect(within(error).queryByRole("button", { name: /Continue|Retry|Start over|View details/ })).toBeNull();
   });
 
-  it("renders canonical execution items chronologically and restores completed turns folded", async () => {
+  it("renders canonical execution items chronologically with the outer timeline expanded", async () => {
     const user = userEvent.setup();
     const stores = createStores();
     const timeline = timelineFromReactMessages("s1", [{
@@ -829,11 +842,9 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
-    const toggle = await screen.findByRole("button", { name: /Work performed 4 actions/ });
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.getByText("Verification passed.")).toBeTruthy();
-    await user.click(toggle);
+    const toggle = await screen.findByRole("button", { name: /Work performed: thought ×1 · file read ×1/ });
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Verification passed.")).toBeTruthy();
     const orderedItems = document.querySelectorAll(".react-execution-timeline__item");
     expect([...orderedItems].map((item) => item.getAttribute("data-kind"))).toEqual([
       "reasoning",
@@ -846,6 +857,54 @@ describe("ChatPage", () => {
     expect(toolItem.querySelector(".react-tool-activity")).not.toBeNull();
     expect(screen.getByText("I found the first file.")).toBeTruthy();
     expect(screen.getByText("Now I will verify it.")).toBeTruthy();
+    await user.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("summarizes execution by activity type without exposing reasoning content", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const timeline = timelineFromReactMessages("s1", [{
+      id: "u-activity-summary",
+      role: "user" as const,
+      createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      text: "Inspect and verify",
+      status: "complete" as const,
+    }]);
+    const turn = timeline.turns[0];
+    turn.status = "running";
+    turn.steps = [
+      {
+        agentContext: { id: "main", title: "Tinybot", type: "main" },
+        id: "reasoning-summary",
+        kind: "reasoning",
+        sequence: 1,
+        startedAt: "2026-07-04T12:01:00.000Z",
+        status: "completed",
+        summary: "Private reasoning content must stay hidden.",
+        title: "Thinking complete",
+        completedAt: "2026-07-04T12:01:00.400Z",
+      },
+      executionToolStep("read-summary", 2, "workspace.read_file"),
+      executionToolStep("patch-summary", 3, "apply_patch"),
+      executionToolStep("command-summary", 4, "exec_command"),
+      executionToolStep("search-summary", 5, "workspace.search"),
+      executionToolStep("web-summary", 6, "web.read"),
+      executionToolStep("browser-summary", 7, "web.act"),
+    ];
+    turn.executionItems = turn.steps;
+    stores.chatStore.load = vi.fn(async () => timeline);
+
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
+
+    const toggle = await screen.findByRole("button", {
+      name: /Running · thought ×1 · file read ×1 · file change ×1 · command ×1 · search ×1 · web ×1 · browser action ×1/,
+    });
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.queryByText("Private reasoning content must stay hidden.")).toBeNull();
+    expect(screen.getByText("Thought for less than 1 second")).toBeTruthy();
+    await user.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("renders apply_patch tool results as an inline file diff", async () => {
@@ -891,6 +950,9 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
+    const toolToggle = await screen.findByRole("button", { name: "Toggle details for Edited parser.rs" });
+    expect(toolToggle.getAttribute("aria-expanded")).toBe("false");
+    await userEvent.setup().click(toolToggle);
     expect(await screen.findByRole("region", { name: "Changes from apply_patch" })).toBeTruthy();
     expect(screen.getByRole("article", { name: "Diff for src/parser.rs" })).toBeTruthy();
     expect(screen.getByText("let marker = line.trim();")).toBeTruthy();
@@ -899,7 +961,7 @@ describe("ChatPage", () => {
     expect(screen.queryByRole("button", { name: "Open details for Edited parser.rs" })).toBeNull();
   });
 
-  it("auto-folds untouched execution on final answer and preserves explicit user-open intent", async () => {
+  it("keeps untouched execution expanded through live updates and preserves explicit user-closed intent", async () => {
     const user = userEvent.setup();
     const stores = createStores();
     let listener: ((event: ChatEvent) => void) | undefined;
@@ -948,54 +1010,15 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
-    let toggle = await screen.findByRole("button", { name: /Work performed Running · 1 action/ });
+    let toggle = await screen.findByRole("button", { name: /Work performed: Running/ });
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    const conversation = document.querySelector<HTMLElement>(".react-conversation-view")!;
-    const executionTimeline = document.querySelector<HTMLElement>(".react-execution-timeline")!;
-    Object.defineProperties(conversation, {
-      clientHeight: { configurable: true, value: 500 },
-      scrollHeight: { configurable: true, value: 2_000 },
-      scrollTop: { configurable: true, value: 800, writable: true },
-    });
-    const timelineRect = vi.spyOn(executionTimeline, "getBoundingClientRect").mockImplementation(() => ({
-      bottom: toggle.getAttribute("aria-expanded") === "true" ? 400 : 50,
-      height: toggle.getAttribute("aria-expanded") === "true" ? 400 : 50,
-      left: 0,
-      right: 760,
-      top: 0,
-      width: 760,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    }));
-    const conversationRect = vi.spyOn(conversation, "getBoundingClientRect").mockImplementation(() => ({
-      bottom: 600,
-      height: 500,
-      left: 0,
-      right: 1_000,
-      top: 100,
-      width: 1_000,
-      x: 0,
-      y: 100,
-      toJSON: () => ({}),
-    }));
-    let animationFrame: FrameRequestCallback | undefined;
-    const requestFrame = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      animationFrame = callback;
-      return 1;
-    });
     act(() => listener?.({ type: "timeline.patch", timeline: timelineFor(true) }));
-    toggle = await screen.findByRole("button", { name: /Work performed 1 action/ });
-    await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("false"));
-    act(() => animationFrame?.(0));
-    expect(conversation.scrollTop).toBe(450);
-    await user.click(toggle);
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    act(() => listener?.({ type: "timeline.patch", timeline: timelineFor(true, 42) }));
+    toggle = await screen.findByRole("button", { name: /Work performed:/ });
     await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("true"));
-    requestFrame.mockRestore();
-    conversationRect.mockRestore();
-    timelineRect.mockRestore();
+    await user.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    act(() => listener?.({ type: "timeline.patch", timeline: timelineFor(true, 42) }));
+    await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("false"));
   });
 
   it("does not reopen explicitly closed execution when the final answer arrives", async () => {
@@ -1030,7 +1053,8 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
-    const toggle = await screen.findByRole("button", { name: /Work performed Running · 1 action/ });
+    const toggle = await screen.findByRole("button", { name: /Work performed: Running/ });
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     await user.click(toggle);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     turn.status = "completed";
@@ -1044,7 +1068,7 @@ describe("ChatPage", () => {
     await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("false"));
   });
 
-  it("keeps abnormal canonical execution expanded with the inline error visible", async () => {
+  it("keeps abnormal canonical execution expanded with the inline failure visible", async () => {
     const stores = createStores();
     const timeline = failedPlanTimeline();
     timeline.turns[0].executionItems = timeline.turns[0].steps;
@@ -1052,7 +1076,7 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
-    const toggle = await screen.findByRole("button", { name: /Work performed Failed · 3 actions/ });
+    const toggle = await screen.findByRole("button", { name: /Work performed: Failed/ });
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     const error = screen.getByRole("alert", { name: "Task execution failed" });
     expect(within(error).getByRole("button", { name: "Copy error" })).toBeTruthy();
@@ -1067,7 +1091,8 @@ describe("ChatPage", () => {
 
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 2, 0)} sessionStore={stores.sessionStore} />);
 
-    expect(await screen.findByRole("button", { name: /Work performed Interrupted/ })).toBeTruthy();
+    const toggle = await screen.findByRole("button", { name: /Work performed: Interrupted/ });
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(within(screen.getByRole("region", { name: "Execution plan" })).getByText("Read project files")).toBeTruthy();
     expect(screen.queryByRole("alert", { name: "Task execution failed" })).toBeNull();
   });

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -12,6 +12,7 @@ import {
   FileText,
   GitBranch,
   ImageIcon,
+  Lightbulb,
   ListCollapse,
   Loader2,
   PanelRightOpen,
@@ -286,8 +287,6 @@ function groupCanonicalSteps(steps: ChatStep[]): Array<ChatStep | ChatStep[]> {
   return groups;
 }
 
-type ExecutionFoldIntent = "untouched" | "user_open" | "user_closed";
-
 function ExecutionTimeline({
   executionItems,
   focusError,
@@ -303,73 +302,40 @@ function ExecutionTimeline({
 }) {
   const { t } = useTranslation("chat");
   const contentId = useId();
-  const timelineRef = useRef<HTMLElement | null>(null);
   const abnormal = executionItems.some((step) => step.status === "failed" || step.status === "cancelled" || step.status === "blocked")
     || turn.status === "failed"
     || turn.status === "interrupted"
     || turn.status === "awaiting_user";
-  const hasFinalAnswer = Boolean(turn.finalAnswer ?? turn.finalMessage);
-  const [foldIntent, setFoldIntent] = useState<ExecutionFoldIntent>("untouched");
-  const [open, setOpen] = useState(() => abnormal || !hasFinalAnswer);
+  const [open, setOpen] = useState(true);
   const visibleExecutionItems = turn.status === "interrupted"
     ? executionItems.filter((step) => step.kind !== "error")
     : executionItems;
   const errorItems = visibleExecutionItems.filter((step) => step.kind === "error");
 
-  useEffect(() => {
-    if (foldIntent !== "untouched") {
-      return;
-    }
-    const nextOpen = abnormal || !hasFinalAnswer;
-    setOpen((currentOpen) => {
-      if (currentOpen === nextOpen) {
-        return currentOpen;
-      }
-      if (currentOpen && !nextOpen) {
-        const timeline = timelineRef.current;
-        const scroller = timeline?.closest<HTMLElement>(".react-conversation-view");
-        const heightBefore = timeline?.getBoundingClientRect().height ?? 0;
-        const timelineTop = timeline?.getBoundingClientRect().top ?? 0;
-        const scrollerTop = scroller?.getBoundingClientRect().top ?? 0;
-        const userIsReadingHistory = Boolean(scroller && scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight >= 96);
-        requestAnimationFrame(() => {
-          if (!timeline || !scroller || !userIsReadingHistory || timelineTop >= scrollerTop) {
-            return;
-          }
-          const collapsedBy = Math.max(0, heightBefore - timeline.getBoundingClientRect().height);
-          scroller.scrollTop = Math.max(0, scroller.scrollTop - collapsedBy);
-        });
-      }
-      return nextOpen;
-    });
-  }, [abnormal, foldIntent, hasFinalAnswer]);
-
   const summary = executionTimelineSummary(turn, executionItems, abnormal, t);
   return (
-    <section className="react-execution-timeline" data-abnormal={abnormal ? "true" : undefined} ref={timelineRef}>
+    <section className="react-execution-timeline" data-abnormal={abnormal ? "true" : undefined} data-status={turn.status}>
       <button
         aria-controls={contentId}
         aria-expanded={open}
+        aria-label={`${t("turn.workPerformed")}: ${summary}`}
         className="react-execution-timeline__trigger"
+        title={summary}
         type="button"
-        onClick={() => {
-          setOpen((currentOpen) => {
-            setFoldIntent(currentOpen ? "user_closed" : "user_open");
-            return !currentOpen;
-          });
-        }}
+        onClick={() => setOpen((currentOpen) => !currentOpen)}
       >
         <span className="react-execution-timeline__status"><Activity aria-hidden="true" size={17} /></span>
         <span className="react-execution-timeline__heading">
-          <strong>{t("turn.workPerformed")}</strong>
-          <small aria-live="polite">{summary}</small>
+          <span aria-live="polite" className="react-execution-timeline__summary">{summary}</span>
         </span>
         <ChevronRight aria-hidden="true" className="react-execution-timeline__chevron" size={16} />
       </button>
       <div className="react-execution-timeline__content" hidden={!open} id={contentId}>
         {visibleExecutionItems.map((step) => (
           <div className="react-execution-timeline__item" data-kind={step.kind} data-status={step.status} key={step.id}>
-            {step.kind === "error" ? (
+            {step.kind === "reasoning" ? (
+              <ExecutionReasoningActivity step={step} />
+            ) : step.kind === "error" ? (
               <InlineExecutionError
                 focusOnMount={focusError && step.id === errorItems[errorItems.length - 1]?.id}
                 step={step}
@@ -389,17 +355,45 @@ function ExecutionTimeline({
   );
 }
 
+type ExecutionActivityCategory =
+  | "reasoning"
+  | "fileRead"
+  | "fileChange"
+  | "command"
+  | "search"
+  | "web"
+  | "subagent"
+  | "browser"
+  | "plan"
+  | "interaction"
+  | "other";
+
+const EXECUTION_ACTIVITY_ORDER: ExecutionActivityCategory[] = [
+  "reasoning",
+  "fileRead",
+  "fileChange",
+  "command",
+  "search",
+  "web",
+  "subagent",
+  "browser",
+  "plan",
+  "interaction",
+  "other",
+];
+
 function executionTimelineSummary(turn: ChatTurn, items: ChatStep[], abnormal: boolean, t: TFunction<"chat">): string {
   const plan = [...items].reverse().find((step) => step.plan)?.plan;
-  const durationMs = turn.completedAt
-    ? Math.max(0, Date.parse(turn.completedAt) - Date.parse(turn.startedAt))
-    : undefined;
-  const parts = [executionStatusLabel(turn.status, t), t("execution.actionCount", { count: items.length })]
-    .filter((part): part is string => Boolean(part));
+  const durationMs = executionDurationMs(turn);
+  const activityParts = executionActivitySummary(items, t);
+  const parts = [
+    executionStatusLabel(turn.status, t),
+    ...(activityParts.length ? activityParts : [t("execution.actionCount", { count: items.length })]),
+  ].filter((part): part is string => Boolean(part));
   if (plan) {
     parts.push(t("execution.plan", { completed: plan.completed, total: plan.total }));
   }
-  if (durationMs !== undefined && Number.isFinite(durationMs)) {
+  if (durationMs !== undefined) {
     parts.push(formatExecutionDuration(durationMs));
   }
   if (abnormal) {
@@ -407,6 +401,87 @@ function executionTimelineSummary(turn: ChatTurn, items: ChatStep[], abnormal: b
     parts.push(blocked?.title || t("execution.attention"));
   }
   return parts.join(" · ");
+}
+
+function executionActivitySummary(items: ChatStep[], t: TFunction<"chat">): string[] {
+  const counts = Object.fromEntries(
+    EXECUTION_ACTIVITY_ORDER.map((category) => [category, 0]),
+  ) as Record<ExecutionActivityCategory, number>;
+  for (const item of items) {
+    const category = executionActivityCategory(item);
+    if (category) {
+      counts[category] += 1;
+    }
+  }
+  return EXECUTION_ACTIVITY_ORDER
+    .filter((category) => counts[category] > 0)
+    .map((category) => executionActivityLabel(category, counts[category], t));
+}
+
+function executionActivityCategory(step: ChatStep): ExecutionActivityCategory | undefined {
+  switch (step.kind) {
+    case "reasoning": return "reasoning";
+    case "delegate": return "subagent";
+    case "browser": return "browser";
+    case "plan": return "plan";
+    case "form": return "interaction";
+    case "tool_call": return step.toolCall ? toolExecutionActivityCategory(step.toolCall.name) : "other";
+    case "message":
+    case "error": return undefined;
+    default: return "other";
+  }
+}
+
+function toolExecutionActivityCategory(name: string): ExecutionActivityCategory {
+  const normalized = name.toLowerCase();
+  if (normalized === "apply_patch" || normalized.includes("write_file") || normalized.includes("edit_file")) return "fileChange";
+  if (normalized === "workspace.read_file" || normalized === "read_file" || normalized.endsWith(".read_file")) return "fileRead";
+  if (normalized === "exec_command" || normalized === "write_stdin" || normalized.startsWith("shell.")) return "command";
+  if (normalized.includes("search")) return "search";
+  if (normalized === "web.act" || normalized.includes("browser")) return "browser";
+  if (normalized.startsWith("web.")) return "web";
+  if (normalized.startsWith("subagent.")) return "subagent";
+  if (normalized === "update_plan") return "plan";
+  if (normalized === "request_user_input") return "interaction";
+  return "other";
+}
+
+function executionActivityLabel(category: ExecutionActivityCategory, count: number, t: TFunction<"chat">): string {
+  switch (category) {
+    case "reasoning": return t("execution.activity.reasoning", { count });
+    case "fileRead": return t("execution.activity.fileRead", { count });
+    case "fileChange": return t("execution.activity.fileChange", { count });
+    case "command": return t("execution.activity.command", { count });
+    case "search": return t("execution.activity.search", { count });
+    case "web": return t("execution.activity.web", { count });
+    case "subagent": return t("execution.activity.subagent", { count });
+    case "browser": return t("execution.activity.browser", { count });
+    case "plan": return t("execution.activity.plan", { count });
+    case "interaction": return t("execution.activity.interaction", { count });
+    case "other": return t("execution.activity.other", { count });
+  }
+}
+
+function executionDurationMs(turn: ChatTurn): number | undefined {
+  const startedAtMs = Date.parse(turn.startedAt);
+  const endedAtMs = Date.parse(turn.completedAt ?? turn.updatedAt);
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(endedAtMs)) {
+    return undefined;
+  }
+  return Math.max(0, endedAtMs - startedAtMs);
+}
+
+function ExecutionReasoningActivity({ step }: { step: ChatStep }) {
+  const { t } = useTranslation("chat");
+  const label = step.status === "running"
+    ? t("reasoning.thinking")
+    : formatThinkingLabel(reasoningDurationMs(step), t);
+  return (
+    <div aria-label={t("reasoning.label")} className="react-execution-reasoning">
+      <Lightbulb aria-hidden="true" size={16} />
+      <span>{label}</span>
+    </div>
+  );
 }
 
 function executionStatusLabel(status: ChatTurn["status"], t: TFunction<"chat">): string | undefined {

--- a/src/react-workbench/chat/PatchDiffCard.test.tsx
+++ b/src/react-workbench/chat/PatchDiffCard.test.tsx
@@ -36,14 +36,17 @@ afterEach(() => {
 });
 
 describe("PatchDiffCard", () => {
-  it("unwraps the executor result and renders an expanded line diff", () => {
+  it("unwraps the executor result and keeps the line diff collapsed until requested", async () => {
+    const user = userEvent.setup();
     expect(patchChangeSetFromToolResult(applyPatchToolCall.resultJson)?.files).toHaveLength(1);
 
     render(<PatchDiffCard status="completed" toolCall={applyPatchToolCall} />);
 
-    expect(screen.getByRole("button", { name: "Toggle details for Edited lib.rs" })
-      .getAttribute("aria-expanded"))
-      .toBe("true");
+    const toggle = screen.getByRole("button", { name: "Toggle details for Edited lib.rs" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByTestId("patch-diff-content").closest("[hidden]")).not.toBeNull();
+    await user.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(screen.queryByText("Completed")).toBeNull();
     const file = screen.getByRole("article", { name: "Diff for src/lib.rs" });
     expect(within(file).getByText("fn before() {}").closest("[data-diff-kind='remove']"))
@@ -54,7 +57,7 @@ describe("PatchDiffCard", () => {
     expect(within(file).getByText("12", { selector: "[data-line-side='new']" })).toBeTruthy();
   });
 
-  it("collapses the preview and copies a unified diff", async () => {
+  it("expands the preview and copies a unified diff", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     const user = userEvent.setup();
     Object.defineProperty(navigator, "clipboard", {
@@ -64,11 +67,11 @@ describe("PatchDiffCard", () => {
     render(<PatchDiffCard status="completed" toolCall={applyPatchToolCall} />);
 
     const toggle = screen.getByRole("button", { name: "Toggle details for Edited lib.rs" });
-    await user.click(toggle);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(screen.getByTestId("patch-diff-content").closest("[hidden]")).not.toBeNull();
 
     await user.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     await user.click(screen.getByRole("button", { name: "Copy diff for src/lib.rs" }));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(expect.stringContaining("--- a/src/lib.rs")));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining("+fn after() {}"));

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:e45490825b113653564223b9f34b5b4b89e3a4cadb163351bb59846e4f58c284 -->
+<!-- tinybot-module-fingerprint: sha256:65d78517d645d1d759f991ed8762f89de894985facf4b550cc15f1ba90904b53 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -7,6 +7,12 @@ canonical timeline presentation, the composer, and detail drawers.
 `ChatTimeline.tsx` owns the reusable canonical message and execution rendering;
 its action callbacks are optional so read-only consumers can omit unavailable
 branch, recovery, artifact, delegate, and tool-detail controls.
+Every canonical execution trace starts expanded and keeps the user's explicit
+fold choice across live timeline revisions. Its summary derives compact counts
+from semantic Step and Tool kinds, exposes running and abnormal status without
+logos, and never renders reasoning content. Individual Tool and Diff rows start
+collapsed, so the ordered activity stays scannable until a user opens one row's
+details.
 `FloatingPlanStatus.tsx` mirrors the most recent canonical plan across Turns in
 a fixed top-right note without introducing another plan store. A newer Turn
 without a plan keeps the previous plan visible; the next plan replaces it. New

--- a/src/react-workbench/chat/ToolActivityItem.test.tsx
+++ b/src/react-workbench/chat/ToolActivityItem.test.tsx
@@ -8,7 +8,7 @@ import { ToolActivityItem } from "./ToolActivityItem";
 afterEach(cleanup);
 
 describe("ToolActivityItem", () => {
-  it("renders a completed command as two expandable preview blocks", async () => {
+  it("keeps a completed command collapsed until its preview is requested", async () => {
     const user = userEvent.setup();
     render(<ToolActivityItem
       status="completed"
@@ -24,16 +24,15 @@ describe("ToolActivityItem", () => {
     expect(screen.getByText("Ran npm test")).toBeTruthy();
     expect(screen.getByText("Terminal · 2.4s")).toBeTruthy();
     expect(screen.queryByText("Completed")).toBeNull();
+    const toggle = screen.getByRole("button", { name: "Toggle details for Ran npm test" });
+    expect(screen.getByText("Ran npm test").closest("button")).toBe(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByTestId("tool-activity-details").hasAttribute("hidden")).toBe(true);
+    await user.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("$", { selector: ".react-tool-activity__prompt" })).toBeTruthy();
     expect(screen.getByText(/248 tests passed/)).toBeTruthy();
     expect(document.querySelectorAll(".react-tool-activity__preview")).toHaveLength(2);
-
-    const toggle = screen.getByRole("button", { name: "Toggle details for Ran npm test" });
-    expect(screen.getByText("Ran npm test").closest("button")).toBe(toggle);
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    await user.click(toggle);
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.getByTestId("tool-activity-details").hasAttribute("hidden")).toBe(true);
   });
 
   it("extracts retained command chunks without rendering raw result JSON", () => {
@@ -53,12 +52,14 @@ describe("ToolActivityItem", () => {
       }}
     />);
 
+    expect(screen.getByRole("button", { name: "Toggle details for Ran npm test" }).getAttribute("aria-expanded")).toBe("false");
     expect(screen.getByText(/Test Files\s+3 passed/)).toBeTruthy();
     expect(screen.getByText(/Tests\s+107 passed/)).toBeTruthy();
     expect(screen.queryByText(/"chunks"/)).toBeNull();
   });
 
-  it("renders a file path and line-numbered file preview", () => {
+  it("keeps a file preview collapsed until requested", async () => {
+    const user = userEvent.setup();
     render(<ToolActivityItem
       status="completed"
       toolCall={{
@@ -71,6 +72,11 @@ describe("ToolActivityItem", () => {
     />);
 
     expect(screen.getByText("Inspected ChatPage.tsx")).toBeTruthy();
+    const toggle = screen.getByRole("button", { name: "Toggle details for Inspected ChatPage.tsx" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByTestId("tool-activity-details").hasAttribute("hidden")).toBe(true);
+    await user.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("src/react-workbench/chat/ChatPage.tsx")).toBeTruthy();
     expect(screen.getByText("Lines 40–42")).toBeTruthy();
     expect(screen.getByText("40")).toBeTruthy();
@@ -99,7 +105,8 @@ describe("ToolActivityItem", () => {
     expect(screen.getByText("Reviewed the composition controller APIs.")).toBeTruthy();
   });
 
-  it("surfaces failed command output without raw result JSON", () => {
+  it("surfaces failed command output after the collapsed row is opened", async () => {
+    const user = userEvent.setup();
     render(<ToolActivityItem
       status="failed"
       toolCall={{
@@ -113,6 +120,9 @@ describe("ToolActivityItem", () => {
 
     expect(screen.getByText("Command failed")).toBeTruthy();
     expect(screen.getByText("Failed")).toBeTruthy();
+    const toggle = screen.getByRole("button", { name: "Toggle details for Command failed" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    await user.click(toggle);
     expect(screen.getByText("error[E0308]: mismatched types")).toBeTruthy();
     expect(screen.queryByText(/\{"stderr"/)).toBeNull();
   });

--- a/src/react-workbench/chat/ToolActivityItem.tsx
+++ b/src/react-workbench/chat/ToolActivityItem.tsx
@@ -51,7 +51,6 @@ export function ToolActivityItem({
   return (
     <ToolActivityFrame
       category={descriptor.category}
-      defaultOpen={descriptor.kind !== "web" && previews.length > 0}
       durationMs={toolCall.durationMs}
       icon={<ToolActivityIcon kind={descriptor.kind} />}
       status={status}
@@ -67,7 +66,7 @@ export function ToolActivityItem({
 export function ToolActivityFrame({
   category,
   children,
-  defaultOpen = true,
+  defaultOpen = false,
   durationMs,
   icon,
   status,

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:32503b00bafe084b0a66554d5ce087a96a1ccde23c8f6c4ecd626d4362e827ff -->
+<!-- tinybot-module-fingerprint: sha256:35591f3a87733e20009ade38e32580004916e9a22ef19dcfa78b0b8ce2f6ec80 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles.

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1054,6 +1054,12 @@ export const en = {
     },
     execution: {
       actionCount: "{{count}} actions", plan: "plan {{completed}}/{{total}}", attention: "attention required",
+      activity: {
+        reasoning: "thought ×{{count}}", fileRead: "file read ×{{count}}", fileChange: "file change ×{{count}}",
+        command: "command ×{{count}}", search: "search ×{{count}}", web: "web ×{{count}}",
+        subagent: "subagent ×{{count}}", browser: "browser action ×{{count}}", plan: "plan update ×{{count}}",
+        interaction: "interaction ×{{count}}", other: "other action ×{{count}}",
+      },
       status: { failed: "Failed", interrupted: "Interrupted", awaiting: "Awaiting input", running: "Running" },
     },
     form: { submitted: "Submitted", cancelled: "Cancelled", resolved: "Resolved", waiting: "Waiting for input" },

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -534,6 +534,12 @@ export const zh = {
     },
     execution: {
       actionCount: "{{count}} 个操作", plan: "计划 {{completed}}/{{total}}", attention: "需要处理",
+      activity: {
+        reasoning: "思考 {{count}} 次", fileRead: "读取文件 {{count}} 次", fileChange: "修改文件 {{count}} 次",
+        command: "执行命令 {{count}} 次", search: "搜索 {{count}} 次", web: "访问网页 {{count}} 次",
+        subagent: "调用子 Agent {{count}} 次", browser: "浏览器操作 {{count}} 次", plan: "更新计划 {{count}} 次",
+        interaction: "交互 {{count}} 次", other: "其他操作 {{count}} 次",
+      },
       status: { failed: "失败", interrupted: "已中断", awaiting: "等待输入", running: "执行中" },
     },
     form: { submitted: "已提交", cancelled: "已取消", resolved: "已解决", waiting: "等待输入" },

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:ac2efea0e43ee164170c1ca04ed33c8c3ba9fa6c0a5b708467288e63c4440cd2 -->
+<!-- tinybot-module-fingerprint: sha256:e936f35da3cc62c13afb69f2022074247b580cd943e399ea87b7356bc13c5aac -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.

--- a/src/react-workbench/styles/workbench.test.ts
+++ b/src/react-workbench/styles/workbench.test.ts
@@ -57,7 +57,9 @@ describe("workbench CSS interaction contracts", () => {
   test("keeps execution summaries and tool activity compact without shrinking action controls", () => {
     const timelineTriggerRule = chatStylesheet.match(/\.react-execution-timeline__trigger\s*\{([^}]+)\}/);
     const timelineHeadingRule = chatStylesheet.match(/\.react-execution-timeline__heading\s*\{([^}]+)\}/);
-    const timelineTitleRule = chatStylesheet.match(/\.react-execution-timeline__heading strong\s*\{([^}]+)\}/);
+    const timelineSummaryRule = chatStylesheet.match(/\.react-execution-timeline__summary\s*\{([^}]+)\}/);
+    const timelineContentRule = chatStylesheet.match(/\.react-execution-timeline__content\s*\{([^}]+)\}/);
+    const reasoningRule = chatStylesheet.match(/\.react-execution-reasoning\s*\{([^}]+)\}/);
     const headerRule = chatStylesheet.match(/\.react-tool-activity__header\s*\{([^}]+)\}/);
     const actionRule = chatStylesheet.match(/\.react-patch-file__copy\s*\{([^}]+)\}/);
     const detailsRule = chatStylesheet.match(/\.react-tool-activity__details\s*\{([^}]+)\}/);
@@ -69,8 +71,11 @@ describe("workbench CSS interaction contracts", () => {
     expect(timelineTriggerRule?.[1]).toContain("padding: 0 0 4px");
     expect(timelineTriggerRule?.[1]).toContain("justify-content: flex-start");
     expect(timelineHeadingRule?.[1]).toContain("display: flex");
-    expect(timelineTitleRule?.[1]).toContain("color: var(--color-body)");
-    expect(timelineTitleRule?.[1]).toContain("font-weight: 600");
+    expect(timelineHeadingRule?.[1]).toContain("flex: 1 1 auto");
+    expect(timelineSummaryRule?.[1]).toContain("text-overflow: ellipsis");
+    expect(timelineSummaryRule?.[1]).toContain("white-space: nowrap");
+    expect(timelineContentRule?.[1]).toContain("padding: 4px 0 4px 28px");
+    expect(reasoningRule?.[1]).toContain("min-height: 34px");
     expect(headerRule?.[1]).toContain("min-height: 34px");
     expect(headerRule?.[1]).toContain("padding: 2px 0");
     expect(headerRule?.[1]).toContain("display: flex");


### PR DESCRIPTION
Summary: add compact semantic execution summaries, keep the outer execution timeline expanded by default, collapse individual tool and diff details by default, and keep reasoning content hidden. Validation: npm test (126 files, 729 tests), npm run build, npm run typecheck, npm run lint, npm run readme:check.