### PR TITLE
refactor(chat): unify timeline activity rendering and disclosures

### DIFF
--- a/src/react-workbench/chat/ChatDisclosureIcon.css
+++ b/src/react-workbench/chat/ChatDisclosureIcon.css
@@ -1,0 +1,74 @@
+.react-chat-disclosure-icon {
+  display: inline-grid;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  pointer-events: none;
+}
+
+.react-chat-disclosure-icon__symbol,
+.react-chat-disclosure-icon__chevron {
+  grid-area: 1 / 1;
+  width: 16px;
+  height: 16px;
+  transition: opacity var(--motion-duration-fast) var(--motion-ease-standard), transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.react-chat-disclosure-icon__symbol {
+  display: inline-grid;
+  place-items: center;
+}
+
+.react-chat-disclosure-icon__symbol > svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+
+.react-chat-disclosure-icon__chevron {
+  opacity: 0;
+  transform: rotate(0deg);
+}
+
+.react-chat-disclosure-trigger:is(:focus-visible, [aria-expanded="true"]) .react-chat-disclosure-icon__symbol {
+  opacity: 0;
+}
+
+.react-chat-disclosure-trigger:is(:focus-visible, [aria-expanded="true"]) .react-chat-disclosure-icon__chevron {
+  opacity: 1;
+}
+
+.react-chat-disclosure-trigger[aria-expanded="true"] .react-chat-disclosure-icon__chevron {
+  transform: rotate(180deg);
+}
+
+.react-chat-disclosure-trigger:focus-visible .react-chat-disclosure-icon > * {
+  transition: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .react-chat-disclosure-trigger:hover .react-chat-disclosure-icon__symbol {
+    opacity: 0;
+  }
+
+  .react-chat-disclosure-trigger:hover .react-chat-disclosure-icon__chevron {
+    opacity: 1;
+  }
+}
+
+@media (hover: none) {
+  .react-chat-disclosure-icon__symbol {
+    opacity: 0;
+  }
+
+  .react-chat-disclosure-icon__chevron {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .react-chat-disclosure-icon > * {
+    transition: none;
+  }
+}

--- a/src/react-workbench/chat/ChatDisclosureIcon.tsx
+++ b/src/react-workbench/chat/ChatDisclosureIcon.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { ChevronDown } from "lucide-react";
+import "./ChatDisclosureIcon.css";
 
 export function ChatDisclosureIcon({ icon }: { icon: ReactNode }) {
   return (

--- a/src/react-workbench/chat/ChatDisclosureIcon.tsx
+++ b/src/react-workbench/chat/ChatDisclosureIcon.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+
+export function ChatDisclosureIcon({ icon }: { icon: ReactNode }) {
+  return (
+    <span aria-hidden="true" className="react-chat-disclosure-icon">
+      <span className="react-chat-disclosure-icon__symbol">{icon}</span>
+      <ChevronDown className="react-chat-disclosure-icon__chevron" size={16} />
+    </span>
+  );
+}

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -653,34 +653,20 @@
   font-size: 12px;
 }
 
-.react-message-reasoning__trigger {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+.react-message-reasoning .react-timeline-activity__header {
   gap: 5px;
-  width: 100%;
   min-height: 36px;
-  border: 0;
   border-bottom: 1px solid var(--color-hairline);
   border-radius: 0;
   padding: 0;
-  color: var(--color-muted);
-  font-size: 12px;
-  font-weight: 500;
-  text-align: left;
   transition: color var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
-.react-message-reasoning__trigger:hover,
-.react-message-reasoning__trigger:focus-visible {
+.react-message-reasoning .react-timeline-activity__header:hover,
+.react-message-reasoning .react-timeline-activity__header:focus-visible {
   border-bottom-color: color-mix(in srgb, var(--color-body) 24%, var(--color-hairline));
   background: transparent;
   color: var(--color-body);
-}
-
-.react-message-reasoning__trigger:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--color-primary) 42%, transparent);
-  outline-offset: 2px;
 }
 
 .react-message-reasoning__content {
@@ -896,45 +882,41 @@
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 64%);
 }
 
-.react-agent-steps__header {
-  display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) auto;
-  align-items: center;
+.react-agent-steps__activity > .react-timeline-activity__header {
   gap: 8px;
-  width: 100%;
   padding: 9px 10px;
   color: var(--color-body);
-  text-align: left;
 }
 
-.react-agent-steps__header:hover,
-.react-agent-steps__header:focus-visible {
+.react-agent-steps__activity > .react-timeline-activity__header:hover,
+.react-agent-steps__activity > .react-timeline-activity__header:focus-visible {
   background: var(--color-panel);
 }
 
-.react-agent-steps__header-icon,
+.react-agent-steps__activity > .react-timeline-activity__header > .react-timeline-activity__icon,
 .react-agent-step-item__marker {
   display: inline-grid;
   place-items: center;
   border-radius: 999px;
 }
 
-.react-agent-steps__header-icon {
+.react-agent-steps__activity > .react-timeline-activity__header > .react-timeline-activity__icon {
   width: 22px;
   height: 22px;
 }
 
-.react-agent-steps__title {
-  min-width: 0;
-  overflow: hidden;
+.react-agent-steps__activity > .react-timeline-activity__header > .react-timeline-activity__heading,
+.react-agent-steps__activity > .react-timeline-activity__header .react-timeline-activity__title {
+  flex: 1;
+}
+
+.react-agent-steps__activity > .react-timeline-activity__header .react-timeline-activity__title {
   color: var(--color-ink);
   font-size: 13px;
   font-weight: 650;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.react-agent-steps__header small {
+.react-agent-steps__activity > .react-timeline-activity__header .react-timeline-activity__meta {
   color: var(--color-muted);
   font-size: 12px;
 }
@@ -1036,30 +1018,30 @@
   white-space: nowrap;
 }
 
-.react-agent-steps__header-icon[data-status="success"],
+.react-agent-steps[data-status="success"] > .react-agent-steps__activity > .react-timeline-activity__header > .react-timeline-activity__icon,
 .react-agent-step-item__marker[data-status="success"] {
   background: color-mix(in srgb, var(--color-success) 14%, var(--color-panel));
   color: var(--color-success);
 }
 
-.react-agent-steps__header-icon[data-status="active"],
+.react-agent-steps[data-status="active"] > .react-agent-steps__activity > .react-timeline-activity__header > .react-timeline-activity__icon,
 .react-agent-step-item__marker[data-status="active"] {
   background: color-mix(in srgb, #4c8bf5 13%, var(--color-panel));
   color: #3b75d9;
 }
 
-.react-agent-steps__header-icon[data-status="active"] .react-chat-disclosure-icon__symbol svg,
+.react-agent-steps[data-status="active"] > .react-agent-steps__activity > .react-timeline-activity__header .react-chat-disclosure-icon__symbol svg,
 .react-agent-step-item__marker[data-status="active"] svg {
   animation: react-spin 1s linear infinite;
 }
 
-.react-agent-steps__header-icon[data-status="waiting"],
+.react-agent-steps[data-status="waiting"] > .react-agent-steps__activity > .react-timeline-activity__header > .react-timeline-activity__icon,
 .react-agent-step-item__marker[data-status="waiting"] {
   background: color-mix(in srgb, var(--color-warning) 16%, var(--color-panel));
   color: var(--color-warning);
 }
 
-.react-agent-steps__header-icon[data-status="error"],
+.react-agent-steps[data-status="error"] > .react-agent-steps__activity > .react-timeline-activity__header > .react-timeline-activity__icon,
 .react-agent-step-item__marker[data-status="error"] {
   background: color-mix(in srgb, var(--color-error) 14%, var(--color-panel));
   color: var(--color-error);
@@ -2041,44 +2023,29 @@
   color: var(--color-error);
 }
 
-.react-execution-timeline__trigger {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+.react-execution-timeline__activity > .react-timeline-activity__header {
   gap: 6px;
-  width: 100%;
   min-height: 40px;
   border-bottom: 1px solid color-mix(in srgb, var(--color-hairline) 65%, transparent);
   border-radius: 0;
   padding: 0 0 4px;
   color: inherit;
-  text-align: left;
-  cursor: pointer;
   transition: color 180ms ease, border-color 180ms ease;
 }
 
-.react-execution-timeline__trigger:hover {
+.react-execution-timeline__activity > .react-timeline-activity__header:hover {
   border-bottom-color: var(--color-hairline);
   background: transparent;
   color: var(--color-body);
 }
 
-.react-execution-timeline__trigger:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+.react-execution-timeline__activity > .react-timeline-activity__header > .react-timeline-activity__icon {
+  color: inherit;
 }
 
-.react-execution-timeline__status {
-  display: inline-grid;
-  place-items: center;
-  color: var(--color-muted-soft);
-}
-
-.react-execution-timeline__heading {
-  display: flex;
+.react-execution-timeline__activity > .react-timeline-activity__header > .react-timeline-activity__heading,
+.react-execution-timeline__activity > .react-timeline-activity__header .react-timeline-activity__title {
   flex: 1 1 auto;
-  align-items: center;
-  min-width: 0;
 }
 
 .react-execution-timeline__summary {
@@ -2091,12 +2058,12 @@
   white-space: nowrap;
 }
 
-.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__status,
+.react-execution-timeline[data-abnormal="true"] > .react-execution-timeline__activity > .react-timeline-activity__header,
 .react-execution-timeline[data-abnormal="true"] .react-execution-timeline__summary {
   color: var(--color-error);
 }
 
-.react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__status,
+.react-execution-timeline[data-status="awaiting_user"] > .react-execution-timeline__activity > .react-timeline-activity__header,
 .react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__summary {
   color: var(--color-warning);
 }
@@ -2116,10 +2083,6 @@
   width: 1px;
   background: color-mix(in srgb, var(--color-hairline) 76%, transparent);
   content: "";
-}
-
-.react-execution-timeline__content[hidden] {
-  display: none;
 }
 
 .react-execution-timeline__item {
@@ -2212,113 +2175,8 @@
   font-weight: 500;
 }
 
-.react-execution-reasoning__trigger {
-  display: grid;
-  grid-template-columns: max-content minmax(0, 1fr);
-  width: 100%;
-  min-width: 0;
-  min-height: 34px;
-  align-items: center;
-  gap: 8px;
-  border: 0;
-  padding: 2px 0;
-  color: inherit;
-  cursor: pointer;
-  text-align: left;
-}
-
-.react-execution-reasoning__trigger:hover {
+.react-execution-reasoning .react-timeline-activity__header:hover {
   color: var(--color-ink);
-}
-
-.react-execution-reasoning__trigger:focus-visible {
-  border-radius: 4px;
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-.react-execution-reasoning__label {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 4px;
-  white-space: nowrap;
-}
-
-.react-chat-disclosure-icon {
-  display: inline-grid;
-  flex: none;
-  width: 16px;
-  height: 16px;
-  place-items: center;
-  pointer-events: none;
-}
-
-.react-chat-disclosure-icon__symbol,
-.react-chat-disclosure-icon__chevron {
-  grid-area: 1 / 1;
-  width: 16px;
-  height: 16px;
-  transition: opacity var(--motion-duration-fast) var(--motion-ease-standard), transform var(--motion-duration-fast) var(--motion-ease-standard);
-}
-
-.react-chat-disclosure-icon__symbol {
-  display: inline-grid;
-  place-items: center;
-}
-
-.react-chat-disclosure-icon__symbol > svg {
-  display: block;
-  width: 16px;
-  height: 16px;
-}
-
-.react-chat-disclosure-icon__chevron {
-  opacity: 0;
-  transform: rotate(0deg);
-}
-
-.react-chat-disclosure-trigger:is(:focus-visible, [aria-expanded="true"]) .react-chat-disclosure-icon__symbol,
-details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__symbol {
-  opacity: 0;
-}
-
-.react-chat-disclosure-trigger:is(:focus-visible, [aria-expanded="true"]) .react-chat-disclosure-icon__chevron,
-details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chevron {
-  opacity: 1;
-}
-
-.react-chat-disclosure-trigger[aria-expanded="true"] .react-chat-disclosure-icon__chevron,
-details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chevron {
-  transform: rotate(180deg);
-}
-
-.react-chat-disclosure-trigger:focus-visible .react-chat-disclosure-icon > * {
-  transition: none;
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .react-chat-disclosure-trigger:hover .react-chat-disclosure-icon__symbol {
-    opacity: 0;
-  }
-
-  .react-chat-disclosure-trigger:hover .react-chat-disclosure-icon__chevron {
-    opacity: 1;
-  }
-}
-
-@media (hover: none) {
-  .react-chat-disclosure-icon__symbol {
-    opacity: 0;
-  }
-
-  .react-chat-disclosure-icon__chevron {
-    opacity: 1;
-  }
-}
-
-.react-execution-reasoning__label .react-chat-disclosure-icon {
-  color: var(--color-muted-soft);
 }
 
 .react-execution-reasoning__preview {
@@ -2343,10 +2201,6 @@ details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chev
   font-size: 12px;
   font-weight: 400;
   line-height: 1.6;
-}
-
-.react-execution-timeline__item > .react-agent-steps > .react-agent-steps__header {
-  display: none;
 }
 
 .react-execution-timeline__item > .react-agent-steps > .react-agent-steps__list {
@@ -2381,74 +2235,6 @@ details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chev
   display: grid;
   min-width: 0;
   color: var(--color-ink);
-}
-
-.react-tool-activity__header {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 4px;
-  width: 100%;
-  min-width: 0;
-  min-height: 34px;
-  border: 0;
-  background: transparent;
-  padding: 2px 0;
-  color: var(--color-muted);
-  font: inherit;
-  text-align: left;
-  transition: background-color var(--motion-duration-fast) ease;
-}
-
-.react-tool-activity__header:is(button) {
-  cursor: pointer;
-}
-
-.react-tool-activity__header:is(button):hover {
-  background: color-mix(in srgb, var(--color-surface-soft) 42%, transparent);
-}
-
-.react-tool-activity__header:is(button):focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 1px;
-}
-
-.react-tool-activity__icon {
-  display: inline-grid;
-  place-items: center;
-  color: var(--color-muted-soft);
-}
-
-.react-tool-activity__icon svg {
-  width: 16px;
-  height: 16px;
-}
-
-.react-tool-activity__copy {
-  display: flex;
-  flex: 0 1 auto;
-  align-items: baseline;
-  gap: 6px;
-  min-width: 0;
-}
-
-.react-tool-activity__copy strong,
-.react-tool-activity__copy small {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.react-tool-activity__copy strong {
-  color: inherit;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.react-tool-activity__copy small {
-  color: var(--color-muted-soft);
-  font-size: 10px;
 }
 
 .react-tool-activity__status {
@@ -2507,10 +2293,6 @@ details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chev
   display: grid;
   gap: 4px;
   padding: 0 0 6px 22px;
-}
-
-.react-tool-activity__details[hidden] {
-  display: none;
 }
 
 .react-tool-activity__preview,
@@ -2874,20 +2656,27 @@ details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chev
   accent-color: var(--color-accent);
 }
 
-.react-canonical-plan__heading {
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) auto;
-  align-items: center;
+.react-canonical-plan > .react-timeline-activity__header {
   gap: 10px;
-  width: 100%;
-  border: 0;
+  min-height: 0;
   padding: 0;
   color: inherit;
-  text-align: left;
-  cursor: pointer;
 }
 
-.react-canonical-plan__heading span,
+.react-canonical-plan .react-timeline-activity__heading,
+.react-canonical-plan .react-timeline-activity__title {
+  flex: 1;
+}
+
+.react-canonical-plan .react-timeline-activity__title {
+  font-size: inherit;
+}
+
+.react-canonical-plan .react-timeline-activity__title strong {
+  font-weight: bold;
+}
+
+.react-canonical-plan .react-timeline-activity__meta,
 .react-canonical-plan__explanation {
   color: var(--color-muted);
   font-size: 12px;
@@ -4115,20 +3904,15 @@ details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chev
   padding-block: 4px;
 }
 
-.react-canonical-step[data-kind="compaction"] summary {
-  display: flex;
+.react-canonical-step[data-kind="compaction"] .react-timeline-activity__header {
   min-height: 32px;
-  align-items: center;
   gap: 8px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 500;
+  padding: 0;
   line-height: 1.45;
-  list-style: none;
 }
 
-.react-canonical-step[data-kind="compaction"] summary::-webkit-details-marker {
-  display: none;
+.react-canonical-step[data-kind="compaction"] .react-timeline-activity__title {
+  font-size: 14px;
 }
 
 .react-canonical-step p,
@@ -4711,10 +4495,6 @@ details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chev
 }
 
 @media (prefers-reduced-motion: reduce) {
-
-  .react-chat-disclosure-icon > * {
-    transition: none;
-  }
 
   .react-agent-step-item[aria-current="step"] .react-agent-step-item__marker,
 .react-message-markdown [data-sd-animate],

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -898,7 +898,7 @@
 
 .react-agent-steps__header {
   display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) auto 18px;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   width: 100%;
@@ -1048,7 +1048,7 @@
   color: #3b75d9;
 }
 
-.react-agent-steps__header-icon[data-status="active"] svg,
+.react-agent-steps__header-icon[data-status="active"] .react-chat-disclosure-icon__symbol svg,
 .react-agent-step-item__marker[data-status="active"] svg {
   animation: react-spin 1s linear infinite;
 }
@@ -2091,34 +2091,21 @@
   white-space: nowrap;
 }
 
-.react-execution-timeline__chevron {
-  flex: none;
-  margin-left: auto;
-  color: var(--color-muted-soft);
-  transition: transform 180ms ease;
-}
-
 .react-execution-timeline[data-abnormal="true"] .react-execution-timeline__status,
-.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__summary,
-.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__chevron {
+.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__summary {
   color: var(--color-error);
 }
 
 .react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__status,
-.react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__summary,
-.react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__chevron {
+.react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__summary {
   color: var(--color-warning);
-}
-
-.react-execution-timeline__trigger[aria-expanded="true"] .react-execution-timeline__chevron {
-  transform: rotate(90deg);
 }
 
 .react-execution-timeline__content {
   position: relative;
   display: grid;
-  gap: 0;
-  padding: 8px 0 8px 28px;
+  gap: 12px;
+  padding: 4px 0 4px 28px;
 }
 
 .react-execution-timeline__content::before {
@@ -2220,19 +2207,21 @@
   display: grid;
   min-width: 0;
   min-height: 34px;
-  color: var(--color-body);
+  color: var(--color-muted);
   font-size: 12px;
   font-weight: 500;
 }
 
 .react-execution-reasoning__trigger {
   display: grid;
-  grid-template-columns: max-content minmax(0, 1fr) max-content;
+  grid-template-columns: max-content minmax(0, 1fr);
   width: 100%;
   min-width: 0;
   min-height: 34px;
   align-items: center;
   gap: 8px;
+  border: 0;
+  padding: 2px 0;
   color: inherit;
   cursor: pointer;
   text-align: left;
@@ -2256,9 +2245,79 @@
   white-space: nowrap;
 }
 
-.react-execution-reasoning__label svg,
-.react-execution-reasoning__trigger > svg {
+.react-chat-disclosure-icon {
+  display: inline-grid;
   flex: none;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  pointer-events: none;
+}
+
+.react-chat-disclosure-icon__symbol,
+.react-chat-disclosure-icon__chevron {
+  grid-area: 1 / 1;
+  width: 16px;
+  height: 16px;
+  transition: opacity var(--motion-duration-fast) var(--motion-ease-standard), transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.react-chat-disclosure-icon__symbol {
+  display: inline-grid;
+  place-items: center;
+}
+
+.react-chat-disclosure-icon__symbol > svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+
+.react-chat-disclosure-icon__chevron {
+  opacity: 0;
+  transform: rotate(0deg);
+}
+
+.react-chat-disclosure-trigger:is(:focus-visible, [aria-expanded="true"]) .react-chat-disclosure-icon__symbol,
+details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__symbol {
+  opacity: 0;
+}
+
+.react-chat-disclosure-trigger:is(:focus-visible, [aria-expanded="true"]) .react-chat-disclosure-icon__chevron,
+details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chevron {
+  opacity: 1;
+}
+
+.react-chat-disclosure-trigger[aria-expanded="true"] .react-chat-disclosure-icon__chevron,
+details[open] > .react-chat-disclosure-trigger .react-chat-disclosure-icon__chevron {
+  transform: rotate(180deg);
+}
+
+.react-chat-disclosure-trigger:focus-visible .react-chat-disclosure-icon > * {
+  transition: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .react-chat-disclosure-trigger:hover .react-chat-disclosure-icon__symbol {
+    opacity: 0;
+  }
+
+  .react-chat-disclosure-trigger:hover .react-chat-disclosure-icon__chevron {
+    opacity: 1;
+  }
+}
+
+@media (hover: none) {
+  .react-chat-disclosure-icon__symbol {
+    opacity: 0;
+  }
+
+  .react-chat-disclosure-icon__chevron {
+    opacity: 1;
+  }
+}
+
+.react-execution-reasoning__label .react-chat-disclosure-icon {
   color: var(--color-muted-soft);
 }
 
@@ -2335,7 +2394,7 @@
   border: 0;
   background: transparent;
   padding: 2px 0;
-  color: inherit;
+  color: var(--color-muted);
   font: inherit;
   text-align: left;
   transition: background-color var(--motion-duration-fast) ease;
@@ -2382,7 +2441,7 @@
 }
 
 .react-tool-activity__copy strong {
-  color: var(--color-body);
+  color: inherit;
   font-size: 12px;
   font-weight: 600;
 }
@@ -2444,16 +2503,6 @@
   outline-offset: 1px;
 }
 
-.react-tool-activity__chevron {
-  flex: none;
-  color: var(--color-muted-soft);
-  transition: transform var(--motion-duration-fast) ease;
-}
-
-.react-tool-activity[data-open="true"] .react-tool-activity__chevron {
-  transform: rotate(90deg);
-}
-
 .react-tool-activity__details {
   display: grid;
   gap: 4px;
@@ -2500,7 +2549,7 @@
 .react-tool-activity__preview pre,
 .react-tool-activity__preview code {
   margin: 0;
-  color: var(--color-body);
+  color: var(--color-muted);
   font-family: var(--font-code);
   font-size: 11px;
   line-height: 1.45;
@@ -2510,7 +2559,7 @@
 
 .react-tool-activity__preview p {
   margin: 0;
-  color: var(--color-body);
+  color: var(--color-muted);
   font-size: 12px;
   line-height: 1.45;
 }
@@ -2819,17 +2868,19 @@
 }
 
 .react-canonical-plan progress {
-  width: min(360px, 100%);
+  width: min(360px, calc(100% - 26px));
   height: 6px;
+  margin-left: 26px;
   accent-color: var(--color-accent);
 }
 
 .react-canonical-plan__heading {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto 18px;
-  align-items: baseline;
-  gap: 12px;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
   width: 100%;
+  border: 0;
   padding: 0;
   color: inherit;
   text-align: left;
@@ -2860,6 +2911,7 @@
 .react-canonical-plan__content {
   display: grid;
   gap: 5px;
+  padding-left: 26px;
 }
 
 .react-canonical-plan__steps li small {
@@ -4079,15 +4131,6 @@
   display: none;
 }
 
-.react-context-compaction-chevron {
-  margin-left: auto;
-  transition: transform 160ms ease;
-}
-
-.react-canonical-step[data-kind="compaction"][open] .react-context-compaction-chevron {
-  transform: rotate(90deg);
-}
-
 .react-canonical-step p,
 .react-canonical-step ul,
 .react-timeline-error {
@@ -4668,6 +4711,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+
+  .react-chat-disclosure-icon > * {
+    transition: none;
+  }
 
   .react-agent-step-item[aria-current="step"] .react-agent-step-item__marker,
 .react-message-markdown [data-sd-animate],

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -82,7 +82,7 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const message = await screen.findByTestId("message-a-thinking");
-    const reasoning = within(message).getByLabelText("Reasoning");
+    const reasoning = within(message).getByRole("region", { name: "Reasoning" });
     const reasoningToggle = within(reasoning).getByRole("button", { name: "Reasoning" });
     expect(reasoningToggle.getAttribute("aria-expanded")).toBe("false");
     expect(within(reasoning).queryByText("Checking the current workspace before answering.")).toBeNull();
@@ -121,7 +121,7 @@ describe("ChatPage", () => {
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
     const message = await screen.findByTestId("message-a-live-thinking");
-    const reasoning = within(message).getByLabelText("Reasoning");
+    const reasoning = within(message).getByRole("region", { name: "Reasoning" });
     const reasoningToggle = within(reasoning).getByRole("button", { name: "Thinking" });
     expect(reasoningToggle.getAttribute("aria-expanded")).toBe("true");
     expect(within(reasoning).getByText("Inspecting the workspace.")).toBeTruthy();
@@ -586,9 +586,10 @@ describe("ChatPage", () => {
     expect(within(floatingPlan).getByText("Implementation order updated")).toBeTruthy();
     expect(within(floatingPlan).getByText("Render progress")).toBeTruthy();
     await user.click(screen.getByText("Context compacted"));
-    const compaction = screen.getByText("Before: 12,000 tokens").closest("details");
-    expect(compaction?.textContent).toContain("After: 4,200 tokens");
-    expect(compaction?.textContent).toContain("Dropped items: 12");
+    const compaction = screen.getByRole("region", { name: "Context compacted" });
+    expect(compaction.textContent).toContain("Before: 12,000 tokens");
+    expect(compaction.textContent).toContain("After: 4,200 tokens");
+    expect(compaction.textContent).toContain("Dropped items: 12");
   });
 
   it("restores floating plan progress after switching away and back", async () => {
@@ -859,7 +860,7 @@ describe("ChatPage", () => {
       "message",
     ]);
     const toolItem = [...orderedItems].find((item) => item.getAttribute("data-kind") === "tool_call")!;
-    expect(toolItem.querySelector(".react-agent-steps__header")).toBeNull();
+    expect(toolItem.querySelector(".react-agent-steps > .react-timeline-activity")).toBeNull();
     expect(toolItem.querySelector(".react-tool-activity")).not.toBeNull();
     expect(screen.getByText("I found the first file.")).toBeTruthy();
     expect(screen.getByText("Now I will verify it.")).toBeTruthy();

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import type { TFunction } from "i18next";
 import {
@@ -40,7 +40,7 @@ import { AssistantMarkdown } from "./AssistantMarkdown";
 import type { AssistantFileLink } from "./assistantFileLinks";
 import { isApplyPatchToolCall, PatchDiffCard, patchChangeSetFromToolResult } from "./PatchDiffCard";
 import { ToolActivityItem } from "./ToolActivityItem";
-import { ChatDisclosureIcon } from "./ChatDisclosureIcon";
+import { TimelineActivity } from "./TimelineActivity";
 import { DataViewCard } from "./DataViewCard";
 
 export type ChatTimelineActions = {
@@ -296,7 +296,6 @@ function ExecutionTimeline({
   turn: ChatTurn;
 }) {
   const { t } = useTranslation("chat");
-  const contentId = useId();
   const abnormal = executionItems.some((step) => step.status === "failed" || step.status === "cancelled" || step.status === "blocked")
     || turn.status === "failed"
     || turn.status === "interrupted"
@@ -318,41 +317,37 @@ function ExecutionTimeline({
   const summary = executionTimelineSummary(turn, executionItems, abnormal, t);
   return (
     <section className="react-execution-timeline" data-abnormal={abnormal ? "true" : undefined} data-status={turn.status}>
-      <button
-        aria-controls={contentId}
-        aria-expanded={open}
-        aria-label={`${t("turn.workPerformed")}: ${summary}`}
-        className="react-execution-timeline__trigger react-chat-disclosure-trigger"
-        title={summary}
-        type="button"
-        onClick={() => setOpen((currentOpen) => !currentOpen)}
+      <TimelineActivity
+        className="react-execution-timeline__activity"
+        icon={<Activity size={16} />}
+        keepMounted
+        onOpenChange={setOpen}
+        open={open}
+        title={<span aria-live="polite" className="react-execution-timeline__summary" title={summary}>{summary}</span>}
+        triggerLabel={`${t("turn.workPerformed")}: ${summary}`}
       >
-        <span className="react-execution-timeline__status"><ChatDisclosureIcon icon={<Activity size={16} />} /></span>
-        <span className="react-execution-timeline__heading">
-          <span aria-live="polite" className="react-execution-timeline__summary">{summary}</span>
-        </span>
-      </button>
-      <div className="react-execution-timeline__content" hidden={!open} id={contentId}>
-        {visibleExecutionItems.map((step) => (
-          <div className="react-execution-timeline__item" data-kind={step.kind} data-status={step.status} key={step.id}>
-            {step.kind === "reasoning" ? (
-              <ExecutionReasoningActivity step={step} />
-            ) : step.kind === "error" ? (
-              <InlineExecutionError
-                focusOnMount={focusError && step.id === errorItems[errorItems.length - 1]?.id}
-                step={step}
-                turn={turn}
-              />
-            ) : (
-              <CanonicalChatStep
-                onOpenArtifact={onOpenArtifact}
-                onOpenSubagent={onOpenSubagent}
-                step={step}
-              />
-            )}
-          </div>
-        ))}
-      </div>
+        <div className="react-execution-timeline__content">
+          {visibleExecutionItems.map((step) => (
+            <div className="react-execution-timeline__item" data-kind={step.kind} data-status={step.status} key={step.id}>
+              {step.kind === "reasoning" ? (
+                <ExecutionReasoningActivity step={step} />
+              ) : step.kind === "error" ? (
+                <InlineExecutionError
+                  focusOnMount={focusError && step.id === errorItems[errorItems.length - 1]?.id}
+                  step={step}
+                  turn={turn}
+                />
+              ) : (
+                <CanonicalChatStep
+                  onOpenArtifact={onOpenArtifact}
+                  onOpenSubagent={onOpenSubagent}
+                  step={step}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      </TimelineActivity>
     </section>
   );
 }
@@ -476,8 +471,6 @@ function executionDurationMs(turn: ChatTurn): number | undefined {
 function ExecutionReasoningActivity({ step }: { step: ChatStep }) {
   const { t } = useTranslation("chat");
   const streaming = step.status === "running";
-  const contentId = useId();
-  const triggerId = useId();
   const previewRef = useRef<HTMLSpanElement | null>(null);
   const wasStreaming = useRef(streaming);
   const [expanded, setExpanded] = useState(false);
@@ -514,40 +507,25 @@ function ExecutionReasoningActivity({ step }: { step: ChatStep }) {
       data-expanded={expanded ? "true" : undefined}
       data-streaming={streaming ? "true" : undefined}
     >
-      <button
-        aria-controls={contentId}
-        aria-expanded={expanded}
-        aria-label={label}
-        className="react-execution-reasoning__trigger react-chat-disclosure-trigger"
-        id={triggerId}
-        type="button"
-        onClick={() => setExpanded((open) => !open)}
+      <TimelineActivity
+        icon={<Lightbulb size={16} />}
+        onOpenChange={setExpanded}
+        open={expanded}
+        preview={(
+          <span
+            ref={previewRef}
+            className="react-execution-reasoning__preview"
+            data-streaming={streaming ? "true" : undefined}
+            data-testid="execution-reasoning-preview"
+          >{step.summary}</span>
+        )}
+        title={label}
+        triggerLabel={label}
       >
-        <span className="react-execution-reasoning__label">
-          <ChatDisclosureIcon icon={<Lightbulb size={16} />} />
-          <span>{label}</span>
-        </span>
-        <span
-          ref={previewRef}
-          aria-hidden="true"
-          className="react-execution-reasoning__preview"
-          data-streaming={streaming && !expanded ? "true" : undefined}
-          data-testid="execution-reasoning-preview"
-        >
-          {expanded ? null : step.summary}
-        </span>
-      </button>
-      {expanded ? (
-        <div
-          aria-labelledby={triggerId}
-          className="react-execution-reasoning__content"
-          data-testid="execution-reasoning-content"
-          id={contentId}
-          role="region"
-        >
+        <div className="react-execution-reasoning__content" data-testid="execution-reasoning-content">
           <PlainMessageText text={step.summary ?? ""} />
         </div>
-      ) : null}
+      </TimelineActivity>
     </section>
   );
 }
@@ -751,20 +729,18 @@ function CanonicalChatStep({
   if (step.kind === "compaction") {
     const compaction = step.compaction;
     return (
-      <details className="react-canonical-step" data-kind={step.kind} data-status={step.status}>
-        <summary className="react-chat-disclosure-trigger">
-          <ChatDisclosureIcon icon={<ListCollapse size={16} />} />
-          <span>{t("turn.contextCompacted")}</span>
-        </summary>
-        {step.summary ? <p>{step.summary}</p> : null}
-        {compaction ? (
-          <ul aria-label={t("turn.compactionDetails")}>
-            {compaction.estimatedTokensBefore !== undefined ? <li>{t("compaction.before", { value: compaction.estimatedTokensBefore.toLocaleString(i18n.resolvedLanguage) })}</li> : null}
-            {compaction.estimatedTokensAfter !== undefined ? <li>{t("compaction.after", { value: compaction.estimatedTokensAfter.toLocaleString(i18n.resolvedLanguage) })}</li> : null}
-            <li>{t("compaction.dropped", { value: compaction.droppedItemCount.toLocaleString(i18n.resolvedLanguage) })}</li>
-          </ul>
-        ) : null}
-      </details>
+      <section className="react-canonical-step" data-kind={step.kind} data-status={step.status}>
+        <TimelineActivity icon={<ListCollapse size={16} />} keepMounted title={t("turn.contextCompacted")}>
+          {step.summary ? <p>{step.summary}</p> : null}
+          {compaction ? (
+            <ul aria-label={t("turn.compactionDetails")}>
+              {compaction.estimatedTokensBefore !== undefined ? <li>{t("compaction.before", { value: compaction.estimatedTokensBefore.toLocaleString(i18n.resolvedLanguage) })}</li> : null}
+              {compaction.estimatedTokensAfter !== undefined ? <li>{t("compaction.after", { value: compaction.estimatedTokensAfter.toLocaleString(i18n.resolvedLanguage) })}</li> : null}
+              <li>{t("compaction.dropped", { value: compaction.droppedItemCount.toLocaleString(i18n.resolvedLanguage) })}</li>
+            </ul>
+          ) : null}
+        </TimelineActivity>
+      </section>
     );
   }
   return (
@@ -815,7 +791,6 @@ function InlineExecutionError({ focusOnMount, step, turn }: { focusOnMount: bool
 
 function CanonicalPlanCard({ step }: { step: ChatStep }) {
   const { t } = useTranslation("chat");
-  const contentId = useId();
   const [expanded, setExpanded] = useState(step.status !== "completed");
   const plan = step.plan;
   const completed = plan?.steps.filter((item) => item.status === "completed").length ?? 0;
@@ -834,41 +809,37 @@ function CanonicalPlanCard({ step }: { step: ChatStep }) {
 
   return (
     <section aria-label={t("plan.label")} aria-live="polite" className="react-canonical-step" data-kind={step.kind} data-status={step.status}>
-      <div className="react-canonical-plan">
-        <button
-          aria-controls={contentId}
-          aria-expanded={expanded}
-          className="react-canonical-plan__heading react-chat-disclosure-trigger"
-          type="button"
-          onClick={() => setExpanded((open) => !open)}
-        >
-          <ChatDisclosureIcon icon={<AgentStepIcon status={canonicalStepIconStatus(step)} />} />
-          <strong>{t("plan.label")}</strong>
-          <span>{t("plan.completed", { completed, total: plan.total })}</span>
-        </button>
-        <progress
-          aria-label={step.title}
-          aria-valuemax={plan.total}
-          aria-valuemin={0}
-          aria-valuenow={completed}
-          max={Math.max(plan.total, 1)}
-          value={completed}
-        />
-        {expanded ? (
-          <div className="react-canonical-plan__content" id={contentId}>
-            {plan.explanation ? <p className="react-canonical-plan__explanation">{plan.explanation}</p> : null}
-            <ol className="react-canonical-plan__steps">
-              {plan.steps.map((planStep, index) => (
-                <li data-status={planStep.status} key={`${index}:${planStep.step}`}>
-                  <span className="react-canonical-plan__step-icon"><PlanStepIcon status={planStep.status} /></span>
-                  <PlanStepLabel text={planStep.step} />
-                  <small>{formatPlanStepStatus(planStep.status, t)}</small>
-                </li>
-              ))}
-            </ol>
-          </div>
-        ) : null}
-      </div>
+      <TimelineActivity
+        className="react-canonical-plan"
+        icon={<AgentStepIcon status={canonicalStepIconStatus(step)} />}
+        meta={t("plan.completed", { completed, total: plan.total })}
+        onOpenChange={setExpanded}
+        open={expanded}
+        summary={(
+          <progress
+            aria-label={step.title}
+            aria-valuemax={plan.total}
+            aria-valuemin={0}
+            aria-valuenow={completed}
+            max={Math.max(plan.total, 1)}
+            value={completed}
+          />
+        )}
+        title={<strong>{t("plan.label")}</strong>}
+      >
+        <div className="react-canonical-plan__content">
+          {plan.explanation ? <p className="react-canonical-plan__explanation">{plan.explanation}</p> : null}
+          <ol className="react-canonical-plan__steps">
+            {plan.steps.map((planStep, index) => (
+              <li data-status={planStep.status} key={`${index}:${planStep.step}`}>
+                <span className="react-canonical-plan__step-icon"><PlanStepIcon status={planStep.status} /></span>
+                <PlanStepLabel text={planStep.step} />
+                <small>{formatPlanStepStatus(planStep.status, t)}</small>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </TimelineActivity>
     </section>
   );
 }
@@ -1075,7 +1046,6 @@ function MessageReasoning({ durationMs, streaming, text }: { durationMs?: number
   const { t } = useTranslation("chat");
   const [expanded, setExpanded] = useState(streaming);
   const wasStreaming = useRef(streaming);
-  const contentId = useId();
 
   useEffect(() => {
     if (wasStreaming.current !== streaming) {
@@ -1086,21 +1056,16 @@ function MessageReasoning({ durationMs, streaming, text }: { durationMs?: number
 
   return (
     <section className="react-message-reasoning" aria-label={t("reasoning.label")}>
-      <button
-        aria-controls={contentId}
-        aria-expanded={expanded}
-        className="react-message-reasoning__trigger react-chat-disclosure-trigger"
-        type="button"
-        onClick={() => setExpanded((open) => !open)}
+      <TimelineActivity
+        icon={<Lightbulb size={16} />}
+        onOpenChange={setExpanded}
+        open={expanded}
+        title={streaming ? t("reasoning.thinking") : formatThinkingLabel(durationMs, t)}
       >
-        <ChatDisclosureIcon icon={<Lightbulb size={16} />} />
-        <span>{streaming ? t("reasoning.thinking") : formatThinkingLabel(durationMs, t)}</span>
-      </button>
-      {expanded ? (
-        <div className="react-message-reasoning__content" id={contentId}>
+        <div className="react-message-reasoning__content">
           <PlainMessageText text={text} />
         </div>
-      ) : null}
+      </TimelineActivity>
     </section>
   );
 }
@@ -1213,76 +1178,66 @@ function AgentSteps({
   toolCalls: ToolCallSummary[];
 }) {
   const { t } = useTranslation("chat");
-  const [expanded, setExpanded] = useState(false);
-  const listId = useId();
   const overallStatus = resolveAgentStepsStatus(toolCalls);
   const countLabel = t("steps.count", { count: toolCalls.length });
   const currentStepIndex = resolveCurrentAgentStepIndex(toolCalls);
+  const list = (
+    <ol aria-label={t("steps.label")} className="react-agent-steps__list">
+      {toolCalls.map((toolCall, index) => {
+        const status = normalizeAgentStepStatus(toolCall.status);
+        const isLast = index === toolCalls.length - 1;
+        const isCurrent = index === currentStepIndex;
+        return (
+          <li
+            aria-current={isCurrent ? "step" : undefined}
+            className="react-agent-step-item"
+            data-motion-role="step"
+            data-status={status}
+            data-step-count={toolCalls.length}
+            data-step-index={index}
+            key={toolCall.id}
+          >
+            {!isLast ? <span aria-hidden="true" className="react-agent-step-item__line" /> : null}
+            <span className="react-agent-step-item__marker" data-status={status}>
+              <AgentStepIcon status={status} />
+            </span>
+            {onOpenTool ? <button
+              aria-label={t("steps.openDetails", { name: toolCall.name })}
+              className="react-agent-step"
+              type="button"
+              onClick={() => onOpenTool(toolCall)}
+            >
+              <span className="react-agent-step__content">
+                <span>{toolCall.name}</span>
+                {toolCall.summary ? <small>{toolCall.summary}</small> : null}
+              </span>
+              <small className="react-agent-step__status">{formatAgentStepStatus(toolCall.status, t)}</small>
+              <PanelRightOpen aria-hidden="true" size={15} />
+            </button> : (
+              <div className="react-agent-step">
+                <span className="react-agent-step__content">
+                  <span>{toolCall.name}</span>
+                  {toolCall.summary ? <small>{toolCall.summary}</small> : null}
+                </span>
+                <small className="react-agent-step__status">{formatAgentStepStatus(toolCall.status, t)}</small>
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
   return (
     <section className="react-agent-steps" data-flat={flat ? "true" : undefined} data-status={overallStatus} data-stepper="true">
-      {!flat ? (
-        <button
-          aria-controls={listId}
-          aria-expanded={expanded}
-          aria-label={`${t("steps.label")}, ${countLabel}`}
-          className="react-agent-steps__header react-chat-disclosure-trigger"
-          type="button"
-          onClick={() => setExpanded((open) => !open)}
-        >
-          <span className="react-agent-steps__header-icon" data-status={overallStatus}>
-            <ChatDisclosureIcon icon={<AgentStepIcon status={overallStatus} />} />
-          </span>
-          <span className="react-agent-steps__title">{t("steps.title")}</span>
-          <small>{countLabel}</small>
-        </button>
-      ) : null}
-
-      {flat || expanded ? (
-        <ol aria-label={t("steps.label")} className="react-agent-steps__list" id={listId}>
-          {toolCalls.map((toolCall, index) => {
-            const status = normalizeAgentStepStatus(toolCall.status);
-            const isLast = index === toolCalls.length - 1;
-            const isCurrent = index === currentStepIndex;
-            return (
-              <li
-                aria-current={isCurrent ? "step" : undefined}
-                className="react-agent-step-item"
-                data-motion-role="step"
-                data-status={status}
-                data-step-count={toolCalls.length}
-                data-step-index={index}
-                key={toolCall.id}
-              >
-                {!isLast ? <span aria-hidden="true" className="react-agent-step-item__line" /> : null}
-                <span className="react-agent-step-item__marker" data-status={status}>
-                  <AgentStepIcon status={status} />
-                </span>
-                {onOpenTool ? <button
-                  aria-label={t("steps.openDetails", { name: toolCall.name })}
-                  className="react-agent-step"
-                  type="button"
-                  onClick={() => onOpenTool(toolCall)}
-                >
-                  <span className="react-agent-step__content">
-                    <span>{toolCall.name}</span>
-                    {toolCall.summary ? <small>{toolCall.summary}</small> : null}
-                  </span>
-                  <small className="react-agent-step__status">{formatAgentStepStatus(toolCall.status, t)}</small>
-                  <PanelRightOpen aria-hidden="true" size={15} />
-                </button> : (
-                  <div className="react-agent-step">
-                    <span className="react-agent-step__content">
-                      <span>{toolCall.name}</span>
-                      {toolCall.summary ? <small>{toolCall.summary}</small> : null}
-                    </span>
-                    <small className="react-agent-step__status">{formatAgentStepStatus(toolCall.status, t)}</small>
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ol>
-      ) : null}
+      {flat ? list : (
+        <TimelineActivity
+          className="react-agent-steps__activity"
+          icon={<AgentStepIcon status={overallStatus} />}
+          meta={countLabel}
+          title={t("steps.title")}
+          triggerLabel={`${t("steps.label")}, ${countLabel}`}
+        >{list}</TimelineActivity>
+      )}
     </section>
   );
 }

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -5,8 +5,6 @@ import {
   Activity,
   AlertTriangle,
   Check,
-  ChevronDown,
-  ChevronRight,
   Circle,
   Copy,
   FileText,
@@ -42,6 +40,7 @@ import { AssistantMarkdown } from "./AssistantMarkdown";
 import type { AssistantFileLink } from "./assistantFileLinks";
 import { isApplyPatchToolCall, PatchDiffCard, patchChangeSetFromToolResult } from "./PatchDiffCard";
 import { ToolActivityItem } from "./ToolActivityItem";
+import { ChatDisclosureIcon } from "./ChatDisclosureIcon";
 import { DataViewCard } from "./DataViewCard";
 
 export type ChatTimelineActions = {
@@ -323,16 +322,15 @@ function ExecutionTimeline({
         aria-controls={contentId}
         aria-expanded={open}
         aria-label={`${t("turn.workPerformed")}: ${summary}`}
-        className="react-execution-timeline__trigger"
+        className="react-execution-timeline__trigger react-chat-disclosure-trigger"
         title={summary}
         type="button"
         onClick={() => setOpen((currentOpen) => !currentOpen)}
       >
-        <span className="react-execution-timeline__status"><Activity aria-hidden="true" size={17} /></span>
+        <span className="react-execution-timeline__status"><ChatDisclosureIcon icon={<Activity size={16} />} /></span>
         <span className="react-execution-timeline__heading">
           <span aria-live="polite" className="react-execution-timeline__summary">{summary}</span>
         </span>
-        <ChevronRight aria-hidden="true" className="react-execution-timeline__chevron" size={16} />
       </button>
       <div className="react-execution-timeline__content" hidden={!open} id={contentId}>
         {visibleExecutionItems.map((step) => (
@@ -520,13 +518,13 @@ function ExecutionReasoningActivity({ step }: { step: ChatStep }) {
         aria-controls={contentId}
         aria-expanded={expanded}
         aria-label={label}
-        className="react-execution-reasoning__trigger"
+        className="react-execution-reasoning__trigger react-chat-disclosure-trigger"
         id={triggerId}
         type="button"
         onClick={() => setExpanded((open) => !open)}
       >
         <span className="react-execution-reasoning__label">
-          <Lightbulb aria-hidden="true" size={16} />
+          <ChatDisclosureIcon icon={<Lightbulb size={16} />} />
           <span>{label}</span>
         </span>
         <span
@@ -538,7 +536,6 @@ function ExecutionReasoningActivity({ step }: { step: ChatStep }) {
         >
           {expanded ? null : step.summary}
         </span>
-        {expanded ? <ChevronDown aria-hidden="true" size={14} /> : <ChevronRight aria-hidden="true" size={14} />}
       </button>
       {expanded ? (
         <div
@@ -755,10 +752,9 @@ function CanonicalChatStep({
     const compaction = step.compaction;
     return (
       <details className="react-canonical-step" data-kind={step.kind} data-status={step.status}>
-        <summary>
-          <span className="react-canonical-step__icon"><ListCollapse aria-hidden="true" size={16} /></span>
+        <summary className="react-chat-disclosure-trigger">
+          <ChatDisclosureIcon icon={<ListCollapse size={16} />} />
           <span>{t("turn.contextCompacted")}</span>
-          <ChevronRight aria-hidden="true" className="react-context-compaction-chevron" size={15} />
         </summary>
         {step.summary ? <p>{step.summary}</p> : null}
         {compaction ? (
@@ -838,18 +834,17 @@ function CanonicalPlanCard({ step }: { step: ChatStep }) {
 
   return (
     <section aria-label={t("plan.label")} aria-live="polite" className="react-canonical-step" data-kind={step.kind} data-status={step.status}>
-      <span className="react-canonical-step__icon"><AgentStepIcon status={canonicalStepIconStatus(step)} /></span>
       <div className="react-canonical-plan">
         <button
           aria-controls={contentId}
           aria-expanded={expanded}
-          className="react-canonical-plan__heading"
+          className="react-canonical-plan__heading react-chat-disclosure-trigger"
           type="button"
           onClick={() => setExpanded((open) => !open)}
         >
+          <ChatDisclosureIcon icon={<AgentStepIcon status={canonicalStepIconStatus(step)} />} />
           <strong>{t("plan.label")}</strong>
           <span>{t("plan.completed", { completed, total: plan.total })}</span>
-          {expanded ? <ChevronDown aria-hidden="true" size={15} /> : <ChevronRight aria-hidden="true" size={15} />}
         </button>
         <progress
           aria-label={step.title}
@@ -1094,12 +1089,12 @@ function MessageReasoning({ durationMs, streaming, text }: { durationMs?: number
       <button
         aria-controls={contentId}
         aria-expanded={expanded}
-        className="react-message-reasoning__trigger"
+        className="react-message-reasoning__trigger react-chat-disclosure-trigger"
         type="button"
         onClick={() => setExpanded((open) => !open)}
       >
+        <ChatDisclosureIcon icon={<Lightbulb size={16} />} />
         <span>{streaming ? t("reasoning.thinking") : formatThinkingLabel(durationMs, t)}</span>
-        {expanded ? <ChevronDown aria-hidden="true" size={14} /> : <ChevronRight aria-hidden="true" size={14} />}
       </button>
       {expanded ? (
         <div className="react-message-reasoning__content" id={contentId}>
@@ -1230,16 +1225,15 @@ function AgentSteps({
           aria-controls={listId}
           aria-expanded={expanded}
           aria-label={`${t("steps.label")}, ${countLabel}`}
-          className="react-agent-steps__header"
+          className="react-agent-steps__header react-chat-disclosure-trigger"
           type="button"
           onClick={() => setExpanded((open) => !open)}
         >
           <span className="react-agent-steps__header-icon" data-status={overallStatus}>
-            <AgentStepIcon status={overallStatus} />
+            <ChatDisclosureIcon icon={<AgentStepIcon status={overallStatus} />} />
           </span>
           <span className="react-agent-steps__title">{t("steps.title")}</span>
           <small>{countLabel}</small>
-          {expanded ? <ChevronDown aria-hidden="true" size={15} /> : <ChevronRight aria-hidden="true" size={15} />}
         </button>
       ) : null}
 

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:a87ee7b2823ee97d63300239f20adfc6a49405eaff96b53f32ddb77906773c3e -->
+<!-- tinybot-module-fingerprint: sha256:2c3430872150b45b64733e22894f45c6b2f5059bd92b0ea8a203b793114718ce -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -20,6 +20,12 @@ uses an ellipsis when the line does not fit. The user can expand the row for the
 complete naturally wrapped text. Individual Tool and Diff rows also start
 collapsed, so the ordered activity stays scannable until a user opens one row's
 details.
+`ChatDisclosureIcon.tsx` shares the leading icon and disclosure arrow across
+Reasoning, Tool, Diff, Plan, compaction, and execution-summary headers. Their
+triggers crossfade the icon to a down arrow on hover and keep an up arrow while
+expanded, using `aria-expanded` or native `details[open]` as the state source.
+Keyboard focus and reduced-motion mode switch immediately; non-hover devices
+keep the arrow visible. Each row retains its own expansion lifecycle and content.
 `FloatingPlanStatus.tsx` mirrors the most recent canonical plan across Turns in
 a fixed top-right note without introducing another plan store. A newer Turn
 without a plan keeps the previous plan visible; the next plan replaces it. New

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:2c3430872150b45b64733e22894f45c6b2f5059bd92b0ea8a203b793114718ce -->
+<!-- tinybot-module-fingerprint: sha256:d766d68e753ffad3b25b1032f94f4854f458ef856844049742191f4e8898a1f1 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -23,9 +23,22 @@ details.
 `ChatDisclosureIcon.tsx` shares the leading icon and disclosure arrow across
 Reasoning, Tool, Diff, Plan, compaction, and execution-summary headers. Their
 triggers crossfade the icon to a down arrow on hover and keep an up arrow while
-expanded, using `aria-expanded` or native `details[open]` as the state source.
+expanded, using the shared trigger's `aria-expanded` as the state source.
 Keyboard focus and reduced-motion mode switch immediately; non-hover devices
-keep the arrow visible. Each row retains its own expansion lifecycle and content.
+keep the arrow visible.
+`TimelineActivity.tsx` owns the shared Tool, Diff, Reasoning, Plan, compaction,
+execution-summary, and legacy tool-group shell:
+header layout, disclosure controls, stable accessible IDs, collapsed previews,
+and the details region. Its CSS and the disclosure icon CSS are imported by
+their owning modules. Ordinary tools use local expansion state; Reasoning and
+Plan supply controlled `open` and `onOpenChange` values to preserve their own
+streaming and completion rules. The `summary` slot stays visible when details
+are collapsed, so plan progress remains readable. Details unmount by default;
+tools and compaction opt into `keepMounted` to preserve their existing preview
+lifecycle. Execution summaries also keep their children mounted so folding the
+whole trace preserves individually expanded rows. Flat legacy tool groups use
+the same list renderer without a disclosure shell. Business-specific renderers
+own content and lifecycle decisions; they do not create disclosure buttons or IDs.
 `FloatingPlanStatus.tsx` mirrors the most recent canonical plan across Turns in
 a fixed top-right note without introducing another plan store. A newer Turn
 without a plan keeps the previous plan visible; the next plan replaces it. New

--- a/src/react-workbench/chat/TimelineActivity.css
+++ b/src/react-workbench/chat/TimelineActivity.css
@@ -1,0 +1,92 @@
+.react-timeline-activity {
+  display: grid;
+  min-width: 0;
+}
+
+.react-timeline-activity__header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  min-height: 34px;
+  border: 0;
+  background: transparent;
+  padding: 2px 0;
+  color: var(--color-muted);
+  font: inherit;
+  text-align: left;
+  transition: background-color var(--motion-duration-fast) ease;
+}
+
+button.react-timeline-activity__header:hover {
+  background: color-mix(in srgb, var(--color-surface-soft) 42%, transparent);
+}
+
+button.react-timeline-activity__header:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.react-timeline-activity__icon {
+  display: inline-grid;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  color: var(--color-muted-soft);
+}
+
+.react-timeline-activity__icon > svg {
+  width: 16px;
+  height: 16px;
+}
+
+.react-timeline-activity__heading {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+.react-timeline-activity__title,
+.react-timeline-activity__meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.react-timeline-activity__title {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.react-timeline-activity__title strong {
+  font-weight: 600;
+}
+
+.react-timeline-activity__meta {
+  color: var(--color-muted-soft);
+  font-size: 12px;
+}
+
+.react-timeline-activity__meta small {
+  font-size: 10px;
+}
+
+.react-timeline-activity__preview {
+  flex: 1;
+  min-width: 0;
+  margin-left: 4px;
+  overflow: hidden;
+}
+
+.react-timeline-activity__content {
+  min-width: 0;
+}
+
+.react-timeline-activity__content[hidden],
+.react-timeline-activity__preview[hidden] {
+  display: none;
+}

--- a/src/react-workbench/chat/TimelineActivity.test.tsx
+++ b/src/react-workbench/chat/TimelineActivity.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TimelineActivity } from "./TimelineActivity";
+
+afterEach(cleanup);
+
+describe("TimelineActivity", () => {
+  it("links each trigger to its own details and supports mouse and keyboard toggles", async () => {
+    const user = userEvent.setup();
+    render(<>
+      <TimelineActivity icon={<span>A</span>} title="First">First details</TimelineActivity>
+      <TimelineActivity icon={<span>B</span>} title="Second">Second details</TimelineActivity>
+    </>);
+    const first = screen.getByRole("button", { name: "First" });
+    const second = screen.getByRole("button", { name: "Second" });
+    expect(first).toHaveAttribute("aria-expanded", "false");
+    expect(first.getAttribute("aria-controls")).not.toBe(second.getAttribute("aria-controls"));
+    expect(screen.queryByText("First details")).toBeNull();
+    await user.click(first);
+    const region = screen.getByRole("region", { name: "First" });
+    expect(region.id).toBe(first.getAttribute("aria-controls"));
+    expect(region).toHaveTextContent("First details");
+    expect(second).toHaveAttribute("aria-expanded", "false");
+    await user.keyboard(" ");
+    expect(first).toHaveAttribute("aria-expanded", "false");
+    await user.keyboard("{Enter}");
+    expect(first).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("lets a controlled caller decide when an expansion request takes effect", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const view = (open: boolean) => <TimelineActivity icon={null} onOpenChange={onOpenChange} open={open} title="Controlled">Details</TimelineActivity>;
+    const { rerender } = render(view(false));
+    const trigger = screen.getByRole("button", { name: "Controlled" });
+    await user.click(trigger);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    rerender(view(true));
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    await user.click(trigger);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    rerender(view(false));
+    expect(screen.queryByText("Details")).toBeNull();
+  });
+
+  it("does not offer expansion for an item without details", () => {
+    render(<TimelineActivity defaultOpen icon={null} title="No details">{[null, false]}</TimelineActivity>);
+    expect(screen.getByText("No details")).toBeVisible();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByRole("region", { hidden: true })).toBeNull();
+  });
+
+  it("preserves mounted detail state while keeping it inaccessible when collapsed", async () => {
+    const user = userEvent.setup();
+    render(<TimelineActivity defaultOpen icon={null} keepMounted title="Editor"><input aria-label="Draft" /></TimelineActivity>);
+    const trigger = screen.getByRole("button", { name: "Editor" });
+    const input = screen.getByRole("textbox", { name: "Draft" });
+    await user.type(input, "Saved draft");
+    await user.click(trigger);
+    expect(input).not.toBeVisible();
+    expect(screen.queryByRole("textbox", { name: "Draft" })).toBeNull();
+    await user.click(trigger);
+    expect(screen.getByRole("textbox", { name: "Draft" })).toBe(input);
+    expect(input).toHaveValue("Saved draft");
+  });
+
+  it("preserves child disclosure choices when a containing activity is folded", async () => {
+    const user = userEvent.setup();
+    render(<TimelineActivity defaultOpen icon={null} keepMounted title="Trace">
+      <TimelineActivity icon={null} title="Tool">Tool details</TimelineActivity>
+    </TimelineActivity>);
+    const trace = screen.getByRole("button", { name: "Trace" });
+    const tool = screen.getByRole("button", { name: "Tool" });
+    await user.click(tool);
+    await user.click(trace);
+    expect(screen.queryByRole("button", { name: "Tool" })).toBeNull();
+    await user.click(trace);
+    expect(screen.getByRole("button", { name: "Tool" })).toBe(tool);
+    expect(tool).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("region", { name: "Tool" })).toHaveTextContent("Tool details");
+  });
+
+  it("hides the collapsed preview on expansion and keeps the summary outside the trigger", async () => {
+    const user = userEvent.setup();
+    render(<TimelineActivity
+      icon={null}
+      preview={<span>Latest text</span>}
+      summary={<progress aria-label="Progress" max={2} value={1} />}
+      title="Activity"
+      triggerLabel="Toggle activity"
+    >Full details</TimelineActivity>);
+    const trigger = screen.getByRole("button", { name: "Toggle activity" });
+    const preview = screen.getByText("Latest text");
+    const progress = screen.getByRole("progressbar", { name: "Progress" });
+    expect(preview).toBeVisible();
+    expect(trigger).not.toContainElement(progress);
+    await user.click(trigger);
+    expect(preview).not.toBeVisible();
+    expect(progress).toBeVisible();
+    await user.click(trigger);
+    expect(preview).toBeVisible();
+    expect(progress).toBeVisible();
+  });
+});

--- a/src/react-workbench/chat/TimelineActivity.tsx
+++ b/src/react-workbench/chat/TimelineActivity.tsx
@@ -1,0 +1,70 @@
+import { Children, useId, useState, type ReactNode } from "react";
+import { ChatDisclosureIcon } from "./ChatDisclosureIcon";
+import "./TimelineActivity.css";
+
+type Expansion =
+  | { open: boolean; onOpenChange: (open: boolean) => void; defaultOpen?: never }
+  | { open?: never; onOpenChange?: never; defaultOpen?: boolean };
+
+type TimelineActivityProps = Expansion & {
+  icon: ReactNode;
+  title: ReactNode;
+  triggerLabel?: string;
+  meta?: ReactNode;
+  preview?: ReactNode;
+  status?: ReactNode;
+  summary?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+  keepMounted?: boolean;
+};
+
+export function TimelineActivity({
+  icon, title, triggerLabel, meta, preview, status, summary, children,
+  className = "", keepMounted = false, open, onOpenChange, defaultOpen = false,
+}: TimelineActivityProps) {
+  const id = useId();
+  const triggerId = `${id}-trigger`;
+  const contentId = `${id}-content`;
+  const [localOpen, setLocalOpen] = useState(defaultOpen);
+  const hasContent = Children.toArray(children).length > 0;
+  const expanded = hasContent && (open ?? localOpen);
+  const heading = (
+    <>
+      <span aria-hidden="true" className="react-timeline-activity__icon">
+        {hasContent ? <ChatDisclosureIcon icon={icon} /> : icon}
+      </span>
+      <span className="react-timeline-activity__heading">
+        <span className="react-timeline-activity__title">{title}</span>
+        {meta ? <span className="react-timeline-activity__meta">{meta}</span> : null}
+      </span>
+      {preview ? <span aria-hidden="true" className="react-timeline-activity__preview" hidden={expanded}>{preview}</span> : null}
+      {status}
+    </>
+  );
+
+  return (
+    <div className={`react-timeline-activity ${className}`} data-open={expanded ? "true" : undefined}>
+      {hasContent ? (
+        <button
+          aria-controls={contentId}
+          aria-expanded={expanded}
+          aria-label={triggerLabel}
+          className="react-timeline-activity__header react-chat-disclosure-trigger"
+          id={triggerId}
+          type="button"
+          onClick={() => {
+            if (open === undefined) setLocalOpen(!expanded);
+            else onOpenChange(!expanded);
+          }}
+        >{heading}</button>
+      ) : <div className="react-timeline-activity__header">{heading}</div>}
+      {summary}
+      {hasContent ? (
+        <div aria-labelledby={triggerId} className="react-timeline-activity__content" hidden={!expanded} id={contentId} role="region">
+          {expanded || keepMounted ? children : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/react-workbench/chat/ToolActivityItem.test.tsx
+++ b/src/react-workbench/chat/ToolActivityItem.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import { ToolActivityItem } from "./ToolActivityItem";
@@ -27,7 +28,7 @@ describe("ToolActivityItem", () => {
     const toggle = screen.getByRole("button", { name: "Toggle details for Ran npm test" });
     expect(screen.getByText("Ran npm test").closest("button")).toBe(toggle);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.getByTestId("tool-activity-details").hasAttribute("hidden")).toBe(true);
+    expect(screen.getByTestId("tool-activity-details")).not.toBeVisible();
     await user.click(toggle);
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("$", { selector: ".react-tool-activity__prompt" })).toBeTruthy();
@@ -74,7 +75,7 @@ describe("ToolActivityItem", () => {
     expect(screen.getByText("Inspected ChatPage.tsx")).toBeTruthy();
     const toggle = screen.getByRole("button", { name: "Toggle details for Inspected ChatPage.tsx" });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.getByTestId("tool-activity-details").hasAttribute("hidden")).toBe(true);
+    expect(screen.getByTestId("tool-activity-details")).not.toBeVisible();
     await user.click(toggle);
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("src/react-workbench/chat/ChatPage.tsx")).toBeTruthy();
@@ -100,7 +101,7 @@ describe("ToolActivityItem", () => {
     expect(screen.getByText("Opened WebView2 APIs")).toBeTruthy();
     const toggle = screen.getByRole("button", { name: "Toggle details for Opened WebView2 APIs" });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.getByTestId("tool-activity-details").hasAttribute("hidden")).toBe(true);
+    expect(screen.getByTestId("tool-activity-details")).not.toBeVisible();
     await user.click(toggle);
     expect(screen.getByText("Reviewed the composition controller APIs.")).toBeTruthy();
   });

--- a/src/react-workbench/chat/ToolActivityItem.tsx
+++ b/src/react-workbench/chat/ToolActivityItem.tsx
@@ -1,4 +1,4 @@
-import { Children, useId, useMemo, useState, type ReactNode } from "react";
+import { Children, useMemo, type ReactNode } from "react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import {
@@ -14,7 +14,7 @@ import {
   XCircle,
 } from "lucide-react";
 import type { ChatStepStatus, ToolCallState } from "../../app-core/chat/chatTurnContracts";
-import { ChatDisclosureIcon } from "./ChatDisclosureIcon";
+import { TimelineActivity } from "./TimelineActivity";
 
 type ToolActivityKind = "file" | "generic" | "plan" | "subagent" | "terminal" | "web";
 
@@ -81,42 +81,21 @@ export function ToolActivityFrame({
   title: string;
 }) {
   const { t } = useTranslation("chat");
-  const contentId = useId();
-  const hasContent = Children.count(children) > 0;
-  const [open, setOpen] = useState(defaultOpen && hasContent);
+  const hasContent = Children.toArray(children).length > 0;
   const meta = [category, durationMs === undefined ? "" : formatToolDuration(durationMs)].filter(Boolean).join(" · ");
-  const headerContent = (
-    <>
-      <span aria-hidden="true" className="react-tool-activity__icon">
-        {hasContent ? <ChatDisclosureIcon icon={icon} /> : icon}
-      </span>
-      <span className="react-tool-activity__copy">
-        <strong>{title}</strong>
-        {meta ? <small>{meta}</small> : null}
-      </span>
-      <ToolActivityStatus status={status} />
-    </>
-  );
-
   return (
-    <section className="react-tool-activity" data-open={open ? "true" : undefined} data-status={status}>
-      {hasContent ? (
-        <button
-          aria-controls={contentId}
-          aria-expanded={open}
-          aria-label={t("toolActivity.toggleDetails", { title })}
-          className="react-tool-activity__header react-chat-disclosure-trigger"
-          type="button"
-          onClick={() => setOpen((current) => !current)}
-        >
-          {headerContent}
-        </button>
-      ) : <div className="react-tool-activity__header">{headerContent}</div>}
-      {hasContent ? (
-        <div className="react-tool-activity__details" data-testid="tool-activity-details" hidden={!open} id={contentId}>
-          {children}
-        </div>
-      ) : null}
+    <section className="react-tool-activity" data-status={status}>
+      <TimelineActivity
+        defaultOpen={defaultOpen}
+        icon={icon}
+        keepMounted
+        meta={meta ? <small>{meta}</small> : undefined}
+        status={<ToolActivityStatus status={status} />}
+        title={<strong>{title}</strong>}
+        triggerLabel={t("toolActivity.toggleDetails", { title })}
+      >
+        {hasContent ? <div className="react-tool-activity__details" data-testid="tool-activity-details">{children}</div> : null}
+      </TimelineActivity>
     </section>
   );
 }

--- a/src/react-workbench/chat/ToolActivityItem.tsx
+++ b/src/react-workbench/chat/ToolActivityItem.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import {
   AlertTriangle,
   Bot,
-  ChevronRight,
   Circle,
   FileText,
   Globe2,
@@ -15,6 +14,7 @@ import {
   XCircle,
 } from "lucide-react";
 import type { ChatStepStatus, ToolCallState } from "../../app-core/chat/chatTurnContracts";
+import { ChatDisclosureIcon } from "./ChatDisclosureIcon";
 
 type ToolActivityKind = "file" | "generic" | "plan" | "subagent" | "terminal" | "web";
 
@@ -87,13 +87,14 @@ export function ToolActivityFrame({
   const meta = [category, durationMs === undefined ? "" : formatToolDuration(durationMs)].filter(Boolean).join(" · ");
   const headerContent = (
     <>
-      <span aria-hidden="true" className="react-tool-activity__icon">{icon}</span>
+      <span aria-hidden="true" className="react-tool-activity__icon">
+        {hasContent ? <ChatDisclosureIcon icon={icon} /> : icon}
+      </span>
       <span className="react-tool-activity__copy">
         <strong>{title}</strong>
         {meta ? <small>{meta}</small> : null}
       </span>
       <ToolActivityStatus status={status} />
-      {hasContent ? <ChevronRight aria-hidden="true" className="react-tool-activity__chevron" size={15} /> : null}
     </>
   );
 
@@ -104,7 +105,7 @@ export function ToolActivityFrame({
           aria-controls={contentId}
           aria-expanded={open}
           aria-label={t("toolActivity.toggleDetails", { title })}
-          className="react-tool-activity__header"
+          className="react-tool-activity__header react-chat-disclosure-trigger"
           type="button"
           onClick={() => setOpen((current) => !current)}
         >

--- a/src/react-workbench/chat/test/ChatPageTestHarness.tsx
+++ b/src/react-workbench/chat/test/ChatPageTestHarness.tsx
@@ -123,6 +123,8 @@ export function mountWorkbenchCss(): void {
 export function readWorkbenchCss(): string {
   return [
     "src/react-workbench/styles/workbench.css",
+    "src/react-workbench/chat/ChatDisclosureIcon.css",
+    "src/react-workbench/chat/TimelineActivity.css",
     "src/react-workbench/chat/ChatPage.css",
   ].map((path) => readFileSync(path, "utf8")).join("\n");
 }


### PR DESCRIPTION
Chat timeline rows previously duplicated their disclosure buttons, accessibility wiring, and layout, so a single interaction change required edits across multiple renderers. This PR introduces TimelineActivity for tool calls, patch diffs, reasoning, plans, compaction, execution summaries, and legacy tool groups. Each renderer supplies its content and lifecycle rules through a shared interface; details can preserve mounted state, and folding an execution summary preserves the user's expanded child rows.

The timeline uses 4px vertical padding and a 12px item gap, aligned leading icons, and muted tool/reasoning text. Trailing disclosure arrows are replaced by a leading icon that crossfades to a down arrow on hover and stays as an up arrow while expanded. Keyboard focus and reduced-motion preferences retain immediate, visible feedback. Shared styles are imported by their owning modules.

Validation:
- `npm run analyze:frontend:ci`: passed, including ESLint, type checking, 750 tests, production build, and source/bundle regression budgets.
- Module README and engineering documentation freshness checks passed.
- Playwright checks against actual React components covered icon alignment, hover transitions, mouse and keyboard toggles, reduced motion, static rows, and preservation of child expansion when folding the trace.
