### PR TITLE
feat(ui): add turn metrics and polish desktop motion

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -9,7 +9,7 @@ src/app-core/native/desktopNativeTauriEvents.ts
 src/app-core/native/desktopNativeTauriEvents.test.ts
 src/react-workbench/adapters/desktopNativeEventBridge.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:1b0741d5125eaaed11a022bdd55537860ee8cdaea44e092e9ace61a7a5827e6c -->
+<!-- tinybot-doc-fingerprint: sha256:069c222200059e006f323c9877ac5d34c096c0e7a7f91be6285826d86f4cd099 -->
 
 This document lists frontend-visible events emitted by the native runtime. It
 is part of the [Rust backend API reference](rust-backend-api.md), which defines
@@ -96,6 +96,13 @@ context-window budget fields to the typed `payload.agentItem`, while
 Rollouts omit redundant outer enriched copies. Replay of earlier compact usage Items restores
 missing context-window fields from the adjacent `agent.token_count` record; that record also
 remains authoritative for normalized cache and reasoning counters.
+
+New usage Items also carry optional `modelTiming`: `modelCallId`,
+`timeToFirstTokenMs`, and `decodeDurationMs`. Durations use a backend monotonic
+clock for one provider invocation; absent stream timing is represented by null.
+The same typed Item reaches live patches and durable Rollout replay. This is an
+additive field in `tinybot.turn_item.v2`; it requires no SQLite or Rollout migration.
+Older Items omit it and cannot supply historical TTFT or TPS.
 
 - `context_window_tokens` / `contextWindowTokens`: effective per-model context window from the
   turn, provider profile, known-model catalog, legacy unknown-model fallback, or backend default.

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -11,7 +11,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:e03536e6c396166620cde8ddd56712484b181acf493ddb2364cdfa58c97ee692 -->
+<!-- tinybot-doc-fingerprint: sha256:1fb27d59c87ae4ad3dd243fa83567535b356fa884b8674b0735f40e34d6ac39e -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal
@@ -139,6 +139,17 @@ different wire formats but share the same provider/tool loop, permission
 checks, cancellation, trace, and result construction.
 
 ## Continuation and cancellation
+
+Completed provider invocations persist usage before executing tools, including
+tools that suspend the Turn for user input. Each usage Item carries optional
+`modelTiming` measured with `Instant`: invocation start to first non-empty text,
+reasoning, or tool-call output, and first output to provider completion. Each
+invocation owns its timing; non-streaming calls have no first-token reading.
+The settled Turn footer takes TTFT from its first usage Item and divides summed
+provider output tokens by summed positive decode durations from matching samples.
+Tools and waits between calls do not enter TPS. Total elapsed time spans the
+Turn's start and terminal boundary, including time spent waiting. The frontend
+derives these figures from canonical Items on live updates and history reload.
 
 - A Turn awaiting typed form input is waiting, not terminal.
 - Entering `awaiting_form` checkpoints the resumable runtime and ends the active

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -12,7 +12,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:4dc4901d7194a67dc5cbed2897ca5e13998b1a9488acfb56c05f8a650afe51dd -->
+<!-- tinybot-doc-fingerprint: sha256:5df32e47c8bd88ac5c20b1f2659aa11116af8e4f31584afe81092e8f8a9bfe24 -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:77f115bb05d68c8bdd903e0278a82913f78b127b5e2d5a0516b5c416fe2add27 -->
+<!-- tinybot-doc-fingerprint: sha256:8426ee6d08b416f7c062432a571d449ad1b47e361a94af8d1e13d0fcfac90dc2 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -164,6 +164,10 @@ Desktop Commands / Desktop Host
 - Sidecar Terminal process ownership: the dedicated desktop terminal runtime;
   Agent shell processes remain owned by the Agent runtime's independent shell
   registry.
+- Panel exit animation is renderer-only presentation. Closing disables input
+  and hides native browser surfaces immediately; retained React content may
+  finish its CSS transition without extending native resource ownership or
+  adding persistent animation state.
 - Desktop process residency: the Rust desktop host owns the system tray and
   main-window lifecycle. Closing `main` hides that window while the Native
   Runtime and auxiliary pet windows remain active; only the explicit tray exit

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:daf95a0fd4de78ef31129807c46ae5b601392f50acccef6a4f778fd72b310de1 -->
+<!-- tinybot-doc-fingerprint: sha256:77f115bb05d68c8bdd903e0278a82913f78b127b5e2d5a0516b5c416fe2add27 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -200,6 +200,11 @@ instead of choosing desktop persistence or transport internally.
 
 The renderer entry point has three surfaces. The main window follows
 `main.tsx -> App -> DesktopShell` and composes the application services. The
+initial HTML owns a white, centered-logo startup surface; the main window
+dismisses it after its first React frame, with reduced-motion support. The
+small `src/main.ts` bootstrap loads the workbench asynchronously and displays
+renderer diagnostics if that import fails. Startup presentation does not gate
+native session restoration and is hidden for both pet surfaces. The
 Windows-only `?surface=desktop-pet` path mounts `DesktopPetWindow` directly
 under the shared language, appearance, error, and diagnostic providers. It
 receives snapshots from `DesktopShell` through `app-core/native`, so showing a

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:e851e984c832b851d5e7e6d2ed69d30664561ffe50664a8340a9d3932bb455cd -->
+<!-- tinybot-doc-fingerprint: sha256:daf95a0fd4de78ef31129807c46ae5b601392f50acccef6a4f778fd72b310de1 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -11,7 +11,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:1937167b7c16c3d9ad46d271cd73b39651f0bd8d32b7d5e1b10288768a0cbc93 -->
+<!-- tinybot-doc-fingerprint: sha256:b5cdecb5a15bca338405547c20652ac6154de9fb95d7202732e4fdb9fbe60ee3 -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,

--- a/index.html
+++ b/index.html
@@ -9,9 +9,43 @@
       content="Tinybot desktop React workbench backed by the local gateway."
     />
     <link rel="icon" type="image/svg+xml" href="/assets/logo-mark.svg" />
+    <script>
+      document.documentElement.dataset.surface = new URLSearchParams(window.location.search).get("surface") || "main";
+    </script>
+    <style>
+      #tinybot-startup {
+        position: fixed;
+        inset: 0;
+        z-index: 10000;
+        display: grid;
+        place-items: center;
+        background: #fff;
+        pointer-events: none;
+      }
+      #tinybot-startup img {
+        display: block;
+        width: 80px;
+        height: 80px;
+        animation: tinybot-startup-logo 240ms cubic-bezier(0.2, 0, 0, 1) both;
+      }
+      :root[data-surface="desktop-pet"] #tinybot-startup,
+      :root[data-surface="desktop-pet-chat"] #tinybot-startup {
+        display: none;
+      }
+      @keyframes tinybot-startup-logo {
+        from { opacity: 0; transform: scale(0.94); }
+        to { opacity: 1; transform: scale(1); }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #tinybot-startup img { animation: none; }
+      }
+    </style>
     <script type="module" src="/src/main.ts" defer></script>
   </head>
   <body>
+    <div id="tinybot-startup" aria-hidden="true">
+      <img src="/assets/logo-mark.svg" width="80" height="80" alt="" />
+    </div>
     <div id="root"></div>
   </body>
 </html>

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -1,5 +1,5 @@
 # Agent
-<!-- tinybot-module-fingerprint: sha256:8ed87800209c3d2d9dde1777ba3af0aa443e07154d55ebe40d7ed775c50b1b6d -->
+<!-- tinybot-module-fingerprint: sha256:51e236d0bbdf05ead04d4485cd57417ff57f01368de1348d93cca40f79f5476e -->
 
 `agent` contains the native agent stack. It connects provider configuration,
 the turn runtime, durable runtime events, and the desktop integration bridge.

--- a/src-tauri/src/agent/provider/README.md
+++ b/src-tauri/src/agent/provider/README.md
@@ -1,5 +1,5 @@
 # Agent Providers
-<!-- tinybot-module-fingerprint: sha256:175cc974eab79215e1cf98c53a73a9825df676ff58913266a051aff41695f27e -->
+<!-- tinybot-module-fingerprint: sha256:9d09486427d6989f83354120f92589b3853e19cf77fbeda7e844ae4ebc916bf4 -->
 
 This module resolves provider and model configuration and performs streaming
 Chat Completions or Responses API requests.
@@ -38,3 +38,5 @@ Chat Completions or Responses API requests.
   response.
 - `streaming.rs` normalizes streamed provider events. Responses reasoning
   accepts both summary deltas and provider-compatible textual reasoning deltas.
+  Non-empty tool names and argument deltas also notify the runtime's timing
+  observer in both protocols; empty chunks and metadata do not mark first output.

--- a/src-tauri/src/agent/provider/streaming.rs
+++ b/src-tauri/src/agent/provider/streaming.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum NativeProviderStreamEvent {
+    ToolCallDelta,
     MessagePhase(String),
     ContentDelta(String),
     ReasoningDelta(String),
@@ -49,6 +50,29 @@ impl StreamingResponsesCompletion {
             .and_then(Value::as_str)
             .ok_or_else(|| "Responses API stream event requires type".to_string())?;
         match event_type {
+            "response.function_call_arguments.delta" => {
+                if event
+                    .get("delta")
+                    .and_then(Value::as_str)
+                    .is_some_and(|delta| !delta.is_empty())
+                {
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer(NativeProviderStreamEvent::ToolCallDelta);
+                    }
+                }
+            }
+            "response.output_item.added" => {
+                if event.pointer("/item/type").and_then(Value::as_str) == Some("function_call")
+                    && event
+                        .pointer("/item/name")
+                        .and_then(Value::as_str)
+                        .is_some_and(|name| !name.is_empty())
+                {
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer(NativeProviderStreamEvent::ToolCallDelta);
+                    }
+                }
+            }
             "response.output_text.delta" => {
                 if let Some(delta) = event.get("delta").and_then(Value::as_str) {
                     if !delta.is_empty() {
@@ -179,6 +203,20 @@ fn observe_parsed_stream_chunk(
     chunk: &ParsedStreamChunk<'_>,
     observer: &mut (dyn FnMut(NativeProviderStreamEvent) + Send),
 ) {
+    if chunk.tool_call_deltas.is_some_and(|deltas| {
+        deltas.iter().any(|delta| {
+            ["/function/name", "/function/arguments"]
+                .iter()
+                .any(|path| {
+                    delta
+                        .pointer(path)
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| !value.is_empty())
+                })
+        })
+    }) {
+        observer(NativeProviderStreamEvent::ToolCallDelta);
+    }
     if let Some(phase) = chunk.phase {
         observer(NativeProviderStreamEvent::MessagePhase(phase.to_string()));
     }

--- a/src-tauri/src/agent/provider_tests.rs
+++ b/src-tauri/src/agent/provider_tests.rs
@@ -1003,6 +1003,37 @@ fn streaming_observer_does_not_change_completion_reduction() {
 }
 
 #[test]
+fn tool_stream_timing_ignores_empty_chunks_and_observes_names_and_arguments() {
+    let mut chat = StreamingChatCompletion::default();
+    let mut observed = Vec::new();
+    for delta in [
+        json!({"index": 0, "id": "call-1", "function": {"arguments": ""}}),
+        json!({"index": 0, "function": {"name": "read_file"}}),
+        json!({"index": 0, "function": {"arguments": "{}"}}),
+    ] {
+        chat.push_chunk(
+            &json!({"choices": [{"delta": {"tool_calls": [delta]}}]}),
+            Some(&mut |event| observed.push(event)),
+        )
+        .unwrap();
+    }
+    assert_eq!(observed, vec![NativeProviderStreamEvent::ToolCallDelta; 2]);
+    observed.clear();
+    let mut responses = StreamingResponsesCompletion::default();
+    for event in [
+        json!({"type": "response.output_item.added", "item": {"type": "message"}}),
+        json!({"type": "response.function_call_arguments.delta", "delta": ""}),
+        json!({"type": "response.output_item.added", "item": {"type": "function_call", "name": "read_file"}}),
+        json!({"type": "response.function_call_arguments.delta", "delta": "{}"}),
+    ] {
+        responses
+            .push_event(&event, Some(&mut |event| observed.push(event)))
+            .unwrap();
+    }
+    assert_eq!(observed, vec![NativeProviderStreamEvent::ToolCallDelta; 2]);
+}
+
+#[test]
 fn aggregates_streaming_reasoning_and_usage_for_agent_completion() {
     let completion = aggregate_stream_chunks(&[
         json!({"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"reasoning_content":"think "},"finish_reason":null}]}),

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:88953d2eeb109d244654b4d05e08b8f16b6f4af37fd5f14ed858a472ccb1ef51 -->
+<!-- tinybot-module-fingerprint: sha256:5c6e82f0a82475b6c30c8cf77bc6d370b94af8733920bfe7f1cec61d95673311 -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed
@@ -9,6 +9,12 @@ terminal result.
 The module is independent of the Tauri command surface. Desktop integration,
 history selection, attachment lifetime, and durable turn orchestration belong
 to [`agent::bridge`](../bridge/README.md).
+
+Provider timing uses a per-invocation monotonic clock. Text, reasoning, or tool
+output marks the first token; provider completion ends the decode interval.
+Usage and its optional `modelTiming` are persisted before executing tools so
+waiting for input or tool failure cannot discard completed model work. Calls
+without streaming output carry null timings and do not fabricate throughput.
 
 ## Responsibilities
 

--- a/src-tauri/src/agent/runtime/item_event_projection.rs
+++ b/src-tauri/src/agent/runtime/item_event_projection.rs
@@ -165,6 +165,10 @@ fn agent_item_for_runtime_event(kind: AgentEventKind, payload: &Value) -> Option
                 .unwrap_or_else(|| provider_usage.clone());
             let mut usage = AgentUsageItem::from_runtime_usage(provider_usage, normalized_usage)
                 .expect("runtime usage payload must be an object");
+            usage.model_timing = payload.get("modelTiming").map(|timing| {
+                serde_json::from_value(timing.clone())
+                    .expect("runtime model timing must match AgentModelTiming")
+            });
             usage.id = Some(format!(
                 "{turn_id}:usage:{}",
                 payload

--- a/src-tauri/src/agent/runtime/items.rs
+++ b/src-tauri/src/agent/runtime/items.rs
@@ -239,6 +239,8 @@ pub struct AgentErrorItem {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentUsageItem {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_timing: Option<crate::agent::runtime_protocol::AgentModelTiming>,
     pub id: Option<String>,
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
@@ -640,6 +642,7 @@ impl AgentUsageItem {
             .or(provider_token_usage);
         let mut item = Self {
             id: None,
+            model_timing: None,
             input_tokens: token_usage.as_ref().map(|usage| usage.input_tokens),
             output_tokens: token_usage.as_ref().map(|usage| usage.output_tokens),
             total_tokens: token_usage.as_ref().map(|usage| usage.total_tokens),

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -194,6 +194,7 @@ pub struct NativeAgentProviderResponse {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum NativeAgentProviderStreamEvent {
+    ToolCallDelta,
     MessagePhase(crate::agent::runtime_protocol::AgentAssistantMessagePhase),
     ContentDelta(String),
     ReasoningDelta(String),

--- a/src-tauri/src/agent/runtime/provider.rs
+++ b/src-tauri/src/agent/runtime/provider.rs
@@ -33,6 +33,9 @@ impl NativeAgentProvider for RustNativeAgentProvider {
             .unwrap_or_else(|| adapter.build_request(context))?;
         let mut provider_observer =
             |event: crate::agent::provider::NativeProviderStreamEvent| match event {
+                crate::agent::provider::NativeProviderStreamEvent::ToolCallDelta => {
+                    observer(NativeAgentProviderStreamEvent::ToolCallDelta)
+                }
                 crate::agent::provider::NativeProviderStreamEvent::MessagePhase(phase) => {
                     observer(NativeAgentProviderStreamEvent::MessagePhase(
                         parse_message_phase(&phase),
@@ -75,6 +78,9 @@ impl NativeAgentProvider for RustNativeAgentProvider {
             });
             let mut provider_observer =
                 |event: crate::agent::provider::NativeProviderStreamEvent| match event {
+                    crate::agent::provider::NativeProviderStreamEvent::ToolCallDelta => {
+                        observer(NativeAgentProviderStreamEvent::ToolCallDelta)
+                    }
                     crate::agent::provider::NativeProviderStreamEvent::MessagePhase(phase) => {
                         observer(NativeAgentProviderStreamEvent::MessagePhase(
                             parse_message_phase(&phase),

--- a/src-tauri/src/agent/runtime/provider_loop.rs
+++ b/src-tauri/src/agent/runtime/provider_loop.rs
@@ -273,6 +273,7 @@ impl ProviderStreamState {
             return;
         }
         match event {
+            NativeAgentProviderStreamEvent::ToolCallDelta => {}
             NativeAgentProviderStreamEvent::MessagePhase(phase) => {
                 self.message_phase = phase;
                 if let Err(error) = state.emit(ModelOutputEvent::MessagePhase(serde_json::json!({
@@ -427,6 +428,7 @@ struct PreparedProviderIteration {
 struct CompletedProviderIteration {
     response: NativeAgentProviderResponse,
     attempt: ProviderAttempt,
+    timing: crate::agent::runtime_protocol::AgentModelTiming,
 }
 
 impl<'a> NativeAgentTurnExecution<'a> {
@@ -956,8 +958,18 @@ impl<'a> NativeAgentTurnExecution<'a> {
             mut attempt,
         } = prepared;
         let provider_started_at = Instant::now();
+        let mut first_token_at = None;
         let provider_response = {
             let mut stream_observer = |event: NativeAgentProviderStreamEvent| {
+                let has_output = match &event {
+                    NativeAgentProviderStreamEvent::ContentDelta(delta)
+                    | NativeAgentProviderStreamEvent::ReasoningDelta(delta) => !delta.is_empty(),
+                    NativeAgentProviderStreamEvent::ToolCallDelta => true,
+                    NativeAgentProviderStreamEvent::MessagePhase(_) => false,
+                };
+                if has_output && first_token_at.is_none() && provider_context.stream {
+                    first_token_at = Some(Instant::now());
+                }
                 attempt.stream.observe(
                     &self.context,
                     &mut self.state,
@@ -991,6 +1003,16 @@ impl<'a> NativeAgentTurnExecution<'a> {
             return Err(error);
         }
         let provider_duration = provider_started_at.elapsed();
+        let timing = crate::agent::runtime_protocol::AgentModelTiming {
+            model_call_id: attempt.id.clone(),
+            time_to_first_token_ms: first_token_at
+                .map(|first| first.duration_since(provider_started_at).as_millis() as u64),
+            decode_duration_ms: first_token_at.map(|first| {
+                provider_duration
+                    .saturating_sub(first.duration_since(provider_started_at))
+                    .as_millis() as u64
+            }),
+        };
         self.context
             .metrics()
             .record_duration("provider.durationMs", provider_duration);
@@ -1056,6 +1078,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
         Ok(ExecutionStage::Ready(CompletedProviderIteration {
             response,
             attempt,
+            timing,
         }))
     }
 
@@ -1172,7 +1195,20 @@ impl<'a> NativeAgentTurnExecution<'a> {
         &mut self,
         completed: CompletedProviderIteration,
     ) -> Result<IterationOutcome, String> {
-        let CompletedProviderIteration { response, attempt } = completed;
+        let CompletedProviderIteration {
+            response,
+            attempt,
+            timing,
+        } = completed;
+        // Persist completed model work before tools can pause, fail, or cancel the turn.
+        self.state.record_usage(
+            &self.context,
+            attempt.iteration,
+            &attempt.id,
+            response.usage,
+            attempt.estimated_context_tokens,
+            timing,
+        )?;
         if attempt.stream.streamed_content
             || !response.final_content.is_empty()
             || !response.response_items.is_empty()
@@ -1222,13 +1258,6 @@ impl<'a> NativeAgentTurnExecution<'a> {
                 }),
             ))?;
         }
-        self.state.record_usage(
-            &self.context,
-            attempt.iteration,
-            &attempt.id,
-            response.usage,
-            attempt.estimated_context_tokens,
-        )?;
         Ok(IterationOutcome::Continue)
     }
 
@@ -1236,7 +1265,11 @@ impl<'a> NativeAgentTurnExecution<'a> {
         &mut self,
         completed: CompletedProviderIteration,
     ) -> Result<Value, String> {
-        let CompletedProviderIteration { response, attempt } = completed;
+        let CompletedProviderIteration {
+            response,
+            attempt,
+            timing,
+        } = completed;
         let final_content = response.final_content;
         self.state.record_usage(
             &self.context,
@@ -1244,6 +1277,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
             &attempt.id,
             response.usage,
             attempt.estimated_context_tokens,
+            timing,
         )?;
         self.state.transition_phase(
             AgentRuntimePhase::Finalizing,

--- a/src-tauri/src/agent/runtime/state.rs
+++ b/src-tauri/src/agent/runtime/state.rs
@@ -516,6 +516,7 @@ impl AgentTurnState {
         model_call_id: &str,
         provider_usage: Option<Value>,
         estimated_context_tokens: i64,
+        model_timing: crate::agent::runtime_protocol::AgentModelTiming,
     ) -> Result<(), String> {
         let normalized_provider_usage = crate::token_usage::normalize_provider_token_usage(
             provider_usage.as_ref().unwrap_or(&Value::Null),
@@ -565,6 +566,7 @@ impl AgentTurnState {
             "modelCallId": model_call_id,
             "usage": usage,
             "providerUsage": provider_usage,
+            "modelTiming": model_timing,
         })))
     }
 }

--- a/src-tauri/src/agent/runtime/tests/README.md
+++ b/src-tauri/src/agent/runtime/tests/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Tests
-<!-- tinybot-module-fingerprint: sha256:dd2d7948bb760e6da6af5a4e8cb5f0beb5dda02084634fb7a6ec26be1e435ce7 -->
+<!-- tinybot-module-fingerprint: sha256:55be2860871ca674220acbe91ff8a7980bbed21a524dbaa037562bbff70d4903 -->
 
 This directory groups the larger agent runtime test suites by concern:
 configuration, context, interactions, lifecycle, and tools.
@@ -23,6 +23,9 @@ Shared fixtures and helpers live in `mod.rs`.
 Lifecycle coverage verifies prompt, before-tool, and after-tool hook stages and
 confirms that normalized before-tool replacements reach dispatch. It also
 checks that provider reasoning has matching live and reloaded canonical items.
+Timing coverage uses an asynchronous streaming provider to verify first-token
+and decode intervals survive serialization, and asserts usage is recorded before
+a tool suspends the Turn for input.
 Interaction coverage keeps resumable user-input checkpoints and their deferred tool-hook
 context on the same Turn, and verifies that form submission acknowledgement
 precedes the resumed provider request.

--- a/src-tauri/src/agent/runtime/tests/interactions.rs
+++ b/src-tauri/src/agent/runtime/tests/interactions.rs
@@ -211,6 +211,14 @@ fn request_user_input_waits_then_resumes_the_same_tool_chain() {
     .expect("user input request should create a waiting checkpoint");
 
     assert_eq!(waiting["stopReason"], "awaiting_form");
+    let usage = waiting["runtimeEvents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|event| event["eventName"] == "agent.usage")
+        .expect("completed model usage must be durable before waiting for input");
+    assert!(usage["payload"]["agentItem"]["modelTiming"]["modelCallId"].is_string());
+    assert!(usage["payload"]["agentItem"]["modelTiming"]["timeToFirstTokenMs"].is_null());
     assert_eq!(waiting["form"]["form_id"], "user-input:clarify-1");
     assert_eq!(waiting["form"]["title"], "Choose a target");
     assert_eq!(waiting["checkpoint"]["payload"]["kind"], "user_input");

--- a/src-tauri/src/agent/runtime/tests/lifecycle.rs
+++ b/src-tauri/src/agent/runtime/tests/lifecycle.rs
@@ -948,26 +948,38 @@ fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
             })
         }
 
-        fn complete_streaming(
-            &self,
-            _context: &AgentTurnContext,
-            observer: &mut (dyn FnMut(NativeAgentProviderStreamEvent) + Send),
-        ) -> Result<NativeAgentProviderResponse, String> {
-            observer(NativeAgentProviderStreamEvent::ReasoningDelta(
-                "thinking".to_string(),
-            ));
-            observer(NativeAgentProviderStreamEvent::ContentDelta(
-                "Hel".to_string(),
-            ));
-            observer(NativeAgentProviderStreamEvent::ContentDelta(
-                "lo".to_string(),
-            ));
-            Ok(NativeAgentProviderResponse {
-                final_content: "Hello".to_string(),
-                reasoning_delta: Some("thinking".to_string()),
-                usage: None,
-                response_items: Vec::new(),
-                tool_calls: Vec::new(),
+        fn complete_streaming_async<'a>(
+            self: Arc<Self>,
+            _context: &'a AgentTurnContext,
+            observer: &'a mut (dyn FnMut(NativeAgentProviderStreamEvent) + Send),
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<NativeAgentProviderResponse, NativeAgentProviderFailure>,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                observer(NativeAgentProviderStreamEvent::ContentDelta(String::new()));
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                observer(NativeAgentProviderStreamEvent::ReasoningDelta(
+                    "thinking".to_string(),
+                ));
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                observer(NativeAgentProviderStreamEvent::ContentDelta(
+                    "Hel".to_string(),
+                ));
+                observer(NativeAgentProviderStreamEvent::ContentDelta(
+                    "lo".to_string(),
+                ));
+                Ok(NativeAgentProviderResponse {
+                    final_content: "Hello".to_string(),
+                    reasoning_delta: Some("thinking".to_string()),
+                    usage: None,
+                    response_items: Vec::new(),
+                    tool_calls: Vec::new(),
+                })
             })
         }
     }
@@ -1017,6 +1029,28 @@ fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
     assert_eq!(reasoning_completed.len(), 1);
     assert_eq!(reasoning_completed[0]["payload"]["summary"], "thinking");
     assert_eq!(result["finalContent"], "Hello");
+    let usage = result["runtimeEvents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|event| event["eventName"] == "agent.usage")
+        .unwrap();
+    let timing = &usage["payload"]["agentItem"]["modelTiming"];
+    assert_eq!(timing["modelCallId"], "turn-streaming-provider:provider:1");
+    assert!(timing["timeToFirstTokenMs"].as_u64().unwrap() >= 5);
+    assert!(timing["decodeDurationMs"].as_u64().unwrap() >= 5);
+    // Durable event serialization and history projection retain exactly the live reading.
+    let events: Vec<crate::agent::runtime_protocol::AgentRuntimeEventEnvelope> =
+        serde_json::from_value(result["runtimeEvents"].clone()).unwrap();
+    let items = crate::agent::runtime_protocol::project_turn_items_from_trace_events(&events);
+    let persisted = items
+        .iter()
+        .find(|item| item.kind == crate::agent::runtime_protocol::AgentTurnItemKind::Usage)
+        .unwrap();
+    assert_eq!(
+        serde_json::to_value(&persisted.data).unwrap()["modelTiming"],
+        *timing
+    );
 }
 
 #[test]

--- a/src-tauri/src/agent/runtime/tests/tools.rs
+++ b/src-tauri/src/agent/runtime/tests/tools.rs
@@ -105,6 +105,25 @@ fn runs_fixture_tool_event_sequence() {
                 "iteration": 0,
             }),
             json!({
+                "event": "agent.model_call.completed",
+                "phase": "planning",
+                "iteration": 0,
+                "modelCall": "turn-tool:provider:1",
+            }),
+            json!({
+                "event": "agent.token_count",
+                "phase": "planning",
+                "iteration": 0,
+                "modelCall": "turn-tool:provider:1",
+            }),
+            json!({
+                "event": "agent.usage",
+                "phase": "calling_model",
+                "iteration": 0,
+                "item": "turn-tool:usage:0",
+                "modelCall": "turn-tool:provider:1",
+            }),
+            json!({
                 "event": "agent.phase.changed",
                 "phase": "tool_calling",
                 "iteration": 0,
@@ -153,25 +172,6 @@ fn runs_fixture_tool_event_sequence() {
                 "phase": "planning",
                 "iteration": 0,
                 "transition": ["tool_running", "planning"],
-            }),
-            json!({
-                "event": "agent.model_call.completed",
-                "phase": "planning",
-                "iteration": 0,
-                "modelCall": "turn-tool:provider:1",
-            }),
-            json!({
-                "event": "agent.token_count",
-                "phase": "planning",
-                "iteration": 0,
-                "modelCall": "turn-tool:provider:1",
-            }),
-            json!({
-                "event": "agent.usage",
-                "phase": "calling_model",
-                "iteration": 0,
-                "item": "turn-tool:usage:0",
-                "modelCall": "turn-tool:provider:1",
             }),
             json!({
                 "event": "agent.phase.changed",
@@ -2081,11 +2081,11 @@ fn provider_error_after_tool_result_preserves_accumulated_tool_state() {
     assert_eq!(
         relevant_events,
         vec![
+            "agent.model_call.completed",
+            "agent.usage",
             "agent.tool_call.delta",
             "agent.tool.start",
             "agent.tool.result",
-            "agent.model_call.completed",
-            "agent.usage",
             "agent.error"
         ]
     );

--- a/src-tauri/src/agent/runtime_protocol/README.md
+++ b/src-tauri/src/agent/runtime_protocol/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Protocol
-<!-- tinybot-module-fingerprint: sha256:1488a4021fe9e8da1283e4ba55b065f92c7844e616bf991b7876ec49f25d52c8 -->
+<!-- tinybot-module-fingerprint: sha256:e7b4c8e2fac2a7d390b61b22ca5435f9deb487af19df5b1d63943cd004427a1e -->
 
 `runtime_protocol` defines the durable events exchanged by the agent runtime
 and the projections built from them.
@@ -22,3 +22,8 @@ Usage timeline items treat the typed `agentItem` as canonical. Their projected
 payload omits the redundant enriched `usage` and raw `providerUsage` event
 fields once the typed item contains explicit normalized context metrics and the
 original provider usage payload.
+
+Usage Items optionally carry `modelTiming` with a model-call identity, TTFT,
+and decode duration in milliseconds. Typed live projection and durable replay
+retain the same values. Older v2 Items omit the field; no schema migration is
+needed and absent timing remains unavailable.

--- a/src-tauri/src/agent/runtime_protocol/timeline_projection.rs
+++ b/src-tauri/src/agent/runtime_protocol/timeline_projection.rs
@@ -859,6 +859,7 @@ fn legacy_item_data(
         AgentTurnItemKind::Usage => {
             let usage = payload.get("usage").unwrap_or(payload);
             AgentTurnItemData::Usage {
+                model_timing: None,
                 id: event
                     .item_id
                     .clone()

--- a/src-tauri/src/agent/runtime_protocol/wire.rs
+++ b/src-tauri/src/agent/runtime_protocol/wire.rs
@@ -257,6 +257,8 @@ pub enum AgentTurnItemData {
         estimated_tokens_after: Option<u64>,
     },
     Usage {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model_timing: Option<AgentModelTiming>,
         id: Option<String>,
         input_tokens: Option<i64>,
         output_tokens: Option<i64>,
@@ -293,6 +295,15 @@ pub enum AgentTurnItemData {
         message: String,
         detail: Value,
     },
+}
+
+/// Monotonic timings for one provider invocation, excluding tool execution.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentModelTiming {
+    pub model_call_id: String,
+    pub time_to_first_token_ms: Option<u64>,
+    pub decode_duration_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/src-tauri/src/threads/domain/store/README.md
+++ b/src-tauri/src/threads/domain/store/README.md
@@ -1,5 +1,5 @@
 # Thread Stores
-<!-- tinybot-module-fingerprint: sha256:525b85a8f71a28ebd0cec23cba9c77aeff2fae8923d9087b06722d7d8f97215f -->
+<!-- tinybot-module-fingerprint: sha256:69fc0f62ef53d1a1ea7f558a7b4b3a5789645238bcee7403dff4c7b4bd446cb1 -->
 
 This module implements thread storage operations and projections used by the
 thread domain.
@@ -8,6 +8,8 @@ It covers metadata, indexes, turns, checkpoints, forks, activity, memory,
 subagents, queries, and conversion from stored items into runtime views.
 Runtime projection preserves canonical event identity and ordering and avoids
 emitting duplicate lifecycle fallbacks when a semantic event already exists.
+Typed usage replay preserves optional per-model timings with their output counts;
+tests cover reloading those fields without changing the stored Item format.
 Persisted provider reasoning prefers summary text and falls back to textual
 reasoning content when reconstructing the user-visible timeline.
 When a completed semantic reasoning event and its provider-native reasoning

--- a/src-tauri/src/threads/domain/store/runtime_projection_tests.rs
+++ b/src-tauri/src/threads/domain/store/runtime_projection_tests.rs
@@ -643,3 +643,30 @@ fn unrelated_domain_events_are_not_projected_as_agent_context_state() {
     assert!(runtime_events_from_thread_items(&items, "thread-1", "turn-1").is_empty());
     assert!(turn_items_from_thread_items(&items, "thread-1", "turn-1").is_empty());
 }
+
+#[test]
+fn persisted_typed_usage_retains_model_timing_on_reload() {
+    let timing =
+        json!({ "modelCallId": "call-1", "timeToFirstTokenMs": 600, "decodeDurationMs": 2000 });
+    let item = ThreadItem {
+        item_id: "usage-1".to_string(),
+        thread_id: "thread-1".to_string(),
+        turn_id: "turn-1".to_string(),
+        parent_item_id: None,
+        sequence: 2,
+        created_at: "1786673534920".to_string(),
+        kind: ThreadItemKind::Event(json!({
+            "eventName": "agent.usage", "sequence": 2, "timestamp": "1786673534920",
+            "source": "provider", "visibility": "debug", "turnId": "turn-1", "itemId": "usage-1",
+            "payload": {"agentItem": {"type": "usage", "id": "usage-1", "inputTokens": 100,
+                "outputTokens": 216, "totalTokens": 316, "providerPayload": {}, "modelTiming": timing }}
+        })),
+    };
+    let restored: ThreadItem =
+        serde_json::from_value(serde_json::to_value(&item).unwrap()).unwrap();
+    let projected = turn_items_from_thread_items(&[restored], "thread-1", "turn-1");
+    assert_eq!(projected.len(), 1);
+    let data = serde_json::to_value(&projected[0].data).unwrap();
+    assert_eq!(data["modelTiming"], timing);
+    assert_eq!(data["outputTokens"], 216);
+}

--- a/src/app-core/chat/README.md
+++ b/src/app-core/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Application Core
-<!-- tinybot-module-fingerprint: sha256:857f97491a5bc7451cf9c51ae267c8694fcfe543c9ff64f43ade013e910b3ec3 -->
+<!-- tinybot-module-fingerprint: sha256:e0db572676bbea1d701ae6bc3421cdfd0b275456a86824f4cdf1e8e2a710f751 -->
 
 `chat` contains framework-independent chat and Thread contracts, command
 construction, canonical timeline validation, UI projection, input state, and
@@ -27,6 +27,12 @@ normalized top-level fields and persisted Provider `prompt_tokens_details` or
 `input_tokens_details` payloads, so historical and new Threads share one
 cache-hit-rate contract. Typed top-level context-window metrics are merged with
 that untouched Provider payload before the composer derives its usage indicator.
+
+`turnMetrics.ts` derives first-call TTFT and weighted output speed from optional
+`modelTiming` on canonical usage Items. Speed includes only samples with both
+provider output counts and a positive decode duration. Old or non-streaming
+Items supply no invented timings; a later call never replaces missing first-call
+latency. Completed Turn duration uses the existing start and end timestamps.
 
 `desktopChatSessionController` requires every submission to name its target
 Thread explicitly. The controller validates that target and never derives a

--- a/src/app-core/chat/chatProjection.ts
+++ b/src/app-core/chat/chatProjection.ts
@@ -24,6 +24,7 @@ import type {
   ToolCallState,
 } from "./chatTurnContracts";
 import { safeArtifactPreview, sanitizeTextPreview } from "./chatPreview";
+import { deriveTurnMetrics } from "./turnMetrics";
 import { parseDataViewDocument, type DataViewDocument } from "./dataView";
 
 export function projectLoadedArtifactDetail(
@@ -111,6 +112,7 @@ function runtimeStateToTurn(
     .sort(compareRuntimeTimestamps);
   const lastUpdatedAt = updatedAt[updatedAt.length - 1] || startedAt;
   const turn: ChatTurn = {
+    metrics: deriveTurnMetrics(runtimeState.timeline.items),
     canonicalItems: [...runtimeState.timeline.items],
     id: runtimeState.timeline.turnId,
     sessionKey,

--- a/src/app-core/chat/chatTimelinePayload.ts
+++ b/src/app-core/chat/chatTimelinePayload.ts
@@ -145,6 +145,18 @@ function normalizeCanonicalTurnItem(
   if (kind === "reasoning") {
     requiredCanonicalString(data, "modelCallId");
   }
+  if (kind === "usage" && data.modelTiming !== undefined) {
+    const timing = payloadRecord(data.modelTiming);
+    requiredCanonicalString(timing, "modelCallId");
+    for (const key of ["timeToFirstTokenMs", "decodeDurationMs"] as const) {
+      if (timing[key] !== null && (typeof timing[key] !== "number" || !Number.isSafeInteger(timing[key]) || timing[key] < 0)) {
+        throw new Error(`Canonical model timing ${key} must be a non-negative integer or null`);
+      }
+    }
+    if (data.outputTokens != null && (typeof data.outputTokens !== "number" || !Number.isSafeInteger(data.outputTokens) || data.outputTokens < 0)) {
+      throw new Error("Canonical model outputTokens must be a non-negative integer or null");
+    }
+  }
   return {
     schemaVersion: "tinybot.turn_item.v2",
     itemId,

--- a/src/app-core/chat/chatTurnContracts.ts
+++ b/src/app-core/chat/chatTurnContracts.ts
@@ -200,6 +200,7 @@ export type ChatStep = {
 };
 
 export type ChatTurn = {
+  metrics?: TurnMetrics;
   canonicalItems?: BackendAgentTurnItem[];
   completedAt?: string;
   executionItems?: ChatStep[];
@@ -214,6 +215,17 @@ export type ChatTurn = {
   usage?: TokenUsage;
   userMessage: ChatMessage;
   userMessageId: string;
+};
+
+export type TurnMetrics = {
+  timeToFirstTokenMs?: number;
+  tokensPerSecond?: number;
+};
+
+export type ModelCallTiming = {
+  modelCallId: string;
+  timeToFirstTokenMs: number | null;
+  decodeDurationMs: number | null;
 };
 
 export type CanonicalTurnItemKind =
@@ -241,7 +253,7 @@ export type CanonicalTurnItemData = Record<string, unknown> & (
   | { type: "subagent_message"; agentId: string; messageId: string; content: string; visibility: string }
   | { type: "plan_progress"; id: string; explanation?: string | null; steps: Array<{ step: string; status: "pending" | "in_progress" | "completed" }>; summary: string; completed: number; total: number; currentStep?: string | null }
   | { type: "context_compaction"; id: string; summary: string; droppedItemCount: number; contextWindowTokens?: number | null; strategy?: string | null; estimatedTokensBefore?: number | null; estimatedTokensAfter?: number | null }
-  | { type: "usage"; id?: string | null; inputTokens?: number | null; outputTokens?: number | null; totalTokens?: number | null; providerPayload: unknown }
+  | { type: "usage"; id?: string | null; inputTokens?: number | null; outputTokens?: number | null; totalTokens?: number | null; providerPayload: unknown; modelTiming?: ModelCallTiming }
   | { type: "file_reference"; id: string; path: string; mimeType?: string | null; referenceKind: string }
   | { type: "error"; id?: string | null; code: string; message: string; commandId?: string | null; cancelled: boolean }
   | { type: "system_notice"; message: string; detail: unknown }

--- a/src/app-core/chat/turnMetrics.test.ts
+++ b/src/app-core/chat/turnMetrics.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { normalizeAgentTurnRuntimeStatePayload } from "./chatTimelinePayload";
+import { projectBackendTimeline } from "./chatProjection";
+import { turnDurationMs } from "./turnMetrics";
+
+function restoredTurn(samples: Array<{ tokens?: number; first?: number | null; decode?: number | null; legacy?: boolean }>) {
+  const items = samples.map((sample, index) => ({
+    schemaVersion: "tinybot.turn_item.v2", sessionId: "session", turnId: "turn",
+    itemId: `usage-${index}`, kind: "usage", status: "completed", sequence: index + 1, revision: 1,
+    createdAt: String(1000 + index * 50_000),
+    data: {
+      type: "usage", outputTokens: sample.tokens ?? null, providerPayload: {},
+      ...(!sample.legacy ? { modelTiming: { modelCallId: `call-${index}`, timeToFirstTokenMs: sample.first ?? null, decodeDurationMs: sample.decode ?? null } } : {}),
+    },
+  }));
+  const payload = JSON.parse(JSON.stringify({
+    status: "completed", completedAt: "101000",
+    timeline: { schemaVersion: "tinybot.timeline.v2", sessionId: "session", turnId: "turn", snapshotRevision: items.length, items },
+  }));
+  return projectBackendTimeline("session", [normalizeAgentTurnRuntimeStatePayload(payload)])[0];
+}
+
+describe("durable turn metrics", () => {
+  test("restores weighted throughput and first-call latency without counting gaps between calls", () => {
+    const turn = restoredTurn([{ tokens: 40, first: 1200, decode: 3000 }, { tokens: 60, first: 200, decode: 2000 }]);
+    expect(turn.metrics).toEqual({ timeToFirstTokenMs: 1200, tokensPerSecond: 20 });
+    expect(turnDurationMs(turn)).toBe(100_000);
+  });
+
+  test("does not replace a missing first-call latency with a later call", () => {
+    expect(restoredTurn([{ legacy: true, tokens: 500 }, { tokens: 30, first: 500, decode: 2000 }]).metrics)
+      .toEqual({ tokensPerSecond: 15 });
+  });
+
+  test("requires matching output counts and positive decode durations for each speed sample", () => {
+    expect(restoredTurn([
+      { first: 800, decode: 100_000 },
+      { tokens: 500, first: 0, decode: 0 },
+      { tokens: 60, first: 200, decode: 2000 },
+    ]).metrics).toEqual({ timeToFirstTokenMs: 800, tokensPerSecond: 30 });
+    expect(restoredTurn([{ tokens: 50, legacy: true }]).metrics).toBeUndefined();
+    expect(restoredTurn([{ tokens: 50 }]).metrics).toBeUndefined();
+  });
+
+  test("rejects corrupt persisted timing instead of showing a fabricated number", () => {
+    expect(() => restoredTurn([{ tokens: 10, first: -5, decode: 100 }])).toThrow(/model timing/);
+    expect(() => restoredTurn([{ tokens: -10, first: 5, decode: 100 }])).toThrow(/outputTokens/);
+  });
+});

--- a/src/app-core/chat/turnMetrics.ts
+++ b/src/app-core/chat/turnMetrics.ts
@@ -1,0 +1,30 @@
+import type { BackendAgentTurnItem, ChatTurn, TurnMetrics } from "./chatTurnContracts";
+
+/** Fold durable model samples; tools and gaps between invocations never enter the denominator. */
+export function deriveTurnMetrics(items: readonly BackendAgentTurnItem[]): TurnMetrics | undefined {
+  const usages = items.filter((item) => item.data.type === "usage").sort((a, b) => a.sequence - b.sequence);
+  const first = usages[0]?.data;
+  const metrics: TurnMetrics = {};
+  if (first?.type === "usage" && first.modelTiming?.timeToFirstTokenMs != null) {
+    metrics.timeToFirstTokenMs = first.modelTiming.timeToFirstTokenMs;
+  }
+  let outputTokens = 0;
+  let decodeMs = 0;
+  for (const { data } of usages) {
+    if (data.type !== "usage") continue;
+    const duration = data.modelTiming?.decodeDurationMs;
+    if (duration != null && duration > 0 && data.outputTokens != null) {
+      outputTokens += data.outputTokens;
+      decodeMs += duration;
+    }
+  }
+  if (decodeMs > 0) metrics.tokensPerSecond = outputTokens / (decodeMs / 1_000);
+  return Object.keys(metrics).length ? metrics : undefined;
+}
+
+export function turnDurationMs(turn: ChatTurn): number | undefined {
+  if (!turn.completedAt) return undefined;
+  const timestamp = (value: string) => /^\d+$/.test(value) ? Number(value) : Date.parse(value);
+  const duration = timestamp(turn.completedAt) - timestamp(turn.startedAt);
+  return Number.isFinite(duration) && duration >= 0 ? duration : undefined;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,1 +1,15 @@
-import "./react-workbench/main";
+import {
+  buildRendererDiagnostic,
+  recordRendererDiagnostic,
+  showRendererDiagnosticOverlay,
+} from "./app-core/native/rendererDiagnostics";
+import { removeStartupSplash } from "./react-workbench/startupSplash";
+
+// Keep bootstrap failures visible even when the workbench chunk cannot load.
+void import("./react-workbench/main").catch((error: unknown) => {
+  console.error("[tinybot-startup-error]", error);
+  removeStartupSplash();
+  const diagnostic = buildRendererDiagnostic("window.unhandledrejection", error);
+  showRendererDiagnosticOverlay(diagnostic);
+  void recordRendererDiagnostic(diagnostic);
+});

--- a/src/react-workbench/App.test.tsx
+++ b/src/react-workbench/App.test.tsx
@@ -15,6 +15,9 @@ describe("TinybotErrorBoundary", () => {
   test("renders a visible fallback and records diagnostics after a render crash", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const recordDiagnostic = vi.fn(async () => undefined);
+    const splash = document.createElement("div");
+    splash.id = "tinybot-startup";
+    document.body.append(splash);
 
     render(
       <TinybotErrorBoundary recordDiagnostic={recordDiagnostic}>
@@ -27,6 +30,7 @@ describe("TinybotErrorBoundary", () => {
     expect(alerts.map((alert) => alert.textContent).join("\n")).toContain("render exploded");
     expect(alerts.map((alert) => alert.textContent).join("\n")).toContain("Crash ID");
     expect(screen.getAllByRole("button", { name: "Reload" }).length).toBeGreaterThan(0);
+    expect(splash.isConnected).toBe(false);
     expect(recordDiagnostic).toHaveBeenCalledWith(expect.objectContaining({
       type: "react.render",
       message: "render exploded",

--- a/src/react-workbench/App.tsx
+++ b/src/react-workbench/App.tsx
@@ -10,6 +10,7 @@ import {
 import { createDesktopAppServices } from "./defaultServices";
 import type { DesktopNativeStartupTrace } from "../app-core/native/desktopNativeChatDebug";
 import { DesktopShell } from "./shell/DesktopShell";
+import { dismissStartupSplash, removeStartupSplash } from "./startupSplash";
 
 export function App({ startupTrace }: { startupTrace?: DesktopNativeStartupTrace } = {}) {
   const services = useMemo(() => createDesktopAppServices({ startupTrace }), [startupTrace]);
@@ -20,6 +21,7 @@ export function App({ startupTrace }: { startupTrace?: DesktopNativeStartupTrace
     const frame = window.requestAnimationFrame(() => {
       startupTrace?.complete("react.firstFrame");
       startupTrace?.mark("ui.interactive");
+      void dismissStartupSplash().then(() => startupTrace?.mark("splash.dismissed"));
     });
     return () => window.cancelAnimationFrame(frame);
   }, [startupTrace]);
@@ -48,6 +50,7 @@ export class TinybotErrorBoundary extends Component<TinybotErrorBoundaryProps, T
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
+    removeStartupSplash();
     console.error("[tinybot-renderer-error]", error, info.componentStack);
     const diagnostic = buildRendererDiagnostic("react.render", error, {
       componentStack: info.componentStack ?? undefined,

--- a/src/react-workbench/README.md
+++ b/src/react-workbench/README.md
@@ -1,11 +1,18 @@
 # React Workbench
-<!-- tinybot-module-fingerprint: sha256:0ad67d3b14a87e9b3df4315821c3a05a3c38cbed8454df2c73f538c9984aa800 -->
+<!-- tinybot-module-fingerprint: sha256:ff4a0c1879d1880b5cab7ad0b6337aad1f07a16e50f97c55febbb98345fe0f4d -->
 
 `react-workbench` contains the React renderer for Tinybot's desktop application.
 `main.tsx` mounts `App` for the main window and selects lightweight
 `DesktopPetWindow` and `DesktopPetQuickChatWindow` surfaces for the Windows-only
 pet webviews. The quick-chat surface owns an independent renderer service graph
 so it remains usable while the main window is minimized.
+The initial HTML displays a white startup surface with the centered Tinybot mark
+before the renderer bundle loads. `startupSplash.ts` finishes its short logo
+entrance and fades the surface out after `App` renders its first frame; it does
+not wait for session restoration. Reduced motion removes it immediately. The
+pet webviews hide it before their first paint and remove it when mounted.
+The small `src/main.ts` bootstrap reports workbench import failures through the
+renderer diagnostic overlay; render errors also remove the startup surface.
 `DesktopShell` owns the desktop chrome, and `defaultServices.ts` composes the
 renderer-facing stores including the native `WorkspaceRegistry` Adapter and
 the optional native pet and quick-chat hosts.

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -3716,7 +3716,6 @@
   border-radius: 12px;
   background: transparent;
   transform: translateX(-8px);
-  scrollbar-width: thin;
   transition:
     width 180ms var(--motion-ease-standard),
     transform 180ms var(--motion-ease-standard),
@@ -4032,7 +4031,6 @@
   max-height: min(320px, 42vh);
   overflow-y: auto;
   padding: 2px;
-  scrollbar-width: thin;
 }
 
 .react-agent-ui-form-field__choice {

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -35,6 +35,10 @@
   grid-template-columns: minmax(280px, 0.58fr) minmax(560px, 1fr);
 }
 
+.react-chat-workspace[data-sidecar-layout-motion="instant"] {
+  transition-duration: 0ms;
+}
+
 .react-chat-header h1,
 .react-right-drawer h2 {
   margin: 0;
@@ -1881,18 +1885,22 @@
 }
 
 .react-right-drawer[data-motion="fade-content"] {
-  animation: react-drawer-enter var(--motion-duration-medium) var(--motion-ease-standard) both;
+  opacity: 1;
+  transform: translateX(0);
+  transition:
+    opacity var(--motion-duration-medium) var(--motion-ease-standard),
+    transform var(--motion-duration-medium) var(--motion-ease-standard);
 }
 
-@keyframes react-drawer-enter {
-  from {
+.react-right-drawer[data-state="closing"] {
+  opacity: 0;
+  transform: translateX(18px);
+}
+
+@starting-style {
+  .react-right-drawer[data-motion="fade-content"] {
     opacity: 0;
     transform: translateX(18px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateX(0);
   }
 }
 
@@ -4509,6 +4517,17 @@
 
   .react-chat-workspace {
     transition-duration: 0ms;
+  }
+
+  .react-right-drawer[data-motion="fade-content"] {
+    transition: none;
+  }
+
+  @starting-style {
+    .react-right-drawer[data-motion="fade-content"] {
+      opacity: 1;
+      transform: none;
+    }
   }
 
   .react-floating-plan {

--- a/src/react-workbench/chat/ChatPage.sessions.test.tsx
+++ b/src/react-workbench/chat/ChatPage.sessions.test.tsx
@@ -1066,7 +1066,7 @@ describe("ChatPage", () => {
     expect(screen.queryByText("No sessions yet.")).toBeNull();
   });
 
-  it("adds Animated List hooks to session rows", async () => {
+  it("keeps session rows available without a blanket entrance animation", async () => {
     const stores = createStores();
     render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
 
@@ -1074,9 +1074,8 @@ describe("ChatPage", () => {
     const sessionButton = screen.getByRole("button", { name: "Planning notes" });
     const row = sessionButton.closest(".react-session-row") as HTMLElement | null;
 
-    expect(rows.getAttribute("data-motion")).toBe("animated-list");
+    expect(rows.hasAttribute("data-motion")).toBe(false);
     expect(row?.getAttribute("data-motion-role")).toBe("item");
-    expect(row?.style.getPropertyValue("--react-session-row-index")).toBe("0");
     expect(row?.querySelector(".react-session-row__avatar")).toBeNull();
   });
 

--- a/src/react-workbench/chat/ChatPage.sidecar.test.tsx
+++ b/src/react-workbench/chat/ChatPage.sidecar.test.tsx
@@ -13,6 +13,34 @@ import {
 } from "./test/ChatPageTestHarness";
 
 describe("ChatPage", () => {
+  it("keeps the native browser obscured until the details drawer exits", async () => {
+    const user = userEvent.setup();
+    const browserRuntime = sidecarBrowserRuntime();
+    const stores = createStores({ browserRuntime });
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+    await user.click(await screen.findByRole("button", { name: "Show Sidecar" }));
+    await user.click(within(screen.getByLabelText("Sidecar")).getAllByRole("button", { name: "New Sidecar tab" })[0]);
+    await user.click(screen.getByRole("menuitem", { name: /Browser/ }));
+    await waitFor(() => expect(document.querySelector(".react-sidecar-browser-surface")?.getAttribute("data-live")).toBe("true"));
+    await user.click(await screen.findByRole("button", { name: /Agent steps, 1 step/i }));
+    await user.click(await screen.findByRole("button", { name: "Open details for shell" }));
+    const drawer = screen.getByLabelText("Details drawer");
+    let finish!: () => void;
+    const animation = {
+      transitionProperty: "opacity",
+      playState: "running",
+      finished: new Promise<void>((resolve) => { finish = resolve; }),
+    };
+    Object.defineProperty(drawer, "getAnimations", { value: () => [animation] });
+    await user.click(within(drawer).getByRole("button", { name: "Close details drawer" }));
+    expect(drawer.dataset.state).toBe("closing");
+    expect(document.querySelector(".react-sidecar-browser-surface")?.getAttribute("data-live")).toBeNull();
+    await waitFor(() => expect(browserRuntime.updateSurface).toHaveBeenLastCalledWith(expect.objectContaining({ visible: false })));
+    await act(async () => { animation.playState = "finished"; finish(); });
+    expect(document.querySelector(".react-sidecar-browser-surface")?.getAttribute("data-live")).toBe("true");
+    expect(browserRuntime.closeSession).not.toHaveBeenCalled();
+  });
+
   it("creates only Browser or Terminal resource tabs and restores hidden Sidecar resources", async () => {
     const user = userEvent.setup();
     const stores = createStores({ sessions: [{
@@ -28,6 +56,10 @@ describe("ChatPage", () => {
 
     await user.click(await screen.findByRole("button", { name: "Show Sidecar" }));
     const sidecar = screen.getByLabelText("Sidecar");
+    const workspace = document.querySelector<HTMLElement>(".react-chat-workspace");
+    within(sidecar).getByRole("separator").focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(workspace?.dataset.sidecarLayoutMotion).toBe("instant");
     await user.click(within(sidecar).getAllByRole("button", { name: "New Sidecar tab" })[0]);
     const menu = within(sidecar).getByRole("menu", { name: "Choose a resource" });
     expect(within(menu).getAllByRole("menuitem")).toHaveLength(2);
@@ -44,6 +76,7 @@ describe("ChatPage", () => {
     expect(document.querySelector<HTMLElement>(".react-sidecar")?.dataset.hidden).toBe("true");
 
     await user.click(screen.getByRole("button", { name: "Show Sidecar" }));
+    expect(workspace?.dataset.sidecarLayoutMotion).toBe("animated");
     expect(within(screen.getByLabelText("Sidecar")).getByRole("tab", { name: "PowerShell" })).toBeTruthy();
   });
 

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -317,6 +317,34 @@ describe("ChatPage", () => {
     expect(drawer.textContent).toContain("file contents");
   });
 
+  it("keeps closing details until exit finishes and restores focus without stale removal", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    render(<ChatPage chatStore={stores.chatStore} now={() => Date.UTC(2026, 6, 4, 12, 0, 0)} sessionStore={stores.sessionStore} />);
+    await user.click(await screen.findByRole("button", { name: /Agent steps, 1 step/i }));
+    const trigger = await screen.findByRole("button", { name: "Open details for shell" });
+    await user.click(trigger);
+    const drawer = screen.getByLabelText("Details drawer");
+    let finish!: () => void;
+    const animation = {
+      transitionProperty: "opacity",
+      playState: "running",
+      finished: new Promise<void>((resolve) => { finish = resolve; }),
+    };
+    Object.defineProperty(drawer, "getAnimations", { value: () => [animation] });
+    await user.click(within(drawer).getByRole("button", { name: "Close details drawer" }));
+    expect(drawer.dataset.state).toBe("closing");
+    expect(drawer.hasAttribute("inert")).toBe(true);
+    expect(drawer.textContent).toContain("Done");
+    expect(document.activeElement).toBe(trigger);
+    await user.click(trigger);
+    await act(async () => { animation.playState = "finished"; finish(); });
+    expect(screen.getByLabelText("Details drawer")).toBe(drawer);
+    expect(drawer.dataset.state).toBe("open");
+    await user.click(within(drawer).getByRole("button", { name: "Close details drawer" }));
+    expect(screen.queryByLabelText("Details drawer")).toBeNull();
+  });
+
   it("submits active agent-ui forms from the chat page", async () => {
     const user = userEvent.setup();
     const stores = createStores();

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useCallback, useEffect, useEffectEvent, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { lazy, Suspense, useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { elementTransitions, useExitPresence } from "../lib/useExitPresence";
 import type { TFunction } from "i18next";
 import {
   Check,
@@ -370,6 +371,10 @@ export function ChatPage({
   const [sessionCreatePending, setSessionCreatePending] = useState(false);
   const [localSessionSidebarCollapsed, setLocalSessionSidebarCollapsed] = useState(false);
   const [drawer, setDrawer] = useState<DrawerState>(null);
+  const [drawerSessionId, setDrawerSessionId] = useState("");
+  const drawerElementRef = useRef<HTMLElement>(null);
+  const drawerTriggerRef = useRef<HTMLElement | null>(null);
+  const sidecarToggleRef = useRef<HTMLButtonElement>(null);
   const [sidecar, dispatchSidecar] = useReducer(
     reduceSidecarState,
     undefined,
@@ -423,6 +428,10 @@ export function ChatPage({
   sessionTabsRef.current = sessionTabs;
   sessionsLoadedRef.current = sessionsLoaded;
   const activeSessionId = sessionTabs.activeSessionId;
+  const currentDrawer = drawerSessionId === activeSessionId ? drawer : null;
+  const readDrawerTransitions = useCallback(() => elementTransitions(drawerElementRef.current, ["opacity", "transform"]), []);
+  const presentDrawer = useExitPresence(currentDrawer, activeSessionId, readDrawerTransitions);
+  useLayoutEffect(() => { setDrawer(null); }, [activeSessionId]);
   const activeSession = useMemo(
     () => sessions.find((session) => session.id === activeSessionId),
     [activeSessionId, sessions],
@@ -1871,7 +1880,7 @@ export function ChatPage({
     if (!activeSession) {
       return;
     }
-    setDrawer({ kind: "subagent", title: delegate.title, delegate, loading: Boolean(chatStore.loadDelegateTrace) });
+    openDrawer({ kind: "subagent", title: delegate.title, delegate, loading: Boolean(chatStore.loadDelegateTrace) });
     if (!chatStore.loadDelegateTrace) {
       return;
     }
@@ -2149,7 +2158,7 @@ export function ChatPage({
         browserRuntime={chatStore.browserRuntime}
         externalError={browserProvisionErrors[tab.id] || browserError}
         snapshot={browserSnapshot?.data.sessionId === tab.threadId ? browserSnapshot : undefined}
-        surfaceVisible={surfaceVisible && !drawer}
+        surfaceVisible={surfaceVisible && !presentDrawer}
         tab={tab}
         onHandoffComplete={() => handleBrowserHandoffComplete(tab)}
         onRetryProvision={() => {
@@ -2286,6 +2295,27 @@ export function ChatPage({
     }
   }
 
+  function openDrawer(next: NonNullable<DrawerState>) {
+    if (!drawerElementRef.current?.contains(document.activeElement)) {
+      drawerTriggerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    }
+    setDrawerSessionId(activeSessionId);
+    setDrawer(next);
+  }
+
+  function closeDrawer() {
+    if (drawerElementRef.current?.contains(document.activeElement)) {
+      if (drawerTriggerRef.current?.isConnected) drawerTriggerRef.current.focus();
+      else setComposerFocusRequestId((current) => current + 1);
+    }
+    setDrawer(null);
+  }
+
+  function hideSidecar() {
+    sidecarToggleRef.current?.focus();
+    dispatchSidecar({ type: "presentation.hide" });
+  }
+
   function handleComposerDraftChange(value: string) {
     dispatchSessionTabs({ type: "draft.changed", sessionId: activeSessionId, value });
   }
@@ -2367,6 +2397,7 @@ export function ChatPage({
       <div
         className="react-chat-workspace"
         data-sidecar-presentation={sidecar.presentation}
+        data-sidecar-layout-motion={sidecar.layoutMotion}
         style={{ "--react-sidecar-width": `${sidecar.width}px` } as CSSProperties}
       >
       <main className="react-chat-surface" data-empty-session={emptyActiveSession ? "true" : undefined}>
@@ -2382,6 +2413,7 @@ export function ChatPage({
             <button
               aria-label={sidecar.presentation === "closed" ? t("sidecar.show") : t("sidecar.hide")}
               aria-pressed={sidecar.presentation !== "closed"}
+              ref={sidecarToggleRef}
               title={sidecar.presentation === "closed" ? t("sidecar.show") : t("sidecar.hide")}
               type="button"
               onClick={() => dispatchSidecar({
@@ -2440,7 +2472,7 @@ export function ChatPage({
               onOpenArtifact: (artifact) => void handleOpenArtifact(artifact),
               onOpenFileLink: (link) => void handleOpenAssistantFileLink(link),
               onOpenSubagent: (delegate) => void handleOpenSubagent(delegate),
-              onOpenTool: (toolCall) => setDrawer({ kind: "tool", title: toolCall.name, toolCall }),
+              onOpenTool: (toolCall) => openDrawer({ kind: "tool", title: toolCall.name, toolCall }),
             }}
             error={timelineError}
             hookResults={hookResults}
@@ -2641,6 +2673,7 @@ export function ChatPage({
       </main>
 
       <Sidecar
+        scopeKey={JSON.stringify([activeSessionId, activeWorkspaceId])}
         activeTabId={sidecarActiveTab?.id ?? ""}
         canCreateBrowser={Boolean(activeSession)}
         canCreateTerminal={Boolean(activeWorkspaceId)}
@@ -2654,24 +2687,32 @@ export function ChatPage({
         onCloseTab={handleCloseSidecarTab}
         onCreateBrowser={() => dispatchSidecar({ type: "tab.newBrowser" })}
         onCreateTerminal={(shell) => dispatchSidecar({ shell, type: "tab.newTerminal" })}
-        onHide={() => dispatchSidecar({ type: "presentation.hide" })}
+        onHide={hideSidecar}
         onResize={(width, maxWidth) => dispatchSidecar({ maxWidth, type: "presentation.resize", width })}
         onToggleExpanded={() => dispatchSidecar({ type: "presentation.toggleExpanded" })}
       />
 
-      {drawer ? (
-        <aside className="react-right-drawer" aria-label={t("shell.detailsDrawer")} data-motion="fade-content" data-state="open">
+      {presentDrawer ? (
+        <aside
+          ref={drawerElementRef}
+          className="react-right-drawer"
+          aria-label={t("shell.detailsDrawer")}
+          aria-hidden={!currentDrawer || undefined}
+          inert={!currentDrawer || undefined}
+          data-motion="fade-content"
+          data-state={currentDrawer ? "open" : "closing"}
+        >
           <div className="react-right-drawer__header">
-            <h2>{drawer.title}</h2>
-            <button aria-label={t("shell.closeDetails")} type="button" onClick={() => setDrawer(null)}>
+            <h2>{presentDrawer.title}</h2>
+            <button aria-label={t("shell.closeDetails")} type="button" onClick={closeDrawer}>
               <X aria-hidden="true" size={16} />
             </button>
           </div>
           <div className="react-right-drawer__content">
-            {drawer.kind === "tool" ? (
-              <ToolCallDetails toolCall={drawer.toolCall} />
+            {presentDrawer.kind === "tool" ? (
+              <ToolCallDetails toolCall={presentDrawer.toolCall} />
             ) : (
-              <SubagentDetails delegate={drawer.delegate} error={drawer.error} loading={drawer.loading} />
+              <SubagentDetails delegate={presentDrawer.delegate} error={presentDrawer.error} loading={presentDrawer.loading} />
             )}
           </div>
         </aside>

--- a/src/react-workbench/chat/ChatSessionWorkspace.test.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { cleanup, createEvent, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, createEvent, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { pickDesktopWorkspaceDirectory } from "../../app-core/native/desktopNativeWorkspacePicker";
 import type { ProjectGroupStore, SessionSummary, WorkspaceRegistryStore } from "../services";
@@ -20,6 +20,94 @@ afterEach(() => {
 });
 
 describe("ChatSessionWorkspace", () => {
+  test("bounds first content entrance to three rows across groups and consumes each animation", () => {
+    renderWorkspace({ sessions: manySessions() });
+    const rows = screen.getByLabelText("Session list rows");
+    const entering = Array.from(rows.querySelectorAll<HTMLElement>("[data-entering='true']"));
+    expect(rows.querySelectorAll(".react-session-row")).toHaveLength(60);
+    expect(entering).toHaveLength(3);
+    expect(entering.map((row) => row.style.getPropertyValue("--react-session-row-index")))
+      .toEqual(["0", "1", "2"]);
+    expect(entering.map((row) => row.closest("[role='group']")?.getAttribute("aria-label")))
+      .toEqual(["Workspace group-0", "Workspace group-1", "Workspace group-2"]);
+
+    fireEvent.animationEnd(entering[0], { animationName: "unrelated-animation" });
+    fireEvent.animationEnd(entering[0].querySelector("button")!, { animationName: "react-list-enter" });
+    expect(rows.querySelectorAll("[data-entering='true']")).toHaveLength(3);
+    for (const row of entering) {
+      fireEvent.animationEnd(row, { animationName: "react-list-enter" });
+    }
+    expect(rows.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+  });
+
+  test("settles an unfinished entrance when searching and never replays on clearing search", () => {
+    renderWorkspace({ sessions: manySessions() });
+    const rows = screen.getByLabelText("Session list rows");
+    expect(rows.querySelectorAll("[data-entering='true']")).toHaveLength(3);
+    fireEvent.click(screen.getByRole("button", { name: /search chats/i }));
+    const input = screen.getByRole("textbox", { name: "Search chats" });
+    fireEvent.change(input, { target: { value: "Session 59" } });
+    expect(screen.getByRole("button", { name: "Session 59" })).toBeTruthy();
+    expect(rows.querySelectorAll(".react-session-row")).toHaveLength(1);
+    expect(rows.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+    fireEvent.change(input, { target: { value: "" } });
+    expect(rows.querySelectorAll(".react-session-row")).toHaveLength(60);
+    expect(rows.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+  });
+
+  test("waits for the first nonempty session batch without rearming on later refreshes", async () => {
+    const view = renderWorkspace({ sessions: [] });
+    await act(async () => undefined);
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+    view.rerenderSessions(manySessions());
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(3);
+    view.rerenderSessions(manySessions());
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+  });
+
+  test("selection settles the batch even if the parent keeps the same active session", () => {
+    const actions = createActions();
+    const sessions = manySessions();
+    renderWorkspace({ actions, sessions });
+    fireEvent.click(screen.getByRole("button", { name: "Session 0" }));
+    expect(actions.onSelectSession).toHaveBeenCalledWith(sessions[0]);
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+  });
+
+  test("data refresh and workspace reorder keep all rows immediately available", () => {
+    const sessions = manySessions();
+    const view = renderWorkspace({ sessions });
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(3);
+    view.rerenderSessions([...sessions]);
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+    const firstGroup = screen.getByRole("group", { name: "Workspace group-0" });
+    fireEvent.keyDown(firstGroup.querySelector("summary")!, { altKey: true, key: "ArrowDown" });
+    expect(sidebarGroupLabels(screen.getByLabelText("Session list rows")).slice(0, 2))
+      .toEqual(["Workspace group-1", "Workspace group-0"]);
+    expect(document.querySelectorAll(".react-session-row")).toHaveLength(60);
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+  });
+
+  test.each([true, false])("reduced motion consumes entrance eligibility (initially %s)", (initiallyReduced) => {
+    const preference = Object.assign(new EventTarget(), { matches: initiallyReduced });
+    const originalMatchMedia = window.matchMedia.bind(window);
+    vi.spyOn(window, "matchMedia").mockImplementation((query) => query === "(prefers-reduced-motion: reduce)"
+      ? preference as unknown as MediaQueryList
+      : originalMatchMedia(query));
+    renderWorkspace({ sessions: manySessions() });
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(initiallyReduced ? 0 : 3);
+    act(() => {
+      preference.matches = true;
+      preference.dispatchEvent(new Event("change"));
+    });
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+    act(() => {
+      preference.matches = false;
+      preference.dispatchEvent(new Event("change"));
+    });
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(0);
+  });
+
   test("owns sidebar selection and inline search lifecycle behind one actions interface", () => {
     const actions = createActions();
     const session = planningSession();
@@ -220,11 +308,13 @@ describe("ChatSessionWorkspace", () => {
     });
     const workspace = screen.getByRole("group", { name: "Workspace tinybot" });
     const row = within(workspace).getByRole("button", { name: "Planning notes" });
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(2);
 
     fireEvent.keyDown(row, { altKey: true, key: "ArrowDown" });
 
     expect(sessionTitles(workspace)).toEqual(["Knowledge review", "Planning notes"]);
     expect(screen.getByText("Moved Planning notes after Knowledge review.")).toBeTruthy();
+    expect(document.querySelectorAll("[data-entering='true']")).toHaveLength(0);
   });
 
   test("registers a picked workspace before creating its first session", async () => {
@@ -330,7 +420,7 @@ function renderWorkspace({
   sessions?: SessionSummary[];
   workspaceRegistryStore?: WorkspaceRegistryStore;
 } = {}) {
-  return render(
+  const workspace = (nextSessions: SessionSummary[]) => (
     <ChatSessionWorkspace
       actions={actions}
       activeSessionId="session-1"
@@ -341,12 +431,24 @@ function renderWorkspace({
       error=""
       now={() => Date.UTC(2026, 7, 15)}
       projectGroupStore={projectGroupStore}
-      sessions={sessions}
+      sessions={nextSessions}
       workspaceRegistryStore={workspaceRegistryStore}
     >
       <main>Conversation surface</main>
-    </ChatSessionWorkspace>,
+    </ChatSessionWorkspace>
   );
+  const view = render(workspace(sessions));
+  return { ...view, rerenderSessions: (nextSessions: SessionSummary[]) => view.rerender(workspace(nextSessions)) };
+}
+
+function manySessions(): SessionSummary[] {
+  return Array.from({ length: 60 }, (_, index) => ({
+    ...planningSession(),
+    id: `session-${index}`,
+    title: `Session ${index}`,
+    workingDirectory: `D:\\Code\\group-${index}`,
+    updatedAtMs: 60 - index,
+  }));
 }
 
 function createWorkspaceRegistryStore(sessions: SessionSummary[]): WorkspaceRegistryStore {

--- a/src/react-workbench/chat/ChatSessionWorkspace.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -288,6 +289,52 @@ export function ChatSessionWorkspace({
     itemId: group.itemId,
     label: group.label,
   })), [rootGroups]);
+  const sessionRowsRef = useRef<HTMLDivElement>(null);
+  const [entrance, setEntrance] = useState<"waiting" | "settled" | {
+    groups: typeof rootGroups;
+    activeSessionId: string;
+    searchQuery: string;
+    indices: ReadonlyMap<string, number>;
+  }>("waiting");
+  const entranceCurrent = typeof entrance === "object"
+    && entrance.groups === rootGroups
+    && entrance.activeSessionId === activeSessionId
+    && entrance.searchQuery === searchQuery
+    && !collapsed;
+  const entranceSettled = entrance === "settled";
+
+  useLayoutEffect(() => {
+    if (entrance === "settled") return;
+    if (entrance !== "waiting") {
+      if (!entranceCurrent) setEntrance("settled");
+      return;
+    }
+    if (collapsed || searchQuery || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setEntrance("settled");
+      return;
+    }
+    // Read the committed order so nested groups share one bounded entrance batch.
+    const rows = sessionRowsRef.current?.querySelectorAll<HTMLElement>(".react-session-row");
+    if (!rows?.length) return;
+    setEntrance({
+      groups: rootGroups,
+      activeSessionId,
+      searchQuery,
+      indices: new Map(Array.from(rows).slice(0, 3).map((row, index) => [row.dataset.sessionId!, index])),
+    });
+  }, [activeSessionId, collapsed, entrance, entranceCurrent, rootGroups, searchQuery]);
+
+  useEffect(() => {
+    if (entranceSettled) return;
+    const preference = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const settleWhenReduced = () => {
+      if (preference.matches) setEntrance("settled");
+    };
+    preference.addEventListener("change", settleWhenReduced);
+    settleWhenReduced();
+    return () => preference.removeEventListener("change", settleWhenReduced);
+  }, [entranceSettled]);
+
   const projectDialogGroup = projectDialogGroupId && projectDialogGroupId !== "new"
     ? projectGroups.find((group) => group.projectGroupId === projectDialogGroupId)
     : undefined;
@@ -403,9 +450,8 @@ export function ChatSessionWorkspace({
       itemId: session.id,
       label: displaySessionTitle(session.title, t),
     }));
-    return orderedSessions.map((session, index) => renderSidebarSessionRow(
+    return orderedSessions.map((session) => renderSidebarSessionRow(
       session,
-      index,
       containerId,
       currentItems,
     ));
@@ -413,7 +459,6 @@ export function ChatSessionWorkspace({
 
   function renderSidebarSessionRow(
     session: SessionSummary,
-    index: number,
     containerId: string,
     currentItems: readonly SidebarOrderItem[],
   ) {
@@ -421,6 +466,9 @@ export function ChatSessionWorkspace({
     const dissolving = dissolvingSessionIds.has(session.id);
     const sessionLabel = displaySessionTitle(session.title, t);
     const reorderItem = { containerId, itemId: session.id, label: sessionLabel };
+    const entranceIndex = entranceCurrent && typeof entrance === "object"
+      ? entrance.indices.get(session.id)
+      : undefined;
     return (
       <div
         className="react-session-row"
@@ -432,14 +480,27 @@ export function ChatSessionWorkspace({
         data-drop-position={sidebarDropPosition(containerId, session.id)}
         data-dissolving={dissolving ? "true" : undefined}
         data-motion-role="item"
+        data-session-id={session.id}
+        data-entering={entranceIndex !== undefined ? "true" : undefined}
         draggable={!dissolving}
         key={session.id}
+        onAnimationEnd={(event) => {
+          if (event.target !== event.currentTarget || event.animationName !== "react-list-enter") return;
+          setEntrance((current) => {
+            if (typeof current !== "object" || !current.indices.has(session.id)) return current;
+            const indices = new Map(current.indices);
+            indices.delete(session.id);
+            return indices.size ? { ...current, indices } : "settled";
+          });
+        }}
         onDragEnd={finishSidebarDrag}
         onDragOver={(event) => updateSidebarDropTarget(event, reorderItem)}
         onDragStart={(event) => beginSidebarDrag(event, reorderItem)}
         onDrop={(event) => dropSidebarItem(event, reorderItem, currentItems)}
         onMouseLeave={() => actions.onCancelDeleteConfirmation(session.id)}
-        style={{ "--react-session-row-index": String(index) } as CSSProperties}
+        style={entranceIndex !== undefined
+          ? { "--react-session-row-index": String(entranceIndex) } as CSSProperties
+          : undefined}
       >
         <button
           aria-description={t("shell.reorderSession", { name: sessionLabel })}
@@ -448,7 +509,10 @@ export function ChatSessionWorkspace({
           className="react-session-row__select"
           type="button"
           disabled={dissolving}
-          onClick={() => actions.onSelectSession(session)}
+          onClick={() => {
+            setEntrance("settled");
+            actions.onSelectSession(session);
+          }}
           onKeyDown={(event) => moveSidebarItemWithKeyboard(event, reorderItem, currentItems)}
         >
           <span className="react-session-row__title">{sessionLabel}</span>
@@ -725,7 +789,12 @@ export function ChatSessionWorkspace({
             ) : null}
           </div>
         )}
-        <div className="react-session-list__rows" aria-label={t("shell.sessionRows")} data-motion="animated-list">
+        <div
+          className="react-session-list__rows"
+          aria-label={t("shell.sessionRows")}
+          ref={sessionRowsRef}
+          onFocusCapture={() => setEntrance("settled")}
+        >
           {rootGroups.map((rootGroup) => {
             if (rootGroup.kind === "workspace") {
               const { workspace } = rootGroup;

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import type { TFunction } from "i18next";
 import {
@@ -42,6 +42,8 @@ import { isApplyPatchToolCall, PatchDiffCard, patchChangeSetFromToolResult } fro
 import { ToolActivityItem } from "./ToolActivityItem";
 import { TimelineActivity } from "./TimelineActivity";
 import { DataViewCard } from "./DataViewCard";
+import { TurnMetrics } from "./TurnMetrics";
+import { turnDurationMs } from "../../app-core/chat/turnMetrics";
 
 export type ChatTimelineActions = {
   onBranch?: (messageId: string) => void;
@@ -130,6 +132,8 @@ function CanonicalChatTurn({
   const { t } = useTranslation("chat");
   const executionItems = turn.executionItems ?? turn.steps;
   const finalAnswer = turn.finalAnswer ?? turn.finalMessage;
+  const metricsFooter = (turn.status === "completed" || turn.status === "failed" || turn.status === "interrupted")
+    && turnDurationMs(turn) !== undefined ? <TurnMetrics turn={turn} /> : undefined;
   const reasoningSteps = turn.steps.filter((step) => step.kind === "reasoning");
   const planSteps = turn.steps.filter((step) => step.kind === "plan");
   const errorSteps = turn.status === "interrupted"
@@ -192,6 +196,7 @@ function CanonicalChatTurn({
         <CanonicalMessage
           allowActions={turn.status === "completed"}
           messageId={finalAnswer.id}
+          footer={metricsFooter}
           reasoning={turn.executionItems ? [] : reasoningSteps}
           references={finalAnswer.references}
           role="assistant"
@@ -211,6 +216,7 @@ function CanonicalChatTurn({
           onOpenFileLink={onOpenFileLink}
         />
       ) : null}
+      {!finalAnswer && metricsFooter ? <div className="react-message__actions">{metricsFooter}</div> : null}
     </section>
   );
 }
@@ -554,6 +560,7 @@ function formatExecutionDuration(durationMs: number): string {
 
 function CanonicalMessage({
   allowActions = true,
+  footer,
   messageId,
   onBranch,
   onOpenFileLink,
@@ -564,6 +571,7 @@ function CanonicalMessage({
   text,
 }: {
   allowActions?: boolean;
+  footer?: ReactNode;
   messageId: string;
   onBranch?: () => void;
   onOpenFileLink?: (link: AssistantFileLink) => void;
@@ -592,16 +600,17 @@ function CanonicalMessage({
         {inlineReferences.length ? <MessageContext references={inlineReferences} /> : null}
         {streaming ? <span aria-label={t("turn.agentResponding")} className="react-message__streaming" /> : null}
       </div>
-      {allowActions && text.trim() ? (
+      {(allowActions && text.trim()) || footer ? (
         <div className="react-message__actions" data-align={role === "user" ? "right" : "left"}>
-          <button aria-label={t("turn.copyMessage")} type="button" onClick={() => void writeClipboardText(text)}>
+          {allowActions && text.trim() ? <button aria-label={t("turn.copyMessage")} type="button" onClick={() => void writeClipboardText(text)}>
             <Copy aria-hidden="true" size={14} />
-          </button>
-          {onBranch ? (
+          </button> : null}
+          {allowActions && onBranch ? (
             <button aria-label={t("turn.branchHere")} type="button" onClick={onBranch}>
               <GitBranch aria-hidden="true" size={14} />
             </button>
           ) : null}
+          {footer}
         </div>
       ) : null}
     </article>

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,9 +1,14 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:fc05cfe397300c0cce07ffce81049a29f9319dd01b94f6ffa84f1749a9c49f5b -->
+<!-- tinybot-module-fingerprint: sha256:b934f412d4581224c76f8e6695afb4f0abfdda745cb08de2a700383b2eeab62d -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
 `ChatPage.tsx` is the route-level composition module.
+Its details drawer retains closing content through a reversible 220 ms
+opacity/transform transition using `lib/useExitPresence`. Closing immediately
+makes the drawer inert and restores trigger focus; reopening cancels pending
+removal. Thread changes clear incompatible details. Native Sidecar browser
+visibility remains suppressed until the details drawer has fully left.
 `ChatTimeline.tsx` owns the reusable canonical message and execution rendering;
 its action callbacks are optional so read-only consumers can omit unavailable
 branch, recovery, artifact, delegate, and tool-detail controls.
@@ -216,6 +221,11 @@ filters session title, ID, and working-directory fields while preserving
 matching workspace and project context. Closing with its button or Escape
 clears the query, restores the full hierarchy, and returns focus to the search
 trigger.
+
+The first nonempty sidebar render may reveal at most three session rows with
+0/30/60 ms delays and the shared 220 ms entrance. Search, row focus, selection,
+reorder and refreshed grouping settle that one-shot entrance immediately;
+clearing a search never replays it. Reduced motion keeps rows fully visible.
 
 The expanded session sidebar keeps a renderer-local, versioned user order for
 its top-level workspace/project blocks, each project's member workspaces, and

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:ff71eb94c9e8b25c70df2ac5356a0b0e97acd3aa079b563ff3777093a544b738 -->
+<!-- tinybot-module-fingerprint: sha256:20f44dff7755b534a33a173f5f70609f079237e13e26609f65ee9613c859173d -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -38,7 +38,13 @@ and the details region. Its CSS and the disclosure icon CSS are imported by
 their owning modules. Ordinary tools use local expansion state; Reasoning and
 Plan supply controlled `open` and `onOpenChange` values to preserve their own
 streaming and completion rules. The `summary` slot stays visible when details
-are collapsed, so plan progress remains readable. Details unmount by default;
+are collapsed, so plan progress remains readable. Details expand and collapse
+with a reversible 200 ms grid-height and opacity transition. The grid follows
+nested and streaming content without fixed-height measurement. Closing details
+become inert and leave the accessibility tree immediately, then unmount once
+their transitions finish; reopening cancels that pending unmount. Initially
+open content does not animate on mount, and reduced motion switches immediately.
+Details unmount by default;
 tools and compaction opt into `keepMounted` to preserve their existing preview
 lifecycle. Execution summaries also keep their children mounted so folding the
 whole trace preserves individually expanded rows. Flat legacy tool groups use

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:d766d68e753ffad3b25b1032f94f4854f458ef856844049742191f4e8898a1f1 -->
+<!-- tinybot-module-fingerprint: sha256:ff71eb94c9e8b25c70df2ac5356a0b0e97acd3aa079b563ff3777093a544b738 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -9,6 +9,11 @@ its action callbacks are optional so read-only consumers can omit unavailable
 branch, recovery, artifact, delegate, and tool-detail controls.
 Assistant message actions belong only to a Turn's final answer; commentary in
 the ordered execution trace remains readable but does not expose copy actions.
+`TurnMetrics.tsx` places one elapsed-time pill beside final-answer actions, or
+at the end of a failed/interrupted Turn without a final answer. It appears only
+after the Turn ends. Clicking opens a viewport-clamped dialog with total time
+and available TPS/TTFT readings; Escape restores trigger focus, and outside
+pointer or Tab dismisses it. Old Turns show duration alone.
 A running canonical execution trace starts expanded, then folds once when its
 final answer first appears; completed traces therefore mount folded. A user can
 still reopen the trace, and later streaming revisions preserve that explicit

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:20f44dff7755b534a33a173f5f70609f079237e13e26609f65ee9613c859173d -->
+<!-- tinybot-module-fingerprint: sha256:fc05cfe397300c0cce07ffce81049a29f9319dd01b94f6ffa84f1749a9c49f5b -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.

--- a/src/react-workbench/chat/TimelineActivity.css
+++ b/src/react-workbench/chat/TimelineActivity.css
@@ -83,10 +83,31 @@ button.react-timeline-activity__header:focus-visible {
 }
 
 .react-timeline-activity__content {
+  display: grid;
+  grid-template-rows: 0fr;
   min-width: 0;
+  opacity: 0;
+  transition: grid-template-rows 200ms cubic-bezier(0.2, 0, 0, 1), opacity 200ms ease-out;
 }
 
-.react-timeline-activity__content[hidden],
-.react-timeline-activity__preview[hidden] {
+.react-timeline-activity[data-open="true"] > .react-timeline-activity__content {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.react-timeline-activity__content-inner {
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.react-timeline-activity__preview[hidden],
+.react-timeline-activity__content-inner[hidden] {
   display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .react-timeline-activity__content {
+    transition: none;
+  }
 }

--- a/src/react-workbench/chat/TimelineActivity.test.tsx
+++ b/src/react-workbench/chat/TimelineActivity.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -53,6 +53,44 @@ describe("TimelineActivity", () => {
     expect(screen.getByText("No details")).toBeVisible();
     expect(screen.queryByRole("button")).toBeNull();
     expect(screen.queryByRole("region", { hidden: true })).toBeNull();
+  });
+
+  it("keeps closing content mounted but inaccessible until its transition finishes", async () => {
+    const user = userEvent.setup();
+    render(<TimelineActivity defaultOpen icon={null} title="Animated"><input aria-label="Detail" /></TimelineActivity>);
+    const region = screen.getByRole("region", { name: "Animated" });
+    const input = screen.getByRole("textbox", { name: "Detail" });
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => { finish = resolve; });
+    Object.defineProperty(region, "getAnimations", { value: () => [{ finished }] });
+
+    await user.click(screen.getByRole("button", { name: "Animated" }));
+    expect(region).toContainElement(input);
+    expect(region).toHaveAttribute("inert");
+    expect(screen.queryByRole("textbox", { name: "Detail" })).toBeNull();
+    await act(async () => { finish(); });
+    expect(region).not.toContainElement(input);
+  });
+
+  it("ignores a stale closing transition when reopened, and settles cancelled motion", async () => {
+    const user = userEvent.setup();
+    render(<TimelineActivity defaultOpen icon={null} title="Animated">Detail</TimelineActivity>);
+    const region = screen.getByRole("region", { name: "Animated" });
+    const trigger = screen.getByRole("button", { name: "Animated" });
+    let finish!: () => void;
+    let cancel!: (reason: DOMException) => void;
+    let finished = new Promise<void>((resolve) => { finish = resolve; });
+    Object.defineProperty(region, "getAnimations", { value: () => [{ finished }] });
+
+    await user.click(trigger);
+    await user.click(trigger);
+    await act(async () => { finish(); });
+    expect(region).toHaveTextContent("Detail");
+    expect(region).not.toHaveAttribute("inert");
+    finished = new Promise<void>((_, reject) => { cancel = reject; });
+    await user.click(trigger);
+    await act(async () => { cancel(new DOMException("Reduced motion enabled", "AbortError")); });
+    expect(screen.queryByText("Detail")).toBeNull();
   });
 
   it("preserves mounted detail state while keeping it inaccessible when collapsed", async () => {

--- a/src/react-workbench/chat/TimelineActivity.tsx
+++ b/src/react-workbench/chat/TimelineActivity.tsx
@@ -1,4 +1,4 @@
-import { Children, useId, useState, type ReactNode } from "react";
+import { Children, useId, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { ChatDisclosureIcon } from "./ChatDisclosureIcon";
 import "./TimelineActivity.css";
 
@@ -29,6 +29,33 @@ export function TimelineActivity({
   const [localOpen, setLocalOpen] = useState(defaultOpen);
   const hasContent = Children.toArray(children).length > 0;
   const expanded = hasContent && (open ?? localOpen);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [present, setPresent] = useState(expanded);
+
+  useLayoutEffect(() => {
+    if (expanded) {
+      setPresent(true);
+      return;
+    }
+    const content = contentRef.current;
+    if (!content || !present) return;
+    // Reading the transitions flushes the new grid target. CSS handles reversal
+    // and changing content height; React only owns the closing content's lifetime.
+    const animations = content.getAnimations?.() ?? [];
+    if (!animations.length) {
+      setPresent(false);
+      return;
+    }
+    let disposed = false;
+    void Promise.all(animations.map((animation) => animation.finished.catch((error: unknown) => {
+      // A reversed transition or a switch to reduced motion cancels its animation.
+      if (!(error instanceof DOMException && error.name === "AbortError")) throw error;
+    }))).then(() => {
+      if (!disposed) setPresent(false);
+    });
+    return () => { disposed = true; };
+  }, [expanded, present]);
+
   const heading = (
     <>
       <span aria-hidden="true" className="react-timeline-activity__icon">
@@ -61,8 +88,18 @@ export function TimelineActivity({
       ) : <div className="react-timeline-activity__header">{heading}</div>}
       {summary}
       {hasContent ? (
-        <div aria-labelledby={triggerId} className="react-timeline-activity__content" hidden={!expanded} id={contentId} role="region">
-          {expanded || keepMounted ? children : null}
+        <div
+          aria-hidden={!expanded}
+          aria-labelledby={triggerId}
+          className="react-timeline-activity__content"
+          id={contentId}
+          inert={!expanded}
+          ref={contentRef}
+          role="region"
+        >
+          <div className="react-timeline-activity__content-inner" hidden={!expanded && !present}>
+            {expanded || present || keepMounted ? children : null}
+          </div>
         </div>
       ) : null}
     </div>

--- a/src/react-workbench/chat/TurnMetrics.css
+++ b/src/react-workbench/chat/TurnMetrics.css
@@ -1,0 +1,56 @@
+.react-message__actions .react-turn-metrics__trigger,
+.react-turn-metrics__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: auto;
+  min-height: 30px;
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  box-shadow: none;
+  color: var(--color-muted);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.react-turn-metrics__trigger[aria-expanded="true"],
+.react-turn-metrics__trigger:hover {
+  color: var(--color-body);
+  background: var(--color-hairline);
+}
+
+.react-turn-metrics__trigger:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.react-turn-metrics__trigger:active { transform: scale(0.97); }
+
+.react-turn-metrics__panel {
+  position: fixed;
+  z-index: 1000;
+  width: min(350px, calc(100vw - 24px));
+  box-sizing: border-box;
+  padding: 18px 20px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 16px;
+  background: var(--color-panel);
+  color: var(--color-body);
+  box-shadow: 0 8px 32px rgb(0 0 0 / 12%);
+  outline: none;
+  font-size: 13px;
+}
+
+.react-turn-metrics__title { display: flex; align-items: center; gap: 8px; padding-bottom: 12px; border-bottom: 1px solid var(--color-hairline); }
+.react-turn-metrics__panel dl { display: grid; grid-template-columns: 1fr auto; gap: 10px 20px; margin: 14px 0 0; }
+.react-turn-metrics__panel dt { color: var(--color-muted); }
+.react-turn-metrics__panel dd { margin: 0; text-align: right; font-variant-numeric: tabular-nums; }
+.react-turn-metrics__panel p { margin: 14px 0 0; color: var(--color-muted); font-size: 11px; line-height: 1.6; }
+
+@media (prefers-reduced-motion: reduce) {
+  .react-turn-metrics__trigger:active { transform: none; }
+}

--- a/src/react-workbench/chat/TurnMetrics.test.tsx
+++ b/src/react-workbench/chat/TurnMetrics.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import type { ChatTurn } from "../../app-core/chat/chatTurnContracts";
+import { ChatTimeline } from "./ChatTimeline";
+
+afterEach(cleanup);
+
+function turn(id: string, patch: Partial<ChatTurn> = {}): ChatTurn {
+  return {
+    id, sessionKey: "session", status: "completed", startedAt: "1000", completedAt: "20000", updatedAt: "20000",
+    steps: [], executionItems: [], userMessageId: `user-${id}`,
+    userMessage: { id: `user-${id}`, role: "user", text: "Question", timestamp: "1000" },
+    finalAnswer: { id: `answer-${id}`, role: "assistant", text: "Answer", timestamp: "20000" },
+    metrics: { timeToFirstTokenMs: 600, tokensPerSecond: 108 }, ...patch,
+  };
+}
+
+function timeline(turns: ChatTurn[]) {
+  return <ChatTimeline actions={{}} hookResults={[]} interactiveFormIds={new Set()} latestFailedTurnId="" optimisticMessages={[]} sessionRunning={false} turns={turns} />;
+}
+
+describe("turn timing footer", () => {
+  test("places one timing button beside final-answer actions for each settled turn", () => {
+    render(timeline([turn("one"), turn("two")]));
+    expect(screen.getAllByRole("button", { name: "Took 19s" })).toHaveLength(2);
+    const answer = screen.getByTestId("message-answer-one");
+    const trigger = within(answer).getByRole("button", { name: "Took 19s" });
+    expect(trigger.parentElement).toBe(within(answer).getByRole("button", { name: "Copy message" }).parentElement);
+    fireEvent.click(trigger);
+    const dialog = screen.getByRole("dialog", { name: "Turn time and speed" });
+    expect(document.activeElement).toBe(dialog);
+    expect(within(dialog).getByText("108 tok/s")).toBeTruthy();
+    expect(within(dialog).getByText("0.6s")).toBeTruthy();
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    fireEvent.click(trigger);
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  test("shows duration alone for old records, including failed turns without a final answer", () => {
+    render(timeline([turn("old", { metrics: undefined, finalAnswer: undefined, status: "failed" })]));
+    fireEvent.click(screen.getByRole("button", { name: "Took 19s" }));
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Total turn time")).toBeTruthy();
+    expect(within(dialog).queryByText("Output speed (TPS)")).toBeNull();
+    expect(within(dialog).queryByText("Time to first token (TTFT)")).toBeNull();
+  });
+
+  test("does not display a completed metric while a turn is running or waiting for input", () => {
+    const { rerender } = render(timeline([turn("active", { status: "running" })]));
+    expect(screen.queryByRole("button", { name: /Took/ })).toBeNull();
+    rerender(timeline([turn("active", { status: "awaiting_user" })]));
+    expect(screen.queryByRole("button", { name: /Took/ })).toBeNull();
+    rerender(timeline([turn("active", { status: "interrupted" })]));
+    expect(screen.getByRole("button", { name: "Took 19s" })).toBeTruthy();
+  });
+});

--- a/src/react-workbench/chat/TurnMetrics.tsx
+++ b/src/react-workbench/chat/TurnMetrics.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Clock3 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ChatTurn } from "../../app-core/chat/chatTurnContracts";
+import { turnDurationMs } from "../../app-core/chat/turnMetrics";
+import "./TurnMetrics.css";
+
+export function TurnMetrics({ turn }: { turn: ChatTurn }) {
+  const { t } = useTranslation("chat");
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<{ left: number; top: number }>();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const id = useId();
+  const duration = turnDurationMs(turn);
+  const terminal = turn.status === "completed" || turn.status === "failed" || turn.status === "interrupted";
+  const positioned = position !== undefined;
+
+  useEffect(() => {
+    if (open && positioned) panelRef.current?.focus({ preventScroll: true });
+  }, [open, positioned]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const place = () => {
+      const anchor = triggerRef.current?.getBoundingClientRect();
+      const panel = panelRef.current?.getBoundingClientRect();
+      if (!anchor || !panel) return;
+      const top = anchor.top - panel.height - 8;
+      setPosition({
+        left: Math.max(12, Math.min(anchor.left, window.innerWidth - panel.width - 12)),
+        top: Math.max(12, Math.min(top >= 12 ? top : anchor.bottom + 8, window.innerHeight - panel.height - 12)),
+      });
+    };
+    place();
+    window.addEventListener("resize", place);
+    window.addEventListener("scroll", place, true);
+    return () => {
+      window.removeEventListener("resize", place);
+      window.removeEventListener("scroll", place, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.target instanceof Node && !panelRef.current?.contains(event.target) && !triggerRef.current?.contains(event.target)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+      if (event.key === "Tab") {
+        triggerRef.current?.focus();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  if (!terminal || duration === undefined) return null;
+  const formatDuration = (ms: number) => ms < 60_000
+    ? t("metrics.seconds", { value: Number((ms / 1_000).toFixed(1)) })
+    : t("metrics.minutesSeconds", { minutes: Math.floor(ms / 60_000), seconds: Math.floor(ms % 60_000 / 1_000) });
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        className="react-turn-metrics__trigger"
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-controls={open ? id : undefined}
+        onClick={() => { setPosition(undefined); setOpen(!open); }}
+      >
+        <Clock3 aria-hidden="true" size={15} />
+        {t("metrics.elapsed", { duration: formatDuration(duration) })}
+      </button>
+      {open && createPortal(
+        <div ref={panelRef} id={id} className="react-turn-metrics__panel" role="dialog" aria-label={t("metrics.title")} tabIndex={-1} style={position ?? { visibility: "hidden" }}>
+          <div className="react-turn-metrics__title"><Clock3 aria-hidden="true" size={17} />{t("metrics.title")}</div>
+          <dl>
+            <dt>{t("metrics.duration")}</dt><dd>{formatDuration(duration)}</dd>
+            {turn.metrics?.tokensPerSecond !== undefined && <><dt>{t("metrics.speed")}</dt><dd>{t("metrics.tokensPerSecond", { value: Number(turn.metrics.tokensPerSecond.toFixed(turn.metrics.tokensPerSecond < 10 ? 1 : 0)) })}</dd></>}
+            {turn.metrics?.timeToFirstTokenMs !== undefined && <><dt>{t("metrics.ttft")}</dt><dd>{formatDuration(turn.metrics.timeToFirstTokenMs)}</dd></>}
+          </dl>
+          {turn.metrics && <p>{t("metrics.description")}</p>}
+        </div>, document.body,
+      )}
+    </>
+  );
+}

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:5716a9d08929735ca7ed227095730c3e96db457eff346f5ec14558b977b3468c -->
+<!-- tinybot-module-fingerprint: sha256:27eb0d6904f8ddd0b53db03ba9acb4c09223b68447ff3e3dde53aba639349a72 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles.

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1116,6 +1116,12 @@ export const en = {
       delete: "Delete queued input", interrupt: "Interrupt", interruptHelp: "Interrupt the current response and send this message now", sending: "Sending as a new turn", interruptFailed: "Interrupt failed", interrupting: "Interrupting the current response",
       paused: "Paused", sent: "Sent", failed: "Failed", waiting: "Waiting", limit: "Already have {{count}} queued messages. Wait for processing or delete one before sending more.",
     },
+    metrics: {
+      title: "Turn time and speed", elapsed: "Took {{duration}}", duration: "Total turn time",
+      speed: "Output speed (TPS)", ttft: "Time to first token (TTFT)",
+      seconds: "{{value}}s", minutesSeconds: "{{minutes}}m {{seconds}}s", tokensPerSecond: "{{value}} tok/s",
+      description: "First token includes reasoning and tool calls. Speed uses recorded model generation time and excludes tool execution and waits between calls.",
+    },
     turn: {
       label: "Chat turn", workPerformed: "Work performed",
       agentResponding: "Agent is responding", copyMessage: "Copy message", branchHere: "Branch from here", formErrors: "Form errors", agentForms: "Agent forms",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -564,6 +564,12 @@ export const zh = {
       delete: "删除排队输入", interrupt: "中断", interruptHelp: "中断当前回复并立即发送这条消息", sending: "正在发送为新一轮", interruptFailed: "插入失败", interrupting: "正在中断当前回复",
       paused: "已暂停", sent: "已发送", failed: "失败", waiting: "等待中", limit: "已有 {{count}} 条排队消息。请等待处理完成，或删除一条后再发送。",
     },
+    metrics: {
+      title: "本轮用时和速度", elapsed: "用时 {{duration}}", duration: "本轮总用时",
+      speed: "输出速度（TPS）", ttft: "首 token 用时（TTFT）",
+      seconds: "{{value}}秒", minutesSeconds: "{{minutes}}分{{seconds}}秒", tokensPerSecond: "{{value}} tok/s",
+      description: "首 token 包含思考和工具调用输出。速度按已记录的模型生成时间计算，不含工具执行和调用之间的等待。",
+    },
     turn: {
       label: "会话轮次", workPerformed: "已执行的工作",
       agentResponding: "Agent 正在回复", copyMessage: "复制消息", branchHere: "从此处分支", formErrors: "表单错误", agentForms: "Agent 表单",

--- a/src/react-workbench/lib/README.md
+++ b/src/react-workbench/lib/README.md
@@ -1,8 +1,16 @@
 # Renderer Library
-<!-- tinybot-module-fingerprint: sha256:c67a904d102a0edca23014009dd9003f98f09d25e0c9223b8ff74d9088f8ba92 -->
+<!-- tinybot-module-fingerprint: sha256:fd50037e5c51e14ab5e8663cb245fcf591083ffeaf1b8b241c5b79d316769aec -->
 
 `lib` contains small, renderer-only presentation helpers shared by frontend
-modules. Helpers here should be pure and independent of React route state.
+modules. Formatting helpers are pure; presentation hooks do not own route state.
+
+`useExitPresence` retains closing content within its owner scope until the
+owning CSS transitions finish. Callers supply the live value and a stable
+transition reader, and independently enforce logical visibility, inertness and
+native surface visibility. Reopening or changing scope invalidates pending
+removal. `elementTransitions` selects only an element's own named CSS
+transitions, excluding descendant cursors/spinners; cancellation rechecks the
+current transitions, while unexpected failures remain observable.
 
 Protocol normalization, native transport, and domain projections belong in
 their owning `app-core` or adapter modules rather than in a general utility

--- a/src/react-workbench/lib/useExitPresence.test.tsx
+++ b/src/react-workbench/lib/useExitPresence.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { useCallback, useRef } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { elementTransitions, useExitPresence } from "./useExitPresence";
+
+afterEach(cleanup);
+
+function pendingTransition(transitionProperty = "opacity") {
+  let finish!: () => void;
+  let cancel!: () => void;
+  const animation = {
+    transitionProperty,
+    playState: "running",
+    finished: new Promise<void>((resolve, reject) => {
+      finish = () => { animation.playState = "finished"; resolve(); };
+      cancel = () => { animation.playState = "idle"; reject(new DOMException("Cancelled", "AbortError")); };
+    }),
+  };
+  return { animation, finish, cancel };
+}
+
+function Panel({ value, scope = "a" }: { value: string | null; scope?: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const read = useCallback(() => elementTransitions(ref.current, ["opacity", "transform"]), []);
+  const content = useExitPresence(value, scope, read);
+  return content === null ? null : <div ref={ref} data-testid="panel" inert={value === null}>{content}</div>;
+}
+
+describe("exit presence", () => {
+  it("releases immediately without transitions, including reduced motion", () => {
+    const { rerender } = render(<Panel value="detail" />);
+    rerender(<Panel value={null} />);
+    expect(screen.queryByTestId("panel")).toBeNull();
+  });
+
+  it("does not remove a reopened panel when an earlier transition completes", async () => {
+    const { rerender } = render(<Panel value="first" />);
+    const panel = screen.getByTestId("panel");
+    const transition = pendingTransition();
+    Object.defineProperty(panel, "getAnimations", { value: () => [transition.animation] });
+    rerender(<Panel value={null} />);
+    expect(panel.hasAttribute("inert")).toBe(true);
+    rerender(<Panel value="second" />);
+    await act(async () => transition.finish());
+    expect(screen.getByTestId("panel")).toBe(panel);
+    expect(panel.textContent).toBe("second");
+    expect(panel.hasAttribute("inert")).toBe(false);
+  });
+
+  it("rechecks replacement transitions after cancellation and ignores unrelated animations", async () => {
+    const { rerender } = render(<Panel value="detail" />);
+    const panel = screen.getByTestId("panel");
+    const first = pendingTransition();
+    const replacement = pendingTransition("transform");
+    let animations = [first.animation];
+    Object.defineProperty(panel, "getAnimations", { value: () => [
+      ...animations,
+      { playState: "running", finished: new Promise(() => {}), animationName: "cursor" },
+    ] });
+    rerender(<Panel value={null} />);
+    await act(async () => { animations = [replacement.animation]; first.cancel(); });
+    expect(screen.getByTestId("panel")).toBe(panel);
+    await act(async () => replacement.finish());
+    expect(screen.queryByTestId("panel")).toBeNull();
+  });
+
+  it("clears retained content immediately across owner scope changes", async () => {
+    const { rerender } = render(<Panel value="old thread" />);
+    const panel = screen.getByTestId("panel");
+    const transition = pendingTransition();
+    Object.defineProperty(panel, "getAnimations", { value: () => [transition.animation] });
+    rerender(<Panel value={null} />);
+    rerender(<Panel value={null} scope="b" />);
+    expect(screen.queryByTestId("panel")).toBeNull();
+    await act(async () => transition.finish());
+  });
+});

--- a/src/react-workbench/lib/useExitPresence.ts
+++ b/src/react-workbench/lib/useExitPresence.ts
@@ -1,0 +1,53 @@
+import { useLayoutEffect, useState } from "react";
+
+/** Retain only closing content, within its owner scope, until CSS finishes. */
+export function useExitPresence<T>(
+  value: T | null,
+  scope: string,
+  readTransitions: () => Animation[],
+): T | null {
+  const [retained, setRetained] = useState({ scope, value });
+  if (retained.scope !== scope || (value !== null && retained.value !== value)) {
+    setRetained({ scope, value });
+  }
+  const present = value ?? (retained.scope === scope ? retained.value : null);
+
+  useLayoutEffect(() => {
+    if (value !== null || present === null) return;
+    let disposed = false;
+    const release = () => {
+      if (!disposed) setRetained({ scope, value: null });
+    };
+    const transitions = readTransitions();
+    if (!transitions.length) {
+      release();
+      return;
+    }
+    void (async () => {
+      let pending = transitions;
+      while (pending.length && !disposed) {
+        await Promise.all(pending.map((animation) => animation.finished.catch((error: unknown) => {
+          // Reversal, breakpoint changes and reduced motion can cancel CSS transitions.
+          if (!(error instanceof DOMException && error.name === "AbortError")) throw error;
+        })));
+        if (disposed) return;
+        // A breakpoint can replace the transition that was just cancelled.
+        pending = readTransitions();
+      }
+      release();
+    })();
+    return () => { disposed = true; };
+  }, [value, present, scope, readTransitions]);
+
+  return present;
+}
+
+/** Exclude descendant animations (including infinite cursors and spinners). */
+export function elementTransitions(element: HTMLElement | null, properties: readonly string[]): Animation[] {
+  return (element?.getAnimations?.() ?? []).filter((animation) => (
+    "transitionProperty" in animation
+    && properties.includes(animation.transitionProperty as string)
+    && animation.playState !== "finished"
+    && animation.playState !== "idle"
+  ));
+}

--- a/src/react-workbench/main.tsx
+++ b/src/react-workbench/main.tsx
@@ -8,6 +8,7 @@ import { AppAppearanceProvider } from "./settings/AppAppearanceContext";
 import { AppLanguageProvider } from "./settings/AppLanguageContext";
 import { DesktopPetWindow } from "./shell/DesktopPetWindow";
 import { DesktopPetQuickChatWindow } from "./shell/DesktopPetQuickChatWindow";
+import { removeStartupSplash } from "./startupSplash";
 import "./styles/workbench.css";
 
 const root = document.querySelector("#root");
@@ -19,9 +20,11 @@ if (!root) {
 const surface = new URLSearchParams(window.location.search).get("surface");
 
 if (surface === "desktop-pet") {
+  removeStartupSplash();
   document.documentElement.dataset.surface = "desktop-pet";
   createRoot(root).render(<DesktopPetApp />);
 } else if (surface === "desktop-pet-chat") {
+  removeStartupSplash();
   document.documentElement.dataset.surface = "desktop-pet-chat";
   createRoot(root).render(<DesktopPetQuickChatApp />);
 } else {

--- a/src/react-workbench/settings/ProfileSettingsPage.test.tsx
+++ b/src/react-workbench/settings/ProfileSettingsPage.test.tsx
@@ -7,6 +7,7 @@ import { ProfileSettingsPage } from "./ProfileSettingsPage";
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -31,7 +32,180 @@ describe("ProfileSettingsPage", () => {
 
       unobserve() {}
     });
-    const settingsStore: SettingsStore = {
+    const settingsStore = createSettingsStore();
+
+    const { container } = render(<ProfileSettingsPage settingsStore={settingsStore} />);
+
+    const summary = await screen.findByRole("region", { name: "Total tokens" });
+    expect(within(summary).getByText("17,000")).toBeTruthy();
+    expect(screen.getByRole("img", { name: /Daily token usage peaked/ })).toBeTruthy();
+    expect(screen.getByRole("img", { name: /openai \/ gpt-5 ranks first/ })).toBeTruthy();
+    expect(screen.getByRole("table", { name: "Token usage by provider and model" })).toBeTruthy();
+    expect(screen.getByRole("table", { name: "Daily token usage" })).toBeTruthy();
+    expect(container.querySelector(".react-profile-chart-card figcaption p")).toBeNull();
+    expect(container.querySelector(".react-profile-chart-card__source")).toBeNull();
+    expect(container.querySelector(".react-profile-usage-note")).toBeNull();
+
+    const chartCards = [...container.querySelectorAll<HTMLElement>(".react-profile-chart-card")];
+    expect(chartCards).toHaveLength(2);
+    expect(chartCards.every((card) => card.dataset.revealState === "pending")).toBe(true);
+    const completions = chartCards.map(mockChartAnimations);
+    await waitFor(() => expect(observerCallbacks).toHaveLength(2));
+
+    act(() => {
+      for (const callback of observerCallbacks) {
+        callback([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+      }
+    });
+
+    expect(chartCards.every((card) => card.dataset.revealState === "revealing")).toBe(true);
+    expect(observerDisconnect).toHaveBeenCalled();
+
+    const dailyChart = chartCards[0].querySelector("svg");
+    fireEvent.click(chartCards[0]);
+    expect(chartCards[0].querySelector("svg")).not.toBe(dailyChart);
+
+    const modelChart = chartCards[1].querySelector("svg");
+    fireEvent.keyDown(chartCards[1], { key: "Enter" });
+    expect(chartCards[1].querySelector("svg")).not.toBe(modelChart);
+    await act(async () => completions.forEach((runs) => runs[0]()));
+    expect(chartCards.every((card) => card.dataset.revealState === "revealing")).toBe(true);
+
+    const currentCharts = chartCards.map((card) => card.querySelector("svg"));
+    selectProvider("anthropic");
+
+    expect(within(summary).getByText("5,000")).toBeTruthy();
+    expect(screen.getByRole("rowheader", { name: "anthropic" })).toBeTruthy();
+    expect(screen.queryByRole("rowheader", { name: "openai" })).toBeNull();
+    expect(chartCards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+    chartCards.forEach((card, index) => expect(card.querySelector("svg")).toBe(currentCharts[index]));
+
+    const anthropicTick = chartCards[1].querySelector(".react-profile-chart__model-tick");
+    selectProvider("All providers");
+    expect(chartCards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+    expect(chartCards[1].querySelector(".react-profile-chart__model-tick")).not.toBe(anthropicTick);
+    chartCards.forEach((card, index) => expect(card.querySelector("svg")).toBe(currentCharts[index]));
+
+    fireEvent.keyDown(chartCards[0], { key: " " });
+    expect(chartCards[0].dataset.revealState).toBe("revealing");
+    await act(async () => completions.forEach((runs) => runs[1]()));
+    expect(chartCards[0].dataset.revealState).toBe("revealing");
+    await act(async () => completions[0][2]());
+    expect(chartCards[0].dataset.revealState).toBe("settled");
+
+    selectProvider("anthropic");
+    fireEvent.click(screen.getByRole("button", { name: /Filter token usage by model/ }));
+    expect(screen.getByRole("menuitemradio", { name: "claude-sonnet" })).toBeTruthy();
+    expect(screen.getByRole("rowheader", { name: "Aug 31, 2026" })).toBeTruthy();
+  });
+
+  test("settles a filter change before viewport entry and ignores stale observer callbacks", async () => {
+    const callbacks: IntersectionObserverCallback[] = [];
+    vi.stubGlobal("IntersectionObserver", class {
+      constructor(callback: IntersectionObserverCallback) { callbacks.push(callback); }
+      observe() {}
+      disconnect() {}
+    });
+    const { container } = render(<ProfileSettingsPage settingsStore={createSettingsStore()} />);
+    await screen.findByRole("region", { name: "Total tokens" });
+    const cards = [...container.querySelectorAll<HTMLElement>(".react-profile-chart-card")];
+    expect(cards.every((card) => card.dataset.revealState === "pending")).toBe(true);
+    selectProvider("openai");
+    expect(cards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+    act(() => callbacks.forEach((callback) => callback(
+      [{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver,
+    )));
+    expect(cards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+    selectProvider("All providers");
+    expect(cards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+  });
+
+  test("keeps reduced-motion charts settled before entry and when replay is requested", async () => {
+    const preference = window.matchMedia("(prefers-reduced-motion: reduce)");
+    Object.defineProperty(preference, "matches", { configurable: true, value: true });
+    vi.spyOn(window, "matchMedia").mockReturnValue(preference);
+    const { container } = render(<ProfileSettingsPage settingsStore={createSettingsStore()} />);
+    await screen.findByRole("region", { name: "Total tokens" });
+    const cards = [...container.querySelectorAll<HTMLElement>(".react-profile-chart-card")];
+    expect(cards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+    fireEvent.click(cards[0]);
+    fireEvent.keyDown(cards[1], { key: "Enter" });
+    expect(cards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+  });
+
+  test("observes newly populated charts and preserves settled history across empty data", async () => {
+    const observed: HTMLElement[] = [];
+    vi.stubGlobal("IntersectionObserver", class {
+      observe(figure: HTMLElement) { observed.push(figure); }
+      disconnect() {}
+    });
+    const settingsStore = createSettingsStore();
+    const snapshot = await settingsStore.loadTokenUsage!();
+    const initialDays = snapshot.days;
+    const initialModels = snapshot.modelDays;
+    snapshot.days = [];
+    snapshot.modelDays = [];
+    settingsStore.loadTokenUsage = vi.fn(async () => snapshot);
+    const { container, rerender } = render(<ProfileSettingsPage settingsStore={settingsStore} />);
+    await screen.findByRole("region", { name: "Total tokens" });
+    expect(container.querySelectorAll(".react-profile-chart-card")).toHaveLength(0);
+    expect(observed).toHaveLength(0);
+
+    snapshot.days = initialDays;
+    snapshot.modelDays = initialModels;
+    rerender(<ProfileSettingsPage settingsStore={settingsStore} />);
+    expect(observed).toHaveLength(2);
+    expect(observed.every((card) => card.dataset.revealState === "pending")).toBe(true);
+    selectProvider("anthropic");
+    expect(observed.every((card) => card.dataset.revealState === "settled")).toBe(true);
+    selectProvider("All providers");
+
+    snapshot.days = [];
+    snapshot.modelDays = [];
+    rerender(<ProfileSettingsPage settingsStore={settingsStore} />);
+    expect(container.querySelectorAll(".react-profile-chart-card")).toHaveLength(0);
+    snapshot.days = initialDays;
+    snapshot.modelDays = initialModels;
+    rerender(<ProfileSettingsPage settingsStore={settingsStore} />);
+    const cards = [...container.querySelectorAll<HTMLElement>(".react-profile-chart-card")];
+    expect(cards).toHaveLength(2);
+    expect(cards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+    expect(observed).toHaveLength(2);
+  });
+
+  test("settles an active reveal when reduced motion is enabled", async () => {
+    const preference = window.matchMedia("(prefers-reduced-motion: reduce)");
+    vi.spyOn(window, "matchMedia").mockReturnValue(preference);
+    vi.stubGlobal("IntersectionObserver", undefined);
+    const { container } = render(<ProfileSettingsPage settingsStore={createSettingsStore()} />);
+    await screen.findByRole("region", { name: "Total tokens" });
+    const card = container.querySelector<HTMLElement>(".react-profile-chart-card")!;
+    const runs = mockChartAnimations(card);
+    fireEvent.click(card);
+    expect(card.dataset.revealState).toBe("revealing");
+    Object.defineProperty(preference, "matches", { configurable: true, value: true });
+    act(() => preference.dispatchEvent(new Event("change")));
+    expect(card.dataset.revealState).toBe("settled");
+    await act(async () => runs[0]());
+    expect(card.dataset.revealState).toBe("settled");
+  });
+});
+
+function mockChartAnimations(card: HTMLElement): Array<() => void> {
+  const completions: Array<() => void> = [];
+  card.getAnimations = vi.fn(() => [{
+    finished: new Promise<Animation>((resolve) => completions.push(() => resolve({} as Animation))),
+  } as Animation]);
+  return completions;
+}
+
+function selectProvider(name: string) {
+  fireEvent.click(screen.getByRole("button", { name: /Filter token usage by provider/ }));
+  fireEvent.click(screen.getByRole("menuitemradio", { name }));
+}
+
+function createSettingsStore(): SettingsStore {
+  return {
       load: vi.fn(async () => []),
       loadTokenUsage: vi.fn(async () => ({
         schemaVersion: "tinybot.token_usage.v2" as const,
@@ -61,53 +235,8 @@ describe("ProfileSettingsPage", () => {
           },
         ],
       })),
-    };
-
-    const { container } = render(<ProfileSettingsPage settingsStore={settingsStore} />);
-
-    const summary = await screen.findByRole("region", { name: "Total tokens" });
-    expect(within(summary).getByText("17,000")).toBeTruthy();
-    expect(screen.getByRole("img", { name: /Daily token usage peaked/ })).toBeTruthy();
-    expect(screen.getByRole("img", { name: /openai \/ gpt-5 ranks first/ })).toBeTruthy();
-    expect(screen.getByRole("table", { name: "Token usage by provider and model" })).toBeTruthy();
-    expect(screen.getByRole("table", { name: "Daily token usage" })).toBeTruthy();
-    expect(container.querySelector(".react-profile-chart-card figcaption p")).toBeNull();
-    expect(container.querySelector(".react-profile-chart-card__source")).toBeNull();
-    expect(container.querySelector(".react-profile-usage-note")).toBeNull();
-
-    const chartCards = [...container.querySelectorAll<HTMLElement>(".react-profile-chart-card")];
-    expect(chartCards).toHaveLength(2);
-    expect(chartCards.every((card) => card.dataset.revealState === "pending")).toBe(true);
-    await waitFor(() => expect(observerCallbacks).toHaveLength(2));
-
-    act(() => {
-      for (const callback of observerCallbacks) {
-        callback([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
-      }
-    });
-
-    expect(chartCards.every((card) => card.dataset.revealState === "revealed")).toBe(true);
-    expect(observerDisconnect).toHaveBeenCalledTimes(2);
-
-    const dailyChart = chartCards[0].querySelector("svg");
-    fireEvent.click(chartCards[0]);
-    expect(chartCards[0].querySelector("svg")).not.toBe(dailyChart);
-
-    const modelChart = chartCards[1].querySelector("svg");
-    fireEvent.keyDown(chartCards[1], { key: "Enter" });
-    expect(chartCards[1].querySelector("svg")).not.toBe(modelChart);
-
-    fireEvent.click(screen.getByRole("button", { name: /Filter token usage by provider/ }));
-    fireEvent.click(screen.getByRole("menuitemradio", { name: "anthropic" }));
-
-    expect(within(summary).getByText("5,000")).toBeTruthy();
-    expect(screen.getByRole("rowheader", { name: "anthropic" })).toBeTruthy();
-    expect(screen.queryByRole("rowheader", { name: "openai" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: /Filter token usage by model/ }));
-    expect(screen.getByRole("menuitemradio", { name: "claude-sonnet" })).toBeTruthy();
-    expect(screen.getByRole("rowheader", { name: "Aug 31, 2026" })).toBeTruthy();
-  });
-});
+  };
+}
 
 function usage(
   inputTokens: number,

--- a/src/react-workbench/settings/ProfileSettingsPage.tsx
+++ b/src/react-workbench/settings/ProfileSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { RefreshCw } from "lucide-react";
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import type {
   DailyModelTokenUsage,
@@ -202,21 +202,19 @@ function TokenUsageContent({ locale, snapshot }: { locale: string; snapshot: Tok
         </dl>
       </section>
 
-      {filteredDays.length ? (
-        <section className="react-profile-charts" aria-label={t("profile.chartsLabel")}>
-          <DailyUsageChart
-            days={filteredDays}
-            endDate={snapshot.days[0]?.date}
-            formatCompactTokens={formatCompactTokens}
-            locale={locale}
-          />
-          <ModelUsageChart
-            formatCompactTokens={formatCompactTokens}
-            modelTotals={modelTotals}
-            unknownLabel={t("profile.unknown")}
-          />
-        </section>
-      ) : null}
+      <section className="react-profile-charts" aria-label={t("profile.chartsLabel")} hidden={!filteredDays.length}>
+        <DailyUsageChart
+          days={filteredDays}
+          endDate={snapshot.days[0]?.date}
+          formatCompactTokens={formatCompactTokens}
+          locale={locale}
+        />
+        <ModelUsageChart
+          formatCompactTokens={formatCompactTokens}
+          modelTotals={modelTotals}
+          unknownLabel={t("profile.unknown")}
+        />
+      </section>
 
       <section className="react-profile-models" aria-labelledby="profile-models-title">
         <header>
@@ -307,8 +305,10 @@ function DailyUsageChart({
   locale: string;
 }) {
   const { t } = useTranslation("settings");
-  const { figureRef, isRevealed, replay, replayKey } = useChartReveal();
   const series = fillRecentDays(days, endDate, 30);
+  const seriesKey = series.map((day) => `${day.date}:${day.totalTokens}`).join("|");
+  const { figureRef, revealState, replay, replayKey } = useChartReveal(seriesKey, days.length > 0);
+  if (!days.length) return null;
   const width = 640;
   const height = 250;
   const left = 24;
@@ -328,13 +328,12 @@ function DailyUsageChart({
     date: formatUsageDate(peak.date, locale),
     tokens: formatCompactTokens(peak.totalTokens),
   });
-  const seriesKey = series.map((day) => `${day.date}:${day.totalTokens}`).join("|");
 
   return (
     <figure
       aria-label={t("profile.replayChartLabel", { chart: chartLabel })}
       className="react-profile-chart-card"
-      data-reveal-state={isRevealed ? "revealed" : "pending"}
+      data-reveal-state={revealState}
       onClick={replay}
       onKeyDown={(event) => handleChartReplayKeyDown(event, replay)}
       ref={figureRef}
@@ -344,7 +343,7 @@ function DailyUsageChart({
       <figcaption>
         <h3>{t("profile.trendTitle", { date: formatUsageDate(peak.date, locale) })}</h3>
       </figcaption>
-      <svg aria-label={chartLabel} key={`${seriesKey}:${replayKey}`} role="img" viewBox={`0 0 ${width} ${height}`}>
+      <svg aria-label={chartLabel} key={replayKey} role="img" viewBox={`0 0 ${width} ${height}`}>
         <title>{chartLabel}</title>
         <desc>{t("profile.trendDescription")}</desc>
         {[0, 0.5, 1].map((ratio, gridIndex) => {
@@ -439,8 +438,11 @@ function ModelUsageChart({
   unknownLabel: string;
 }) {
   const { t } = useTranslation("settings");
-  const { figureRef, isRevealed, replay, replayKey } = useChartReveal();
   const rows = modelTotals.slice(0, 6);
+  const rowsKey = rows
+    .map((row) => `${modelUsageKey(row.providerId, row.modelId)}:${row.totalTokens}`)
+    .join("|");
+  const { figureRef, revealState, replay, replayKey } = useChartReveal(rowsKey, rows.length > 0);
   if (!rows.length) return null;
   const width = 640;
   const height = 64 + rows.length * 52;
@@ -455,15 +457,12 @@ function ModelUsageChart({
     model: topLabel,
     tokens: formatCompactTokens(top.totalTokens),
   });
-  const rowsKey = rows
-    .map((row) => `${modelUsageKey(row.providerId, row.modelId)}:${row.totalTokens}`)
-    .join("|");
 
   return (
     <figure
       aria-label={t("profile.replayChartLabel", { chart: chartLabel })}
       className="react-profile-chart-card"
-      data-reveal-state={isRevealed ? "revealed" : "pending"}
+      data-reveal-state={revealState}
       onClick={replay}
       onKeyDown={(event) => handleChartReplayKeyDown(event, replay)}
       ref={figureRef}
@@ -473,7 +472,7 @@ function ModelUsageChart({
       <figcaption>
         <h3>{t("profile.modelChartTitle", { model: topLabel })}</h3>
       </figcaption>
-      <svg aria-label={chartLabel} key={`${rowsKey}:${replayKey}`} role="img" viewBox={`0 0 ${width} ${height}`}>
+      <svg aria-label={chartLabel} key={replayKey} role="img" viewBox={`0 0 ${width} ${height}`}>
         <title>{chartLabel}</title>
         <desc>{t("profile.modelChartDescription", { unit: formatCompactTokens(unit) })}</desc>
         {rows.map((row, rowIndex) => {
@@ -554,33 +553,81 @@ function profileModelTone(rowIndex: number): string {
   return tones[Math.min(rowIndex, tones.length - 1)];
 }
 
-function useChartReveal() {
+type ChartReveal = {
+  signature: string | null;
+  phase: "pending" | "revealing" | "settled";
+  epoch: number;
+};
+
+function useChartReveal(signature: string, renderable: boolean) {
   const figureRef = useRef<HTMLElement | null>(null);
-  const [isRevealed, setIsRevealed] = useState(false);
-  const [replayKey, setReplayKey] = useState(0);
+  const currentSignature = renderable ? signature : null;
+  const [reveal, setReveal] = useState<ChartReveal>({ signature: currentSignature, phase: "pending", epoch: 0 });
+
+  // Adjust before committing new marks: a filter must never inherit an old reveal.
+  if (reveal.signature !== currentSignature) {
+    setReveal({
+      ...reveal,
+      signature: currentSignature,
+      phase: reveal.signature === null && reveal.phase === "pending" ? "pending" : "settled",
+    });
+  }
+
+  useLayoutEffect(() => {
+    const preference = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const settle = () => {
+      if (preference.matches) setReveal((current) => ({ ...current, phase: "settled" }));
+    };
+    settle();
+    preference.addEventListener("change", settle);
+    return () => preference.removeEventListener("change", settle);
+  }, []);
 
   useEffect(() => {
+    if (reveal.phase !== "pending" || !renderable) return;
     const figure = figureRef.current;
     if (!figure) return;
+    const startReveal = () => setReveal((current) => current === reveal
+      ? { ...current, phase: "revealing" }
+      : current);
     if (typeof IntersectionObserver === "undefined") {
-      setIsRevealed(true);
+      startReveal();
       return;
     }
 
     const observer = new IntersectionObserver(([entry]) => {
       if (!entry?.isIntersecting) return;
-      setIsRevealed(true);
+      startReveal();
       observer.disconnect();
     }, { threshold: 0.3 });
     observer.observe(figure);
     return () => observer.disconnect();
-  }, []);
+  }, [renderable, reveal]);
+
+  useLayoutEffect(() => {
+    if (reveal.phase !== "revealing") return;
+    const animations = figureRef.current?.getAnimations?.({ subtree: true }) ?? [];
+    let disposed = false;
+    const settle = () => {
+      if (!disposed) setReveal((current) => current === reveal ? { ...current, phase: "settled" } : current);
+    };
+    if (!animations.length) settle();
+    else void Promise.all(animations.map((animation) => animation.finished.catch((cause: unknown) => {
+      if (!(cause instanceof DOMException && cause.name === "AbortError")) throw cause;
+    }))).then(settle);
+    return () => { disposed = true; };
+  }, [reveal]);
 
   const replay = () => {
-    if (isRevealed) setReplayKey((value) => value + 1);
+    if (reveal.phase === "pending") return;
+    setReveal((current) => ({
+      ...current,
+      epoch: current.epoch + 1,
+      phase: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "settled" : "revealing",
+    }));
   };
 
-  return { figureRef, isRevealed, replay, replayKey };
+  return { figureRef, revealState: reveal.phase, replay, replayKey: reveal.epoch };
 }
 
 function handleChartReplayKeyDown(event: ReactKeyboardEvent<HTMLElement>, replay: () => void): void {

--- a/src/react-workbench/settings/README.md
+++ b/src/react-workbench/settings/README.md
@@ -1,5 +1,5 @@
 # Settings Workbench
-<!-- tinybot-module-fingerprint: sha256:fe1677e95ba478dc61569783060a19f375fc9d9d8d8b9c44bcbf6079caa30e12 -->
+<!-- tinybot-module-fingerprint: sha256:1489ce295e40329d050cd827c307bfc1b87e60a04c1107cade316a4d2cd1ec20 -->
 
 `settings` owns the Settings route, its navigation, pages, sheets, appearance
 and language contexts, and form presentation. `SettingsRoute.tsx` is loaded as
@@ -37,6 +37,10 @@ views: the daily trend separates ordinary and peak values, while model rank
 moves through one blue luminance scale without relying on color alone. Charts
 reveal when they enter the viewport and replay when clicked or activated from
 the keyboard, while reduced-motion preferences render them without animation.
+Filtering or updating chart data settles geometry and labels immediately;
+SVG identity is tied only to explicit replay, so added model rows cannot replay
+an old entrance. Empty results preserve the chart's reveal history. Animation
+completion is scoped to the active run and cannot settle a later replay.
 
 `HooksSettingsPage` is backed by the separate optional Hooks store because its
 catalog and trust file are not ordinary config patches. It can inspect another
@@ -72,6 +76,10 @@ reuse its trigger, popover, selected state, keyboard navigation, and co-located
 stylesheet instead of rendering platform-native select menus. App-language
 choices keep their names and descriptions in each target language so they remain
 discoverable regardless of the currently selected interface language.
+Each choice menu owns the input source for its opening event, independently of
+shell-menu history. Pointer openings use the shared 160 ms anchored transition;
+keyboard openings are immediate. Reduced motion keeps only a 140 ms pointer
+fade, with keyboard behavior still immediate.
 The Agent Defaults time-zone choice lists runtime-supported IANA zones and
 starts from the Windows/system zone reported through `Intl`; Provider fallback
 and temperature remain owned by Provider/model configuration rather than being

--- a/src/react-workbench/settings/README.md
+++ b/src/react-workbench/settings/README.md
@@ -1,5 +1,5 @@
 # Settings Workbench
-<!-- tinybot-module-fingerprint: sha256:35a9f16f2afc7e2bf7fd126b105f80231f2029145f330e6174238b0c919a46dd -->
+<!-- tinybot-module-fingerprint: sha256:fe1677e95ba478dc61569783060a19f375fc9d9d8d8b9c44bcbf6079caa30e12 -->
 
 `settings` owns the Settings route, its navigation, pages, sheets, appearance
 and language contexts, and form presentation. `SettingsRoute.tsx` is loaded as

--- a/src/react-workbench/settings/SettingsChoiceList.css
+++ b/src/react-workbench/settings/SettingsChoiceList.css
@@ -122,6 +122,7 @@
 }
 
 .react-settings-choice-popover {
+  position: absolute;
   top: calc(100% + 8px);
   right: 0;
   left: 0;
@@ -129,6 +130,37 @@
   width: auto;
   max-height: 260px;
   overflow: auto;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transform-origin: top left;
+  transition:
+    opacity var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+@starting-style {
+  .react-settings-choice-popover[data-input-source="pointer"] {
+    opacity: 0;
+    transform: translateY(-4px) scale(.98);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .react-settings-choice-popover {
+    transform: none;
+    transition: opacity 140ms var(--motion-ease-standard);
+  }
+
+  @starting-style {
+    .react-settings-choice-popover[data-input-source="pointer"] {
+      transform: none;
+    }
+  }
+}
+
+.react-settings-choice-popover[data-input-source="keyboard"] {
+  transform: none;
+  transition: none;
 }
 
 .react-settings-choice-item {

--- a/src/react-workbench/settings/SettingsChoiceList.test.tsx
+++ b/src/react-workbench/settings/SettingsChoiceList.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { SettingsChoiceList } from "./SettingsChoiceList";
+
+afterEach(cleanup);
+
+function renderChoice(shellSource: "pointer" | "keyboard") {
+  const onChange = vi.fn();
+  render(
+    <div className="react-desktop-shell" data-menu-motion={shellSource}>
+      <SettingsChoiceList
+        label="Theme"
+        onChange={onChange}
+        options={[
+          { label: "System", value: "system" },
+          { label: "Light", value: "light" },
+          { disabled: true, label: "Unavailable", value: "unavailable" },
+          { label: "Dark", value: "dark" },
+        ]}
+        value="light"
+      />
+      <button type="button">Outside</button>
+    </div>,
+  );
+  return { onChange, trigger: screen.getByRole("button", { name: "Theme: Light" }) };
+}
+
+describe("SettingsChoiceList", () => {
+  test.each(["pointer", "keyboard"] as const)("uses its pointer opening under a %s shell", async (shellSource) => {
+    const user = userEvent.setup();
+    const { trigger } = renderChoice(shellSource);
+
+    await user.click(trigger);
+
+    const menu = screen.getByRole("menu");
+    expect(menu.dataset.inputSource).toBe("pointer");
+    expect(menu.classList.contains("react-top-menu__popover")).toBe(false);
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("menuitemradio", { name: "Light" })));
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+
+    await user.keyboard("{Enter}");
+    expect(screen.getByRole("menu").dataset.inputSource).toBe("keyboard");
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    await user.click(trigger);
+    expect(screen.getByRole("menu").dataset.inputSource).toBe("pointer");
+  });
+
+  test.each(["{Enter}", " ", "{ArrowDown}", "{ArrowUp}"])("opens immediately from %s and preserves keyboard selection", async (key) => {
+    const user = userEvent.setup();
+    const { trigger, onChange } = renderChoice("pointer");
+    trigger.focus();
+
+    await user.keyboard(key);
+
+    expect(screen.getByRole("menu").dataset.inputSource).toBe("keyboard");
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("menuitemradio", { name: "Light" })));
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(screen.getByRole("menuitemradio", { name: "Dark" }));
+    await user.keyboard("{Enter}");
+    expect(onChange).toHaveBeenCalledExactlyOnceWith("dark");
+    expect(screen.queryByRole("menu")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  test("treats assistive activation as immediate and dismisses on outside pointerdown", () => {
+    const { trigger } = renderChoice("pointer");
+    fireEvent.click(trigger, { detail: 0 });
+    expect(screen.getByRole("menu").dataset.inputSource).toBe("keyboard");
+
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  test("dismisses when Tab moves focus outside the choices", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderChoice("keyboard");
+    await user.click(trigger);
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("menuitemradio", { name: "Light" })));
+
+    await user.keyboard("{End}{Tab}");
+
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Outside" }));
+  });
+});

--- a/src/react-workbench/settings/SettingsChoiceList.tsx
+++ b/src/react-workbench/settings/SettingsChoiceList.tsx
@@ -41,6 +41,7 @@ export function SettingsChoiceList({
   const errorId = error ? `${id}-error` : undefined;
   const menuId = `${id}-menu`;
   const [open, setOpen] = useState(false);
+  const [inputSource, setInputSource] = useState<"pointer" | "keyboard">("pointer");
   const selectedOption = options.find((option) => option.value === value) ?? options[0];
   const selectedIndex = options.findIndex((option) => option.value === selectedOption?.value);
   const defaultFocusIndex = selectedIndex >= 0 && !options[selectedIndex]?.disabled
@@ -129,10 +130,14 @@ export function SettingsChoiceList({
         disabled={disabled}
         ref={triggerRef}
         type="button"
-        onClick={() => setOpen((current) => !current)}
+        onClick={(event) => {
+          setInputSource(event.detail === 0 ? "keyboard" : "pointer");
+          setOpen((current) => !current);
+        }}
         onKeyDown={(event) => {
           if (event.key === "ArrowDown" || event.key === "ArrowUp") {
             event.preventDefault();
+            setInputSource("keyboard");
             setOpen(true);
           }
         }}
@@ -146,7 +151,8 @@ export function SettingsChoiceList({
       {open ? (
         <div
           aria-label={optionsAriaLabel ?? t("choice.options", { label })}
-          className="react-popover-surface react-top-menu__popover react-settings-choice-popover"
+          className="react-popover-surface react-settings-choice-popover"
+          data-input-source={inputSource}
           id={menuId}
           role="menu"
           onKeyDown={onMenuKeyDown}

--- a/src/react-workbench/settings/SettingsRoute.css
+++ b/src/react-workbench/settings/SettingsRoute.css
@@ -2389,8 +2389,6 @@
   min-height: 0;
   max-height: 220px;
   overflow-y: auto;
-  scrollbar-color: color-mix(in srgb, var(--color-muted) 42%, transparent) transparent;
-  scrollbar-width: thin;
 }
 
 .react-default-model-picker__models-list > button {

--- a/src/react-workbench/settings/SettingsRoute.css
+++ b/src/react-workbench/settings/SettingsRoute.css
@@ -1912,17 +1912,34 @@
   opacity: 0;
 }
 
-.react-profile-chart-card[data-reveal-state="revealed"] .react-profile-chart__line {
+.react-profile-charts[hidden] {
+  display: none;
+}
+
+.react-profile-chart-card[data-reveal-state="revealing"] .react-profile-chart__line {
   animation: react-profile-chart-draw 1200ms cubic-bezier(0.165, 0.84, 0.44, 1) both;
 }
 
-.react-profile-chart-card[data-reveal-state="revealed"] .react-profile-chart__dot {
+.react-profile-chart-card[data-reveal-state="revealing"] .react-profile-chart__dot {
   animation: react-profile-chart-reveal 500ms cubic-bezier(0.165, 0.84, 0.44, 1) both;
 }
 
-.react-profile-chart-card[data-reveal-state="revealed"] .react-profile-chart__fade,
-.react-profile-chart-card[data-reveal-state="revealed"] .react-profile-chart__model-tick {
+.react-profile-chart-card[data-reveal-state="revealing"] .react-profile-chart__fade,
+.react-profile-chart-card[data-reveal-state="revealing"] .react-profile-chart__model-tick {
   animation: react-profile-chart-fade 900ms cubic-bezier(0.165, 0.84, 0.44, 1) both;
+}
+
+.react-profile-chart-card[data-reveal-state="settled"] .react-profile-chart__line {
+  animation: none;
+  stroke-dashoffset: 0;
+}
+
+.react-profile-chart-card[data-reveal-state="settled"] .react-profile-chart__dot,
+.react-profile-chart-card[data-reveal-state="settled"] .react-profile-chart__fade,
+.react-profile-chart-card[data-reveal-state="settled"] .react-profile-chart__model-tick {
+  animation: none;
+  opacity: 1;
+  transform: none;
 }
 
 .react-profile-chart__peak {

--- a/src/react-workbench/sidecar/README.md
+++ b/src/react-workbench/sidecar/README.md
@@ -1,5 +1,5 @@
 # Sidecar
-<!-- tinybot-module-fingerprint: sha256:a1b042ca7225c1f2789c1138b4be3d9f786fa026425d357880f3ddd317b74f9e -->
+<!-- tinybot-module-fingerprint: sha256:394bd3547d2de50a20c7c74deac1afa2d1d72f95b1523acc1ce12e5c74ee82c3 -->
 
 `sidecar` owns the React resource shell displayed beside Chat. It presents
 thread-scoped Browser and Artifact resources, workspace-scoped Terminal
@@ -38,9 +38,17 @@ resize handle. Width is persisted separately from resource state. The live and
 restored width is clamped against the measured Chat workspace: docked mode
 preserves the minimum Chat column, while narrow overlay mode preserves a
 viewport gutter.
+Direct pointer, keyboard and viewport-clamp width updates are immediate; the
+ephemeral reducer `layoutMotion` policy restores the 220 ms grid transition
+when presentation changes. Only numeric width is persisted.
 The shell stays mounted but inert while hidden so its layout can transition in
-either direction; active resource surfaces still unmount immediately and keep
-their existing native lifecycle boundaries.
+either direction. React content remains until its grid/overlay exit finishes;
+the shell also keeps its last visible presentation during that exit so an
+expanded panel does not snap back to docked width on close.
+Reopening invalidates pending removal, and changing owner scope or active tab
+discards incompatible retained content. Browser native visibility becomes false
+immediately on logical close, independently of retained React chrome. Hiding
+does not terminate browser or terminal resources.
 The resource menu reuses the global popover surface and item interaction states;
 Sidecar CSS retains only its anchored placement and two-line resource layout.
 

--- a/src/react-workbench/sidecar/README.md
+++ b/src/react-workbench/sidecar/README.md
@@ -1,5 +1,5 @@
 # Sidecar
-<!-- tinybot-module-fingerprint: sha256:d330183c778e96280b12824c0411ba05cb3aae32ec54c31ef5d12d742de0801e -->
+<!-- tinybot-module-fingerprint: sha256:a1b042ca7225c1f2789c1138b4be3d9f786fa026425d357880f3ddd317b74f9e -->
 
 `sidecar` owns the React resource shell displayed beside Chat. It presents
 thread-scoped Browser and Artifact resources, workspace-scoped Terminal

--- a/src/react-workbench/sidecar/Sidecar.test.tsx
+++ b/src/react-workbench/sidecar/Sidecar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Sidecar } from "./Sidecar";
@@ -20,6 +20,7 @@ const tabs: SidecarTab[] = [
 
 function renderSidecar(overrides: Partial<Parameters<typeof Sidecar>[0]> = {}) {
   const props: Parameters<typeof Sidecar>[0] = {
+    scopeKey: "thread-1",
     activeTabId: "terminal-1",
     canCreateBrowser: true,
     canCreateTerminal: true,
@@ -59,6 +60,47 @@ function mockWorkspaceWidth(readWidth: () => number) {
 }
 
 describe("Sidecar", () => {
+  it("retains closing browser chrome while hiding its native surface and cancels stale exits", async () => {
+    const { props, rerender } = renderSidecar({ activeTabId: "browser-1" });
+    const aside = screen.getByLabelText("Sidecar");
+    let finish!: () => void;
+    const animation = {
+      transitionProperty: "transform",
+      playState: "running",
+      finished: new Promise<void>((resolve) => { finish = resolve; }),
+    };
+    Object.defineProperty(aside, "getAnimations", { value: () => [animation], configurable: true });
+    rerender(<Sidecar {...props} presentation="closed" />);
+    expect(aside.hasAttribute("inert")).toBe(true);
+    expect(screen.getByText("Browser surface hidden")).toBeTruthy();
+    rerender(<Sidecar {...props} />);
+    await act(async () => { animation.playState = "finished"; finish(); });
+    expect(screen.getByText("Browser surface visible")).toBeTruthy();
+    rerender(<Sidecar {...props} presentation="closed" />);
+    expect(screen.queryByText(/Browser surface/)).toBeNull();
+    expect(props.onCloseTab).not.toHaveBeenCalled();
+  });
+
+  it("waits for the desktop grid exit, but removes incompatible content on scope changes", async () => {
+    const { props, rerender } = renderSidecar({ presentation: "expanded" });
+    const aside = screen.getByLabelText("Sidecar");
+    let finish!: () => void;
+    const animation = {
+      transitionProperty: "grid-template-columns",
+      playState: "running",
+      finished: new Promise<void>((resolve) => { finish = resolve; }),
+    };
+    Object.defineProperty(aside.parentElement, "getAnimations", { value: () => [animation], configurable: true });
+    rerender(<Sidecar {...props} presentation="closed" />);
+    expect(aside.dataset.presentation).toBe("expanded");
+    expect(screen.getByText("Terminal surface")).toBeTruthy();
+    rerender(<Sidecar {...props} presentation="closed" scopeKey="different-thread" />);
+    expect(aside.dataset.presentation).toBe("closed");
+    expect(screen.queryByText("Terminal surface")).toBeNull();
+    await act(async () => { animation.playState = "finished"; finish(); });
+    expect(props.onCloseTab).not.toHaveBeenCalled();
+  });
+
   it("keeps a non-interactive shell mounted while closed", () => {
     const renderTerminal = vi.fn(() => <p>Terminal surface</p>);
     const { container } = renderSidecar({ presentation: "closed", renderTerminal });

--- a/src/react-workbench/sidecar/Sidecar.tsx
+++ b/src/react-workbench/sidecar/Sidecar.tsx
@@ -11,6 +11,7 @@ import {
   X,
 } from "lucide-react";
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -21,6 +22,7 @@ import {
   type ReactNode,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { elementTransitions, useExitPresence } from "../lib/useExitPresence";
 import {
   maxSidecarWidthForWorkspace,
   MIN_SIDECAR_WIDTH,
@@ -34,6 +36,7 @@ import {
 import "./Sidecar.css";
 
 export type SidecarProps = {
+  scopeKey: string;
   activeTabId: string;
   canCreateBrowser: boolean;
   canCreateTerminal: boolean;
@@ -53,6 +56,7 @@ export type SidecarProps = {
 };
 
 export function Sidecar({
+  scopeKey,
   activeTabId,
   canCreateBrowser,
   canCreateTerminal,
@@ -85,6 +89,18 @@ export function Sidecar({
   const activeTab = tabs.find((tab) => tab.id === activeTabId);
   const hidden = presentation === "closed";
   const expanded = presentation === "expanded";
+  const [visiblePresentation, setVisiblePresentation] = useState(presentation);
+  if (!hidden && visiblePresentation !== presentation) setVisiblePresentation(presentation);
+  const readExitTransitions = useCallback(() => [
+    ...elementTransitions(sidecarRef.current, ["transform"]),
+    ...elementTransitions(sidecarRef.current?.parentElement ?? null, ["grid-template-columns"]),
+  ], []);
+  const presentTabId = useExitPresence(
+    hidden ? null : activeTabId,
+    JSON.stringify([scopeKey, activeTabId]),
+    readExitTransitions,
+  );
+  const contentPresent = presentTabId !== null;
 
   useEffect(() => {
     setNewTabMenuOpen(false);
@@ -244,7 +260,7 @@ export function Sidecar({
       aria-label={hidden ? undefined : t("sidecar.label")}
       className="react-sidecar"
       data-hidden={hidden}
-      data-presentation={presentation}
+      data-presentation={hidden && contentPresent ? visiblePresentation : presentation}
       inert={hidden || undefined}
       ref={sidecarRef}
       style={{ "--react-sidecar-width": `${width}px` } as CSSProperties}
@@ -381,12 +397,12 @@ export function Sidecar({
         id="tinybot-sidecar-panel"
         role="tabpanel"
       >
-        {!hidden && activeTab?.kind === "browser" ? renderBrowser(activeTab, !newTabMenuOpen) : null}
-        {!hidden && activeTab?.kind === "terminal" ? renderTerminal(activeTab) : null}
-        {!hidden && activeTab?.kind === "artifact" ? (
+        {contentPresent && activeTab?.kind === "browser" ? renderBrowser(activeTab, !hidden && !newTabMenuOpen) : null}
+        {contentPresent && activeTab?.kind === "terminal" ? renderTerminal(activeTab) : null}
+        {contentPresent && activeTab?.kind === "artifact" ? (
           <div className="react-sidecar__artifact">{renderArtifact(activeTab)}</div>
         ) : null}
-        {!hidden && !activeTab ? (
+        {contentPresent && !activeTab ? (
           <SidecarEmptyState
             canCreateBrowser={canCreateBrowser}
             canCreateTerminal={canCreateTerminal}

--- a/src/react-workbench/sidecar/SidecarTerminal.css
+++ b/src/react-workbench/sidecar/SidecarTerminal.css
@@ -16,11 +16,6 @@
   height: 100%;
 }
 
-.react-sidecar-terminal__surface .xterm-viewport {
-  scrollbar-color: #68635b transparent;
-  scrollbar-width: thin;
-}
-
 .react-sidecar-terminal__unavailable {
   display: grid;
   height: 100%;

--- a/src/react-workbench/sidecar/SidecarTerminal.tsx
+++ b/src/react-workbench/sidecar/SidecarTerminal.tsx
@@ -59,6 +59,9 @@ export function SidecarTerminal({
         cursor: "#f3eee5",
         foreground: "#f3eee5",
         selectionBackground: "#766d5f80",
+        scrollbarSliderBackground: "#f3eee52e",
+        scrollbarSliderHoverBackground: "#f3eee566",
+        scrollbarSliderActiveBackground: "#f3eee580",
       },
     });
     const fitAddon = new FitAddon();

--- a/src/react-workbench/sidecar/sidecarModel.test.ts
+++ b/src/react-workbench/sidecar/sidecarModel.test.ts
@@ -22,6 +22,27 @@ function scopedState(threadId = "thread-1", workspaceId = "D:/code/tinybot") {
 }
 
 describe("sidecar resource tabs", () => {
+  it("applies direct resize immediately and restores motion only for presentation changes", () => {
+    let state = reduceSidecarState(scopedState(), { type: "tab.newTerminal" });
+    for (const width of [504, 700, 999, 999]) {
+      state = reduceSidecarState(state, { type: "presentation.resize", width, maxWidth: 720 });
+      expect(state.layoutMotion).toBe("instant");
+      expect(state.width).toBe(Math.min(width, 720));
+    }
+    state = reduceSidecarState(state, { type: "tab.activate", tabId: state.activeTabId });
+    expect(state.layoutMotion).toBe("instant");
+    for (const type of ["presentation.hide", "presentation.show", "presentation.toggleExpanded"] as const) {
+      state = reduceSidecarState(state, { type });
+      expect(state.layoutMotion).toBe("animated");
+      state = reduceSidecarState(state, { type: "presentation.resize", width: 480, maxWidth: 720 });
+    }
+    state = reduceSidecarState(state, { type: "presentation.hide" });
+    state = reduceSidecarState(state, { type: "presentation.resize", width: 480, maxWidth: 720 });
+    state = reduceSidecarState(state, { type: "tab.newBrowser" });
+    expect(state.layoutMotion).toBe("animated");
+    expect(state.presentation).toBe("docked");
+  });
+
   it("creates browser and terminal resources in the current scope", () => {
     let state = scopedState();
     state = reduceSidecarState(state, { type: "tab.newBrowser" });

--- a/src/react-workbench/sidecar/sidecarModel.ts
+++ b/src/react-workbench/sidecar/sidecarModel.ts
@@ -46,6 +46,7 @@ export type SidecarState = {
   currentWorkspaceId: string;
   nextResourceSequence: number;
   presentation: SidecarPresentation;
+  layoutMotion: "animated" | "instant";
   tabs: SidecarTab[];
   width: number;
 };
@@ -75,12 +76,21 @@ export function createInitialSidecarState(width = DEFAULT_SIDECAR_WIDTH): Sideca
     currentWorkspaceId: "",
     nextResourceSequence: 1,
     presentation: "closed",
+    layoutMotion: "animated",
     tabs: [],
     width: clampSidecarWidth(width, Number.POSITIVE_INFINITY),
   };
 }
 
 export function reduceSidecarState(state: SidecarState, event: SidecarEvent): SidecarState {
+  const next = reduceSidecarEvent(state, event);
+  const layoutMotion = next.presentation !== state.presentation
+    ? "animated"
+    : event.type === "presentation.resize" ? "instant" : state.layoutMotion;
+  return next.layoutMotion === layoutMotion ? next : { ...next, layoutMotion };
+}
+
+function reduceSidecarEvent(state: SidecarState, event: SidecarEvent): SidecarState {
   switch (event.type) {
     case "scope.changed": {
       const scoped = {

--- a/src/react-workbench/startupSplash.test.ts
+++ b/src/react-workbench/startupSplash.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dismissStartupSplash, removeStartupSplash } from "./startupSplash";
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="tinybot-startup"><img alt="" /></div><div id="root">Workbench</div>';
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("startup splash", () => {
+  it("waits for the logo entrance, fades once, and preserves the mounted workbench", async () => {
+    const splash = document.getElementById("tinybot-startup")!;
+    const entrance = pendingAnimation();
+    const fade = pendingAnimation();
+    const animate = vi.fn(() => ({ finished: fade.finished }));
+    Object.assign(splash, { getAnimations: () => [{ finished: entrance.finished }], animate });
+
+    const dismissed = dismissStartupSplash();
+    await dismissStartupSplash();
+    expect(animate).not.toHaveBeenCalled();
+    entrance.finish();
+    await vi.waitFor(() => expect(animate).toHaveBeenCalledTimes(1));
+    expect(splash.isConnected).toBe(true);
+    fade.finish();
+    await dismissed;
+    expect(splash.isConnected).toBe(false);
+    expect(document.getElementById("root")?.textContent).toBe("Workbench");
+  });
+
+  it("removes the surface immediately with reduced motion", async () => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    Object.defineProperty(media, "matches", { value: true });
+    vi.spyOn(window, "matchMedia").mockReturnValue(media);
+    await dismissStartupSplash();
+    expect(document.getElementById("tinybot-startup")).toBeNull();
+  });
+
+  it("does not start a fade after an error removes the loading surface", async () => {
+    const splash = document.getElementById("tinybot-startup")!;
+    const entrance = pendingAnimation();
+    const animate = vi.fn();
+    Object.assign(splash, { getAnimations: () => [{ finished: entrance.finished }], animate });
+    const dismissed = dismissStartupSplash();
+    removeStartupSplash();
+    entrance.cancel(new DOMException("Removed", "AbortError"));
+    await dismissed;
+    expect(animate).not.toHaveBeenCalled();
+    expect(document.getElementById("tinybot-startup")).toBeNull();
+  });
+
+  it("finishes an active fade when reduced motion is enabled", async () => {
+    const splash = document.getElementById("tinybot-startup")!;
+    const fade = pendingAnimation();
+    const finish = vi.fn(fade.finish);
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    vi.spyOn(window, "matchMedia").mockReturnValue(media);
+    const animate = vi.fn(() => ({ finished: fade.finished, finish }));
+    Object.assign(splash, { getAnimations: () => [], animate });
+    const dismissed = dismissStartupSplash();
+    await vi.waitFor(() => expect(animate).toHaveBeenCalledOnce());
+    Object.defineProperty(media, "matches", { value: true });
+    media.dispatchEvent(new Event("change"));
+    await dismissed;
+    expect(finish).toHaveBeenCalledOnce();
+    expect(splash.isConnected).toBe(false);
+  });
+});
+
+function pendingAnimation() {
+  let finish!: () => void;
+  let cancel!: (error: DOMException) => void;
+  const finished = new Promise<void>((resolve, reject) => { finish = resolve; cancel = reject; });
+  return { finished, finish, cancel };
+}

--- a/src/react-workbench/startupSplash.ts
+++ b/src/react-workbench/startupSplash.ts
@@ -1,0 +1,46 @@
+/** The HTML splash is independent of React so it covers bundle loading too. */
+export function removeStartupSplash(): void {
+  document.getElementById("tinybot-startup")?.remove();
+}
+
+export async function dismissStartupSplash(): Promise<void> {
+  const splash = document.getElementById("tinybot-startup");
+  if (!splash || splash.dataset.dismissing) return;
+  splash.dataset.dismissing = "true";
+  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+  if (reducedMotion.matches) {
+    splash.remove();
+    return;
+  }
+
+  // Finish the short logo entrance, without adding a minimum loading timeout.
+  await Promise.all(splash.getAnimations({ subtree: true }).map(waitForAnimation));
+  if (!splash.isConnected) return;
+  if (reducedMotion.matches) {
+    splash.remove();
+    return;
+  }
+
+  const fade = splash.animate([{ opacity: 1 }, { opacity: 0 }], {
+    duration: 180,
+    easing: "ease-out",
+    fill: "forwards",
+  });
+  const onMotionChange = () => { if (reducedMotion.matches) fade.finish(); };
+  reducedMotion.addEventListener("change", onMotionChange);
+  try {
+    await waitForAnimation(fade);
+  } finally {
+    reducedMotion.removeEventListener("change", onMotionChange);
+    splash.remove();
+  }
+}
+
+async function waitForAnimation(animation: Animation): Promise<void> {
+  try {
+    await animation.finished;
+  } catch (error) {
+    // Removing the splash on failure or disabling motion cancels CSS animations.
+    if (!(error instanceof DOMException && error.name === "AbortError")) throw error;
+  }
+}

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:c9f8cb6375b0777d081b74559b3fdf921dff5f68730d4e630c98448528e3d41e -->
+<!-- tinybot-module-fingerprint: sha256:e87004cb50263baff9b358f7c530b6ee0ea481c7fd8b2c28cfed51debe537791 -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.
@@ -31,6 +31,9 @@ The desktop session sidebar uses workspace headers and complete session rows as
 drag sources, with a grab cursor and high-contrast insertion line but no
 separate grip control. Dragging lowers the source opacity while keeping its
 footprint stable; reduced-motion mode retains these static state cues.
+Session-row entrance styles apply only to the workspace's explicitly eligible
+initial rows, with a bounded 30 ms stagger. Ordinary search/navigation never
+inherits an entrance animation from the list container.
 Its search action expands from the compact icon into a full-width inline input;
 focus-within styling keeps the active boundary visible and reduced-motion mode
 shortens the reveal through the shared global motion rule.

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,8 +1,18 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:b88dd4ca403559cc105f63dc980ab8e00fc0f543b1d9458fbb0053b05d704f46 -->
+<!-- tinybot-module-fingerprint: sha256:c9f8cb6375b0777d081b74559b3fdf921dff5f68730d4e630c98448528e3d41e -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.
+
+Shared scrollbar tokens keep native overflow thumbs quiet against the current
+theme, with stronger hover and drag states and transparent tracks. Desktop
+WebViews use thumb-local pseudo-element styling; browsers without that support
+use standard scrollbar colors on container hover. Route CSS must not set
+`scrollbar-color` or a non-auto `scrollbar-width` for visible desktop scrollbars,
+because those properties override the shared pseudo-element styling. Hidden tab
+scrollers retain their existing rules, and forced-colors mode uses system styling.
+The Sidecar terminal configures the equivalent states through xterm's slider
+theme because its scrollbar is rendered by xterm rather than the browser.
 
 Menu-like floating surfaces use `react-popover-surface` and
 `react-popover-item` as the single visual authority for shell, selection,

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1623,9 +1623,9 @@ button:disabled {
   bottom: -3px;
 }
 
-.react-session-list__rows[data-motion="animated-list"] .react-session-row {
+.react-session-row[data-entering="true"] {
   animation: react-list-enter var(--motion-duration-medium) var(--motion-ease-standard) both;
-  animation-delay: calc(var(--react-session-row-index, 0) * 22ms);
+  animation-delay: calc(var(--react-session-row-index, 0) * 30ms);
 }
 
 .react-session-row[data-active="true"],
@@ -1722,7 +1722,6 @@ button:disabled {
   color: var(--color-error);
 }
 
-.react-session-list__rows[data-motion="animated-list"] .react-session-row[data-dissolving="true"],
 .react-session-row[data-dissolving="true"] {
   pointer-events: none;
   opacity: 0;
@@ -2101,7 +2100,7 @@ button:disabled {
     scroll-behavior: auto !important;
   }
 
-  .react-session-list__rows[data-motion="animated-list"] .react-session-row {
+  .react-session-row[data-entering="true"] {
     opacity: 1;
     transform: none;
     animation: none !important;

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -9,6 +9,9 @@
   --color-body: #3d3d3a;
   --color-muted: #6c6a64;
   --color-muted-soft: #8e8b82;
+  --color-scrollbar-thumb: color-mix(in srgb, var(--color-ink) 16%, transparent);
+  --color-scrollbar-thumb-hover: color-mix(in srgb, var(--color-ink) 42%, transparent);
+  --color-scrollbar-thumb-active: color-mix(in srgb, var(--color-ink) 56%, transparent);
   --color-primary: #cc785c;
   --color-primary-active: #a9583e;
   --color-on-primary: #fff;
@@ -48,6 +51,56 @@
 
 * {
   box-sizing: border-box;
+}
+
+/* Keep hover local to the thumb in the desktop WebView. A non-auto standard
+   scrollbar-color/width would override these pseudo-elements in Chromium. */
+@media (forced-colors: none) {
+  @supports selector(::-webkit-scrollbar) {
+    ::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
+
+    ::-webkit-scrollbar-track,
+    ::-webkit-scrollbar-corner {
+      background: transparent;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      min-height: 28px;
+      min-width: 28px;
+      border: 2px solid transparent;
+      border-radius: 999px;
+      background: var(--color-scrollbar-thumb);
+      background-clip: padding-box;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background-color: var(--color-scrollbar-thumb-hover);
+    }
+
+    ::-webkit-scrollbar-thumb:active {
+      background-color: var(--color-scrollbar-thumb-active);
+    }
+
+    ::-webkit-scrollbar-button {
+      display: none;
+      width: 0;
+      height: 0;
+    }
+  }
+
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: var(--color-scrollbar-thumb) transparent;
+    }
+
+    *:hover {
+      scrollbar-color: var(--color-scrollbar-thumb-hover) transparent;
+    }
+  }
 }
 
 html,


### PR DESCRIPTION
## Summary

Make the desktop workbench quieter and more responsive, and expose per-turn performance without interrupting the conversation.

- Show elapsed time beneath completed turns, with available output speed and time to first token in the details popover. Carry optional timing metadata through runtime events and persisted projections while keeping older history compatible; no storage migration is required.
- Add a white startup splash with a centered logo, and lighten scrollbars until thumb hover or dragging.
- Make timeline, reasoning, and tool disclosure transitions reversible. Keep drawer and Sidecar content present through closing, cancel stale removal on reopening, and preserve native browser visibility boundaries.
- Apply Sidecar resizing immediately, bound initial session-list entrances, display chart filter updates without replaying their entrance, and distinguish pointer from keyboard openings in settings menus.

## Validation

- Full frontend suite: 131 test files, 791 tests passed.
- TypeScript checks and production build passed.
- Engineering documentation and module README freshness checks passed.
- Browser checks with real components and local fixture data covered pointer/keyboard resize, desktop and overlay panel reversal, expanded-panel closing, 60-session search/restore, chart filtering and explicit replay, settings menu input sources, and reduced motion.
- Native browser visibility is covered by an adapter integration regression test; actual Windows WebView2 layering has not been smoke-tested in this change.

Local implementation plans and unrelated working-tree files are excluded.
