### PR TITLE
Stabilize workspace ordering and polish sidebar and settings UI

### DIFF
--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -116,7 +116,7 @@
   justify-items: center;
   overflow: visible;
   padding-top: 32px;
-  padding-bottom: 32px;
+  padding-bottom: clamp(48px, 10vh, 112px);
 }
 
 .react-empty-chat-start {
@@ -165,7 +165,7 @@
   font: inherit;
   font-size: 20px;
   font-weight: 650;
-  line-height: 1;
+  line-height: 1.4;
   cursor: pointer;
   transition: border-color var(--motion-duration-fast), background var(--motion-duration-fast);
 }
@@ -4423,7 +4423,7 @@
   }
 
   .react-chat-surface[data-empty-session="true"] .react-conversation-view {
-    padding: 24px 18px;
+    padding: 24px 18px clamp(32px, 6vh, 56px);
   }
 
   .react-empty-chat-start {

--- a/src/react-workbench/chat/ChatPage.sessions.test.tsx
+++ b/src/react-workbench/chat/ChatPage.sessions.test.tsx
@@ -17,6 +17,42 @@ import {
 } from "./test/ChatPageTestHarness";
 
 describe("ChatPage", () => {
+  it("keeps an imported workspace in place after leaving its untouched draft", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    const workingDirectory = "D:\\Code\\VirtualHome";
+    nativeWorkspacePickerMocks.pickDesktopWorkspaceDirectory.mockResolvedValueOnce(workingDirectory);
+    const props = { chatStore: stores.chatStore, sessionStore: stores.sessionStore };
+    const view = render(<ChatPage {...props} />);
+
+    const sidebar = await screen.findByLabelText("Sessions");
+    await user.click(within(sidebar).getByRole("button", { name: "Workspace and project actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Add workspace folder" }));
+    expect(await within(sidebar).findByRole("group", { name: "Workspace VirtualHome" })).toBeTruthy();
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    const workspaceOrder = () => within(sidebar).getAllByRole("group", { name: /^Workspace / })
+      .map((group) => group.getAttribute("aria-label"));
+    const importedOrder = workspaceOrder();
+
+    await user.click(within(sidebar).getByRole("button", { name: "Planning notes" }));
+    expect(screen.queryByRole("tab", { name: "New chat" })).toBeNull();
+    expect(within(sidebar).queryByRole("group", { name: "Workspace VirtualHome" })).not.toBeNull();
+    expect(workspaceOrder()).toEqual(importedOrder);
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+
+    view.unmount();
+    render(<ChatPage {...props} />);
+    const restoredSidebar = await screen.findByLabelText("Sessions");
+    const restoredWorkspace = await within(restoredSidebar).findByRole("group", { name: "Workspace VirtualHome" });
+    expect(within(restoredSidebar).getAllByRole("group", { name: /^Workspace / })
+      .map((group) => group.getAttribute("aria-label"))).toEqual(importedOrder);
+    await user.click(within(restoredWorkspace).getByRole("button", { name: "New session in VirtualHome" }));
+    expect(stores.sessionStore.create).not.toHaveBeenCalled();
+    await user.type(screen.getByRole("textbox", { name: /message/i }), "Inspect this workspace");
+    await user.click(screen.getByRole("button", { name: /send message/i }));
+    await waitFor(() => expect(stores.sessionStore.create).toHaveBeenCalledWith({ workingDirectory }));
+  });
+
   it("starts in an uncreated conversation instead of restoring saved session tabs", async () => {
     const stores = createStores();
     window.localStorage.setItem(CHAT_SESSION_TABS_STORAGE_KEY, JSON.stringify({

--- a/src/react-workbench/chat/ChatSessionWorkspace.test.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.test.tsx
@@ -20,6 +20,28 @@ afterEach(() => {
 });
 
 describe("ChatSessionWorkspace", () => {
+  test("keeps workspace order when session recency changes, including after remount", async () => {
+    const first = { ...planningSession(), title: "First workspace chat", updatedAtMs: 30 };
+    const older = { ...first, id: "older", title: "Older chat", updatedAtMs: 10 };
+    const second = { ...first, id: "second", title: "Second workspace chat", workingDirectory: "D:\\Code\\another", updatedAtMs: 20 };
+    const workspaceRegistryStore = createWorkspaceRegistryStore([first, second]);
+    const view = renderWorkspace({ sessions: [first, second, older], workspaceRegistryStore });
+    await act(async () => undefined);
+    const rows = screen.getByLabelText("Session list rows");
+    const originalOrder = sidebarGroupLabels(rows);
+    const updated = [{ ...second, updatedAtMs: 60 }, { ...older, updatedAtMs: 50 }, first];
+
+    view.rerenderSessions(updated);
+    expect(sidebarGroupLabels(rows)).toEqual(originalOrder);
+    expect(sessionTitles(screen.getByRole("group", { name: "Workspace tinybot" })))
+      .toEqual(["Older chat", "First workspace chat"]);
+
+    view.unmount();
+    renderWorkspace({ sessions: updated, workspaceRegistryStore });
+    await act(async () => undefined);
+    expect(sidebarGroupLabels(screen.getByLabelText("Session list rows"))).toEqual(originalOrder);
+  });
+
   test("bounds first content entrance to three rows across groups and consumes each animation", () => {
     renderWorkspace({ sessions: manySessions() });
     const rows = screen.getByLabelText("Session list rows");
@@ -29,7 +51,7 @@ describe("ChatSessionWorkspace", () => {
     expect(entering.map((row) => row.style.getPropertyValue("--react-session-row-index")))
       .toEqual(["0", "1", "2"]);
     expect(entering.map((row) => row.closest("[role='group']")?.getAttribute("aria-label")))
-      .toEqual(["Workspace group-0", "Workspace group-1", "Workspace group-2"]);
+      .toEqual(["Workspace group-0", "Workspace group-1", "Workspace group-10"]);
 
     fireEvent.animationEnd(entering[0], { animationName: "unrelated-animation" });
     fireEvent.animationEnd(entering[0].querySelector("button")!, { animationName: "react-list-enter" });
@@ -175,7 +197,7 @@ describe("ChatSessionWorkspace", () => {
     expect(manageButton.closest(".react-session-workspace__actions")?.parentElement).toBe(workspace);
   });
 
-  test("drags workspace groups into a persisted user order", () => {
+  test("drags workspace groups into a persisted user order", async () => {
     const sessions = [
       planningSession(),
       {
@@ -187,6 +209,7 @@ describe("ChatSessionWorkspace", () => {
       },
     ];
     const rendered = renderWorkspace({ sessions });
+    await act(async () => undefined);
     const rows = screen.getByLabelText("Session list rows");
     expect(sidebarGroupLabels(rows)).toEqual(["Workspace tinybot", "Workspace release"]);
 
@@ -202,6 +225,7 @@ describe("ChatSessionWorkspace", () => {
 
     rendered.unmount();
     renderWorkspace({ sessions });
+    await act(async () => undefined);
     expect(sidebarGroupLabels(screen.getByLabelText("Session list rows")))
       .toEqual(["Workspace release", "Workspace tinybot"]);
   });

--- a/src/react-workbench/chat/ChatSessionWorkspace.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.tsx
@@ -13,7 +13,6 @@ import {
 import {
   CirclePlus,
   ChevronLeft,
-  ChevronRight,
   Folder,
   FolderOpen,
   FolderPlus,
@@ -263,7 +262,15 @@ export function ChatSessionWorkspace({
           workingDirectory: workspace.path,
         }];
       });
-      return [...groups, ...emptyRegisteredGroups];
+      const registryOrder = new Map(workspaces.map((workspace, index) => [
+        `session-workspace:${normalizedWorkspacePathKey(workspace.path)}`,
+        index,
+      ]));
+      const workspaceRank = (workspace: (typeof groups)[number]) => registryOrder.get(workspace.key)
+        ?? (workspace.workingDirectory ? workspaces.length : workspaces.length + 1);
+      return [...groups, ...emptyRegisteredGroups].sort((left, right) => (
+        workspaceRank(left) - workspaceRank(right) || left.key.localeCompare(right.key)
+      ));
     },
     [normalizedSearchQuery, projectGroups, projectProjection.ungroupedSessions, t, workspaceByKey, workspaces],
   );
@@ -515,6 +522,7 @@ export function ChatSessionWorkspace({
           }}
           onKeyDown={(event) => moveSidebarItemWithKeyboard(event, reorderItem, currentItems)}
         >
+          <span aria-hidden="true" className="react-session-row__icon-placeholder" />
           <span className="react-session-row__title">{sessionLabel}</span>
           <small>{formatRelativeUpdatedTime(session.updatedAtMs, now())}</small>
         </button>
@@ -826,14 +834,12 @@ export function ChatSessionWorkspace({
                       onDrop={(event) => dropSidebarItem(event, reorderItem, rootOrderItems)}
                       onKeyDown={(event) => moveSidebarItemWithKeyboard(event, reorderItem, rootOrderItems)}
                     >
-                      <ChevronRight aria-hidden="true" className="react-session-workspace__chevron" size={14} />
                       <span aria-hidden="true" className="react-session-workspace__folder">
                         <Folder className="react-session-workspace__folder-icon--collapsed" size={15} />
                         <FolderOpen className="react-session-workspace__folder-icon--expanded" size={15} />
                       </span>
                       <span className="react-session-workspace__copy">
                         <strong>{workspace.label}</strong>
-                        {workspace.workingDirectory ? <small>{workspace.workingDirectory}</small> : null}
                       </span>
                     </summary>
                     <div className="react-session-workspace__sessions">
@@ -911,7 +917,6 @@ export function ChatSessionWorkspace({
                   onDrop={(event) => dropSidebarItem(event, reorderItem, rootOrderItems)}
                   onKeyDown={(event) => moveSidebarItemWithKeyboard(event, reorderItem, rootOrderItems)}
                 >
-                  <ChevronRight aria-hidden="true" className="react-project-group__chevron" size={14} />
                   <GitBranch aria-hidden="true" className="react-project-group__icon" size={15} />
                   <strong>{projectGroup.project.name}</strong>
                 </summary>
@@ -993,31 +998,32 @@ export function ChatSessionWorkspace({
                         <Folder aria-hidden="true" size={13} />
                         <span>
                           <strong>{workspace.label}</strong>
-                          <small>{workspace.workspaceId}</small>
                         </span>
-                        <button
-                          aria-label={t("projectGroups.newWorkspaceSession", { name: workspace.label })}
-                          disabled={createPending || registeredWorkspace?.exists === false}
-                          draggable={false}
-                          onClick={() => void actions.onCreateSession(workspace.workspaceId, {
-                            projectGroupId: projectGroup.project.projectGroupId,
-                          })}
-                          title={t("projectGroups.newWorkspaceSession", { name: workspace.label })}
-                          type="button"
-                        >
-                          <Plus aria-hidden="true" size={13} />
-                        </button>
-                        {registeredWorkspace ? (
+                        <div className="react-project-group__member-actions">
                           <button
-                            aria-label={t("workspaces.manage", { name: workspace.label })}
+                            aria-label={t("projectGroups.newWorkspaceSession", { name: workspace.label })}
+                            disabled={createPending || registeredWorkspace?.exists === false}
                             draggable={false}
-                            onClick={() => setWorkspaceDialogPath(registeredWorkspace.path)}
-                            title={t("workspaces.manage", { name: workspace.label })}
+                            onClick={() => void actions.onCreateSession(workspace.workspaceId, {
+                              projectGroupId: projectGroup.project.projectGroupId,
+                            })}
+                            title={t("projectGroups.newWorkspaceSession", { name: workspace.label })}
                             type="button"
                           >
-                            <MoreHorizontal aria-hidden="true" size={13} />
+                            <Plus aria-hidden="true" size={13} />
                           </button>
-                        ) : null}
+                          {registeredWorkspace ? (
+                            <button
+                              aria-label={t("workspaces.manage", { name: workspace.label })}
+                              draggable={false}
+                              onClick={() => setWorkspaceDialogPath(registeredWorkspace.path)}
+                              title={t("workspaces.manage", { name: workspace.label })}
+                              type="button"
+                            >
+                              <MoreHorizontal aria-hidden="true" size={13} />
+                            </button>
+                          ) : null}
+                        </div>
                       </div>
                       <div className="react-project-workspace__sessions">
                         {renderSidebarSessionRows(

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:b934f412d4581224c76f8e6695afb4f0abfdda745cb08de2a700383b2eeab62d -->
+<!-- tinybot-module-fingerprint: sha256:7657e9924d99274304e420938cc21e07ee90d66460d04d5df887b79058302cb7 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -237,7 +237,10 @@ grip control. Their existing focus targets also support `Alt+ArrowUp` and
 discovered blocks and sessions appear ahead of a saved manual order; stale saved
 IDs are ignored. Invalid persisted state is reported through the
 `session-sidebar-order` diagnostic boundary before the sidebar returns to its
-natural recency order.
+default grouping order. Session recency affects only the rows within a group.
+Workspace groups follow registry order, with unregistered historical paths in
+path order and General chats last; project groups and their member workspaces
+follow their stored order. Manual ordering overrides these defaults.
 
 The sidebar reads imported folders and their display names from the shared
 `WorkspaceRegistryStore`. Choosing a folder registers it before creating a
@@ -245,11 +248,17 @@ workspace draft, so every new Thread receives the portable canonical path
 returned by Rust rather than the file picker's raw Windows path. Rename changes
 only the registry display name. An older in-flight registry snapshot cannot
 replace a successful register, rename, or forget, so discarding a pristine
-workspace draft does not remove its already registered folder. Forget removes
+workspace draft does not remove its already registered folder. Empty registered
+folders retain the same registry position as folders with sessions, so discarding
+a draft cannot move its workspace to the bottom of the list. Forget removes
 only the registry entry, leaves historical sessions and disk content intact,
 disables new sessions from that historical group, and surfaces the backend error
 when a project still references the workspace. Project-folder selection uses the
 same register operation.
+Sidebar workspace paths are available through header tooltips rather than a
+second text line. Workspace and session titles share the same icon-column
+alignment; session rows use an empty decorative slot and retain their trailing
+timestamp/delete interaction.
 
 The editable new-session empty state consumes that same registry through the
 sidebar owner. Its heading defaults to General chats and exposes a keyboard
@@ -257,6 +266,10 @@ accessible workspace menu for choosing or registering a folder. Selection
 updates only the local draft creation input, preserves any composer text already
 entered, and reaches `SessionStore.create` on the first send. Persisted Threads
 do not expose this picker because their creation-time workspace is immutable.
+The empty-state heading reserves a viewport-scaled gap above the raised composer
+to sit higher in the available space; narrow windows use a smaller bounded gap.
+The workspace trigger uses a 1.4 line height so its ellipsis clipping preserves
+letter descenders while keeping long names on one line.
 
 Session creation follows the entry point's target. Workspace and project
 actions capture their workspace and project context on the local draft. With the

--- a/src/react-workbench/chat/projectSessionGroups.test.ts
+++ b/src/react-workbench/chat/projectSessionGroups.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from "vitest";
 import { projectSessionGroups } from "./projectSessionGroups";
 
 describe("projectSessionGroups", () => {
+  it("keeps project order independent of conversation recency", () => {
+    const projects = ["first", "second"].map((projectGroupId) => ({ projectGroupId, name: projectGroupId, workspaceIds: [] }));
+    const result = projectSessionGroups(projects, [
+      { id: "newer", title: "Newer", projectGroupId: "second", projectCoordinator: true, updatedAtMs: 20 },
+      { id: "older", title: "Older", projectGroupId: "first", projectCoordinator: true, updatedAtMs: 10 },
+    ]);
+    expect(result.groups.map((group) => group.project.projectGroupId)).toEqual(["first", "second"]);
+  });
+
   it("groups only project-scoped sessions and leaves unrelated workspace sessions standalone", () => {
     const result = projectSessionGroups([{
       projectGroupId: "commerce",

--- a/src/react-workbench/chat/projectSessionGroups.ts
+++ b/src/react-workbench/chat/projectSessionGroups.ts
@@ -42,7 +42,7 @@ export function projectSessionGroups(
     const updatedAtMs = [...coordinatorSessions, ...workspaces.flatMap((workspace) => workspace.sessions)]
       .reduce((latest, session) => Math.max(latest, session.updatedAtMs), 0);
     return { coordinatorSessions, project, updatedAtMs, workspaces };
-  }).sort((left, right) => right.updatedAtMs - left.updatedAtMs);
+  });
   return {
     groups,
     ungroupedSessions: sessions.filter((session) => !groupedSessionIds.has(session.id)),

--- a/src/react-workbench/settings/AgentDefaultsSettingsPage.tsx
+++ b/src/react-workbench/settings/AgentDefaultsSettingsPage.tsx
@@ -134,6 +134,7 @@ export function AgentDefaultsSettingsPage({ settingsStore }: AgentDefaultsSettin
             <SettingsChoiceList
               error={validationMessage(t, errors.contextWindowStrategy)}
               label={t("agent.contextStrategy")}
+              showMenuDescriptions={false}
               options={[
                 { value: "discard", label: t("agent.discard"), description: t("agent.discardDescription") },
                 { value: "compact", label: t("agent.compact"), description: t("agent.compactDescription") },
@@ -150,7 +151,6 @@ export function AgentDefaultsSettingsPage({ settingsStore }: AgentDefaultsSettin
           </div>
         </section>
         <footer>
-          {data.revision ? <small>{t("agent.revision", { revision: data.revision })}</small> : <span />}
           <button type="submit" aria-label={t("agent.saveLabel")} data-press-feedback="true" disabled={saving}>
             {saving
               ? <Loader2 aria-hidden="true" className="react-settings-spinner" size={15} />

--- a/src/react-workbench/settings/ConfigSettingsPage.tsx
+++ b/src/react-workbench/settings/ConfigSettingsPage.tsx
@@ -198,7 +198,6 @@ export function ConfigSettingsPage({ groupId, settingsStore }: ConfigSettingsPag
 
         <footer>
           <div>
-            <span>{revisionFromConfig(data.currentConfig, t)}</span>
             {dirty ? <small>{t("config.unsaved")}</small> : <small>{t("config.upToDate")}</small>}
           </div>
           <div>
@@ -413,17 +412,6 @@ function formatSaveStatus(saved: DesktopConfigSettingsSaveResult, t: TFunction<"
     return t("config.savedReload");
   }
   return t("config.saved");
-}
-
-function revisionFromConfig(config: unknown, t: TFunction<"settings">): string {
-  if (!config || typeof config !== "object" || Array.isArray(config)) {
-    return t("config.revisionUnavailable");
-  }
-  const record = config as Record<string, unknown>;
-  const revision = record.revision;
-  return typeof revision === "string" && revision
-    ? t("config.revision", { revision })
-    : t("config.revisionUnavailable");
 }
 
 function friendlyOptionLabel(value: string): string {

--- a/src/react-workbench/settings/ProfileSettingsPage.test.tsx
+++ b/src/react-workbench/settings/ProfileSettingsPage.test.tsx
@@ -174,20 +174,40 @@ describe("ProfileSettingsPage", () => {
   });
 
   test("settles an active reveal when reduced motion is enabled", async () => {
+    const callbacks: IntersectionObserverCallback[] = [];
     const preference = window.matchMedia("(prefers-reduced-motion: reduce)");
     vi.spyOn(window, "matchMedia").mockReturnValue(preference);
-    vi.stubGlobal("IntersectionObserver", undefined);
+    vi.stubGlobal("IntersectionObserver", class {
+      constructor(callback: IntersectionObserverCallback) { callbacks.push(callback); }
+      observe() {}
+      disconnect() {}
+    });
     const { container } = render(<ProfileSettingsPage settingsStore={createSettingsStore()} />);
     await screen.findByRole("region", { name: "Total tokens" });
     const card = container.querySelector<HTMLElement>(".react-profile-chart-card")!;
     const runs = mockChartAnimations(card);
-    fireEvent.click(card);
+    await waitFor(() => expect(callbacks).toHaveLength(2));
+    expect(card.dataset.revealState).toBe("pending");
+    act(() => callbacks[0](
+      [{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver,
+    ));
     expect(card.dataset.revealState).toBe("revealing");
     Object.defineProperty(preference, "matches", { configurable: true, value: true });
     act(() => preference.dispatchEvent(new Event("change")));
     expect(card.dataset.revealState).toBe("settled");
     await act(async () => runs[0]());
     expect(card.dataset.revealState).toBe("settled");
+  });
+
+  test("settles charts without viewport observation or browser animations", async () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    const { container } = render(<ProfileSettingsPage settingsStore={createSettingsStore()} />);
+    await screen.findByRole("region", { name: "Total tokens" });
+    await waitFor(() => {
+      const cards = [...container.querySelectorAll<HTMLElement>(".react-profile-chart-card")];
+      expect(cards).toHaveLength(2);
+      expect(cards.every((card) => card.dataset.revealState === "settled")).toBe(true);
+    });
   });
 });
 

--- a/src/react-workbench/settings/README.md
+++ b/src/react-workbench/settings/README.md
@@ -1,5 +1,5 @@
 # Settings Workbench
-<!-- tinybot-module-fingerprint: sha256:1489ce295e40329d050cd827c307bfc1b87e60a04c1107cade316a4d2cd1ec20 -->
+<!-- tinybot-module-fingerprint: sha256:8446df0fbd9b3ab4fb5fedcd556c047c2b7d48850bf91e06d5f6eef80e0a310c -->
 
 `settings` owns the Settings route, its navigation, pages, sheets, appearance
 and language contexts, and form presentation. `SettingsRoute.tsx` is loaded as
@@ -24,7 +24,8 @@ second configuration surface.
 
 Settings contracts, metadata, validation, value semantics, and persistence
 patches live in `app-core/settings`. Native reads and writes are exposed through
-the Settings store adapter.
+the Settings store adapter. Config revisions remain internal to persistence
+and are not displayed in settings footers.
 
 The Profile module loads `tinybot.token_usage.v2` from the native Settings-store
 adapter and shows filterable Provider/model totals, a 30-day daily trend, a
@@ -80,6 +81,8 @@ Each choice menu owns the input source for its opening event, independently of
 shell-menu history. Pointer openings use the shared 160 ms anchored transition;
 keyboard openings are immediate. Reduced motion keeps only a 140 ms pointer
 fade, with keyboard behavior still immediate.
+The context-window strategy menu shows option names only via
+`showMenuDescriptions={false}`; its trigger retains the selected explanation.
 The Agent Defaults time-zone choice lists runtime-supported IANA zones and
 starts from the Windows/system zone reported through `Intl`; Provider fallback
 and temperature remain owned by Provider/model configuration rather than being

--- a/src/react-workbench/settings/README.md
+++ b/src/react-workbench/settings/README.md
@@ -1,5 +1,5 @@
 # Settings Workbench
-<!-- tinybot-module-fingerprint: sha256:8446df0fbd9b3ab4fb5fedcd556c047c2b7d48850bf91e06d5f6eef80e0a310c -->
+<!-- tinybot-module-fingerprint: sha256:78cea5ab0520b89c807ce2932e826b10648ca36d224cc7abcb6900aa2a8854e8 -->
 
 `settings` owns the Settings route, its navigation, pages, sheets, appearance
 and language contexts, and form presentation. `SettingsRoute.tsx` is loaded as

--- a/src/react-workbench/settings/SettingsChoiceList.tsx
+++ b/src/react-workbench/settings/SettingsChoiceList.tsx
@@ -20,6 +20,7 @@ export function SettingsChoiceList({
   onChange,
   options,
   optionsAriaLabel,
+  showMenuDescriptions = true,
   value,
 }: {
   ariaLabel?: string;
@@ -31,6 +32,7 @@ export function SettingsChoiceList({
   onChange: (value: string) => void;
   options: SettingsChoiceOption[];
   optionsAriaLabel?: string;
+  showMenuDescriptions?: boolean;
   value: string;
 }) {
   const { t } = useTranslation("settings");
@@ -180,7 +182,7 @@ export function SettingsChoiceList({
             >
               <span className="react-top-menu__menu-label">
                 <strong>{option.label}</strong>
-                {option.description ? <small>{option.description}</small> : null}
+                {showMenuDescriptions && option.description ? <small>{option.description}</small> : null}
               </span>
               {selected ? <Check aria-hidden="true" size={15} /> : <span />}
             </button>

--- a/src/react-workbench/settings/SettingsRoute.css
+++ b/src/react-workbench/settings/SettingsRoute.css
@@ -2659,13 +2659,8 @@
 .react-agent-defaults-form footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 12px;
-}
-
-.react-agent-defaults-form footer small {
-  color: var(--color-muted);
-  font-size: 12px;
 }
 
 .react-agent-defaults-form footer > button {

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:e87004cb50263baff9b358f7c530b6ee0ea481c7fd8b2c28cfed51debe537791 -->
+<!-- tinybot-module-fingerprint: sha256:a16db2b5d9add8a22c2cdd0a553ba70ae010c81226221fd076cdad90d95b004f -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.
@@ -45,6 +45,18 @@ use the same visible focus treatment as other sidebar controls. The workspace
 row, rather than the native `details` content box, anchors a fixed right-aligned
 two-button area so its create and manage actions cannot drop below the workspace
 label.
+Workspace and project headers show their icon and label without a separate
+disclosure arrow. Native summary activation still toggles each group, and
+workspace folder icons reflect the open or closed state.
+Workspace, project, and session rows share a 36px minimum height, 8px corners,
+and a 16px icon column. Session rows reserve that column with an aria-hidden
+placeholder so their titles align with the workspace title. Project contents
+keep one nesting inset. Session hover and selection use the same surface color.
+Workspace and project headers highlight only on hover or keyboard focus, not
+because they contain the active session.
+Workspace paths appear only in header tooltips; nested workspace actions share
+one trailing flex container to keep both buttons on the title line.
+The session list keeps a 2px right inset beside its scrollbar and an 8px left inset.
 
 The desktop document root is fixed to the WebView viewport and never owns page
 scrolling. `html`, `body`, and `#root` contain the `100%` shell while route,

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1057,7 +1057,7 @@ button:disabled {
 .react-session-list__rows {
   min-height: 0;
   overflow: auto;
-  padding: 0 8px 12px;
+  padding: 0 2px 12px 8px;
 }
 
 .react-session-list__error {
@@ -1081,44 +1081,54 @@ button:disabled {
   margin-top: 5px;
 }
 
-.react-session-workspace__details > summary {
+.react-session-workspace__details > summary,
+.react-project-group > summary,
+.react-project-group__member-title,
+.react-session-row__select {
   display: grid;
-  grid-template-columns: 14px 16px minmax(0, 1fr);
+  grid-template-columns: 16px minmax(0, 1fr);
   align-items: center;
   gap: 6px;
-  min-height: 44px;
-  padding: 5px 68px 5px 5px;
+  min-width: 0;
+  min-height: 36px;
+  padding: 0 6px;
+  border: 0;
   border-radius: 8px;
-  color: var(--color-muted);
-  cursor: pointer;
-  list-style: none;
+  color: var(--color-ink);
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: left;
   transition:
     background-color var(--motion-duration-fast) ease,
     color var(--motion-duration-fast) ease;
 }
 
-.react-session-workspace__details > summary::-webkit-details-marker {
+.react-session-workspace__details > summary,
+.react-project-group > summary {
+  padding-right: 70px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.react-session-workspace__details > summary::-webkit-details-marker,
+.react-project-group > summary::-webkit-details-marker {
   display: none;
 }
 
 .react-session-workspace__details > summary:hover,
 .react-session-workspace__details > summary:focus-visible,
-.react-session-workspace[data-active="true"] > .react-session-workspace__details > summary {
-  background: color-mix(in srgb, var(--color-cream-strong) 58%, transparent);
+.react-project-group > summary:hover,
+.react-project-group > summary:focus-visible,
+.react-project-group__member-title:hover,
+.react-project-group__member-title:focus-within {
+  background: var(--color-cream-strong);
   color: var(--color-ink);
 }
 
-.react-session-workspace__details > summary:focus-visible {
+.react-session-workspace__details > summary:focus-visible,
+.react-project-group > summary:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--color-primary) 74%, transparent);
   outline-offset: -2px;
-}
-
-.react-session-workspace__chevron {
-  transition: transform var(--motion-duration-fast) ease;
-}
-
-.react-session-workspace__details[open] > summary .react-session-workspace__chevron {
-  transform: rotate(90deg);
 }
 
 .react-session-workspace__folder {
@@ -1146,8 +1156,7 @@ button:disabled {
   gap: 1px;
 }
 
-.react-session-workspace__copy strong,
-.react-session-workspace__copy small {
+.react-session-workspace__copy strong {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1159,24 +1168,25 @@ button:disabled {
   font-weight: 650;
 }
 
-.react-session-workspace__copy small {
-  color: var(--color-muted-soft);
-  font-size: 9px;
-  font-weight: 450;
-}
-
-.react-session-workspace__actions {
+.react-session-workspace__actions,
+.react-project-group__actions {
   position: absolute;
   z-index: 1;
-  top: 6px;
-  right: 1px;
+  top: 2px;
+  right: 6px;
   display: flex;
   width: 64px;
   justify-content: flex-end;
   flex-wrap: nowrap;
 }
 
-.react-session-workspace__actions > button {
+.react-project-group__member-actions {
+  display: flex;
+}
+
+.react-session-workspace__actions > button,
+.react-project-group__actions > button,
+.react-project-group__member-actions > button {
   display: inline-grid;
   place-items: center;
   width: 32px;
@@ -1190,7 +1200,11 @@ button:disabled {
 }
 
 .react-session-workspace__actions > button:hover,
-.react-session-workspace__actions > button:focus-visible {
+.react-session-workspace__actions > button:focus-visible,
+.react-project-group__actions > button:hover,
+.react-project-group__actions > button:focus-visible,
+.react-project-group__member-actions > button:hover,
+.react-project-group__member-actions > button:focus-visible {
   background: color-mix(in srgb, var(--color-panel) 72%, transparent);
   color: var(--color-ink);
   opacity: 1;
@@ -1198,10 +1212,6 @@ button:disabled {
 
 .react-session-workspace__details:not([open]) > .react-session-workspace__sessions {
   display: none;
-}
-
-.react-session-workspace__sessions {
-  padding-left: 13px;
 }
 
 .react-project-group {
@@ -1212,35 +1222,6 @@ button:disabled {
   background: color-mix(in srgb, var(--color-panel) 86%, transparent);
 }
 
-.react-project-group > summary {
-  display: grid;
-  grid-template-columns: 14px 16px minmax(0, 1fr);
-  align-items: center;
-  gap: 6px;
-  min-height: 44px;
-  padding: 5px 68px 5px 6px;
-  border-radius: 8px;
-  color: var(--color-muted);
-  cursor: pointer;
-  list-style: none;
-}
-
-.react-project-group > summary::-webkit-details-marker {
-  display: none;
-}
-
-.react-project-group > summary:hover,
-.react-project-group > summary:focus-visible,
-.react-project-group[data-active="true"] > summary {
-  background: color-mix(in srgb, var(--color-primary) 7%, var(--color-panel));
-  color: var(--color-ink);
-}
-
-.react-project-group > summary:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--color-primary) 74%, transparent);
-  outline-offset: -2px;
-}
-
 .react-project-group > summary strong {
   overflow: hidden;
   font-size: 12px;
@@ -1249,44 +1230,8 @@ button:disabled {
   white-space: nowrap;
 }
 
-.react-project-group__chevron {
-  transition: transform var(--motion-duration-fast) ease;
-}
-
-.react-project-group[open] > summary .react-project-group__chevron {
-  transform: rotate(90deg);
-}
-
 .react-project-group__icon {
   color: var(--color-primary);
-}
-
-.react-project-group__actions {
-  position: absolute;
-  z-index: 1;
-  top: 6px;
-  right: 3px;
-  display: flex;
-}
-
-.react-project-group__actions button,
-.react-project-group__member-title > button {
-  display: inline-grid;
-  place-items: center;
-  width: 30px;
-  min-width: 30px;
-  height: 30px;
-  min-height: 30px;
-  padding: 0;
-  color: var(--color-muted);
-}
-
-.react-project-group__actions button:hover,
-.react-project-group__actions button:focus-visible,
-.react-project-group__member-title > button:hover,
-.react-project-group__member-title > button:focus-visible {
-  background: var(--color-cream-strong);
-  color: var(--color-ink);
 }
 
 .react-project-group:not([open]) > .react-project-group__content {
@@ -1307,18 +1252,11 @@ button:disabled {
 }
 
 .react-project-group__member-title {
-  display: grid;
-  grid-template-columns: 14px minmax(0, 1fr) 30px;
-  align-items: center;
-  gap: 5px;
-  min-height: 34px;
-  color: var(--color-muted);
-  font-size: 11px;
+  grid-template-columns: 16px minmax(0, 1fr) max-content;
 }
 
-.react-project-group__coordinators .react-project-group__member-title {
-  grid-template-columns: 14px minmax(0, 1fr);
-  padding-right: 5px;
+.react-project-group__member-title > svg {
+  color: var(--color-primary);
 }
 
 .react-project-group__member-title > span {
@@ -1326,8 +1264,7 @@ button:disabled {
   min-width: 0;
 }
 
-.react-project-group__member-title strong,
-.react-project-group__member-title small {
+.react-project-group__member-title strong {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1335,17 +1272,7 @@ button:disabled {
 
 .react-project-group__member-title strong {
   color: var(--color-ink);
-  font-size: 11px;
-}
-
-.react-project-group__member-title small {
-  color: var(--color-muted-soft);
-  font-size: 10px;
-}
-
-.react-project-group__coordinators > .react-session-row,
-.react-project-workspace__sessions > .react-session-row {
-  margin-left: 9px;
+  font-size: inherit;
 }
 
 .react-project-dialog-backdrop {
@@ -1635,18 +1562,11 @@ button:disabled {
 }
 
 .react-session-row__select {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content;
-  align-items: center;
-  column-gap: 8px;
+  grid-template-columns: 16px minmax(0, 1fr) max-content;
   width: 100%;
-  min-width: 0;
-  height: 34px;
   overflow: hidden;
   border-radius: inherit;
-  padding: 0 10px;
   cursor: inherit;
-  text-align: left;
 }
 
 .react-session-row__select:hover,
@@ -1662,7 +1582,6 @@ button:disabled {
 }
 
 .react-session-row__title {
-  max-width: 180px;
   color: var(--color-ink);
   font-size: 12px;
 }


### PR DESCRIPTION
Workspace groups moved when conversation activity changed, and abandoning an untouched draft could move its workspace below the populated groups. This keeps workspace and project ordering independent of conversation recency while preserving manual ordering and first-send session creation.

- Align workspace, project, and conversation rows with a shared icon column, title, and trailing actions. Remove disclosure arrows and inline paths, reduce the scrollbar gap, and show header highlighting only on hover or keyboard focus.
- Raise the empty-chat heading with responsive spacing and preserve letter descenders in the workspace selector without changing the button height or long-name ellipsis.
- Remove configuration revision labels from settings footers and descriptions from the context-strategy menu options; retain the selected option explanation and persistence behavior.

Validation: all 131 test files / 794 tests pass, the production build passes, and staged documentation checks pass. Browser checks cover responsive empty-chat spacing, workspace-label clipping and ellipsis, sidebar alignment, collapse/keyboard expansion, selection, hover controls, and narrow layouts. Regression tests cover stable workspace order after activity updates and remounting, imported workspaces surviving discarded drafts, and preserved manual ordering.
