### PR TITLE
fix(shell): reduce token usage for long-running commands

### DIFF
--- a/docs/api/tools-and-processes.md
+++ b/docs/api/tools-and-processes.md
@@ -14,7 +14,7 @@ src-tauri/src/rpc/tests/threads_and_tools.rs
 src-tauri/tests/crate/retry.rs
 src/app-core/native/desktopNativeThreads.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:3b822883eeb770f3ae5bea03e26b7d97849c7f0889d4014350fa3d72981d1384 -->
+<!-- tinybot-doc-fingerprint: sha256:0c8208a3cfed66e65c4dc7e79a3cf404dd75c047b41ef73401b4e917898db36a -->
 
 This document covers native tool processes, background execution, and browser
 sessions. It is part of the [Rust backend API reference](rust-backend-api.md),
@@ -58,13 +58,39 @@ written, resized, interrupted, or terminated without its matching Turn owner.
 | --- | --- |
 | `shell.start` | Start a pipe or PTY process and wait for a bounded initial yield. |
 | `shell.poll` | Return output after a sequence cursor, waiting up to `yieldTimeMs`. |
-| `shell.write_stdin` | Write `input` (or alias `chars`) and return newly available output. |
+| `shell.write_stdin` | Write `input` (or alias `chars`), or wait for completion with empty input. |
 | `shell.resize` | Resize an active PTY in rows and columns. |
 | `shell.interrupt` | Send SIGINT on Unix or Ctrl-C to a Windows PTY. |
 | `shell.terminate` | Terminate one owned process tree and verify its exit. |
 | `shell.terminate_owner` | Terminate all live processes owned by one owner. |
 | `shell.list` | List retained process snapshots, optionally filtered by `ownerId`. |
 | `shell.shutdown` | Terminate live processes, join terminal lifecycle threads, and release records. |
+
+`shell.start` defaults to a 10-second initial wait, capped at 30 seconds.
+For `shell.write_stdin`, empty input collects output until the process finishes
+or the wait deadline expires. Its default wait is 30 seconds; explicit waits
+are clamped to 5-300 seconds, including a request for zero. New progress logs
+do not end the wait. Process exit and cancellation return early, while reaching
+the deadline leaves the process running. Supply the previous result's `cursor`
+to retrieve only subsequent output. Running Agent results suggest this same
+30-second continuation through `nextAction`.
+
+Non-empty input is written immediately and waits for new output for up to
+`yieldTimeMs` (default 1 second, maximum 30 seconds; zero returns immediately).
+`shell.poll` also retains its output-triggered behavior for interactive clients,
+including the Sidecar terminal. `yieldTimeMs` is a per-call wait budget, separate
+from the process lifetime and the one-shot `shell.execute` timeout.
+
+The runtime diagnostic metrics include background wait durations
+(`process.wait.durationMs`) and counts of still-running, finished, and empty-output
+returns (`process.wait.stillRunning`, `process.wait.finished`, and
+`process.wait.emptyOutput`).
+
+Model observations retain `processId`, `status`, `running`, `exitCode`,
+`output`, `cursor`, `truncated`, `droppedBytes`, and `failure` when non-null.
+Results requiring a next action wrap those fields with `toolOutcome` guidance;
+they do not repeat the transcript through `stdout` and `chunks`. The raw RPC
+snapshot retains the full stream representation for diagnostics and UI use.
 
 `shell.start` accepts:
 

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -11,7 +11,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:164217406dde39ee264a40ac772aa05451bae9a8d659cf3deb12f2f27f5c6b73 -->
+<!-- tinybot-doc-fingerprint: sha256:cf8a692a4800f17bc225998aa62b38345b95554b29bd713f5690edeb62321cd3 -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -12,7 +12,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:5df32e47c8bd88ac5c20b1f2659aa11116af8e4f31584afe81092e8f8a9bfe24 -->
+<!-- tinybot-doc-fingerprint: sha256:87b2ecc47cd234ab903d6dec169a73e1006ded06d424f40202b1ffaf4393f9c1 -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:719c6e0d939f20b08beaf5fab017020c06cf37d110bb255d7451e5dc1480caa6 -->
+<!-- tinybot-doc-fingerprint: sha256:177f21a2d72c99b02cb1e977cedd80cf94d655274dd551f15fa54657b3ab0d9e -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:19f10fbdd93870da3b9b928279e8d5ace26fd11d94aa0ad0aec4ccb08ebbd4d0 -->
+<!-- tinybot-doc-fingerprint: sha256:c62d68e2c0abc8959a6f5bcac3d90e1cce7d9dfeb6de928d4c7cfaacb654c003 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -11,7 +11,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:6e6f8bed210090a5af07322d3973894e40b67526551180c44c0f61e725868f36 -->
+<!-- tinybot-doc-fingerprint: sha256:38da4a8a03331ad5d85e2479886168bcbc2ee971a842891dd6b0ef239e82f684 -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -11,7 +11,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:b5cdecb5a15bca338405547c20652ac6154de9fb95d7202732e4fdb9fbe60ee3 -->
+<!-- tinybot-doc-fingerprint: sha256:6e6f8bed210090a5af07322d3973894e40b67526551180c44c0f61e725868f36 -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,
@@ -190,6 +190,25 @@ the model-visible observation and cannot roll back workspace, process, network,
 or session side effects. Hook-added context is emitted after the complete tool
 result block so both Chat Completions and Responses preserve call/result
 pairing.
+
+## Retained Shell waits
+
+An active `exec_command` returns a process ID and a cursor. Its projected
+`nextAction` suggests empty-input `write_stdin` with a 30-second wait. The
+Shell process manager collects progress output until completion or the wait
+deadline, so individual log chunks do not trigger another provider iteration.
+Pure waits have a 5-second floor and a 300-second ceiling; cancellation and
+process exit return early. Interactive input and direct `shell.poll` keep
+their output-triggered response semantics. Wait deadlines do not terminate
+processes. See the [Shell RPC contract](../api/tools-and-processes.md) for
+defaults, cursor handling, and diagnostic metrics.
+
+Running, failed, and truncated retained Shell results use the same compact
+model fields as ordinary completed results. The outcome constructor accepts
+the model result separately from raw evidence, preserving `toolOutcome`
+guidance and `nextAction` while avoiding repeated transcripts in `stdout`,
+`output`, and `chunks`. Full stream chunks remain in the raw envelope for
+diagnostics and UI projection.
 
 ## Invariants
 

--- a/src-tauri/src/agent/bridge/README.md
+++ b/src-tauri/src/agent/bridge/README.md
@@ -1,5 +1,5 @@
 # Native Agent Bridge
-<!-- tinybot-module-fingerprint: sha256:eaad79f61a90d3c30d999aef602643d20c486e7fc4a7a43ce14bcb7690af28b6 -->
+<!-- tinybot-module-fingerprint: sha256:7119e833db73af20069ac842e795f642206933f21dbb6f20b5818f1bfb8b32ac -->
 
 `agent::bridge` is the application-service layer around the generic
 native agent runtime. It coordinates the resources required for a complete
@@ -57,6 +57,14 @@ Registered subagent lifecycle tools execute through Worker RPC so their state
 is restored from and committed to the canonical Thread store. Only the
 runtime-only `subagent.query` and `subagent.cancel` controls use the direct
 subagent dispatcher fallback; unregistered alternative names fail normally.
+
+Running Shell results suggest an empty-input `write_stdin` with the latest
+cursor and the Shell module's default 30-second wait, so progress collection
+does not encourage repeated one-second model iterations.
+All retained Shell results, including running, failed, and truncated outcomes,
+share one compact model projection: one output string plus process status,
+cursor, exit code, and failure/truncation evidence. Raw stream chunks remain in
+the envelope for diagnostics and UI; they are not duplicated in model content.
 
 Changing this order requires care. In particular, a turn must be recoverable
 after its start is visible, and trace flushing must not be reported as success

--- a/src-tauri/src/agent/bridge/tool_dispatcher.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher.rs
@@ -941,9 +941,16 @@ fn native_tool_result_from_executor_response(
         ));
     }
     if let Some(outcome) = native_shell_tool_outcome(&tool_call.name, &raw_result) {
-        return Ok(NativeAgentToolResult::success_with_outcome(
-            tool_call, raw_result, outcome,
-        ));
+        let model_result =
+            compact_shell_process_model_result(&raw_result).unwrap_or_else(|| raw_result.clone());
+        return Ok(
+            NativeAgentToolResult::success_with_outcome_and_model_result(
+                tool_call,
+                raw_result,
+                model_result,
+                outcome,
+            ),
+        );
     }
     let model_content = native_tool_executor_model_content(&raw_result);
     let summary = native_tool_executor_summary(&raw_result, &model_content);
@@ -1021,7 +1028,7 @@ fn native_shell_tool_outcome(
             let mut arguments = serde_json::json!({
                 "processId": process_id,
                 "input": "",
-                "yieldTimeMs": 1000,
+                "yieldTimeMs": crate::tools::shell::DEFAULT_PROCESS_WAIT_MS,
             });
             if let Some(cursor) = integer_field(raw, "cursor", "cursor") {
                 arguments["cursor"] = serde_json::json!(cursor);
@@ -1296,13 +1303,13 @@ fn native_tool_executor_model_content(value: &serde_json::Value) -> String {
     if let Some(content) = value.get("content").and_then(serde_json::Value::as_str) {
         return content.to_string();
     }
-    if let Some(content) = compact_shell_process_model_content(value) {
-        return content;
+    if let Some(content) = compact_shell_process_model_result(value) {
+        return content.to_string();
     }
     value.to_string()
 }
 
-fn compact_shell_process_model_content(value: &serde_json::Value) -> Option<String> {
+fn compact_shell_process_model_result(value: &serde_json::Value) -> Option<serde_json::Value> {
     let source = value.as_object()?;
     if !source.contains_key("processId") || !source.contains_key("output") {
         return None;
@@ -1326,5 +1333,5 @@ fn compact_shell_process_model_content(value: &serde_json::Value) -> Option<Stri
             compact.insert(field.to_string(), field_value.clone());
         }
     }
-    Some(serde_json::Value::Object(compact).to_string())
+    Some(serde_json::Value::Object(compact))
 }

--- a/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher_tests.rs
@@ -174,10 +174,14 @@ fn running_shell_result_exposes_poll_action_and_retry_semantics() {
             "running": true,
             "exitCode": null,
             "output": "working",
+            "stdout": "working",
+            "stderr": "",
+            "chunks": [{ "sequence": 7, "stream": "stdout", "content": "working" }],
             "cursor": 7,
             "truncated": false
         }
     });
+    let raw = executor_response["result"].clone();
 
     let result = native_tool_result_from_executor_response(&tool_call, executor_response)
         .expect("running shell result should be projected");
@@ -195,6 +199,19 @@ fn running_shell_result_exposes_poll_action_and_retry_semantics() {
     assert_eq!(outcome["nextAction"]["tool"], "write_stdin");
     assert_eq!(outcome["nextAction"]["arguments"]["processId"], "process-1");
     assert_eq!(outcome["nextAction"]["arguments"]["cursor"], 7);
+    assert_eq!(outcome["nextAction"]["arguments"]["yieldTimeMs"], 30_000);
+    assert_eq!(
+        model_content["result"],
+        serde_json::json!({
+            "processId": "process-1",
+            "status": "running",
+            "running": true,
+            "output": "working",
+            "cursor": 7,
+            "truncated": false,
+        })
+    );
+    assert_eq!(result.envelope["raw"], raw);
     assert!(model_content["toolOutcome"]["guidance"]
         .as_str()
         .is_some_and(|guidance| guidance.contains("Follow nextAction")));
@@ -202,7 +219,7 @@ fn running_shell_result_exposes_poll_action_and_retry_semantics() {
 
 #[test]
 fn shell_terminal_special_states_use_structured_outcomes() {
-    for (name, raw, effect, reason_code, retry) in [
+    for (name, mut raw, effect, reason_code, retry) in [
         (
             "exec_command",
             serde_json::json!({
@@ -245,6 +262,14 @@ fn shell_terminal_special_states_use_structured_outcomes() {
             "do_not_retry",
         ),
     ] {
+        let expected_model_result = raw.clone();
+        if let Some(output) = raw.get("output").cloned() {
+            raw["stdout"] = output.clone();
+            raw["stderr"] = serde_json::json!("");
+            raw["chunks"] = serde_json::json!([
+                { "sequence": 1, "stream": "stdout", "content": output }
+            ]);
+        }
         let tool_call = PreparedToolCall::prepare(NativeAgentToolCall {
             id: format!("call-{reason_code}"),
             name: name.to_string(),
@@ -262,6 +287,14 @@ fn shell_terminal_special_states_use_structured_outcomes() {
         assert_eq!(outcome["effect"], effect, "reason {reason_code}");
         assert_eq!(outcome["reasonCode"], reason_code, "reason {reason_code}");
         assert_eq!(outcome["retry"], retry, "reason {reason_code}");
+        let model_content: serde_json::Value = serde_json::from_str(
+            result.envelope["modelContent"]
+                .as_str()
+                .expect("model content should be text"),
+        )
+        .expect("model content should be JSON");
+        assert_eq!(model_content["result"], expected_model_result);
+        assert_eq!(result.envelope["raw"], raw);
     }
 }
 

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:5c6e82f0a82475b6c30c8cf77bc6d370b94af8733920bfe7f1cec61d95673311 -->
+<!-- tinybot-module-fingerprint: sha256:1a390eb303c74ef3bf3b2cc6fa38a5e2f7fadd43a6fcdda626528c868936343f -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed
@@ -260,6 +260,11 @@ Every runtime event in one Turn shares the same trace context. Provider events
 add `providerAttemptId`, tool events retain `itemId` and `toolCallId`, and
 internal Worker RPC operations derive request IDs under the same root trace.
 Persisted tool envelopes use the configured secret-redaction path.
+
+Outcome results can supply a model result separately from raw evidence. This
+keeps outcome guidance and UI actions intact while letting the tool adapter
+remove redundant fields from the provider observation. The raw envelope remains
+available to diagnostics and UI consumers.
 
 Special tool results use the shared `tool_outcome` envelope projection instead
 of relying on tool-specific prose hidden in raw JSON. The outer envelope status

--- a/src-tauri/src/agent/runtime/tool_outcome_projection.rs
+++ b/src-tauri/src/agent/runtime/tool_outcome_projection.rs
@@ -10,7 +10,7 @@ pub(super) struct NativeToolOutcomeProjection {
 
 pub(super) fn project_tool_outcome(
     tool_call: &NativeAgentToolCall,
-    raw_content: &Value,
+    model_result: &Value,
     outcome: &NativeToolOutcome,
 ) -> NativeToolOutcomeProjection {
     let structured_outcome =
@@ -29,7 +29,7 @@ pub(super) fn project_tool_outcome(
         summary: summary.clone(),
         model_content: serde_json::json!({
             "toolOutcome": model_outcome,
-            "result": raw_content,
+            "result": model_result,
         })
         .to_string(),
         structured: serde_json::json!({

--- a/src-tauri/src/agent/runtime/tool_result.rs
+++ b/src-tauri/src/agent/runtime/tool_result.rs
@@ -42,9 +42,10 @@ impl NativeToolResultEnvelope {
     fn success_with_outcome(
         tool_call: &NativeAgentToolCall,
         raw_content: Value,
+        model_result: Value,
         outcome: NativeToolOutcome,
     ) -> Self {
-        let projection = project_tool_outcome(tool_call, &raw_content, &outcome);
+        let projection = project_tool_outcome(tool_call, &model_result, &outcome);
         Self::from_parts(
             "ok",
             projection.summary,
@@ -235,8 +236,27 @@ impl NativeAgentToolResult {
         raw_content: Value,
         outcome: NativeToolOutcome,
     ) -> Self {
-        let envelope =
-            NativeToolResultEnvelope::success_with_outcome(tool_call, raw_content, outcome);
+        Self::success_with_outcome_and_model_result(
+            tool_call,
+            raw_content.clone(),
+            raw_content,
+            outcome,
+        )
+    }
+
+    /// Keep full raw evidence while supplying a separate result to the model.
+    pub(crate) fn success_with_outcome_and_model_result(
+        tool_call: &NativeAgentToolCall,
+        raw_content: Value,
+        model_result: Value,
+        outcome: NativeToolOutcome,
+    ) -> Self {
+        let envelope = NativeToolResultEnvelope::success_with_outcome(
+            tool_call,
+            raw_content,
+            model_result,
+            outcome,
+        );
         let model_content = envelope
             .get("modelContent")
             .and_then(Value::as_str)

--- a/src-tauri/src/tools/registry/README.md
+++ b/src-tauri/src/tools/registry/README.md
@@ -1,5 +1,5 @@
 # Tool Registry
-<!-- tinybot-module-fingerprint: sha256:d7bbfbeabc29643892891b28fca062bfcc1fabb2a62282dcff5fcb60fd189b45 -->
+<!-- tinybot-module-fingerprint: sha256:c74093ca439bcb3ee863d9f8832179cba87bf0001f6eaa0794e986820f0c6840 -->
 
 `registry` is the catalog of tools available to the runtime. Each entry records
 its schema, exposure, execution target, required capabilities, cancellation
@@ -22,3 +22,7 @@ For `publish_data_view`, this includes supported view kinds and the table
 The `write_stdin` contract distinguishes empty-input completion waits from
 interactive writes. It exposes waits up to 300 seconds and explains output
 batching, the 5-second floor, and the default 30-second background wait.
+The `exec_command` description teaches the complete long-command workflow:
+start once, distinguish the initial wait from a process timeout, reuse the
+process ID and latest cursor, and prefer longer continuation waits over
+repeated short polls.

--- a/src-tauri/src/tools/registry/README.md
+++ b/src-tauri/src/tools/registry/README.md
@@ -1,5 +1,5 @@
 # Tool Registry
-<!-- tinybot-module-fingerprint: sha256:8edb807bc6e3bc17a9d555fd67932810577ee9f6a736a51c951dc387b9d50848 -->
+<!-- tinybot-module-fingerprint: sha256:d7bbfbeabc29643892891b28fca062bfcc1fabb2a62282dcff5fcb60fd189b45 -->
 
 `registry` is the catalog of tools available to the runtime. Each entry records
 its schema, exposure, execution target, required capabilities, cancellation
@@ -19,3 +19,6 @@ Threads.
 Provider-visible schemas include nested contracts used by native validation.
 For `publish_data_view`, this includes supported view kinds and the table
 `defaultSort` object with required `field` and `direction` properties.
+The `write_stdin` contract distinguishes empty-input completion waits from
+interactive writes. It exposes waits up to 300 seconds and explains output
+batching, the 5-second floor, and the default 30-second background wait.

--- a/src-tauri/src/tools/registry/mod.rs
+++ b/src-tauri/src/tools/registry/mod.rs
@@ -601,7 +601,7 @@ fn core_tool_entries() -> Vec<ToolRegistryEntry> {
             "shell.start",
             "shell",
             "Start shell command",
-            "Start a shell command with the current user's permissions. Set workingDir explicitly when needed and use yieldTimeMs for a short initial wait. If the process remains active, continue it with write_stdin using the returned processId. Check the exit status and output before reporting success.",
+            "Start a shell command with the current user's permissions. Set workingDir explicitly when needed. yieldTimeMs is the initial wait budget (default 10000; maximum 30000 ms), not an execution timeout. For downloads, dependency installs, tests, and builds, start once with the default wait. If running=true, the process continues: use write_stdin with the returned processId, latest cursor, empty input, and yieldTimeMs of 30000-300000 ms. Prefer longer waits when there is no actionable progress; do independent work between waits when useful. Progress logs are batched and process completion returns early. Avoid repeated short polls or restarting a running command. Check the exit status and output before reporting success.",
             ToolExposure::Model,
             false,
             runtime_policy(false, ToolCancellationMode::TerminateProcess, true, false),

--- a/src-tauri/src/tools/registry/mod.rs
+++ b/src-tauri/src/tools/registry/mod.rs
@@ -624,7 +624,7 @@ fn core_tool_entries() -> Vec<ToolRegistryEntry> {
             "shell.write_stdin",
             "shell",
             "Write shell input",
-            "Write input to a retained shell process and return newly available output.",
+            "Continue a retained shell process using processId and the latest cursor. With empty input, wait for completion and collect output for up to yieldTimeMs (default 30000; clamped to 5000-300000 ms). Progress logs do not end this wait; process exit or cancellation returns early. For downloads, tests, and builds, use 30000-300000 ms to avoid frequent polling. Non-empty input writes immediately and waits briefly for output (default 1000; maximum 30000 ms).",
             ToolExposure::Model,
             false,
             runtime_policy(false, ToolCancellationMode::DetachForbidden, true, false),
@@ -636,7 +636,7 @@ fn core_tool_entries() -> Vec<ToolRegistryEntry> {
                     "processId": { "type": "string" },
                     "input": { "type": "string" },
                     "cursor": { "type": "integer", "minimum": 0 },
-                    "yieldTimeMs": { "type": "integer", "minimum": 0, "maximum": 30000 }
+                    "yieldTimeMs": { "type": "integer", "minimum": 0, "maximum": crate::tools::shell::MAX_PROCESS_WAIT_MS }
                 }
             }),
         ),

--- a/src-tauri/src/tools/shell/README.md
+++ b/src-tauri/src/tools/shell/README.md
@@ -1,5 +1,5 @@
 # Shell Tools
-<!-- tinybot-module-fingerprint: sha256:a8fd144ee79393f641e5a6b9c57e9b1a7c66c0b3ef2b7942a269f54fd90346e0 -->
+<!-- tinybot-module-fingerprint: sha256:39843feebcc46fdc46d3d83bfbf62d9b5a0932b8fee4697a85d3154578554116 -->
 
 `shell` runs commands for agents and RPC clients in a validated working
 directory. Relative paths resolve from the configured workspace; an existing
@@ -12,6 +12,15 @@ that require a different next step. A retained process includes a structured
 `write_stdin` continuation, while cancellation, timeout, non-zero exit,
 process failure, and truncated output carry explicit retry guidance. Ordinary
 successful commands keep the generic result projection.
+
+Empty-input `write_stdin` waits for process completion, collecting progress in
+the bounded transcript instead of returning on each log chunk. Its default
+wait is 30 seconds, with a 5-second floor and a 300-second ceiling; completion
+and cancellation wake the wait early. The deadline retains a running process.
+Non-empty input and `shell.poll` retain their responsive output waits, including
+Sidecar terminal polling. Callers pass the latest cursor for incremental output.
+Runtime metrics record `process.wait.durationMs`, `process.wait.stillRunning`,
+`process.wait.finished`, and `process.wait.emptyOutput` to diagnose polling churn.
 
 Platform-specific process containment is implemented separately where needed.
 On Windows, the Job Object helper is also reused by trusted subprocess runners

--- a/src-tauri/src/tools/shell/mod.rs
+++ b/src-tauri/src/tools/shell/mod.rs
@@ -24,6 +24,8 @@ use self::process_manager::{ShellProcessManager, ValidatedShellStart};
 
 const MAX_TIMEOUT_SECONDS: u64 = 600;
 const MAX_OUTPUT_CHARS: usize = 10_000;
+pub(crate) const DEFAULT_PROCESS_WAIT_MS: u64 = 30_000;
+pub(crate) const MAX_PROCESS_WAIT_MS: u64 = 300_000;
 
 #[derive(Clone, Debug)]
 pub struct WorkerShellRpc {
@@ -137,12 +139,17 @@ impl WorkerShellRpc {
         params: ShellProcessInputParams,
     ) -> Result<ShellProcessOutput, WorkerProtocolError> {
         self.require(WorkerCapability::ShellExecute)?;
+        let default_yield_time_ms = if params.input.is_empty() {
+            DEFAULT_PROCESS_WAIT_MS
+        } else {
+            1_000
+        };
         self.processes.write_stdin(
             &params.process_id,
             params.owner_id.as_deref(),
             params.input.as_bytes(),
             params.cursor.unwrap_or(0),
-            params.yield_time_ms.unwrap_or(1_000),
+            params.yield_time_ms.unwrap_or(default_yield_time_ms),
         )
     }
 

--- a/src-tauri/src/tools/shell/process_manager.rs
+++ b/src-tauri/src/tools/shell/process_manager.rs
@@ -2,6 +2,7 @@
 use super::windows_job::WindowsProcessJob;
 use super::{
     shell_command, shell_error, ShellOutputChunk, ShellProcessCleanupReport, ShellProcessOutput,
+    MAX_PROCESS_WAIT_MS,
 };
 use crate::protocol::{WorkerProtocolError, WorkerRequestCancellation};
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtySize};
@@ -21,6 +22,7 @@ use windows_sys::Win32::Globalization::{
 
 const MAX_PROCESS_RECORDS: usize = 64;
 const MAX_YIELD_TIME_MS: u64 = 30_000;
+const MIN_PROCESS_WAIT_MS: u64 = 5_000;
 const TERMINATION_WAIT: Duration = Duration::from_secs(2);
 const OUTPUT_HEAD_BYTES: usize = 256 * 1024;
 const OUTPUT_TAIL_BYTES: usize = 768 * 1024;
@@ -166,9 +168,26 @@ impl ShellProcessManager {
         yield_time_ms: u64,
     ) -> Result<ShellProcessOutput, WorkerProtocolError> {
         let record = self.lookup(process_id, owner_id)?;
-        if !input.is_empty() {
-            record.write_stdin(input)?;
+        if input.is_empty() {
+            // Progress logs are collected in the bounded process buffer. Only
+            // completion or the wait deadline should resume the model.
+            let wait_ms = yield_time_ms.clamp(MIN_PROCESS_WAIT_MS, MAX_PROCESS_WAIT_MS);
+            let started_at = Instant::now();
+            record.wait_for_terminal(Duration::from_millis(wait_ms));
+            let output = record.snapshot(cursor);
+            let metrics = crate::runtime::observability::global_agent_runtime_metrics();
+            metrics.record_duration("process.wait.durationMs", started_at.elapsed());
+            metrics.increment(if output.running {
+                "process.wait.stillRunning"
+            } else {
+                "process.wait.finished"
+            });
+            if output.output.is_empty() {
+                metrics.increment("process.wait.emptyOutput");
+            }
+            return Ok(output);
         }
+        record.write_stdin(input)?;
         Ok(record.wait_for_output(
             cursor,
             Duration::from_millis(clamp_yield_time(yield_time_ms)),

--- a/src-tauri/src/tools/shell/process_manager_tests.rs
+++ b/src-tauri/src/tools/shell/process_manager_tests.rs
@@ -1,8 +1,145 @@
-﻿use super::*;
+use super::*;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::time::Duration;
+
+#[test]
+fn empty_stdin_collects_progress_until_process_exits() {
+    let fixture = ProcessFixture::new();
+    let rpc = shell_rpc(&fixture);
+    let command = if cfg!(target_os = "windows") {
+        "powershell -NoProfile -Command \"0..9 | ForEach-Object { [Console]::WriteLine('progress-' + $_); Start-Sleep -Milliseconds 100 }; [Console]::WriteLine('finished')\""
+    } else {
+        "i=0; while [ $i -lt 10 ]; do printf 'progress-%s\\n' \"$i\"; sleep 0.1; i=$((i+1)); done; printf 'finished\\n'"
+    };
+    let started = rpc
+        .start(ShellStartParams {
+            command: command.to_string(),
+            working_dir: Some(".".to_string()),
+            tty: Some(false),
+            yield_time_ms: Some(0),
+            rows: None,
+            cols: None,
+            owner_id: Some("turn-batched-progress".to_string()),
+            tool_call_id: Some("tool-batched-progress".to_string()),
+            cancellation: None,
+        })
+        .expect("progress command should start");
+    let first = rpc
+        .poll(ShellProcessPollParams {
+            process_id: started.process_id.clone(),
+            owner_id: Some("turn-batched-progress".to_string()),
+            cursor: Some(0),
+            yield_time_ms: Some(5_000),
+        })
+        .expect("first progress should be observable");
+    assert!(first.running, "fixture must still be running: {first:?}");
+    let wait_started = std::time::Instant::now();
+    let output = rpc
+        .write_stdin(ShellProcessInputParams {
+            process_id: started.process_id,
+            owner_id: Some("turn-batched-progress".to_string()),
+            input: String::new(),
+            cursor: Some(first.cursor),
+            yield_time_ms: None,
+        })
+        .expect("background wait should collect progress");
+    let elapsed = wait_started.elapsed();
+    let cleanup = rpc.shutdown();
+    assert!(cleanup.failures.is_empty(), "{cleanup:?}");
+    assert!(
+        !output.running,
+        "progress output must not force another model polling round: {output:?}"
+    );
+    assert_eq!(output.exit_code, Some(0));
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "exit returned after {elapsed:?}"
+    );
+    assert!(output.output.contains("progress-9"), "{output:?}");
+    assert!(output.output.contains("finished"), "{output:?}");
+    assert!(!output.output.contains("progress-0"), "{output:?}");
+}
+
+#[test]
+fn empty_stdin_enforces_wait_floor_without_terminating_process() {
+    let fixture = ProcessFixture::new();
+    let rpc = shell_rpc(&fixture);
+    let started = start_blocking_process(&rpc, "turn-wait-floor", "tool-wait-floor");
+    let wait_started = std::time::Instant::now();
+    let output = rpc
+        .write_stdin(ShellProcessInputParams {
+            process_id: started.process_id.clone(),
+            owner_id: Some("turn-wait-floor".to_string()),
+            input: String::new(),
+            cursor: Some(started.cursor),
+            yield_time_ms: Some(0),
+        })
+        .expect("empty input should wait even when the model requests zero milliseconds");
+    let elapsed = wait_started.elapsed();
+    let cleanup = rpc.shutdown();
+    assert!(cleanup.failures.is_empty(), "{cleanup:?}");
+    assert!(
+        elapsed >= Duration::from_secs(5),
+        "returned after {elapsed:?}"
+    );
+    assert!(
+        output.running,
+        "wait deadline must retain the process: {output:?}"
+    );
+    assert_eq!(output.process_id, started.process_id);
+    assert_eq!(output.exit_code, None);
+    assert!(output.output.is_empty(), "{output:?}");
+}
+
+#[test]
+fn empty_stdin_long_wait_returns_promptly_when_cancelled() {
+    let fixture = ProcessFixture::new();
+    let rpc = shell_rpc(&fixture);
+    let cancellation = Arc::new(TestCancellation::default());
+    let started = rpc
+        .start(ShellStartParams {
+            command: blocking_command(),
+            working_dir: Some(".".to_string()),
+            tty: Some(false),
+            yield_time_ms: Some(0),
+            rows: None,
+            cols: None,
+            owner_id: Some("turn-cancel-wait".to_string()),
+            tool_call_id: Some("tool-cancel-wait".to_string()),
+            cancellation: Some(cancellation.clone()),
+        })
+        .expect("cancellable process should start");
+    let waiting_rpc = rpc.clone();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let waiter = std::thread::spawn(move || {
+        let result = waiting_rpc.write_stdin(ShellProcessInputParams {
+            process_id: started.process_id,
+            owner_id: Some("turn-cancel-wait".to_string()),
+            input: String::new(),
+            cursor: Some(started.cursor),
+            yield_time_ms: Some(300_000),
+        });
+        sender
+            .send(result)
+            .expect("wait result should be delivered");
+    });
+    assert!(matches!(
+        receiver.recv_timeout(Duration::from_millis(100)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+    ));
+    cancellation.cancel();
+    let received = receiver.recv_timeout(Duration::from_secs(2));
+    let cleanup = rpc.shutdown();
+    waiter.join().expect("waiter should finish");
+    assert!(cleanup.failures.is_empty(), "{cleanup:?}");
+    let output = received
+        .expect("cancellation should interrupt a five-minute wait promptly")
+        .expect("cancelled process should have a final snapshot");
+    assert!(!output.running, "{output:?}");
+    assert_eq!(output.status, "cancelled");
+}
 
 #[cfg(target_os = "windows")]
 #[test]


### PR DESCRIPTION
Long-running commands could return on each progress log, while their continuation guidance suggested one-second polls. Each return could trigger another model iteration. Running and exceptional shell results also bypassed transcript compaction, repeating the same output in `chunks`, `stdout`, and `output`.

Empty-input `write_stdin` now collects output until completion or a bounded wait deadline: 30 seconds by default, with a 5-second minimum and 300-second maximum. Interactive writes retain their existing response behavior. Shell outcomes use one compact model result while preserving raw diagnostic evidence, status, cursor, errors, and continuation guidance. The tool descriptions explain how to wait efficiently for downloads, dependency installs, tests, and builds, and runtime metrics expose wait duration and empty-output returns.

Validation:
- Regression tests reproduced log-triggered early returns and duplicated model output before their respective fixes and passed afterward. Coverage includes minimum waits, retained processes, cancellation, outcome guidance, and preservation of raw evidence.
- Shell-focused tests and the retained-tool registry test passed. Formatting, documentation checks, and commit-hook `cargo check` passed.
- A desktop replay of a 40-second script emitting one line per second required two continuation calls: about 30 seconds, then an early return on completion. Its running model result contained one transcript and retained continuation guidance.
- The full Rust library run was not fully green: 1065 passed, 1 failed, 1 ignored. `desktop_terminal::tests::creates_each_terminal_resource_only_once` failed with Windows access denied (os error 5) during process-tree termination. This failure also occurred before the outcome-compaction change; its isolated rerun passed. The terminal cleanup path is unchanged.
