### PR TITLE
refactor(chat): separate application state from page and Sidecar resources

### DIFF
--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,12 +16,17 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:b5d25ac18a2a9db2bb7f63911a64e093157d9b1c8f9e176662c1b02a3511a9b0 -->
+<!-- tinybot-doc-fingerprint: sha256:e201852f7cbad2c7f20051824382151d7a546e7c06083286d7b60bc170cd9b41 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
 and the Rust backend owns native capabilities, Agent execution, durable
 conversation state, and process lifecycle.
+
+The Chat application owns client submission preparation, optimistic messages,
+queue and command coordination. Native Chat command orchestration is injected
+by the renderer composition root; canonical conversation projection remains
+owned by the existing Timeline model.
 
 Chat can release offscreen Markdown and chart renderers while retaining message
 interaction owners and semantic scroll anchors. The native browser owns idle

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:e201852f7cbad2c7f20051824382151d7a546e7c06083286d7b60bc170cd9b41 -->
+<!-- tinybot-doc-fingerprint: sha256:b29d7888dc52c3bffe867ed03b6923e26283d0a4be129b0b1d64184661eafbc6 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -74,7 +74,7 @@ Desktop Commands / Desktop Host
 | --- | --- | --- |
 | `react-workbench` | React routes, presentation, route state, and shared menu-popover primitives | Native transport or durable domain state |
 | `react-workbench/agent-graph` | Standalone Agent Graph library and unbounded spatial canvas, node configuration, Run history, and per-node inspection | Chat route state or native execution rules |
-| `react-workbench/sidecar` | Resource tabs, scope filtering, and Browser, Terminal, or contextual Artifact presentation | Native Browser or Terminal lifecycle, Artifact domain state, or workspace file authorization |
+| `react-workbench/sidecar` | Resource lifecycle coordination, native Browser snapshot consumption, scope filtering, and Browser, Terminal, or contextual Artifact presentation | Native Browser or Terminal lifecycle, Artifact domain state, or workspace file authorization |
 | `app-core` | Framework-independent contracts, validation, commands, and projections | React rendering or Tauri invocation |
 | `app-core/agent-graph` | Versioned Graph contracts, validation, edit operations, persistence Interface, and runtime Interface | React rendering, native filesystem I/O, or Agent execution |
 | `app-core/desktop-pet` | Pet preferences plus monitor-aware pet and quick-chat window geometry | React rendering or native window calls |

--- a/src/react-workbench/README.md
+++ b/src/react-workbench/README.md
@@ -1,5 +1,5 @@
 # React Workbench
-<!-- tinybot-module-fingerprint: sha256:061d9c17966a33e7c092a59d21f9601e174d19e1460cd83543c21c4cfe2d6110 -->
+<!-- tinybot-module-fingerprint: sha256:be2ae4e17b9a555178aabfe9e9ee07567061366e03845e49db00d5264951ef8a -->
 
 `react-workbench` contains the React renderer for Tinybot's desktop application.
 `src/main.ts` selects a dynamic entry before importing React surfaces:
@@ -19,6 +19,9 @@ renderer diagnostic overlay; render errors also remove the startup surface.
 `DesktopShell` owns the desktop chrome, and `defaultServices.ts` composes the
 renderer-facing stores including the native `WorkspaceRegistry` Adapter and
 the optional native pet and quick-chat hosts.
+Native Chat submission, model resolution, cancellation, compaction, and fork
+lookup are implemented by `chat/desktopChatCommands.ts`, which receives the
+native adapters and event notifications from this composition root.
 
 The standalone [`agent-graph/`](agent-graph/README.md) route owns the in-memory
 Agent Graph canvas editor without importing `ChatPage` or consuming Chat route

--- a/src/react-workbench/chat/ChatPage.queue-rendering.test.tsx
+++ b/src/react-workbench/chat/ChatPage.queue-rendering.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, it, vi } from "vitest";
+import { ChatPageUnderTest, createStores } from "./test/ChatPageTestHarness";
+
+const renders = vi.hoisted(() => ({ timeline: 0 }));
+vi.mock("./ChatTimeline", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./ChatTimeline")>();
+  return {
+    ...original,
+    ChatTimeline: (props: Parameters<typeof original.ChatTimeline>[0]) => {
+      renders.timeline += 1;
+      return <original.ChatTimeline {...props} />;
+    },
+  };
+});
+
+it("updates the queue after deletion without rerendering the conversation or refreshing sessions", async () => {
+  const user = userEvent.setup();
+  const stores = createStores({ sessions: [{
+    id: "s1", chatId: "s1", title: "Chat", status: "running", updatedAtMs: 0,
+  }] });
+  const timeline = await stores.chatStore.load("s1");
+  timeline.turns[timeline.turns.length - 1].status = "running";
+  vi.mocked(stores.chatStore.load).mockResolvedValue(timeline);
+  render(<ChatPageUnderTest {...stores} />);
+  await user.type(await screen.findByRole("textbox", { name: /message/i }), "queued message{enter}");
+  await waitFor(() => expect(screen.getByLabelText("Queued inputs").textContent).toContain("queued message"));
+  await act(async () => {});
+  const before = { renders: renders.timeline, refreshes: vi.mocked(stores.sessionStore.list).mock.calls.length };
+  await user.click(screen.getByRole("button", { name: "Delete queued input" }));
+  expect(screen.queryByLabelText("Queued inputs")).toBeNull();
+  expect(renders.timeline - before.renders).toBe(0);
+  expect(vi.mocked(stores.sessionStore.list).mock.calls.length - before.refreshes).toBe(0);
+});

--- a/src/react-workbench/chat/ChatPage.queue-rendering.test.tsx
+++ b/src/react-workbench/chat/ChatPage.queue-rendering.test.tsx
@@ -4,6 +4,8 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, it, vi } from "vitest";
 import { ChatPageUnderTest, createStores } from "./test/ChatPageTestHarness";
+import type { ChatEvent } from "../services";
+import { createNativeBrowserSessionSnapshot } from "../../app-core/native/nativeBrowserSnapshot";
 
 const renders = vi.hoisted(() => ({ timeline: 0 }));
 vi.mock("./ChatTimeline", async (importOriginal) => {
@@ -15,6 +17,27 @@ vi.mock("./ChatTimeline", async (importOriginal) => {
       return <original.ChatTimeline {...props} />;
     },
   };
+});
+
+it("applies Browser snapshots without rerendering the conversation", async () => {
+  const stores = createStores();
+  let receive!: (event: ChatEvent) => void;
+  stores.chatStore.subscribe = vi.fn((_sessionId, listener) => { receive = listener; return () => {}; });
+  render(<ChatPageUnderTest {...stores} />);
+  await screen.findByRole("button", { name: "Show Sidecar" });
+  await waitFor(() => expect(stores.chatStore.subscribe).toHaveBeenCalled());
+  await act(async () => {});
+  const before = renders.timeline;
+  const browserSnapshot = createNativeBrowserSessionSnapshot({
+    activeTabId: "tab-1", browserSessionId: "browser-1", contract: "browser_session_v1",
+    interaction: { click: true, navigate: true, type: true }, kind: "browser_session", lifecycle: "ready",
+    operationId: "op-1", runtimeKind: "windows_webview2", sessionId: "s1", state: "running",
+    tabs: [{ activeHistoryIndex: 0, captures: [], history: [{ title: "Example", url: "https://example.com" }], loading: false,
+      rendererLifecycle: "running", tabId: "tab-1", title: "Example", url: "https://example.com" }],
+  }, { observedAt: "2026-09-08T00:00:00Z", sourceId: "native-browser:browser-1", revision: 1 });
+  await act(async () => { receive({ type: "browser.snapshot", browserSnapshot }); });
+  expect(renders.timeline - before).toBe(0);
+  expect(stores.chatStore.subscribe).toHaveBeenCalledOnce();
 });
 
 it("updates the queue after deletion without rerendering the conversation or refreshing sessions", async () => {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1,3 +1,5 @@
+import { useChatSessions } from "./useChatSessions";
+import type { ChatSessionChange } from "./chatSessionApplication";
 import { SidecarResources, initialSidecarLayout, type SidecarResourcesHandle, type SidecarLayout } from "../sidecar/SidecarResources";
 import { useChatSubmission } from "./useChatSubmission";
 import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
@@ -46,7 +48,6 @@ import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { AgentUiFormCard } from "./AgentUiFormCard";
 import {
   projectChatEventEffects,
-  projectTimelineSessionStatus,
 } from "./chatEventPolicy";
 import {
   projectLatestContextUsage,
@@ -106,7 +107,6 @@ import {
 } from "./ChatSessionWorkspace";
 import {
   displaySessionTitle,
-  isDefaultSessionTitle,
 } from "./sessionTitle";
 import { projectTinybotMascotMood, type TinybotMascotMood } from "./TinybotMascot";
 
@@ -276,8 +276,10 @@ export function ChatPage({
 }: ChatPageProps) {
   const { i18n, t } = useTranslation("chat");
   const slashCommands = useMemo(() => composerSlashCommands(t), [t]);
-  const [sessions, setSessions] = useState<SessionSummary[]>([]);
-  const [sessionsLoaded, setSessionsLoaded] = useState(false);
+  const [retainedDeletingSessions, setRetainedDeletingSessions] = useState<SessionSummary[]>([]);
+  const sessionData = useChatSessions(sessionStore, now, handleSessionChange);
+  const { application: sessionApplication, loaded: sessionsLoaded, error: sessionWorkspaceError, creating: sessionCreatePending } = sessionData;
+  const sessions = useMemo(() => [...sessionData.sessions, ...retainedDeletingSessions], [sessionData.sessions, retainedDeletingSessions]);
   const [startInNewSessionOnMount] = useState(startInNewSession);
   const [sessionTabs, dispatchSessionTabs] = useReducer(
     reduceSessionTabWorkspace,
@@ -293,8 +295,6 @@ export function ChatPage({
   const [composerTools, setComposerTools] = useState<ToolSummary[]>([]);
   const [contextUsageDefaults, setContextUsageDefaults] = useState<ContextUsageDefaults>({});
   const [headerMenuOpen, setHeaderMenuOpen] = useState(false);
-  const [sessionWorkspaceError, setSessionWorkspaceError] = useState("");
-  const [sessionCreatePending, setSessionCreatePending] = useState(false);
   const [localSessionSidebarCollapsed, setLocalSessionSidebarCollapsed] = useState(false);
   const [drawer, setDrawer] = useState<DrawerState>(null);
   const [drawerSessionId, setDrawerSessionId] = useState("");
@@ -313,15 +313,11 @@ export function ChatPage({
   const [showBackToLatest, setShowBackToLatest] = useState(false);
   const [dissolvingSessionIds, setDissolvingSessionIds] = useState<Set<string>>(() => new Set());
   const [deleteState, dispatchDelete] = useReducer(reduceSessionDeleteState, { confirmingSessionId: "" });
-  const sessionsRef = useRef<SessionSummary[]>([]);
   const deleteDissolveTimers = useRef<number[]>([]);
   const lastCreateSessionSignal = useRef(createSessionSignal);
   const lastActivateSessionSignal = useRef<number | null>(null);
-  const draftSessionCreatePromise = useRef<Promise<SessionSummary> | null>(null);
-  const draftSessionSequence = useRef(0);
   const sessionTabsRef = useRef(sessionTabs);
   const sessionsLoadedRef = useRef(sessionsLoaded);
-  const optimisticSessionTitlesRef = useRef<Map<string, string>>(new Map());
   const conversationRef = useRef<HTMLDivElement | null>(null);
   const conversationEndRef = useRef<HTMLDivElement | null>(null);
   const conversationViewBySessionRef = useRef<Map<string, ConversationViewState>>(new Map());
@@ -379,11 +375,8 @@ export function ChatPage({
   const submission = useChatSubmission({
     chatStore, settingsStore, artifactReviews: workspaceStore?.artifactReviews,
     sessionId: activeSessionId, now, t, reload: reloadSessionRuntime,
-    refreshSessions: handleSessionStoreRefresh, materializeDraft: createSessionForDraft,
-    previewSession(session) {
-      optimisticSessionTitlesRef.current.set(session.id, session.title);
-      setSessions((current) => current.map((candidate) => candidate.id === session.id ? session : candidate));
-    },
+    refreshSessions: sessionApplication.refresh, materializeDraft: createSessionForDraft,
+    previewSession: sessionApplication.preview,
     consumeDraft(sessionId) { dispatchSessionTabs({ type: "draft.changed", sessionId, value: "" }); },
   });
   const { optimisticMessages, compactingSessionId, artifactReviewEpoch } = submission;
@@ -509,7 +502,7 @@ export function ChatPage({
   } = useChatTurnApplication({
     dispatch: chatStore.dispatch,
     submitTurn: submission.submitTurn,
-    refreshSessions: handleSessionStoreRefresh,
+    refreshSessions: sessionApplication.refresh,
     reportError: reportTimelineError,
     clearError: clearTimelineError,
     now,
@@ -534,10 +527,6 @@ export function ChatPage({
     () => activeSession && timelineLoaded ? latestTurnPlan(timeline) : undefined,
     [activeSession, timeline, timelineLoaded],
   );
-  useEffect(() => {
-    sessionsRef.current = sessions;
-  }, [sessions]);
-
   useEffect(() => {
     if (!activePersistedSessionId) {
       setThreadCapabilities(unavailableThreadEffectiveCapabilities("", "no_session", t("runtime.noSessionSelected")));
@@ -579,32 +568,6 @@ export function ChatPage({
     };
   }, []);
 
-  const notifyStartupSessionHydrated = useEffectEvent(() => {
-    onStartupSessionHydrated?.();
-  });
-  useEffect(() => {
-    let cancelled = false;
-    void sessionStore.list().then((nextSessions) => {
-      if (cancelled) {
-        return;
-      }
-      sessionsRef.current = nextSessions;
-      setSessions(nextSessions);
-      setSessionsLoaded(true);
-      dispatchSessionTabs({
-        type: "hydrate",
-        availableSessionIds: nextSessions.map((session) => session.id),
-        persisted: startInNewSessionOnMount
-          ? { activeSessionId: "", draftsBySession: {}, openSessionIds: [] }
-          : readPersistedSessionTabWorkspace(window.localStorage),
-      });
-      notifyStartupSessionHydrated();
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionStore, startInNewSessionOnMount]);
-
   useEffect(() => {
     if (!sessionsLoaded) {
       return;
@@ -633,13 +596,7 @@ export function ChatPage({
   }, [createSessionSignal]);
 
   const activateRequestedSession = useEffectEvent(async (sessionId: string) => {
-    const nextSessions = sessionStore.refresh
-      ? await sessionStore.refresh()
-      : await sessionStore.list();
-    const target = nextSessions.find((session) => session.id === sessionId);
-    if (!target) throw new Error(`Cannot activate unknown Thread ${sessionId}`);
-    sessionsRef.current = nextSessions;
-    setSessions(nextSessions);
+    await sessionApplication.activateExternal(sessionId);
     dispatchDelete({ type: "session-selected", sessionId });
     dispatchSessionTabs({ type: "open", sessionId });
   });
@@ -664,7 +621,7 @@ export function ChatPage({
     chatApplication.receiveCommand(sessionId, event);
     if (event.timeline) {
       chatApplication.receiveTimeline(sessionId, event.timeline);
-      updateSessionStatusFromTimeline(sessionId, event.timeline);
+      sessionApplication.receiveTimeline(sessionId, event.timeline);
       dispatchSessionTabs({ type: "activity", sessionId });
     }
     if (effects.backgroundTabActivity) {
@@ -788,20 +745,10 @@ export function ChatPage({
     }
   }, [activeSessionId, timeline, optimisticMessages, agentUiForms.length]);
 
-  function createLocalDraft(input: DraftSessionCreateInput): DraftSession {
-    const createdAtMs = now();
-    return {
-      id: `draft:${createdAtMs}:${++draftSessionSequence.current}`,
-      createdAtMs,
-      createInput: input,
-    };
-  }
-
   async function handleCreateSession(
     workingDirectory?: string,
     projectContext?: ProjectSessionContext,
   ): Promise<SessionSummary | null> {
-    setSessionWorkspaceError("");
     const inheritedProjectContext: ProjectSessionContext | undefined = workingDirectory === undefined
       && activeDisplaySession?.projectGroupId
       && !activeDisplaySession.projectCoordinator
@@ -823,10 +770,10 @@ export function ChatPage({
     if (!activeSessionId && composerDraft.trim()) {
       dispatchSessionTabs({
         type: "startup-draft.materialize",
-        draft: createLocalDraft({}),
+        draft: sessionApplication.createDraft({}),
       });
     }
-    const draft = createLocalDraft(createInput);
+    const draft = sessionApplication.createDraft(createInput);
     dispatchDelete({ type: "session-selected", sessionId: draft.id });
     dispatchSessionTabs({ type: "session-draft.open", draft });
     return projectDraftSessionSummary(draft);
@@ -848,7 +795,7 @@ export function ChatPage({
     if (!normalizedWorkingDirectory) return;
 
     const startupDraft = composerDraft;
-    const draft = createLocalDraft({ workingDirectory: normalizedWorkingDirectory });
+    const draft = sessionApplication.createDraft({ workingDirectory: normalizedWorkingDirectory });
     dispatchSessionTabs({ type: "session-draft.open", draft });
     if (startupDraft) {
       dispatchSessionTabs({ type: "draft.changed", sessionId: draft.id, value: startupDraft });
@@ -870,16 +817,8 @@ export function ChatPage({
         installedPluginEnabled: result.plugin.enabled,
         ...(result.cleanupWarning ? { cleanupWarning: result.cleanupWarning } : {}),
       };
-      setSessions((current) => current.map((candidate) => (
-        candidate.id === session.id ? { ...candidate, pluginMigration: installedMigration } : candidate
-      )));
       try {
-        await sessionStore.markPluginMigrationInstalled?.(
-          session.id,
-          result.plugin.name,
-          result.plugin.enabled,
-          result.cleanupWarning,
-        );
+        await sessionApplication.recordMigration(session.id, installedMigration);
       } catch (error) {
         setMigrationInstallError(
           `Plugin ${result.plugin.name} was installed, but the migration status could not be saved: ${error instanceof Error ? error.message : String(error)}`,
@@ -900,101 +839,13 @@ export function ChatPage({
         dispatchSessionTabs({ type: "remove", sessionId: session.id });
         return;
       }
-      await sessionStore.delete(session.id);
-      optimisticSessionTitlesRef.current.delete(session.id);
-      setDissolvingSessionIds((current) => new Set(current).add(session.id));
-      const timer = window.setTimeout(() => {
-        const remaining = sessionsRef.current.filter((item) => item.id !== session.id);
-        sessionsRef.current = remaining;
-        setSessions(remaining);
-        dispatchSessionTabs({ type: "remove", sessionId: session.id });
-        conversationViewBySessionRef.current.delete(session.id);
-        submission.forgetSession(session.id);
-        setDissolvingSessionIds((current) => {
-          const nextIds = new Set(current);
-          nextIds.delete(session.id);
-          return nextIds;
-        });
-      }, SESSION_DELETE_DISSOLVE_MS);
-      deleteDissolveTimers.current.push(timer);
+      await sessionApplication.delete(session);
     }
-  }
-
-  async function handleSessionStoreRefresh(preserveSession?: SessionSummary): Promise<SessionSummary[]> {
-    const listedSessions = await sessionStore.list();
-    let titledSessions = listedSessions.map((session) => {
-      if (!isDefaultSessionTitle(session.title)) {
-        optimisticSessionTitlesRef.current.delete(session.id);
-        return session;
-      }
-      const optimisticTitle = optimisticSessionTitlesRef.current.get(session.id);
-      return optimisticTitle ? { ...session, title: optimisticTitle } : session;
-    });
-    const listedSessionIdsBeforeReconciliation = new Set(titledSessions.map((session) => session.id));
-    const knownSessionIds = new Set(sessionsRef.current.map((session) => session.id));
-    const missingOptimisticSessions = sessionsRef.current.filter((session) => (
-      optimisticSessionTitlesRef.current.has(session.id) && !listedSessionIdsBeforeReconciliation.has(session.id)
-    ));
-    const replacementCandidates = titledSessions.filter((session) => !knownSessionIds.has(session.id));
-    let sessionIdReplacement: { previousSessionId: string; sessionId: string } | undefined;
-    if (missingOptimisticSessions.length === 1 && replacementCandidates.length === 1) {
-      const pendingSession = missingOptimisticSessions[0];
-      const replacementSession = replacementCandidates[0];
-      sessionIdReplacement = {
-        previousSessionId: pendingSession.id,
-        sessionId: replacementSession.id,
-      };
-      const optimisticTitle = optimisticSessionTitlesRef.current.get(pendingSession.id);
-      optimisticSessionTitlesRef.current.delete(pendingSession.id);
-      if (optimisticTitle && isDefaultSessionTitle(replacementSession.title)) {
-        optimisticSessionTitlesRef.current.set(replacementSession.id, optimisticTitle);
-        titledSessions = titledSessions.map((session) => (
-          session.id === replacementSession.id ? { ...session, title: optimisticTitle } : session
-        ));
-      }
-    }
-    const listedSessionIds = new Set(titledSessions.map((session) => session.id));
-    const pendingOptimisticSessions = sessionsRef.current.filter((session) => (
-      optimisticSessionTitlesRef.current.has(session.id) && !listedSessionIds.has(session.id)
-    )).map((session) => ({
-      ...session,
-      title: optimisticSessionTitlesRef.current.get(session.id) ?? session.title,
-    }));
-    const visibleSessions = [...pendingOptimisticSessions, ...titledSessions];
-    const preserveOptimisticTitle = preserveSession && !isDefaultSessionTitle(preserveSession.title);
-    const nextSessions = preserveSession && !visibleSessions.some((session) => session.id === preserveSession.id)
-      ? [preserveSession, ...visibleSessions]
-      : visibleSessions.map((session) => (
-        preserveOptimisticTitle && session.id === preserveSession.id && isDefaultSessionTitle(session.title)
-          ? { ...session, title: preserveSession.title }
-          : session
-      ));
-    sessionsRef.current = nextSessions;
-    setSessions(nextSessions);
-    if (sessionIdReplacement) {
-      dispatchSessionTabs({ type: "replace", ...sessionIdReplacement });
-      moveMapValue(
-        conversationViewBySessionRef.current,
-        sessionIdReplacement.previousSessionId,
-        sessionIdReplacement.sessionId,
-      );
-      submission.replaceSession(sessionIdReplacement.previousSessionId, sessionIdReplacement.sessionId);
-      chatApplication.replaceSession(
-        sessionIdReplacement.previousSessionId,
-        sessionIdReplacement.sessionId,
-      );
-    }
-    dispatchSessionTabs({
-      type: "reconcile",
-      availableSessionIds: nextSessions.map((session) => session.id),
-    });
-    return nextSessions;
   }
 
   async function handlePinConversation(session: SessionSummary) {
     const pinned = !session.pinned;
-    await sessionStore.pin(session.id, pinned);
-    setSessions((current) => current.map((item) => item.id === session.id ? { ...item, pinned } : item));
+    await sessionApplication.pin(session.id, pinned);
     setHeaderMenuOpen(false);
   }
 
@@ -1004,9 +855,7 @@ export function ChatPage({
       setHeaderMenuOpen(false);
       return;
     }
-    await sessionStore.rename(session.id, nextTitle);
-    optimisticSessionTitlesRef.current.delete(session.id);
-    setSessions((current) => current.map((item) => item.id === session.id ? { ...item, title: nextTitle } : item));
+    await sessionApplication.rename(session.id, nextTitle);
     setHeaderMenuOpen(false);
   }
 
@@ -1021,21 +870,13 @@ export function ChatPage({
   }
 
   async function handleArchiveConversation(session: SessionSummary) {
-    await sessionStore.archive(session.id);
-    const remaining = sessions.filter((item) => item.id !== session.id);
-    sessionsRef.current = remaining;
-    setSessions(remaining);
-    dispatchSessionTabs({ type: "remove", sessionId: session.id });
-    conversationViewBySessionRef.current.delete(session.id);
+    await sessionApplication.archive(session);
     setHeaderMenuOpen(false);
   }
 
   async function handleBranchFromMessage(session: SessionSummary, messageId: string) {
     const branched = await submission.fork(session.id, messageId);
-    const nextSessions = [branched, ...sessionsRef.current.filter((item) => item.id !== branched.id)];
-    sessionsRef.current = nextSessions;
-    setSessions(nextSessions);
-    dispatchSessionTabs({ type: "open", sessionId: branched.id });
+    sessionApplication.accept(branched);
   }
 
   async function handleComposerSend(
@@ -1054,7 +895,7 @@ export function ChatPage({
       pastedContent,
       selectedSkillIds: composerSelectedSkillIds,
       selectedSessionIds: composerSessionMentionIds,
-      sessions: sessionsRef.current.map((session) => ({
+      sessions: sessionApplication.snapshot().sessions.map((session) => ({
         id: session.id,
         title: displaySessionTitle(session.title, t),
         updatedAtMs: session.updatedAtMs,
@@ -1089,51 +930,42 @@ export function ChatPage({
   }
 
   async function createSessionForDraft(): Promise<SessionSummary | null> {
-    if (!draftNewSession) {
-      return null;
-    }
-    if (!draftSessionCreatePromise.current) {
-      const draftSession = sessionTabs.draftSessionsById[activeSessionId];
-      const modelInput = composerSessionModelInput(composerModels, composerModel);
-      const createInput = {
-        ...draftSession?.createInput,
-        ...modelInput,
-      };
-      const createArgument = draftSession || Object.keys(createInput).length
-        ? createInput
-        : undefined;
-      const materializingSessionId = activeSessionId;
-      setSessionCreatePending(true);
-      setSessionWorkspaceError("");
-      draftSessionCreatePromise.current = sessionStore.create(createArgument)
-        .then((created) => {
-          activateCreatedSession(created, materializingSessionId);
-          return created;
-        })
-        .catch((error) => {
-          const message = error instanceof Error ? error.message : String(error);
-          setSessionWorkspaceError(message);
-          console.error("[session-workspaces] session.create.failed", {
-            error: message,
-            workingDirectory: draftSession?.createInput.workingDirectory ?? "",
-            projectGroupId: draftSession?.createInput.projectGroupId ?? "",
-          });
-          return Promise.reject(error);
-        })
-        .finally(() => {
-          draftSessionCreatePromise.current = null;
-          setSessionCreatePending(false);
-        });
-    }
-    return draftSessionCreatePromise.current;
+    if (!draftNewSession) return null;
+    return sessionApplication.materializeDraft(activeSessionId, sessionTabs.draftSessionsById[activeSessionId],
+      composerSessionModelInput(composerModels, composerModel));
   }
 
-  function activateCreatedSession(created: SessionSummary, previousSessionId = ""): void {
-    sessionsRef.current = [created, ...sessionsRef.current.filter((session) => session.id !== created.id)];
-    setSessions((current) => [created, ...current.filter((session) => session.id !== created.id)]);
-    dispatchSessionTabs(previousSessionId !== created.id
-      ? { type: "replace", previousSessionId, sessionId: created.id }
-      : { type: "open", sessionId: created.id });
+  function handleSessionChange(event: ChatSessionChange) {
+    if (event.type === "loaded") {
+      dispatchSessionTabs({ type: "hydrate", availableSessionIds: event.sessions.map((session) => session.id),
+        persisted: startInNewSessionOnMount ? { activeSessionId: "", draftsBySession: {}, openSessionIds: [] }
+          : readPersistedSessionTabWorkspace(window.localStorage) });
+      onStartupSessionHydrated?.();
+    } else if (event.type === "reconciled") {
+      dispatchSessionTabs({ type: "reconcile", availableSessionIds: event.sessions.map((session) => session.id) });
+    } else if (event.type === "created") {
+      dispatchSessionTabs(event.previousSessionId !== undefined && event.previousSessionId !== event.session.id
+        ? { type: "replace", previousSessionId: event.previousSessionId, sessionId: event.session.id }
+        : { type: "open", sessionId: event.session.id });
+    } else if (event.type === "replaced") {
+      dispatchSessionTabs({ type: "replace", previousSessionId: event.previousSessionId, sessionId: event.sessionId });
+      moveMapValue(conversationViewBySessionRef.current, event.previousSessionId, event.sessionId);
+      submission.replaceSession(event.previousSessionId, event.sessionId);
+      chatApplication.replaceSession(event.previousSessionId, event.sessionId);
+    } else if (event.type === "removed") {
+      const sessionId = event.session.id;
+      const finish = () => {
+        dispatchSessionTabs({ type: "remove", sessionId });
+        conversationViewBySessionRef.current.delete(sessionId);
+        submission.forgetSession(sessionId);
+        setRetainedDeletingSessions((current) => current.filter((session) => session.id !== sessionId));
+        setDissolvingSessionIds((current) => { const next = new Set(current); next.delete(sessionId); return next; });
+      };
+      if (event.reason === "archive") { finish(); return; }
+      setRetainedDeletingSessions((current) => [...current, event.session]);
+      setDissolvingSessionIds((current) => new Set(current).add(sessionId));
+      deleteDissolveTimers.current.push(window.setTimeout(finish, SESSION_DELETE_DISSOLVE_MS));
+    }
   }
 
   async function handleStopGeneration(session: SessionSummary) {
@@ -1142,7 +974,7 @@ export function ChatPage({
 
   function handleChatSessionRuntimeEffect(effect: ChatSessionRuntimeEffect): void {
     if (effect.type === "timeline_applied") {
-      updateSessionStatusFromTimeline(effect.sessionId, effect.timeline);
+      sessionApplication.receiveTimeline(effect.sessionId, effect.timeline);
       submission.receiveTimeline(effect.sessionId, effect.timeline);
       return;
     }
@@ -1156,18 +988,6 @@ export function ChatPage({
     }
 
     chatApplication.receiveCommand(effect.sessionId, effect.event);
-  }
-
-  function updateSessionStatusFromTimeline(sessionId: string, nextTimeline: ChatTimelineSnapshot) {
-    const status = projectTimelineSessionStatus(nextTimeline);
-    if (!status) return;
-    setSessions((current) => {
-      const next = current.map((session) => (
-        session.id === sessionId ? { ...session, status } : session
-      ));
-      sessionsRef.current = next;
-      return next;
-    });
   }
 
   async function handleOpenSubagent(delegate: DelegatedAgentState) {
@@ -1529,18 +1349,7 @@ export function ChatPage({
               });
             }
             if (activeSession) {
-              setSessions((current) => current.map((session) => (
-                session.id === activeSession.id
-                  ? {
-                      ...session,
-                      model: selectedModelId,
-                      modelProvider: selected.providerId,
-                    }
-                  : session
-              )));
-              const setModel = selected.providerId
-                ? sessionStore.setModel?.(activeSession.id, selectedModelId, selected.providerId)
-                : sessionStore.setModel?.(activeSession.id, selectedModelId);
+              const setModel = sessionApplication.selectModel(activeSession.id, selectedModelId, selected.providerId);
               void setModel?.catch((error) => {
                 reportTimelineError(t("errors.modelSaveFailed", { message: error instanceof Error ? error.message : String(error) }));
               });
@@ -1603,7 +1412,7 @@ export function ChatPage({
         onAskForSpreadsheetChange={handleSpreadsheetAskForChange}
         onHandoff={async (sessionId) => {
           await submission.submitTurn(sessionId, { text: t("browserHandoffContinue") }, "browser-handoff-complete");
-          await handleSessionStoreRefresh(activeSession);
+          await sessionApplication.refresh(activeSession);
         }}
         onError={reportTimelineError}
       />
@@ -1805,4 +1614,3 @@ function projectDraftSessionSummary(draft: DraftSession): SessionSummary {
 function boundedSpreadsheetSelectionValue(value: string): string {
   return value.length > 12000 ? `${value.slice(0, 12000)}\n[Selection excerpt truncated; read the referenced range for all values.]` : value;
 }
-

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { useChatSessions } from "./useChatSessions";
 import type { ChatSessionChange } from "./chatSessionApplication";
 import { SidecarResources, initialSidecarLayout, type SidecarResourcesHandle, type SidecarLayout } from "../sidecar/SidecarResources";
-import { useChatSubmission } from "./useChatSubmission";
+import { useChatApplication } from "./useChatApplication";
 import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { elementTransitions, useExitPresence } from "../lib/useExitPresence";
 import type { TFunction } from "i18next";
@@ -18,7 +18,6 @@ import {
 import { useTranslation } from "react-i18next";
 import "./ChatPage.css";
 import { ChatQueueNotice, ChatQueuedInputs } from "./ChatQueuedInputs";
-import { useChatTurnApplication } from "./useChatTurnApplication";
 import {
   ClaudeStyleAiInput,
   type ComposerContextReference,
@@ -32,7 +31,7 @@ import {
   type PastedContent,
 } from "../../components/ui/claude-style-ai-input";
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
-import type { ChatEvent, ChatModelOption, ChatStore, ProjectGroupStore, SessionStore, SessionSummary, SettingsStore, SkillSummary, ToolSummary, ToolsStore, WorkspaceRegistryStore, WorkspaceStore } from "../services";
+import type { ChatModelOption, ChatStore, ProjectGroupStore, SessionStore, SessionSummary, SettingsStore, SkillSummary, ToolSummary, ToolsStore, WorkspaceRegistryStore, WorkspaceStore } from "../services";
 import {
   clearDefaultChatModel,
   readDefaultChatModelPreference,
@@ -46,9 +45,6 @@ import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
 import type { ToolCallSummary } from "./messageActions";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { AgentUiFormCard } from "./AgentUiFormCard";
-import {
-  projectChatEventEffects,
-} from "./chatEventPolicy";
 import {
   projectLatestContextUsage,
   type ContextUsageDefaults,
@@ -84,14 +80,6 @@ import {
   type ThreadCommandLifecycle,
   type ThreadCommand,
 } from "../../app-core/chat/threadCommand";
-import {
-  unavailableThreadEffectiveCapabilities,
-  type ThreadEffectiveCapabilities,
-} from "../../app-core/chat/threadCapabilities";
-import {
-  useChatSessionRuntime,
-  type ChatSessionRuntimeEffect,
-} from "./useChatSessionRuntime";
 import {
   MAX_COMPOSER_SESSION_REFERENCES,
   type SpreadsheetComposerAnnotation,
@@ -285,9 +273,6 @@ export function ChatPage({
     reduceSessionTabWorkspace,
     INITIAL_SESSION_TAB_WORKSPACE,
   );
-  const [threadCapabilities, setThreadCapabilities] = useState<ThreadEffectiveCapabilities>(() => (
-    unavailableThreadEffectiveCapabilities("", "loading", t("runtime.loadingCapabilities"))
-  ));
   const [composerModels, setComposerModels] = useState<ModelOption[]>([]);
   const [composerModel, setComposerModel] = useState("");
   const [composerReasoningEffort, setComposerReasoningEffort] = useState(readCurrentChatReasoningEffort);
@@ -355,31 +340,20 @@ export function ChatPage({
     onActiveWorkspaceChange?.(workingDirectory);
   }, [activeDisplaySession?.pluginMigration, activeDisplaySession?.workingDirectory, onActiveWorkspaceChange]);
   const activePersistedSessionId = activeSession?.id ?? "";
-  const sessionRuntime = useChatSessionRuntime({
-    chatStore,
-    onEffect: handleChatSessionRuntimeEffect,
-    sessionId: activePersistedSessionId,
+  const { state: chatState, actions: chatActions, turns: chatApplication } = useChatApplication({
+    chatStore, sessions: sessionApplication, settingsStore, artifactReviews: workspaceStore?.artifactReviews,
+    sessionId: activeSessionId, session: activeSession, openSessionIds: sessionTabs.openSessionIds,
+    drafts: sessionTabs.draftSessionsById, model: composerSessionModelInput(composerModels, composerModel), now, t,
+    onDraftConsumed(sessionId) { dispatchSessionTabs({ type: "draft.changed", sessionId, value: "" }); },
+    onBackgroundActivity(sessionId) { dispatchSessionTabs({ type: "activity", sessionId }); },
   });
   const {
-    agentUiForms,
-    error: timelineError,
-    hookResults,
-    timeline,
-  } = sessionRuntime.state;
-  const {
-    clearError: clearTimelineError,
-    reload: reloadSessionRuntime,
-    reportError: reportTimelineError,
-  } = sessionRuntime.actions;
+    agentUiForms, error: timelineError, hookResults, timeline,
+    optimisticMessages, compactingSessionId, artifactReviewEpoch,
+    lifecycle: commandLifecycle, canCancel: canCancelTurn, cancelUnavailableReason,
+  } = chatState;
+  const { reportError: reportTimelineError } = chatActions;
   const composerDraft = sessionTabDraft(sessionTabs, activeSessionId);
-  const submission = useChatSubmission({
-    chatStore, settingsStore, artifactReviews: workspaceStore?.artifactReviews,
-    sessionId: activeSessionId, now, t, reload: reloadSessionRuntime,
-    refreshSessions: sessionApplication.refresh, materializeDraft: createSessionForDraft,
-    previewSession: sessionApplication.preview,
-    consumeDraft(sessionId) { dispatchSessionTabs({ type: "draft.changed", sessionId, value: "" }); },
-  });
-  const { optimisticMessages, compactingSessionId, artifactReviewEpoch } = submission;
 
   const resolvedSessionSidebarCollapsed = sessionSidebarCollapsed ?? localSessionSidebarCollapsed;
   const composerSkillOptions = useMemo(
@@ -494,20 +468,6 @@ export function ChatPage({
       activeSession?.pluginMigration?.status === "pending"
       && latestTurnStatus === "completed"
     );
-  const {
-    application: chatApplication,
-    lifecycle: commandLifecycle,
-    canCancel: canCancelTurn,
-    cancelUnavailableReason,
-  } = useChatTurnApplication({
-    dispatch: chatStore.dispatch,
-    submitTurn: submission.submitTurn,
-    refreshSessions: sessionApplication.refresh,
-    reportError: reportTimelineError,
-    clearError: clearTimelineError,
-    now,
-    t,
-  }, activePersistedSessionId, { timeline, capabilities: threadCapabilities });
   const compactingActiveSession = Boolean(activeSession && compactingSessionId === activeSession.id);
   const showCommandLifecycleStatus = commandLifecycle.stage !== "idle"
     && commandLifecycle.command.kind !== "agent.cancel";
@@ -527,33 +487,6 @@ export function ChatPage({
     () => activeSession && timelineLoaded ? latestTurnPlan(timeline) : undefined,
     [activeSession, timeline, timelineLoaded],
   );
-  useEffect(() => {
-    if (!activePersistedSessionId) {
-      setThreadCapabilities(unavailableThreadEffectiveCapabilities("", "no_session", t("runtime.noSessionSelected")));
-      return;
-    }
-    let cancelled = false;
-    setThreadCapabilities(unavailableThreadEffectiveCapabilities(
-      activePersistedSessionId,
-      "loading",
-      t("runtime.loadingCapabilities"),
-    ));
-    void chatStore.loadEffectiveCapabilities(activePersistedSessionId).then((capabilities) => {
-      if (!cancelled) setThreadCapabilities(capabilities);
-    }).catch((error) => {
-      if (!cancelled) {
-        setThreadCapabilities(unavailableThreadEffectiveCapabilities(
-          activePersistedSessionId,
-          "capability_query_failed",
-          error instanceof Error ? error.message : String(error),
-        ));
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [activeTurn?.id, activeTurn?.status, activePersistedSessionId, chatStore, t]);
-
   useEffect(() => {
     setComposerSessionMentionIds([]);
     setComposerSelectedSkillIds([]);
@@ -615,32 +548,6 @@ export function ChatPage({
       });
     });
   }, [activateSessionRequest, reportTimelineError, sessionsLoaded]);
-
-  const handleBackgroundChatEvent = useEffectEvent((sessionId: string, event: ChatEvent) => {
-    const effects = projectChatEventEffects(event);
-    chatApplication.receiveCommand(sessionId, event);
-    if (event.timeline) {
-      chatApplication.receiveTimeline(sessionId, event.timeline);
-      sessionApplication.receiveTimeline(sessionId, event.timeline);
-      dispatchSessionTabs({ type: "activity", sessionId });
-    }
-    if (effects.backgroundTabActivity) {
-      dispatchSessionTabs({ type: "activity", sessionId });
-    }
-    if (effects.reloadSessions) {
-      void chatApplication.receiveSessionEvent(sessionId, event);
-    }
-  });
-  useEffect(() => {
-    const unsubscribes = sessionTabs.openSessionIds
-      .filter((sessionId) => (
-        sessionId !== activeSessionId && !(sessionId in sessionTabs.draftSessionsById)
-      ))
-      .map((sessionId) => chatStore.subscribe(sessionId, (event) => {
-        handleBackgroundChatEvent(sessionId, event);
-      }));
-    return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
-  }, [activeSessionId, chatStore, sessionTabs.draftSessionsById, sessionTabs.openSessionIds]);
 
   useEffect(() => {
     if (!settingsStore?.loadChatModels) {
@@ -875,8 +782,7 @@ export function ChatPage({
   }
 
   async function handleBranchFromMessage(session: SessionSummary, messageId: string) {
-    const branched = await submission.fork(session.id, messageId);
-    sessionApplication.accept(branched);
+    await chatActions.fork(session.id, messageId);
   }
 
   async function handleComposerSend(
@@ -886,7 +792,7 @@ export function ChatPage({
     options: ComposerSendOptions,
   ) {
     const availableMentionIds = new Set(composerSessionMentionOptions.map((option) => option.id));
-    await submission.send({
+    await chatActions.send({
       availableSessionIds: availableMentionIds,
       files,
       isRunning: activeSession ? sessionResponding : false,
@@ -902,7 +808,7 @@ export function ChatPage({
       })),
       artifactReferences: composerArtifactReferences.map(({ id: _id, ...reference }) => reference),
       spreadsheetAnnotations: composerSpreadsheetAnnotations,
-    }, activeSession, chatApplication);
+    });
   }
 
   function handleConversationScroll(): void {
@@ -929,12 +835,6 @@ export function ChatPage({
     conversationEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }
 
-  async function createSessionForDraft(): Promise<SessionSummary | null> {
-    if (!draftNewSession) return null;
-    return sessionApplication.materializeDraft(activeSessionId, sessionTabs.draftSessionsById[activeSessionId],
-      composerSessionModelInput(composerModels, composerModel));
-  }
-
   function handleSessionChange(event: ChatSessionChange) {
     if (event.type === "loaded") {
       dispatchSessionTabs({ type: "hydrate", availableSessionIds: event.sessions.map((session) => session.id),
@@ -950,14 +850,11 @@ export function ChatPage({
     } else if (event.type === "replaced") {
       dispatchSessionTabs({ type: "replace", previousSessionId: event.previousSessionId, sessionId: event.sessionId });
       moveMapValue(conversationViewBySessionRef.current, event.previousSessionId, event.sessionId);
-      submission.replaceSession(event.previousSessionId, event.sessionId);
-      chatApplication.replaceSession(event.previousSessionId, event.sessionId);
     } else if (event.type === "removed") {
       const sessionId = event.session.id;
       const finish = () => {
         dispatchSessionTabs({ type: "remove", sessionId });
         conversationViewBySessionRef.current.delete(sessionId);
-        submission.forgetSession(sessionId);
         setRetainedDeletingSessions((current) => current.filter((session) => session.id !== sessionId));
         setDissolvingSessionIds((current) => { const next = new Set(current); next.delete(sessionId); return next; });
       };
@@ -970,24 +867,6 @@ export function ChatPage({
 
   async function handleStopGeneration(session: SessionSummary) {
     await chatApplication.cancel(session.id);
-  }
-
-  function handleChatSessionRuntimeEffect(effect: ChatSessionRuntimeEffect): void {
-    if (effect.type === "timeline_applied") {
-      sessionApplication.receiveTimeline(effect.sessionId, effect.timeline);
-      submission.receiveTimeline(effect.sessionId, effect.timeline);
-      return;
-    }
-    if (effect.type === "message_received") {
-      submission.receiveMessage(effect.sessionId, effect.message);
-      return;
-    }
-    if (effect.type === "session_refresh_requested") {
-      void chatApplication.receiveSessionEvent(effect.sessionId, effect.event);
-      return;
-    }
-
-    chatApplication.receiveCommand(effect.sessionId, effect.event);
   }
 
   async function handleOpenSubagent(delegate: DelegatedAgentState) {
@@ -1341,7 +1220,7 @@ export function ChatPage({
             const selectedModelId = selected.modelId || selected.id;
             setComposerModel(modelId);
             if (emptyActiveSession) {
-              const persistence = submission.saveDefaultModel(selectedModelId, selected.providerId);
+              const persistence = chatActions.saveDefaultModel(selectedModelId, selected.providerId);
               void persistence.catch((error) => {
                 reportTimelineError(t("errors.modelSaveFailed", {
                   message: error instanceof Error ? error.message : String(error),
@@ -1410,10 +1289,7 @@ export function ChatPage({
           setComposerFocusRequestId((current) => current + 1);
         }}
         onAskForSpreadsheetChange={handleSpreadsheetAskForChange}
-        onHandoff={async (sessionId) => {
-          await submission.submitTurn(sessionId, { text: t("browserHandoffContinue") }, "browser-handoff-complete");
-          await sessionApplication.refresh(activeSession);
-        }}
+        onHandoff={chatActions.completeBrowserHandoff}
         onError={reportTimelineError}
       />
 

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1,5 +1,6 @@
+import { SidecarResources, initialSidecarLayout, type SidecarResourcesHandle, type SidecarLayout } from "../sidecar/SidecarResources";
 import { useChatSubmission } from "./useChatSubmission";
-import { lazy, Suspense, useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { elementTransitions, useExitPresence } from "../lib/useExitPresence";
 import type { TFunction } from "i18next";
 import {
@@ -43,7 +44,6 @@ import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
 import type { ToolCallSummary } from "./messageActions";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { AgentUiFormCard } from "./AgentUiFormCard";
-import { DataViewCard } from "./DataViewCard";
 import {
   projectChatEventEffects,
   projectTimelineSessionStatus,
@@ -64,31 +64,20 @@ import {
 } from "./sessionTabWorkspace";
 import {
   groupSessionsByWorkspace,
-  sessionWorkspaceName,
 } from "./sessionWorkspaces";
 import {
   applyLoadedDelegatedAgentTrace,
-  projectLoadedArtifactDetail,
 } from "../../app-core/chat/chatProjection";
 import type {
   ArtifactRef,
   DelegatedAgentState,
-  LoadedArtifactDetail,
 } from "../../app-core/chat/chatTurnContracts";
 import {
-  type OfficeArtifactSource,
   type SpreadsheetCellChangeRequest,
 } from "../../app-core/chat/officeArtifact";
-import { officeContentReference } from "../../app-core/chat/officeContentReference";
-import { ArtifactReviewPanel } from "../sidecar/ArtifactReviewPanel";
-import { useArtifactFile } from "./useArtifactFile";
 import type { AgentInputReference } from "../../app-core/chat/agentInputReference";
 import { logRendererEvent } from "../../app-core/native/rendererLogger";
 import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
-import type {
-  NativeBrowserSession,
-  NativeBrowserSnapshot,
-} from "../../app-core/native/nativeBrowserSnapshot";
 import {
   isThreadCommandInFlight,
   type ThreadCommandLifecycle,
@@ -110,14 +99,7 @@ import { ChatTimeline } from "./ChatTimeline";
 import { captureConversationView, restoreConversationView, type ConversationViewState } from "./conversationViewport";
 import { EmptyChatStart } from "./EmptyChatStart";
 import { FloatingPlanStatus } from "./FloatingPlanStatus";
-import { AssistantMarkdown } from "./AssistantMarkdown";
-import {
-  AssistantFileLinkError,
-  assistantFileArtifact,
-  assistantFileLinkTitle,
-  resolveAssistantFileLink,
-  type AssistantFileLink,
-} from "./assistantFileLinks";
+import type { AssistantFileLink } from "./assistantFileLinks";
 import {
   ChatSessionWorkspace,
   type ProjectSessionContext,
@@ -127,23 +109,6 @@ import {
   isDefaultSessionTitle,
 } from "./sessionTitle";
 import { projectTinybotMascotMood, type TinybotMascotMood } from "./TinybotMascot";
-import { Sidecar } from "../sidecar/Sidecar";
-import { SidecarBrowser } from "../sidecar/SidecarBrowser";
-import { OfficeArtifactPreview } from "../sidecar/OfficeArtifactPreview";
-import {
-  activeSidecarTab,
-  createInitialSidecarState,
-  DEFAULT_SIDECAR_WORKSPACE_ID,
-  readPersistedSidecarWidth,
-  reduceSidecarState,
-  sidecarArtifactTabId,
-  visibleSidecarTabs,
-  writePersistedSidecarWidth,
-  type SidecarArtifactTab,
-  type SidecarBrowserTab,
-  type SidecarTab,
-  type SidecarTerminalTab,
-} from "../sidecar/sidecarModel";
 
 export type ChatPageProps = {
   chatStore: ChatStore;
@@ -182,23 +147,6 @@ type DrawerState =
   | { kind: "tool"; title: string; toolCall: ToolCallSummary }
   | { kind: "subagent"; title: string; delegate: DelegatedAgentState; loading: boolean; error?: string }
   | null;
-
-type ArtifactSidecarContent = {
-  localFile?: boolean;
-  artifact: ArtifactRef;
-  detail?: LoadedArtifactDetail;
-  error?: string;
-  loading: boolean;
-  notice?: string;
-  office?: OfficeArtifactSource;
-};
-
-type BrowserSnapshot = NativeBrowserSnapshot<NativeBrowserSession>;
-
-const LazySidecarTerminal = lazy(async () => {
-  const module = await import("../sidecar/SidecarTerminal");
-  return { default: module.SidecarTerminal };
-});
 
 function resolveComposerModel(
   models: readonly ModelOption[],
@@ -353,16 +301,9 @@ export function ChatPage({
   const drawerElementRef = useRef<HTMLElement>(null);
   const drawerTriggerRef = useRef<HTMLElement | null>(null);
   const sidecarToggleRef = useRef<HTMLButtonElement>(null);
-  const [sidecar, dispatchSidecar] = useReducer(
-    reduceSidecarState,
-    undefined,
-    () => createInitialSidecarState(readPersistedSidecarWidth(window.localStorage)),
-  );
-  const [artifactSidecarContent, setArtifactSidecarContent] = useState<Record<string, ArtifactSidecarContent>>({});
+  const sidecarResources = useRef<SidecarResourcesHandle>(null);
+  const [sidecar, setSidecar] = useState<SidecarLayout>(initialSidecarLayout);
   const [composerFocusRequestId, setComposerFocusRequestId] = useState(0);
-  const [browserProvisionErrors, setBrowserProvisionErrors] = useState<Record<string, string>>({});
-  const [terminalErrors, setTerminalErrors] = useState<Record<string, string>>({});
-  const [browserProvisionEpoch, setBrowserProvisionEpoch] = useState(0);
   const [composerSessionMentionIds, setComposerSessionMentionIds] = useState<string[]>([]);
   const [composerSelectedSkillIds, setComposerSelectedSkillIds] = useState<string[]>([]);
   const [composerArtifactReferences, setComposerArtifactReferences] = useState<(AgentInputReference & { id: string })[]>([]);
@@ -387,10 +328,6 @@ export function ChatPage({
   const pendingConversationRestoreRef = useRef("");
   const hasActivatedSessionRef = useRef(false);
   const stickToLatestRef = useRef(true);
-  const sidecarRef = useRef(sidecar);
-  const browserProvisioningResourceIdRef = useRef("");
-  const browserActivationTargetRef = useRef("");
-  sidecarRef.current = sidecar;
   sessionTabsRef.current = sessionTabs;
   sessionsLoadedRef.current = sessionsLoaded;
   const activeSessionId = sessionTabs.activeSessionId;
@@ -429,16 +366,11 @@ export function ChatPage({
   });
   const {
     agentUiForms,
-    browserError,
-    browserSnapshot,
     error: timelineError,
     hookResults,
     timeline,
   } = sessionRuntime.state;
   const {
-    acceptBrowserSnapshot,
-    clearBrowserError,
-    clearBrowserSnapshot,
     clearError: clearTimelineError,
     reload: reloadSessionRuntime,
     reportError: reportTimelineError,
@@ -483,16 +415,6 @@ export function ChatPage({
       label: annotation.fileTitle,
     }))]
   ), [composerArtifactReferences, composerSpreadsheetAnnotations, t]);
-  const sidecarTabs = useMemo(() => visibleSidecarTabs(sidecar), [sidecar]);
-  const sidecarActiveTab = useMemo(() => activeSidecarTab(sidecar), [sidecar]);
-  const explicitWorkspaceId = activeDisplaySession?.workingDirectory?.trim() ?? "";
-  const activeWorkspaceId = activeDisplaySession
-    ? explicitWorkspaceId || DEFAULT_SIDECAR_WORKSPACE_ID
-    : "";
-  const activeWorkspaceLabel = explicitWorkspaceId
-    ? sessionWorkspaceName(explicitWorkspaceId)
-    : activeDisplaySession ? t("shell.generalSessions") : "";
-
   useEffect(() => {
     if (!toolsStore?.loadCatalog) {
       setComposerSkills([]);
@@ -523,166 +445,6 @@ export function ChatPage({
       cancelled = true;
     };
   }, [activeDisplaySession?.pluginMigration, activeDisplaySession?.workingDirectory, toolsStore]);
-  const unboundBrowserResource = useMemo(() => sidecar.tabs.find((tab): tab is SidecarBrowserTab => (
-    tab.kind === "browser"
-      && tab.threadId === activeSession?.id
-      && !tab.nativeTabId
-  )), [activeSession?.id, sidecar.tabs]);
-  const retainedBrowserResource = useMemo(() => sidecar.tabs.find((tab): tab is SidecarBrowserTab => (
-    tab.kind === "browser"
-      && tab.threadId === activeSession?.id
-      && Boolean(tab.browserSessionId)
-      && Boolean(tab.nativeTabId)
-  )), [activeSession?.id, sidecar.tabs]);
-
-  const synchronizeBrowserSnapshot = useCallback((snapshot: BrowserSnapshot, acceptForActiveThread = true) => {
-    if (acceptForActiveThread && snapshot.data.sessionId === activeSessionId) {
-      acceptBrowserSnapshot(snapshot);
-    }
-    dispatchSidecar({
-      browserSessionId: snapshot.data.browserSessionId,
-      tabs: snapshot.data.tabs.map((tab) => ({
-        nativeTabId: tab.tabId,
-        title: browserResourceTitle(tab.title, tab.url, t("sidecar.browser")),
-      })),
-      threadId: snapshot.data.sessionId,
-      type: "tab.syncBrowserSession",
-    });
-  }, [acceptBrowserSnapshot, activeSessionId, t]);
-
-  useEffect(() => {
-    dispatchSidecar({
-      threadId: activeSession?.id ?? "",
-      type: "scope.changed",
-      workspaceId: activeWorkspaceId,
-    });
-  }, [activeSession?.id, activeWorkspaceId]);
-
-  useEffect(() => {
-    if (browserSnapshot) synchronizeBrowserSnapshot(browserSnapshot, false);
-  }, [browserSnapshot, synchronizeBrowserSnapshot]);
-
-  useEffect(() => {
-    const resource = retainedBrowserResource;
-    const browserRuntime = chatStore.browserRuntime;
-    if (!resource?.browserSessionId
-      || !browserRuntime
-      || browserSnapshot?.data.browserSessionId === resource.browserSessionId) return;
-    let cancelled = false;
-    void browserRuntime.snapshot(resource.browserSessionId)
-      .then((snapshot) => {
-        if (cancelled) return;
-        if (snapshot.data.sessionId !== resource.threadId) {
-          throw new Error(
-            `Browser snapshot session ${snapshot.data.sessionId} does not match resource thread ${resource.threadId}.`,
-          );
-        }
-        synchronizeBrowserSnapshot(snapshot);
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setBrowserProvisionErrors((current) => ({ ...current, [resource.id]: errorMessage(error) }));
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    browserProvisionEpoch,
-    browserSnapshot?.data.browserSessionId,
-    chatStore.browserRuntime,
-    retainedBrowserResource,
-    synchronizeBrowserSnapshot,
-  ]);
-
-  useEffect(() => {
-    const resource = unboundBrowserResource;
-    const browserRuntime = chatStore.browserRuntime;
-    if (!resource
-      || browserProvisionErrors[resource.id]
-      || browserProvisioningResourceIdRef.current) return;
-    browserProvisioningResourceIdRef.current = resource.id;
-    void (async () => {
-      try {
-        if (!browserRuntime) throw new Error(t("sidecar.browserBuildUnavailable"));
-        let snapshot = await browserRuntime.createSession({ ownerSessionId: resource.threadId });
-
-        const currentResources = sidecarRef.current.tabs.filter((tab): tab is SidecarBrowserTab => (
-          tab.kind === "browser" && tab.threadId === resource.threadId
-        ));
-        const currentResource = currentResources.find((tab) => tab.id === resource.id);
-        const resourceStillExists = Boolean(currentResource);
-        const resourceAlreadyBound = Boolean(
-          currentResource?.browserSessionId === snapshot.data.browserSessionId
-            && currentResource.nativeTabId
-            && snapshot.data.tabs.some((tab) => tab.tabId === currentResource.nativeTabId),
-        );
-        const boundNativeTabIds = new Set(currentResources.flatMap((tab) => tab.nativeTabId ? [tab.nativeTabId] : []));
-        const hasUnboundNativeTab = snapshot.data.tabs.some((tab) => !boundNativeTabIds.has(tab.tabId));
-        let createdNativeTabId = "";
-        if (resourceStillExists && !resourceAlreadyBound && !hasUnboundNativeTab) {
-          const previousNativeTabIds = new Set(snapshot.data.tabs.map((tab) => tab.tabId));
-          snapshot = await browserRuntime.createTab(snapshot.data.browserSessionId);
-          createdNativeTabId = snapshot.data.tabs.find((tab) => !previousNativeTabIds.has(tab.tabId))?.tabId ?? "";
-        }
-
-        if (!sidecarRef.current.tabs.some((tab) => tab.id === resource.id)) {
-          if (createdNativeTabId && snapshot.data.tabs.length > 1) {
-            await browserRuntime.closeTab(snapshot.data.browserSessionId, createdNativeTabId);
-          }
-          return;
-        }
-        synchronizeBrowserSnapshot(snapshot);
-      } catch (error) {
-        if (sidecarRef.current.tabs.some((tab) => tab.id === resource.id)) {
-          setBrowserProvisionErrors((current) => ({ ...current, [resource.id]: errorMessage(error) }));
-        }
-      } finally {
-        if (browserProvisioningResourceIdRef.current === resource.id) {
-          browserProvisioningResourceIdRef.current = "";
-        }
-        setBrowserProvisionEpoch((current) => current + 1);
-      }
-    })();
-  }, [
-    browserProvisionEpoch,
-    browserProvisionErrors,
-    chatStore.browserRuntime,
-    synchronizeBrowserSnapshot,
-    t,
-    unboundBrowserResource,
-  ]);
-
-  useEffect(() => {
-    const resource = sidecarActiveTab?.kind === "browser" ? sidecarActiveTab : undefined;
-    const browserRuntime = chatStore.browserRuntime;
-    if (!resource?.browserSessionId
-      || !resource.nativeTabId
-      || !browserRuntime
-      || browserSnapshot?.data.browserSessionId !== resource.browserSessionId) return;
-    const activationTarget = `${resource.browserSessionId}:${resource.nativeTabId}`;
-    if (browserSnapshot.data.activeTabId === resource.nativeTabId) {
-      if (browserActivationTargetRef.current === activationTarget) {
-        browserActivationTargetRef.current = "";
-      }
-      return;
-    }
-    if (browserActivationTargetRef.current === activationTarget) return;
-    browserActivationTargetRef.current = activationTarget;
-    void browserRuntime.activateTab(resource.browserSessionId, resource.nativeTabId)
-      .then((snapshot) => synchronizeBrowserSnapshot(snapshot))
-      .catch((error) => {
-        if (browserActivationTargetRef.current === activationTarget) {
-          browserActivationTargetRef.current = "";
-        }
-        setBrowserProvisionErrors((current) => ({ ...current, [resource.id]: errorMessage(error) }));
-      });
-  }, [browserSnapshot, chatStore.browserRuntime, sidecarActiveTab, synchronizeBrowserSnapshot]);
-
-  useEffect(() => {
-    writePersistedSidecarWidth(window.localStorage, sidecar.width);
-  }, [sidecar.width]);
-
   useEffect(() => {
     setMigrationInstallError("");
   }, [activeSessionId]);
@@ -1434,229 +1196,8 @@ export function ChatPage({
     }
   }
 
-  async function handleOpenArtifact(artifact: ArtifactRef) {
-    if (!activeSession) {
-      return;
-    }
-    const tabId = sidecarArtifactTabId(activeSession.id, artifact.id);
-    dispatchSidecar({
-      artifactId: artifact.id,
-      threadId: activeSession.id,
-      title: artifact.title,
-      type: "tab.openArtifact",
-    });
-    if (artifact.kind === "data_view") {
-      setArtifactSidecarContent((current) => ({
-        ...current,
-        [tabId]: {
-          artifact,
-          ...(artifact.dataView ? { detail: { id: artifact.id, title: artifact.title, mimeType: artifact.mimeType, dataView: artifact.dataView } } : {}),
-          loading: false,
-          ...(artifact.dataViewError ? { error: artifact.dataViewError } : {}),
-        },
-      }));
-      return;
-    }
-    setArtifactSidecarContent((current) => ({
-      ...current,
-      [tabId]: { artifact, loading: Boolean(chatStore.loadArtifact) },
-    }));
-    if (!chatStore.loadArtifact) {
-      return;
-    }
-    try {
-      const payload = await chatStore.loadArtifact({
-        artifactId: artifact.id,
-        sessionKey: activeSession.id,
-      });
-      const detail = projectLoadedArtifactDetail(artifact, payload);
-      setArtifactSidecarContent((current) => current[tabId]
-        ? { ...current, [tabId]: { ...current[tabId], detail, loading: false } }
-        : current);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setArtifactSidecarContent((current) => current[tabId]
-        ? { ...current, [tabId]: { ...current[tabId], error: message, loading: false } }
-        : current);
-    }
-  }
-
-  async function handleOpenAssistantFileLink(link: AssistantFileLink) {
-    if (!activeSession) {
-      return;
-    }
-
-    let artifact: ArtifactRef;
-    try {
-      artifact = assistantFileArtifact(resolveAssistantFileLink(link.href, activeSession.workingDirectory));
-      logRendererEvent("info", "artifact.file_link.resolved", {
-        href: link.href, path: artifact.fetchPath, sessionId: activeSession.id,
-      });
-    } catch (error) {
-      artifact = assistantFileArtifact({ path: link.href, title: assistantFileLinkTitle(link.href) });
-      const tabId = sidecarArtifactTabId(activeSession.id, artifact.id);
-      dispatchSidecar({
-        artifactId: artifact.id,
-        threadId: activeSession.id,
-        title: artifact.title,
-        type: "tab.openArtifact",
-      });
-      const message = error instanceof AssistantFileLinkError && error.code === "outside_workspace"
-        ? t("details.fileOutsideWorkspace")
-        : errorMessage(error);
-      console.error("[artifact-preview] workspace file link resolution failed", {
-        error,
-        href: link.href,
-        sessionId: activeSession.id,
-        workspaceRoot: activeSession.workingDirectory,
-      });
-      setArtifactSidecarContent((current) => ({
-        ...current,
-        [tabId]: { artifact, error: message, loading: false },
-      }));
-      return;
-    }
-
-    const tabId = sidecarArtifactTabId(activeSession.id, artifact.id);
-    dispatchSidecar({
-      artifactId: artifact.id,
-      threadId: activeSession.id,
-      title: artifact.title,
-      type: "tab.openArtifact",
-    });
-    setArtifactSidecarContent((current) => ({
-      ...current,
-      [tabId]: { artifact, localFile: true, loading: false },
-    }));
-  }
-
-  async function handleCloseSidecarTab(tab: SidecarTab) {
-    if (tab.kind === "browser") {
-      setBrowserProvisionErrors((current) => omitRecordKey(current, tab.id));
-      const browserRuntime = chatStore.browserRuntime;
-      if (!browserRuntime || !tab.browserSessionId || !tab.nativeTabId) {
-        dispatchSidecar({ tabId: tab.id, type: "tab.close" });
-        return;
-      }
-      try {
-        let snapshot = await browserRuntime.snapshot(tab.browserSessionId);
-        const remainingResources = sidecarRef.current.tabs.filter((candidate) => (
-          candidate.kind === "browser"
-            && candidate.threadId === tab.threadId
-            && candidate.id !== tab.id
-        ));
-        if (snapshot.data.tabs.length === 1 && remainingResources.length) {
-          snapshot = await browserRuntime.createTab(snapshot.data.browserSessionId);
-        }
-        if (snapshot.data.tabs.length === 1) {
-          await browserRuntime.closeSession(snapshot.data.browserSessionId);
-          clearBrowserSnapshot(snapshot.data.browserSessionId);
-          dispatchSidecar({ tabId: tab.id, type: "tab.close" });
-          return;
-        }
-        const next = await browserRuntime.closeTab(snapshot.data.browserSessionId, tab.nativeTabId);
-        dispatchSidecar({ tabId: tab.id, type: "tab.close" });
-        synchronizeBrowserSnapshot(next);
-      } catch (error) {
-        setBrowserProvisionErrors((current) => ({ ...current, [tab.id]: errorMessage(error) }));
-      }
-      return;
-    }
-
-    if (tab.kind === "terminal") {
-      setTerminalErrors((current) => omitRecordKey(current, tab.id));
-      try {
-        await chatStore.terminalRuntime?.terminate(tab.id);
-      } catch (error) {
-        setTerminalErrors((current) => ({ ...current, [tab.id]: errorMessage(error) }));
-        return;
-      }
-      dispatchSidecar({ tabId: tab.id, type: "tab.close" });
-      return;
-    }
-
-    dispatchSidecar({ tabId: tab.id, type: "tab.close" });
-    if (tab.kind === "artifact") {
-      setArtifactSidecarContent((current) => omitRecordKey(current, tab.id));
-    }
-  }
-
-  function renderSidecarArtifact(tab: SidecarArtifactTab) {
-    const content = artifactSidecarContent[tab.id];
-    if (!content) {
-      return <p className="react-empty-state">{t("details.noPreview")}</p>;
-    }
-    return (
-      <ArtifactDetails
-        key={tab.id}
-        reviewEpoch={artifactReviewEpoch}
-        responding={sessionResponding}
-        localThreadId={content.localFile ? tab.threadId : undefined}
-        observeFile={sidecar.presentation !== "closed" && tab.threadId === activeSessionId}
-        workspaceStore={workspaceStore}
-        onReference={(reference) => {
-          const id = "artifact:" + tab.id + ":" + reference.detail;
-          setComposerArtifactReferences((current) => [...current.filter((item) => item.id !== id), { ...reference, id }]);
-          setComposerFocusRequestId((current) => current + 1);
-        }}
-        artifact={content.artifact}
-        detail={content.detail}
-        error={content.error}
-        loading={content.loading}
-        notice={content.notice}
-        office={content.office}
-        onAskForSpreadsheetChange={handleSpreadsheetAskForChange}
-        onOpenFileLink={handleOpenAssistantFileLink}
-      />
-    );
-  }
-
-  function renderSidecarBrowser(tab: SidecarBrowserTab, surfaceVisible: boolean) {
-    return (
-      <SidecarBrowser
-        browserRuntime={chatStore.browserRuntime}
-        externalError={browserProvisionErrors[tab.id] || browserError}
-        snapshot={browserSnapshot?.data.sessionId === tab.threadId ? browserSnapshot : undefined}
-        surfaceVisible={surfaceVisible && !presentDrawer}
-        tab={tab}
-        onHandoffComplete={() => handleBrowserHandoffComplete(tab)}
-        onRetryProvision={() => {
-          clearBrowserError();
-          setBrowserProvisionErrors((current) => omitRecordKey(current, tab.id));
-          setBrowserProvisionEpoch((current) => current + 1);
-        }}
-        onSnapshot={synchronizeBrowserSnapshot}
-      />
-    );
-  }
-
-  function renderSidecarTerminal(tab: SidecarTerminalTab) {
-    return (
-      <Suspense fallback={(
-        <div aria-busy="true" className="react-sidecar__deferred" role="status">
-          <Loader2 aria-hidden="true" size={18} />
-          <span>{t("sidecar.terminalStarting")}</span>
-        </div>
-      )}>
-        <LazySidecarTerminal
-          externalError={terminalErrors[tab.id]}
-          tab={tab}
-          terminalRuntime={chatStore.terminalRuntime}
-          workspaceLabel={activeWorkspaceLabel}
-        />
-      </Suspense>
-    );
-  }
-
-  async function handleBrowserHandoffComplete(tab: SidecarBrowserTab) {
-    if (!activeSession || activeSession.id !== tab.threadId) return;
-    try {
-      await submission.submitTurn(activeSession.id, { text: t("browserHandoffContinue") }, "browser-handoff-complete");
-      await handleSessionStoreRefresh(activeSession);
-    } catch (error) {
-      reportTimelineError(t("sidecar.browserHandoffFailed", { message: errorMessage(error) }));
-    }
-  }
+  function handleOpenArtifact(artifact: ArtifactRef) { return sidecarResources.current?.openArtifact(artifact); }
+  function handleOpenAssistantFileLink(link: AssistantFileLink) { return sidecarResources.current?.openFileLink(link); }
 
   async function handleSubmitAgentUiForm(form: AgentUiForm, values: Record<string, unknown>) {
     await chatApplication.submitForm(activePersistedSessionId, form, values);
@@ -1704,11 +1245,6 @@ export function ChatPage({
       else setComposerFocusRequestId((current) => current + 1);
     }
     setDrawer(null);
-  }
-
-  function hideSidecar() {
-    sidecarToggleRef.current?.focus();
-    dispatchSidecar({ type: "presentation.hide" });
   }
 
   function handleComposerDraftChange(value: string) {
@@ -1813,9 +1349,7 @@ export function ChatPage({
               ref={sidecarToggleRef}
               title={sidecar.presentation === "closed" ? t("sidecar.show") : t("sidecar.hide")}
               type="button"
-              onClick={() => dispatchSidecar({
-                type: sidecar.presentation === "closed" ? "presentation.show" : "presentation.hide",
-              })}
+              onClick={() => sidecarResources.current?.toggle()}
             >
               {sidecar.presentation === "closed"
                 ? <PanelRightOpen aria-hidden="true" size={17} />
@@ -2050,24 +1584,28 @@ export function ChatPage({
         </div>
       </main>
 
-      <Sidecar
-        scopeKey={JSON.stringify([activeSessionId, activeWorkspaceId])}
-        activeTabId={sidecarActiveTab?.id ?? ""}
-        canCreateBrowser={Boolean(activeSession)}
-        canCreateTerminal={Boolean(activeWorkspaceId)}
-        presentation={sidecar.presentation}
-        renderArtifact={renderSidecarArtifact}
-        renderBrowser={renderSidecarBrowser}
-        renderTerminal={renderSidecarTerminal}
-        tabs={sidecarTabs}
-        width={sidecar.width}
-        onActivateTab={(tabId) => dispatchSidecar({ tabId, type: "tab.activate" })}
-        onCloseTab={handleCloseSidecarTab}
-        onCreateBrowser={() => dispatchSidecar({ type: "tab.newBrowser" })}
-        onCreateTerminal={(shell) => dispatchSidecar({ shell, type: "tab.newTerminal" })}
-        onHide={hideSidecar}
-        onResize={(width, maxWidth) => dispatchSidecar({ maxWidth, type: "presentation.resize", width })}
-        onToggleExpanded={() => dispatchSidecar({ type: "presentation.toggleExpanded" })}
+      <SidecarResources
+        ref={sidecarResources}
+        activeSession={activeSession}
+        activeDisplaySession={activeDisplaySession}
+        activeSessionId={activeSessionId}
+        chatStore={chatStore}
+        workspaceStore={workspaceStore}
+        artifactReviewEpoch={artifactReviewEpoch}
+        sessionResponding={sessionResponding}
+        presentDrawer={Boolean(presentDrawer)}
+        onLayoutChange={setSidecar}
+        onHide={() => sidecarToggleRef.current?.focus()}
+        onReference={(reference) => {
+          setComposerArtifactReferences((current) => [...current.filter((item) => item.id !== reference.id), reference]);
+          setComposerFocusRequestId((current) => current + 1);
+        }}
+        onAskForSpreadsheetChange={handleSpreadsheetAskForChange}
+        onHandoff={async (sessionId) => {
+          await submission.submitTurn(sessionId, { text: t("browserHandoffContinue") }, "browser-handoff-complete");
+          await handleSessionStoreRefresh(activeSession);
+        }}
+        onError={reportTimelineError}
       />
 
       {presentDrawer ? (
@@ -2223,116 +1761,6 @@ function SubagentDetails({
   );
 }
 
-function ArtifactDetails({
-  artifact,
-  detail: storedDetail,
-  error: storedError,
-  loading: storedLoading,
-  notice: storedNotice,
-  office: storedOffice,
-  localThreadId,
-  reviewEpoch,
-  responding,
-  observeFile,
-  workspaceStore,
-  onReference,
-  onAskForSpreadsheetChange,
-  onOpenFileLink,
-}: {
-  artifact: ArtifactRef;
-  detail?: LoadedArtifactDetail;
-  error?: string;
-  loading: boolean;
-  notice?: string;
-  office?: OfficeArtifactSource;
-  localThreadId?: string;
-  reviewEpoch: number;
-  responding: boolean;
-  observeFile: boolean;
-  workspaceStore?: Pick<WorkspaceStore, "readThreadFile" | "readThreadFileBytes" | "artifactReviews">;
-  onReference: (reference: AgentInputReference) => void;
-  onAskForSpreadsheetChange: (artifact: ArtifactRef, request: SpreadsheetCellChangeRequest, revision?: string) => void;
-  onOpenFileLink: (link: AssistantFileLink) => void;
-}) {
-  const { t } = useTranslation("chat");
-  const [refreshKey, setRefreshKey] = useState(0);
-  const file = useArtifactFile({
-    refreshKey,
-    artifact, enabled: Boolean(localThreadId) && observeFile, threadId: localThreadId, workspaceStore,
-    unavailableMessage: t("details.filePreviewUnavailable"), binaryMessage: t("details.binaryFilePreviewUnsupported"),
-  });
-  const { detail, error, loading, office } = localThreadId ? file : { detail: storedDetail, error: storedError, loading: storedLoading, office: storedOffice };
-  const notice = localThreadId ? (file.truncated ? t("details.filePreviewTruncated") : undefined) : storedNotice;
-  function referenceArtifact() {
-    const text = detail?.dataView ? JSON.stringify(detail.dataView) : detail?.textContent;
-    const excerpt = text && text.length > 12000 ? text.slice(0, 12000) + "\n[Preview excerpt truncated]" : text;
-    onReference({
-      kind: "reference", title: artifact.title, detail: t("details.artifactReference"),
-      ...(localThreadId ? { referenceKind: "file", sourcePath: artifact.fetchPath, scope: localThreadId, revision: file.revision } as const : {}),
-      sourceText: [
-        `Artifact: ${artifact.title}`, `Artifact ID: ${artifact.id}`,
-        ...(localThreadId ? [`File: ${artifact.fetchPath}`, `Viewed revision: ${file.revision}`, "Verify the current file before editing; this reference describes the viewed revision."] : []),
-        ...(excerpt ? [excerpt] : []),
-      ].join("\n"),
-    });
-  }
-  const markdown = isMarkdownArtifact(artifact, detail);
-  const markdownContent = detail?.textContent && markdown
-    ? { text: detail.textContent, title: detail.title }
-    : undefined;
-  return (
-    <div className="react-artifact-detail" data-content={markdown || office?.kind === "document" ? "document" : "preview"}>
-      <div className="react-artifact-detail__toolbar">
-        <button disabled={loading || Boolean(error)} onClick={referenceArtifact} type="button">{t("details.referenceInChat")}</button>
-        {localThreadId ? <span role="status">{t("details.fileAutoUpdates")}</span> : null}
-      </div>
-      {localThreadId && artifact.fetchPath && workspaceStore?.artifactReviews ? (
-        <ArtifactReviewPanel store={workspaceStore.artifactReviews} path={artifact.fetchPath} threadId={localThreadId}
-          revision={error ? undefined : file.revision} epoch={reviewEpoch} responding={responding}
-          kind={office?.kind} title={artifact.title} onRestored={() => setRefreshKey((value) => value + 1)} />
-      ) : null}
-      {!markdown && !office ? (
-        <dl>
-          <div><dt>{t("details.id")}</dt><dd>{artifact.id}</dd></div>
-          {detail?.mimeType || artifact.mimeType ? <div><dt>{t("details.type")}</dt><dd>{detail?.mimeType || artifact.mimeType}</dd></div> : null}
-        </dl>
-      ) : null}
-      {loading ? <p aria-live="polite">{t("details.loadingArtifact")}</p> : null}
-      {error ? <p role="alert">{error}</p> : null}
-      {notice ? <p className="react-artifact-detail__notice">{notice}</p> : null}
-      {detail?.imageDataUrl ? <img alt={detail.title} src={detail.imageDataUrl} /> : null}
-      {detail?.dataView ? <DataViewCard artifact={{ ...artifact, dataView: detail.dataView }} expanded /> : null}
-      {office ? (
-        <OfficeArtifactPreview
-          onAskForContentChange={!error && localThreadId && file.revision && artifact.fetchPath ? (request) => {
-            const position = request.start === request.end ? String(request.start) : `${request.start}–${request.end}`;
-            onReference(officeContentReference({ request, path: artifact.fetchPath!, title: artifact.title, threadId: localThreadId, revision: file.revision!,
-              label: t(request.kind === "document" ? "details.officeParagraphSelection" : "details.officeSlideSelection", { position }),
-            }));
-          } : undefined}
-          onAskForChange={error ? undefined : (selection) => onAskForSpreadsheetChange(artifact, selection, file.revision)}
-          source={office}
-        />
-      ) : null}
-      {markdownContent ? (
-        <article aria-label={markdownContent.title} className="react-artifact-detail__document" role="document">
-          <AssistantMarkdown
-            onOpenFileLink={onOpenFileLink}
-            streaming={false}
-            text={markdownContent.text}
-          />
-        </article>
-      ) : detail?.textContent ? <pre className="react-artifact-detail__text">{detail.textContent}</pre> : null}
-      {!loading && !error && !office && !detail?.dataView && !detail?.imageDataUrl && !detail?.textContent ? <p>{t("details.noPreview")}</p> : null}
-    </div>
-  );
-}
-
-function isMarkdownArtifact(artifact: ArtifactRef, detail?: LoadedArtifactDetail): boolean {
-  const mimeType = (detail?.mimeType || artifact.mimeType || "").split(";", 1)[0].trim().toLowerCase();
-  return artifact.kind.toLowerCase() === "markdown" || mimeType === "text/markdown";
-}
-
 function toolCallDetailSections(toolCall: ToolCallSummary, t: TFunction<"chat">): Array<{ label: string; value: string }> {
   return [
     { label: t("details.status"), value: toolCall.status },
@@ -2362,19 +1790,6 @@ function formatDetailLines(rows: Array<[string, string | undefined]>): string {
     .join("\n");
 }
 
-function browserResourceTitle(title: string, url: string, fallback: string): string {
-  const normalizedTitle = title.trim();
-  if (normalizedTitle && normalizedTitle !== "about:blank" && normalizedTitle !== "New tab") {
-    return normalizedTitle;
-  }
-  if (!url || url === "about:blank") return fallback;
-  try {
-    return new URL(url).hostname || url;
-  } catch {
-    return url;
-  }
-}
-
 function projectDraftSessionSummary(draft: DraftSession): SessionSummary {
   return {
     id: draft.id,
@@ -2387,17 +1802,7 @@ function projectDraftSessionSummary(draft: DraftSession): SessionSummary {
   };
 }
 
-function omitRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {
-  if (!(key in record)) return record;
-  const next = { ...record };
-  delete next[key];
-  return next;
-}
-
 function boundedSpreadsheetSelectionValue(value: string): string {
   return value.length > 12000 ? `${value.slice(0, 12000)}\n[Selection excerpt truncated; read the referenced range for all values.]` : value;
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -1,3 +1,4 @@
+import { useChatSubmission } from "./useChatSubmission";
 import { lazy, Suspense, useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { elementTransitions, useExitPresence } from "../lib/useExitPresence";
 import type { TFunction } from "i18next";
@@ -28,8 +29,7 @@ import {
   type PastedContent,
 } from "../../components/ui/claude-style-ai-input";
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
-import type { ChatEvent, ChatInput, ChatModelOption, ChatStore, ProjectGroupStore, SessionStore, SessionSummary, SettingsStore, SkillSummary, ToolSummary, ToolsStore, WorkspaceRegistryStore, WorkspaceStore } from "../services";
-import { createDesktopCompactCommand, createDesktopTurnSubmitCommand } from "../../app-core/chat/desktopCommand";
+import type { ChatEvent, ChatModelOption, ChatStore, ProjectGroupStore, SessionStore, SessionSummary, SettingsStore, SkillSummary, ToolSummary, ToolsStore, WorkspaceRegistryStore, WorkspaceStore } from "../services";
 import {
   clearDefaultChatModel,
   readDefaultChatModelPreference,
@@ -40,7 +40,7 @@ import {
 } from "../../app-core/chat/reasoningEffort";
 import { pickDesktopChatFiles } from "../../app-core/native/desktopNativeFilePicker";
 import { reduceSessionDeleteState } from "../sessions/sessionDeleteState";
-import type { ReactChatMessage, ToolCallSummary } from "./messageActions";
+import type { ToolCallSummary } from "./messageActions";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { AgentUiFormCard } from "./AgentUiFormCard";
 import { DataViewCard } from "./DataViewCard";
@@ -81,7 +81,6 @@ import {
 } from "../../app-core/chat/officeArtifact";
 import { officeContentReference } from "../../app-core/chat/officeContentReference";
 import { ArtifactReviewPanel } from "../sidecar/ArtifactReviewPanel";
-import { prepareArtifactReviews } from "./prepareArtifactReviews";
 import { useArtifactFile } from "./useArtifactFile";
 import type { AgentInputReference } from "../../app-core/chat/agentInputReference";
 import { logRendererEvent } from "../../app-core/native/rendererLogger";
@@ -105,7 +104,6 @@ import {
 } from "./useChatSessionRuntime";
 import {
   MAX_COMPOSER_SESSION_REFERENCES,
-  prepareChatSubmission,
   type SpreadsheetComposerAnnotation,
 } from "./chatSubmission";
 import { ChatTimeline } from "./ChatTimeline";
@@ -125,7 +123,6 @@ import {
   type ProjectSessionContext,
 } from "./ChatSessionWorkspace";
 import {
-  deriveSessionTitle,
   displaySessionTitle,
   isDefaultSessionTitle,
 } from "./sessionTitle";
@@ -294,7 +291,6 @@ function buildComposerToolOptions(tools: readonly ToolSummary[]): ComposerToolOp
 }
 
 const SESSION_DELETE_DISSOLVE_MS = 180;
-const EMPTY_OPTIMISTIC_MESSAGES: ReactChatMessage[] = [];
 
 function latestTurnPlan(timeline: ChatTimelineSnapshot | null | undefined) {
   const turns = timeline?.turns ?? [];
@@ -339,9 +335,6 @@ export function ChatPage({
     reduceSessionTabWorkspace,
     INITIAL_SESSION_TAB_WORKSPACE,
   );
-  const [optimisticMessagesBySession, setOptimisticMessagesBySession] = useState<Map<string, ReactChatMessage[]>>(
-    () => new Map(),
-  );
   const [threadCapabilities, setThreadCapabilities] = useState<ThreadEffectiveCapabilities>(() => (
     unavailableThreadEffectiveCapabilities("", "loading", t("runtime.loadingCapabilities"))
   ));
@@ -370,10 +363,8 @@ export function ChatPage({
   const [browserProvisionErrors, setBrowserProvisionErrors] = useState<Record<string, string>>({});
   const [terminalErrors, setTerminalErrors] = useState<Record<string, string>>({});
   const [browserProvisionEpoch, setBrowserProvisionEpoch] = useState(0);
-  const [compactingSessionId, setCompactingSessionId] = useState("");
   const [composerSessionMentionIds, setComposerSessionMentionIds] = useState<string[]>([]);
   const [composerSelectedSkillIds, setComposerSelectedSkillIds] = useState<string[]>([]);
-  const [artifactReviewEpoch, setArtifactReviewEpoch] = useState(0);
   const [composerArtifactReferences, setComposerArtifactReferences] = useState<(AgentInputReference & { id: string })[]>([]);
   const [composerSpreadsheetAnnotations, setComposerSpreadsheetAnnotations] = useState<SpreadsheetComposerAnnotation[]>([]);
   const [installingMigrationJobId, setInstallingMigrationJobId] = useState("");
@@ -386,7 +377,6 @@ export function ChatPage({
   const lastCreateSessionSignal = useRef(createSessionSignal);
   const lastActivateSessionSignal = useRef<number | null>(null);
   const draftSessionCreatePromise = useRef<Promise<SessionSummary> | null>(null);
-  const defaultModelSavePromise = useRef<Promise<void>>(Promise.resolve());
   const draftSessionSequence = useRef(0);
   const sessionTabsRef = useRef(sessionTabs);
   const sessionsLoadedRef = useRef(sessionsLoaded);
@@ -454,7 +444,17 @@ export function ChatPage({
     reportError: reportTimelineError,
   } = sessionRuntime.actions;
   const composerDraft = sessionTabDraft(sessionTabs, activeSessionId);
-  const optimisticMessages = optimisticMessagesBySession.get(activeSessionId) ?? EMPTY_OPTIMISTIC_MESSAGES;
+  const submission = useChatSubmission({
+    chatStore, settingsStore, artifactReviews: workspaceStore?.artifactReviews,
+    sessionId: activeSessionId, now, t, reload: reloadSessionRuntime,
+    refreshSessions: handleSessionStoreRefresh, materializeDraft: createSessionForDraft,
+    previewSession(session) {
+      optimisticSessionTitlesRef.current.set(session.id, session.title);
+      setSessions((current) => current.map((candidate) => candidate.id === session.id ? session : candidate));
+    },
+    consumeDraft(sessionId) { dispatchSessionTabs({ type: "draft.changed", sessionId, value: "" }); },
+  });
+  const { optimisticMessages, compactingSessionId, artifactReviewEpoch } = submission;
 
   const resolvedSessionSidebarCollapsed = sessionSidebarCollapsed ?? localSessionSidebarCollapsed;
   const composerSkillOptions = useMemo(
@@ -746,7 +746,7 @@ export function ChatPage({
     cancelUnavailableReason,
   } = useChatTurnApplication({
     dispatch: chatStore.dispatch,
-    submitTurn: dispatchTurn,
+    submitTurn: submission.submitTurn,
     refreshSessions: handleSessionStoreRefresh,
     reportError: reportTimelineError,
     clearError: clearTimelineError,
@@ -1147,12 +1147,7 @@ export function ChatPage({
         setSessions(remaining);
         dispatchSessionTabs({ type: "remove", sessionId: session.id });
         conversationViewBySessionRef.current.delete(session.id);
-        setOptimisticMessagesBySession((current) => {
-          if (!current.has(session.id)) return current;
-          const next = new Map(current);
-          next.delete(session.id);
-          return next;
-        });
+        submission.forgetSession(session.id);
         setDissolvingSessionIds((current) => {
           const nextIds = new Set(current);
           nextIds.delete(session.id);
@@ -1221,11 +1216,7 @@ export function ChatPage({
         sessionIdReplacement.previousSessionId,
         sessionIdReplacement.sessionId,
       );
-      setOptimisticMessagesBySession((current) => replaceMapKey(
-        current,
-        sessionIdReplacement.previousSessionId,
-        sessionIdReplacement.sessionId,
-      ));
+      submission.replaceSession(sessionIdReplacement.previousSessionId, sessionIdReplacement.sessionId);
       chatApplication.replaceSession(
         sessionIdReplacement.previousSessionId,
         sessionIdReplacement.sessionId,
@@ -1278,52 +1269,11 @@ export function ChatPage({
   }
 
   async function handleBranchFromMessage(session: SessionSummary, messageId: string) {
-    const branched = await chatStore.branchFromMessage(session.id, messageId);
+    const branched = await submission.fork(session.id, messageId);
     const nextSessions = [branched, ...sessionsRef.current.filter((item) => item.id !== branched.id)];
     sessionsRef.current = nextSessions;
     setSessions(nextSessions);
     dispatchSessionTabs({ type: "open", sessionId: branched.id });
-  }
-
-  async function dispatchTurn(
-    sessionId: string,
-    input: ChatInput,
-    control: string,
-    optimisticText?: string,
-  ): Promise<void> {
-    const command = createDesktopTurnSubmitCommand({
-      message: input,
-      sessionId,
-      source: { control, surface: "chat" },
-    });
-    if (await prepareArtifactReviews(input.references, workspaceStore?.artifactReviews, sessionId, command.commandId)) {
-      setArtifactReviewEpoch((value) => value + 1);
-    }
-    if (optimisticText) {
-      setOptimisticMessagesBySession((current) => updateSessionMessages(
-        current,
-        sessionId,
-        (messages) => [...messages, {
-          createdAtMs: now(),
-          id: command.commandId,
-          role: "user",
-          status: "complete",
-          text: optimisticText,
-        }],
-      ));
-    }
-    try {
-      await chatStore.dispatch(command);
-    } catch (error) {
-      if (optimisticText) {
-        setOptimisticMessagesBySession((current) => updateSessionMessages(
-          current,
-          sessionId,
-          (messages) => messages.filter((message) => message.id !== command.commandId),
-        ));
-      }
-      throw error;
-    }
   }
 
   async function handleComposerSend(
@@ -1333,16 +1283,13 @@ export function ChatPage({
     options: ComposerSendOptions,
   ) {
     const availableMentionIds = new Set(composerSessionMentionOptions.map((option) => option.id));
-    const prepared = await prepareChatSubmission({
+    await submission.send({
       availableSessionIds: availableMentionIds,
       files,
       isRunning: activeSession ? sessionResponding : false,
-      loadSessionTranscript: chatStore.copyMarkdown,
       message,
-      now: chatApplication.nextInputTimestamp,
       options,
       pastedContent,
-      queuedInputs: chatApplication.queue(activePersistedSessionId).inputs,
       selectedSkillIds: composerSelectedSkillIds,
       selectedSessionIds: composerSessionMentionIds,
       sessions: sessionsRef.current.map((session) => ({
@@ -1352,68 +1299,7 @@ export function ChatPage({
       })),
       artifactReferences: composerArtifactReferences.map(({ id: _id, ...reference }) => reference),
       spreadsheetAnnotations: composerSpreadsheetAnnotations,
-      t,
-    });
-    if (prepared.kind === "compact") {
-      if (!activeSession) {
-        throw new Error(t("errors.compactNeedsSession"));
-      }
-      const compactSession = activeSession;
-      handleComposerDraftChange("");
-      setCompactingSessionId(compactSession.id);
-      try {
-        await chatStore.dispatch(createDesktopCompactCommand({
-          sessionId: compactSession.id,
-          source: { control: "slash-compact", surface: "chat" },
-        }));
-        await reloadSessionRuntime();
-        await handleSessionStoreRefresh(compactSession);
-      } catch (error) {
-        console.error("[chat] context.compact.failed", {
-          error: error instanceof Error ? error.message : String(error),
-          sessionId: compactSession.id,
-        });
-        throw error;
-      } finally {
-        setCompactingSessionId((current) => current === compactSession.id ? "" : current);
-      }
-      return;
-    }
-    if (prepared.kind === "empty") {
-      return;
-    }
-    if (prepared.kind === "queue_limit_reached") {
-      chatApplication.reportQueueLimit(activePersistedSessionId);
-      return;
-    }
-    await defaultModelSavePromise.current;
-    const materializingDraft = !activeSession;
-    const sendSession = activeSession ?? await createSessionForDraft();
-    if (!sendSession) {
-      return;
-    }
-    if (prepared.kind === "queue_input") {
-      chatApplication.enqueue(sendSession.id, prepared.input);
-      return;
-    }
-    const visibleText = prepared.visibleText;
-    const optimisticSession = isDefaultSessionTitle(sendSession.title)
-      ? { ...sendSession, title: deriveSessionTitle(visibleText, t) }
-      : sendSession;
-    if (optimisticSession !== sendSession) {
-      optimisticSessionTitlesRef.current.set(sendSession.id, optimisticSession.title);
-      setSessions((current) => current.map((session) => session.id === sendSession.id ? optimisticSession : session));
-    }
-    await dispatchTurn(
-      sendSession.id,
-      prepared.turnInput,
-      "composer-send",
-      materializingDraft ? visibleText : undefined,
-    );
-    await handleSessionStoreRefresh(optimisticSession);
-    if (materializingDraft) {
-      dispatchSessionTabs({ type: "draft.changed", sessionId: sendSession.id, value: "" });
-    }
+    }, activeSession, chatApplication);
   }
 
   function handleConversationScroll(): void {
@@ -1495,27 +1381,11 @@ export function ChatPage({
   function handleChatSessionRuntimeEffect(effect: ChatSessionRuntimeEffect): void {
     if (effect.type === "timeline_applied") {
       updateSessionStatusFromTimeline(effect.sessionId, effect.timeline);
-      setOptimisticMessagesBySession((current) => updateSessionMessages(
-        current,
-        effect.sessionId,
-        (messages) => messages.filter((message) => !effect.timeline.turns.some((turn) => (
-          turn.userMessage.clientEventId === message.id
-        ))),
-      ));
+      submission.receiveTimeline(effect.sessionId, effect.timeline);
       return;
     }
     if (effect.type === "message_received") {
-      setOptimisticMessagesBySession((current) => updateSessionMessages(
-        current,
-        effect.sessionId,
-        (messages) => (
-          messages.some((message) => message.id === effect.message.id)
-            ? messages.map((message) => (
-              message.id === effect.message.id ? { ...message, ...effect.message } : message
-            ))
-            : [...messages, effect.message]
-        ),
-      ));
+      submission.receiveMessage(effect.sessionId, effect.message);
       return;
     }
     if (effect.type === "session_refresh_requested") {
@@ -1781,7 +1651,7 @@ export function ChatPage({
   async function handleBrowserHandoffComplete(tab: SidecarBrowserTab) {
     if (!activeSession || activeSession.id !== tab.threadId) return;
     try {
-      await dispatchTurn(activeSession.id, { text: t("browserHandoffContinue") }, "browser-handoff-complete");
+      await submission.submitTurn(activeSession.id, { text: t("browserHandoffContinue") }, "browser-handoff-complete");
       await handleSessionStoreRefresh(activeSession);
     } catch (error) {
       reportTimelineError(t("sidecar.browserHandoffFailed", { message: errorMessage(error) }));
@@ -2117,19 +1987,7 @@ export function ChatPage({
             const selectedModelId = selected.modelId || selected.id;
             setComposerModel(modelId);
             if (emptyActiveSession) {
-              const saveDefault = settingsStore?.saveDefaultChatModel;
-              const persistence = defaultModelSavePromise.current
-                .catch(() => undefined)
-                .then(() => {
-                  if (!saveDefault || !selected.providerId) {
-                    throw new Error("Native default Provider/model persistence is unavailable.");
-                  }
-                  return saveDefault({
-                    modelId: selectedModelId,
-                    providerId: selected.providerId,
-                  });
-                });
-              defaultModelSavePromise.current = persistence;
+              const persistence = submission.saveDefaultModel(selectedModelId, selected.providerId);
               void persistence.catch((error) => {
                 reportTimelineError(t("errors.modelSaveFailed", {
                   message: error instanceof Error ? error.message : String(error),
@@ -2281,36 +2139,6 @@ function isVisibleAgentUiForm(form: AgentUiForm): boolean {
 
 async function writeClipboardText(value: string): Promise<void> {
   await navigator.clipboard?.writeText(value);
-}
-
-function updateSessionMessages(
-  current: Map<string, ReactChatMessage[]>,
-  sessionId: string,
-  update: (messages: ReactChatMessage[]) => ReactChatMessage[],
-): Map<string, ReactChatMessage[]> {
-  const nextMessages = update(current.get(sessionId) ?? EMPTY_OPTIMISTIC_MESSAGES);
-  const next = new Map(current);
-  if (nextMessages.length) {
-    next.set(sessionId, nextMessages);
-  } else {
-    next.delete(sessionId);
-  }
-  return next;
-}
-
-function replaceMapKey<T>(
-  current: Map<string, T>,
-  previousSessionId: string,
-  sessionId: string,
-): Map<string, T> {
-  if (!current.has(previousSessionId) || previousSessionId === sessionId) {
-    return current;
-  }
-  const next = new Map(current);
-  const value = next.get(previousSessionId) as T;
-  next.delete(previousSessionId);
-  next.set(sessionId, value);
-  return next;
 }
 
 function moveMapValue<T>(

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -13,15 +13,8 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import "./ChatPage.css";
-import {
-  MAX_QUEUED_INPUTS,
-  deleteQueuedInput,
-  dispatchNextQueuedInput,
-  pauseQueuedInputs,
-  resumeNextQueuedInput,
-  updateInterruptStatus,
-} from "../../app-core/chat/chatInputState";
-import type { QueuedInput } from "../../app-core/chat/chatUiProjection";
+import { ChatQueueNotice, ChatQueuedInputs } from "./ChatQueuedInputs";
+import { useChatTurnApplication } from "./useChatTurnApplication";
 import {
   ClaudeStyleAiInput,
   type ComposerContextReference,
@@ -52,7 +45,6 @@ import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { AgentUiFormCard } from "./AgentUiFormCard";
 import { DataViewCard } from "./DataViewCard";
 import {
-  canDispatchQueuedInput,
   projectChatEventEffects,
   projectTimelineSessionStatus,
 } from "./chatEventPolicy";
@@ -99,14 +91,7 @@ import type {
   NativeBrowserSnapshot,
 } from "../../app-core/native/nativeBrowserSnapshot";
 import {
-  THREAD_COMMAND_ACK_TIMEOUT_MS,
-  canonicalThreadCommandAcknowledgement,
-  canonicalThreadCommandCompletion,
-  createThreadAgentCancelCommand,
-  createThreadFormCancelCommand,
-  createThreadFormSubmitCommand,
   isThreadCommandInFlight,
-  reduceThreadCommandLifecycle,
   type ThreadCommandLifecycle,
   type ThreadCommand,
 } from "../../app-core/chat/threadCommand";
@@ -121,7 +106,6 @@ import {
 import {
   MAX_COMPOSER_SESSION_REFERENCES,
   prepareChatSubmission,
-  type QueuedComposerInput,
   type SpreadsheetComposerAnnotation,
 } from "./chatSubmission";
 import { ChatTimeline } from "./ChatTimeline";
@@ -386,13 +370,7 @@ export function ChatPage({
   const [browserProvisionErrors, setBrowserProvisionErrors] = useState<Record<string, string>>({});
   const [terminalErrors, setTerminalErrors] = useState<Record<string, string>>({});
   const [browserProvisionEpoch, setBrowserProvisionEpoch] = useState(0);
-  const [commandLifecycle, dispatchCommandLifecycle] = useReducer(
-    reduceThreadCommandLifecycle,
-    { stage: "idle" } as ThreadCommandLifecycle,
-  );
   const [compactingSessionId, setCompactingSessionId] = useState("");
-  const [queuedInputsBySession, setQueuedInputsBySession] = useState<Map<string, QueuedComposerInput[]>>(() => new Map());
-  const [queueMessage, setQueueMessage] = useState("");
   const [composerSessionMentionIds, setComposerSessionMentionIds] = useState<string[]>([]);
   const [composerSelectedSkillIds, setComposerSelectedSkillIds] = useState<string[]>([]);
   const [artifactReviewEpoch, setArtifactReviewEpoch] = useState(0);
@@ -404,11 +382,6 @@ export function ChatPage({
   const [dissolvingSessionIds, setDissolvingSessionIds] = useState<Set<string>>(() => new Set());
   const [deleteState, dispatchDelete] = useReducer(reduceSessionDeleteState, { confirmingSessionId: "" });
   const sessionsRef = useRef<SessionSummary[]>([]);
-  const queuedInputsRef = useRef<Map<string, QueuedComposerInput[]>>(new Map());
-  const queuedInputSequence = useRef(0);
-  const interruptCancellationConfirmedInputIdsRef = useRef(new Set<string>());
-  const interruptDispatchingInputIdsRef = useRef(new Set<string>());
-  const interruptTerminalInputIdsRef = useRef(new Set<string>());
   const deleteDissolveTimers = useRef<number[]>([]);
   const lastCreateSessionSignal = useRef(createSessionSignal);
   const lastActivateSessionSignal = useRef<number | null>(null);
@@ -766,20 +739,20 @@ export function ChatPage({
       activeSession?.pluginMigration?.status === "pending"
       && latestTurnStatus === "completed"
     );
-  const cancelCapability = threadCapabilities.capabilities.agent.cancel;
-  const capabilityTargetsActiveTurn = !threadCapabilities.evaluatedTurnId
-    || threadCapabilities.evaluatedTurnId === activeTurn?.id;
-  const canCancelTurn = Boolean(
-    activeSession
-    && activeTurn
-    && threadCapabilities.threadId === activeSession.id
-    && capabilityTargetsActiveTurn
-    && cancelCapability.available
-  );
-  const cancelUnavailableReason = !capabilityTargetsActiveTurn
-    ? t("runtime.staleCapabilities")
-    : cancelCapability.reason || t("runtime.cancelUnavailable");
-  const cancelInFlight = isThreadCommandInFlight(commandLifecycle);
+  const {
+    application: chatApplication,
+    lifecycle: commandLifecycle,
+    canCancel: canCancelTurn,
+    cancelUnavailableReason,
+  } = useChatTurnApplication({
+    dispatch: chatStore.dispatch,
+    submitTurn: dispatchTurn,
+    refreshSessions: handleSessionStoreRefresh,
+    reportError: reportTimelineError,
+    clearError: clearTimelineError,
+    now,
+    t,
+  }, activePersistedSessionId, { timeline, capabilities: threadCapabilities });
   const compactingActiveSession = Boolean(activeSession && compactingSessionId === activeSession.id);
   const showCommandLifecycleStatus = commandLifecycle.stage !== "idle"
     && commandLifecycle.command.kind !== "agent.cancel";
@@ -788,15 +761,6 @@ export function ChatPage({
     && isThreadCommandInFlight(commandLifecycle)
     ? commandLifecycle.command.form.formId
     : "";
-  const activeQueuedInputs = activeSession ? queuedInputsBySession.get(activeSession.id) ?? [] : [];
-  const canInterruptQueuedInput = Boolean(
-    activeTurn
-    && activeTurn.status !== "awaiting_user"
-    && !cancelInFlight
-    && !activeQueuedInputs.some((input) => (
-      input.mode === "interrupt" && (input.status === "queued" || input.status === "sent")
-    )),
-  );
   const activeContextUsage = useMemo(
     () => projectLatestContextUsage(timeline?.turns ?? [], contextUsageDefaults),
     [contextUsageDefaults, timeline],
@@ -844,59 +808,7 @@ export function ChatPage({
     setComposerSelectedSkillIds([]);
     setComposerSpreadsheetAnnotations([]);
     setComposerArtifactReferences([]);
-    dispatchCommandLifecycle({ type: "reset" });
   }, [activeSessionId]);
-
-  useEffect(() => {
-    if (!timeline || commandLifecycle.stage === "idle" || commandLifecycle.stage === "completed") return;
-    if (commandLifecycle.stage === "acknowledged") {
-      const completion = canonicalThreadCommandCompletion(
-        timeline.turns,
-        commandLifecycle.command,
-      );
-      if (!completion) return;
-      dispatchCommandLifecycle({
-        commandId: commandLifecycle.command.commandId,
-        completion,
-        nowMs: now(),
-        type: "operation_completed",
-      });
-      return;
-    }
-    const acknowledgement = canonicalThreadCommandAcknowledgement(
-      timeline.turns,
-      commandLifecycle.command.commandId,
-    );
-    if (!acknowledgement) return;
-    dispatchCommandLifecycle({
-      acknowledgement,
-      commandId: commandLifecycle.command.commandId,
-      nowMs: now(),
-      type: "canonical_acknowledged",
-    });
-  }, [commandLifecycle, now, timeline]);
-
-  useEffect(() => {
-    if (commandLifecycle.stage !== "sending" && commandLifecycle.stage !== "waiting_for_canonical") return;
-    const elapsed = Math.max(0, now() - commandLifecycle.dispatchedAtMs);
-    const timer = window.setTimeout(() => {
-      dispatchCommandLifecycle({ commandId: commandLifecycle.command.commandId, type: "ack_timeout" });
-    }, Math.max(0, THREAD_COMMAND_ACK_TIMEOUT_MS - elapsed));
-    return () => window.clearTimeout(timer);
-  }, [commandLifecycle, now]);
-
-  useEffect(() => {
-    if (commandLifecycle.stage === "idle") return;
-    if (commandLifecycle.command.kind === "operation.retry"
-      && (commandLifecycle.stage === "rejected" || commandLifecycle.stage === "timed_out")) {
-      reportTimelineError(`Retry failed: ${commandLifecycle.error}`);
-      return;
-    }
-    if ((commandLifecycle.command.kind === "form.submit" || commandLifecycle.command.kind === "form.cancel")
-      && (commandLifecycle.stage === "rejected" || commandLifecycle.stage === "timed_out")) {
-      reportTimelineError(`Form ${commandLifecycle.command.kind === "form.cancel" ? "cancellation" : "submission"} failed: ${commandLifecycle.error}`);
-    }
-  }, [commandLifecycle, reportTimelineError]);
 
   useEffect(() => {
     return () => {
@@ -987,7 +899,9 @@ export function ChatPage({
 
   const handleBackgroundChatEvent = useEffectEvent((sessionId: string, event: ChatEvent) => {
     const effects = projectChatEventEffects(event);
+    chatApplication.receiveCommand(sessionId, event);
     if (event.timeline) {
+      chatApplication.receiveTimeline(sessionId, event.timeline);
       updateSessionStatusFromTimeline(sessionId, event.timeline);
       dispatchSessionTabs({ type: "activity", sessionId });
     }
@@ -995,7 +909,7 @@ export function ChatPage({
       dispatchSessionTabs({ type: "activity", sessionId });
     }
     if (effects.reloadSessions) {
-      void handleQueueStateAfterChatEvent(sessionId, event);
+      void chatApplication.receiveSessionEvent(sessionId, event);
     }
   });
   useEffect(() => {
@@ -1312,11 +1226,10 @@ export function ChatPage({
         sessionIdReplacement.previousSessionId,
         sessionIdReplacement.sessionId,
       ));
-      updateQueuedInputsBySession((current) => replaceMapKey(
-        current,
+      chatApplication.replaceSession(
         sessionIdReplacement.previousSessionId,
         sessionIdReplacement.sessionId,
-      ));
+      );
     }
     dispatchSessionTabs({
       type: "reconcile",
@@ -1426,10 +1339,10 @@ export function ChatPage({
       isRunning: activeSession ? sessionResponding : false,
       loadSessionTranscript: chatStore.copyMarkdown,
       message,
-      now: nextQueuedInputTimestamp,
+      now: chatApplication.nextInputTimestamp,
       options,
       pastedContent,
-      queuedInputs: activeQueuedInputs,
+      queuedInputs: chatApplication.queue(activePersistedSessionId).inputs,
       selectedSkillIds: composerSelectedSkillIds,
       selectedSessionIds: composerSessionMentionIds,
       sessions: sessionsRef.current.map((session) => ({
@@ -1470,7 +1383,7 @@ export function ChatPage({
       return;
     }
     if (prepared.kind === "queue_limit_reached") {
-      setQueueMessage(t("queue.limit", { count: MAX_QUEUED_INPUTS }));
+      chatApplication.reportQueueLimit(activePersistedSessionId);
       return;
     }
     await defaultModelSavePromise.current;
@@ -1480,7 +1393,7 @@ export function ChatPage({
       return;
     }
     if (prepared.kind === "queue_input") {
-      handleQueuedComposerResult(sendSession.id, prepared.input);
+      chatApplication.enqueue(sendSession.id, prepared.input);
       return;
     }
     const visibleText = prepared.visibleText;
@@ -1525,62 +1438,6 @@ export function ChatPage({
     });
     setShowBackToLatest(false);
     conversationEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }
-
-  function handleQueuedComposerResult(
-    sessionId: string,
-    input: QueuedComposerInput,
-  ) {
-    setQueueMessage("");
-    updateQueuedInputsBySession((current) => {
-      const next = new Map(current);
-      next.set(sessionId, [...(next.get(sessionId) ?? []), input]);
-      return next;
-    });
-  }
-
-  async function handleInterruptComposerResult(
-    sessionId: string,
-    turnId: string,
-    input: QueuedComposerInput,
-  ) {
-    setQueueMessage("");
-    updateQueuedInputsBySession((current) => {
-      const next = new Map(current);
-      next.set(sessionId, (next.get(sessionId) ?? []).map((candidate) => (
-        candidate.id === input.id ? input : candidate
-      )));
-      return next;
-    });
-    const command = createThreadAgentCancelCommand({
-      sessionId,
-      source: { control: "composer-interrupt", surface: "chat" },
-      turnId,
-    });
-    try {
-      await chatStore.dispatch(command);
-      interruptCancellationConfirmedInputIdsRef.current.add(input.id);
-      await sendPendingInterruptInput(sessionId);
-    } catch (error) {
-      interruptCancellationConfirmedInputIdsRef.current.delete(input.id);
-      interruptTerminalInputIdsRef.current.delete(input.id);
-      updateInterruptForSession(sessionId, input.id, "failed");
-      throw error;
-    }
-  }
-
-  function updateInterruptForSession(
-    sessionId: string,
-    inputId: string,
-    status: "sent" | "failed",
-  ) {
-    updateQueuedInputsBySession((current) => {
-      const inputs = current.get(sessionId) ?? [];
-      if (!inputs.some((input) => input.id === inputId && input.mode === "interrupt")) return current;
-      const next = new Map(current);
-      next.set(sessionId, updateInterruptStatus(inputs, inputId, status) as QueuedComposerInput[]);
-      return next;
-    });
   }
 
   async function createSessionForDraft(): Promise<SessionSummary | null> {
@@ -1631,105 +1488,8 @@ export function ChatPage({
       : { type: "open", sessionId: created.id });
   }
 
-  function handleDeleteQueuedInput(sessionId: string, inputId: string) {
-    setQueueMessage("");
-    removeQueuedInputForSession(sessionId, inputId);
-  }
-
-  async function handleInterruptQueuedInput(sessionId: string, inputId: string) {
-    setQueueMessage("");
-    if (!activeTurn || activeTurn.status === "awaiting_user") {
-      setQueueMessage(t("errors.noInterruptibleTurn"));
-      return;
-    }
-    const inputs = queuedInputsRef.current.get(sessionId) ?? [];
-    if (inputs.some((input) => (
-      input.mode === "interrupt" && (input.status === "queued" || input.status === "sent")
-    ))) {
-      setQueueMessage(t("errors.interruptPending"));
-      return;
-    }
-    const queuedInput = inputs.find((input) => (
-      input.id === inputId
-      && input.mode === "queued"
-      && (input.status === "queued" || input.status === "paused")
-    ));
-    try {
-      if (!queuedInput) {
-        throw new Error(`Queued input ${inputId} is no longer available`);
-      }
-      await handleInterruptComposerResult(sessionId, activeTurn.id, {
-        ...queuedInput,
-        mode: "interrupt",
-        status: "queued",
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error("[chat] queued-input.interrupt.failed", {
-        error: message,
-        inputId,
-        sessionId,
-      });
-      setQueueMessage(t("errors.interruptFailed", { message }));
-    }
-  }
-
-  function removeQueuedInputForSession(sessionId: string, inputId: string) {
-    updateQueuedInputsBySession((current) => {
-      const next = new Map(current);
-      const remaining = deleteQueuedInput(next.get(sessionId) ?? [], inputId);
-      if (remaining.length) {
-        next.set(sessionId, remaining as QueuedComposerInput[]);
-      } else {
-        next.delete(sessionId);
-      }
-      return next;
-    });
-  }
-
   async function handleStopGeneration(session: SessionSummary) {
-    if (cancelInFlight) return;
-    if (!canCancelTurn) {
-      reportTimelineError(`Cannot cancel: ${cancelUnavailableReason}`);
-      return;
-    }
-    if (!activeTurn) {
-      reportTimelineError(t("runtime.cancelActiveTurnUnavailable"));
-      return;
-    }
-    const command = createThreadAgentCancelCommand({
-      sessionId: session.id,
-      source: { control: "stop-response", surface: "chat" },
-      threadId: activeTurn.canonicalItems?.find((item) => item.threadId)?.threadId,
-      turnId: activeTurn.id,
-    });
-    pauseQueuedInputsForSession(session.id);
-    dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
-    try {
-      await chatStore.dispatch(command);
-    } catch (error) {
-      dispatchCommandLifecycle({
-        commandId: command.commandId,
-        error: error instanceof Error ? error.message : String(error),
-        type: "rejected",
-      });
-    }
-  }
-
-  function updateQueuedInputsBySession(
-    updater: (current: Map<string, QueuedComposerInput[]>) => Map<string, QueuedComposerInput[]>,
-  ) {
-    setQueuedInputsBySession((current) => {
-      const next = updater(current);
-      queuedInputsRef.current = next;
-      return next;
-    });
-  }
-
-  function nextQueuedInputTimestamp(): string {
-    const sequence = queuedInputSequence.current;
-    queuedInputSequence.current += 1;
-    return new Date(now() + sequence).toISOString();
+    await chatApplication.cancel(session.id);
   }
 
   function handleChatSessionRuntimeEffect(effect: ChatSessionRuntimeEffect): void {
@@ -1759,47 +1519,11 @@ export function ChatPage({
       return;
     }
     if (effect.type === "session_refresh_requested") {
-      void handleQueueStateAfterChatEvent(effect.sessionId, effect.event);
+      void chatApplication.receiveSessionEvent(effect.sessionId, effect.event);
       return;
     }
 
-    const event = effect.event;
-    if (event.command && event.type === "command.dispatched") {
-      pauseQueuedInputsForSession(event.command.target.sessionId);
-      dispatchCommandLifecycle({ command: event.command, nowMs: now(), type: "dispatch" });
-      return;
-    }
-    if (event.commandId && event.type === "command.accepted") {
-      dispatchCommandLifecycle({ commandId: event.commandId, nowMs: now(), type: "transport_accepted" });
-      return;
-    }
-    if (event.commandId && event.type === "error") {
-      dispatchCommandLifecycle({
-        commandId: event.commandId,
-        error: event.error || t("runtime.commandRejected"),
-        type: "rejected",
-      });
-    }
-  }
-
-  async function handleQueueStateAfterChatEvent(sessionId: string, event: ChatEvent) {
-    const nextSessions = await handleSessionStoreRefresh();
-    const effects = projectChatEventEffects(event);
-    if (effects.terminalAgentEvent && await sendPendingInterruptInput(sessionId, true)) {
-      return;
-    }
-    if (effects.queuedInputDisposition === "pause") {
-      pauseQueuedInputsForSession(sessionId);
-      return;
-    }
-    if (effects.queuedInputDisposition !== "dispatch_next") {
-      return;
-    }
-    const nextSession = nextSessions.find((session) => session.id === sessionId);
-    if (!canDispatchQueuedInput(nextSession)) {
-      return;
-    }
-    await sendNextQueuedInput(sessionId, "normal_completion");
+    chatApplication.receiveCommand(effect.sessionId, effect.event);
   }
 
   function updateSessionStatusFromTimeline(sessionId: string, nextTimeline: ChatTimelineSnapshot) {
@@ -1810,74 +1534,6 @@ export function ChatPage({
         session.id === sessionId ? { ...session, status } : session
       ));
       sessionsRef.current = next;
-      return next;
-    });
-  }
-
-  async function sendPendingInterruptInput(
-    sessionId: string,
-    terminalEventReceived = false,
-  ): Promise<boolean> {
-    const input = (queuedInputsRef.current.get(sessionId) ?? []).find((candidate) => (
-      candidate.mode === "interrupt" && (candidate.status === "queued" || candidate.status === "sent")
-    ));
-    if (!input) return false;
-    if (terminalEventReceived) {
-      interruptTerminalInputIdsRef.current.add(input.id);
-    }
-    if (!interruptCancellationConfirmedInputIdsRef.current.has(input.id)
-      || !interruptTerminalInputIdsRef.current.has(input.id)) {
-      return true;
-    }
-    if (interruptDispatchingInputIdsRef.current.has(input.id)) return true;
-    interruptDispatchingInputIdsRef.current.add(input.id);
-    updateInterruptForSession(sessionId, input.id, "sent");
-    try {
-      await dispatchTurn(sessionId, toChatInput(input), "interrupt-new-turn");
-      removeQueuedInputForSession(sessionId, input.id);
-      await handleSessionStoreRefresh();
-    } catch (error) {
-      updateInterruptForSession(sessionId, input.id, "failed");
-      setQueueMessage(t("errors.interruptFailed", { message: error instanceof Error ? error.message : String(error) }));
-    } finally {
-      interruptCancellationConfirmedInputIdsRef.current.delete(input.id);
-      interruptDispatchingInputIdsRef.current.delete(input.id);
-      interruptTerminalInputIdsRef.current.delete(input.id);
-    }
-    return true;
-  }
-
-  async function handleResumeQueuedInputs(sessionId: string) {
-    await sendNextQueuedInput(sessionId, "manual_resume");
-  }
-
-  async function sendNextQueuedInput(sessionId: string, mode: "normal_completion" | "manual_resume") {
-    const inputs = queuedInputsRef.current.get(sessionId) ?? [];
-    const result = mode === "manual_resume" ? resumeNextQueuedInput(inputs) : dispatchNextQueuedInput(inputs);
-    if (!result.nextInput) {
-      return;
-    }
-    await dispatchTurn(sessionId, toChatInput(result.nextInput as QueuedComposerInput), `queue-${mode}`);
-    updateQueuedInputsBySession((current) => {
-      const next = new Map(current);
-      if (result.remainingInputs.length) {
-        next.set(sessionId, result.remainingInputs as QueuedComposerInput[]);
-      } else {
-        next.delete(sessionId);
-      }
-      return next;
-    });
-    await handleSessionStoreRefresh();
-  }
-
-  function pauseQueuedInputsForSession(sessionId: string) {
-    updateQueuedInputsBySession((current) => {
-      const inputs = current.get(sessionId) ?? [];
-      if (!inputs.length) {
-        return current;
-      }
-      const next = new Map(current);
-      next.set(sessionId, pauseQueuedInputs(inputs) as QueuedComposerInput[]);
       return next;
     });
   }
@@ -2132,76 +1788,12 @@ export function ChatPage({
     }
   }
 
-  async function handleSubmitAgentUiForm(
-    form: AgentUiForm,
-    values: Record<string, unknown>,
-  ) {
-    if (!activeSession || isThreadCommandInFlight(commandLifecycle)) {
-      return;
-    }
-    if (!activeTurn) {
-      reportTimelineError(t("runtime.submitFormTurnUnavailable"));
-      return;
-    }
-    const formTurnId = agentUiFormCorrelationString(form, "turn_id") || form.turn_id || activeTurn.id;
-    if (formTurnId !== activeTurn.id) {
-      reportTimelineError(t("runtime.submitFormStaleTurn", { turnId: formTurnId }));
-      return;
-    }
-    const command = createThreadFormSubmitCommand({
-      formId: form.form_id,
-      sessionId: activeSession.id,
-      source: { control: "chat-form", surface: "chat" },
-      threadId: agentUiFormCorrelationString(form, "thread_id")
-        || activeTurn.canonicalItems?.find((item) => item.threadId)?.threadId,
-      turnId: activeTurn.id,
-      values,
-    });
-    clearTimelineError();
-    dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
-    try {
-      await chatStore.dispatch(command);
-    } catch (error) {
-      dispatchCommandLifecycle({
-        commandId: command.commandId,
-        error: error instanceof Error ? error.message : String(error),
-        type: "rejected",
-      });
-    }
+  async function handleSubmitAgentUiForm(form: AgentUiForm, values: Record<string, unknown>) {
+    await chatApplication.submitForm(activePersistedSessionId, form, values);
   }
 
   async function handleCancelAgentUiForm(form: AgentUiForm) {
-    if (!activeSession || isThreadCommandInFlight(commandLifecycle)) {
-      return;
-    }
-    if (!activeTurn) {
-      reportTimelineError(t("runtime.cancelFormTurnUnavailable"));
-      return;
-    }
-    const formTurnId = agentUiFormCorrelationString(form, "turn_id") || form.turn_id || activeTurn.id;
-    if (formTurnId !== activeTurn.id) {
-      reportTimelineError(t("runtime.cancelFormStaleTurn", { turnId: formTurnId }));
-      return;
-    }
-    const command = createThreadFormCancelCommand({
-      formId: form.form_id,
-      sessionId: activeSession.id,
-      source: { control: "chat-form", surface: "chat" },
-      threadId: agentUiFormCorrelationString(form, "thread_id")
-        || activeTurn.canonicalItems?.find((item) => item.threadId)?.threadId,
-      turnId: activeTurn.id,
-    });
-    clearTimelineError();
-    dispatchCommandLifecycle({ command, nowMs: now(), type: "dispatch" });
-    try {
-      await chatStore.dispatch(command);
-    } catch (error) {
-      dispatchCommandLifecycle({
-        commandId: command.commandId,
-        error: error instanceof Error ? error.message : String(error),
-        type: "rejected",
-      });
-    }
+    await chatApplication.submitForm(activePersistedSessionId, form);
   }
 
   function handleSessionSidebarCollapsedChange(collapsed: boolean) {
@@ -2488,7 +2080,7 @@ export function ChatPage({
           <button className="react-back-to-latest" type="button" onClick={handleBackToLatest}>{t("shell.backToLatest")}</button>
         ) : null}
 
-        {queueMessage ? <p className="react-queued-inputs__message">{queueMessage}</p> : null}
+        <ChatQueueNotice application={chatApplication} sessionId={activePersistedSessionId} />
         {compactingActiveSession ? (
           <p aria-live="polite" className="react-context-compaction-status" role="status">
             <Loader2 aria-hidden="true" />
@@ -2506,15 +2098,7 @@ export function ChatPage({
           </p>
         ) : null}
         <div className="react-composer-drop-target">
-          {activeSession && activeQueuedInputs.length ? (
-            <QueuedInputsPanel
-              canInterrupt={canInterruptQueuedInput}
-              inputs={activeQueuedInputs}
-              onDelete={(inputId) => handleDeleteQueuedInput(activeSession.id, inputId)}
-              onInterrupt={(inputId) => void handleInterruptQueuedInput(activeSession.id, inputId)}
-              onResume={() => void handleResumeQueuedInputs(activeSession.id)}
-            />
-          ) : null}
+          <ChatQueuedInputs application={chatApplication} sessionId={activePersistedSessionId} />
           <ClaudeStyleAiInput
             className={["react-composer", emptyActiveSession ? "react-composer--raised" : ""].filter(Boolean).join(" ")}
             contextReferences={composerArtifactContextReferences}
@@ -2665,10 +2249,6 @@ function EmptyStateText({ text }: { text: string }) {
   return <p className="react-empty-state">{text}</p>;
 }
 
-function toChatInput(input: QueuedComposerInput): ChatInput {
-  return input.turnInput;
-}
-
 function threadCommandLifecycleLabel(lifecycle: ThreadCommandLifecycle, t: TFunction<"chat">): string {
   const commandKind = lifecycle.stage === "idle" ? "agent.cancel" : lifecycle.command.kind;
   const operation = ({
@@ -2693,11 +2273,6 @@ function threadCommandLifecycleLabel(lifecycle: ThreadCommandLifecycle, t: TFunc
     case "timed_out":
       return lifecycle.error;
   }
-}
-
-function agentUiFormCorrelationString(form: AgentUiForm, key: string): string {
-  const value = form.correlation[key];
-  return typeof value === "string" ? value : "";
 }
 
 function isVisibleAgentUiForm(form: AgentUiForm): boolean {
@@ -2764,83 +2339,6 @@ function toComposerModelOption(model: ChatModelOption, t: TFunction<"chat">): Mo
     ...(model.supportsImageInput ? { badge: t("composer.imageInput") } : {}),
   };
 }
-
-function QueuedInputsPanel({
-  canInterrupt,
-  inputs,
-  onDelete,
-  onInterrupt,
-  onResume,
-}: {
-  canInterrupt: boolean;
-  inputs: QueuedInput[];
-  onDelete: (inputId: string) => void;
-  onInterrupt: (inputId: string) => void;
-  onResume: () => void;
-}) {
-  const { t } = useTranslation("chat");
-  const hasPausedInput = inputs.some((input) => input.status === "paused");
-  const pendingCount = inputs.filter((input) => input.status === "queued" || input.status === "paused").length;
-  return (
-    <section aria-label={t("queue.label")} aria-live="polite" className="react-queued-inputs">
-      <div className="react-queued-inputs__header">
-        <h2>{t("queue.title")}</h2>
-        <div>
-          <span>{t("queue.pending", { max: MAX_QUEUED_INPUTS, pending: pendingCount })}</span>
-          {hasPausedInput ? <button type="button" onClick={onResume}>{t("queue.resume")}</button> : null}
-        </div>
-      </div>
-      <ol>
-        {inputs.map((input) => (
-          <li className="react-queued-input" data-status={input.status} key={input.id}>
-            <span>{queuedInputStatusLabel(input, t)}</span>
-            <p>{input.content}</p>
-            {(input.mode === "queued" && (input.status === "queued" || input.status === "paused")) || (input.mode === "interrupt" && input.status !== "queued") ? (
-              <div className="react-queued-input__actions">
-                {input.mode === "queued" && canInterrupt ? (
-                  <button
-                    className="react-queued-input__interrupt"
-                    title={t("queue.interruptHelp")}
-                    type="button"
-                    onClick={() => onInterrupt(input.id)}
-                  >
-                    {t("queue.interrupt")}
-                  </button>
-                ) : null}
-                <button type="button" onClick={() => onDelete(input.id)}>{input.mode === "interrupt" ? t("queue.clearInterrupt") : t("queue.delete")}</button>
-              </div>
-            ) : null}
-          </li>
-        ))}
-      </ol>
-    </section>
-  );
-}
-
-function queuedInputStatusLabel(input: QueuedInput, t: TFunction<"chat">): string {
-  if (input.mode === "interrupt") {
-    switch (input.status) {
-      case "sent":
-        return t("queue.sending");
-      case "failed":
-        return t("queue.interruptFailed");
-      default:
-        return t("queue.interrupting");
-    }
-  }
-  switch (input.status) {
-    case "paused":
-      return t("queue.paused");
-    case "sent":
-      return t("queue.sent");
-    case "failed":
-      return t("queue.failed");
-    default:
-      return t("queue.waiting");
-  }
-}
-
-
 
 function ToolCallDetails({ toolCall }: { toolCall: ToolCallSummary }) {
   const { t } = useTranslation("chat");

--- a/src/react-workbench/chat/ChatQueuedInputs.tsx
+++ b/src/react-workbench/chat/ChatQueuedInputs.tsx
@@ -1,0 +1,107 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+import { MAX_QUEUED_INPUTS } from "../../app-core/chat/chatInputState";
+import type { QueuedInput } from "../../app-core/chat/chatUiProjection";
+import type { ChatTurnApplication } from "./chatTurnApplication";
+
+type Props = { application: ChatTurnApplication; sessionId: string };
+
+function useQueue({ application, sessionId }: Props) {
+  return useSyncExternalStore(application.subscribe,
+    useCallback(() => application.queue(sessionId), [application, sessionId]));
+}
+
+export function ChatQueueNotice(props: Props) {
+  const { message } = useQueue(props);
+  return message ? <p className="react-queued-inputs__message">{message}</p> : null;
+}
+
+export function ChatQueuedInputs(props: Props) {
+  const { application, sessionId } = props;
+  const { inputs } = useQueue(props);
+  const turn = useSyncExternalStore(application.subscribe,
+    useCallback(() => application.turn(sessionId), [application, sessionId]));
+  if (!inputs.length) return null;
+  const canInterrupt = turn.canInterrupt && !inputs.some((input) =>
+    input.mode === "interrupt" && (input.status === "queued" || input.status === "sent"));
+  return <QueuedInputsPanel inputs={inputs} canInterrupt={canInterrupt}
+    onDelete={(id) => application.remove(sessionId, id)}
+    onInterrupt={(id) => void application.interrupt(sessionId, id)}
+    onResume={() => void application.resume(sessionId)} />;
+}
+
+function QueuedInputsPanel({
+  canInterrupt,
+  inputs,
+  onDelete,
+  onInterrupt,
+  onResume,
+}: {
+  canInterrupt: boolean;
+  inputs: QueuedInput[];
+  onDelete: (inputId: string) => void;
+  onInterrupt: (inputId: string) => void;
+  onResume: () => void;
+}) {
+  const { t } = useTranslation("chat");
+  const hasPausedInput = inputs.some((input) => input.status === "paused");
+  const pendingCount = inputs.filter((input) => input.status === "queued" || input.status === "paused").length;
+  return (
+    <section aria-label={t("queue.label")} aria-live="polite" className="react-queued-inputs">
+      <div className="react-queued-inputs__header">
+        <h2>{t("queue.title")}</h2>
+        <div>
+          <span>{t("queue.pending", { max: MAX_QUEUED_INPUTS, pending: pendingCount })}</span>
+          {hasPausedInput ? <button type="button" onClick={onResume}>{t("queue.resume")}</button> : null}
+        </div>
+      </div>
+      <ol>
+        {inputs.map((input) => (
+          <li className="react-queued-input" data-status={input.status} key={input.id}>
+            <span>{queuedInputStatusLabel(input, t)}</span>
+            <p>{input.content}</p>
+            {(input.mode === "queued" && (input.status === "queued" || input.status === "paused")) || (input.mode === "interrupt" && input.status !== "queued") ? (
+              <div className="react-queued-input__actions">
+                {input.mode === "queued" && canInterrupt ? (
+                  <button
+                    className="react-queued-input__interrupt"
+                    title={t("queue.interruptHelp")}
+                    type="button"
+                    onClick={() => onInterrupt(input.id)}
+                  >
+                    {t("queue.interrupt")}
+                  </button>
+                ) : null}
+                <button type="button" onClick={() => onDelete(input.id)}>{input.mode === "interrupt" ? t("queue.clearInterrupt") : t("queue.delete")}</button>
+              </div>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function queuedInputStatusLabel(input: QueuedInput, t: TFunction<"chat">): string {
+  if (input.mode === "interrupt") {
+    switch (input.status) {
+      case "sent":
+        return t("queue.sending");
+      case "failed":
+        return t("queue.interruptFailed");
+      default:
+        return t("queue.interrupting");
+    }
+  }
+  switch (input.status) {
+    case "paused":
+      return t("queue.paused");
+    case "sent":
+      return t("queue.sent");
+    case "failed":
+      return t("queue.failed");
+    default:
+      return t("queue.waiting");
+  }
+}

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,9 +1,16 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:985749c7affe59a69eb32b9ea34a23efe4d442c962127e72a5b3262e587f3f6e -->
+<!-- tinybot-module-fingerprint: sha256:26d42714f165dd5629688a49d65fd3d23e9b4bf59f3ef7383c30ecd9d892cc53 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
 `ChatPage.tsx` is the route-level composition module.
+`chatSessionApplication.ts` owns session data, optimistic titles, per-draft
+creation promises, persisted-ID reconciliation, metadata operations, and
+Timeline-derived session status. `useChatSessions.ts` connects its snapshot and
+semantic changes to React. The page owns tab selection, composer draft
+persistence, scroll restoration, and temporary deleted-row animation snapshots;
+it does not mutate the application's session data. Module tests cover concurrent
+draft creation, ID/title reconciliation, deletion events, and visible failures.
 `SidecarResources` owns Browser, Terminal, and Artifact state and lifecycle
 coordination. The page holds only Sidecar layout presentation and invokes its
 open/toggle operations; resource snapshots never enter page state.

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,10 +1,25 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:77960357c1793a49fbf6bc1d991cd88b3b0f3cbe6ea02cb7952fbf1e396ddb49 -->
+<!-- tinybot-module-fingerprint: sha256:ba256b557a5e416c54b19ca90975ea3c80c049fc6b9e8549ec51448657332c9f -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
 `ChatPage.tsx` is the route-level composition module.
-Its details drawer retains closing content through a reversible 220 ms
+`chatTurnApplication.ts` owns per-session input queues, cancellation and
+interrupt continuation, form commands, and transport/canonical command
+confirmation with acknowledgement timeouts. It consumes Timeline snapshots;
+the existing Timeline model remains authoritative for server state. Queue
+submissions reserve their input before awaiting transport and remove only that
+input on success, preserving concurrent queue edits. Failed submissions remain
+visible and paused for manual retry.
+`useChatTurnApplication.ts` adapts the application to React and keeps background
+command errors scoped to their session. `ChatQueuedInputs.tsx` subscribes directly
+to queue snapshots, so queue-only changes do not rerender the route's Timeline.
+`chatTurnApplication.test.ts` verifies event ordering, duplicate delivery,
+concurrent queue edits, failure handling, and per-session command confirmation
+without mounting Chat or provisioning Sidecar resources.
+`ChatPage.queue-rendering.test.tsx` verifies that deleting a queued input adds
+neither a Timeline render nor a session-list request.
+The ChatPage details drawer retains closing content through a reversible 220 ms
 opacity/transform transition using `lib/useExitPresence`. Closing immediately
 makes the drawer inert and restores trigger focus; reopening cancels pending
 removal. Thread changes clear incompatible details. Native Sidecar browser

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,9 +1,12 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:fbaafe00613a05a97e7191e010a1e8e3f03cc5aa676fbca70ed327236429539c -->
+<!-- tinybot-module-fingerprint: sha256:985749c7affe59a69eb32b9ea34a23efe4d442c962127e72a5b3262e587f3f6e -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
 `ChatPage.tsx` is the route-level composition module.
+`SidecarResources` owns Browser, Terminal, and Artifact state and lifecycle
+coordination. The page holds only Sidecar layout presentation and invokes its
+open/toggle operations; resource snapshots never enter page state.
 `useChatSubmission.ts` owns submission preparation, model-save ordering,
 optimistic message reconciliation, Artifact review capture, and compaction.
 Session operations are supplied through semantic operations; the page supplies
@@ -201,7 +204,7 @@ the native Provider Profile/model pair before updating that renderer preference;
 the first send waits for that persistence to complete.
 Browser runtime snapshots are retained by the
 session runtime and projected into Sidecar Browser resources. Each resource tab
-maps to one native WebView2 tab in the Chat-owned shared Browser Session, so user
+maps to one native WebView2 tab in the Thread-scoped shared Browser Session, so user
 input and Agent browser tools operate on the same tabs, profile, and navigation
 state without a nested browser tab strip. Sidecar owns the user's selected
 resource while native snapshots synchronize tab identity and content; the selected

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,9 +1,18 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:26d42714f165dd5629688a49d65fd3d23e9b4bf59f3ef7383c30ecd9d892cc53 -->
+<!-- tinybot-module-fingerprint: sha256:4d87fc632d93d5696af9a45470600a7dea03f37ceea596c49a86013634965b37 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
 `ChatPage.tsx` is the route-level composition module.
+`useChatApplication.ts` coordinates submission, session data, turn commands,
+active runtime effects, background subscriptions, and effective-capability
+queries. The page supplies the selected session and composer context and receives
+draft-consumed and background-activity notifications. Session replacement and
+removal reconcile client state inside the application, independently of tab
+animations. Background canonical updates load command acknowledgements without
+replacing the active Timeline; obsolete loads and capability responses are
+discarded when their session changes. Its tests exercise these workflows without
+mounting page layout or Sidecar resources.
 `chatSessionApplication.ts` owns session data, optimistic titles, per-draft
 creation promises, persisted-ID reconciliation, metadata operations, and
 Timeline-derived session status. `useChatSessions.ts` connects its snapshot and
@@ -35,7 +44,8 @@ to queue snapshots, so queue-only changes do not rerender the route's Timeline.
 concurrent queue edits, failure handling, and per-session command confirmation
 without mounting Chat or provisioning Sidecar resources.
 `ChatPage.queue-rendering.test.tsx` verifies that deleting a queued input adds
-neither a Timeline render nor a session-list request.
+neither a Timeline render nor a session-list request, and that browser snapshots
+add no Timeline render while Chat and Sidecar share one native subscription.
 The ChatPage details drawer retains closing content through a reversible 220 ms
 opacity/transform transition using `lib/useExitPresence`. Closing immediately
 makes the drawer inert and restores trigger focus; reopening cancels pending

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,9 +1,16 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:ba256b557a5e416c54b19ca90975ea3c80c049fc6b9e8549ec51448657332c9f -->
+<!-- tinybot-module-fingerprint: sha256:fbaafe00613a05a97e7191e010a1e8e3f03cc5aa676fbca70ed327236429539c -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
 `ChatPage.tsx` is the route-level composition module.
+`useChatSubmission.ts` owns submission preparation, model-save ordering,
+optimistic message reconciliation, Artifact review capture, and compaction.
+Session operations are supplied through semantic operations; the page supplies
+composer selections and responds to consumed drafts. `desktopChatCommands.ts`
+implements native Chat dispatch, model resolution, and canonical fork lookup,
+leaving `defaultServices.ts` to wire its dependencies. Submission tests exercise
+failure rollback and draft-ID reconciliation without mounting the page.
 `chatTurnApplication.ts` owns per-session input queues, cancellation and
 interrupt continuation, form commands, and transport/canonical command
 confirmation with acknowledgement timeouts. It consumes Timeline snapshots;

--- a/src/react-workbench/chat/chatEventSource.test.ts
+++ b/src/react-workbench/chat/chatEventSource.test.ts
@@ -1,0 +1,27 @@
+import { expect, it, vi } from "vitest";
+import type { ChatEvent, ChatStore } from "../services";
+import { subscribeChatEvents } from "./chatEventSource";
+
+it("shares native delivery and releases it only after the last module leaves", () => {
+  let receive!: (event: ChatEvent) => void;
+  const unsubscribe = vi.fn();
+  const source: Pick<ChatStore, "subscribe"> = { subscribe: vi.fn((_sessionId, listener) => {
+    receive = listener;
+    return unsubscribe;
+  }) };
+  const chat = vi.fn();
+  const browser = vi.fn();
+  const leaveChat = subscribeChatEvents(source, "s1", chat);
+  const leaveBrowser = subscribeChatEvents(source, "s1", browser);
+  expect(source.subscribe).toHaveBeenCalledOnce();
+  receive({ type: "attached" });
+  expect(chat).toHaveBeenCalledOnce();
+  expect(browser).toHaveBeenCalledOnce();
+  leaveChat();
+  expect(unsubscribe).not.toHaveBeenCalled();
+  receive({ type: "attached" });
+  expect(chat).toHaveBeenCalledOnce();
+  expect(browser).toHaveBeenCalledTimes(2);
+  leaveBrowser();
+  expect(unsubscribe).toHaveBeenCalledOnce();
+});

--- a/src/react-workbench/chat/chatEventSource.ts
+++ b/src/react-workbench/chat/chatEventSource.ts
@@ -1,0 +1,27 @@
+import type { ChatEvent, ChatStore } from "../services";
+
+type Source = Pick<ChatStore, "subscribe">;
+type Channel = { listeners: Set<(event: ChatEvent) => void>; unsubscribe(): void };
+const sources = new WeakMap<Source, Map<string, Channel>>();
+
+/** Chat and Sidecar share one native subscription while owning their own event consumers. */
+export function subscribeChatEvents(source: Source, sessionId: string, listener: (event: ChatEvent) => void) {
+  let channels = sources.get(source);
+  if (!channels) { channels = new Map(); sources.set(source, channels); }
+  let channel = channels.get(sessionId);
+  if (!channel) {
+    const listeners = new Set([listener]);
+    const unsubscribe = source.subscribe(sessionId, (event) => {
+      for (const receive of [...listeners]) receive(event);
+    });
+    channel = { listeners, unsubscribe };
+    channels.set(sessionId, channel);
+  } else channel.listeners.add(listener);
+  return () => {
+    channel.listeners.delete(listener);
+    if (!channel.listeners.size) {
+      channel.unsubscribe();
+      channels.delete(sessionId);
+    }
+  };
+}

--- a/src/react-workbench/chat/chatSessionApplication.test.ts
+++ b/src/react-workbench/chat/chatSessionApplication.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionStore, SessionSummary } from "../services";
+import { createChatSessionApplication } from "./chatSessionApplication";
+
+const session = (id: string, title = "New chat"): SessionSummary => ({ id, chatId: id, title, status: "idle", updatedAtMs: 1 });
+function setup() {
+  const store: SessionStore = {
+    list: vi.fn(async () => []), create: vi.fn(async () => session("s1")),
+    rename: vi.fn(async () => {}), delete: vi.fn(async () => {}), archive: vi.fn(async () => {}), pin: vi.fn(async () => {}),
+  };
+  return { store, application: createChatSessionApplication(store, () => 1) };
+}
+
+describe("Chat session application", () => {
+  it("deduplicates materialization per draft without sharing another draft's creation", async () => {
+    const { store, application } = setup();
+    let complete!: (value: SessionSummary) => void;
+    vi.mocked(store.create).mockImplementationOnce(() => new Promise((resolve) => { complete = resolve; }));
+    const first = application.createDraft({ workingDirectory: "D:/first" });
+    const second = application.createDraft({ workingDirectory: "D:/second" });
+    const pending = application.materializeDraft(first.id, first, { model: "chosen" });
+    expect(application.materializeDraft(first.id, first, {})).toBe(pending);
+    await application.materializeDraft(second.id, second, {});
+    expect(store.create).toHaveBeenCalledTimes(2);
+    expect(application.snapshot().creating).toBe(true);
+    complete(session("first"));
+    await pending;
+    expect(application.snapshot().creating).toBe(false);
+    expect(application.snapshot().sessions.map((value) => value.id)).toEqual(["first", "s1"]);
+  });
+
+  it("reconciles an optimistic session ID and title with the persisted session", async () => {
+    const { store, application } = setup();
+    const changed = vi.fn();
+    application.onChange(changed);
+    application.accept(session("temporary"));
+    application.preview(session("temporary", "First prompt"));
+    vi.mocked(store.list).mockResolvedValue([session("persisted")]);
+    await application.refresh();
+    expect(application.snapshot().sessions).toMatchObject([{ id: "persisted", title: "First prompt" }]);
+    expect(changed).toHaveBeenCalledWith({ type: "replaced", previousSessionId: "temporary", sessionId: "persisted" });
+    await application.rename("persisted", "Renamed");
+    vi.mocked(store.list).mockResolvedValue([session("persisted", "Renamed")]);
+    await application.refresh();
+    expect(application.snapshot().sessions[0].title).toBe("Renamed");
+  });
+
+  it("reports deletion with the removed row so presentation can finish its animation independently", async () => {
+    const { application } = setup();
+    const removed = session("s1", "Deleting");
+    application.accept(removed);
+    const changed = vi.fn();
+    application.onChange(changed);
+    await application.delete(removed);
+    expect(application.snapshot().sessions).toEqual([]);
+    expect(changed).toHaveBeenCalledWith({ type: "removed", session: removed, reason: "delete" });
+  });
+
+  it("retains creation errors and releases pending state for an explicit retry", async () => {
+    const { store, application } = setup();
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(store.create).mockRejectedValueOnce(new Error("workspace missing"));
+    const draft = application.createDraft({ workingDirectory: "Z:/missing" });
+    await expect(application.materializeDraft(draft.id, draft, {})).rejects.toThrow("workspace missing");
+    expect(application.snapshot()).toMatchObject({ creating: false, error: "workspace missing" });
+    await application.materializeDraft(draft.id, draft, {});
+    expect(application.snapshot()).toMatchObject({ creating: false, error: "" });
+    log.mockRestore();
+  });
+});

--- a/src/react-workbench/chat/chatSessionApplication.ts
+++ b/src/react-workbench/chat/chatSessionApplication.ts
@@ -1,0 +1,150 @@
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+import type { SessionStore, SessionSummary } from "../services";
+import { projectTimelineSessionStatus } from "./chatEventPolicy";
+import { isDefaultSessionTitle } from "./sessionTitle";
+import type { DraftSession, DraftSessionCreateInput } from "./sessionTabWorkspace";
+
+export type ChatSessionChange =
+  | { type: "loaded" | "reconciled"; sessions: SessionSummary[] }
+  | { type: "created"; session: SessionSummary; previousSessionId?: string }
+  | { type: "replaced"; previousSessionId: string; sessionId: string }
+  | { type: "removed"; session: SessionSummary; reason: "delete" | "archive" };
+
+export function createChatSessionApplication(store: SessionStore, now: () => number = Date.now) {
+  let state = { sessions: [] as SessionSummary[], loaded: false, error: "", creating: false };
+  const listeners = new Set<() => void>();
+  const changes = new Set<(event: ChatSessionChange) => void>();
+  const titles = new Map<string, string>();
+  const creations = new Map<string, Promise<SessionSummary>>();
+  let draftSequence = 0;
+  const emit = (event: ChatSessionChange) => changes.forEach((listener) => listener(event));
+  const publish = (patch: Partial<typeof state>) => {
+    state = { ...state, ...patch };
+    listeners.forEach((listener) => listener());
+  };
+  const updateSession = (id: string, patch: Partial<SessionSummary>) => {
+    publish({ sessions: state.sessions.map((session) => session.id === id ? { ...session, ...patch } : session) });
+  };
+  function accept(session: SessionSummary, previousSessionId?: string) {
+    publish({ sessions: [session, ...state.sessions.filter((candidate) => candidate.id !== session.id)] });
+    emit({ type: "created", session, previousSessionId });
+  }
+  async function load() {
+    try {
+      const sessions = await store.list();
+      publish({ sessions, loaded: true, error: "" });
+      emit({ type: "loaded", sessions });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      publish({ error: message });
+      console.error("[chat-sessions] load.failed", { error: message });
+    }
+  }
+  async function refresh(preserveSession?: SessionSummary): Promise<SessionSummary[]> {
+    const listedSessions = await store.list();
+    let titledSessions = listedSessions.map((session) => {
+      if (!isDefaultSessionTitle(session.title)) { titles.delete(session.id); return session; }
+      const title = titles.get(session.id);
+      return title ? { ...session, title } : session;
+    });
+    const listedIds = new Set(titledSessions.map((session) => session.id));
+    const knownIds = new Set(state.sessions.map((session) => session.id));
+    const missing = state.sessions.filter((session) => titles.has(session.id) && !listedIds.has(session.id));
+    const replacements = titledSessions.filter((session) => !knownIds.has(session.id));
+    let replacement: { previousSessionId: string; sessionId: string } | undefined;
+    if (missing.length === 1 && replacements.length === 1) {
+      const pending = missing[0];
+      const persisted = replacements[0];
+      replacement = { previousSessionId: pending.id, sessionId: persisted.id };
+      const title = titles.get(pending.id);
+      titles.delete(pending.id);
+      if (title && isDefaultSessionTitle(persisted.title)) {
+        titles.set(persisted.id, title);
+        titledSessions = titledSessions.map((session) => session.id === persisted.id ? { ...session, title } : session);
+      }
+    }
+    const pending = state.sessions.filter((session) => titles.has(session.id) && !listedIds.has(session.id))
+      .map((session) => ({ ...session, title: titles.get(session.id) ?? session.title }));
+    const visible = [...pending, ...titledSessions];
+    const preserveTitle = preserveSession && !isDefaultSessionTitle(preserveSession.title);
+    const sessions = preserveSession && !visible.some((session) => session.id === preserveSession.id)
+      ? [preserveSession, ...visible]
+      : visible.map((session) => preserveTitle && session.id === preserveSession.id && isDefaultSessionTitle(session.title)
+        ? { ...session, title: preserveSession.title } : session);
+    publish({ sessions });
+    if (replacement) emit({ type: "replaced", ...replacement });
+    emit({ type: "reconciled", sessions });
+    return sessions;
+  }
+  async function remove(session: SessionSummary, reason: "delete" | "archive") {
+    await store[reason](session.id);
+    titles.delete(session.id);
+    publish({ sessions: state.sessions.filter((candidate) => candidate.id !== session.id) });
+    emit({ type: "removed", session, reason });
+  }
+
+  return {
+    snapshot: () => state,
+    subscribe(listener: () => void) { listeners.add(listener); return () => { listeners.delete(listener); }; },
+    onChange(listener: (event: ChatSessionChange) => void) { changes.add(listener); return () => { changes.delete(listener); }; },
+    load, refresh, accept,
+    preview(session: SessionSummary) { titles.set(session.id, session.title); updateSession(session.id, session); },
+    createDraft(input: DraftSessionCreateInput): DraftSession {
+      publish({ error: "" });
+      const createdAtMs = now();
+      return { id: `draft:${createdAtMs}:${++draftSequence}`, createdAtMs, createInput: input };
+    },
+    materializeDraft(draftId: string, draft: DraftSession | undefined, model: { model?: string; modelProvider?: string }) {
+      const pending = creations.get(draftId);
+      if (pending) return pending;
+      const input = { ...draft?.createInput, ...model };
+      publish({ creating: true, error: "" });
+      const creation = store.create(draft || Object.keys(input).length ? input : undefined)
+        .then((session) => { accept(session, draftId); return session; })
+        .catch((error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          publish({ error: message });
+          console.error("[session-workspaces] session.create.failed", { draftId, error: message, workingDirectory: input.workingDirectory, projectGroupId: input.projectGroupId });
+          throw error;
+        }).finally(() => {
+          creations.delete(draftId);
+          publish({ creating: creations.size > 0 });
+        });
+      creations.set(draftId, creation);
+      return creation;
+    },
+    async activateExternal(sessionId: string) {
+      const sessions = store.refresh ? await store.refresh() : await store.list();
+      const session = sessions.find((candidate) => candidate.id === sessionId);
+      if (!session) throw new Error(`Cannot activate unknown Thread ${sessionId}`);
+      publish({ sessions });
+      return session;
+    },
+    delete(session: SessionSummary) { return remove(session, "delete"); },
+    archive(session: SessionSummary) { return remove(session, "archive"); },
+    async rename(sessionId: string, title: string) {
+      await store.rename(sessionId, title);
+      titles.delete(sessionId);
+      updateSession(sessionId, { title });
+    },
+    async pin(sessionId: string, pinned: boolean) {
+      await store.pin(sessionId, pinned);
+      updateSession(sessionId, { pinned });
+    },
+    async selectModel(sessionId: string, model: string, modelProvider?: string) {
+      updateSession(sessionId, { model, modelProvider });
+      if (modelProvider) await store.setModel?.(sessionId, model, modelProvider);
+      else await store.setModel?.(sessionId, model);
+    },
+    async recordMigration(sessionId: string, migration: NonNullable<SessionSummary["pluginMigration"]>) {
+      updateSession(sessionId, { pluginMigration: migration });
+      await store.markPluginMigrationInstalled?.(sessionId, migration.installedPluginName!, migration.installedPluginEnabled!, migration.cleanupWarning);
+    },
+    receiveTimeline(sessionId: string, timeline: ChatTimelineSnapshot) {
+      const status = projectTimelineSessionStatus(timeline);
+      if (status && state.sessions.some((session) => session.id === sessionId && session.status !== status)) updateSession(sessionId, { status });
+    },
+  };
+}
+
+export type ChatSessionApplication = ReturnType<typeof createChatSessionApplication>;

--- a/src/react-workbench/chat/chatTurnApplication.test.ts
+++ b/src/react-workbench/chat/chatTurnApplication.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TFunction } from "i18next";
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+import type { ChatTurn } from "../../app-core/chat/chatTurnContracts";
+import type { ThreadEffectiveCapabilities } from "../../app-core/chat/threadCapabilities";
+import { THREAD_COMMAND_ACK_TIMEOUT_MS } from "../../app-core/chat/threadCommand";
+import type { ChatEvent } from "../services";
+import { createChatTurnApplication } from "./chatTurnApplication";
+import type { QueuedComposerInput } from "./chatSubmission";
+
+const completed: ChatEvent = { type: "agent.event", eventType: "agent.turn.completed" };
+const interrupted: ChatEvent = { type: "agent.event", eventType: "agent.turn.interrupted" };
+const applications: ReturnType<typeof createChatTurnApplication>[] = [];
+
+afterEach(() => {
+  applications.splice(0).forEach((application) => application.dispose());
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function input(id: string): QueuedComposerInput {
+  return { id, content: id, createdAt: "2026-09-08T00:00:00Z", mode: "queued", status: "queued", turnInput: { text: id } };
+}
+
+function context(sessionId = "s1") {
+  const timeline: ChatTimelineSnapshot = {
+    schemaVersion: "tinybot.chat_timeline.v1", source: "canonical", sessionId, diagnostics: [], turnRevisions: {},
+    turns: [{
+      id: `turn-${sessionId}`, sessionKey: sessionId, userMessageId: "user-1",
+      userMessage: { id: "user-1", role: "user", text: "hello", timestamp: "2026-09-08T00:00:00Z" },
+      status: "running", steps: [], startedAt: "2026-09-08T00:00:00Z", updatedAt: "2026-09-08T00:00:00Z",
+    }],
+  };
+  const capabilities: ThreadEffectiveCapabilities = {
+    schemaVersion: "tinybot.effective_capabilities.v2", threadId: sessionId,
+    capabilities: { agent: { cancel: { available: true }, retry: { available: false } } },
+  };
+  return { timeline, capabilities };
+}
+
+function setup() {
+  const dependencies = {
+    dispatch: vi.fn<Parameters<typeof createChatTurnApplication>[0]["dispatch"]>(async () => {}),
+    submitTurn: vi.fn(async (_sessionId: string, _input: { text: string }, _control: string) => {}),
+    refreshSessions: vi.fn(async () => [{ id: "s1", chatId: "s1", title: "Chat", status: "idle" as const, updatedAtMs: 0 }]),
+    reportError: vi.fn(), clearError: vi.fn(), now: () => Date.now(),
+    t: ((key: string) => key) as TFunction<"chat">,
+  };
+  const application = createChatTurnApplication(dependencies);
+  applications.push(application);
+  application.observe("s1", context());
+  return { application, ...dependencies };
+}
+
+describe("Chat turn application", () => {
+  it.each(["terminal-first", "transport-first"])("interrupts exactly once with %s delivery", async (order) => {
+    const { application, dispatch, submitTurn } = setup();
+    const cancellation = deferred();
+    dispatch.mockReturnValueOnce(cancellation.promise);
+    application.enqueue("s1", input("replace"));
+    application.enqueue("s1", input("later"));
+    const request = application.interrupt("s1", "replace");
+    if (order === "terminal-first") {
+      await Promise.all([application.receiveSessionEvent("s1", interrupted), application.receiveSessionEvent("s1", interrupted)]);
+      expect(submitTurn).not.toHaveBeenCalled();
+      cancellation.resolve();
+      await request;
+    } else {
+      cancellation.resolve();
+      await request;
+      expect(submitTurn).not.toHaveBeenCalled();
+      await Promise.all([application.receiveSessionEvent("s1", interrupted), application.receiveSessionEvent("s1", interrupted)]);
+    }
+    expect(submitTurn).toHaveBeenCalledExactlyOnceWith("s1", { text: "replace" }, "interrupt-new-turn");
+    expect(application.queue("s1").inputs.map((item) => item.id)).toEqual(["later"]);
+  });
+
+  it("reserves a pending submission and preserves inputs added or removed during its await", async () => {
+    const { application, submitTurn } = setup();
+    const submission = deferred();
+    submitTurn.mockReturnValueOnce(submission.promise);
+    application.enqueue("s1", input("first"));
+    application.enqueue("s1", input("remove"));
+    const sending = application.receiveSessionEvent("s1", completed);
+    await vi.waitFor(() => expect(submitTurn).toHaveBeenCalledTimes(1));
+    application.enqueue("s1", input("new"));
+    application.remove("s1", "remove");
+    await application.receiveSessionEvent("s1", completed);
+    expect(submitTurn).toHaveBeenCalledTimes(1);
+    submission.resolve();
+    await sending;
+    expect(application.queue("s1").inputs.map((item) => item.id)).toEqual(["new"]);
+  });
+
+  it("pauses on cancel, requires manual resume, and resumes only one input", async () => {
+    const { application, dispatch, submitTurn } = setup();
+    application.enqueue("s1", input("first"));
+    application.enqueue("s1", input("second"));
+    await application.cancel("s1");
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ kind: "agent.cancel", target: { sessionId: "s1", turnId: "turn-s1" } }));
+    expect(application.queue("s1").inputs.map((item) => item.status)).toEqual(["paused", "paused"]);
+    await application.receiveSessionEvent("s1", completed);
+    expect(submitTurn).not.toHaveBeenCalled();
+    await application.resume("s1");
+    expect(submitTurn).toHaveBeenCalledExactlyOnceWith("s1", { text: "first" }, "queue-manual_resume");
+    expect(application.queue("s1").inputs).toMatchObject([{ id: "second", status: "paused" }]);
+  });
+
+  it("keeps a failed submission visible and retryable without automatic retry", async () => {
+    const { application, submitTurn } = setup();
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    application.enqueue("s1", input("first"));
+    submitTurn.mockRejectedValueOnce(new Error("submission unavailable"));
+    await application.receiveSessionEvent("s1", completed);
+    expect(application.queue("s1")).toMatchObject({ inputs: [{ id: "first", status: "paused" }], message: "submission unavailable" });
+    expect(log).toHaveBeenCalledWith("[chat-turn] queue.submit.failed", expect.objectContaining({ sessionId: "s1", inputId: "first" }));
+    await application.receiveSessionEvent("s1", completed);
+    expect(submitTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send an interrupt after cancellation fails, even when the terminal event arrived", async () => {
+    const { application, dispatch, submitTurn } = setup();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const cancellation = deferred();
+    dispatch.mockReturnValueOnce(cancellation.promise);
+    application.enqueue("s1", input("replacement"));
+    const request = application.interrupt("s1", "replacement");
+    await application.receiveSessionEvent("s1", interrupted);
+    cancellation.reject(new Error("cancel rejected"));
+    await request;
+    expect(submitTurn).not.toHaveBeenCalled();
+    expect(application.queue("s1")).toMatchObject({ inputs: [{ status: "failed" }], message: "errors.interruptFailed" });
+  });
+
+  it("rejects capabilities evaluated for an older turn", async () => {
+    const { application, dispatch, reportError } = setup();
+    const stale = context();
+    stale.capabilities.evaluatedTurnId = "old-turn";
+    application.observe("s1", stale);
+    await application.cancel("s1");
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledWith("Cannot cancel: runtime.staleCapabilities", "s1");
+  });
+
+  it("keeps transport acceptance separate from canonical acknowledgement and completion", async () => {
+    const { application, dispatch } = setup();
+    await application.cancel("s1");
+    const commandId = dispatch.mock.calls[0][0].commandId;
+    application.receiveCommand("s1", { type: "command.accepted", commandId });
+    expect(application.turn("s1").lifecycle.stage).toBe("waiting_for_canonical");
+    const canonical = context();
+    canonical.timeline.turns[0].canonicalItems = [{
+      data: { detail: { commandId, commandStatus: "acknowledged" } }, itemId: "ack", revision: 1, status: "completed",
+    }] as ChatTurn["canonicalItems"];
+    application.observe("s2", context("s2"));
+    application.receiveTimeline("s1", canonical.timeline);
+    expect(application.turn("s1").lifecycle.stage).toBe("acknowledged");
+    canonical.timeline.turns[0].canonicalItems!.push({
+      data: { commandId }, itemId: "done", revision: 2, status: "cancelled",
+    } as NonNullable<ChatTurn["canonicalItems"]>[number]);
+    application.receiveTimeline("s1", canonical.timeline);
+    expect(application.turn("s1").lifecycle).toMatchObject({ stage: "completed", completion: { itemId: "done", status: "cancelled" } });
+    expect(application.turn("s2").lifecycle.stage).toBe("idle");
+  });
+
+  it("keeps command confirmation isolated across sessions and releases timers on disposal", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { application } = setup();
+    await application.cancel("s1");
+    application.observe("s2", context("s2"));
+    expect(application.turn("s2").lifecycle.stage).toBe("idle");
+    vi.advanceTimersByTime(THREAD_COMMAND_ACK_TIMEOUT_MS);
+    expect(application.turn("s1").lifecycle.stage).toBe("timed_out");
+    await application.cancel("s2");
+    application.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves command and unrelated session snapshot identity when the queue changes", () => {
+    const { application } = setup();
+    const controls = application.turn("s1");
+    const otherQueue = application.queue("s2");
+    application.enqueue("s1", input("first"));
+    application.remove("s1", "first");
+    expect(application.turn("s1")).toBe(controls);
+    expect(application.queue("s2")).toBe(otherQueue);
+  });
+});

--- a/src/react-workbench/chat/chatTurnApplication.ts
+++ b/src/react-workbench/chat/chatTurnApplication.ts
@@ -246,6 +246,15 @@ export function createChatTurnApplication(deps: Dependencies) {
       queues.set(sessionId, previous);
       notify();
     },
+    forgetSession(sessionId: string) {
+      clearTimeout(timers.get(sessionId));
+      timers.delete(sessionId);
+      queues.delete(sessionId);
+      turns.delete(sessionId);
+      contexts.delete(sessionId);
+      interrupts.delete(sessionId);
+      notify();
+    },
     remove,
     resume(sessionId: string) { return sendNext(sessionId, "manual_resume"); },
     async cancel(sessionId: string) {

--- a/src/react-workbench/chat/chatTurnApplication.ts
+++ b/src/react-workbench/chat/chatTurnApplication.ts
@@ -1,0 +1,341 @@
+import type { TFunction } from "i18next";
+import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+import {
+  MAX_QUEUED_INPUTS, deleteQueuedInput, dispatchNextQueuedInput,
+  pauseQueuedInputs, resumeNextQueuedInput, updateInterruptStatus,
+} from "../../app-core/chat/chatInputState";
+import {
+  THREAD_COMMAND_ACK_TIMEOUT_MS, canonicalThreadCommandAcknowledgement,
+  canonicalThreadCommandCompletion, createThreadAgentCancelCommand,
+  createThreadFormCancelCommand, createThreadFormSubmitCommand,
+  isThreadCommandInFlight, reduceThreadCommandLifecycle,
+  type ThreadCommand, type ThreadCommandLifecycle, type ThreadCommandLifecycleAction,
+} from "../../app-core/chat/threadCommand";
+import type { ThreadEffectiveCapabilities } from "../../app-core/chat/threadCapabilities";
+import type { ChatEvent, ChatInput, ChatStore, SessionSummary } from "../services";
+import { canDispatchQueuedInput, projectChatEventEffects } from "./chatEventPolicy";
+import type { QueuedComposerInput } from "./chatSubmission";
+
+type Dependencies = {
+  dispatch: ChatStore["dispatch"];
+  submitTurn(sessionId: string, input: ChatInput, control: string): Promise<void>;
+  refreshSessions(): Promise<SessionSummary[]>;
+  reportError(error: string, sessionId: string): void;
+  clearError(): void;
+  now(): number;
+  t: TFunction<"chat">;
+};
+
+export type ChatQueueSnapshot = {
+  inputs: QueuedComposerInput[];
+  message: string;
+};
+
+export type ChatTurnSnapshot = {
+  lifecycle: ThreadCommandLifecycle;
+  canCancel: boolean;
+  cancelUnavailableReason: string;
+  canInterrupt: boolean;
+};
+
+const EMPTY_QUEUE: ChatQueueSnapshot = { inputs: [], message: "" };
+const EMPTY_TURN: ChatTurnSnapshot = {
+  lifecycle: { stage: "idle" }, canCancel: false, cancelUnavailableReason: "", canInterrupt: false,
+};
+type Context = { timeline: ChatTimelineSnapshot | null; capabilities: ThreadEffectiveCapabilities };
+type Interrupt = { inputId: string; cancellationAccepted: boolean; terminalReceived: boolean; dispatching: boolean };
+
+/** Owns client command/queue state; canonical turns remain owned by the Timeline model. */
+export function createChatTurnApplication(deps: Dependencies) {
+  const queues = new Map<string, ChatQueueSnapshot>();
+  const turns = new Map<string, ChatTurnSnapshot>();
+  const contexts = new Map<string, Context>();
+  const interrupts = new Map<string, Interrupt>();
+  const dispatchingQueues = new Set<string>();
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  const listeners = new Set<() => void>();
+  let sequence = 0;
+
+  const queue = (sessionId: string) => queues.get(sessionId) ?? EMPTY_QUEUE;
+  const turn = (sessionId: string) => turns.get(sessionId) ?? EMPTY_TURN;
+  const notify = () => listeners.forEach((listener) => listener());
+  const activeTurn = (sessionId: string) => [...(contexts.get(sessionId)?.timeline?.turns ?? [])]
+    .reverse().find((candidate) => ["pending", "running", "awaiting_user"].includes(candidate.status));
+
+  function publishQueue(sessionId: string, inputs: QueuedComposerInput[], message = queue(sessionId).message) {
+    const previous = queue(sessionId);
+    if (previous.inputs === inputs && previous.message === message) return;
+    queues.set(sessionId, { inputs, message });
+    notify();
+  }
+
+  function publishTurn(sessionId: string, lifecycle = turn(sessionId).lifecycle) {
+    const context = contexts.get(sessionId);
+    const active = activeTurn(sessionId);
+    const capabilities = context?.capabilities;
+    const matchesTurn = !capabilities?.evaluatedTurnId || capabilities.evaluatedTurnId === active?.id;
+    const next: ChatTurnSnapshot = {
+      lifecycle,
+      canCancel: Boolean(active && capabilities?.threadId === sessionId
+        && matchesTurn && capabilities.capabilities.agent.cancel.available),
+      cancelUnavailableReason: !matchesTurn
+        ? deps.t("runtime.staleCapabilities")
+        : capabilities?.capabilities.agent.cancel.reason || deps.t("runtime.cancelUnavailable"),
+      canInterrupt: Boolean(active && active.status !== "awaiting_user" && !isThreadCommandInFlight(lifecycle)),
+    };
+    const previous = turn(sessionId);
+    if (previous.lifecycle === next.lifecycle && previous.canCancel === next.canCancel
+      && previous.cancelUnavailableReason === next.cancelUnavailableReason
+      && previous.canInterrupt === next.canInterrupt) return;
+    turns.set(sessionId, next);
+    notify();
+  }
+
+  function transition(sessionId: string, action: ThreadCommandLifecycleAction) {
+    const previous = turn(sessionId).lifecycle;
+    const next = reduceThreadCommandLifecycle(previous, action);
+    if (next === previous) return;
+    clearTimeout(timers.get(sessionId));
+    timers.delete(sessionId);
+    publishTurn(sessionId, next);
+    if (next.stage === "sending" || next.stage === "waiting_for_canonical") {
+      timers.set(sessionId, setTimeout(() => {
+        transition(sessionId, { commandId: next.command.commandId, type: "ack_timeout" });
+      }, Math.max(0, THREAD_COMMAND_ACK_TIMEOUT_MS - Math.max(0, deps.now() - next.dispatchedAtMs))));
+    }
+    if (next.stage === "rejected" || next.stage === "timed_out") {
+      console.error("[chat-turn] command.failed", {
+        sessionId, commandId: next.command.commandId, kind: next.command.kind, stage: next.stage, error: next.error,
+      });
+      if (next.command.kind === "operation.retry") deps.reportError(`Retry failed: ${next.error}`, sessionId);
+      if (next.command.kind === "form.submit" || next.command.kind === "form.cancel") {
+        deps.reportError(`Form ${next.command.kind === "form.cancel" ? "cancellation" : "submission"} failed: ${next.error}`, sessionId);
+      }
+    }
+  }
+
+  function acknowledge(sessionId: string) {
+    const timeline = contexts.get(sessionId)?.timeline;
+    let lifecycle = turn(sessionId).lifecycle;
+    if (!timeline || lifecycle.stage === "idle" || lifecycle.stage === "completed") return;
+    if (lifecycle.stage !== "acknowledged") {
+      const acknowledgement = canonicalThreadCommandAcknowledgement(timeline.turns, lifecycle.command.commandId);
+      if (acknowledgement) transition(sessionId, {
+        acknowledgement, commandId: lifecycle.command.commandId, nowMs: deps.now(), type: "canonical_acknowledged",
+      });
+    }
+    lifecycle = turn(sessionId).lifecycle;
+    if (lifecycle.stage !== "acknowledged") return;
+    const completion = canonicalThreadCommandCompletion(timeline.turns, lifecycle.command);
+    if (completion) transition(sessionId, {
+      completion, commandId: lifecycle.command.commandId, nowMs: deps.now(), type: "operation_completed",
+    });
+  }
+
+  function pause(sessionId: string) {
+    const inputs = queue(sessionId).inputs;
+    if (inputs.some((input) => input.mode === "queued" && input.status === "queued")) {
+      publishQueue(sessionId, pauseQueuedInputs(inputs) as QueuedComposerInput[]);
+    }
+  }
+
+  function remove(sessionId: string, inputId: string) {
+    publishQueue(sessionId, deleteQueuedInput(queue(sessionId).inputs, inputId) as QueuedComposerInput[], "");
+  }
+
+  function failQueue(sessionId: string, operation: string, error: unknown, inputId?: string) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[chat-turn] ${operation}.failed`, { sessionId, inputId, error: message });
+    publishQueue(sessionId, queue(sessionId).inputs, operation === "interrupt"
+      ? deps.t("errors.interruptFailed", { message }) : message);
+  }
+
+  async function dispatchCommand(command: ThreadCommand) {
+    const sessionId = command.target.sessionId;
+    transition(sessionId, { command, nowMs: deps.now(), type: "dispatch" });
+    try {
+      await deps.dispatch(command);
+      acknowledge(sessionId);
+    } catch (error) {
+      transition(sessionId, {
+        commandId: command.commandId, error: error instanceof Error ? error.message : String(error), type: "rejected",
+      });
+    }
+  }
+
+  async function sendNext(sessionId: string, mode: "normal_completion" | "manual_resume") {
+    if (dispatchingQueues.has(sessionId)) return;
+    const inputs = queue(sessionId).inputs;
+    const result = mode === "manual_resume" ? resumeNextQueuedInput(inputs) : dispatchNextQueuedInput(inputs);
+    if (!result.nextInput) return;
+    const input = result.nextInput as QueuedComposerInput;
+    dispatchingQueues.add(sessionId);
+    // Reserve synchronously: terminal events and user actions may arrive while submitting.
+    publishQueue(sessionId, inputs.map((candidate) => candidate.id === input.id ? { ...candidate, status: "sent" } : candidate), "");
+    try {
+      await deps.submitTurn(sessionId, input.turnInput, `queue-${mode}`);
+      publishQueue(sessionId, queue(sessionId).inputs.filter((candidate) => candidate.id !== input.id));
+      await deps.refreshSessions();
+    } catch (error) {
+      publishQueue(sessionId, queue(sessionId).inputs.map((candidate) => candidate.id === input.id
+        ? { ...candidate, status: "paused" } : candidate));
+      failQueue(sessionId, "queue.submit", error, input.id);
+    } finally {
+      dispatchingQueues.delete(sessionId);
+    }
+  }
+
+  async function sendInterrupt(sessionId: string, terminalReceived = false): Promise<boolean> {
+    const pending = interrupts.get(sessionId);
+    if (!pending) return false;
+    pending.terminalReceived ||= terminalReceived;
+    if (!pending.cancellationAccepted || !pending.terminalReceived || pending.dispatching) return true;
+    const input = queue(sessionId).inputs.find((candidate) => candidate.id === pending.inputId);
+    if (!input) { interrupts.delete(sessionId); return false; }
+    pending.dispatching = true;
+    publishQueue(sessionId, updateInterruptStatus(queue(sessionId).inputs, input.id, "sent") as QueuedComposerInput[]);
+    try {
+      await deps.submitTurn(sessionId, input.turnInput, "interrupt-new-turn");
+      remove(sessionId, input.id);
+      await deps.refreshSessions();
+    } catch (error) {
+      publishQueue(sessionId, updateInterruptStatus(queue(sessionId).inputs, input.id, "failed") as QueuedComposerInput[]);
+      failQueue(sessionId, "interrupt", error, input.id);
+    } finally {
+      interrupts.delete(sessionId);
+    }
+    return true;
+  }
+
+  return {
+    subscribe(listener: () => void) { listeners.add(listener); return () => { listeners.delete(listener); }; },
+    queue,
+    turn,
+    observe(sessionId: string, context: Context) {
+      if (!sessionId) return;
+      if (context.timeline && context.timeline.sessionId !== sessionId) return;
+      contexts.set(sessionId, context);
+      publishTurn(sessionId);
+      acknowledge(sessionId);
+    },
+    receiveTimeline(sessionId: string, timeline: ChatTimelineSnapshot) {
+      const context = contexts.get(sessionId);
+      if (!context) return;
+      if (timeline.sessionId !== sessionId) throw new Error(`Timeline session ${timeline.sessionId} does not match ${sessionId}`);
+      contexts.set(sessionId, { ...context, timeline });
+      publishTurn(sessionId);
+      acknowledge(sessionId);
+    },
+    nextInputTimestamp() { return new Date(deps.now() + sequence++).toISOString(); },
+    enqueue(sessionId: string, input: QueuedComposerInput) {
+      const inputs = queue(sessionId).inputs;
+      if (inputs.filter((candidate) => candidate.status === "queued" || candidate.status === "paused").length >= MAX_QUEUED_INPUTS) {
+        publishQueue(sessionId, inputs, deps.t("queue.limit", { count: MAX_QUEUED_INPUTS }));
+        return;
+      }
+      publishQueue(sessionId, [...inputs, input], "");
+    },
+    reportQueueLimit(sessionId: string) {
+      publishQueue(sessionId, queue(sessionId).inputs, deps.t("queue.limit", { count: MAX_QUEUED_INPUTS }));
+    },
+    replaceSession(previousSessionId: string, sessionId: string) {
+      const previous = queues.get(previousSessionId);
+      if (!previous) return;
+      queues.delete(previousSessionId);
+      queues.set(sessionId, previous);
+      notify();
+    },
+    remove,
+    resume(sessionId: string) { return sendNext(sessionId, "manual_resume"); },
+    async cancel(sessionId: string) {
+      if (isThreadCommandInFlight(turn(sessionId).lifecycle)) return;
+      if (!turn(sessionId).canCancel) { deps.reportError(`Cannot cancel: ${turn(sessionId).cancelUnavailableReason}`, sessionId); return; }
+      const active = activeTurn(sessionId);
+      if (!active) throw new Error("Cannot cancel: the session has no active turn");
+      pause(sessionId);
+      await dispatchCommand(createThreadAgentCancelCommand({
+        sessionId, turnId: active.id, threadId: active.canonicalItems?.find((item) => item.threadId)?.threadId,
+        source: { control: "stop-response", surface: "chat" },
+      }));
+    },
+    async interrupt(sessionId: string, inputId: string) {
+      publishQueue(sessionId, queue(sessionId).inputs, "");
+      const active = activeTurn(sessionId);
+      if (!active || active.status === "awaiting_user") {
+        publishQueue(sessionId, queue(sessionId).inputs, deps.t("errors.noInterruptibleTurn")); return;
+      }
+      if (interrupts.has(sessionId) || isThreadCommandInFlight(turn(sessionId).lifecycle)) {
+        publishQueue(sessionId, queue(sessionId).inputs, deps.t("errors.interruptPending")); return;
+      }
+      const input = queue(sessionId).inputs.find((candidate) => candidate.id === inputId
+        && candidate.mode === "queued" && (candidate.status === "queued" || candidate.status === "paused"));
+      try {
+        if (!input) throw new Error(`Queued input ${inputId} is no longer available`);
+        const pending: Interrupt = { inputId, cancellationAccepted: false, terminalReceived: false, dispatching: false };
+        interrupts.set(sessionId, pending);
+        publishQueue(sessionId, queue(sessionId).inputs.map((candidate) => candidate.id === inputId
+          ? { ...candidate, mode: "interrupt", status: "queued" } : candidate));
+        await deps.dispatch(createThreadAgentCancelCommand({
+          sessionId, turnId: active.id, source: { control: "composer-interrupt", surface: "chat" },
+        }));
+        pending.cancellationAccepted = true;
+        await sendInterrupt(sessionId);
+      } catch (error) {
+        interrupts.delete(sessionId);
+        publishQueue(sessionId, updateInterruptStatus(queue(sessionId).inputs, inputId, "failed") as QueuedComposerInput[]);
+        failQueue(sessionId, "interrupt", error, inputId);
+      }
+    },
+    async submitForm(sessionId: string, form: AgentUiForm, values?: Record<string, unknown>) {
+      if (!sessionId || isThreadCommandInFlight(turn(sessionId).lifecycle)) return;
+      const active = activeTurn(sessionId);
+      const cancelling = values === undefined;
+      if (!active) {
+        deps.reportError(deps.t(cancelling ? "runtime.cancelFormTurnUnavailable" : "runtime.submitFormTurnUnavailable"), sessionId); return;
+      }
+      const formTurnId = correlation(form, "turn_id") || form.turn_id || active.id;
+      if (formTurnId !== active.id) {
+        deps.reportError(deps.t(cancelling ? "runtime.cancelFormStaleTurn" : "runtime.submitFormStaleTurn", { turnId: formTurnId }), sessionId); return;
+      }
+      const target = {
+        formId: form.form_id, sessionId, turnId: active.id,
+        threadId: correlation(form, "thread_id") || active.canonicalItems?.find((item) => item.threadId)?.threadId,
+        source: { control: "chat-form", surface: "chat" as const },
+      };
+      deps.clearError();
+      await dispatchCommand(cancelling ? createThreadFormCancelCommand(target) : createThreadFormSubmitCommand({ ...target, values }));
+    },
+    receiveCommand(sessionId: string, event: ChatEvent) {
+      if (event.command && event.type === "command.dispatched") {
+        pause(sessionId);
+        transition(sessionId, { command: event.command, nowMs: deps.now(), type: "dispatch" });
+        acknowledge(sessionId);
+      } else if (event.commandId && event.type === "command.accepted") {
+        transition(sessionId, { commandId: event.commandId, nowMs: deps.now(), type: "transport_accepted" });
+        acknowledge(sessionId);
+      } else if (event.commandId && event.type === "error") {
+        transition(sessionId, { commandId: event.commandId, error: event.error || deps.t("runtime.commandRejected"), type: "rejected" });
+      }
+    },
+    async receiveSessionEvent(sessionId: string, event: ChatEvent) {
+      try {
+        const sessions = await deps.refreshSessions();
+        const effects = projectChatEventEffects(event);
+        if (effects.terminalAgentEvent && await sendInterrupt(sessionId, true)) return;
+        if (effects.queuedInputDisposition === "pause") { pause(sessionId); return; }
+        if (effects.queuedInputDisposition === "dispatch_next" && canDispatchQueuedInput(sessions.find((session) => session.id === sessionId))) {
+          await sendNext(sessionId, "normal_completion");
+        }
+      } catch (error) { failQueue(sessionId, "session.refresh", error); }
+    },
+    dispose() { timers.forEach(clearTimeout); timers.clear(); },
+  };
+}
+
+function correlation(form: AgentUiForm, key: string): string {
+  const value = form.correlation[key];
+  return typeof value === "string" ? value : "";
+}
+
+export type ChatTurnApplication = ReturnType<typeof createChatTurnApplication>;

--- a/src/react-workbench/chat/desktopChatCommands.ts
+++ b/src/react-workbench/chat/desktopChatCommands.ts
@@ -1,0 +1,317 @@
+import type { DesktopChatSessionController } from "../../app-core/chat/desktopChatSessionController";
+import type { DesktopCommand, DesktopTurnSubmitCommand } from "../../app-core/chat/desktopCommand";
+import { createThreadAgentCancelCommand, type ThreadCommand } from "../../app-core/chat/threadCommand";
+import { readDefaultChatModelPreference } from "../../app-core/chat/chatModelPreference";
+import { agentInputAttachmentKind, type AgentInputReference } from "../../app-core/chat/agentInputReference";
+import type { createDesktopNativeThreadsApi, NativeThreadRecord } from "../../app-core/native/desktopNativeThreads";
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+import type { ChatEvent, SessionSummary } from "../services";
+import type { ReactChatMessage } from "./messageActions";
+
+type Dependencies = {
+  initialize(): Promise<void>;
+  controller: DesktopChatSessionController;
+  nativeThreads(): ReturnType<typeof createDesktopNativeThreadsApi>;
+  notifySession(sessionId: string, event: ChatEvent): void;
+  notifyTerminalTimelineState(sessionId: string, timeline: ChatTimelineSnapshot): void;
+  mapSession(thread: NativeThreadRecord, responding: boolean, fallbackPayload?: unknown): SessionSummary;
+};
+
+export function createDesktopChatCommands({ initialize, controller, nativeThreads, notifySession, notifyTerminalTimelineState, mapSession }: Dependencies) {
+  async function dispatchThreadCommand(command: ThreadCommand): Promise<void> {
+    await initialize();
+    const thread = controller.state.threads.find((item) => item.threadId === command.target.sessionId);
+    if (thread && controller.state.activeThreadId !== thread.threadId) {
+      await controller.selectSession(thread.threadId);
+    }
+    const threadId = thread?.threadId || command.target.threadId || command.target.sessionId;
+    if (command.kind === "agent.cancel") {
+      await nativeThreads().interrupt({
+        threadId,
+        turnId: command.target.turnId,
+        clientEventId: command.commandId,
+        reason: "user_requested",
+      });
+    } else if (command.kind === "form.submit" || command.kind === "form.cancel") {
+      await nativeThreads().submitForm({
+        commandId: command.commandId,
+        threadId,
+        formId: command.form.formId,
+        source: command.source,
+        target: { ...command.target, threadId },
+        values: command.kind === "form.submit" ? command.form.values : {},
+        action: command.kind === "form.submit" ? "submit" : "cancel",
+      });
+    } else {
+      await nativeThreads().retryOperation({
+        commandId: command.commandId,
+        source: command.source,
+        sourceItemId: command.operation.itemId,
+        sourceTurnId: command.operation.turnId,
+        targetTurnId: command.target.turnId,
+        threadId,
+      });
+    }
+    notifySession(command.target.sessionId, { commandId: command.commandId, type: "command.accepted" });
+    notifySession(command.target.sessionId, { commandId: command.commandId, type: "command.canonical-updated" });
+  }
+
+  async function dispatchTurnSubmit(command: DesktopTurnSubmitCommand): Promise<void> {
+    await initialize();
+    const sessionId = command.target.sessionId;
+    const thread = controller.state.threads.find((item) => item.threadId === sessionId);
+    if (!thread) throw new Error(`Cannot send to unknown Thread ${sessionId}`);
+    if (controller.state.activeThreadId !== thread.threadId) {
+      await controller.selectSession(thread.threadId);
+    }
+    const input = command.input;
+    const preference = readDefaultChatModelPreference();
+    const threadExtra = isRecord(thread.metadata?.extra) ? thread.metadata.extra : {};
+    const threadModel = stringValue(thread.metadata?.model);
+    const threadProvider = stringValue(threadExtra.modelProvider);
+    const model = stringValue(input.model) || threadModel || preference?.modelId || "";
+    const provider = stringValue(input.provider)
+      || (model === threadModel ? threadProvider : "")
+      || (model === preference?.modelId ? preference.providerId ?? "" : "");
+    if (model && (model !== threadModel || provider !== threadProvider)) {
+      await controller.patchSession(sessionId, {
+        model,
+        metadata: withModelProvider(threadExtra, provider),
+      });
+    }
+    const result = await controller.submitMessage(sessionId, input.text, {
+      ...(model ? { model } : {}),
+      ...(provider ? { provider } : {}),
+      ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
+      ...(input.references?.length ? { references: input.references } : {}),
+      ...(input.selectedSkills?.length ? { selectedSkills: input.selectedSkills } : {}),
+      ...(input.selectedTools ? { selectedTools: input.selectedTools } : {}),
+      clientEventId: command.commandId,
+    });
+    const optimisticText = result.status === "sent" ? result.content : "";
+    const optimisticMessage = result.status === "empty"
+      ? undefined
+      : createOptimisticUserMessage(result.clientEventId, optimisticText, input.references);
+    notifySession(sessionId, {
+      type: "message-sent",
+      ...(optimisticMessage ? { message: optimisticMessage } : {}),
+    });
+    if (result.status === "sent") {
+      void result.completion
+        .then((timeline) => {
+          notifySession(sessionId, { type: "timeline.patch", timeline });
+          notifyTerminalTimelineState(sessionId, timeline);
+        })
+        .catch(async (error) => {
+          let recoveryError = "";
+          try {
+            const timeline = await controller.reloadTimeline(sessionId);
+            notifySession(sessionId, { type: "timeline.patch", timeline });
+            notifyTerminalTimelineState(sessionId, timeline);
+          } catch (timelineError) {
+            recoveryError = timelineError instanceof Error ? timelineError.message : String(timelineError);
+          }
+          const message = error instanceof Error ? error.message : String(error);
+          notifySession(sessionId, {
+            type: "timeline.error",
+            error: recoveryError
+              ? `${message}; failed to reload terminal timeline state: ${recoveryError}`
+              : message,
+          });
+        });
+    }
+  }
+
+  async function dispatchDesktopCommand(command: DesktopCommand): Promise<void> {
+    if (command.kind === "turn.submit") {
+      await dispatchTurnSubmit(command);
+      return;
+    }
+    if (command.kind === "agent.stop") {
+      await initialize();
+      const sessionId = command.target.sessionId;
+      const timeline = await controller.loadTimeline(sessionId);
+      const turn = [...timeline.turns].reverse().find((candidate) => (
+        candidate.status === "pending"
+        || candidate.status === "running"
+        || candidate.status === "awaiting_user"
+      ));
+      if (!turn) throw new Error("Cannot cancel: the session has no active turn");
+      const cancelCommand = createThreadAgentCancelCommand({
+        commandId: command.commandId,
+        issuedAt: command.issuedAt,
+        sessionId,
+        source: command.source,
+        threadId: turn.canonicalItems?.find((item) => item.threadId)?.threadId,
+        turnId: turn.id,
+      });
+      notifySession(sessionId, { command: cancelCommand, type: "command.dispatched" });
+      await dispatchThreadCommand(cancelCommand);
+      return;
+    }
+    if (command.kind === "context.compact") {
+      await initialize();
+      const sessionId = command.target.sessionId;
+      const thread = controller.state.threads.find((candidate) => candidate.threadId === sessionId);
+      if (!thread) throw new Error(`Cannot compact unknown Thread ${sessionId}`);
+      if (controller.state.activeThreadId !== sessionId) {
+        await controller.selectSession(sessionId);
+      }
+      await nativeThreads().compact({
+        threadId: sessionId,
+        clientEventId: command.commandId,
+      });
+      const timeline = await controller.loadTimeline(sessionId);
+      notifySession(sessionId, { type: "timeline.patch", timeline });
+      notifyTerminalTimelineState(sessionId, timeline);
+      return;
+    }
+    await dispatchThreadCommand(command);
+  }
+
+  async function resolveForkSequence(threadId: string, itemIds: Set<string>): Promise<number | undefined> {
+    let cursor = "";
+    const seenCursors = new Set<string>();
+    while (true) {
+      const payload = await nativeThreads().read({
+        threadId,
+        limit: 500,
+        ...(cursor ? { cursor } : {}),
+      });
+      if (!isRecord(payload)) {
+        throw new Error(`Thread ${threadId} returned an invalid read result while resolving a fork boundary`);
+      }
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      for (const value of items) {
+        if (!isRecord(value)) continue;
+        const kind = isRecord(value.kind) ? value.kind : {};
+        const itemPayload = isRecord(kind.payload) ? kind.payload : {};
+        const itemId = stringValue(value.itemId ?? value.item_id);
+        const messageId = stringValue(itemPayload.messageId ?? itemPayload.message_id);
+        if (!itemIds.has(itemId) && !itemIds.has(messageId)) continue;
+        const sequence = numberValue(value.sequence);
+        if (sequence === undefined) {
+          throw new Error(`Thread item ${itemId || messageId} is missing its canonical sequence`);
+        }
+        return sequence;
+      }
+      const nextCursor = stringValue(
+        payload.nextCursor
+        ?? payload.next_cursor
+        ?? (isRecord(payload.pagination)
+          ? payload.pagination.nextCursor ?? payload.pagination.next_cursor
+          : undefined),
+      );
+      if (!nextCursor) return undefined;
+      if (seenCursors.has(nextCursor)) {
+        throw new Error(`Thread ${threadId} returned a repeated pagination cursor while resolving a fork boundary`);
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    }
+  }
+
+  async function branchFromMessage(sessionId: string, messageId: string): Promise<SessionSummary> {
+        await initialize();
+        const sourceThread = controller.state.threads.find((thread) => thread.threadId === sessionId);
+        if (!sourceThread) {
+          throw new Error(`Cannot branch from unknown Thread ${sessionId}`);
+        }
+        const timeline = await controller.loadTimeline(sessionId);
+        const canonicalItem = timeline.turns
+          .flatMap((turn) => turn.canonicalItems ?? [])
+          .find((item) => (
+            item.itemId === messageId
+            || stringValue(item.data.messageId ?? item.data.message_id) === messageId
+          ));
+        if (!canonicalItem) {
+          throw new Error(`Cannot fork Thread ${sessionId} at unknown canonical message ${messageId}`);
+        }
+        const sourceThreadId = sourceThread.threadId;
+        const forkAfterSequence = await resolveForkSequence(sourceThreadId, new Set([
+          messageId,
+          canonicalItem.itemId,
+          stringValue(canonicalItem.data.messageId ?? canonicalItem.data.message_id),
+        ].filter(Boolean)));
+        if (forkAfterSequence === undefined) {
+          throw new Error(`Cannot resolve persisted fork boundary for canonical message ${messageId}`);
+        }
+        const title = `${sourceThread.title} · 分叉`;
+        const forkedThread = await nativeThreads().fork({
+          threadId: sourceThreadId,
+          clientEventId: `fork:${sourceThreadId}:${messageId}`,
+          title,
+          forkAfterSequence,
+        });
+        await controller.loadSessions();
+        const branchThread = controller.state.threads.find((thread) => (
+          thread.threadId === forkedThread.threadId
+        ));
+        if (!branchThread) {
+          throw new Error(`Forked Thread ${forkedThread.threadId} is missing from the Thread list`);
+        }
+        return mapSession(branchThread, false, forkedThread);
+  }
+
+  return { dispatch: dispatchDesktopCommand, branchFromMessage };
+}
+
+function createOptimisticUserMessage(clientEventId: string, text: string, references: AgentInputReference[] = []): ReactChatMessage {
+  return {
+    id: clientEventId,
+    role: "user",
+    createdAtMs: Date.now(),
+    text,
+    status: "complete",
+    ...(references.length ? {
+      contextReferences: references.map((reference, index) => {
+        const attachmentKind = agentInputAttachmentKind(reference);
+        const attachment = Boolean(attachmentKind) && Boolean(reference.rawPath) && !reference.sourcePath;
+        return {
+          ...(attachment ? {
+            attachmentKind,
+            ...(attachmentKind === "image" && reference.rawPath
+              ? { attachmentPreviewPath: reference.rawPath }
+              : {}),
+          } : {}),
+          detail: reference.detail,
+          id: reference.evidenceId || `reference-${index}`,
+          kind: reference.kind,
+          presentation: attachment ? "attachment" as const : "context" as const,
+          sourceLine: reference.sourceLine,
+          sourcePath: reference.sourcePath,
+          title: reference.title,
+        };
+      }),
+    } : {}),
+  };
+}
+
+function withModelProvider(extra: Record<string, unknown>, provider?: string): Record<string, unknown> {
+  const next = { ...extra };
+  delete next.modelProvider;
+  if (provider?.trim()) {
+    next.modelProvider = provider.trim();
+  }
+  return next;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function numberValue(value: unknown): number | undefined {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+

--- a/src/react-workbench/chat/useChatApplication.test.tsx
+++ b/src/react-workbench/chat/useChatApplication.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { TFunction } from "i18next";
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+import type { ChatTurn } from "../../app-core/chat/chatTurnContracts";
+import type { ThreadEffectiveCapabilities } from "../../app-core/chat/threadCapabilities";
+import type { ChatEvent, ChatStore, SessionStore, SessionSummary } from "../services";
+import { createChatSessionApplication } from "./chatSessionApplication";
+import { useChatApplication } from "./useChatApplication";
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+const session = (id: string): SessionSummary => ({ id, chatId: id, title: "New chat", status: "running", updatedAtMs: 1 });
+const input = { id: "q1", content: "next", createdAt: "2026-09-08T00:00:00Z", mode: "queued" as const, status: "queued" as const, turnInput: { text: "next" } };
+function timeline(sessionId: string): ChatTimelineSnapshot {
+  return {
+    schemaVersion: "tinybot.chat_timeline.v1", source: "canonical", sessionId, diagnostics: [], turnRevisions: {},
+    turns: [{
+      id: `turn-${sessionId}`, sessionKey: sessionId, userMessageId: "u1",
+      userMessage: { id: "u1", role: "user", text: "hello", timestamp: "2026-09-08T00:00:00Z" },
+      status: "running", steps: [], startedAt: "2026-09-08T00:00:00Z", updatedAt: "2026-09-08T00:00:00Z",
+    }],
+  };
+}
+function capabilities(threadId: string, available = true): ThreadEffectiveCapabilities {
+  return {
+    schemaVersion: "tinybot.effective_capabilities.v2", threadId,
+    capabilities: { agent: { cancel: { available }, retry: { available: false } } },
+  };
+}
+function setup() {
+  const listeners = new Map<string, (event: ChatEvent) => void>();
+  const store = {
+    load: vi.fn(async (id: string) => timeline(id)),
+    listAgentUiForms: vi.fn(async () => []),
+    loadEffectiveCapabilities: vi.fn(async (id: string) => capabilities(id)),
+    dispatch: vi.fn(async () => {}),
+    subscribe: vi.fn((id: string, listener: (event: ChatEvent) => void) => {
+      listeners.set(id, listener);
+      return () => { listeners.delete(id); };
+    }),
+  };
+  const sessionStore: SessionStore = {
+    list: vi.fn(async () => [session("s1"), session("s2")]), create: vi.fn(async () => session("created")),
+    rename: vi.fn(async () => {}), delete: vi.fn(async () => {}), archive: vi.fn(async () => {}), pin: vi.fn(async () => {}),
+  };
+  const sessions = createChatSessionApplication(sessionStore);
+  sessions.accept(session("s1"));
+  sessions.accept(session("s2"));
+  const onBackgroundActivity = vi.fn();
+  const options = {
+    chatStore: store as unknown as ChatStore, sessions, openSessionIds: ["s1", "s2"], drafts: {}, model: {},
+    now: Date.now, t: ((key: string) => key) as TFunction<"chat">,
+    onDraftConsumed: vi.fn(), onBackgroundActivity,
+  };
+  return {
+    store, sessionStore, sessions, listeners, onBackgroundActivity,
+    render: () => renderHook(({ id }) => useChatApplication({ ...options, sessionId: id, session: session(id) }), { initialProps: { id: "s1" } }),
+  };
+}
+
+it("ignores capability responses from the previous session", async () => {
+  const { store, render } = setup();
+  let resolve!: (value: ThreadEffectiveCapabilities) => void;
+  const pending = new Promise<ThreadEffectiveCapabilities>((done) => { resolve = done; });
+  store.loadEffectiveCapabilities.mockImplementation(async (id) => id === "s1" ? pending : capabilities(id, false));
+  const { result, rerender } = render();
+  await waitFor(() => expect(result.current.state.status).toBe("ready"));
+  rerender({ id: "s2" });
+  await waitFor(() => expect(result.current.state.timeline?.sessionId).toBe("s2"));
+  await act(async () => resolve(capabilities("s1")));
+  expect(result.current.state.canCancel).toBe(false);
+  expect(result.current.state.error).toBe("");
+});
+
+it("acknowledges commands through the background subscription after switching tabs", async () => {
+  const { store, render, listeners } = setup();
+  const { result, rerender, unmount } = render();
+  await waitFor(() => expect(result.current.state.canCancel).toBe(true));
+  await act(async () => result.current.turns.cancel("s1"));
+  const lifecycle = result.current.turns.turn("s1").lifecycle;
+  if (lifecycle.stage === "idle") throw new Error("Expected a dispatched command");
+  const commandId = lifecycle.command.commandId;
+  act(() => listeners.get("s1")!({ type: "command.accepted", commandId }));
+  expect(result.current.turns.turn("s1").lifecycle.stage).toBe("waiting_for_canonical");
+  rerender({ id: "s2" });
+  await waitFor(() => expect(result.current.state.timeline?.sessionId).toBe("s2"));
+  const canonical = timeline("s1");
+  canonical.turns[0].canonicalItems = [{
+    data: { detail: { commandId, commandStatus: "acknowledged" } }, itemId: "ack", revision: 1, status: "completed",
+  }] as ChatTurn["canonicalItems"];
+  store.load.mockResolvedValueOnce(canonical);
+  act(() => listeners.get("s1")!({ type: "command.canonical-updated", commandId }));
+  await waitFor(() => expect(result.current.turns.turn("s1").lifecycle.stage).toBe("acknowledged"));
+  expect(result.current.state.timeline?.sessionId).toBe("s2");
+  expect(result.current.state.lifecycle.stage).toBe("idle");
+  unmount();
+  expect(listeners.size).toBe(0);
+});
+
+it("owns background queue continuation without replacing the active timeline", async () => {
+  const { store, sessionStore, render, listeners } = setup();
+  const { result, rerender } = render();
+  await waitFor(() => expect(result.current.state.canCancel).toBe(true));
+  act(() => result.current.turns.enqueue("s1", input));
+  rerender({ id: "s2" });
+  await waitFor(() => expect(result.current.state.timeline?.sessionId).toBe("s2"));
+  vi.mocked(sessionStore.list).mockResolvedValue([{ ...session("s1"), status: "idle" }, session("s2")]);
+  act(() => listeners.get("s1")!({ type: "agent.event", eventType: "agent.turn.completed" }));
+  await waitFor(() => expect(store.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+    kind: "turn.submit", target: expect.objectContaining({ sessionId: "s1" }),
+  })));
+  expect(result.current.turns.queue("s1").inputs).toEqual([]);
+  expect(result.current.state.timeline?.sessionId).toBe("s2");
+});
+
+it("moves optimistic messages and queued inputs when session data reconciles an ID", async () => {
+  const { sessionStore, sessions, render, listeners } = setup();
+  const { result, rerender } = render();
+  await waitFor(() => expect(result.current.state.canCancel).toBe(true));
+  act(() => {
+    result.current.turns.enqueue("s1", input);
+    listeners.get("s1")!({ type: "message", message: { id: "optimistic", role: "user", text: "hello", status: "complete", createdAtMs: 1 } });
+    sessions.preview({ ...session("s1"), title: "First prompt" });
+  });
+  vi.mocked(sessionStore.list).mockResolvedValue([session("persisted"), session("s2")]);
+  await act(async () => { await sessions.refresh(); });
+  rerender({ id: "persisted" });
+  expect(result.current.turns.queue("persisted").inputs).toEqual([input]);
+  expect(result.current.turns.queue("s1").inputs).toEqual([]);
+  expect(result.current.state.optimisticMessages.map((message) => message.id)).toEqual(["optimistic"]);
+});
+
+it("clears application state on removal without waiting for page animations", async () => {
+  const { sessions, render, listeners } = setup();
+  const { result } = render();
+  await waitFor(() => expect(result.current.state.canCancel).toBe(true));
+  act(() => {
+    result.current.turns.enqueue("s1", input);
+    result.current.turns.enqueue("s2", input);
+    listeners.get("s1")!({ type: "message", message: { id: "optimistic", role: "user", text: "hello", status: "complete", createdAtMs: 1 } });
+  });
+  await act(async () => result.current.turns.cancel("s1"));
+  await act(async () => sessions.delete(session("s1")));
+  expect(result.current.turns.queue("s1").inputs).toEqual([]);
+  expect(result.current.turns.turn("s1").lifecycle.stage).toBe("idle");
+  expect(result.current.state.optimisticMessages).toEqual([]);
+  expect(result.current.turns.queue("s2").inputs).toEqual([input]);
+});

--- a/src/react-workbench/chat/useChatApplication.ts
+++ b/src/react-workbench/chat/useChatApplication.ts
@@ -1,0 +1,161 @@
+import { useEffect, useEffectEvent, useState } from "react";
+import type { TFunction } from "i18next";
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+import { unavailableThreadEffectiveCapabilities } from "../../app-core/chat/threadCapabilities";
+import type { ChatEvent, ChatStore, SessionSummary, SettingsStore, WorkspaceStore } from "../services";
+import { subscribeChatEvents } from "./chatEventSource";
+import { projectChatEventEffects } from "./chatEventPolicy";
+import type { ChatSessionApplication, ChatSessionChange } from "./chatSessionApplication";
+import type { DraftSession } from "./sessionTabWorkspace";
+import { useChatSessionRuntime, type ChatSessionRuntimeEffect } from "./useChatSessionRuntime";
+import { useChatSubmission } from "./useChatSubmission";
+import { useChatTurnApplication } from "./useChatTurnApplication";
+
+type Options = {
+  chatStore: ChatStore;
+  sessions: ChatSessionApplication;
+  settingsStore?: SettingsStore;
+  artifactReviews?: WorkspaceStore["artifactReviews"];
+  sessionId: string;
+  session?: SessionSummary;
+  openSessionIds: readonly string[];
+  drafts: Readonly<Record<string, DraftSession>>;
+  model: { model?: string; modelProvider?: string };
+  now(): number;
+  t: TFunction<"chat">;
+  onDraftConsumed(sessionId: string): void;
+  onBackgroundActivity(sessionId: string): void;
+};
+
+/** Coordinates Chat workflows; the page supplies selection and receives UI notifications. */
+export function useChatApplication(options: Options) {
+  const { chatStore, sessions, sessionId, session, openSessionIds, drafts, t } = options;
+  const persistedSessionId = session?.id ?? "";
+  const runtime = useChatSessionRuntime({ chatStore, sessionId: persistedSessionId, onEffect: receiveRuntimeEffect });
+  const submission = useChatSubmission({
+    chatStore, settingsStore: options.settingsStore, artifactReviews: options.artifactReviews,
+    sessionId, now: options.now, t, reload: runtime.actions.reload,
+    refreshSessions: sessions.refresh,
+    materializeDraft: async () => {
+      if (!sessions.snapshot().loaded || (sessionId && !drafts[sessionId])) return null;
+      return sessions.materializeDraft(sessionId, drafts[sessionId], options.model);
+    },
+    previewSession: sessions.preview, consumeDraft: options.onDraftConsumed,
+  });
+  const [capabilities, setCapabilities] = useState(() => (
+    unavailableThreadEffectiveCapabilities("", "loading", t("runtime.loadingCapabilities"))
+  ));
+  const { timeline } = runtime.state;
+  const activeTurn = timeline?.sessionId === persistedSessionId
+    ? [...timeline.turns].reverse().find((turn) => ["pending", "running", "awaiting_user"].includes(turn.status))
+    : undefined;
+  const { application: turns, ...turnState } = useChatTurnApplication({
+    dispatch: chatStore.dispatch, submitTurn: submission.submitTurn, refreshSessions: sessions.refresh,
+    reportError: runtime.actions.reportError, clearError: runtime.actions.clearError,
+    now: options.now, t,
+  }, persistedSessionId, { timeline, capabilities });
+
+  useEffect(() => {
+    if (!persistedSessionId) {
+      setCapabilities(unavailableThreadEffectiveCapabilities("", "no_session", t("runtime.noSessionSelected")));
+      return;
+    }
+    let cancelled = false;
+    setCapabilities(unavailableThreadEffectiveCapabilities(persistedSessionId, "loading", t("runtime.loadingCapabilities")));
+    void chatStore.loadEffectiveCapabilities(persistedSessionId).then((value) => {
+      if (!cancelled) setCapabilities(value);
+    }).catch((error) => {
+      if (!cancelled) setCapabilities(unavailableThreadEffectiveCapabilities(
+        persistedSessionId, "capability_query_failed", error instanceof Error ? error.message : String(error),
+      ));
+    });
+    return () => { cancelled = true; };
+  }, [activeTurn?.id, activeTurn?.status, persistedSessionId, chatStore, t]);
+
+  function receiveTimeline(targetSessionId: string, snapshot: ChatTimelineSnapshot) {
+    sessions.receiveTimeline(targetSessionId, snapshot);
+    submission.receiveTimeline(targetSessionId, snapshot);
+    turns.receiveTimeline(targetSessionId, snapshot);
+  }
+
+  function receiveRuntimeEffect(effect: ChatSessionRuntimeEffect) {
+    if (effect.type === "timeline_applied") receiveTimeline(effect.sessionId, effect.timeline);
+    else if (effect.type === "message_received") submission.receiveMessage(effect.sessionId, effect.message);
+    else if (effect.type === "session_refresh_requested") void turns.receiveSessionEvent(effect.sessionId, effect.event);
+    else turns.receiveCommand(effect.sessionId, effect.event);
+  }
+
+  const receiveSessionChange = useEffectEvent((event: ChatSessionChange) => {
+    if (event.type === "replaced") {
+      submission.replaceSession(event.previousSessionId, event.sessionId);
+      turns.replaceSession(event.previousSessionId, event.sessionId);
+    } else if (event.type === "removed") {
+      submission.forgetSession(event.session.id);
+      turns.forgetSession(event.session.id);
+    }
+  });
+  useEffect(() => sessions.onChange(receiveSessionChange), [sessions]);
+
+  const receiveBackgroundTimeline = useEffectEvent((targetSessionId: string, snapshot: ChatTimelineSnapshot) => {
+    receiveTimeline(targetSessionId, snapshot);
+    options.onBackgroundActivity(targetSessionId);
+  });
+  const receiveBackgroundEvent = useEffectEvent((targetSessionId: string, event: ChatEvent) => {
+    const effects = projectChatEventEffects(event);
+    turns.receiveCommand(targetSessionId, event);
+    if (event.message) submission.receiveMessage(targetSessionId, event.message);
+    if (effects.backgroundTabActivity) options.onBackgroundActivity(targetSessionId);
+    if (effects.reloadSessions) void turns.receiveSessionEvent(targetSessionId, event);
+  });
+  useEffect(() => {
+    const unsubscribes = openSessionIds.filter((id) => id !== sessionId && !(id in drafts)).map((id) => {
+      let cancelled = false;
+      let timelineEpoch = 0;
+      let loadSequence = 0;
+      const unsubscribe = subscribeChatEvents(chatStore, id, (event) => {
+        if (event.browserSnapshot) return;
+        if (event.timeline) {
+          timelineEpoch += 1;
+          receiveBackgroundTimeline(id, event.timeline);
+        }
+        receiveBackgroundEvent(id, event);
+        // Canonical acknowledgements must still arrive after switching away from a command's tab.
+        if (event.commandId && event.type === "command.canonical-updated") {
+          const epoch = timelineEpoch;
+          const sequence = ++loadSequence;
+          void chatStore.load(id).then((snapshot) => {
+            if (!cancelled && epoch === timelineEpoch && sequence === loadSequence) receiveBackgroundTimeline(id, snapshot);
+          }).catch((error) => {
+            if (cancelled || sequence !== loadSequence) return;
+            console.error("[chat-application] background.timeline.load.failed", { sessionId: id, error });
+            receiveBackgroundEvent(id, { type: "error", error: error instanceof Error ? error.message : String(error) });
+          });
+        }
+      });
+      return () => { cancelled = true; unsubscribe(); };
+    });
+    return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
+  }, [chatStore, drafts, openSessionIds, sessionId]);
+
+  return {
+    state: {
+      ...runtime.state, ...turnState,
+      optimisticMessages: submission.optimisticMessages,
+      compactingSessionId: submission.compactingSessionId,
+      artifactReviewEpoch: submission.artifactReviewEpoch,
+    },
+    turns,
+    actions: {
+      ...runtime.actions,
+      send: (input: Parameters<typeof submission.send>[0]) => submission.send(input, session, turns),
+      saveDefaultModel: submission.saveDefaultModel,
+      async fork(targetSessionId: string, messageId: string) {
+        sessions.accept(await submission.fork(targetSessionId, messageId));
+      },
+      async completeBrowserHandoff(targetSessionId: string) {
+        await submission.submitTurn(targetSessionId, { text: t("browserHandoffContinue") }, "browser-handoff-complete");
+        await sessions.refresh(session);
+      },
+    },
+  };
+}

--- a/src/react-workbench/chat/useChatSessionRuntime.test.tsx
+++ b/src/react-workbench/chat/useChatSessionRuntime.test.tsx
@@ -4,7 +4,6 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
-import { createNativeBrowserSessionSnapshot } from "../../app-core/native/nativeBrowserSnapshot";
 import type { ChatEvent } from "../services";
 import {
   useChatSessionRuntime,
@@ -127,34 +126,6 @@ describe("useChatSessionRuntime", () => {
     expect(result.current.state).toMatchObject({ error: "forms unavailable", status: "failed" });
   });
 
-  test("does not replace a newer visible Browser snapshot with a stale hidden response", async () => {
-    let listener: ((event: ChatEvent) => void) | undefined;
-    const store = runtimeStore({
-      subscribe: vi.fn((_sessionId, nextListener) => {
-        listener = nextListener;
-        return vi.fn();
-      }),
-    });
-    const { result } = renderHook(() => useChatSessionRuntime({
-      chatStore: store,
-      sessionId: "session-1",
-    }));
-    await waitFor(() => expect(result.current.state.status).toBe("ready"));
-
-    act(() => listener?.({
-      browserSnapshot: nativeBrowserSnapshot(3, "visible"),
-      type: "browser.snapshot",
-    }));
-    await waitFor(() => expect(result.current.state.browserSnapshot?.data.surface?.lifecycle).toBe("visible"));
-    act(() => listener?.({
-      browserSnapshot: nativeBrowserSnapshot(2, "hidden"),
-      type: "browser.snapshot",
-    }));
-
-    expect(result.current.state.browserSnapshot?.data.surface?.lifecycle).toBe("visible");
-    expect(result.current.state.browserSnapshot?.revision).toBe(3);
-  });
-
   test("keeps a live hook result when the initial timeline finishes loading later", async () => {
     let listener: ((event: ChatEvent) => void) | undefined;
     let resolveTimeline: ((value: ChatTimelineSnapshot) => void) | undefined;
@@ -221,32 +192,3 @@ function runningTimeline(sessionId: string, turnId: string): ChatTimelineSnapsho
   };
 }
 
-function nativeBrowserSnapshot(revision: number, surfaceLifecycle: "hidden" | "visible") {
-  return createNativeBrowserSessionSnapshot({
-    activeTabId: "browser-tab-1",
-    browserSessionId: "browser-session-1",
-    contract: "browser_session_v1",
-    interaction: { click: true, navigate: true, type: true },
-    kind: "browser_session",
-    lifecycle: "ready",
-    operationId: "browser-operation-1",
-    runtimeKind: "windows_webview2",
-    sessionId: "session-1",
-    state: "running",
-    surface: { layoutRevision: revision, lifecycle: surfaceLifecycle },
-    tabs: [{
-      activeHistoryIndex: 0,
-      captures: [],
-      history: [{ title: "Example", url: "https://example.com" }],
-      loading: false,
-      rendererLifecycle: "running",
-      tabId: "browser-tab-1",
-      title: "Example",
-      url: "https://example.com",
-    }],
-  }, {
-    observedAt: "2026-08-18T08:00:00Z",
-    revision,
-    sourceId: "native-browser:browser-session-1",
-  });
-}

--- a/src/react-workbench/chat/useChatSessionRuntime.ts
+++ b/src/react-workbench/chat/useChatSessionRuntime.ts
@@ -1,11 +1,8 @@
+import { subscribeChatEvents } from "./chatEventSource";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
 import type { HookExecutionResult } from "../../app-core/chat/hookExecutionResult";
-import type {
-  NativeBrowserSession,
-  NativeBrowserSnapshot,
-} from "../../app-core/native/nativeBrowserSnapshot";
 import type { ChatEvent, ChatStore } from "../services";
 import type { ReactChatMessage } from "./messageActions";
 import { projectChatEventEffects } from "./chatEventPolicy";
@@ -14,8 +11,6 @@ export type ChatSessionRuntimeStatus = "idle" | "loading" | "ready" | "failed";
 
 export type ChatSessionRuntimeState = {
   agentUiForms: AgentUiForm[];
-  browserError: string;
-  browserSnapshot?: NativeBrowserSnapshot<NativeBrowserSession>;
   error: string;
   hookResults: HookExecutionResult[];
   sessionId: string;
@@ -30,12 +25,8 @@ export type ChatSessionRuntimeEffect =
   | { sessionId: string; timeline: ChatTimelineSnapshot; type: "timeline_applied" };
 
 export type ChatSessionRuntimeActions = {
-  acceptBrowserSnapshot(snapshot: NativeBrowserSnapshot<NativeBrowserSession>): void;
-  clearBrowserError(): void;
-  clearBrowserSnapshot(browserSessionId?: string): void;
   clearError(): void;
   reload(): Promise<void>;
-  reportBrowserError(error: unknown): void;
   reportError(error: unknown): void;
 };
 
@@ -70,38 +61,6 @@ export function useChatSessionRuntime({
       error: "",
       status: current.sessionId ? (current.timeline ? "ready" : "loading") : "idle",
     }));
-  }, []);
-  const reportBrowserError = useCallback((error: unknown) => {
-    setState((current) => ({ ...current, browserError: errorMessage(error) }));
-  }, []);
-  const clearBrowserError = useCallback(() => {
-    setState((current) => ({ ...current, browserError: "" }));
-  }, []);
-  const acceptBrowserSnapshot = useCallback((snapshot: NativeBrowserSnapshot<NativeBrowserSession>) => {
-    const activeSessionId = activeSessionIdRef.current;
-    if (activeSessionId && snapshot.data.sessionId !== activeSessionId) {
-      throw new Error(
-        `Browser snapshot session ${snapshot.data.sessionId} does not match active session ${activeSessionId}.`,
-      );
-    }
-    setState((current) => {
-      const previous = current.browserSnapshot;
-      if (previous?.sourceId === snapshot.sourceId
-        && typeof previous.revision === "number"
-        && typeof snapshot.revision === "number"
-        && snapshot.revision < previous.revision) {
-        return current;
-      }
-      return { ...current, browserError: "", browserSnapshot: snapshot };
-    });
-  }, []);
-  const clearBrowserSnapshot = useCallback((browserSessionId?: string) => {
-    setState((current) => {
-      if (browserSessionId && current.browserSnapshot?.data.browserSessionId !== browserSessionId) {
-        return current;
-      }
-      return { ...current, browserError: "", browserSnapshot: undefined };
-    });
   }, []);
   const reload = useCallback(async () => {
     await reloadRef.current?.();
@@ -204,16 +163,9 @@ export function useChatSessionRuntime({
 
     reloadRef.current = reloadSession;
     void reloadSession();
-    const unsubscribe = chatStore.subscribe(sessionId, (event) => {
+    const unsubscribe = subscribeChatEvents(chatStore, sessionId, (event) => {
       const effects = projectChatEventEffects(event);
-      if (event.browserSnapshot) {
-        try {
-          acceptBrowserSnapshot(event.browserSnapshot);
-        } catch (error) {
-          fail("browser-snapshot.apply", error);
-        }
-        return;
-      }
+      if (event.browserSnapshot) return;
       if (event.hookResults) {
         setState((current) => (
           current.sessionId === sessionId
@@ -266,23 +218,15 @@ export function useChatSessionRuntime({
       if (reloadRef.current === reloadSession) reloadRef.current = null;
       unsubscribe();
     };
-  }, [acceptBrowserSnapshot, chatStore, sessionId]);
+  }, [chatStore, sessionId]);
 
   const actions = useMemo<ChatSessionRuntimeActions>(() => ({
-    acceptBrowserSnapshot,
-    clearBrowserError,
-    clearBrowserSnapshot,
     clearError,
     reload,
-    reportBrowserError,
     reportError,
   }), [
-    acceptBrowserSnapshot,
-    clearBrowserError,
-    clearBrowserSnapshot,
     clearError,
     reload,
-    reportBrowserError,
     reportError,
   ]);
 
@@ -295,7 +239,6 @@ function initialState(
 ): ChatSessionRuntimeState {
   return {
     agentUiForms: [],
-    browserError: "",
     error: "",
     hookResults: [],
     sessionId,

--- a/src/react-workbench/chat/useChatSessions.ts
+++ b/src/react-workbench/chat/useChatSessions.ts
@@ -1,0 +1,16 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import type { SessionStore } from "../services";
+import { createChatSessionApplication, type ChatSessionChange } from "./chatSessionApplication";
+
+export function useChatSessions(store: SessionStore, now: () => number, onChange: (event: ChatSessionChange) => void) {
+  const latest = useRef({ now, onChange });
+  useLayoutEffect(() => { latest.current = { now, onChange }; });
+  const application = useMemo(() => createChatSessionApplication(store, () => latest.current.now()), [store]);
+  useEffect(() => {
+    const unsubscribe = application.onChange((event) => latest.current.onChange(event));
+    void application.load();
+    return unsubscribe;
+  }, [application]);
+  const state = useSyncExternalStore(application.subscribe, application.snapshot);
+  return { application, ...state };
+}

--- a/src/react-workbench/chat/useChatSubmission.test.tsx
+++ b/src/react-workbench/chat/useChatSubmission.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { TFunction } from "i18next";
+import type { ChatStore } from "../services";
+import { useChatSubmission } from "./useChatSubmission";
+
+afterEach(cleanup);
+
+function setup(dispatch: ChatStore["dispatch"]) {
+  return renderHook(() => useChatSubmission({
+    chatStore: { dispatch } as ChatStore,
+    sessionId: "s1", now: () => 1, t: ((key: string) => key) as TFunction<"chat">,
+    reload: async () => {}, refreshSessions: async () => [], materializeDraft: async () => null,
+    previewSession: () => {}, consumeDraft: () => {},
+  }));
+}
+
+it("retracts only the failed optimistic submission while retaining independently received messages", async () => {
+  let reject!: (error: Error) => void;
+  const dispatch = vi.fn(() => new Promise<void>((_resolve, fail) => { reject = fail; }));
+  const { result } = setup(dispatch);
+  let submitted!: Promise<void>;
+  await act(async () => {
+    submitted = result.current.submitTurn("s1", { text: "draft" }, "composer-send", "draft");
+    await Promise.resolve();
+  });
+  expect(result.current.optimisticMessages).toHaveLength(1);
+  act(() => result.current.receiveMessage("s1", { id: "other", role: "user", text: "other", status: "complete", createdAtMs: 2 }));
+  await act(async () => {
+    reject(new Error("submission rejected"));
+    await expect(submitted).rejects.toThrow("submission rejected");
+  });
+  expect(result.current.optimisticMessages.map((message) => message.id)).toEqual(["other"]);
+});
+
+it("keeps optimistic messages scoped to their session when a draft receives its persisted ID", () => {
+  const { result } = setup(async () => {});
+  act(() => result.current.receiveMessage("draft", { id: "pending", role: "user", text: "draft", status: "complete", createdAtMs: 1 }));
+  expect(result.current.optimisticMessages).toEqual([]);
+  act(() => result.current.replaceSession("draft", "s1"));
+  expect(result.current.optimisticMessages.map((message) => message.id)).toEqual(["pending"]);
+  act(() => result.current.forgetSession("s1"));
+  expect(result.current.optimisticMessages).toEqual([]);
+});

--- a/src/react-workbench/chat/useChatSubmission.ts
+++ b/src/react-workbench/chat/useChatSubmission.ts
@@ -1,0 +1,134 @@
+import { useRef, useState } from "react";
+import type { TFunction } from "i18next";
+import { createDesktopCompactCommand, createDesktopTurnSubmitCommand } from "../../app-core/chat/desktopCommand";
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+import type { ChatInput, ChatStore, SessionSummary, SettingsStore, WorkspaceStore } from "../services";
+import type { ReactChatMessage } from "./messageActions";
+import { prepareArtifactReviews } from "./prepareArtifactReviews";
+import { prepareChatSubmission, type PrepareChatSubmissionInput } from "./chatSubmission";
+import type { ChatTurnApplication } from "./chatTurnApplication";
+import { deriveSessionTitle, isDefaultSessionTitle } from "./sessionTitle";
+
+type Options = {
+  chatStore: ChatStore;
+  settingsStore?: SettingsStore;
+  artifactReviews?: WorkspaceStore["artifactReviews"];
+  sessionId: string;
+  now(): number;
+  t: TFunction<"chat">;
+  reload(): Promise<void>;
+  refreshSessions(preserveSession?: SessionSummary): Promise<SessionSummary[]>;
+  materializeDraft(): Promise<SessionSummary | null>;
+  previewSession(session: SessionSummary): void;
+  consumeDraft(sessionId: string): void;
+};
+const EMPTY_MESSAGES: ReactChatMessage[] = [];
+
+export function useChatSubmission(options: Options) {
+  const { chatStore, artifactReviews, now, t } = options;
+  const [messages, setMessages] = useState(new Map<string, ReactChatMessage[]>());
+  const [compactingSessionId, setCompactingSessionId] = useState("");
+  const [artifactReviewEpoch, setArtifactReviewEpoch] = useState(0);
+  const modelSave = useRef<Promise<void>>(Promise.resolve());
+
+  function updateMessages(sessionId: string, update: (current: ReactChatMessage[]) => ReactChatMessage[]) {
+    setMessages((current) => {
+      const nextMessages = update(current.get(sessionId) ?? EMPTY_MESSAGES);
+      if (nextMessages === current.get(sessionId) || (!nextMessages.length && !current.has(sessionId))) return current;
+      const next = new Map(current);
+      if (nextMessages.length) next.set(sessionId, nextMessages);
+      else next.delete(sessionId);
+      return next;
+    });
+  }
+
+  async function submitTurn(sessionId: string, input: ChatInput, control: string, optimisticText?: string) {
+    const command = createDesktopTurnSubmitCommand({ message: input, sessionId, source: { control, surface: "chat" } });
+    if (await prepareArtifactReviews(input.references, artifactReviews, sessionId, command.commandId)) {
+      setArtifactReviewEpoch((value) => value + 1);
+    }
+    if (optimisticText) updateMessages(sessionId, (current) => [...current, {
+      createdAtMs: now(), id: command.commandId, role: "user", status: "complete", text: optimisticText,
+    }]);
+    try {
+      await chatStore.dispatch(command);
+    } catch (error) {
+      if (optimisticText) updateMessages(sessionId, (current) => current.filter((message) => message.id !== command.commandId));
+      throw error;
+    }
+  }
+
+  return {
+    optimisticMessages: messages.get(options.sessionId) ?? EMPTY_MESSAGES,
+    compactingSessionId,
+    artifactReviewEpoch,
+    submitTurn,
+    saveDefaultModel(modelId: string, providerId?: string): Promise<void> {
+      const persistence = modelSave.current.catch(() => undefined).then(() => {
+        if (!options.settingsStore?.saveDefaultChatModel || !providerId) {
+          throw new Error("Native default Provider/model persistence is unavailable.");
+        }
+        return options.settingsStore.saveDefaultChatModel({ modelId, providerId });
+      });
+      modelSave.current = persistence;
+      return persistence;
+    },
+    async send(
+      input: Omit<PrepareChatSubmissionInput, "now" | "queuedInputs" | "loadSessionTranscript" | "t">,
+      session: SessionSummary | undefined,
+      queue: ChatTurnApplication,
+    ) {
+      const prepared = await prepareChatSubmission({
+        ...input, now: queue.nextInputTimestamp, queuedInputs: queue.queue(options.sessionId).inputs,
+        loadSessionTranscript: chatStore.copyMarkdown, t,
+      });
+      if (prepared.kind === "compact") {
+        if (!session) throw new Error(t("errors.compactNeedsSession"));
+        options.consumeDraft(session.id);
+        setCompactingSessionId(session.id);
+        try {
+          await chatStore.dispatch(createDesktopCompactCommand({ sessionId: session.id, source: { control: "slash-compact", surface: "chat" } }));
+          await options.reload();
+          await options.refreshSessions(session);
+        } catch (error) {
+          console.error("[chat] context.compact.failed", { sessionId: session.id, error: error instanceof Error ? error.message : String(error) });
+          throw error;
+        } finally {
+          setCompactingSessionId((current) => current === session.id ? "" : current);
+        }
+        return;
+      }
+      if (prepared.kind === "empty") return;
+      if (prepared.kind === "queue_limit_reached") { queue.reportQueueLimit(options.sessionId); return; }
+      await modelSave.current;
+      const sendSession = session ?? await options.materializeDraft();
+      if (!sendSession) return;
+      if (prepared.kind === "queue_input") { queue.enqueue(sendSession.id, prepared.input); return; }
+      const preview = isDefaultSessionTitle(sendSession.title)
+        ? { ...sendSession, title: deriveSessionTitle(prepared.visibleText, t) } : sendSession;
+      if (preview !== sendSession) options.previewSession(preview);
+      await submitTurn(sendSession.id, prepared.turnInput, "composer-send", session ? undefined : prepared.visibleText);
+      await options.refreshSessions(preview);
+      if (!session) options.consumeDraft(sendSession.id);
+    },
+    fork(sessionId: string, messageId: string) { return chatStore.branchFromMessage(sessionId, messageId); },
+    receiveTimeline(sessionId: string, timeline: ChatTimelineSnapshot) {
+      updateMessages(sessionId, (current) => current.filter((message) => !timeline.turns.some((turn) => turn.userMessage.clientEventId === message.id)));
+    },
+    receiveMessage(sessionId: string, message: ReactChatMessage) {
+      updateMessages(sessionId, (current) => current.some((candidate) => candidate.id === message.id)
+        ? current.map((candidate) => candidate.id === message.id ? { ...candidate, ...message } : candidate)
+        : [...current, message]);
+    },
+    forgetSession(sessionId: string) { updateMessages(sessionId, () => []); },
+    replaceSession(previousSessionId: string, sessionId: string) {
+      setMessages((current) => {
+        if (!current.has(previousSessionId) || previousSessionId === sessionId) return current;
+        const next = new Map(current);
+        next.set(sessionId, next.get(previousSessionId)!);
+        next.delete(previousSessionId);
+        return next;
+      });
+    },
+  };
+}

--- a/src/react-workbench/chat/useChatTurnApplication.ts
+++ b/src/react-workbench/chat/useChatTurnApplication.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { createChatTurnApplication } from "./chatTurnApplication";
+
+type Dependencies = Parameters<typeof createChatTurnApplication>[0];
+type Context = Parameters<ReturnType<typeof createChatTurnApplication>["observe"]>[1];
+
+/** React adapter; queue mutations are subscribed to by the queue views, not the page. */
+export function useChatTurnApplication(
+  dependencies: Dependencies,
+  sessionId: string,
+  context: Context,
+) {
+  const latest = useRef(dependencies);
+  const activeSession = useRef(sessionId);
+  const { timeline, capabilities } = context;
+  useLayoutEffect(() => { latest.current = dependencies; activeSession.current = sessionId; });
+  const application = useMemo(() => createChatTurnApplication({
+    dispatch: (command) => latest.current.dispatch(command),
+    submitTurn: (...args) => latest.current.submitTurn(...args),
+    refreshSessions: () => latest.current.refreshSessions(),
+    reportError: (error, targetSessionId) => {
+      if (activeSession.current === targetSessionId) latest.current.reportError(error, targetSessionId);
+    },
+    clearError: () => latest.current.clearError(),
+    now: () => latest.current.now(),
+    get t() { return latest.current.t; },
+  }), []);
+  useLayoutEffect(() => {
+    application.observe(sessionId, { timeline, capabilities });
+  }, [application, sessionId, timeline, capabilities, dependencies.t]);
+  useEffect(() => () => application.dispose(), [application]);
+  const snapshot = useSyncExternalStore(
+    application.subscribe,
+    useCallback(() => application.turn(sessionId), [application, sessionId]),
+  );
+  return { application, ...snapshot };
+}

--- a/src/react-workbench/defaultServices.ts
+++ b/src/react-workbench/defaultServices.ts
@@ -1,12 +1,8 @@
+import { createDesktopChatCommands } from "./chat/desktopChatCommands";
 import { invoke } from "@tauri-apps/api/core";
 import { rendererPerformanceSnapshot } from "../app-core/native/rendererPerformance";
 import { listen } from "@tauri-apps/api/event";
 import { createDesktopChatSessionController } from "../app-core/chat/desktopChatSessionController";
-import {
-  agentInputAttachmentKind,
-  type AgentInputReference,
-} from "../app-core/chat/agentInputReference";
-import type { DesktopCommand, DesktopTurnSubmitCommand } from "../app-core/chat/desktopCommand";
 import { createDesktopNativeConfigApi } from "../app-core/native/desktopNativeConfig";
 import { createDesktopNativeAgentGraphsApi } from "../app-core/native/desktopNativeAgentGraphs";
 import { createDesktopNativeAgentGraphRuntime } from "../app-core/native/desktopNativeAgentGraphRuntime";
@@ -47,11 +43,6 @@ import { createDesktopNativeEventBridge } from "./adapters/desktopNativeEventBri
 import { createDesktopSettingsStore } from "./adapters/desktopSettingsStore";
 import { createDesktopToolsStore } from "./adapters/desktopToolsStore";
 import { createDesktopWorkspaceStore } from "./adapters/desktopWorkspaceStore";
-import type { ReactChatMessage } from "./chat/messageActions";
-import {
-  createThreadAgentCancelCommand,
-  type ThreadCommand,
-} from "../app-core/chat/threadCommand";
 import {
   readDefaultChatModelPreference,
 } from "../app-core/chat/chatModelPreference";
@@ -186,198 +177,11 @@ export function createDesktopAppServices(
     }
   }
 
-  async function dispatchThreadCommand(command: ThreadCommand): Promise<void> {
-    await initialize();
-    const thread = controller.state.threads.find((item) => item.threadId === command.target.sessionId);
-    if (thread && controller.state.activeThreadId !== thread.threadId) {
-      await controller.selectSession(thread.threadId);
-    }
-    const threadId = thread?.threadId || command.target.threadId || command.target.sessionId;
-    if (command.kind === "agent.cancel") {
-      await requireNative(nativeThreads, "Thread").interrupt({
-        threadId,
-        turnId: command.target.turnId,
-        clientEventId: command.commandId,
-        reason: "user_requested",
-      });
-    } else if (command.kind === "form.submit" || command.kind === "form.cancel") {
-      await requireNative(nativeThreads, "Thread").submitForm({
-        commandId: command.commandId,
-        threadId,
-        formId: command.form.formId,
-        source: command.source,
-        target: { ...command.target, threadId },
-        values: command.kind === "form.submit" ? command.form.values : {},
-        action: command.kind === "form.submit" ? "submit" : "cancel",
-      });
-    } else {
-      await requireNative(nativeThreads, "Thread").retryOperation({
-        commandId: command.commandId,
-        source: command.source,
-        sourceItemId: command.operation.itemId,
-        sourceTurnId: command.operation.turnId,
-        targetTurnId: command.target.turnId,
-        threadId,
-      });
-    }
-    notifySession(command.target.sessionId, { commandId: command.commandId, type: "command.accepted" });
-    notifySession(command.target.sessionId, { commandId: command.commandId, type: "command.canonical-updated" });
-  }
-
-  async function dispatchTurnSubmit(command: DesktopTurnSubmitCommand): Promise<void> {
-    await initialize();
-    const sessionId = command.target.sessionId;
-    const thread = controller.state.threads.find((item) => item.threadId === sessionId);
-    if (!thread) throw new Error(`Cannot send to unknown Thread ${sessionId}`);
-    if (controller.state.activeThreadId !== thread.threadId) {
-      await controller.selectSession(thread.threadId);
-    }
-    const input = command.input;
-    const preference = readDefaultChatModelPreference();
-    const threadExtra = isRecord(thread.metadata?.extra) ? thread.metadata.extra : {};
-    const threadModel = stringValue(thread.metadata?.model);
-    const threadProvider = stringValue(threadExtra.modelProvider);
-    const model = stringValue(input.model) || threadModel || preference?.modelId || "";
-    const provider = stringValue(input.provider)
-      || (model === threadModel ? threadProvider : "")
-      || (model === preference?.modelId ? preference.providerId ?? "" : "");
-    if (model && (model !== threadModel || provider !== threadProvider)) {
-      await controller.patchSession(sessionId, {
-        model,
-        metadata: withModelProvider(threadExtra, provider),
-      });
-    }
-    const result = await controller.submitMessage(sessionId, input.text, {
-      ...(model ? { model } : {}),
-      ...(provider ? { provider } : {}),
-      ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
-      ...(input.references?.length ? { references: input.references } : {}),
-      ...(input.selectedSkills?.length ? { selectedSkills: input.selectedSkills } : {}),
-      ...(input.selectedTools ? { selectedTools: input.selectedTools } : {}),
-      clientEventId: command.commandId,
-    });
-    const optimisticText = result.status === "sent" ? result.content : "";
-    const optimisticMessage = result.status === "empty"
-      ? undefined
-      : createOptimisticUserMessage(result.clientEventId, optimisticText, input.references);
-    notifySession(sessionId, {
-      type: "message-sent",
-      ...(optimisticMessage ? { message: optimisticMessage } : {}),
-    });
-    if (result.status === "sent") {
-      void result.completion
-        .then((timeline) => {
-          notifySession(sessionId, { type: "timeline.patch", timeline });
-          nativeEvents.notifyTerminalTimelineState(sessionId, timeline);
-        })
-        .catch(async (error) => {
-          let recoveryError = "";
-          try {
-            const timeline = await controller.reloadTimeline(sessionId);
-            notifySession(sessionId, { type: "timeline.patch", timeline });
-            nativeEvents.notifyTerminalTimelineState(sessionId, timeline);
-          } catch (timelineError) {
-            recoveryError = timelineError instanceof Error ? timelineError.message : String(timelineError);
-          }
-          const message = error instanceof Error ? error.message : String(error);
-          notifySession(sessionId, {
-            type: "timeline.error",
-            error: recoveryError
-              ? `${message}; failed to reload terminal timeline state: ${recoveryError}`
-              : message,
-          });
-        });
-    }
-  }
-
-  async function dispatchDesktopCommand(command: DesktopCommand): Promise<void> {
-    if (command.kind === "turn.submit") {
-      await dispatchTurnSubmit(command);
-      return;
-    }
-    if (command.kind === "agent.stop") {
-      await initialize();
-      const sessionId = command.target.sessionId;
-      const timeline = await controller.loadTimeline(sessionId);
-      const turn = [...timeline.turns].reverse().find((candidate) => (
-        candidate.status === "pending"
-        || candidate.status === "running"
-        || candidate.status === "awaiting_user"
-      ));
-      if (!turn) throw new Error("Cannot cancel: the session has no active turn");
-      const cancelCommand = createThreadAgentCancelCommand({
-        commandId: command.commandId,
-        issuedAt: command.issuedAt,
-        sessionId,
-        source: command.source,
-        threadId: turn.canonicalItems?.find((item) => item.threadId)?.threadId,
-        turnId: turn.id,
-      });
-      notifySession(sessionId, { command: cancelCommand, type: "command.dispatched" });
-      await dispatchThreadCommand(cancelCommand);
-      return;
-    }
-    if (command.kind === "context.compact") {
-      await initialize();
-      const sessionId = command.target.sessionId;
-      const thread = controller.state.threads.find((candidate) => candidate.threadId === sessionId);
-      if (!thread) throw new Error(`Cannot compact unknown Thread ${sessionId}`);
-      if (controller.state.activeThreadId !== sessionId) {
-        await controller.selectSession(sessionId);
-      }
-      await requireNative(nativeThreads, "Thread").compact({
-        threadId: sessionId,
-        clientEventId: command.commandId,
-      });
-      const timeline = await controller.loadTimeline(sessionId);
-      notifySession(sessionId, { type: "timeline.patch", timeline });
-      nativeEvents.notifyTerminalTimelineState(sessionId, timeline);
-      return;
-    }
-    await dispatchThreadCommand(command);
-  }
-
-  async function resolveForkSequence(threadId: string, itemIds: Set<string>): Promise<number | undefined> {
-    let cursor = "";
-    const seenCursors = new Set<string>();
-    while (true) {
-      const payload = await requireNative(nativeThreads, "Thread").read({
-        threadId,
-        limit: 500,
-        ...(cursor ? { cursor } : {}),
-      });
-      if (!isRecord(payload)) {
-        throw new Error(`Thread ${threadId} returned an invalid read result while resolving a fork boundary`);
-      }
-      const items = Array.isArray(payload.items) ? payload.items : [];
-      for (const value of items) {
-        if (!isRecord(value)) continue;
-        const kind = isRecord(value.kind) ? value.kind : {};
-        const itemPayload = isRecord(kind.payload) ? kind.payload : {};
-        const itemId = stringValue(value.itemId ?? value.item_id);
-        const messageId = stringValue(itemPayload.messageId ?? itemPayload.message_id);
-        if (!itemIds.has(itemId) && !itemIds.has(messageId)) continue;
-        const sequence = numberValue(value.sequence);
-        if (sequence === undefined) {
-          throw new Error(`Thread item ${itemId || messageId} is missing its canonical sequence`);
-        }
-        return sequence;
-      }
-      const nextCursor = stringValue(
-        payload.nextCursor
-        ?? payload.next_cursor
-        ?? (isRecord(payload.pagination)
-          ? payload.pagination.nextCursor ?? payload.pagination.next_cursor
-          : undefined),
-      );
-      if (!nextCursor) return undefined;
-      if (seenCursors.has(nextCursor)) {
-        throw new Error(`Thread ${threadId} returned a repeated pagination cursor while resolving a fork boundary`);
-      }
-      seenCursors.add(nextCursor);
-      cursor = nextCursor;
-    }
-  }
+  const chatCommands = createDesktopChatCommands({
+    initialize, controller, notifySession, mapSession,
+    nativeThreads: () => requireNative(nativeThreads, "Thread"),
+    notifyTerminalTimelineState: nativeEvents.notifyTerminalTimelineState,
+  });
 
   return {
     desktopPetHost,
@@ -534,7 +338,7 @@ export function createDesktopAppServices(
         );
       },
       async dispatch(command) {
-        await dispatchDesktopCommand(command);
+        await chatCommands.dispatch(command);
       },
       async listAgentUiForms(sessionId) {
         await initialize();
@@ -548,47 +352,7 @@ export function createDesktopAppServices(
         await initialize();
         return controller.loadArtifact(selection);
       },
-      async branchFromMessage(sessionId, messageId) {
-        await initialize();
-        const sourceThread = controller.state.threads.find((thread) => thread.threadId === sessionId);
-        if (!sourceThread) {
-          throw new Error(`Cannot branch from unknown Thread ${sessionId}`);
-        }
-        const timeline = await controller.loadTimeline(sessionId);
-        const canonicalItem = timeline.turns
-          .flatMap((turn) => turn.canonicalItems ?? [])
-          .find((item) => (
-            item.itemId === messageId
-            || stringValue(item.data.messageId ?? item.data.message_id) === messageId
-          ));
-        if (!canonicalItem) {
-          throw new Error(`Cannot fork Thread ${sessionId} at unknown canonical message ${messageId}`);
-        }
-        const sourceThreadId = sourceThread.threadId;
-        const forkAfterSequence = await resolveForkSequence(sourceThreadId, new Set([
-          messageId,
-          canonicalItem.itemId,
-          stringValue(canonicalItem.data.messageId ?? canonicalItem.data.message_id),
-        ].filter(Boolean)));
-        if (forkAfterSequence === undefined) {
-          throw new Error(`Cannot resolve persisted fork boundary for canonical message ${messageId}`);
-        }
-        const title = `${sourceThread.title} · 分叉`;
-        const forkedThread = await requireNative(nativeThreads, "Thread").fork({
-          threadId: sourceThreadId,
-          clientEventId: `fork:${sourceThreadId}:${messageId}`,
-          title,
-          forkAfterSequence,
-        });
-        await controller.loadSessions();
-        const branchThread = controller.state.threads.find((thread) => (
-          thread.threadId === forkedThread.threadId
-        ));
-        if (!branchThread) {
-          throw new Error(`Forked Thread ${forkedThread.threadId} is missing from the Thread list`);
-        }
-        return mapSession(branchThread, false, forkedThread);
-      },
+      branchFromMessage: chatCommands.branchFromMessage,
       async copyMarkdown(sessionId) {
         await initialize();
         const timeline = await controller.loadTimeline(sessionId);
@@ -729,37 +493,6 @@ function mapSession(thread: NativeThreadRecord, responding: boolean, fallbackPay
     status: responding || thread.status === "running" || thread.status === "cancelling"
       ? "running"
       : thread.status === "failed" ? "failed" : "idle",
-  };
-}
-
-function createOptimisticUserMessage(clientEventId: string, text: string, references: AgentInputReference[] = []): ReactChatMessage {
-  return {
-    id: clientEventId,
-    role: "user",
-    createdAtMs: Date.now(),
-    text,
-    status: "complete",
-    ...(references.length ? {
-      contextReferences: references.map((reference, index) => {
-        const attachmentKind = agentInputAttachmentKind(reference);
-        const attachment = Boolean(attachmentKind) && Boolean(reference.rawPath) && !reference.sourcePath;
-        return {
-          ...(attachment ? {
-            attachmentKind,
-            ...(attachmentKind === "image" && reference.rawPath
-              ? { attachmentPreviewPath: reference.rawPath }
-              : {}),
-          } : {}),
-          detail: reference.detail,
-          id: reference.evidenceId || `reference-${index}`,
-          kind: reference.kind,
-          presentation: attachment ? "attachment" as const : "context" as const,
-          sourceLine: reference.sourceLine,
-          sourcePath: reference.sourcePath,
-          title: reference.title,
-        };
-      }),
-    } : {}),
   };
 }
 

--- a/src/react-workbench/sidecar/README.md
+++ b/src/react-workbench/sidecar/README.md
@@ -1,20 +1,26 @@
 # Sidecar
-<!-- tinybot-module-fingerprint: sha256:18ea8d30478623769cb881e9d9cae2f763974c91a433a470058bec590c39d2da -->
+<!-- tinybot-module-fingerprint: sha256:2e09f6a8731fa0c9780715c2f64714164c586058cb68ba45cb0b0cd1e1e5541c -->
 
 `sidecar` owns the React resource shell displayed beside Chat. It presents
 thread-scoped Browser and Artifact resources, workspace-scoped Terminal
 resources, their tab selection, and the docked, hidden, or expanded Sidecar
 layout.
 
-The module owns renderer state and presentation only. Chat provisions and
+The module owns renderer state, presentation, and resource lifecycle coordination.
+`SidecarResources.tsx` provisions and
 releases native resources, the native Browser runtime owns WebView2 sessions
 and tabs, and the desktop Terminal runtime owns user PTY processes. Sidecar
 must not become a second authority for either native lifecycle.
 
+`useSidecarBrowserState.ts` owns native Browser snapshots and revision ordering.
+It shares one native event subscription with Chat through `chatEventSource`;
+Browser updates do not enter the Chat runtime state. The page receives only
+presentation geometry and explicit requests to reference content or resume Chat.
+
 ## Resource model
 
 `sidecarModel.ts` defines the reducer and the stable resource identities used
-by Chat:
+by `SidecarResources`:
 
 - Browser resources belong to the current Thread and bind one-to-one to native
   WebView2 tabs in that Thread's shared Browser Session.
@@ -27,7 +33,7 @@ by Chat:
 
 Creating a resource selects it and reveals Sidecar. Closing a selected resource
 chooses the next visible resource, then the previous one, and finally no active
-resource. The reducer removes renderer state; the Chat owner performs any
+resource. The reducer removes renderer state; the resource owner performs any
 required native Browser close or Terminal termination before dispatching the
 close event.
 
@@ -55,22 +61,22 @@ Sidecar CSS retains only its anchored placement and two-line resource layout.
 `SidecarBrowser.tsx` renders Browser chrome and coordinates visible-surface
 attachment with the native Browser adapter. It does not render remote page
 content in React. Browser snapshots are authoritative for native session and
-tab identity. Chat guards activation so a snapshot update cannot create a
+tab identity. `SidecarResources` guards activation so a snapshot update cannot create a
 reverse activation feedback loop.
 
 `SidecarTerminal.tsx` attaches xterm.js to the dedicated user-only native PTY
-adapter. Chat loads this terminal surface on demand and Sidecar presents a
+adapter. `SidecarResources` loads this terminal surface on demand and Sidecar presents a
 bounded pending state while its code chunk arrives, keeping xterm out of the
 main startup bundle. Mounting and unmounting the React view never terminate the process:
 hiding Sidecar and switching resources may remount the view, while closing the
-resource invokes termination through Chat. Terminal input is serialized with
+resource invokes termination through `SidecarResources`. Terminal input is serialized with
 polling so cursor-based output cannot be reordered.
 
 Artifact presentation is supplied by Chat through the Sidecar render contract;
 Artifact domain state does not live in this module. Artifact tabs may come from
 canonical Agent artifacts or from local file links in assistant Markdown. File
 links are contextual only, so the resource menu does not create an empty
-Artifact tab. Chat presents Markdown Artifacts as rendered documents and keeps
+Artifact tab. Sidecar presents Markdown Artifacts as rendered documents and keeps
 the Artifact panel as the single vertical scrolling surface. Modern Office
 files (`.xlsx`, `.docx`, and `.pptx`) are parsed locally into sheet, continuous
 document, and slide-list previews; plain text, image, and data-view Artifacts
@@ -99,7 +105,7 @@ Sidecar does not own or submit the Chat composer state.
 - User Terminal processes, input, output, and lifecycle are isolated from Agent
   shell tools.
 - Hiding Sidecar or switching tabs preserves native resources; closing a
-  resource releases the native resource through its Chat owner.
+  resource releases the native resource through its Sidecar resource owner.
 - Persisted widths cannot force Chat or the resource surface outside the
   current workspace bounds.
 - Resource provisioning failures remain visible and retryable rather than
@@ -117,7 +123,7 @@ Sidecar does not own or submit the Chat composer state.
   handoff, and Browser failure states.
 - `SidecarTerminal.test.tsx` covers PTY creation, ordered input and polling,
   reattachment, resize, and renderer disposal without termination.
-- `../chat/ChatPage.sidecar.test.tsx` covers Chat-owned provisioning, Browser
+- `../chat/ChatPage.sidecar.test.tsx` covers Sidecar-owned provisioning, Browser
   activation, session reattachment, workspace fallback, and close-time cleanup.
 - `../chat/ChatPage.timeline.test.tsx` covers assistant file-link Artifact
   previews, spreadsheet change requests, and visible path-boundary failures.

--- a/src/react-workbench/sidecar/SidecarResources.tsx
+++ b/src/react-workbench/sidecar/SidecarResources.tsx
@@ -1,0 +1,645 @@
+import { lazy, Suspense, useCallback, useEffect, useImperativeHandle, useMemo, useReducer, useRef, useState, type Ref } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2 } from "lucide-react";
+import type { ChatStore, SessionSummary, WorkspaceStore } from "../services";
+import type { ArtifactRef, LoadedArtifactDetail } from "../../app-core/chat/chatTurnContracts";
+import type { OfficeArtifactSource, SpreadsheetCellChangeRequest } from "../../app-core/chat/officeArtifact";
+import type { AgentInputReference } from "../../app-core/chat/agentInputReference";
+import type { NativeBrowserSnapshot, NativeBrowserSession } from "../../app-core/native/nativeBrowserSnapshot";
+import { officeContentReference } from "../../app-core/chat/officeContentReference";
+import { projectLoadedArtifactDetail } from "../../app-core/chat/chatProjection";
+import { logRendererEvent } from "../../app-core/native/rendererLogger";
+import { AssistantFileLinkError, assistantFileArtifact, assistantFileLinkTitle, resolveAssistantFileLink, type AssistantFileLink } from "../chat/assistantFileLinks";
+import { sessionWorkspaceName } from "../chat/sessionWorkspaces";
+import { useArtifactFile } from "../chat/useArtifactFile";
+import { DataViewCard } from "../chat/DataViewCard";
+import { AssistantMarkdown } from "../chat/AssistantMarkdown";
+import { ArtifactReviewPanel } from "./ArtifactReviewPanel";
+import { OfficeArtifactPreview } from "./OfficeArtifactPreview";
+import { Sidecar } from "./Sidecar";
+import { SidecarBrowser } from "./SidecarBrowser";
+import { useSidecarBrowserState } from "./useSidecarBrowserState";
+import { activeSidecarTab, createInitialSidecarState, DEFAULT_SIDECAR_WORKSPACE_ID, readPersistedSidecarWidth, reduceSidecarState,
+  sidecarArtifactTabId, visibleSidecarTabs, writePersistedSidecarWidth, type SidecarArtifactTab, type SidecarBrowserTab, type SidecarTab, type SidecarTerminalTab, type SidecarState } from "./sidecarModel";
+
+export type SidecarLayout = Pick<SidecarState, "presentation" | "layoutMotion" | "width">;
+export function initialSidecarLayout(): SidecarLayout {
+  const { presentation, layoutMotion, width } = createInitialSidecarState(readPersistedSidecarWidth(window.localStorage));
+  return { presentation, layoutMotion, width };
+}
+export type SidecarResourcesHandle = {
+  toggle(): void;
+  openArtifact(artifact: ArtifactRef): Promise<void>;
+  openFileLink(link: AssistantFileLink): Promise<void>;
+};
+type Props = {
+  ref?: Ref<SidecarResourcesHandle>;
+  activeSession?: SessionSummary;
+  activeDisplaySession?: SessionSummary;
+  activeSessionId: string;
+  chatStore: ChatStore;
+  workspaceStore?: Pick<WorkspaceStore, "readThreadFile" | "readThreadFileBytes" | "artifactReviews">;
+  artifactReviewEpoch: number;
+  sessionResponding: boolean;
+  presentDrawer: boolean;
+  onLayoutChange(layout: SidecarLayout): void;
+  onHide(): void;
+  onReference(reference: AgentInputReference & { id: string }): void;
+  onAskForSpreadsheetChange(artifact: ArtifactRef, request: SpreadsheetCellChangeRequest, revision?: string): void;
+  onHandoff(sessionId: string): Promise<void>;
+  onError(error: string): void;
+};
+
+type ArtifactSidecarContent = {
+  localFile?: boolean;
+  artifact: ArtifactRef;
+  detail?: LoadedArtifactDetail;
+  error?: string;
+  loading: boolean;
+  notice?: string;
+  office?: OfficeArtifactSource;
+};
+
+type BrowserSnapshot = NativeBrowserSnapshot<NativeBrowserSession>;
+
+const LazySidecarTerminal = lazy(async () => {
+  const module = await import("./SidecarTerminal");
+  return { default: module.SidecarTerminal };
+});
+
+export function SidecarResources({ ref, activeSession, activeDisplaySession, activeSessionId, chatStore, workspaceStore, artifactReviewEpoch,
+  sessionResponding, presentDrawer, onLayoutChange, onHide, onReference, onAskForSpreadsheetChange: handleSpreadsheetAskForChange,
+  onHandoff, onError: reportTimelineError }: Props) {
+  const { t } = useTranslation("chat");
+  const browser = useSidecarBrowserState(chatStore, activeSession?.id ?? "");
+  const { browserError, browserSnapshot } = browser.state;
+  const { acceptBrowserSnapshot, clearBrowserError, clearBrowserSnapshot } = browser;
+  const [sidecar, dispatchSidecar] = useReducer(
+    reduceSidecarState,
+    undefined,
+    () => createInitialSidecarState(readPersistedSidecarWidth(window.localStorage)),
+  );
+  const [artifactSidecarContent, setArtifactSidecarContent] = useState<Record<string, ArtifactSidecarContent>>({});
+  const [browserProvisionErrors, setBrowserProvisionErrors] = useState<Record<string, string>>({});
+  const [terminalErrors, setTerminalErrors] = useState<Record<string, string>>({});
+  const [browserProvisionEpoch, setBrowserProvisionEpoch] = useState(0);
+  const sidecarRef = useRef(sidecar);
+  const browserProvisioningResourceIdRef = useRef("");
+  const browserActivationTargetRef = useRef("");
+  sidecarRef.current = sidecar;
+  const sidecarTabs = useMemo(() => visibleSidecarTabs(sidecar), [sidecar]);
+  const sidecarActiveTab = useMemo(() => activeSidecarTab(sidecar), [sidecar]);
+  const explicitWorkspaceId = activeDisplaySession?.workingDirectory?.trim() ?? "";
+  const activeWorkspaceId = activeDisplaySession
+    ? explicitWorkspaceId || DEFAULT_SIDECAR_WORKSPACE_ID
+    : "";
+  const activeWorkspaceLabel = explicitWorkspaceId
+    ? sessionWorkspaceName(explicitWorkspaceId)
+    : activeDisplaySession ? t("shell.generalSessions") : "";
+
+  const unboundBrowserResource = useMemo(() => sidecar.tabs.find((tab): tab is SidecarBrowserTab => (
+    tab.kind === "browser"
+      && tab.threadId === activeSession?.id
+      && !tab.nativeTabId
+  )), [activeSession?.id, sidecar.tabs]);
+  const retainedBrowserResource = useMemo(() => sidecar.tabs.find((tab): tab is SidecarBrowserTab => (
+    tab.kind === "browser"
+      && tab.threadId === activeSession?.id
+      && Boolean(tab.browserSessionId)
+      && Boolean(tab.nativeTabId)
+  )), [activeSession?.id, sidecar.tabs]);
+
+  const synchronizeBrowserSnapshot = useCallback((snapshot: BrowserSnapshot, acceptForActiveThread = true) => {
+    if (acceptForActiveThread && snapshot.data.sessionId === activeSessionId) {
+      acceptBrowserSnapshot(snapshot);
+    }
+    dispatchSidecar({
+      browserSessionId: snapshot.data.browserSessionId,
+      tabs: snapshot.data.tabs.map((tab) => ({
+        nativeTabId: tab.tabId,
+        title: browserResourceTitle(tab.title, tab.url, t("sidecar.browser")),
+      })),
+      threadId: snapshot.data.sessionId,
+      type: "tab.syncBrowserSession",
+    });
+  }, [acceptBrowserSnapshot, activeSessionId, t]);
+
+  useEffect(() => {
+    dispatchSidecar({
+      threadId: activeSession?.id ?? "",
+      type: "scope.changed",
+      workspaceId: activeWorkspaceId,
+    });
+  }, [activeSession?.id, activeWorkspaceId]);
+
+  useEffect(() => {
+    if (browserSnapshot) synchronizeBrowserSnapshot(browserSnapshot, false);
+  }, [browserSnapshot, synchronizeBrowserSnapshot]);
+
+  useEffect(() => {
+    const resource = retainedBrowserResource;
+    const browserRuntime = chatStore.browserRuntime;
+    if (!resource?.browserSessionId
+      || !browserRuntime
+      || browserSnapshot?.data.browserSessionId === resource.browserSessionId) return;
+    let cancelled = false;
+    void browserRuntime.snapshot(resource.browserSessionId)
+      .then((snapshot) => {
+        if (cancelled) return;
+        if (snapshot.data.sessionId !== resource.threadId) {
+          throw new Error(
+            `Browser snapshot session ${snapshot.data.sessionId} does not match resource thread ${resource.threadId}.`,
+          );
+        }
+        synchronizeBrowserSnapshot(snapshot);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setBrowserProvisionErrors((current) => ({ ...current, [resource.id]: errorMessage(error) }));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    browserProvisionEpoch,
+    browserSnapshot?.data.browserSessionId,
+    chatStore.browserRuntime,
+    retainedBrowserResource,
+    synchronizeBrowserSnapshot,
+  ]);
+
+  useEffect(() => {
+    const resource = unboundBrowserResource;
+    const browserRuntime = chatStore.browserRuntime;
+    if (!resource
+      || browserProvisionErrors[resource.id]
+      || browserProvisioningResourceIdRef.current) return;
+    browserProvisioningResourceIdRef.current = resource.id;
+    void (async () => {
+      try {
+        if (!browserRuntime) throw new Error(t("sidecar.browserBuildUnavailable"));
+        let snapshot = await browserRuntime.createSession({ ownerSessionId: resource.threadId });
+
+        const currentResources = sidecarRef.current.tabs.filter((tab): tab is SidecarBrowserTab => (
+          tab.kind === "browser" && tab.threadId === resource.threadId
+        ));
+        const currentResource = currentResources.find((tab) => tab.id === resource.id);
+        const resourceStillExists = Boolean(currentResource);
+        const resourceAlreadyBound = Boolean(
+          currentResource?.browserSessionId === snapshot.data.browserSessionId
+            && currentResource.nativeTabId
+            && snapshot.data.tabs.some((tab) => tab.tabId === currentResource.nativeTabId),
+        );
+        const boundNativeTabIds = new Set(currentResources.flatMap((tab) => tab.nativeTabId ? [tab.nativeTabId] : []));
+        const hasUnboundNativeTab = snapshot.data.tabs.some((tab) => !boundNativeTabIds.has(tab.tabId));
+        let createdNativeTabId = "";
+        if (resourceStillExists && !resourceAlreadyBound && !hasUnboundNativeTab) {
+          const previousNativeTabIds = new Set(snapshot.data.tabs.map((tab) => tab.tabId));
+          snapshot = await browserRuntime.createTab(snapshot.data.browserSessionId);
+          createdNativeTabId = snapshot.data.tabs.find((tab) => !previousNativeTabIds.has(tab.tabId))?.tabId ?? "";
+        }
+
+        if (!sidecarRef.current.tabs.some((tab) => tab.id === resource.id)) {
+          if (createdNativeTabId && snapshot.data.tabs.length > 1) {
+            await browserRuntime.closeTab(snapshot.data.browserSessionId, createdNativeTabId);
+          }
+          return;
+        }
+        synchronizeBrowserSnapshot(snapshot);
+      } catch (error) {
+        if (sidecarRef.current.tabs.some((tab) => tab.id === resource.id)) {
+          setBrowserProvisionErrors((current) => ({ ...current, [resource.id]: errorMessage(error) }));
+        }
+      } finally {
+        if (browserProvisioningResourceIdRef.current === resource.id) {
+          browserProvisioningResourceIdRef.current = "";
+        }
+        setBrowserProvisionEpoch((current) => current + 1);
+      }
+    })();
+  }, [
+    browserProvisionEpoch,
+    browserProvisionErrors,
+    chatStore.browserRuntime,
+    synchronizeBrowserSnapshot,
+    t,
+    unboundBrowserResource,
+  ]);
+
+  useEffect(() => {
+    const resource = sidecarActiveTab?.kind === "browser" ? sidecarActiveTab : undefined;
+    const browserRuntime = chatStore.browserRuntime;
+    if (!resource?.browserSessionId
+      || !resource.nativeTabId
+      || !browserRuntime
+      || browserSnapshot?.data.browserSessionId !== resource.browserSessionId) return;
+    const activationTarget = `${resource.browserSessionId}:${resource.nativeTabId}`;
+    if (browserSnapshot.data.activeTabId === resource.nativeTabId) {
+      if (browserActivationTargetRef.current === activationTarget) {
+        browserActivationTargetRef.current = "";
+      }
+      return;
+    }
+    if (browserActivationTargetRef.current === activationTarget) return;
+    browserActivationTargetRef.current = activationTarget;
+    void browserRuntime.activateTab(resource.browserSessionId, resource.nativeTabId)
+      .then((snapshot) => synchronizeBrowserSnapshot(snapshot))
+      .catch((error) => {
+        if (browserActivationTargetRef.current === activationTarget) {
+          browserActivationTargetRef.current = "";
+        }
+        setBrowserProvisionErrors((current) => ({ ...current, [resource.id]: errorMessage(error) }));
+      });
+  }, [browserSnapshot, chatStore.browserRuntime, sidecarActiveTab, synchronizeBrowserSnapshot]);
+
+  useEffect(() => {
+    writePersistedSidecarWidth(window.localStorage, sidecar.width);
+  }, [sidecar.width]);
+
+
+  const { presentation, width, layoutMotion } = sidecar;
+  useEffect(() => { onLayoutChange({ presentation, width, layoutMotion }); }, [presentation, width, layoutMotion, onLayoutChange]);
+  useImperativeHandle(ref, () => ({
+    toggle() { dispatchSidecar({ type: sidecar.presentation === "closed" ? "presentation.show" : "presentation.hide" }); },
+    openArtifact: handleOpenArtifact,
+    openFileLink: handleOpenAssistantFileLink,
+  }));
+  function hideSidecar() { onHide(); dispatchSidecar({ type: "presentation.hide" }); }
+  async function handleOpenArtifact(artifact: ArtifactRef) {
+    if (!activeSession) {
+      return;
+    }
+    const tabId = sidecarArtifactTabId(activeSession.id, artifact.id);
+    dispatchSidecar({
+      artifactId: artifact.id,
+      threadId: activeSession.id,
+      title: artifact.title,
+      type: "tab.openArtifact",
+    });
+    if (artifact.kind === "data_view") {
+      setArtifactSidecarContent((current) => ({
+        ...current,
+        [tabId]: {
+          artifact,
+          ...(artifact.dataView ? { detail: { id: artifact.id, title: artifact.title, mimeType: artifact.mimeType, dataView: artifact.dataView } } : {}),
+          loading: false,
+          ...(artifact.dataViewError ? { error: artifact.dataViewError } : {}),
+        },
+      }));
+      return;
+    }
+    setArtifactSidecarContent((current) => ({
+      ...current,
+      [tabId]: { artifact, loading: Boolean(chatStore.loadArtifact) },
+    }));
+    if (!chatStore.loadArtifact) {
+      return;
+    }
+    try {
+      const payload = await chatStore.loadArtifact({
+        artifactId: artifact.id,
+        sessionKey: activeSession.id,
+      });
+      const detail = projectLoadedArtifactDetail(artifact, payload);
+      setArtifactSidecarContent((current) => current[tabId]
+        ? { ...current, [tabId]: { ...current[tabId], detail, loading: false } }
+        : current);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setArtifactSidecarContent((current) => current[tabId]
+        ? { ...current, [tabId]: { ...current[tabId], error: message, loading: false } }
+        : current);
+    }
+  }
+
+  async function handleOpenAssistantFileLink(link: AssistantFileLink) {
+    if (!activeSession) {
+      return;
+    }
+
+    let artifact: ArtifactRef;
+    try {
+      artifact = assistantFileArtifact(resolveAssistantFileLink(link.href, activeSession.workingDirectory));
+      logRendererEvent("info", "artifact.file_link.resolved", {
+        href: link.href, path: artifact.fetchPath, sessionId: activeSession.id,
+      });
+    } catch (error) {
+      artifact = assistantFileArtifact({ path: link.href, title: assistantFileLinkTitle(link.href) });
+      const tabId = sidecarArtifactTabId(activeSession.id, artifact.id);
+      dispatchSidecar({
+        artifactId: artifact.id,
+        threadId: activeSession.id,
+        title: artifact.title,
+        type: "tab.openArtifact",
+      });
+      const message = error instanceof AssistantFileLinkError && error.code === "outside_workspace"
+        ? t("details.fileOutsideWorkspace")
+        : errorMessage(error);
+      console.error("[artifact-preview] workspace file link resolution failed", {
+        error,
+        href: link.href,
+        sessionId: activeSession.id,
+        workspaceRoot: activeSession.workingDirectory,
+      });
+      setArtifactSidecarContent((current) => ({
+        ...current,
+        [tabId]: { artifact, error: message, loading: false },
+      }));
+      return;
+    }
+
+    const tabId = sidecarArtifactTabId(activeSession.id, artifact.id);
+    dispatchSidecar({
+      artifactId: artifact.id,
+      threadId: activeSession.id,
+      title: artifact.title,
+      type: "tab.openArtifact",
+    });
+    setArtifactSidecarContent((current) => ({
+      ...current,
+      [tabId]: { artifact, localFile: true, loading: false },
+    }));
+  }
+
+  async function handleCloseSidecarTab(tab: SidecarTab) {
+    if (tab.kind === "browser") {
+      setBrowserProvisionErrors((current) => omitRecordKey(current, tab.id));
+      const browserRuntime = chatStore.browserRuntime;
+      if (!browserRuntime || !tab.browserSessionId || !tab.nativeTabId) {
+        dispatchSidecar({ tabId: tab.id, type: "tab.close" });
+        return;
+      }
+      try {
+        let snapshot = await browserRuntime.snapshot(tab.browserSessionId);
+        const remainingResources = sidecarRef.current.tabs.filter((candidate) => (
+          candidate.kind === "browser"
+            && candidate.threadId === tab.threadId
+            && candidate.id !== tab.id
+        ));
+        if (snapshot.data.tabs.length === 1 && remainingResources.length) {
+          snapshot = await browserRuntime.createTab(snapshot.data.browserSessionId);
+        }
+        if (snapshot.data.tabs.length === 1) {
+          await browserRuntime.closeSession(snapshot.data.browserSessionId);
+          clearBrowserSnapshot(snapshot.data.browserSessionId);
+          dispatchSidecar({ tabId: tab.id, type: "tab.close" });
+          return;
+        }
+        const next = await browserRuntime.closeTab(snapshot.data.browserSessionId, tab.nativeTabId);
+        dispatchSidecar({ tabId: tab.id, type: "tab.close" });
+        synchronizeBrowserSnapshot(next);
+      } catch (error) {
+        setBrowserProvisionErrors((current) => ({ ...current, [tab.id]: errorMessage(error) }));
+      }
+      return;
+    }
+
+    if (tab.kind === "terminal") {
+      setTerminalErrors((current) => omitRecordKey(current, tab.id));
+      try {
+        await chatStore.terminalRuntime?.terminate(tab.id);
+      } catch (error) {
+        setTerminalErrors((current) => ({ ...current, [tab.id]: errorMessage(error) }));
+        return;
+      }
+      dispatchSidecar({ tabId: tab.id, type: "tab.close" });
+      return;
+    }
+
+    dispatchSidecar({ tabId: tab.id, type: "tab.close" });
+    if (tab.kind === "artifact") {
+      setArtifactSidecarContent((current) => omitRecordKey(current, tab.id));
+    }
+  }
+
+  function renderSidecarArtifact(tab: SidecarArtifactTab) {
+    const content = artifactSidecarContent[tab.id];
+    if (!content) {
+      return <p className="react-empty-state">{t("details.noPreview")}</p>;
+    }
+    return (
+      <ArtifactDetails
+        key={tab.id}
+        reviewEpoch={artifactReviewEpoch}
+        responding={sessionResponding}
+        localThreadId={content.localFile ? tab.threadId : undefined}
+        observeFile={sidecar.presentation !== "closed" && tab.threadId === activeSessionId}
+        workspaceStore={workspaceStore}
+        onReference={(reference) => {
+          const id = "artifact:" + tab.id + ":" + reference.detail;
+          onReference({ ...reference, id });
+        }}
+        artifact={content.artifact}
+        detail={content.detail}
+        error={content.error}
+        loading={content.loading}
+        notice={content.notice}
+        office={content.office}
+        onAskForSpreadsheetChange={handleSpreadsheetAskForChange}
+        onOpenFileLink={handleOpenAssistantFileLink}
+      />
+    );
+  }
+
+  function renderSidecarBrowser(tab: SidecarBrowserTab, surfaceVisible: boolean) {
+    return (
+      <SidecarBrowser
+        browserRuntime={chatStore.browserRuntime}
+        externalError={browserProvisionErrors[tab.id] || browserError}
+        snapshot={browserSnapshot?.data.sessionId === tab.threadId ? browserSnapshot : undefined}
+        surfaceVisible={surfaceVisible && !presentDrawer}
+        tab={tab}
+        onHandoffComplete={() => handleBrowserHandoffComplete(tab)}
+        onRetryProvision={() => {
+          clearBrowserError();
+          setBrowserProvisionErrors((current) => omitRecordKey(current, tab.id));
+          setBrowserProvisionEpoch((current) => current + 1);
+        }}
+        onSnapshot={synchronizeBrowserSnapshot}
+      />
+    );
+  }
+
+  function renderSidecarTerminal(tab: SidecarTerminalTab) {
+    return (
+      <Suspense fallback={(
+        <div aria-busy="true" className="react-sidecar__deferred" role="status">
+          <Loader2 aria-hidden="true" size={18} />
+          <span>{t("sidecar.terminalStarting")}</span>
+        </div>
+      )}>
+        <LazySidecarTerminal
+          externalError={terminalErrors[tab.id]}
+          tab={tab}
+          terminalRuntime={chatStore.terminalRuntime}
+          workspaceLabel={activeWorkspaceLabel}
+        />
+      </Suspense>
+    );
+  }
+
+  async function handleBrowserHandoffComplete(tab: SidecarBrowserTab) {
+    if (!activeSession || activeSession.id !== tab.threadId) return;
+    try {
+      await onHandoff(activeSession.id);
+    } catch (error) {
+      reportTimelineError(t("sidecar.browserHandoffFailed", { message: errorMessage(error) }));
+    }
+  }
+
+  return (
+<Sidecar
+        scopeKey={JSON.stringify([activeSessionId, activeWorkspaceId])}
+        activeTabId={sidecarActiveTab?.id ?? ""}
+        canCreateBrowser={Boolean(activeSession)}
+        canCreateTerminal={Boolean(activeWorkspaceId)}
+        presentation={sidecar.presentation}
+        renderArtifact={renderSidecarArtifact}
+        renderBrowser={renderSidecarBrowser}
+        renderTerminal={renderSidecarTerminal}
+        tabs={sidecarTabs}
+        width={sidecar.width}
+        onActivateTab={(tabId) => dispatchSidecar({ tabId, type: "tab.activate" })}
+        onCloseTab={handleCloseSidecarTab}
+        onCreateBrowser={() => dispatchSidecar({ type: "tab.newBrowser" })}
+        onCreateTerminal={(shell) => dispatchSidecar({ shell, type: "tab.newTerminal" })}
+        onHide={hideSidecar}
+        onResize={(width, maxWidth) => dispatchSidecar({ maxWidth, type: "presentation.resize", width })}
+        onToggleExpanded={() => dispatchSidecar({ type: "presentation.toggleExpanded" })}
+      />
+  );
+}
+
+function ArtifactDetails({
+  artifact,
+  detail: storedDetail,
+  error: storedError,
+  loading: storedLoading,
+  notice: storedNotice,
+  office: storedOffice,
+  localThreadId,
+  reviewEpoch,
+  responding,
+  observeFile,
+  workspaceStore,
+  onReference,
+  onAskForSpreadsheetChange,
+  onOpenFileLink,
+}: {
+  artifact: ArtifactRef;
+  detail?: LoadedArtifactDetail;
+  error?: string;
+  loading: boolean;
+  notice?: string;
+  office?: OfficeArtifactSource;
+  localThreadId?: string;
+  reviewEpoch: number;
+  responding: boolean;
+  observeFile: boolean;
+  workspaceStore?: Pick<WorkspaceStore, "readThreadFile" | "readThreadFileBytes" | "artifactReviews">;
+  onReference: (reference: AgentInputReference) => void;
+  onAskForSpreadsheetChange: (artifact: ArtifactRef, request: SpreadsheetCellChangeRequest, revision?: string) => void;
+  onOpenFileLink: (link: AssistantFileLink) => void;
+}) {
+  const { t } = useTranslation("chat");
+  const [refreshKey, setRefreshKey] = useState(0);
+  const file = useArtifactFile({
+    refreshKey,
+    artifact, enabled: Boolean(localThreadId) && observeFile, threadId: localThreadId, workspaceStore,
+    unavailableMessage: t("details.filePreviewUnavailable"), binaryMessage: t("details.binaryFilePreviewUnsupported"),
+  });
+  const { detail, error, loading, office } = localThreadId ? file : { detail: storedDetail, error: storedError, loading: storedLoading, office: storedOffice };
+  const notice = localThreadId ? (file.truncated ? t("details.filePreviewTruncated") : undefined) : storedNotice;
+  function referenceArtifact() {
+    const text = detail?.dataView ? JSON.stringify(detail.dataView) : detail?.textContent;
+    const excerpt = text && text.length > 12000 ? text.slice(0, 12000) + "\n[Preview excerpt truncated]" : text;
+    onReference({
+      kind: "reference", title: artifact.title, detail: t("details.artifactReference"),
+      ...(localThreadId ? { referenceKind: "file", sourcePath: artifact.fetchPath, scope: localThreadId, revision: file.revision } as const : {}),
+      sourceText: [
+        `Artifact: ${artifact.title}`, `Artifact ID: ${artifact.id}`,
+        ...(localThreadId ? [`File: ${artifact.fetchPath}`, `Viewed revision: ${file.revision}`, "Verify the current file before editing; this reference describes the viewed revision."] : []),
+        ...(excerpt ? [excerpt] : []),
+      ].join("\n"),
+    });
+  }
+  const markdown = isMarkdownArtifact(artifact, detail);
+  const markdownContent = detail?.textContent && markdown
+    ? { text: detail.textContent, title: detail.title }
+    : undefined;
+  return (
+    <div className="react-artifact-detail" data-content={markdown || office?.kind === "document" ? "document" : "preview"}>
+      <div className="react-artifact-detail__toolbar">
+        <button disabled={loading || Boolean(error)} onClick={referenceArtifact} type="button">{t("details.referenceInChat")}</button>
+        {localThreadId ? <span role="status">{t("details.fileAutoUpdates")}</span> : null}
+      </div>
+      {localThreadId && artifact.fetchPath && workspaceStore?.artifactReviews ? (
+        <ArtifactReviewPanel store={workspaceStore.artifactReviews} path={artifact.fetchPath} threadId={localThreadId}
+          revision={error ? undefined : file.revision} epoch={reviewEpoch} responding={responding}
+          kind={office?.kind} title={artifact.title} onRestored={() => setRefreshKey((value) => value + 1)} />
+      ) : null}
+      {!markdown && !office ? (
+        <dl>
+          <div><dt>{t("details.id")}</dt><dd>{artifact.id}</dd></div>
+          {detail?.mimeType || artifact.mimeType ? <div><dt>{t("details.type")}</dt><dd>{detail?.mimeType || artifact.mimeType}</dd></div> : null}
+        </dl>
+      ) : null}
+      {loading ? <p aria-live="polite">{t("details.loadingArtifact")}</p> : null}
+      {error ? <p role="alert">{error}</p> : null}
+      {notice ? <p className="react-artifact-detail__notice">{notice}</p> : null}
+      {detail?.imageDataUrl ? <img alt={detail.title} src={detail.imageDataUrl} /> : null}
+      {detail?.dataView ? <DataViewCard artifact={{ ...artifact, dataView: detail.dataView }} expanded /> : null}
+      {office ? (
+        <OfficeArtifactPreview
+          onAskForContentChange={!error && localThreadId && file.revision && artifact.fetchPath ? (request) => {
+            const position = request.start === request.end ? String(request.start) : `${request.start}–${request.end}`;
+            onReference(officeContentReference({ request, path: artifact.fetchPath!, title: artifact.title, threadId: localThreadId, revision: file.revision!,
+              label: t(request.kind === "document" ? "details.officeParagraphSelection" : "details.officeSlideSelection", { position }),
+            }));
+          } : undefined}
+          onAskForChange={error ? undefined : (selection) => onAskForSpreadsheetChange(artifact, selection, file.revision)}
+          source={office}
+        />
+      ) : null}
+      {markdownContent ? (
+        <article aria-label={markdownContent.title} className="react-artifact-detail__document" role="document">
+          <AssistantMarkdown
+            onOpenFileLink={onOpenFileLink}
+            streaming={false}
+            text={markdownContent.text}
+          />
+        </article>
+      ) : detail?.textContent ? <pre className="react-artifact-detail__text">{detail.textContent}</pre> : null}
+      {!loading && !error && !office && !detail?.dataView && !detail?.imageDataUrl && !detail?.textContent ? <p>{t("details.noPreview")}</p> : null}
+    </div>
+  );
+}
+
+function isMarkdownArtifact(artifact: ArtifactRef, detail?: LoadedArtifactDetail): boolean {
+  const mimeType = (detail?.mimeType || artifact.mimeType || "").split(";", 1)[0].trim().toLowerCase();
+  return artifact.kind.toLowerCase() === "markdown" || mimeType === "text/markdown";
+}
+
+function browserResourceTitle(title: string, url: string, fallback: string): string {
+  const normalizedTitle = title.trim();
+  if (normalizedTitle && normalizedTitle !== "about:blank" && normalizedTitle !== "New tab") {
+    return normalizedTitle;
+  }
+  if (!url || url === "about:blank") return fallback;
+  try {
+    return new URL(url).hostname || url;
+  } catch {
+    return url;
+  }
+}
+
+function omitRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in record)) return record;
+  const next = { ...record };
+  delete next[key];
+  return next;
+}
+
+
+function errorMessage(error: unknown): string { return error instanceof Error ? error.message : String(error); }

--- a/src/react-workbench/sidecar/useSidecarBrowserState.test.tsx
+++ b/src/react-workbench/sidecar/useSidecarBrowserState.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import { createNativeBrowserSessionSnapshot } from "../../app-core/native/nativeBrowserSnapshot";
+import type { ChatEvent } from "../services";
+import { useSidecarBrowserState } from "./useSidecarBrowserState";
+afterEach(cleanup);
+  test("does not replace a newer visible Browser snapshot with a stale hidden response", async () => {
+    let listener: ((event: ChatEvent) => void) | undefined;
+    const store = {
+      subscribe: vi.fn((_sessionId: string, nextListener: (event: ChatEvent) => void) => {
+        listener = nextListener;
+        return vi.fn();
+      }),
+    };
+    const { result } = renderHook(() => useSidecarBrowserState(store, "session-1"));
+
+    act(() => listener?.({
+      browserSnapshot: nativeBrowserSnapshot(3, "visible"),
+      type: "browser.snapshot",
+    }));
+    await waitFor(() => expect(result.current.state.browserSnapshot?.data.surface?.lifecycle).toBe("visible"));
+    act(() => listener?.({
+      browserSnapshot: nativeBrowserSnapshot(2, "hidden"),
+      type: "browser.snapshot",
+    }));
+
+    expect(result.current.state.browserSnapshot?.data.surface?.lifecycle).toBe("visible");
+    expect(result.current.state.browserSnapshot?.revision).toBe(3);
+  });
+
+function nativeBrowserSnapshot(revision: number, surfaceLifecycle: "hidden" | "visible") {
+  return createNativeBrowserSessionSnapshot({
+    activeTabId: "browser-tab-1",
+    browserSessionId: "browser-session-1",
+    contract: "browser_session_v1",
+    interaction: { click: true, navigate: true, type: true },
+    kind: "browser_session",
+    lifecycle: "ready",
+    operationId: "browser-operation-1",
+    runtimeKind: "windows_webview2",
+    sessionId: "session-1",
+    state: "running",
+    surface: { layoutRevision: revision, lifecycle: surfaceLifecycle },
+    tabs: [{
+      activeHistoryIndex: 0,
+      captures: [],
+      history: [{ title: "Example", url: "https://example.com" }],
+      loading: false,
+      rendererLifecycle: "running",
+      tabId: "browser-tab-1",
+      title: "Example",
+      url: "https://example.com",
+    }],
+  }, {
+    observedAt: "2026-08-18T08:00:00Z",
+    revision,
+    sourceId: "native-browser:browser-session-1",
+  });
+}

--- a/src/react-workbench/sidecar/useSidecarBrowserState.ts
+++ b/src/react-workbench/sidecar/useSidecarBrowserState.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { NativeBrowserSnapshot, NativeBrowserSession } from "../../app-core/native/nativeBrowserSnapshot";
+import type { ChatStore } from "../services";
+import { subscribeChatEvents } from "../chat/chatEventSource";
+
+type Snapshot = NativeBrowserSnapshot<NativeBrowserSession>;
+export function useSidecarBrowserState(chatStore: Pick<ChatStore, "subscribe">, sessionId: string) {
+  const [state, setState] = useState<{ browserError: string; browserSnapshot?: Snapshot }>({ browserError: "" });
+  const owner = useRef(sessionId);
+  useLayoutEffect(() => { owner.current = sessionId; }, [sessionId]);
+  const acceptBrowserSnapshot = useCallback((snapshot: Snapshot) => {
+    if (owner.current && snapshot.data.sessionId !== owner.current) {
+      throw new Error(`Browser snapshot session ${snapshot.data.sessionId} does not match active session ${owner.current}.`);
+    }
+    setState((current) => {
+      const previous = current.browserSnapshot;
+      if (previous?.sourceId === snapshot.sourceId && typeof previous.revision === "number"
+        && typeof snapshot.revision === "number" && snapshot.revision < previous.revision) return current;
+      return { browserError: "", browserSnapshot: snapshot };
+    });
+  }, []);
+  const clearBrowserSnapshot = useCallback((browserSessionId?: string) => {
+    setState((current) => browserSessionId && current.browserSnapshot?.data.browserSessionId !== browserSessionId
+      ? current : { browserError: "" });
+  }, []);
+  const clearBrowserError = useCallback(() => setState((current) => ({ ...current, browserError: "" })), []);
+  useEffect(() => {
+    setState({ browserError: "" });
+    if (!sessionId) return;
+    return subscribeChatEvents(chatStore, sessionId, (event) => {
+      if (!event.browserSnapshot) return;
+      try { acceptBrowserSnapshot(event.browserSnapshot); }
+      catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error("[sidecar] browser-snapshot.apply.failed", { sessionId, error: message });
+        setState((current) => ({ ...current, browserError: message }));
+      }
+    });
+  }, [acceptBrowserSnapshot, chatStore, sessionId]);
+  return { state, acceptBrowserSnapshot, clearBrowserSnapshot, clearBrowserError };
+}


### PR DESCRIPTION
Chat submission, queueing, cancellation, session data, and Sidecar resources were coordinated by ChatPage and defaultServices. This change moves state together with its operations into dedicated Chat and Sidecar modules, so changing queue or cancellation behavior no longer requires understanding browser lifecycle or page layout.

- Centralize turn queues, interruption, form commands, and transport/canonical acknowledgements in the Chat turn application.
- Move submission preparation, optimistic messages, model-save ordering, compaction, and native fork/dispatch behavior into Chat modules.
- Give Sidecar ownership of browser, terminal, and Artifact resources; share native event subscriptions without sending browser snapshots through page state.
- Move session data, optimistic titles, per-draft creation promises, and persisted-ID reconciliation into the session application.
- Coordinate active/background events, capability queries, command confirmation, and client-state cleanup inside the Chat application. Keep tab selection, focus, scroll, menus, and layout in the page, and retain the Timeline model as the authority for server-state projections.

ChatPage decreases from 3,077 to 1,492 lines. The initial queue migration and each of the four subsequent migrations are separate commits.

Validation: full frontend test suite and production build passed for each migration commit; targeted TypeScript and ESLint checks passed. Regression tests cover queue/event ordering, concurrent submissions, failures, session reconciliation, background acknowledgements, and stale capability responses. Render-count tests verify that queue deletion and browser snapshot updates add no Timeline renders.