### PR TITLE
Fix update notes typography to match Chat

### DIFF
--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,8 +1,12 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:ba3b2e5b521fd168c4596b8de00d3368fa7a90013466fea5ddeca97e35cd6940 -->
+<!-- tinybot-module-fingerprint: sha256:f8c4cf133bf8ae5d8c220a1e75fff7a2495296ef154d3c33d44f20a464225cd1 -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.
+
+Update notes and upgrade notices use 13px body text, matching Chat. Their
+Markdown selectors reach through the viewport wrapper, keeping compact headings
+and list spacing effective in both the update prompt and saved release notes.
 
 Session sidebar width uses a renderer-owned CSS variable. Its 8 px resize target
 highlights on hover and focus, with increasing emphasis past the minimum width.

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -624,38 +624,38 @@ button:disabled {
   padding: 11px 13px;
 }
 
-.desktop-update-dialog__notice strong,
+.desktop-update-dialog__notice > strong,
 .desktop-update-dialog__notes h3 {
   color: var(--color-ink);
   font-size: 12px;
   font-weight: 700;
 }
 
-.desktop-update-dialog__notice > .react-message-markdown,
-.desktop-update-dialog__notes > .react-message-markdown,
+.desktop-update-dialog__notice .react-message-markdown,
+.desktop-update-dialog__notes .react-message-markdown,
 .desktop-update-dialog__notes > p {
   margin-top: 6px;
   color: var(--color-body);
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1.6;
   overflow-wrap: anywhere;
 }
 
-.desktop-update-dialog__notice > .react-message-markdown,
-.desktop-update-dialog__notes > .react-message-markdown {
+.desktop-update-dialog__notice .react-message-markdown,
+.desktop-update-dialog__notes .react-message-markdown {
   gap: 6px;
 }
 
-.desktop-update-dialog__notice > .react-message-markdown [data-streamdown^="heading-"],
-.desktop-update-dialog__notes > .react-message-markdown [data-streamdown^="heading-"] {
+.desktop-update-dialog__notice .react-message-markdown [data-streamdown^="heading-"],
+.desktop-update-dialog__notes .react-message-markdown [data-streamdown^="heading-"] {
   font-size: 13px;
   line-height: 1.4;
 }
 
-.desktop-update-dialog__notice > .react-message-markdown ul,
-.desktop-update-dialog__notice > .react-message-markdown ol,
-.desktop-update-dialog__notes > .react-message-markdown ul,
-.desktop-update-dialog__notes > .react-message-markdown ol {
+.desktop-update-dialog__notice .react-message-markdown ul,
+.desktop-update-dialog__notice .react-message-markdown ol,
+.desktop-update-dialog__notes .react-message-markdown ul,
+.desktop-update-dialog__notes .react-message-markdown ol {
   gap: 3px;
   padding-left: 18px;
 }


### PR DESCRIPTION
Update notes inherited oversized body text because the Markdown viewport wrapper prevented direct-child CSS selectors from matching. Use descendant selectors so update prompts and saved release notes apply 13px body text, matching Chat, with compact headings and list spacing. Scope the notice label styling to its own label so bold Markdown text keeps the body size.

Validation:
- Browser check of the rendered update dialog: Chat body, release notes, headings, notice text, and bold notice text all compute to 13px.
- All 6 existing update-dialog tests passed.
- Full frontend tests and production build passed through the commit hook.
- Documentation freshness and whitespace checks passed.
