### PR TITLE
Improve chat rendering performance and composer interactions

### DIFF
--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:7f1b018f55e22b1783c02b59a9529df55fd533af82722c802d03b29b84e1c24e -->
+<!-- tinybot-doc-fingerprint: sha256:15106782b9da8b347c4b20b6ebddfede06c29128e17ab40b951f462bd74838fa -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -26,7 +26,11 @@ conversation state, and process lifecycle.
 The Chat application owns client submission preparation, optimistic messages,
 queue and command coordination. Native Chat command orchestration is injected
 by the renderer composition root; canonical conversation projection remains
-owned by the existing Timeline model.
+owned by the existing Timeline model. Item patches reproject only the changed
+Turn and preserve historical references. Streaming content is published through
+a session-scoped source consumed by the Timeline view; the Chat route subscribes
+to stable lifecycle, plan and usage summaries. Content commits retain scroll
+following and restoration without rerendering the composer on each text update.
 
 Chat can release offscreen Markdown and chart renderers while retaining message
 interaction owners and semantic scroll anchors. The native browser owns idle

--- a/src/app-core/chat/README.md
+++ b/src/app-core/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Application Core
-<!-- tinybot-module-fingerprint: sha256:054a43dd0a3ff608912c2d281e7924838eeb48c4648c2a7359134cba4b8248c6 -->
+<!-- tinybot-module-fingerprint: sha256:1a1835b15d2ba86ab76afc9d64f4d005ca35ee5ac1564fd130d18cc769213a82 -->
 
 `chat` contains framework-independent chat and Thread contracts, command
 construction, canonical timeline validation, UI projection, input state, and
@@ -9,6 +9,16 @@ Persisted input references use `referenceKind` to distinguish ordinary file
 attachments, managed images, referenced Threads, and browser evidence. Image references preserve their local path,
 MIME type, byte size, and content hash through canonical timeline projection;
 they never store an encoded payload.
+
+`agentTimelineModel` caches each published snapshot. An accepted Item patch
+reprojects only its Turn, retaining unchanged historical Turn references and
+inserting the changed Turn into canonical start order. Live Item revisions can
+advance without changing the durable snapshot revision, so cache invalidation
+tracks Item-array changes rather than the durable revision alone. Duplicate or
+stale patches reuse the snapshot; full loads replace the cache. Hook results are
+projected on load because Item patches do not change runtime events.
+`agentTimelineModel.performance.test.ts` checks a 250-Turn history under 30
+streaming updates and reports elapsed projection time without a timing gate.
 
 The module does not render React views or invoke Tauri directly. Renderer code
 consumes these interfaces from `react-workbench/chat`, while native transport

--- a/src/app-core/chat/agentTimelineModel.performance.test.ts
+++ b/src/app-core/chat/agentTimelineModel.performance.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import { createAgentTimelineModel } from "./agentTimelineModel";
+
+// Deterministic work-count assertion; timings are reported, never used as a flaky gate.
+test("streaming patches preserve history and only project the changed turn", () => {
+  const sessionId = "performance";
+  const turnCount = 250;
+  const patchCount = 30;
+  const states = Array.from({ length: turnCount }, (_, index) => ({
+    runtimeEvents: [],
+    timeline: {
+      schemaVersion: "tinybot.timeline.v2", sessionId, turnId: `turn-${index}`, snapshotRevision: 1,
+      items: [{
+        schemaVersion: "tinybot.turn_item.v2", sessionId, turnId: `turn-${index}`,
+        itemId: `answer-${index}`, sequence: 1, revision: 1, kind: "assistant_message",
+        status: index === turnCount - 1 ? "running" : "completed",
+        createdAt: new Date(Date.UTC(2026, 0, 1) + index * 1000).toISOString(),
+        data: { type: "assistant_message", messageId: `answer-${index}`, modelCallId: `call-${index}`,
+          phase: "final_answer", content: "History with a code block.\n```ts\nconst result = 42;\n```\n".repeat(8) },
+      }],
+    },
+  }));
+  const model = createAgentTimelineModel();
+  let previous = model.load(sessionId, states);
+  const original = previous;
+  const active = states[turnCount - 1].timeline;
+  let changedTurns = 0;
+  const start = performance.now();
+  for (let index = 0; index < patchCount; index += 1) {
+    const next = model.applyPatch(sessionId, {
+      schemaVersion: "tinybot.timeline_patch.v2", sessionId, turnId: active.turnId,
+      snapshotRevision: 1,
+      item: { ...active.items[0], revision: index + 2,
+        data: { ...active.items[0].data, content: `Streaming ${index}` } },
+    });
+    changedTurns += next.turns.filter((turn, offset) => turn !== previous.turns[offset]).length;
+    previous = next;
+  }
+  console.info("[chat-performance] timeline", {
+    turnCount, patchCount, changedTurns, patchMs: Math.round((performance.now() - start) * 100) / 100,
+  });
+  expect(previous.turns[turnCount - 1]?.finalAnswer?.text).toBe("Streaming 29");
+  expect(original.turns[turnCount - 1]?.finalAnswer?.text).toContain("History");
+  expect(changedTurns).toBe(patchCount);
+});

--- a/src/app-core/chat/agentTimelineModel.test.ts
+++ b/src/app-core/chat/agentTimelineModel.test.ts
@@ -642,3 +642,35 @@ describe("canonical agent timeline model", () => {
     ]);
   });
 });
+
+
+test("retains cached snapshots for duplicate and stale live patches", () => {
+  const model = createAgentTimelineModel();
+  const initial = model.load(sessionId, [runtimeState(1, [item({ revision: 3 })])]);
+  expect(model.snapshot(sessionId)).toBe(initial);
+  expect(model.applyPatch(sessionId, patch(1, { revision: 3 }))).toBe(initial);
+  expect(model.applyPatch(sessionId, patch(1, { revision: 2 }))).toBe(initial);
+  const revisionOnly = model.applyPatch(sessionId, patch(2, { revision: 2 }));
+  expect(revisionOnly.turns).toBe(initial.turns);
+  expect(revisionOnly.turnRevisions[turnId]).toBe(2);
+  expect(revisionOnly.diagnostics).toHaveLength(1);
+  expect(initial.diagnostics).toHaveLength(0);
+});
+
+test("inserts newly discovered earlier turns in canonical order and replaces the cache on reload", () => {
+  const model = createAgentTimelineModel();
+  const initial = model.load(sessionId, [runtimeState()]);
+  const earlier = model.applyPatch(sessionId, {
+    ...patch(1), turnId: "earlier",
+    item: item({ turnId: "earlier", itemId: "earlier-answer", createdAt: "2026-07-10T00:00:00Z" }),
+  });
+  expect(earlier.turns.map((turn) => turn.id)).toEqual(["earlier", turnId]);
+  expect(earlier.turns[1]).toBe(initial.turns[0]);
+  const reloaded = model.load(sessionId, [runtimeState(1, [item({ revision: 4,
+    data: { type: "assistant_message", messageId: "assistant-1", modelCallId: "call-1", phase: "final_answer", content: "Reloaded answer" },
+  })])]);
+  expect(model.snapshot(sessionId)).toBe(reloaded);
+  expect(reloaded.turns).toHaveLength(1);
+  expect(reloaded.turns[0].finalAnswer?.text).toBe("Reloaded answer");
+  expect(initial.turns[0]).not.toBe(reloaded.turns[0]);
+});

--- a/src/app-core/chat/agentTimelineModel.ts
+++ b/src/app-core/chat/agentTimelineModel.ts
@@ -1,4 +1,4 @@
-import { projectBackendTimeline } from "./chatProjection";
+import { compareRuntimeStatesByStart, projectBackendTimeline } from "./chatProjection";
 import {
   normalizeAgentTurnRuntimeStatePayload,
   normalizeAgentTimelinePatchPayload,
@@ -63,6 +63,7 @@ export class TimelineItemIdentityConflictError extends Error {
 type SessionTimelineState = {
   diagnostics: TimelineDiagnostic[];
   turns: Map<string, BackendAgentTurnRuntimeState>;
+  snapshot: ChatTimelineSnapshot;
 };
 
 export function createAgentTimelineModel(): AgentTimelineModel {
@@ -82,8 +83,10 @@ export function createAgentTimelineModel(): AgentTimelineModel {
         }
         turns.set(timeline.turnId, runtimeState);
       }
-      sessions.set(sessionId, { diagnostics: [], turns });
-      return projectSessionSnapshot(sessionId, sessions.get(sessionId)!);
+      const state = { diagnostics: [], turns, snapshot: emptyTimelineSnapshot(sessionId) };
+      state.snapshot = projectSessionSnapshot(sessionId, state);
+      sessions.set(sessionId, state);
+      return state.snapshot;
     },
 
     applyPatch(sessionId, patchPayload) {
@@ -95,8 +98,35 @@ export function createAgentTimelineModel(): AgentTimelineModel {
       if (!session) {
         throw new Error(`Canonical timeline session ${sessionId} has not been loaded`);
       }
+      const previous = session.turns.get(patch.turnId);
+      const previousItems = previous?.timeline.items;
+      const previousRevision = previous?.timeline.snapshotRevision;
       applyPatchToSession(session, patch);
-      return projectSessionSnapshot(sessionId, session);
+      const current = session.turns.get(patch.turnId)!;
+      if (previousItems === current.timeline.items && previousRevision === current.timeline.snapshotRevision) {
+        return session.snapshot;
+      }
+      const snapshot = session.snapshot;
+      let projectedTurns = snapshot.turns;
+      if (previousItems !== current.timeline.items) {
+        const projected = projectBackendTimeline(sessionId, [current])[0];
+        projectedTurns = snapshot.turns.filter((turn) => turn.id !== patch.turnId);
+        // Existing history is already ordered. Insert only the changed turn; text
+        // patches normally compare once against the last historical turn.
+        let insertion = projectedTurns.length;
+        while (insertion > 0 && compareRuntimeStatesByStart(
+          session.turns.get(projectedTurns[insertion - 1].id)!, current,
+        ) > 0) insertion -= 1;
+        projectedTurns.splice(insertion, 0, projected);
+      }
+      session.snapshot = {
+        ...snapshot,
+        turns: projectedTurns,
+        turnRevisions: { ...snapshot.turnRevisions, [patch.turnId]: current.timeline.snapshotRevision },
+        diagnostics: session.diagnostics.length === snapshot.diagnostics.length
+          ? snapshot.diagnostics : [...session.diagnostics],
+      };
+      return session.snapshot;
     },
 
     snapshot(sessionId) {
@@ -104,7 +134,7 @@ export function createAgentTimelineModel(): AgentTimelineModel {
       if (!session) {
         return emptyTimelineSnapshot(sessionId);
       }
-      return projectSessionSnapshot(sessionId, session);
+      return session.snapshot;
     },
   };
 }

--- a/src/app-core/chat/chatProjection.ts
+++ b/src/app-core/chat/chatProjection.ts
@@ -88,7 +88,7 @@ export function projectBackendTimeline(
   return statesWithItems.map((runtimeState) => runtimeStateToTurn(sessionKey, runtimeState));
 }
 
-function compareRuntimeStatesByStart(left: BackendAgentTurnRuntimeState, right: BackendAgentTurnRuntimeState): number {
+export function compareRuntimeStatesByStart(left: BackendAgentTurnRuntimeState, right: BackendAgentTurnRuntimeState): number {
   return compareRuntimeTimestamps(runtimeStateStart(left), runtimeStateStart(right))
     || left.timeline.turnId.localeCompare(right.timeline.turnId);
 }

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -1,5 +1,5 @@
 # Shared UI
-<!-- tinybot-module-fingerprint: sha256:e1b0e1938512b83adffa3dfef0ef579c98a4d9772bb207da3560719bbf48f810 -->
+<!-- tinybot-module-fingerprint: sha256:600d28e10da55787f8bc2adbc34c676ffa7b42877bcdb28d1fa137a69ad231cf -->
 
 `components/ui` contains reusable renderer UI whose interface is not owned by
 a single route. It includes the shared chat composer, file metadata formatting,
@@ -22,6 +22,11 @@ existing incompatible image blocks sending after a model switch until the user
 removes it or selects an image-capable model.
 Its slash listbox combines route-provided executable commands with searchable
 Skill options, including shared arrow-key, Enter/Tab, and Escape behavior.
+Shift+Enter inserts a newline in both editor variants, including while slash or
+mention suggestions are open. Enter selects an active suggestion or sends the
+draft with its internal line breaks preserved.
+The inline editor renders a display-only trailing break after a terminal newline
+so the blank line and caret remain visible without adding text to the draft.
 Any slash immediately behind the caret starts or resets the active query; typing
 continues filtering until the query is dismissed or the caret leaves it.
 Selected Skills render as atomic removable tokens inline with editable user

--- a/src/components/ui/claude-style-ai-input.test.tsx
+++ b/src/components/ui/claude-style-ai-input.test.tsx
@@ -42,6 +42,46 @@ const skillOptions = [
 
 afterEach(cleanup);
 
+describe("composer multiline keyboard input", () => {
+  it.each([
+    [false, "Hello"],
+    [true, "Hello"],
+    [false, "/comp"],
+    [true, "/comp"],
+    [false, "@arch"],
+    [true, "@arch"],
+  ] as const)("inserts a newline before sending with inline=%s and draft=%s", async (inline, draft) => {
+    const user = userEvent.setup();
+    const onSendMessage = vi.fn();
+    const onAddSessionMention = vi.fn();
+    render(<ClaudeStyleAiInput
+      onSendMessage={onSendMessage}
+      onAddSessionMention={onAddSessionMention}
+      sessionMentionOptions={[{ id: "thread-1", label: "Architecture review", detail: "Current project" }]}
+      slashCommands={[{
+        command: "/compact",
+        description: "Compact context",
+        label: "Compact",
+        prompt: "/compact",
+        submitOnSelect: true,
+      }]}
+      {...(inline ? { skillOptions, onAddSkill: vi.fn() } : {})}
+    />);
+    const input = screen.getByRole("textbox", { name: "Message" });
+    await user.type(input, draft);
+    if (draft !== "Hello") expect(screen.getByRole("listbox")).toBeTruthy();
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(inline ? input.textContent : (input as HTMLTextAreaElement).value).toBe(`${draft}\n`);
+    expect(onSendMessage).not.toHaveBeenCalled();
+    expect(onAddSessionMention).not.toHaveBeenCalled();
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(inline ? input.textContent : (input as HTMLTextAreaElement).value).toBe(`${draft}\n\n`);
+    await user.keyboard("Second line{Enter}");
+    expect(onSendMessage).toHaveBeenCalledOnce();
+    expect(onSendMessage.mock.calls[0][0]).toBe(`${draft}\n\nSecond line`);
+  });
+});
+
 describe("composer file drop and paste", () => {
   const file = new File(["image"], "diagram.png", { type: "image/png" });
   const attachment = { name: file.name, path: "managed/diagram.png", mimeType: file.type, sizeBytes: file.size };

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -644,6 +644,14 @@ export function ClaudeStyleAiInput({
   }
 
   function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement | HTMLDivElement>) {
+    if (event.key === "Enter" && event.shiftKey) {
+      if (event.currentTarget instanceof HTMLDivElement) {
+        event.preventDefault();
+        insertPlainTextAtSelection(event.currentTarget, "\n");
+        syncInlineEditorInput();
+      }
+      return;
+    }
     if (event.currentTarget instanceof HTMLDivElement && removeAdjacentInlineSkill(event as KeyboardEvent<HTMLDivElement>)) {
       return;
     }
@@ -688,13 +696,7 @@ export function ClaudeStyleAiInput({
         return;
       }
     }
-    if (event.key === "Enter" && event.shiftKey && event.currentTarget instanceof HTMLDivElement) {
-      event.preventDefault();
-      insertPlainTextAtSelection(event.currentTarget, "\n");
-      syncInlineEditorInput();
-      return;
-    }
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (event.key === "Enter") {
       event.preventDefault();
       event.currentTarget.closest("form")?.requestSubmit();
     }
@@ -1634,6 +1636,12 @@ function renderInlineComposerDom(
   }
 
   if (textOffset < message.length) fragment.append(document.createTextNode(message.slice(textOffset)));
+  if (fragment.lastChild?.nodeType === Node.TEXT_NODE && fragment.lastChild.textContent?.endsWith("\n")) {
+    // A terminal newline needs a following line box for the editable caret.
+    const trailingBreak = document.createElement("br");
+    trailingBreak.dataset.composerTrailingBreak = "true";
+    fragment.append(trailingBreak);
+  }
   editor.replaceChildren(fragment);
 }
 
@@ -1691,6 +1699,7 @@ function readInlineComposerContent(root: Node): {
     }
     if (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE) return;
     const element = node.nodeType === Node.ELEMENT_NODE ? node as HTMLElement : undefined;
+    if (element?.dataset.composerTrailingBreak) return;
     const skillId = element?.dataset.composerSkillId;
     if (skillId) {
       placements.push({ id: skillId, offset: message.length });

--- a/src/react-workbench/chat/AssistantMarkdown.test.tsx
+++ b/src/react-workbench/chat/AssistantMarkdown.test.tsx
@@ -18,16 +18,46 @@ afterEach(() => {
 });
 
 describe("AssistantMarkdown", () => {
-  it("repairs incomplete Markdown without per-token animation", async () => {
+  it("repairs incomplete Markdown and removes animation wrappers after completion", async () => {
     const { container, rerender } = render(<AssistantMarkdown streaming text="Checking **the current state" />);
 
     expect(container.querySelector("strong")?.textContent).toBe("the current state");
-    expect(container.querySelector("[data-sd-animate]")).toBeNull();
+    expect(container.querySelector("[data-sd-animate]")).not.toBeNull();
 
     rerender(<AssistantMarkdown streaming={false} text="Checking **the current state**" />);
 
     expect(container.querySelector("strong")?.textContent).toBe("the current state");
     expect(container.querySelector("[data-sd-animate]")).toBeNull();
+  });
+
+  it("fades only appended Chinese text and keeps existing character nodes", async () => {
+    const { container, rerender } = render(<AssistantMarkdown streaming text="正在检查" />);
+    const old = Array.from(container.querySelectorAll<HTMLElement>("[data-sd-animate]"));
+    expect(old).toHaveLength(4);
+    rerender(<AssistantMarkdown streaming text="正在检查新增内容" />);
+    await waitFor(() => expect(container.textContent).toBe("正在检查新增内容"));
+    const spans = Array.from(container.querySelectorAll<HTMLElement>("[data-sd-animate]"));
+    expect(spans).toHaveLength(8);
+    old.forEach((node, index) => {
+      expect(spans[index]).toBe(node);
+      expect(node.style.getPropertyValue("--sd-duration")).toBe("0ms");
+    });
+    spans.slice(4).forEach((node) => {
+      expect(node.style.getPropertyValue("--sd-animation")).toBe("sd-fadeIn");
+      expect(node.style.getPropertyValue("--sd-duration")).toBe("160ms");
+      expect(node.style.getPropertyValue("--sd-delay")).toBe("");
+    });
+  });
+
+  it("fades a new paragraph without replaying the preceding paragraph", async () => {
+    const { container, rerender } = render(<AssistantMarkdown streaming text="已有内容" />);
+    const first = container.querySelector("p");
+    rerender(<AssistantMarkdown streaming text={"已有内容\n\n新的段落"} />);
+    await waitFor(() => expect(container.querySelectorAll("p")).toHaveLength(2));
+    expect(container.querySelector("p")).toBe(first);
+    const spans = Array.from(container.querySelectorAll<HTMLElement>("p:last-child [data-sd-animate]"));
+    expect(spans).toHaveLength(4);
+    spans.forEach((node) => expect(node.style.getPropertyValue("--sd-duration")).toBe("160ms"));
   });
 
   it("renders common technical Markdown and CJK-adjacent emphasis", async () => {

--- a/src/react-workbench/chat/AssistantMarkdown.tsx
+++ b/src/react-workbench/chat/AssistantMarkdown.tsx
@@ -7,6 +7,7 @@ import type { Extension, Handle } from "mdast-util-from-markdown";
 import type { Processor } from "unified";
 import {
   Streamdown,
+  type AnimateOptions,
   type Components,
   type ControlsConfig,
   defaultRemarkPlugins,
@@ -17,6 +18,13 @@ import {
 import "streamdown/styles.css";
 import { isAssistantFileHref, type AssistantFileLink } from "./assistantFileLinks";
 import { ViewportContent } from "./ViewportContent";
+
+// Character boundaries keep appended CJK text incremental, too. No staggered
+// delay: a streamed chunk becomes readable immediately and fades together.
+const ASSISTANT_TEXT_FADE = {
+  animation: "fadeIn", duration: 160, easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+  sep: "char", stagger: 0,
+} satisfies AnimateOptions;
 
 const ASSISTANT_MARKDOWN_CONTROLS = {
   code: { copy: true, download: false },
@@ -216,12 +224,12 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
     <ViewportContent pinned={streaming} placeholder={text}
       estimatedHeight={Math.max(48, Math.ceil(text.length / 80) * 24)}>
     <Streamdown
-      animated={false}
+      animated={streaming ? ASSISTANT_TEXT_FADE : false}
       className="react-message-markdown"
       components={components}
       controls={ASSISTANT_MARKDOWN_CONTROLS}
       disallowedElements={DISALLOWED_ASSISTANT_ELEMENTS}
-      isAnimating={false}
+      isAnimating={streaming}
       key={streaming ? "streaming" : "complete"}
       lineNumbers={false}
       linkSafety={ASSISTANT_MARKDOWN_LINK_SAFETY}

--- a/src/react-workbench/chat/ChatPage.streaming-performance.test.tsx
+++ b/src/react-workbench/chat/ChatPage.streaming-performance.test.tsx
@@ -32,7 +32,7 @@ test("streaming text updates the answer without rerendering the composer or hist
   let receive!: (event: ChatEvent) => void;
   stores.chatStore.subscribe = vi.fn((session, listener) => { if (session === "s1") receive = listener; return () => {}; });
   render(<ChatPageUnderTest {...stores} />);
-  await screen.findByText("Streaming 0");
+  await waitFor(() => expect(screen.getByTestId("message-active-answer").textContent).toContain("Streaming 0"));
   await act(async () => {});
   // Establish the running session boundary before measuring text-only updates.
   act(() => receive({ type: "agent_timeline_updated", timeline: snapshot }));
@@ -47,7 +47,7 @@ test("streaming text updates the answer without rerendering the composer or hist
       turns: [history, { ...active, finalAnswer: { ...active.finalAnswer, text: `Streaming 0${".".repeat(index)}` } }],
     } }));
     await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
-    await waitFor(() => expect(screen.getByText(`Streaming 0${".".repeat(index)}`)).toBeTruthy());
+    await waitFor(() => expect(screen.getByTestId("message-active-answer").textContent).toContain(`Streaming 0${".".repeat(index)}`));
   }
   const counts = { composer: renders.composer - before.composer,
     historicalMarkdown: renders.historicalMarkdown - before.historicalMarkdown };
@@ -65,7 +65,7 @@ test("streaming text updates the answer without rerendering the composer or hist
   act(() => receive({ type: "timeline.patch", timeline: { ...snapshot,
     turns: [history, { ...active, finalAnswer: { ...active.finalAnswer, text: "Streaming 0......" } }],
   } }));
-  await screen.findByText("Streaming 0......");
+  await waitFor(() => expect(screen.getByTestId("message-active-answer").textContent).toContain("Streaming 0......"));
   expect(scroll.mock.instances.filter((element) => element === end)).toHaveLength(0);
   expect(view.scrollTop).toBe(500);
   act(() => receive({ type: "timeline.patch", timeline: { ...snapshot,

--- a/src/react-workbench/chat/ChatPage.streaming-performance.test.tsx
+++ b/src/react-workbench/chat/ChatPage.streaming-performance.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+import type { ChatEvent } from "../services";
+import { ChatPageUnderTest, createStores } from "./test/ChatPageTestHarness";
+
+const renders = vi.hoisted(() => ({ composer: 0, historicalMarkdown: 0 }));
+vi.mock("../../components/ui/claude-style-ai-input", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../components/ui/claude-style-ai-input")>();
+  return { ...original, ClaudeStyleAiInput: (props: Parameters<typeof original.ClaudeStyleAiInput>[0]) => {
+    renders.composer += 1;
+    return <original.ClaudeStyleAiInput {...props} />;
+  } };
+});
+vi.mock("./AssistantMarkdown", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./AssistantMarkdown")>();
+  return { ...original, AssistantMarkdown: (props: Parameters<typeof original.AssistantMarkdown>[0]) => {
+    if (props.text === "Historical answer") renders.historicalMarkdown += 1;
+    return <original.AssistantMarkdown {...props} />;
+  } };
+});
+
+test("streaming text updates the answer without rerendering the composer or history", async () => {
+  const stores = createStores();
+  const initial = await stores.chatStore.load("s1");
+  const history = { ...initial.turns[0], id: "history", status: "completed" as const,
+    finalAnswer: { id: "historical-answer", role: "assistant" as const, text: "Historical answer", timestamp: "2026-01-01" } };
+  const active = { ...initial.turns[0], id: "active", status: "running" as const,
+    finalAnswer: { ...history.finalAnswer, id: "active-answer", text: "Streaming 0" } };
+  const snapshot = { ...initial, turns: [history, active] };
+  vi.mocked(stores.chatStore.load).mockResolvedValue(snapshot);
+  let receive!: (event: ChatEvent) => void;
+  stores.chatStore.subscribe = vi.fn((session, listener) => { if (session === "s1") receive = listener; return () => {}; });
+  render(<ChatPageUnderTest {...stores} />);
+  await screen.findByText("Streaming 0");
+  await act(async () => {});
+  // Establish the running session boundary before measuring text-only updates.
+  act(() => receive({ type: "agent_timeline_updated", timeline: snapshot }));
+  await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+  const before = { ...renders };
+  const scroll = vi.spyOn(Element.prototype, "scrollIntoView");
+  const view = document.querySelector<HTMLElement>(".react-conversation-view")!;
+  const end = view.lastElementChild;
+  scroll.mockClear();
+  for (let index = 1; index <= 5; index += 1) {
+    act(() => receive({ type: "agent_timeline_updated", timeline: { ...snapshot,
+      turns: [history, { ...active, finalAnswer: { ...active.finalAnswer, text: `Streaming 0${".".repeat(index)}` } }],
+    } }));
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+    await waitFor(() => expect(screen.getByText(`Streaming 0${".".repeat(index)}`)).toBeTruthy());
+  }
+  const counts = { composer: renders.composer - before.composer,
+    historicalMarkdown: renders.historicalMarkdown - before.historicalMarkdown };
+  console.info("[chat-performance] rendering", { frames: 5, ...counts });
+  expect(counts).toEqual({ composer: 0, historicalMarkdown: 0 });
+  expect(scroll.mock.instances.filter((element) => element === end)).toHaveLength(5);
+  Object.defineProperties(view, {
+    scrollHeight: { configurable: true, value: 2000 },
+    clientHeight: { configurable: true, value: 600 },
+    scrollTop: { configurable: true, writable: true, value: 500 },
+  });
+  fireEvent.scroll(view);
+  await act(async () => {});
+  scroll.mockClear();
+  act(() => receive({ type: "timeline.patch", timeline: { ...snapshot,
+    turns: [history, { ...active, finalAnswer: { ...active.finalAnswer, text: "Streaming 0......" } }],
+  } }));
+  await screen.findByText("Streaming 0......");
+  expect(scroll.mock.instances.filter((element) => element === end)).toHaveLength(0);
+  expect(view.scrollTop).toBe(500);
+  act(() => receive({ type: "timeline.patch", timeline: { ...snapshot,
+    turns: [history, { ...active, status: "completed", finalAnswer: { ...active.finalAnswer, text: "Final answer" } }],
+  } }));
+  expect(await screen.findByText("Final answer")).toBeTruthy();
+  expect(view.querySelector('[data-scroll-anchor="turn:active"]')?.getAttribute("data-status")).toBe("completed");
+  expect(view.scrollTop).toBe(500);
+  scroll.mockRestore();
+});

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -779,7 +779,7 @@ describe("ChatPage", () => {
     expect(requestFrame).toHaveBeenCalledTimes(1);
     expect(screen.queryByText("AB")).toBeNull();
     act(() => frame?.(0));
-    expect(await screen.findByText("AB")).toBeTruthy();
+    expect((await screen.findByTestId("message-a-stream-frame")).textContent).toContain("AB");
     requestFrame.mockRestore();
   });
 

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -45,7 +45,6 @@ import type { ToolCallSummary } from "./messageActions";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import { AgentUiFormCard } from "./AgentUiFormCard";
 import {
-  projectLatestContextUsage,
   type ContextUsageDefaults,
 } from "./chatContextUsage";
 import { SessionTabStrip, type SessionTabItem } from "./SessionTabStrip";
@@ -73,7 +72,6 @@ import {
 } from "../../app-core/chat/officeArtifact";
 import type { AgentInputReference } from "../../app-core/chat/agentInputReference";
 import { logRendererEvent } from "../../app-core/native/rendererLogger";
-import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
 import {
   isThreadCommandInFlight,
   type ThreadCommandLifecycle,
@@ -83,7 +81,7 @@ import {
   MAX_COMPOSER_SESSION_REFERENCES,
   type SpreadsheetComposerAnnotation,
 } from "./chatSubmission";
-import { ChatTimeline } from "./ChatTimeline";
+import { LiveChatTimeline } from "./LiveChatTimeline";
 import { captureConversationView, restoreConversationView, type ConversationViewState } from "./conversationViewport";
 import { EmptyChatStart } from "./EmptyChatStart";
 import { QuickStart } from "./QuickStart";
@@ -231,21 +229,6 @@ function buildComposerToolOptions(tools: readonly ToolSummary[]): ComposerToolOp
 
 const SESSION_DELETE_DISSOLVE_MS = 180;
 
-function latestTurnPlan(timeline: ChatTimelineSnapshot | null | undefined) {
-  const turns = timeline?.turns ?? [];
-  for (let turnIndex = turns.length - 1; turnIndex >= 0; turnIndex -= 1) {
-    const turn = turns[turnIndex];
-    const step = [...turn.steps].reverse().find((candidate) => candidate.kind === "plan" && candidate.plan);
-    if (!step?.plan) continue;
-    return {
-      identityKey: `${turn.id}:${step.id}`,
-      plan: step.plan,
-      revisionKey: JSON.stringify({ plan: step.plan, status: step.status }),
-    };
-  }
-  return undefined;
-}
-
 export function ChatPage({
   activateSessionRequest = null,
   chatStore,
@@ -353,21 +336,21 @@ export function ChatPage({
     onActiveWorkspaceChange?.(workingDirectory);
   }, [activeDisplaySession?.pluginMigration, activeDisplaySession?.workingDirectory, onActiveWorkspaceChange]);
   const activePersistedSessionId = activeSession?.id ?? "";
-  const { state: chatState, actions: chatActions, turns: chatApplication } = useChatApplication({
+  const { state: chatState, actions: chatActions, turns: chatApplication, timelineSource } = useChatApplication({
     chatStore, sessions: sessionApplication, settingsStore, artifactReviews: workspaceStore?.artifactReviews,
     sessionId: activeSessionId, session: activeSession, openSessionIds: sessionTabs.openSessionIds,
-    drafts: sessionTabs.draftSessionsById, model: composerSessionModelInput(composerModels, composerModel), now, t,
+    contextUsageDefaults, drafts: sessionTabs.draftSessionsById, model: composerSessionModelInput(composerModels, composerModel), now, t,
     onDraftConsumed(sessionId) { dispatchSessionTabs({ type: "draft.changed", sessionId, value: "" }); },
     onBackgroundActivity(sessionId) { dispatchSessionTabs({ type: "activity", sessionId }); },
   });
   const {
-    agentUiForms, error: timelineError, hookResults, timeline,
+    agentUiForms, error: timelineError, hookResults, timelineSummary,
     optimisticMessages, compactingSessionId, artifactReviewEpoch,
     lifecycle: commandLifecycle, canCancel: canCancelTurn, cancelUnavailableReason,
   } = chatState;
   const { reportError: reportTimelineError } = chatActions;
   const composerDraft = sessionTabDraft(sessionTabs, activeSessionId);
-  const completedTask = timeline?.source === "canonical" && timeline.turns.some((turn) => turn.status === "completed" && Boolean(turn.userMessage.text.trim()));
+  const { completedTask } = timelineSummary;
   const { completeTask } = quickStart;
   useEffect(() => { if (completedTask) completeTask(); }, [completedTask, completeTask]);
 
@@ -463,8 +446,8 @@ export function ChatPage({
   const draftNewSession = sessionsLoaded && !activeSession && (
     Boolean(activeDraftSession) || !activeSessionId
   );
-  const timelineLoaded = Boolean(activeSession) && timeline?.sessionId === activeSession?.id;
-  const emptyActiveSession = draftNewSession || (timelineLoaded && timeline?.turns.length === 0 && optimisticMessages.length === 0);
+  const timelineLoaded = Boolean(activeSession) && timelineSummary.sessionId === activeSession?.id;
+  const emptyActiveSession = draftNewSession || (timelineLoaded && timelineSummary.turnCount === 0 && optimisticMessages.length === 0);
   const showQuickStart = emptyActiveSession && quickStart.visible;
   const openQuickStart = useEffectEvent(() => {
     quickStart.open();
@@ -475,18 +458,11 @@ export function ChatPage({
     if (sessionsLoaded && quickStartRequest !== null) openQuickStart();
   }, [sessionsLoaded, quickStartRequest]);
   const sessionRunning = activeSession?.status === "running";
-  const activeTurn = useMemo(() => timelineLoaded
-    ? [...(timeline?.turns ?? [])].reverse().find((turn) => (
-      turn.status === "pending"
-      || turn.status === "running"
-      || turn.status === "awaiting_user"
-    ))
-    : undefined, [timeline, timelineLoaded]);
   const sessionResponding = timelineLoaded
-    ? Boolean(activeTurn) || (sessionRunning && optimisticMessages.length > 0)
+    ? Boolean(timelineSummary.activeTurnId) || (sessionRunning && optimisticMessages.length > 0)
     : sessionRunning && !emptyActiveSession;
   const latestTurnStatus = timelineLoaded
-    ? timeline?.turns[timeline.turns.length - 1]?.status
+    ? timelineSummary.latestTurnStatus
     : undefined;
   const showPluginMigrationResult = activeSession?.pluginMigration?.status === "installed"
     || (
@@ -501,17 +477,9 @@ export function ChatPage({
     && isThreadCommandInFlight(commandLifecycle)
     ? commandLifecycle.command.form.formId
     : "";
-  const activeContextUsage = useMemo(
-    () => projectLatestContextUsage(timeline?.turns ?? [], contextUsageDefaults),
-    [contextUsageDefaults, timeline],
-  );
-  const latestFailedTurnId = useMemo(() => (
-    [...(timeline?.turns ?? [])].reverse().find((turn) => turn.status === "failed" || turn.status === "interrupted")?.id ?? ""
-  ), [timeline]);
-  const floatingPlan = useMemo(
-    () => activeSession && timelineLoaded ? latestTurnPlan(timeline) : undefined,
-    [activeSession, timeline, timelineLoaded],
-  );
+  const activeContextUsage = timelineSummary.contextUsage;
+  const latestFailedTurnId = timelineSummary.latestFailedTurnId;
+  const floatingPlan = activeSession && timelineLoaded ? timelineSummary.floatingPlan : undefined;
   useEffect(() => {
     setComposerSessionMentionIds([]);
     setComposerSelectedSkillIds([]);
@@ -619,7 +587,7 @@ export function ChatPage({
     onStopGenerationTargetChange?.(stopGenerationSessionId);
   }, [onStopGenerationTargetChange, stopGenerationSessionId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const view = conversationViewBySessionRef.current.get(activeSessionId);
     if (activeSessionId && !hasActivatedSessionRef.current) {
       hasActivatedSessionRef.current = true;
@@ -631,13 +599,13 @@ export function ChatPage({
     setShowBackToLatest(view ? !view.stickToLatest : false);
   }, [activeSessionId]);
 
-  useEffect(() => {
+  const handleTimelineContentChanged = useCallback(() => {
     const element = conversationRef.current;
     const view = conversationViewBySessionRef.current.get(activeSessionId);
     const shouldRestore = Boolean(
       activeSessionId
       && pendingConversationRestoreRef.current === activeSessionId
-      && timeline?.sessionId === activeSessionId,
+      && timelineSummary.sessionId === activeSessionId,
     );
     if (element && view && !view.stickToLatest && shouldRestore) {
       return restoreConversationView(element, view, () => {
@@ -650,7 +618,7 @@ export function ChatPage({
     if (stickToLatestRef.current) {
       conversationEndRef.current?.scrollIntoView({ block: "end" });
     }
-  }, [activeSessionId, timeline, optimisticMessages, agentUiForms.length]);
+  }, [activeSessionId, timelineSummary.sessionId]);
 
   async function handleCreateSession(
     workingDirectory?: string,
@@ -987,8 +955,8 @@ export function ChatPage({
     void handleStopGeneration(activeSession);
   }
 
-  const visibleAgentUiForms = agentUiForms.filter(isVisibleAgentUiForm);
-  const interactiveFormIds = new Set(visibleAgentUiForms.map((form) => form.form_id));
+  const visibleAgentUiForms = useMemo(() => agentUiForms.filter(isVisibleAgentUiForm), [agentUiForms]);
+  const interactiveFormIds = useMemo(() => new Set(visibleAgentUiForms.map((form) => form.form_id)), [visibleAgentUiForms]);
   const headerTitle = activeDisplaySession
     ? displaySessionTitle(activeDisplaySession.title, t)
     : draftNewSession ? t("shell.newChat") : t("shell.noSelection");
@@ -1096,7 +1064,10 @@ export function ChatPage({
           role="tabpanel"
           onScroll={handleConversationScroll}
         >
-          <ChatTimeline
+          <LiveChatTimeline
+            source={timelineSource}
+            formCount={agentUiForms.length}
+            onContentChanged={handleTimelineContentChanged}
             actions={{
               onBranch: (messageId) => activeSession && void handleBranchFromMessage(activeSession, messageId),
               onOpenArtifact: (artifact) => void handleOpenArtifact(artifact),
@@ -1110,9 +1081,8 @@ export function ChatPage({
             latestFailedTurnId={latestFailedTurnId}
             optimisticMessages={optimisticMessages}
             sessionRunning={sessionRunning}
-            turns={activeSession ? timeline?.turns ?? [] : []}
           />
-          {activeSession && timeline?.turns.length ? null : emptyActiveSession ? (
+          {activeSession && timelineSummary.turnCount ? null : emptyActiveSession ? (
             showQuickStart && settingsStore ? <QuickStart
               ready={quickStart.models.length > 0}
               settingsStore={settingsStore}

--- a/src/react-workbench/chat/ChatTimeline.test.tsx
+++ b/src/react-workbench/chat/ChatTimeline.test.tsx
@@ -32,7 +32,7 @@ describe("ChatTimeline", () => {
 
     expect(screen.getByText("Timeline connection failed").getAttribute("aria-live")).toBe("assertive");
     expect(screen.getByText("Canonical answer")).toBeTruthy();
-    expect(screen.getByText("Pending answer")).toBeTruthy();
+    expect(screen.getByTestId("message-optimistic-1").textContent).toContain("Pending answer");
 
     fireEvent.click(screen.getByRole("button", { name: /branch/i }));
     expect(actions.onBranch).toHaveBeenCalledWith("assistant-1");

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { memo, useMemo, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import type { TFunction } from "i18next";
 import {
@@ -53,6 +53,8 @@ export type ChatTimelineActions = {
   onOpenTool?: (toolCall: ToolCallSummary) => void;
 };
 
+const EMPTY_HOOK_RESULTS: HookExecutionResult[] = [];
+
 export function ChatTimeline({
   actions,
   error,
@@ -72,6 +74,15 @@ export function ChatTimeline({
   sessionRunning: boolean;
   turns: readonly ChatTurn[];
 }) {
+  const hooksByTurn = useMemo(() => {
+    const groups = new Map<string, HookExecutionResult[]>();
+    for (const result of hookResults) {
+      const group = groups.get(result.turnId);
+      if (group) group.push(result);
+      else groups.set(result.turnId, [result]);
+    }
+    return groups;
+  }, [hookResults]);
   return (
     <>
       {error ? <p aria-live="assertive" className="react-timeline-error">{error}</p> : null}
@@ -80,7 +91,7 @@ export function ChatTimeline({
           focusError={turn.id === latestFailedTurnId}
           interactiveFormIds={interactiveFormIds}
           key={turn.id}
-          hookResults={hookResults.filter((result) => result.turnId === turn.id)}
+          hookResults={hooksByTurn.get(turn.id) ?? EMPTY_HOOK_RESULTS}
           turn={turn}
           onBranch={actions.onBranch}
           onOpenArtifact={actions.onOpenArtifact}
@@ -108,7 +119,7 @@ async function writeClipboardText(value: string): Promise<void> {
   await navigator.clipboard?.writeText(value);
 }
 
-function CanonicalChatTurn({
+const CanonicalChatTurn = memo(function CanonicalChatTurn({
   focusError,
   hookResults,
   interactiveFormIds,
@@ -219,7 +230,7 @@ function CanonicalChatTurn({
       {!finalAnswer && metricsFooter ? <div className="react-message__actions">{metricsFooter}</div> : null}
     </section>
   );
-}
+});
 
 function HookExecutionResults({ results }: { results: readonly HookExecutionResult[] }) {
   const { t } = useTranslation("chat");

--- a/src/react-workbench/chat/LiveChatTimeline.tsx
+++ b/src/react-workbench/chat/LiveChatTimeline.tsx
@@ -1,0 +1,17 @@
+import { memo, useEffect, useSyncExternalStore, type ComponentProps } from "react";
+import type { ChatTurn } from "../../app-core/chat/chatTurnContracts";
+import { ChatTimeline } from "./ChatTimeline";
+import type { ChatTimelineSource } from "./chatTimelineSource";
+
+const EMPTY_TURNS: ChatTurn[] = [];
+
+/** Streaming snapshots terminate here instead of rerendering the Chat route. */
+export const LiveChatTimeline = memo(function LiveChatTimeline({ source, formCount, onContentChanged, ...props }: Omit<ComponentProps<typeof ChatTimeline>, "turns"> & {
+  source: ChatTimelineSource;
+  formCount: number;
+  onContentChanged(): void | (() => void);
+}) {
+  const timeline = useSyncExternalStore(source.subscribe, source.getSnapshot);
+  useEffect(() => onContentChanged(), [onContentChanged, timeline, props.optimisticMessages, formCount]);
+  return <ChatTimeline {...props} turns={timeline?.turns ?? EMPTY_TURNS} />;
+});

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:b92d3d83e6b16901e8d8569b42aea5082401003f6be9583b4ecd838754e56868 -->
+<!-- tinybot-module-fingerprint: sha256:160550ea8022fa945591b6b48dbf77b2ac3fdd4d7f0642e98068b585a8250655 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -159,7 +159,13 @@ progress capsule; manual expansion stays open until the user closes it, and
 reduced-motion mode replaces the slide with a short opacity transition. Normal
 Turn completion keeps the last canonical plan state; failed or interrupted
 Turns still reconcile unfinished steps to their terminal outcome.
-`AssistantMarkdown.tsx` owns assistant prose and link presentation.
+`AssistantMarkdown.tsx` owns assistant prose and link presentation. Streaming
+prose uses Streamdown's incremental 160 ms opacity fade, with character boundaries
+for uninterrupted CJK text and no stagger delay. Existing character nodes are
+reused without replaying their fade; completed messages render without animation
+wrappers. Code and math are excluded by Streamdown's animation plugin, and the
+existing reduced-motion rule disables the fade. Tests cover CJK appends, new
+paragraphs, Markdown completion, and the existing streaming render boundary.
 `ViewportContent` mounts expensive Markdown and chart bodies within 800 pixels
 of the conversation viewport and releases them outside it. Lightweight message
 and disclosure owners stay mounted, preserving their interaction state. Last

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:105e8e2fad2562b81fe57c7a0a8a5b878888fa7b5efd91896ccf71c91654b4e0 -->
+<!-- tinybot-module-fingerprint: sha256:b92d3d83e6b16901e8d8569b42aea5082401003f6be9583b4ecd838754e56868 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -49,6 +49,17 @@ animations. Background canonical updates load command acknowledgements without
 replacing the active Timeline; obsolete loads and capability responses are
 discarded when their session changes. Its tests exercise these workflows without
 mounting page layout or Sidecar resources.
+`useChatSessionRuntime` publishes frame-batched streaming snapshots through a
+session-scoped `chatTimelineSource`. `LiveChatTimeline` subscribes to full content;
+`useChatTimelineSummary` gives the route stable lifecycle, plan and usage state.
+Text-only updates do not rerender the composer or historical Turn components.
+Canonical Turn memoization relies on preserved model references and grouped Hook
+results. The timeline notifies the page after content commits so follow-to-bottom
+and saved scroll anchors continue working independently of page renders.
+`ChatPage.streaming-performance.test.tsx` measures render counts and checks scroll
+following, reading history, and final-answer delivery. Run it alongside
+`agentTimelineModel.performance.test.ts` for repeatable streaming work counts;
+timing output is informational and has no machine-dependent pass threshold.
 `chatSessionApplication.ts` owns session data, optimistic titles, per-draft
 creation promises, persisted-ID reconciliation, metadata operations, and
 Timeline-derived session status. `useChatSessions.ts` connects its snapshot and

--- a/src/react-workbench/chat/chatTimelineSource.ts
+++ b/src/react-workbench/chat/chatTimelineSource.ts
@@ -1,0 +1,24 @@
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+
+/** React consumers choose between the full timeline and a stable page summary. */
+export function createChatTimelineSource(sessionId: string) {
+  let snapshot: ChatTimelineSnapshot | null = null;
+  const listeners = new Set<() => void>();
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+    publish(next: ChatTimelineSnapshot | null) {
+      if (next && next.sessionId !== sessionId) {
+        throw new Error(`Timeline session ${next.sessionId} does not match ${sessionId}.`);
+      }
+      if (snapshot === next) return;
+      snapshot = next;
+      listeners.forEach((listener) => listener());
+    },
+  };
+}
+
+export type ChatTimelineSource = ReturnType<typeof createChatTimelineSource>;

--- a/src/react-workbench/chat/useChatApplication.test.tsx
+++ b/src/react-workbench/chat/useChatApplication.test.tsx
@@ -50,7 +50,7 @@ function setup() {
   sessions.accept(session("s2"));
   const onBackgroundActivity = vi.fn();
   const options = {
-    chatStore: store as unknown as ChatStore, sessions, openSessionIds: ["s1", "s2"], drafts: {}, model: {},
+    chatStore: store as unknown as ChatStore, sessions, openSessionIds: ["s1", "s2"], drafts: {}, model: {}, contextUsageDefaults: {},
     now: Date.now, t: ((key: string) => key) as TFunction<"chat">,
     onDraftConsumed: vi.fn(), onBackgroundActivity,
   };
@@ -68,7 +68,7 @@ it("ignores capability responses from the previous session", async () => {
   const { result, rerender } = render();
   await waitFor(() => expect(result.current.state.status).toBe("ready"));
   rerender({ id: "s2" });
-  await waitFor(() => expect(result.current.state.timeline?.sessionId).toBe("s2"));
+  await waitFor(() => expect(result.current.timelineSource.getSnapshot()?.sessionId).toBe("s2"));
   await act(async () => resolve(capabilities("s1")));
   expect(result.current.state.canCancel).toBe(false);
   expect(result.current.state.error).toBe("");
@@ -85,7 +85,7 @@ it("acknowledges commands through the background subscription after switching ta
   act(() => listeners.get("s1")!({ type: "command.accepted", commandId }));
   expect(result.current.turns.turn("s1").lifecycle.stage).toBe("waiting_for_canonical");
   rerender({ id: "s2" });
-  await waitFor(() => expect(result.current.state.timeline?.sessionId).toBe("s2"));
+  await waitFor(() => expect(result.current.timelineSource.getSnapshot()?.sessionId).toBe("s2"));
   const canonical = timeline("s1");
   canonical.turns[0].canonicalItems = [{
     data: { detail: { commandId, commandStatus: "acknowledged" } }, itemId: "ack", revision: 1, status: "completed",
@@ -93,7 +93,7 @@ it("acknowledges commands through the background subscription after switching ta
   store.load.mockResolvedValueOnce(canonical);
   act(() => listeners.get("s1")!({ type: "command.canonical-updated", commandId }));
   await waitFor(() => expect(result.current.turns.turn("s1").lifecycle.stage).toBe("acknowledged"));
-  expect(result.current.state.timeline?.sessionId).toBe("s2");
+  expect(result.current.timelineSource.getSnapshot()?.sessionId).toBe("s2");
   expect(result.current.state.lifecycle.stage).toBe("idle");
   unmount();
   expect(listeners.size).toBe(0);
@@ -105,14 +105,14 @@ it("owns background queue continuation without replacing the active timeline", a
   await waitFor(() => expect(result.current.state.canCancel).toBe(true));
   act(() => result.current.turns.enqueue("s1", input));
   rerender({ id: "s2" });
-  await waitFor(() => expect(result.current.state.timeline?.sessionId).toBe("s2"));
+  await waitFor(() => expect(result.current.timelineSource.getSnapshot()?.sessionId).toBe("s2"));
   vi.mocked(sessionStore.list).mockResolvedValue([{ ...session("s1"), status: "idle" }, session("s2")]);
   act(() => listeners.get("s1")!({ type: "agent.event", eventType: "agent.turn.completed" }));
   await waitFor(() => expect(store.dispatch).toHaveBeenCalledWith(expect.objectContaining({
     kind: "turn.submit", target: expect.objectContaining({ sessionId: "s1" }),
   })));
   expect(result.current.turns.queue("s1").inputs).toEqual([]);
-  expect(result.current.state.timeline?.sessionId).toBe("s2");
+  expect(result.current.timelineSource.getSnapshot()?.sessionId).toBe("s2");
 });
 
 it("moves optimistic messages and queued inputs when session data reconciles an ID", async () => {

--- a/src/react-workbench/chat/useChatApplication.ts
+++ b/src/react-workbench/chat/useChatApplication.ts
@@ -10,6 +10,8 @@ import type { DraftSession } from "./sessionTabWorkspace";
 import { useChatSessionRuntime, type ChatSessionRuntimeEffect } from "./useChatSessionRuntime";
 import { useChatSubmission } from "./useChatSubmission";
 import { useChatTurnApplication } from "./useChatTurnApplication";
+import { useChatTimelineSummary } from "./useChatTimelineSummary";
+import type { ContextUsageDefaults } from "./chatContextUsage";
 
 type Options = {
   chatStore: ChatStore;
@@ -21,6 +23,7 @@ type Options = {
   openSessionIds: readonly string[];
   drafts: Readonly<Record<string, DraftSession>>;
   model: { model?: string; modelProvider?: string };
+  contextUsageDefaults: ContextUsageDefaults;
   now(): number;
   t: TFunction<"chat">;
   onDraftConsumed(sessionId: string): void;
@@ -45,15 +48,12 @@ export function useChatApplication(options: Options) {
   const [capabilities, setCapabilities] = useState(() => (
     unavailableThreadEffectiveCapabilities("", "loading", t("runtime.loadingCapabilities"))
   ));
-  const { timeline } = runtime.state;
-  const activeTurn = timeline?.sessionId === persistedSessionId
-    ? [...timeline.turns].reverse().find((turn) => ["pending", "running", "awaiting_user"].includes(turn.status))
-    : undefined;
+  const timelineSummary = useChatTimelineSummary(runtime.timelineSource, options.contextUsageDefaults);
   const { application: turns, ...turnState } = useChatTurnApplication({
     dispatch: chatStore.dispatch, submitTurn: submission.submitTurn, refreshSessions: sessions.refresh,
     reportError: runtime.actions.reportError, clearError: runtime.actions.clearError,
     now: options.now, t,
-  }, persistedSessionId, { timeline, capabilities });
+  }, persistedSessionId, { timelineSource: runtime.timelineSource, capabilities });
 
   useEffect(() => {
     if (!persistedSessionId) {
@@ -70,12 +70,12 @@ export function useChatApplication(options: Options) {
       ));
     });
     return () => { cancelled = true; };
-  }, [activeTurn?.id, activeTurn?.status, persistedSessionId, chatStore, t]);
+  }, [timelineSummary.activeTurnId, timelineSummary.activeTurnStatus, persistedSessionId, chatStore, t]);
 
   function receiveTimeline(targetSessionId: string, snapshot: ChatTimelineSnapshot) {
     sessions.receiveTimeline(targetSessionId, snapshot);
     submission.receiveTimeline(targetSessionId, snapshot);
-    turns.receiveTimeline(targetSessionId, snapshot);
+    if (targetSessionId !== persistedSessionId) turns.receiveTimeline(targetSessionId, snapshot);
   }
 
   function receiveRuntimeEffect(effect: ChatSessionRuntimeEffect) {
@@ -140,11 +140,13 @@ export function useChatApplication(options: Options) {
   return {
     state: {
       ...runtime.state, ...turnState,
+      timelineSummary,
       optimisticMessages: submission.optimisticMessages,
       compactingSessionId: submission.compactingSessionId,
       artifactReviewEpoch: submission.artifactReviewEpoch,
     },
     turns,
+    timelineSource: runtime.timelineSource,
     actions: {
       ...runtime.actions,
       send: (input: Parameters<typeof submission.send>[0]) => submission.send(input, session, turns),

--- a/src/react-workbench/chat/useChatSessionRuntime.test.tsx
+++ b/src/react-workbench/chat/useChatSessionRuntime.test.tsx
@@ -35,7 +35,7 @@ describe("useChatSessionRuntime", () => {
     }));
 
     await waitFor(() => expect(result.current.state.status).toBe("ready"));
-    expect(result.current.state.timeline?.sessionId).toBe("session-1");
+    expect(result.current.timelineSource.getSnapshot()?.sessionId).toBe("session-1");
     expect(result.current.state.agentUiForms).toEqual([form]);
     expect(effects).toEqual([]);
 
@@ -66,7 +66,7 @@ describe("useChatSessionRuntime", () => {
       listener?.({ timeline: runningTimeline("session-1", "turn-2"), type: "agent_timeline_updated" });
     });
 
-    await waitFor(() => expect(result.current.state.timeline?.turns[0]?.id).toBe("turn-2"));
+    await waitFor(() => expect(result.current.timelineSource.getSnapshot()?.turns[0]?.id).toBe("turn-2"));
     expect(onEffect).toHaveBeenCalledTimes(1);
     expect(onEffect).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: "session-1",
@@ -122,7 +122,7 @@ describe("useChatSessionRuntime", () => {
 
     act(() => resolveTimeline?.(timeline("session-1")));
 
-    await waitFor(() => expect(result.current.state.timeline?.sessionId).toBe("session-1"));
+    await waitFor(() => expect(result.current.timelineSource.getSnapshot()?.sessionId).toBe("session-1"));
     expect(result.current.state).toMatchObject({ error: "forms unavailable", status: "failed" });
   });
 
@@ -192,3 +192,47 @@ function runningTimeline(sessionId: string, turnId: string): ChatTimelineSnapsho
   };
 }
 
+
+
+test("a terminal snapshot cancels a pending streaming frame", async () => {
+  let receive!: (event: ChatEvent) => void;
+  const store = runtimeStore({ subscribe: vi.fn((_id, listener) => { receive = listener; return () => {}; }) });
+  const onEffect = vi.fn();
+  const { result } = renderHook(() => useChatSessionRuntime({ chatStore: store, sessionId: "session-1", onEffect }));
+  await waitFor(() => expect(result.current.state.status).toBe("ready"));
+  const pending = runningTimeline("session-1", "turn-1");
+  const completed = { ...pending, turns: [{ ...pending.turns[0], status: "completed" as const }] };
+  act(() => {
+    receive({ type: "timeline.patch", timeline: pending });
+    receive({ type: "timeline.patch", timeline: completed });
+  });
+  expect(result.current.timelineSource.getSnapshot()).toBe(completed);
+  await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+  expect(result.current.timelineSource.getSnapshot()).toBe(completed);
+  expect(onEffect).toHaveBeenCalledOnce();
+});
+
+test("switching sessions cancels pending streaming content and isolates subscriptions", async () => {
+  const listeners = new Map<string, (event: ChatEvent) => void>();
+  const store = runtimeStore({ subscribe: vi.fn((id, listener) => {
+    listeners.set(id, listener);
+    return () => { listeners.delete(id); };
+  }) });
+  const onEffect = vi.fn();
+  const { result, rerender, unmount } = renderHook(({ id }) => useChatSessionRuntime({
+    chatStore: store, sessionId: id, onEffect,
+  }), { initialProps: { id: "session-1" } });
+  await waitFor(() => expect(result.current.state.status).toBe("ready"));
+  const previousSource = result.current.timelineSource;
+  act(() => listeners.get("session-1")!({ type: "timeline.patch", timeline: runningTimeline("session-1", "old-turn") }));
+  rerender({ id: "session-2" });
+  await waitFor(() => expect(result.current.timelineSource.getSnapshot()?.sessionId).toBe("session-2"));
+  await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+  expect(result.current.timelineSource).not.toBe(previousSource);
+  expect(previousSource.getSnapshot()?.turns).toEqual([]);
+  expect(result.current.timelineSource.getSnapshot()?.turns).toEqual([]);
+  expect(onEffect).not.toHaveBeenCalled();
+  expect([...listeners.keys()]).toEqual(["session-2"]);
+  unmount();
+  expect(listeners.size).toBe(0);
+});

--- a/src/react-workbench/chat/useChatSessionRuntime.ts
+++ b/src/react-workbench/chat/useChatSessionRuntime.ts
@@ -6,6 +6,7 @@ import type { HookExecutionResult } from "../../app-core/chat/hookExecutionResul
 import type { ChatEvent, ChatStore } from "../services";
 import type { ReactChatMessage } from "./messageActions";
 import { projectChatEventEffects } from "./chatEventPolicy";
+import { createChatTimelineSource, type ChatTimelineSource } from "./chatTimelineSource";
 
 export type ChatSessionRuntimeStatus = "idle" | "loading" | "ready" | "failed";
 
@@ -15,7 +16,6 @@ export type ChatSessionRuntimeState = {
   hookResults: HookExecutionResult[];
   sessionId: string;
   status: ChatSessionRuntimeStatus;
-  timeline: ChatTimelineSnapshot | null;
 };
 
 export type ChatSessionRuntimeEffect =
@@ -43,7 +43,9 @@ export function useChatSessionRuntime({
 }: UseChatSessionRuntimeInput): {
   actions: ChatSessionRuntimeActions;
   state: ChatSessionRuntimeState;
+  timelineSource: ChatTimelineSource;
 } {
+  const timelineSource = useMemo(() => createChatTimelineSource(sessionId), [sessionId]);
   const [state, setState] = useState<ChatSessionRuntimeState>(() => initialState(sessionId));
   const activeSessionIdRef = useRef(sessionId);
   const onEffectRef = useRef(onEffect);
@@ -59,14 +61,15 @@ export function useChatSessionRuntime({
     setState((current) => ({
       ...current,
       error: "",
-      status: current.sessionId ? (current.timeline ? "ready" : "loading") : "idle",
+      status: current.sessionId ? (timelineSource.getSnapshot() ? "ready" : "loading") : "idle",
     }));
-  }, []);
+  }, [timelineSource]);
   const reload = useCallback(async () => {
     await reloadRef.current?.();
   }, []);
 
   useEffect(() => {
+    timelineSource.publish(null);
     if (!sessionId) {
       reloadRef.current = null;
       setState(initialState(""));
@@ -101,17 +104,15 @@ export function useChatSessionRuntime({
         return;
       }
       timelineEpoch += 1;
-      setState((current) => (
-        current.sessionId === sessionId
-          ? {
-              ...current,
-              error: notifyEffect ? "" : current.error,
-              hookResults: mergeHookResults(current.hookResults, timeline.hookResults ?? []),
-              status: !notifyEffect && current.error ? "failed" : "ready",
-              timeline,
-            }
-          : current
-      ));
+      timelineSource.publish(timeline);
+      setState((current) => {
+        if (current.sessionId !== sessionId) return current;
+        const error = notifyEffect ? "" : current.error;
+        const hookResults = mergeHookResults(current.hookResults, timeline.hookResults ?? []);
+        const status = !notifyEffect && current.error ? "failed" : "ready";
+        return current.error === error && current.hookResults === hookResults && current.status === status
+          ? current : { ...current, error, hookResults, status };
+      });
       if (notifyEffect) {
         onEffectRef.current?.({ sessionId, timeline, type: "timeline_applied" });
       }
@@ -218,7 +219,7 @@ export function useChatSessionRuntime({
       if (reloadRef.current === reloadSession) reloadRef.current = null;
       unsubscribe();
     };
-  }, [chatStore, sessionId]);
+  }, [chatStore, sessionId, timelineSource]);
 
   const actions = useMemo<ChatSessionRuntimeActions>(() => ({
     clearError,
@@ -230,7 +231,7 @@ export function useChatSessionRuntime({
     reportError,
   ]);
 
-  return { actions, state };
+  return { actions, state, timelineSource };
 }
 
 function initialState(
@@ -243,14 +244,14 @@ function initialState(
     hookResults: [],
     sessionId,
     status,
-    timeline: null,
   };
 }
 
 function mergeHookResults(
-  current: readonly HookExecutionResult[],
+  current: HookExecutionResult[],
   incoming: readonly HookExecutionResult[],
 ): HookExecutionResult[] {
+  if (!incoming.length || incoming.every((result) => current.includes(result))) return current;
   const merged = new Map(current.map((result) => [result.id, result]));
   for (const result of incoming) merged.set(result.id, result);
   return [...merged.values()];

--- a/src/react-workbench/chat/useChatSubmission.ts
+++ b/src/react-workbench/chat/useChatSubmission.ts
@@ -113,7 +113,10 @@ export function useChatSubmission(options: Options) {
     },
     fork(sessionId: string, messageId: string) { return chatStore.branchFromMessage(sessionId, messageId); },
     receiveTimeline(sessionId: string, timeline: ChatTimelineSnapshot) {
-      updateMessages(sessionId, (current) => current.filter((message) => !timeline.turns.some((turn) => turn.userMessage.clientEventId === message.id)));
+      updateMessages(sessionId, (current) => {
+        const remaining = current.filter((message) => !timeline.turns.some((turn) => turn.userMessage.clientEventId === message.id));
+        return remaining.length === current.length ? current : remaining;
+      });
     },
     receiveMessage(sessionId: string, message: ReactChatMessage) {
       updateMessages(sessionId, (current) => current.some((candidate) => candidate.id === message.id)

--- a/src/react-workbench/chat/useChatTimelineSummary.ts
+++ b/src/react-workbench/chat/useChatTimelineSummary.ts
@@ -1,0 +1,57 @@
+import { useMemo, useSyncExternalStore } from "react";
+import type { ChatTimelineSnapshot } from "../../app-core/chat/agentTimelineModel";
+import type { ChatTimelineSource } from "./chatTimelineSource";
+import { projectLatestContextUsage, type ContextUsageDefaults } from "./chatContextUsage";
+
+/** Page state deliberately excludes streaming text, tool payloads and timestamps. */
+export function useChatTimelineSummary(source: ChatTimelineSource, defaults: ContextUsageDefaults) {
+  const select = useMemo(() => {
+    let previousTimeline: ChatTimelineSnapshot | null | undefined;
+    let previous = projectSummary(null, defaults);
+    let previousKey = JSON.stringify(previous);
+    return () => {
+      const timeline = source.getSnapshot();
+      if (timeline === previousTimeline) return previous;
+      previousTimeline = timeline;
+      const next = projectSummary(timeline, defaults);
+      // Only the small UI summary is compared, never messages or the full timeline.
+      const key = JSON.stringify(next);
+      if (key !== previousKey) { previous = next; previousKey = key; }
+      return previous;
+    };
+  }, [source, defaults]);
+  return useSyncExternalStore(source.subscribe, select);
+}
+
+function projectSummary(timeline: ChatTimelineSnapshot | null, defaults: ContextUsageDefaults) {
+  const turns = timeline?.turns ?? [];
+  const reversed = [...turns].reverse();
+  const active = reversed.find((turn) => (
+    turn.status === "pending" || turn.status === "running" || turn.status === "awaiting_user"
+  ));
+  return {
+    sessionId: timeline?.sessionId,
+    turnCount: turns.length,
+    completedTask: turns.some((turn) => turn.status === "completed" && Boolean(turn.userMessage.text.trim())),
+    activeTurnId: active?.id,
+    activeTurnStatus: active?.status,
+    latestTurnStatus: turns[turns.length - 1]?.status,
+    latestFailedTurnId: reversed.find((turn) => turn.status === "failed" || turn.status === "interrupted")?.id ?? "",
+    contextUsage: projectLatestContextUsage(turns, defaults),
+    floatingPlan: latestTurnPlan(timeline),
+  };
+}
+
+function latestTurnPlan(timeline: ChatTimelineSnapshot | null) {
+  const turns = timeline?.turns ?? [];
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const turn = turns[index];
+    const step = [...turn.steps].reverse().find((candidate) => candidate.kind === "plan" && candidate.plan);
+    if (step?.plan) return {
+      identityKey: `${turn.id}:${step.id}`,
+      plan: step.plan,
+      revisionKey: JSON.stringify({ plan: step.plan, status: step.status }),
+    };
+  }
+  return undefined;
+}

--- a/src/react-workbench/chat/useChatTurnApplication.ts
+++ b/src/react-workbench/chat/useChatTurnApplication.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import { createChatTurnApplication } from "./chatTurnApplication";
+import type { ChatTimelineSource } from "./chatTimelineSource";
 
 type Dependencies = Parameters<typeof createChatTurnApplication>[0];
 type Context = Parameters<ReturnType<typeof createChatTurnApplication>["observe"]>[1];
@@ -8,11 +9,11 @@ type Context = Parameters<ReturnType<typeof createChatTurnApplication>["observe"
 export function useChatTurnApplication(
   dependencies: Dependencies,
   sessionId: string,
-  context: Context,
+  context: { timelineSource: ChatTimelineSource; capabilities: Context["capabilities"] },
 ) {
   const latest = useRef(dependencies);
   const activeSession = useRef(sessionId);
-  const { timeline, capabilities } = context;
+  const { timelineSource, capabilities } = context;
   useLayoutEffect(() => { latest.current = dependencies; activeSession.current = sessionId; });
   const application = useMemo(() => createChatTurnApplication({
     dispatch: (command) => latest.current.dispatch(command),
@@ -26,8 +27,10 @@ export function useChatTurnApplication(
     get t() { return latest.current.t; },
   }), []);
   useLayoutEffect(() => {
-    application.observe(sessionId, { timeline, capabilities });
-  }, [application, sessionId, timeline, capabilities, dependencies.t]);
+    const observe = () => application.observe(sessionId, { timeline: timelineSource.getSnapshot(), capabilities });
+    observe();
+    return timelineSource.subscribe(observe);
+  }, [application, sessionId, timelineSource, capabilities, dependencies.t]);
   useEffect(() => () => application.dispose(), [application]);
   const snapshot = useSyncExternalStore(
     application.subscribe,

--- a/src/react-workbench/shell/DesktopPetQuickChatWindow.tsx
+++ b/src/react-workbench/shell/DesktopPetQuickChatWindow.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import type { TFunction } from "i18next";
@@ -109,7 +110,7 @@ export function DesktopPetQuickChatWindow({
     onEffect: handleRuntimeEffect,
     sessionId: session?.id ?? "",
   });
-  const timeline = sessionRuntime.state.timeline;
+  const timeline = useSyncExternalStore(sessionRuntime.timelineSource.subscribe, sessionRuntime.timelineSource.getSnapshot);
   const activeContextUsage = useMemo(
     () => projectLatestContextUsage(timeline?.turns ?? [], contextUsageDefaults),
     [contextUsageDefaults, timeline],

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:c17bf0032c6465af738b45c06dc27c9afd2f2cc9ae292de3690354a1d90080ab -->
+<!-- tinybot-module-fingerprint: sha256:5a636384b048f5713d33734f3278c8dadf86e02d5d7fa02126bdb09fc0ee91c3 -->
 
 Desktop-pet quick chat shares composer drop and clipboard import with main Chat;
 its window permission set includes the bounded binary attachment import command.
@@ -64,7 +64,8 @@ browser-fallback hosts both apply that reset immediately.
 The pet accepts external HTML5 `text/plain` and `Files` drops. It forwards text
 unchanged and asks the native Adapter to import local files before sending a
 versioned quick-chat request to the independent `desktop-pet-chat` window.
-`DesktopPetQuickChatWindow.tsx` reuses Chat's canonical composer, attachment
+`DesktopPetQuickChatWindow.tsx` subscribes directly to the session runtime's
+Timeline source for its content and context-usage display. It reuses Chat's canonical composer, attachment
 submission, and timeline presentation; dropped attachments remain removable,
 and the composer file picker uses the same native importer. It keeps the draft
 editable, exposes the same model picker and context-token usage, and persists


### PR DESCRIPTION
## Summary

Long conversations previously rebuilt every turn projection for each streaming patch and rerendered the page and composer as text arrived. Cache timeline snapshots, reproject only changed turns, and subscribe to streaming updates inside the live timeline so unrelated UI and historical turns stay stable.

- Fade newly streamed text over 160 ms, including CJK text, without replaying animations on existing text. Completed messages remove animation wrappers, and reduced-motion settings remain respected.
- Give Shift+Enter precedence over slash and session suggestions in both composer editors. Render a display-only trailing break so a terminal newline immediately shows a new line and caret, while submitted text preserves the intended line breaks.
- Retain existing offscreen content deferral; this change does not introduce full list virtualization.

## Validation

- Full frontend test suite: 159 files and 942 tests passed with two test workers.
- Production build passed through the pre-commit hook; existing large-chunk warnings remain.
- TypeScript and targeted ESLint checks.
- Browser verification of visible trailing blank lines, consecutive newlines, and multiline submission.
- Regression coverage for CJK incremental fade, suggestion-menu keyboard behavior, and streaming render isolation. The 250-turn, 30-patch fixture reduces rebuilt turns from 7,500 to 30; streaming frames do not rerender the composer or stable historical turns.
