### PR TITLE
Refactor Agent dependency boundaries and fix document-relative file links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docs/superpowers/
 *.tmp
 *.temp
 .VSCodeCounter/
+output/

--- a/docs/api/agent-runtime.md
+++ b/docs/api/agent-runtime.md
@@ -6,7 +6,7 @@ src-tauri/src/agent/runtime_protocol_tests.rs
 src-tauri/src/desktop_commands/runtime.rs
 src-tauri/src/desktop_commands/runtime_tests.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:9e552cfed08bc790fb07e09472ce31508af89aad8169407cadb554539d42b284 -->
+<!-- tinybot-doc-fingerprint: sha256:e79dab2d87d9b681ee2b60ccb214e4fd962eb9645312e2cb727f51a4d473d691 -->
 
 This document covers native Agent turn execution and provider-facing behavior.
 It is part of the [Rust backend API reference](rust-backend-api.md), which

--- a/docs/api/agent-runtime.md
+++ b/docs/api/agent-runtime.md
@@ -6,7 +6,7 @@ src-tauri/src/agent/runtime_protocol_tests.rs
 src-tauri/src/desktop_commands/runtime.rs
 src-tauri/src/desktop_commands/runtime_tests.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:e79dab2d87d9b681ee2b60ccb214e4fd962eb9645312e2cb727f51a4d473d691 -->
+<!-- tinybot-doc-fingerprint: sha256:afd287b5e77769d3a787c1cefd186988952fe71dcccbd4c57f40786ca92b888e -->
 
 This document covers native Agent turn execution and provider-facing behavior.
 It is part of the [Rust backend API reference](rust-backend-api.md), which

--- a/docs/api/desktop.md
+++ b/docs/api/desktop.md
@@ -17,7 +17,7 @@ src/app-core/native/desktopNativePet.ts
 src/app-core/native/desktopNativePetQuickChat.ts
 src/app-core/native/nativeBackendContract.test.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:7168e408f6cb8172bd447ec354d34890162ad6d7e6fb97f89e4f272f020600d3 -->
+<!-- tinybot-doc-fingerprint: sha256:bc17cd6f2775ffc5cbe72c360141902e511eddbc6343a542c24198e4c8dbd0cd -->
 
 This document covers native desktop lifecycle and operating-system integration
 commands. It is part of the [Rust backend API reference](rust-backend-api.md),
@@ -31,6 +31,11 @@ typed commands. Closing `main` hides the window in the system tray and keeps the
 active; explicit tray exit or updater installation runs its bounded shutdown path. There are no
 renderer commands for managing a separate backend process, and the runtime cannot be configured to
 remain alive after the App exits.
+
+Storage initialization receives explicit workspace and application-data paths.
+A legacy-storage migration failure aborts construction with those paths in the
+error. Workspace rebinding uses the same initializer and records a startup failure;
+startup on an already initialized store does not repeat migration.
 
 The internal lifecycle state records native-runtime recovery and cleanup. Startup pauses new agent
 continuations while the process-local Thread index is rebuilt from canonical Rollouts and checked for

--- a/docs/api/desktop.md
+++ b/docs/api/desktop.md
@@ -11,13 +11,15 @@ src-tauri/src/desktop_terminal.rs
 src-tauri/src/desktop_commands/config.rs
 src-tauri/src/desktop_commands/hooks.rs
 src-tauri/src/desktop_commands/plugins.rs
+src-tauri/src/desktop_commands/runtime.rs
+src-tauri/src/runtime/lifecycle.rs
 src-tauri/src/agent/provider/completion.rs
 src/app-core/native/desktopNativeHooks.ts
 src/app-core/native/desktopNativePet.ts
 src/app-core/native/desktopNativePetQuickChat.ts
 src/app-core/native/nativeBackendContract.test.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:bc17cd6f2775ffc5cbe72c360141902e511eddbc6343a542c24198e4c8dbd0cd -->
+<!-- tinybot-doc-fingerprint: sha256:6a379f9369035d4cde752ca92d66a633dea2d255018b95fa1c376a2a30ccf95c -->
 
 This document covers native desktop lifecycle and operating-system integration
 commands. It is part of the [Rust backend API reference](rust-backend-api.md),
@@ -48,6 +50,12 @@ later Rollout/index mismatch. A persisted `running` turn with no live owner is t
 `stopReason: "runtime_restarted"`; waiting turns and their checkpoints remain unchanged. A storage
 error leaves the task runtime non-accepting, sets `last_error`, and appends a
 `startup_recovery` diagnostic instead of silently continuing.
+
+Shutdown cancels and joins the application-owned Memory workers before closing
+Thread persistence. Its internal report includes a `memory` stage with
+`completed` and `detail`; failures also appear in the shared `failures` list.
+Unfinished extraction jobs remain durable and are retried by the heartbeat after
+restart. Failure to initialize Memory storage aborts startup with diagnostics.
 
 ## Windows Desktop Pet Windows
 

--- a/docs/api/rust-backend-api.md
+++ b/docs/api/rust-backend-api.md
@@ -10,7 +10,7 @@ src/app-core/native/desktopNativeWorkspaceRegistry.ts
 src/app-core/native/desktopNativeWebui.ts
 src/app-core/native/nativeBackendContract.test.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:b2dd052ee17b0ce7a527556733635dea50d5682de704b87994bff82b7a0902bf -->
+<!-- tinybot-doc-fingerprint: sha256:1aff2f953f660946258062e9246ed6ca019c7359df3f092b98e7d4aa231f7362 -->
 
 This document describes the API surfaces exposed by the Rust/Tauri backend in `src-tauri`.
 It is intended for frontend callers and integrators who need command names, invocation

--- a/docs/api/threads-and-memory.md
+++ b/docs/api/threads-and-memory.md
@@ -15,7 +15,7 @@ src-tauri/src/threads/workspace_store.rs
 src-tauri/tests/crate/threads.rs
 src/app-core/chat/agentInputReference.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:3a9a61a6f43101213d379537ff4834fbda2b8de2a2102389b414fcc0f5d33e96 -->
+<!-- tinybot-doc-fingerprint: sha256:7c77da3ed58cf4188d19ec83c917ed70a1db38be813a7357cac6aa4053e3f938 -->
 
 This document covers Thread queries, memory, persistence, and project grouping.
 It is part of the [Rust backend API reference](rust-backend-api.md), which

--- a/docs/api/threads-and-memory.md
+++ b/docs/api/threads-and-memory.md
@@ -15,7 +15,7 @@ src-tauri/src/threads/workspace_store.rs
 src-tauri/tests/crate/threads.rs
 src/app-core/chat/agentInputReference.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:297c2d7c5b66b900cd79b12beb78e7a57ece249507500dd1a6f427926cb1ae8a -->
+<!-- tinybot-doc-fingerprint: sha256:3a9a61a6f43101213d379537ff4834fbda2b8de2a2102389b414fcc0f5d33e96 -->
 
 This document covers Thread queries, memory, persistence, and project grouping.
 It is part of the [Rust backend API reference](rust-backend-api.md), which

--- a/docs/api/threads-and-memory.md
+++ b/docs/api/threads-and-memory.md
@@ -15,7 +15,7 @@ src-tauri/src/threads/workspace_store.rs
 src-tauri/tests/crate/threads.rs
 src/app-core/chat/agentInputReference.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:3be56e5684c20c40ded2d270c70fc1c550aa47e3282f176a007e35c43316c5d2 -->
+<!-- tinybot-doc-fingerprint: sha256:297c2d7c5b66b900cd79b12beb78e7a57ece249507500dd1a6f427926cb1ae8a -->
 
 This document covers Thread queries, memory, persistence, and project grouping.
 It is part of the [Rust backend API reference](rust-backend-api.md), which

--- a/docs/api/tools-and-processes.md
+++ b/docs/api/tools-and-processes.md
@@ -14,7 +14,7 @@ src-tauri/src/rpc/tests/threads_and_tools.rs
 src-tauri/tests/crate/retry.rs
 src/app-core/native/desktopNativeThreads.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:0eb047687dd2c7f8f06015b0b8020d654d72b7d82a527be6d8da05bb8471dd48 -->
+<!-- tinybot-doc-fingerprint: sha256:533b3a3b89b92153e3b19750fb8fa3e3f150251f6a790920c3f839601dace52f -->
 
 This document covers native tool processes, background execution, and browser
 sessions. It is part of the [Rust backend API reference](rust-backend-api.md),

--- a/docs/api/workspace-and-extensions.md
+++ b/docs/api/workspace-and-extensions.md
@@ -20,7 +20,7 @@ src-tauri/src/workspace/types.rs
 src-tauri/src/workspace/artifact_review.rs
 src-tauri/src/rpc/tests/workspace_and_shell.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:e8ad966a3d9a8d8b388d5623e337c08f6d3922f853623f1f8501d2fc69b11346 -->
+<!-- tinybot-doc-fingerprint: sha256:57e75a32d98a78989684f4518afd178ce982b7f35c35844cb4de2c0a4d048f9a -->
 
 This document covers workspace operations and the extension catalogs available
 to Agents. It is part of the [Rust backend API reference](rust-backend-api.md),

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -22,7 +22,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:27f13d2bdac447fa429d8263875ed29b823bed30a3b4d771f6292251fee371ad -->
+<!-- tinybot-doc-fingerprint: sha256:9acb94eaea607edbf77eef9db7fdb556600eccc061bb34625959e0732395e8de -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -3,18 +3,21 @@
 src-tauri/src/agent/bridge/README.md
 src-tauri/src/agent/bridge/agent_flow.rs
 src-tauri/src/agent/bridge/thread_flow.rs
+src-tauri/src/agent/bridge/workspace_threads.rs
 src-tauri/src/agent/runtime/README.md
+src-tauri/src/agent/runtime/mod.rs
 src-tauri/src/agent/runtime/provider_loop.rs
 src-tauri/src/agent/runtime/tool_runtime.rs
 src-tauri/src/agent/runtime/turn_result.rs
 src-tauri/src/agent/runtime/turn_input.rs
 src-tauri/src/runtime/turn_execution.rs
+src-tauri/src/desktop/state.rs
 src-tauri/src/agent/runtime_protocol/README.md
 src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:fecc870e4eeb74655d15addf77d55be4f229c5d98e6d6b304aa75a76c7de1450 -->
+<!-- tinybot-doc-fingerprint: sha256:c7e828ccf2366c41ef7ad6b3da57ca7fc666d3e3b0c85410709d5bee16da9d7f -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal
@@ -28,6 +31,15 @@ outcome that follow. Resolving a form continues the same Turn identity.
 - `TurnExecutionRuntime` owns the current live generation, cancellation, and
   terminal-result publication for a Turn ID.
 - `threads::rollout::store` owns canonical durability and reconstruction.
+
+The desktop state owner constructs shared Agent resources explicitly and passes
+`NativeAgentRuntimeDependencies` to the runtime. Provider streaming and tool
+dispatch require asynchronous implementations; production and tests use the same
+execution contracts. Blocking test fixtures have separate adapters.
+The bridge dispatcher supplies project-coordinator tool definitions and performs
+workspace-thread execution. The loop does not call back into the bridge or Thread
+RPC for those tools. Child cancellation still propagates from the parent and waits
+for cleanup, while runtime scheduling retains its cleanup timeout policy.
 
 The provider loop, task owner, bridge, and Graph/workspace-thread callers share
 `AgentTurnResult`. Its required `AgentStopReason` replaces string lookup for
@@ -95,6 +107,11 @@ fails, the bridge persists a failed terminal state with `runtime_error` (or
 `invalid_request` for runtime validation) and the structured error before
 returning the original error to the desktop caller; the renderer can then
 reload the canonical Rollout instead of leaving the Turn active.
+
+The dispatcher captures its child-Turn services only after checkpoint, trace, and
+command-hook adapters are installed. Form continuation follows the same ordering
+for checkpoint and trace adapters. Capturing the services earlier would omit live
+child timeline output even if child execution and persistence completed normally.
 
 For an empty default-titled Thread, that durable start also gates one detached
 title request. It uses the resolved Provider and model but has no tools and does

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -2,6 +2,9 @@
 <!-- tinybot-doc-watch:
 src-tauri/src/agent/bridge/README.md
 src-tauri/src/agent/bridge/agent_flow.rs
+src-tauri/src/agent/bridge/application.rs
+src-tauri/src/agent/bridge/tool_catalog.rs
+src-tauri/src/agent/bridge/webui_continuation.rs
 src-tauri/src/agent/bridge/thread_flow.rs
 src-tauri/src/agent/bridge/workspace_threads.rs
 src-tauri/src/agent/runtime/README.md
@@ -17,7 +20,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:c7e828ccf2366c41ef7ad6b3da57ca7fc666d3e3b0c85410709d5bee16da9d7f -->
+<!-- tinybot-doc-fingerprint: sha256:d83dfa55689a5c33efc62537787ff3c9021c70fbb44c6f1b1fa3eba41475f4f7 -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal
@@ -32,14 +35,20 @@ outcome that follow. Resolving a form continues the same Turn identity.
   terminal-result publication for a Turn ID.
 - `threads::rollout::store` owns canonical durability and reconstruction.
 
-The desktop state owner constructs shared Agent resources explicitly and passes
-`NativeAgentRuntimeDependencies` to the runtime. Provider streaming and tool
-dispatch require asynchronous implementations; production and tests use the same
-execution contracts. Blocking test fixtures have separate adapters.
-The bridge dispatcher supplies project-coordinator tool definitions and performs
-workspace-thread execution. The loop does not call back into the bridge or Thread
-RPC for those tools. Child cancellation still propagates from the parent and waits
-for cleanup, while runtime scheduling retains its cleanup timeout policy.
+Desktop state initializes the Thread store with explicit workspace and data paths;
+legacy migration errors abort initialization. It owns application resources and
+passes only Provider, dispatcher, checkpoints, cancellation, tasks and metrics as
+`NativeAgentRuntimeDependencies`. `AgentApplicationServices` carries the shared
+Thread, MCP, Shell, browser and subagent resources outside the core runtime.
+Ordinary and resumed form Turns use one `prepare_turn` assembly path. Persistence,
+trace and hooks are installed before the dispatcher captures child-Turn services.
+Provider streaming, tool preparation and tool dispatch cross asynchronous
+interfaces. Blocking test fixtures have separate adapters.
+The bridge dispatcher discovers Graph/MCP/workspace-thread contributions and
+performs application-specific execution. Discovery cancellation preserves its
+phase and transport details before provider execution. Child cancellation still
+propagates from the parent and waits for cleanup, while runtime scheduling retains
+its cleanup timeout policy.
 
 The provider loop, task owner, bridge, and Graph/workspace-thread callers share
 `AgentTurnResult`. Its required `AgentStopReason` replaces string lookup for

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -3,12 +3,14 @@
 src-tauri/src/agent/bridge/README.md
 src-tauri/src/agent/bridge/agent_flow.rs
 src-tauri/src/agent/bridge/application.rs
+src-tauri/src/agent/bridge/command_hooks.rs
 src-tauri/src/agent/bridge/tool_catalog.rs
 src-tauri/src/agent/bridge/webui_continuation.rs
 src-tauri/src/agent/bridge/thread_flow.rs
 src-tauri/src/agent/bridge/workspace_threads.rs
 src-tauri/src/agent/runtime/README.md
 src-tauri/src/agent/runtime/mod.rs
+src-tauri/src/agent/runtime/hooks.rs
 src-tauri/src/agent/runtime/provider_loop.rs
 src-tauri/src/agent/runtime/tool_runtime.rs
 src-tauri/src/agent/runtime/turn_result.rs
@@ -20,7 +22,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:d83dfa55689a5c33efc62537787ff3c9021c70fbb44c6f1b1fa3eba41475f4f7 -->
+<!-- tinybot-doc-fingerprint: sha256:27f13d2bdac447fa429d8263875ed29b823bed30a3b4d771f6292251fee371ad -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal
@@ -176,7 +178,12 @@ call as an ordering barrier. `update_plan` is such a barrier, so a plan update
 may precede ordinary calls in the same response without rejecting the batch.
 
 The bridge loads additive global and effective-working-directory command hooks
-for each Turn. `UserPromptSubmit` runs after the durable Turn start, so a denied
+for each Turn, adapting the engine to the same asynchronous `AgentHook`
+interface used by in-process hooks. The core owns effect merging and conflict
+decisions without depending on the command engine. Invalid configuration or
+trust-store loading fails preparation with diagnostics and marks a newly
+started durable Turn failed before a provider request.
+`UserPromptSubmit` runs after the durable Turn start, so a denied
 prompt still produces a recoverable terminal Turn. `PreToolUse` may deny or
 replace normalized arguments before dispatch; `PostToolUse` may replace only
 the next model-visible observation; `PostCompact` runs after replacement

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -1,6 +1,7 @@
 # Context and Instructions
 <!-- tinybot-doc-watch:
 src-tauri/src/agent/README.md
+src-tauri/src/agent/instruction_sources.rs
 src-tauri/src/agent/bridge/thread_flow.rs
 src-tauri/src/agent/runtime/README.md
 src-tauri/src/agent/runtime/instructions.rs
@@ -13,7 +14,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:06385a38f4ade550502056d254de2e0a71dda7bc7b85521657e402d969fcbce9 -->
+<!-- tinybot-doc-fingerprint: sha256:b3c1d9fb0e738b56652f256c8023e6805f017961380cece33f4754709a0e15dd -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction
@@ -50,7 +51,12 @@ exist and must be a directory.
 
 ## Instruction order
 
-`InstructionComposer` renders instruction sources in increasing precedence:
+`InstructionLoader` resolves filesystem sources, bounded project reads and enabled
+plugin catalogs using the application's data path. Its `LoadedInstructionSources`
+contains contents, paths, warnings, truncation flags and the load timestamp.
+`InstructionComposer` consumes those values without filesystem, plugin-store or
+clock access. Skill selection, precedence, provenance and content hashes can be
+verified using in-memory inputs. It renders sources in increasing precedence:
 
 1. Built-in Tinybot identity.
 2. Turn-scoped developer instructions, when present.

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -13,7 +13,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:90233d2d24a16bf968d463b76ef1ac1bcfa8f998d824ca468b3894898a8237d6 -->
+<!-- tinybot-doc-fingerprint: sha256:06385a38f4ade550502056d254de2e0a71dda7bc7b85521657e402d969fcbce9 -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -14,7 +14,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:b3c1d9fb0e738b56652f256c8023e6805f017961380cece33f4754709a0e15dd -->
+<!-- tinybot-doc-fingerprint: sha256:0bb07d75feb1f3e8359ace1855f48c7eaa2993bf2b0381b7fea8043d7de495b7 -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:a74a6d5bb51db803c8a11ecf79ec664818598f22c0b90b7f8748c66b140ac6f6 -->
+<!-- tinybot-doc-fingerprint: sha256:ff3e0c6ccd97367741c60b2099a99fe399c8d8d3c6fbda958faa76b4b6990f43 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:fc70bbe13da1ded3a184daf997a80d71bd8725e34e331e2de14e1404824d8d04 -->
+<!-- tinybot-doc-fingerprint: sha256:87cce1655d82580f2bc809258d1a005591fd48839b6420fbd6e02be15e0109b7 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:87cce1655d82580f2bc809258d1a005591fd48839b6420fbd6e02be15e0109b7 -->
+<!-- tinybot-doc-fingerprint: sha256:8318a380f91005070ccf972eb42b3484a99d1d24bc725b51caf82e2d968c36c3 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:8318a380f91005070ccf972eb42b3484a99d1d24bc725b51caf82e2d968c36c3 -->
+<!-- tinybot-doc-fingerprint: sha256:a74a6d5bb51db803c8a11ecf79ec664818598f22c0b90b7f8748c66b140ac6f6 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:f71d51d146f3e5dc46e2d02d46f1213c62f6e87b70d9f57bf250996c297c0b11 -->
+<!-- tinybot-doc-fingerprint: sha256:b6f9e3cecf0fc7026ef75ce194e2cbac8f6493c69051113d0480f272648cc773 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:b6f9e3cecf0fc7026ef75ce194e2cbac8f6493c69051113d0480f272648cc773 -->
+<!-- tinybot-doc-fingerprint: sha256:17ecfa1610a7c165be7078a1d3eff091248a380c788054e2c5098378096a4425 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:17ecfa1610a7c165be7078a1d3eff091248a380c788054e2c5098378096a4425 -->
+<!-- tinybot-doc-fingerprint: sha256:8887faa06fdeacdfb24b55e38634b8ead2e4646e1f030e06ab8d72b38e22b8d9 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:196501a6cebff8e3b04dafabc17d849b36c99bda92729b3139822162352f51d1 -->
+<!-- tinybot-doc-fingerprint: sha256:f71d51d146f3e5dc46e2d02d46f1213c62f6e87b70d9f57bf250996c297c0b11 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -1,6 +1,7 @@
 # Tool Execution and Permissions
 <!-- tinybot-doc-watch:
 src-tauri/src/agent/bridge/tool_dispatcher.rs
+src-tauri/src/agent/bridge/workspace_threads.rs
 src-tauri/src/agent/runtime/README.md
 src-tauri/src/agent/runtime/tool_router.rs
 src-tauri/src/agent/runtime/tool_runtime.rs
@@ -11,7 +12,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:360a29f02f6334bb5153292093880d093de76db8c358a479fb0862d35c560445 -->
+<!-- tinybot-doc-fingerprint: sha256:81d664a47521b452c7b6e5e04b8b4dc4f0f27059fd57ac1403a4802241af5214 -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,
@@ -42,9 +43,10 @@ Model tool-call batch
     |-- prepare arguments or return one error result per call ID
     |-- run trusted PreToolUse hooks (deny or replace arguments)
     |-- plan parallel read waves and exclusive mutation waves
+    |-- execute loop-state controls (plan, form, data view) in the runtime
     v
 Injected dispatcher
-    |-- runtime-control tool
+    |-- persistent workspace Thread spawn or follow-up input
     |-- workspace Agent Graph Run
     |-- Worker RPC tool executor
     |-- MCP runtime
@@ -82,6 +84,15 @@ make a Turn workspace-backed. Per-file Graph parse or validation failures are
 diagnosed and skipped at this discovery boundary so valid tools remain usable;
 Graph management operations retain strict validation. Duplicate contributor
 IDs, tool IDs, or methods fail registry construction.
+
+The dispatcher contributes application-owned tools during Turn preparation.
+For workspace-thread tools the bridge queries the current project group; the
+runtime receives ordinary contributors and does not query Thread storage.
+Discovery errors abort preparation with their structured service error intact.
+Spawn and send calls then use the required asynchronous dispatch method, whose
+`AgentError` result preserves service details in the tool-result envelope.
+Execution rechecks membership and parent ownership, so an earlier tool definition
+does not grant access after project membership changes.
 
 ## Exposure and availability
 

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -1,6 +1,7 @@
 # Tool Execution and Permissions
 <!-- tinybot-doc-watch:
 src-tauri/src/agent/bridge/tool_dispatcher.rs
+src-tauri/src/agent/bridge/tool_catalog.rs
 src-tauri/src/agent/bridge/workspace_threads.rs
 src-tauri/src/agent/runtime/README.md
 src-tauri/src/agent/runtime/tool_router.rs
@@ -12,7 +13,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:81d664a47521b452c7b6e5e04b8b4dc4f0f27059fd57ac1403a4802241af5214 -->
+<!-- tinybot-doc-fingerprint: sha256:b2ceaa059717cebc10c45b00fb54911f728413680585ae1773238ad2fc7f5a5d -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,
@@ -75,6 +76,11 @@ Provider-visible schemas describe nested argument contracts, not only their
 top-level names. For example, `publish_data_view` exposes the supported view
 kinds and requires table `defaultSort` to use `{field, direction}` so providers
 can construct the same shape the native validator accepts.
+
+The dispatcher prepares application tool contributions asynchronously through
+`prepare_tools`, returning a catalog plus the effective selection or a cancellation
+with checkpoint details. `bridge::tool_catalog` owns Graph and MCP discovery;
+the provider loop consumes the result without holding those application resources.
 
 Ordered contributors assemble built-in, workspace, MCP, runtime-control, and
 eligible project-group tools. For ordinary workspace-backed Chat Turns, they

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -13,7 +13,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:b2ceaa059717cebc10c45b00fb54911f728413680585ae1773238ad2fc7f5a5d -->
+<!-- tinybot-doc-fingerprint: sha256:4bb106104a14172295e77fdfca067d88eee5cc6e96bf6355fc2862ff53727efd -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:a5291577b75f3d978903a5ea83469518c45f2862d7fc0c68895074e4e9fcb372 -->
+<!-- tinybot-module-fingerprint: sha256:f29490c602cfc773a741c3a9fc108e1c75b2b3ca8d176eb5dedaef5cedef401e -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:f4157ab314855bc0b977bd470589be5fcc516345dd0c8244a75854b0d2378072 -->
+<!-- tinybot-module-fingerprint: sha256:2b525fea23172282e6b638d301999f65c0ff63d48d4cc64e4b457600d31e758f -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:f29490c602cfc773a741c3a9fc108e1c75b2b3ca8d176eb5dedaef5cedef401e -->
+<!-- tinybot-module-fingerprint: sha256:f4157ab314855bc0b977bd470589be5fcc516345dd0c8244a75854b0d2378072 -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -1,5 +1,5 @@
 # Agent
-<!-- tinybot-module-fingerprint: sha256:4d7b03f3de57e5313120b5dd31caa094dd5da71ace0429e3a77ccfb0e02dfe29 -->
+<!-- tinybot-module-fingerprint: sha256:23098df73a5256683fb75ff626de736fd186023a75b1cceffb9f85ce7c7f0f0d -->
 
 `agent` contains the native agent stack. It connects provider configuration,
 the turn runtime, durable runtime events, and the desktop integration bridge.
@@ -26,3 +26,7 @@ settings, streaming choice, and response decoder as the initiating Turn. Only
 the prompt is replaced; no separate output-token budget is added. The result is
 normalized and committed asynchronously without entering the Agent Loop or
 delaying that Turn.
+
+`instruction_sources.rs` owns bounded filesystem reads, workspace discovery and
+plugin loading. It passes loaded values to the runtime's pure instruction composer;
+the application data path determines the plugin catalog and its provenance.

--- a/src-tauri/src/agent/bridge/README.md
+++ b/src-tauri/src/agent/bridge/README.md
@@ -1,5 +1,5 @@
 # Native Agent Bridge
-<!-- tinybot-module-fingerprint: sha256:0cf1ae22e997d3e6a79feb5643a07d67da7950adb97e7cb6fdb54ca6eee23cbb -->
+<!-- tinybot-module-fingerprint: sha256:58af0148042f577c95ddbfa1bd905790f7495f3fac0175ec56ed6ed8e671fc92 -->
 
 `agent::bridge` is the application-service layer around the generic
 native agent runtime. It coordinates the resources required for a complete
@@ -86,6 +86,8 @@ Dynamic tool arguments and external tool RPC adapters retain their extension sch
 the bridge records a failed terminal state for an already-started Turn before
 any provider request. Resumable checkpoints remain available when preparation
 fails during continuation.
+Unsupported command-hook stages return no runs and emit no decision events;
+an unevaluated command is distinct from an explicit in-process `Continue`.
 
 The tool dispatcher retains the unmerged base configuration alongside the
 parent Turn's services. When a Graph Agent node targets another workspace, its

--- a/src-tauri/src/agent/bridge/README.md
+++ b/src-tauri/src/agent/bridge/README.md
@@ -1,5 +1,5 @@
 # Native Agent Bridge
-<!-- tinybot-module-fingerprint: sha256:72db246495d6a68f0db9b8ee7c41d80b8a70937b6a987410f8a38546750b1dbc -->
+<!-- tinybot-module-fingerprint: sha256:0cf1ae22e997d3e6a79feb5643a07d67da7950adb97e7cb6fdb54ca6eee23cbb -->
 
 `agent::bridge` is the application-service layer around the generic
 native agent runtime. It coordinates the resources required for a complete
@@ -78,7 +78,14 @@ Dynamic tool arguments and external tool RPC adapters retain their extension sch
 7. Persist the terminal boundary or resumable checkpoint as applicable. If
    runtime execution or trace flush fails, persist a failed terminal with the
    original error before returning it to the caller.
-8. Schedule memory extraction only after a completed turn is durably persisted.
+8. Schedule memory extraction through the application-owned `MemoryRuntime`
+   only after a completed turn is durably persisted.
+
+`command_hooks.rs` adapts the command engine to the core's asynchronous
+`AgentHook` interface. Loading invalid configuration fails Turn preparation;
+the bridge records a failed terminal state for an already-started Turn before
+any provider request. Resumable checkpoints remain available when preparation
+fails during continuation.
 
 The tool dispatcher retains the unmerged base configuration alongside the
 parent Turn's services. When a Graph Agent node targets another workspace, its

--- a/src-tauri/src/agent/bridge/README.md
+++ b/src-tauri/src/agent/bridge/README.md
@@ -1,5 +1,5 @@
 # Native Agent Bridge
-<!-- tinybot-module-fingerprint: sha256:5647db55ca0690db2c03b8de04499e79846866e5d5432103c65111648debf850 -->
+<!-- tinybot-module-fingerprint: sha256:9046f277a0ecef6e5abf28b407db44ed3139491b3d14fc0da87455871c34ca24 -->
 
 `agent::bridge` is the application-service layer around the generic
 native agent runtime. It coordinates the resources required for a complete
@@ -59,8 +59,9 @@ Dynamic tool arguments and external tool RPC adapters retain their extension sch
    carries the initiating Turn specification so the runtime can reuse its
    effective Provider settings without a title-only token budget.
 4. Hydrate the runtime history from the canonical Thread projection.
-5. Build tool, context-checkpoint, trace, and workspace command-hook services,
-   selecting the Thread-owned or direct-session trace path.
+5. Install context-checkpoint, trace, and workspace command-hook services,
+   selecting the Thread-owned or direct-session trace path. Construct the tool
+   dispatcher last so child Turns inherit these installed services and live output.
 6. Execute the native agent loop and flush the trace sink.
 7. Persist the terminal boundary or resumable checkpoint as applicable. If
    runtime execution or trace flush fails, persist a failed terminal with the
@@ -102,6 +103,11 @@ when it failed.
 - `tool_dispatcher.rs`: construct runtime services backed by registered tools.
   It also owns Agent-only `mcp.config.*` dispatch because configuration changes
   require asynchronous runtime reconciliation rather than generic Worker RPC.
+- `workspace_threads.rs`: discover project-coordinator tools, authorize targets,
+  create persistent child Threads, send follow-up input, and execute child Turns.
+  The dispatcher owns discovery and execution; the runtime only schedules the
+  calls. Execution rechecks project membership and parent ownership even after
+  discovery. Parent cancellation requests child cancellation and awaits cleanup.
 - `result_projection.rs`: input identity, model, provider, and setting accessors.
 - `webui_continuation.rs`: form continuations for WebUI callers.
 

--- a/src-tauri/src/agent/bridge/README.md
+++ b/src-tauri/src/agent/bridge/README.md
@@ -1,10 +1,22 @@
 # Native Agent Bridge
-<!-- tinybot-module-fingerprint: sha256:9046f277a0ecef6e5abf28b407db44ed3139491b3d14fc0da87455871c34ca24 -->
+<!-- tinybot-module-fingerprint: sha256:72db246495d6a68f0db9b8ee7c41d80b8a70937b6a987410f8a38546750b1dbc -->
 
 `agent::bridge` is the application-service layer around the generic
 native agent runtime. It coordinates the resources required for a complete
 desktop or Thread-owned turn without moving those concerns into the provider
 loop.
+
+
+`AgentApplicationServices` keeps the core execution services alongside the shared
+Thread store, MCP, Shell, browser and subagent resources owned by desktop state.
+Its `prepare_turn` path is used by ordinary Turns and form continuations: install
+checkpoint persistence, trace and hooks, then capture those services in the tool
+executor so child Turns inherit the same live output and persistence.
+`tool_catalog.rs` discovers Graph, workspace-thread and MCP contributions through
+the dispatcher's asynchronous preparation interface. MCP snapshot cancellation
+retains phase/server/transport diagnostics; unavailable concrete selections are
+removed with the existing generic-MCP suppression rule. Graph discovery requires
+an explicit working directory and remains disabled for Graph node Turns.
 
 ## Responsibilities
 

--- a/src-tauri/src/agent/bridge/agent_flow.rs
+++ b/src-tauri/src/agent/bridge/agent_flow.rs
@@ -58,14 +58,9 @@ pub(super) async fn run_agent_with_services(
     let memory_scope_root = instructions.working_directory.clone();
     persist_native_agent_turn_start(&request, &instructions, &thread_store)?;
     hydrate_native_agent_history_for_runtime(&mut request.input, &thread_store)?;
-    let services = native_agent_services_with_tool_executor(
-        base_services,
-        workspace_root.clone(),
-        graph_base_config_snapshot,
-    )?
-    .with_context_checkpoint_committer(native_agent_context_checkpoint_committer(
-        thread_store.clone(),
-    ));
+    let services = base_services.with_context_checkpoint_committer(
+        native_agent_context_checkpoint_committer(thread_store.clone()),
+    );
     let services = match live_trace_sink {
         Some(live_trace_sink) => services.with_trace_sink(native_agent_trace_sink(
             thread_store.clone(),
@@ -79,6 +74,12 @@ pub(super) async fn run_agent_with_services(
         &crate::config::application::tinybot_data_root(),
         &instructions.working_directory,
     ));
+    // Child Turn orchestration must inherit the installed trace/checkpoint services.
+    let services = native_agent_services_with_tool_executor(
+        services,
+        workspace_root.clone(),
+        graph_base_config_snapshot,
+    )?;
     let session_id = request.input.session_id.clone();
     let turn_result = run_native_agent_turn_with_workspace_and_instructions_async(
         &services,

--- a/src-tauri/src/agent/bridge/agent_flow.rs
+++ b/src-tauri/src/agent/bridge/agent_flow.rs
@@ -1,14 +1,15 @@
+use super::AgentApplicationServices;
 use crate::agent::bridge::{
     hydrate_native_agent_history_for_runtime, hydrate_native_agent_memory_snapshot_for_runtime,
-    native_agent_context_checkpoint_committer, native_agent_services_with_tool_executor,
-    native_agent_trace_sink, persist_native_agent_checkpoint_if_present,
-    persist_native_agent_turn_start, persist_native_agent_turn_terminal_if_present,
-    reject_native_agent_terminal_turn_reentry,
+    persist_native_agent_checkpoint_if_present, persist_native_agent_turn_start,
+    persist_native_agent_turn_terminal_if_present, reject_native_agent_terminal_turn_reentry,
 };
+use crate::agent::instruction_sources::InstructionLoader;
 use crate::agent::runtime::AgentError;
+#[cfg(test)]
+use crate::agent::runtime::NativeAgentRuntimeServices;
 use crate::agent::runtime::{
-    run_native_agent_turn_with_workspace_and_instructions_async, InstructionComposer,
-    NativeAgentRuntimeServices, NativeAgentTraceSink,
+    run_native_agent_turn_with_workspace_and_instructions_async, NativeAgentTraceSink,
 };
 #[cfg(not(test))]
 use crate::agent::runtime::{AgentExecutionStatus, AgentStopReason};
@@ -21,7 +22,7 @@ use std::sync::Arc;
 mod tests;
 
 pub(crate) async fn run_agent_from_wire_with_services(
-    services: NativeAgentRuntimeServices,
+    services: AgentApplicationServices,
     spec: serde_json::Value,
     workspace_root: PathBuf,
     config: serde_json::Value,
@@ -32,13 +33,13 @@ pub(crate) async fn run_agent_from_wire_with_services(
 }
 
 pub(super) async fn run_agent_with_services(
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     mut request: super::turn_request::AgentTurnRequest,
     workspace_root: PathBuf,
     mut config_snapshot: serde_json::Value,
     live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 ) -> Result<AgentTurnResult, AgentError> {
-    let thread_store = base_services.thread_store()?;
+    let thread_store = base_services.thread_store.clone();
     let trace_context = request.input.trace_context.clone();
     if let Some(mut rejection) =
         reject_native_agent_terminal_turn_reentry(&request.input, &thread_store)?
@@ -47,8 +48,8 @@ pub(super) async fn run_agent_with_services(
         return Ok(rejection);
     }
     hydrate_native_agent_memory_snapshot_for_runtime(&mut request, &thread_store)?;
-    let instructions =
-        InstructionComposer::default().compose_input(&workspace_root, &request.instructions)?;
+    let instructions = InstructionLoader::new(thread_store.data_root().join("plugins"))
+        .compose_input(&workspace_root, &request.instructions)?;
     let graph_base_config_snapshot = config_snapshot.clone();
     crate::workspace_extensions::merge_workspace_mcp_servers(
         &mut config_snapshot,
@@ -58,28 +59,12 @@ pub(super) async fn run_agent_with_services(
     let memory_scope_root = instructions.working_directory.clone();
     persist_native_agent_turn_start(&request, &instructions, &thread_store)?;
     hydrate_native_agent_history_for_runtime(&mut request.input, &thread_store)?;
-    let services = base_services.with_context_checkpoint_committer(
-        native_agent_context_checkpoint_committer(thread_store.clone()),
-    );
-    let services = match live_trace_sink {
-        Some(live_trace_sink) => services.with_trace_sink(native_agent_trace_sink(
-            thread_store.clone(),
-            Some(live_trace_sink),
-        )),
-        None => services
-            .with_trace_sink_if_missing(|| native_agent_trace_sink(thread_store.clone(), None)),
-    };
-    #[cfg(not(test))]
-    let services = services.with_command_hooks(crate::command_hooks::CommandHookEngine::load(
-        &crate::config::application::tinybot_data_root(),
+    let services = base_services.prepare_turn(
+        &workspace_root,
         &instructions.working_directory,
-    ));
-    // Child Turn orchestration must inherit the installed trace/checkpoint services.
-    let services = native_agent_services_with_tool_executor(
-        services,
-        workspace_root.clone(),
         graph_base_config_snapshot,
-    )?;
+        live_trace_sink,
+    );
     let session_id = request.input.session_id.clone();
     let turn_result = run_native_agent_turn_with_workspace_and_instructions_async(
         &services,

--- a/src-tauri/src/agent/bridge/agent_flow.rs
+++ b/src-tauri/src/agent/bridge/agent_flow.rs
@@ -59,12 +59,23 @@ pub(super) async fn run_agent_with_services(
     let memory_scope_root = instructions.working_directory.clone();
     persist_native_agent_turn_start(&request, &instructions, &thread_store)?;
     hydrate_native_agent_history_for_runtime(&mut request.input, &thread_store)?;
-    let services = base_services.prepare_turn(
-        &workspace_root,
-        &instructions.working_directory,
-        graph_base_config_snapshot,
-        live_trace_sink,
-    );
+    #[cfg(not(test))]
+    let memory_runtime = base_services.memory_runtime.clone();
+    let services = base_services
+        .prepare_turn(
+            &workspace_root,
+            &instructions.working_directory,
+            graph_base_config_snapshot,
+            live_trace_sink,
+        )
+        .map_err(|error| {
+            persist_failed_agent_turn(
+                &request.input.session_id,
+                &trace_context,
+                &thread_store,
+                error.into(),
+            )
+        })?;
     let session_id = request.input.session_id.clone();
     let turn_result = run_native_agent_turn_with_workspace_and_instructions_async(
         &services,
@@ -106,6 +117,7 @@ pub(super) async fn run_agent_with_services(
     persist_native_agent_checkpoint_if_present(&result, &thread_store)?;
     #[cfg(not(test))]
     schedule_completed_turn_memory_extraction(
+        &memory_runtime,
         &trace_context,
         &result,
         &workspace_root,
@@ -138,6 +150,7 @@ fn persist_failed_agent_turn(
 
 #[cfg(not(test))]
 fn schedule_completed_turn_memory_extraction(
+    memory_runtime: &crate::memory::MemoryRuntime,
     trace_context: &crate::agent::runtime_protocol::AgentTraceContext,
     result: &AgentTurnResult,
     workspace_root: &std::path::Path,
@@ -165,12 +178,16 @@ fn schedule_completed_turn_memory_extraction(
             return;
         }
     };
-    crate::memory::schedule_turn_extraction(
-        workspace_root.to_path_buf(),
+    if let Err(error) = memory_runtime.schedule_turn_extraction(
         thread_store.clone(),
         config_snapshot.clone(),
         thread_id,
         turn_id,
         workspace_path,
-    );
+    ) {
+        eprintln!(
+            "memory_phase1_schedule_failed workspace={} error={error}",
+            workspace_root.display()
+        );
+    }
 }

--- a/src-tauri/src/agent/bridge/agent_flow_tests.rs
+++ b/src-tauri/src/agent/bridge/agent_flow_tests.rs
@@ -1,8 +1,9 @@
 use super::*;
+#[cfg(test)]
+use crate::agent::runtime::test_support::BlockingTestProvider;
 use crate::agent::runtime::{
     AgentTurnContext, FakeNativeAgentToolDispatcher, InMemoryNativeAgentCancellation,
-    InMemoryNativeAgentCheckpointStore, NativeAgentProvider, NativeAgentProviderResponse,
-    NativeAgentToolCall,
+    InMemoryNativeAgentCheckpointStore, NativeAgentProviderResponse, NativeAgentToolCall,
 };
 use crate::agent::runtime_protocol::{AgentRuntimeEventEnvelope, AgentTimelinePatch};
 use crate::protocol::capability::default_desktop_capability_policy;
@@ -16,7 +17,7 @@ struct DataViewProvider {
     calls: AtomicUsize,
 }
 
-impl NativeAgentProvider for DataViewProvider {
+impl BlockingTestProvider for DataViewProvider {
     fn complete(&self, _context: &AgentTurnContext) -> Result<NativeAgentProviderResponse, String> {
         if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
             return Ok(NativeAgentProviderResponse {

--- a/src-tauri/src/agent/bridge/agent_flow_tests.rs
+++ b/src-tauri/src/agent/bridge/agent_flow_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 #[cfg(test)]
+use crate::agent::bridge::TestApplicationServices;
+#[cfg(test)]
 use crate::agent::runtime::test_support::BlockingTestProvider;
 use crate::agent::runtime::{
     AgentTurnContext, FakeNativeAgentToolDispatcher, InMemoryNativeAgentCancellation,
@@ -210,7 +212,7 @@ fn invalid_continuation_is_rejected_before_durability_and_task_ownership() {
             Arc::new(InMemoryNativeAgentCancellation::default()),
         )
         .with_thread_store(store.clone());
-        let runtime = services.task_runtime().clone();
+        let runtime = services.runtime.task_runtime().clone();
         let error = run_agent_from_wire_with_services(
             services,
             serde_json::json!({

--- a/src-tauri/src/agent/bridge/agent_flow_tests.rs
+++ b/src-tauri/src/agent/bridge/agent_flow_tests.rs
@@ -352,3 +352,38 @@ fn runtime_error_after_tool_delta_persists_a_failed_turn() {
         assert_eq!(runtime_state["stopReason"], "runtime_error");
     });
 }
+#[test]
+fn invalid_command_hooks_fail_the_durable_turn_before_provider_execution() {
+    tauri::async_runtime::block_on(async {
+        let workspace = TestWorkspace::new();
+        let data_root = workspace.root.join("thread-data");
+        std::fs::create_dir_all(&data_root).unwrap();
+        std::fs::write(data_root.join("hooks.json"), "{invalid").unwrap();
+        let store = WorkspaceThreadStore::new_with_data_root(
+            workspace.root.clone(),
+            data_root,
+            default_desktop_capability_policy(),
+        );
+        let provider = Arc::new(DataViewProvider {
+            calls: AtomicUsize::new(0),
+        });
+        let services = NativeAgentRuntimeServices::new(
+            provider.clone(),
+            Arc::new(FakeNativeAgentToolDispatcher),
+            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+            Arc::new(InMemoryNativeAgentCancellation::default()),
+        )
+        .with_thread_store(store.clone());
+        let error = run_agent_from_wire_with_services(services, serde_json::json!({
+            "sessionId":"hook-thread", "threadId":"hook-thread", "turnId":"hook-turn", "model":"fixture-model",
+            "messages":[{"role":"user", "content":"hello"}],
+        }), workspace.root.clone(), serde_json::json!({}), None).await.unwrap_err();
+        assert!(error.to_string().contains("hook_config_invalid_json"));
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+        let turn = store
+            .agent_turn("hook-thread", "hook-turn")
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.status, crate::threads::turn::AgentTurnStatus::Failed);
+    });
+}

--- a/src-tauri/src/agent/bridge/application.rs
+++ b/src-tauri/src/agent/bridge/application.rs
@@ -1,0 +1,76 @@
+use crate::agent::runtime::{NativeAgentRuntimeServices, NativeAgentTraceSink};
+use crate::collaboration::subagents::SubagentThreadManager;
+use crate::runtime::mcp::McpRuntime;
+use crate::threads::workspace_store::WorkspaceThreadStore;
+use crate::tools::shell::WorkerShellRuntime;
+use std::{path::Path, sync::Arc};
+
+/// Application-owned resources shared by parent, child and resumed Turns.
+#[derive(Clone)]
+pub(crate) struct AgentApplicationServices {
+    pub runtime: NativeAgentRuntimeServices,
+    pub thread_store: WorkspaceThreadStore,
+    pub mcp_runtime: McpRuntime,
+    pub shell_runtime: WorkerShellRuntime,
+    pub subagent_manager: SubagentThreadManager,
+    pub browser_runtime: Option<crate::native_browser::SharedBrowserRuntime>,
+}
+
+impl AgentApplicationServices {
+    /// Install persistence and tracing before capturing the services for child Turns.
+    pub(super) fn prepare_turn(
+        mut self,
+        workspace_root: &Path,
+        working_directory: &Path,
+        base_config_snapshot: serde_json::Value,
+        live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
+    ) -> NativeAgentRuntimeServices {
+        self.runtime = self.runtime.with_context_checkpoint_committer(
+            super::native_agent_context_checkpoint_committer(self.thread_store.clone()),
+        );
+        self.runtime = match live_trace_sink {
+            Some(sink) => self.runtime.with_trace_sink(super::native_agent_trace_sink(
+                self.thread_store.clone(),
+                Some(sink),
+            )),
+            None => self.runtime.with_trace_sink_if_missing(|| {
+                super::native_agent_trace_sink(self.thread_store.clone(), None)
+            }),
+        };
+        #[cfg(not(test))]
+        {
+            self.runtime =
+                self.runtime
+                    .with_command_hooks(crate::command_hooks::CommandHookEngine::load(
+                        self.thread_store.data_root(),
+                        working_directory,
+                    ));
+        }
+        #[cfg(test)]
+        let _ = working_directory;
+        super::native_agent_services_with_tool_executor(
+            self,
+            workspace_root.to_path_buf(),
+            base_config_snapshot,
+        )
+    }
+}
+
+#[cfg(test)]
+pub(crate) trait TestApplicationServices {
+    fn with_thread_store(self, store: WorkspaceThreadStore) -> AgentApplicationServices;
+}
+
+#[cfg(test)]
+impl TestApplicationServices for NativeAgentRuntimeServices {
+    fn with_thread_store(self, store: WorkspaceThreadStore) -> AgentApplicationServices {
+        AgentApplicationServices {
+            runtime: self,
+            thread_store: store,
+            mcp_runtime: McpRuntime::new(),
+            shell_runtime: WorkerShellRuntime::default(),
+            subagent_manager: SubagentThreadManager::default(),
+            browser_runtime: None,
+        }
+    }
+}

--- a/src-tauri/src/agent/bridge/application.rs
+++ b/src-tauri/src/agent/bridge/application.rs
@@ -11,6 +11,8 @@ pub(crate) struct AgentApplicationServices {
     pub runtime: NativeAgentRuntimeServices,
     pub thread_store: WorkspaceThreadStore,
     pub mcp_runtime: McpRuntime,
+    #[cfg_attr(test, allow(dead_code))]
+    pub memory_runtime: crate::memory::MemoryRuntime,
     pub shell_runtime: WorkerShellRuntime,
     pub subagent_manager: SubagentThreadManager,
     pub browser_runtime: Option<crate::native_browser::SharedBrowserRuntime>,
@@ -24,7 +26,7 @@ impl AgentApplicationServices {
         working_directory: &Path,
         base_config_snapshot: serde_json::Value,
         live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
-    ) -> NativeAgentRuntimeServices {
+    ) -> Result<NativeAgentRuntimeServices, String> {
         self.runtime = self.runtime.with_context_checkpoint_committer(
             super::native_agent_context_checkpoint_committer(self.thread_store.clone()),
         );
@@ -37,22 +39,17 @@ impl AgentApplicationServices {
                 super::native_agent_trace_sink(self.thread_store.clone(), None)
             }),
         };
-        #[cfg(not(test))]
-        {
-            self.runtime =
-                self.runtime
-                    .with_command_hooks(crate::command_hooks::CommandHookEngine::load(
-                        self.thread_store.data_root(),
-                        working_directory,
-                    ));
-        }
-        #[cfg(test)]
-        let _ = working_directory;
-        super::native_agent_services_with_tool_executor(
+        self.runtime =
+            self.runtime
+                .with_hook(Arc::new(crate::command_hooks::CommandHookEngine::load(
+                    self.thread_store.data_root(),
+                    working_directory,
+                )?));
+        Ok(super::native_agent_services_with_tool_executor(
             self,
             workspace_root.to_path_buf(),
             base_config_snapshot,
-        )
+        ))
     }
 }
 
@@ -68,6 +65,9 @@ impl TestApplicationServices for NativeAgentRuntimeServices {
             runtime: self,
             thread_store: store,
             mcp_runtime: McpRuntime::new(),
+            memory_runtime: crate::memory::MemoryRuntime::new(Arc::new(
+                crate::memory::NativeMemoryModel,
+            )),
             shell_runtime: WorkerShellRuntime::default(),
             subagent_manager: SubagentThreadManager::default(),
             browser_runtime: None,

--- a/src-tauri/src/agent/bridge/command_hooks.rs
+++ b/src-tauri/src/agent/bridge/command_hooks.rs
@@ -1,6 +1,5 @@
 use crate::agent::runtime::{
-    AgentHook, AgentHookDecision, AgentHookInvocation, AgentHookOutput, AgentHookRun,
-    AgentHookStage,
+    AgentHook, AgentHookInvocation, AgentHookOutput, AgentHookRun, AgentHookStage,
 };
 use crate::command_hooks::{CommandHookEngine, CommandHookEvent, CommandHookRequest};
 use futures_util::future::BoxFuture;
@@ -15,7 +14,8 @@ impl AgentHook for CommandHookEngine {
     ) -> BoxFuture<'a, Result<AgentHookOutput, String>> {
         Box::pin(async move {
             let Some(request) = command_request(invocation) else {
-                return Ok(AgentHookOutput::Decision(AgentHookDecision::Continue));
+                // No command ran at this stage, so there is no decision to record.
+                return Ok(AgentHookOutput::Runs(Vec::new()));
             };
             let result = CommandHookEngine::evaluate(self, &request).await;
             Ok(AgentHookOutput::Runs(

--- a/src-tauri/src/agent/bridge/command_hooks.rs
+++ b/src-tauri/src/agent/bridge/command_hooks.rs
@@ -1,0 +1,69 @@
+use crate::agent::runtime::{
+    AgentHook, AgentHookDecision, AgentHookInvocation, AgentHookOutput, AgentHookRun,
+    AgentHookStage,
+};
+use crate::command_hooks::{CommandHookEngine, CommandHookEvent, CommandHookRequest};
+use futures_util::future::BoxFuture;
+
+impl AgentHook for CommandHookEngine {
+    fn name(&self) -> &'static str {
+        "command_hooks"
+    }
+    fn evaluate<'a>(
+        &'a self,
+        invocation: &'a AgentHookInvocation,
+    ) -> BoxFuture<'a, Result<AgentHookOutput, String>> {
+        Box::pin(async move {
+            let Some(request) = command_request(invocation) else {
+                return Ok(AgentHookOutput::Decision(AgentHookDecision::Continue));
+            };
+            let result = CommandHookEngine::evaluate(self, &request).await;
+            Ok(AgentHookOutput::Runs(
+                result
+                    .runs
+                    .into_iter()
+                    .map(|run| AgentHookRun {
+                        hook_hash: run.hook_hash,
+                        hook_name: run.hook_name,
+                        source_path: run.source_path.display().to_string(),
+                        duration_ms: run.duration_ms,
+                        decision: run.decision,
+                        denied_reason: run.denied_reason,
+                        updated_input: run.updated_input,
+                        additional_context: run.additional_context,
+                        system_message: run.system_message,
+                        tool_feedback: run.tool_feedback,
+                        failure: run.failure,
+                    })
+                    .collect(),
+            ))
+        })
+    }
+}
+
+fn command_request(invocation: &AgentHookInvocation) -> Option<CommandHookRequest> {
+    let event = match invocation.stage {
+        AgentHookStage::UserPromptSubmit => CommandHookEvent::UserPromptSubmit,
+        AgentHookStage::BeforeToolUse => CommandHookEvent::PreToolUse,
+        AgentHookStage::AfterToolUse => CommandHookEvent::PostToolUse,
+        AgentHookStage::CompactionComplete => CommandHookEvent::PostCompact,
+        _ => return None,
+    };
+    Some(CommandHookRequest {
+        event,
+        session_id: invocation.session_id.clone().unwrap_or_default(),
+        turn_id: invocation.trace_context.turn_id.clone(),
+        model: invocation.model.clone().unwrap_or_default(),
+        permission_mode: invocation
+            .permission_mode
+            .clone()
+            .unwrap_or_else(|| "local-worker".to_string()),
+        prompt: invocation.prompt.clone(),
+        tool_name: invocation.tool_name.clone(),
+        tool_match_names: invocation.tool_name.clone().into_iter().collect(),
+        tool_use_id: invocation.tool_call_id.clone(),
+        tool_input: invocation.normalized_input.clone(),
+        tool_response: invocation.tool_response.clone(),
+        trigger: invocation.compaction_trigger.clone(),
+    })
+}

--- a/src-tauri/src/agent/bridge/mod.rs
+++ b/src-tauri/src/agent/bridge/mod.rs
@@ -1,9 +1,14 @@
+#[cfg(test)]
+pub(crate) use application::TestApplicationServices;
+mod application;
+pub(crate) use application::AgentApplicationServices;
 mod agent_flow;
 mod context_checkpoint;
 mod history;
 mod persistence;
 mod result_projection;
 mod thread_flow;
+mod tool_catalog;
 mod tool_dispatcher;
 mod trace_sink;
 pub(crate) mod turn_request;

--- a/src-tauri/src/agent/bridge/mod.rs
+++ b/src-tauri/src/agent/bridge/mod.rs
@@ -1,3 +1,4 @@
+mod command_hooks;
 #[cfg(test)]
 pub(crate) use application::TestApplicationServices;
 mod application;

--- a/src-tauri/src/agent/bridge/mod.rs
+++ b/src-tauri/src/agent/bridge/mod.rs
@@ -8,6 +8,7 @@ mod tool_dispatcher;
 mod trace_sink;
 pub(crate) mod turn_request;
 mod webui_continuation;
+mod workspace_threads;
 
 pub(crate) use agent_flow::run_agent_from_wire_with_services;
 pub(crate) use context_checkpoint::native_agent_context_checkpoint_committer;

--- a/src-tauri/src/agent/bridge/thread_flow.rs
+++ b/src-tauri/src/agent/bridge/thread_flow.rs
@@ -1,12 +1,11 @@
+use super::AgentApplicationServices;
 use crate::agent::bridge::{
     native_agent_current_user_message, native_agent_model, native_agent_provider,
     native_agent_string_field, native_agent_turn_id,
 };
 use crate::agent::conversation_title::{should_generate_title, ConversationTitleTask};
 use crate::agent::runtime::AgentError;
-use crate::agent::runtime::{
-    AgentHookInvocation, AgentHookStage, NativeAgentRuntimeServices, NativeAgentTraceSink,
-};
+use crate::agent::runtime::{AgentHookInvocation, AgentHookStage, NativeAgentTraceSink};
 use crate::agent::runtime::{AgentResultError, AgentStopReason, AgentTurnResult};
 use crate::agent::runtime_protocol::AgentTraceContext;
 use crate::threads::domain::{StartThreadTurnRequest, ThreadRecord, ThreadSnapshot};
@@ -50,13 +49,13 @@ pub(crate) struct CompactThreadInput {
 }
 
 pub(crate) async fn compact_thread_with_services(
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     input: CompactThreadInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
     live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 ) -> Result<serde_json::Value, AgentError> {
-    let thread_store = base_services.thread_store()?;
+    let thread_store = base_services.thread_store.clone();
     let snapshot = read_thread_snapshot(
         &input.thread_id,
         &thread_store,
@@ -117,7 +116,7 @@ pub(crate) async fn compact_thread_with_services(
 }
 
 pub(crate) async fn submit_thread_turn_with_services(
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     input: SubmitThreadTurnInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
@@ -139,13 +138,13 @@ pub(crate) async fn submit_thread_turn_with_services(
 }
 
 pub(crate) async fn execute_thread_turn_with_services(
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     input: SubmitThreadTurnInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
     live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 ) -> Result<ExecutedThreadTurn, AgentError> {
-    let thread_store = base_services.thread_store()?;
+    let thread_store = base_services.thread_store.clone();
     let thread =
         ensure_thread_turn_target(input.thread_id, &thread_store, config_snapshot.clone())?;
     let thread_id = thread.thread_id.clone();
@@ -257,8 +256,9 @@ pub(crate) async fn execute_thread_turn_with_services(
     let thread_hook_services = base_services.clone();
     let thread_start_invocation =
         AgentHookInvocation::lifecycle(AgentHookStage::ThreadStart, trace_context.clone());
-    let thread_start_evaluation =
-        thread_hook_services.evaluate_hook_invocation(thread_start_invocation)?;
+    let thread_start_evaluation = thread_hook_services
+        .runtime
+        .evaluate_hook_invocation(thread_start_invocation)?;
     if let Some(reason) = thread_start_evaluation.denied_reason.clone() {
         return Err(format!("thread start hook denied: {reason}").into());
     }
@@ -288,7 +288,9 @@ pub(crate) async fn execute_thread_turn_with_services(
     .await?;
     let thread_stop_invocation =
         AgentHookInvocation::lifecycle(AgentHookStage::ThreadStop, trace_context);
-    thread_hook_services.evaluate_hook_invocation(thread_stop_invocation)?;
+    thread_hook_services
+        .runtime
+        .evaluate_hook_invocation(thread_stop_invocation)?;
     Ok(ExecutedThreadTurn {
         thread_id,
         session_id,
@@ -335,7 +337,7 @@ mod role_binding_tests {
 }
 
 pub(crate) async fn submit_thread_form_with_services(
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     input: SubmitThreadFormInput,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
@@ -345,7 +347,7 @@ pub(crate) async fn submit_thread_form_with_services(
     if command_id.is_empty() {
         return Err("thread form commandId must not be empty".to_string().into());
     }
-    let thread_store = base_services.thread_store()?;
+    let thread_store = base_services.thread_store.clone();
     let target_snapshot =
         read_thread_snapshot(&input.thread_id, &thread_store, "thread form target read")?;
     let thread_id = target_snapshot.thread.thread_id.clone();

--- a/src-tauri/src/agent/bridge/thread_flow.rs
+++ b/src-tauri/src/agent/bridge/thread_flow.rs
@@ -258,7 +258,8 @@ pub(crate) async fn execute_thread_turn_with_services(
         AgentHookInvocation::lifecycle(AgentHookStage::ThreadStart, trace_context.clone());
     let thread_start_evaluation = thread_hook_services
         .runtime
-        .evaluate_hook_invocation(thread_start_invocation)?;
+        .evaluate_hook_invocation(thread_start_invocation)
+        .await?;
     if let Some(reason) = thread_start_evaluation.denied_reason.clone() {
         return Err(format!("thread start hook denied: {reason}").into());
     }
@@ -290,7 +291,8 @@ pub(crate) async fn execute_thread_turn_with_services(
         AgentHookInvocation::lifecycle(AgentHookStage::ThreadStop, trace_context);
     thread_hook_services
         .runtime
-        .evaluate_hook_invocation(thread_stop_invocation)?;
+        .evaluate_hook_invocation(thread_stop_invocation)
+        .await?;
     Ok(ExecutedThreadTurn {
         thread_id,
         session_id,

--- a/src-tauri/src/agent/bridge/tool_catalog.rs
+++ b/src-tauri/src/agent/bridge/tool_catalog.rs
@@ -1,0 +1,105 @@
+use crate::agent::runtime::{
+    AgentError, AgentTurnContext, NativeAgentToolCatalog, NativeAgentToolPreparation,
+};
+use crate::runtime::mcp::McpRuntime;
+use crate::threads::workspace_store::WorkspaceThreadStore;
+use crate::tools::registry::{AgentGraphToolContributor, McpToolContributor, ToolContributor};
+use std::{path::Path, sync::Arc};
+
+pub(super) async fn prepare_tools(
+    context: &AgentTurnContext,
+    config_snapshot: &serde_json::Value,
+    workspace_root: &Path,
+    thread_store: &WorkspaceThreadStore,
+    mcp_runtime: &McpRuntime,
+) -> Result<NativeAgentToolPreparation, AgentError> {
+    let capability_policy = context.settings.capability_policy()?;
+    let mcp_workspace_root = context
+        .settings
+        .working_directory
+        .as_deref()
+        .unwrap_or(workspace_root);
+    let cancellation = context
+        .cancellation
+        .clone()
+        .map(|c| Arc::new(c) as Arc<dyn crate::protocol::WorkerRequestCancellation>);
+    let mcp_snapshot =
+        if capability_policy.allows(&crate::protocol::capability::WorkerCapability::McpCall) {
+            match mcp_runtime
+                .registry_snapshot(mcp_workspace_root, config_snapshot, cancellation)
+                .await
+            {
+                Ok(snapshot) => Some(snapshot),
+                Err(error) if error.cancelled => {
+                    return Ok(NativeAgentToolPreparation::Cancelled {
+                        phase: "mcp_discovery".into(),
+                        server: Some(error.server),
+                        transport: Some(error.transport),
+                    })
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "MCP registry snapshot failed for server `{}` over {}: {}",
+                        error.server, error.transport, error.message
+                    )
+                    .into())
+                }
+            }
+        } else {
+            None
+        };
+    let mut contributors: Vec<Arc<dyn ToolContributor>> = Vec::new();
+    let graph_node_turn = ["graphRunId", "graph_run_id"]
+        .iter()
+        .any(|key| context.metadata.get(*key).is_some());
+    if !graph_node_turn && context.controls.declares_working_directory {
+        if let Some(definition_workspace_root) = context.settings.working_directory.as_deref() {
+            let definition_workspace =
+                crate::workspace_registry::canonical_workspace(definition_workspace_root)?;
+            let discovery =
+                crate::agent_graphs::discover_tools_for_workspace(&definition_workspace)?;
+            if !discovery.graphs.is_empty() {
+                contributors.push(Arc::new(AgentGraphToolContributor::new(
+                    crate::workspace_registry::workspace_id(&definition_workspace),
+                    discovery.graphs,
+                )?));
+            }
+        }
+    }
+
+    if let Some(contributor) = super::workspace_threads::tool_contributor(thread_store, context)? {
+        contributors.push(Arc::new(contributor));
+    }
+    let mut selected_tools = context.settings.selected_tools.clone();
+    for server in mcp_snapshot
+        .as_deref()
+        .into_iter()
+        .flat_map(|snapshot| snapshot.servers.iter())
+        .filter(|server| server.available && server.tools.iter().any(|tool| tool.allowed))
+    {
+        contributors.push(Arc::new(McpToolContributor::from_registry(server)?));
+    }
+    if let (Some(snapshot), Some(selected_tools)) =
+        (mcp_snapshot.as_deref(), selected_tools.as_mut())
+    {
+        let unavailable_mcp_tools = snapshot
+            .servers
+            .iter()
+            .filter(|server| !server.available)
+            .flat_map(|server| server.tools.iter().map(|tool| tool.id.as_str()))
+            .collect::<std::collections::BTreeSet<_>>();
+        let dropped_concrete_mcp = selected_tools
+            .iter()
+            .any(|tool_id| unavailable_mcp_tools.contains(tool_id.as_str()));
+        selected_tools.retain(|tool_id| {
+            !unavailable_mcp_tools.contains(tool_id.as_str())
+                && (!dropped_concrete_mcp
+                    || tool_id != crate::tools::registry::MCP_CALL_TOOL_METHOD)
+        });
+    }
+
+    Ok(NativeAgentToolPreparation::Ready(NativeAgentToolCatalog {
+        contributors,
+        selected_tools,
+    }))
+}

--- a/src-tauri/src/agent/bridge/tool_dispatcher.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher.rs
@@ -1,9 +1,9 @@
+use super::AgentApplicationServices;
 use crate::agent::runtime::{
     AgentTurnContext, NativeAgentCancellationContext, NativeAgentRuntimeServices,
     NativeAgentToolDispatcher, NativeAgentToolResult, NativeToolNextAction, NativeToolOutcome,
     NativeToolRetry, PreparedToolCall,
 };
-use crate::collaboration::subagents::SubagentThreadManager;
 use crate::config::application::{
     default_tinybot_config_path, native_config_snapshot, native_runtime_config_snapshot,
 };
@@ -16,9 +16,7 @@ use crate::rpc::call_rust_state_service_with_mcp_runtime;
 use crate::runtime::mcp::{
     configured_mcp_servers, mcp_tool_is_enabled, McpRuntime, McpRuntimeError, McpRuntimeErrorKind,
 };
-use crate::threads::workspace_store::WorkspaceThreadStore;
 use crate::tools::registry::ToolExecutionTarget;
-use crate::tools::shell::WorkerShellRuntime;
 use crate::tools::web::{self, WebToolCancellation};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -26,14 +24,9 @@ use std::sync::Arc;
 #[derive(Clone)]
 struct NativeAgentToolExecutorDispatcher {
     workspace_root: PathBuf,
-    thread_store: WorkspaceThreadStore,
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     base_config_snapshot: serde_json::Value,
     fallback: Arc<dyn NativeAgentToolDispatcher>,
-    mcp_runtime: McpRuntime,
-    shell_runtime: WorkerShellRuntime,
-    subagent_manager: SubagentThreadManager,
-    browser_runtime: Option<crate::native_browser::SharedBrowserRuntime>,
 }
 
 impl WebToolCancellation for NativeAgentCancellationContext {
@@ -47,20 +40,24 @@ impl WebToolCancellation for NativeAgentCancellationContext {
 }
 
 impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
-    fn tool_contributors(
-        &self,
-        context: &AgentTurnContext,
-    ) -> Result<
-        Vec<Arc<dyn crate::tools::registry::ToolContributor>>,
-        crate::agent::runtime::AgentError,
+    fn prepare_tools<'a>(
+        &'a self,
+        context: &'a AgentTurnContext,
+        config_snapshot: &'a serde_json::Value,
+    ) -> futures_util::future::BoxFuture<
+        'a,
+        Result<
+            crate::agent::runtime::NativeAgentToolPreparation,
+            crate::agent::runtime::AgentError,
+        >,
     > {
-        let mut contributors: Vec<Arc<dyn crate::tools::registry::ToolContributor>> = Vec::new();
-        if let Some(contributor) =
-            super::workspace_threads::tool_contributor(&self.thread_store, context)?
-        {
-            contributors.push(Arc::new(contributor));
-        }
-        Ok(contributors)
+        Box::pin(super::tool_catalog::prepare_tools(
+            context,
+            config_snapshot,
+            &self.workspace_root,
+            &self.base_services.thread_store,
+            &self.base_services.mcp_runtime,
+        ))
     }
 
     fn dispatch(
@@ -156,12 +153,12 @@ impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
             ),
         };
         let executor_result = call_rust_state_service_with_mcp_runtime(
-            &self.thread_store,
+            &self.base_services.thread_store,
             tool_workspace_root,
             context.config_snapshot.clone(),
-            self.mcp_runtime.clone(),
-            self.shell_runtime.clone(),
-            self.subagent_manager.clone(),
+            self.base_services.mcp_runtime.clone(),
+            self.base_services.shell_runtime.clone(),
+            self.base_services.subagent_manager.clone(),
             WorkerRequest::new(
                 format!("{}:tool:{}", context.trace_context.request_id, tool_call.id),
                 context.trace_context.trace_id.clone(),
@@ -318,6 +315,7 @@ impl NativeAgentToolExecutorDispatcher {
                     .as_deref()
                     .unwrap_or(&self.workspace_root);
                 if let Err(error) = self
+                    .base_services
                     .mcp_runtime
                     .reconcile(workspace_root, &config_snapshot)
                     .await
@@ -341,7 +339,7 @@ impl NativeAgentToolExecutorDispatcher {
                     )));
                 };
                 let status = refresh_mcp_server_status(
-                    &self.mcp_runtime,
+                    &self.base_services.mcp_runtime,
                     workspace_root,
                     &name,
                     server_config,
@@ -399,7 +397,7 @@ impl NativeAgentToolExecutorDispatcher {
                     .as_deref()
                     .unwrap_or(&self.workspace_root);
                 let status = refresh_mcp_server_status(
-                    &self.mcp_runtime,
+                    &self.base_services.mcp_runtime,
                     workspace_root,
                     &name,
                     server_config,
@@ -444,7 +442,7 @@ impl NativeAgentToolExecutorDispatcher {
             )));
         };
         let run = crate::graph_runs::start(
-            self.thread_store.data_root(),
+            self.base_services.thread_store.data_root(),
             self.base_services.clone(),
             self.workspace_root.clone(),
             self.base_config_snapshot.clone(),
@@ -472,7 +470,7 @@ impl NativeAgentToolExecutorDispatcher {
         if !web::is_web_tool(&tool_call.name) {
             return None;
         }
-        let runtime = match self.browser_runtime.clone() {
+        let runtime = match self.base_services.browser_runtime.clone() {
             Some(runtime) => runtime,
             None => {
                 return Some(Err(
@@ -619,6 +617,7 @@ impl NativeAgentToolExecutorDispatcher {
             .clone()
             .map(|cancellation| Arc::new(cancellation) as Arc<dyn WorkerRequestCancellation>);
         let result = self
+            .base_services
             .mcp_runtime
             .call_tool(
                 context
@@ -856,30 +855,18 @@ fn native_web_tool_outcome(tool_name: &str, raw: &serde_json::Value) -> Option<N
 }
 
 pub(crate) fn native_agent_services_with_tool_executor(
-    services: NativeAgentRuntimeServices,
+    services: AgentApplicationServices,
     workspace_root: PathBuf,
     base_config_snapshot: serde_json::Value,
-) -> Result<NativeAgentRuntimeServices, String> {
-    let base_services = services.clone();
-    let fallback = services.tool_dispatcher();
-    let thread_store = services.thread_store()?;
-    let mcp_runtime = services.mcp_runtime();
-    let shell_runtime = services.shell_runtime();
-    let subagent_manager = services.subagent_manager();
-    let browser_runtime = services.browser_runtime();
-    Ok(
-        services.with_tool_dispatcher(Arc::new(NativeAgentToolExecutorDispatcher {
-            workspace_root,
-            thread_store,
-            base_services,
-            base_config_snapshot,
-            fallback,
-            mcp_runtime,
-            shell_runtime,
-            subagent_manager,
-            browser_runtime,
-        })),
-    )
+) -> NativeAgentRuntimeServices {
+    let runtime = services.runtime.clone();
+    let fallback = runtime.tool_dispatcher();
+    runtime.with_tool_dispatcher(Arc::new(NativeAgentToolExecutorDispatcher {
+        workspace_root,
+        base_services: services,
+        base_config_snapshot,
+        fallback,
+    }))
 }
 
 fn normalize_subagent_arguments(

--- a/src-tauri/src/agent/bridge/tool_dispatcher.rs
+++ b/src-tauri/src/agent/bridge/tool_dispatcher.rs
@@ -47,6 +47,22 @@ impl WebToolCancellation for NativeAgentCancellationContext {
 }
 
 impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
+    fn tool_contributors(
+        &self,
+        context: &AgentTurnContext,
+    ) -> Result<
+        Vec<Arc<dyn crate::tools::registry::ToolContributor>>,
+        crate::agent::runtime::AgentError,
+    > {
+        let mut contributors: Vec<Arc<dyn crate::tools::registry::ToolContributor>> = Vec::new();
+        if let Some(contributor) =
+            super::workspace_threads::tool_contributor(&self.thread_store, context)?
+        {
+            contributors.push(Arc::new(contributor));
+        }
+        Ok(contributors)
+    }
+
     fn dispatch(
         &self,
         context: &AgentTurnContext,
@@ -87,10 +103,14 @@ impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
         }
         if matches!(
             &execution_target,
-            Some(ToolExecutionTarget::AgentGraph { .. })
+            Some(
+                ToolExecutionTarget::AgentGraph { .. }
+                    | ToolExecutionTarget::SpawnWorkspaceThread
+                    | ToolExecutionTarget::SendThreadMessage
+            )
         ) {
             return Err(format!(
-                "native tool `{}` requires asynchronous Agent Graph dispatch",
+                "native tool `{}` requires asynchronous turn orchestration",
                 tool_call.name
             ));
         }
@@ -167,28 +187,55 @@ impl NativeAgentToolDispatcher for NativeAgentToolExecutorDispatcher {
         context: AgentTurnContext,
         tool_call: PreparedToolCall,
     ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send>,
+        Box<
+            dyn std::future::Future<
+                    Output = Result<NativeAgentToolResult, crate::agent::runtime::AgentError>,
+                > + Send,
+        >,
     > {
         Box::pin(async move {
+            let workspace_result = match context.tool_execution_target(&tool_call.name) {
+                Some(ToolExecutionTarget::SpawnWorkspaceThread) => Some(
+                    super::workspace_threads::spawn_workspace_thread(
+                        &self.base_services,
+                        &context,
+                        tool_call.arguments(),
+                    )
+                    .await,
+                ),
+                Some(ToolExecutionTarget::SendThreadMessage) => Some(
+                    super::workspace_threads::send_thread_message(
+                        &self.base_services,
+                        &context,
+                        tool_call.arguments(),
+                    )
+                    .await,
+                ),
+                _ => None,
+            };
+            if let Some(result) = workspace_result {
+                return result
+                    .map(|value| NativeAgentToolResult::generic_success(&tool_call, value));
+            }
             if let Some(result) = self
                 .dispatch_agent_graph_if_needed(&context, &tool_call)
                 .await
             {
-                return result;
+                return result.map_err(Into::into);
             }
             if let Some(result) = self.dispatch_web_if_needed(&context, &tool_call).await {
-                return result;
+                return result.map_err(Into::into);
             }
             if let Some(result) = self
                 .dispatch_mcp_config_if_needed(&context, &tool_call)
                 .await
             {
-                return result;
+                return result.map_err(Into::into);
             }
             if let Some(result) = self.dispatch_mcp_if_needed(&context, &tool_call).await {
-                return result;
+                return result.map_err(Into::into);
             }
-            self.dispatch(&context, &tool_call)
+            self.dispatch(&context, &tool_call).map_err(Into::into)
         })
     }
 }

--- a/src-tauri/src/agent/bridge/webui_continuation.rs
+++ b/src-tauri/src/agent/bridge/webui_continuation.rs
@@ -1,13 +1,12 @@
+use super::AgentApplicationServices;
 use crate::agent::bridge::{
-    native_agent_context_checkpoint_committer, native_agent_services_with_tool_executor,
-    native_agent_trace_sink, persist_native_agent_checkpoint_if_present,
-    persist_native_agent_turn_terminal_if_present,
+    persist_native_agent_checkpoint_if_present, persist_native_agent_turn_terminal_if_present,
 };
+use crate::agent::instruction_sources::InstructionLoader;
 use crate::agent::runtime::AgentError;
 use crate::agent::runtime::{
     run_native_agent_turn_with_workspace_and_instructions_async, AgentCheckpoint,
-    AgentCheckpointPayload, AgentTurnInput, InstructionComposer, NativeAgentRuntimeServices,
-    NativeAgentTraceSink,
+    AgentCheckpointPayload, AgentTurnInput, NativeAgentTraceSink,
 };
 use crate::threads::workspace_store::WorkspaceThreadStore;
 use std::path::PathBuf;
@@ -43,7 +42,7 @@ pub(crate) fn native_webui_agent_ui_form_not_found_body(form_id: String) -> serd
 }
 
 pub(crate) async fn resolve_agent_ui_form_body_with_services(
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     form_id: String,
     body: &serde_json::Value,
     cancelled: bool,
@@ -65,7 +64,7 @@ pub(crate) async fn resolve_agent_ui_form_body_with_services(
 }
 
 pub(crate) async fn resolve_agent_ui_form_body_with_checkpoint(
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     form_id: String,
     body: &serde_json::Value,
     cancelled: bool,
@@ -74,7 +73,7 @@ pub(crate) async fn resolve_agent_ui_form_body_with_checkpoint(
     config_snapshot: serde_json::Value,
     live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 ) -> Result<(u16, serde_json::Value), AgentError> {
-    let thread_store = base_services.thread_store()?;
+    let thread_store = base_services.thread_store.clone();
     let session_key = agent_ui_form_session_key(body).unwrap_or_default();
     let values = body
         .get("values")
@@ -260,7 +259,7 @@ pub(crate) fn native_agent_ui_form_event(
 }
 
 pub(crate) async fn resolve_agent_ui_form_with_services(
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     session_key: &str,
     checkpoint: AgentCheckpoint,
     is_canonical: bool,
@@ -272,40 +271,28 @@ pub(crate) async fn resolve_agent_ui_form_with_services(
     config_snapshot: serde_json::Value,
     live_trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
 ) -> Result<serde_json::Value, AgentError> {
-    let thread_store = base_services.thread_store()?;
+    let thread_store = base_services.thread_store.clone();
     let continuation_spec =
         native_agent_ui_form_continuation_spec(&checkpoint, body, &form_id, &values, cancelled);
     let mut input = AgentTurnInput::from_wire(&continuation_spec, &config_snapshot)
         .map_err(AgentError::invalid_input)?;
     input.messages = checkpoint.messages.clone();
     let trace = input.trace_context.clone();
-    let instructions = InstructionComposer::default().compose_with_config(
-        &workspace_root,
-        &continuation_spec,
-        &config_snapshot,
-    )?;
+    let instructions = InstructionLoader::new(thread_store.data_root().join("plugins"))
+        .compose(&workspace_root, &continuation_spec)?;
+    let graph_base_config_snapshot = config_snapshot.clone();
     let mut config_snapshot = config_snapshot;
     crate::workspace_extensions::merge_workspace_mcp_servers(
         &mut config_snapshot,
         &instructions.working_directory,
     )?;
-    base_services.save_checkpoint(checkpoint);
-    let services = base_services.with_context_checkpoint_committer(
-        native_agent_context_checkpoint_committer(thread_store.clone()),
+    base_services.runtime.save_checkpoint(checkpoint);
+    let services = base_services.prepare_turn(
+        &workspace_root,
+        &instructions.working_directory,
+        graph_base_config_snapshot,
+        live_trace_sink,
     );
-    let services = match live_trace_sink {
-        Some(live_trace_sink) => services.with_trace_sink(native_agent_trace_sink(
-            thread_store.clone(),
-            Some(live_trace_sink),
-        )),
-        None => services
-            .with_trace_sink_if_missing(|| native_agent_trace_sink(thread_store.clone(), None)),
-    };
-    let services = native_agent_services_with_tool_executor(
-        services,
-        workspace_root.clone(),
-        config_snapshot.clone(),
-    )?;
     let turn_result = run_native_agent_turn_with_workspace_and_instructions_async(
         &services,
         input,

--- a/src-tauri/src/agent/bridge/webui_continuation.rs
+++ b/src-tauri/src/agent/bridge/webui_continuation.rs
@@ -290,14 +290,9 @@ pub(crate) async fn resolve_agent_ui_form_with_services(
         &instructions.working_directory,
     )?;
     base_services.save_checkpoint(checkpoint);
-    let services = native_agent_services_with_tool_executor(
-        base_services,
-        workspace_root.clone(),
-        config_snapshot.clone(),
-    )?
-    .with_context_checkpoint_committer(native_agent_context_checkpoint_committer(
-        thread_store.clone(),
-    ));
+    let services = base_services.with_context_checkpoint_committer(
+        native_agent_context_checkpoint_committer(thread_store.clone()),
+    );
     let services = match live_trace_sink {
         Some(live_trace_sink) => services.with_trace_sink(native_agent_trace_sink(
             thread_store.clone(),
@@ -306,6 +301,11 @@ pub(crate) async fn resolve_agent_ui_form_with_services(
         None => services
             .with_trace_sink_if_missing(|| native_agent_trace_sink(thread_store.clone(), None)),
     };
+    let services = native_agent_services_with_tool_executor(
+        services,
+        workspace_root.clone(),
+        config_snapshot.clone(),
+    )?;
     let turn_result = run_native_agent_turn_with_workspace_and_instructions_async(
         &services,
         input,

--- a/src-tauri/src/agent/bridge/webui_continuation.rs
+++ b/src-tauri/src/agent/bridge/webui_continuation.rs
@@ -292,7 +292,7 @@ pub(crate) async fn resolve_agent_ui_form_with_services(
         &instructions.working_directory,
         graph_base_config_snapshot,
         live_trace_sink,
-    );
+    )?;
     let turn_result = run_native_agent_turn_with_workspace_and_instructions_async(
         &services,
         input,

--- a/src-tauri/src/agent/bridge/workspace_threads.rs
+++ b/src-tauri/src/agent/bridge/workspace_threads.rs
@@ -1,11 +1,16 @@
+use super::AgentApplicationServices;
+#[cfg(test)]
+use crate::agent::bridge::TestApplicationServices;
 use crate::agent::bridge::{
     execute_thread_turn_with_services, native_agent_string_field, SubmitThreadTurnInput,
 };
 #[cfg(test)]
 use crate::agent::runtime::test_support::BlockingTestProvider;
 use crate::agent::runtime::AgentError;
+use crate::agent::runtime::AgentTurnContext;
+#[cfg(test)]
+use crate::agent::runtime::NativeAgentRuntimeServices;
 use crate::agent::runtime::{AgentExecutionStatus, AgentStopReason};
-use crate::agent::runtime::{AgentTurnContext, NativeAgentRuntimeServices};
 use crate::project_groups::ProjectGroup;
 #[cfg(test)]
 use crate::project_groups::SaveProjectGroupInput;
@@ -58,13 +63,13 @@ pub(super) fn tool_contributor(
 }
 
 pub(super) async fn spawn_workspace_thread(
-    services: &NativeAgentRuntimeServices,
+    services: &AgentApplicationServices,
     context: &AgentTurnContext,
     arguments: &serde_json::Map<String, Value>,
 ) -> Result<Value, AgentError> {
     let args = parse_spawn_args(arguments)?;
     let parent_thread_id = current_thread_id(context)?;
-    let thread_store = services.thread_store()?;
+    let thread_store = services.thread_store.clone();
     let project_group =
         coordinator_project_group(&thread_store, context.config_snapshot.clone(), context)?
             .ok_or_else(|| {
@@ -125,13 +130,13 @@ pub(super) async fn spawn_workspace_thread(
 }
 
 pub(super) async fn send_thread_message(
-    services: &NativeAgentRuntimeServices,
+    services: &AgentApplicationServices,
     context: &AgentTurnContext,
     arguments: &serde_json::Map<String, Value>,
 ) -> Result<Value, AgentError> {
     let args = parse_send_args(arguments)?;
     let parent_thread_id = current_thread_id(context)?;
-    let thread_store = services.thread_store()?;
+    let thread_store = services.thread_store.clone();
     let project_group =
         coordinator_project_group(&thread_store, context.config_snapshot.clone(), context)?
             .ok_or_else(|| {
@@ -177,7 +182,7 @@ pub(super) async fn send_thread_message(
 }
 
 fn run_workspace_thread_turn(
-    services: &NativeAgentRuntimeServices,
+    services: &AgentApplicationServices,
     context: &AgentTurnContext,
     thread_id: &str,
     message: &str,
@@ -228,7 +233,7 @@ fn run_workspace_thread_turn(
                             "turnId": child_turn_id,
                         })
                     );
-                    services.cancel(&child_turn_id);
+                    services.runtime.cancel(&child_turn_id);
                     (&mut execution).await?
                 }
             }
@@ -336,12 +341,12 @@ fn current_thread_id(context: &AgentTurnContext) -> Result<String, AgentError> {
 }
 
 fn thread_id_workspace(
-    services: &NativeAgentRuntimeServices,
+    services: &AgentApplicationServices,
     context: &AgentTurnContext,
     thread_id: &str,
 ) -> Result<String, AgentError> {
     let thread = read_thread(
-        &services.thread_store()?,
+        &services.thread_store,
         context.config_snapshot.clone(),
         thread_id,
         "workspace thread execution target read",
@@ -858,8 +863,7 @@ mod tests {
                 services,
                 workspace.root.clone(),
                 json!({}),
-            )
-            .unwrap();
+            );
             let run_services = services.clone();
             let workspace_root = workspace.root.clone();
             let run_task = tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/agent/bridge/workspace_threads.rs
+++ b/src-tauri/src/agent/bridge/workspace_threads.rs
@@ -1,9 +1,11 @@
-use super::{AgentExecutionStatus, AgentStopReason};
-use super::{AgentTurnContext, NativeAgentRuntimeServices};
 use crate::agent::bridge::{
     execute_thread_turn_with_services, native_agent_string_field, SubmitThreadTurnInput,
 };
+#[cfg(test)]
+use crate::agent::runtime::test_support::BlockingTestProvider;
 use crate::agent::runtime::AgentError;
+use crate::agent::runtime::{AgentExecutionStatus, AgentStopReason};
+use crate::agent::runtime::{AgentTurnContext, NativeAgentRuntimeServices};
 use crate::project_groups::ProjectGroup;
 #[cfg(test)]
 use crate::project_groups::SaveProjectGroupInput;
@@ -38,14 +40,11 @@ struct SendThreadMessageArgs {
 }
 
 pub(super) fn tool_contributor(
-    services: &NativeAgentRuntimeServices,
+    thread_store: &WorkspaceThreadStore,
     context: &AgentTurnContext,
 ) -> Result<Option<WorkspaceThreadToolContributor>, AgentError> {
-    let Some(thread_store) = services.optional_thread_store() else {
-        return Ok(None);
-    };
     let Some(project_group) =
-        coordinator_project_group(&thread_store, context.config_snapshot.clone(), context)?
+        coordinator_project_group(thread_store, context.config_snapshot.clone(), context)?
     else {
         return Ok(None);
     };
@@ -523,7 +522,7 @@ mod tests {
         calls: AtomicU64,
     }
 
-    impl NativeAgentProvider for ChildTurnProvider {
+    impl BlockingTestProvider for ChildTurnProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -605,7 +604,7 @@ mod tests {
             workspace_ids: Vec<String>,
         }
 
-        impl NativeAgentProvider for ParallelSpawnProvider {
+        impl BlockingTestProvider for ParallelSpawnProvider {
             fn complete(
                 &self,
                 context: &AgentTurnContext,
@@ -699,24 +698,27 @@ mod tests {
             Arc::new(InMemoryNativeAgentCheckpointStore::default()),
             Arc::new(InMemoryNativeAgentCancellation::default()),
         )
-        .with_trace_sink(trace_sink.clone())
         .with_thread_store(store);
 
-        let result = tauri::async_runtime::block_on(run_native_agent_turn_with_workspace_async(
-            &services,
-            json!({
-                "runtime": "rust",
-                "threadId": "parallel-parent-thread",
-                "sessionId": "parallel-parent-thread",
-                "turnId": "parallel-parent-turn",
-                "model": "fixture-model",
-                "maxIterations": 3,
-                "messages": [{ "role": "user", "content": "inspect both workspaces" }],
-            }),
+        let result = tauri::async_runtime::block_on(execute_thread_turn_with_services(
+            services,
+            SubmitThreadTurnInput {
+                thread_id: Some("parallel-parent-thread".to_string()),
+                input: json!({"content": "inspect both workspaces"}),
+                spec: json!({
+                    "runtime": "rust",
+                    "turnId": "parallel-parent-turn",
+                    "model": "fixture-model",
+                    "maxIterations": 3,
+                    "messages": [{ "role": "user", "content": "inspect both workspaces" }],
+                }),
+            },
+            workspace.root.clone(),
             json!({}),
-            &workspace.root,
+            Some(trace_sink.clone()),
         ))
-        .expect("parallel workspace spawns should complete");
+        .expect("parallel workspace spawns should complete")
+        .result;
 
         assert_eq!(result.stop_reason.as_str(), "final_response");
         assert_eq!(result.final_content, "all workspace threads completed");
@@ -751,13 +753,6 @@ mod tests {
         }
 
         impl NativeAgentProvider for PendingWorkspaceTurnProvider {
-            fn complete(
-                &self,
-                _context: &AgentTurnContext,
-            ) -> Result<NativeAgentProviderResponse, String> {
-                panic!("workspace cancellation test must use async provider dispatch");
-            }
-
             fn complete_streaming_async<'a>(
                 self: Arc<Self>,
                 context: &'a AgentTurnContext,
@@ -859,6 +854,12 @@ mod tests {
                 Arc::new(InMemoryNativeAgentCancellation::default()),
             )
             .with_thread_store(store.clone());
+            let services = crate::agent::bridge::native_agent_services_with_tool_executor(
+                services,
+                workspace.root.clone(),
+                json!({}),
+            )
+            .unwrap();
             let run_services = services.clone();
             let workspace_root = workspace.root.clone();
             let run_task = tauri::async_runtime::spawn(async move {
@@ -989,7 +990,7 @@ mod tests {
             json!({}),
         );
         assert!(
-            tool_contributor(&services, &ordinary_context)
+            tool_contributor(&store, &ordinary_context)
                 .expect("ordinary thread lookup should succeed")
                 .is_none(),
             "ordinary workspace threads must not receive project coordination tools"
@@ -1005,7 +1006,7 @@ mod tests {
             json!({}),
         );
         assert!(
-            tool_contributor(&services, &context)
+            tool_contributor(&store, &context)
                 .expect("project group lookup should succeed")
                 .is_some(),
             "project coordinator should receive tools for explicit members"
@@ -1110,10 +1111,37 @@ mod tests {
 
         store
             .project_groups()
+            .save(SaveProjectGroupInput {
+                project_group_id: Some(project_group.project_group_id.clone()),
+                name: "Commerce".to_string(),
+                workspace_ids: vec![workspace.root.display().to_string()],
+            })
+            .expect("project membership should update");
+        let revoked = tauri::async_runtime::block_on(send_thread_message(
+            &services,
+            &context,
+            json!({"threadId": spawned_thread_id, "message": "Must not run after revocation"})
+                .as_object()
+                .unwrap(),
+        ))
+        .expect_err("execution must recheck membership after tool discovery");
+        assert!(revoked
+            .to_string()
+            .contains("is not a member of project group"));
+        let denied_spawn = tauri::async_runtime::block_on(spawn_workspace_thread(
+            &services, &context,
+            json!({"workspaceId": workspace_id(&child_workspace.canonicalize().unwrap()), "message": "Must not spawn after revocation"}).as_object().unwrap(),
+        )).expect_err("spawn must recheck membership after tool discovery");
+        assert!(denied_spawn
+            .to_string()
+            .contains("is not a member of project group"));
+
+        store
+            .project_groups()
             .delete(&project_group.project_group_id)
             .expect("project group should delete");
         assert!(
-            tool_contributor(&services, &context)
+            tool_contributor(&store, &context)
                 .expect("deleted project group lookup should succeed")
                 .is_none(),
             "a retained coordinator thread must lose cross-workspace tools after its group is deleted"

--- a/src-tauri/src/agent/instruction_sources.rs
+++ b/src-tauri/src/agent/instruction_sources.rs
@@ -1,0 +1,428 @@
+//! Filesystem and plugin loading for instructions. The runtime composes only loaded values.
+use crate::agent::runtime::instructions::*;
+use serde_json::Value;
+use std::{
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct InstructionLoader {
+    project_instruction_max_bytes: usize,
+    plugin_root: PathBuf,
+}
+impl Default for InstructionLoader {
+    fn default() -> Self {
+        Self::new(crate::config::application::tinybot_data_root().join("plugins"))
+    }
+}
+impl InstructionLoader {
+    pub(crate) fn new(plugin_root: PathBuf) -> Self {
+        Self {
+            project_instruction_max_bytes: PROJECT_INSTRUCTION_MAX_BYTES,
+            plugin_root,
+        }
+    }
+    #[cfg(test)]
+    pub(crate) fn with_plugin_store_root(mut self, root: PathBuf) -> Self {
+        self.plugin_root = root;
+        self
+    }
+    pub(crate) fn compose(
+        &self,
+        root: &Path,
+        spec: &Value,
+    ) -> Result<ComposedInstructions, String> {
+        self.compose_input(root, &TurnInstructionInput::from_wire(spec, root)?)
+    }
+    pub(crate) fn compose_input(
+        &self,
+        root: &Path,
+        input: &TurnInstructionInput,
+    ) -> Result<ComposedInstructions, String> {
+        InstructionComposer.compose(root, input, self.load(root, &input.working_directory)?)
+    }
+    pub(crate) fn load(
+        &self,
+        root: &Path,
+        working_directory: &Path,
+    ) -> Result<LoadedInstructionSources, String> {
+        let loaded_at_ms = current_unix_ms();
+        let system_content =
+            crate::system_prompt::load_or_create_system_prompt_for_working_directory(
+                root,
+                working_directory,
+            )?;
+        crate::tool_notes::create_default_tool_notes_if_missing(root)?;
+        let mut profiles = Vec::new();
+        for (name, kind) in [
+            ("SOUL.md", InstructionSourceKind::WorkspaceSoul),
+            ("USER.md", InstructionSourceKind::WorkspaceUser),
+            (
+                crate::tool_notes::TOOL_NOTES_FILE_NAME,
+                InstructionSourceKind::WorkspaceTools,
+            ),
+        ] {
+            let path = root.join(name);
+            if let Some((content, warnings)) = read_optional_workspace_instruction(&path)? {
+                profiles.push(LoadedInstructionFile {
+                    path,
+                    scope_root: root.to_path_buf(),
+                    kind,
+                    content,
+                    warnings,
+                    truncated: false,
+                });
+            }
+        }
+        let mut projects = Vec::new();
+        let mut remaining_bytes = self.project_instruction_max_bytes;
+        for candidate in project_instruction_paths(working_directory)? {
+            let (content, truncated, warnings, consumed_bytes) =
+                read_project_instruction(&candidate.path, remaining_bytes)?;
+            remaining_bytes = remaining_bytes.saturating_sub(consumed_bytes);
+            projects.push(LoadedInstructionFile {
+                path: candidate.path,
+                scope_root: candidate.scope_root,
+                kind: candidate.kind,
+                content,
+                truncated,
+                warnings,
+            });
+        }
+        let workspace_skills =
+            crate::workspace_extensions::discover_workspace_skills(working_directory)?
+                .into_iter()
+                .map(|s| InstructionSkill {
+                    name: s.name,
+                    description: s.description,
+                    path: s.path,
+                    root: s.root,
+                    content: s.content,
+                })
+                .collect();
+        let plugin_skills = crate::plugins::PluginStore::new(self.plugin_root.clone())
+            .enabled()
+            .map_err(|error| format!("failed to discover Agent Plugin skills: {error}"))?
+            .into_iter()
+            .flat_map(|p| p.skills)
+            .map(|s| InstructionSkill {
+                name: s.qualified_name(),
+                description: s.description,
+                path: s.path,
+                root: s.root,
+                content: s.content,
+            })
+            .collect();
+        Ok(LoadedInstructionSources {
+            loaded_at_ms,
+            system_content,
+            profiles,
+            projects,
+            workspace_skills,
+            plugin_skills,
+            plugin_root: self.plugin_root.clone(),
+        })
+    }
+}
+
+const PROJECT_INSTRUCTION_OVERRIDE_FILE_NAME: &str = "AGENTS.override.md";
+
+const PROJECT_INSTRUCTION_FILE_NAME: &str = "AGENTS.md";
+
+const WORKSPACE_PROFILE_MAX_BYTES: usize = 64 * 1024;
+
+const PROJECT_INSTRUCTION_MAX_BYTES: usize = 64 * 1024;
+
+impl TurnInstructionInput {
+    pub(crate) fn from_wire(spec: &Value, workspace_root: &Path) -> Result<Self, String> {
+        Ok(Self {
+            working_directory: instruction_working_directory(spec, workspace_root)?,
+            developer: optional_turn_instruction(
+                spec,
+                &["developerInstructions", "developer_instructions"],
+                "developer instructions",
+            )?,
+            collaboration: optional_turn_instruction(
+                spec,
+                &["collaborationMode", "collaboration_mode"],
+                "collaboration mode instructions",
+            )?,
+            agent_role: optional_turn_instruction(
+                spec,
+                &["agentRole", "agent_role"],
+                "agent role instructions",
+            )?,
+            memory_snapshot: long_term_memory_snapshot(spec)?,
+            selected_skills: selected_skill_names(spec)?,
+        })
+    }
+}
+
+fn instruction_working_directory(spec: &Value, workspace_root: &Path) -> Result<PathBuf, String> {
+    let candidate = instruction_string_field(spec, "cwd")
+        .or_else(|| instruction_string_field(spec, "workingDirectory"))
+        .or_else(|| instruction_string_field(spec, "working_directory"))
+        .or_else(|| {
+            spec.get("metadata")
+                .and_then(|metadata| instruction_string_field(metadata, "cwd"))
+        })
+        .or_else(|| {
+            spec.get("metadata")
+                .and_then(|metadata| instruction_string_field(metadata, "workingDirectory"))
+        })
+        .or_else(|| {
+            spec.get("metadata")
+                .and_then(|metadata| instruction_string_field(metadata, "working_directory"))
+        })
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root.to_path_buf());
+    crate::runtime::working_directory::resolve_existing_working_directory(
+        workspace_root,
+        &candidate,
+    )
+}
+
+fn read_optional_workspace_instruction(
+    path: &Path,
+) -> Result<Option<(String, Vec<String>)>, String> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect workspace instructions `{}`: {error}",
+                path.display()
+            ));
+        }
+    };
+    if !metadata.is_file() {
+        return Err(format!(
+            "workspace instruction path is not a file: `{}`",
+            path.display()
+        ));
+    }
+    if metadata.len() > WORKSPACE_PROFILE_MAX_BYTES as u64 {
+        return Err(format!(
+            "workspace instructions exceed the {WORKSPACE_PROFILE_MAX_BYTES}-byte limit: `{}`",
+            path.display()
+        ));
+    }
+    let content = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "failed to read workspace instructions `{}`: {error}",
+            path.display()
+        )
+    })?;
+    let warnings = if content.trim().is_empty() {
+        vec!["workspace instruction source is empty".to_string()]
+    } else {
+        Vec::new()
+    };
+    Ok(Some((content, warnings)))
+}
+
+struct ProjectInstructionCandidate {
+    path: PathBuf,
+    scope_root: PathBuf,
+    kind: InstructionSourceKind,
+}
+
+fn project_instruction_paths(
+    working_directory: &Path,
+) -> Result<Vec<ProjectInstructionCandidate>, String> {
+    let mut candidates = Vec::new();
+    for directory in crate::workspace_extensions::project_scope_directories(working_directory)? {
+        if let Some((path, kind)) = instruction_candidate_in_directory(&directory)? {
+            candidates.push(ProjectInstructionCandidate {
+                path,
+                scope_root: directory,
+                kind,
+            });
+        }
+    }
+    Ok(candidates)
+}
+
+fn instruction_candidate_in_directory(
+    directory: &Path,
+) -> Result<Option<(PathBuf, InstructionSourceKind)>, String> {
+    for (name, kind) in [
+        (
+            PROJECT_INSTRUCTION_OVERRIDE_FILE_NAME,
+            InstructionSourceKind::ProjectOverride,
+        ),
+        (
+            PROJECT_INSTRUCTION_FILE_NAME,
+            InstructionSourceKind::ProjectAgents,
+        ),
+    ] {
+        let path = directory.join(name);
+        match fs::metadata(&path) {
+            Ok(metadata) if metadata.is_file() => return Ok(Some((path, kind))),
+            Ok(_) => {
+                return Err(format!(
+                    "project instruction path is not a file: `{}`",
+                    path.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect project instruction path `{}`: {error}",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn read_project_instruction(
+    path: &Path,
+    remaining_bytes: usize,
+) -> Result<(String, bool, Vec<String>, usize), String> {
+    let file = fs::File::open(path).map_err(|error| {
+        format!(
+            "failed to read project instructions `{}`: {error}",
+            path.display()
+        )
+    })?;
+    let original_len = file
+        .metadata()
+        .map_err(|error| {
+            format!(
+                "failed to inspect project instructions `{}`: {error}",
+                path.display()
+            )
+        })?
+        .len();
+    let read_limit = remaining_bytes.saturating_add(1) as u64;
+    let mut data = Vec::with_capacity(remaining_bytes.saturating_add(1));
+    file.take(read_limit)
+        .read_to_end(&mut data)
+        .map_err(|error| {
+            format!(
+                "failed to read project instructions `{}`: {error}",
+                path.display()
+            )
+        })?;
+    let truncated = original_len > remaining_bytes as u64 || data.len() > remaining_bytes;
+    data.truncate(remaining_bytes);
+    let consumed_bytes = data.len();
+    let mut warnings = Vec::new();
+    if truncated {
+        warnings.push(format!(
+            "project instructions were truncated from {original_len} to {consumed_bytes} bytes"
+        ));
+    }
+    let content = match String::from_utf8(data) {
+        Ok(content) => content,
+        Err(error) => {
+            warnings.push(
+                "project instructions contained invalid UTF-8 and were decoded lossily".to_string(),
+            );
+            String::from_utf8_lossy(error.as_bytes()).into_owned()
+        }
+    };
+    if content.trim().is_empty() {
+        warnings.push("project instruction source is empty".to_string());
+    }
+    Ok((content, truncated, warnings, consumed_bytes))
+}
+
+fn current_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+fn instruction_string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn long_term_memory_snapshot(spec: &Value) -> Result<Option<String>, String> {
+    let value = std::iter::once(spec)
+        .chain(spec.get("metadata"))
+        .find_map(|source| {
+            source
+                .get("longTermMemorySnapshot")
+                .or_else(|| source.get("long_term_memory_snapshot"))
+        });
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let content = value
+        .as_str()
+        .ok_or_else(|| "long-term memory snapshot must be a string".to_string())?;
+    if content.trim().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(content.to_string()))
+    }
+}
+
+fn selected_skill_names(spec: &Value) -> Result<Vec<String>, String> {
+    let value = std::iter::once(spec)
+        .chain(spec.get("metadata"))
+        .find_map(|source| {
+            ["selectedSkills", "selected_skills"]
+                .iter()
+                .find_map(|key| source.get(*key))
+        });
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let values = value
+        .as_array()
+        .ok_or_else(|| "selected skills must be an array of names".to_string())?;
+    let mut names = Vec::with_capacity(values.len());
+    for value in values {
+        let name = value
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "selected skills must contain non-empty strings".to_string())?;
+        if !name.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.' | ':')
+        }) {
+            return Err(format!("selected skill name is invalid: `{name}`"));
+        }
+        if names.iter().any(|existing| existing == name) {
+            return Err(format!("selected skill is duplicated: `{name}`"));
+        }
+        names.push(name.to_string());
+    }
+    Ok(names)
+}
+
+fn optional_turn_instruction(
+    spec: &Value,
+    keys: &[&str],
+    label: &str,
+) -> Result<Option<String>, String> {
+    let value = std::iter::once(spec)
+        .chain(spec.get("metadata"))
+        .find_map(|source| keys.iter().find_map(|key| source.get(*key)));
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .map(Some)
+        .ok_or_else(|| format!("{label} must be a non-empty string"))
+}
+#[cfg(test)]
+#[path = "instruction_sources_tests.rs"]
+mod tests;

--- a/src-tauri/src/agent/instruction_sources_tests.rs
+++ b/src-tauri/src/agent/instruction_sources_tests.rs
@@ -6,7 +6,7 @@ fn allows_a_working_directory_outside_the_workspace_root() {
     let outside = fixture.root.with_extension("outside");
     fs::create_dir_all(&outside).expect("outside working directory fixture should create");
 
-    let composed = InstructionComposer::default()
+    let composed = InstructionLoader::default()
         .compose(
             &fixture.root,
             &serde_json::json!({ "workingDirectory": &outside }),
@@ -25,9 +25,9 @@ fn reports_truncation_and_invalid_utf8_without_hiding_the_source() {
         b"abc\xFFdef",
     )
     .expect("invalid UTF-8 project instructions should write");
-    let composer = InstructionComposer {
+    let composer = InstructionLoader {
         project_instruction_max_bytes: 5,
-        ..InstructionComposer::default()
+        ..InstructionLoader::default()
     };
 
     let composed = composer
@@ -63,7 +63,7 @@ fn composes_editable_workspace_identity_user_and_tool_instructions() {
 
     let plugin_store_root = fixture.root.join("plugin-store");
     fs::create_dir_all(&plugin_store_root).expect("empty plugin store should create");
-    let composed = InstructionComposer::default()
+    let composed = InstructionLoader::default()
         .with_plugin_store_root(plugin_store_root)
         .compose(&fixture.root, &serde_json::json!({ "cwd": fixture.root }))
         .expect("editable workspace instructions should compose");
@@ -114,7 +114,7 @@ fn composes_explicit_turn_developer_instructions_before_workspace_system() {
     )
     .expect("workspace system instructions should write");
 
-    let composed = InstructionComposer::default()
+    let composed = InstructionLoader::default()
         .compose(
             &fixture.root,
             &serde_json::json!({
@@ -150,7 +150,7 @@ fn composes_selected_agent_plugin_skill_with_provenance() {
         "Review the actual diff before reporting.",
     );
 
-    let composed = InstructionComposer::default()
+    let composed = InstructionLoader::default()
         .with_plugin_store_root(plugin_store_root)
         .compose(
             &fixture.root,
@@ -184,7 +184,7 @@ fn composes_thread_memory_after_workspace_instructions_and_before_turn_context()
     )
     .expect("workspace user instructions should write");
 
-    let composed = InstructionComposer::default()
+    let composed = InstructionLoader::default()
         .compose(
             &fixture.root,
             &serde_json::json!({
@@ -217,7 +217,7 @@ fn exposes_enabled_plugin_skill_metadata_without_eagerly_loading_its_body() {
         "Follow private workspace rules.",
     );
 
-    let composed = InstructionComposer::default()
+    let composed = InstructionLoader::default()
         .with_plugin_store_root(plugin_store_root.clone())
         .compose(&fixture.root, &serde_json::json!({ "cwd": fixture.root }))
         .expect("plugin skill catalog should compose");
@@ -231,7 +231,7 @@ fn exposes_enabled_plugin_skill_metadata_without_eagerly_loading_its_body() {
     crate::plugins::PluginStore::new(plugin_store_root.clone())
         .set_enabled("workspace-tools", false)
         .expect("plugin should disable");
-    let disabled = InstructionComposer::default()
+    let disabled = InstructionLoader::default()
         .with_plugin_store_root(plugin_store_root)
         .compose(&fixture.root, &serde_json::json!({ "cwd": fixture.root }))
         .expect("disabled plugin should still compose");
@@ -264,7 +264,7 @@ fn exposes_workspace_agent_skills_from_the_working_directory_hierarchy() {
     )
     .expect("nested workspace skill should write");
 
-    let catalog = InstructionComposer::default()
+    let catalog = InstructionLoader::default()
         .compose(&fixture.root, &serde_json::json!({ "cwd": nested }))
         .expect("workspace skill catalog should compose");
     assert!(catalog.rendered_prompt().contains("review-work"));
@@ -274,7 +274,7 @@ fn exposes_workspace_agent_skills_from_the_working_directory_hierarchy() {
         .rendered_prompt()
         .contains("Preserve API compatibility."));
 
-    let selected = InstructionComposer::default()
+    let selected = InstructionLoader::default()
         .compose(
             &fixture.root,
             &serde_json::json!({
@@ -292,7 +292,7 @@ fn exposes_workspace_agent_skills_from_the_working_directory_hierarchy() {
 fn composes_identity_role_collaboration_and_runtime_facts() {
     let fixture = InstructionFixture::new("turn-world-state");
 
-    let composed = InstructionComposer::default()
+    let composed = InstructionLoader::default()
         .compose(
             &fixture.root,
             &serde_json::json!({

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod bridge;
 pub(crate) mod conversation_title;
+pub(crate) mod instruction_sources;
 pub(crate) mod provider;
 pub(crate) mod router;
 pub(crate) mod runtime;

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:ecd9ab893f44750ec49f065cd4c1869f75609a076662ce9dfead83b89b1d69e2 -->
+<!-- tinybot-module-fingerprint: sha256:3217ef9439fc7e6fc1fd2f2c2f92535957e89a9e21c1bb78de049abb49c9ac3b -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed
@@ -288,7 +288,11 @@ Model-visible context comes from composed instructions, restored conversation
 history, and active hooks. Long-term memory is an instruction source.
 
 Typed in-process hooks run at provider, turn, thread, tool, and
-context-compaction boundaries. A typed hook error, malformed diagnostic, or
+context-compaction boundaries through one asynchronous `AgentHook` interface.
+The bridge adapts the command engine into this same pipeline; the core only
+merges neutral decisions, effects, and run diagnostics. Registrations have
+executor identities so child and resumed Turns replace their inherited command
+executor without running it twice. A typed hook error, malformed diagnostic, or
 invalid decision at an active stage fails the turn. Before-tool hooks run after
 registry and capability validation and may replace normalized arguments or
 return a model-visible denied result without dispatching the tool.

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:e1c483d9e683931d8664413f5ed044599a2f60cd2fd02cb599ee56764175d51e -->
+<!-- tinybot-module-fingerprint: sha256:1f4377a3b23d6e6f47d370eeff47a37aa5519ca520a15fb8a0a018ba420eb3f0 -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed
@@ -37,6 +37,20 @@ causes. String conversion is reserved for legacy response boundaries and diagnos
 The module is independent of the Tauri command surface. Desktop integration,
 history selection, attachment lifetime, and durable turn orchestration belong
 to [`agent::bridge`](../bridge/README.md).
+
+Provider streaming and tool dispatch require explicit asynchronous implementations
+in both production and tests. The production traits have no synchronous test
+fallback. Deliberately blocking fixtures use the adapters in `test_support.rs`;
+real Provider tests exercise the asynchronous implementation.
+The desktop owner supplies `NativeAgentRuntimeDependencies` with the selected
+Provider, dispatcher, checkpoints, cancellation, MCP, Shell, subagent, task, and
+metrics instances. Turn adapters may attach persistence and live output without
+recreating those shared resources. The service bundle still carries the concrete
+Thread store for bridge callers; it is not a standalone storage-free core bundle.
+The dispatcher contributes application-owned tool definitions during preparation
+and executes them through the ordinary asynchronous scheduling path. Discovery
+and execution preserve structured `AgentError` values. Project-group lookup,
+workspace-thread authorization, and child Turn orchestration live in the bridge.
 
 Provider timing uses a per-invocation monotonic clock. Text, reasoning, or tool
 output marks the first token; provider completion ends the decode interval.
@@ -230,8 +244,7 @@ conditionals throughout those shared runtime modules.
   instruction composition.
 - `tool_router.rs`, `tool_dispatcher.rs`, `tool_runtime.rs`: discovery,
   routing, execution, cleanup, and deferred tools.
-- `workspace_threads.rs`: project-group authorization, persistent child Thread
-  execution, follow-up messages, and parent cancellation propagation.
+- `test_support.rs`: test-only service construction and blocking fixture adapters.
 - `tool_projection.rs`, `tool_result.rs`: normalized tool lifecycle output.
 - `hooks.rs`, `events.rs`, `trace_commit.rs`: runtime hooks, event construction,
   and ordered trace commits.

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:1f4377a3b23d6e6f47d370eeff47a37aa5519ca520a15fb8a0a018ba420eb3f0 -->
+<!-- tinybot-module-fingerprint: sha256:ecd9ab893f44750ec49f065cd4c1869f75609a076662ce9dfead83b89b1d69e2 -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed
@@ -62,18 +62,14 @@ without streaming output carry null timings and do not fabricate throughput.
 
 - Normalize turn settings, input history, and context-window behavior.
 - Compose bounded context contributions and instruction provenance.
-- Catalog project-local `.agents/skills` and `.codex/skills` alongside enabled Agent Plugin skills,
-  injecting full Skill content only for explicit selections.
+- Compose already loaded instruction sources and skill catalogs, injecting full
+  Skill content only for explicit selections; filesystem and plugin loading live
+  in `agent::instruction_sources`.
 - Call the configured provider and adapt provider-specific responses.
 - Maintain the typed `AgentItem` history used inside the runtime.
 - Route model-requested tools through injected dispatch services.
-- Catalog saved Agent Graphs only for an ordinary Turn's explicitly declared
-  working directory, and suppress them for Graph-created Agent node Turns and
-  Turns that only inherit the backend workspace fallback. Invalid Graph files
-  are skipped with diagnostics during tool discovery instead of aborting the
-  Turn; the management listing path remains strict.
-- Expose persistent cross-workspace Thread tools only to eligible project-group
-  coordinator Turns.
+- Request an asynchronous tool catalog from the injected dispatcher and preserve
+  cancellation checkpoints from preparation before any provider call.
 - Evaluate hooks around provider, turn, thread, and context-compaction stages.
 - Emit correlated runtime events and project typed items for compatibility
   consumers.
@@ -97,8 +93,8 @@ decide which durable conversation store a caller uses.
    then hydrates typed input fields
    and provides `NativeAgentRuntimeServices`, the typed input, the
    effective configuration, workspace context, and composed instructions.
-2. `provider_loop.rs` merges project-local MCP definitions for the effective
-   working directory and prepares the typed history from legacy messages.
+2. `provider_loop.rs` consumes the effective configuration already merged by the
+   bridge and asks the dispatcher to prepare tool contributions and selection.
    A standalone manual-compaction turn summarizes older history through the
    same context path, installs its checkpoint, and finishes without a normal
    assistant message.
@@ -126,8 +122,10 @@ decide which durable conversation store a caller uses.
 7. Usage and runtime events are emitted through the injected trace sink, and
    `result.rs` builds the terminal response.
 
-MCP discovery and calls use the effective working directory as their runtime
-key and stdio default cwd.
+The bridge owns Graph and MCP discovery. The core holds no MCP, Shell, browser,
+subagent-manager or Thread-store resources. Its dependencies are Provider, tool
+dispatcher, checkpoints, cancellation, task ownership and metrics; trace sinks
+and hooks are installed per Turn.
 
 Tool selection distinguishes omission from an explicit list. Omission keeps
 the default model tools, while an explicit allowlist can activate deferred

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:3217ef9439fc7e6fc1fd2f2c2f92535957e89a9e21c1bb78de049abb49c9ac3b -->
+<!-- tinybot-module-fingerprint: sha256:3b3c373016c8c8ce7dd4c96a274f534b2dcdf34589d5819cb93180efa01b517c -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed

--- a/src-tauri/src/agent/runtime/context.rs
+++ b/src-tauri/src/agent/runtime/context.rs
@@ -15,7 +15,7 @@ use tokio_util::sync::CancellationToken;
 
 impl AgentTurnContext {
     #[cfg(test)]
-    pub(super) fn from_spec(spec: Value, config_snapshot: Value) -> Self {
+    pub(crate) fn from_spec(spec: Value, config_snapshot: Value) -> Self {
         let input = super::AgentTurnInput::from_wire(&spec, &config_snapshot)
             .expect("test turn input must be valid");
         Self::from_input(input, config_snapshot)

--- a/src-tauri/src/agent/runtime/context.rs
+++ b/src-tauri/src/agent/runtime/context.rs
@@ -66,20 +66,11 @@ impl AgentTurnContext {
         self.metrics = services.metrics.clone();
     }
 
-    pub(crate) fn evaluate_hook(
+    pub(crate) async fn evaluate_hook(
         &self,
         invocation: AgentHookInvocation,
     ) -> Result<AgentHookEvaluation, String> {
-        self.hooks.evaluate(invocation, &self.metrics)
-    }
-
-    pub(crate) async fn evaluate_command_hook(
-        &self,
-        invocation: AgentHookInvocation,
-    ) -> Result<AgentHookEvaluation, String> {
-        self.hooks
-            .evaluate_command_hooks(invocation, &self.metrics)
-            .await
+        self.hooks.evaluate(invocation, &self.metrics).await
     }
 
     pub(crate) fn hook_permission_mode(&self) -> String {

--- a/src-tauri/src/agent/runtime/hooks.rs
+++ b/src-tauri/src/agent/runtime/hooks.rs
@@ -1,7 +1,4 @@
 use crate::agent::runtime_protocol::AgentTraceContext;
-use crate::command_hooks::{
-    CommandHookEngine, CommandHookEvaluation, CommandHookEvent, CommandHookRequest,
-};
 use crate::runtime::observability::AgentRuntimeMetrics;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -216,41 +213,39 @@ impl AgentHookInvocation {
             compaction_trigger: Some(trigger),
         }
     }
-
-    fn command_request(&self) -> Option<CommandHookRequest> {
-        let event = match self.stage {
-            AgentHookStage::UserPromptSubmit => CommandHookEvent::UserPromptSubmit,
-            AgentHookStage::BeforeToolUse => CommandHookEvent::PreToolUse,
-            AgentHookStage::AfterToolUse => CommandHookEvent::PostToolUse,
-            AgentHookStage::CompactionComplete => CommandHookEvent::PostCompact,
-            _ => return None,
-        };
-        Some(CommandHookRequest {
-            event,
-            session_id: self.session_id.clone().unwrap_or_default(),
-            turn_id: self.trace_context.turn_id.clone(),
-            model: self.model.clone().unwrap_or_default(),
-            permission_mode: self
-                .permission_mode
-                .clone()
-                .unwrap_or_else(|| "local-worker".to_string()),
-            prompt: self.prompt.clone(),
-            tool_name: self.tool_name.clone(),
-            tool_match_names: self.tool_name.clone().into_iter().collect(),
-            tool_use_id: self.tool_call_id.clone(),
-            tool_input: self.normalized_input.clone(),
-            tool_response: self.tool_response.clone(),
-            trigger: self.compaction_trigger.clone(),
-        })
-    }
 }
 
 pub trait AgentHook: Send + Sync + 'static {
+    /// Registration identity: installing the same executor replaces its prior instance.
     fn name(&self) -> &'static str {
-        "agent_hook"
+        std::any::type_name::<Self>()
     }
 
-    fn evaluate(&self, invocation: &AgentHookInvocation) -> Result<AgentHookDecision, String>;
+    fn evaluate<'a>(
+        &'a self,
+        invocation: &'a AgentHookInvocation,
+    ) -> futures_util::future::BoxFuture<'a, Result<AgentHookOutput, String>>;
+}
+
+pub enum AgentHookOutput {
+    Decision(AgentHookDecision),
+    Runs(Vec<AgentHookRun>),
+}
+
+/// Executor-neutral effects and diagnostic evidence returned by an external hook.
+#[derive(Clone, Debug, Default)]
+pub struct AgentHookRun {
+    pub hook_hash: String,
+    pub hook_name: String,
+    pub source_path: String,
+    pub duration_ms: u64,
+    pub decision: String,
+    pub denied_reason: Option<String>,
+    pub updated_input: Option<Value>,
+    pub additional_context: Option<String>,
+    pub system_message: Option<String>,
+    pub tool_feedback: Option<String>,
+    pub failure: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -324,19 +319,9 @@ impl AgentHookEvaluation {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct AgentHookPipeline {
     hooks: Arc<Vec<Arc<dyn AgentHook>>>,
-    command_hooks: Arc<CommandHookEngine>,
-}
-
-impl Default for AgentHookPipeline {
-    fn default() -> Self {
-        Self {
-            hooks: Arc::new(Vec::new()),
-            command_hooks: Arc::new(CommandHookEngine::default()),
-        }
-    }
 }
 
 impl fmt::Debug for AgentHookPipeline {
@@ -344,31 +329,26 @@ impl fmt::Debug for AgentHookPipeline {
         formatter
             .debug_struct("AgentHookPipeline")
             .field("hook_count", &self.hooks.len())
-            .field("command_hook_engine", &self.command_hooks)
             .finish()
     }
 }
 
 impl AgentHookPipeline {
-    #[cfg(test)]
     pub(crate) fn with_hook(&self, hook: Arc<dyn AgentHook>) -> Self {
-        let mut hooks = self.hooks.as_ref().clone();
+        // Reassembling a child or resumed Turn replaces its named executor.
+        let mut hooks = self
+            .hooks
+            .iter()
+            .filter(|existing| existing.name() != hook.name())
+            .cloned()
+            .collect::<Vec<_>>();
         hooks.push(hook);
         Self {
             hooks: Arc::new(hooks),
-            command_hooks: self.command_hooks.clone(),
         }
     }
 
-    #[cfg_attr(test, allow(dead_code))]
-    pub(crate) fn with_command_hooks(&self, command_hooks: CommandHookEngine) -> Self {
-        Self {
-            hooks: self.hooks.clone(),
-            command_hooks: Arc::new(command_hooks),
-        }
-    }
-
-    pub(crate) fn evaluate(
+    pub(crate) async fn evaluate(
         &self,
         invocation: AgentHookInvocation,
         metrics: &AgentRuntimeMetrics,
@@ -379,7 +359,7 @@ impl AgentHookPipeline {
             ..AgentHookEvaluation::default()
         };
         for hook in self.hooks.iter() {
-            let decision = hook.evaluate(&invocation).map_err(|error| {
+            let decision = hook.evaluate(&invocation).await.map_err(|error| {
                 metrics.increment("hook.error");
                 format!(
                     "agent hook `{}` failed at {}: {error}",
@@ -387,42 +367,36 @@ impl AgentHookPipeline {
                     invocation.stage.as_str()
                 )
             })?;
-            metrics.increment(&format!(
-                "hook.{}.{}",
-                invocation.stage.as_str(),
-                decision.kind()
-            ));
-            apply_decision(&mut invocation, &mut evaluation, hook.name(), decision)?;
+            match decision {
+                AgentHookOutput::Decision(decision) => {
+                    metrics.increment(&format!(
+                        "hook.{}.{}",
+                        invocation.stage.as_str(),
+                        decision.kind()
+                    ));
+                    apply_decision(&mut invocation, &mut evaluation, hook.name(), decision)?;
+                }
+                AgentHookOutput::Runs(runs) => {
+                    merge_hook_runs(&invocation, &mut evaluation, runs, metrics);
+                    invocation.normalized_input = evaluation.normalized_input.clone();
+                }
+            }
             if evaluation.denied_reason.is_some() {
                 break;
             }
         }
         Ok(evaluation)
     }
-
-    pub(crate) async fn evaluate_command_hooks(
-        &self,
-        invocation: AgentHookInvocation,
-        metrics: &AgentRuntimeMetrics,
-    ) -> Result<AgentHookEvaluation, String> {
-        let mut evaluation = self.evaluate(invocation.clone(), metrics)?;
-        let Some(request) = invocation.command_request() else {
-            return Ok(evaluation);
-        };
-        let command_evaluation = self.command_hooks.evaluate(&request).await;
-        merge_command_evaluation(&invocation, &mut evaluation, command_evaluation, metrics);
-        Ok(evaluation)
-    }
 }
 
-fn merge_command_evaluation(
+fn merge_hook_runs(
     invocation: &AgentHookInvocation,
     evaluation: &mut AgentHookEvaluation,
-    command_evaluation: CommandHookEvaluation,
+    runs: Vec<AgentHookRun>,
     metrics: &AgentRuntimeMetrics,
 ) {
     let mut replacement = evaluation.normalized_input.clone();
-    for run in command_evaluation.runs {
+    for run in runs {
         metrics.increment(&format!(
             "hook.{}.{}",
             invocation.stage.as_str(),
@@ -461,7 +435,7 @@ fn merge_command_evaluation(
         evaluation.command_runs.push(CommandHookRunRecord {
             hook_name: run.hook_name,
             hook_hash: run.hook_hash,
-            source_path: run.source_path.to_string_lossy().to_string(),
+            source_path: run.source_path,
             duration_ms: run.duration_ms,
             decision: run.decision,
             failure: run

--- a/src-tauri/src/agent/runtime/hooks.rs
+++ b/src-tauri/src/agent/runtime/hooks.rs
@@ -228,6 +228,8 @@ pub trait AgentHook: Send + Sync + 'static {
 }
 
 pub enum AgentHookOutput {
+    // In-process hook implementations currently live in the test fixtures.
+    #[cfg_attr(not(test), allow(dead_code))]
     Decision(AgentHookDecision),
     Runs(Vec<AgentHookRun>),
 }

--- a/src-tauri/src/agent/runtime/hooks_tests.rs
+++ b/src-tauri/src/agent/runtime/hooks_tests.rs
@@ -13,9 +13,14 @@ fn trace_context() -> AgentTraceContext {
 struct InvalidAfterHook;
 
 impl AgentHook for InvalidAfterHook {
-    fn evaluate(&self, _invocation: &AgentHookInvocation) -> Result<AgentHookDecision, String> {
-        Ok(AgentHookDecision::Deny {
-            reason: "too late".to_string(),
+    fn evaluate<'a>(
+        &'a self,
+        _invocation: &'a AgentHookInvocation,
+    ) -> futures_util::future::BoxFuture<'a, Result<AgentHookOutput, String>> {
+        Box::pin(async move {
+            Ok(AgentHookOutput::Decision(AgentHookDecision::Deny {
+                reason: "too late".to_string(),
+            }))
         })
     }
 }
@@ -23,17 +28,16 @@ impl AgentHook for InvalidAfterHook {
 #[test]
 fn invalid_decision_for_stage_fails_instead_of_becoming_success() {
     let pipeline = AgentHookPipeline::default().with_hook(Arc::new(InvalidAfterHook));
-    let error = pipeline
-        .evaluate(
-            AgentHookInvocation::provider(
-                AgentHookStage::AfterProviderResponse,
-                trace_context(),
-                "provider-1".to_string(),
-                Some("completed".to_string()),
-            ),
-            &AgentRuntimeMetrics::isolated(),
-        )
-        .expect_err("after-tool denial should be rejected");
+    let error = tauri::async_runtime::block_on(pipeline.evaluate(
+        AgentHookInvocation::provider(
+            AgentHookStage::AfterProviderResponse,
+            trace_context(),
+            "provider-1".to_string(),
+            Some("completed".to_string()),
+        ),
+        &AgentRuntimeMetrics::isolated(),
+    ))
+    .expect_err("after-tool denial should be rejected");
 
     assert!(error.contains("unsupported stage after_provider_response"));
 }
@@ -43,24 +47,33 @@ fn diagnostic_metadata_redacts_sensitive_values_before_emission() {
     struct DiagnosticHook;
 
     impl AgentHook for DiagnosticHook {
-        fn evaluate(&self, _invocation: &AgentHookInvocation) -> Result<AgentHookDecision, String> {
-            Ok(AgentHookDecision::AppendDiagnosticMetadata {
-                metadata: serde_json::json!({
-                    "code": "safe-code",
-                    "arguments": { "token": "must-not-leak" },
-                    "nested": { "apiKey": "must-not-leak" },
-                }),
+        fn evaluate<'a>(
+            &'a self,
+            _invocation: &'a AgentHookInvocation,
+        ) -> futures_util::future::BoxFuture<'a, Result<AgentHookOutput, String>> {
+            Box::pin(async move {
+                Ok(AgentHookOutput::Decision(
+                    AgentHookDecision::AppendDiagnosticMetadata {
+                        metadata: serde_json::json!({
+                            "code": "safe-code",
+                            "arguments": { "token": "must-not-leak" },
+                            "nested": { "apiKey": "must-not-leak" },
+                        }),
+                    },
+                ))
             })
         }
     }
 
-    let evaluation = AgentHookPipeline::default()
-        .with_hook(Arc::new(DiagnosticHook))
-        .evaluate(
-            AgentHookInvocation::lifecycle(AgentHookStage::TurnStart, trace_context()),
-            &AgentRuntimeMetrics::isolated(),
-        )
-        .expect("diagnostic hook should evaluate");
+    let evaluation = tauri::async_runtime::block_on(
+        AgentHookPipeline::default()
+            .with_hook(Arc::new(DiagnosticHook))
+            .evaluate(
+                AgentHookInvocation::lifecycle(AgentHookStage::TurnStart, trace_context()),
+                &AgentRuntimeMetrics::isolated(),
+            ),
+    )
+    .expect("diagnostic hook should evaluate");
 
     assert_eq!(evaluation.diagnostic_metadata["code"], "safe-code");
     assert_eq!(evaluation.diagnostic_metadata["arguments"], "[redacted]");
@@ -68,4 +81,67 @@ fn diagnostic_metadata_redacts_sensitive_values_before_emission() {
         evaluation.diagnostic_metadata["nested"]["apiKey"],
         "[redacted]"
     );
+}
+#[test]
+fn asynchronous_executor_replacement_preserves_conflict_and_run_diagnostics() {
+    struct Executor;
+    impl AgentHook for Executor {
+        fn name(&self) -> &'static str {
+            "fixture-executor"
+        }
+        fn evaluate<'a>(
+            &'a self,
+            _input: &'a AgentHookInvocation,
+        ) -> futures_util::future::BoxFuture<'a, Result<AgentHookOutput, String>> {
+            Box::pin(async {
+                tokio::task::yield_now().await;
+                Ok(AgentHookOutput::Runs(vec![
+                    AgentHookRun {
+                        hook_name: "first".into(),
+                        decision: "allow".into(),
+                        updated_input: Some(serde_json::json!({"path":"a"})),
+                        additional_context: Some("context".into()),
+                        ..Default::default()
+                    },
+                    AgentHookRun {
+                        hook_name: "second".into(),
+                        decision: "allow".into(),
+                        updated_input: Some(serde_json::json!({"path":"b"})),
+                        ..Default::default()
+                    },
+                ]))
+            })
+        }
+    }
+    tauri::async_runtime::block_on(async {
+        let pipeline = AgentHookPipeline::default()
+            .with_hook(Arc::new(Executor))
+            .with_hook(Arc::new(Executor));
+        let input = AgentHookInvocation::tool(
+            AgentHookStage::BeforeToolUse,
+            trace_context(),
+            "session".into(),
+            "model".into(),
+            "local-worker".into(),
+            "call".into(),
+            "workspace.read_file".into(),
+            serde_json::json!({"path":"original"}),
+            None,
+        );
+        let evaluation = pipeline
+            .evaluate(input, &AgentRuntimeMetrics::isolated())
+            .await
+            .unwrap();
+        assert_eq!(
+            evaluation.command_runs.len(),
+            2,
+            "reassembly replaces the executor instead of duplicating execution"
+        );
+        assert!(evaluation
+            .denied_reason
+            .unwrap()
+            .contains("conflicting updatedInput"));
+        assert_eq!(evaluation.normalized_input.unwrap()["path"], "a");
+        assert_eq!(evaluation.additional_context, ["context"]);
+    });
 }

--- a/src-tauri/src/agent/runtime/instructions.rs
+++ b/src-tauri/src/agent/runtime/instructions.rs
@@ -1,10 +1,6 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::fs;
-use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const BUILTIN_IDENTITY_PRECEDENCE: u32 = 100;
 const WORKSPACE_SYSTEM_PRECEDENCE: u32 = 300;
@@ -20,11 +16,7 @@ const SELECTED_SKILL_PRECEDENCE: u32 = 700;
 const COLLABORATION_PRECEDENCE: u32 = 800;
 const AGENT_ROLE_PRECEDENCE: u32 = 810;
 const RUNTIME_ENVIRONMENT_PRECEDENCE: u32 = 900;
-const PROJECT_INSTRUCTION_MAX_BYTES: usize = 64 * 1024;
 const WORKSPACE_SYSTEM_MAX_BYTES: usize = 128 * 1024;
-const WORKSPACE_PROFILE_MAX_BYTES: usize = 64 * 1024;
-const PROJECT_INSTRUCTION_FILE_NAME: &str = "AGENTS.md";
-const PROJECT_INSTRUCTION_OVERRIDE_FILE_NAME: &str = "AGENTS.override.md";
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -103,81 +95,56 @@ pub struct TurnInstructionInput {
     pub selected_skills: Vec<String>,
 }
 
-impl TurnInstructionInput {
-    pub(crate) fn from_wire(spec: &Value, workspace_root: &Path) -> Result<Self, String> {
-        Ok(Self {
-            working_directory: instruction_working_directory(spec, workspace_root)?,
-            developer: optional_turn_instruction(
-                spec,
-                &["developerInstructions", "developer_instructions"],
-                "developer instructions",
-            )?,
-            collaboration: optional_turn_instruction(
-                spec,
-                &["collaborationMode", "collaboration_mode"],
-                "collaboration mode instructions",
-            )?,
-            agent_role: optional_turn_instruction(
-                spec,
-                &["agentRole", "agent_role"],
-                "agent role instructions",
-            )?,
-            memory_snapshot: long_term_memory_snapshot(spec)?,
-            selected_skills: selected_skill_names(spec)?,
-        })
-    }
+#[derive(Clone, Debug)]
+pub(crate) struct LoadedInstructionFile {
+    pub path: PathBuf,
+    pub scope_root: PathBuf,
+    pub kind: InstructionSourceKind,
+    pub content: String,
+    pub truncated: bool,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
-pub struct InstructionComposer {
-    project_instruction_max_bytes: usize,
-    plugin_store: crate::plugins::PluginStore,
+pub(crate) struct InstructionSkill {
+    pub name: String,
+    pub description: String,
+    pub path: PathBuf,
+    pub root: PathBuf,
+    pub content: String,
 }
 
-impl Default for InstructionComposer {
-    fn default() -> Self {
-        Self {
-            project_instruction_max_bytes: PROJECT_INSTRUCTION_MAX_BYTES,
-            plugin_store: crate::plugins::PluginStore::default_global(),
-        }
-    }
+#[derive(Clone, Debug)]
+pub(crate) struct LoadedInstructionSources {
+    pub loaded_at_ms: u64,
+    pub system_content: String,
+    pub profiles: Vec<LoadedInstructionFile>,
+    pub projects: Vec<LoadedInstructionFile>,
+    pub workspace_skills: Vec<InstructionSkill>,
+    pub plugin_skills: Vec<InstructionSkill>,
+    pub plugin_root: PathBuf,
 }
+
+/// Pure composition: contents, catalogs and timestamps are supplied by the caller.
+pub(crate) struct InstructionComposer;
 
 impl InstructionComposer {
-    #[cfg(test)]
-    pub fn compose(
-        &self,
-        workspace_root: &Path,
-        spec: &Value,
-    ) -> Result<ComposedInstructions, String> {
-        self.compose_with_config(workspace_root, spec, &Value::Null)
-    }
-
-    pub fn compose_with_config(
-        &self,
-        workspace_root: &Path,
-        spec: &Value,
-        _config_snapshot: &Value,
-    ) -> Result<ComposedInstructions, String> {
-        self.compose_input(
-            workspace_root,
-            &TurnInstructionInput::from_wire(spec, workspace_root)?,
-        )
-    }
-
-    pub(crate) fn compose_input(
+    pub(crate) fn compose(
         &self,
         workspace_root: &Path,
         input: &TurnInstructionInput,
+        loaded: LoadedInstructionSources,
     ) -> Result<ComposedInstructions, String> {
         let working_directory = input.working_directory.clone();
-        let loaded_at_ms = current_unix_ms();
-        let system_content =
-            crate::system_prompt::load_or_create_system_prompt_for_working_directory(
-                workspace_root,
-                &working_directory,
-            )?;
-        crate::tool_notes::create_default_tool_notes_if_missing(workspace_root)?;
+        let LoadedInstructionSources {
+            loaded_at_ms,
+            system_content,
+            profiles,
+            projects,
+            workspace_skills,
+            plugin_skills,
+            plugin_root,
+        } = loaded;
         if system_content.len() > WORKSPACE_SYSTEM_MAX_BYTES {
             return Err(format!(
                 "workspace system instructions exceed the {WORKSPACE_SYSTEM_MAX_BYTES}-byte limit: `{}`",
@@ -232,61 +199,39 @@ impl InstructionComposer {
             false,
         );
 
-        for (file_name, kind, precedence) in [
-            (
-                "SOUL.md",
-                InstructionSourceKind::WorkspaceSoul,
-                WORKSPACE_SOUL_PRECEDENCE,
-            ),
-            (
-                "USER.md",
-                InstructionSourceKind::WorkspaceUser,
-                WORKSPACE_USER_PRECEDENCE,
-            ),
-            (
-                crate::tool_notes::TOOL_NOTES_FILE_NAME,
-                InstructionSourceKind::WorkspaceTools,
-                WORKSPACE_TOOLS_PRECEDENCE,
-            ),
-        ] {
-            let path = workspace_root.join(file_name);
-            let Some((content, warnings)) = read_optional_workspace_instruction(&path)? else {
-                continue;
+        for file in profiles {
+            let precedence = match file.kind {
+                InstructionSourceKind::WorkspaceSoul => WORKSPACE_SOUL_PRECEDENCE,
+                InstructionSourceKind::WorkspaceUser => WORKSPACE_USER_PRECEDENCE,
+                InstructionSourceKind::WorkspaceTools => WORKSPACE_TOOLS_PRECEDENCE,
+                _ => return Err("invalid workspace profile instruction kind".into()),
             };
             push_instruction_source(
                 &mut messages,
                 &mut sources,
-                kind,
-                path,
-                workspace_root.to_path_buf(),
+                file.kind,
+                file.path,
+                file.scope_root,
                 precedence,
                 loaded_at_ms,
-                content,
-                false,
-                warnings,
+                file.content,
+                file.truncated,
+                file.warnings,
                 false,
             );
         }
-
-        let mut remaining_bytes = self.project_instruction_max_bytes;
-        for (depth, candidate) in project_instruction_paths(&working_directory)?
-            .into_iter()
-            .enumerate()
-        {
-            let (content, truncated, warnings, consumed_bytes) =
-                read_project_instruction(&candidate.path, remaining_bytes)?;
-            remaining_bytes = remaining_bytes.saturating_sub(consumed_bytes);
+        for (depth, file) in projects.into_iter().enumerate() {
             push_instruction_source(
                 &mut messages,
                 &mut sources,
-                candidate.kind,
-                candidate.path,
-                candidate.scope_root,
+                file.kind,
+                file.path,
+                file.scope_root,
                 PROJECT_INSTRUCTION_PRECEDENCE.saturating_add(depth as u32),
                 loaded_at_ms,
-                content,
-                truncated,
-                warnings,
+                file.content,
+                file.truncated,
+                file.warnings,
                 true,
             );
         }
@@ -313,8 +258,6 @@ impl InstructionComposer {
         }
 
         let selected_skills = input.selected_skills.clone();
-        let workspace_skills =
-            crate::workspace_extensions::discover_workspace_skills(&working_directory)?;
         if !workspace_skills.is_empty() {
             push_instruction_source(
                 &mut messages,
@@ -330,20 +273,13 @@ impl InstructionComposer {
                 false,
             );
         }
-        let plugin_skills = self
-            .plugin_store
-            .enabled()
-            .map_err(|error| format!("failed to discover Agent Plugin skills: {error}"))?
-            .into_iter()
-            .flat_map(|plugin| plugin.skills)
-            .collect::<Vec<_>>();
         if !plugin_skills.is_empty() {
             push_instruction_source(
                 &mut messages,
                 &mut sources,
                 InstructionSourceKind::PluginSkillCatalog,
                 PathBuf::from("plugins:skill-catalog"),
-                crate::config::application::tinybot_data_root().join("plugins"),
+                plugin_root,
                 PLUGIN_SKILL_CATALOG_PRECEDENCE,
                 loaded_at_ms,
                 render_plugin_skill_catalog(&plugin_skills),
@@ -354,15 +290,12 @@ impl InstructionComposer {
         }
         let mut activated = Vec::new();
         for selected in &selected_skills {
-            if let Some(skill) = plugin_skills
-                .iter()
-                .find(|skill| skill.qualified_name() == *selected)
-            {
+            if let Some(skill) = plugin_skills.iter().find(|skill| skill.name == *selected) {
                 activated.push((
                     skill.path.clone(),
                     skill.root.clone(),
                     skill.content.clone(),
-                    format!("Agent Plugin skill activation: {}", skill.qualified_name()),
+                    format!("Agent Plugin skill activation: {}", skill.name),
                 ));
             } else if let Some(skill) = workspace_skills
                 .iter()
@@ -458,15 +391,9 @@ impl InstructionComposer {
             rendered_prompt,
         })
     }
-
-    #[cfg(test)]
-    pub(crate) fn with_plugin_store_root(mut self, root: PathBuf) -> Self {
-        self.plugin_store = crate::plugins::PluginStore::new(root);
-        self
-    }
 }
 
-fn render_plugin_skill_catalog(skills: &[crate::plugins::PluginSkill]) -> String {
+fn render_plugin_skill_catalog(skills: &[InstructionSkill]) -> String {
     let mut content = String::from(
         "# Available Agent Plugin skills\n\n\
          The following globally enabled Agent Skills are available in every workspace. \
@@ -477,7 +404,7 @@ fn render_plugin_skill_catalog(skills: &[crate::plugins::PluginSkill]) -> String
     for skill in skills {
         content.push_str(&format!(
             "\n- `{}`: {} (file: `{}`)",
-            skill.qualified_name(),
+            skill.name,
             skill.description,
             skill.path.display()
         ));
@@ -485,9 +412,7 @@ fn render_plugin_skill_catalog(skills: &[crate::plugins::PluginSkill]) -> String
     content
 }
 
-fn render_workspace_skill_catalog(
-    skills: &[crate::workspace_extensions::WorkspaceSkill],
-) -> String {
+fn render_workspace_skill_catalog(skills: &[InstructionSkill]) -> String {
     let mut content = String::from(
         "# Available workspace skills\n\n\
          The following Agent Skills apply to the current working directory. \
@@ -504,120 +429,6 @@ fn render_workspace_skill_catalog(
         ));
     }
     content
-}
-
-fn long_term_memory_snapshot(spec: &Value) -> Result<Option<String>, String> {
-    let value = std::iter::once(spec)
-        .chain(spec.get("metadata"))
-        .find_map(|source| {
-            source
-                .get("longTermMemorySnapshot")
-                .or_else(|| source.get("long_term_memory_snapshot"))
-        });
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    let content = value
-        .as_str()
-        .ok_or_else(|| "long-term memory snapshot must be a string".to_string())?;
-    if content.trim().is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(content.to_string()))
-    }
-}
-
-fn selected_skill_names(spec: &Value) -> Result<Vec<String>, String> {
-    let value = std::iter::once(spec)
-        .chain(spec.get("metadata"))
-        .find_map(|source| {
-            ["selectedSkills", "selected_skills"]
-                .iter()
-                .find_map(|key| source.get(*key))
-        });
-    let Some(value) = value else {
-        return Ok(Vec::new());
-    };
-    let values = value
-        .as_array()
-        .ok_or_else(|| "selected skills must be an array of names".to_string())?;
-    let mut names = Vec::with_capacity(values.len());
-    for value in values {
-        let name = value
-            .as_str()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| "selected skills must contain non-empty strings".to_string())?;
-        if !name.chars().all(|character| {
-            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.' | ':')
-        }) {
-            return Err(format!("selected skill name is invalid: `{name}`"));
-        }
-        if names.iter().any(|existing| existing == name) {
-            return Err(format!("selected skill is duplicated: `{name}`"));
-        }
-        names.push(name.to_string());
-    }
-    Ok(names)
-}
-
-fn optional_turn_instruction(
-    spec: &Value,
-    keys: &[&str],
-    label: &str,
-) -> Result<Option<String>, String> {
-    let value = std::iter::once(spec)
-        .chain(spec.get("metadata"))
-        .find_map(|source| keys.iter().find_map(|key| source.get(*key)));
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    value
-        .as_str()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .map(Some)
-        .ok_or_else(|| format!("{label} must be a non-empty string"))
-}
-
-fn read_optional_workspace_instruction(
-    path: &Path,
-) -> Result<Option<(String, Vec<String>)>, String> {
-    let metadata = match fs::metadata(path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => {
-            return Err(format!(
-                "failed to inspect workspace instructions `{}`: {error}",
-                path.display()
-            ));
-        }
-    };
-    if !metadata.is_file() {
-        return Err(format!(
-            "workspace instruction path is not a file: `{}`",
-            path.display()
-        ));
-    }
-    if metadata.len() > WORKSPACE_PROFILE_MAX_BYTES as u64 {
-        return Err(format!(
-            "workspace instructions exceed the {WORKSPACE_PROFILE_MAX_BYTES}-byte limit: `{}`",
-            path.display()
-        ));
-    }
-    let content = fs::read_to_string(path).map_err(|error| {
-        format!(
-            "failed to read workspace instructions `{}`: {error}",
-            path.display()
-        )
-    })?;
-    let warnings = if content.trim().is_empty() {
-        vec!["workspace instruction source is empty".to_string()]
-    } else {
-        Vec::new()
-    };
-    Ok(Some((content, warnings)))
 }
 
 impl ComposedInstructions {
@@ -649,139 +460,6 @@ impl ComposedInstructions {
             })
             .collect()
     }
-}
-
-struct ProjectInstructionCandidate {
-    path: PathBuf,
-    scope_root: PathBuf,
-    kind: InstructionSourceKind,
-}
-
-fn instruction_working_directory(spec: &Value, workspace_root: &Path) -> Result<PathBuf, String> {
-    let candidate = instruction_string_field(spec, "cwd")
-        .or_else(|| instruction_string_field(spec, "workingDirectory"))
-        .or_else(|| instruction_string_field(spec, "working_directory"))
-        .or_else(|| {
-            spec.get("metadata")
-                .and_then(|metadata| instruction_string_field(metadata, "cwd"))
-        })
-        .or_else(|| {
-            spec.get("metadata")
-                .and_then(|metadata| instruction_string_field(metadata, "workingDirectory"))
-        })
-        .or_else(|| {
-            spec.get("metadata")
-                .and_then(|metadata| instruction_string_field(metadata, "working_directory"))
-        })
-        .map(PathBuf::from)
-        .unwrap_or_else(|| workspace_root.to_path_buf());
-    crate::runtime::working_directory::resolve_existing_working_directory(
-        workspace_root,
-        &candidate,
-    )
-}
-
-fn project_instruction_paths(
-    working_directory: &Path,
-) -> Result<Vec<ProjectInstructionCandidate>, String> {
-    let mut candidates = Vec::new();
-    for directory in crate::workspace_extensions::project_scope_directories(working_directory)? {
-        if let Some((path, kind)) = instruction_candidate_in_directory(&directory)? {
-            candidates.push(ProjectInstructionCandidate {
-                path,
-                scope_root: directory,
-                kind,
-            });
-        }
-    }
-    Ok(candidates)
-}
-
-fn instruction_candidate_in_directory(
-    directory: &Path,
-) -> Result<Option<(PathBuf, InstructionSourceKind)>, String> {
-    for (name, kind) in [
-        (
-            PROJECT_INSTRUCTION_OVERRIDE_FILE_NAME,
-            InstructionSourceKind::ProjectOverride,
-        ),
-        (
-            PROJECT_INSTRUCTION_FILE_NAME,
-            InstructionSourceKind::ProjectAgents,
-        ),
-    ] {
-        let path = directory.join(name);
-        match fs::metadata(&path) {
-            Ok(metadata) if metadata.is_file() => return Ok(Some((path, kind))),
-            Ok(_) => {
-                return Err(format!(
-                    "project instruction path is not a file: `{}`",
-                    path.display()
-                ));
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(format!(
-                    "failed to inspect project instruction path `{}`: {error}",
-                    path.display()
-                ));
-            }
-        }
-    }
-    Ok(None)
-}
-
-fn read_project_instruction(
-    path: &Path,
-    remaining_bytes: usize,
-) -> Result<(String, bool, Vec<String>, usize), String> {
-    let file = fs::File::open(path).map_err(|error| {
-        format!(
-            "failed to read project instructions `{}`: {error}",
-            path.display()
-        )
-    })?;
-    let original_len = file
-        .metadata()
-        .map_err(|error| {
-            format!(
-                "failed to inspect project instructions `{}`: {error}",
-                path.display()
-            )
-        })?
-        .len();
-    let read_limit = remaining_bytes.saturating_add(1) as u64;
-    let mut data = Vec::with_capacity(remaining_bytes.saturating_add(1));
-    file.take(read_limit)
-        .read_to_end(&mut data)
-        .map_err(|error| {
-            format!(
-                "failed to read project instructions `{}`: {error}",
-                path.display()
-            )
-        })?;
-    let truncated = original_len > remaining_bytes as u64 || data.len() > remaining_bytes;
-    data.truncate(remaining_bytes);
-    let consumed_bytes = data.len();
-    let mut warnings = Vec::new();
-    if truncated {
-        warnings.push(format!(
-            "project instructions were truncated from {original_len} to {consumed_bytes} bytes"
-        ));
-    }
-    let content = match String::from_utf8(data) {
-        Ok(content) => content,
-        Err(error) => {
-            warnings.push(
-                "project instructions contained invalid UTF-8 and were decoded lossily".to_string(),
-            );
-            String::from_utf8_lossy(error.as_bytes()).into_owned()
-        }
-    };
-    if content.trim().is_empty() {
-        warnings.push("project instruction source is empty".to_string());
-    }
-    Ok((content, truncated, warnings, consumed_bytes))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -826,27 +504,108 @@ fn push_instruction_source(
     }
 }
 
-fn instruction_string_field(value: &Value, key: &str) -> Option<String> {
-    value
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
 fn content_hash(content: &str) -> String {
     let digest = Sha256::digest(content.as_bytes());
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
-fn current_unix_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
-        .unwrap_or(0)
-}
-
 #[cfg(test)]
-#[path = "instructions_tests.rs"]
-mod tests;
+mod tests {
+    use super::*;
+
+    fn inputs() -> (TurnInstructionInput, LoadedInstructionSources) {
+        let root = PathBuf::from("virtual-workspace");
+        (
+            TurnInstructionInput {
+                working_directory: root.clone(),
+                developer: Some("developer".into()),
+                collaboration: None,
+                agent_role: None,
+                memory_snapshot: None,
+                selected_skills: vec!["plugin:skill".into()],
+            },
+            LoadedInstructionSources {
+                loaded_at_ms: 42,
+                system_content: "system".into(),
+                profiles: vec![],
+                projects: vec![LoadedInstructionFile {
+                    path: root.join("AGENTS.md"),
+                    scope_root: root.clone(),
+                    kind: InstructionSourceKind::ProjectAgents,
+                    content: "project".into(),
+                    truncated: true,
+                    warnings: vec!["truncated input".into()],
+                }],
+                workspace_skills: vec![],
+                plugin_skills: vec![InstructionSkill {
+                    name: "plugin:skill".into(),
+                    description: "skill description".into(),
+                    path: root.join("SKILL.md"),
+                    root: root.clone(),
+                    content: "skill body".into(),
+                }],
+                plugin_root: root.join("plugins"),
+            },
+        )
+    }
+
+    #[test]
+    fn loaded_values_determine_content_and_preserve_provenance() {
+        let (input, loaded) = inputs();
+        let first = InstructionComposer
+            .compose(&input.working_directory, &input, loaded.clone())
+            .unwrap();
+        let mut later = loaded;
+        later.loaded_at_ms = 99;
+        let second = InstructionComposer
+            .compose(&input.working_directory, &input, later)
+            .unwrap();
+        assert_eq!(first.rendered_prompt(), second.rendered_prompt());
+        assert_eq!(first.content_hash, second.content_hash);
+        assert!(first
+            .sources
+            .windows(2)
+            .all(|pair| pair[0].precedence < pair[1].precedence));
+        assert!(first.sources.iter().all(|source| source.loaded_at_ms == 42));
+        let project = first
+            .sources
+            .iter()
+            .find(|s| s.kind == InstructionSourceKind::ProjectAgents)
+            .unwrap();
+        assert!(project.truncated);
+        assert_eq!(first.diagnostics()[0].message, "truncated input");
+        assert!(first
+            .messages
+            .iter()
+            .all(|item| item.source_index < first.sources.len()));
+        assert!(first.rendered_prompt().contains("skill body"));
+        let catalog = first
+            .sources
+            .iter()
+            .find(|s| s.kind == InstructionSourceKind::PluginSkillCatalog)
+            .unwrap();
+        assert_eq!(
+            catalog.scope_root,
+            input
+                .working_directory
+                .join("plugins")
+                .display()
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn loaded_values_reject_missing_skills_and_oversized_system_instructions() {
+        let (input, mut loaded) = inputs();
+        loaded.plugin_skills.clear();
+        assert!(InstructionComposer
+            .compose(&input.working_directory, &input, loaded.clone())
+            .unwrap_err()
+            .contains("does not exist or is disabled"));
+        loaded.system_content = "x".repeat(WORKSPACE_SYSTEM_MAX_BYTES + 1);
+        assert!(InstructionComposer
+            .compose(&input.working_directory, &input, loaded)
+            .unwrap_err()
+            .contains("exceed"));
+    }
+}

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -67,9 +67,10 @@ pub(crate) use self::context::ensure_agent_trace_context;
 pub(crate) use self::events::standalone_runtime_event;
 pub(crate) use self::hooks::AgentHookEvaluation;
 
-#[cfg(test)]
 pub use self::hooks::AgentHookDecision;
-pub use self::hooks::{AgentHook, AgentHookInvocation, AgentHookStage};
+pub use self::hooks::{
+    AgentHook, AgentHookInvocation, AgentHookOutput, AgentHookRun, AgentHookStage,
+};
 pub(crate) use self::instructions::{ComposedInstructions, TurnInstructionInput};
 #[cfg(test)]
 pub use self::items::AgentPlanStepStatus;
@@ -635,15 +636,6 @@ impl NativeAgentRuntimeServices {
         self
     }
 
-    #[cfg_attr(test, allow(dead_code))]
-    pub(crate) fn with_command_hooks(
-        mut self,
-        command_hooks: crate::command_hooks::CommandHookEngine,
-    ) -> Self {
-        self.hooks = self.hooks.with_command_hooks(command_hooks);
-        self
-    }
-
     pub fn with_context_checkpoint_committer(
         mut self,
         committer: Arc<dyn NativeAgentContextCheckpointCommitter>,
@@ -668,7 +660,6 @@ impl NativeAgentRuntimeServices {
             .map_or(Ok(()), |trace_sink| trace_sink.flush())
     }
 
-    #[cfg(test)]
     pub fn with_hook(mut self, hook: Arc<dyn AgentHook>) -> Self {
         self.hooks = self.hooks.with_hook(hook);
         self
@@ -680,11 +671,11 @@ impl NativeAgentRuntimeServices {
         self
     }
 
-    pub(crate) fn evaluate_hook_invocation(
+    pub(crate) async fn evaluate_hook_invocation(
         &self,
         invocation: AgentHookInvocation,
     ) -> Result<AgentHookEvaluation, String> {
-        self.hooks.evaluate(invocation, &self.metrics)
+        self.hooks.evaluate(invocation, &self.metrics).await
     }
 
     pub fn tool_dispatcher(&self) -> Arc<dyn NativeAgentToolDispatcher> {

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -53,6 +53,8 @@ mod settings;
 mod state;
 mod stores;
 mod subagent_projection;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod tool_dispatcher;
 mod tool_loop_guard;
 mod tool_outcome_projection;
@@ -63,7 +65,6 @@ mod tool_runtime;
 mod trace_commit;
 mod usage;
 mod user_input;
-mod workspace_threads;
 
 pub(crate) use self::context::ensure_agent_trace_context;
 pub(crate) use self::events::standalone_runtime_event;
@@ -85,9 +86,10 @@ pub use self::items::{
 pub(crate) use self::provider::complete_tool_free_text_for_agent;
 #[cfg(test)]
 pub(crate) use self::provider::tool_free_text_request_for_agent;
+pub(crate) use self::provider::RustNativeAgentProvider;
 #[cfg(test)]
 use self::provider::{agent_chat_completion_request, agent_responses_request};
-use self::provider::{agent_provider_config, chat_completion_content, RustNativeAgentProvider};
+use self::provider::{agent_provider_config, chat_completion_content};
 pub use self::settings::AgentTurnSettings;
 use self::tool_router::NativeToolRouter;
 use self::usage::context_window_messages_async;
@@ -400,18 +402,6 @@ pub struct NativeToolResultEnvelope {
 }
 
 pub trait NativeAgentProvider: Send + Sync + 'static {
-    #[cfg(test)]
-    fn complete(&self, context: &AgentTurnContext) -> Result<NativeAgentProviderResponse, String>;
-
-    #[cfg(test)]
-    fn complete_streaming(
-        &self,
-        context: &AgentTurnContext,
-        _observer: &mut (dyn FnMut(NativeAgentProviderStreamEvent) + Send),
-    ) -> Result<NativeAgentProviderResponse, String> {
-        self.complete(context)
-    }
-
     fn complete_streaming_async<'a>(
         self: Arc<Self>,
         context: &'a AgentTurnContext,
@@ -422,41 +412,19 @@ pub trait NativeAgentProvider: Send + Sync + 'static {
                 + Send
                 + 'a,
         >,
-    > {
-        #[cfg(test)]
-        {
-            let context = context.clone();
-            return Box::pin(async move {
-                let (result, events) = tauri::async_runtime::spawn_blocking(move || {
-                    let mut events = Vec::new();
-                    let result = self.complete_streaming(&context, &mut |event| events.push(event));
-                    (result, events)
-                })
-                .await
-                .map_err(|error| {
-                    NativeAgentProviderFailure::provider(format!(
-                        "blocking provider test task failed: {error}"
-                    ))
-                })?;
-                for event in events {
-                    observer(event);
-                }
-                result.map_err(NativeAgentProviderFailure::provider)
-            });
-        }
-        #[cfg(not(test))]
-        {
-            let _ = (self, context, observer);
-            Box::pin(async {
-                Err(NativeAgentProviderFailure::provider(
-                    "native agent provider must implement complete_streaming_async",
-                ))
-            })
-        }
-    }
+    >;
 }
 
 pub trait NativeAgentToolDispatcher: Send + Sync + 'static {
+    /// Optional tool definitions owned by this execution adapter.
+    /// Discovery errors abort turn preparation; execution still rechecks authorization.
+    fn tool_contributors(
+        &self,
+        _context: &AgentTurnContext,
+    ) -> Result<Vec<Arc<dyn crate::tools::registry::ToolContributor>>, AgentError> {
+        Ok(Vec::new())
+    }
+
     fn dispatch(
         &self,
         context: &AgentTurnContext,
@@ -467,32 +435,7 @@ pub trait NativeAgentToolDispatcher: Send + Sync + 'static {
         self: Arc<Self>,
         context: AgentTurnContext,
         tool_call: PreparedToolCall,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send>,
-    > {
-        #[cfg(test)]
-        {
-            return Box::pin(async move {
-                match tauri::async_runtime::spawn_blocking(move || {
-                    self.dispatch(&context, &tool_call)
-                })
-                .await
-                {
-                    Ok(result) => result,
-                    Err(error) => {
-                        panic!("blocking native tool test task failed to join: {error}")
-                    }
-                }
-            });
-        }
-        #[cfg(not(test))]
-        {
-            let _ = (self, context, tool_call);
-            Box::pin(async {
-                Err("native agent tool dispatcher must implement dispatch_async".to_string())
-            })
-        }
-    }
+    ) -> Pin<Box<dyn Future<Output = Result<NativeAgentToolResult, AgentError>> + Send>>;
 }
 
 pub trait NativeAgentCheckpointStore: Send + Sync {
@@ -514,7 +457,7 @@ pub trait NativeAgentContextCheckpointCommitter: Send + Sync {
 }
 
 #[derive(Default)]
-struct InMemoryNativeAgentContextCheckpointCommitter {
+pub(crate) struct InMemoryNativeAgentContextCheckpointCommitter {
     state: std::sync::Mutex<InMemoryContextCheckpointState>,
 }
 
@@ -616,6 +559,20 @@ pub trait NativeAgentTraceSink: Send + Sync {
     }
 }
 
+/// Resources selected by the application owner before any Turn is started.
+pub(crate) struct NativeAgentRuntimeDependencies {
+    pub provider: Arc<dyn NativeAgentProvider>,
+    pub tools: Arc<dyn NativeAgentToolDispatcher>,
+    pub checkpoints: Arc<dyn NativeAgentCheckpointStore>,
+    pub context_checkpoint_committer: Arc<dyn NativeAgentContextCheckpointCommitter>,
+    pub cancellations: Arc<dyn NativeAgentCancellation>,
+    pub subagents: SubagentThreadManager,
+    pub mcp_runtime: McpRuntime,
+    pub shell_runtime: WorkerShellRuntime,
+    pub task_runtime: TurnExecutionRuntime,
+    pub metrics: AgentRuntimeMetrics,
+}
+
 #[derive(Clone)]
 pub struct NativeAgentRuntimeServices {
     provider: Arc<dyn NativeAgentProvider>,
@@ -639,49 +596,27 @@ pub struct NativeAgentRuntimeServices {
 }
 
 impl NativeAgentRuntimeServices {
-    pub fn new(
-        provider: Arc<dyn NativeAgentProvider>,
-        tools: Arc<dyn NativeAgentToolDispatcher>,
-        checkpoints: Arc<dyn NativeAgentCheckpointStore>,
-        cancellations: Arc<dyn NativeAgentCancellation>,
-    ) -> Self {
+    pub(crate) fn from_dependencies(dependencies: NativeAgentRuntimeDependencies) -> Self {
         Self {
-            provider,
-            tools,
-            checkpoints,
-            context_checkpoint_committer: Arc::new(
-                InMemoryNativeAgentContextCheckpointCommitter::default(),
-            ),
-            cancellations,
-            subagents: SubagentThreadManager::default(),
+            provider: dependencies.provider,
+            tools: dependencies.tools,
+            checkpoints: dependencies.checkpoints,
+            context_checkpoint_committer: dependencies.context_checkpoint_committer,
+            cancellations: dependencies.cancellations,
+            subagents: dependencies.subagents,
             trace_sink: None,
-            mcp_runtime: McpRuntime::new(),
-            shell_runtime: WorkerShellRuntime::default(),
+            mcp_runtime: dependencies.mcp_runtime,
+            shell_runtime: dependencies.shell_runtime,
             browser_runtime: None,
-            task_runtime: TurnExecutionRuntime::new(),
+            task_runtime: dependencies.task_runtime,
             hooks: hooks::AgentHookPipeline::default(),
-            metrics: crate::runtime::observability::global_agent_runtime_metrics().clone(),
+            metrics: dependencies.metrics,
             thread_store: None,
             #[cfg(test)]
             test_activated_tool_ids: Vec::new(),
             #[cfg(test)]
             test_tool_registry_entries: None,
         }
-    }
-
-    pub fn with_subagent_manager(subagents: SubagentThreadManager) -> Self {
-        Self::new(
-            Arc::new(RustNativeAgentProvider),
-            Arc::new(SubagentNativeAgentToolDispatcher::new(subagents.clone())),
-            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
-            Arc::new(InMemoryNativeAgentCancellation::default()),
-        )
-        .with_subagents(subagents)
-    }
-
-    fn with_subagents(mut self, subagents: SubagentThreadManager) -> Self {
-        self.subagents = subagents;
-        self
     }
 
     pub fn with_trace_sink(mut self, trace_sink: Arc<dyn NativeAgentTraceSink>) -> Self {
@@ -760,11 +695,6 @@ impl NativeAgentRuntimeServices {
         self
     }
 
-    pub(crate) fn with_mcp_runtime(mut self, runtime: McpRuntime) -> Self {
-        self.mcp_runtime = runtime;
-        self
-    }
-
     pub(crate) fn with_thread_store(
         mut self,
         thread_store: crate::threads::workspace_store::WorkspaceThreadStore,
@@ -779,12 +709,6 @@ impl NativeAgentRuntimeServices {
         self.thread_store
             .clone()
             .ok_or_else(|| "native agent workspace thread store is unavailable".to_string())
-    }
-
-    pub(crate) fn optional_thread_store(
-        &self,
-    ) -> Option<crate::threads::workspace_store::WorkspaceThreadStore> {
-        self.thread_store.clone()
     }
 
     pub(crate) fn mcp_runtime(&self) -> McpRuntime {
@@ -891,19 +815,6 @@ impl NativeAgentRuntimeServices {
     #[cfg(test)]
     pub fn clear_turn_checkpoint(&self, session_id: &str, turn_id: &str) {
         self.checkpoints.clear_for_turn(session_id, turn_id);
-    }
-}
-
-impl Default for NativeAgentRuntimeServices {
-    fn default() -> Self {
-        let subagents = SubagentThreadManager::default();
-        Self::new(
-            Arc::new(RustNativeAgentProvider),
-            Arc::new(SubagentNativeAgentToolDispatcher::new(subagents.clone())),
-            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
-            Arc::new(InMemoryNativeAgentCancellation::default()),
-        )
-        .with_subagents(subagents)
     }
 }
 

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -67,6 +67,7 @@ pub(crate) use self::context::ensure_agent_trace_context;
 pub(crate) use self::events::standalone_runtime_event;
 pub(crate) use self::hooks::AgentHookEvaluation;
 
+#[cfg(test)]
 pub use self::hooks::AgentHookDecision;
 pub use self::hooks::{
     AgentHook, AgentHookInvocation, AgentHookOutput, AgentHookRun, AgentHookStage,

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -1,13 +1,10 @@
 mod context_checkpoint;
 use crate::agent::runtime_protocol::{AgentRuntimeEventEnvelope, AgentTraceContext};
-use crate::collaboration::subagents::SubagentThreadManager;
 #[cfg(test)]
 use crate::collaboration::subagents::{
     SubagentInputSender, SubagentSendInputParams, SubagentTargetParams,
 };
-use crate::runtime::mcp::McpRuntime;
 use crate::runtime::turn_execution::{AgentCancelReason, TurnExecutionRuntime};
-use crate::tools::shell::WorkerShellRuntime;
 pub(crate) use checkpoint_types::AgentCheckpointPayload;
 pub use context_checkpoint::AgentContextCheckpoint;
 use serde::{Deserialize, Serialize};
@@ -35,7 +32,7 @@ pub use execution_payloads::{
     AgentCancellationCleanup, CompletedAgentToolResult, PendingAgentToolCall, TerminalAgentTurn,
 };
 mod hooks;
-mod instructions;
+pub(crate) mod instructions;
 mod item_event_projection;
 mod items;
 mod provider;
@@ -73,9 +70,7 @@ pub(crate) use self::hooks::AgentHookEvaluation;
 #[cfg(test)]
 pub use self::hooks::AgentHookDecision;
 pub use self::hooks::{AgentHook, AgentHookInvocation, AgentHookStage};
-pub(crate) use self::instructions::{
-    ComposedInstructions, InstructionComposer, TurnInstructionInput,
-};
+pub(crate) use self::instructions::{ComposedInstructions, TurnInstructionInput};
 #[cfg(test)]
 pub use self::items::AgentPlanStepStatus;
 pub use self::items::{
@@ -180,7 +175,7 @@ pub struct AgentTurnContext {
     pub session_id: String,
     pub thread_id: Option<String>,
     continuation: Option<crate::agent::runtime_protocol::AgentContinuationInput>,
-    controls: turn_input::AgentTurnControls,
+    pub(crate) controls: turn_input::AgentTurnControls,
     context_window_projected: bool,
     pub messages: AgentItemHistory,
     pub config_snapshot: Value,
@@ -415,14 +410,33 @@ pub trait NativeAgentProvider: Send + Sync + 'static {
     >;
 }
 
+/// Catalog preparation may finish through cancellation before model execution begins.
+pub struct NativeAgentToolCatalog {
+    pub contributors: Vec<Arc<dyn crate::tools::registry::ToolContributor>>,
+    pub selected_tools: Option<Vec<String>>,
+}
+
+pub enum NativeAgentToolPreparation {
+    Ready(NativeAgentToolCatalog),
+    Cancelled {
+        phase: String,
+        server: Option<String>,
+        transport: Option<String>,
+    },
+}
+
 pub trait NativeAgentToolDispatcher: Send + Sync + 'static {
-    /// Optional tool definitions owned by this execution adapter.
-    /// Discovery errors abort turn preparation; execution still rechecks authorization.
-    fn tool_contributors(
-        &self,
-        _context: &AgentTurnContext,
-    ) -> Result<Vec<Arc<dyn crate::tools::registry::ToolContributor>>, AgentError> {
-        Ok(Vec::new())
+    fn prepare_tools<'a>(
+        &'a self,
+        context: &'a AgentTurnContext,
+        _config_snapshot: &'a Value,
+    ) -> futures_util::future::BoxFuture<'a, Result<NativeAgentToolPreparation, AgentError>> {
+        Box::pin(async move {
+            Ok(NativeAgentToolPreparation::Ready(NativeAgentToolCatalog {
+                contributors: Vec::new(),
+                selected_tools: context.settings.selected_tools.clone(),
+            }))
+        })
     }
 
     fn dispatch(
@@ -566,9 +580,6 @@ pub(crate) struct NativeAgentRuntimeDependencies {
     pub checkpoints: Arc<dyn NativeAgentCheckpointStore>,
     pub context_checkpoint_committer: Arc<dyn NativeAgentContextCheckpointCommitter>,
     pub cancellations: Arc<dyn NativeAgentCancellation>,
-    pub subagents: SubagentThreadManager,
-    pub mcp_runtime: McpRuntime,
-    pub shell_runtime: WorkerShellRuntime,
     pub task_runtime: TurnExecutionRuntime,
     pub metrics: AgentRuntimeMetrics,
 }
@@ -580,15 +591,10 @@ pub struct NativeAgentRuntimeServices {
     checkpoints: Arc<dyn NativeAgentCheckpointStore>,
     context_checkpoint_committer: Arc<dyn NativeAgentContextCheckpointCommitter>,
     cancellations: Arc<dyn NativeAgentCancellation>,
-    subagents: SubagentThreadManager,
     trace_sink: Option<Arc<dyn NativeAgentTraceSink>>,
-    mcp_runtime: McpRuntime,
-    shell_runtime: WorkerShellRuntime,
-    browser_runtime: Option<crate::native_browser::SharedBrowserRuntime>,
     task_runtime: TurnExecutionRuntime,
     hooks: hooks::AgentHookPipeline,
     metrics: AgentRuntimeMetrics,
-    thread_store: Option<crate::threads::workspace_store::WorkspaceThreadStore>,
     #[cfg(test)]
     test_activated_tool_ids: Vec<String>,
     #[cfg(test)]
@@ -603,15 +609,10 @@ impl NativeAgentRuntimeServices {
             checkpoints: dependencies.checkpoints,
             context_checkpoint_committer: dependencies.context_checkpoint_committer,
             cancellations: dependencies.cancellations,
-            subagents: dependencies.subagents,
             trace_sink: None,
-            mcp_runtime: dependencies.mcp_runtime,
-            shell_runtime: dependencies.shell_runtime,
-            browser_runtime: None,
             task_runtime: dependencies.task_runtime,
             hooks: hooks::AgentHookPipeline::default(),
             metrics: dependencies.metrics,
-            thread_store: None,
             #[cfg(test)]
             test_activated_tool_ids: Vec::new(),
             #[cfg(test)]
@@ -695,42 +696,6 @@ impl NativeAgentRuntimeServices {
         self
     }
 
-    pub(crate) fn with_thread_store(
-        mut self,
-        thread_store: crate::threads::workspace_store::WorkspaceThreadStore,
-    ) -> Self {
-        self.thread_store = Some(thread_store);
-        self
-    }
-
-    pub(crate) fn thread_store(
-        &self,
-    ) -> Result<crate::threads::workspace_store::WorkspaceThreadStore, String> {
-        self.thread_store
-            .clone()
-            .ok_or_else(|| "native agent workspace thread store is unavailable".to_string())
-    }
-
-    pub(crate) fn mcp_runtime(&self) -> McpRuntime {
-        self.mcp_runtime.clone()
-    }
-
-    pub(crate) fn shell_runtime(&self) -> WorkerShellRuntime {
-        self.shell_runtime.clone()
-    }
-
-    pub(crate) fn with_browser_runtime(
-        mut self,
-        runtime: crate::native_browser::SharedBrowserRuntime,
-    ) -> Self {
-        self.browser_runtime = Some(runtime);
-        self
-    }
-
-    pub(crate) fn browser_runtime(&self) -> Option<crate::native_browser::SharedBrowserRuntime> {
-        self.browser_runtime.clone()
-    }
-
     pub(crate) fn task_runtime(&self) -> TurnExecutionRuntime {
         self.task_runtime.clone()
     }
@@ -751,10 +716,6 @@ impl NativeAgentRuntimeServices {
     ) -> Self {
         self.test_tool_registry_entries = Some(entries);
         self
-    }
-
-    pub fn subagent_manager(&self) -> SubagentThreadManager {
-        self.subagents.clone()
     }
 
     pub fn cancel(&self, turn_id: &str) -> Value {

--- a/src-tauri/src/agent/runtime/provider.rs
+++ b/src-tauri/src/agent/runtime/provider.rs
@@ -9,50 +9,9 @@ use super::{
 use serde_json::Value;
 use std::sync::Arc;
 
-pub(super) struct RustNativeAgentProvider;
+pub(crate) struct RustNativeAgentProvider;
 
 impl NativeAgentProvider for RustNativeAgentProvider {
-    #[cfg(test)]
-    fn complete(&self, context: &AgentTurnContext) -> Result<NativeAgentProviderResponse, String> {
-        let mut observer = |_event: NativeAgentProviderStreamEvent| {};
-        self.complete_streaming(context, &mut observer)
-    }
-
-    #[cfg(test)]
-    fn complete_streaming(
-        &self,
-        context: &AgentTurnContext,
-        observer: &mut (dyn FnMut(NativeAgentProviderStreamEvent) + Send),
-    ) -> Result<NativeAgentProviderResponse, String> {
-        let provider_config = agent_provider_config(context);
-        let adapter = ProviderProtocolAdapter::resolve(context, &provider_config)?;
-        let request = context
-            .prepared_provider_request()
-            .cloned()
-            .map(Ok)
-            .unwrap_or_else(|| adapter.build_request(context))?;
-        let mut provider_observer =
-            |event: crate::agent::provider::NativeProviderStreamEvent| match event {
-                crate::agent::provider::NativeProviderStreamEvent::ToolCallDelta => {
-                    observer(NativeAgentProviderStreamEvent::ToolCallDelta)
-                }
-                crate::agent::provider::NativeProviderStreamEvent::MessagePhase(phase) => {
-                    observer(NativeAgentProviderStreamEvent::MessagePhase(
-                        parse_message_phase(&phase),
-                    ));
-                }
-                crate::agent::provider::NativeProviderStreamEvent::ContentDelta(delta) => {
-                    observer(NativeAgentProviderStreamEvent::ContentDelta(delta));
-                }
-                crate::agent::provider::NativeProviderStreamEvent::ReasoningDelta(delta) => {
-                    observer(NativeAgentProviderStreamEvent::ReasoningDelta(delta));
-                }
-            };
-        let completion = adapter.complete(&provider_config, &request, &mut provider_observer)?;
-        emit_completion_phase(&completion, adapter, observer);
-        provider_response_from_completion(context, adapter, completion)
-    }
-
     fn complete_streaming_async<'a>(
         self: Arc<Self>,
         context: &'a AgentTurnContext,

--- a/src-tauri/src/agent/runtime/provider_loop.rs
+++ b/src-tauri/src/agent/runtime/provider_loop.rs
@@ -12,8 +12,6 @@ use super::usage::{
 use super::user_input::{
     prepare_user_input_continuation, UserInputContinuationOutcome, UserInputResume,
 };
-#[cfg(test)]
-use super::InstructionComposer;
 use super::{
     AgentExecutionStatus, AgentResultError, AgentStopReason, AgentTurnInput, AgentTurnMetrics,
     AgentTurnResult,
@@ -23,18 +21,17 @@ use super::{
     NativeAgentContextCheckpointCommit, NativeAgentProviderFailure, NativeAgentProviderFailureKind,
     NativeAgentProviderResponse, NativeAgentProviderStreamEvent, NativeAgentRuntimeServices,
 };
+#[cfg(test)]
+use crate::agent::instruction_sources::InstructionLoader;
 use crate::agent::runtime::AgentError;
 use crate::agent::runtime_protocol::{
     AgentAssistantMessagePhase, AgentEventKind, AgentRuntimePhase, ModelOutputEvent,
     PendingAgentEvent, TerminalEvent,
 };
 use crate::runtime::turn_execution::StartAgentTurn;
-use crate::tools::registry::{
-    AgentGraphToolContributor, McpToolContributor, WorkerToolRegistryRpc,
-};
+use crate::tools::registry::WorkerToolRegistryRpc;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[cfg(test)]
@@ -92,11 +89,7 @@ pub async fn run_native_agent_turn_with_workspace_async(
     mut config_snapshot: Value,
     workspace_root: &Path,
 ) -> Result<AgentTurnResult, AgentError> {
-    let instructions = InstructionComposer::default().compose_with_config(
-        workspace_root,
-        &spec,
-        &config_snapshot,
-    )?;
+    let instructions = InstructionLoader::default().compose(workspace_root, &spec)?;
     crate::workspace_extensions::merge_workspace_mcp_servers(
         &mut config_snapshot,
         &instructions.working_directory,
@@ -522,117 +515,53 @@ impl<'a> NativeAgentTurnExecution<'a> {
                 ),
             ));
         }
-        if let Some(workspace_root) = workspace_root {
-            let capability_policy = context.settings.capability_policy()?;
-            let mcp_workspace_root = context
-                .settings
-                .working_directory
-                .as_deref()
-                .unwrap_or(workspace_root);
-            let cancellation = context.cancellation.clone().map(|cancellation| {
-                Arc::new(cancellation) as Arc<dyn crate::protocol::WorkerRequestCancellation>
-            });
-            let mcp_snapshot = if capability_policy
-                .allows(&crate::protocol::capability::WorkerCapability::McpCall)
+        if workspace_root.is_some() {
+            let catalog = match dependencies
+                .tools
+                .prepare_tools(&context, &config_snapshot)
+                .await?
             {
-                match dependencies
-                    .mcp_runtime
-                    .registry_snapshot(mcp_workspace_root, &config_snapshot, cancellation)
-                    .await
-                {
-                    Ok(snapshot) => Some(snapshot),
-                    Err(error) if error.cancelled => {
-                        let checkpoint = save_phase_checkpoint(
-                            dependencies,
-                            &context,
-                            crate::agent::runtime_protocol::AgentRuntimePhase::Cancelled,
-                            super::checkpoint_types::PhaseCheckpointInput {
-                                payload: super::checkpoint_types::AgentCheckpointPayload::Execution(
-                                    super::checkpoint_types::ExecutionCheckpoint {
-                                        cancelled: Some(true),
-                                        phase: Some("mcp_discovery".into()),
-                                        server: Some(error.server),
-                                        transport: Some(error.transport),
-                                        ..Default::default()
-                                    },
-                                ),
-                                ..Default::default()
-                            },
-                        );
-                        return Ok(PreparedNativeAgentTurnExecution::Finished(
-                            cancelled_result(
-                                dependencies,
-                                &context.turn_id,
-                                &context.session_id,
-                                checkpoint,
+                super::NativeAgentToolPreparation::Ready(catalog) => catalog,
+                super::NativeAgentToolPreparation::Cancelled {
+                    phase,
+                    server,
+                    transport,
+                } => {
+                    let checkpoint = save_phase_checkpoint(
+                        dependencies,
+                        &context,
+                        crate::agent::runtime_protocol::AgentRuntimePhase::Cancelled,
+                        super::checkpoint_types::PhaseCheckpointInput {
+                            payload: super::checkpoint_types::AgentCheckpointPayload::Execution(
+                                super::checkpoint_types::ExecutionCheckpoint {
+                                    cancelled: Some(true),
+                                    phase: Some(phase),
+                                    server: server,
+                                    transport: transport,
+                                    ..Default::default()
+                                },
                             ),
-                        ));
-                    }
-                    Err(error) => {
-                        return Err(format!(
-                            "MCP registry snapshot failed for server `{}` over {}: {}",
-                            error.server, error.transport, error.message
-                        )
-                        .into());
-                    }
+                            ..Default::default()
+                        },
+                    );
+                    return Ok(PreparedNativeAgentTurnExecution::Finished(
+                        cancelled_result(
+                            dependencies,
+                            &context.turn_id,
+                            &context.session_id,
+                            checkpoint,
+                        ),
+                    ));
                 }
-            } else {
-                None
             };
-            let mut tool_registry =
-                WorkerToolRegistryRpc::new_with_config(capability_policy, config_snapshot);
-            let graph_node_turn = ["graphRunId", "graph_run_id"]
-                .iter()
-                .any(|key| context.metadata.get(*key).is_some());
-            if !graph_node_turn && context.controls.declares_working_directory {
-                if let Some(definition_workspace_root) =
-                    context.settings.working_directory.as_deref()
-                {
-                    let definition_workspace =
-                        crate::workspace_registry::canonical_workspace(definition_workspace_root)?;
-                    let discovery =
-                        crate::agent_graphs::discover_tools_for_workspace(&definition_workspace)?;
-                    if !discovery.graphs.is_empty() {
-                        tool_registry = tool_registry.with_contributor(Arc::new(
-                            AgentGraphToolContributor::new(
-                                crate::workspace_registry::workspace_id(&definition_workspace),
-                                discovery.graphs,
-                            )?,
-                        ))?;
-                    }
-                }
-            }
-            for contributor in dependencies.tools.tool_contributors(&context)? {
+            let mut tool_registry = WorkerToolRegistryRpc::new_with_config(
+                context.settings.capability_policy()?,
+                config_snapshot,
+            );
+            for contributor in catalog.contributors {
                 tool_registry = tool_registry.with_contributor(contributor)?;
             }
-            for server in mcp_snapshot
-                .as_deref()
-                .into_iter()
-                .flat_map(|snapshot| snapshot.servers.iter())
-                .filter(|server| server.available && server.tools.iter().any(|tool| tool.allowed))
-            {
-                tool_registry = tool_registry
-                    .with_contributor(Arc::new(McpToolContributor::from_registry(server)?))?;
-            }
-            if let (Some(snapshot), Some(selected_tools)) = (
-                mcp_snapshot.as_deref(),
-                context.settings.selected_tools.as_mut(),
-            ) {
-                let unavailable_mcp_tools = snapshot
-                    .servers
-                    .iter()
-                    .filter(|server| !server.available)
-                    .flat_map(|server| server.tools.iter().map(|tool| tool.id.as_str()))
-                    .collect::<std::collections::BTreeSet<_>>();
-                let dropped_concrete_mcp = selected_tools
-                    .iter()
-                    .any(|tool_id| unavailable_mcp_tools.contains(tool_id.as_str()));
-                selected_tools.retain(|tool_id| {
-                    !unavailable_mcp_tools.contains(tool_id.as_str())
-                        && (!dropped_concrete_mcp
-                            || tool_id != crate::tools::registry::MCP_CALL_TOOL_METHOD)
-                });
-            }
+            context.settings.selected_tools = catalog.selected_tools;
             context.tool_router =
                 super::tool_router::NativeToolRouter::new(tool_registry.list_tools().tools);
         }

--- a/src-tauri/src/agent/runtime/provider_loop.rs
+++ b/src-tauri/src/agent/runtime/provider_loop.rs
@@ -602,10 +602,8 @@ impl<'a> NativeAgentTurnExecution<'a> {
                     }
                 }
             }
-            if let Some(contributor) =
-                super::workspace_threads::tool_contributor(dependencies, &context)?
-            {
-                tool_registry = tool_registry.with_contributor(Arc::new(contributor))?;
+            for contributor in dependencies.tools.tool_contributors(&context)? {
+                tool_registry = tool_registry.with_contributor(contributor)?;
             }
             for server in mcp_snapshot
                 .as_deref()

--- a/src-tauri/src/agent/runtime/provider_loop.rs
+++ b/src-tauri/src/agent/runtime/provider_loop.rs
@@ -195,11 +195,14 @@ async fn run_owned_native_agent_turn_async(
                 AgentHookStage::TurnAbort,
                 identity.trace_context.clone(),
             );
-            identity.evaluate_hook(invocation).map_err(|hook_error| {
-                error
-                    .clone()
-                    .combine(AgentError::from(hook_error).context("turn abort hook failed"))
-            })?;
+            identity
+                .evaluate_hook(invocation)
+                .await
+                .map_err(|hook_error| {
+                    error
+                        .clone()
+                        .combine(AgentError::from(hook_error).context("turn abort hook failed"))
+                })?;
             return Err(error);
         }
     };
@@ -229,7 +232,7 @@ async fn run_owned_native_agent_turn_async(
         .metrics()
         .record_duration("turn.durationMs", duration);
     let invocation = AgentHookInvocation::lifecycle(stage, identity.trace_context.clone());
-    let evaluation = identity.evaluate_hook(invocation.clone())?;
+    let evaluation = identity.evaluate_hook(invocation.clone()).await?;
     append_hook_evaluation_to_result(&mut result, services, &identity, &invocation, &evaluation)?;
     result.trace_context = Some(identity.trace_context.clone());
     result.turn_metrics = Some(AgentTurnMetrics {
@@ -637,7 +640,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
                 context.hook_permission_mode(),
                 prompt,
             );
-            let evaluation = context.evaluate_command_hook(invocation.clone()).await?;
+            let evaluation = context.evaluate_hook(invocation.clone()).await?;
             state.apply_hook_evaluation(&mut context, &evaluation)?;
             state.emit_hook_evaluation(&invocation, &evaluation)?;
             if let Some(reason) = evaluation.denied_reason {
@@ -656,7 +659,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
             AgentHookStage::TurnStart,
             context.trace_context.clone(),
         );
-        let turn_start_evaluation = context.evaluate_hook(turn_start_invocation.clone())?;
+        let turn_start_evaluation = context.evaluate_hook(turn_start_invocation.clone()).await?;
         state.emit_hook_evaluation(&turn_start_invocation, &turn_start_evaluation)?;
         if let Some(reason) = turn_start_evaluation.denied_reason {
             return Ok(PreparedNativeAgentTurnExecution::Finished(
@@ -802,10 +805,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
                     self.context.hook_permission_mode(),
                     trigger.to_string(),
                 );
-                let evaluation = self
-                    .context
-                    .evaluate_command_hook(invocation.clone())
-                    .await?;
+                let evaluation = self.context.evaluate_hook(invocation.clone()).await?;
                 self.state
                     .apply_hook_evaluation(&mut self.context, &evaluation)?;
                 self.state.emit_hook_evaluation(&invocation, &evaluation)?;
@@ -877,7 +877,8 @@ impl<'a> NativeAgentTurnExecution<'a> {
         );
         let before_provider_evaluation = self
             .context
-            .evaluate_hook(before_provider_invocation.clone())?;
+            .evaluate_hook(before_provider_invocation.clone())
+            .await?;
         self.state
             .emit_hook_evaluation(&before_provider_invocation, &before_provider_evaluation)?;
         if let Some(reason) = before_provider_evaluation.denied_reason {
@@ -985,7 +986,8 @@ impl<'a> NativeAgentTurnExecution<'a> {
         );
         let after_provider_evaluation = self
             .context
-            .evaluate_hook(after_provider_invocation.clone())?;
+            .evaluate_hook(after_provider_invocation.clone())
+            .await?;
         self.state
             .emit_hook_evaluation(&after_provider_invocation, &after_provider_evaluation)?;
         if attempt.stream.observer_cancelled {

--- a/src-tauri/src/agent/runtime/provider_protocol.rs
+++ b/src-tauri/src/agent/runtime/provider_protocol.rs
@@ -121,27 +121,6 @@ impl ProviderProtocolAdapter {
         }
     }
 
-    #[cfg(test)]
-    pub fn complete(
-        self,
-        provider_config: &Value,
-        request: &Value,
-        observer: &mut (dyn FnMut(NativeProviderStreamEvent) + Send),
-    ) -> Result<Value, String> {
-        match self {
-            Self::ChatCompletions => crate::agent::provider::complete_chat_for_agent_with_observer(
-                provider_config,
-                request,
-                observer,
-            ),
-            Self::Responses => crate::agent::provider::complete_responses_for_agent_with_observer(
-                provider_config,
-                request,
-                observer,
-            ),
-        }
-    }
-
     pub async fn complete_async(
         self,
         provider_config: &Value,

--- a/src-tauri/src/agent/runtime/settings.rs
+++ b/src-tauri/src/agent/runtime/settings.rs
@@ -189,7 +189,7 @@ impl AgentTurnSettings {
         }
     }
 
-    pub(super) fn capability_policy(&self) -> Result<CapabilityPolicy, String> {
+    pub(crate) fn capability_policy(&self) -> Result<CapabilityPolicy, String> {
         self.validate()?;
         match self.permission_profile.as_deref().unwrap_or("local-worker") {
             "local-worker" => Ok(default_desktop_capability_policy()),

--- a/src-tauri/src/agent/runtime/test_support.rs
+++ b/src-tauri/src/agent/runtime/test_support.rs
@@ -1,0 +1,131 @@
+//! Adapters for deliberately blocking test fixtures. Production implementations
+//! must implement the same asynchronous contracts exercised by the runtime.
+use super::{
+    AgentError, AgentTurnContext, NativeAgentProvider, NativeAgentProviderFailure,
+    NativeAgentProviderResponse, NativeAgentProviderStreamEvent, NativeAgentToolDispatcher,
+    NativeAgentToolResult, PreparedToolCall,
+};
+use futures_util::future::BoxFuture;
+use std::sync::Arc;
+
+impl super::NativeAgentRuntimeServices {
+    pub(crate) fn with_mcp_runtime(mut self, runtime: super::McpRuntime) -> Self {
+        self.mcp_runtime = runtime;
+        self
+    }
+
+    pub fn new(
+        provider: Arc<dyn NativeAgentProvider>,
+        tools: Arc<dyn NativeAgentToolDispatcher>,
+        checkpoints: Arc<dyn super::NativeAgentCheckpointStore>,
+        cancellations: Arc<dyn super::NativeAgentCancellation>,
+    ) -> Self {
+        Self::from_dependencies(super::NativeAgentRuntimeDependencies {
+            provider,
+            tools,
+            checkpoints,
+            context_checkpoint_committer: Arc::new(
+                super::InMemoryNativeAgentContextCheckpointCommitter::default(),
+            ),
+            cancellations,
+            subagents: super::SubagentThreadManager::default(),
+            mcp_runtime: super::McpRuntime::new(),
+            shell_runtime: super::WorkerShellRuntime::default(),
+            task_runtime: super::TurnExecutionRuntime::new(),
+            metrics: crate::runtime::observability::global_agent_runtime_metrics().clone(),
+        })
+    }
+
+    pub fn with_subagent_manager(subagents: super::SubagentThreadManager) -> Self {
+        Self::from_dependencies(super::NativeAgentRuntimeDependencies {
+            provider: Arc::new(super::RustNativeAgentProvider),
+            tools: Arc::new(super::SubagentNativeAgentToolDispatcher::new(
+                subagents.clone(),
+            )),
+            checkpoints: Arc::new(super::InMemoryNativeAgentCheckpointStore::default()),
+            context_checkpoint_committer: Arc::new(
+                super::InMemoryNativeAgentContextCheckpointCommitter::default(),
+            ),
+            cancellations: Arc::new(super::InMemoryNativeAgentCancellation::default()),
+            subagents,
+            mcp_runtime: super::McpRuntime::new(),
+            shell_runtime: super::WorkerShellRuntime::default(),
+            task_runtime: super::TurnExecutionRuntime::new(),
+            metrics: crate::runtime::observability::global_agent_runtime_metrics().clone(),
+        })
+    }
+}
+
+impl Default for super::NativeAgentRuntimeServices {
+    fn default() -> Self {
+        Self::with_subagent_manager(super::SubagentThreadManager::default())
+    }
+}
+
+pub(crate) trait BlockingTestProvider: Send + Sync + 'static {
+    fn complete(&self, context: &AgentTurnContext) -> Result<NativeAgentProviderResponse, String>;
+
+    fn complete_streaming(
+        &self,
+        context: &AgentTurnContext,
+        _observer: &mut (dyn FnMut(NativeAgentProviderStreamEvent) + Send),
+    ) -> Result<NativeAgentProviderResponse, String> {
+        self.complete(context)
+    }
+}
+
+impl<T: BlockingTestProvider> NativeAgentProvider for T {
+    fn complete_streaming_async<'a>(
+        self: Arc<Self>,
+        context: &'a AgentTurnContext,
+        observer: &'a mut (dyn FnMut(NativeAgentProviderStreamEvent) + Send),
+    ) -> BoxFuture<'a, Result<NativeAgentProviderResponse, NativeAgentProviderFailure>> {
+        let context = context.clone();
+        Box::pin(async move {
+            let (result, events) = tauri::async_runtime::spawn_blocking(move || {
+                let mut events = Vec::new();
+                let result = self.complete_streaming(&context, &mut |event| events.push(event));
+                (result, events)
+            })
+            .await
+            .expect("blocking test provider task must join");
+            for event in events {
+                observer(event);
+            }
+            result.map_err(NativeAgentProviderFailure::provider)
+        })
+    }
+}
+
+pub(crate) trait BlockingTestToolDispatcher: Send + Sync + 'static {
+    fn dispatch(
+        &self,
+        context: &AgentTurnContext,
+        tool_call: &PreparedToolCall,
+    ) -> Result<NativeAgentToolResult, String>;
+}
+
+impl<T: BlockingTestToolDispatcher> NativeAgentToolDispatcher for T {
+    fn dispatch(
+        &self,
+        context: &AgentTurnContext,
+        tool_call: &PreparedToolCall,
+    ) -> Result<NativeAgentToolResult, String> {
+        BlockingTestToolDispatcher::dispatch(self, context, tool_call)
+    }
+
+    fn dispatch_async(
+        self: Arc<Self>,
+        context: AgentTurnContext,
+        tool_call: PreparedToolCall,
+    ) -> BoxFuture<'static, Result<NativeAgentToolResult, AgentError>> {
+        Box::pin(async move {
+            tauri::async_runtime::spawn_blocking(move || {
+                BlockingTestToolDispatcher::dispatch(self.as_ref(), &context, &tool_call)
+            })
+            .await
+            .expect("blocking test tool task must join")
+            .map_err(AgentError::from)
+        })
+    }
+}

--- a/src-tauri/src/agent/runtime/test_support.rs
+++ b/src-tauri/src/agent/runtime/test_support.rs
@@ -9,11 +9,6 @@ use futures_util::future::BoxFuture;
 use std::sync::Arc;
 
 impl super::NativeAgentRuntimeServices {
-    pub(crate) fn with_mcp_runtime(mut self, runtime: super::McpRuntime) -> Self {
-        self.mcp_runtime = runtime;
-        self
-    }
-
     pub fn new(
         provider: Arc<dyn NativeAgentProvider>,
         tools: Arc<dyn NativeAgentToolDispatcher>,
@@ -28,15 +23,14 @@ impl super::NativeAgentRuntimeServices {
                 super::InMemoryNativeAgentContextCheckpointCommitter::default(),
             ),
             cancellations,
-            subagents: super::SubagentThreadManager::default(),
-            mcp_runtime: super::McpRuntime::new(),
-            shell_runtime: super::WorkerShellRuntime::default(),
             task_runtime: super::TurnExecutionRuntime::new(),
             metrics: crate::runtime::observability::global_agent_runtime_metrics().clone(),
         })
     }
 
-    pub fn with_subagent_manager(subagents: super::SubagentThreadManager) -> Self {
+    pub fn with_subagent_manager(
+        subagents: crate::collaboration::subagents::SubagentThreadManager,
+    ) -> Self {
         Self::from_dependencies(super::NativeAgentRuntimeDependencies {
             provider: Arc::new(super::RustNativeAgentProvider),
             tools: Arc::new(super::SubagentNativeAgentToolDispatcher::new(
@@ -47,9 +41,6 @@ impl super::NativeAgentRuntimeServices {
                 super::InMemoryNativeAgentContextCheckpointCommitter::default(),
             ),
             cancellations: Arc::new(super::InMemoryNativeAgentCancellation::default()),
-            subagents,
-            mcp_runtime: super::McpRuntime::new(),
-            shell_runtime: super::WorkerShellRuntime::default(),
             task_runtime: super::TurnExecutionRuntime::new(),
             metrics: crate::runtime::observability::global_agent_runtime_metrics().clone(),
         })
@@ -58,7 +49,9 @@ impl super::NativeAgentRuntimeServices {
 
 impl Default for super::NativeAgentRuntimeServices {
     fn default() -> Self {
-        Self::with_subagent_manager(super::SubagentThreadManager::default())
+        Self::with_subagent_manager(
+            crate::collaboration::subagents::SubagentThreadManager::default(),
+        )
     }
 }
 

--- a/src-tauri/src/agent/runtime/tests/README.md
+++ b/src-tauri/src/agent/runtime/tests/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Tests
-<!-- tinybot-module-fingerprint: sha256:6ec85ffa363f5f5ac8be580f283609abe5fdbac5d61c4ac97a640d4580956ac4 -->
+<!-- tinybot-module-fingerprint: sha256:41c190fa21582d96b435f415b1351f1a1a438a7fd9ce1f6e38b799d16d9c3125 -->
 
 This directory groups the larger agent runtime test suites by concern:
 configuration, context, interactions, lifecycle, and tools.

--- a/src-tauri/src/agent/runtime/tests/README.md
+++ b/src-tauri/src/agent/runtime/tests/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Tests
-<!-- tinybot-module-fingerprint: sha256:72a6093d199f6ce5d23a4832497671537f33a543b4deaa5797d5c90b7398bc35 -->
+<!-- tinybot-module-fingerprint: sha256:6ec85ffa363f5f5ac8be580f283609abe5fdbac5d61c4ac97a640d4580956ac4 -->
 
 This directory groups the larger agent runtime test suites by concern:
 configuration, context, interactions, lifecycle, and tools.

--- a/src-tauri/src/agent/runtime/tests/README.md
+++ b/src-tauri/src/agent/runtime/tests/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Tests
-<!-- tinybot-module-fingerprint: sha256:db15d14b5fd34f65f80b3c66f056b74a2eb41abe00c6f05889505a5e497fc983 -->
+<!-- tinybot-module-fingerprint: sha256:72a6093d199f6ce5d23a4832497671537f33a543b4deaa5797d5c90b7398bc35 -->
 
 This directory groups the larger agent runtime test suites by concern:
 configuration, context, interactions, lifecycle, and tools.
@@ -22,7 +22,14 @@ exercising multi-request summaries, unsplittable-unit failures, and durable
 checkpoint installation. Fixture model output validates runtime behavior;
 semantic retention quality requires separate real-model conversation evaluation.
 
-Shared fixtures and helpers live in `mod.rs`.
+Shared fixtures and helpers live in `mod.rs`. Deliberately blocking Provider and
+dispatcher fixtures implement the test-only contracts in `../test_support.rs`,
+which adapt them to the production asynchronous interfaces.
+`tool_adapters.rs` verifies workspace-tool discovery and dispatch without a Thread
+store, failure before Provider invocation when discovery fails, and structured
+service errors retained in tool results. Persistence, project membership,
+parallel child Turns, and parent cancellation are tested in
+`../../bridge/workspace_threads.rs` using the production dispatcher.
 
 Lifecycle coverage verifies prompt, before-tool, and after-tool hook stages and
 confirms that normalized before-tool replacements reach dispatch. It also

--- a/src-tauri/src/agent/runtime/tests/configuration.rs
+++ b/src-tauri/src/agent/runtime/tests/configuration.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::agent::runtime::provider_protocol::ProviderProtocolAdapter;
+#[cfg(test)]
+use crate::agent::runtime::test_support::BlockingTestProvider;
 
 #[test]
 fn defaults_context_window_strategy_to_compact() {
@@ -434,9 +436,10 @@ fn rust_provider_selects_responses_adapter_only_for_internal_api_mode() {
         }),
     );
 
-    let response = RustNativeAgentProvider
-        .complete(&context)
-        .expect("fixture Responses turn should complete");
+    let response = tauri::async_runtime::block_on(
+        Arc::new(RustNativeAgentProvider).complete_streaming_async(&context, &mut |_| {}),
+    )
+    .expect("fixture Responses turn should complete");
 
     assert_eq!(response.final_content, "Responses answer");
     assert!(!response.response_items.is_empty());
@@ -457,7 +460,7 @@ fn composed_workspace_instructions_reach_provider_and_reload_user_edits() {
         working_directories: Arc<Mutex<Vec<Option<PathBuf>>>>,
     }
 
-    impl NativeAgentProvider for CapturingProvider {
+    impl BlockingTestProvider for CapturingProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,

--- a/src-tauri/src/agent/runtime/tests/context.rs
+++ b/src-tauri/src/agent/runtime/tests/context.rs
@@ -3,6 +3,8 @@ use super::super::usage::{
     prepare_provider_request,
 };
 use super::*;
+#[cfg(test)]
+use crate::agent::runtime::test_support::{BlockingTestProvider, BlockingTestToolDispatcher};
 
 #[test]
 fn runs_fixture_streaming_final_answer_with_frontend_events() {
@@ -1155,7 +1157,7 @@ fn compacted_context_becomes_the_next_tool_iteration_baseline() {
         contexts: Arc<Mutex<Vec<Vec<Value>>>>,
     }
 
-    impl NativeAgentProvider for ToolThenFinishProvider {
+    impl BlockingTestProvider for ToolThenFinishProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -1191,7 +1193,7 @@ fn compacted_context_becomes_the_next_tool_iteration_baseline() {
 
     struct ReadDispatcher;
 
-    impl NativeAgentToolDispatcher for ReadDispatcher {
+    impl BlockingTestToolDispatcher for ReadDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1373,9 +1375,10 @@ fn rust_provider_dispatches_the_request_used_for_the_final_estimate() {
     context.set_prepared_provider_request(request);
     context.messages.clear();
 
-    let response = RustNativeAgentProvider
-        .complete(&context)
-        .expect("provider should dispatch the retained request");
+    let response = tauri::async_runtime::block_on(
+        Arc::new(RustNativeAgentProvider).complete_streaming_async(&context, &mut |_| {}),
+    )
+    .expect("provider should dispatch the retained request");
 
     assert_eq!(response.final_content, "fixture answer");
 }
@@ -1576,7 +1579,7 @@ fn responses_usage_is_normalized_for_existing_usage_consumers() {
 fn agent_usage_event_falls_back_to_estimated_context_when_provider_omits_usage() {
     struct NoUsageProvider;
 
-    impl NativeAgentProvider for NoUsageProvider {
+    impl BlockingTestProvider for NoUsageProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,

--- a/src-tauri/src/agent/runtime/tests/interactions.rs
+++ b/src-tauri/src/agent/runtime/tests/interactions.rs
@@ -1,5 +1,7 @@
 use super::*;
 #[cfg(test)]
+use crate::agent::bridge::TestApplicationServices;
+#[cfg(test)]
 use crate::agent::runtime::test_support::{BlockingTestProvider, BlockingTestToolDispatcher};
 
 #[test]
@@ -60,7 +62,6 @@ fn strict_patch_search_and_real_dispatch_work_end_to_end() {
         persistence_workspace.root.clone(),
         json!({}),
     )
-    .expect("workspace thread store should configure the tool executor")
     .with_trace_sink(trace_sink.clone());
 
     let run_services = services.clone();
@@ -523,23 +524,24 @@ lines.on("line", (line) => {
         }}}
     });
     let trace_sink = Arc::new(RecordingTraceSink::default());
+    let app = NativeAgentRuntimeServices::new(
+        Arc::new(McpDiscoveryProvider {
+            calls: AtomicUsize::new(0),
+        }),
+        Arc::new(FakeNativeAgentToolDispatcher),
+        Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+        Arc::new(InMemoryNativeAgentCancellation::default()),
+    )
+    .with_thread_store(crate::threads::workspace_store::WorkspaceThreadStore::new(
+        workspace.root.clone(),
+        crate::protocol::capability::default_desktop_capability_policy(),
+    ));
+    let mcp_runtime = app.mcp_runtime.clone();
     let services = crate::agent::bridge::native_agent_services_with_tool_executor(
-        NativeAgentRuntimeServices::new(
-            Arc::new(McpDiscoveryProvider {
-                calls: AtomicUsize::new(0),
-            }),
-            Arc::new(FakeNativeAgentToolDispatcher),
-            Arc::new(InMemoryNativeAgentCheckpointStore::default()),
-            Arc::new(InMemoryNativeAgentCancellation::default()),
-        )
-        .with_thread_store(crate::threads::workspace_store::WorkspaceThreadStore::new(
-            workspace.root.clone(),
-            crate::protocol::capability::default_desktop_capability_policy(),
-        )),
+        app,
         workspace.root.clone(),
         config.clone(),
     )
-    .expect("workspace thread store should configure the tool executor")
     .with_trace_sink(trace_sink.clone());
 
     let run_services = services.clone();
@@ -566,7 +568,7 @@ lines.on("line", (line) => {
     assert_eq!(completed["stopReason"], "final_response");
     assert_eq!(completed["finalContent"], "real MCP complete");
     assert_eq!(completed["toolsUsed"], json!(["mcp.4:docs.4:echo"]));
-    tauri::async_runtime::block_on(services.mcp_runtime().shutdown())
+    tauri::async_runtime::block_on(mcp_runtime.shutdown())
         .expect("agent MCP fixture should shut down");
     let global_after = crate::runtime::observability::global_agent_runtime_metrics().snapshot();
     assert!(

--- a/src-tauri/src/agent/runtime/tests/interactions.rs
+++ b/src-tauri/src/agent/runtime/tests/interactions.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(test)]
+use crate::agent::runtime::test_support::{BlockingTestProvider, BlockingTestToolDispatcher};
 
 #[test]
 fn strict_patch_search_and_real_dispatch_work_end_to_end() {
@@ -6,7 +8,7 @@ fn strict_patch_search_and_real_dispatch_work_end_to_end() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for PatchProvider {
+    impl BlockingTestProvider for PatchProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -105,7 +107,7 @@ fn request_user_input_waits_then_resumes_the_same_tool_chain() {
         trace_events: Arc<Mutex<Vec<AgentRuntimeEventEnvelope>>>,
     }
 
-    impl NativeAgentProvider for RequestInputThenReadProvider {
+    impl BlockingTestProvider for RequestInputThenReadProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -347,7 +349,7 @@ fn request_user_input_rejects_invalid_forms_without_waiting() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for InvalidInputProvider {
+    impl BlockingTestProvider for InvalidInputProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -421,7 +423,7 @@ fn discovered_allowlisted_mcp_tool_is_injected_and_calls_real_server() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for McpDiscoveryProvider {
+    impl BlockingTestProvider for McpDiscoveryProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -747,7 +749,7 @@ fn direct_calls_to_unactivated_deferred_tools_are_rejected() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for DeferredToolProvider {
+    impl BlockingTestProvider for DeferredToolProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -791,7 +793,7 @@ fn direct_calls_to_unactivated_deferred_tools_are_rejected() {
 
     struct PanickingDeferredDispatcher;
 
-    impl NativeAgentToolDispatcher for PanickingDeferredDispatcher {
+    impl BlockingTestToolDispatcher for PanickingDeferredDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -859,7 +861,7 @@ fn tool_batch_dispatches_directly_and_injects_all_results_before_the_next_model_
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for BatchProvider {
+    impl BlockingTestProvider for BatchProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -908,7 +910,7 @@ fn tool_batch_dispatches_directly_and_injects_all_results_before_the_next_model_
         dispatched: Arc<Mutex<Vec<String>>>,
     }
 
-    impl NativeAgentToolDispatcher for RecordingBatchDispatcher {
+    impl BlockingTestToolDispatcher for RecordingBatchDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -972,7 +974,7 @@ fn write_tool_dispatches_and_does_not_abort_the_turn() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for DeniedProvider {
+    impl BlockingTestProvider for DeniedProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -1015,7 +1017,7 @@ fn write_tool_dispatches_and_does_not_abort_the_turn() {
 
     struct SuccessDispatcher;
 
-    impl NativeAgentToolDispatcher for SuccessDispatcher {
+    impl BlockingTestToolDispatcher for SuccessDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1464,7 +1466,7 @@ fn selected_turn_tools_limit_the_production_provider_registry() {
         activated: Arc<Mutex<Vec<Vec<String>>>>,
     }
 
-    impl NativeAgentProvider for ToolRegistryProvider {
+    impl BlockingTestProvider for ToolRegistryProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -1552,7 +1554,7 @@ fn invalid_turn_policy_stops_before_provider_dispatch() {
         calls: Arc<AtomicUsize>,
     }
 
-    impl NativeAgentProvider for CountingProvider {
+    impl BlockingTestProvider for CountingProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,

--- a/src-tauri/src/agent/runtime/tests/lifecycle.rs
+++ b/src-tauri/src/agent/runtime/tests/lifecycle.rs
@@ -1,6 +1,7 @@
 use super::*;
 #[cfg(test)]
 use crate::agent::runtime::test_support::{BlockingTestProvider, BlockingTestToolDispatcher};
+use crate::collaboration::subagents::SubagentThreadManager;
 
 #[test]
 fn owned_task_runtime_cancels_normal_turn_and_ignores_late_provider_result() {

--- a/src-tauri/src/agent/runtime/tests/lifecycle.rs
+++ b/src-tauri/src/agent/runtime/tests/lifecycle.rs
@@ -1494,13 +1494,20 @@ fn trace_context_follows_provider_tool_and_completion_with_tool_hook_rewrite() {
     struct RewriteToolInputHook;
 
     impl AgentHook for RewriteToolInputHook {
-        fn evaluate(&self, invocation: &AgentHookInvocation) -> Result<AgentHookDecision, String> {
-            if invocation.stage == AgentHookStage::BeforeToolUse {
-                return Ok(AgentHookDecision::ReplaceNormalizedInput {
-                    normalized_input: json!({ "path": "after.md" }),
-                });
-            }
-            Ok(AgentHookDecision::Continue)
+        fn evaluate<'a>(
+            &'a self,
+            invocation: &'a AgentHookInvocation,
+        ) -> futures_util::future::BoxFuture<'a, Result<AgentHookOutput, String>> {
+            Box::pin(async move {
+                let decision = if invocation.stage == AgentHookStage::BeforeToolUse {
+                    AgentHookDecision::ReplaceNormalizedInput {
+                        normalized_input: json!({ "path": "after.md" }),
+                    }
+                } else {
+                    AgentHookDecision::Continue
+                };
+                Ok(AgentHookOutput::Decision(decision))
+            })
         }
     }
 
@@ -1605,13 +1612,20 @@ fn lifecycle_hook_denial_aborts_before_provider_call() {
     struct DenyTurnStartHook;
 
     impl AgentHook for DenyTurnStartHook {
-        fn evaluate(&self, invocation: &AgentHookInvocation) -> Result<AgentHookDecision, String> {
-            if invocation.stage == AgentHookStage::TurnStart {
-                return Ok(AgentHookDecision::Deny {
-                    reason: "blocked by lifecycle policy".to_string(),
-                });
-            }
-            Ok(AgentHookDecision::Continue)
+        fn evaluate<'a>(
+            &'a self,
+            invocation: &'a AgentHookInvocation,
+        ) -> futures_util::future::BoxFuture<'a, Result<AgentHookOutput, String>> {
+            Box::pin(async move {
+                let decision = if invocation.stage == AgentHookStage::TurnStart {
+                    AgentHookDecision::Deny {
+                        reason: "blocked by lifecycle policy".to_string(),
+                    }
+                } else {
+                    AgentHookDecision::Continue
+                };
+                Ok(AgentHookOutput::Decision(decision))
+            })
         }
     }
 

--- a/src-tauri/src/agent/runtime/tests/lifecycle.rs
+++ b/src-tauri/src/agent/runtime/tests/lifecycle.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(test)]
+use crate::agent::runtime::test_support::{BlockingTestProvider, BlockingTestToolDispatcher};
 
 #[test]
 fn owned_task_runtime_cancels_normal_turn_and_ignores_late_provider_result() {
@@ -7,7 +9,7 @@ fn owned_task_runtime_cancels_normal_turn_and_ignores_late_provider_result() {
         release: Mutex<mpsc::Receiver<()>>,
     }
 
-    impl NativeAgentProvider for BlockingOwnedProvider {
+    impl BlockingTestProvider for BlockingOwnedProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -90,7 +92,7 @@ fn cancellation_during_subagent_wait_prevents_followup_model_call() {
         calls: Mutex<u32>,
     }
 
-    impl NativeAgentProvider for SpawnWaitProvider {
+    impl BlockingTestProvider for SpawnWaitProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -155,18 +157,22 @@ fn cancellation_during_subagent_wait_prevents_followup_model_call() {
             context: AgentTurnContext,
             tool_call: PreparedToolCall,
         ) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send>,
+            Box<
+                dyn std::future::Future<
+                        Output = Result<NativeAgentToolResult, crate::agent::runtime::AgentError>,
+                    > + Send,
+            >,
         > {
             let result = self.fallback.dispatch(&context, &tool_call);
             if tool_call.name != "subagent.wait" {
-                return Box::pin(async move { result });
+                return Box::pin(async move { result.map_err(Into::into) });
             }
             let cancellations = self.cancellations.clone();
             let turn_id = context.turn_id.clone();
             Box::pin(async move {
                 cancellations.cancel(&turn_id);
                 tokio::time::sleep(Duration::from_millis(10)).await;
-                result
+                result.map_err(Into::into)
             })
         }
     }
@@ -239,7 +245,7 @@ fn stores_active_turn_tool_wait_and_cancellation_checkpoints() {
         calls: Mutex<u32>,
     }
 
-    impl NativeAgentProvider for CheckpointAwareProvider {
+    impl BlockingTestProvider for CheckpointAwareProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -284,7 +290,7 @@ fn stores_active_turn_tool_wait_and_cancellation_checkpoints() {
         checkpoints: Arc<InMemoryNativeAgentCheckpointStore>,
     }
 
-    impl NativeAgentToolDispatcher for CheckpointAwareToolDispatcher {
+    impl BlockingTestToolDispatcher for CheckpointAwareToolDispatcher {
         fn dispatch(
             &self,
             context: &AgentTurnContext,
@@ -419,7 +425,7 @@ fn native_turn_projects_core_canonical_timeline_equally_live_and_after_reload() 
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for AcceptanceProvider {
+    impl BlockingTestProvider for AcceptanceProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -670,7 +676,7 @@ fn invalid_update_plan_returns_a_tool_error_that_the_model_can_correct() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for RecoveringPlanProvider {
+    impl BlockingTestProvider for RecoveringPlanProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -790,7 +796,7 @@ fn queued_user_message_continuation_becomes_next_turn_input() {
         seen_messages: Mutex<Vec<Vec<Value>>>,
     }
 
-    impl NativeAgentProvider for RecordingProvider {
+    impl BlockingTestProvider for RecordingProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -852,7 +858,7 @@ fn guidance_continuation_is_inserted_before_next_model_call_after_tools() {
         seen_messages: Mutex<Vec<Vec<Value>>>,
     }
 
-    impl NativeAgentProvider for ToolThenFinalProvider {
+    impl BlockingTestProvider for ToolThenFinalProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -947,19 +953,6 @@ fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
     struct StreamingProvider;
 
     impl NativeAgentProvider for StreamingProvider {
-        fn complete(
-            &self,
-            _context: &AgentTurnContext,
-        ) -> Result<NativeAgentProviderResponse, String> {
-            Ok(NativeAgentProviderResponse {
-                final_content: "Hello".to_string(),
-                reasoning_delta: None,
-                usage: None,
-                response_items: Vec::new(),
-                tool_calls: Vec::new(),
-            })
-        }
-
         fn complete_streaming_async<'a>(
             self: Arc<Self>,
             _context: &'a AgentTurnContext,
@@ -1069,7 +1062,7 @@ fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
 fn async_provider_is_not_called_when_turn_was_cancelled_before_request() {
     struct CountingProvider(Arc<AtomicUsize>);
 
-    impl NativeAgentProvider for CountingProvider {
+    impl BlockingTestProvider for CountingProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -1129,13 +1122,6 @@ fn async_provider_cancellation_after_partial_output_drops_stream_without_late_ev
     }
 
     impl NativeAgentProvider for PendingStreamingProvider {
-        fn complete(
-            &self,
-            _context: &AgentTurnContext,
-        ) -> Result<NativeAgentProviderResponse, String> {
-            panic!("async provider path should not call the blocking completion method");
-        }
-
         fn complete_streaming_async<'a>(
             self: Arc<Self>,
             _context: &'a AgentTurnContext,
@@ -1250,13 +1236,6 @@ fn async_provider_failures_keep_distinct_stop_reasons() {
     struct FailingProvider(NativeAgentProviderFailureKind);
 
     impl NativeAgentProvider for FailingProvider {
-        fn complete(
-            &self,
-            _context: &AgentTurnContext,
-        ) -> Result<NativeAgentProviderResponse, String> {
-            panic!("async provider path should not call the blocking completion method");
-        }
-
         fn complete_streaming_async<'a>(
             self: Arc<Self>,
             _context: &'a AgentTurnContext,
@@ -1321,7 +1300,7 @@ fn async_provider_failures_keep_distinct_stop_reasons() {
 fn hanging_cleanup_tool_batch_times_out_without_hanging_the_owned_turn() {
     struct HangingToolProvider;
 
-    impl NativeAgentProvider for HangingToolProvider {
+    impl BlockingTestProvider for HangingToolProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -1376,7 +1355,11 @@ fn hanging_cleanup_tool_batch_times_out_without_hanging_the_owned_turn() {
             _context: AgentTurnContext,
             _tool_call: PreparedToolCall,
         ) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send>,
+            Box<
+                dyn std::future::Future<
+                        Output = Result<NativeAgentToolResult, crate::agent::runtime::AgentError>,
+                    > + Send,
+            >,
         > {
             let started = self
                 .started
@@ -1389,7 +1372,7 @@ fn hanging_cleanup_tool_batch_times_out_without_hanging_the_owned_turn() {
                 if let Some(started) = started {
                     started.send(()).expect("hanging tool start should send");
                 }
-                std::future::pending::<Result<NativeAgentToolResult, String>>().await
+                std::future::pending::<Result<NativeAgentToolResult, AgentError>>().await
             })
         }
     }
@@ -1477,7 +1460,7 @@ fn trace_context_follows_provider_tool_and_completion_with_tool_hook_rewrite() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for ToolThenFinalProvider {
+    impl BlockingTestProvider for ToolThenFinalProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -1524,7 +1507,7 @@ fn trace_context_follows_provider_tool_and_completion_with_tool_hook_rewrite() {
         arguments: Arc<Mutex<Vec<Value>>>,
     }
 
-    impl NativeAgentToolDispatcher for RecordingDispatcher {
+    impl BlockingTestToolDispatcher for RecordingDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1633,7 +1616,7 @@ fn lifecycle_hook_denial_aborts_before_provider_call() {
 
     struct CountingProvider(Arc<AtomicUsize>);
 
-    impl NativeAgentProvider for CountingProvider {
+    impl BlockingTestProvider for CountingProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,

--- a/src-tauri/src/agent/runtime/tests/mod.rs
+++ b/src-tauri/src/agent/runtime/tests/mod.rs
@@ -199,6 +199,7 @@ mod configuration;
 mod context;
 mod interactions;
 mod lifecycle;
+mod tool_adapters;
 mod tools;
 
 fn runtime_transcript(result: &Value) -> Vec<Value> {

--- a/src-tauri/src/agent/runtime/tests/tool_adapters.rs
+++ b/src-tauri/src/agent/runtime/tests/tool_adapters.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::protocol::{WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource};
 use crate::tools::registry::{
-    ToolContributor, WorkspaceThreadTarget, WorkspaceThreadToolContributor,
-    SEND_THREAD_MESSAGE_METHOD, SPAWN_WORKSPACE_THREAD_METHOD,
+    WorkspaceThreadTarget, WorkspaceThreadToolContributor, SEND_THREAD_MESSAGE_METHOD,
+    SPAWN_WORKSPACE_THREAD_METHOD,
 };
 use futures_util::future::BoxFuture;
 
@@ -58,23 +58,37 @@ impl NativeAgentProvider for CoordinatorProvider {
 struct WorkspaceDispatcher {
     calls: Mutex<Vec<String>>,
     discovery_error: Option<AgentError>,
+    cancel_discovery: bool,
     execution_error: Option<AgentError>,
 }
 
 impl NativeAgentToolDispatcher for WorkspaceDispatcher {
-    fn tool_contributors(
-        &self,
-        _context: &AgentTurnContext,
-    ) -> Result<Vec<Arc<dyn ToolContributor>>, AgentError> {
-        if let Some(error) = &self.discovery_error {
-            return Err(error.clone());
-        }
-        Ok(vec![Arc::new(WorkspaceThreadToolContributor::new(vec![
-            WorkspaceThreadTarget {
-                workspace_id: "fixture-workspace".into(),
-                label: "Fixture".into(),
-            },
-        ])?)])
+    fn prepare_tools<'a>(
+        &'a self,
+        context: &'a AgentTurnContext,
+        _config: &'a Value,
+    ) -> BoxFuture<'a, Result<NativeAgentToolPreparation, AgentError>> {
+        Box::pin(async move {
+            if self.cancel_discovery {
+                return Ok(NativeAgentToolPreparation::Cancelled {
+                    phase: "mcp_discovery".into(),
+                    server: Some("fixture".into()),
+                    transport: Some("stdio".into()),
+                });
+            }
+            if let Some(error) = &self.discovery_error {
+                return Err(error.clone());
+            }
+            Ok(NativeAgentToolPreparation::Ready(NativeAgentToolCatalog {
+                contributors: vec![Arc::new(WorkspaceThreadToolContributor::new(vec![
+                    WorkspaceThreadTarget {
+                        workspace_id: "fixture-workspace".into(),
+                        label: "Fixture".into(),
+                    },
+                ])?)],
+                selected_tools: context.settings.selected_tools.clone(),
+            }))
+        })
     }
 
     fn dispatch(
@@ -147,6 +161,7 @@ fn workspace_tools_are_discovered_and_dispatched_without_storage() {
     let dispatcher = Arc::new(WorkspaceDispatcher {
         calls: Mutex::new(Vec::new()),
         discovery_error: None,
+        cancel_discovery: false,
         execution_error: None,
     });
     let result = run_with_dispatcher(
@@ -171,6 +186,7 @@ fn discovery_failure_preserves_service_error_and_prevents_provider_call() {
     let dispatcher = Arc::new(WorkspaceDispatcher {
         calls: Mutex::new(Vec::new()),
         discovery_error: Some(error.clone()),
+        cancel_discovery: false,
         execution_error: None,
     });
     let provider = Arc::new(CoordinatorProvider {
@@ -190,6 +206,7 @@ fn asynchronous_dispatch_preserves_structured_service_failures() {
     let dispatcher = Arc::new(WorkspaceDispatcher {
         calls: Mutex::new(Vec::new()),
         discovery_error: None,
+        cancel_discovery: false,
         execution_error: Some(error.clone()),
     });
     let result = run_with_dispatcher(
@@ -208,4 +225,24 @@ fn asynchronous_dispatch_preserves_structured_service_failures() {
             serde_json::to_value(&error).unwrap()
         );
     }
+}
+
+#[test]
+fn cancelled_discovery_retains_checkpoint_details_without_calling_the_provider() {
+    let dispatcher = Arc::new(WorkspaceDispatcher {
+        calls: Mutex::new(Vec::new()),
+        discovery_error: None,
+        execution_error: None,
+        cancel_discovery: true,
+    });
+    let provider = Arc::new(CoordinatorProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let result = run_with_dispatcher(dispatcher.clone(), provider.clone()).unwrap();
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    assert!(dispatcher.calls.lock().unwrap().is_empty());
+    assert_eq!(result["checkpoint"]["phase"], "cancelled");
+    assert_eq!(result["checkpoint"]["payload"]["phase"], "mcp_discovery");
+    assert_eq!(result["checkpoint"]["payload"]["server"], "fixture");
+    assert_eq!(result["checkpoint"]["payload"]["transport"], "stdio");
 }

--- a/src-tauri/src/agent/runtime/tests/tool_adapters.rs
+++ b/src-tauri/src/agent/runtime/tests/tool_adapters.rs
@@ -1,0 +1,211 @@
+use super::*;
+use crate::protocol::{WorkerProtocolError, WorkerProtocolErrorCode, WorkerProtocolErrorSource};
+use crate::tools::registry::{
+    ToolContributor, WorkspaceThreadTarget, WorkspaceThreadToolContributor,
+    SEND_THREAD_MESSAGE_METHOD, SPAWN_WORKSPACE_THREAD_METHOD,
+};
+use futures_util::future::BoxFuture;
+
+struct CoordinatorProvider {
+    calls: AtomicUsize,
+}
+
+impl NativeAgentProvider for CoordinatorProvider {
+    fn complete_streaming_async<'a>(
+        self: Arc<Self>,
+        context: &'a AgentTurnContext,
+        _observer: &'a mut (dyn FnMut(NativeAgentProviderStreamEvent) + Send),
+    ) -> BoxFuture<'a, Result<NativeAgentProviderResponse, NativeAgentProviderFailure>> {
+        Box::pin(async move {
+            assert_eq!(
+                context.tool_execution_target(SPAWN_WORKSPACE_THREAD_METHOD),
+                Some(ToolExecutionTarget::SpawnWorkspaceThread)
+            );
+            let call = match self.calls.fetch_add(1, Ordering::SeqCst) {
+                0 => Some((
+                    SPAWN_WORKSPACE_THREAD_METHOD,
+                    json!({"workspaceId": "fixture-workspace", "message": "inspect"}),
+                )),
+                1 => Some((
+                    SEND_THREAD_MESSAGE_METHOD,
+                    json!({"threadId": "fixture-child", "message": "continue"}),
+                )),
+                _ => None,
+            };
+            Ok(NativeAgentProviderResponse {
+                final_content: if call.is_none() {
+                    "coordinator complete".into()
+                } else {
+                    String::new()
+                },
+                reasoning_delta: None,
+                usage: None,
+                tool_calls: call
+                    .into_iter()
+                    .map(|(name, arguments)| NativeAgentToolCall {
+                        id: name.into(),
+                        name: name.into(),
+                        arguments_json: arguments.to_string(),
+                        result: Value::Null,
+                    })
+                    .collect(),
+                response_items: Vec::new(),
+            })
+        })
+    }
+}
+
+struct WorkspaceDispatcher {
+    calls: Mutex<Vec<String>>,
+    discovery_error: Option<AgentError>,
+    execution_error: Option<AgentError>,
+}
+
+impl NativeAgentToolDispatcher for WorkspaceDispatcher {
+    fn tool_contributors(
+        &self,
+        _context: &AgentTurnContext,
+    ) -> Result<Vec<Arc<dyn ToolContributor>>, AgentError> {
+        if let Some(error) = &self.discovery_error {
+            return Err(error.clone());
+        }
+        Ok(vec![Arc::new(WorkspaceThreadToolContributor::new(vec![
+            WorkspaceThreadTarget {
+                workspace_id: "fixture-workspace".into(),
+                label: "Fixture".into(),
+            },
+        ])?)])
+    }
+
+    fn dispatch(
+        &self,
+        _context: &AgentTurnContext,
+        _call: &PreparedToolCall,
+    ) -> Result<NativeAgentToolResult, String> {
+        panic!("workspace orchestration must use asynchronous dispatch")
+    }
+
+    fn dispatch_async(
+        self: Arc<Self>,
+        _context: AgentTurnContext,
+        call: PreparedToolCall,
+    ) -> BoxFuture<'static, Result<NativeAgentToolResult, AgentError>> {
+        Box::pin(async move {
+            self.calls.lock().unwrap().push(call.name.clone());
+            if let Some(error) = &self.execution_error {
+                return Err(error.clone());
+            }
+            Ok(NativeAgentToolResult::generic_success(
+                &call,
+                json!({
+                    "threadId": "fixture-child", "status": "completed", "finalMessage": "done",
+                }),
+            ))
+        })
+    }
+}
+
+fn persistence_failure() -> AgentError {
+    AgentError::persistence(
+        "workspace thread",
+        WorkerProtocolError::new(
+            WorkerProtocolErrorCode::InvalidProtocol,
+            "fixture persistence rejected",
+            json!({"threadId": "fixture-child", "operation": "append"}),
+            false,
+            WorkerProtocolErrorSource::RustCore,
+        ),
+    )
+}
+
+fn run_with_dispatcher(
+    dispatcher: Arc<WorkspaceDispatcher>,
+    provider: Arc<CoordinatorProvider>,
+) -> Result<Value, AgentError> {
+    let workspace = SystemPromptWorkspace::new();
+    let services = NativeAgentRuntimeServices::new(
+        provider,
+        dispatcher,
+        Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+        Arc::new(InMemoryNativeAgentCancellation::default()),
+    );
+    // No thread store or bridge adapter: discovery and execution cross the same interface.
+    run_native_agent_turn_with_workspace(
+        &services,
+        json!({
+            "threadId": "fixture-parent", "sessionId": "fixture-parent", "turnId": "fixture-turn",
+            "model": "fixture-model", "maxIterations": 3,
+            "messages": [{"role": "user", "content": "coordinate work"}],
+        }),
+        json!({}),
+        &workspace.root,
+    )
+}
+
+#[test]
+fn workspace_tools_are_discovered_and_dispatched_without_storage() {
+    let dispatcher = Arc::new(WorkspaceDispatcher {
+        calls: Mutex::new(Vec::new()),
+        discovery_error: None,
+        execution_error: None,
+    });
+    let result = run_with_dispatcher(
+        dispatcher.clone(),
+        Arc::new(CoordinatorProvider {
+            calls: AtomicUsize::new(0),
+        }),
+    )
+    .unwrap();
+    assert_eq!(result["stopReason"], "final_response");
+    assert_eq!(result["finalContent"], "coordinator complete");
+    assert_eq!(
+        *dispatcher.calls.lock().unwrap(),
+        [SPAWN_WORKSPACE_THREAD_METHOD, SEND_THREAD_MESSAGE_METHOD]
+    );
+    assert_eq!(result["completedToolResults"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn discovery_failure_preserves_service_error_and_prevents_provider_call() {
+    let error = persistence_failure();
+    let dispatcher = Arc::new(WorkspaceDispatcher {
+        calls: Mutex::new(Vec::new()),
+        discovery_error: Some(error.clone()),
+        execution_error: None,
+    });
+    let provider = Arc::new(CoordinatorProvider {
+        calls: AtomicUsize::new(0),
+    });
+    assert_eq!(
+        run_with_dispatcher(dispatcher.clone(), provider.clone()).unwrap_err(),
+        error
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    assert!(dispatcher.calls.lock().unwrap().is_empty());
+}
+
+#[test]
+fn asynchronous_dispatch_preserves_structured_service_failures() {
+    let error = persistence_failure();
+    let dispatcher = Arc::new(WorkspaceDispatcher {
+        calls: Mutex::new(Vec::new()),
+        discovery_error: None,
+        execution_error: Some(error.clone()),
+    });
+    let result = run_with_dispatcher(
+        dispatcher,
+        Arc::new(CoordinatorProvider {
+            calls: AtomicUsize::new(0),
+        }),
+    )
+    .unwrap();
+    let results = result["completedToolResults"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+    for result in results {
+        assert_eq!(result["status"], "error");
+        assert_eq!(
+            result["envelope"]["error"],
+            serde_json::to_value(&error).unwrap()
+        );
+    }
+}

--- a/src-tauri/src/agent/runtime/tests/tools.rs
+++ b/src-tauri/src/agent/runtime/tests/tools.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(test)]
+use crate::agent::runtime::test_support::{BlockingTestProvider, BlockingTestToolDispatcher};
 
 #[test]
 fn runs_fixture_tool_event_sequence() {
@@ -249,7 +251,7 @@ fn feeds_tool_observation_back_into_second_provider_call() {
         seen_messages: Mutex<Vec<Value>>,
     }
 
-    impl NativeAgentProvider for TwoStepProvider {
+    impl BlockingTestProvider for TwoStepProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -339,7 +341,7 @@ fn rejected_tool_batch_records_a_result_for_every_provider_call() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for MixedPolicyProvider {
+    impl BlockingTestProvider for MixedPolicyProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -410,7 +412,7 @@ fn exclusive_runtime_control_runs_as_a_barrier_in_a_mixed_batch() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for MixedControlProvider {
+    impl BlockingTestProvider for MixedControlProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -510,7 +512,7 @@ fn selected_deferred_tool_calls_are_permitted_by_runtime_dispatch() {
         calls: Mutex<usize>,
     }
 
-    impl NativeAgentProvider for DeferredLookupProvider {
+    impl BlockingTestProvider for DeferredLookupProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -581,7 +583,7 @@ fn tool_runtime_dispatches_through_async_dispatch_seam() {
         calls: Mutex<usize>,
     }
 
-    impl NativeAgentProvider for OneToolThenFinalProvider {
+    impl BlockingTestProvider for OneToolThenFinalProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -630,7 +632,11 @@ fn tool_runtime_dispatches_through_async_dispatch_seam() {
             _context: AgentTurnContext,
             tool_call: PreparedToolCall,
         ) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send>,
+            Box<
+                dyn std::future::Future<
+                        Output = Result<NativeAgentToolResult, crate::agent::runtime::AgentError>,
+                    > + Send,
+            >,
         > {
             self.async_dispatches.fetch_add(1, Ordering::SeqCst);
             Box::pin(async move {
@@ -676,7 +682,7 @@ fn repeated_no_progress_call_is_returned_to_model_without_redispatch() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for RepeatingProvider {
+    impl BlockingTestProvider for RepeatingProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -740,7 +746,7 @@ fn repeated_no_progress_call_is_returned_to_model_without_redispatch() {
         dispatches: AtomicUsize,
     }
 
-    impl NativeAgentToolDispatcher for NoProgressDispatcher {
+    impl BlockingTestToolDispatcher for NoProgressDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -909,7 +915,7 @@ fn read_only_tool_batch_runs_concurrently_and_preserves_model_ordered_observatio
         seen_messages: Mutex<Vec<Vec<Value>>>,
     }
 
-    impl NativeAgentProvider for TwoReadOnlyToolsThenFinalProvider {
+    impl BlockingTestProvider for TwoReadOnlyToolsThenFinalProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -959,7 +965,7 @@ fn read_only_tool_batch_runs_concurrently_and_preserves_model_ordered_observatio
         max_running: AtomicUsize,
     }
 
-    impl NativeAgentToolDispatcher for OverlapRecordingDispatcher {
+    impl BlockingTestToolDispatcher for OverlapRecordingDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1037,7 +1043,7 @@ fn mcp_call_scheduling_uses_registry_runtime_policy() {
         calls: Mutex<usize>,
     }
 
-    impl NativeAgentProvider for TwoMcpToolsThenFinalProvider {
+    impl BlockingTestProvider for TwoMcpToolsThenFinalProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -1085,7 +1091,7 @@ fn mcp_call_scheduling_uses_registry_runtime_policy() {
         max_running: AtomicUsize,
     }
 
-    impl NativeAgentToolDispatcher for McpOverlapDispatcher {
+    impl BlockingTestToolDispatcher for McpOverlapDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1168,7 +1174,7 @@ fn shell_read_only_allowlist_uses_read_lock_only_when_explicitly_enabled() {
         calls: Mutex<usize>,
     }
 
-    impl NativeAgentProvider for TwoShellReadsThenFinalProvider {
+    impl BlockingTestProvider for TwoShellReadsThenFinalProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -1212,7 +1218,7 @@ fn shell_read_only_allowlist_uses_read_lock_only_when_explicitly_enabled() {
         max_running: AtomicUsize,
     }
 
-    impl NativeAgentToolDispatcher for ShellOverlapDispatcher {
+    impl BlockingTestToolDispatcher for ShellOverlapDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1280,7 +1286,7 @@ fn parallel_tool_failures_are_returned_to_the_model_in_call_order() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for TwoFailingToolsProvider {
+    impl BlockingTestProvider for TwoFailingToolsProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -1333,7 +1339,7 @@ fn parallel_tool_failures_are_returned_to_the_model_in_call_order() {
 
     struct FailingParallelDispatcher;
 
-    impl NativeAgentToolDispatcher for FailingParallelDispatcher {
+    impl BlockingTestToolDispatcher for FailingParallelDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1406,7 +1412,7 @@ fn mixed_parallel_and_non_parallel_tool_batch_uses_read_write_lock_scheduling() 
         seen_messages: Mutex<Vec<Vec<Value>>>,
     }
 
-    impl NativeAgentProvider for MixedToolsThenFinalProvider {
+    impl BlockingTestProvider for MixedToolsThenFinalProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -1470,7 +1476,7 @@ fn mixed_parallel_and_non_parallel_tool_batch_uses_read_write_lock_scheduling() 
         write_overlaps: AtomicUsize,
     }
 
-    impl NativeAgentToolDispatcher for ReadWriteLockRecordingDispatcher {
+    impl BlockingTestToolDispatcher for ReadWriteLockRecordingDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1654,7 +1660,7 @@ fn cancellation_before_queued_write_lock_dispatch_skips_waiting_tool() {
         calls: Mutex<usize>,
     }
 
-    impl NativeAgentProvider for ReadThenWriteProvider {
+    impl BlockingTestProvider for ReadThenWriteProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -1698,7 +1704,7 @@ fn cancellation_before_queued_write_lock_dispatch_skips_waiting_tool() {
         write_dispatches: AtomicUsize,
     }
 
-    impl NativeAgentToolDispatcher for CancellingReadDispatcher {
+    impl BlockingTestToolDispatcher for CancellingReadDispatcher {
         fn dispatch(
             &self,
             context: &AgentTurnContext,
@@ -1766,7 +1772,7 @@ fn returned_failure_before_queued_write_does_not_skip_waiting_tool() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for FailingWriteThenWriteProvider {
+    impl BlockingTestProvider for FailingWriteThenWriteProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -1815,7 +1821,7 @@ fn returned_failure_before_queued_write_does_not_skip_waiting_tool() {
         second_write_dispatches: AtomicUsize,
     }
 
-    impl NativeAgentToolDispatcher for FailingWriteDispatcher {
+    impl BlockingTestToolDispatcher for FailingWriteDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -1874,7 +1880,7 @@ fn returned_failure_before_queued_write_does_not_skip_waiting_tool() {
 fn cancellation_during_non_cleanup_parallel_tool_returns_without_waiting_for_late_result() {
     struct SlowReadProvider;
 
-    impl NativeAgentProvider for SlowReadProvider {
+    impl BlockingTestProvider for SlowReadProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -1908,7 +1914,7 @@ fn cancellation_during_non_cleanup_parallel_tool_returns_without_waiting_for_lat
         release_rx: Arc<Mutex<std::sync::mpsc::Receiver<()>>>,
     }
 
-    impl NativeAgentToolDispatcher for SlowCancellingReadDispatcher {
+    impl BlockingTestToolDispatcher for SlowCancellingReadDispatcher {
         fn dispatch(
             &self,
             context: &AgentTurnContext,
@@ -2011,7 +2017,7 @@ fn provider_error_after_tool_result_preserves_accumulated_tool_state() {
         calls: Mutex<usize>,
     }
 
-    impl NativeAgentProvider for ToolThenErrorProvider {
+    impl BlockingTestProvider for ToolThenErrorProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -2622,7 +2628,7 @@ fn private_user_subagent_input_is_not_added_to_main_model_context() {
         seen_messages: Mutex<Vec<Vec<Value>>>,
     }
 
-    impl NativeAgentProvider for SpawnThenFinalProvider {
+    impl BlockingTestProvider for SpawnThenFinalProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -2667,7 +2673,7 @@ fn private_user_subagent_input_is_not_added_to_main_model_context() {
         fallback: SubagentNativeAgentToolDispatcher,
     }
 
-    impl NativeAgentToolDispatcher for DirectUserInputAfterSpawnDispatcher {
+    impl BlockingTestToolDispatcher for DirectUserInputAfterSpawnDispatcher {
         fn dispatch(
             &self,
             context: &AgentTurnContext,
@@ -2882,7 +2888,7 @@ fn later_tool_error_and_earlier_success_are_both_returned_to_the_model() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for TwoToolProvider {
+    impl BlockingTestProvider for TwoToolProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -2932,7 +2938,7 @@ fn later_tool_error_and_earlier_success_are_both_returned_to_the_model() {
 
     struct FailingSecondToolDispatcher;
 
-    impl NativeAgentToolDispatcher for FailingSecondToolDispatcher {
+    impl BlockingTestToolDispatcher for FailingSecondToolDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -3000,7 +3006,7 @@ fn single_tool_dispatch_error_is_returned_to_the_model() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for RecoveringProvider {
+    impl BlockingTestProvider for RecoveringProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -3043,7 +3049,7 @@ fn single_tool_dispatch_error_is_returned_to_the_model() {
 
     struct FailingDispatcher;
 
-    impl NativeAgentToolDispatcher for FailingDispatcher {
+    impl BlockingTestToolDispatcher for FailingDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -3261,7 +3267,7 @@ fn denied_tool_is_returned_to_the_model_without_tool_dispatch() {
 fn tool_task_panic_remains_terminal() {
     struct OneToolProvider;
 
-    impl NativeAgentProvider for OneToolProvider {
+    impl BlockingTestProvider for OneToolProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -3283,7 +3289,7 @@ fn tool_task_panic_remains_terminal() {
 
     struct PanickingToolDispatcher;
 
-    impl NativeAgentToolDispatcher for PanickingToolDispatcher {
+    impl BlockingTestToolDispatcher for PanickingToolDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -3327,7 +3333,7 @@ fn cancellation_before_tool_dispatch_stops_without_dispatching_tool() {
         cancellations: Arc<InMemoryNativeAgentCancellation>,
     }
 
-    impl NativeAgentProvider for CancellingProvider {
+    impl BlockingTestProvider for CancellingProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -3350,7 +3356,7 @@ fn cancellation_before_tool_dispatch_stops_without_dispatching_tool() {
 
     struct PanickingToolDispatcher;
 
-    impl NativeAgentToolDispatcher for PanickingToolDispatcher {
+    impl BlockingTestToolDispatcher for PanickingToolDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -3443,7 +3449,7 @@ fn cancellation_context_is_available_to_provider_and_tool_dispatch() {
         saw_context: Arc<Mutex<bool>>,
     }
 
-    impl NativeAgentProvider for ContextAwareProvider {
+    impl BlockingTestProvider for ContextAwareProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -3475,7 +3481,7 @@ fn cancellation_context_is_available_to_provider_and_tool_dispatch() {
         saw_cancelled_context: Arc<Mutex<bool>>,
     }
 
-    impl NativeAgentToolDispatcher for ContextAwareToolDispatcher {
+    impl BlockingTestToolDispatcher for ContextAwareToolDispatcher {
         fn dispatch(
             &self,
             context: &AgentTurnContext,
@@ -3538,7 +3544,7 @@ fn cancellation_after_tool_result_preserves_completed_tool_state() {
         calls: Mutex<u32>,
     }
 
-    impl NativeAgentProvider for SingleToolProvider {
+    impl BlockingTestProvider for SingleToolProvider {
         fn complete(
             &self,
             _context: &AgentTurnContext,
@@ -3571,7 +3577,7 @@ fn cancellation_after_tool_result_preserves_completed_tool_state() {
         cancellations: Arc<InMemoryNativeAgentCancellation>,
     }
 
-    impl NativeAgentToolDispatcher for CancellingToolDispatcher {
+    impl BlockingTestToolDispatcher for CancellingToolDispatcher {
         fn dispatch(
             &self,
             context: &AgentTurnContext,
@@ -3668,7 +3674,7 @@ fn malformed_tool_arguments_are_returned_to_the_model() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for InvalidArgumentsProvider {
+    impl BlockingTestProvider for InvalidArgumentsProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -3712,7 +3718,7 @@ fn malformed_tool_arguments_are_returned_to_the_model() {
 
     struct PanickingDispatcher;
 
-    impl NativeAgentToolDispatcher for PanickingDispatcher {
+    impl BlockingTestToolDispatcher for PanickingDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,
@@ -3772,7 +3778,7 @@ fn malformed_tool_batch_returns_a_result_for_every_call() {
         calls: AtomicUsize,
     }
 
-    impl NativeAgentProvider for PartiallyInvalidBatchProvider {
+    impl BlockingTestProvider for PartiallyInvalidBatchProvider {
         fn complete(
             &self,
             context: &AgentTurnContext,
@@ -3831,7 +3837,7 @@ fn malformed_tool_batch_returns_a_result_for_every_call() {
 
     struct PanickingDispatcher;
 
-    impl NativeAgentToolDispatcher for PanickingDispatcher {
+    impl BlockingTestToolDispatcher for PanickingDispatcher {
         fn dispatch(
             &self,
             _context: &AgentTurnContext,

--- a/src-tauri/src/agent/runtime/tests/tools.rs
+++ b/src-tauri/src/agent/runtime/tests/tools.rs
@@ -1,6 +1,7 @@
 use super::*;
 #[cfg(test)]
 use crate::agent::runtime::test_support::{BlockingTestProvider, BlockingTestToolDispatcher};
+use crate::collaboration::subagents::SubagentThreadManager;
 
 #[test]
 fn runs_fixture_tool_event_sequence() {

--- a/src-tauri/src/agent/runtime/tool_dispatcher.rs
+++ b/src-tauri/src/agent/runtime/tool_dispatcher.rs
@@ -9,6 +9,15 @@ use serde_json::Value;
 pub struct FakeNativeAgentToolDispatcher;
 
 impl NativeAgentToolDispatcher for FakeNativeAgentToolDispatcher {
+    fn dispatch_async(
+        self: std::sync::Arc<Self>,
+        context: AgentTurnContext,
+        tool_call: PreparedToolCall,
+    ) -> futures_util::future::BoxFuture<'static, Result<NativeAgentToolResult, super::AgentError>>
+    {
+        Box::pin(async move { self.dispatch(&context, &tool_call).map_err(Into::into) })
+    }
+
     fn dispatch(
         &self,
         _context: &AgentTurnContext,
@@ -213,9 +222,13 @@ impl NativeAgentToolDispatcher for SubagentNativeAgentToolDispatcher {
         context: AgentTurnContext,
         tool_call: PreparedToolCall,
     ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<NativeAgentToolResult, String>> + Send>,
+        Box<
+            dyn std::future::Future<
+                    Output = Result<NativeAgentToolResult, crate::agent::runtime::AgentError>,
+                > + Send,
+        >,
     > {
-        Box::pin(async move { self.dispatch(&context, &tool_call) })
+        Box::pin(async move { self.dispatch(&context, &tool_call).map_err(Into::into) })
     }
 }
 

--- a/src-tauri/src/agent/runtime/tool_runtime.rs
+++ b/src-tauri/src/agent/runtime/tool_runtime.rs
@@ -20,8 +20,7 @@ use crate::agent::runtime_protocol::{
 };
 use crate::tools::registry::ToolCancellationMode;
 use crate::tools::registry::{
-    PUBLISH_DATA_VIEW_METHOD, REQUEST_USER_INPUT_METHOD, SEND_THREAD_MESSAGE_METHOD,
-    SPAWN_WORKSPACE_THREAD_METHOD, UPDATE_PLAN_METHOD,
+    PUBLISH_DATA_VIEW_METHOD, REQUEST_USER_INPUT_METHOD, UPDATE_PLAN_METHOD,
 };
 use futures_util::{future::join_all, FutureExt};
 use serde::Deserialize;
@@ -703,7 +702,10 @@ async fn dispatch_tool_with_cancellation_policy(
     let dispatch_call = tool_call.clone();
     context.metrics().increment("tool.started");
     let tool_started_at = std::time::Instant::now();
-    let operation = dispatch_tool_call(&services, context.clone(), dispatch_call);
+    let operation = services
+        .tools
+        .clone()
+        .dispatch_async(context.clone(), dispatch_call);
     tokio::pin!(operation);
     let outcome = tokio::select! {
         biased;
@@ -760,44 +762,6 @@ async fn dispatch_tool_with_cancellation_policy(
         .metrics()
         .increment(&format!("tool.{outcome_label}"));
     outcome
-}
-
-async fn dispatch_tool_call(
-    services: &NativeAgentRuntimeServices,
-    context: AgentTurnContext,
-    tool_call: PreparedToolCall,
-) -> Result<super::NativeAgentToolResult, AgentError> {
-    let raw_result = match tool_call.name.as_str() {
-        SPAWN_WORKSPACE_THREAD_METHOD => Some(
-            super::workspace_threads::spawn_workspace_thread(
-                services,
-                &context,
-                tool_call.arguments(),
-            )
-            .await,
-        ),
-        SEND_THREAD_MESSAGE_METHOD => Some(
-            super::workspace_threads::send_thread_message(
-                services,
-                &context,
-                tool_call.arguments(),
-            )
-            .await,
-        ),
-        _ => None,
-    };
-    match raw_result {
-        Some(Ok(value)) => Ok(super::NativeAgentToolResult::generic_success(
-            &tool_call, value,
-        )),
-        Some(Err(error)) => Err(error.into()),
-        None => services
-            .tools
-            .clone()
-            .dispatch_async(context, tool_call)
-            .await
-            .map_err(AgentError::from),
-    }
 }
 
 async fn execute_planned_tool_call(

--- a/src-tauri/src/agent/runtime/tool_runtime.rs
+++ b/src-tauri/src/agent/runtime/tool_runtime.rs
@@ -369,7 +369,7 @@ async fn evaluate_pre_tool_hooks(
             tool_call.arguments_value(),
             None,
         );
-        let evaluation = context.evaluate_command_hook(invocation.clone()).await?;
+        let evaluation = context.evaluate_hook(invocation.clone()).await?;
         context.queue_tool_hook_context(&evaluation);
         state.emit_hook_evaluation(&invocation, &evaluation)?;
         if let Some(reason) = evaluation.denied_reason {
@@ -409,7 +409,7 @@ async fn commit_executed_tool_observation(
             "envelope": result.envelope,
         })),
     );
-    let evaluation = context.evaluate_command_hook(invocation.clone()).await?;
+    let evaluation = context.evaluate_hook(invocation.clone()).await?;
     context.queue_tool_hook_context(&evaluation);
     state.emit_hook_evaluation(&invocation, &evaluation)?;
     if !evaluation.tool_feedback.is_empty() {

--- a/src-tauri/src/agent/runtime/turn_input.rs
+++ b/src-tauri/src/agent/runtime/turn_input.rs
@@ -1,4 +1,6 @@
 use super::{AgentTurnSettings, DEFAULT_NATIVE_AGENT_MAX_ITERATIONS};
+#[cfg(test)]
+use crate::agent::runtime::test_support::BlockingTestProvider;
 use crate::agent::runtime_protocol::{AgentContinuationInput, AgentTraceContext};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -318,7 +320,7 @@ mod tests {
         use super::super::*;
         use std::sync::Arc;
         struct UnexpectedProvider;
-        impl NativeAgentProvider for UnexpectedProvider {
+        impl BlockingTestProvider for UnexpectedProvider {
             fn complete(
                 &self,
                 _: &AgentTurnContext,

--- a/src-tauri/src/agent/runtime/user_input.rs
+++ b/src-tauri/src/agent/runtime/user_input.rs
@@ -76,7 +76,7 @@ impl UserInputResume {
                 "envelope": result.envelope,
             })),
         );
-        let evaluation = context.evaluate_command_hook(invocation.clone()).await?;
+        let evaluation = context.evaluate_hook(invocation.clone()).await?;
         context.queue_tool_hook_context(&evaluation);
         state.emit_hook_evaluation(&invocation, &evaluation)?;
         if !evaluation.tool_feedback.is_empty() {

--- a/src-tauri/src/command_hooks/README.md
+++ b/src-tauri/src/command_hooks/README.md
@@ -1,9 +1,17 @@
 # Command Hooks
-<!-- tinybot-module-fingerprint: sha256:f97bb076395b40648d928872672dcd10b3f519c2ce1bd7121d8f0d610e41ba2c -->
+<!-- tinybot-module-fingerprint: sha256:d7f3d99eff5954699fbebbde9f7302e35bfa82e9426de33082c2338b61110766 -->
 
 `command_hooks` discovers, validates, reviews, and runs user-defined lifecycle
 commands. Tinybot loads `hooks.json` from the global data directory and the
 active workspace's `.tinybot` directory. Sources are additive.
+
+The application bridge loads the engine for each Turn and adapts it to the
+runtime's asynchronous `AgentHook` interface. The Agent core receives neutral
+effects and run diagnostics; it does not discover configuration or construct
+command processes. Missing optional configuration is valid, but invalid
+configuration or an unreadable trust store fails preparation with source
+diagnostics. A newly started durable Turn is marked failed before any provider
+request. Catalog inspection still returns diagnostics for the settings UI.
 
 The first supported Codex-compatible events are `UserPromptSubmit`,
 `PreToolUse`, `PostToolUse`, and `PostCompact`. Each command receives one JSON

--- a/src-tauri/src/command_hooks/mod.rs
+++ b/src-tauri/src/command_hooks/mod.rs
@@ -106,15 +106,20 @@ impl fmt::Debug for CommandHookEngine {
 }
 
 impl CommandHookEngine {
-    pub(crate) fn load(data_root: &Path, workspace_root: &Path) -> Self {
+    pub(crate) fn load(data_root: &Path, workspace_root: &Path) -> Result<Self, String> {
         let workspace_root = absolute_path(workspace_root);
-        let hooks = load_resolved_hooks(data_root, &workspace_root)
-            .map(|catalog| catalog.hooks)
-            .unwrap_or_default();
-        Self {
-            workspace_root,
-            hooks,
+        let catalog = load_resolved_hooks(data_root, &workspace_root)?;
+        if !catalog.diagnostics.is_empty() {
+            return Err(format!(
+                "command hook configuration is invalid: {}",
+                serde_json::to_string(&catalog.diagnostics)
+                    .map_err(|error| format!("failed to encode hook diagnostics: {error}"))?
+            ));
         }
+        Ok(Self {
+            workspace_root,
+            hooks: catalog.hooks,
+        })
     }
 
     pub(crate) async fn evaluate(&self, request: &CommandHookRequest) -> CommandHookEvaluation {

--- a/src-tauri/src/command_hooks/tests.rs
+++ b/src-tauri/src/command_hooks/tests.rs
@@ -219,20 +219,22 @@ fn managed_hook_save_owns_configuration_but_preserves_the_user_script() {
     set_hook_trusted(&data_root, &workspace_root, &edited.hooks[0].hash, true)
         .expect("disabled definition may retain trust for later re-enabling");
     let evaluation = tauri::async_runtime::block_on(
-        CommandHookEngine::load(&data_root, &workspace_root).evaluate(&CommandHookRequest {
-            event: CommandHookEvent::PostToolUse,
-            session_id: "session-managed".to_string(),
-            turn_id: "turn-managed".to_string(),
-            model: "test-model".to_string(),
-            permission_mode: "local-worker".to_string(),
-            prompt: None,
-            tool_name: Some("workspace.read_file".to_string()),
-            tool_match_names: vec!["workspace.read_file".to_string()],
-            tool_use_id: Some("call-managed".to_string()),
-            tool_input: Some(json!({ "path": "README.md" })),
-            tool_response: Some(json!({ "content": "test" })),
-            trigger: None,
-        }),
+        CommandHookEngine::load(&data_root, &workspace_root)
+            .expect("valid hook configuration")
+            .evaluate(&CommandHookRequest {
+                event: CommandHookEvent::PostToolUse,
+                session_id: "session-managed".to_string(),
+                turn_id: "turn-managed".to_string(),
+                model: "test-model".to_string(),
+                permission_mode: "local-worker".to_string(),
+                prompt: None,
+                tool_name: Some("workspace.read_file".to_string()),
+                tool_match_names: vec!["workspace.read_file".to_string()],
+                tool_use_id: Some("call-managed".to_string()),
+                tool_input: Some(json!({ "path": "README.md" })),
+                tool_response: Some(json!({ "content": "test" })),
+                trigger: None,
+            }),
     );
     assert!(
         evaluation.runs.is_empty(),
@@ -280,7 +282,8 @@ fn managed_script_changes_invalidate_trust_and_the_loaded_engine() {
         .clone();
     set_hook_trusted(&data_root, &workspace_root, &original_hash, true)
         .expect("managed hook should be trusted");
-    let engine = CommandHookEngine::load(&data_root, &workspace_root);
+    let engine =
+        CommandHookEngine::load(&data_root, &workspace_root).expect("valid hook configuration");
     assert_eq!(engine.hooks.len(), 1);
     assert!(engine.hooks[0].trusted);
     assert_eq!(engine.hooks[0].event, CommandHookEvent::PreToolUse);
@@ -441,7 +444,8 @@ fn trusted_command_hook_runs_with_json_input_and_output() {
     let hash = loaded.hooks[0].hash.clone();
     set_hook_trusted(&data_root, &workspace_root, &hash, true)
         .expect("configured hook should be trusted");
-    let engine = CommandHookEngine::load(&data_root, &workspace_root);
+    let engine =
+        CommandHookEngine::load(&data_root, &workspace_root).expect("valid hook configuration");
     let evaluation = tauri::async_runtime::block_on(engine.evaluate(&CommandHookRequest {
         event: CommandHookEvent::PreToolUse,
         session_id: "session-1".to_string(),
@@ -496,7 +500,8 @@ fn hook_timeout_covers_inherited_output_pipe_lifetime() {
         .expect("hook config should load before trusting");
     set_hook_trusted(&data_root, &workspace_root, &loaded.hooks[0].hash, true)
         .expect("configured hook should be trusted");
-    let engine = CommandHookEngine::load(&data_root, &workspace_root);
+    let engine =
+        CommandHookEngine::load(&data_root, &workspace_root).expect("valid hook configuration");
 
     let started = Instant::now();
     let evaluation = tauri::async_runtime::block_on(engine.evaluate(&CommandHookRequest {
@@ -550,4 +555,26 @@ fn event_specific_stop_outputs_are_mapped_without_rolling_back_tools() {
         post_compact.denied_reason.as_deref(),
         Some("compaction policy stopped the turn")
     );
+}
+#[test]
+fn runtime_loader_rejects_invalid_configuration_and_trust_with_diagnostics() {
+    let root = TestDirectory::new("invalid-runtime-config");
+    let data = root.path().join("data");
+    let workspace = root.path().join("workspace");
+    fs::create_dir_all(&data).unwrap();
+    fs::create_dir_all(&workspace).unwrap();
+    assert!(
+        CommandHookEngine::load(&data, &workspace).is_ok(),
+        "missing optional hooks are valid"
+    );
+
+    fs::write(data.join("hooks.json"), "{broken").unwrap();
+    let error = CommandHookEngine::load(&data, &workspace).unwrap_err();
+    assert!(error.contains("hook_config_invalid_json"));
+    assert!(error.contains("hooks.json"));
+    fs::remove_file(data.join("hooks.json")).unwrap();
+    fs::write(data.join("hook-trust.json"), "{broken").unwrap();
+    assert!(CommandHookEngine::load(&data, &workspace)
+        .unwrap_err()
+        .contains("trust store"));
 }

--- a/src-tauri/src/desktop/README.md
+++ b/src-tauri/src/desktop/README.md
@@ -1,13 +1,18 @@
 # Desktop Runtime
-<!-- tinybot-module-fingerprint: sha256:6bde6dd80d785c6ba5f6521a8e65671ed1e3224980a116afc8cc978f15fc2c36 -->
+<!-- tinybot-module-fingerprint: sha256:3acad625b29e5d8e883530871fc711975cb51d393ec374b48f822ba78e788b31 -->
 
 `desktop` wires the Rust backend into the Tauri application. It owns startup,
 shared desktop state, logging, file helpers, menus, and application updates.
 
-`state.rs` selects the Agent dependencies and supplies them through
-`NativeAgentRuntimeDependencies`. Desktop state and Agent services share the same
-MCP and subagent instances; service construction does not allocate replacement
-defaults. Shell, task ownership, cancellation, and metrics are selected here too.
+`state.rs` initializes storage through `NativeRuntimeState::initialize`, with
+explicit workspace and application-data paths. Migration failure returns an
+error before a usable state is created. Workspace rebinding uses the same storage
+initializer; unchanged startup does not rerun migration. Startup failures remain
+visible in lifecycle status and logs.
+Desktop state owns MCP, Shell, browser, subagent and Thread-store resources.
+`native_agent_services` creates an application context sharing those instances.
+`NativeAgentRuntimeDependencies` contains only core execution dependencies;
+Provider, task ownership, cancellation and metrics are selected here.
 
 `files` is the shared chat-attachment importer for picker and desktop-pet
 drops. It rejects non-files, detects supported images by content, copies images

--- a/src-tauri/src/desktop/README.md
+++ b/src-tauri/src/desktop/README.md
@@ -1,5 +1,5 @@
 # Desktop Runtime
-<!-- tinybot-module-fingerprint: sha256:3acad625b29e5d8e883530871fc711975cb51d393ec374b48f822ba78e788b31 -->
+<!-- tinybot-module-fingerprint: sha256:a96df8be401a2c9954ced0332596860f76bc472dcd6a5275e022c77cb5923f8f -->
 
 `desktop` wires the Rust backend into the Tauri application. It owns startup,
 shared desktop state, logging, file helpers, menus, and application updates.

--- a/src-tauri/src/desktop/README.md
+++ b/src-tauri/src/desktop/README.md
@@ -1,8 +1,13 @@
 # Desktop Runtime
-<!-- tinybot-module-fingerprint: sha256:739e5f1f65dc8618fec03247003112c0b8654e5fe59b64e41f3127819bcb628e -->
+<!-- tinybot-module-fingerprint: sha256:6bde6dd80d785c6ba5f6521a8e65671ed1e3224980a116afc8cc978f15fc2c36 -->
 
 `desktop` wires the Rust backend into the Tauri application. It owns startup,
 shared desktop state, logging, file helpers, menus, and application updates.
+
+`state.rs` selects the Agent dependencies and supplies them through
+`NativeAgentRuntimeDependencies`. Desktop state and Agent services share the same
+MCP and subagent instances; service construction does not allocate replacement
+defaults. Shell, task ownership, cancellation, and metrics are selected here too.
 
 `files` is the shared chat-attachment importer for picker and desktop-pet
 drops. It rejects non-files, detects supported images by content, copies images

--- a/src-tauri/src/desktop/bootstrap.rs
+++ b/src-tauri/src/desktop/bootstrap.rs
@@ -96,7 +96,25 @@ pub(crate) fn run() {
     let process_started_at = chrono::Utc::now().timestamp_millis();
     crate::runtime::observability::global_agent_runtime_metrics()
         .set_gauge("desktop.process.startedAtUnixMs", process_started_at);
-    let runtime_state = Arc::new(Mutex::new(NativeRuntimeState::default()));
+    let runtime_state = Arc::new(Mutex::new(
+        NativeRuntimeState::initialize(
+            crate::config::application::native_backend_workspace_root(),
+            crate::config::application::tinybot_data_root(),
+        )
+        .unwrap_or_else(|error| {
+            if let Err(log_error) = super::logging::append_default_native_backend_log_event(
+                "runtime",
+                NativeLogEvent::new(
+                    NativeLogLevel::Error,
+                    "runtime.initialization_failed",
+                    serde_json::json!({ "error": error }),
+                ),
+            ) {
+                eprintln!("failed to record runtime initialization error: {log_error}");
+            }
+            panic!("native runtime initialization failed: {error}");
+        }),
+    ));
     let update_state = super::update::new_shared_desktop_update_state(env!("CARGO_PKG_VERSION"));
     let exit_state = runtime_state.clone();
     let terminal_runtime = desktop_terminal::create_runtime();
@@ -120,10 +138,7 @@ pub(crate) fn run() {
             let browser_runtime = native_browser::create_runtime(app.handle())?;
             {
                 let mut runtime = lock_runtime(&setup_state);
-                runtime.native_agent_runtime = runtime
-                    .native_agent_runtime
-                    .clone()
-                    .with_browser_runtime(browser_runtime.clone());
+                runtime.browser_runtime = Some(browser_runtime.clone());
             }
             app.manage(browser_runtime);
             startup_metrics.record_duration(

--- a/src-tauri/src/desktop/state.rs
+++ b/src-tauri/src/desktop/state.rs
@@ -26,6 +26,7 @@ pub(crate) type SharedNativeRuntime = Arc<Mutex<NativeRuntimeState>>;
 pub(crate) struct NativeRuntimeState {
     pub(crate) native_agent_runtime: NativeAgentRuntimeServices,
     pub(crate) mcp_runtime: McpRuntime,
+    pub(crate) memory_runtime: crate::memory::MemoryRuntime,
     pub(crate) shell_runtime: crate::tools::shell::WorkerShellRuntime,
     pub(crate) browser_runtime: Option<crate::native_browser::SharedBrowserRuntime>,
     pub(crate) subagent_manager: SubagentThreadManager,
@@ -95,6 +96,9 @@ impl NativeRuntimeState {
                 },
             ),
             mcp_runtime,
+            memory_runtime: crate::memory::MemoryRuntime::new(Arc::new(
+                crate::memory::NativeMemoryModel,
+            )),
             shell_runtime: crate::tools::shell::WorkerShellRuntime::default(),
             browser_runtime: None,
             subagent_manager,
@@ -112,6 +116,7 @@ impl NativeRuntimeState {
             runtime: self.native_agent_runtime.clone(),
             thread_store: self.thread_store.clone(),
             mcp_runtime: self.mcp_runtime.clone(),
+            memory_runtime: self.memory_runtime.clone(),
             shell_runtime: self.shell_runtime.clone(),
             subagent_manager: self.subagent_manager.clone(),
             browser_runtime: self.browser_runtime.clone(),

--- a/src-tauri/src/desktop/state.rs
+++ b/src-tauri/src/desktop/state.rs
@@ -26,6 +26,8 @@ pub(crate) type SharedNativeRuntime = Arc<Mutex<NativeRuntimeState>>;
 pub(crate) struct NativeRuntimeState {
     pub(crate) native_agent_runtime: NativeAgentRuntimeServices,
     pub(crate) mcp_runtime: McpRuntime,
+    pub(crate) shell_runtime: crate::tools::shell::WorkerShellRuntime,
+    pub(crate) browser_runtime: Option<crate::native_browser::SharedBrowserRuntime>,
     pub(crate) subagent_manager: SubagentThreadManager,
     pub(crate) thread_store: WorkspaceThreadStore,
     pub(crate) lifecycle_status: RuntimeLifecycleStatus,
@@ -35,37 +37,38 @@ pub(crate) struct NativeRuntimeState {
     pub(crate) last_error: Option<String>,
 }
 
+#[cfg(test)]
 impl Default for NativeRuntimeState {
     fn default() -> Self {
-        #[cfg(test)]
-        {
-            let workspace_root = crate::config::application::native_backend_workspace_root();
-            Self::with_thread_store(WorkspaceThreadStore::new(
-                workspace_root,
-                crate::protocol::capability::default_desktop_capability_policy(),
-            ))
-        }
-        #[cfg(not(test))]
-        {
-            let workspace_root = crate::config::application::native_backend_workspace_root();
-            let data_root = crate::config::application::tinybot_data_root();
-            let migration_error = crate::threads::workspace_store::migrate_legacy_thread_storage(
-                &workspace_root,
-                &data_root,
-            )
-            .err()
-            .map(|error| error.message);
-            let mut state = Self::new_with_data_root(workspace_root, data_root);
-            state.last_error = migration_error;
-            state
-        }
+        Self::with_thread_store(WorkspaceThreadStore::new(
+            crate::config::application::native_backend_workspace_root(),
+            crate::protocol::capability::default_desktop_capability_policy(),
+        ))
     }
 }
 
 impl NativeRuntimeState {
-    #[cfg(not(test))]
-    pub(crate) fn new_with_data_root(workspace_root: PathBuf, data_root: PathBuf) -> Self {
-        Self::with_thread_store(WorkspaceThreadStore::new_with_data_root(
+    pub(crate) fn initialize(workspace_root: PathBuf, data_root: PathBuf) -> Result<Self, String> {
+        Ok(Self::with_thread_store(Self::initialize_thread_store(
+            workspace_root,
+            data_root,
+        )?))
+    }
+
+    pub(crate) fn initialize_thread_store(
+        workspace_root: PathBuf,
+        data_root: PathBuf,
+    ) -> Result<WorkspaceThreadStore, String> {
+        crate::threads::workspace_store::migrate_legacy_thread_storage(&workspace_root, &data_root)
+            .map_err(|error| {
+                format!(
+                    "thread storage initialization failed (workspace `{}`, data `{}`): {}",
+                    workspace_root.display(),
+                    data_root.display(),
+                    error.message
+                )
+            })?;
+        Ok(WorkspaceThreadStore::new_with_data_root(
             workspace_root,
             data_root,
             crate::protocol::capability::default_desktop_capability_policy(),
@@ -87,15 +90,13 @@ impl NativeRuntimeState {
                         InMemoryNativeAgentContextCheckpointCommitter::default(),
                     ),
                     cancellations: Arc::new(InMemoryNativeAgentCancellation::default()),
-                    subagents: subagent_manager.clone(),
-                    mcp_runtime: mcp_runtime.clone(),
-                    shell_runtime: crate::tools::shell::WorkerShellRuntime::default(),
                     task_runtime: crate::runtime::turn_execution::TurnExecutionRuntime::new(),
                     metrics: crate::runtime::observability::global_agent_runtime_metrics().clone(),
                 },
-            )
-            .with_thread_store(thread_store.clone()),
+            ),
             mcp_runtime,
+            shell_runtime: crate::tools::shell::WorkerShellRuntime::default(),
+            browser_runtime: None,
             subagent_manager,
             thread_store,
             lifecycle_status: RuntimeLifecycleStatus::default(),
@@ -106,10 +107,15 @@ impl NativeRuntimeState {
         }
     }
 
-    pub(crate) fn native_agent_services(&self) -> NativeAgentRuntimeServices {
-        self.native_agent_runtime
-            .clone()
-            .with_thread_store(self.thread_store.clone())
+    pub(crate) fn native_agent_services(&self) -> crate::agent::bridge::AgentApplicationServices {
+        crate::agent::bridge::AgentApplicationServices {
+            runtime: self.native_agent_runtime.clone(),
+            thread_store: self.thread_store.clone(),
+            mcp_runtime: self.mcp_runtime.clone(),
+            shell_runtime: self.shell_runtime.clone(),
+            subagent_manager: self.subagent_manager.clone(),
+            browser_runtime: self.browser_runtime.clone(),
+        }
     }
 }
 

--- a/src-tauri/src/desktop/state.rs
+++ b/src-tauri/src/desktop/state.rs
@@ -1,4 +1,8 @@
-use crate::agent::runtime::NativeAgentRuntimeServices;
+use crate::agent::runtime::{
+    InMemoryNativeAgentCancellation, InMemoryNativeAgentCheckpointStore,
+    InMemoryNativeAgentContextCheckpointCommitter, NativeAgentRuntimeDependencies,
+    NativeAgentRuntimeServices, RustNativeAgentProvider, SubagentNativeAgentToolDispatcher,
+};
 use crate::collaboration::subagents::SubagentThreadManager;
 use crate::runtime::lifecycle::RuntimeLifecycleStatus;
 use crate::runtime::mcp::McpRuntime;
@@ -72,10 +76,24 @@ impl NativeRuntimeState {
         let subagent_manager = SubagentThreadManager::default();
         let mcp_runtime = McpRuntime::new();
         Self {
-            native_agent_runtime: NativeAgentRuntimeServices::with_subagent_manager(
-                subagent_manager.clone(),
+            native_agent_runtime: NativeAgentRuntimeServices::from_dependencies(
+                NativeAgentRuntimeDependencies {
+                    provider: Arc::new(RustNativeAgentProvider),
+                    tools: Arc::new(SubagentNativeAgentToolDispatcher::new(
+                        subagent_manager.clone(),
+                    )),
+                    checkpoints: Arc::new(InMemoryNativeAgentCheckpointStore::default()),
+                    context_checkpoint_committer: Arc::new(
+                        InMemoryNativeAgentContextCheckpointCommitter::default(),
+                    ),
+                    cancellations: Arc::new(InMemoryNativeAgentCancellation::default()),
+                    subagents: subagent_manager.clone(),
+                    mcp_runtime: mcp_runtime.clone(),
+                    shell_runtime: crate::tools::shell::WorkerShellRuntime::default(),
+                    task_runtime: crate::runtime::turn_execution::TurnExecutionRuntime::new(),
+                    metrics: crate::runtime::observability::global_agent_runtime_metrics().clone(),
+                },
             )
-            .with_mcp_runtime(mcp_runtime.clone())
             .with_thread_store(thread_store.clone()),
             mcp_runtime,
             subagent_manager,

--- a/src-tauri/src/desktop_commands/README.md
+++ b/src-tauri/src/desktop_commands/README.md
@@ -1,5 +1,5 @@
 # Desktop Commands
-<!-- tinybot-module-fingerprint: sha256:8e132c8cc3956d622d83411959048c3154331b436dd416928ba5c58de2eaef69 -->
+<!-- tinybot-module-fingerprint: sha256:166580fd7680510e01e62dfbc6e98c0da268ddfaf63847a42c5e8f1d6940b032 -->
 
 `desktop_commands` contains the Tauri command boundary used by the desktop
 frontend. Commands are grouped by agent, configuration, hooks, memory, runtime,

--- a/src-tauri/src/desktop_commands/README.md
+++ b/src-tauri/src/desktop_commands/README.md
@@ -1,5 +1,5 @@
 # Desktop Commands
-<!-- tinybot-module-fingerprint: sha256:166580fd7680510e01e62dfbc6e98c0da268ddfaf63847a42c5e8f1d6940b032 -->
+<!-- tinybot-module-fingerprint: sha256:be41b56711221ef23b972db003b66b0f34025533ba5a328ba55a2ab6488c32d0 -->
 
 `desktop_commands` contains the Tauri command boundary used by the desktop
 frontend. Commands are grouped by agent, configuration, hooks, memory, runtime,

--- a/src-tauri/src/desktop_commands/memory.rs
+++ b/src-tauri/src/desktop_commands/memory.rs
@@ -1,4 +1,4 @@
-use crate::config::application::native_backend_workspace_root;
+use crate::desktop::state::{lock_runtime, SharedNativeRuntime};
 use crate::memory::{normalized_workspace_path, MemoryRecord, MemoryScope, MemoryStore};
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -20,10 +20,18 @@ struct WorkerWorkspaceMemory {
 }
 
 #[tauri::command]
-pub(crate) fn worker_memory_snapshot() -> Result<WorkerMemorySnapshot, String> {
-    let workspace_root = native_backend_workspace_root();
+pub(crate) fn worker_memory_snapshot(
+    state: tauri::State<'_, SharedNativeRuntime>,
+) -> Result<WorkerMemorySnapshot, String> {
+    let (workspace_root, data_root) = {
+        let runtime = lock_runtime(state.inner());
+        (
+            runtime.thread_store.workspace_root().to_path_buf(),
+            runtime.thread_store.data_root().to_path_buf(),
+        )
+    };
     let current_workspace_path = normalized_workspace_path(&workspace_root)?;
-    let memories = MemoryStore::for_workspace(&workspace_root).active_memories()?;
+    let memories = MemoryStore::new(&data_root).active_memories()?;
     Ok(build_memory_snapshot(current_workspace_path, memories))
 }
 

--- a/src-tauri/src/desktop_commands/runtime.rs
+++ b/src-tauri/src/desktop_commands/runtime.rs
@@ -73,11 +73,22 @@ pub(crate) fn start_native_runtime_with_workspace_root(
         }
     }
     #[cfg(not(test))]
-    crate::memory::start_workspace_runtime(
-        workspace_root,
-        thread_store.clone(),
-        crate::config::application::native_runtime_config_snapshot(),
-    );
+    {
+        let memory = lock_runtime(shared).memory_runtime.clone();
+        if let Err(message) = memory.start(
+            thread_store.clone(),
+            crate::config::application::native_runtime_config_snapshot(),
+        ) {
+            let mut runtime = lock_runtime(shared);
+            runtime.last_error = Some(message.clone());
+            runtime
+                .lifecycle_status
+                .record_startup_failure(message.clone());
+            drop(runtime);
+            push_log(shared, &message);
+            return Err(message);
+        }
+    }
     if let Err(error) = shell_runtime.resume_accepting() {
         let message = format!("runtime resume failed: {}", error.message);
         {
@@ -130,6 +141,7 @@ async fn shutdown_native_runtime_async_with_timeout(
             runtime.native_agent_runtime.task_runtime(),
             runtime.shell_runtime.clone(),
             runtime.mcp_runtime.clone(),
+            runtime.memory_runtime.clone(),
             runtime.subagent_manager.clone(),
             runtime.thread_store.clone(),
         )

--- a/src-tauri/src/desktop_commands/runtime.rs
+++ b/src-tauri/src/desktop_commands/runtime.rs
@@ -14,37 +14,33 @@ pub(crate) fn start_native_runtime_with_workspace_root(
     let data_root = crate::config::application::tinybot_data_root();
     #[cfg(test)]
     let data_root = workspace_root.join(".tinybot");
-    if let Err(error) =
-        crate::threads::workspace_store::migrate_legacy_thread_storage(&workspace_root, &data_root)
-    {
-        let message = error.message;
-        {
-            let mut runtime = lock_runtime(shared);
-            runtime.last_error = Some(message.clone());
-        }
-        push_log(shared, &message);
-        return Err(message);
-    }
     let (agent_task_runtime, shell_runtime, thread_store, startup_reconciled) = {
         let mut runtime = lock_runtime(shared);
         if runtime.thread_store.workspace_root() != workspace_root
             || runtime.thread_store.data_root() != data_root
         {
             let thread_store =
-                crate::threads::workspace_store::WorkspaceThreadStore::new_with_data_root(
+                match crate::desktop::state::NativeRuntimeState::initialize_thread_store(
                     workspace_root.clone(),
                     data_root,
-                    crate::protocol::capability::default_desktop_capability_policy(),
-                );
-            runtime.thread_store = thread_store.clone();
-            runtime.native_agent_runtime = runtime
-                .native_agent_runtime
-                .clone()
-                .with_thread_store(thread_store);
+                ) {
+                    Ok(store) => store,
+                    Err(message) => {
+                        runtime.last_error = Some(message.clone());
+                        runtime
+                            .lifecycle_status
+                            .record_startup_failure(message.clone());
+                        drop(runtime);
+                        push_log(shared, &message);
+                        return Err(message);
+                    }
+                };
+            runtime.thread_store = thread_store;
+            runtime.lifecycle_status.startup_reconciled = false;
         }
         (
             runtime.native_agent_runtime.task_runtime(),
-            runtime.native_agent_runtime.shell_runtime(),
+            runtime.shell_runtime.clone(),
             runtime.thread_store.clone(),
             runtime.lifecycle_status.startup_reconciled,
         )
@@ -132,7 +128,7 @@ async fn shutdown_native_runtime_async_with_timeout(
         let runtime = lock_runtime(shared);
         RuntimeLifecycle::new(
             runtime.native_agent_runtime.task_runtime(),
-            runtime.native_agent_runtime.shell_runtime(),
+            runtime.shell_runtime.clone(),
             runtime.mcp_runtime.clone(),
             runtime.subagent_manager.clone(),
             runtime.thread_store.clone(),

--- a/src-tauri/src/desktop_commands/thread.rs
+++ b/src-tauri/src/desktop_commands/thread.rs
@@ -261,7 +261,7 @@ pub(crate) fn worker_thread_request_with_options(
                 let runtime = crate::desktop::state::lock_runtime(shared);
                 runtime.native_agent_services()
             };
-            let cancellation = services.cancel(&turn_id);
+            let cancellation = services.runtime.cancel(&turn_id);
             let result_object = result.as_object_mut().ok_or_else(|| {
                 "thread interrupt result must be a JSON object before task cancellation projection"
                     .to_string()

--- a/src-tauri/src/graph_runs.rs
+++ b/src-tauri/src/graph_runs.rs
@@ -1,7 +1,12 @@
+use crate::agent::bridge::AgentApplicationServices;
+#[cfg(test)]
+use crate::agent::bridge::TestApplicationServices;
 use crate::agent::bridge::{execute_thread_turn_with_services, SubmitThreadTurnInput};
 use crate::agent::router;
+use crate::agent::runtime::NativeAgentCancellationContext;
+#[cfg(test)]
+use crate::agent::runtime::NativeAgentRuntimeServices;
 use crate::agent::runtime::{AgentResultError, AgentStopReason};
-use crate::agent::runtime::{NativeAgentCancellationContext, NativeAgentRuntimeServices};
 #[cfg(test)]
 use crate::agent_graphs::AgentLoopReasoningEffort;
 use crate::agent_graphs::{
@@ -186,7 +191,7 @@ pub(crate) fn list(
 
 pub(crate) async fn start(
     data_root: &Path,
-    base_services: NativeAgentRuntimeServices,
+    base_services: AgentApplicationServices,
     workspace_root: PathBuf,
     config_snapshot: serde_json::Value,
     input: StartAgentGraphRunInput,
@@ -219,7 +224,7 @@ pub(crate) async fn start(
     };
     write_run(data_root, &run)?;
 
-    let thread_store = base_services.thread_store()?;
+    let thread_store = base_services.thread_store.clone();
     let mut current_input = graph_input;
     let mut cursor = single_outgoing_edge(&plan, &plan.input_node_id)?
         .target
@@ -285,7 +290,7 @@ pub(crate) async fn start(
                     tokio::select! {
                         biased;
                         _ = cancellation.cancelled() => {
-                            base_services.cancel(&turn_id);
+                            base_services.runtime.cancel(&turn_id);
                             let _ = (&mut result).await;
                             return finish_cancelled_run(data_root, run, Some(index));
                         }

--- a/src-tauri/src/memory/README.md
+++ b/src-tauri/src/memory/README.md
@@ -1,5 +1,5 @@
 # Long-Term Memory
-<!-- tinybot-module-fingerprint: sha256:435fdd7f4598a5ddf2ae5c47ec3e3149dc6ef140e616a242e6ab3c02d56a83e7 -->
+<!-- tinybot-module-fingerprint: sha256:3ffb2db6529033788ac8a2647ecdf334aab81ab1d186a8ab64acb2cb15f95520 -->
 
 `memory` provides Tinybot's local long-term memory. The V1 implementation is
 intentionally limited to two model-backed phases:
@@ -8,6 +8,25 @@ intentionally limited to two model-backed phases:
 2. periodically consolidate those fragments into the active memory set.
 
 This document describes the implemented V1 behavior and its boundaries.
+
+## Ownership and dependencies
+
+The application owns one `MemoryRuntime` and injects it into Turn completion
+and runtime lifecycle orchestration. Each workspace/data-directory pair has one
+worker that serializes extraction and heartbeat work. `MemoryModel` supplies
+the asynchronous extraction and selection operations; `NativeMemoryModel`
+adapts the configured provider. There is no process-global worker registry.
+
+`MemoryStore::new` receives the application data directory explicitly. Background
+workers, the desktop snapshot command, and new Thread snapshots use the same
+directory from `WorkspaceThreadStore`, including in tests.
+
+Shutdown stops accepting jobs, cancels in-flight model futures, and joins the
+workers before Thread persistence closes. Model implementations must keep their
+request work inside the returned future so dropping it cancels that work.
+Unfinished extractions remain in SQLite for the next start's heartbeat. A
+worker failure or shutdown timeout is reported through lifecycle diagnostics.
+Restart is accepted only after the previous workers have finished shutdown.
 
 ## Authority
 

--- a/src-tauri/src/memory/mod.rs
+++ b/src-tauri/src/memory/mod.rs
@@ -4,7 +4,8 @@ mod model;
 mod runtime;
 mod store;
 
-pub(crate) use self::runtime::{schedule_turn_extraction, start_workspace_runtime};
+pub(crate) use self::model::NativeMemoryModel;
+pub(crate) use self::runtime::MemoryRuntime;
 pub(crate) use self::store::{normalized_workspace_path, MemoryStore};
 
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/memory/model.rs
+++ b/src-tauri/src/memory/model.rs
@@ -299,3 +299,35 @@ pub(super) fn model_config_for_test(config_snapshot: &Value) -> Result<Value, St
 pub(super) fn parse_diff_for_test(content: &str) -> Result<SelectionDiff, String> {
     parse_selection_diff(content)
 }
+
+/// Model work can be cancelled by dropping its future; implementations must not detach requests.
+pub(crate) trait MemoryModel: Send + Sync + 'static {
+    fn extract<'a>(
+        &'a self,
+        config: &'a Value,
+        evidence: &'a TurnEvidence,
+    ) -> futures_util::future::BoxFuture<'a, Result<Vec<ExtractedMemory>, String>>;
+    fn select<'a>(
+        &'a self,
+        config: &'a Value,
+        input: &'a Phase2Input,
+    ) -> futures_util::future::BoxFuture<'a, Result<SelectionDiff, String>>;
+}
+
+pub(crate) struct NativeMemoryModel;
+impl MemoryModel for NativeMemoryModel {
+    fn extract<'a>(
+        &'a self,
+        config: &'a Value,
+        evidence: &'a TurnEvidence,
+    ) -> futures_util::future::BoxFuture<'a, Result<Vec<ExtractedMemory>, String>> {
+        Box::pin(extract_memories(config, evidence))
+    }
+    fn select<'a>(
+        &'a self,
+        config: &'a Value,
+        input: &'a Phase2Input,
+    ) -> futures_util::future::BoxFuture<'a, Result<SelectionDiff, String>> {
+        Box::pin(select_diff(config, input))
+    }
+}

--- a/src-tauri/src/memory/runtime.rs
+++ b/src-tauri/src/memory/runtime.rs
@@ -1,13 +1,14 @@
-use super::model::{extract_memories, select_diff, TurnEvidence};
+use super::model::{MemoryModel, TurnEvidence};
 use super::store::{MemoryStore, PendingMemoryTurn};
 use crate::threads::turn::AgentTurnStatus;
 use crate::threads::workspace_store::WorkspaceThreadStore;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 const MEMORY_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 const MAX_PENDING_EXTRACTIONS_PER_TICK: usize = 10;
@@ -16,148 +17,221 @@ struct WorkspaceMemoryRuntime {
     store: MemoryStore,
     thread_store: WorkspaceThreadStore,
     thread_store_path: String,
-    latest_config: Mutex<Value>,
-    phase_lock: tokio::sync::Mutex<()>,
-    heartbeat_started: AtomicBool,
+    latest_config: Arc<Mutex<Value>>,
+    model: Arc<dyn MemoryModel>,
+    cancellation: CancellationToken,
 }
 
-static MEMORY_RUNTIMES: OnceLock<Mutex<HashMap<PathBuf, Arc<WorkspaceMemoryRuntime>>>> =
-    OnceLock::new();
+struct MemoryWorker {
+    store: MemoryStore,
+    thread_store_path: String,
+    config: Arc<Mutex<Value>>,
+    sender: mpsc::UnboundedSender<PendingMemoryTurn>,
+    cancellation: CancellationToken,
+    task: tauri::async_runtime::JoinHandle<()>,
+}
 
-pub(crate) fn start_workspace_runtime(
-    workspace_root: PathBuf,
-    thread_store: WorkspaceThreadStore,
-    config_snapshot: Value,
-) {
-    match workspace_runtime(&workspace_root, thread_store, config_snapshot) {
-        Ok(runtime) => runtime.start_heartbeat(),
-        Err(error) => report_failure("startup", &workspace_root, None, None, &error),
+#[derive(Default)]
+struct MemoryRuntimeState {
+    workers: HashMap<(PathBuf, PathBuf), MemoryWorker>,
+    stopped: bool,
+    shutting_down: bool,
+}
+
+/// Application-owned workers. Accepted jobs are durable before they enter the queue.
+#[derive(Clone)]
+pub(crate) struct MemoryRuntime {
+    state: Arc<Mutex<MemoryRuntimeState>>,
+    model: Arc<dyn MemoryModel>,
+    heartbeat_interval: Duration,
+}
+
+impl MemoryRuntime {
+    pub(crate) fn new(model: Arc<dyn MemoryModel>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(MemoryRuntimeState::default())),
+            model,
+            heartbeat_interval: MEMORY_HEARTBEAT_INTERVAL,
+        }
     }
-}
 
-pub(crate) fn schedule_turn_extraction(
-    workspace_root: PathBuf,
-    thread_store: WorkspaceThreadStore,
-    config_snapshot: Value,
-    thread_id: String,
-    turn_id: String,
-    workspace_path: String,
-) {
-    let runtime = match workspace_runtime(&workspace_root, thread_store, config_snapshot) {
-        Ok(runtime) => runtime,
-        Err(error) => {
-            report_failure(
-                "phase1_schedule",
-                &workspace_root,
-                Some(&thread_id),
-                Some(&turn_id),
-                &error,
-            );
-            return;
-        }
-    };
-    runtime.start_heartbeat();
-    tauri::async_runtime::spawn(async move {
-        if let Err(error) = runtime
-            .enqueue_and_process(thread_id.clone(), turn_id.clone(), workspace_path)
-            .await
-        {
-            report_failure(
-                "phase1",
-                &workspace_root,
-                Some(&thread_id),
-                Some(&turn_id),
-                &error,
-            );
-        }
-    });
-}
-
-fn workspace_runtime(
-    workspace_root: &Path,
-    thread_store: WorkspaceThreadStore,
-    config_snapshot: Value,
-) -> Result<Arc<WorkspaceMemoryRuntime>, String> {
-    let key = std::fs::canonicalize(workspace_root).map_err(|error| {
-        format!(
-            "failed to canonicalize memory runtime workspace `{}`: {error}",
-            workspace_root.display()
-        )
-    })?;
-    let runtimes = MEMORY_RUNTIMES.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut runtimes = runtimes
-        .lock()
-        .map_err(|_| "memory runtime registry lock is poisoned".to_string())?;
-    if let Some(runtime) = runtimes.get(&key) {
-        *runtime
-            .latest_config
+    pub(crate) fn start(&self, threads: WorkspaceThreadStore, config: Value) -> Result<(), String> {
+        let mut state = self
+            .state
             .lock()
-            .map_err(|_| "memory runtime config lock is poisoned".to_string())? = config_snapshot;
-        return Ok(runtime.clone());
-    }
-    let store = MemoryStore::for_workspace(&key);
-    store.initialize()?;
-    let thread_store_path = super::normalized_workspace_path(&key)?;
-    let runtime = Arc::new(WorkspaceMemoryRuntime {
-        store,
-        thread_store,
-        thread_store_path,
-        latest_config: Mutex::new(config_snapshot),
-        phase_lock: tokio::sync::Mutex::new(()),
-        heartbeat_started: AtomicBool::new(false),
-    });
-    runtimes.insert(key, runtime.clone());
-    Ok(runtime)
-}
-
-impl WorkspaceMemoryRuntime {
-    fn start_heartbeat(self: &Arc<Self>) {
-        if self.heartbeat_started.swap(true, Ordering::AcqRel) {
-            return;
+            .map_err(|_| "memory runtime lock is poisoned")?;
+        if state.shutting_down {
+            return Err("memory workers are still shutting down".into());
         }
-        let runtime = self.clone();
-        tauri::async_runtime::spawn(async move {
-            let mut interval = tokio::time::interval(MEMORY_HEARTBEAT_INTERVAL);
-            interval.tick().await;
-            loop {
-                interval.tick().await;
-                if let Err(error) = runtime.run_heartbeat().await {
-                    report_failure(
-                        "heartbeat",
-                        runtime.store_workspace_root(),
-                        None,
-                        None,
-                        &error,
-                    );
-                }
-            }
-        });
+        self.worker(&mut state, threads, config)?;
+        state.stopped = false;
+        Ok(())
     }
 
-    async fn enqueue_and_process(
+    pub(crate) fn schedule_turn_extraction(
         &self,
+        threads: WorkspaceThreadStore,
+        config: Value,
         thread_id: String,
         turn_id: String,
         workspace_path: String,
     ) -> Result<(), String> {
-        self.store.enqueue_turn(
-            &self.thread_store_path,
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "memory runtime lock is poisoned")?;
+        if state.stopped {
+            return Err("memory runtime is not accepting extractions".into());
+        }
+        let worker = self.worker(&mut state, threads, config)?;
+        worker.store.enqueue_turn(
+            &worker.thread_store_path,
             &thread_id,
             &turn_id,
             &workspace_path,
         )?;
-        let _guard = self.phase_lock.lock().await;
-        let pending = PendingMemoryTurn {
-            thread_store_path: self.thread_store_path.clone(),
-            thread_id,
-            turn_id,
-            workspace_path,
+        worker
+            .sender
+            .send(PendingMemoryTurn {
+                thread_store_path: worker.thread_store_path.clone(),
+                thread_id,
+                turn_id,
+                workspace_path,
+            })
+            .map_err(|_| "memory worker exited; extraction remains queued in storage".to_string())
+    }
+
+    fn worker<'a>(
+        &self,
+        state: &'a mut MemoryRuntimeState,
+        threads: WorkspaceThreadStore,
+        config: Value,
+    ) -> Result<&'a MemoryWorker, String> {
+        let root = std::fs::canonicalize(threads.workspace_root()).map_err(|error| {
+            format!(
+                "failed to resolve memory workspace `{}`: {error}",
+                threads.workspace_root().display()
+            )
+        })?;
+        let key = (root.clone(), threads.data_root().to_path_buf());
+        if !state.workers.contains_key(&key) {
+            let store = MemoryStore::new(threads.data_root());
+            store.initialize()?;
+            let thread_store_path = super::normalized_workspace_path(&root)?;
+            let latest_config = Arc::new(Mutex::new(config.clone()));
+            let cancellation = CancellationToken::new();
+            let (sender, receiver) = mpsc::unbounded_channel();
+            let runtime = WorkspaceMemoryRuntime {
+                store: store.clone(),
+                thread_store: threads,
+                thread_store_path: thread_store_path.clone(),
+                latest_config: latest_config.clone(),
+                model: self.model.clone(),
+                cancellation: cancellation.clone(),
+            };
+            let task = tauri::async_runtime::spawn(runtime.run(receiver, self.heartbeat_interval));
+            state.workers.insert(
+                key.clone(),
+                MemoryWorker {
+                    store,
+                    thread_store_path,
+                    config: latest_config,
+                    sender,
+                    cancellation,
+                    task,
+                },
+            );
+        }
+        let worker = state.workers.get(&key).expect("worker was inserted");
+        if worker.sender.is_closed() {
+            return Err("memory worker has exited unexpectedly".into());
+        }
+        *worker
+            .config
+            .lock()
+            .map_err(|_| "memory config lock is poisoned")? = config;
+        Ok(worker)
+    }
+
+    pub(crate) async fn shutdown(&self, timeout: Duration) -> Result<(), String> {
+        // Prevent a new generation from starting until every old worker has exited.
+        let tasks = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| "memory runtime lock is poisoned")?;
+            if state.shutting_down {
+                return Err("memory shutdown is already in progress".into());
+            }
+            state.stopped = true;
+            state.shutting_down = true;
+            for worker in state.workers.values() {
+                worker.cancellation.cancel();
+            }
+            std::mem::take(&mut state.workers)
         };
-        self.process_pending_turn(&pending).await
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut failures = Vec::new();
+        for ((workspace, _), mut worker) in tasks {
+            match tokio::time::timeout_at(deadline, &mut worker.task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => failures.push(format!(
+                    "memory worker `{}` failed: {error}",
+                    workspace.display()
+                )),
+                Err(_) => {
+                    worker.task.abort();
+                    let _cancelled = worker.task.await;
+                    failures.push(format!("memory worker `{}` exceeded shutdown timeout; pending extractions remain durable", workspace.display()));
+                }
+            }
+        }
+        self.state
+            .lock()
+            .map_err(|_| "memory runtime lock is poisoned")?
+            .shutting_down = false;
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(failures.join("; "))
+        }
+    }
+}
+
+impl WorkspaceMemoryRuntime {
+    async fn run(
+        self,
+        mut receiver: mpsc::UnboundedReceiver<PendingMemoryTurn>,
+        heartbeat_interval: Duration,
+    ) {
+        let mut interval = tokio::time::interval(heartbeat_interval);
+        interval.tick().await;
+        loop {
+            let work = async {
+                tokio::select! {
+                    pending = receiver.recv() => {
+                        let Some(pending) = pending else { return false; };
+                        if let Err(error) = self.process_pending_turn(&pending).await {
+                            report_failure("phase1", self.store_workspace_root(), Some(&pending.thread_id), Some(&pending.turn_id), &error);
+                        }
+                    }
+                    _ = interval.tick() => {
+                        if let Err(error) = self.run_heartbeat().await {
+                            report_failure("heartbeat", self.store_workspace_root(), None, None, &error);
+                        }
+                    }
+                }
+                true
+            };
+            tokio::select! {
+                biased;
+                _ = self.cancellation.cancelled() => break,
+                keep_running = work => if !keep_running { break; },
+            }
+        }
     }
 
     async fn run_heartbeat(&self) -> Result<(), String> {
-        let _guard = self.phase_lock.lock().await;
         for pending in self
             .store
             .pending_turns(&self.thread_store_path, MAX_PENDING_EXTRACTIONS_PER_TICK)?
@@ -187,13 +261,18 @@ impl WorkspaceMemoryRuntime {
         }
         let config = self.config_snapshot()?;
         increment_metric("memory.phase1.model.started");
-        let memories = extract_memories(&config, &evidence)
+        let memories = self
+            .model
+            .extract(&config, &evidence)
             .await
             .map_err(|error| {
                 increment_metric("memory.phase1.model.failed");
                 error
             })?;
         increment_metric("memory.phase1.model.completed");
+        if self.cancellation.is_cancelled() {
+            return Err("memory extraction cancelled".into());
+        }
         let inserted = self.store.complete_extraction(pending, &memories)?;
         increment_metric("memory.phase1.fragments.inserted");
         if inserted == 0 {
@@ -208,11 +287,14 @@ impl WorkspaceMemoryRuntime {
         };
         let config = self.config_snapshot()?;
         increment_metric("memory.phase2.model.started");
-        let diff = select_diff(&config, &input).await.map_err(|error| {
+        let diff = self.model.select(&config, &input).await.map_err(|error| {
             increment_metric("memory.phase2.model.failed");
             error
         })?;
         increment_metric("memory.phase2.model.completed");
+        if self.cancellation.is_cancelled() {
+            return Err("memory selection cancelled".into());
+        }
         let changed = self.store.apply_selection_diff(&input, &diff)?;
         increment_metric(if changed {
             "memory.phase2.diff.changed"
@@ -352,3 +434,15 @@ fn report_failure(
 pub(super) fn successful_tool_result_for_test(result: &Value) -> bool {
     successful_tool_result(result)
 }
+
+impl Drop for MemoryRuntimeState {
+    fn drop(&mut self) {
+        for worker in self.workers.values() {
+            worker.cancellation.cancel();
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/src-tauri/src/memory/runtime_tests.rs
+++ b/src-tauri/src/memory/runtime_tests.rs
@@ -1,0 +1,233 @@
+use super::*;
+use crate::memory::{ExtractedMemory, MemoryScope, Phase2Input, SelectionAdd, SelectionDiff};
+use futures_util::future::BoxFuture;
+use serde_json::json;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tokio::sync::{Notify, Semaphore};
+
+struct Fixture {
+    root: PathBuf,
+    threads: WorkspaceThreadStore,
+    store: MemoryStore,
+    scope: String,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "tinybot-memory-owner-{}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            NEXT_ID.fetch_add(1, Ordering::Relaxed),
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let data = root.join("application-data");
+        let threads = WorkspaceThreadStore::new_with_data_root(
+            root.clone(),
+            data.clone(),
+            crate::protocol::capability::default_desktop_capability_policy(),
+        );
+        let input = crate::agent::runtime::AgentTurnInput::from_wire(
+            &json!({"sessionId":"thread", "turnId":"turn"}),
+            &json!({}),
+        )
+        .unwrap();
+        let record = crate::agent::bridge::native_agent_turn_start_record(&input, "thread", "turn");
+        let message = crate::threads::rollout::format::ResponseItem::from_value(json!({
+            "role":"user", "content":"Please remember that I prefer Chinese.", "turnId":"turn",
+        }))
+        .unwrap();
+        threads
+            .start_agent_turn(record, None, vec![message])
+            .unwrap();
+        threads
+            .complete_agent_turn(
+                "thread",
+                "turn",
+                "final_response",
+                Some("Done".into()),
+                None,
+            )
+            .unwrap();
+        let store = MemoryStore::new(&data);
+        store.initialize().unwrap();
+        let scope = crate::memory::normalized_workspace_path(&root).unwrap();
+        Self {
+            root,
+            threads,
+            store,
+            scope,
+        }
+    }
+
+    fn schedule(&self, runtime: &MemoryRuntime) -> Result<(), String> {
+        runtime.schedule_turn_extraction(
+            self.threads.clone(),
+            json!({"revision": 2}),
+            "thread".into(),
+            "turn".into(),
+            self.scope.clone(),
+        )
+    }
+
+    fn pending(&self) -> usize {
+        self.store.pending_turns(&self.scope, 10).unwrap().len()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.threads.shutdown().unwrap();
+        std::fs::remove_dir_all(&self.root).unwrap();
+    }
+}
+
+struct Model {
+    calls: AtomicUsize,
+    dropped: AtomicUsize,
+    fail_once: AtomicBool,
+    started: Notify,
+    release: Semaphore,
+}
+
+impl Model {
+    fn new(fail_once: bool, permits: usize) -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            dropped: AtomicUsize::new(0),
+            fail_once: AtomicBool::new(fail_once),
+            started: Notify::new(),
+            release: Semaphore::new(permits),
+        }
+    }
+}
+
+struct RequestGuard<'a>(&'a AtomicUsize);
+impl Drop for RequestGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl MemoryModel for Model {
+    fn extract<'a>(
+        &'a self,
+        config: &'a Value,
+        evidence: &'a TurnEvidence,
+    ) -> BoxFuture<'a, Result<Vec<ExtractedMemory>, String>> {
+        Box::pin(async move {
+            assert!(!evidence.user_messages.is_empty());
+            assert_eq!(config["revision"], 2);
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let _guard = RequestGuard(&self.dropped);
+            self.started.notify_one();
+            if self.fail_once.swap(false, Ordering::SeqCst) {
+                return Err("fixture model failure".into());
+            }
+            self.release.acquire().await.unwrap().forget();
+            Ok(vec![ExtractedMemory {
+                scope: MemoryScope::User,
+                content: "Prefers Chinese.".into(),
+            }])
+        })
+    }
+    fn select<'a>(
+        &'a self,
+        _config: &'a Value,
+        input: &'a Phase2Input,
+    ) -> BoxFuture<'a, Result<SelectionDiff, String>> {
+        Box::pin(async move {
+            Ok(SelectionDiff {
+                add: input
+                    .fragments
+                    .iter()
+                    .map(|m| SelectionAdd {
+                        scope: m.scope,
+                        path: m.path.clone(),
+                        content: m.content.clone(),
+                    })
+                    .collect(),
+                update: vec![],
+                remove: vec![],
+            })
+        })
+    }
+}
+
+async fn wait_for(mut condition: impl FnMut() -> bool) {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while !condition() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("observable worker state should converge");
+}
+
+#[test]
+fn shutdown_drops_in_flight_model_work_and_restart_recovers_durable_queue() {
+    tauri::async_runtime::block_on(async {
+        let fixture = Fixture::new();
+        let model = Arc::new(Model::new(false, 0));
+        let mut runtime = MemoryRuntime::new(model.clone());
+        runtime.heartbeat_interval = Duration::from_millis(20);
+        fixture.schedule(&runtime).unwrap();
+        tokio::time::timeout(Duration::from_secs(3), model.started.notified())
+            .await
+            .unwrap();
+        runtime.shutdown(Duration::from_secs(1)).await.unwrap();
+        assert_eq!(
+            model.dropped.load(Ordering::SeqCst),
+            1,
+            "shutdown joins the cancelled request"
+        );
+        assert_eq!(fixture.pending(), 1);
+        assert!(fixture
+            .schedule(&runtime)
+            .unwrap_err()
+            .contains("not accepting"));
+        assert!(runtime.state.lock().unwrap().workers.is_empty());
+
+        model.release.add_permits(1);
+        runtime
+            .start(fixture.threads.clone(), json!({"revision": 2}))
+            .unwrap();
+        wait_for(|| fixture.pending() == 0).await;
+        wait_for(|| !fixture.store.active_memories().unwrap().is_empty()).await;
+        runtime.shutdown(Duration::from_secs(1)).await.unwrap();
+        assert_eq!(model.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            fixture.store.active_memories().unwrap()[0].content,
+            "Prefers Chinese."
+        );
+        assert!(
+            !fixture.root.join(".tinybot/state/memory.sqlite").exists(),
+            "storage uses the injected data directory"
+        );
+    });
+}
+
+#[test]
+fn model_failure_remains_pending_until_heartbeat_retry_succeeds() {
+    tauri::async_runtime::block_on(async {
+        let fixture = Fixture::new();
+        let model = Arc::new(Model::new(true, 0));
+        let mut runtime = MemoryRuntime::new(model.clone());
+        runtime.heartbeat_interval = Duration::from_millis(20);
+        fixture.schedule(&runtime).unwrap();
+        wait_for(|| model.calls.load(Ordering::SeqCst) >= 2).await;
+        assert_eq!(
+            fixture.pending(),
+            1,
+            "failed and unfinished work must remain durable"
+        );
+        model.release.add_permits(1);
+        wait_for(|| fixture.pending() == 0).await;
+        runtime.shutdown(Duration::from_secs(1)).await.unwrap();
+        assert_eq!(model.calls.load(Ordering::SeqCst), 2);
+    });
+}

--- a/src-tauri/src/memory/store.rs
+++ b/src-tauri/src/memory/store.rs
@@ -18,16 +18,10 @@ pub(crate) struct MemoryStore {
 }
 
 impl MemoryStore {
-    pub(crate) fn for_workspace(workspace_root: &Path) -> Self {
-        #[cfg(not(test))]
-        let data_root = crate::config::application::tinybot_data_root();
-        #[cfg(test)]
-        let data_root = workspace_root.join(".tinybot");
-        #[cfg(not(test))]
-        let _ = workspace_root;
+    pub(crate) fn new(data_root: &Path) -> Self {
         Self {
-            database_path: data_root.join("state").join("memory.sqlite"),
-            markdown_path: data_root.join("memory").join("raw_memories.md"),
+            database_path: data_root.join("state/memory.sqlite"),
+            markdown_path: data_root.join("memory/raw_memories.md"),
         }
     }
 

--- a/src-tauri/src/memory/tests.rs
+++ b/src-tauri/src/memory/tests.rs
@@ -32,7 +32,7 @@ impl MemoryFixture {
         ));
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&root).unwrap();
-        let store = MemoryStore::for_workspace(&root);
+        let store = MemoryStore::new(&root.join(".tinybot"));
         store.initialize().unwrap();
         let workspace_path = normalized_workspace_path(&root).unwrap();
         Self {

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -3,6 +3,5 @@ mod manifest;
 mod runtime;
 mod store;
 
-pub(crate) use manifest::PluginSkill;
 pub(crate) use runtime::merge_enabled_mcp_servers;
 pub(crate) use store::PluginStore;

--- a/src-tauri/src/rpc/README.md
+++ b/src-tauri/src/rpc/README.md
@@ -3,7 +3,7 @@
 Turn-persistence dispatch adapts wire parameters to the typed workspace store
 service. Internal Agent persistence calls that service directly, sharing its
 lifecycle lock, canonical writes, projection synchronization, and recovery.
-<!-- tinybot-module-fingerprint: sha256:430d24325db24e87a92ab79b8cd96f64318303d8f6738a6ba161629f753440e9 -->
+<!-- tinybot-module-fingerprint: sha256:016eb43b8337b8ef2d687ebbab6de61e874713e4489fa34abd143eed3d9c705b -->
 
 `rpc` is the versioned method-routing boundary for native backend services.
 The module root is `mod.rs`; protocol envelopes and parameter validation live
@@ -83,6 +83,8 @@ Runtime lifecycle changes belong to the application lifecycle owner.
 - Unknown methods fail explicitly; dispatch must not silently no-op.
 - Tool methods validate typed parameters, capability grants, and availability
   before dispatch.
+- Generic tool execution rejects runtime controls, Agent Graphs, and workspace
+  Thread orchestration targets. Their execution requires the owning Agent path.
 - The generic tool executor maps authoritative Turn context to `ownerId` for
   retained Shell process operations instead of forwarding `sessionId`, whose
   legacy Shell alias identifies a process rather than an Agent session.

--- a/src-tauri/src/rpc/mod.rs
+++ b/src-tauri/src/rpc/mod.rs
@@ -323,7 +323,10 @@ impl WorkerRpcRouter {
                     "session_id": params.session_id,
                 }),
             ),
-            ToolExecutionTarget::RuntimeControl(_) | ToolExecutionTarget::AgentGraph { .. } => {
+            ToolExecutionTarget::RuntimeControl(_)
+            | ToolExecutionTarget::AgentGraph { .. }
+            | ToolExecutionTarget::SpawnWorkspaceThread
+            | ToolExecutionTarget::SendThreadMessage => {
                 return Err(WorkerProtocolError::new(
                     WorkerProtocolErrorCode::InvalidProtocol,
                     "runtime-owned tools cannot be dispatched through tool_executor.execute",

--- a/src-tauri/src/runtime/README.md
+++ b/src-tauri/src/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Runtime Services
-<!-- tinybot-module-fingerprint: sha256:34c7d5867f84f0ce4658f260a8a1410f24a4fc83cf5f52114b271543b932eda5 -->
+<!-- tinybot-module-fingerprint: sha256:c6f6ba4f93edd9ac52f45c288aeea1f6bc586f8081b250ba0c32c105f4ca0478 -->
 
 `runtime` owns process-local services that must outlive an individual backend
 request: turn execution ownership, shared MCP connections, startup/shutdown
@@ -54,9 +54,11 @@ Startup reconciliation runs before the runtime accepts new agent work. It:
 4. Records a queryable recovery report or a visible startup failure.
 
 Shutdown stops accepting new work, requests cancellation, drains owned agent
-tasks, cleans up shell processes, MCP connections, and subagents, then flushes
+tasks, cancels and joins application-owned Memory workers, cleans up shell
+processes, MCP connections, and subagents, then flushes
 or shuts down Thread persistence. All stage failures remain in the lifecycle
-report.
+report, including a separate `memory` stage. Pending Memory jobs remain durable
+and resume on the heartbeat after runtime startup succeeds.
 
 ## Invariants
 

--- a/src-tauri/src/runtime/lifecycle.rs
+++ b/src-tauri/src/runtime/lifecycle.rs
@@ -63,6 +63,7 @@ pub(crate) struct RuntimeShutdownReport {
     pub(crate) agent_tasks: ShutdownReport,
     pub(crate) shell: ShellProcessCleanupReport,
     pub(crate) mcp: LifecycleStageReport,
+    pub(crate) memory: LifecycleStageReport,
     pub(crate) subagents: SubagentShutdownReport,
     pub(crate) state_persistence: LifecycleStageReport,
     pub(crate) failures: Vec<LifecycleFailure>,
@@ -131,6 +132,7 @@ pub(crate) struct RuntimeLifecycle {
     agent_tasks: TurnExecutionRuntime,
     shell: WorkerShellRuntime,
     mcp: McpRuntime,
+    memory: crate::memory::MemoryRuntime,
     subagents: SubagentThreadManager,
     threads: WorkspaceThreadStore,
 }
@@ -140,6 +142,7 @@ impl RuntimeLifecycle {
         agent_tasks: TurnExecutionRuntime,
         shell: WorkerShellRuntime,
         mcp: McpRuntime,
+        memory: crate::memory::MemoryRuntime,
         subagents: SubagentThreadManager,
         threads: WorkspaceThreadStore,
     ) -> Self {
@@ -147,6 +150,7 @@ impl RuntimeLifecycle {
             agent_tasks,
             shell,
             mcp,
+            memory,
             subagents,
             threads,
         }
@@ -171,6 +175,24 @@ impl RuntimeLifecycle {
                 ),
             });
         }
+
+        let memory = match self.memory.shutdown(timeout).await {
+            Ok(()) => LifecycleStageReport {
+                completed: true,
+                detail: "memory workers stopped; pending extractions remain durable".into(),
+            },
+            Err(message) => {
+                failures.push(LifecycleFailure {
+                    stage: "memory".into(),
+                    code: "shutdown_failed".into(),
+                    message: message.clone(),
+                });
+                LifecycleStageReport {
+                    completed: false,
+                    detail: message,
+                }
+            }
+        };
 
         let shell = self.shell.shutdown();
         failures.extend(
@@ -290,6 +312,7 @@ impl RuntimeLifecycle {
             agent_tasks,
             shell,
             mcp,
+            memory,
             subagents,
             state_persistence,
             failures,

--- a/src-tauri/src/threads/rollout/store/README.md
+++ b/src-tauri/src/threads/rollout/store/README.md
@@ -1,5 +1,5 @@
 # Worker Thread Log
-<!-- tinybot-module-fingerprint: sha256:d045339106b244179687b64419690af029a5265f1280cbd3de1b7f72d44ae202 -->
+<!-- tinybot-module-fingerprint: sha256:b1b76c04dac503a66175be0add3210a6cccdef256a5cee7be402effe9e81fc8b -->
 
 `threads::rollout::store` owns Tinybot's canonical append-only Rollout. It validates
 paths, records typed lines, reconstructs Thread and runtime projections,

--- a/src-tauri/src/threads/rollout/store/mod.rs
+++ b/src-tauri/src/threads/rollout/store/mod.rs
@@ -71,6 +71,7 @@ pub struct WorkerThreadLogRpc {
     canonical_scan_count: Arc<AtomicUsize>,
     #[cfg(test)]
     projection_read_count: Arc<AtomicUsize>,
+    memory_store: crate::memory::MemoryStore,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -198,6 +199,7 @@ impl WorkerThreadLogRpc {
             recorder,
             workspace_root,
             thread_root: data_root.join("threads"),
+            memory_store: crate::memory::MemoryStore::new(&data_root),
             archive_root: data_root.join("archived_threads"),
             state: ThreadStateIndex::new(),
             policy,
@@ -255,7 +257,7 @@ impl WorkerThreadLogRpc {
                     }),
                 )
             })?;
-        crate::memory::MemoryStore::for_workspace(&self.workspace_root)
+        self.memory_store
             .render_thread_snapshot(&workspace_path)
             .map_err(|error| {
                 thread_log_consistency_error(

--- a/src-tauri/src/tools/registry/README.md
+++ b/src-tauri/src/tools/registry/README.md
@@ -1,5 +1,5 @@
 # Tool Registry
-<!-- tinybot-module-fingerprint: sha256:c74093ca439bcb3ee863d9f8832179cba87bf0001f6eaa0794e986820f0c6840 -->
+<!-- tinybot-module-fingerprint: sha256:c1635b4384415d7174dd3d9f73348e8fd46944650709c79f457b27c5f289839c -->
 
 `registry` is the catalog of tools available to the runtime. Each entry records
 its schema, exposure, execution target, required capabilities, cancellation
@@ -15,6 +15,11 @@ workspace, Graph ID, and revision; their provider schema exposes only the
 transient Run input. Dynamic contributors must enforce their eligibility scope
 so coordinator-only or cross-workspace tools do not appear in ordinary
 Threads.
+
+Workspace-thread spawn and send entries have dedicated execution targets handled
+by the Agent bridge dispatcher. They are not loop-state runtime controls. Their
+schemas, capability grants, parallelism, and cancellation policy remain registry
+metadata; the bridge rechecks project membership and parent ownership on execution.
 
 Provider-visible schemas include nested contracts used by native validation.
 For `publish_data_view`, this includes supported view kinds and the table

--- a/src-tauri/src/tools/registry/contributors.rs
+++ b/src-tauri/src/tools/registry/contributors.rs
@@ -367,9 +367,7 @@ impl ToolContributor for WorkspaceThreadToolContributor {
                     "additionalProperties": false
                 }),
                 output_schema: result_schema.clone(),
-                execution_target: ToolExecutionTarget::RuntimeControl(
-                    ToolRuntimeControl::SpawnWorkspaceThread,
-                ),
+                execution_target: ToolExecutionTarget::SpawnWorkspaceThread,
             },
             ToolRegistryEntry {
                 tool_id: SEND_THREAD_MESSAGE_METHOD.to_string(),
@@ -396,9 +394,7 @@ impl ToolContributor for WorkspaceThreadToolContributor {
                     "additionalProperties": false
                 }),
                 output_schema: result_schema,
-                execution_target: ToolExecutionTarget::RuntimeControl(
-                    ToolRuntimeControl::SendThreadMessage,
-                ),
+                execution_target: ToolExecutionTarget::SendThreadMessage,
             },
         ]
     }

--- a/src-tauri/src/tools/registry/mod.rs
+++ b/src-tauri/src/tools/registry/mod.rs
@@ -95,6 +95,8 @@ pub enum ToolExecutionTarget {
         graph_id: String,
         graph_revision: String,
     },
+    SpawnWorkspaceThread,
+    SendThreadMessage,
     RuntimeControl(ToolRuntimeControl),
 }
 
@@ -102,8 +104,6 @@ pub enum ToolExecutionTarget {
 pub enum ToolRuntimeControl {
     PublishDataView,
     RequestUserInput,
-    SpawnWorkspaceThread,
-    SendThreadMessage,
     UpdatePlan,
 }
 

--- a/src-tauri/src/tools/registry/registry_tests.rs
+++ b/src-tauri/src/tools/registry/registry_tests.rs
@@ -315,11 +315,11 @@ fn workspace_thread_contributor_exposes_exact_result_contract() {
 
     assert_eq!(
         spawn.execution_target,
-        ToolExecutionTarget::RuntimeControl(ToolRuntimeControl::SpawnWorkspaceThread)
+        ToolExecutionTarget::SpawnWorkspaceThread
     );
     assert_eq!(
         send.execution_target,
-        ToolExecutionTarget::RuntimeControl(ToolRuntimeControl::SendThreadMessage)
+        ToolExecutionTarget::SendThreadMessage
     );
     assert_eq!(
         spawn.input_schema["properties"]["workspaceId"]["enum"],

--- a/src-tauri/tests/crate/lifecycle.rs
+++ b/src-tauri/tests/crate/lifecycle.rs
@@ -114,10 +114,6 @@ lines.on("close", () => {
     .expect("MCP shutdown fixture should start");
     let mut runtime = NativeRuntimeState::default();
     runtime.mcp_runtime = mcp_runtime.clone();
-    runtime.native_agent_runtime = runtime
-        .native_agent_runtime
-        .clone()
-        .with_mcp_runtime(mcp_runtime.clone());
     let shared = Arc::new(Mutex::new(runtime));
 
     shutdown_native_runtime(&shared, false).expect("app shutdown should stop MCP runtime");
@@ -485,7 +481,7 @@ fn close_shutdown_stops_shell_and_interrupts_subagents_with_report() {
     let (shell_runtime, subagents) = {
         let runtime = lock_runtime(&shared);
         (
-            runtime.native_agent_runtime.shell_runtime(),
+            runtime.shell_runtime.clone(),
             runtime.subagent_manager.clone(),
         )
     };
@@ -932,4 +928,36 @@ lines.on("line", (line) => {
         serde_json::json!({}),
     ));
     assert!(shutdown.error.is_none(), "{:?}", shutdown.error);
+}
+#[test]
+fn runtime_initialization_reports_migration_conflicts_before_creating_state() {
+    let fixture = WorkspaceFixture::new();
+    let data_root = fixture.root.join("application-data");
+    let legacy = fixture.root.join(".tinybot/threads/initialization-fixture");
+    let target = data_root.join("threads/initialization-fixture");
+    std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::fs::write(&legacy, "legacy content").unwrap();
+    std::fs::write(&target, "conflicting content").unwrap();
+
+    let error = match NativeRuntimeState::initialize(fixture.root.clone(), data_root.clone()) {
+        Ok(_) => panic!("conflicting storage must prevent runtime initialization"),
+        Err(error) => error,
+    };
+    assert!(error.contains("thread storage initialization failed"));
+    assert!(error.contains(&fixture.root.display().to_string()));
+    assert!(error.contains(&data_root.display().to_string()));
+    assert_eq!(std::fs::read_to_string(&legacy).unwrap(), "legacy content");
+    assert_eq!(
+        std::fs::read_to_string(&target).unwrap(),
+        "conflicting content"
+    );
+
+    std::fs::remove_file(&target).unwrap();
+    let state = NativeRuntimeState::initialize(fixture.root.clone(), data_root.clone()).unwrap();
+    assert_eq!(state.thread_store.data_root(), data_root);
+    assert_eq!(state.thread_store.workspace_root(), fixture.root);
+    assert_eq!(std::fs::read_to_string(target).unwrap(), "legacy content");
+    assert!(!legacy.exists());
+    assert!(state.last_error.is_none());
 }

--- a/src-tauri/tests/crate/threads.rs
+++ b/src-tauri/tests/crate/threads.rs
@@ -158,7 +158,7 @@ fn worker_submit_thread_turn_creates_thread_and_runs_native_agent() {
 fn worker_submit_thread_turn_forwards_live_streaming_timeline_patches() {
     struct StreamingProvider;
 
-    impl crate::agent::runtime::NativeAgentProvider for StreamingProvider {
+    impl crate::agent::runtime::test_support::BlockingTestProvider for StreamingProvider {
         fn complete(
             &self,
             _context: &crate::agent::runtime::AgentTurnContext,

--- a/src-tauri/tests/crate/threads.rs
+++ b/src-tauri/tests/crate/threads.rs
@@ -7,7 +7,7 @@ fn persist_native_agent_turn_start(
     let root = workspace.root.clone();
     let request =
         crate::agent::bridge::turn_request::AgentTurnRequest::from_wire(spec, &config, &root)?;
-    let instructions = crate::agent::runtime::InstructionComposer::default()
+    let instructions = crate::agent::instruction_sources::InstructionLoader::default()
         .compose_input(&root, &request.instructions)?;
     crate::agent::bridge::persist_native_agent_turn_start(&request, &instructions, store)
 }

--- a/src-tauri/tests/crate/turns.rs
+++ b/src-tauri/tests/crate/turns.rs
@@ -318,7 +318,7 @@ fn worker_run_agent_stops_before_provider_when_run_start_persistence_fails() {
         calls: Arc<Mutex<usize>>,
     }
 
-    impl crate::agent::runtime::NativeAgentProvider for CountingProvider {
+    impl crate::agent::runtime::test_support::BlockingTestProvider for CountingProvider {
         fn complete(
             &self,
             _context: &crate::agent::runtime::AgentTurnContext,
@@ -383,7 +383,7 @@ fn worker_run_agent_fails_when_trace_persistence_breaks_after_provider_response(
         calls: Arc<Mutex<usize>>,
     }
 
-    impl crate::agent::runtime::NativeAgentProvider for PersistenceBreakingProvider {
+    impl crate::agent::runtime::test_support::BlockingTestProvider for PersistenceBreakingProvider {
         fn complete(
             &self,
             _context: &crate::agent::runtime::AgentTurnContext,
@@ -451,7 +451,7 @@ fn worker_run_agent_fails_when_trace_persistence_breaks_after_provider_response(
 #[derive(Clone)]
 struct UsageNativeAgentProvider;
 
-impl crate::agent::runtime::NativeAgentProvider for UsageNativeAgentProvider {
+impl crate::agent::runtime::test_support::BlockingTestProvider for UsageNativeAgentProvider {
     fn complete(
         &self,
         _context: &crate::agent::runtime::AgentTurnContext,
@@ -477,7 +477,7 @@ fn long_final_content() -> String {
 #[derive(Clone)]
 struct LongFinalNativeAgentProvider;
 
-impl crate::agent::runtime::NativeAgentProvider for LongFinalNativeAgentProvider {
+impl crate::agent::runtime::test_support::BlockingTestProvider for LongFinalNativeAgentProvider {
     fn complete(
         &self,
         _context: &crate::agent::runtime::AgentTurnContext,
@@ -497,7 +497,7 @@ struct RecordingNativeAgentProvider {
     calls: Arc<Mutex<Vec<Vec<serde_json::Value>>>>,
 }
 
-impl crate::agent::runtime::NativeAgentProvider for RecordingNativeAgentProvider {
+impl crate::agent::runtime::test_support::BlockingTestProvider for RecordingNativeAgentProvider {
     fn complete(
         &self,
         context: &crate::agent::runtime::AgentTurnContext,
@@ -521,7 +521,9 @@ struct ToolLoopRecordingNativeAgentProvider {
     calls: Arc<Mutex<Vec<Vec<serde_json::Value>>>>,
 }
 
-impl crate::agent::runtime::NativeAgentProvider for ToolLoopRecordingNativeAgentProvider {
+impl crate::agent::runtime::test_support::BlockingTestProvider
+    for ToolLoopRecordingNativeAgentProvider
+{
     fn complete(
         &self,
         context: &crate::agent::runtime::AgentTurnContext,
@@ -566,7 +568,7 @@ struct MultiExchangeRecallProvider {
     calls: Arc<Mutex<Vec<Vec<serde_json::Value>>>>,
 }
 
-impl crate::agent::runtime::NativeAgentProvider for MultiExchangeRecallProvider {
+impl crate::agent::runtime::test_support::BlockingTestProvider for MultiExchangeRecallProvider {
     fn complete(
         &self,
         context: &crate::agent::runtime::AgentTurnContext,

--- a/src-tauri/tests/crate/turns.rs
+++ b/src-tauri/tests/crate/turns.rs
@@ -51,6 +51,12 @@ fn worker_run_agent_uses_rust_runtime_when_selected() {
         .iter()
         .any(|event| event["eventName"] == "agent.message.completed"));
     assert_eq!(events.last().unwrap()["eventName"], "agent.done");
+    assert!(
+        !events
+            .iter()
+            .any(|event| event["eventName"] == "agent.hook.decision"),
+        "an unconfigured command hook must not emit synthetic decisions"
+    );
 }
 
 #[test]

--- a/src/react-workbench/chat/ChatPage.artifacts.test.tsx
+++ b/src/react-workbench/chat/ChatPage.artifacts.test.tsx
@@ -20,6 +20,27 @@ function setup(href = "report.md", workingDirectory = "D:\\work") {
 }
 
 describe("Artifact collaboration", () => {
+  it("opens a report's sibling PPT relative to the displayed Markdown file", async () => {
+    const user = userEvent.setup();
+    const root = "C:/Users/viewer/.tinybot/workspace";
+    const report = `${root}/github-agent-report/report.md`;
+    const ppt = `${root}/github-agent-report/github_agent_projects.pptx`;
+    const stores = createStores({ sessions: [{ id: "s1", chatId: "chat-1", title: "Files", updatedAtMs: 1, status: "idle", workingDirectory: "" }] });
+    stores.chatStore.load = vi.fn(async (id) => timelineFromReactMessages(id, [{
+      id: "file-message", role: "assistant", createdAtMs: 1, status: "complete",
+      text: `Open [report](${report}).`,
+    }]));
+    const readThreadFile = vi.fn(async ({ path }: { path: string }) => {
+      if (path === report) return { path, revision: "v1", content: "[Download PPT](./github_agent_projects.pptx)", contentType: "text" as const, sizeBytes: 55 };
+      if (path === ppt) return { path, revision: "v2", contentType: "binary" as const, sizeBytes: 158198 };
+      throw new Error(`failed to resolve workspace path; path=${root}/${path}`);
+    });
+    render(<ChatPage chatStore={stores.chatStore} sessionStore={stores.sessionStore} workspaceStore={{ readThreadFile }} />);
+    await user.click(await screen.findByRole("link", { name: "report" }));
+    await user.click(await screen.findByRole("link", { name: "Download PPT" }));
+    await waitFor(() => expect(readThreadFile).toHaveBeenCalledWith({ path: ppt, threadId: "s1" }));
+  });
+
   it("attaches the displayed file and its revision without replacing the draft", async () => {
     const user = userEvent.setup();
     const stores = setup();

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:cafe12dd20c99c1c542ef42403764cb62a21890803e2500d7258aed5f06aead3 -->
+<!-- tinybot-module-fingerprint: sha256:2101d3ed902e4c6715c1f09817b995e39dd6f51d4ff9fdf866339775961ad538 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.

--- a/src/react-workbench/chat/assistantFileLinks.test.ts
+++ b/src/react-workbench/chat/assistantFileLinks.test.ts
@@ -36,6 +36,24 @@ describe("assistant file links", () => {
       .toThrowError(expect.objectContaining({ code: "outside_workspace" }));
   });
 
+  it("resolves document links from their parent directory while keeping the workspace boundary", () => {
+    const root = "C:/Users/viewer/.tinybot/workspace";
+    expect(resolveAssistantFileLink("./github_agent_projects.pptx", root, "github-agent-report/report.md").path)
+      .toBe("github-agent-report/github_agent_projects.pptx");
+    expect(resolveAssistantFileLink("../data.csv#L12", root, "github-agent-report/report.md"))
+      .toEqual({ path: "data.csv", title: "data.csv", line: 12 });
+    expect(resolveAssistantFileLink("./nested/../Hello%20World.md", "", `${root}/github-agent-report/report.md`).path)
+      .toBe(`${root}/github-agent-report/Hello World.md`);
+    expect(resolveAssistantFileLink("./chart.png", root, "reports/100%20done#final/report.md").path)
+      .toBe("reports/100%20done#final/chart.png");
+    expect(resolveAssistantFileLink("C:/Users/viewer/.tinybot/workspace/data.csv", root, "github-agent-report/report.md").path)
+      .toBe("data.csv");
+    expect(() => resolveAssistantFileLink("../../secret.txt", root, "github-agent-report/report.md"))
+      .toThrowError(expect.objectContaining({ code: "outside_workspace" }));
+    expect(() => resolveAssistantFileLink("../../secret.txt", root, `${root}/github-agent-report/report.md`))
+      .toThrowError(expect.objectContaining({ code: "outside_workspace" }));
+  });
+
   it("projects a deterministic text artifact from the resolved file", () => {
     expect(assistantFileArtifact({ path: "docs/guide.md", title: "guide.md" })).toEqual({
       fetchPath: "docs/guide.md",

--- a/src/react-workbench/chat/assistantFileLinks.ts
+++ b/src/react-workbench/chat/assistantFileLinks.ts
@@ -2,6 +2,8 @@ import type { ArtifactRef } from "../../app-core/chat/chatTurnContracts";
 
 export type AssistantFileLink = {
   href: string;
+  /** Resolved file path of the document containing this link; not a URL. */
+  sourcePath?: string;
 };
 
 export type ResolvedAssistantFileLink = {
@@ -36,12 +38,15 @@ export function isAssistantFileHref(href: string): boolean {
   return !EXTERNAL_PROTOCOL.test(value);
 }
 
-export function resolveAssistantFileLink(href: string, workspaceRoot = ""): ResolvedAssistantFileLink {
+export function resolveAssistantFileLink(href: string, workspaceRoot = "", sourcePath?: string): ResolvedAssistantFileLink {
   const decoded = decodeAssistantFileHref(href);
   const fragmentLine = lineFromFragment(decoded.fragment);
   const suffix = stripLineSuffix(decoded.path);
   const line = fragmentLine ?? suffix.line;
-  const candidate = normalizeSlashes(suffix.path);
+  const target = normalizeSlashes(suffix.path);
+  const candidate = sourcePath && !isAbsolutePath(target)
+    ? resolveDocumentRelativePath(target, normalizeSlashes(sourcePath))
+    : target;
   const normalizedRoot = normalizeSlashes(workspaceRoot).replace(/\/+$/, "");
   let relativePath = candidate;
 
@@ -146,6 +151,24 @@ function normalizeRelativePath(value: string): string {
     throw new AssistantFileLinkError("outside_workspace", "The file is outside the active workspace.");
   }
   return segments.join("/");
+}
+
+function resolveDocumentRelativePath(target: string, sourcePath: string): string {
+  const segments = sourcePath.split("/").filter(Boolean);
+  segments.pop();
+  const rootDepth = WINDOWS_ABSOLUTE_PATH.test(sourcePath) ? 1 : 0;
+  for (const segment of target.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length <= rootDepth) {
+        throw new AssistantFileLinkError("outside_workspace", "The file is outside the active workspace.");
+      }
+      segments.pop();
+    } else {
+      segments.push(segment);
+    }
+  }
+  return `${sourcePath.startsWith("/") ? "/" : ""}${segments.join("/")}`;
 }
 
 function lineFromFragment(fragment: string): number | undefined {

--- a/src/react-workbench/sidecar/README.md
+++ b/src/react-workbench/sidecar/README.md
@@ -1,5 +1,5 @@
 # Sidecar
-<!-- tinybot-module-fingerprint: sha256:a7c10efb2501c41baa474fb3696d9739afbfd452cefb127c96df070a5440cb64 -->
+<!-- tinybot-module-fingerprint: sha256:97fa6bb5a3a7ac1f1ecd68a38851776fabce176c9e213ed72cf47d66fc26fe53 -->
 
 `sidecar` owns the React resource shell displayed beside Chat. It presents
 thread-scoped Browser and Artifact resources, workspace-scoped Terminal
@@ -87,7 +87,12 @@ Artifact domain state does not live in this module. Artifact tabs may come from
 canonical Agent artifacts or from local file links in assistant Markdown. File
 links are contextual only, so the resource menu does not create an empty
 Artifact tab. Sidecar presents Markdown Artifacts as rendered documents and keeps
-the Artifact panel as the single vertical scrolling surface. Modern Office
+the Artifact panel as the single vertical scrolling surface. Links inside a
+local Markdown preview carry that document's resolved path, so relative links
+resolve from its containing directory. Chat-message links retain their workspace
+base, absolute targets keep their own paths, and native workspace authorization
+remains authoritative. Link diagnostics record the source document, original
+href, and resolved target together. Modern Office
 files (`.xlsx`, `.docx`, and `.pptx`) are parsed locally into sheet, continuous
 document, and slide-list previews; plain text, image, and data-view Artifacts
 retain their type-specific previews. PowerPoint previews overlay a collapsed

--- a/src/react-workbench/sidecar/SidecarResources.tsx
+++ b/src/react-workbench/sidecar/SidecarResources.tsx
@@ -326,9 +326,9 @@ export function SidecarResources({ ref, activeSession, activeDisplaySession, act
 
     let artifact: ArtifactRef;
     try {
-      artifact = assistantFileArtifact(resolveAssistantFileLink(link.href, activeSession.workingDirectory));
+      artifact = assistantFileArtifact(resolveAssistantFileLink(link.href, activeSession.workingDirectory, link.sourcePath));
       logRendererEvent("info", "artifact.file_link.resolved", {
-        href: link.href, path: artifact.fetchPath, sessionId: activeSession.id,
+        href: link.href, sourcePath: link.sourcePath, path: artifact.fetchPath, sessionId: activeSession.id,
       });
     } catch (error) {
       artifact = assistantFileArtifact({ path: link.href, title: assistantFileLinkTitle(link.href) });
@@ -345,6 +345,7 @@ export function SidecarResources({ ref, activeSession, activeDisplaySession, act
       console.error("[artifact-preview] workspace file link resolution failed", {
         error,
         href: link.href,
+        sourcePath: link.sourcePath,
         sessionId: activeSession.id,
         workspaceRoot: activeSession.workingDirectory,
       });
@@ -612,7 +613,7 @@ function ArtifactDetails({
       {markdownContent ? (
         <article aria-label={markdownContent.title} className="react-artifact-detail__document" role="document">
           <AssistantMarkdown
-            onOpenFileLink={onOpenFileLink}
+            onOpenFileLink={(link) => onOpenFileLink({ ...link, sourcePath: localThreadId ? artifact.fetchPath : undefined })}
             streaming={false}
             text={markdownContent.text}
           />


### PR DESCRIPTION
## Summary

The Agent runtime previously mixed execution policy with concrete workspace services, command-hook construction, and process-global Memory workers. This change moves application resources and per-Turn assembly into the bridge, injects the runtime dependencies, and makes background Memory ownership explicit.

- Separate workspace orchestration, tool catalog assembly, instruction sources, and checkpoint/trace adapters from the execution core.
- Run hooks through one asynchronous interface. Unsupported command-hook stages return no runs, preserving terminal event ordering without synthetic Continue decisions. Invalid hook configuration fails preparation with diagnostics and persists a failed Turn before any provider request.
- Inject Memory model operations and the application data directory. Cancel and join application-owned workers before closing Thread persistence; unfinished extractions remain durable for restart and retry.
- Fix relative links inside local Markdown previews by carrying the source document path. For example, clicking `./github_agent_projects.pptx` inside `github-agent-report/report.md` now opens its sibling file instead of looking in the workspace root. Preserve workspace authorization and log the source and resolved target.
- Update architecture/API documentation and module fingerprints.

## Validation

- Replacement CI run [34373587623](https://github.com/SudoJacky/tinybot/actions/runs/34373587623) passed on `477b217b`: frontend, Windows, and desktop checks are green. Windows Rust tests: 1100 passed, 1 ignored, 0 failed. Installer build steps were skipped by workflow conditions.

- Rust library suite: 1099 passed, 1 ignored, 1 known failure. `desktop_terminal::tests::creates_each_terminal_resource_only_once` fails with Windows process termination access denied (OS error 5); the same failure was reproduced on the baseline and is unrelated to these changes.
- Targeted hook tests: 17 passed. The CI-failing `worker_run_agent_uses_rust_runtime_when_selected` was reproduced locally and passes after the adapter fix; its regression assertion now also rejects synthetic decisions when no command hooks are configured. The full Rust suite was rerun with CI's `--test-threads=1` setting, with only the known local terminal permission failure remaining.
- Frontend Markdown, file-link, artifact, and timeline tests: 57 passed, including the report-to-sibling-PPT regression reproduced before the fix.
- `cargo check --manifest-path src-tauri/Cargo.toml --lib`, Rust formatting, `npm run typecheck`, and staged documentation/README freshness checks passed.

