### PR TITLE
Fix form completion state and refine the chat workbench UI

### DIFF
--- a/docs/api/agent-runtime.md
+++ b/docs/api/agent-runtime.md
@@ -6,7 +6,7 @@ src-tauri/src/agent/runtime_protocol_tests.rs
 src-tauri/src/desktop_commands/runtime.rs
 src-tauri/src/desktop_commands/runtime_tests.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:afd287b5e77769d3a787c1cefd186988952fe71dcccbd4c57f40786ca92b888e -->
+<!-- tinybot-doc-fingerprint: sha256:db8fec478c26c2f23796d627b97b8008f6a8b75ab3c6458633c8d097b2b2575d -->
 
 This document covers native Agent turn execution and provider-facing behavior.
 It is part of the [Rust backend API reference](rust-backend-api.md), which
@@ -215,3 +215,7 @@ after its active Turn stops, continue the conversation through the normal compos
 resolution and before any resumed provider request, so transport callers do not wait for the
 provider response to confirm submission. Submitting resumes the same provider chain, while
 cancellation returns `stopReason: "form_cancelled"`.
+
+Accepted form resolutions are persisted as `agent.form.resolution` before their
+completed timeline Item is published. Replay consumes the matching waiting
+checkpoint and returns the same Turn to running, restoring cancellation capability.

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -9,7 +9,7 @@ src/app-core/native/desktopNativeTauriEvents.ts
 src/app-core/native/desktopNativeTauriEvents.test.ts
 src/react-workbench/adapters/desktopNativeEventBridge.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:cef6f29fdaa854720c19ca7285c9a923b45caaa8e4a73c36c9aa394d6b65bf5d -->
+<!-- tinybot-doc-fingerprint: sha256:6a32ced58c9ee9279c705c38ace56c9cf9de660982e1395ebfbce6755a637875 -->
 
 This document lists frontend-visible events emitted by the native runtime. It
 is part of the [Rust backend API reference](rust-backend-api.md), which defines
@@ -49,6 +49,11 @@ context compaction/trimming, errors/cancellation, usage updates, and user file/i
 Runtime event `itemId` is derived from the same typed item ID, so live delivery, trace persistence,
 and replay refer to one semantic item. Unknown or malformed internally constructed semantic events
 fail at the projection boundary instead of being persisted as an incomplete item.
+
+`agent.form.resolution` is durable and carries the form identity, submit/cancel
+action, values, and command correlation. Its completed timeline Item is published
+after persistence. The desktop bridge uses that Item to resolve the interactive
+form cache and notify Chat; late awaiting-form delivery cannot reopen it.
 
 `agent.plan.progress` is durable and carries the complete current plan snapshot. Repeated updates
 revise the same Turn-local plan item, and an authoritative timeline reload restores the latest

--- a/docs/api/tools-and-processes.md
+++ b/docs/api/tools-and-processes.md
@@ -14,7 +14,7 @@ src-tauri/src/rpc/tests/threads_and_tools.rs
 src-tauri/tests/crate/retry.rs
 src/app-core/native/desktopNativeThreads.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:533b3a3b89b92153e3b19750fb8fa3e3f150251f6a790920c3f839601dace52f -->
+<!-- tinybot-doc-fingerprint: sha256:94b3f560095d0bb2b628172d50c8ba5f21fdbc1166c018ed79af57611a6c8698 -->
 
 This document covers native tool processes, background execution, and browser
 sessions. It is part of the [Rust backend API reference](rust-backend-api.md),
@@ -71,7 +71,9 @@ For `shell.write_stdin`, empty input collects output until the process finishes
 or the wait deadline expires. Its default wait is 30 seconds; explicit waits
 are clamped to 5-300 seconds, including a request for zero. New progress logs
 do not end the wait. Process exit and cancellation return early, while reaching
-the deadline leaves the process running. Supply the previous result's `cursor`
+the deadline leaves the process running. Waits recheck the monotonic deadline
+after every condition-variable wakeup, including timeout reports from the
+platform timer. Supply the previous result's `cursor`
 to retrieve only subsequent output. Running Agent results suggest this same
 30-second continuation through `nextAction`.
 

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -22,7 +22,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:9acb94eaea607edbf77eef9db7fdb556600eccc061bb34625959e0732395e8de -->
+<!-- tinybot-doc-fingerprint: sha256:9872376cb0956022a81f0936b14721517ca1883069c7685a8e02a910eebf521f -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal
@@ -220,6 +220,9 @@ derives these figures from canonical Items on live updates and history reload.
 - A form submit or cancel command is acknowledged with its command identity
   before provider work resumes. Submitted values become the original pending
   tool call's model-visible result in that same provider chain.
+- A form resolution is persisted before its completed timeline Item is published.
+  Replay consumes the matching waiting checkpoint and restores the same Turn to
+  running; cancellation capabilities therefore reflect the resumed execution.
 - Cancellation is cooperative at provider and tool seams. A replaced
   generation may drain, but its late result cannot become the current terminal
   result.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:ff3e0c6ccd97367741c60b2099a99fe399c8d8d3c6fbda958faa76b4b6990f43 -->
+<!-- tinybot-doc-fingerprint: sha256:ac8b9b5765a8db35dda668919810ab43b54bd3f4f6676c0878d96405c6c24c4d -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -48,6 +48,12 @@ Before dispatch, Chat asks the native Workspace service to save the original
 bytes. Sidecar presents value/preview comparisons and explicit keep/restore
 actions; native storage owns the baseline and exact-content conflict checks.
 Keeping acknowledges the live file, while restoring atomically replaces it.
+
+Form answers resume the same Turn. Native persistence owns the resolution
+boundary and consumes its waiting checkpoint before publishing the completed
+form Item. Renderer adapters reconcile the interactive form from that Item,
+and Chat refreshes cancellation capabilities when the resolution arrives.
+Plan progress remains available through a top-right capsule and expandable details.
 
 ## System map
 

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,7 +9,7 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:8887faa06fdeacdfb24b55e38634b8ead2e4646e1f030e06ab8d72b38e22b8d9 -->
+<!-- tinybot-doc-fingerprint: sha256:2aef2e5e0cbc0fbb8b56a5be82377d41414f87308b2b6109af8731f0d6f0d783 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the
@@ -119,6 +119,11 @@ diagnostic redaction or truncation. Blocking status boundaries and Turn exits
 are durable barriers. Eligible events may be appended in bounded batches while
 preserving their causal order, identity, timestamp, and sequence; streaming
 deltas and non-blocking status updates remain live-only.
+
+Form resolutions are durable semantic Items. Replay consumes the matching
+waiting checkpoint at that append position and restores the same Turn to running.
+Later checkpoints still supersede that resolution in append order; renderer
+form state and cancellation capability queries therefore share the same boundary.
 
 In Responses mode, reasoning completion can reach a durability boundary before
 the provider-native response batch. The Rollout therefore stores the completed

--- a/src-tauri/src/agent/runtime_protocol/README.md
+++ b/src-tauri/src/agent/runtime_protocol/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Protocol
-<!-- tinybot-module-fingerprint: sha256:e7b4c8e2fac2a7d390b61b22ca5435f9deb487af19df5b1d63943cd004427a1e -->
+<!-- tinybot-module-fingerprint: sha256:bff1fdaee4c3e6fd14a249664a396ddadc3098a269a4bd9225a4509eb4eb1a53 -->
 
 `runtime_protocol` defines the durable events exchanged by the agent runtime
 and the projections built from them.
@@ -27,3 +27,7 @@ Usage Items optionally carry `modelTiming` with a model-call identity, TTFT,
 and decode duration in milliseconds. Typed live projection and durable replay
 retain the same values. Older v2 Items omit the field; no schema migration is
 needed and absent timing remains unavailable.
+
+Form resolution is a durable event. Its values and command correlation are
+persisted before the completed form timeline patch reaches the renderer.
+The initial form request remains represented durably by its awaiting-form checkpoint.

--- a/src-tauri/src/agent/runtime_protocol/event_catalog.rs
+++ b/src-tauri/src/agent/runtime_protocol/event_catalog.rs
@@ -577,7 +577,7 @@ impl AgentEventKind {
                 UserVisibility,
                 Some(Form),
                 FormIdentity,
-                Ephemeral,
+                Durable,
             ),
             Self::Checkpoint => definition(
                 "agent.checkpoint",

--- a/src-tauri/src/threads/domain/store/README.md
+++ b/src-tauri/src/threads/domain/store/README.md
@@ -1,5 +1,5 @@
 # Thread Stores
-<!-- tinybot-module-fingerprint: sha256:69fc0f62ef53d1a1ea7f558a7b4b3a5789645238bcee7403dff4c7b4bd446cb1 -->
+<!-- tinybot-module-fingerprint: sha256:cfb75e89e8281e5e3c5afad1010f7aa2accaf0f4318b808e7b1430a77d45ae79 -->
 
 This module implements thread storage operations and projections used by the
 thread domain.
@@ -21,3 +21,6 @@ event's source sequence as identity metadata.
 Generated-title mutation validates the first user Turn while holding the store
 lock, rejects archived or manually titled Threads, and records `titleSource` as
 `model` only when the compare-and-set succeeds.
+
+Runtime projection also replays persisted form resolutions as completed form
+Items, preserving submitted values and the original form identity.

--- a/src-tauri/src/threads/domain/store/runtime_projection.rs
+++ b/src-tauri/src/threads/domain/store/runtime_projection.rs
@@ -110,6 +110,7 @@ fn persisted_semantic_event(value: &Value) -> Option<(AgentEventKind, Value)> {
         EventNameResolution::Canonical(
             kind @ (AgentEventKind::ContextCompacted
             | AgentEventKind::ContextTrimmed
+            | AgentEventKind::FormResolution
             | AgentEventKind::PlanProgress
             | AgentEventKind::ReasoningCompleted
             | AgentEventKind::Usage

--- a/src-tauri/src/threads/rollout/store/README.md
+++ b/src-tauri/src/threads/rollout/store/README.md
@@ -1,5 +1,5 @@
 # Worker Thread Log
-<!-- tinybot-module-fingerprint: sha256:b1b76c04dac503a66175be0add3210a6cccdef256a5cee7be402effe9e81fc8b -->
+<!-- tinybot-module-fingerprint: sha256:726b3dc700566e9df7a84752c40ef5faa5e1e5ff58e38e3363c0709dd5c4cb18 -->
 
 `threads::rollout::store` owns Tinybot's canonical append-only Rollout. It validates
 paths, records typed lines, reconstructs Thread and runtime projections,
@@ -194,3 +194,8 @@ ordinal validation, reconstruction and projection build/install. Cache hit,
 miss and eviction counts plus decoded line bytes and line counts explain work
 volume. Timings can be nested; per-file I/O/parse sums are not wall-clock spans.
 The read/parse total retains failure outcomes without changing storage results.
+
+A durable form resolution consumes its matching waiting checkpoint and restores
+the same Turn to running before live publication. Replay applies this boundary
+in append order, so later form checkpoints still wait and completed answers
+cannot leave cancellation capabilities stuck in the waiting state.

--- a/src-tauri/src/threads/rollout/store/protocol_projection.rs
+++ b/src-tauri/src/threads/rollout/store/protocol_projection.rs
@@ -587,7 +587,7 @@ pub(super) fn semantic_thread_item_from_runtime_event(
         AgentEventKind::ContextCompacted | AgentEventKind::ContextTrimmed => {
             crate::threads::domain::ThreadItemKind::Event(event.clone())
         }
-        AgentEventKind::PlanProgress => {
+        AgentEventKind::PlanProgress | AgentEventKind::FormResolution => {
             crate::threads::domain::ThreadItemKind::Event(event.clone())
         }
         AgentEventKind::Usage => {

--- a/src-tauri/src/threads/rollout/store/turn.rs
+++ b/src-tauri/src/threads/rollout/store/turn.rs
@@ -1025,6 +1025,51 @@ pub(super) fn turn_records_from_lines(
                     &line.timestamp,
                 );
             }
+            super::EventKind::ThreadItem => {
+                let Some(event) = payload.pointer("/item/kind/payload") else {
+                    continue;
+                };
+                if event.get("eventName").and_then(Value::as_str) != Some("agent.form.resolution") {
+                    continue;
+                }
+                let turn_id = payload
+                    .pointer("/item/turnId")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        turn_replay_error("form resolution is missing turnId", line, payload)
+                    })?;
+                let record = turns.get_mut(turn_id).ok_or_else(|| {
+                    turn_replay_error("form resolution references an unknown turn", line, payload)
+                })?;
+                let resolution = event.get("payload").unwrap_or(&Value::Null);
+                let form_id = resolution
+                    .get("formId")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        turn_replay_error("form resolution is missing formId", line, payload)
+                    })?;
+                if record
+                    .checkpoint
+                    .as_ref()
+                    .and_then(|checkpoint| checkpoint.pointer("/payload/formId"))
+                    .and_then(Value::as_str)
+                    != Some(form_id)
+                {
+                    return Err(turn_replay_error(
+                        "form resolution does not match the waiting checkpoint",
+                        line,
+                        payload,
+                    ));
+                }
+                // A persisted resolution consumes the wait before its live patch is published.
+                // Cancellation continues to the runtime's terminal cancellation boundary.
+                record.checkpoint = None;
+                record.pending_tool_calls.clear();
+                record.status = AgentTurnStatus::Running;
+                record.phase = "planning".to_string();
+                record.stop_reason = None;
+                record.updated_at = line.timestamp.clone();
+            }
             super::EventKind::SessionCleared => {
                 for record in turns.values_mut() {
                     record.checkpoint = None;
@@ -1038,8 +1083,7 @@ pub(super) fn turn_records_from_lines(
             | super::EventKind::ThreadRolledBack
             | super::EventKind::TokenCount
             | super::EventKind::MetadataUpdated
-            | super::EventKind::SessionTrimmed
-            | super::EventKind::ThreadItem => {}
+            | super::EventKind::SessionTrimmed => {}
         }
     }
     Ok(turns.into_values().collect())

--- a/src-tauri/src/threads/rollout/store/turn_tests.rs
+++ b/src-tauri/src/threads/rollout/store/turn_tests.rs
@@ -1350,3 +1350,84 @@ fn invalid_token_count_batch_does_not_append_partial_rollout_items() {
     drop(rpc);
     std::fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn submitted_form_restores_cancellation_and_consumes_the_waiting_checkpoint() {
+    let root = std::env::temp_dir().join(format!(
+        "tinybot-form-resume-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    let rpc = WorkerThreadLogRpc::new(
+        root.clone(),
+        CapabilityPolicy::new([
+            WorkerCapability::SessionWrite,
+            WorkerCapability::SessionMetadataRead,
+        ]),
+    );
+    let checkpoint = json!({
+        "sessionId": "form-session", "turnId": "form-turn", "phase": "awaiting_form",
+        "stopReason": "awaiting_form", "messages": [{"role":"user", "content":"research"}],
+        "pendingToolCalls": [{"toolCallId":"call-2", "toolName":"request_user_input", "argumentsJson":"{}"}],
+        "payload": {"kind":"user_input", "formId":"user-input:call-2"}
+    });
+    rpc.set_turn_checkpoint("form-session", "form-turn", checkpoint.clone())
+        .unwrap();
+    assert_eq!(
+        rpc.get_turn("form-session", "form-turn")
+            .unwrap()
+            .unwrap()
+            .status,
+        AgentTurnStatus::Waiting
+    );
+    let event = json!({
+        "eventId":"form-resolution-1", "eventName":"agent.form.resolution",
+        "sessionId":"form-session", "turnId":"form-turn", "itemId":"user-input:call-2",
+        "sequence": 20, "timestamp":"1789010710769", "phase":"awaiting_form",
+        "payload":{"formId":"user-input:call-2", "status":"completed", "action":"submit", "values":{"goal":"research"}}
+    });
+    rpc.append_turn_semantic_event("form-session", "form-turn", event)
+        .unwrap();
+    let resumed = rpc.get_turn("form-session", "form-turn").unwrap().unwrap();
+    assert_eq!(resumed.status, AgentTurnStatus::Running);
+    assert!(resumed.checkpoint.is_none());
+    assert!(resumed.pending_tool_calls.is_empty());
+    assert!(resumed.stop_reason.is_none());
+    assert!(rpc
+        .latest_turn_checkpoint("form-session")
+        .unwrap()
+        .is_none());
+    let capabilities = crate::desktop_commands::thread::build_thread_effective_capabilities(
+        "form-session",
+        &json!({"turns":[resumed]}),
+    );
+    assert_eq!(
+        capabilities["capabilities"]["agent"]["cancel"]["available"],
+        true
+    );
+    let runtime = rpc
+        .get_turn_runtime_state("form-session", "form-turn")
+        .unwrap()
+        .unwrap();
+    assert!(runtime
+        .timeline
+        .items
+        .iter()
+        .any(|item| item.item_id == "user-input:call-2"
+            && item.status == crate::agent::runtime_protocol::AgentTurnItemStatus::Completed));
+    rpc.set_turn_checkpoint("form-session", "form-turn", checkpoint)
+        .unwrap();
+    assert_eq!(
+        rpc.get_turn("form-session", "form-turn")
+            .unwrap()
+            .unwrap()
+            .status,
+        AgentTurnStatus::Waiting
+    );
+    drop(rpc);
+    std::fs::remove_dir_all(root).unwrap();
+}

--- a/src-tauri/src/tools/shell/README.md
+++ b/src-tauri/src/tools/shell/README.md
@@ -1,5 +1,5 @@
 # Shell Tools
-<!-- tinybot-module-fingerprint: sha256:39843feebcc46fdc46d3d83bfbf62d9b5a0932b8fee4697a85d3154578554116 -->
+<!-- tinybot-module-fingerprint: sha256:f9d7d65ad7263a03d25f5c58485902947467f4660c060d846ac69c4e87b30253 -->
 
 `shell` runs commands for agents and RPC clients in a validated working
 directory. Relative paths resolve from the configured workspace; an existing
@@ -17,6 +17,9 @@ Empty-input `write_stdin` waits for process completion, collecting progress in
 the bounded transcript instead of returning on each log chunk. Its default
 wait is 30 seconds, with a 5-second floor and a 300-second ceiling; completion
 and cancellation wake the wait early. The deadline retains a running process.
+Terminal and output waits recheck their monotonic deadline after every condition
+variable wakeup, including platform timeout reports. Repeated deadline tests
+cover early timer returns without launching subprocesses.
 Non-empty input and `shell.poll` retain their responsive output waits, including
 Sidecar terminal polling. Callers pass the latest cursor for incremental output.
 Runtime metrics record `process.wait.durationMs`, `process.wait.stillRunning`,

--- a/src-tauri/src/tools/shell/process_manager.rs
+++ b/src-tauri/src/tools/shell/process_manager.rs
@@ -1319,14 +1319,13 @@ impl ShellProcessRecord {
             if remaining.is_zero() {
                 return false;
             }
-            let (next_state, wait_result) = self
+            // A platform timeout can precede the monotonic deadline. Recheck
+            // the deadline and process state after every wakeup.
+            let (next_state, _) = self
                 .changed
                 .wait_timeout(state, remaining)
                 .expect("shell process state lock should not be poisoned while waiting");
             state = next_state;
-            if wait_result.timed_out() && state.status.is_running() {
-                return false;
-            }
         }
         true
     }
@@ -1345,14 +1344,13 @@ impl ShellProcessRecord {
             if remaining.is_zero() {
                 break;
             }
-            let (next_state, wait_result) = self
+            // A platform timeout can precede the monotonic deadline. Recheck
+            // the deadline and process state after every wakeup.
+            let (next_state, _) = self
                 .changed
                 .wait_timeout(state, remaining)
                 .expect("shell process state lock should not be poisoned while waiting");
             state = next_state;
-            if wait_result.timed_out() {
-                break;
-            }
         }
         self.snapshot_from_state(&state, cursor)
     }
@@ -1782,6 +1780,10 @@ fn ceil_utf8_boundary(bytes: &[u8], minimum: usize) -> usize {
 #[cfg(test)]
 #[path = "process_manager_output_tests.rs"]
 mod output_tests;
+
+#[cfg(test)]
+#[path = "process_manager_wait_tests.rs"]
+mod wait_tests;
 
 struct BufferedOutputChunk {
     sequence: u64,

--- a/src-tauri/src/tools/shell/process_manager_wait_tests.rs
+++ b/src-tauri/src/tools/shell/process_manager_wait_tests.rs
@@ -1,0 +1,56 @@
+use super::{ShellProcessRecord, ValidatedShellStart};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+fn running_record() -> Arc<ShellProcessRecord> {
+    ShellProcessRecord::new(
+        "wait-test".to_string(),
+        None,
+        &ValidatedShellStart {
+            command: String::new(),
+            working_dir: PathBuf::from("."),
+            working_dir_display: ".".to_string(),
+            tty: false,
+            yield_time_ms: 0,
+            rows: 24,
+            cols: 80,
+            owner_id: None,
+            tool_call_id: None,
+            cancellation: None,
+        },
+    )
+}
+
+#[test]
+fn terminal_wait_rechecks_the_deadline_after_timer_wakeups() {
+    let record = running_record();
+    for attempt in 0..32 {
+        let timeout = Duration::from_millis(125);
+        let started = Instant::now();
+        assert!(!record.wait_for_terminal(timeout));
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= timeout,
+            "attempt {attempt}: {elapsed:?} < {timeout:?}"
+        );
+        assert!(record.is_running());
+    }
+}
+
+#[test]
+fn output_wait_rechecks_the_deadline_after_timer_wakeups() {
+    let record = running_record();
+    for attempt in 0..32 {
+        let timeout = Duration::from_millis(125);
+        let started = Instant::now();
+        let output = record.wait_for_output(0, timeout);
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= timeout,
+            "attempt {attempt}: {elapsed:?} < {timeout:?}"
+        );
+        assert!(output.running);
+        assert!(output.output.is_empty());
+    }
+}

--- a/src/app-core/settings/README.md
+++ b/src/app-core/settings/README.md
@@ -1,5 +1,5 @@
 # Settings Application Core
-<!-- tinybot-module-fingerprint: sha256:c6087b0f65c474508965db38f167c2035e0c7ef658a802502f94b56d64a27a14 -->
+<!-- tinybot-module-fingerprint: sha256:40affc317b842f994fa0aa02e6c23979df437bd701c275c56b20fe330ac7c3c0 -->
 
 `settings` owns framework-independent settings contracts, metadata, value
 semantics, validation, pane models, and persistence patch construction.
@@ -53,3 +53,7 @@ Provider model settings keep the discovered `models` catalog separate from
 persist image-input overrides through `modelCapabilities`; the known defaults
 for `glm-5.3-flash` and `deepseek-v4-flash-vision-exp` stay aligned with the
 Rust provider resolver.
+
+The default light appearance uses a near-white canvas, cooler navigation chrome,
+and graphite emphasis. Loading the unchanged previous default palette upgrades
+it to these defaults; customized palettes and the dark theme are preserved.

--- a/src/app-core/settings/appAppearance.test.ts
+++ b/src/app-core/settings/appAppearance.test.ts
@@ -33,6 +33,19 @@ describe("app appearance preference", () => {
     expect(loadAppearancePreferences(storage)).toEqual(preferences);
   });
 
+  test("upgrades the previous default light palette while preserving custom themes", () => {
+    const previousLight = {
+      accent: "#cc785c", background: "#faf9f5", foreground: "#141413",
+      uiFont: "inter", codeFont: "jetbrains", translucentSidebar: true, contrast: 45,
+    };
+    const read = (light: object) => loadAppearancePreferences(createStorage({
+      [APPEARANCE_STORAGE_KEY]: JSON.stringify({ ...DEFAULT_APPEARANCE_PREFERENCES, light }),
+    }));
+    expect(read(previousLight).light).toEqual(DEFAULT_APPEARANCE_PREFERENCES.light);
+    expect(read({ ...previousLight, accent: "#3366ff" }).light).toEqual({ ...previousLight, accent: "#3366ff" });
+    expect(read({ ...previousLight, contrast: 60 }).light).toEqual({ ...previousLight, contrast: 60 });
+  });
+
   test("normalizes malformed stored fields instead of applying invalid CSS", () => {
     const storage = createStorage({
       [APPEARANCE_STORAGE_KEY]: JSON.stringify({

--- a/src/app-core/settings/appAppearance.ts
+++ b/src/app-core/settings/appAppearance.ts
@@ -39,11 +39,11 @@ export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
   mode: "system",
   light: {
     accent: "#cc785c",
-    background: "#faf9f5",
-    foreground: "#141413",
+    background: "#fcfcfa",
+    foreground: "#202521",
     uiFont: "inter",
     codeFont: "jetbrains",
-    translucentSidebar: true,
+    translucentSidebar: false,
     contrast: 45,
   },
   dark: {
@@ -92,10 +92,11 @@ export function applyAppearancePreferences(
 ): ResolvedTheme {
   const resolvedTheme = resolveThemeMode(preferences.mode, systemDark);
   const theme = preferences[resolvedTheme];
+  const light = resolvedTheme === "light";
   const surfaceSoftStrength = 2 + theme.contrast * 0.05;
   const surfaceCardStrength = 4 + theme.contrast * 0.09;
   const surfaceStrongStrength = 6 + theme.contrast * 0.13;
-  const hairlineStrength = 7 + theme.contrast * 0.08;
+  const hairlineStrength = 7 + theme.contrast * (light ? 0.2 : 0.08);
 
   root.dataset.theme = resolvedTheme;
   root.dataset.themeMode = preferences.mode;
@@ -104,14 +105,22 @@ export function applyAppearancePreferences(
   root.style.setProperty("--font-code", CODE_FONT_STACKS[theme.codeFont]);
   root.style.setProperty("--color-canvas", theme.background);
   root.style.setProperty("--color-ink", theme.foreground);
-  root.style.setProperty("--color-body", "color-mix(in srgb, var(--color-ink) 82%, var(--color-canvas))");
+  root.style.setProperty("--color-body", `color-mix(in srgb, var(--color-ink) ${light ? 90 : 82}%, var(--color-canvas))`);
   root.style.setProperty("--color-muted", "color-mix(in srgb, var(--color-ink) 62%, var(--color-canvas))");
-  root.style.setProperty("--color-muted-soft", "color-mix(in srgb, var(--color-ink) 46%, var(--color-canvas))");
+  root.style.setProperty("--color-muted-soft", `color-mix(in srgb, var(--color-ink) ${light ? 62 : 46}%, var(--color-canvas))`);
   root.style.setProperty("--color-primary", theme.accent);
   root.style.setProperty("--color-primary-active", "color-mix(in srgb, var(--color-primary) 78%, var(--color-ink))");
   root.style.setProperty("--color-on-primary", contrastingTextColor(theme.accent));
   root.style.setProperty("--color-accent", theme.accent);
-  root.style.setProperty("--color-panel", "color-mix(in srgb, var(--color-canvas), var(--color-ink) 1%)");
+  root.style.setProperty("--color-panel", light
+    ? "color-mix(in srgb, var(--color-canvas) 35%, white)"
+    : "color-mix(in srgb, var(--color-canvas), var(--color-ink) 1%)");
+  root.style.setProperty("--color-chrome", light
+    ? "color-mix(in srgb, var(--color-canvas) 90%, #83909d)"
+    : "var(--color-surface-soft)");
+  root.style.setProperty("--color-emphasis", light
+    ? "color-mix(in srgb, var(--color-ink) 92%, var(--color-canvas))"
+    : "var(--color-primary)");
   root.style.setProperty("--color-panel-warm", "color-mix(in srgb, var(--color-canvas), var(--color-primary) 2%)");
   root.style.setProperty("--color-surface", "var(--color-panel)");
   root.style.setProperty("--color-surface-soft", colorMixWithInk(surfaceSoftStrength));
@@ -122,8 +131,8 @@ export function applyAppearancePreferences(
   root.style.setProperty(
     "--sidebar-background",
     theme.translucentSidebar
-      ? "color-mix(in srgb, var(--color-surface-soft) 78%, transparent)"
-      : "var(--color-surface-soft)",
+      ? `color-mix(in srgb, var(${light ? "--color-chrome" : "--color-surface-soft"}) 78%, transparent)`
+      : `var(${light ? "--color-chrome" : "--color-surface-soft"})`,
   );
   root.style.setProperty("--sidebar-backdrop-filter", theme.translucentSidebar ? "blur(18px) saturate(1.08)" : "none");
   return resolvedTheme;
@@ -133,9 +142,20 @@ function normalizePreferences(input: unknown): AppearancePreferences {
   const source = isRecord(input) ? input : {};
   return {
     mode: isThemeMode(source.mode) ? source.mode : DEFAULT_APPEARANCE_PREFERENCES.mode,
-    light: normalizeTheme(source.light, DEFAULT_APPEARANCE_PREFERENCES.light),
+    light: normalizeTheme(isPreviousDefaultLightTheme(source.light) ? undefined : source.light, DEFAULT_APPEARANCE_PREFERENCES.light),
     dark: normalizeTheme(source.dark, DEFAULT_APPEARANCE_PREFERENCES.dark),
   };
+}
+
+// Theme switches persist both palettes. Upgrade the unchanged previous default,
+// while retaining every intentionally customized palette.
+function isPreviousDefaultLightTheme(input: unknown): boolean {
+  if (!isRecord(input)) return false;
+  const previous: AppearanceTheme = {
+    accent: "#cc785c", background: "#faf9f5", foreground: "#141413",
+    uiFont: "inter", codeFont: "jetbrains", translucentSidebar: true, contrast: 45,
+  };
+  return Object.entries(previous).every(([key, value]) => input[key] === value);
 }
 
 function normalizeTheme(input: unknown, fallback: AppearanceTheme): AppearanceTheme {

--- a/src/react-workbench/adapters/README.md
+++ b/src/react-workbench/adapters/README.md
@@ -1,5 +1,5 @@
 # Desktop Adapters
-<!-- tinybot-module-fingerprint: sha256:58cc71677518931135f864372f5bc29a1e888a51266a11ce9592eb13b77580d7 -->
+<!-- tinybot-module-fingerprint: sha256:6c8a648f3b86faac3fb749eaf2fb0cfcf5c531640d7ca7d732efc99eab8d2f6d -->
 
 `adapters` implements renderer store interfaces over Tinybot's native and
 app-core modules. It owns event projection and the Settings, Tools, and
@@ -67,3 +67,8 @@ completed after navigation still reaches the sidebar.
 `desktopArtifactReviewStore` validates native review responses, decodes binary
 snapshots and forwards expected revisions and content hashes. Workspace store
 initialization precedes review calls, and failures propagate to Chat/Sidecar.
+
+The native event bridge reconciles form caches from completed canonical form
+Items before notifying Chat. Submit and cancel resolutions carry their values
+and terminal status; a late awaiting-form event cannot reopen a resolved form.
+Resolution diagnostics record identities and revisions without answer content.

--- a/src/react-workbench/adapters/desktopNativeEventBridge.test.ts
+++ b/src/react-workbench/adapters/desktopNativeEventBridge.test.ts
@@ -183,6 +183,27 @@ describe("desktop native event bridge", () => {
     });
   });
 
+  it.each([['submit', 'submitted'], ['cancel', 'cancelled']])("reconciles a %s form from the canonical resolution while the agent continues", async (action, status) => {
+    const harness = createHarness();
+    await harness.bridge.register();
+    await harness.handlers.get("agent:awaiting_form")!({ payload: {
+      formId: "user-input:call-2", traceContext: { threadId: "thread-1", turnId: "turn-1" },
+      form: { title: "Research requirements", fields: [{ name: "goal", type: "text", label: "Goal" }] },
+    } });
+    expect(harness.bridge.listAgentUiForms("thread-1")[0].status).toBe("pending");
+    const timeline = { turns: [{ id: "turn-1", status: "running", canonicalItems: [{
+      schemaVersion: "tinybot.turn_item.v2", itemId: "user-input:call-2", sessionId: "thread-1",
+      turnId: "turn-1", sequence: 10, revision: 2, kind: "form", status: "completed",
+      createdAt: "2026-09-10T03:23:44Z", updatedAt: "2026-09-10T03:25:10Z",
+      data: { type: "form", formId: "user-input:call-2", status: "completed", action, fieldIds: ["goal"], values: { goal: "research" } },
+    }] }] } as unknown as ChatTimelineSnapshot;
+    harness.applyTimelinePatch.mockResolvedValue(timeline);
+    harness.notifySession.mockClear();
+    await harness.handlers.get("agent:timeline:patch")!({ payload: { sessionId: "thread-1", turnId: "turn-1" } });
+    expect(harness.bridge.listAgentUiForms("thread-1")[0]).toMatchObject({ status, values: { goal: "research" } });
+    expect(harness.notifySession).toHaveBeenCalledWith("thread-1", { type: "agent-ui.form" });
+  });
+
   it("projects completed command hooks without exposing hashes or source paths", async () => {
     const harness = createHarness();
     await harness.bridge.register();

--- a/src/react-workbench/adapters/desktopNativeEventBridge.ts
+++ b/src/react-workbench/adapters/desktopNativeEventBridge.ts
@@ -1,6 +1,7 @@
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import {
   AGENT_UI_EVENT_TYPES,
+  AGENT_UI_EVENT_SCHEMA_VERSION,
   createAgentUiEventState,
   normalizeAgentUiEvents,
   reduceAgentUiEventState,
@@ -104,6 +105,8 @@ export function createDesktopNativeEventBridge({
     if (normalizationError) {
       throw new Error(stringValue(normalizationError.payload.message) || `Native agent form ${formId} is invalid.`);
     }
+    const existing = agentUiState.forms.get(formId);
+    if (existing?.status === "submitted" || existing?.status === "cancelled") return { formId, sessionId: threadId, turnId, ignored: "already_resolved" };
     for (const agentUiEvent of agentUiEvents) {
       reduceAgentUiEventState(agentUiState, agentUiEvent);
     }
@@ -114,6 +117,30 @@ export function createDesktopNativeEventBridge({
       sessionId: threadId,
       turnId,
     };
+  }
+
+  function reconcileCanonicalForms(sessionId: string, timeline: ChatTimelineSnapshot): void {
+    let changed = false;
+    for (const turn of timeline.turns) {
+      for (const item of turn.canonicalItems ?? []) {
+        if (item.data.type !== "form" || item.status !== "completed") continue;
+        const { formId, action, values } = item.data;
+        const status = action === "cancel" ? "cancelled" : "submitted";
+        const existing = agentUiState.forms.get(formId);
+        if (existing?.status === status) continue;
+        reduceAgentUiEventState(agentUiState, {
+          schema_version: AGENT_UI_EVENT_SCHEMA_VERSION,
+          event_id: item.itemId + ":" + item.revision,
+          event_type: "ui.form." + status,
+          chat_id: sessionId, message_id: "", parent_id: "", turn_id: turn.id,
+          timestamp: item.updatedAt ?? item.createdAt, metadata: {},
+          payload: { form_id: formId, values, correlation: { session_key: sessionId, thread_id: sessionId, turn_id: turn.id } },
+        });
+        changed = true;
+        logDesktopNativeDebug("nativeEventBridge.agentForm.resolved", { sessionId, turnId: turn.id, formId, status, revision: item.revision });
+      }
+    }
+    if (changed) notifySession(sessionId, { type: "agent-ui.form" });
   }
 
   async function handleTimelinePatch(event: NativeEvent): Promise<void> {
@@ -156,6 +183,7 @@ export function createDesktopNativeEventBridge({
         turnCount: timeline?.turns.length ?? 0,
       });
       if (timeline) {
+        reconcileCanonicalForms(sessionId, timeline);
         notifySession(sessionId, { type: "timeline.patch", timeline });
         notifyTerminalTimelineState(sessionId, timeline);
       }

--- a/src/react-workbench/chat/ChatPage.artifacts.test.tsx
+++ b/src/react-workbench/chat/ChatPage.artifacts.test.tsx
@@ -20,6 +20,33 @@ function setup(href = "report.md", workingDirectory = "D:\\work") {
 }
 
 describe("Artifact collaboration", () => {
+  it("opens CSV as a table, refreshes it, and references the viewed source revision", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    stores.chatStore.load = vi.fn(async (id) => timelineFromReactMessages(id, [{
+      id: "csv-message", role: "assistant", createdAtMs: 1, status: "complete", text: "[repos.csv](repos.csv)",
+    }]));
+    let revision = "csv-v1";
+    let content = "Repository,Stars\nAutoGPT,187218";
+    const readThreadFile = vi.fn(async () => ({ path: "repos.csv", revision, content, contentType: "text" as const, sizeBytes: content.length }));
+    render(<ChatPage chatStore={stores.chatStore} sessionStore={stores.sessionStore} workspaceStore={{ readThreadFile, artifactReviews: { prepare: vi.fn().mockResolvedValue({}), load: vi.fn().mockResolvedValue(null), compare: vi.fn(), resolve: vi.fn() } }} />);
+    await user.click(await screen.findByRole("link", { name: "repos.csv" }));
+    expect(within(await screen.findByRole("table", { name: "repos.csv" })).getByText("187218")).toBeTruthy();
+    content = "Repository,Stars\nAutoGPT,187219";
+    revision = "csv-v2";
+    fireEvent.focus(window);
+    await screen.findByText("187219");
+    await user.click(screen.getByRole("button", { name: "Source" }));
+    expect(screen.getByLabelText("repos.csv", { selector: "pre" }).textContent).toBe(content);
+    await user.click(screen.getByRole("button", { name: "Reference in chat" }));
+    await user.type(screen.getByRole("textbox", { name: "Message" }), "Explain this data");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(stores.chatStore.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({ references: [expect.objectContaining({ sourcePath: "repos.csv", revision: "csv-v2", sourceText: expect.stringContaining(content) })] }),
+    })));
+  });
+
+
   it("opens a report's sibling PPT relative to the displayed Markdown file", async () => {
     const user = userEvent.setup();
     const root = "C:/Users/viewer/.tinybot/workspace";

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -28,7 +28,7 @@
 }
 
 .react-chat-workspace[data-sidecar-presentation="docked"] {
-  grid-template-columns: minmax(320px, 1fr) var(--react-sidecar-width, 480px);
+  grid-template-columns: minmax(320px, 1fr) var(--react-sidecar-width, 520px);
 }
 
 .react-chat-workspace[data-sidecar-presentation="expanded"] {
@@ -48,6 +48,8 @@
 }
 
 .react-chat-surface {
+  --react-chat-content-max-width: 800px;
+  --react-chat-content-gutter: clamp(20px, 4%, 40px);
   position: relative;
   display: grid;
   grid-template-rows: 42px minmax(0, 1fr) auto;
@@ -64,7 +66,7 @@
   gap: 0;
   padding: 0 8px 0 0;
   border-bottom: 1px solid var(--color-hairline);
-  background: color-mix(in srgb, var(--color-canvas) 92%, var(--color-panel));
+  background: var(--color-surface-soft);
 }
 
 .react-chat-surface[data-empty-session="true"] .react-chat-header {
@@ -102,14 +104,14 @@
 
 .react-conversation-view {
   display: grid;
-  grid-template-columns: minmax(0, min(920px, 100%));
+  grid-template-columns: minmax(0, min(var(--react-chat-content-max-width, 920px), 100%));
   grid-auto-rows: max-content;
   align-content: start;
   justify-content: center;
   gap: 16px;
   min-height: 0;
   overflow: auto;
-  padding: 24px min(6vw, 56px);
+  padding: 18px var(--react-chat-content-gutter, clamp(18px, 2vw, 28px));
 }
 
 .react-chat-surface[data-empty-session="true"] .react-conversation-view {
@@ -270,7 +272,7 @@
 .react-floating-plan__note,
 .react-floating-plan__capsule {
   grid-area: 1 / 1;
-  border: 1px solid color-mix(in srgb, var(--color-text) 13%, var(--color-hairline));
+  border: 1px solid color-mix(in srgb, var(--color-ink) 13%, var(--color-hairline));
   background: color-mix(in srgb, var(--color-panel) 96%, transparent);
   box-shadow: 0 14px 38px rgb(20 20 19 / 14%);
   backdrop-filter: blur(18px) saturate(135%);
@@ -310,7 +312,7 @@
   border: 0;
   border-radius: 14px 14px 0 0;
   background: transparent;
-  color: var(--color-text);
+  color: var(--color-ink);
   padding: 9px 11px 8px 13px;
   font: inherit;
   text-align: left;
@@ -318,7 +320,7 @@
 }
 
 .react-floating-plan__heading:hover {
-  background: color-mix(in srgb, var(--color-text) 4%, transparent);
+  background: color-mix(in srgb, var(--color-ink) 4%, transparent);
 }
 
 .react-floating-plan__heading:focus-visible,
@@ -353,6 +355,10 @@
   padding: 0 13px 13px;
 }
 
+.react-floating-plan .react-canonical-plan__steps li {
+  grid-template-columns: 18px minmax(0, 1fr);
+}
+
 .react-floating-plan__content progress {
   width: 100%;
   height: 3px;
@@ -369,7 +375,7 @@
   justify-content: center;
   gap: 7px;
   border-radius: 999px;
-  color: var(--color-text);
+  color: var(--color-ink);
   padding: 0 12px;
   font: inherit;
   font-size: 12px;
@@ -384,7 +390,7 @@
 }
 
 .react-floating-plan__capsule:hover {
-  background: color-mix(in srgb, var(--color-text) 5%, var(--color-panel));
+  background: color-mix(in srgb, var(--color-ink) 5%, var(--color-panel));
 }
 
 .react-floating-plan[data-expanded="true"] .react-floating-plan__capsule {
@@ -478,6 +484,7 @@
 .react-message-markdown [data-streamdown^="heading-"] {
   color: var(--color-ink);
   line-height: 1.35;
+  margin-top: 8px;
 }
 
 .react-message-markdown [data-streamdown="heading-1"] {
@@ -518,6 +525,20 @@
     color var(--motion-duration-fast) var(--motion-ease-standard),
     text-decoration-color var(--motion-duration-fast) var(--motion-ease-standard);
   vertical-align: baseline;
+}
+
+.react-message-markdown [data-link-kind="file"] {
+  align-items: center;
+  border: 1px solid var(--color-hairline);
+  border-radius: 6px;
+  padding: 2px 8px;
+  background: var(--color-panel);
+  color: var(--color-ink);
+  text-decoration: none;
+}
+
+.react-message-markdown [data-link-kind="file"]:hover {
+  background: var(--color-surface-soft);
 }
 
 .react-message-markdown__link-icon {
@@ -776,6 +797,8 @@
 
 .react-message-markdown [data-streamdown="table-header-cell"],
 .react-message-markdown [data-streamdown="table-cell"] {
+  min-width: 6em;
+  overflow-wrap: normal;
   border: 1px solid var(--color-hairline);
   padding: 7px 9px;
   text-align: left;
@@ -1069,13 +1092,12 @@
 
 .react-composer {
   display: grid;
-  width: min(860px, calc(100% - 48px));
+  width: min(var(--react-chat-content-max-width), calc(100% - var(--react-chat-content-gutter) - var(--react-chat-content-gutter)));
   margin: 0 auto;
   padding: 14px 0 18px;
 }
 
 .react-composer--raised {
-  width: min(920px, calc(100% - 56px));
   padding: 0 0 min(18vh, 148px);
 }
 
@@ -2053,8 +2075,8 @@
 
 .react-execution-timeline__activity > .react-timeline-activity__header {
   gap: 6px;
-  min-height: 40px;
-  border-bottom: 1px solid color-mix(in srgb, var(--color-hairline) 65%, transparent);
+  min-height: 34px;
+  border-bottom: 0;
   border-radius: 0;
   padding: 0 0 4px;
   color: inherit;
@@ -2079,20 +2101,18 @@
 .react-execution-timeline__summary {
   min-width: 0;
   overflow: hidden;
-  color: var(--color-body);
+  color: var(--color-muted);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 400;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.react-execution-timeline[data-abnormal="true"] > .react-execution-timeline__activity > .react-timeline-activity__header,
-.react-execution-timeline[data-abnormal="true"] .react-execution-timeline__summary {
+.react-execution-timeline[data-abnormal="true"] > .react-execution-timeline__activity > .react-timeline-activity__header > .react-timeline-activity__icon {
   color: var(--color-error);
 }
 
-.react-execution-timeline[data-status="awaiting_user"] > .react-execution-timeline__activity > .react-timeline-activity__header,
-.react-execution-timeline[data-status="awaiting_user"] .react-execution-timeline__summary {
+.react-execution-timeline[data-status="awaiting_user"] > .react-execution-timeline__activity > .react-timeline-activity__header > .react-timeline-activity__icon {
   color: var(--color-warning);
 }
 
@@ -3388,8 +3408,31 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px 0 12px;
+  min-height: 44px;
+  padding: 4px 0 8px;
 }
+
+.react-artifact-detail__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.react-artifact-detail__metadata {
+  margin-top: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-hairline);
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.react-artifact-detail__metadata > summary {
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.react-artifact-detail__metadata[open] > summary { margin-bottom: 10px; }
 
 .react-artifact-detail__toolbar span {
   color: var(--color-muted);
@@ -3401,7 +3444,7 @@
   border-radius: 6px;
   padding: 6px 10px;
   background: var(--color-panel);
-  color: var(--color-text);
+  color: var(--color-ink);
   font: inherit;
   font-size: 12px;
   cursor: pointer;
@@ -3442,8 +3485,14 @@
 .react-artifact-detail__text {
   min-width: 0;
   margin: 0;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
+  overflow: auto;
+  padding: 14px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 6px;
+  background: var(--color-panel);
+  color: var(--color-body);
+  font: 13px/1.65 var(--font-code);
+  white-space: pre;
 }
 
 .react-artifact-detail__document {
@@ -4479,7 +4528,7 @@
   }
 
   .react-chat-surface[data-empty-session="true"] .react-conversation-view {
-    padding: 24px 18px clamp(32px, 6vh, 56px);
+    padding: 24px var(--react-chat-content-gutter) clamp(32px, 6vh, 56px);
   }
 
   .react-empty-chat-start {
@@ -4504,7 +4553,6 @@
   }
 
   .react-composer--raised {
-    width: calc(100% - 28px);
     padding-bottom: 96px;
   }
 

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
 import type { ChatStep } from "../../app-core/chat/chatTurnContracts";
+import { createDesktopNativeEventBridge } from "../adapters/desktopNativeEventBridge";
 import type { ChatEvent } from "../services";
 import type { ReactChatMessage } from "./messageActions";
 import { timelineFromReactMessages } from "./test/timelineFixtures";
@@ -417,6 +418,60 @@ describe("ChatPage", () => {
       target: expect.objectContaining({ turnId: "turn-1", sessionId: "s1" }),
     }));
     expect(within(card).getByRole("button", { name: "Save preferences" }).hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes the submitted form and enables Stop while native output continues", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    let listener: ((event: ChatEvent) => void) | undefined;
+    stores.chatStore.subscribe = vi.fn((_id, callback) => { listener = callback; return () => {}; });
+    const handlers = new Map<string, (event: { payload: unknown }) => void | Promise<void>>();
+    let canonical = timelineFromReactMessages("s1", [{ id: "u-form", turnId: "turn-1", role: "user", text: "Research", status: "complete", createdAtMs: 1 }]);
+    canonical.turns[0].status = "awaiting_user";
+    const bridge = createDesktopNativeEventBridge({
+      controller: {
+        state: { threads: [{ threadId: "s1", title: "Research", status: "running", createdAt: "1", updatedAt: "1" }], activeThreadId: "s1", respondingThreadIds: new Set(["s1"]), error: "" },
+        loadSessions: vi.fn(async () => 1), applyTimelinePatch: vi.fn(async () => canonical),
+      },
+      listen: async (name, handler) => { handlers.set(name, handler); return () => {}; },
+      notifyAll: (event) => listener?.(event), notifySession: (_id, event) => listener?.(event),
+    });
+    await bridge.register();
+    await handlers.get("agent:awaiting_form")!({ payload: {
+      formId: "user-input:call-2", traceContext: { threadId: "s1", turnId: "turn-1" },
+      form: { title: "Research requirements", fields: [{ name: "goal", type: "text", label: "Goal", required: true }] },
+    } });
+    stores.chatStore.load = vi.fn(async () => canonical);
+    stores.chatStore.listAgentUiForms = vi.fn(async (id) => bridge.listAgentUiForms(id));
+    stores.chatStore.loadEffectiveCapabilities = vi.fn(async (threadId) => ({
+      schemaVersion: "tinybot.effective_capabilities.v2" as const, threadId, evaluatedTurnId: "turn-1",
+      capabilities: { agent: { cancel: { available: canonical.turns[0].status === "running" }, retry: { available: false } } },
+    }));
+    render(<ChatPage chatStore={stores.chatStore} now={() => 1000} sessionStore={stores.sessionStore} />);
+    const form = await screen.findByRole("form", { name: "Research requirements" });
+    await user.type(within(form).getByLabelText("Goal"), "Smart home agents");
+    await user.click(within(form).getByRole("button", { name: "Submit" }));
+    const command = vi.mocked(stores.chatStore.dispatch).mock.calls[0][0];
+    canonical = timelineFromReactMessages("s1", [
+      { id: "u-form", turnId: "turn-1", role: "user", text: "Research", status: "complete", createdAtMs: 1 },
+      { id: "a-resume", turnId: "turn-1", role: "assistant", text: "Continuing the research with your answers.", status: "streaming", createdAtMs: 2000 },
+    ]);
+    canonical.turns[0].canonicalItems = [{
+      schemaVersion: "tinybot.turn_item.v2", itemId: "ack", turnId: "turn-1", sessionId: "s1", sequence: 2, revision: 1, kind: "system_notice", status: "completed", createdAt: "2026-09-10T03:25:10Z",
+      data: { type: "system_notice", message: "", detail: { commandId: command.commandId, commandStatus: "acknowledged" } },
+    }, {
+      schemaVersion: "tinybot.turn_item.v2", itemId: "user-input:call-2", turnId: "turn-1", sessionId: "s1", sequence: 3, revision: 2, kind: "form", status: "completed", createdAt: "2026-09-10T03:25:10Z",
+      data: { type: "form", formId: "user-input:call-2", commandId: command.commandId, status: "completed", action: "submit", values: { goal: "Smart home agents" }, fieldIds: ["goal"] },
+    }];
+    canonical.turns[0].canonicalItems.push({
+      schemaVersion: "tinybot.turn_item.v2", itemId: "a-resume", turnId: "turn-1", sessionId: "s1", sequence: 4, revision: 1, kind: "assistant_message", status: "running", createdAt: "2026-09-10T03:25:11Z",
+      data: { type: "assistant_message", messageId: "a-resume", modelCallId: "model-2", phase: "commentary", content: "Continuing the research with your answers." },
+    });
+    await act(async () => handlers.get("agent:timeline:patch")!({ payload: { sessionId: "s1", turnId: "turn-1" } }));
+    await waitFor(() => expect(screen.queryByRole("form", { name: "Research requirements" })).toBeNull());
+    await waitFor(() => expect(document.body.textContent).toContain("Continuing the research with your answers."));
+    await waitFor(() => expect(screen.getByRole("button", { name: /Stop/ }).hasAttribute("disabled")).toBe(false));
+    expect(document.querySelector('.react-agent-command-status')).toBeNull();
   });
 
   it("cancels active agent-ui forms through Thread command dispatch", async () => {

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -477,7 +477,11 @@ export function ChatPage({
       && latestTurnStatus === "completed"
     );
   const compactingActiveSession = Boolean(activeSession && compactingSessionId === activeSession.id);
+  const completedFormCommand = commandLifecycle.stage === "completed"
+    && commandLifecycle.completion.status !== "failed"
+    && (commandLifecycle.command.kind === "form.submit" || commandLifecycle.command.kind === "form.cancel");
   const showCommandLifecycleStatus = commandLifecycle.stage !== "idle"
+    && !completedFormCommand
     && commandLifecycle.command.kind !== "agent.cancel";
   const submittingFormId = commandLifecycle.stage !== "idle"
     && (commandLifecycle.command.kind === "form.submit" || commandLifecycle.command.kind === "form.cancel")

--- a/src/react-workbench/chat/FloatingPlanStatus.tsx
+++ b/src/react-workbench/chat/FloatingPlanStatus.tsx
@@ -88,11 +88,10 @@ export function FloatingPlanStatus({ identityKey, plan, revisionKey }: FloatingP
           <ol className="react-canonical-plan__steps">
             {plan.steps.map((step, index) => (
               <li data-status={step.status} key={`${index}:${step.step}`}>
-                <span aria-hidden="true" className="react-canonical-plan__step-icon">
+                <span aria-label={planStepStatusLabel(step.status, t)} className="react-canonical-plan__step-icon" role="img">
                   <FloatingPlanStepIcon status={step.status} />
                 </span>
                 <span>{step.step}</span>
-                <small>{planStepStatusLabel(step.status, t)}</small>
               </li>
             ))}
           </ol>

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:2101d3ed902e4c6715c1f09817b995e39dd6f51d4ff9fdf866339775961ad538 -->
+<!-- tinybot-module-fingerprint: sha256:a2809560a91cf206588b62fb3fe5a1d916f28aa2390b2f026fd990fa548e5dae -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -16,8 +16,11 @@ successful canonical user Turns establish task completion. Errors remain
 visible with retry. Examples append to the composer without sending, and
 project examples use the existing workspace picker. The model dialog uses the
 shared modal focus and native-surface occlusion conventions.
+Conversation content and the composer share an 800px maximum width and remain
+centered within the Chat surface. Horizontal gutters scale with the available
+Chat width from 20px to 40px, including docked Sidecar and empty-chat layouts.
 `SessionSidebarResizeHandle` owns sidebar width and its drag lifecycle. Expanded
-width defaults to 280 px and ranges from 220 to 420 px, with the maximum reduced
+width defaults to 240 px and ranges from 220 to 420 px, with the maximum reduced
 to reserve 480 px for the chat workspace where possible. Pointer movement updates
 only sidebar geometry and the separator, without rerendering Chat content.
 Dragging 48 px beyond the minimum invokes the existing collapse operation while
@@ -151,14 +154,15 @@ lifecycle. Execution summaries also keep their children mounted so folding the
 whole trace preserves individually expanded rows. Flat legacy tool groups use
 the same list renderer without a disclosure shell. Business-specific renderers
 own content and lifecycle decisions; they do not create disclosure buttons or IDs.
-`FloatingPlanStatus.tsx` mirrors the most recent canonical plan across Turns in
-a fixed top-right note without introducing another plan store. A newer Turn
-without a plan keeps the previous plan visible; the next plan replaces it. New
-plans and status revisions open the note briefly before it contracts to a
-progress capsule; manual expansion stays open until the user closes it, and
-reduced-motion mode replaces the slide with a short opacity transition. Normal
-Turn completion keeps the last canonical plan state; failed or interrupted
-Turns still reconcile unfinished steps to their terminal outcome.
+`FloatingPlanStatus` mirrors the latest canonical plan at the top right across Turns.
+The capsule expands into step details; updates expand it for five seconds, while
+manual expansion stays open. Failed and interrupted Turns reconcile unfinished
+steps to their terminal outcome. Each floating step shows its status through a
+labelled leading icon, without a duplicate text column; the heading retains the
+overall progress count. Reduced motion disables its spatial transitions.
+Form completion refreshes stop capabilities even when the active Turn ID and
+status are unchanged, because a live resume acknowledgement may arrive before
+the persisted resolution. Successful form-command status no longer stays above the composer; failures remain visible.
 `AssistantMarkdown.tsx` owns assistant prose and link presentation. Streaming
 prose uses Streamdown's incremental 160 ms opacity fade, with character boundaries
 for uninterrupted CJK text and no stagger delay. Existing character nodes are
@@ -205,8 +209,7 @@ appearance uses the original flat fills; dimensional appearance adds only SVG
 gradient lighting and restrained shadows. Reduced-motion mode preserves each
 mood's static pose without transitions or looping animation.
 Ambient mascot animation also pauses when the document or native pet preference
-is hidden. Floating plan controls let the browser manage temporary compositor
-layers instead of retaining a permanent `will-change` hint.
+is hidden.
 
 Chat contracts, commands, and projections live in `app-core/chat`. This folder
 owns React state and presentation. Composer submission turns native managed

--- a/src/react-workbench/chat/SessionSidebarResizeHandle.test.tsx
+++ b/src/react-workbench/chat/SessionSidebarResizeHandle.test.tsx
@@ -51,7 +51,7 @@ function setup() {
 test("tracks the grab offset without rerendering chat content and saves only on release", () => {
   const view = setup();
   const writes = vi.spyOn(Storage.prototype, "setItem");
-  view.down(275);
+  view.down(235);
   view.move(345);
   expect(view.width()).toBe(350);
   act(() => resize());
@@ -134,13 +134,13 @@ test("cancelling while collapsed ends capture and preserves the saved expanded w
 
 test.each(["escape", "pointercancel", "blur", "lostcapture"])("cancels %s without saving and restores page interaction", (reason) => {
   const view = setup();
-  view.down(280);
+  view.down(240);
   view.move(360);
   if (reason === "escape") fireEvent.keyDown(view.handle, { key: "Escape" });
   if (reason === "pointercancel") fireEvent.pointerCancel(view.handle, { pointerId: 1 });
   if (reason === "blur") fireEvent.blur(window);
   if (reason === "lostcapture") fireEvent.lostPointerCapture(view.handle, { pointerId: 1 });
-  expect(view.width()).toBe(280);
+  expect(view.width()).toBe(240);
   expect(localStorage.getItem(key)).toBeNull();
   expect(document.body.style.userSelect).toBe("");
   expect(document.body.style.cursor).toBe("");
@@ -163,9 +163,9 @@ test("temporarily limits width for the window and restores the saved preference 
 test("supports keyboard increments, bounds, and double-click reset", () => {
   const view = setup();
   fireEvent.keyDown(view.handle, { key: "ArrowRight" });
-  expect(view.width()).toBe(288);
+  expect(view.width()).toBe(248);
   fireEvent.keyDown(view.handle, { key: "ArrowLeft", shiftKey: true });
-  expect(view.width()).toBe(256);
+  expect(view.width()).toBe(220);
   fireEvent.keyDown(view.handle, { key: "Home" });
   fireEvent.keyDown(view.handle, { key: "ArrowLeft" });
   expect(view.width()).toBe(220);
@@ -173,14 +173,14 @@ test("supports keyboard increments, bounds, and double-click reset", () => {
   fireEvent.keyDown(view.handle, { key: "End" });
   expect(view.width()).toBe(420);
   fireEvent.doubleClick(view.handle);
-  expect(view.width()).toBe(280);
-  expect(localStorage.getItem(key)).toBe("280");
+  expect(view.width()).toBe(240);
+  expect(localStorage.getItem(key)).toBe("240");
 });
 
 test("releases global drag styles when the sidebar unmounts mid-gesture", () => {
   document.body.style.cursor = "crosshair";
   const view = setup();
-  view.down(280);
+  view.down(240);
   view.move(340);
   view.unmount();
   expect(document.body.style.cursor).toBe("crosshair");

--- a/src/react-workbench/chat/SessionSidebarResizeHandle.tsx
+++ b/src/react-workbench/chat/SessionSidebarResizeHandle.tsx
@@ -2,7 +2,7 @@ import { useCallback, useLayoutEffect, useRef, useState, type PointerEvent } fro
 import { useTranslation } from "react-i18next";
 
 const STORAGE_KEY = "tinybot.session-sidebar-width";
-const DEFAULT_WIDTH = 280;
+const DEFAULT_WIDTH = 240;
 const MIN_WIDTH = 220;
 const MAX_WIDTH = 420;
 const MIN_CHAT_WIDTH = 480;

--- a/src/react-workbench/chat/ToolActivityItem.tsx
+++ b/src/react-workbench/chat/ToolActivityItem.tsx
@@ -219,7 +219,7 @@ function toolActivityDescriptor(toolCall: ToolCallState, status: ChatStepStatus,
     return genericDescriptor(title, t("toolActivity.category.subagent"), "subagent", toolCall, fallbackSummary, task);
   }
   if (name === "request_user_input") {
-    return genericDescriptor(t("toolActivity.requestedInput"), t("toolActivity.category.interaction"), "generic", toolCall, fallbackSummary);
+    return genericDescriptor(t(status === "completed" ? "toolActivity.receivedInput" : "toolActivity.requestedInput"), t("toolActivity.category.interaction"), "generic", toolCall, fallbackSummary);
   }
   return genericDescriptor(humanizeToolName(toolCall.name, t), t("toolActivity.category.tool"), "generic", toolCall, fallbackSummary);
 }

--- a/src/react-workbench/chat/useChatApplication.test.tsx
+++ b/src/react-workbench/chat/useChatApplication.test.tsx
@@ -148,3 +148,26 @@ it("clears application state on removal without waiting for page animations", as
   expect(result.current.state.optimisticMessages).toEqual([]);
   expect(result.current.turns.queue("s2").inputs).toEqual([input]);
 });
+
+it("refreshes stop capability when a form resolves within the same running turn", async () => {
+  const { store, render, listeners } = setup();
+  // A live resume/ack patch may precede the durable form resolution.
+  store.loadEffectiveCapabilities.mockImplementation(async (id) => capabilities(id, false));
+  const { result } = render();
+  await waitFor(() => expect(result.current.state.status).toBe("ready"));
+  await waitFor(() => expect(store.loadEffectiveCapabilities).toHaveBeenCalled());
+  expect(result.current.state.canCancel).toBe(false);
+  store.loadEffectiveCapabilities.mockImplementation(async (id) => capabilities(id, true));
+  const resumed = timeline("s1");
+  resumed.turns[0].canonicalItems = [{
+    schemaVersion: "tinybot.turn_item.v2", sessionId: "s1", turnId: "turn-s1", sequence: 2, createdAt: "2026-09-10T03:25:10Z",
+    itemId: "form-1", revision: 2, kind: "form", status: "completed",
+    data: { type: "form", formId: "form-1", action: "submit", status: "completed", values: {}, fieldIds: [] },
+  }] as ChatTurn["canonicalItems"];
+  act(() => listeners.get("s1")!({ type: "timeline.patch", timeline: resumed }));
+  await waitFor(() => expect(result.current.state.canCancel).toBe(true));
+  const loads = store.loadEffectiveCapabilities.mock.calls.length;
+  act(() => listeners.get("s1")!({ type: "timeline.patch", timeline: { ...resumed } }));
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 30)); });
+  expect(store.loadEffectiveCapabilities).toHaveBeenCalledTimes(loads);
+});

--- a/src/react-workbench/chat/useChatApplication.ts
+++ b/src/react-workbench/chat/useChatApplication.ts
@@ -70,7 +70,7 @@ export function useChatApplication(options: Options) {
       ));
     });
     return () => { cancelled = true; };
-  }, [timelineSummary.activeTurnId, timelineSummary.activeTurnStatus, persistedSessionId, chatStore, t]);
+  }, [timelineSummary.activeTurnId, timelineSummary.activeTurnStatus, timelineSummary.formResolutionKey, persistedSessionId, chatStore, t]);
 
   function receiveTimeline(targetSessionId: string, snapshot: ChatTimelineSnapshot) {
     sessions.receiveTimeline(targetSessionId, snapshot);

--- a/src/react-workbench/chat/useChatTimelineSummary.ts
+++ b/src/react-workbench/chat/useChatTimelineSummary.ts
@@ -29,7 +29,9 @@ function projectSummary(timeline: ChatTimelineSnapshot | null, defaults: Context
   const active = reversed.find((turn) => (
     turn.status === "pending" || turn.status === "running" || turn.status === "awaiting_user"
   ));
+  const resolvedForm = [...(active?.canonicalItems ?? [])].reverse().find((item) => item.kind === "form" && item.status === "completed");
   return {
+    formResolutionKey: resolvedForm ? `${resolvedForm.itemId}:${resolvedForm.revision}` : "",
     sessionId: timeline?.sessionId,
     turnCount: turns.length,
     completedTask: turns.some((turn) => turn.status === "completed" && Boolean(turn.userMessage.text.trim())),

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:fa5d384a5cf5c07bd270363f3508d124368cd023d9755bb5b5e529a78b324792 -->
+<!-- tinybot-module-fingerprint: sha256:fa379c284e2ce1bf1615bd5465ab86b6eca2d24215ad02235fc705d6fc38d967 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles. Composer drag targets and attachment preparation
@@ -117,3 +117,7 @@ annotation; finishing the mode is separate from attaching a comment.
 
 Typed style controls localize the drag handle and scrubbing hint, unit and slider
 labels, color alpha, four spacing directions, linkage, and invalid CSS feedback.
+
+Delimited file views localize the Table/Source switch, row label, parse-error
+message, and collapsed file details. The floating plan capsule keeps localized expand/collapse labels. Successful
+user-input tool calls have a distinct received-input title.

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1200,8 +1200,9 @@ export const en = {
       label: "Task execution failed", cancelled: "Task cancelled", interrupted: "Task interrupted", copyError: "Copy error",
     },
     plan: {
+      floatingLabel: "Task progress", floatingExpand: "Expand task progress", floatingCollapse: "Collapse task progress",
       label: "Execution plan", completed: "{{completed}} of {{total}} completed", status: { completed: "Completed", inProgress: "In progress", failed: "Failed", cancelled: "Cancelled", pending: "Pending" },
-      collapse: "Collapse", expand: "Expand", floatingLabel: "Task progress", floatingExpand: "Expand task progress", floatingCollapse: "Collapse task progress",
+      collapse: "Collapse", expand: "Expand",
     },
     artifacts: { label: "Artifacts", preview: "Preview {{name}}" },
     dataView: {
@@ -1241,6 +1242,8 @@ export const en = {
       textTruncated: "Showing the first 32 KB of this version."
     },
     details: {
+      fileDetails: "File details", delimitedViews: "File view", delimitedTable: "Table", delimitedSource: "Source", delimitedRow: "Row",
+      delimitedFailed: "Table preview failed: {{message}}. Switch to Source to inspect the original text.",
       status: "Status", interruptedAt: "Interrupted at",
       unavailable: "Details unavailable.", id: "ID", trace: "Trace", childTurn: "Child turn", loadingTrace: "Loading trace…", finalOutput: "Final output",
       type: "Type", loadingArtifact: "Loading artifact…", noPreview: "No preview content is available.", subagentTrace: "Subagent trace",
@@ -1275,7 +1278,7 @@ export const en = {
       status: { running: "Running", waiting: "Waiting", failed: "Failed", cancelled: "Cancelled", pending: "Pending" },
       category: { terminal: "Terminal", fileRead: "File read", web: "Web", planning: "Planning", presentation: "Data view", subagent: "Subagent", interaction: "Interaction", tool: "Tool" },
       command: "command", workspaceFile: "workspace file", currentPage: "current page", usedTool: "Used a tool",
-      updatedPlan: "Updated execution plan", preparingDataView: "Preparing data view…", publishedDataView: "Published data view", dataViewFailed: "Data view publication failed", dataViewCancelled: "Data view publication cancelled", delegated: "Delegated a task", waitedSubagents: "Waited for subagents", updatedSubagent: "Updated a subagent", requestedInput: "Requested user input",
+      updatedPlan: "Updated execution plan", preparingDataView: "Preparing data view…", publishedDataView: "Published data view", dataViewFailed: "Data view publication failed", dataViewCancelled: "Data view publication cancelled", delegated: "Delegated a task", waitedSubagents: "Waited for subagents", updatedSubagent: "Updated a subagent", requestedInput: "Requested user input", receivedInput: "Received user input",
       commandFailed: "Command failed", commandCancelled: "Command cancelled", runningCommand: "Running {{command}}", waitingCommand: "Waiting to run {{command}}", ranCommand: "Ran {{command}}",
       inspectFailed: "Could not inspect {{target}}", inspecting: "Inspecting {{target}}", inspected: "Inspected {{target}}", webFailed: "Web action failed",
       opening: "Opening {{page}}", opened: "Opened {{page}}", reviewing: "Reviewing {{page}}", reviewed: "Reviewed {{page}}", scrolled: "Scrolled {{page}}",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -647,8 +647,9 @@ export const zh = {
       label: "任务执行失败", cancelled: "任务已取消", interrupted: "任务已中断", copyError: "复制错误",
     },
     plan: {
+      floatingLabel: "任务进度", floatingExpand: "展开任务进度", floatingCollapse: "收起任务进度",
       label: "执行计划", completed: "已完成 {{completed}}/{{total}}", status: { completed: "已完成", inProgress: "执行中", failed: "失败", cancelled: "已取消", pending: "待执行" },
-      collapse: "收起", expand: "展开", floatingLabel: "任务进度", floatingExpand: "展开任务进度", floatingCollapse: "收起任务进度",
+      collapse: "收起", expand: "展开",
     },
     artifacts: { label: "产物", preview: "预览 {{name}}" },
     dataView: {
@@ -688,6 +689,8 @@ export const zh = {
       textTruncated: "仅显示此版本的前 32 KB。"
     },
     details: {
+      fileDetails: "文件详情", delimitedViews: "文件视图", delimitedTable: "表格", delimitedSource: "原文", delimitedRow: "行号",
+      delimitedFailed: "表格预览失败：{{message}}。可以切换到原文检查文件内容。",
       status: "状态", interruptedAt: "中断位置",
       unavailable: "详情不可用。", id: "ID", trace: "Trace", childTurn: "子任务轮次", loadingTrace: "正在加载 Trace…", finalOutput: "最终输出",
       type: "类型", loadingArtifact: "正在加载产物…", noPreview: "没有可预览的内容。", subagentTrace: "子 Agent Trace",
@@ -722,7 +725,7 @@ export const zh = {
       status: { running: "执行中", waiting: "等待中", failed: "失败", cancelled: "已取消", pending: "待执行" },
       category: { terminal: "终端", fileRead: "读取文件", web: "网页", planning: "计划", presentation: "数据视图", subagent: "子 Agent", interaction: "交互", tool: "工具" },
       command: "命令", workspaceFile: "工作区文件", currentPage: "当前页面", usedTool: "使用了工具",
-      updatedPlan: "更新了执行计划", preparingDataView: "正在准备数据视图…", publishedDataView: "已发布数据视图", dataViewFailed: "数据视图发布失败", dataViewCancelled: "已取消发布数据视图", delegated: "委派了任务", waitedSubagents: "等待子 Agent", updatedSubagent: "更新了子 Agent", requestedInput: "请求用户输入",
+      updatedPlan: "更新了执行计划", preparingDataView: "正在准备数据视图…", publishedDataView: "已发布数据视图", dataViewFailed: "数据视图发布失败", dataViewCancelled: "已取消发布数据视图", delegated: "委派了任务", waitedSubagents: "等待子 Agent", updatedSubagent: "更新了子 Agent", requestedInput: "请求用户输入", receivedInput: "已收到用户输入",
       commandFailed: "命令执行失败", commandCancelled: "命令已取消", runningCommand: "正在执行 {{command}}", waitingCommand: "等待执行 {{command}}", ranCommand: "已执行 {{command}}",
       inspectFailed: "无法查看 {{target}}", inspecting: "正在查看 {{target}}", inspected: "已查看 {{target}}", webFailed: "网页操作失败",
       opening: "正在打开 {{page}}", opened: "已打开 {{page}}", reviewing: "正在查看 {{page}}", reviewed: "已查看 {{page}}", scrolled: "已滚动 {{page}}",

--- a/src/react-workbench/sidecar/DelimitedTextPreview.css
+++ b/src/react-workbench/sidecar/DelimitedTextPreview.css
@@ -1,0 +1,97 @@
+.react-delimited-views {
+  display: flex;
+  flex: none;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 7px;
+  background: var(--color-surface-card);
+}
+
+.react-artifact-detail__toolbar .react-delimited-views button {
+  min-height: 28px;
+  padding: 3px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--color-muted);
+}
+
+.react-artifact-detail__toolbar .react-delimited-views button[aria-pressed="true"] {
+  background: var(--color-panel);
+  color: var(--color-ink);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
+}
+
+.react-delimited-dimensions {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.react-delimited-table {
+  min-width: 0;
+  max-width: 100%;
+  overflow: auto;
+  border: 1px solid var(--color-hairline);
+  border-radius: 6px;
+  background: var(--color-panel);
+}
+
+.react-delimited-table:focus-visible {
+  outline: 2px solid var(--color-emphasis);
+  outline-offset: 2px;
+}
+
+.react-delimited-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font: 13px/1.5 var(--font-ui);
+}
+
+.react-delimited-table th, .react-delimited-table td {
+  height: 40px;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--color-hairline);
+  border-right: 1px solid var(--color-hairline);
+  text-align: left;
+  white-space: pre;
+}
+
+.react-delimited-table thead th {
+  background: var(--color-surface-soft);
+  color: var(--color-ink);
+  font-weight: 600;
+}
+
+.react-delimited-table tbody th {
+  color: var(--color-muted);
+  font-weight: 400;
+  text-align: right;
+}
+
+.react-delimited-table td {
+  color: var(--color-body);
+}
+
+.react-delimited-table td[data-numeric] {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.react-delimited-table tbody tr:last-child > * {
+  border-bottom: 0;
+}
+
+.react-delimited-table tbody tr:hover {
+  background: var(--color-surface-soft);
+}
+
+.react-delimited-error {
+  color: var(--color-error);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.react-delimited-limit {
+  color: var(--color-muted);
+  font-size: 12px;
+}

--- a/src/react-workbench/sidecar/DelimitedTextPreview.test.tsx
+++ b/src/react-workbench/sidecar/DelimitedTextPreview.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DelimitedTextPreview } from './DelimitedTextPreview';
+import { artifactDelimiter, parseDelimitedText } from './delimitedText';
+
+afterEach(cleanup);
+
+describe('delimited text', () => {
+  it('preserves quoted separators, escaped quotes, newlines, Unicode and integer precision', () => {
+    expect(parseDelimitedText('\uFEFFname,note,id\r\n"中文, repo","line 1\nline ""2""",9007199254740993\r\n', ',')).toEqual({
+      headers: ['name', 'note', 'id'], rows: [['中文, repo', 'line 1\nline "2"', '9007199254740993']],
+    });
+    expect(parseDelimitedText('a\tb\n1\t\n', '\t').rows).toEqual([['1', '']]);
+    expect(parseDelimitedText('', ',')).toEqual({ headers: [], rows: [] });
+    expect(parseDelimitedText('a,b\n"",', ',').rows).toEqual([['', '']]);
+  });
+  it('rejects malformed quoting and uneven rows instead of changing the data', () => {
+    expect(() => parseDelimitedText('a,b\n"unfinished,2', ',')).toThrow('Unclosed quoted field');
+    expect(() => parseDelimitedText('a,b\n"closed"extra,2', ',')).toThrow('Unexpected text');
+    expect(() => parseDelimitedText('a,b\n1,2,3', ',')).toThrow('Record 2 has 3 fields; expected 2');
+  });
+  it('recognizes file extensions even when the backend reports text/plain', () => {
+    expect(artifactDelimiter('gh_agents/repos.CSV', 'text/plain')).toBe(',');
+    expect(artifactDelimiter('values.tsv', 'text/plain')).toBe('\t');
+    expect(artifactDelimiter('export', 'text/csv; charset=utf-8')).toBe(',');
+    expect(artifactDelimiter('notes.txt', 'text/plain')).toBeUndefined();
+  });
+});
+
+describe('DelimitedTextPreview', () => {
+  it('switches to intact source and retains the reference action and updated contents', () => {
+    const reference = vi.fn();
+    const props = { actions: <button onClick={reference}>Reference in chat</button>, delimiter: ',' as const, title: 'repos.csv' };
+    const view = render(<DelimitedTextPreview {...props} text={'repo,stars\nAutoGPT,9007199254740993'} />);
+    expect(within(screen.getByRole('table')).getByRole('cell', { name: '9007199254740993' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Source' }));
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.getByLabelText('repos.csv').textContent).toBe('repo,stars\nAutoGPT,9007199254740993');
+    fireEvent.click(screen.getByRole('button', { name: 'Reference in chat' }));
+    expect(reference).toHaveBeenCalledOnce();
+    view.rerender(<DelimitedTextPreview {...props} text={'repo,stars\ndify,155176'} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+    expect(within(screen.getByRole('table')).getByRole('cell', { name: 'dify' })).toBeTruthy();
+  });
+  it('keeps invalid source accessible with an explicit parse error', () => {
+    render(<DelimitedTextPreview actions={null} delimiter="," title="broken.csv" text={'a,b\n"unfinished'} />);
+    expect(screen.getByRole('alert').textContent).toContain('Unclosed quoted field');
+    fireEvent.click(screen.getByRole('button', { name: 'Source' }));
+    expect(screen.getByLabelText('broken.csv').textContent).toBe('a,b\n"unfinished');
+  });
+  it('bounds rendered rows and explains that more data exists', () => {
+    render(<DelimitedTextPreview actions={null} delimiter="," title="large.csv" text={'id\n' + Array.from({ length: 220 }, (_, i) => i).join('\n')} />);
+    expect(within(screen.getByRole('table')).getAllByRole('row')).toHaveLength(201);
+    expect(screen.getByRole('status').textContent).toContain('200');
+  });
+});

--- a/src/react-workbench/sidecar/DelimitedTextPreview.tsx
+++ b/src/react-workbench/sidecar/DelimitedTextPreview.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { logRendererEvent } from '../../app-core/native/rendererLogger';
+import { parseDelimitedText } from './delimitedText';
+import './DelimitedTextPreview.css';
+
+const MAX_ROWS = 200;
+const MAX_COLUMNS = 50;
+
+export function DelimitedTextPreview({ text, delimiter, title, actions, truncated = false }: {
+  text: string;
+  delimiter: ',' | '\t';
+  title: string;
+  actions: ReactNode;
+  truncated?: boolean;
+}) {
+  const { t } = useTranslation('chat');
+  const [view, setView] = useState<'table' | 'source'>('table');
+  const parsed = useMemo(() => {
+    try { return { data: parseDelimitedText(text, delimiter), error: undefined }; }
+    catch (cause) { return { data: undefined, error: cause instanceof Error ? cause.message : String(cause) }; }
+  }, [text, delimiter]);
+  useEffect(() => {
+    if (parsed.error) logRendererEvent('warn', 'artifact.delimited.parse.failed', { title, message: parsed.error, truncated });
+  }, [parsed.error, title, truncated]);
+  const data = parsed.data;
+  const limited = data && (data.rows.length > MAX_ROWS || data.headers.length > MAX_COLUMNS);
+  return <>
+    <div className="react-artifact-detail__toolbar">
+      <div aria-label={t('details.delimitedViews')} className="react-delimited-views" role="group">
+        <button aria-pressed={view === 'table'} onClick={() => setView('table')} type="button">{t('details.delimitedTable')}</button>
+        <button aria-pressed={view === 'source'} onClick={() => setView('source')} type="button">{t('details.delimitedSource')}</button>
+      </div>
+      {data ? <span className="react-delimited-dimensions">{t('dataView.dimensions', { rows: data.rows.length, columns: data.headers.length })}{truncated ? '+' : ''}</span> : null}
+      <div className="react-artifact-detail__actions">{actions}</div>
+    </div>
+    {view === 'source' ? <pre aria-label={title} className="react-artifact-detail__text">{text}</pre>
+      : parsed.error ? <p className="react-delimited-error" role="alert">{t('details.delimitedFailed', { message: parsed.error })}</p>
+      : data?.headers.length ? <>
+        <div aria-label={title} className="react-delimited-table" role="region" tabIndex={0}>
+          <table aria-label={title}>
+            <thead><tr><th aria-label={t('details.delimitedRow')} scope="col">#</th>{data.headers.slice(0, MAX_COLUMNS).map((header, index) => <th key={index} scope="col">{header}</th>)}</tr></thead>
+            <tbody>{data.rows.slice(0, MAX_ROWS).map((row, rowIndex) => <tr key={rowIndex}>
+              <th scope="row">{rowIndex + 1}</th>
+              {row.slice(0, MAX_COLUMNS).map((value, columnIndex) => <td data-numeric={/^[+-]?\d+(?:[.,]\d+)*(?:[eE][+-]?\d+)?%?$/.test(value.trim()) || undefined} key={columnIndex}>{value}</td>)}
+            </tr>)}</tbody>
+          </table>
+        </div>
+        {limited ? <p className="react-delimited-limit" role="status">{t('details.officeSpreadsheetTruncated', { rows: MAX_ROWS, columns: MAX_COLUMNS })}</p> : null}
+      </> : <p>{t('details.noPreview')}</p>}
+  </>;
+}

--- a/src/react-workbench/sidecar/README.md
+++ b/src/react-workbench/sidecar/README.md
@@ -1,5 +1,5 @@
 # Sidecar
-<!-- tinybot-module-fingerprint: sha256:97fa6bb5a3a7ac1f1ecd68a38851776fabce176c9e213ed72cf47d66fc26fe53 -->
+<!-- tinybot-module-fingerprint: sha256:80a6cd877c4fcfbd4fbb0317f29d93888ffa045a655b1be70eb22b69c736faf6 -->
 
 `sidecar` owns the React resource shell displayed beside Chat. It presents
 thread-scoped Browser and Artifact resources, workspace-scoped Terminal
@@ -81,6 +81,14 @@ main startup bundle. Mounting and unmounting the React view never terminate the 
 hiding Sidecar and switching resources may remount the view, while closing the
 resource invokes termination through `SidecarResources`. Terminal input is serialized with
 polling so cursor-based output cannot be reordered.
+
+The default docked width is 520px; explicit saved widths remain respected.
+CSV and TSV files render as bounded tables (200 rows, 50 columns) with a source
+switch, row/column counts, and the existing reference-in-chat action. Extension
+recognition also handles files reported as text/plain. Parsing preserves quoted
+fields and numeric precision; malformed data produces a visible, logged error
+and leaves the original source available. File metadata is collapsed below the
+preview. File refreshes and revision-bound references use the existing lifecycle.
 
 Artifact presentation is supplied by Chat through the Sidecar render contract;
 Artifact domain state does not live in this module. Artifact tabs may come from

--- a/src/react-workbench/sidecar/Sidecar.css
+++ b/src/react-workbench/sidecar/Sidecar.css
@@ -7,7 +7,7 @@
   min-height: 0;
   overflow: visible;
   border-left: 1px solid var(--color-hairline);
-  background: var(--color-panel);
+  background: var(--color-chrome);
 }
 
 .react-sidecar[data-presentation="expanded"] {
@@ -65,7 +65,7 @@
   min-width: 0;
   align-items: stretch;
   border-bottom: 1px solid var(--color-hairline);
-  background: color-mix(in srgb, var(--color-canvas) 92%, var(--color-panel));
+  background: var(--color-chrome);
 }
 
 .react-sidecar-tabs {
@@ -108,7 +108,11 @@
 }
 
 .react-sidecar-tab[data-active="true"]::after {
-  background: var(--color-primary);
+  background: var(--color-emphasis);
+}
+
+.react-sidecar-tab[data-active="true"] .react-sidecar-tab__select {
+  font-weight: 600;
 }
 
 .react-sidecar-tab__select {

--- a/src/react-workbench/sidecar/SidecarResources.tsx
+++ b/src/react-workbench/sidecar/SidecarResources.tsx
@@ -15,6 +15,8 @@ import { useArtifactFile } from "../chat/useArtifactFile";
 import { DataViewCard } from "../chat/DataViewCard";
 import { AssistantMarkdown } from "../chat/AssistantMarkdown";
 import { ArtifactReviewPanel } from "./ArtifactReviewPanel";
+import { DelimitedTextPreview } from "./DelimitedTextPreview";
+import { artifactDelimiter } from "./delimitedText";
 import { OfficeArtifactPreview } from "./OfficeArtifactPreview";
 import { Sidecar } from "./Sidecar";
 import { SidecarBrowser } from "./SidecarBrowser";
@@ -573,26 +575,25 @@ function ArtifactDetails({
     });
   }
   const markdown = isMarkdownArtifact(artifact, detail);
+  const delimiter = !markdown && !office && !detail?.dataView && !detail?.imageDataUrl
+    ? artifactDelimiter(artifact.fetchPath || artifact.title, detail?.mimeType || artifact.mimeType) : undefined;
+  const delimited = delimiter !== undefined && detail?.textContent !== undefined;
+  const referenceAction = <button disabled={loading || Boolean(error)} onClick={referenceArtifact} type="button">{t("details.referenceInChat")}</button>;
   const markdownContent = detail?.textContent && markdown
     ? { text: detail.textContent, title: detail.title }
     : undefined;
   return (
     <div className="react-artifact-detail" data-content={markdown || office?.kind === "document" ? "document" : "preview"}>
-      <div className="react-artifact-detail__toolbar">
-        <button disabled={loading || Boolean(error)} onClick={referenceArtifact} type="button">{t("details.referenceInChat")}</button>
+      {!delimited ? <div className="react-artifact-detail__toolbar">
         {localThreadId ? <span role="status">{t("details.fileAutoUpdates")}</span> : null}
-      </div>
+        <div className="react-artifact-detail__actions">{referenceAction}</div>
+      </div> : null}
       {localThreadId && artifact.fetchPath && workspaceStore?.artifactReviews ? (
         <ArtifactReviewPanel store={workspaceStore.artifactReviews} path={artifact.fetchPath} threadId={localThreadId}
           revision={error ? undefined : file.revision} epoch={reviewEpoch} responding={responding}
           kind={office?.kind} title={artifact.title} onRestored={() => setRefreshKey((value) => value + 1)} />
       ) : null}
-      {!markdown && !office ? (
-        <dl>
-          <div><dt>{t("details.id")}</dt><dd>{artifact.id}</dd></div>
-          {detail?.mimeType || artifact.mimeType ? <div><dt>{t("details.type")}</dt><dd>{detail?.mimeType || artifact.mimeType}</dd></div> : null}
-        </dl>
-      ) : null}
+
       {loading ? <p aria-live="polite">{t("details.loadingArtifact")}</p> : null}
       {error ? <p role="alert">{error}</p> : null}
       {notice ? <p className="react-artifact-detail__notice">{notice}</p> : null}
@@ -610,7 +611,7 @@ function ArtifactDetails({
           source={office}
         />
       ) : null}
-      {markdownContent ? (
+      {delimited ? <DelimitedTextPreview actions={referenceAction} delimiter={delimiter} key={artifact.id} text={detail.textContent!} title={artifact.title} truncated={Boolean(notice)} /> : markdownContent ? (
         <article aria-label={markdownContent.title} className="react-artifact-detail__document" role="document">
           <AssistantMarkdown
             onOpenFileLink={(link) => onOpenFileLink({ ...link, sourcePath: localThreadId ? artifact.fetchPath : undefined })}
@@ -619,7 +620,15 @@ function ArtifactDetails({
           />
         </article>
       ) : detail?.textContent ? <pre className="react-artifact-detail__text">{detail.textContent}</pre> : null}
-      {!loading && !error && !office && !detail?.dataView && !detail?.imageDataUrl && !detail?.textContent ? <p>{t("details.noPreview")}</p> : null}
+      {!markdown && !office ? <details className="react-artifact-detail__metadata">
+        <summary>{t("details.fileDetails")}</summary>
+        <dl>
+          <div><dt>{t("details.id")}</dt><dd>{artifact.id}</dd></div>
+          {detail?.mimeType || artifact.mimeType ? <div><dt>{t("details.type")}</dt><dd>{detail?.mimeType || artifact.mimeType}</dd></div> : null}
+          {localThreadId ? <div><dt>{t("details.status")}</dt><dd>{t("details.fileAutoUpdates")}</dd></div> : null}
+        </dl>
+      </details> : null}
+      {!loading && !error && !office && !delimited && !detail?.dataView && !detail?.imageDataUrl && !detail?.textContent ? <p>{t("details.noPreview")}</p> : null}
     </div>
   );
 }

--- a/src/react-workbench/sidecar/delimitedText.ts
+++ b/src/react-workbench/sidecar/delimitedText.ts
@@ -1,0 +1,42 @@
+/** Parse quoted CSV/TSV without changing field values or numeric precision. */
+export function parseDelimitedText(text: string, delimiter: ',' | '\t') {
+  const input = text.replace(/^\uFEFF/, '');
+  const records: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let quoted = false;
+  let closedQuote = false;
+  const finishField = () => { row.push(field); field = ''; closedQuote = false; };
+  const finishRow = () => { finishField(); records.push(row); row = []; };
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index];
+    if (quoted) {
+      if (character !== '"') field += character;
+      else if (input[index + 1] === '"') { field += '"'; index += 1; }
+      else { quoted = false; closedQuote = true; }
+      continue;
+    }
+    if (character === delimiter) finishField();
+    else if (character === '\r' || character === '\n') {
+      finishRow();
+      if (character === '\r' && input[index + 1] === '\n') index += 1;
+    } else if (character === '"' && !field && !closedQuote) quoted = true;
+    else {
+      if (closedQuote || character === '"') throw new Error('Unexpected text beside a quoted field at record ' + (records.length + 1));
+      field += character;
+    }
+  }
+  if (quoted) throw new Error('Unclosed quoted field at record ' + (records.length + 1));
+  if (field || row.length || closedQuote) finishRow();
+  const [headers = [], ...rows] = records;
+  const invalidIndex = rows.findIndex((record) => record.length !== headers.length);
+  if (invalidIndex !== -1) throw new Error('Record ' + (invalidIndex + 2) + ' has ' + rows[invalidIndex].length + ' fields; expected ' + headers.length);
+  return { headers, rows };
+}
+
+export function artifactDelimiter(name: string, mimeType?: string): ',' | '\t' | undefined {
+  const type = mimeType?.split(';', 1)[0].trim().toLowerCase();
+  if (/\.tsv$/i.test(name) || type === 'text/tab-separated-values') return '\t';
+  if (/\.csv$/i.test(name) || type === 'text/csv' || type === 'application/csv') return ',';
+  return undefined;
+}

--- a/src/react-workbench/sidecar/sidecarModel.ts
+++ b/src/react-workbench/sidecar/sidecarModel.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_SIDECAR_WIDTH = 480;
+export const DEFAULT_SIDECAR_WIDTH = 520;
 export const MIN_DOCKED_CHAT_WIDTH = 320;
 export const MIN_SIDECAR_WIDTH = 380;
 export const SIDECAR_OVERLAY_BREAKPOINT = 1100;

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:f8c4cf133bf8ae5d8c220a1e75fff7a2495296ef154d3c33d44f20a464225cd1 -->
+<!-- tinybot-module-fingerprint: sha256:42dd4f9001c88f5f031316122dc71128c33e3d45cfbd29cb8de1e88ed3a8937b -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.
@@ -77,7 +77,10 @@ workspace folder icons reflect the open or closed state.
 Workspace, project, and session rows share a 36px minimum height, 8px corners,
 and a 16px icon column. Session rows reserve that column with an aria-hidden
 placeholder so their titles align with the workspace title. Project contents
-keep one nesting inset. Session hover and selection use the same surface color.
+keep one nesting inset. Light-theme selected sessions use a graphite surface and light text, distinct
+from the subtle hover surface. Chat uses a near-white reading surface, while
+the sidebar and Sidecar chrome use a cooler neutral surface. Reduced-transparency
+mode keeps those opaque region colors.
 Workspace and project headers highlight only on hover or keyboard focus, not
 because they contain the active session.
 Workspace paths appear only in header tooltips; nested workspace actions share

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1,14 +1,16 @@
 :root {
-  --color-canvas: #faf9f5;
+  --color-canvas: #fcfcfa;
   --color-panel: #fff;
   --color-panel-warm: #fffdfa;
-  --color-surface-soft: #f5f0e8;
-  --color-surface-card: #efe9de;
-  --color-cream-strong: #e8e0d2;
-  --color-ink: #141413;
+  --color-surface-soft: #f3f3f1;
+  --color-surface-card: #eaebe8;
+  --color-cream-strong: #e2e3e0;
+  --color-chrome: #f0f1f2;
+  --color-emphasis: #343936;
+  --color-ink: #202521;
   --color-body: #3d3d3a;
   --color-muted: #6c6a64;
-  --color-muted-soft: #8e8b82;
+  --color-muted-soft: #737770;
   --color-scrollbar-thumb: color-mix(in srgb, var(--color-ink) 16%, transparent);
   --color-scrollbar-thumb-hover: color-mix(in srgb, var(--color-ink) 42%, transparent);
   --color-scrollbar-thumb-active: color-mix(in srgb, var(--color-ink) 56%, transparent);
@@ -17,7 +19,7 @@
   --color-on-primary: #fff;
   --color-accent: var(--color-primary);
   --color-surface: var(--color-panel);
-  --color-hairline: #e6dfd8;
+  --color-hairline: #d9dad7;
   --color-success: #5db872;
   --color-warning: #d4a017;
   --color-error: #c64545;
@@ -37,7 +39,7 @@
   --lieflat-porcelain-halo: rgba(247, 242, 235, 0.92);
   --font-ui: Inter, "Noto Sans SC", "Microsoft YaHei UI", "Microsoft YaHei", "PingFang SC", "Hiragino Sans GB", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Arial, sans-serif;
   --font-code: "JetBrains Mono", "Cascadia Code", "Cascadia Mono", Consolas, "Liberation Mono", monospace;
-  --sidebar-background: var(--color-surface-soft);
+  --sidebar-background: var(--color-chrome);
   --sidebar-backdrop-filter: none;
   --motion-duration-fast: 160ms;
   --motion-duration-medium: 220ms;
@@ -803,7 +805,7 @@ button:disabled {
   position: relative;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  width: var(--session-sidebar-width, 280px);
+  width: var(--session-sidebar-width, 240px);
   min-height: 0;
   overflow: hidden;
   border-right: 1px solid var(--color-hairline);
@@ -1623,10 +1625,29 @@ button:disabled {
   animation-delay: calc(var(--react-session-row-index, 0) * 30ms);
 }
 
-.react-session-row[data-active="true"],
 .react-session-row:hover,
 .react-session-row:focus-within {
   background: var(--color-cream-strong);
+}
+
+.react-session-row[data-active="true"] {
+  background: var(--color-cream-strong);
+}
+
+:root[data-theme="light"] .react-session-row[data-active="true"] {
+  background: var(--color-emphasis);
+}
+
+:root[data-theme="light"] .react-session-row[data-active="true"] :is(.react-session-row__title, .react-session-row__select small, .react-session-row__delete) {
+  color: var(--color-canvas);
+}
+
+:root[data-theme="light"] .react-session-row[data-active="true"] .react-session-row__delete:hover {
+  background: color-mix(in srgb, var(--color-canvas) 18%, transparent);
+}
+
+.react-session-row[data-active="true"] .react-session-row__title {
+  font-weight: 600;
 }
 
 .react-session-row__select {
@@ -1791,8 +1812,8 @@ button:disabled {
 }
 
 .react-session-tab[data-active="true"] {
-  background: color-mix(in srgb, var(--color-cream-strong) 54%, var(--color-canvas));
-  box-shadow: inset 0 -2px var(--color-primary);
+  background: var(--color-panel);
+  box-shadow: inset 0 -2px var(--color-emphasis);
   color: var(--color-ink);
 }
 
@@ -2012,7 +2033,7 @@ button:disabled {
 
 @media (prefers-reduced-transparency: reduce) {
   .react-session-list {
-    background: var(--color-panel);
+    background: var(--color-chrome);
     backdrop-filter: none;
   }
 }


### PR DESCRIPTION
Submitted input forms could remain visible after the agent resumed, while cancellation stayed unavailable because the persisted turn still reflected its waiting checkpoint. Persist and replay form resolutions, reconcile the renderer's form cache, and refresh cancellation capabilities when a form completes. Successful submissions clear their command banner; genuine validation failures remain visible.

Refine the light theme with stronger regional contrast, compact typography, and a centered 800px maximum width shared by conversation content and the composer. Preserve the floating Plan capsule and expandable details, remove duplicate per-step status text, and add bounded CSV/TSV table previews with a source toggle and visible parsing errors.

Shell process waits also recheck their monotonic deadline after every wakeup. This prevents Windows timer timeout reports from ending a wait slightly early, while preserving early returns for process completion, cancellation, and new output.

## Validation

- 78 targeted frontend tests passed for form completion, timeline rendering, and chat lifecycle behavior.
- Rust library validation: 1102 tests passed in the full run; the terminal cleanup test passed when rerun outside the sandbox (1 test ignored). The original five-second wait-floor test and both new deadline regressions passed.
- Floating Plan interaction tests passed after simplifying the status display.
- Frontend production build, targeted ESLint, and native desktop build passed.
- Browser checks covered wide and narrow layouts, new conversations, Sidecar previews, and the floating Plan.
- Staged engineering documentation and module README checks passed.