### PR TITLE
fix: align data view contracts and simplify session tabs

### DIFF
--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -22,7 +22,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:9872376cb0956022a81f0936b14721517ca1883069c7685a8e02a910eebf521f -->
+<!-- tinybot-doc-fingerprint: sha256:d80ee217e1585b9d5d34b213c2921297c36b166a8e24391d3f5f6a3d5042796a -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -14,7 +14,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:0bb07d75feb1f3e8359ace1855f48c7eaa2993bf2b0381b7fea8043d7de495b7 -->
+<!-- tinybot-doc-fingerprint: sha256:134d8f38f64cfacd8d45263ab401d6f6b37149ed909e17487e9e65abc6864398 -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:ac8b9b5765a8db35dda668919810ab43b54bd3f4f6676c0878d96405c6c24c4d -->
+<!-- tinybot-doc-fingerprint: sha256:a745f0157e4e119ce26d8caffa3d6080b61ebc7d149580cc16d9e3dae0359c3d -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -13,7 +13,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:4bb106104a14172295e77fdfca067d88eee5cc6e96bf6355fc2862ff53727efd -->
+<!-- tinybot-doc-fingerprint: sha256:11910b4eeef9e29191c18bfc2ff043666cf903050ae27f39d1dabf0ea5660234 -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,
@@ -73,9 +73,11 @@ Every registry entry declares:
 - parallelism, mutation, cancellation, and cleanup policy.
 
 Provider-visible schemas describe nested argument contracts, not only their
-top-level names. For example, `publish_data_view` exposes the supported view
-kinds and requires table `defaultSort` to use `{field, direction}` so providers
-can construct the same shape the native validator accepts.
+top-level names. For example, `publish_data_view` exposes disjoint view shapes
+and reserves numeric formatting for number columns. Table `defaultSort` uses
+`{field, direction}`; view fields retain camelCase in persisted artifacts.
+Row IDs accept unique nonblank natural identifiers. Publication has no per-Turn
+count quota; each artifact still obeys the native size and data limits.
 
 The dispatcher prepares application tool contributions asynchronously through
 `prepare_tools`, returning a catalog plus the effective selection or a cancellation

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,10 +1,14 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:3b3c373016c8c8ce7dd4c96a274f534b2dcdf34589d5819cb93180efa01b517c -->
+<!-- tinybot-module-fingerprint: sha256:39bbecbddab5dc740fc4fa0cb868b91793096a4d883d745a0f9f86896d91614c -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed
 instructions into typed agent items, runtime events, checkpoints, usage, and a
 terminal result.
+
+Data-view validation accepts unique nonblank natural row IDs, while column and
+source identifiers follow the registry's documented pattern. View-specific wire
+fields use camelCase (`defaultSort`, `totalField`) on input and persisted output.
 
 Execution results stay as `AgentTurnResult` through provider/tool iterations,
 task ownership, lifecycle hooks, bridge persistence, and Graph/workspace-thread

--- a/src-tauri/src/agent/runtime/data_view.rs
+++ b/src-tauri/src/agent/runtime/data_view.rs
@@ -74,7 +74,12 @@ struct DataViewRow {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
 enum DataView {
     Metrics {
         items: Vec<DataViewMetric>,
@@ -374,7 +379,9 @@ fn validate_document(document: &DataViewDocument) -> Result<(), String> {
 
     let mut row_ids = HashSet::new();
     for row in &document.dataset.rows {
-        validate_identifier("row id", &row.id)?;
+        if row.id.trim().is_empty() {
+            return Err("data_view_invalid_shape: row id must be nonblank".to_string());
+        }
         if !row_ids.insert(row.id.as_str()) {
             return Err(format!(
                 "data_view_invalid_shape: duplicate row id `{}`",
@@ -564,7 +571,7 @@ fn validate_identifier(label: &str, value: &str) -> Result<(), String> {
         .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '.' | '-'));
     if !valid_first || !valid_rest {
         return Err(format!(
-            "data_view_invalid_shape: {label} `{value}` is not a valid identifier"
+            "data_view_invalid_shape: {label} `{value}` must match [A-Za-z_][A-Za-z0-9_.-]*"
         ));
     }
     Ok(())
@@ -662,6 +669,44 @@ mod tests {
         .as_object()
         .unwrap()
         .clone()
+    }
+
+    #[test]
+    fn accepts_natural_row_ids_but_rejects_blank_and_duplicate_ids() {
+        let mut input = Value::Object(valid_view());
+        input["dataset"]["rows"][0]["id"] = json!("Significant-Gravitas/AutoGPT");
+        input["dataset"]["rows"][1]["id"] = json!("2026/中文");
+        assert!(publish_data_view(input.as_object().unwrap(), "t", "c").is_ok());
+        input["dataset"]["rows"][1]["id"] = json!("Significant-Gravitas/AutoGPT");
+        assert!(publish_data_view(input.as_object().unwrap(), "t", "c")
+            .err()
+            .unwrap()
+            .contains("duplicate row id"));
+        input["dataset"]["rows"][1]["id"] = json!("   ");
+        assert!(publish_data_view(input.as_object().unwrap(), "t", "c")
+            .err()
+            .unwrap()
+            .contains("nonblank"));
+    }
+
+    #[test]
+    fn preserves_camel_case_view_fields_for_the_renderer() {
+        let mut input = Value::Object(valid_view());
+        input["view"] =
+            json!({"kind": "table", "defaultSort": {"field": "revenue", "direction": "desc"}});
+        let published = publish_data_view(input.as_object().unwrap(), "t", "c").unwrap();
+        assert_eq!(
+            published.artifact["content"]["view"]["defaultSort"],
+            input["view"]["defaultSort"]
+        );
+        input["dataset"]["columns"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({"key":"total", "label":"Total", "type":"boolean"}));
+        input["dataset"]["rows"][0]["values"]["total"] = json!(true);
+        input["view"] = json!({"kind":"waterfall", "category":"period", "value":"revenue", "totalField":"total"});
+        let published = publish_data_view(input.as_object().unwrap(), "t", "c").unwrap();
+        assert_eq!(published.artifact["content"]["view"]["totalField"], "total");
     }
 
     #[test]

--- a/src-tauri/src/agent/runtime/tests/README.md
+++ b/src-tauri/src/agent/runtime/tests/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Tests
-<!-- tinybot-module-fingerprint: sha256:41c190fa21582d96b435f415b1351f1a1a438a7fd9ce1f6e38b799d16d9c3125 -->
+<!-- tinybot-module-fingerprint: sha256:d33d03e3be10e046da68080d6311d2b089b61d651a2ba80a9abb4dd67960195e -->
 
 This directory groups the larger agent runtime test suites by concern:
 configuration, context, interactions, lifecycle, and tools.
@@ -45,7 +45,7 @@ Tool coverage verifies provider call/result pairing, multi-call batches, and
 native tool errors that remain model-visible so the next provider iteration can
 respond. Mixed-batch coverage verifies that the exclusive `update_plan`
 runtime control forms an ordering barrier and does not reject its ordinary
-tool siblings. Data-view cases cover successful artifact publication and
+tool siblings. Data-view cases cover four successful publications in one Turn and
 parseable arguments rejected by the native schema. Malformed argument JSON
 covers both a single call and a partially invalid batch, asserting that
 dispatch is blocked, every call ID receives a non-empty error result, and the

--- a/src-tauri/src/agent/runtime/tests/tools.rs
+++ b/src-tauri/src/agent/runtime/tests/tools.rs
@@ -2338,6 +2338,7 @@ fn publish_data_view_handles_multiple_calls_from_one_provider_response() {
         ("call-data-view-1", "Revenue", "bar"),
         ("call-data-view-2", "Profit", "line"),
         ("call-data-view-3", "Cash flow", "bar"),
+        ("call-data-view-4", "Expenses", "line"),
     ]
     .into_iter()
     .map(|(id, title, mark)| {
@@ -2389,7 +2390,7 @@ fn publish_data_view_handles_multiple_calls_from_one_provider_response() {
                 "fixture": {
                     "responses": [
                         { "content": "", "toolCalls": tool_calls },
-                        { "content": "Published three data views." }
+                        { "content": "Published four data views." }
                     ]
                 }
             }
@@ -2401,7 +2402,7 @@ fn publish_data_view_handles_multiple_calls_from_one_provider_response() {
     let completed = result["completedToolResults"]
         .as_array()
         .expect("completed tool results should be present");
-    assert_eq!(completed.len(), 3);
+    assert_eq!(completed.len(), 4);
     assert!(completed.iter().all(|result| {
         result["envelope"]["status"] == "ok"
             && result["envelope"]["artifacts"][0]["kind"] == "data_view"
@@ -2415,7 +2416,12 @@ fn publish_data_view_handles_multiple_calls_from_one_provider_response() {
         .collect::<Vec<_>>();
     assert_eq!(
         result_call_ids,
-        vec!["call-data-view-1", "call-data-view-2", "call-data-view-3"]
+        vec![
+            "call-data-view-1",
+            "call-data-view-2",
+            "call-data-view-3",
+            "call-data-view-4"
+        ]
     );
 }
 

--- a/src-tauri/src/agent/runtime/tool_runtime.rs
+++ b/src-tauri/src/agent/runtime/tool_runtime.rs
@@ -458,7 +458,7 @@ async fn execute_publish_data_views(
             planned_call.tool_call
         };
 
-        let result = publish_data_view_result(context, state, &tool_call);
+        let result = publish_data_view_result(context, &tool_call);
         commit_executed_tool_observation(context, state, iteration, tool_call, result).await?;
     }
 
@@ -480,34 +480,10 @@ async fn execute_publish_data_views(
 
 fn publish_data_view_result(
     context: &AgentTurnContext,
-    state: &AgentTurnState,
     tool_call: &PreparedToolCall,
 ) -> super::NativeAgentToolResult {
     context.metrics().increment("tool.started");
     let tool_started_at = std::time::Instant::now();
-    let published_count = state
-        .completed_tool_results
-        .iter()
-        .filter(|result| {
-            result
-                .envelope
-                .pointer("/structured/kind")
-                .and_then(Value::as_str)
-                == Some("data_view_published")
-        })
-        .count();
-    if published_count >= 3 {
-        context
-            .metrics()
-            .record_duration("tool.durationMs", tool_started_at.elapsed());
-        context.metrics().increment("tool.failed");
-        return super::NativeAgentToolResult::generic_error(
-            tool_call,
-            "data_view_turn_limit: at most three data views may be published in one turn"
-                .to_string(),
-        );
-    }
-
     let published = match super::data_view::publish_data_view(
         tool_call.arguments(),
         &context.turn_id,

--- a/src-tauri/src/tools/registry/README.md
+++ b/src-tauri/src/tools/registry/README.md
@@ -1,5 +1,5 @@
 # Tool Registry
-<!-- tinybot-module-fingerprint: sha256:c1635b4384415d7174dd3d9f73348e8fd46944650709c79f457b27c5f289839c -->
+<!-- tinybot-module-fingerprint: sha256:7ceeba22a925fff3817c83d522df71276257235407505f409b1d069aa627345b -->
 
 `registry` is the catalog of tools available to the runtime. Each entry records
 its schema, exposure, execution target, required capabilities, cancellation
@@ -22,8 +22,10 @@ schemas, capability grants, parallelism, and cancellation policy remain registry
 metadata; the bridge rechecks project membership and parent ownership on execution.
 
 Provider-visible schemas include nested contracts used by native validation.
-For `publish_data_view`, this includes supported view kinds and the table
-`defaultSort` object with required `field` and `direction` properties.
+For `publish_data_view`, disjoint view shapes prevent mixing table sorting with
+chart encodings, and column shapes reserve numeric formatting for number columns.
+Row IDs accept nonblank natural identifiers; column and source keys retain their
+documented identifier pattern.
 The `write_stdin` contract distinguishes empty-input completion waits from
 interactive writes. It exposes waits up to 300 seconds and explains output
 batching, the 5-second floor, and the default 30-second background wait.

--- a/src-tauri/src/tools/registry/mod.rs
+++ b/src-tauri/src/tools/registry/mod.rs
@@ -384,39 +384,152 @@ fn core_tool_entries() -> Vec<ToolRegistryEntry> {
             vec![WorkerCapability::SessionWrite],
             json!({
                 "type": "object",
-                "required": ["schemaVersion", "title", "insight", "dataset", "view", "provenance"],
+                "required": [
+                    "schemaVersion",
+                    "title",
+                    "insight",
+                    "dataset",
+                    "view",
+                    "provenance"
+                ],
                 "properties": {
-                    "schemaVersion": { "type": "string", "const": "tinybot.data_view.v1" },
-                    "title": { "type": "string", "minLength": 1, "maxLength": 160 },
-                    "insight": { "type": "string", "minLength": 1, "maxLength": 500 },
+                    "schemaVersion": {
+                        "type": "string",
+                        "const": "tinybot.data_view.v1"
+                    },
+                    "title": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 160
+                    },
+                    "insight": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 500
+                    },
                     "dataset": {
                         "type": "object",
-                        "required": ["columns", "rows"],
+                        "required": [
+                            "columns",
+                            "rows"
+                        ],
                         "properties": {
                             "columns": {
-                                "type": "array", "minItems": 1, "maxItems": 20,
+                                "type": "array",
+                                "minItems": 1,
+                                "maxItems": 20,
                                 "items": {
-                                    "type": "object", "required": ["key", "label", "type"],
-                                    "properties": {
-                                        "key": { "type": "string" },
-                                        "label": { "type": "string" },
-                                        "type": { "type": "string", "enum": ["category", "string", "number", "date", "datetime", "boolean"] },
-                                        "format": { "type": "string", "enum": ["number", "integer", "compact", "percent", "currency"] },
-                                        "currency": { "type": "string", "description": "Three-letter ISO 4217 code, for example USD." },
-                                        "unit": { "type": "string", "description": "Display unit only; values must already use this unit." },
-                                        "fractionDigits": { "type": "integer", "minimum": 0, "maximum": 4 }
-                                    },
-                                    "additionalProperties": false
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "key",
+                                                "label",
+                                                "type"
+                                            ],
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "pattern": "^[A-Za-z_][A-Za-z0-9_.-]*$",
+                                                    "description": "Unique column key referenced by row values and view fields."
+                                                },
+                                                "label": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 120
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "const": "number"
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "number",
+                                                        "integer",
+                                                        "compact",
+                                                        "percent",
+                                                        "currency"
+                                                    ],
+                                                    "description": "Only for number columns. Percent uses percentage points: 9.4 displays as 9.4%. Currency format requires currency."
+                                                },
+                                                "currency": {
+                                                    "type": "string",
+                                                    "description": "Only with currency format. Required uppercase three-letter ISO 4217 code, for example USD."
+                                                },
+                                                "unit": {
+                                                    "type": "string",
+                                                    "description": "Display unit only; values must already use this unit."
+                                                },
+                                                "fractionDigits": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "maximum": 4
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "key",
+                                                "label",
+                                                "type"
+                                            ],
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "pattern": "^[A-Za-z_][A-Za-z0-9_.-]*$",
+                                                    "description": "Unique column key referenced by row values and view fields."
+                                                },
+                                                "label": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 120
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "category",
+                                                        "string",
+                                                        "date",
+                                                        "datetime",
+                                                        "boolean"
+                                                    ],
+                                                    "description": "date cells use YYYY-MM-DD; datetime cells use RFC3339 with timezone."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    ]
                                 }
                             },
                             "rows": {
-                                "type": "array", "minItems": 1, "maxItems": 1000,
+                                "type": "array",
+                                "minItems": 1,
+                                "maxItems": 1000,
                                 "items": {
-                                    "type": "object", "required": ["id", "values"],
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "values"
+                                    ],
                                     "properties": {
-                                        "id": { "type": "string" },
-                                        "values": { "type": "object", "description": "Keys must match declared columns; values must match column types. Null is allowed for missing data." },
-                                        "sourceIds": { "type": "array", "items": { "type": "string" } }
+                                        "id": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "description": "Unique nonblank row ID. Natural identifiers such as owner/repo and Unicode names are accepted."
+                                        },
+                                        "values": {
+                                            "type": "object",
+                                            "description": "Keys must match declared columns; values must match column types. Null is allowed for missing data."
+                                        },
+                                        "sourceIds": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
                                     },
                                     "additionalProperties": false
                                 }
@@ -425,83 +538,250 @@ fn core_tool_entries() -> Vec<ToolRegistryEntry> {
                         "additionalProperties": false
                     },
                     "view": {
-                        "type": "object",
-                        "required": ["kind"],
-                        "properties": {
-                            "kind": {
-                                "type": "string",
-                                "enum": ["metrics", "table", "cartesian", "waterfall"]
+                        "description": "Choose exactly one shape; never mix fields from different kinds. Table fields may be omitted or empty to show all columns.",
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "required": [
+                                    "kind",
+                                    "items"
+                                ],
+                                "properties": {
+                                    "kind": {
+                                        "type": "string",
+                                        "const": "metrics"
+                                    },
+                                    "items": {
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "maxItems": 6,
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "field"
+                                            ],
+                                            "properties": {
+                                                "field": {
+                                                    "type": "string",
+                                                    "description": "Key of a number column."
+                                                },
+                                                "comparisonField": {
+                                                    "type": "string",
+                                                    "description": "Key of a number column."
+                                                },
+                                                "direction": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "higher_is_better",
+                                                        "lower_is_better",
+                                                        "neutral"
+                                                    ]
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                },
+                                "additionalProperties": false
                             },
-                            "items": {
-                                "type": "array", "minItems": 1, "maxItems": 6,
+                            {
+                                "type": "object",
+                                "required": [
+                                    "kind"
+                                ],
+                                "properties": {
+                                    "kind": {
+                                        "type": "string",
+                                        "const": "table"
+                                    },
+                                    "fields": {
+                                        "type": "array",
+                                        "maxItems": 20,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "defaultSort": {
+                                        "type": "object",
+                                        "required": [
+                                            "field",
+                                            "direction"
+                                        ],
+                                        "properties": {
+                                            "field": {
+                                                "type": "string"
+                                            },
+                                            "direction": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "asc",
+                                                    "desc"
+                                                ]
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            {
+                                "type": "object",
+                                "required": [
+                                    "kind",
+                                    "x",
+                                    "series"
+                                ],
+                                "properties": {
+                                    "kind": {
+                                        "type": "string",
+                                        "const": "cartesian"
+                                    },
+                                    "x": {
+                                        "type": "string",
+                                        "description": "Key of a category, string, date or datetime column, never number. Rows determine display order; sort dataset.rows before publishing."
+                                    },
+                                    "series": {
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "maxItems": 6,
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "field",
+                                                "mark"
+                                            ],
+                                            "properties": {
+                                                "field": {
+                                                    "type": "string",
+                                                    "description": "Key of a number column."
+                                                },
+                                                "mark": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "line",
+                                                        "bar",
+                                                        "area"
+                                                    ]
+                                                },
+                                                "axis": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "left",
+                                                        "right"
+                                                    ],
+                                                    "description": "Defaults to left. Right requires a left series, at most two series total, and a different unit, format or currency."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "stack": {
+                                        "type": "string",
+                                        "enum": [
+                                            "none",
+                                            "normal"
+                                        ],
+                                        "description": "Defaults to none. Normal stacking permits only bar/area series on the same axis."
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            {
+                                "type": "object",
+                                "required": [
+                                    "kind",
+                                    "category",
+                                    "value"
+                                ],
+                                "properties": {
+                                    "kind": {
+                                        "type": "string",
+                                        "const": "waterfall"
+                                    },
+                                    "category": {
+                                        "type": "string",
+                                        "description": "Key of a category or string column."
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "Key of a number column."
+                                    },
+                                    "totalField": {
+                                        "type": "string",
+                                        "description": "Key of a boolean column; true marks an absolute total instead of a delta."
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        ]
+                    },
+                    "provenance": {
+                        "type": "object",
+                        "required": [
+                            "status"
+                        ],
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "enum": [
+                                    "sourced",
+                                    "user_provided",
+                                    "unsourced"
+                                ],
+                                "description": "Sourced requires at least one source."
+                            },
+                            "asOf": {
+                                "type": "string"
+                            },
+                            "sources": {
+                                "type": "array",
+                                "maxItems": 64,
                                 "items": {
-                                    "type": "object", "required": ["field"],
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "kind",
+                                        "title"
+                                    ],
                                     "properties": {
-                                        "field": { "type": "string" },
-                                        "comparisonField": { "type": "string" },
-                                        "direction": {
+                                        "id": {
                                             "type": "string",
-                                            "enum": ["higher_is_better", "lower_is_better", "neutral"]
+                                            "pattern": "^[A-Za-z_][A-Za-z0-9_.-]*$"
+                                        },
+                                        "kind": {
+                                            "type": "string",
+                                            "enum": [
+                                                "url",
+                                                "file",
+                                                "user_input"
+                                            ]
+                                        },
+                                        "title": {
+                                            "type": "string"
+                                        },
+                                        "uri": {
+                                            "type": "string",
+                                            "description": "Required for url sources; use an absolute HTTP or HTTPS URL."
+                                        },
+                                        "locator": {
+                                            "type": "string"
+                                        },
+                                        "publishedAt": {
+                                            "type": "string"
                                         }
                                     },
                                     "additionalProperties": false
                                 }
                             },
-                            "fields": {
-                                "type": "array", "maxItems": 20,
-                                "items": { "type": "string" }
+                            "methodology": {
+                                "type": "string"
                             },
-                            "defaultSort": {
-                                "type": "object", "required": ["field", "direction"],
-                                "properties": {
-                                    "field": { "type": "string" },
-                                    "direction": { "type": "string", "enum": ["asc", "desc"] }
-                                },
-                                "additionalProperties": false
-                            },
-                            "x": { "type": "string" },
-                            "series": {
-                                "type": "array", "minItems": 1, "maxItems": 6,
+                            "caveats": {
+                                "type": "array",
                                 "items": {
-                                    "type": "object", "required": ["field", "mark"],
-                                    "properties": {
-                                        "field": { "type": "string" },
-                                        "mark": { "type": "string", "enum": ["line", "bar", "area"] },
-                                        "axis": { "type": "string", "enum": ["left", "right"] }
-                                    },
-                                    "additionalProperties": false
+                                    "type": "string"
                                 }
-                            },
-                            "stack": { "type": "string", "enum": ["none", "normal"] },
-                            "category": { "type": "string" },
-                            "value": { "type": "string" },
-                            "totalField": { "type": "string" }
-                        },
-                        "additionalProperties": false,
-                        "description": "Choose the fields that match kind: metrics uses items; table uses fields and optional defaultSort {field,direction}; cartesian uses x, series and optional stack; waterfall uses category, value and optional totalField."
-                    },
-                    "provenance": {
-                        "type": "object", "required": ["status"],
-                        "properties": {
-                            "status": { "type": "string", "enum": ["sourced", "user_provided", "unsourced"] },
-                            "asOf": { "type": "string" },
-                            "sources": {
-                                "type": "array", "maxItems": 64,
-                                "items": {
-                                    "type": "object", "required": ["id", "kind", "title"],
-                                    "properties": {
-                                        "id": { "type": "string" },
-                                        "kind": { "type": "string", "enum": ["url", "file", "user_input"] },
-                                        "title": { "type": "string" },
-                                        "uri": { "type": "string" },
-                                        "locator": { "type": "string" },
-                                        "publishedAt": { "type": "string" }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            },
-                            "methodology": { "type": "string" },
-                            "caveats": { "type": "array", "items": { "type": "string" } }
+                            }
                         },
                         "additionalProperties": false
                     }

--- a/src-tauri/src/tools/registry/registry_tests.rs
+++ b/src-tauri/src/tools/registry/registry_tests.rs
@@ -76,7 +76,8 @@ fn publish_data_view_is_model_visible_and_requires_session_write() {
         available.input_schema["properties"]["schemaVersion"]["const"],
         "tinybot.data_view.v1"
     );
-    let default_sort = &available.input_schema["properties"]["view"]["properties"]["defaultSort"];
+    let default_sort =
+        &available.input_schema["properties"]["view"]["anyOf"][1]["properties"]["defaultSort"];
     assert_eq!(default_sort["type"], "object");
     assert_eq!(default_sort["required"], json!(["field", "direction"]));
     assert_eq!(

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:a2809560a91cf206588b62fb3fe5a1d916f28aa2390b2f026fd990fa548e5dae -->
+<!-- tinybot-module-fingerprint: sha256:4523dbdd728e62952123fc981ac2b78a55e9c4f36047770b0b18ac618f094638 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -19,6 +19,9 @@ shared modal focus and native-surface occlusion conventions.
 Conversation content and the composer share an 800px maximum width and remain
 centered within the Chat surface. Horizontal gutters scale with the available
 Chat width from 20px to 40px, including docked Sidecar and empty-chat layouts.
+`SessionTabStrip` presents open conversations directly in the header. Overflowing
+tabs remain reachable through horizontal wheel scrolling and keyboard navigation;
+activating a tab scrolls it into view. Each tab retains its close action.
 `SessionSidebarResizeHandle` owns sidebar width and its drag lifecycle. Expanded
 width defaults to 240 px and ranges from 220 to 420 px, with the maximum reduced
 to reserve 480 px for the chat workspace where possible. Pointer movement updates

--- a/src/react-workbench/chat/SessionTabStrip.tsx
+++ b/src/react-workbench/chat/SessionTabStrip.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useLayoutEffect, useRef, useState, type KeyboardEvent } from "react";
-import { AlertTriangle, Circle, List, Loader2, X } from "lucide-react";
+import { useEffect, useLayoutEffect, useRef, type KeyboardEvent } from "react";
+import { AlertTriangle, Circle, Loader2, X } from "lucide-react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import type { SessionSummary } from "../services";
@@ -23,13 +23,8 @@ export function SessionTabStrip({
   tabs,
 }: SessionTabStripProps) {
   const { t } = useTranslation("chat");
-  const [menuOpen, setMenuOpen] = useState(false);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef(new Map<string, HTMLButtonElement>());
-
-  useEffect(() => {
-    setMenuOpen(false);
-  }, [activeSessionId]);
 
   useLayoutEffect(() => {
     tabRefs.current.get(activeSessionId)?.scrollIntoView({ block: "nearest", inline: "nearest" });
@@ -161,39 +156,6 @@ export function SessionTabStrip({
           </div>
         )}
       </div>
-      {tabs.length > 1 ? (
-        <div className="react-session-tabs__controls">
-          <div className="react-session-tabs__overflow">
-            <button
-              aria-expanded={menuOpen}
-              aria-haspopup="menu"
-              aria-label={t("tabs.menu")}
-              title={t("tabs.openTabs")}
-              type="button"
-              onClick={() => setMenuOpen((open) => !open)}
-            >
-              <List aria-hidden="true" size={15} />
-            </button>
-            {menuOpen ? (
-              <div className="react-popover-surface react-session-tabs__menu" role="menu">
-                {tabs.map((tab) => (
-                  <button
-                    aria-current={tab.id === activeSessionId ? "page" : undefined}
-                    className="react-popover-item"
-                    key={tab.id}
-                    role="menuitem"
-                    type="button"
-                    onClick={() => onActivate(tab.id)}
-                  >
-                    <SessionTabStatus tab={tab} />
-                    <span className="react-session-tabs__menu-title">{tab.title}</span>
-                  </button>
-                ))}
-              </div>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:fa379c284e2ce1bf1615bd5465ab86b6eca2d24215ad02235fc705d6fc38d967 -->
+<!-- tinybot-module-fingerprint: sha256:63fba2971800625b880770ca0aeb65cc955781e9c49e66ca2a2b9f3fe13ca5dc -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles. Composer drag targets and attachment preparation

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1114,7 +1114,7 @@ export const en = {
       workspacePicker: "Workspace: {{workspace}}",
       workspaceMenu: "Choose a workspace",
     },
-    tabs: { open: "Open conversations", closeTab: "Close {{name}} tab", close: "Close {{name}}", menu: "Open tabs menu", openTabs: "Open tabs", status: { running: "running", failed: "failed", unread: "unread activity" } },
+    tabs: { open: "Open conversations", closeTab: "Close {{name}} tab", close: "Close {{name}}", status: { running: "running", failed: "failed", unread: "unread activity" } },
     annotation: {
       moveEditor: "Move annotation editor (drag or use arrow keys)",
       scrubHint: "Click to type; drag up or down to adjust. Hold Shift for larger steps.",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -561,7 +561,7 @@ export const zh = {
       workspacePicker: "工作区：{{workspace}}",
       workspaceMenu: "选择工作区",
     },
-    tabs: { open: "打开的会话", closeTab: "关闭 {{name}} 标签页", close: "关闭 {{name}}", menu: "打开标签页菜单", openTabs: "打开的标签页", status: { running: "运行中", failed: "失败", unread: "有未读活动" } },
+    tabs: { open: "打开的会话", closeTab: "关闭 {{name}} 标签页", close: "关闭 {{name}}", status: { running: "运行中", failed: "失败", unread: "有未读活动" } },
     annotation: {
       moveEditor: "移动批注窗口（拖拽或使用方向键）",
       scrubHint: "单击输入；上下拖动调整，按住 Shift 加快调整。",

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:42dd4f9001c88f5f031316122dc71128c33e3d45cfbd29cb8de1e88ed3a8937b -->
+<!-- tinybot-module-fingerprint: sha256:7d93a8a23a777f345d018a6e41645cd5ee4bdb8fd02011c6cdd6ffbefc92ba3b -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.
@@ -20,7 +20,7 @@ held drag can reverse direction and reopen the sidebar.
 
 Workspace session reveal buttons align with session titles and use the sidebar's
 muted text, row hover surface, and keyboard focus styling.
-Session tab close and overflow controls use centered 32px targets, matching the
+Session tab close controls use centered 32px targets, matching the
 Chat header and Sidecar toolbar actions. Tab selection fills the available height
 inside the 42px header without overflowing its bottom border.
 

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1908,66 +1908,6 @@ button:disabled {
   outline-offset: -3px;
 }
 
-.react-session-tabs__controls {
-  display: flex;
-  align-items: center;
-  flex: 0 0 auto;
-  padding: 0 4px;
-  border-left: 1px solid color-mix(in srgb, var(--color-hairline) 76%, transparent);
-}
-
-.react-session-tabs__controls > button,
-.react-session-tabs__overflow > button {
-  display: inline-grid;
-  place-items: center;
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
-  min-height: 32px;
-  padding: 0;
-  color: var(--color-muted);
-}
-
-.react-session-tabs__controls > button:hover,
-.react-session-tabs__controls > button:focus-visible,
-.react-session-tabs__overflow > button:hover,
-.react-session-tabs__overflow > button:focus-visible {
-  color: var(--color-ink);
-}
-
-.react-session-tabs__overflow {
-  position: relative;
-}
-
-.react-session-tabs__menu {
-  position: absolute;
-  top: calc(100% + 5px);
-  right: 0;
-  z-index: 20;
-  width: min(280px, 42vw);
-  max-height: min(360px, 60vh);
-  overflow: auto;
-}
-
-.react-session-tabs__menu button {
-  display: grid;
-  grid-template-columns: 14px minmax(0, 1fr);
-  align-items: center;
-  gap: 8px;
-  min-height: 40px;
-  padding: 8px 10px;
-}
-
-.react-session-tabs__menu button span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.react-session-tabs__menu-title {
-  grid-column: 2;
-}
-
 @keyframes react-session-tab-spin {
   to {
     transform: rotate(360deg);


### PR DESCRIPTION
Data-view publishing could require repeated retries because the tool schema permitted inputs rejected by native validation, and a hidden three-view quota blocked otherwise valid output. This change separates view and column schema branches, documents encoding constraints, accepts unique nonblank natural row IDs, fixes camelCase view fields, and removes the per-turn publication quota while retaining per-artifact limits.

Also removes the redundant session-tab overflow menu, its styles, and unused translations. Horizontal scrolling, keyboard navigation, automatic active-tab visibility, and close actions remain available.

Validation:
- `cargo test --lib data_view -j 2`: 12 tests passed, including four successful publications in one turn and natural-ID/camelCase regressions.
- `npx tsc --noEmit`: passed.
- `npx vitest run src/react-workbench/chat/SessionTabStrip.test.tsx --maxWorkers=2`: 4 tests passed.
- Checked recorded publication arguments against the updated schema.
- Staged engineering-documentation and module README checks passed.