### PR TITLE
Fix provider presets, data-view validation, and download feedback

### DIFF
--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -14,7 +14,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:134d8f38f64cfacd8d45263ab401d6f6b37149ed909e17487e9e65abc6864398 -->
+<!-- tinybot-doc-fingerprint: sha256:23e1ba9f6547527a775d37023af161d6a9d55b53ace82525e940670271f18d02 -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:a745f0157e4e119ce26d8caffa3d6080b61ebc7d149580cc16d9e3dae0359c3d -->
+<!-- tinybot-doc-fingerprint: sha256:9e07977ed996a94333f42ff6f05636da61ecb666d5f1546370f54fca643d3003 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:6a19be51d3fed6b41e9a00739163e36a40364450570be9fc4f7bd4b0c6910d3b -->
+<!-- tinybot-module-fingerprint: sha256:a01334b4b82f7d4f364b3212adccf10ef8e67442810642ad2ac6814eb19a9bf7 -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:a01334b4b82f7d4f364b3212adccf10ef8e67442810642ad2ac6814eb19a9bf7 -->
+<!-- tinybot-module-fingerprint: sha256:d002d97c70576e1e88814c2594198ef79bc70e6191831f074432a3b88ab433cc -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -1,5 +1,5 @@
 # Agent
-<!-- tinybot-module-fingerprint: sha256:23098df73a5256683fb75ff626de736fd186023a75b1cceffb9f85ce7c7f0f0d -->
+<!-- tinybot-module-fingerprint: sha256:1e74d480d592f42ebb0193ba453ad1e547171c88fbef3a8c46d2cfb14f4d89f4 -->
 
 `agent` contains the native agent stack. It connects provider configuration,
 the turn runtime, durable runtime events, and the desktop integration bridge.

--- a/src-tauri/src/agent/provider/README.md
+++ b/src-tauri/src/agent/provider/README.md
@@ -1,5 +1,5 @@
 # Agent Providers
-<!-- tinybot-module-fingerprint: sha256:9d09486427d6989f83354120f92589b3853e19cf77fbeda7e844ae4ebc916bf4 -->
+<!-- tinybot-module-fingerprint: sha256:a6b8b252dfbd034e9d3b52cf15b89aadc86397511b778aaf0de797b64c62fce7 -->
 
 This module resolves provider and model configuration and performs streaming
 Chat Completions or Responses API requests.
@@ -19,7 +19,7 @@ Chat Completions or Responses API requests.
   keeps effort out of provider requests. Profile `modelContextWindows` entries
   are normalized into positive per-model context-window overrides. Profile
   `modelCapabilities` entries override built-in input modalities per model;
-  `glm-5.3-flash` and `deepseek-v4-flash-vision-exp` accept images by default.
+  `glm-5.3-flash`, `deepseek-flash`, and the legacy Flash aliases accept images by default.
   Built-in providers declare their supported protocol modes; Z.ai is Chat
   Completions only and uses a static GLM model list.
 - `completion.rs` performs provider requests. Provider selection requires an

--- a/src-tauri/src/agent/provider/catalog.rs
+++ b/src-tauri/src/agent/provider/catalog.rs
@@ -8,7 +8,12 @@ use super::plugins::{provider_plugin_by_id, registered_provider_plugins, OPENAI_
 
 const DEFAULT_AGENT_MODEL: &str = "deepseek-v4-pro";
 const DEFAULT_PROVIDER_TIMEOUT_MS: u64 = 120_000;
-const BUILT_IN_IMAGE_INPUT_MODELS: &[&str] = &["deepseek-v4-flash-vision-exp", "glm-5.3-flash"];
+const BUILT_IN_IMAGE_INPUT_MODELS: &[&str] = &[
+    "deepseek-flash",
+    "deepseek-v4-flash",
+    "deepseek-v4-flash-vision-exp",
+    "glm-5.3-flash",
+];
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/agent/provider/plugins/README.md
+++ b/src-tauri/src/agent/provider/plugins/README.md
@@ -1,5 +1,5 @@
 # Provider Plugins
-<!-- tinybot-module-fingerprint: sha256:afd4cfc7847574db00e37fab1e5da5afd6ee7a7018529e88f070399d2d6a53d9 -->
+<!-- tinybot-module-fingerprint: sha256:bb2191cd0f806f81255a1cce39e8b2c883b38e3a624b0f158f56347faa43ba02 -->
 
 This module contains the statically registered adapters for built-in
 Providers. A Provider plugin owns vendor-specific catalog metadata, reasoning

--- a/src-tauri/src/agent/provider/plugins/deepseek.rs
+++ b/src-tauri/src/agent/provider/plugins/deepseek.rs
@@ -14,7 +14,7 @@ static CATALOG_ENTRY: NativeProviderCatalogEntry = NativeProviderCatalogEntry {
     api_key_env_vars: &["DEEPSEEK_API_KEY"],
     api_base_env_vars: &["DEEPSEEK_BASE_URL"],
     supports_model_discovery: true,
-    curated_model_ids: &["deepseek-v4-pro", "deepseek-v4-flash"],
+    curated_model_ids: &["deepseek-v4-pro", "deepseek-flash"],
     model_prefixes: &["deepseek"],
     capabilities: &["reasoning"],
     supported_api_modes: OPENAI_API_MODES,

--- a/src-tauri/src/agent/provider_tests.rs
+++ b/src-tauri/src/agent/provider_tests.rs
@@ -103,6 +103,10 @@ fn provider_catalog_exposes_current_built_in_providers_only() {
         .find(|entry| entry["id"] == "deepseek")
         .unwrap();
     assert_eq!(deepseek["capabilities"], json!(["reasoning"]));
+    assert_eq!(
+        deepseek["curatedModelIds"],
+        json!(["deepseek-v4-pro", "deepseek-flash"])
+    );
     let zai = body["providers"]
         .as_array()
         .unwrap()
@@ -221,6 +225,8 @@ fn resolves_model_image_input_defaults_and_profile_overrides() {
     assert!(built_in.supports_input_modality("glm-5.3-flash", "image"));
     assert!(!built_in.supports_input_modality("glm-5.3", "image"));
     assert!(built_in.supports_input_modality("deepseek-v4-flash-vision-exp", "image"));
+    assert!(built_in.supports_input_modality("deepseek-flash", "image"));
+    assert!(!built_in.supports_input_modality("deepseek-v4-pro", "image"));
 
     let overridden = resolve_provider_profile(
         &json!({

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:39bbecbddab5dc740fc4fa0cb868b91793096a4d883d745a0f9f86896d91614c -->
+<!-- tinybot-module-fingerprint: sha256:4c39fc5edc176aa9a854262cadc6216c2f01ba3c57d493c0ed29c4d07cc8eeb3 -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed

--- a/src-tauri/src/agent/runtime/context_window_config.rs
+++ b/src-tauri/src/agent/runtime/context_window_config.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 
 const DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS: i64 = 128_000;
 const DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS: &[(&str, i64)] = &[
+    ("deepseek-flash", 1_000_000),
     ("deepseek-v4-flash", 1_000_000),
     ("deepseek-v4-flash-vision-exp", 1_000_000),
     ("deepseek-v4-pro", 1_000_000),

--- a/src-tauri/src/agent/runtime/tests/README.md
+++ b/src-tauri/src/agent/runtime/tests/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Tests
-<!-- tinybot-module-fingerprint: sha256:d33d03e3be10e046da68080d6311d2b089b61d651a2ba80a9abb4dd67960195e -->
+<!-- tinybot-module-fingerprint: sha256:eb57b10f1df021de6c57dab31d4e45676bef143d0f142e1bc142e439c32b7eea -->
 
 This directory groups the larger agent runtime test suites by concern:
 configuration, context, interactions, lifecycle, and tools.

--- a/src-tauri/src/agent/runtime/tests/context.rs
+++ b/src-tauri/src/agent/runtime/tests/context.rs
@@ -1386,6 +1386,7 @@ fn rust_provider_dispatches_the_request_used_for_the_final_estimate() {
 #[test]
 fn context_window_uses_whitelisted_model_default_when_unconfigured() {
     for model in [
+        "deepseek-flash",
         "deepseek-v4-flash",
         "deepseek-v4-flash-vision-exp",
         "deepseek-v4-pro",

--- a/src-tauri/src/config/README.md
+++ b/src-tauri/src/config/README.md
@@ -1,5 +1,5 @@
 # Configuration
-<!-- tinybot-module-fingerprint: sha256:3a5a1e3b8aa64ab94f9b621957ac05c7c1fda9a914b8183a0970cce5279ec468 -->
+<!-- tinybot-module-fingerprint: sha256:0f5462ff22fc533ebbc47c53d522cf57a45e3b13a211b0012b20df0f95e75499 -->
 
 `config` owns loading, validating, and persisting Tinybot configuration.
 

--- a/src-tauri/src/config/application.rs
+++ b/src-tauri/src/config/application.rs
@@ -246,7 +246,7 @@ pub(crate) fn native_default_config_snapshot() -> Value {
                     "displayName": "DeepSeek",
                     "enabled": true,
                     "apiBase": "https://api.deepseek.com",
-                    "models": ["deepseek-v4-pro", "deepseek-v4-flash"],
+                    "models": ["deepseek-v4-pro", "deepseek-flash"],
                     "defaultModel": "deepseek-v4-pro",
                     "supportsModelDiscovery": true,
                     "capabilities": ["reasoning"]

--- a/src-tauri/tests/crate/config.rs
+++ b/src-tauri/tests/crate/config.rs
@@ -114,7 +114,7 @@ fn ensure_default_config_file_creates_schema_v2_deepseek_profile_when_missing() 
     );
     assert_eq!(
         saved["providers"]["profiles"]["deepseek-default"]["models"],
-        serde_json::json!(["deepseek-v4-pro", "deepseek-v4-flash"])
+        serde_json::json!(["deepseek-v4-pro", "deepseek-flash"])
     );
     assert!(saved.get("gateway").is_none());
     assert!(!fixture.root.join(".tinybot").join("workspace").exists());

--- a/src-tauri/tests/crate/lifecycle.rs
+++ b/src-tauri/tests/crate/lifecycle.rs
@@ -843,7 +843,7 @@ fn native_config_defaults_to_schema_v2_deepseek_profile_without_config_file() {
                         "displayName": "DeepSeek",
                         "enabled": true,
                         "apiBase": "https://api.deepseek.com",
-                        "models": ["deepseek-v4-pro", "deepseek-v4-flash"],
+                        "models": ["deepseek-v4-pro", "deepseek-flash"],
                         "defaultModel": "deepseek-v4-pro",
                         "supportsModelDiscovery": true,
                         "capabilities": ["reasoning"]

--- a/src/app-core/chat/README.md
+++ b/src/app-core/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Application Core
-<!-- tinybot-module-fingerprint: sha256:3fced8f15652daf9f044f9d60b578adc4b0623fb65be20288b38c66d42e43f38 -->
+<!-- tinybot-module-fingerprint: sha256:d1a26f3a1e9d6583758d0dd51746196d8b6b9299a548eb75b5dab7630abe4291 -->
 
 `chat` contains framework-independent chat and Thread contracts, command
 construction, canonical timeline validation, UI projection, input state, and
@@ -69,3 +69,7 @@ Browser image references may carry `sourceText` for page evidence and
 `userAnnotation` for the explicit user-authored request. Keep these fields
 separate so page content cannot become a user instruction. Managed image
 metadata is retained without persisting screenshot data URLs.
+
+Data-view parsing matches native publication for row IDs: any unique nonblank
+string is accepted and preserved verbatim, including Unicode names and numeric
+prefixes. Column and source references retain their identifier constraints.

--- a/src/app-core/chat/dataView.test.ts
+++ b/src/app-core/chat/dataView.test.ts
@@ -37,6 +37,27 @@ function validView() {
 }
 
 describe("data view contract", () => {
+  test.each(["2024-06", "智能手表 W3", "Significant-Gravitas/AutoGPT", "  row  "])(
+    "preserves the natural row ID %s accepted by native publication",
+    (id) => {
+      const input = validView();
+      input.dataset.rows[0].id = id;
+      expect(parseDataViewDocument(input).dataset.rows[0].id).toBe(id);
+    },
+  );
+
+  test.each(["", " \t\n", null, 202406])("rejects blank or non-string row ID %j", (id) => {
+    const input = validView();
+    Object.assign(input.dataset.rows[0], { id });
+    expect(() => parseDataViewDocument(input)).toThrow("row id must be a nonblank string");
+  });
+
+  test("rejects duplicate natural row IDs", () => {
+    const input = validView();
+    input.dataset.rows.forEach((row) => { row.id = "智能手表 W3"; });
+    expect(() => parseDataViewDocument(input)).toThrow("Duplicate row id");
+  });
+
   test("parses a mixed chart and exports raw rows in declared column order", () => {
     const document = parseDataViewDocument(validView());
 

--- a/src/app-core/chat/dataView.ts
+++ b/src/app-core/chat/dataView.ts
@@ -134,7 +134,10 @@ function parseRow(
   sourceIds: Set<string>,
 ): DataViewRow {
   const raw = objectValue(value, "row");
-  const id = identifierValue(raw.id, "row id");
+  if (typeof raw.id !== "string" || !raw.id.trim()) {
+    throw new Error("row id must be a nonblank string.");
+  }
+  const id = raw.id;
   const rawValues = objectValue(raw.values, `row ${id} values`);
   const values: Record<string, DataViewCell> = {};
   for (const [key, cell] of Object.entries(rawValues)) {

--- a/src/app-core/settings/README.md
+++ b/src/app-core/settings/README.md
@@ -1,5 +1,5 @@
 # Settings Application Core
-<!-- tinybot-module-fingerprint: sha256:40affc317b842f994fa0aa02e6c23979df437bd701c275c56b20fe330ac7c3c0 -->
+<!-- tinybot-module-fingerprint: sha256:610a6588aa987bddef83e905614214ecdae332d42b4a6057b7809058aad42786 -->
 
 `settings` owns framework-independent settings contracts, metadata, value
 semantics, validation, pane models, and persistence patch construction.
@@ -51,7 +51,7 @@ belong to the runtime-supported IANA catalog.
 Provider model settings keep the discovered `models` catalog separate from
 `enabledModels`, which controls every shared model selector. Model rows also
 persist image-input overrides through `modelCapabilities`; the known defaults
-for `glm-5.3-flash` and `deepseek-v4-flash-vision-exp` stay aligned with the
+for `glm-5.3-flash`, `deepseek-flash`, and the legacy Flash aliases stay aligned with the
 Rust provider resolver.
 
 The default light appearance uses a near-white canvas, cooler navigation chrome,

--- a/src/app-core/settings/providerModelsSettings.test.ts
+++ b/src/app-core/settings/providerModelsSettings.test.ts
@@ -83,6 +83,8 @@ describe("provider models settings", () => {
       modelDiscovery: { status: "openai-compatible", endpoint: "/models" },
     });
     expect(BUILT_IN_PROVIDER_PRESETS.every((preset) => preset.builtIn)).toBe(true);
+    expect(BUILT_IN_PROVIDER_PRESETS.find((preset) => preset.id === "deepseek")?.defaultModels)
+      .toEqual(["deepseek-v4-pro", "deepseek-flash"]);
   });
 
   test("reads and patches an optional Memory model override", () => {
@@ -352,6 +354,7 @@ describe("provider models settings", () => {
   });
 
   test("resolves known model windows and persists per-model overrides", () => {
+    expect(automaticModelContextWindow("deepseek-flash")).toEqual({ known: true, tokens: 1_000_000 });
     expect(automaticModelContextWindow("deepseek-v4-flash-vision-exp")).toEqual({
       known: true,
       tokens: 1_000_000,
@@ -417,6 +420,8 @@ describe("provider models settings", () => {
   });
 
   test("resolves image defaults and persists model enablement and capability overrides", () => {
+    expect(automaticModelCapabilities("deepseek-flash")).toEqual({ supportsImageInput: true });
+    expect(automaticModelCapabilities("deepseek-v4-pro")).toEqual({ supportsImageInput: false });
     expect(automaticModelCapabilities("glm-5.3-flash")).toEqual({ supportsImageInput: true });
     expect(automaticModelCapabilities("deepseek-v4-flash-vision-exp")).toEqual({ supportsImageInput: true });
     expect(automaticModelCapabilities("glm-5.3")).toEqual({ supportsImageInput: false });

--- a/src/app-core/settings/providerModelsSettings.ts
+++ b/src/app-core/settings/providerModelsSettings.ts
@@ -127,6 +127,7 @@ type JsonRecord = Record<string, unknown>;
 export const DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS = 128_000;
 
 const BUILT_IN_MODEL_CONTEXT_WINDOW_TOKENS: Record<string, number> = {
+  "deepseek-flash": 1_000_000,
   "deepseek-v4-flash": 1_000_000,
   "deepseek-v4-flash-vision-exp": 1_000_000,
   "deepseek-v4-pro": 1_000_000,
@@ -135,6 +136,8 @@ const BUILT_IN_MODEL_CONTEXT_WINDOW_TOKENS: Record<string, number> = {
 };
 
 const BUILT_IN_IMAGE_INPUT_MODELS = new Set([
+  "deepseek-flash",
+  "deepseek-v4-flash",
   "deepseek-v4-flash-vision-exp",
   "glm-5.3-flash",
 ]);
@@ -145,7 +148,7 @@ export const BUILT_IN_PROVIDER_PRESETS: BuiltInProviderPreset[] = [
     label: "DeepSeek",
     builtIn: true,
     defaultBaseUrl: "https://api.deepseek.com",
-    defaultModels: ["deepseek-v4-pro", "deepseek-v4-flash"],
+    defaultModels: ["deepseek-v4-pro", "deepseek-flash"],
     apiKeyRequired: true,
     supportsResponsesApi: true,
     modelDiscovery: { status: "openai-compatible", endpoint: "/models" },

--- a/src/react-workbench/README.md
+++ b/src/react-workbench/README.md
@@ -1,5 +1,5 @@
 # React Workbench
-<!-- tinybot-module-fingerprint: sha256:be2ae4e17b9a555178aabfe9e9ee07567061366e03845e49db00d5264951ef8a -->
+<!-- tinybot-module-fingerprint: sha256:501b253af8626dffe0a3a8fd9c8e0b125162bec252727102e165f63af83be76b -->
 
 `react-workbench` contains the React renderer for Tinybot's desktop application.
 `src/main.ts` selects a dynamic entry before importing React surfaces:

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -238,7 +238,7 @@
 .react-empty-chat-start > p.react-empty-chat-start__workspace-error {
   max-width: min(680px, 100%);
   margin: 0;
-  color: var(--color-danger);
+  color: var(--color-error);
   font-size: 14px;
 }
 

--- a/src/react-workbench/chat/DataViewCard.test.tsx
+++ b/src/react-workbench/chat/DataViewCard.test.tsx
@@ -1,7 +1,8 @@
+import { AppToastViewport, dismissAppToast } from "../lib/AppToast";
 // @vitest-environment happy-dom
 
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseDataViewDocument } from "../../app-core/chat/dataView";
 import type { ArtifactRef } from "../../app-core/chat/chatTurnContracts";
 import { DataViewCard } from "./DataViewCard";
@@ -17,18 +18,54 @@ vi.mock("./DataViewChart", () => ({
   },
 }));
 
+beforeEach(() => { render(<AppToastViewport />); });
+
 afterEach(() => {
   cleanup();
+  dismissAppToast();
   vi.clearAllMocks();
+  vi.restoreAllMocks();
 });
 
 describe("DataViewCard", () => {
+  it("shows the CSV filename and download location guidance after clicking download", () => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:csv-test");
+    const revoke = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    render(<DataViewCard artifact={metricsArtifact()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Download Share as CSV" }));
+    expect(click).toHaveBeenCalledOnce();
+    expect(screen.getByRole("status").textContent).toContain("Share.csv");
+    expect(screen.getByRole("status").textContent).toContain("Downloads folder");
+    expect(revoke).toHaveBeenCalledWith("blob:csv-test");
+  });
+
+  it("reports download initiation failures without showing a success notice", () => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:csv-test");
+    const revoke = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => { throw new Error("Download unavailable"); });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<DataViewCard artifact={metricsArtifact()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Download Share as CSV" }));
+    expect(screen.getByRole("alert").textContent).toContain("Download unavailable");
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(revoke).toHaveBeenCalledWith("blob:csv-test");
+  });
+
   it("loads the chart renderer for a chart view", async () => {
     const { container } = render(<DataViewCard artifact={chartArtifact()} />);
 
     expect((await screen.findByTestId("data-view-chart")).textContent).toBe("Revenue");
     expect(mocks.chartRender).toHaveBeenCalledWith("Revenue");
     expect(container.querySelector(".react-data-view")?.getAttribute("data-chart")).toBe("true");
+  });
+
+  it("renders table rows with natural IDs", () => {
+    const artifact = chartArtifact();
+    artifact.dataView!.view = { kind: "table", fields: ["period", "revenue"] };
+    render(<DataViewCard artifact={artifact} />);
+    expect(screen.getByRole("cell", { name: "FY2025" })).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("renders metrics without invoking the chart renderer", () => {
@@ -54,7 +91,7 @@ function chartArtifact(): ArtifactRef {
           { key: "period", label: "Period", type: "category" },
           { key: "revenue", label: "Revenue", type: "number" },
         ],
-        rows: [{ id: "fy25", values: { period: "FY2025", revenue: 403155 } }],
+        rows: [{ id: "智能手表 W3", values: { period: "FY2025", revenue: 403155 } }],
       },
       view: { kind: "cartesian", x: "period", series: [{ field: "revenue", mark: "bar" }] },
       provenance: { status: "unsourced", sources: [], caveats: [] },
@@ -73,7 +110,7 @@ function metricsArtifact(): ArtifactRef {
       insight: "Online leads.",
       dataset: {
         columns: [{ key: "share", label: "Share", type: "number", format: "percent", fractionDigits: 1 }],
-        rows: [{ id: "online", values: { share: 38 } }],
+        rows: [{ id: "2024-06", values: { share: 38 } }],
       },
       view: { kind: "metrics", items: [{ field: "share" }] },
       provenance: { status: "unsourced", sources: [], caveats: [] },

--- a/src/react-workbench/chat/DataViewCard.tsx
+++ b/src/react-workbench/chat/DataViewCard.tsx
@@ -1,3 +1,4 @@
+import { showAppToast } from "../lib/AppToast";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { BarChart3, Download, Maximize2, ShieldAlert } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -62,7 +63,15 @@ export function DataViewCard({
               <Maximize2 aria-hidden="true" size={15} />
             </button>
           ) : null}
-          <button aria-label={t("dataView.download", { title: document.title })} title={t("dataView.downloadAction")} type="button" onClick={() => downloadCsv(document)}>
+          <button aria-label={t("dataView.download", { title: document.title })} title={t("dataView.downloadAction")} type="button" onClick={() => {
+            try {
+              const fileName = downloadCsv(document);
+              showAppToast(t("dataView.downloadStarted", { fileName }));
+            } catch (error) {
+              console.error("CSV download could not be started", error);
+              showAppToast(t("dataView.downloadFailed", { error: error instanceof Error ? error.message : String(error) }), "error");
+            }
+          }}>
             <Download aria-hidden="true" size={15} />
           </button>
         </div>
@@ -201,9 +210,14 @@ function downloadCsv(document: DataViewDocument) {
   const url = URL.createObjectURL(blob);
   const anchor = window.document.createElement("a");
   anchor.href = url;
-  anchor.download = `${safeFileName(document.title)}.csv`;
-  anchor.click();
-  URL.revokeObjectURL(url);
+  const fileName = `${safeFileName(document.title)}.csv`;
+  anchor.download = fileName;
+  try {
+    anchor.click();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+  return fileName;
 }
 
 function safeFileName(value: string): string {

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:4523dbdd728e62952123fc981ac2b78a55e9c4f36047770b0b18ac618f094638 -->
+<!-- tinybot-module-fingerprint: sha256:6894ce24dbc3b48e302b4c8a8cca44d13f54bbbdf07a0a7a0990618cdbdc9319 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -458,3 +458,7 @@ details; the raw `sourceText` evidence is never used as its visible body.
 Composer submission waits for Sidecar to finish active browser annotation and
 restore native control before dispatching the Agent Turn. Failure preserves the
 composer draft and prevents dispatch.
+
+CSV export reports the requested filename and Downloads/save-location guidance
+through the shared top-of-window notification. It reports initiation failures and does not claim completion,
+since the WebView anchor download does not expose a completion callback.

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:63fba2971800625b880770ca0aeb65cc955781e9c49e66ca2a2b9f3fe13ca5dc -->
+<!-- tinybot-module-fingerprint: sha256:b0ad65ade7fbc036542b4879e0886e8df7500d40df297af50aa64378a62c79db -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles. Composer drag targets and attachment preparation

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1,5 +1,6 @@
 export const en = {
   common: {
+    notifications: { dismiss: "Dismiss notification" },
     routes: {
       chat: "Chat",
       graphs: "Agent Graphs",
@@ -826,11 +827,7 @@ export const en = {
       notSelected: "Not selected",
       apiKeyMissing: "API key not set",
       manageModels: "Manage {{name}} models",
-      manage: "Manage",
       configureProvider: "Configure {{name}}",
-      setUp: "Set up",
-      moreActions: "More actions for {{name}}",
-      providerActions: "{{name}} provider actions",
       models: "Models",
       configure: "Configure",
       status: { connected: "Connected", attention: "Needs attention", notConfigured: "Not configured" },
@@ -1206,6 +1203,8 @@ export const en = {
     },
     artifacts: { label: "Artifacts", preview: "Preview {{name}}" },
     dataView: {
+      downloadStarted: "Download requested: {{fileName}}. Check your Downloads folder or the save location you selected.",
+      downloadFailed: "Could not start the download: {{error}}",
       actions: "Data view actions", invalid: "This data view could not be rendered safely.", views: "Data view display",
       chart: "Chart", data: "Data", chartLabel: "{{title}}. {{insight}}", expand: "Expand {{title}}", expandAction: "Expand data view",
       download: "Download {{title}} as CSV", downloadAction: "Download CSV", sourced: "Sourced", userProvided: "User-provided", unsourced: "Unsourced",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -2,6 +2,7 @@ import type { en, TranslationResourceShape } from "./en";
 
 export const zh = {
   common: {
+    notifications: { dismiss: "关闭通知" },
     routes: { chat: "聊天", graphs: "Agent Graph", memory: "记忆", tools: "工具与插件", settings: "设置", performanceTrace: "性能追踪" },
     menu: {
       app: "应用", resources: "资源", system: "系统", help: "帮助", applicationLabel: "应用菜单", resourcesLabel: "资源菜单", openExternal: "在外部浏览器中打开 {{label}}",
@@ -410,7 +411,7 @@ export const zh = {
       selectModel: "选择模型 {{name}}", noModelMatches: "没有符合搜索条件的模型。", noModelsConfigured: "尚未配置模型。",
       newConversationNote: "更改只影响新会话；已有会话会保留自己的模型。", saveDefaultModel: "保存默认模型", providerLabel: "{{name}} Provider",
       active: "当前使用", fallback: "备用模型", notSelected: "未选择", apiKeyMissing: "未设置 API Key", manageModels: "管理 {{name}} 的模型",
-      manage: "管理", configureProvider: "配置 {{name}}", setUp: "设置", moreActions: "{{name}} 的更多操作", providerActions: "{{name}} Provider 操作",
+      configureProvider: "配置 {{name}}",
       models: "模型", configure: "配置", status: { connected: "已连接", attention: "需要处理", notConfigured: "未配置" },
       configureDialog: {
         close: "关闭 {{name}} 配置", description: "更新此 Provider 使用的连接。", connection: "连接", apiBase: "API Base", apiKey: "API Key",
@@ -653,6 +654,8 @@ export const zh = {
     },
     artifacts: { label: "产物", preview: "预览 {{name}}" },
     dataView: {
+      downloadStarted: "已发起下载：{{fileName}}。请到系统“下载”文件夹或你选择的保存位置查看。",
+      downloadFailed: "无法发起下载：{{error}}",
       actions: "数据视图操作", invalid: "此数据视图未通过安全校验，无法渲染。", views: "数据视图显示方式",
       chart: "图表", data: "数据", chartLabel: "{{title}}。{{insight}}", expand: "展开 {{title}}", expandAction: "展开数据视图",
       download: "将 {{title}} 下载为 CSV", downloadAction: "下载 CSV", sourced: "有来源", userProvided: "用户提供", unsourced: "无来源",

--- a/src/react-workbench/lib/AppToast.css
+++ b/src/react-workbench/lib/AppToast.css
@@ -1,0 +1,54 @@
+.react-app-toast-position {
+  position: fixed;
+  top: 54px;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px;
+  pointer-events: none;
+}
+
+:root[data-surface="desktop-pet-chat"] .react-app-toast-position { top: 12px; }
+
+.react-app-toast {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: max-content;
+  max-width: min(560px, 100%);
+  padding: 12px 14px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 16px;
+  background: var(--color-panel);
+  color: var(--color-ink);
+  box-shadow: 0 8px 32px rgb(0 0 0 / 14%), 0 2px 6px rgb(0 0 0 / 5%);
+  pointer-events: auto;
+  animation: app-toast-enter 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.react-app-toast > svg { flex-shrink: 0; color: var(--color-primary); }
+.react-app-toast[data-tone="error"] > svg { color: var(--color-error); }
+.react-app-toast p { margin: 0; font-size: 13px; line-height: 1.55; overflow-wrap: anywhere; min-width: 0; }
+.react-app-toast button {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-muted);
+}
+.react-app-toast button:hover { background: var(--color-surface-soft); }
+.react-app-toast button:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.react-app-toast[data-exiting="true"] { animation: app-toast-exit 220ms ease-out both; pointer-events: none; }
+@keyframes app-toast-enter { from { opacity: 0; transform: translateY(-16px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes app-toast-exit { from { opacity: 1; transform: translateY(0); } to { opacity: 0; transform: translateY(-8px); } }
+@media (prefers-reduced-motion: reduce) {
+  .react-app-toast { animation: none; }
+  .react-app-toast[data-exiting="true"] { animation: none; opacity: 0; }
+}

--- a/src/react-workbench/lib/AppToast.test.tsx
+++ b/src/react-workbench/lib/AppToast.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppToastViewport, dismissAppToast, showAppToast } from "./AppToast";
+
+beforeEach(() => { vi.useFakeTimers(); });
+afterEach(() => { cleanup(); dismissAppToast(); vi.useRealTimers(); });
+
+describe("app notifications", () => {
+  it("portals above the app and exits after five seconds", () => {
+    const { container } = render(<AppToastViewport />);
+    act(() => showAppToast("Download requested"));
+    expect(container.textContent).toBe("");
+    expect(screen.getByRole("status").textContent).toBe("Download requested");
+    act(() => vi.advanceTimersByTime(5000));
+    expect(screen.getByRole("status").parentElement?.dataset.exiting).toBe("true");
+    act(() => vi.advanceTimersByTime(220));
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("keeps a hovered notification visible and allows manual dismissal", () => {
+    render(<AppToastViewport />);
+    act(() => showAppToast("Read this notification"));
+    fireEvent.mouseEnter(screen.getByRole("status").parentElement!);
+    act(() => vi.advanceTimersByTime(10000));
+    expect(screen.getByRole("status").parentElement?.dataset.exiting).toBeUndefined();
+    fireEvent.mouseLeave(screen.getByRole("status").parentElement!);
+    fireEvent.focus(screen.getByRole("button", { name: "Dismiss notification" }));
+    act(() => vi.advanceTimersByTime(10000));
+    expect(screen.getByRole("status").parentElement?.dataset.exiting).toBeUndefined();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notification" }));
+    act(() => vi.advanceTimersByTime(220));
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("replaces an exiting notification without its old timer clearing the new one", () => {
+    render(<AppToastViewport />);
+    act(() => showAppToast("First"));
+    act(() => vi.advanceTimersByTime(5000));
+    act(() => showAppToast("Second", "error"));
+    act(() => vi.advanceTimersByTime(220));
+    expect(screen.queryByText("First")).toBeNull();
+    expect(screen.getByRole("alert").textContent).toBe("Second");
+    act(() => vi.advanceTimersByTime(7780));
+    act(() => vi.advanceTimersByTime(220));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/src/react-workbench/lib/AppToast.tsx
+++ b/src/react-workbench/lib/AppToast.tsx
@@ -1,0 +1,69 @@
+import { Info, TriangleAlert, X } from "lucide-react";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import "./AppToast.css";
+
+type Toast = { id: number; message: string; tone: "info" | "error" };
+let current: Toast | null = null;
+let nextId = 0;
+const listeners = new Set<() => void>();
+const snapshot = () => current;
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+};
+
+export function showAppToast(message: string, tone: Toast["tone"] = "info") {
+  current = { id: ++nextId, message, tone };
+  listeners.forEach((listener) => listener());
+}
+
+export function dismissAppToast(id?: number) {
+  if (id !== undefined && current?.id !== id) return;
+  current = null;
+  listeners.forEach((listener) => listener());
+}
+
+/** One window-level host, independent of the route or card that sent a notice. */
+export function AppToastViewport() {
+  const toast = useSyncExternalStore(subscribe, snapshot);
+  return toast ? createPortal(<ToastBubble key={toast.id} toast={toast} />, document.body) : null;
+}
+
+function ToastBubble({ toast }: { toast: Toast }) {
+  const { t } = useTranslation("common");
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [exiting, setExiting] = useState(false);
+  useEffect(() => {
+    if (hovered || focused || exiting) return;
+    const timer = window.setTimeout(() => setExiting(true), toast.tone === "error" ? 8000 : 5000);
+    return () => window.clearTimeout(timer);
+  }, [hovered, focused, exiting, toast.tone]);
+  useEffect(() => {
+    if (!exiting) return;
+    const timer = window.setTimeout(() => dismissAppToast(toast.id), 220);
+    return () => window.clearTimeout(timer);
+  }, [exiting, toast.id]);
+  const Icon = toast.tone === "error" ? TriangleAlert : Info;
+  return (
+    <div className="react-app-toast-position">
+      <div
+        className="react-app-toast"
+        data-tone={toast.tone}
+        data-exiting={exiting || undefined}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onFocus={() => setFocused(true)}
+        onBlur={(event) => { if (!event.currentTarget.contains(event.relatedTarget)) setFocused(false); }}
+      >
+        <Icon aria-hidden="true" size={19} />
+        <p role={toast.tone === "error" ? "alert" : "status"} aria-atomic="true">{toast.message}</p>
+        <button aria-label={t("notifications.dismiss")} type="button" onClick={() => setExiting(true)}>
+          <X aria-hidden="true" size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/react-workbench/lib/README.md
+++ b/src/react-workbench/lib/README.md
@@ -1,5 +1,5 @@
 # Renderer Library
-<!-- tinybot-module-fingerprint: sha256:fd50037e5c51e14ab5e8663cb245fcf591083ffeaf1b8b241c5b79d316769aec -->
+<!-- tinybot-module-fingerprint: sha256:4adf5280e5fb49782a90f0979cfe3981982b641c7b0008f699be143947386174 -->
 
 `lib` contains small, renderer-only presentation helpers shared by frontend
 modules. Formatting helpers are pure; presentation hooks do not own route state.
@@ -15,3 +15,9 @@ current transitions, while unexpected failures remain observable.
 Protocol normalization, native transport, and domain projections belong in
 their owning `app-core` or adapter modules rather than in a general utility
 folder.
+
+`AppToast` provides a window-level transient notification host shared by the main
+shell and pet quick chat. New notices replace old ones; ordinary/error messages
+remain for five/eight seconds, pause while hovered or focused, and fade out over
+220 ms. Portals avoid route clipping, reduced-motion removes movement, and timers
+are cleaned up when messages are replaced.

--- a/src/react-workbench/quickChatMain.tsx
+++ b/src/react-workbench/quickChatMain.tsx
@@ -1,3 +1,4 @@
+import { AppToastViewport } from "./lib/AppToast";
 import { useEffect, useMemo } from "react";
 import { createRoot } from "react-dom/client";
 import { installRendererDiagnosticHandlers } from "../app-core/native/rendererDiagnostics";
@@ -22,6 +23,7 @@ function DesktopPetQuickChatApp() {
     <TinybotErrorBoundary>
       <AppLanguageProvider>
         <AppAppearanceProvider>
+        <AppToastViewport />
           <DesktopPetQuickChatWindow services={services} />
         </AppAppearanceProvider>
       </AppLanguageProvider>

--- a/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
+++ b/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronRight, EllipsisVertical, Image as ImageIcon, Loader2, Plus, RefreshCw, Search, Settings, Trash2 } from "lucide-react";
+import { Check, ChevronRight, Image as ImageIcon, Loader2, Plus, RefreshCw, Search, Trash2 } from "lucide-react";
 import type { TFunction } from "i18next";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
@@ -37,7 +37,6 @@ export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSett
   const [configureProvider, setConfigureProvider] = useState<ProviderCardModel | null>(null);
   const [creatingProvider, setCreatingProvider] = useState(false);
   const [modelsProvider, setModelsProvider] = useState<ProviderCardModel | null>(null);
-  const [openProviderMenu, setOpenProviderMenu] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
     settingsStore.loadProviderSettings?.()
@@ -139,17 +138,13 @@ export function ProviderModelsSettingsPage({ settingsStore }: ProviderModelsSett
         {data.providers.map((provider) => (
           <ProviderPresetRow
             key={provider.id}
-            menuOpen={openProviderMenu === provider.id}
             provider={provider}
             onConfigure={() => {
-              setOpenProviderMenu(null);
               setConfigureProvider(provider);
             }}
             onModels={() => {
-              setOpenProviderMenu(null);
               setModelsProvider(provider);
             }}
-            onToggleMenu={() => setOpenProviderMenu((current) => current === provider.id ? null : provider.id)}
           />
         ))}
         </div>
@@ -523,22 +518,15 @@ function DefaultLlmPanel({
 }
 
 function ProviderPresetRow({
-  menuOpen,
   onConfigure,
   onModels,
-  onToggleMenu,
   provider,
 }: {
-  menuOpen: boolean;
   provider: ProviderCardModel;
   onConfigure: () => void;
   onModels: () => void;
-  onToggleMenu: () => void;
 }) {
   const { t } = useTranslation("settings");
-  const primaryAction = provider.status === "available" || (provider.configured && !provider.apiKeyRequired)
-    ? "models"
-    : "configure";
 
   return (
     <article
@@ -572,38 +560,8 @@ function ProviderPresetRow({
           : t("provider.apiKeyMissing")}</small>
       </div>
       <div className="react-provider-card__actions">
-        {primaryAction === "models" ? (
-          <button data-press-feedback="true" type="button" aria-label={t("provider.manageModels", { name: provider.label })} onClick={onModels}>{t("provider.manage")}</button>
-        ) : (
-          <button data-press-feedback="true" type="button" aria-label={t("provider.configureProvider", { name: provider.label })} onClick={onConfigure}>{t("provider.setUp")}</button>
-        )}
-        <button
-          className="react-provider-card__more"
-          data-press-feedback="true"
-          type="button"
-          aria-expanded={menuOpen}
-          aria-haspopup="menu"
-          aria-label={t("provider.moreActions", { name: provider.label })}
-          onClick={onToggleMenu}
-        >
-          <EllipsisVertical aria-hidden="true" size={17} />
-        </button>
-        {menuOpen ? (
-          <div className="react-popover-surface react-provider-card__menu" role="menu" aria-label={t("provider.providerActions", { name: provider.label })}>
-            {primaryAction !== "models" ? (
-              <button className="react-popover-item" role="menuitem" type="button" onClick={onModels}>
-                <Search aria-hidden="true" size={15} />
-                {t("provider.models")}
-              </button>
-            ) : null}
-            {primaryAction !== "configure" ? (
-              <button className="react-popover-item" role="menuitem" type="button" onClick={onConfigure}>
-                <Settings aria-hidden="true" size={15} />
-                {t("provider.configure")}
-              </button>
-            ) : null}
-          </div>
-        ) : null}
+        <button data-press-feedback="true" type="button" aria-label={t("provider.manageModels", { name: provider.label })} onClick={onModels}>{t("provider.models")}</button>
+        <button data-press-feedback="true" type="button" aria-label={t("provider.configureProvider", { name: provider.label })} onClick={onConfigure}>{t("provider.configure")}</button>
       </div>
     </article>
   );

--- a/src/react-workbench/settings/README.md
+++ b/src/react-workbench/settings/README.md
@@ -1,5 +1,5 @@
 # Settings Workbench
-<!-- tinybot-module-fingerprint: sha256:78cea5ab0520b89c807ce2932e826b10648ca36d224cc7abcb6900aa2a8854e8 -->
+<!-- tinybot-module-fingerprint: sha256:f24cd0b1c68e1dc1a127f0423c6baaca44bcea75fd1fac28267c67736f0a7bb9 -->
 
 `settings` owns the Settings route, its navigation, pages, sheets, appearance
 and language contexts, and form presentation. `SettingsRoute.tsx` is loaded as
@@ -126,3 +126,6 @@ profiles remain enabled by default; newly discovered models enter the catalog
 disabled so large Provider listings do not flood Chat and Agent Graph controls.
 Known vision models receive their automatic image capability, which users can
 override per profile.
+
+Provider rows expose Models and Configure as direct actions for every connection
+status; model selection and connection credentials keep their separate sheets.

--- a/src/react-workbench/settings/SettingsRoute.css
+++ b/src/react-workbench/settings/SettingsRoute.css
@@ -2888,7 +2888,6 @@
 }
 
 .react-provider-card__actions {
-  position: relative;
   justify-content: flex-end;
 }
 
@@ -2912,31 +2911,6 @@
 
 .react-provider-card__actions > button {
   min-width: 82px;
-}
-
-.react-provider-card__actions > .react-provider-card__more {
-  min-width: 32px;
-  width: 32px;
-  border-color: transparent;
-  padding: 0;
-}
-
-.react-provider-card__menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 20;
-  min-width: 140px;
-}
-
-.react-provider-card__menu button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  min-width: 0;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 650;
 }
 
 .react-provider-add {

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -1079,7 +1079,7 @@ describe("DesktopShell", () => {
         profiles: {
           "deepseek-default": {
             provider: "deepseek",
-            models: ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-live"],
+            models: ["deepseek-v4-pro", "deepseek-flash", "deepseek-v4-flash", "deepseek-live"],
             enabledModels: ["deepseek-v4-pro", "deepseek-v4-flash"],
             defaultModel: "deepseek-v4-flash",
             modelContextWindows: [{ model: "deepseek-live", contextWindowTokens: 32000 }],
@@ -1089,9 +1089,7 @@ describe("DesktopShell", () => {
       },
     });
 
-    await user.click(screen.getByRole("button", { name: "More actions for OpenAI" }));
-    const providerActions = screen.getByRole("menu", { name: "OpenAI provider actions" });
-    await user.click(within(providerActions).getByRole("menuitem", { name: "Configure" }));
+    await user.click(screen.getByRole("button", { name: "Configure OpenAI" }));
     const dialog = screen.getByRole("dialog", { name: "Configure OpenAI" });
     expect((within(dialog).getByLabelText("API base") as HTMLInputElement).value).toBe("https://api.openai.com/v1");
     expect(within(dialog).getByText("Configured")).toBeTruthy();
@@ -1195,9 +1193,7 @@ describe("DesktopShell", () => {
     });
     expect(await screen.findByRole("article", { name: "Local OpenAI provider" })).toBeTruthy();
 
-    await user.click(screen.getByRole("button", { name: "More actions for Local OpenAI" }));
-    await user.click(within(screen.getByRole("menu", { name: "Local OpenAI provider actions" }))
-      .getByRole("menuitem", { name: "Configure" }));
+    await user.click(screen.getByRole("button", { name: "Configure Local OpenAI" }));
     const configureDialog = screen.getByRole("dialog", { name: "Configure Local OpenAI" });
     const configuredReasoningEffort = within(configureDialog)
       .getByRole("checkbox", { name: "Send reasoning effort" }) as HTMLInputElement;

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -1,3 +1,4 @@
+import { AppToastViewport } from "../lib/AppToast";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { TFunction } from "i18next";
@@ -193,6 +194,7 @@ export function DesktopShell(props: DesktopShellProps) {
   return (
     <AppLanguageProvider>
       <AppAppearanceProvider>
+        <AppToastViewport />
         <AppShortcutProvider>
           <DesktopShellContent {...props} />
         </AppShortcutProvider>

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:5a636384b048f5713d33734f3278c8dadf86e02d5d7fa02126bdb09fc0ee91c3 -->
+<!-- tinybot-module-fingerprint: sha256:11fdac790e85ffeacc8651155b43bd96bd6ae96e1420a85cd9da0bf7de031a54 -->
 
 Desktop-pet quick chat shares composer drop and clipboard import with main Chat;
 its window permission set includes the bounded binary attachment import command.


### PR DESCRIPTION
## Summary

- Refresh DeepSeek presets to `deepseek-v4-pro` and `deepseek-flash`, including context-window and image-input capabilities, while retaining support for existing configured aliases.
- Replace provider overflow menus with direct Models and Configure actions.
- Accept unique nonblank data-view row IDs so valid persisted charts with dates, Chinese labels, or compound identifiers render correctly.
- Show CSV download initiation and failures in a shared top notification bubble. Notifications slide in, dismiss automatically, pause on hover or focus, and support reduced motion and manual dismissal.

## Validation

- TypeScript: `npx tsc --noEmit` passed.
- Affected frontend suites passed, including 38 tests for toast behavior, CSV feedback, and DesktopShell integration, plus provider settings and data-view validation coverage.
- Rust: 143 targeted provider, context-window, and default-config tests passed with two build jobs.
- Replayed all three affected persisted data views successfully after the row-ID validation fix.
- Engineering documentation and module README freshness checks passed.

The download notification confirms initiation; the browser does not expose completion of the save operation.