### PR TITLE
Add provider API key links and split-flap response feedback

### DIFF
--- a/src/app-core/settings/README.md
+++ b/src/app-core/settings/README.md
@@ -1,8 +1,11 @@
 # Settings Application Core
-<!-- tinybot-module-fingerprint: sha256:610a6588aa987bddef83e905614214ecdae332d42b4a6057b7809058aad42786 -->
+<!-- tinybot-module-fingerprint: sha256:d6ddd835d1ad938550799c31a312ddf060bff49998ba81f12fdf0bb8f2cbd7c7 -->
 
 `settings` owns framework-independent settings contracts, metadata, value
 semantics, validation, pane models, and persistence patch construction.
+
+Built-in cloud provider presets carry their official API-key console URL into
+the provider card model; keyless local and custom providers omit this link.
 
 It is the source of truth for secret handling, defaults, commit behavior, and
 dirty-state semantics. React pages present these models, while the desktop

--- a/src/app-core/settings/providerModelsSettings.ts
+++ b/src/app-core/settings/providerModelsSettings.ts
@@ -7,6 +7,7 @@ export type BuiltInProviderPreset = {
   label: string;
   builtIn: true;
   defaultBaseUrl: string;
+  apiKeyUrl?: string;
   defaultModels: string[];
   apiKeyRequired: boolean;
   supportsResponsesApi: boolean;
@@ -36,6 +37,7 @@ export type ProviderCardModel = {
   statusLabel: string;
   profileId: string;
   baseUrl: string;
+  apiKeyUrl?: string;
   apiKeyConfigured: boolean;
   apiKeyRequired: boolean;
   useResponsesApi: boolean;
@@ -148,6 +150,7 @@ export const BUILT_IN_PROVIDER_PRESETS: BuiltInProviderPreset[] = [
     label: "DeepSeek",
     builtIn: true,
     defaultBaseUrl: "https://api.deepseek.com",
+    apiKeyUrl: "https://platform.deepseek.com/",
     defaultModels: ["deepseek-v4-pro", "deepseek-flash"],
     apiKeyRequired: true,
     supportsResponsesApi: true,
@@ -158,6 +161,7 @@ export const BUILT_IN_PROVIDER_PRESETS: BuiltInProviderPreset[] = [
     label: "DashScope",
     builtIn: true,
     defaultBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    apiKeyUrl: "https://bailian.console.aliyun.com/cn-beijing?tab=model",
     defaultModels: ["qwen-plus", "qwen-max", "qwen-turbo"],
     apiKeyRequired: true,
     supportsResponsesApi: true,
@@ -168,6 +172,7 @@ export const BUILT_IN_PROVIDER_PRESETS: BuiltInProviderPreset[] = [
     label: "OpenAI",
     builtIn: true,
     defaultBaseUrl: "https://api.openai.com/v1",
+    apiKeyUrl: "https://platform.openai.com/api-keys",
     defaultModels: ["gpt-4.1"],
     apiKeyRequired: true,
     supportsResponsesApi: true,
@@ -178,6 +183,7 @@ export const BUILT_IN_PROVIDER_PRESETS: BuiltInProviderPreset[] = [
     label: "Z.ai",
     builtIn: true,
     defaultBaseUrl: "https://open.bigmodel.cn/api/paas/v4",
+    apiKeyUrl: "https://bigmodel.cn/usercenter/proj-mgmt/apikeys",
     defaultModels: ["glm-5.3", "glm-5.3-flash", "glm-5.2"],
     apiKeyRequired: true,
     supportsResponsesApi: false,
@@ -472,6 +478,7 @@ function buildProviderCard(
     baseUrl: stringValue(pick(profile, "apiBase", "api_base")) || preset.defaultBaseUrl,
     apiKeyConfigured,
     apiKeyRequired: preset.apiKeyRequired,
+    apiKeyUrl: preset.apiKeyUrl,
     useResponsesApi: preset.supportsResponsesApi && usesResponsesApi(profile),
     supportsResponsesApi: preset.supportsResponsesApi,
     modelCount: enabledModelItems.length,

--- a/src/react-workbench/chat/AgentResponseIndicator.css
+++ b/src/react-workbench/chat/AgentResponseIndicator.css
@@ -1,0 +1,34 @@
+.react-agent-response {
+  margin-top: 10px;
+  min-height: 24px;
+}
+
+.react-agent-response__board {
+  vertical-align: top;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.react-agent-response__board .split-flap-text__tile {
+  flex-shrink: 0;
+  height: 1.6em;
+  box-shadow: none;
+}
+
+.react-agent-response__board[data-cjk] .split-flap-text__tile {
+  width: 1.3em;
+}
+
+.react-agent-response__board .split-flap-text__char {
+  text-shadow: none;
+}
+
+.react-agent-response__board .split-flap-text__tile::before {
+  background: var(--color-hairline);
+  box-shadow: none;
+}
+
+.react-agent-response__board .split-flap-text__tile::after {
+  border-color: var(--color-hairline);
+  box-shadow: none;
+}

--- a/src/react-workbench/chat/AgentResponseIndicator.tsx
+++ b/src/react-workbench/chat/AgentResponseIndicator.tsx
@@ -1,0 +1,54 @@
+import { memo, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import SplitFlapText from "../lib/SplitFlapText";
+import "./AgentResponseIndicator.css";
+
+export const AgentResponseIndicator = memo(function AgentResponseIndicator() {
+  const { t, i18n } = useTranslation("chat");
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    let inView = true;
+    const update = () => setVisible(inView && !document.hidden);
+    const observer = new IntersectionObserver(([entry]) => {
+      inView = entry.isIntersecting;
+      update();
+    });
+    observer.observe(ref.current!);
+    document.addEventListener("visibilitychange", update);
+    update();
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("visibilitychange", update);
+    };
+  }, []);
+  const words = [
+    t("turn.flapWords.building"),
+    t("turn.flapWords.stirring"),
+    t("turn.flapWords.polishing"),
+    t("turn.flapWords.baking"),
+  ];
+  return (
+    <div ref={ref} className="react-agent-response" role="img" aria-label={t("turn.agentResponding")}>
+      <SplitFlapText
+        aria-hidden="true"
+        className="react-agent-response__board"
+        data-cjk={i18n.resolvedLanguage?.startsWith("zh") || undefined}
+        words={words}
+        loop={visible}
+        text={visible ? undefined : words[0]}
+        charset={words.join("")}
+        padTo={0}
+        fontSize={13}
+        gap={2}
+        tileRadius={3}
+        tileColor="var(--color-surface-soft)"
+        textColor="var(--color-muted)"
+        cycleDelay={3200}
+        flipDuration={0.1}
+        stagger={0.015}
+        flipsPerChar={1}
+      />
+    </div>
+  );
+});

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -766,23 +766,6 @@
   color: var(--color-muted);
 }
 
-.react-message__streaming {
-  display: inline-block;
-  width: 24px;
-  height: 8px;
-  margin-top: 8px;
-  border-radius: 999px;
-  background: radial-gradient(circle closest-side, var(--color-muted) 90%, transparent) 0 50% / 8px 8px repeat-x;
-  opacity: 0.55;
-  animation: react-streaming-pulse 900ms ease-in-out infinite;
-}
-
-@keyframes react-streaming-pulse {
-  50% {
-    opacity: 0.25;
-  }
-}
-
 .react-message-markdown [data-streamdown="table-wrapper"] {
   max-width: 100%;
   overflow-x: auto;
@@ -4608,7 +4591,6 @@
 
   .react-agent-step-item[aria-current="step"] .react-agent-step-item__marker,
 .react-message-markdown [data-sd-animate],
-.react-message__streaming,
 .react-right-drawer[data-motion="fade-content"] {
     opacity: 1;
     transform: none;

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -37,6 +37,7 @@ import {
   type ToolCallSummary,
 } from "./messageActions";
 import { AssistantMarkdown } from "./AssistantMarkdown";
+import { AgentResponseIndicator } from "./AgentResponseIndicator";
 import type { AssistantFileLink } from "./assistantFileLinks";
 import { isApplyPatchToolCall, PatchDiffCard, patchChangeSetFromToolResult } from "./PatchDiffCard";
 import { ToolActivityItem } from "./ToolActivityItem";
@@ -609,7 +610,7 @@ function CanonicalMessage({
         ))}
         {role === "assistant" ? <AssistantMarkdown onOpenFileLink={onOpenFileLink} streaming={streaming} text={text} /> : <PlainMessageText text={text} />}
         {inlineReferences.length ? <MessageContext references={inlineReferences} /> : null}
-        {streaming ? <span aria-label={t("turn.agentResponding")} className="react-message__streaming" /> : null}
+        {streaming ? <AgentResponseIndicator /> : null}
       </div>
       {(allowActions && text.trim()) || footer ? (
         <div className="react-message__actions" data-align={role === "user" ? "right" : "left"}>
@@ -1043,7 +1044,7 @@ function MessageBubble({
         )}
         {inlineReferences.length ? <MessageContext references={inlineReferences} /> : null}
         {message.toolCalls?.length ? <AgentSteps toolCalls={message.toolCalls} onOpenTool={onOpenTool} /> : null}
-        {message.status === "streaming" ? <span className="react-message__streaming" aria-label={t("turn.agentResponding")} /> : null}
+        {message.status === "streaming" ? <AgentResponseIndicator /> : null}
       </div>
       {showCopyAction || showBranchAction ? (
         <div className="react-message__actions" data-align={actionAlignment}>

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:6894ce24dbc3b48e302b4c8a8cca44d13f54bbbdf07a0a7a0990618cdbdc9319 -->
+<!-- tinybot-module-fingerprint: sha256:743983b7c59ba03f6088fb16e90ebc0c4ba61a1e069621f300069ca08ab33f1f -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -462,3 +462,7 @@ composer draft and prevents dispatch.
 CSV export reports the requested filename and Downloads/save-location guidance
 through the shared top-of-window notification. It reports initiation failures and does not claim completion,
 since the WebView anchor download does not expose a completion callback.
+
+AgentResponseIndicator replaces streaming dots with a compact React Bits split-flap
+board. Localized playful phrases cycle while responding, with a stable accessible
+label. Offscreen/background indicators pause, and reduced motion stays static.

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:1774044e26069acecbc9410c6289ed730b8c2cd8ef4aa9b7619209a3414f24d4 -->
+<!-- tinybot-module-fingerprint: sha256:e35a4d72d9fb77d7cd55a7eac4940d1817ed86a737610605cece9239e2c66cd5 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles. Composer drag targets and attachment preparation

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:b0ad65ade7fbc036542b4879e0886e8df7500d40df297af50aa64378a62c79db -->
+<!-- tinybot-module-fingerprint: sha256:1774044e26069acecbc9410c6289ed730b8c2cd8ef4aa9b7619209a3414f24d4 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles. Composer drag targets and attachment preparation

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -841,6 +841,8 @@ export const en = {
         notConfigured: "Not configured",
         newApiKey: "Enter a new API key",
         replaceKey: "Entering a new key replaces the current key.",
+        getApiKey: "Get API Key",
+        openKeyPageFailed: "Could not open the API Key page. Please try again.",
         keyIfRequired: "Enter a key if this endpoint requires one.",
         profile: "Profile",
         activeProfile: "Active profile",

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1174,6 +1174,7 @@ export const en = {
       description: "First token includes reasoning and tool calls. Speed uses recorded model generation time and excludes tool execution and waits between calls.",
     },
     turn: {
+      flapWords: { building: "BRAIN AT WORK", stirring: "IDEA SOUP", polishing: "WORD POLISH", baking: "FRESHLY BAKED" },
       label: "Chat turn", workPerformed: "Work performed",
       agentResponding: "Agent is responding", copyMessage: "Copy message", branchHere: "Branch from here", formErrors: "Form errors", agentForms: "Agent forms",
       openDetails: "Open details for {{name}}", contextCompacted: "Context compacted", compactionDetails: "Compaction details",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -625,6 +625,7 @@ export const zh = {
       description: "首 token 包含思考和工具调用输出。速度按已记录的模型生成时间计算，不含工具执行和调用之间的等待。",
     },
     turn: {
+      flapWords: { building: "脑洞施工中", stirring: "灵感搅拌中", polishing: "给答案抛光", baking: "文字出炉中" },
       label: "会话轮次", workPerformed: "已执行的工作",
       agentResponding: "Agent 正在回复", copyMessage: "复制消息", branchHere: "从此处分支", formErrors: "表单错误", agentForms: "Agent 表单",
       openDetails: "打开 {{name}} 的详情", contextCompacted: "上下文已压缩", compactionDetails: "压缩详情",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -416,6 +416,8 @@ export const zh = {
       configureDialog: {
         close: "关闭 {{name}} 配置", description: "更新此 Provider 使用的连接。", connection: "连接", apiBase: "API Base", apiKey: "API Key",
         configured: "已配置", notConfigured: "未配置", newApiKey: "输入新的 API Key", replaceKey: "输入新 Key 会替换当前 Key。",
+        getApiKey: "获取 API Key",
+        openKeyPageFailed: "无法打开 API Key 页面，请重试。",
         keyIfRequired: "如果 Endpoint 需要，请输入 Key。", profile: "Profile", activeProfile: "当前 Profile", setActiveProfile: "设为当前 Profile",
         activeDescription: "新任务当前使用此 Provider。", setActiveDescription: "保存后让新 Agent 任务使用此 Provider。", apiMode: "API 模式", features: "功能支持",
         responsesHelp: "仅当 Endpoint 支持 /responses 时使用 Responses API。", chatOnlyHelp: "此 Provider 仅支持 Chat Completions。",

--- a/src/react-workbench/lib/README.md
+++ b/src/react-workbench/lib/README.md
@@ -1,5 +1,5 @@
 # Renderer Library
-<!-- tinybot-module-fingerprint: sha256:4adf5280e5fb49782a90f0979cfe3981982b641c7b0008f699be143947386174 -->
+<!-- tinybot-module-fingerprint: sha256:d487c0bc9b70697f78ae77f14032e106491fcf100edbaa957ff37f71f2a9f8b1 -->
 
 `lib` contains small, renderer-only presentation helpers shared by frontend
 modules. Formatting helpers are pure; presentation hooks do not own route state.
@@ -21,3 +21,7 @@ shell and pet quick chat. New notices replace old ones; ordinary/error messages
 remain for five/eight seconds, pause while hovered or focused, and fade out over
 220 ms. Portals avoid route clipping, reduced-motion removes movement, and timers
 are cleaned up when messages are replaced.
+
+SplitFlapText adapts React Bits' split-flap renderer with its upstream license
+retained in the source. It owns only tile transitions and phrase cycling; reduced
+motion renders a static first phrase, and unmounting clears timers and frames.

--- a/src/react-workbench/lib/SplitFlapText.css
+++ b/src/react-workbench/lib/SplitFlapText.css
@@ -1,0 +1,171 @@
+/* React Bits / David Haz — license retained in SplitFlapText.tsx. */
+.split-flap-text {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--split-flap-gap, 6px);
+  color: var(--split-flap-text-color, #f8fafc);
+  font-family: 'SFMono-Regular', 'Roboto Mono', 'Cascadia Code', 'Liberation Mono', Menlo, monospace;
+  font-size: var(--split-flap-font-size, 52px);
+  font-weight: 760;
+  line-height: 1;
+  letter-spacing: 0.035em;
+  white-space: pre;
+  user-select: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.split-flap-text__tile {
+  position: relative;
+  width: 0.78em;
+  height: 1.08em;
+  overflow: hidden;
+  border-radius: var(--split-flap-radius, 8px);
+  background:
+    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.16), transparent 44%),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--split-flap-tile-color, #111827) 82%, white),
+      var(--split-flap-tile-color, #111827)
+    );
+  box-shadow:
+    0 0.035em 0.08em rgba(255, 255, 255, 0.08) inset,
+    0 -0.05em 0.1em rgba(0, 0, 0, 0.38) inset,
+    0 0.16em 0.38em rgba(0, 0, 0, 0.28);
+  perspective: 520px;
+  transform-style: preserve-3d;
+  isolation: isolate;
+}
+
+.split-flap-text__tile::before {
+  content: '';
+  position: absolute;
+  z-index: 8;
+  top: calc(50% - 0.5px);
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.18) 18%,
+    rgba(0, 0, 0, 0.64) 50%,
+    rgba(255, 255, 255, 0.14) 82%,
+    transparent
+  );
+  box-shadow:
+    0 -1px 0 rgba(255, 255, 255, 0.08),
+    0 1px 0 rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+}
+
+.split-flap-text__tile::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 9;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: inherit;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2) inset;
+  pointer-events: none;
+}
+
+.split-flap-text__half,
+.split-flap-text__flap {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 50%;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.07), transparent 34%), var(--split-flap-tile-color, #111827);
+  backface-visibility: hidden;
+}
+
+.split-flap-text__half--top,
+.split-flap-text__flap--front {
+  top: 0;
+}
+
+.split-flap-text__half--bottom,
+.split-flap-text__flap--back {
+  bottom: 0;
+}
+
+.split-flap-text__half--bottom,
+.split-flap-text__flap--back {
+  background:
+    linear-gradient(0deg, rgba(255, 255, 255, 0.06), transparent 38%),
+    color-mix(in srgb, var(--split-flap-tile-color, #111827) 92%, black);
+}
+
+.split-flap-text__char {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 200%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--split-flap-text-color, #f8fafc);
+  text-shadow:
+    0 0.025em 0 rgba(255, 255, 255, 0.16),
+    0 0.09em 0.16em rgba(0, 0, 0, 0.42);
+}
+
+.split-flap-text__half--top .split-flap-text__char,
+.split-flap-text__flap--front .split-flap-text__char {
+  top: 0;
+}
+
+.split-flap-text__half--bottom .split-flap-text__char,
+.split-flap-text__flap--back .split-flap-text__char {
+  bottom: 0;
+}
+
+.split-flap-text__flap {
+  z-index: 6;
+  will-change: transform, filter;
+  transform-style: preserve-3d;
+}
+
+.split-flap-text__flap--front {
+  transform-origin: center bottom;
+  animation: split-flap-front var(--split-flap-flip-duration, 0.12s) cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+.split-flap-text__flap--back {
+  transform-origin: center top;
+  transform: rotateX(90deg);
+  animation: split-flap-back var(--split-flap-flip-duration, 0.12s) cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+@keyframes split-flap-front {
+  0% {
+    transform: rotateX(0deg);
+    filter: brightness(1.08);
+  }
+
+  100% {
+    transform: rotateX(-90deg);
+    filter: brightness(0.52);
+  }
+}
+
+@keyframes split-flap-back {
+  0%,
+  45% {
+    transform: rotateX(90deg);
+    filter: brightness(0.58);
+  }
+
+  100% {
+    transform: rotateX(0deg);
+    filter: brightness(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .split-flap-text__flap {
+    animation: none !important;
+  }
+}

--- a/src/react-workbench/lib/SplitFlapText.test.tsx
+++ b/src/react-workbench/lib/SplitFlapText.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import SplitFlapText from "./SplitFlapText";
+
+afterEach(() => { cleanup(); vi.useRealTimers(); vi.restoreAllMocks(); });
+const phrase = (root: HTMLElement) => Array.from(root.querySelectorAll(".split-flap-text__half--top .split-flap-text__char"), el => el.textContent).join("").trim();
+
+test("cycles through phrases, wraps, and releases animation timers on unmount", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "requestAnimationFrame", "cancelAnimationFrame", "performance"] });
+  const { container, unmount } = render(<SplitFlapText words={["SOUP", "IDEA"]} cycleDelay={400} flipDuration={0.04} stagger={0} flipsPerChar={0} padTo={0} />);
+  expect(phrase(container)).toBe("SOUP");
+  await act(async () => { await vi.advanceTimersByTimeAsync(500); });
+  expect(phrase(container)).toBe("IDEA");
+  await act(async () => { await vi.advanceTimersByTimeAsync(440); });
+  expect(phrase(container)).toBe("SOUP");
+  unmount();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+test("keeps a static phrase when reduced motion is requested", async () => {
+  vi.useFakeTimers();
+  const original = window.matchMedia.bind(window);
+  vi.spyOn(window, "matchMedia").mockImplementation(query => {
+    const media = original(query);
+    Object.defineProperty(media, "matches", { value: true });
+    return media;
+  });
+  const { container } = render(<SplitFlapText words={["脑洞施工中", "灵感搅拌中"]} cycleDelay={400} padTo={0} />);
+  await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+  expect(phrase(container)).toBe("脑洞施工中");
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/src/react-workbench/lib/SplitFlapText.tsx
+++ b/src/react-workbench/lib/SplitFlapText.tsx
@@ -1,0 +1,381 @@
+/*
+Adapted from React Bits SplitFlapText by David Haz.
+https://reactbits.dev/text-animations/split-flap-text
+
+MIT + Commons Clause License Condition v1.0
+
+Copyright (c) 2026 David Haz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, and distribute the Software **as part of an application, website, or product**, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+## Commons Clause Restriction
+
+You may use this Software, including for any commercial purpose, **so long as you do not sell, sublicense, or redistribute the components themselves-whether alone, in a bundle, or as a ported version.**
+
+## No Warranty
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+import { type CSSProperties, type HTMLAttributes, useEffect, useMemo, useRef, useState } from 'react';
+import './SplitFlapText.css';
+
+type TileState = {
+  current: string;
+  next: string;
+  flipping: boolean;
+  tick: number;
+};
+
+type AnimationPlan = {
+  index: number;
+  from: string;
+  target: string;
+  sequence: string[];
+  start: number;
+  step: number;
+  done: boolean;
+};
+
+type TileUpdate = {
+  index: number;
+  current: string;
+  next: string;
+  done: boolean;
+};
+
+export interface SplitFlapTextProps extends HTMLAttributes<HTMLDivElement> {
+  words?: string[];
+  text?: string;
+  flipDuration?: number;
+  stagger?: number;
+  cycleDelay?: number;
+  charset?: string;
+  flipsPerChar?: number;
+  tileColor?: string;
+  textColor?: string;
+  tileRadius?: number | string;
+  gap?: number | string;
+  fontSize?: number | string;
+  loop?: boolean;
+  padTo?: number;
+}
+
+const DEFAULT_WORDS = ['LAUNCH READY', 'SYNC ONLINE', 'SIGNAL LIVE'];
+
+const CHARSETS: Record<string, string> = {
+  alpha: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  alphanumeric: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+  numeric: '0123456789'
+};
+
+const toCssUnit = (value: number | string) => (typeof value === 'number' ? `${value}px` : value);
+
+const resolveCharset = (charset: SplitFlapTextProps['charset']) => {
+  if (charset && CHARSETS[charset]) return CHARSETS[charset];
+  return typeof charset === 'string' && charset.length > 0 ? charset : CHARSETS.alphanumeric;
+};
+
+const normalizePhrase = (phrase: string, width: number) => {
+  const safe = String(phrase ?? '');
+  return safe.padEnd(width, ' ').slice(0, width);
+};
+
+const createTiles = (phrase: string): TileState[] =>
+  phrase.split('').map(char => ({
+    current: char,
+    next: char,
+    flipping: false,
+    tick: 0
+  }));
+
+const sampleChar = (charset: string) => charset.charAt(Math.floor(Math.random() * charset.length)) || ' ';
+
+const buildSequence = (target: string, flips: number, charset: string) => {
+  const steps: string[] = [];
+  for (let i = 0; i < flips; i += 1) {
+    steps.push(sampleChar(charset));
+  }
+  steps.push(target);
+  return steps;
+};
+
+const usePrefersReducedMotion = () => {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = () => setPrefersReduced(mediaQuery.matches);
+
+    handleChange();
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReduced;
+};
+
+const SplitFlapText = ({
+  words = ['LAUNCH READY', 'SYNC ONLINE', 'SIGNAL LIVE'],
+  text,
+  flipDuration = 0.12,
+  stagger = 0.06,
+  cycleDelay = 2400,
+  charset = 'alphanumeric',
+  flipsPerChar = 8,
+  tileColor = '#111827',
+  textColor = '#f8fafc',
+  tileRadius = 8,
+  gap = 6,
+  fontSize = 52,
+  loop = true,
+  padTo = 12,
+  className = '',
+  style = {},
+  ...props
+}: SplitFlapTextProps) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const rafRef = useRef<number | null>(null);
+  const cycleTimerRef = useRef<number | null>(null);
+  const currentTextRef = useRef('');
+
+  const sourceWords = Array.isArray(words) && words.length > 0 ? words : DEFAULT_WORDS;
+  const phrasesKey = typeof text === 'string' ? text : sourceWords.map(word => String(word ?? '')).join('\u001f');
+  const phrases = useMemo(() => phrasesKey.split('\u001f'), [phrasesKey]);
+
+  const width = useMemo(() => {
+    const longest = phrases.reduce((max, phrase) => Math.max(max, phrase.length), 1);
+    return Math.max(1, Math.ceil(Number(padTo) || 0), longest);
+  }, [padTo, phrases]);
+
+  const normalizedPhrases = useMemo(() => phrases.map(phrase => normalizePhrase(phrase, width)), [phrases, width]);
+
+  const [tiles, setTiles] = useState<TileState[]>(() => createTiles(normalizedPhrases[0] || ''));
+
+  useEffect(() => {
+    const clearAnimation = () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+
+      if (cycleTimerRef.current) {
+        clearTimeout(cycleTimerRef.current);
+        cycleTimerRef.current = null;
+      }
+    };
+
+    clearAnimation();
+
+    const firstPhrase = normalizedPhrases[0] || '';
+    currentTextRef.current = firstPhrase;
+    setTiles(createTiles(firstPhrase));
+
+    if (normalizedPhrases.length <= 1 || prefersReducedMotion || typeof window === 'undefined') {
+      return clearAnimation;
+    }
+
+    let phraseIndex = 0;
+    let cancelled = false;
+
+    const safeFlipMs = Math.max(40, (Number(flipDuration) || 0.12) * 1000);
+    const safeStaggerMs = Math.max(0, (Number(stagger) || 0) * 1000);
+    const safeCycleDelay = Math.max(400, Number(cycleDelay) || 2400);
+    const safeFlips = Math.max(0, Math.floor(Number(flipsPerChar) || 0));
+    const activeCharset = resolveCharset(charset);
+
+    const animateTo = (targetPhrase: string) => {
+      if (prefersReducedMotion) {
+        currentTextRef.current = targetPhrase;
+        setTiles(createTiles(targetPhrase));
+        return 0;
+      }
+
+      const fromPhrase = normalizePhrase(currentTextRef.current, width);
+      const targetChars = targetPhrase.split('');
+
+      const plans = targetChars
+        .map<AnimationPlan | null>((targetChar, index) => {
+          const fromChar = fromPhrase[index] || ' ';
+          if (fromChar === targetChar) return null;
+
+          return {
+            index,
+            from: fromChar,
+            target: targetChar,
+            sequence: buildSequence(targetChar, safeFlips, activeCharset),
+            start: index * safeStaggerMs,
+            step: -1,
+            done: false
+          };
+        })
+        .filter((plan): plan is AnimationPlan => plan !== null);
+
+      if (!plans.length) {
+        currentTextRef.current = targetPhrase;
+        setTiles(createTiles(targetPhrase));
+        return 0;
+      }
+
+      const totalDuration = plans.reduce(
+        (max, plan) => Math.max(max, plan.start + plan.sequence.length * safeFlipMs),
+        0
+      );
+      const startedAt = performance.now();
+
+      const updateTiles = (updates: TileUpdate[]) => {
+        setTiles(previous => {
+          const nextTiles = [...previous];
+          updates.forEach(update => {
+            const tile = nextTiles[update.index];
+            if (!tile) return;
+
+            nextTiles[update.index] = {
+              current: update.current,
+              next: update.next,
+              flipping: !update.done,
+              tick: tile.tick + 1
+            };
+          });
+          return nextTiles;
+        });
+      };
+
+      const tick = (now: number) => {
+        if (cancelled) return;
+
+        const elapsed = now - startedAt;
+        const updates: TileUpdate[] = [];
+        let shouldContinue = false;
+
+        plans.forEach(plan => {
+          const localElapsed = elapsed - plan.start;
+
+          if (localElapsed < 0) {
+            shouldContinue = true;
+            return;
+          }
+
+          const step = Math.floor(localElapsed / safeFlipMs);
+
+          if (step < plan.sequence.length) {
+            shouldContinue = true;
+
+            if (step !== plan.step) {
+              plan.step = step;
+              updates.push({
+                index: plan.index,
+                current: step === 0 ? plan.from : plan.sequence[step - 1],
+                next: plan.sequence[step],
+                done: false
+              });
+            }
+          } else if (!plan.done) {
+            plan.done = true;
+            updates.push({
+              index: plan.index,
+              current: plan.target,
+              next: plan.target,
+              done: true
+            });
+          }
+        });
+
+        if (updates.length > 0) updateTiles(updates);
+
+        if (shouldContinue) {
+          rafRef.current = requestAnimationFrame(tick);
+        } else {
+          currentTextRef.current = targetPhrase;
+          rafRef.current = null;
+        }
+      };
+
+      rafRef.current = requestAnimationFrame(tick);
+      return totalDuration;
+    };
+
+    const scheduleNext = (delay: number) => {
+      cycleTimerRef.current = window.setTimeout(() => {
+        if (cancelled) return;
+
+        const nextIndex = phraseIndex + 1;
+
+        if (nextIndex >= normalizedPhrases.length && !loop) return;
+
+        phraseIndex = nextIndex % normalizedPhrases.length;
+        const animationDuration = animateTo(normalizedPhrases[phraseIndex]);
+        scheduleNext(safeCycleDelay + animationDuration);
+      }, delay);
+    };
+
+    scheduleNext(safeCycleDelay);
+
+    return () => {
+      cancelled = true;
+      clearAnimation();
+    };
+  }, [normalizedPhrases, width, loop, cycleDelay, flipDuration, stagger, flipsPerChar, charset, prefersReducedMotion]);
+
+  const settledText = tiles
+    .map(tile => tile.current)
+    .join('')
+    .trimEnd();
+  const componentStyle: CSSProperties & Record<string, string | number | undefined> = {
+    '--split-flap-tile-color': tileColor,
+    '--split-flap-text-color': textColor,
+    '--split-flap-radius': toCssUnit(tileRadius),
+    '--split-flap-gap': toCssUnit(gap),
+    '--split-flap-font-size': toCssUnit(fontSize),
+    '--split-flap-flip-duration': `${Math.max(0.04, Number(flipDuration) || 0.12)}s`,
+    ...style
+  };
+
+  return (
+    <div
+      className={`split-flap-text ${className}`.trim()}
+      style={componentStyle}
+      role="img"
+      aria-label={settledText || undefined}
+      {...props}
+    >
+      {tiles.map((tile, index) => (
+        <span className="split-flap-text__tile" aria-hidden="true" key={`${index}-${tiles.length}`}>
+          <span className="split-flap-text__half split-flap-text__half--top">
+            <span className="split-flap-text__char">{tile.current === ' ' ? '\u00A0' : tile.current}</span>
+          </span>
+          <span className="split-flap-text__half split-flap-text__half--bottom">
+            <span className="split-flap-text__char">{tile.flipping ? tile.next : tile.current}</span>
+          </span>
+
+          {tile.flipping && (
+            <>
+              <span className="split-flap-text__flap split-flap-text__flap--front" key={`front-${index}-${tile.tick}`}>
+                <span className="split-flap-text__char">{tile.current === ' ' ? '\u00A0' : tile.current}</span>
+              </span>
+              <span className="split-flap-text__flap split-flap-text__flap--back" key={`back-${index}-${tile.tick}`}>
+                <span className="split-flap-text__char">{tile.next === ' ' ? '\u00A0' : tile.next}</span>
+              </span>
+            </>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default SplitFlapText;

--- a/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
+++ b/src/react-workbench/settings/ProviderModelsSettingsPage.tsx
@@ -1,4 +1,6 @@
-import { Check, ChevronRight, Image as ImageIcon, Loader2, Plus, RefreshCw, Search, Trash2 } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Check, ChevronRight, ExternalLink, Image as ImageIcon, Loader2, Plus, RefreshCw, Search, Trash2 } from "lucide-react";
+import { showAppToast } from "../lib/AppToast";
 import type { TFunction } from "i18next";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
@@ -695,6 +697,24 @@ function ProviderConfigureDialog({
                   : t("provider.configureDialog.keyIfRequired")}
               </small>
             </label>
+            {provider.apiKeyUrl ? (
+              <a
+                className="react-provider-config__key-link"
+                href={provider.apiKeyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(event) => {
+                  event.preventDefault();
+                  void openUrl(event.currentTarget.href).catch((error: unknown) => {
+                    console.error("Failed to open provider API key page", error);
+                    showAppToast(t("provider.configureDialog.openKeyPageFailed"), "error");
+                  });
+                }}
+              >
+                {t("provider.configureDialog.getApiKey")}
+                <ExternalLink aria-hidden="true" size={13} />
+              </a>
+            ) : null}
           </section>
 
           <section className="react-provider-config__section" aria-labelledby="provider-profile-title">

--- a/src/react-workbench/settings/README.md
+++ b/src/react-workbench/settings/README.md
@@ -1,5 +1,9 @@
 # Settings Workbench
-<!-- tinybot-module-fingerprint: sha256:f24cd0b1c68e1dc1a127f0423c6baaca44bcea75fd1fac28267c67736f0a7bb9 -->
+<!-- tinybot-module-fingerprint: sha256:0afa3990b9fbb9ed36477d72e145397fe5663b18ccffa2d3a5bb54cb714281ab -->
+
+Provider configuration shows a Get API Key link below the credential field for
+built-in cloud providers. The native opener launches the official console in
+the system browser; failures are logged and shown as a transient error notice.
 
 `settings` owns the Settings route, its navigation, pages, sheets, appearance
 and language contexts, and form presentation. `SettingsRoute.tsx` is loaded as

--- a/src/react-workbench/settings/SettingsRoute.css
+++ b/src/react-workbench/settings/SettingsRoute.css
@@ -3143,6 +3143,22 @@
   line-height: 1.45;
 }
 
+.react-provider-config__key-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  justify-self: start;
+  color: var(--color-primary);
+  font-size: 12px;
+  text-underline-offset: 3px;
+}
+
+.react-provider-config__key-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+
 .react-provider-config__switch {
   position: relative;
   display: grid !important;


### PR DESCRIPTION
Provider configuration now offers a Get API Key link beneath the credential field for DeepSeek, DashScope, OpenAI, and Z.ai. Each link opens the official console in the system browser, with logged failures and a transient error notification. Ollama and custom providers omit the link.

Streaming assistant messages replace the pulsing dots with a compact React Bits split-flap board cycling playful English or Chinese phrases. The indicator pauses offscreen and in background windows, stays static with reduced motion, and disappears when streaming ends. Its accessible label remains stable. Upstream attribution and license are retained in the component source; no npm dependency is added.

Validation:
- TypeScript and lint checks passed.
- Provider settings suites: 16 tests passed.
- Split-flap and ChatTimeline suites: 8 tests passed, including cycling, reduced motion, and timer cleanup.
- Browser preview checked Chinese and English rendering and indicator removal.
- Documentation and module README freshness checks passed.