### PR TITLE
fix: improve chat turn feedback and allow mixed data view tools

### DIFF
--- a/docs/api/desktop.md
+++ b/docs/api/desktop.md
@@ -527,7 +527,7 @@ a schema v2 default config with:
 
 - `schemaVersion: 2`
 - `agents.defaults.activeProfile: "deepseek-default"`
-- `agents.defaults.model: "deepseek-v4-pro"`
+- `agents.defaults.model: "deepseek-flash"`
 - `providers.profiles.deepseek-default` with DeepSeek V4 models and the built-in `reasoning` capability
 
 Existing files are never overwritten by this initialization path, including invalid JSON or non-object

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -22,7 +22,7 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:d80ee217e1585b9d5d34b213c2921297c36b166a8e24391d3f5f6a3d5042796a -->
+<!-- tinybot-doc-fingerprint: sha256:bd7e6f55303b712889b6607051d89f34b27514bc609bab5f9bc8dc9a632fab11 -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal
@@ -174,8 +174,10 @@ For each provider iteration, the runtime:
 Several calls in one provider response form an ordered batch, not a requirement
 to execute them simultaneously. Registry policy marks concurrency-safe calls;
 the runtime groups those calls into parallel waves and treats every exclusive
-call as an ordering barrier. `update_plan` is such a barrier, so a plan update
-may precede ordinary calls in the same response without rejecting the batch.
+call as an ordering barrier. `update_plan` and `publish_data_view` are such
+barriers: they may share a response with ordinary tools, retaining provider
+order without rejecting the batch. Chart validation failures are returned as
+tool errors while subsequent calls continue through the scheduler.
 
 The bridge loads additive global and effective-working-directory command hooks
 for each Turn, adapting the engine to the same asynchronous `AgentHook`

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -14,7 +14,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:23e1ba9f6547527a775d37023af161d6a9d55b53ace82525e940670271f18d02 -->
+<!-- tinybot-doc-fingerprint: sha256:d9c28c9895b9aa0dcb0015543df670dabd0c704363efa08686a8e9fe6d800353 -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:9e07977ed996a94333f42ff6f05636da61ecb666d5f1546370f54fca643d3003 -->
+<!-- tinybot-doc-fingerprint: sha256:fba6bdd9a402d0607d5f1bf1f187ff636a0e0ad345058b889238f52b296df744 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -13,7 +13,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:11910b4eeef9e29191c18bfc2ff043666cf903050ae27f39d1dabf0ea5660234 -->
+<!-- tinybot-doc-fingerprint: sha256:a1067392b68c079314a6032b88432f8bdf9b872f38e2ebac72da0036b8ea8350 -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,
@@ -22,6 +22,12 @@ and result projection remain separate concerns joined through narrow seams.
 The independent first-Turn title request reuses the Agent Runtime's Provider
 request and response adapters without entering the Agent Loop. It never receives
 the tool registry and remains a single tool-free Provider call.
+
+`publish_data_view` uses an exclusive wave in the shared batch scheduler, so it
+can appear alongside ordinary tools in one provider response. Publication retains
+provider order and the normal validation, hooks, artifact observations, and
+checkpoint handling. Invalid chart data produces a tool error; later tools in the
+batch still run.
 
 ## Tool flow
 

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,5 +1,5 @@
 # Tinybot Rust Backend
-<!-- tinybot-module-fingerprint: sha256:d002d97c70576e1e88814c2594198ef79bc70e6191831f074432a3b88ab433cc -->
+<!-- tinybot-module-fingerprint: sha256:2cee1b86d4399c8aed4116322ca252abb437850bff7aa3f33fbcc5c4e26e2a00 -->
 
 This single crate is the native backend for Tinybot Desktop. It owns the
 in-process Tauri host, the native agent runtime, RPC services, runtime

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -1,5 +1,5 @@
 # Agent
-<!-- tinybot-module-fingerprint: sha256:1e74d480d592f42ebb0193ba453ad1e547171c88fbef3a8c46d2cfb14f4d89f4 -->
+<!-- tinybot-module-fingerprint: sha256:c4dcc32f434e027487f86e9d64b92467433be01ab9d804ff518f2462236d0c52 -->
 
 `agent` contains the native agent stack. It connects provider configuration,
 the turn runtime, durable runtime events, and the desktop integration bridge.

--- a/src-tauri/src/agent/provider/README.md
+++ b/src-tauri/src/agent/provider/README.md
@@ -1,8 +1,11 @@
 # Agent Providers
-<!-- tinybot-module-fingerprint: sha256:a6b8b252dfbd034e9d3b52cf15b89aadc86397511b778aaf0de797b64c62fce7 -->
+<!-- tinybot-module-fingerprint: sha256:8724286feee694840347abbcfcf9ef2cee8bfefb0db14dc5754ce49618674cec -->
 
 This module resolves provider and model configuration and performs streaming
 Chat Completions or Responses API requests.
+
+The built-in default model is `deepseek-flash`; explicit configured models retain
+their existing selection.
 
 - `plugins/` contains the statically registered Provider adapters. Every
   built-in Provider implements the shared `ProviderPlugin` interface and owns

--- a/src-tauri/src/agent/provider/catalog.rs
+++ b/src-tauri/src/agent/provider/catalog.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use super::plugins::{provider_plugin_by_id, registered_provider_plugins, OPENAI_API_MODES};
 
-const DEFAULT_AGENT_MODEL: &str = "deepseek-v4-pro";
+const DEFAULT_AGENT_MODEL: &str = "deepseek-flash";
 const DEFAULT_PROVIDER_TIMEOUT_MS: u64 = 120_000;
 const BUILT_IN_IMAGE_INPUT_MODELS: &[&str] = &[
     "deepseek-flash",

--- a/src-tauri/src/agent/provider/plugins/README.md
+++ b/src-tauri/src/agent/provider/plugins/README.md
@@ -1,5 +1,5 @@
 # Provider Plugins
-<!-- tinybot-module-fingerprint: sha256:bb2191cd0f806f81255a1cce39e8b2c883b38e3a624b0f158f56347faa43ba02 -->
+<!-- tinybot-module-fingerprint: sha256:609b2bc12c8051ffd4ab7445a13e4d1865d6427399939dfc88873dc1594e6902 -->
 
 This module contains the statically registered adapters for built-in
 Providers. A Provider plugin owns vendor-specific catalog metadata, reasoning

--- a/src-tauri/src/agent/provider/plugins/deepseek.rs
+++ b/src-tauri/src/agent/provider/plugins/deepseek.rs
@@ -14,7 +14,7 @@ static CATALOG_ENTRY: NativeProviderCatalogEntry = NativeProviderCatalogEntry {
     api_key_env_vars: &["DEEPSEEK_API_KEY"],
     api_base_env_vars: &["DEEPSEEK_BASE_URL"],
     supports_model_discovery: true,
-    curated_model_ids: &["deepseek-v4-pro", "deepseek-flash"],
+    curated_model_ids: &["deepseek-flash", "deepseek-v4-pro"],
     model_prefixes: &["deepseek"],
     capabilities: &["reasoning"],
     supported_api_modes: OPENAI_API_MODES,

--- a/src-tauri/src/agent/provider_tests.rs
+++ b/src-tauri/src/agent/provider_tests.rs
@@ -105,7 +105,7 @@ fn provider_catalog_exposes_current_built_in_providers_only() {
     assert_eq!(deepseek["capabilities"], json!(["reasoning"]));
     assert_eq!(
         deepseek["curatedModelIds"],
-        json!(["deepseek-v4-pro", "deepseek-flash"])
+        json!(["deepseek-flash", "deepseek-v4-pro"])
     );
     let zai = body["providers"]
         .as_array()

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:4c39fc5edc176aa9a854262cadc6216c2f01ba3c57d493c0ed29c4d07cc8eeb3 -->
+<!-- tinybot-module-fingerprint: sha256:26f86a69e469455ef05d75f42892ec73c76cad1e487484a1148331afd5140dc5 -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed
@@ -437,6 +437,11 @@ tool names fail before dispatch.
 Valid updates revise one `<turnId>:plan` timeline item and emit
 durable `agent.plan.progress`, so Thread reload reconstructs the last reported
 plan after session changes.
+
+`publish_data_view` runs as an exclusive wave in the shared tool batch scheduler.
+It may share a provider response with other tools; waves retain provider order,
+and chart validation failures return tool errors without skipping later tools.
+Published artifacts use the normal tool observation, hook, and checkpoint path.
 
 Resumable form checkpoints persist the activated tool set. Continuation
 revalidates it against the current registry and capability policy. Stale IDs,

--- a/src-tauri/src/agent/runtime/tests/README.md
+++ b/src-tauri/src/agent/runtime/tests/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Tests
-<!-- tinybot-module-fingerprint: sha256:eb57b10f1df021de6c57dab31d4e45676bef143d0f142e1bc142e439c32b7eea -->
+<!-- tinybot-module-fingerprint: sha256:0bd8a1694370a8661b48c8a8a187d73a47510518e801ee2fcafe7b88e81399dc -->
 
 This directory groups the larger agent runtime test suites by concern:
 configuration, context, interactions, lifecycle, and tools.

--- a/src-tauri/src/agent/runtime/tests/tools.rs
+++ b/src-tauri/src/agent/runtime/tests/tools.rs
@@ -2426,6 +2426,109 @@ fn publish_data_view_handles_multiple_calls_from_one_provider_response() {
 }
 
 #[test]
+fn publish_data_view_mixed_with_write_stdin_preserves_order_and_artifact() {
+    let arguments = json!({
+        "schemaVersion": "tinybot.data_view.v1",
+        "title": "Project stars",
+        "insight": "Compare project stars.",
+        "dataset": {
+            "columns": [{ "key": "stars", "label": "Stars", "type": "number" }],
+            "rows": [{ "id": "project", "values": { "stars": 100 } }]
+        },
+        "view": { "kind": "table", "fields": ["stars"] },
+        "provenance": { "status": "user_provided", "sources": [] }
+    })
+    .to_string();
+    let services = NativeAgentRuntimeServices::default();
+    let result = run_native_agent_turn_with_config(
+        &services,
+        json!({
+            "runtime": "rust",
+            "turnId": "turn-mixed-data-view-order",
+            "sessionId": "websocket:chat-mixed-data-view-order",
+            "maxIterations": 2,
+            "messages": [{ "role": "user", "content": "wait for the report and publish a chart" }]
+        }),
+        json!({
+            "agents": { "defaults": { "provider": "fixture", "model": "fixture-model" } },
+            "providers": { "fixture": { "responses": [
+                { "content": "", "toolCalls": [
+                    {
+                        "id": "call-wait", "name": "write_stdin",
+                        "argumentsJson": "{\"processId\":\"process-5\",\"chars\":\"\"}",
+                        "result": { "content": "Report ready" }
+                    },
+                    {
+                        "id": "call-chart", "name": "publish_data_view",
+                        "argumentsJson": arguments
+                    },
+                    {
+                        "id": "call-plan", "name": "update_plan",
+                        "argumentsJson": "{\"plan\":[{\"step\":\"Publish chart\",\"status\":\"completed\"}]}"
+                    }
+                ] },
+                { "content": "Report and chart ready." }
+            ] } }
+        }),
+    ).expect("mixed tools should finish the turn");
+
+    assert_eq!(result["stopReason"], "final_response");
+    let completed = result["completedToolResults"].as_array().unwrap();
+    assert_eq!(
+        completed
+            .iter()
+            .map(|item| item["toolCallId"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["call-wait", "call-chart", "call-plan"]
+    );
+    assert!(
+        completed.iter().all(|item| item["status"] == "ok"),
+        "{completed:?}"
+    );
+    let artifact = &completed[1]["envelope"]["artifacts"][0];
+    assert_eq!(artifact["kind"], "data_view");
+    assert_eq!(artifact["content"]["title"], "Project stars");
+    let events = result["runtimeEvents"].as_array().unwrap();
+    let results = events
+        .iter()
+        .filter(|event| event["eventName"] == "agent.tool.result")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        results
+            .iter()
+            .map(|event| event["payload"]["toolCallId"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["call-wait", "call-chart", "call-plan"]
+    );
+    assert_eq!(results[1]["payload"]["envelope"]["artifacts"][0], *artifact);
+    let lifecycle = events
+        .iter()
+        .filter(|event| {
+            event["eventName"] == "agent.tool.result"
+                || (event["eventName"] == "agent.tool.start"
+                    && event["payload"]["status"] == "running")
+        })
+        .map(|event| {
+            (
+                event["eventName"].as_str().unwrap(),
+                event["payload"]["toolCallId"].as_str().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        lifecycle,
+        vec![
+            ("agent.tool.start", "call-wait"),
+            ("agent.tool.result", "call-wait"),
+            ("agent.tool.start", "call-chart"),
+            ("agent.tool.result", "call-chart"),
+            ("agent.tool.start", "call-plan"),
+            ("agent.tool.result", "call-plan"),
+        ]
+    );
+}
+
+#[test]
 fn mixed_data_view_error_and_other_tool_success_are_both_returned_to_the_model() {
     let services = NativeAgentRuntimeServices::default()
         .with_test_tool_registry_entries(test_registry_with_model_tools(&["workspace.read_file"]));
@@ -2475,6 +2578,10 @@ fn mixed_data_view_error_and_other_tool_success_are_both_returned_to_the_model()
     assert_eq!(completed.len(), 2);
     assert_eq!(completed[0]["toolCallId"], "call-data-view-mixed");
     assert_eq!(completed[0]["status"], "error");
+    assert!(completed[0]["envelope"]["modelContent"]
+        .as_str()
+        .unwrap()
+        .starts_with("data_view_schema_unsupported:"));
     assert_eq!(completed[1]["toolCallId"], "call-read-mixed");
     assert_eq!(completed[1]["status"], "ok");
 }

--- a/src-tauri/src/agent/runtime/tool_runtime.rs
+++ b/src-tauri/src/agent/runtime/tool_runtime.rs
@@ -322,31 +322,6 @@ pub(super) async fn execute_tool_calls_for_iteration(
         };
     }
 
-    if tool_calls
-        .iter()
-        .any(|tool_call| tool_call.name == PUBLISH_DATA_VIEW_METHOD)
-    {
-        if tool_calls
-            .iter()
-            .any(|tool_call| tool_call.name != PUBLISH_DATA_VIEW_METHOD)
-        {
-            let (data_view_calls, other_tool_calls): (Vec<_>, Vec<_>) = tool_calls
-                .into_iter()
-                .partition(|tool_call| tool_call.name == PUBLISH_DATA_VIEW_METHOD);
-            for tool_call in data_view_calls {
-                record_tool_failure(
-                    context,
-                    state,
-                    iteration,
-                    &tool_call,
-                    "publish_data_view cannot be mixed with other tools in its provider response",
-                )?;
-            }
-            return execute_tool_batch(services, context, state, iteration, other_tool_calls).await;
-        }
-        return execute_publish_data_views(services, context, state, iteration, tool_calls).await;
-    }
-
     execute_tool_batch(services, context, state, iteration, tool_calls).await
 }
 
@@ -416,66 +391,6 @@ async fn commit_executed_tool_observation(
         result.replace_model_content(evaluation.tool_feedback.join("\n"));
     }
     commit_tool_observation(context, state, iteration, tool_call.into_original(), result)
-}
-
-async fn execute_publish_data_views(
-    services: &NativeAgentRuntimeServices,
-    context: &mut AgentTurnContext,
-    state: &mut AgentTurnState,
-    iteration: i64,
-    tool_calls: Vec<PreparedToolCall>,
-) -> Result<NativeAgentToolExecutionOutcome, AgentError> {
-    let is_multi_call = tool_calls.len() > 1;
-    let planned_calls = tool_calls
-        .into_iter()
-        .enumerate()
-        .map(|(index, tool_call)| PlannedToolCall {
-            index,
-            mode: ToolExecutionMode::Exclusive,
-            tool_call,
-        })
-        .collect::<Vec<_>>();
-    if is_multi_call {
-        queue_tool_batch(services, context, state, iteration, &planned_calls)?;
-    }
-
-    for (wave_index, planned_call) in planned_calls.into_iter().enumerate() {
-        if context_is_cancelled(context) {
-            state.clear_pending_tool_calls();
-            return cancelled_result(services, context, state, iteration);
-        }
-        let tool_call = if is_multi_call {
-            let wave = ToolWave::Exclusive(planned_call);
-            mark_tool_wave_running(services, context, state, iteration, wave_index, &wave)?;
-            match wave {
-                ToolWave::Exclusive(call) => call.tool_call,
-                ToolWave::Parallel(_) => {
-                    unreachable!("data views are always published sequentially")
-                }
-            }
-        } else {
-            start_tool_call(services, context, state, iteration, &planned_call.tool_call)?;
-            planned_call.tool_call
-        };
-
-        let result = publish_data_view_result(context, &tool_call);
-        commit_executed_tool_observation(context, state, iteration, tool_call, result).await?;
-    }
-
-    state.apply_pending_tool_hook_context(context)?;
-    state.clear_pending_tool_calls();
-    state.transition_phase(
-        AgentRuntimePhase::Planning,
-        iteration,
-        AgentEventKind::ToolResult.wire_name(),
-    )?;
-    save_phase_checkpoint(
-        services,
-        context,
-        state.phase.clone(),
-        state.active_checkpoint_payload("data_views_published"),
-    );
-    Ok(NativeAgentToolExecutionOutcome::Continue)
 }
 
 fn publish_data_view_result(
@@ -762,6 +677,16 @@ async fn execute_tool_wave(
             Ok(vec![execute_update_plan_call(
                 context, state, iteration, call,
             )?])
+        }
+        ToolWave::Exclusive(call) if call.tool_call.name == PUBLISH_DATA_VIEW_METHOD => {
+            let result = publish_data_view_result(context, &call.tool_call);
+            Ok(vec![IndexedToolDispatchOutcome {
+                index: call.index,
+                outcome: ToolDispatchOutcome::Completed(ToolDispatchCompleted {
+                    tool_call: call.tool_call,
+                    result,
+                }),
+            }])
         }
         ToolWave::Exclusive(call) => Ok(vec![
             execute_planned_tool_call(services.clone(), context.clone(), call).await,

--- a/src-tauri/src/config/README.md
+++ b/src-tauri/src/config/README.md
@@ -1,5 +1,5 @@
 # Configuration
-<!-- tinybot-module-fingerprint: sha256:0f5462ff22fc533ebbc47c53d522cf57a45e3b13a211b0012b20df0f95e75499 -->
+<!-- tinybot-module-fingerprint: sha256:ebad34e15d40105a06b67804795a428b2a30d4d39de3494f9bdd172c3c762537 -->
 
 `config` owns loading, validating, and persisting Tinybot configuration.
 

--- a/src-tauri/src/config/application.rs
+++ b/src-tauri/src/config/application.rs
@@ -235,7 +235,7 @@ pub(crate) fn native_default_config_snapshot() -> Value {
         "agents": {
             "defaults": {
                 "activeProfile": "deepseek-default",
-                "model": "deepseek-v4-pro",
+                "model": "deepseek-flash",
                 "workspace": "~/.tinybot/workspace"
             }
         },
@@ -246,8 +246,8 @@ pub(crate) fn native_default_config_snapshot() -> Value {
                     "displayName": "DeepSeek",
                     "enabled": true,
                     "apiBase": "https://api.deepseek.com",
-                    "models": ["deepseek-v4-pro", "deepseek-flash"],
-                    "defaultModel": "deepseek-v4-pro",
+                    "models": ["deepseek-flash", "deepseek-v4-pro"],
+                    "defaultModel": "deepseek-flash",
                     "supportsModelDiscovery": true,
                     "capabilities": ["reasoning"]
                 }

--- a/src-tauri/tests/crate/config.rs
+++ b/src-tauri/tests/crate/config.rs
@@ -106,7 +106,7 @@ fn ensure_default_config_file_creates_schema_v2_deepseek_profile_when_missing() 
         saved["providers"]["profiles"]["deepseek-default"]["capabilities"],
         serde_json::json!(["reasoning"])
     );
-    assert_eq!(saved["agents"]["defaults"]["model"], "deepseek-v4-pro");
+    assert_eq!(saved["agents"]["defaults"]["model"], "deepseek-flash");
     assert!(saved["agents"]["defaults"].get("provider").is_none());
     assert_eq!(
         saved["providers"]["profiles"]["deepseek-default"]["provider"],
@@ -114,7 +114,7 @@ fn ensure_default_config_file_creates_schema_v2_deepseek_profile_when_missing() 
     );
     assert_eq!(
         saved["providers"]["profiles"]["deepseek-default"]["models"],
-        serde_json::json!(["deepseek-v4-pro", "deepseek-flash"])
+        serde_json::json!(["deepseek-flash", "deepseek-v4-pro"])
     );
     assert!(saved.get("gateway").is_none());
     assert!(!fixture.root.join(".tinybot").join("workspace").exists());

--- a/src-tauri/tests/crate/lifecycle.rs
+++ b/src-tauri/tests/crate/lifecycle.rs
@@ -832,7 +832,7 @@ fn native_config_defaults_to_schema_v2_deepseek_profile_without_config_file() {
             "agents": {
                 "defaults": {
                     "activeProfile": "deepseek-default",
-                    "model": "deepseek-v4-pro",
+                    "model": "deepseek-flash",
                     "workspace": "~/.tinybot/workspace"
                 }
             },
@@ -843,8 +843,8 @@ fn native_config_defaults_to_schema_v2_deepseek_profile_without_config_file() {
                         "displayName": "DeepSeek",
                         "enabled": true,
                         "apiBase": "https://api.deepseek.com",
-                        "models": ["deepseek-v4-pro", "deepseek-flash"],
-                        "defaultModel": "deepseek-v4-pro",
+                        "models": ["deepseek-flash", "deepseek-v4-pro"],
+                        "defaultModel": "deepseek-flash",
                         "supportsModelDiscovery": true,
                         "capabilities": ["reasoning"]
                     }

--- a/src/app-core/settings/README.md
+++ b/src/app-core/settings/README.md
@@ -1,11 +1,12 @@
 # Settings Application Core
-<!-- tinybot-module-fingerprint: sha256:d6ddd835d1ad938550799c31a312ddf060bff49998ba81f12fdf0bb8f2cbd7c7 -->
+<!-- tinybot-module-fingerprint: sha256:dcf6a171d7cc6c8dd166b30f68f31b758037a96d80e158957a6f429ec76f154f -->
 
 `settings` owns framework-independent settings contracts, metadata, value
 semantics, validation, pane models, and persistence patch construction.
 
 Built-in cloud provider presets carry their official API-key console URL into
 the provider card model; keyless local and custom providers omit this link.
+The DeepSeek preset lists `deepseek-flash` first, matching the native default.
 
 It is the source of truth for secret handling, defaults, commit behavior, and
 dirty-state semantics. React pages present these models, while the desktop

--- a/src/app-core/settings/providerModelsSettings.test.ts
+++ b/src/app-core/settings/providerModelsSettings.test.ts
@@ -84,7 +84,7 @@ describe("provider models settings", () => {
     });
     expect(BUILT_IN_PROVIDER_PRESETS.every((preset) => preset.builtIn)).toBe(true);
     expect(BUILT_IN_PROVIDER_PRESETS.find((preset) => preset.id === "deepseek")?.defaultModels)
-      .toEqual(["deepseek-v4-pro", "deepseek-flash"]);
+      .toEqual(["deepseek-flash", "deepseek-v4-pro"]);
   });
 
   test("reads and patches an optional Memory model override", () => {

--- a/src/app-core/settings/providerModelsSettings.ts
+++ b/src/app-core/settings/providerModelsSettings.ts
@@ -151,7 +151,7 @@ export const BUILT_IN_PROVIDER_PRESETS: BuiltInProviderPreset[] = [
     builtIn: true,
     defaultBaseUrl: "https://api.deepseek.com",
     apiKeyUrl: "https://platform.deepseek.com/",
-    defaultModels: ["deepseek-v4-pro", "deepseek-flash"],
+    defaultModels: ["deepseek-flash", "deepseek-v4-pro"],
     apiKeyRequired: true,
     supportsResponsesApi: true,
     modelDiscovery: { status: "openai-compatible", endpoint: "/models" },

--- a/src/react-workbench/chat/AgentResponseIndicator.css
+++ b/src/react-workbench/chat/AgentResponseIndicator.css
@@ -9,6 +9,11 @@
   letter-spacing: 0;
 }
 
+.react-agent-response__waiting {
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
 .react-agent-response__board .split-flap-text__tile {
   flex-shrink: 0;
   height: 1.6em;

--- a/src/react-workbench/chat/AgentResponseIndicator.tsx
+++ b/src/react-workbench/chat/AgentResponseIndicator.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import SplitFlapText from "../lib/SplitFlapText";
 import "./AgentResponseIndicator.css";
 
-export const AgentResponseIndicator = memo(function AgentResponseIndicator() {
+export const AgentResponseIndicator = memo(function AgentResponseIndicator({ awaitingUser = false }: { awaitingUser?: boolean }) {
   const { t, i18n } = useTranslation("chat");
   const ref = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(true);
@@ -29,8 +29,8 @@ export const AgentResponseIndicator = memo(function AgentResponseIndicator() {
     t("turn.flapWords.baking"),
   ];
   return (
-    <div ref={ref} className="react-agent-response" role="img" aria-label={t("turn.agentResponding")}>
-      <SplitFlapText
+    <div ref={ref} className="react-agent-response" role="img" aria-label={awaitingUser ? t("execution.status.awaiting") : t("turn.agentResponding")}>
+      {awaitingUser ? <span className="react-agent-response__waiting">{t("execution.status.awaiting")}</span> : <SplitFlapText
         aria-hidden="true"
         className="react-agent-response__board"
         data-cjk={i18n.resolvedLanguage?.startsWith("zh") || undefined}
@@ -44,11 +44,11 @@ export const AgentResponseIndicator = memo(function AgentResponseIndicator() {
         tileRadius={3}
         tileColor="var(--color-surface-soft)"
         textColor="var(--color-muted)"
-        cycleDelay={3200}
+        cycleDelay={1500}
         flipDuration={0.1}
         stagger={0.015}
         flipsPerChar={1}
-      />
+      />}
     </div>
   );
 });

--- a/src/react-workbench/chat/ChatPage.composer.test.tsx
+++ b/src/react-workbench/chat/ChatPage.composer.test.tsx
@@ -319,6 +319,47 @@ describe("ChatPage", () => {
     consoleError.mockRestore();
   });
 
+  it("follows each new user input after sending from a scrolled-up conversation", async () => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    let receive!: (event: ChatEvent) => void;
+    stores.chatStore.subscribe = vi.fn((_sessionId, listener) => { receive = listener; return () => {}; });
+    render(<ChatPage chatStore={stores.chatStore} sessionStore={stores.sessionStore} />);
+    await screen.findByText("Can you help?");
+    const conversation = screen.getByLabelText("Conversation");
+    Object.defineProperties(conversation, {
+      clientHeight: { configurable: true, value: 400 },
+      scrollHeight: { configurable: true, value: 1200 },
+      scrollTop: { configurable: true, writable: true, value: 200 },
+    });
+    const end = conversation.lastElementChild!;
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(end, "scrollIntoView", { configurable: true, value: scrollIntoView });
+    const messages: ReactChatMessage[] = [];
+    for (const index of [1, 2]) {
+      fireEvent.scroll(conversation);
+      expect(screen.getByRole("button", { name: "Back to latest" })).toBeTruthy();
+      scrollIntoView.mockClear();
+      const text = `New task ${index}`;
+      const input = screen.getByRole("textbox", { name: /message/i });
+      await user.clear(input);
+      await user.type(input, text);
+      await user.keyboard("{Enter}");
+      await waitFor(() => expect(turnSubmitCommands(stores.chatStore)).toHaveLength(index));
+      messages.push({ id: `sent-${index}`, role: "user", text, status: "complete", createdAtMs: index });
+      act(() => receive({ type: "agent_timeline_updated", timeline: timelineFromReactMessages("s1", messages) }));
+      await screen.findByTestId(`message-sent-${index}`);
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: "end" }));
+      expect(screen.queryByRole("button", { name: "Back to latest" })).toBeNull();
+      fireEvent.scroll(conversation);
+      scrollIntoView.mockClear();
+      messages.push({ id: `answer-${index}`, role: "assistant", text: `Answer ${index}`, status: "complete", createdAtMs: index });
+      act(() => receive({ type: "agent_timeline_updated", timeline: timelineFromReactMessages("s1", messages) }));
+      await screen.findByTestId(`message-answer-${index}`);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    }
+  });
+
   it("preserves manual scroll position and offers a back-to-latest action", async () => {
     const user = userEvent.setup();
     const stores = createStores();

--- a/src/react-workbench/chat/ChatPage.messages.test.tsx
+++ b/src/react-workbench/chat/ChatPage.messages.test.tsx
@@ -414,7 +414,9 @@ describe("ChatPage", () => {
     expect(reasoning.textContent).toContain("I am checking the available context.");
     expect(within(message).getByLabelText("Context").textContent).toContain("Project note");
     expect(within(message).getByLabelText("Context").textContent).toContain("Use current backend contracts.");
-    expect(within(message).getByLabelText("Agent is responding")).toBeTruthy();
+    const turn = message.closest(".react-canonical-turn")!;
+    expect(turn.lastElementChild).toBe(screen.getByLabelText("Agent is responding"));
+    expect(within(message).queryByLabelText("Agent is responding")).toBeNull();
     expect(message.querySelector(".react-message-markdown")?.textContent).toContain("Here is the answer.");
   });
 

--- a/src/react-workbench/chat/ChatPage.tsx
+++ b/src/react-workbench/chat/ChatPage.tsx
@@ -771,6 +771,11 @@ export function ChatPage({
     options: ComposerSendOptions,
   ) {
     await sidecarResources.current?.finishBrowserAnnotation();
+    // A send starts following the new input when the timeline commits it.
+    pendingConversationRestoreRef.current = "";
+    stickToLatestRef.current = true;
+    conversationViewBySessionRef.current.delete(activeSessionId);
+    setShowBackToLatest(false);
     if (quickStart.visible) quickStart.beginTask();
     const availableMentionIds = new Set(composerSessionMentionOptions.map((option) => option.id));
     await chatActions.send({

--- a/src/react-workbench/chat/ChatSessionWorkspace.test.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.test.tsx
@@ -20,6 +20,23 @@ afterEach(() => {
 });
 
 describe("ChatSessionWorkspace", () => {
+  test("shares running and failure indicators with tabs and clears them after completion", () => {
+    const actions = createActions();
+    const session = { ...planningSession(), status: "running" as const };
+    const view = renderWorkspace({ actions, sessions: [session] });
+    const row = screen.getByRole("button", { name: session.title }).closest(".react-session-row")!;
+    expect(row.getAttribute("data-has-status")).toBe("true");
+    expect(row.querySelector('.react-session-row__status .react-session-status[data-kind="running"]')).not.toBeNull();
+    view.rerenderSessions([{ ...session, status: "failed" }]);
+    expect(row.querySelector('.react-session-status[data-kind="running"]')).toBeNull();
+    expect(row.querySelector('.react-session-row__status .react-session-status[data-kind="failed"]')).not.toBeNull();
+    fireEvent.click(within(row as HTMLElement).getByRole("button", { name: `Delete ${session.title}` }));
+    expect(actions.onDeleteSession).toHaveBeenCalledWith(expect.objectContaining({ id: session.id, status: "failed" }));
+    view.rerenderSessions([{ ...session, status: "idle" }]);
+    expect(row.getAttribute("data-has-status")).toBe("false");
+    expect(row.querySelector(".react-session-row__status")).toBeNull();
+  });
+
   test.each([6, 7, 12, 19])("reveals %s workspace sessions in stages of six, twelve, then all", (count) => {
     const sessions = workspaceSessions(count);
     renderWorkspace({ sessions });

--- a/src/react-workbench/chat/ChatSessionWorkspace.tsx
+++ b/src/react-workbench/chat/ChatSessionWorkspace.tsx
@@ -38,6 +38,7 @@ import type {
 } from "../services";
 import { formatRelativeUpdatedTime } from "../lib/relativeTime";
 import { ProjectGroupDialog } from "./ProjectGroupDialog";
+import { SessionStatus, sessionStatusLabel } from "./SessionStatus";
 import { projectSessionGroups } from "./projectSessionGroups";
 import {
   INITIAL_SESSION_SIDEBAR_ORDER,
@@ -503,6 +504,7 @@ export function ChatSessionWorkspace({
     const confirming = confirmingDeleteSessionId === session.id;
     const dissolving = dissolvingSessionIds.has(session.id);
     const sessionLabel = displaySessionTitle(session.title, t);
+    const statusLabel = sessionStatusLabel(session, t);
     const reorderItem = { containerId, itemId: session.id, label: sessionLabel };
     const entranceIndex = entranceCurrent && typeof entrance === "object"
       ? entrance.indices.get(session.id)
@@ -519,6 +521,7 @@ export function ChatSessionWorkspace({
         data-dissolving={dissolving ? "true" : undefined}
         data-motion-role="item"
         data-session-id={session.id}
+        data-has-status={Boolean(statusLabel)}
         data-entering={entranceIndex !== undefined ? "true" : undefined}
         draggable={!dissolving}
         key={session.id}
@@ -564,6 +567,11 @@ export function ChatSessionWorkspace({
           <span className="react-session-row__title">{sessionLabel}</span>
           <small>{formatRelativeUpdatedTime(session.updatedAtMs, now())}</small>
         </button>
+        {statusLabel ? (
+          <span className="react-session-row__status" role="img" aria-label={statusLabel}>
+            <SessionStatus status={session.status} />
+          </span>
+        ) : null}
         <button
           aria-label={t(confirming ? "shell.confirmDelete" : "shell.delete", { name: session.title })}
           className="react-session-row__delete"

--- a/src/react-workbench/chat/ChatTimeline.test.tsx
+++ b/src/react-workbench/chat/ChatTimeline.test.tsx
@@ -14,6 +14,53 @@ afterEach(() => {
 });
 
 describe("ChatTimeline", () => {
+  test("keeps one indicator at the turn tail through dispatch, tools, and answer streaming", () => {
+    const base = completedTurn();
+    const timeline = (turns: ChatTurn[], optimisticMessages: ReactChatMessage[] = []) => (
+      <ChatTimeline actions={{}} hookResults={[]} interactiveFormIds={new Set()} latestFailedTurnId=""
+        optimisticMessages={optimisticMessages} sessionRunning turns={turns} />
+    );
+    const { rerender } = render(timeline([], [optimisticMessage()]));
+    expect(screen.getAllByRole("img", { name: "Agent is responding" })).toHaveLength(1);
+
+    const pending: ChatTurn = { ...base, status: "pending", finalMessage: undefined, executionItems: [], steps: [] };
+    rerender(timeline([pending], [optimisticMessage()]));
+    const indicator = screen.getByRole("img", { name: "Agent is responding" });
+    const turnElement = indicator.closest(".react-canonical-turn")!;
+    expect(turnElement.lastElementChild).toBe(indicator);
+    expect(screen.getAllByRole("img", { name: "Agent is responding" })).toHaveLength(1);
+
+    const tool: ChatStep = {
+      id: "tool-running", kind: "tool_call", sequence: 1, title: "Read file", status: "running",
+      agentContext: { id: "main", title: "Tinybot", type: "main" },
+      toolCall: { id: "tool-running", name: "read_file" },
+    };
+    const running: ChatTurn = { ...pending, status: "running", executionItems: [tool], steps: [tool] };
+    rerender(timeline([running]));
+    expect(screen.getByRole("img", { name: "Agent is responding" })).toBe(indicator);
+    expect(turnElement.lastElementChild).toBe(indicator);
+
+    rerender(timeline([{ ...running, finalMessage: base.finalMessage }]));
+    expect(screen.getByTestId("message-assistant-1").textContent).toContain("Canonical answer");
+    expect(screen.getAllByRole("img", { name: "Agent is responding" })).toEqual([indicator]);
+    expect(turnElement.lastElementChild).toBe(indicator);
+
+    rerender(timeline([{ ...running, status: "awaiting_user" }]));
+    expect(screen.queryByRole("img", { name: "Agent is responding" })).toBeNull();
+    const waiting = screen.getByRole("img", { name: "Awaiting input" });
+    expect(waiting.textContent).toBe("Awaiting input");
+    expect(waiting.querySelector(".react-agent-response__board")).toBeNull();
+    expect(turnElement.lastElementChild).toBe(waiting);
+
+    rerender(timeline([running]));
+    expect(screen.getByRole("img", { name: "Agent is responding" })).toBe(indicator);
+    for (const status of ["completed", "failed", "interrupted"] as const) {
+      rerender(timeline([{ ...running, status, finalMessage: base.finalMessage }]));
+      expect(screen.queryByRole("img", { name: "Agent is responding" })).toBeNull();
+      expect(screen.queryByRole("img", { name: "Awaiting input" })).toBeNull();
+    }
+  });
+
   test("renders canonical and optimistic messages and routes message actions through its interface", () => {
     const actions = createActions();
     const turn = completedTurn();

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -112,6 +112,9 @@ export function ChatTimeline({
           sessionRunning={sessionRunning}
         />
       ))}
+      {sessionRunning && optimisticMessages.length > 0 && !turns.some((turn) => (
+        turn.status === "pending" || turn.status === "running" || turn.status === "awaiting_user"
+      )) ? <AgentResponseIndicator /> : null}
     </>
   );
 }
@@ -229,6 +232,9 @@ const CanonicalChatTurn = memo(function CanonicalChatTurn({
         />
       ) : null}
       {!finalAnswer && metricsFooter ? <div className="react-message__actions">{metricsFooter}</div> : null}
+      {turn.status === "pending" || turn.status === "running" || turn.status === "awaiting_user" ? (
+        <AgentResponseIndicator awaitingUser={turn.status === "awaiting_user"} />
+      ) : null}
     </section>
   );
 });
@@ -610,7 +616,6 @@ function CanonicalMessage({
         ))}
         {role === "assistant" ? <AssistantMarkdown onOpenFileLink={onOpenFileLink} streaming={streaming} text={text} /> : <PlainMessageText text={text} />}
         {inlineReferences.length ? <MessageContext references={inlineReferences} /> : null}
-        {streaming ? <AgentResponseIndicator /> : null}
       </div>
       {(allowActions && text.trim()) || footer ? (
         <div className="react-message__actions" data-align={role === "user" ? "right" : "left"}>
@@ -1044,7 +1049,6 @@ function MessageBubble({
         )}
         {inlineReferences.length ? <MessageContext references={inlineReferences} /> : null}
         {message.toolCalls?.length ? <AgentSteps toolCalls={message.toolCalls} onOpenTool={onOpenTool} /> : null}
-        {message.status === "streaming" ? <AgentResponseIndicator /> : null}
       </div>
       {showCopyAction || showBranchAction ? (
         <div className="react-message__actions" data-align={actionAlignment}>

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:743983b7c59ba03f6088fb16e90ebc0c4ba61a1e069621f300069ca08ab33f1f -->
+<!-- tinybot-module-fingerprint: sha256:28039f7e5947d2e0088e12812a166c5d45bb69d385e82ba1eeb742f62bd7442d -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -22,6 +22,10 @@ Chat width from 20px to 40px, including docked Sidecar and empty-chat layouts.
 `SessionTabStrip` presents open conversations directly in the header. Overflowing
 tabs remain reachable through horizontal wheel scrolling and keyboard navigation;
 activating a tab scrolls it into view. Each tab retains its close action.
+`SessionStatus` shares running and failure icons between tabs and sidebar rows;
+tab unread dots remain tab-specific. Sidebar status occupies the delete action's
+slot and replaces the timestamp while active. Row hover, keyboard focus, and
+delete confirmation show the delete button instead. Idle rows retain timestamps.
 `SessionSidebarResizeHandle` owns sidebar width and its drag lifecycle. Expanded
 width defaults to 240 px and ranges from 220 to 420 px, with the maximum reduced
 to reserve 480 px for the chat workspace where possible. Pointer movement updates
@@ -62,6 +66,9 @@ Text-only updates do not rerender the composer or historical Turn components.
 Canonical Turn memoization relies on preserved model references and grouped Hook
 results. The timeline notifies the page after content commits so follow-to-bottom
 and saved scroll anchors continue working independently of page renders.
+Each composer send clears the current saved scroll position and resumes following
+the timeline, revealing the new user input when it mounts. Scrolling up afterward
+pauses following again until the next send or Back to latest action.
 `ChatPage.streaming-performance.test.tsx` measures render counts and checks scroll
 following, reading history, and final-answer delivery. Run it alongside
 `agentTimelineModel.performance.test.ts` for repeatable streaming work counts;
@@ -463,6 +470,10 @@ CSV export reports the requested filename and Downloads/save-location guidance
 through the shared top-of-window notification. It reports initiation failures and does not claim completion,
 since the WebView anchor download does not expose a completion callback.
 
-AgentResponseIndicator replaces streaming dots with a compact React Bits split-flap
-board. Localized playful phrases cycle while responding, with a stable accessible
-label. Offscreen/background indicators pause, and reduced motion stays static.
+AgentResponseIndicator sits at the end of each pending or running turn, after its
+execution items, hook results, and answer. A single split-flap board stays mounted
+through reasoning, tool execution, and message streaming until the turn completes,
+fails, or is interrupted. Awaiting input shows a static localized label; optimistic
+dispatch shows one board until the canonical turn arrives. Localized playful
+phrases cycle with a stable accessible label. Offscreen/background indicators pause,
+and reduced motion stays static.

--- a/src/react-workbench/chat/SessionStatus.tsx
+++ b/src/react-workbench/chat/SessionStatus.tsx
@@ -1,0 +1,25 @@
+import { AlertTriangle, Circle, Loader2 } from "lucide-react";
+import type { TFunction } from "i18next";
+import type { SessionSummary } from "../services";
+
+type SessionStatusProps = Pick<SessionSummary, "status"> & { unread?: boolean };
+
+export function SessionStatus({ status, unread }: SessionStatusProps) {
+  if (status === "running") {
+    return <Loader2 aria-hidden="true" className="react-session-status" data-kind="running" size={11} />;
+  }
+  if (status === "failed") {
+    return <AlertTriangle aria-hidden="true" className="react-session-status" data-kind="failed" size={11} />;
+  }
+  if (unread) {
+    return <Circle aria-hidden="true" className="react-session-status" data-kind="unread" fill="currentColor" size={8} />;
+  }
+  return null;
+}
+
+export function sessionStatusLabel({ status, unread }: SessionStatusProps, t: TFunction<"chat">): string {
+  if (status === "running") return t("tabs.status.running");
+  if (status === "failed") return t("tabs.status.failed");
+  if (unread) return t("tabs.status.unread");
+  return "";
+}

--- a/src/react-workbench/chat/SessionTabStrip.tsx
+++ b/src/react-workbench/chat/SessionTabStrip.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useLayoutEffect, useRef, type KeyboardEvent } from "react";
-import { AlertTriangle, Circle, Loader2, X } from "lucide-react";
-import type { TFunction } from "i18next";
+import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { SessionSummary } from "../services";
+import { SessionStatus, sessionStatusLabel } from "./SessionStatus";
 
 export type SessionTabItem = Pick<SessionSummary, "id" | "status"> & {
   title: string;
@@ -97,7 +97,7 @@ export function SessionTabStrip({
       >
         {tabs.length ? tabs.map((tab) => {
           const active = tab.id === activeSessionId;
-          const statusLabel = sessionTabStatusLabel(tab, t);
+          const statusLabel = sessionStatusLabel(tab, t);
           return (
             <div
               className="react-session-tab"
@@ -126,7 +126,7 @@ export function SessionTabStrip({
                 onClick={() => onActivate(tab.id)}
                 onKeyDown={(event) => handleTabKeyDown(event, tab.id)}
               >
-                <SessionTabStatus tab={tab} />
+                <SessionStatus status={tab.status} unread={tab.unread} />
                 <span>{tab.title}</span>
               </button>
               <button
@@ -158,24 +158,4 @@ export function SessionTabStrip({
       </div>
     </div>
   );
-}
-
-function SessionTabStatus({ tab }: { tab: SessionTabItem }) {
-  if (tab.status === "running") {
-    return <Loader2 aria-hidden="true" className="react-session-tab__status" data-kind="running" size={11} />;
-  }
-  if (tab.status === "failed") {
-    return <AlertTriangle aria-hidden="true" className="react-session-tab__status" data-kind="failed" size={11} />;
-  }
-  if (tab.unread) {
-    return <Circle aria-hidden="true" className="react-session-tab__status" data-kind="unread" fill="currentColor" size={8} />;
-  }
-  return null;
-}
-
-function sessionTabStatusLabel(tab: SessionTabItem, t: TFunction<"chat">): string {
-  if (tab.status === "running") return t("tabs.status.running");
-  if (tab.status === "failed") return t("tabs.status.failed");
-  if (tab.unread) return t("tabs.status.unread");
-  return "";
 }

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -1079,7 +1079,7 @@ describe("DesktopShell", () => {
         profiles: {
           "deepseek-default": {
             provider: "deepseek",
-            models: ["deepseek-v4-pro", "deepseek-flash", "deepseek-v4-flash", "deepseek-live"],
+            models: ["deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-live"],
             enabledModels: ["deepseek-v4-pro", "deepseek-v4-flash"],
             defaultModel: "deepseek-v4-flash",
             modelContextWindows: [{ model: "deepseek-live", contextWindowTokens: 32000 }],

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:11fdac790e85ffeacc8651155b43bd96bd6ae96e1420a85cd9da0bf7de031a54 -->
+<!-- tinybot-module-fingerprint: sha256:53df2e9b6f66cbdfd86a8db3aad9b68c5882d08d25d02c6808b3db753b7c7c80 -->
 
 Desktop-pet quick chat shares composer drop and clipboard import with main Chat;
 its window permission set includes the bounded binary attachment import command.

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:7d93a8a23a777f345d018a6e41645cd5ee4bdb8fd02011c6cdd6ffbefc92ba3b -->
+<!-- tinybot-module-fingerprint: sha256:1f09e4df2e95e9a266052d84fef3c525b360b93e358ea82f8f0802ded5659557 -->
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.
@@ -86,6 +86,9 @@ because they contain the active session.
 Workspace paths appear only in header tooltips; nested workspace actions share
 one trailing flex container to keep both buttons on the title line.
 The session list keeps a 2px right inset beside its scrollbar and an 8px left inset.
+Session rows use the default cursor at rest and retain drag sorting. Running and
+failure icons share the trailing delete-action slot; hover, focus, and delete
+confirmation replace the status with the delete button. Idle rows keep timestamps.
 
 The desktop document root is fixed to the WebView viewport and never owns page
 scrolling. `html`, `body`, and `#root` contain the `100%` shell while route,

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -1572,6 +1572,10 @@ button:disabled {
   outline-offset: -2px;
 }
 
+.react-session-row[draggable="true"] {
+  cursor: default;
+}
+
 .react-session-workspace[data-dragging="true"],
 .react-project-group[data-dragging="true"],
 .react-project-workspace[data-dragging="true"],
@@ -1706,7 +1710,27 @@ button:disabled {
 
 .react-session-row:hover .react-session-row__select small,
 .react-session-row:focus-within .react-session-row__select small,
+.react-session-row[data-has-status="true"] .react-session-row__select small,
 .react-session-row[data-confirming="true"] .react-session-row__select small {
+  opacity: 0;
+}
+
+.react-session-row__status {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition: opacity 140ms ease;
+}
+
+.react-session-row:hover .react-session-row__status,
+.react-session-row:focus-within .react-session-row__status,
+.react-session-row[data-confirming="true"] .react-session-row__status {
   opacity: 0;
 }
 
@@ -1861,25 +1885,25 @@ button:disabled {
   font-weight: 650;
 }
 
-.react-session-tab__status {
+.react-session-status {
   min-width: 11px;
   flex: 0 0 auto;
 }
 
-.react-session-tab__status[data-kind="running"] {
+.react-session-status[data-kind="running"] {
   color: #5f806c;
   animation: react-session-tab-spin 1.2s linear infinite;
 }
 
-.react-session-tab__status[data-kind="waiting"] {
+.react-session-status[data-kind="waiting"] {
   color: #a97821;
 }
 
-.react-session-tab__status[data-kind="failed"] {
+.react-session-status[data-kind="failed"] {
   color: var(--color-error);
 }
 
-.react-session-tab__status[data-kind="unread"] {
+.react-session-status[data-kind="unread"] {
   color: var(--color-primary);
 }
 


### PR DESCRIPTION
## Changes

Keep chat progress visible for the entire turn and allow data views to be published alongside other tools in a provider response.

- Move the split-flap indicator to the turn tail, retain it during tool execution, show a static awaiting-input label, and shorten the phrase delay to 1.5 seconds.
- Resume scrolling to the latest input on each composer send while preserving subsequent manual scrolling.
- Share running and failure icons between tabs and sidebar rows. Sidebar hover/focus reveals the delete action in the same slot; idle rows retain timestamps and use the default cursor.
- Execute `publish_data_view` as an exclusive wave in the shared scheduler, preserving provider order, validation errors, hooks, and artifact observations.
- Default new DeepSeek configuration and presets to `deepseek-flash` while preserving explicit model choices.

## Validation

- Full frontend analysis gate, including 1,005 tests, typecheck, lint, source analysis, production build, and bundle checks.
- Rust formatting passed. The full library run reported 1,105 passed, one ignored, and one failure in the unchanged `desktop_terminal::tests::creates_each_terminal_resource_only_once`: Windows denied shell-process termination. That test passed when run individually; CI will verify it on a clean runner.
- Staged README and engineering-documentation freshness checks.
- Playwright component fixture checks and screenshots for sidebar rest, hover, keyboard focus, and delete confirmation.
