### PR TITLE
feat: expose request preparation timing and polish file attachments

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -9,7 +9,7 @@ src/app-core/native/desktopNativeTauriEvents.ts
 src/app-core/native/desktopNativeTauriEvents.test.ts
 src/react-workbench/adapters/desktopNativeEventBridge.ts
 -->
-<!-- tinybot-doc-fingerprint: sha256:6a32ced58c9ee9279c705c38ace56c9cf9de660982e1395ebfbce6755a637875 -->
+<!-- tinybot-doc-fingerprint: sha256:0955af3bc601f608aa04c2d386d5a45261435d9279962ff4ef14e6ddf5a2a2bd -->
 
 This document lists frontend-visible events emitted by the native runtime. It
 is part of the [Rust backend API reference](rust-backend-api.md), which defines
@@ -108,6 +108,10 @@ clock for one provider invocation; absent stream timing is represented by null.
 The same typed Item reaches live patches and durable Rollout replay. This is an
 additive field in `tinybot.turn_item.v2`; it requires no SQLite or Rollout migration.
 Older Items omit it and cannot supply historical TTFT or TPS.
+`modelTiming.timeToRequestMs` is also optional: it measures backend input receipt
+to that provider invocation, including preparation. Only the first call supplies
+the Turn's preparation metric. Detailed stage timings use `agent.preparation` in
+the native application log; they are not conversation events and are not replayed.
 
 - `context_window_tokens` / `contextWindowTokens`: effective per-model context window from the
   turn, provider profile, known-model catalog, legacy unknown-model fallback, or backend default.

--- a/docs/architecture/agent-turn-lifecycle.md
+++ b/docs/architecture/agent-turn-lifecycle.md
@@ -22,11 +22,18 @@ src-tauri/src/runtime/README.md
 src-tauri/src/threads/domain/README.md
 src-tauri/src/threads/rollout/store/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:bd7e6f55303b712889b6607051d89f34b27514bc609bab5f9bc8dc9a632fab11 -->
+<!-- tinybot-doc-fingerprint: sha256:2d1ef96e1c232a48ce56636720146517fb7f92b1f19d8aec9f892c0d41838db4 -->
 
 A Turn begins with one user request and contains all provider iterations,
 reasoning records, tool calls, tool results, form checkpoints, and the terminal
 outcome that follow. Resolving a form continues the same Turn identity.
+
+Input decoding captures a monotonic receipt time for `modelTiming.timeToRequestMs`.
+Application-only `agent.preparation` summaries cover bridge setup, task ownership,
+tool discovery, runtime preparation, context projection, request construction, and
+hooks. Each summary carries Turn/trace IDs, scope, input-relative offsets, and
+completed/incomplete step outcomes. Nested scopes overlap; the summaries are
+written to `native-backend.log` rather than the conversation trace sink.
 
 ## Ownership
 

--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -14,11 +14,15 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:d9c28c9895b9aa0dcb0015543df670dabd0c704363efa08686a8e9fe6d800353 -->
+<!-- tinybot-doc-fingerprint: sha256:3440c89ce5659ea60c2bef7ca2ab92b8fa788bd8a8fc2aa708bb6e7081cf5958 -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction
 composition and context-window management are separate stages.
+Their timings remain separate in application `agent.preparation` diagnostics:
+`instruction_compose`, `context_projection`, and `request_build`. Input decoding
+captures the shared monotonic origin before instruction loading; only the aggregate
+time-to-request reading is carried by the model timing payload.
 
 The hydrated wire specification becomes `AgentTurnInput` before task ownership.
 This boundary resolves settings aliases and context-window overrides, and parses

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,12 +16,17 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:fba6bdd9a402d0607d5f1bf1f187ff636a0e0ad345058b889238f52b296df744 -->
+<!-- tinybot-doc-fingerprint: sha256:0f2d42d6e4f1ff2d896ee13ba4e3741f02e2f5b5f7cbbfa2fc61f929d1e676ab -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
 and the Rust backend owns native capabilities, Agent execution, durable
 conversation state, and process lifecycle.
+
+Turn metrics expose backend time to the first model call separately from TTFT.
+The native bridge and runtime also write scoped `agent.preparation` diagnostics
+to the application log for identifying preparation delays without adding
+diagnostic events to conversation history.
 
 The Chat application owns client submission preparation, optimistic messages,
 queue and command coordination. Native Chat command orchestration is injected

--- a/docs/architecture/thread-rollout-persistence.md
+++ b/docs/architecture/thread-rollout-persistence.md
@@ -9,12 +9,16 @@ src-tauri/src/threads/rollout/store/README.md
 src-tauri/src/threads/rollout/store/mod.rs
 src-tauri/src/threads/workspace_store.rs
 -->
-<!-- tinybot-doc-fingerprint: sha256:2aef2e5e0cbc0fbb8b56a5be82377d41414f87308b2b6109af8731f0d6f0d783 -->
+<!-- tinybot-doc-fingerprint: sha256:4394a83dae8ea11f3b77cac7e7c8a9c8250477b5865aa483ffcaacfffaf9fa49 -->
 
 Tinybot separates typed conversation behavior from canonical storage. The
 Thread domain provides the in-process interface; the append-only Rollout is the
 durable authority from which Thread, Turn, Item, context, checkpoint, and
 timeline projections are reconstructed.
+
+Usage Items can retain the aggregate `modelTiming.timeToRequestMs` reading.
+Detailed `agent.preparation` step timings belong exclusively to the native
+application log and do not create Rollout entries or canonical Thread Items.
 
 ## Domain hierarchy
 

--- a/docs/architecture/tool-execution-and-permissions.md
+++ b/docs/architecture/tool-execution-and-permissions.md
@@ -13,7 +13,7 @@ src-tauri/src/tools/registry/README.md
 src-tauri/src/tools/registry/mod.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:a1067392b68c079314a6032b88432f8bdf9b872f38e2ebac72da0036b8ea8350 -->
+<!-- tinybot-doc-fingerprint: sha256:a427146dbe3384f8f1943e562f1d5460e45b299b5bc9d3d17d49b66604c028e4 -->
 
 Tinybot exposes one protocol-neutral tool registry to the Agent Runtime. Tool
 metadata, per-Turn exposure, capability policy, execution routing, lifecycle,
@@ -22,6 +22,11 @@ and result projection remain separate concerns joined through narrow seams.
 The independent first-Turn title request reuses the Agent Runtime's Provider
 request and response adapters without entering the Agent Loop. It never receives
 the tool registry and remains a single tool-free Provider call.
+
+Application `agent.preparation` logs split pre-call discovery into `mcp_registry`,
+`graph_tool_discovery`, `workspace_thread_tools`, and `tool_selection`. The `tools`
+scope is nested within `runtime_prepare.tool_catalog`; its duration is already
+included in that parent step. These timings do not enter conversation persistence.
 
 `publish_data_view` uses an exclusive wave in the shared batch scheduler, so it
 can appear alongside ordinary tools in one provider response. Publication retains

--- a/src-tauri/src/agent/README.md
+++ b/src-tauri/src/agent/README.md
@@ -1,8 +1,13 @@
 # Agent
-<!-- tinybot-module-fingerprint: sha256:c4dcc32f434e027487f86e9d64b92467433be01ab9d804ff518f2462236d0c52 -->
+<!-- tinybot-module-fingerprint: sha256:3811a6e6fae904bb128541f9299a285b1a6a5499347c0ee4f2cbf08f37ae4a86 -->
 
 `agent` contains the native agent stack. It connects provider configuration,
 the turn runtime, durable runtime events, and the desktop integration bridge.
+
+`preparation_log.rs` batches sequential preparation steps into application-only
+`agent.preparation` entries in `native-backend.log`. Entries include trace/Turn
+IDs, scope, monotonic input-relative offsets, and completed/incomplete outcomes.
+Nested scopes overlap their parents; these diagnostics never enter Rollouts.
 
 Provider-specific transport details stay in `provider/`, while turn execution
 and event projection live in `runtime/` and `runtime_protocol/`.

--- a/src-tauri/src/agent/bridge/README.md
+++ b/src-tauri/src/agent/bridge/README.md
@@ -1,10 +1,15 @@
 # Native Agent Bridge
-<!-- tinybot-module-fingerprint: sha256:58af0148042f577c95ddbfa1bd905790f7495f3fac0175ec56ed6ed8e671fc92 -->
+<!-- tinybot-module-fingerprint: sha256:bafbf9507fb5c10029bf41517e70a2d3783c27c6301f033e4359911f2aa1d0c4 -->
 
 `agent::bridge` is the application-service layer around the generic
 native agent runtime. It coordinates the resources required for a complete
 desktop or Thread-owned turn without moving those concerns into the provider
 loop.
+
+Preparation diagnostics time memory and instruction loading, MCP configuration,
+Turn-start persistence, history hydration, and service assembly. Tool discovery
+separately times MCP, Graph, workspace-thread, and selection steps. Ordinary and
+form-resumed Turns write these summaries to the application log, not the trace sink.
 
 
 `AgentApplicationServices` keeps the core execution services alongside the shared

--- a/src-tauri/src/agent/bridge/agent_flow.rs
+++ b/src-tauri/src/agent/bridge/agent_flow.rs
@@ -41,15 +41,24 @@ pub(super) async fn run_agent_with_services(
 ) -> Result<AgentTurnResult, AgentError> {
     let thread_store = base_services.thread_store.clone();
     let trace_context = request.input.trace_context.clone();
+    let mut preparation = crate::agent::preparation_log::PreparationLog::new(
+        &trace_context,
+        request.input.received_at,
+        "application",
+        "terminal_check",
+    );
     if let Some(mut rejection) =
         reject_native_agent_terminal_turn_reentry(&request.input, &thread_store)?
     {
         rejection.trace_context = Some(trace_context);
         return Ok(rejection);
     }
+    preparation.next("memory_snapshot");
     hydrate_native_agent_memory_snapshot_for_runtime(&mut request, &thread_store)?;
+    preparation.next("instruction_compose");
     let instructions = InstructionLoader::new(thread_store.data_root().join("plugins"))
         .compose_input(&workspace_root, &request.instructions)?;
+    preparation.next("workspace_mcp_config");
     let graph_base_config_snapshot = config_snapshot.clone();
     crate::workspace_extensions::merge_workspace_mcp_servers(
         &mut config_snapshot,
@@ -57,10 +66,13 @@ pub(super) async fn run_agent_with_services(
     )?;
     #[cfg(not(test))]
     let memory_scope_root = instructions.working_directory.clone();
+    preparation.next("turn_start_persistence");
     persist_native_agent_turn_start(&request, &instructions, &thread_store)?;
+    preparation.next("history_hydration");
     hydrate_native_agent_history_for_runtime(&mut request.input, &thread_store)?;
     #[cfg(not(test))]
     let memory_runtime = base_services.memory_runtime.clone();
+    preparation.next("runtime_services");
     let services = base_services
         .prepare_turn(
             &workspace_root,
@@ -76,6 +88,7 @@ pub(super) async fn run_agent_with_services(
                 error.into(),
             )
         })?;
+    preparation.complete();
     let session_id = request.input.session_id.clone();
     let turn_result = run_native_agent_turn_with_workspace_and_instructions_async(
         &services,

--- a/src-tauri/src/agent/bridge/tool_catalog.rs
+++ b/src-tauri/src/agent/bridge/tool_catalog.rs
@@ -13,6 +13,12 @@ pub(super) async fn prepare_tools(
     thread_store: &WorkspaceThreadStore,
     mcp_runtime: &McpRuntime,
 ) -> Result<NativeAgentToolPreparation, AgentError> {
+    let mut preparation = crate::agent::preparation_log::PreparationLog::new(
+        &context.trace_context,
+        context.received_at,
+        "tools",
+        "mcp_registry",
+    );
     let capability_policy = context.settings.capability_policy()?;
     let mcp_workspace_root = context
         .settings
@@ -48,6 +54,7 @@ pub(super) async fn prepare_tools(
         } else {
             None
         };
+    preparation.next("graph_tool_discovery");
     let mut contributors: Vec<Arc<dyn ToolContributor>> = Vec::new();
     let graph_node_turn = ["graphRunId", "graph_run_id"]
         .iter()
@@ -67,9 +74,11 @@ pub(super) async fn prepare_tools(
         }
     }
 
+    preparation.next("workspace_thread_tools");
     if let Some(contributor) = super::workspace_threads::tool_contributor(thread_store, context)? {
         contributors.push(Arc::new(contributor));
     }
+    preparation.next("tool_selection");
     let mut selected_tools = context.settings.selected_tools.clone();
     for server in mcp_snapshot
         .as_deref()
@@ -98,6 +107,7 @@ pub(super) async fn prepare_tools(
         });
     }
 
+    preparation.complete();
     Ok(NativeAgentToolPreparation::Ready(NativeAgentToolCatalog {
         contributors,
         selected_tools,

--- a/src-tauri/src/agent/bridge/webui_continuation.rs
+++ b/src-tauri/src/agent/bridge/webui_continuation.rs
@@ -278,8 +278,15 @@ pub(crate) async fn resolve_agent_ui_form_with_services(
         .map_err(AgentError::invalid_input)?;
     input.messages = checkpoint.messages.clone();
     let trace = input.trace_context.clone();
+    let mut preparation = crate::agent::preparation_log::PreparationLog::new(
+        &trace,
+        input.received_at,
+        "application_continuation",
+        "instruction_compose",
+    );
     let instructions = InstructionLoader::new(thread_store.data_root().join("plugins"))
         .compose(&workspace_root, &continuation_spec)?;
+    preparation.next("workspace_mcp_config");
     let graph_base_config_snapshot = config_snapshot.clone();
     let mut config_snapshot = config_snapshot;
     crate::workspace_extensions::merge_workspace_mcp_servers(
@@ -287,12 +294,14 @@ pub(crate) async fn resolve_agent_ui_form_with_services(
         &instructions.working_directory,
     )?;
     base_services.runtime.save_checkpoint(checkpoint);
+    preparation.next("runtime_services");
     let services = base_services.prepare_turn(
         &workspace_root,
         &instructions.working_directory,
         graph_base_config_snapshot,
         live_trace_sink,
     )?;
+    preparation.complete();
     let turn_result = run_native_agent_turn_with_workspace_and_instructions_async(
         &services,
         input,

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod bridge;
 pub(crate) mod conversation_title;
 pub(crate) mod instruction_sources;
+pub(crate) mod preparation_log;
 pub(crate) mod provider;
 pub(crate) mod router;
 pub(crate) mod runtime;

--- a/src-tauri/src/agent/preparation_log.rs
+++ b/src-tauri/src/agent/preparation_log.rs
@@ -1,0 +1,120 @@
+//! Application diagnostics only: these timings never enter the conversation trace sink.
+use crate::agent::runtime_protocol::AgentTraceContext;
+use crate::desktop::logging::{
+    append_default_native_backend_log_event, NativeLogEvent, NativeLogLevel,
+};
+use serde::Serialize;
+use std::time::Instant;
+
+/// Sequential steps within one scope. Nested scopes have their own log entry;
+/// their durations overlap the parent and must not be added to it.
+pub(crate) struct PreparationLog {
+    trace: AgentTraceContext,
+    received_at: Instant,
+    scope: &'static str,
+    model_call_id: Option<String>,
+    started_at: Instant,
+    step_started_at: Instant,
+    step: &'static str,
+    steps: Vec<PreparationStep>,
+    completed: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PreparationStep {
+    name: &'static str,
+    start_offset_ms: u64,
+    duration_ms: u64,
+    outcome: &'static str,
+}
+
+impl PreparationLog {
+    pub(crate) fn new(
+        trace: &AgentTraceContext,
+        received_at: Instant,
+        scope: &'static str,
+        first_step: &'static str,
+    ) -> Self {
+        let started_at = Instant::now();
+        Self {
+            trace: trace.clone(),
+            received_at,
+            scope,
+            model_call_id: None,
+            started_at,
+            step_started_at: started_at,
+            step: first_step,
+            steps: Vec::new(),
+            completed: false,
+        }
+    }
+
+    pub(crate) fn next(&mut self, step: &'static str) {
+        self.end_step(Instant::now(), "completed");
+        self.step = step;
+    }
+
+    pub(crate) fn complete(mut self) {
+        self.completed = true;
+    }
+
+    pub(crate) fn model_call(&mut self, id: &str) {
+        self.model_call_id = Some(id.to_string());
+    }
+
+    fn end_step(&mut self, ended_at: Instant, outcome: &'static str) {
+        self.steps.push(PreparationStep {
+            name: self.step,
+            start_offset_ms: self
+                .step_started_at
+                .duration_since(self.received_at)
+                .as_millis() as u64,
+            duration_ms: ended_at.duration_since(self.step_started_at).as_millis() as u64,
+            outcome,
+        });
+        self.step_started_at = ended_at;
+    }
+
+    fn finish_event(&mut self, ended_at: Instant) -> NativeLogEvent {
+        let outcome = if self.completed {
+            "completed"
+        } else {
+            "incomplete"
+        };
+        self.end_step(ended_at, outcome);
+        NativeLogEvent::new(
+            if self.completed {
+                NativeLogLevel::Info
+            } else {
+                NativeLogLevel::Warn
+            },
+            "agent.preparation",
+            serde_json::json!({
+                "requestId": self.trace.request_id,
+                "traceId": self.trace.trace_id,
+                "threadId": self.trace.thread_id,
+                "turnId": self.trace.turn_id,
+                "scope": self.scope,
+                "modelCallId": self.model_call_id,
+                "outcome": outcome,
+                "startOffsetMs": self.started_at.duration_since(self.received_at).as_millis() as u64,
+                "endOffsetMs": ended_at.duration_since(self.received_at).as_millis() as u64,
+                "durationMs": ended_at.duration_since(self.started_at).as_millis() as u64,
+                "steps": self.steps,
+            }),
+        )
+    }
+}
+
+impl Drop for PreparationLog {
+    fn drop(&mut self) {
+        let event = self.finish_event(Instant::now());
+        if let Err(error) = append_default_native_backend_log_event("agent", event) {
+            eprintln!(
+                "agent preparation diagnostic write failed: {error}; turn_id={} scope={}",
+                self.trace.turn_id, self.scope,
+            );
+        }
+    }
+}

--- a/src-tauri/src/agent/runtime/README.md
+++ b/src-tauri/src/agent/runtime/README.md
@@ -1,5 +1,5 @@
 # Native Agent Runtime
-<!-- tinybot-module-fingerprint: sha256:26f86a69e469455ef05d75f42892ec73c76cad1e487484a1148331afd5140dc5 -->
+<!-- tinybot-module-fingerprint: sha256:53c406f7b94ffaa99b99b120ed28c62514a4e25dfce445269871887d1a6cc0ce -->
 
 `agent::runtime` implements Tinybot's native model-and-tool execution
 loop. It turns a validated turn specification, runtime services, and composed
@@ -60,7 +60,12 @@ Provider timing uses a per-invocation monotonic clock. Text, reasoning, or tool
 output marks the first token; provider completion ends the decode interval.
 Usage and its optional `modelTiming` are persisted before executing tools so
 waiting for input or tool failure cannot discard completed model work. Calls
-without streaming output carry null timings and do not fabricate throughput.
+without streaming output carry null stream timings and do not fabricate throughput.
+Optional `timeToRequestMs` measures from backend input decoding to the provider
+invocation, including preparation; the first call supplies the UI reading.
+Application-only `agent.preparation` summaries break down task ownership, tool
+and state setup, context projection, request building, and hooks. Scope and step
+offsets share the input's monotonic origin; nested scopes must not be summed twice.
 
 ## Responsibilities
 

--- a/src-tauri/src/agent/runtime/context.rs
+++ b/src-tauri/src/agent/runtime/context.rs
@@ -31,6 +31,7 @@ impl AgentTurnContext {
             .tools,
         );
         Self {
+            received_at: input.received_at,
             turn_id: input.trace_context.turn_id.clone(),
             session_id: input.session_id,
             thread_id: input.trace_context.thread_id.clone(),

--- a/src-tauri/src/agent/runtime/mod.rs
+++ b/src-tauri/src/agent/runtime/mod.rs
@@ -173,6 +173,7 @@ impl crate::protocol::WorkerRequestCancellation for NativeAgentCancellationConte
 
 #[derive(Clone, Debug)]
 pub struct AgentTurnContext {
+    pub(crate) received_at: std::time::Instant,
     pub turn_id: String,
     pub session_id: String,
     pub thread_id: Option<String>,

--- a/src-tauri/src/agent/runtime/provider_loop.rs
+++ b/src-tauri/src/agent/runtime/provider_loop.rs
@@ -128,8 +128,15 @@ async fn run_owned_native_agent_turn_async(
     workspace_root: Option<PathBuf>,
     instructions: Option<ComposedInstructions>,
 ) -> Result<AgentTurnResult, AgentError> {
+    let mut preparation = crate::agent::preparation_log::PreparationLog::new(
+        &input.trace_context,
+        input.received_at,
+        "runtime_ownership",
+        "context_initialize",
+    );
     let mut identity = AgentTurnContext::from_input(input, config_snapshot.clone());
     identity.attach_observability(services);
+    preparation.next("checkpoint_restore");
     let continuation_metadata = identity.continuation.clone();
     let restored_continuation_checkpoint = continuation_metadata.as_ref().and_then(|_| {
         services
@@ -153,6 +160,7 @@ async fn run_owned_native_agent_turn_async(
                 )
             })?;
     }
+    preparation.next("task_schedule");
     let request = StartAgentTurn::new(identity.turn_id.clone(), identity.session_id.clone());
     let owned_services = services.clone();
     let execution_context = identity.clone();
@@ -182,6 +190,7 @@ async fn run_owned_native_agent_turn_async(
             .to_string()
             .into());
     }
+    preparation.complete();
     let turn_started_at = Instant::now();
     identity.metrics().increment("turn.started");
     let mut result = match handle.wait_async().await {
@@ -477,6 +486,12 @@ impl<'a> NativeAgentTurnExecution<'a> {
         instructions: Option<ComposedInstructions>,
         workspace_root: Option<&Path>,
     ) -> Result<PreparedNativeAgentTurnExecution<'a>, AgentError> {
+        let mut preparation = crate::agent::preparation_log::PreparationLog::new(
+            &context.trace_context,
+            context.received_at,
+            "runtime_prepare",
+            "setup",
+        );
         context.attach_observability(dependencies);
         if let Some(instructions) = instructions.as_ref() {
             context.settings.working_directory = Some(instructions.working_directory.clone());
@@ -519,6 +534,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
             ));
         }
         if workspace_root.is_some() {
+            preparation.next("tool_catalog");
             let catalog = match dependencies
                 .tools
                 .prepare_tools(&context, &config_snapshot)
@@ -557,6 +573,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
                     ));
                 }
             };
+            preparation.next("tool_registry");
             let mut tool_registry = WorkerToolRegistryRpc::new_with_config(
                 context.settings.capability_policy()?,
                 config_snapshot,
@@ -568,6 +585,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
             context.tool_router =
                 super::tool_router::NativeToolRouter::new(tool_registry.list_tools().tools);
         }
+        preparation.next("tool_router_configure");
         #[cfg(test)]
         if let Some(entries) = dependencies.test_tool_registry_entries.clone() {
             context.tool_router = super::tool_router::NativeToolRouter::new(entries);
@@ -580,6 +598,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
             .tool_router
             .activate_for_turn(&dependencies.test_activated_tool_ids)?;
 
+        preparation.next("continuation_restore");
         let (mut context, continuation_resume) =
             match prepare_continuation(dependencies.clone(), context).await? {
                 PreparedContinuation::Finished(result) => {
@@ -595,6 +614,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
                 "Rust agent runtime requires at least one user input or chat message.",
             )));
         }
+        preparation.next("state_initialize");
         let mut state = if continuation_resume.is_some() {
             AgentTurnState::new_for_continuation(&context, dependencies.trace_sink.clone())?
         } else {
@@ -612,6 +632,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
         )?;
         state.emit_thread_command_acknowledgement(&context)?;
         let is_continuation = continuation_resume.is_some();
+        preparation.next("continuation_apply");
         let start_iteration = match continuation_resume {
             Some(resume) => {
                 let iteration = resume.apply(&mut context, &mut state).await?;
@@ -628,6 +649,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
                 0
             }
         };
+        preparation.next("user_prompt_hook");
         if !is_continuation && !context.controls.manual_compaction {
             let prompt = current_user_message(&context.messages)
                 .as_ref()
@@ -655,6 +677,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
                 ));
             }
         }
+        preparation.next("turn_start_hook");
         let turn_start_invocation = AgentHookInvocation::lifecycle(
             AgentHookStage::TurnStart,
             context.trace_context.clone(),
@@ -667,6 +690,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
             ));
         }
 
+        preparation.complete();
         Ok(PreparedNativeAgentTurnExecution::Ready {
             execution: Self {
                 dependencies,
@@ -703,6 +727,12 @@ impl<'a> NativeAgentTurnExecution<'a> {
         &mut self,
         iteration: i64,
     ) -> Result<ExecutionStage<PreparedProviderIteration>, AgentError> {
+        let mut preparation = crate::agent::preparation_log::PreparationLog::new(
+            &self.context.trace_context,
+            self.context.received_at,
+            "provider_request",
+            "checkpoint_and_prompt_history",
+        );
         self.state
             .transition_phase(AgentRuntimePhase::CallingModel, iteration, "provider_call")?;
         if turn_context_is_cancelled(&self.context) {
@@ -719,6 +749,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
         );
         let prompt_messages = self.state.history.for_prompt()?;
         self.context.messages = prompt_messages;
+        preparation.next("context_projection");
         let mut projection = match context_window_projection_async(&self.context).await {
             Ok(projection) => projection,
             Err(error) if error.kind() == NativeAgentProviderFailureKind::Cancelled => {
@@ -741,6 +772,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
                 )?));
             }
         };
+        preparation.next("context_projection_commit");
         if let Some(action) = projection.action.as_ref() {
             provider_protocol(&self.context)?
                 .reset_replay_after_context_projection(&mut self.context)?;
@@ -852,6 +884,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
             )?));
         }
 
+        preparation.next("request_build");
         let mut provider_context =
             context_with_projected_messages(&self.context, projection.messages)?;
         let (provider_request, estimated_context_tokens) =
@@ -869,6 +902,8 @@ impl<'a> NativeAgentTurnExecution<'a> {
             };
         provider_context.set_prepared_provider_request(provider_request);
         let attempt = ProviderAttempt::new(&self.context, iteration, estimated_context_tokens);
+        preparation.model_call(&attempt.id);
+        preparation.next("before_request_hook");
         let before_provider_invocation = AgentHookInvocation::provider(
             AgentHookStage::BeforeProviderRequest,
             self.context.trace_context.clone(),
@@ -891,6 +926,7 @@ impl<'a> NativeAgentTurnExecution<'a> {
             )?));
         }
         self.context.metrics().increment("provider.attempted");
+        preparation.complete();
         Ok(ExecutionStage::Ready(PreparedProviderIteration {
             provider_context,
             attempt,
@@ -953,6 +989,11 @@ impl<'a> NativeAgentTurnExecution<'a> {
         let provider_duration = provider_started_at.elapsed();
         let timing = crate::agent::runtime_protocol::AgentModelTiming {
             model_call_id: attempt.id.clone(),
+            time_to_request_ms: Some(
+                provider_started_at
+                    .duration_since(self.context.received_at)
+                    .as_millis() as u64,
+            ),
             time_to_first_token_ms: first_token_at
                 .map(|first| first.duration_since(provider_started_at).as_millis() as u64),
             decode_duration_ms: first_token_at.map(|first| {

--- a/src-tauri/src/agent/runtime/tests/README.md
+++ b/src-tauri/src/agent/runtime/tests/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Tests
-<!-- tinybot-module-fingerprint: sha256:0bd8a1694370a8661b48c8a8a187d73a47510518e801ee2fcafe7b88e81399dc -->
+<!-- tinybot-module-fingerprint: sha256:5c55b168763e5810baf98cdd682022a7f951a82bc849bc91c4dfb94875757673 -->
 
 This directory groups the larger agent runtime test suites by concern:
 configuration, context, interactions, lifecycle, and tools.
@@ -37,6 +37,9 @@ checks that provider reasoning has matching live and reloaded canonical items.
 Timing coverage uses an asynchronous streaming provider to verify first-token
 and decode intervals survive serialization, and asserts usage is recorded before
 a tool suspends the Turn for input.
+It also includes a delayed before-provider hook in time-to-request, verifies
+older timing payloads deserialize without that field, and excludes application
+preparation diagnostics from runtime events.
 Interaction coverage keeps resumable user-input checkpoints and their deferred tool-hook
 context on the same Turn, and verifies that form submission acknowledgement
 precedes the resumed provider request.

--- a/src-tauri/src/agent/runtime/tests/lifecycle.rs
+++ b/src-tauri/src/agent/runtime/tests/lifecycle.rs
@@ -952,6 +952,21 @@ fn guidance_continuation_is_inserted_before_next_model_call_after_tools() {
 #[test]
 fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
     struct StreamingProvider;
+    struct PreparationHook;
+
+    impl AgentHook for PreparationHook {
+        fn evaluate<'a>(
+            &'a self,
+            invocation: &'a AgentHookInvocation,
+        ) -> futures_util::future::BoxFuture<'a, Result<AgentHookOutput, String>> {
+            Box::pin(async move {
+                if invocation.stage == AgentHookStage::BeforeProviderRequest {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Ok(AgentHookOutput::Decision(AgentHookDecision::Continue))
+            })
+        }
+    }
 
     impl NativeAgentProvider for StreamingProvider {
         fn complete_streaming_async<'a>(
@@ -995,7 +1010,8 @@ fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
         Arc::new(FakeNativeAgentToolDispatcher),
         Arc::new(InMemoryNativeAgentCheckpointStore::default()),
         Arc::new(InMemoryNativeAgentCancellation::default()),
-    );
+    )
+    .with_hook(Arc::new(PreparationHook));
 
     let result = run_native_agent_turn_with_services(
         &services,
@@ -1043,11 +1059,15 @@ fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
         .unwrap();
     let timing = &usage["payload"]["agentItem"]["modelTiming"];
     assert_eq!(timing["modelCallId"], "turn-streaming-provider:provider:1");
+    assert!(timing["timeToRequestMs"].as_u64().unwrap() >= 20);
     assert!(timing["timeToFirstTokenMs"].as_u64().unwrap() >= 5);
     assert!(timing["decodeDurationMs"].as_u64().unwrap() >= 5);
     // Durable event serialization and history projection retain exactly the live reading.
     let events: Vec<crate::agent::runtime_protocol::AgentRuntimeEventEnvelope> =
         serde_json::from_value(result["runtimeEvents"].clone()).unwrap();
+    assert!(events
+        .iter()
+        .all(|event| event.event_name != "agent.preparation"));
     let items = crate::agent::runtime_protocol::project_turn_items_from_trace_events(&events);
     let persisted = items
         .iter()
@@ -1056,6 +1076,17 @@ fn provider_stream_observer_emits_live_deltas_without_duplicate_final_delta() {
     assert_eq!(
         serde_json::to_value(&persisted.data).unwrap()["modelTiming"],
         *timing
+    );
+    let mut legacy_timing = timing.clone();
+    legacy_timing
+        .as_object_mut()
+        .unwrap()
+        .remove("timeToRequestMs");
+    assert!(
+        serde_json::from_value::<crate::agent::runtime_protocol::AgentModelTiming>(legacy_timing)
+            .unwrap()
+            .time_to_request_ms
+            .is_none()
     );
 }
 

--- a/src-tauri/src/agent/runtime/turn_input.rs
+++ b/src-tauri/src/agent/runtime/turn_input.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 /// Normalized execution input. JSON aliases and defaults are resolved before a task is owned.
 #[derive(Clone, Debug)]
 pub struct AgentTurnInput {
+    pub(crate) received_at: std::time::Instant,
     pub(crate) session_id: String,
     pub(crate) trace_context: AgentTraceContext,
     pub(crate) settings: AgentTurnSettings,
@@ -39,6 +40,7 @@ struct ContextCompactionRequest {
 
 impl AgentTurnInput {
     pub(crate) fn from_wire(spec: &Value, config: &Value) -> Result<Self, String> {
+        let received_at = std::time::Instant::now();
         if !spec.is_object() {
             return Err("agent turn spec must be an object".to_string());
         }
@@ -170,6 +172,7 @@ impl AgentTurnInput {
             )?,
         };
         Ok(Self {
+            received_at,
             session_id,
             trace_context,
             settings,

--- a/src-tauri/src/agent/runtime_protocol/README.md
+++ b/src-tauri/src/agent/runtime_protocol/README.md
@@ -1,5 +1,5 @@
 # Agent Runtime Protocol
-<!-- tinybot-module-fingerprint: sha256:bff1fdaee4c3e6fd14a249664a396ddadc3098a269a4bd9225a4509eb4eb1a53 -->
+<!-- tinybot-module-fingerprint: sha256:21e90f9ba737f41726baf2b62e7a66e1270c4fba9b05de30495de37c037d0818 -->
 
 `runtime_protocol` defines the durable events exchanged by the agent runtime
 and the projections built from them.
@@ -27,6 +27,9 @@ Usage Items optionally carry `modelTiming` with a model-call identity, TTFT,
 and decode duration in milliseconds. Typed live projection and durable replay
 retain the same values. Older v2 Items omit the field; no schema migration is
 needed and absent timing remains unavailable.
+Optional `modelTiming.timeToRequestMs` records backend-input-to-invocation time;
+older timing objects may omit it. Detailed `agent.preparation` diagnostics belong
+to the native application log and are not protocol events or Rollout records.
 
 Form resolution is a durable event. Its values and command correlation are
 persisted before the completed form timeline patch reaches the renderer.

--- a/src-tauri/src/agent/runtime_protocol/wire.rs
+++ b/src-tauri/src/agent/runtime_protocol/wire.rs
@@ -297,11 +297,14 @@ pub enum AgentTurnItemData {
     },
 }
 
-/// Monotonic timings for one provider invocation, excluding tool execution.
+/// Monotonic timings for one provider invocation.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentModelTiming {
     pub model_call_id: String,
+    /// Time from backend input receipt to this invocation, including preparation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time_to_request_ms: Option<u64>,
     pub time_to_first_token_ms: Option<u64>,
     pub decode_duration_ms: Option<u64>,
 }

--- a/src/app-core/chat/README.md
+++ b/src/app-core/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Application Core
-<!-- tinybot-module-fingerprint: sha256:d1a26f3a1e9d6583758d0dd51746196d8b6b9299a548eb75b5dab7630abe4291 -->
+<!-- tinybot-module-fingerprint: sha256:c600e5cd6e82e69c86aff771275a09a07a6ff1363a349b838409e619579216aa -->
 
 `chat` contains framework-independent chat and Thread contracts, command
 construction, canonical timeline validation, UI projection, input state, and
@@ -43,6 +43,9 @@ that untouched Provider payload before the composer derives its usage indicator.
 provider output counts and a positive decode duration. Old or non-streaming
 Items supply no invented timings; a later call never replaces missing first-call
 latency. Completed Turn duration uses the existing start and end timestamps.
+Optional first-call `timeToRequestMs` is preserved separately from TTFT, including
+zero. Missing old readings remain unavailable and invalid numeric readings fail
+canonical validation instead of being substituted from a later invocation.
 
 `desktopChatSessionController` requires every submission to name its target
 Thread explicitly. The controller validates that target and never derives a

--- a/src/app-core/chat/chatTimelinePayload.ts
+++ b/src/app-core/chat/chatTimelinePayload.ts
@@ -148,6 +148,9 @@ function normalizeCanonicalTurnItem(
   if (kind === "usage" && data.modelTiming !== undefined) {
     const timing = payloadRecord(data.modelTiming);
     requiredCanonicalString(timing, "modelCallId");
+    if (timing.timeToRequestMs != null && (typeof timing.timeToRequestMs !== "number" || !Number.isSafeInteger(timing.timeToRequestMs) || timing.timeToRequestMs < 0)) {
+      throw new Error("Canonical model timing timeToRequestMs must be a non-negative integer or null");
+    }
     for (const key of ["timeToFirstTokenMs", "decodeDurationMs"] as const) {
       if (timing[key] !== null && (typeof timing[key] !== "number" || !Number.isSafeInteger(timing[key]) || timing[key] < 0)) {
         throw new Error(`Canonical model timing ${key} must be a non-negative integer or null`);

--- a/src/app-core/chat/chatTurnContracts.ts
+++ b/src/app-core/chat/chatTurnContracts.ts
@@ -218,12 +218,14 @@ export type ChatTurn = {
 };
 
 export type TurnMetrics = {
+  timeToRequestMs?: number;
   timeToFirstTokenMs?: number;
   tokensPerSecond?: number;
 };
 
 export type ModelCallTiming = {
   modelCallId: string;
+  timeToRequestMs?: number | null;
   timeToFirstTokenMs: number | null;
   decodeDurationMs: number | null;
 };

--- a/src/app-core/chat/turnMetrics.test.ts
+++ b/src/app-core/chat/turnMetrics.test.ts
@@ -3,14 +3,14 @@ import { normalizeAgentTurnRuntimeStatePayload } from "./chatTimelinePayload";
 import { projectBackendTimeline } from "./chatProjection";
 import { turnDurationMs } from "./turnMetrics";
 
-function restoredTurn(samples: Array<{ tokens?: number; first?: number | null; decode?: number | null; legacy?: boolean }>) {
+function restoredTurn(samples: Array<{ tokens?: number; request?: number | null; first?: number | null; decode?: number | null; legacy?: boolean }>) {
   const items = samples.map((sample, index) => ({
     schemaVersion: "tinybot.turn_item.v2", sessionId: "session", turnId: "turn",
     itemId: `usage-${index}`, kind: "usage", status: "completed", sequence: index + 1, revision: 1,
     createdAt: String(1000 + index * 50_000),
     data: {
       type: "usage", outputTokens: sample.tokens ?? null, providerPayload: {},
-      ...(!sample.legacy ? { modelTiming: { modelCallId: `call-${index}`, timeToFirstTokenMs: sample.first ?? null, decodeDurationMs: sample.decode ?? null } } : {}),
+      ...(!sample.legacy ? { modelTiming: { modelCallId: `call-${index}`, timeToRequestMs: sample.request, timeToFirstTokenMs: sample.first ?? null, decodeDurationMs: sample.decode ?? null } } : {}),
     },
   }));
   const payload = JSON.parse(JSON.stringify({
@@ -21,6 +21,14 @@ function restoredTurn(samples: Array<{ tokens?: number; first?: number | null; d
 }
 
 describe("durable turn metrics", () => {
+  test("restores preparation time from the first call, independently of TTFT and later tools", () => {
+    expect(restoredTurn([{ request: 125, first: 600 }, { request: 5000, first: 200 }]).metrics)
+      .toEqual({ timeToRequestMs: 125, timeToFirstTokenMs: 600 });
+    expect(restoredTurn([{ request: 0 }]).metrics).toEqual({ timeToRequestMs: 0 });
+    expect(restoredTurn([{ request: null }, { request: 5000 }]).metrics).toBeUndefined();
+    expect(restoredTurn([{}, { request: 5000 }]).metrics).toBeUndefined();
+  });
+
   test("restores weighted throughput and first-call latency without counting gaps between calls", () => {
     const turn = restoredTurn([{ tokens: 40, first: 1200, decode: 3000 }, { tokens: 60, first: 200, decode: 2000 }]);
     expect(turn.metrics).toEqual({ timeToFirstTokenMs: 1200, tokensPerSecond: 20 });
@@ -43,6 +51,9 @@ describe("durable turn metrics", () => {
   });
 
   test("rejects corrupt persisted timing instead of showing a fabricated number", () => {
+    for (const request of [-1, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() => restoredTurn([{ request }])).toThrow(/model timing/);
+    }
     expect(() => restoredTurn([{ tokens: 10, first: -5, decode: 100 }])).toThrow(/model timing/);
     expect(() => restoredTurn([{ tokens: -10, first: 5, decode: 100 }])).toThrow(/outputTokens/);
   });

--- a/src/app-core/chat/turnMetrics.ts
+++ b/src/app-core/chat/turnMetrics.ts
@@ -5,6 +5,9 @@ export function deriveTurnMetrics(items: readonly BackendAgentTurnItem[]): TurnM
   const usages = items.filter((item) => item.data.type === "usage").sort((a, b) => a.sequence - b.sequence);
   const first = usages[0]?.data;
   const metrics: TurnMetrics = {};
+  if (first?.type === "usage" && first.modelTiming?.timeToRequestMs != null) {
+    metrics.timeToRequestMs = first.modelTiming.timeToRequestMs;
+  }
   if (first?.type === "usage" && first.modelTiming?.timeToFirstTokenMs != null) {
     metrics.timeToFirstTokenMs = first.modelTiming.timeToFirstTokenMs;
   }

--- a/src/components/ui/FileAttachmentChip.css
+++ b/src/components/ui/FileAttachmentChip.css
@@ -1,0 +1,54 @@
+.file-attachment-chip {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  min-width: 0;
+  max-width: min(300px, 100%);
+  height: 34px;
+  padding: 0 5px 0 10px;
+  border: 1px solid var(--color-hairline);
+  border-radius: 999px;
+  background: var(--color-surface-soft);
+  color: var(--color-ink);
+  font-size: 13px;
+  /* Leave room for CJK glyphs and descenders inside the ellipsis clipping box. */
+  line-height: 1.5;
+}
+.file-attachment-chip .file-attachment-chip__content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 0 5px 0 0;
+  height: 100%;
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+.file-attachment-chip button { cursor: pointer; }
+.file-attachment-chip__icon, .file-attachment-chip__type, .file-attachment-chip__chevron { flex: none; }
+.file-attachment-chip__icon { color: var(--color-muted); }
+.file-attachment-chip[data-category="spreadsheet"] .file-attachment-chip__icon { color: var(--color-success, #39805a); }
+.file-attachment-chip[data-category="pdf"] .file-attachment-chip__icon { color: var(--color-primary); }
+.file-attachment-chip__name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-attachment-chip__type { color: var(--color-muted); font-size: 10px; }
+.file-attachment-chip__chevron { color: var(--color-muted); }
+.file-attachment-chip .file-attachment-chip__remove {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-muted);
+}
+.file-attachment-chip__remove:hover { background: var(--color-panel); color: var(--color-ink); }
+.file-attachment-chip:has(button:hover) { border-color: var(--color-hairline-strong, var(--color-muted)); }
+.file-attachment-chip :focus-visible { outline: 2px solid var(--color-primary); outline-offset: 1px; }
+.react-message__body .file-attachment-chip { background: var(--color-panel); }

--- a/src/components/ui/FileAttachmentChip.tsx
+++ b/src/components/ui/FileAttachmentChip.tsx
@@ -1,0 +1,36 @@
+import { ChevronRight, File, FileArchive, FileImage, FileSpreadsheet, FileText, FileVideo, Music, X } from "lucide-react";
+import "./FileAttachmentChip.css";
+
+export function FileAttachmentChip({ id, name, path, detail, mimeType, onOpen, onRemove, removeLabel }: {
+  id?: string;
+  name: string;
+  path?: string;
+  detail?: string;
+  mimeType?: string;
+  onOpen?: () => void;
+  onRemove?: () => void;
+  removeLabel?: string;
+}) {
+  const extension = /\.[^.\\/]+$/.exec(name)?.[0] ?? "";
+  const type = extension.slice(1).toLowerCase();
+  const category = /^(xlsx?|csv|ods)$/.test(type) ? "spreadsheet"
+    : /^(png|jpe?g|gif|webp|svg|avif|heic)$/.test(type) || mimeType?.startsWith("image/") ? "image"
+    : /^(mp4|mov|webm)$/.test(type) || mimeType?.startsWith("video/") ? "video"
+    : /^(mp3|wav|ogg|flac)$/.test(type) || mimeType?.startsWith("audio/") ? "audio"
+    : /^(zip|rar|7z|tar|gz)$/.test(type) ? "archive"
+    : type === "pdf" ? "pdf" : /^(docx?|txt|md|json|tsx?|jsx?|py|rs)$/.test(type) ? "document" : "file";
+  const Icon = { spreadsheet: FileSpreadsheet, image: FileImage, video: FileVideo, audio: Music, archive: FileArchive, pdf: FileText, document: FileText, file: File }[category];
+  const title = [name, path, detail].filter(Boolean).join("\n");
+  const content = <>
+    <Icon className="file-attachment-chip__icon" aria-hidden="true" size={18} />
+    <span className="file-attachment-chip__name">{name}</span>
+    {type ? <span className="file-attachment-chip__type" aria-hidden="true">{type.toUpperCase()}</span> : null}
+    {onOpen ? <ChevronRight className="file-attachment-chip__chevron" aria-hidden="true" size={14} /> : null}
+  </>;
+  return <div className="file-attachment-chip" data-category={category} data-attachment-id={id}>
+    {onOpen
+      ? <button type="button" className="file-attachment-chip__content" title={title} aria-label={title} onClick={onOpen}>{content}</button>
+      : <span className="file-attachment-chip__content" title={title} role="group" aria-label={title} tabIndex={0}>{content}</span>}
+    {onRemove ? <button type="button" className="file-attachment-chip__remove" aria-label={removeLabel} onClick={onRemove}><X aria-hidden="true" size={14} /></button> : null}
+  </div>;
+}

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -1,5 +1,5 @@
 # Shared UI
-<!-- tinybot-module-fingerprint: sha256:c0e575d6aee6b52b689d4ff20808a440ea0814961d6d7f40c79548b5f4787a7f -->
+<!-- tinybot-module-fingerprint: sha256:ba7540264562708242ed764b9c01e8e42df408a1f93b270fd5c8feaa896ca837 -->
 
 `components/ui` contains reusable renderer UI whose interface is not owned by
 a single route. It includes the shared chat composer, file metadata formatting,
@@ -13,6 +13,12 @@ File drops and clipboard files use the injected `onImportFiles` adapter; plain
 text paste keeps its existing editor behavior. A nested-safe drop cue and import
 status share the panel. Pending imports block sending and cannot attach to a
 different `attachmentContextKey` after navigation.
+File attachments and ordinary workspace file references use the shared
+`FileAttachmentChip`: a single-line pill with a type icon, truncated filename,
+fixed extension label, full-name/path/metadata tooltip, and remove action.
+The row lives inside the composer panel and scrolls horizontally without widening
+the input. Newly added files scroll into view; ordinary draft edits do not move
+the row. Expanded annotation controls keep their existing editing behavior below it.
 Route-owned context references can opt into an expanded annotation card with a
 header, body value, and note while preserving the same remove and successful-send
 clearing callbacks as compact references.

--- a/src/components/ui/claude-style-ai-input.tsx
+++ b/src/components/ui/claude-style-ai-input.tsx
@@ -8,11 +8,11 @@ import { DEFAULT_REASONING_EFFORT, type ReasoningEffort } from "../../app-core/c
 import type { TokenUsage } from "../../app-core/chat/chatTurnContracts";
 import { formatFileMetadata } from "./composerFileMetadata";
 import { ComposerAnnotations } from "./ComposerAnnotations";
+import { FileAttachmentChip } from "./FileAttachmentChip";
 import type { ComposerContextReference } from "./composerContextReference";
 export type { ComposerContextReference } from "./composerContextReference";
 import {
   AlertCircle,
-  Archive,
   ArrowUp,
   Box,
   Check,
@@ -22,14 +22,11 @@ import {
   Command,
   Copy,
   FileText,
-  ImageIcon,
   MessageCircle,
-  Music,
   Plus,
   SlidersHorizontal,
   Square,
   TerminalSquare,
-  Video,
   X,
 } from "lucide-react";
 
@@ -234,6 +231,8 @@ export function ClaudeStyleAiInput({
 }: ClaudeStyleAiInputProps) {
   const { t } = useTranslation("chat");
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const attachmentRowRef = useRef<HTMLDivElement | null>(null);
+  const previousAttachmentIds = useRef(new Set<string>());
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const inlineEditorRef = useRef<HTMLDivElement | null>(null);
   const inlineEditorComposingRef = useRef(false);
@@ -274,6 +273,21 @@ export function ClaudeStyleAiInput({
   const sessionMentionListboxId = useId();
   const currentMessage = value ?? message;
   const files = controlledFiles ?? uncontrolledFiles;
+  useLayoutEffect(() => {
+    const ids = [...contextReferences.map((reference) => reference.id), ...files.map((file) => file.id)];
+    const added = ids.filter((id) => !previousAttachmentIds.current.has(id));
+    previousAttachmentIds.current = new Set(ids);
+    if (!added.length) return;
+    const row = attachmentRowRef.current;
+    const target = row && Array.from(row.querySelectorAll<HTMLElement>("[data-attachment-id]"))
+      .find((element) => element.dataset.attachmentId === added[added.length - 1]);
+    if (row && target) {
+      const bounds = row.getBoundingClientRect();
+      const chip = target.getBoundingClientRect();
+      if (chip.right > bounds.right) row.scrollLeft += chip.right - bounds.right;
+      else if (chip.left < bounds.left) row.scrollLeft += chip.left - bounds.left;
+    }
+  }, [contextReferences, files]);
   const filesRef = useRef(files);
   const selectedModel = useMemo(
     () => models.find((model) => model.id === selectedModelId)
@@ -953,61 +967,75 @@ export function ClaudeStyleAiInput({
           <span>{disabledReason || sendDisabledReason}</span>
         </div>
       ) : null}
-      {files.length || pastedContent.length || contextReferences.length || selectedSessionMentions.length ? (
-        <div className="claude-ai-input__attachments" aria-label={t("composer.attachments")}>
-          {selectedSessionMentions.map((reference) => (
-            <AttachmentChip
-              detail={reference.detail}
-              icon={<MessageCircle aria-hidden="true" size={16} />}
-              key={reference.id}
-              label={reference.label}
-              onRemove={() => onRemoveSessionMention?.(reference.id)}
-              removeLabel={t("composer.remove", { name: reference.label })}
-            />
-          ))}
-          <ComposerAnnotations references={contextReferences.filter((reference) => reference.presentation === "compact-annotation")} onRemove={(id) => onRemoveContextReference?.(id)} />
-          {contextReferences.filter((reference) => reference.presentation !== "compact-annotation").map((reference) => (
-            <AttachmentChip
-              imageUrl={reference.imageUrl}
-              annotation={reference.annotation}
-              body={reference.body}
-              detail={reference.detail}
-              icon={reference.kind === "terminal" ? <TerminalSquare aria-hidden="true" size={16} /> : <FileText aria-hidden="true" size={16} />}
-              key={reference.id}
-              label={reference.label}
-              onRemove={() => onRemoveContextReference?.(reference.id)}
-              removeLabel={t("composer.remove", { name: reference.label })}
-            />
-          ))}
-          {pastedContent.map((item) => (
-            <AttachmentChip
-              detail={t("composer.words", { count: item.wordCount })}
-              icon={<Copy aria-hidden="true" size={16} />}
-              key={item.id}
-              label={t("composer.pastedText")}
-              onRemove={() => removePastedContent(item.id)}
-              removeLabel={t("composer.removePasted")}
-            />
-          ))}
-          {files.map((item) => (
-            <AttachmentChip
-              detail={formatFileMetadata(item.mimeType, item.sizeBytes)}
-              icon={getFileIcon(item.mimeType)}
-              key={item.id}
-              label={item.name}
-              onRemove={() => removeFile(item.id)}
-              removeLabel={t("composer.remove", { name: item.name })}
-            />
-          ))}
-        </div>
-      ) : null}
-
       <div
         ref={panelRef}
         className="claude-ai-input__panel"
         onPointerLeave={handlePanelPointerLeave}
         onPointerMove={handlePanelPointerMove}
       >
+        {files.length || pastedContent.length || contextReferences.length || selectedSessionMentions.length ? (
+          <div aria-label={t("composer.attachments")}>
+            <div ref={attachmentRowRef} className="claude-ai-input__attachments">
+              {selectedSessionMentions.map((reference) => (
+                <AttachmentChip
+                  detail={reference.detail}
+                  icon={<MessageCircle aria-hidden="true" size={16} />}
+                  key={reference.id}
+                  label={reference.label}
+                  onRemove={() => onRemoveSessionMention?.(reference.id)}
+                  removeLabel={t("composer.remove", { name: reference.label })}
+                />
+              ))}
+              <ComposerAnnotations references={contextReferences.filter((reference) => reference.presentation === "compact-annotation")} onRemove={(id) => onRemoveContextReference?.(id)} />
+              {contextReferences.filter((reference) => reference.presentation !== "compact-annotation" && !reference.annotation).map((reference) => reference.kind === "file" ? (
+                <FileAttachmentChip
+                  key={reference.id} id={reference.id} name={reference.label} path={reference.body}
+                  detail={reference.detail} mimeType={reference.mimeType}
+                  onRemove={() => onRemoveContextReference?.(reference.id)}
+                  removeLabel={t("composer.remove", { name: reference.label })}
+                />
+              ) : (
+                <AttachmentChip
+                  imageUrl={reference.imageUrl}
+                  annotation={reference.annotation}
+                  body={reference.body}
+                  detail={reference.detail}
+                  icon={reference.kind === "terminal" ? <TerminalSquare aria-hidden="true" size={16} /> : <FileText aria-hidden="true" size={16} />}
+                  key={reference.id}
+                  label={reference.label}
+                  onRemove={() => onRemoveContextReference?.(reference.id)}
+                  removeLabel={t("composer.remove", { name: reference.label })}
+                />
+              ))}
+              {pastedContent.map((item) => (
+                <AttachmentChip
+                  detail={t("composer.words", { count: item.wordCount })}
+                  icon={<Copy aria-hidden="true" size={16} />}
+                  key={item.id}
+                  label={t("composer.pastedText")}
+                  onRemove={() => removePastedContent(item.id)}
+                  removeLabel={t("composer.removePasted")}
+                />
+              ))}
+              {files.map((item) => (
+                <FileAttachmentChip
+                  id={item.id}
+                  detail={formatFileMetadata(item.mimeType, item.sizeBytes)}
+                  mimeType={item.mimeType}
+                  path={item.path}
+                  key={item.id}
+                  name={item.name}
+                  onRemove={() => removeFile(item.id)}
+                  removeLabel={t("composer.remove", { name: item.name })}
+                />
+              ))}
+            </div>
+            {contextReferences.filter((reference) => reference.presentation !== "compact-annotation" && reference.annotation).map((reference) => (
+              <AttachmentChip key={reference.id} {...reference} icon={<FileText aria-hidden="true" size={16} />}
+                onRemove={() => onRemoveContextReference?.(reference.id)} removeLabel={t("composer.remove", { name: reference.label })} />
+            ))}
+          </div>
+        ) : null}
         {draggingFiles || selectingFiles ? (
           <div className="claude-ai-input__file-status" role="status">
             <FileText aria-hidden="true" size={18} />
@@ -1861,22 +1889,6 @@ function AttachmentChip({
     </div>
   );
 }
-
-const getFileIcon = (type: string) => {
-  if (type.startsWith("image/")) {
-    return <ImageIcon aria-hidden="true" size={16} />;
-  }
-  if (type.startsWith("video/")) {
-    return <Video aria-hidden="true" size={16} />;
-  }
-  if (type.startsWith("audio/")) {
-    return <Music aria-hidden="true" size={16} />;
-  }
-  if (type.includes("zip") || type.includes("rar") || type.includes("tar")) {
-    return <Archive aria-hidden="true" size={16} />;
-  }
-  return <FileText aria-hidden="true" size={16} />;
-};
 
 function countWords(text: string): number {
   return text.trim().split(/\s+/).filter(Boolean).length;

--- a/src/react-workbench/chat/ChatPage.composer.test.tsx
+++ b/src/react-workbench/chat/ChatPage.composer.test.tsx
@@ -792,10 +792,10 @@ describe("ChatPage", () => {
     const body = message.querySelector(".react-message__body");
     expect(message.textContent).toContain("文件中的内容是什么");
     expect(attachments.textContent).toContain("AI_Agent_第一性原理_文档.md");
-    expect(attachments.textContent).toContain("MARKDOWN - 1.67 KB");
-    expect(message.firstElementChild).toBe(attachments);
-    expect(attachments.nextElementSibling).toBe(body);
-    expect(body?.textContent).not.toContain("AI_Agent_第一性原理_文档.md");
+    expect(attachments.textContent).not.toContain("MARKDOWN - 1.67 KB");
+    expect(attachments.querySelector("[title]")?.getAttribute("title")).toContain("MARKDOWN - 1.67 KB");
+    expect(body?.contains(attachments)).toBe(true);
+    expect(body?.textContent).toContain("AI_Agent_第一性原理_文档.md");
     expect(message.textContent).not.toContain("D:\\code\\tinybot\\test");
     expect(message.textContent).not.toContain("Files mentioned by the user");
   });

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -579,12 +579,11 @@
 }
 
 .react-message-attachments {
-  display: grid;
-  justify-items: end;
-  justify-self: end;
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
-  width: min(360px, 100%);
   max-width: 100%;
+  margin-top: 10px;
 }
 
 .react-message-attachment {
@@ -611,54 +610,6 @@
   height: auto;
   max-height: 280px;
   object-fit: contain;
-}
-
-.react-message-attachment[data-kind="file"] {
-  display: grid;
-  grid-template-columns: 34px minmax(0, 1fr);
-  align-items: center;
-  justify-self: end;
-  gap: 10px;
-  width: min(320px, 100%);
-  min-height: 54px;
-  border: 1px solid var(--color-hairline);
-  border-radius: 10px;
-  background: var(--color-surface-card);
-  padding: 8px 10px;
-}
-
-.react-message-attachment__icon {
-  display: inline-grid;
-  place-items: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 8px;
-  background: var(--color-surface-soft);
-  color: var(--color-muted);
-}
-
-.react-message-attachment__summary {
-  display: grid;
-  min-width: 0;
-  gap: 2px;
-}
-
-.react-message-attachment__summary strong,
-.react-message-attachment__summary small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.react-message-attachment__summary strong {
-  color: var(--color-ink);
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.react-message-attachment__summary small {
-  color: var(--color-muted);
-  font-size: 12px;
 }
 
 .react-message-context {
@@ -1119,6 +1070,7 @@
 }
 
 .claude-ai-input {
+  min-width: 0;
   gap: 8px;
 }
 
@@ -1129,6 +1081,7 @@
   --claude-ai-panel-glow-y: 100%;
   --claude-ai-panel-radius: 16px;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   position: relative;
   isolation: isolate;
   overflow: visible;
@@ -1761,9 +1714,21 @@
 
 .claude-ai-input__attachments {
   display: flex;
-  flex-wrap: wrap;
+  min-width: 0;
+  flex-wrap: nowrap;
+  align-items: center;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-hairline) transparent;
   gap: 8px;
+  padding: 3px 2px;
 }
+
+.react-message > .react-message-attachments { width: min(360px, 100%); justify-self: end; margin-top: 0; }
+
+.claude-ai-input__attachments > * { flex-shrink: 0; }
+.claude-ai-input__panel:has(.claude-ai-input__attachments) { min-width: 0; }
 
 .claude-ai-input__attachment {
   max-width: min(260px, 100%);

--- a/src/react-workbench/chat/ChatTimeline.test.tsx
+++ b/src/react-workbench/chat/ChatTimeline.test.tsx
@@ -14,6 +14,27 @@ afterEach(() => {
 });
 
 describe("ChatTimeline", () => {
+  test("shows workspace and uploaded files as chips inside persisted user bubbles", () => {
+    const turn = completedTurn();
+    const onOpenFileLink = vi.fn();
+    turn.userMessage.references = [
+      { kind: "reference", referenceKind: "file", title: "sales.xlsx", detail: "Whole artifact", sourcePath: "reports/sales.xlsx", sourceText: "Artifact: sales.xlsx\nViewed content" },
+      { kind: "reference", referenceKind: "file", title: "notes.pdf", detail: "PDF - 2 KB", rawPath: "C:/uploads/notes.pdf" },
+    ];
+    render(<ChatTimeline actions={{ onOpenFileLink }} hookResults={[]} interactiveFormIds={new Set()} latestFailedTurnId="" optimisticMessages={[]} sessionRunning={false} turns={[turn]} />);
+    const message = screen.getByTestId("message-user-1");
+    const attachments = within(message).getByRole("region", { name: "Attachments" });
+    expect(message.querySelector(".react-message__body")?.contains(attachments)).toBe(true);
+    expect(within(attachments).getByText("sales.xlsx")).toBeTruthy();
+    expect(within(attachments).getByText("notes.pdf")).toBeTruthy();
+    expect(within(message).queryByText("Context")).toBeNull();
+    expect(message.textContent).not.toContain("Whole artifact");
+    const file = within(attachments).getByRole("button", { name: /sales.xlsx/ });
+    expect(file.title).toContain("reports/sales.xlsx");
+    fireEvent.click(file);
+    expect(onOpenFileLink).toHaveBeenCalledWith({ href: "reports/sales.xlsx" });
+  });
+
   test("keeps one indicator at the turn tail through dispatch, tools, and answer streaming", () => {
     const base = completedTurn();
     const timeline = (turns: ChatTurn[], optimisticMessages: ReactChatMessage[] = []) => (

--- a/src/react-workbench/chat/ChatTimeline.tsx
+++ b/src/react-workbench/chat/ChatTimeline.tsx
@@ -44,6 +44,7 @@ import { ToolActivityItem } from "./ToolActivityItem";
 import { TimelineActivity } from "./TimelineActivity";
 import { DataViewCard } from "./DataViewCard";
 import { TurnMetrics } from "./TurnMetrics";
+import { FileAttachmentChip } from "../../components/ui/FileAttachmentChip";
 import { turnDurationMs } from "../../app-core/chat/turnMetrics";
 
 export type ChatTimelineActions = {
@@ -166,6 +167,7 @@ const CanonicalChatTurn = memo(function CanonicalChatTurn({
       {hasUserMessage ? (
         <CanonicalMessage
           messageId={turn.userMessage.id}
+          onOpenFileLink={onOpenFileLink}
           references={turn.userMessage.references}
           role="user"
           text={turn.userMessage.text}
@@ -607,14 +609,17 @@ function CanonicalMessage({
   const inlineReferences = role === "user"
     ? referenceSummaries.filter((reference) => !isAttachmentReference(reference))
     : referenceSummaries;
+  const imageReferences = attachmentReferences.filter((reference) => reference.attachmentKind === "image");
+  const fileReferences = attachmentReferences.filter((reference) => reference.attachmentKind !== "image");
   return (
     <article className="react-message" data-actions-placement="bottom" data-role={role} data-testid={`message-${messageId}`} data-scroll-anchor={`message:${messageId}`}>
-      {attachmentReferences.length ? <MessageAttachments references={attachmentReferences} /> : null}
+      {imageReferences.length ? <MessageAttachments references={imageReferences} /> : null}
       <div className="react-message__body">
         {reasoning.map((step) => (
           <MessageReasoning durationMs={reasoningDurationMs(step)} key={step.id} streaming={step.status === "running"} text={step.summary ?? ""} />
         ))}
         {role === "assistant" ? <AssistantMarkdown onOpenFileLink={onOpenFileLink} streaming={streaming} text={text} /> : <PlainMessageText text={text} />}
+        {fileReferences.length ? <MessageAttachments references={fileReferences} onOpenFileLink={onOpenFileLink} /> : null}
         {inlineReferences.length ? <MessageContext references={inlineReferences} /> : null}
       </div>
       {(allowActions && text.trim()) || footer ? (
@@ -966,16 +971,17 @@ function canonicalFormValue(value: unknown): string {
 }
 
 function canonicalReferenceSummary(reference: AgentInputReference, index: number): ContextReferenceSummary {
-  const attachmentKind = agentInputAttachmentKind(reference) ?? "file";
+  const attachmentKind = agentInputAttachmentKind(reference);
   return {
     attachmentKind,
+    attachmentPath: reference.rawPath,
+    mimeType: reference.mimeType,
     ...(attachmentKind === "image" && reference.rawPath
       ? { attachmentPreviewPath: reference.rawPath }
       : {}),
     id: reference.noteId || reference.evidenceId || `${reference.kind}:${index}`,
     kind: reference.kind,
-    presentation: agentInputAttachmentKind(reference)
-      && Boolean(reference.rawPath) && !reference.sourcePath
+    presentation: attachmentKind && reference.userAnnotation === undefined
       ? "attachment"
       : "context",
     title: reference.title,
@@ -1027,6 +1033,8 @@ function MessageBubble({
   const inlineReferences = message.role === "user"
     ? (message.contextReferences ?? []).filter((reference) => !isAttachmentReference(reference))
     : message.contextReferences ?? [];
+  const imageReferences = attachmentReferences.filter((reference) => reference.attachmentKind === "image");
+  const fileReferences = attachmentReferences.filter((reference) => reference.attachmentKind !== "image");
   const showCopyAction = canCopyMessage(message, { sessionRunning });
   const showBranchAction = canBranchFromMessage(message, { sessionRunning });
   return (
@@ -1037,7 +1045,7 @@ function MessageBubble({
       data-testid={`message-${message.id}`}
       data-scroll-anchor={`message:${message.id}`}
     >
-      {attachmentReferences.length ? <MessageAttachments references={attachmentReferences} /> : null}
+      {imageReferences.length ? <MessageAttachments references={imageReferences} /> : null}
       <div className="react-message__body">
         {message.reasoningText ? (
           <MessageReasoning streaming={message.status === "streaming"} text={message.reasoningText} />
@@ -1047,6 +1055,7 @@ function MessageBubble({
         ) : (
           <PlainMessageText text={message.text} />
         )}
+        {fileReferences.length ? <MessageAttachments references={fileReferences} onOpenFileLink={onOpenFileLink} /> : null}
         {inlineReferences.length ? <MessageContext references={inlineReferences} /> : null}
         {message.toolCalls?.length ? <AgentSteps toolCalls={message.toolCalls} onOpenTool={onOpenTool} /> : null}
       </div>
@@ -1137,18 +1146,18 @@ function isAttachmentReference(reference: ContextReferenceSummary): boolean {
   return reference.presentation === "attachment";
 }
 
-function MessageAttachments({ references }: { references: ContextReferenceSummary[] }) {
+function MessageAttachments({ references, onOpenFileLink }: { references: ContextReferenceSummary[]; onOpenFileLink?: (link: AssistantFileLink) => void }) {
   const { t } = useTranslation("chat");
   return (
     <section aria-label={t("context.attachments")} className="react-message-attachments">
       {references.map((reference) => (
-        <MessageAttachment key={reference.id} reference={reference} />
+        <MessageAttachment key={reference.id} reference={reference} onOpenFileLink={onOpenFileLink} />
       ))}
     </section>
   );
 }
 
-function MessageAttachment({ reference }: { reference: ContextReferenceSummary }) {
+function MessageAttachment({ reference, onOpenFileLink }: { reference: ContextReferenceSummary; onOpenFileLink?: (link: AssistantFileLink) => void }) {
   const [previewFailed, setPreviewFailed] = useState(false);
   const previewSource = reference.attachmentKind === "image" && !previewFailed
     ? managedImagePreviewSource(reference.attachmentPreviewPath)
@@ -1167,17 +1176,9 @@ function MessageAttachment({ reference }: { reference: ContextReferenceSummary }
     );
   }
   return (
-    <div className="react-message-attachment" data-kind="file">
-      <span className="react-message-attachment__icon">
-        {reference.attachmentKind === "image"
-          ? <ImageIcon aria-hidden="true" size={18} />
-          : <FileText aria-hidden="true" size={18} />}
-      </span>
-      <span className="react-message-attachment__summary">
-        <strong>{reference.title}</strong>
-        {reference.detail ? <small>{reference.detail}</small> : null}
-      </span>
-    </div>
+    <FileAttachmentChip name={reference.title} path={reference.sourcePath ?? reference.attachmentPath}
+      detail={reference.detail} mimeType={reference.mimeType}
+      onOpen={reference.sourcePath && onOpenFileLink ? () => onOpenFileLink({ href: reference.sourcePath! }) : undefined} />
   );
 }
 

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:5ead1eb43452bd6d8d0b8297a3af436d108233c2fc84ac6cd42d27d38dee0306 -->
+<!-- tinybot-module-fingerprint: sha256:141772688a512ccfaea2552596deeaa8a76648a74cbdc691a516541ab4e9e3b9 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -225,9 +225,12 @@ is hidden.
 
 Chat contracts, commands, and projections live in `app-core/chat`. This folder
 owns React state and presentation. Composer submission turns native managed
-images into references with `referenceKind: "image"`. User attachments render as a
-separate stack above the text bubble: managed images use the scoped Tauri asset
-protocol for bounded previews, while ordinary files use compact metadata cards.
+images into references with `referenceKind: "image"`. Managed image previews remain
+above the text bubble using the scoped Tauri asset protocol. Uploaded files and
+workspace file references share compact, wrapping chips inside user bubbles in
+both optimistic and persisted Turns. Paths and metadata appear in tooltips;
+workspace chips open the existing file-preview action. Browser annotation
+references retain their context presentation and submitted evidence is unchanged.
 Published `tinybot.data_view.v1` artifacts keep their model-authored data and
 view contract separate from presentation. Chat selects a matching Lieflat
 Porcelain SVG template for supported line, area, bar, stacked, paired, and

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:28039f7e5947d2e0088e12812a166c5d45bb69d385e82ba1eeb742f62bd7442d -->
+<!-- tinybot-module-fingerprint: sha256:5ead1eb43452bd6d8d0b8297a3af436d108233c2fc84ac6cd42d27d38dee0306 -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -128,6 +128,8 @@ at the end of a failed/interrupted Turn without a final answer. It appears only
 after the Turn ends. Clicking opens a viewport-clamped dialog with total time
 and available TPS/TTFT readings; Escape restores trigger focus, and outside
 pointer or Tab dismisses it. Old Turns show duration alone.
+When recorded, the dialog also shows time to the first model call in milliseconds
+and explains its backend-input-to-call boundary separately from TTFT.
 A running canonical execution trace starts expanded, then folds once when its
 final answer first appears; completed traces therefore mount folded. A user can
 still reopen the trace, and later streaming revisions preserve that explicit

--- a/src/react-workbench/chat/TurnMetrics.test.tsx
+++ b/src/react-workbench/chat/TurnMetrics.test.tsx
@@ -12,7 +12,7 @@ function turn(id: string, patch: Partial<ChatTurn> = {}): ChatTurn {
     steps: [], executionItems: [], userMessageId: `user-${id}`,
     userMessage: { id: `user-${id}`, role: "user", text: "Question", timestamp: "1000" },
     finalAnswer: { id: `answer-${id}`, role: "assistant", text: "Answer", timestamp: "20000" },
-    metrics: { timeToFirstTokenMs: 600, tokensPerSecond: 108 }, ...patch,
+    metrics: { timeToRequestMs: 125, timeToFirstTokenMs: 600, tokensPerSecond: 108 }, ...patch,
   };
 }
 
@@ -32,6 +32,8 @@ describe("turn timing footer", () => {
     expect(document.activeElement).toBe(dialog);
     expect(within(dialog).getByText("108 tok/s")).toBeTruthy();
     expect(within(dialog).getByText("0.6s")).toBeTruthy();
+    expect(within(dialog).getByText("Time to first model call")).toBeTruthy();
+    expect(within(dialog).getByText("125ms")).toBeTruthy();
     fireEvent.keyDown(dialog, { key: "Escape" });
     expect(screen.queryByRole("dialog")).toBeNull();
     expect(document.activeElement).toBe(trigger);
@@ -47,6 +49,7 @@ describe("turn timing footer", () => {
     expect(within(dialog).getByText("Total turn time")).toBeTruthy();
     expect(within(dialog).queryByText("Output speed (TPS)")).toBeNull();
     expect(within(dialog).queryByText("Time to first token (TTFT)")).toBeNull();
+    expect(within(dialog).queryByText("Time to first model call")).toBeNull();
   });
 
   test("does not display a completed metric while a turn is running or waiting for input", () => {

--- a/src/react-workbench/chat/TurnMetrics.tsx
+++ b/src/react-workbench/chat/TurnMetrics.tsx
@@ -90,9 +90,11 @@ export function TurnMetrics({ turn }: { turn: ChatTurn }) {
           <div className="react-turn-metrics__title"><Clock3 aria-hidden="true" size={17} />{t("metrics.title")}</div>
           <dl>
             <dt>{t("metrics.duration")}</dt><dd>{formatDuration(duration)}</dd>
+            {turn.metrics?.timeToRequestMs !== undefined && <><dt>{t("metrics.request")}</dt><dd>{t("metrics.milliseconds", { value: turn.metrics.timeToRequestMs })}</dd></>}
             {turn.metrics?.tokensPerSecond !== undefined && <><dt>{t("metrics.speed")}</dt><dd>{t("metrics.tokensPerSecond", { value: Number(turn.metrics.tokensPerSecond.toFixed(turn.metrics.tokensPerSecond < 10 ? 1 : 0)) })}</dd></>}
             {turn.metrics?.timeToFirstTokenMs !== undefined && <><dt>{t("metrics.ttft")}</dt><dd>{formatDuration(turn.metrics.timeToFirstTokenMs)}</dd></>}
           </dl>
+          {turn.metrics?.timeToRequestMs !== undefined && <p>{t("metrics.requestDescription")}</p>}
           {turn.metrics && <p>{t("metrics.description")}</p>}
         </div>, document.body,
       )}

--- a/src/react-workbench/chat/desktopChatCommands.ts
+++ b/src/react-workbench/chat/desktopChatCommands.ts
@@ -266,7 +266,7 @@ function createOptimisticUserMessage(clientEventId: string, text: string, refere
     ...(references.length ? {
       contextReferences: references.map((reference, index) => {
         const attachmentKind = agentInputAttachmentKind(reference);
-        const attachment = Boolean(attachmentKind) && Boolean(reference.rawPath) && !reference.sourcePath;
+        const attachment = Boolean(attachmentKind) && reference.userAnnotation === undefined;
         return {
           ...(attachment ? {
             attachmentKind,
@@ -275,6 +275,8 @@ function createOptimisticUserMessage(clientEventId: string, text: string, refere
               : {}),
           } : {}),
           detail: reference.detail,
+          attachmentPath: reference.rawPath,
+          mimeType: reference.mimeType,
           id: reference.evidenceId || `reference-${index}`,
           kind: reference.kind,
           presentation: attachment ? "attachment" as const : "context" as const,

--- a/src/react-workbench/chat/messageActions.ts
+++ b/src/react-workbench/chat/messageActions.ts
@@ -21,6 +21,8 @@ export type ToolCallSummary = {
 export type ContextReferenceSummary = {
   attachmentKind?: "file" | "image";
   attachmentPreviewPath?: string;
+  attachmentPath?: string;
+  mimeType?: string;
   id: string;
   kind: string;
   title: string;

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,11 +1,13 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:e35a4d72d9fb77d7cd55a7eac4940d1817ed86a737610605cece9239e2c66cd5 -->
+<!-- tinybot-module-fingerprint: sha256:9de7137d69947189d83e090b1e83fa761fa99c5e121d8618db4cf6704da89323 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles. Composer drag targets and attachment preparation
 status are localized in both languages.
 Quick start localizes welcome and model setup, catalog-validation feedback,
 task examples, dismissal, and the Help reentry action in both languages.
+Turn metrics localize the time-to-first-call label, millisecond value, and
+explanation of preprocessing versus TTFT in both languages.
 
 Desktop-pet position reset describes placement inside the main window in both
 languages.

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1169,6 +1169,8 @@ export const en = {
     },
     metrics: {
       title: "Turn time and speed", elapsed: "Took {{duration}}", duration: "Total turn time",
+      request: "Time to first model call", milliseconds: "{{value}}ms",
+      requestDescription: "From backend receipt of this turn's input to the first model call, including instructions, history, tools, and prompt preparation. TTFT starts at that call.",
       speed: "Output speed (TPS)", ttft: "Time to first token (TTFT)",
       seconds: "{{value}}s", minutesSeconds: "{{minutes}}m {{seconds}}s", tokensPerSecond: "{{value}} tok/s",
       description: "First token includes reasoning and tool calls. Speed uses recorded model generation time and excludes tool execution and waits between calls.",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -620,6 +620,8 @@ export const zh = {
     },
     metrics: {
       title: "本轮用时和速度", elapsed: "用时 {{duration}}", duration: "本轮总用时",
+      request: "发起调用用时", milliseconds: "{{value}}毫秒",
+      requestDescription: "从后端接收本轮输入到发起首次模型调用，包含指令加载、历史恢复、工具准备和提示词组装。TTFT 从该调用开始计时。",
       speed: "输出速度（TPS）", ttft: "首 token 用时（TTFT）",
       seconds: "{{value}}秒", minutesSeconds: "{{minutes}}分{{seconds}}秒", tokensPerSecond: "{{value}} tok/s",
       description: "首 token 包含思考和工具调用输出。速度按已记录的模型生成时间计算，不含工具执行和调用之间的等待。",


### PR DESCRIPTION
Expose application-side preparation latency separately from model TTFT, and make attached files easier to scan in the composer and sent messages.

- Add time to first model call to turn metrics and structured application logs for preparation phases. Diagnostic events stay out of conversation persistence.
- Show uploaded and workspace files as compact chips. Composer attachments remain on one horizontally scrolling row, newly added files scroll into view, and sent file chips wrap inside the user bubble.
- Keep full filenames, paths, and metadata in tooltips, retain removal and workspace preview actions, and give filename glyphs enough line height to prevent clipped underscores and descenders.

Validation:
- 79 targeted composer, annotation, timeline, and artifact tests passed.
- Turn-metrics frontend tests and targeted Rust lifecycle tests passed during implementation.
- TypeScript, staged documentation checks, module README checks, and whitespace checks passed.
- Browser verification covered single/multiple files, removal, sending, narrow and dark layouts, and glyph clipping before/after the fix.
