### PR TITLE
fix(desktop): polish menus and sidecar tab scrolling

### DIFF
--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:297b964523feb78663944a2ce0dfc01a7f01c7cf16463f24b912388f77dc4ae0 -->
+<!-- tinybot-doc-fingerprint: sha256:09e9f12b5ae1f58c4852032bca51d0c1f173ea3b19dc33c0b798543e960d1da0 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -825,7 +825,7 @@ describe("DesktopShell", () => {
     await user.click(screen.getByRole("button", { name: "Help" }));
     let helpMenu = screen.getByRole("menu", { name: "Help menu" });
     await user.click(within(helpMenu).getByRole("menuitem", { name: "Documentation (F1)" }));
-    await waitFor(() => expect(openUrl).toHaveBeenLastCalledWith("https://github.com/SudoJacky/tinybot#readme"));
+    await waitFor(() => expect(openUrl).toHaveBeenLastCalledWith("https://sudojacky.github.io/tinybot/"));
     expect(screen.getByRole("heading", { name: "Settings" })).toBeTruthy();
 
     await user.click(screen.getByRole("button", { name: "Help" }));

--- a/src/react-workbench/shell/DesktopShell.tsx
+++ b/src/react-workbench/shell/DesktopShell.tsx
@@ -72,7 +72,7 @@ type TopMenuLabel = string;
 type MotionSource = "keyboard" | "pointer";
 
 const TINYBOT_GITHUB_URL = "https://github.com/SudoJacky/tinybot";
-const TINYBOT_DOCUMENTATION_URL = `${TINYBOT_GITHUB_URL}#readme`;
+const TINYBOT_DOCUMENTATION_URL = "https://sudojacky.github.io/tinybot/";
 const TINYBOT_NEW_ISSUE_URL = `${TINYBOT_GITHUB_URL}/issues/new/choose`;
 
 type TopMenuCommandId =

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,7 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:e342054111cc44a8ffa0276434cdf75bdb2d4aa87025cdd7f84685e3e40ccc96 -->
+<!-- tinybot-module-fingerprint: sha256:eed0ed9795dd997fb6b8e3d4fcdca730500e1d938cb06097f117af4e661cfc42 -->
+
+The Help documentation command and its F1 shortcut open https://sudojacky.github.io/tinybot/ in the system browser.
 
 Desktop-pet quick chat shares composer drop and clipboard import with main Chat;
 it also shares live provider retry status with main Chat.

--- a/src/react-workbench/sidecar/README.md
+++ b/src/react-workbench/sidecar/README.md
@@ -1,5 +1,7 @@
 # Sidecar
-<!-- tinybot-module-fingerprint: sha256:80a6cd877c4fcfbd4fbb0317f29d93888ffa045a655b1be70eb22b69c736faf6 -->
+<!-- tinybot-module-fingerprint: sha256:60da5d203dabb6faf105b1cea0ba0f76e5ac6f3664613252b269d2eca47a05d6 -->
+
+Tabs retain a 150px width and scroll horizontally with the mouse wheel while hiding the scrollbar. Horizontal trackpad gestures and Ctrl-wheel zoom remain native. Activating a tab reveals its whole container, including Close; the unused More control is omitted.
 
 `sidecar` owns the React resource shell displayed beside Chat. It presents
 thread-scoped Browser and Artifact resources, workspace-scoped Terminal

--- a/src/react-workbench/sidecar/Sidecar.css
+++ b/src/react-workbench/sidecar/Sidecar.css
@@ -84,8 +84,8 @@
 .react-sidecar-tab {
   position: relative;
   display: flex;
-  flex: 0 1 150px;
-  min-width: 94px;
+  flex: 0 0 150px;
+  min-width: 150px;
   max-width: 176px;
   align-items: center;
   border-right: 1px solid color-mix(in srgb, var(--color-hairline) 78%, transparent);

--- a/src/react-workbench/sidecar/Sidecar.test.tsx
+++ b/src/react-workbench/sidecar/Sidecar.test.tsx
@@ -60,6 +60,27 @@ function mockWorkspaceWidth(readWidth: () => number) {
 }
 
 describe("Sidecar", () => {
+  it("scrolls overflowing tabs with the wheel and preserves horizontal gestures and zoom", () => {
+    renderSidecar();
+    const list = screen.getByRole("tablist");
+    Object.defineProperties(list, {
+      scrollWidth: { configurable: true, value: 900 },
+      clientWidth: { configurable: true, value: 300 },
+    });
+    expect(fireEvent.wheel(list, { deltaY: 80 })).toBe(false);
+    expect(list.scrollLeft).toBe(80);
+    fireEvent.wheel(list, { deltaY: -2, deltaMode: 1 });
+    expect(list.scrollLeft).toBe(48);
+    expect(fireEvent.wheel(list, { deltaX: 40, deltaY: 2 })).toBe(true);
+    const zoom = new WheelEvent("wheel", { deltaY: 50, bubbles: true, cancelable: true });
+    Object.defineProperty(zoom, "ctrlKey", { value: true });
+    expect(fireEvent(list, zoom)).toBe(true);
+    expect(list.scrollLeft).toBe(48);
+    Object.defineProperty(list, "scrollWidth", { value: 300 });
+    expect(fireEvent.wheel(list, { deltaY: 80 })).toBe(true);
+    expect(list.scrollLeft).toBe(48);
+  });
+
   it("retains closing browser chrome while hiding its native surface and cancels stale exits", async () => {
     const { props, rerender } = renderSidecar({ activeTabId: "browser-1" });
     const aside = screen.getByLabelText("Sidecar");

--- a/src/react-workbench/sidecar/Sidecar.tsx
+++ b/src/react-workbench/sidecar/Sidecar.tsx
@@ -4,7 +4,6 @@ import {
   Globe2,
   Maximize2,
   Minimize2,
-  MoreHorizontal,
   PanelRightClose,
   Plus,
   SquareTerminal,
@@ -82,6 +81,7 @@ export function Sidecar({
   const onResizeRef = useRef(onResize);
   const sidecarRef = useRef<HTMLElement>(null);
   const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+  const tabListRef = useRef<HTMLDivElement>(null);
   const widthRef = useRef(width);
   const [maxWidth, setMaxWidth] = useState(() => maxSidecarWidthForWorkspace(window.innerWidth, window.innerWidth));
   onResizeRef.current = onResize;
@@ -120,8 +120,23 @@ export function Sidecar({
   }, [newTabMenuOpen]);
 
   useLayoutEffect(() => {
-    tabRefs.current.get(activeTabId)?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    tabRefs.current.get(activeTabId)?.parentElement?.scrollIntoView({ block: "nearest", inline: "nearest" });
   }, [activeTabId]);
+
+  useEffect(() => {
+    const list = tabListRef.current;
+    if (!list) return;
+    const scrollTabs = (event: WheelEvent) => {
+      if (event.ctrlKey || list.scrollWidth <= list.clientWidth) return;
+      // Leave horizontal trackpad gestures to the browser.
+      if (Math.abs(event.deltaX) >= Math.abs(event.deltaY)) return;
+      event.preventDefault();
+      const unit = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? list.clientWidth : 1;
+      list.scrollLeft += event.deltaY * unit;
+    };
+    list.addEventListener("wheel", scrollTabs, { passive: false });
+    return () => list.removeEventListener("wheel", scrollTabs);
+  }, []);
 
   useLayoutEffect(() => {
     const workspace = sidecarRef.current?.parentElement;
@@ -282,7 +297,7 @@ export function Sidecar({
       </div>
 
       <header className="react-sidecar__header">
-        <div aria-label={t("sidecar.openTabs")} className="react-sidecar-tabs" role="tablist">
+        <div aria-label={t("sidecar.openTabs")} className="react-sidecar-tabs" ref={tabListRef} role="tablist">
           {tabs.map((tab) => {
             const active = tab.id === activeTabId;
             const Icon = sidecarTabIcon(tab);
@@ -373,9 +388,6 @@ export function Sidecar({
               </div>
             ) : null}
           </div>
-          <button aria-label={t("sidecar.more")} disabled title={t("sidecar.more")} type="button">
-            <MoreHorizontal aria-hidden="true" size={17} />
-          </button>
           <span aria-hidden="true" className="react-sidecar__control-divider" />
           <button
             aria-label={expanded ? t("sidecar.restore") : t("sidecar.expand")}

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,7 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:41e3446bfa76385c526269c95f90de59d26253898591666e9135a6e0d731300c -->
+<!-- tinybot-module-fingerprint: sha256:d6897bfd633c09e732a28bc28a3052b4f31dfec02b83f901b610fe882f241424 -->
+
+The sidebar title aligns with workspace folder icons. Its workspace menu anchors to the title row and fits the available width. Top-menu labels use a 1.5 line height to give glyph descenders room within their clipping boxes.
 
 `styles` contains the always-loaded design tokens, reset rules, accessibility
 defaults, shared primitives, and desktop-shell styles.

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -426,7 +426,7 @@ button:disabled {
   gap: 16px;
   cursor: default;
   font-size: 13px;
-  line-height: 1.25;
+  line-height: 1.5;
 }
 
 .react-top-menu__separator {
@@ -868,11 +868,12 @@ button:disabled {
 .react-session-list__header {
   display: grid;
   gap: 8px;
-  padding: 10px 8px;
+  padding: 10px 8px 10px 14px;
 }
 
 .react-session-list__title-row {
   position: relative;
+  min-width: 0;
   height: 32px;
 }
 
@@ -897,7 +898,6 @@ button:disabled {
 }
 
 .react-session-list__workspace-actions {
-  position: relative;
   display: inline-grid;
 }
 
@@ -906,7 +906,7 @@ button:disabled {
   z-index: 30;
   top: 36px;
   right: 0;
-  width: 196px;
+  width: min(196px, 100%);
 }
 
 .react-session-list__workspace-menu button {

--- a/src/react-workbench/tools/README.md
+++ b/src/react-workbench/tools/README.md
@@ -1,5 +1,7 @@
 # Tools Route
-<!-- tinybot-module-fingerprint: sha256:b45343d42cf7162f25475225fc5fb6b47e4fee5811449cab2609e3a021b85212 -->
+<!-- tinybot-module-fingerprint: sha256:7875adbe830d67449d32e060f512d76f54ecf9a1f63872d12653e6ede3505406 -->
+
+MCP form inputs use the panel background token, with existing border, focus, and validation feedback.
 
 `tools` owns the lazy Tools and Plugins route, including separate Plugins,
 Skills, MCP, and callable Tools views plus catalog, lifecycle, migration,

--- a/src/react-workbench/tools/ToolsRoute.css
+++ b/src/react-workbench/tools/ToolsRoute.css
@@ -833,7 +833,7 @@
   border: 1px solid var(--color-hairline);
   border-radius: 8px;
   outline: 0;
-  background: color-mix(in srgb, var(--color-body) 28%, var(--color-panel));
+  background: var(--color-panel);
   padding: 0 10px;
   color: var(--color-ink);
   font: inherit;


### PR DESCRIPTION
## Summary

Improve desktop navigation and keep crowded sidecar tabs usable.

- Align the sidebar title with workspace icons and keep the workspace menu within the sidebar.
- Use panel backgrounds for MCP inputs, increase top-menu line height, and point Help/F1 to the published documentation site.
- Keep sidecar tabs at a stable width and reveal the entire active tab, including Close. Map vertical mouse-wheel input to horizontal scrolling without showing a scrollbar, preserve native horizontal gestures and Ctrl-wheel zoom, and remove the unused More button.

## Validation

- Frontend type checking, lint, source analysis, all 1,041 tests, and production build passed.
- Browser layout checks covered sidebar widths from 180 to 320px and eight sidecar tabs in a narrow header. Wheel event behavior is covered by component tests.
- Documentation and module README freshness checks passed.
- Menu glyph clipping has not been visually verified with the user's exact desktop font configuration.
