### PR TITLE
feat: enhance sidecar previews and compact desktop chrome

### DIFF
--- a/docs/architecture/context-and-instructions.md
+++ b/docs/architecture/context-and-instructions.md
@@ -14,7 +14,7 @@ src-tauri/src/runtime/working_directory.rs
 src-tauri/src/system_prompt.rs
 src-tauri/src/workspace/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:20a54684f5a6f856456f291ad86df62c8aed41e7a186bba3a40430fddb211c9c -->
+<!-- tinybot-doc-fingerprint: sha256:9c6e5982ea0607b3dcb6871125f116eead34b4fd0d0ce22f8ccbbd9122f6849b -->
 
 Tinybot composes model-visible instructions from explicit, traceable sources
 before the Agent Runtime builds the bounded provider request. Instruction

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ src/react-workbench/agent-graph/README.md
 src/react-workbench/shell/README.md
 src/react-workbench/sidecar/README.md
 -->
-<!-- tinybot-doc-fingerprint: sha256:09e9f12b5ae1f58c4852032bca51d0c1f173ea3b19dc33c0b798543e960d1da0 -->
+<!-- tinybot-doc-fingerprint: sha256:f25020876530645ca9f011caf1d4ffc3d8eed5cb7cae52a9567bc623025fec25 -->
 
 Tinybot Desktop is a local-first React and Rust application. The renderer owns
 presentation, the application core owns framework-independent UI contracts,
@@ -53,6 +53,10 @@ Before dispatch, Chat asks the native Workspace service to save the original
 bytes. Sidecar presents value/preview comparisons and explicit keep/restore
 actions; native storage owns the baseline and exact-content conflict checks.
 Keeping acknowledges the live file, while restoring atomically replaces it.
+
+Raster previews use the same revision-bound binary reads; code previews reuse
+the renderer's syntax highlighter. File-type recognition stays in application
+core, while image URLs, decode errors and preview controls remain renderer-owned.
 
 Form answers resume the same Turn. Native persistence owns the resolution
 boundary and consumes its waiting checkpoint before publishing the completed

--- a/src-tauri/src/memory/README.md
+++ b/src-tauri/src/memory/README.md
@@ -1,5 +1,5 @@
 # Long-Term Memory
-<!-- tinybot-module-fingerprint: sha256:4d6632d070dab77b0ce650e425dc6e4246a99a196025ec770bb8280d5d70e6d6 -->
+<!-- tinybot-module-fingerprint: sha256:a9d030deb88b10935b8103d27037ca4da13996a11030a6b48e3ad8ba799b03be -->
 
 `memory` provides Tinybot's local long-term memory. Automatic maintenance uses
 two model-backed phases:
@@ -17,6 +17,10 @@ and runtime lifecycle orchestration. Each workspace/data-directory pair has one
 worker that serializes extraction and heartbeat work. `MemoryModel` supplies
 the asynchronous extraction and selection operations; `NativeMemoryModel`
 adapts the configured provider. There is no process-global worker registry.
+
+Queue notifications are checked against SQLite before extraction. A heartbeat
+may complete a Turn before its queued notification is received; such stale
+notifications skip model work and increment `memory.phase1.stale_notification.skipped`.
 
 `MemoryStore::new` receives the application data directory explicitly. Background
 workers, desktop management commands, and new Thread snapshots use the same

--- a/src-tauri/src/memory/runtime.rs
+++ b/src-tauri/src/memory/runtime.rs
@@ -252,6 +252,12 @@ impl WorkspaceMemoryRuntime {
     }
 
     async fn process_pending_turn(&self, pending: &PendingMemoryTurn) -> Result<(), String> {
+        // Heartbeats and notifications share this serial worker. A heartbeat
+        // can finish durable work before its queued notification is received.
+        if !self.store.is_turn_pending(pending)? {
+            increment_metric("memory.phase1.stale_notification.skipped");
+            return Ok(());
+        }
         let evidence =
             persisted_turn_evidence(&self.thread_store, &pending.thread_id, &pending.turn_id)?;
         if evidence.user_messages.is_empty() && evidence.successful_tool_results.is_empty() {

--- a/src-tauri/src/memory/runtime_tests.rs
+++ b/src-tauri/src/memory/runtime_tests.rs
@@ -212,6 +212,38 @@ fn shutdown_drops_in_flight_model_work_and_restart_recovers_durable_queue() {
 }
 
 #[test]
+fn queued_notification_does_not_repeat_extraction_completed_by_heartbeat() {
+    tauri::async_runtime::block_on(async {
+        let fixture = Fixture::new();
+        let model = Arc::new(Model::new(true, 2));
+        let runtime = WorkspaceMemoryRuntime {
+            store: fixture.store.clone(),
+            thread_store: fixture.threads.clone(),
+            thread_store_path: fixture.scope.clone(),
+            latest_config: Arc::new(Mutex::new(json!({"revision": 2}))),
+            model: model.clone(),
+            cancellation: CancellationToken::new(),
+        };
+        fixture
+            .store
+            .enqueue_turn(&fixture.scope, "thread", "turn", &fixture.scope)
+            .unwrap();
+        let notification = fixture
+            .store
+            .pending_turns(&fixture.scope, 1)
+            .unwrap()
+            .remove(0);
+        // Heartbeats may win select! before the queued notification is received.
+        runtime.run_heartbeat().await.unwrap();
+        assert_eq!(fixture.pending(), 1);
+        runtime.run_heartbeat().await.unwrap();
+        assert_eq!(fixture.pending(), 0);
+        runtime.process_pending_turn(&notification).await.unwrap();
+        assert_eq!(model.calls.load(Ordering::SeqCst), 2);
+    });
+}
+
+#[test]
 fn model_failure_remains_pending_until_heartbeat_retry_succeeds() {
     tauri::async_runtime::block_on(async {
         let fixture = Fixture::new();

--- a/src-tauri/src/memory/store.rs
+++ b/src-tauri/src/memory/store.rs
@@ -87,6 +87,21 @@ impl MemoryStore {
         rows.collect::<Result<Vec<_>, _>>().map_err(memory_db_error)
     }
 
+    pub(crate) fn is_turn_pending(&self, pending: &PendingMemoryTurn) -> Result<bool, String> {
+        self.open()?
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM pending_memory_turns \
+                 WHERE thread_store_path = ?1 AND thread_id = ?2 AND turn_id = ?3)",
+                params![
+                    pending.thread_store_path,
+                    pending.thread_id,
+                    pending.turn_id
+                ],
+                |row| row.get(0),
+            )
+            .map_err(memory_db_error)
+    }
+
     pub(crate) fn complete_extraction(
         &self,
         pending: &PendingMemoryTurn,

--- a/src/app-core/chat/README.md
+++ b/src/app-core/chat/README.md
@@ -1,9 +1,13 @@
 # Chat Application Core
-<!-- tinybot-module-fingerprint: sha256:a8b5ad63f6e3e81fba7a96c548faa7fc548a5150092aaf0b2b582d1ce36dd52c -->
+<!-- tinybot-module-fingerprint: sha256:5efe0804ade814af5f10046684dc236a715c5daf2345baf8ab3f4e9bfea1018e -->
 
 `chat` contains framework-independent chat and Thread contracts, command
 construction, canonical timeline validation, UI projection, input state, and
 desktop session coordination.
+
+`imageArtifact` resolves supported raster image MIME types. `codeArtifact`
+maps source/configuration filenames and MIME types to syntax languages,
+preserving distinctions such as TSX versus TypeScript.
 
 `providerRetryStatus` validates transient provider status updates and correlates
 them with a Thread, Turn, and model call. It never infers failures from assistant text

--- a/src/app-core/chat/codeArtifact.test.ts
+++ b/src/app-core/chat/codeArtifact.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { code } from "@streamdown/code";
+import { resolveCodeArtifactLanguage } from "./codeArtifact";
+
+describe("code artifact languages", () => {
+  it.each([
+    ["src/main.ts", "typescript"], ["src/App.TSX", "tsx"], ["app.jsx", "jsx"],
+    ["scripts/run.py", "python"], ["src/main.rs", "rust"], ["main.go", "go"],
+    ["main.cpp", "cpp"], ["main.cs", "csharp"], ["Main.java", "java"],
+    ["style.css", "css"], ["theme.scss", "scss"], ["page.html", "html"], ["icon.svg", "xml"],
+    ["config.json", "json"], ["settings.jsonc", "jsonc"], ["config.yaml", "yaml"], ["Cargo.toml", "toml"],
+    ["run.sh", "bash"], ["run.ps1", "powershell"], ["run.cmd", "bat"], ["query.sql", "sql"],
+    ["D:\\项目\\Dockerfile", "dockerfile"], ["Makefile", "make"], ["CMakeLists.txt", "cmake"],
+    [".zshrc", "zsh"], ["App.vue", "vue"], ["App.svelte", "svelte"],
+  ])("selects a supported highlighter for %s", (path, language) => {
+    expect(resolveCodeArtifactLanguage({ path })).toBe(language);
+    expect(code.supportsLanguage(language as Parameters<typeof code.supportsLanguage>[0])).toBe(true);
+  });
+
+  it("uses MIME types for unnamed artifacts but preserves TSX/JSX from the filename", () => {
+    expect(resolveCodeArtifactLanguage({ title: "Result", mimeType: "Application/JSON; charset=utf-8" })).toBe("json");
+    expect(resolveCodeArtifactLanguage({ title: "App.tsx", mimeType: "text/typescript" })).toBe("tsx");
+    expect(resolveCodeArtifactLanguage({ path: "App.jsx", mimeType: "text/javascript" })).toBe("jsx");
+  });
+
+  it.each(["README.md", "table.csv", "notes.txt", "unknown.xyz", "constructor", "toString"])("leaves %s to its existing preview", (path) => {
+    expect(resolveCodeArtifactLanguage({ path, mimeType: "text/plain" })).toBeUndefined();
+  });
+});

--- a/src/app-core/chat/codeArtifact.ts
+++ b/src/app-core/chat/codeArtifact.ts
@@ -1,0 +1,39 @@
+const LANGUAGES_BY_EXTENSION = new Map(Object.entries({
+  js: "javascript", mjs: "javascript", cjs: "javascript", jsx: "jsx",
+  ts: "typescript", mts: "typescript", cts: "typescript", tsx: "tsx",
+  py: "python", pyw: "python", pyi: "python", rs: "rust", go: "go",
+  c: "c", h: "cpp", cc: "cpp", cpp: "cpp", cxx: "cpp", hpp: "cpp",
+  cs: "csharp", java: "java", kt: "kotlin", kts: "kotlin", swift: "swift",
+  rb: "ruby", php: "php", lua: "lua", r: "r", dart: "dart",
+  sh: "bash", bash: "bash", zsh: "zsh", ps1: "powershell", psm1: "powershell", bat: "bat", cmd: "bat",
+  json: "json", jsonc: "jsonc", json5: "json5", yaml: "yaml", yml: "yaml", toml: "toml", ini: "ini",
+  html: "html", htm: "html", xml: "xml", svg: "xml", css: "css", scss: "scss", less: "less",
+  vue: "vue", svelte: "svelte", sql: "sql", graphql: "graphql", gql: "graphql",
+  diff: "diff", patch: "diff", dockerfile: "dockerfile",
+}));
+
+const LANGUAGES_BY_FILENAME = new Map(Object.entries({
+  dockerfile: "dockerfile", containerfile: "dockerfile", makefile: "make", gnumakefile: "make",
+  "cmakelists.txt": "cmake", ".bashrc": "bash", ".bash_profile": "bash", ".zshrc": "zsh",
+}));
+
+const LANGUAGES_BY_MIME_TYPE = new Map(Object.entries({
+  "text/javascript": "javascript", "application/javascript": "javascript",
+  "text/typescript": "typescript", "application/typescript": "typescript",
+  "application/json": "json", "application/ld+json": "json",
+  "application/yaml": "yaml", "text/yaml": "yaml", "application/toml": "toml",
+  "text/html": "html", "text/css": "css", "application/xml": "xml", "text/xml": "xml",
+  "text/x-python": "python", "text/x-rust": "rust", "text/x-shellscript": "bash",
+}));
+
+export function resolveCodeArtifactLanguage({ path, title, mimeType }: {
+  path?: string;
+  title?: string;
+  mimeType?: string;
+}): string | undefined {
+  const filename = (path || title || "").split(/[\\/]/).pop()!.toLowerCase();
+  const extension = /\.([^.]+)$/.exec(filename)?.[1] ?? "";
+  // Extensions distinguish JSX/TSX from their less specific MIME types.
+  return LANGUAGES_BY_FILENAME.get(filename) ?? LANGUAGES_BY_EXTENSION.get(extension)
+    ?? LANGUAGES_BY_MIME_TYPE.get(mimeType?.split(";", 1)[0].trim().toLowerCase() ?? "");
+}

--- a/src/app-core/chat/imageArtifact.ts
+++ b/src/app-core/chat/imageArtifact.ts
@@ -1,0 +1,21 @@
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  avif: "image/avif",
+  ico: "image/x-icon",
+};
+
+export function resolveImageArtifactMimeType({ mimeType, path, title }: {
+  mimeType?: string;
+  path?: string;
+  title?: string;
+}): string | undefined {
+  const normalized = mimeType?.split(";", 1)[0].trim().toLowerCase();
+  if (normalized && Object.values(IMAGE_MIME_TYPES).includes(normalized)) return normalized;
+  const extension = /\.([^./\\]+)$/.exec(path || title || "")?.[1].toLowerCase();
+  return extension && Object.prototype.hasOwnProperty.call(IMAGE_MIME_TYPES, extension) ? IMAGE_MIME_TYPES[extension] : undefined;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,12 @@ import { removeStartupSplash } from "./react-workbench/startupSplash";
 import { installRendererPerformanceTracking } from "./app-core/native/rendererPerformance";
 import { createDesktopNativeStartupTrace } from "./app-core/native/desktopNativeChatDebug";
 
+// App-owned windows share this entry. Keep the browser menu for development,
+// while allowing application context-menu handlers to run in production.
+if (import.meta.env.PROD) {
+  document.addEventListener("contextmenu", (event) => event.preventDefault());
+}
+
 installRendererPerformanceTracking();
 const entryTrace = createDesktopNativeStartupTrace({ startedAt: 0 });
 const surface = new URLSearchParams(window.location.search).get("surface");

--- a/src/react-workbench/chat/ChatPage.css
+++ b/src/react-workbench/chat/ChatPage.css
@@ -52,7 +52,7 @@
   --react-chat-content-gutter: clamp(20px, 4%, 40px);
   position: relative;
   display: grid;
-  grid-template-rows: 42px minmax(0, 1fr) auto;
+  grid-template-rows: 36px minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
   background: var(--color-canvas);
@@ -89,15 +89,15 @@
   align-items: center;
   gap: 4px;
   flex: 0 0 auto;
-  padding-left: 8px;
+  padding-left: 4px;
   border-left: 1px solid color-mix(in srgb, var(--color-hairline) 76%, transparent);
 }
 
 .react-chat-header__actions > button {
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
-  min-height: 32px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
   padding: 0;
 }
 
@@ -3463,6 +3463,14 @@
   max-width: 100%;
   border: 1px solid var(--color-hairline);
   border-radius: 8px;
+}
+
+.react-artifact-detail__image {
+  display: block;
+  justify-self: center;
+  height: auto;
+  max-height: 70vh;
+  object-fit: contain;
 }
 
 .react-artifact-detail__text {

--- a/src/react-workbench/chat/ChatPage.timeline.test.tsx
+++ b/src/react-workbench/chat/ChatPage.timeline.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentUiForm } from "../../app-core/agent-ui/agentUiEvents";
@@ -1338,7 +1338,8 @@ describe("ChatPage", () => {
     expect(readThreadFile).toHaveBeenCalledWith({ path: "src/main.ts", threadId: "s1" });
     const sidecar = await screen.findByLabelText("Sidecar");
     expect(within(sidecar).getByRole("tab", { name: "main.ts" })).toBeTruthy();
-    expect(await within(sidecar).findByText("import { mount } from './react-workbench/main';")).toBeTruthy();
+    await waitFor(() => expect(sidecar.querySelector("pre code")?.textContent).toBe("import { mount } from './react-workbench/main';"));
+    await waitFor(() => expect(sidecar.querySelector('pre span[style*="--sdm-c"]')).not.toBeNull());
   });
 
   it("renders Markdown workspace artifacts as documents instead of raw text previews", async () => {
@@ -1388,6 +1389,29 @@ describe("ChatPage", () => {
     expect(document.querySelector("pre")).toBeNull();
     expect(within(sidecar).queryByText("workspace-file:docs/operator-guide.md")).toBeNull();
     expect(within(sidecar).queryByText("text/markdown")).toBeNull();
+  });
+
+  it.each(["jpg", "png"])("opens a local %s link as an image preview and reports decode failures", async (extension) => {
+    const user = userEvent.setup();
+    const stores = createStores();
+    stores.chatStore.load = vi.fn(async (sessionId) => timelineFromReactMessages(sessionId, [{
+      id: "image-link", role: "assistant", createdAtMs: Date.UTC(2026, 6, 4, 12, 1, 0),
+      text: `View [the image](images/photo.${extension}).`, status: "complete",
+    }]));
+    const readThreadFile = vi.fn(async () => ({ contentType: "binary" as const, path: `images/photo.${extension}`, revision: "image-v1", sizeBytes: 3 }));
+    const readThreadFileBytes = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    vi.spyOn(URL, "createObjectURL").mockReturnValue(`blob:photo-${extension}`);
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    render(<ChatPage chatStore={stores.chatStore} sessionStore={stores.sessionStore}
+      workspaceStore={{ readThreadFile, readThreadFileBytes }} />);
+    await user.click(await screen.findByRole("link", { name: "the image" }));
+    const sidecar = within(await screen.findByLabelText("Sidecar"));
+    const image = await sidecar.findByRole("img", { name: `photo.${extension}` });
+    expect(image.getAttribute("src")).toBe(`blob:photo-${extension}`);
+    expect(readThreadFileBytes).toHaveBeenCalledWith({ path: `images/photo.${extension}`, threadId: "s1", expectedRevision: "image-v1" });
+    expect(sidecar.queryByText("Binary files cannot be previewed here yet.")).toBeNull();
+    fireEvent.error(image);
+    expect(sidecar.getByRole("alert").textContent).toContain(`Could not preview photo.${extension}`);
   });
 
   it("loads modern Office files through the revision-bound binary preview API", async () => {

--- a/src/react-workbench/chat/README.md
+++ b/src/react-workbench/chat/README.md
@@ -1,5 +1,5 @@
 # Chat Workbench
-<!-- tinybot-module-fingerprint: sha256:0c2e81f8d3e9c8f1284c1ce3c31774b388425c08aa905bfbdb3086e01733bb7e -->
+<!-- tinybot-module-fingerprint: sha256:f1138635ec2d99534343ce7d558de46a33d6716cf0a6cba22d25dc7fea9a46eb -->
 
 `chat` owns the desktop Chat route, including session navigation, submission,
 canonical timeline presentation, the composer, and detail drawers.
@@ -95,8 +95,8 @@ open/toggle operations; resource snapshots never enter page state.
 The Chat header offers an open action only while Sidecar is closed. When visible,
 Sidecar owns the single hide action in its toolbar, including expanded mode.
 Hiding restores keyboard focus after the Chat header's open action remounts.
-Chat header icon actions use centered 32px targets matching the Sidecar toolbar;
-the header is 42px tall including its bottom border, aligned with Sidecar.
+Chat header icon actions use centered 28px targets;
+the header is 36px tall including its bottom border.
 `useChatSubmission.ts` owns submission preparation, model-save ordering,
 optimistic message reconciliation, Artifact review capture, and compaction.
 Session operations are supplied through semantic operations; the page supplies
@@ -498,3 +498,5 @@ fails, or is interrupted. Awaiting input shows a static localized label; optimis
 dispatch shows one board until the canonical turn arrives. Localized playful
 phrases cycle with a stable accessible label. Offscreen/background indicators pause,
 and reduced motion stays static.
+
+Local raster previews read revision-bound bytes and release object URLs on replacement or close. Code previews select their syntax language from the filename or MIME type and copy the original source text.

--- a/src/react-workbench/chat/assistantFileLinks.test.ts
+++ b/src/react-workbench/chat/assistantFileLinks.test.ts
@@ -6,6 +6,14 @@ import {
 } from "./assistantFileLinks";
 
 describe("assistant file links", () => {
+  it.each([
+    ["photo.jpg", "image/jpeg"], ["photo.JPEG", "image/jpeg"], ["图表.PNG", "image/png"],
+    ["motion.gif", "image/gif"], ["photo.webp", "image/webp"], ["photo.bmp", "image/bmp"],
+    ["photo.avif", "image/avif"], ["icon.ico", "image/x-icon"],
+  ])("recognizes %s as an image artifact", (title, mimeType) => {
+    expect(assistantFileArtifact({ path: `images/${title}`, title })).toMatchObject({ kind: "image", mimeType });
+  });
+
   it("recognizes workspace-relative, absolute, and file URL targets without treating web URLs as files", () => {
     expect(isAssistantFileHref("./docs/guide.md")).toBe(true);
     expect(isAssistantFileHref("D:/Code/tinybot/src/main.ts")).toBe(true);

--- a/src/react-workbench/chat/assistantFileLinks.ts
+++ b/src/react-workbench/chat/assistantFileLinks.ts
@@ -1,4 +1,5 @@
 import type { ArtifactRef } from "../../app-core/chat/chatTurnContracts";
+import { resolveImageArtifactMimeType } from "../../app-core/chat/imageArtifact";
 
 export type AssistantFileLink = {
   href: string;
@@ -83,7 +84,7 @@ export function assistantFileArtifact(file: Pick<ResolvedAssistantFileLink, "pat
   return {
     fetchPath: file.path,
     id: `workspace-file:${file.path}`,
-    kind: mimeType === "text/markdown" ? "markdown" : mimeType === "application/json" ? "json" : "text",
+    kind: mimeType.startsWith("image/") ? "image" : mimeType === "text/markdown" ? "markdown" : mimeType === "application/json" ? "json" : "text",
     mimeType,
     status: "completed",
     title: file.title,
@@ -189,6 +190,8 @@ function stripLineSuffix(value: string): { line?: number; path: string } {
 }
 
 function assistantFileMimeType(path: string): string {
+  const imageMimeType = resolveImageArtifactMimeType({ path });
+  if (imageMimeType) return imageMimeType;
   const extension = /(?:^|\/)\.?(?:[^./]+)(\.[^./]+)$/.exec(path.toLowerCase())?.[1] ?? "";
   switch (extension) {
     case ".md":

--- a/src/react-workbench/chat/useArtifactFile.test.ts
+++ b/src/react-workbench/chat/useArtifactFile.test.ts
@@ -12,6 +12,58 @@ async function flush() { await act(async () => { await Promise.resolve(); }); }
 afterEach(() => { cleanup(); vi.useRealTimers(); vi.restoreAllMocks(); });
 
 describe("Local artifact observation", () => {
+  it("refreshes changed image bytes and releases URLs on replacement and close", async () => {
+    vi.useFakeTimers();
+    const createUrl = vi.spyOn(URL, "createObjectURL").mockReturnValueOnce("blob:first").mockReturnValueOnce("blob:second");
+    const revokeUrl = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    const readThreadFile = vi.fn().mockResolvedValueOnce(chunk("v1")).mockResolvedValueOnce(chunk("v1", "unchanged")).mockResolvedValueOnce(chunk("v2"));
+    const readThreadFileBytes = vi.fn().mockResolvedValue(new Uint8Array([137, 80, 78, 71]));
+    const { result, unmount } = renderHook(() => useArtifactFile({ ...base,
+      artifact: { ...artifact, fetchPath: "images/图表.PNG", title: "图表.PNG" },
+      workspaceStore: { readThreadFile, readThreadFileBytes },
+    }));
+    await flush();
+    expect(result.current.detail).toMatchObject({ mimeType: "image/png", imageDataUrl: "blob:first" });
+    const blob = createUrl.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("image/png");
+    expect(Array.from(new Uint8Array(await blob.arrayBuffer()))).toEqual([137, 80, 78, 71]);
+    await act(async () => { await vi.advanceTimersByTimeAsync(ARTIFACT_REFRESH_INTERVAL_MS); });
+    expect(createUrl).toHaveBeenCalledTimes(1);
+    expect(revokeUrl).not.toHaveBeenCalled();
+    await act(async () => { await vi.advanceTimersByTimeAsync(ARTIFACT_REFRESH_INTERVAL_MS); });
+    expect(readThreadFileBytes).toHaveBeenLastCalledWith({ path: "images/图表.PNG", threadId: "s1", expectedRevision: "v2" });
+    expect(result.current.detail?.imageDataUrl).toBe("blob:second");
+    expect(revokeUrl).toHaveBeenCalledWith("blob:first");
+    unmount();
+    expect(revokeUrl).toHaveBeenLastCalledWith("blob:second");
+  });
+
+  it("does not allocate an image URL for a binary read completed after close", async () => {
+    const createUrl = vi.spyOn(URL, "createObjectURL");
+    let finish!: (bytes: Uint8Array) => void;
+    const readThreadFile = vi.fn().mockResolvedValue(chunk("v1"));
+    const readThreadFileBytes = vi.fn(() => new Promise<Uint8Array>((resolve) => { finish = resolve; }));
+    const { unmount } = renderHook(() => useArtifactFile({ ...base,
+      artifact: { ...artifact, mimeType: "image/jpeg" }, workspaceStore: { readThreadFile, readThreadFileBytes },
+    }));
+    await flush();
+    unmount();
+    await act(async () => { finish(new Uint8Array([255, 216, 255])); });
+    expect(createUrl).not.toHaveBeenCalled();
+  });
+
+  it("surfaces image byte read errors instead of displaying an empty preview", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const readThreadFile = vi.fn().mockResolvedValue(chunk("v1"));
+    const readThreadFileBytes = vi.fn().mockRejectedValue(new Error("Image revision changed"));
+    const { result } = renderHook(() => useArtifactFile({ ...base,
+      artifact: { ...artifact, fetchPath: "photo.jpg" }, workspaceStore: { readThreadFile, readThreadFileBytes },
+    }));
+    await flush();
+    expect(result.current).toMatchObject({ loading: false, error: "Image revision changed" });
+    expect(result.current.detail).toBeUndefined();
+  });
+
   it("polls conditionally without reloading unchanged Office bytes, then reloads the new revision", async () => {
     vi.useFakeTimers();
     const readThreadFile = vi.fn().mockResolvedValueOnce(chunk("v1")).mockResolvedValueOnce(chunk("v1", "unchanged")).mockResolvedValueOnce(chunk("v2"));

--- a/src/react-workbench/chat/useArtifactFile.ts
+++ b/src/react-workbench/chat/useArtifactFile.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ArtifactRef, LoadedArtifactDetail } from "../../app-core/chat/chatTurnContracts";
 import { resolveOfficeArtifactKind, type OfficeArtifactSource } from "../../app-core/chat/officeArtifact";
+import { resolveImageArtifactMimeType } from "../../app-core/chat/imageArtifact";
 import { logRendererEvent } from "../../app-core/native/rendererLogger";
 import type { WorkspaceStore } from "../services";
 
@@ -36,6 +37,7 @@ export function useArtifactFile({ artifact, enabled, threadId, workspaceStore, u
     let revision: string | undefined;
     let timer: ReturnType<typeof setTimeout>;
     let lastError: string | undefined;
+    let imageUrl: string | undefined;
     setState({ loading: true });
     async function refresh() {
       if (disposed || inFlight || document.visibilityState === "hidden") return;
@@ -52,11 +54,20 @@ export function useArtifactFile({ artifact, enabled, threadId, workspaceStore, u
           return;
         }
         const officeKind = resolveOfficeArtifactKind({ mimeType, path, title });
+        const imageMimeType = resolveImageArtifactMimeType({ mimeType, path, title });
         let next: ArtifactFileState;
-        if (officeKind && file.contentType === "binary") {
+        if ((officeKind || imageMimeType) && file.contentType === "binary") {
           if (!readBytes) throw new Error(unavailableMessage);
           const bytes = await readBytes({ path: path!, threadId: threadId!, expectedRevision: file.revision });
-          next = { loading: false, office: { bytes, kind: officeKind, title }, revision: file.revision };
+          if (disposed) return;
+          if (imageMimeType) {
+            const url = URL.createObjectURL(new Blob([bytes], { type: imageMimeType }));
+            if (imageUrl) URL.revokeObjectURL(imageUrl);
+            imageUrl = url;
+            next = { loading: false, detail: { id, title, mimeType: imageMimeType, imageDataUrl: url }, revision: file.revision };
+          } else {
+            next = { loading: false, office: { bytes, kind: officeKind!, title }, revision: file.revision };
+          }
         } else {
           if (file.contentType !== "text") throw new Error(binaryMessage);
           next = { loading: false, detail: { id, title, mimeType, textContent: file.content ?? "" }, revision: file.revision, truncated: Boolean(file.nextCursor) };
@@ -87,6 +98,7 @@ export function useArtifactFile({ artifact, enabled, threadId, workspaceStore, u
     return () => {
       disposed = true;
       clearTimeout(timer);
+      if (imageUrl) URL.revokeObjectURL(imageUrl);
       window.removeEventListener("focus", wake);
       document.removeEventListener("visibilitychange", wake);
     };

--- a/src/react-workbench/i18n/README.md
+++ b/src/react-workbench/i18n/README.md
@@ -1,5 +1,5 @@
 # Renderer Internationalization
-<!-- tinybot-module-fingerprint: sha256:820666180f1c0196a76dab80ba03c920bb0d379ecf7be69acae66c39bba55f0c -->
+<!-- tinybot-module-fingerprint: sha256:5cf6f7a691fd95a9ecb63530b8a1461879597e35b37d8bc2ccb2e3d9087a7f13 -->
 
 `i18n` configures `i18next` for the React renderer and owns the typed English
 and Chinese resource bundles. Composer drag targets and attachment preparation
@@ -133,3 +133,5 @@ user-input tool calls have a distinct received-input title.
 
 Provider retry status includes waiting/requesting labels, retry counts, delays,
 and transport failure categories in both languages.
+
+Image decode failures use localized chat.details.imagePreviewFailed messages; filenames remain user data.

--- a/src/react-workbench/i18n/resources/en.ts
+++ b/src/react-workbench/i18n/resources/en.ts
@@ -1296,6 +1296,7 @@ export const en = {
       type: "Type", loadingArtifact: "Loading artifact…", noPreview: "No preview content is available.", subagentTrace: "Subagent trace",
       fileOutsideWorkspace: "This file is outside the active workspace.", filePreviewUnavailable: "Workspace file preview is unavailable in this runtime.",
       binaryFilePreviewUnsupported: "Binary files cannot be previewed here yet.", filePreviewTruncated: "Preview truncated. Open the file directly to inspect the remaining content.",
+      imagePreviewFailed: "Could not preview {{name}}. The image may be damaged or use an unsupported format.",
       officePreviewLoading: "Rendering {{format}} preview…", officePreviewFailed: "{{format}} preview failed: {{message}}",
       officeSheets: "Workbook sheets", officeSpreadsheetTruncated: "Showing the first {{rows}} rows and {{columns}} columns.",
       officePresentationNavigation: "PowerPoint slides", officePresentationSlide: "Go to slide {{slide}}",

--- a/src/react-workbench/i18n/resources/zh.ts
+++ b/src/react-workbench/i18n/resources/zh.ts
@@ -746,6 +746,7 @@ export const zh = {
       type: "类型", loadingArtifact: "正在加载产物…", noPreview: "没有可预览的内容。", subagentTrace: "子 Agent Trace",
       fileOutsideWorkspace: "该文件位于当前工作区之外。", filePreviewUnavailable: "当前运行环境无法预览工作区文件。",
       binaryFilePreviewUnsupported: "暂不支持在此处预览二进制文件。", filePreviewTruncated: "预览已截断，请直接打开文件查看剩余内容。",
+      imagePreviewFailed: "无法预览 {{name}}，图片可能已损坏或使用了不支持的格式。",
       officePreviewLoading: "正在渲染 {{format}} 预览…", officePreviewFailed: "{{format}} 预览失败：{{message}}",
       officeSheets: "工作表", officeSpreadsheetTruncated: "仅显示前 {{rows}} 行、{{columns}} 列。",
       officePresentationNavigation: "PowerPoint 幻灯片", officePresentationSlide: "前往第 {{slide}} 页幻灯片",

--- a/src/react-workbench/shell/DesktopShell.test.tsx
+++ b/src/react-workbench/shell/DesktopShell.test.tsx
@@ -464,16 +464,16 @@ describe("DesktopShell", () => {
       "src/react-workbench/settings/SettingsChoiceList.css",
     ].map((path) => readFileSync(path, "utf8")).join("\n");
 
-    expect(css).toMatch(/\.react-window-frame__history button\s*{[^}]*width:\s*32px;[^}]*height:\s*32px;/s);
+    expect(css).toMatch(/\.react-window-frame__history button\s*{[^}]*width:\s*28px;[^}]*height:\s*28px;/s);
     expect(css).toMatch(/\.react-top-menu__trigger\s*{[^}]*font-size:\s*12px;/s);
     expect(css).toMatch(/\.react-top-menu__menu-item\s*{[^}]*font-size:\s*13px;/s);
     expect(css).toMatch(/\.react-workbench-layout\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\);/s);
     expect(css).toMatch(/\.react-route-surface\s*{[^}]*min-height:\s*0;[^}]*overflow-y:\s*auto;/s);
-    expect(css).toMatch(/\.react-chat-surface\s*{[^}]*grid-template-rows:\s*42px minmax\(0,\s*1fr\) auto;/s);
+    expect(css).toMatch(/\.react-chat-surface\s*{[^}]*grid-template-rows:\s*36px minmax\(0,\s*1fr\) auto;/s);
     expect(css).toMatch(/\.react-popover-item\[aria-current="page"\][^{]*\{[^}]*background:/s);
     expect(css).not.toMatch(/\.react-activity-rail/);
     expect(css).toMatch(/\.react-session-list\s*{[^}]*transition:\s*width var\(--motion-duration-medium\) var\(--motion-ease-standard\);/s);
-    expect(css).toMatch(/\.react-session-list\[data-collapsed="true"\]\s*{[^}]*width:\s*42px;/s);
+    expect(css).toMatch(/\.react-session-list\[data-collapsed="true"\]\s*{[^}]*width:\s*36px;/s);
     expect(css).not.toMatch(/\.react-session-list__new/);
     expect(css).toMatch(/\.react-session-row__title\s*{[^}]*font-size:\s*12px;/s);
     expect(css).toMatch(/\.react-default-model-picker\s*{[^}]*grid-template-columns:\s*minmax\(170px,\s*0\.72fr\) minmax\(300px,\s*1\.45fr\);/s);

--- a/src/react-workbench/shell/README.md
+++ b/src/react-workbench/shell/README.md
@@ -1,5 +1,5 @@
 # Desktop Shell
-<!-- tinybot-module-fingerprint: sha256:eed0ed9795dd997fb6b8e3d4fcdca730500e1d938cb06097f117af4e661cfc42 -->
+<!-- tinybot-module-fingerprint: sha256:482ba7721505393aede0851d1c40c580da25dfb31739ea5a6e1ce56b38dec551 -->
 
 The Help documentation command and its F1 shortcut open https://sudojacky.github.io/tinybot/ in the system browser.
 
@@ -97,3 +97,5 @@ Update dialogs retain update lifecycle state in the shell and reuse
 System > What's New reopens the validated latest update record persisted by
 `app-core/native/desktopUpdateNotes`, while automatic update prompts continue
 to render the live native updater snapshot.
+
+The window frame and Chat session bar are 36px tall, with 28px icon buttons and 36px-wide window controls. Production renderer entry points suppress the browser default context menu while development retains it.

--- a/src/react-workbench/sidecar/CodeArtifactPreview.test.tsx
+++ b/src/react-workbench/sidecar/CodeArtifactPreview.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodeArtifactPreview } from "./CodeArtifactPreview";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  document.head.querySelectorAll('[data-test-style="code-preview"]').forEach((style) => style.remove());
+  document.documentElement.removeAttribute("data-theme");
+});
+
+function renderedSource(container: HTMLElement): string {
+  const lines = Array.from(container.querySelectorAll("pre code > span"));
+  return lines.map((line) => line.textContent === "\n" ? "" : line.textContent).join("\n");
+}
+
+describe("code artifact preview", () => {
+  it.each(["light", "dark"])("highlights with the %s theme and preserves indentation", async (theme) => {
+    document.documentElement.dataset.theme = theme;
+    const style = document.createElement("style");
+    style.dataset.testStyle = "code-preview";
+    style.textContent = readFileSync("src/react-workbench/chat/ChatPage.css", "utf8");
+    document.head.append(style);
+    const text = "def hello(name):\n    return 'Hello ' + name";
+    const { container } = render(<CodeArtifactPreview text={text} language="python" />);
+    await waitFor(() => expect(container.querySelector('pre span[style*="--sdm-c"]')).not.toBeNull());
+    expect(renderedSource(container)).toBe(text);
+    const token = container.querySelector<HTMLElement>('pre span[style*="--sdm-c"]')!;
+    expect(getComputedStyle(token).color).toBe(token.style.getPropertyValue(theme === "dark" ? "--shiki-dark" : "--sdm-c"));
+    fireEvent.click(screen.getByRole("button", { name: "Wrap code lines" }));
+    expect(container.querySelector(".react-markdown-code")?.getAttribute("data-wrap")).toBe("true");
+    expect(renderedSource(container)).toBe(text);
+  });
+
+  it("keeps embedded fences, HTML and Markdown literal and copies the original source", async () => {
+    const text = 'const example = `\n```\n````\n<img src=x onerror="alert(1)">\n[link](https://example.com)\n`;\n';
+    const copy = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText: copy } });
+    const { container } = render(<CodeArtifactPreview text={text} language="javascript" />);
+    await waitFor(() => expect(container.querySelector('pre span[style*="--sdm-c"]')).not.toBeNull());
+    expect(container.querySelectorAll("pre")).toHaveLength(1);
+    expect(container.querySelector("img, a")).toBeNull();
+    // The shared code block omits trailing blank lines from its visual layout.
+    expect(renderedSource(container)).toBe(text.trimEnd());
+    fireEvent.click(container.querySelector<HTMLButtonElement>('[data-streamdown="code-block-copy-button"]')!);
+    await waitFor(() => expect(copy).toHaveBeenCalledWith(text));
+  });
+
+  it("updates highlighted code when the file content changes", async () => {
+    const { container, rerender } = render(<CodeArtifactPreview text="const first = 1;" language="typescript" />);
+    await waitFor(() => expect(renderedSource(container)).toBe("const first = 1;"));
+    rerender(<CodeArtifactPreview text="const second = 2;" language="typescript" />);
+    await waitFor(() => expect(renderedSource(container)).toBe("const second = 2;"));
+  });
+
+  it.each(["const value = 1;", "const value = 1;\r\n\r\n"])("copies exact file line endings: %j", async (text) => {
+    const copy = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText: copy } });
+    const { container } = render(<CodeArtifactPreview text={text} language="typescript" />);
+    fireEvent.click(container.querySelector<HTMLButtonElement>('[data-streamdown="code-block-copy-button"]')!);
+    await waitFor(() => expect(copy).toHaveBeenCalledWith(text));
+  });
+});

--- a/src/react-workbench/sidecar/CodeArtifactPreview.tsx
+++ b/src/react-workbench/sidecar/CodeArtifactPreview.tsx
@@ -1,0 +1,31 @@
+import { code } from "@streamdown/code";
+import { memo, useMemo, type ComponentProps } from "react";
+import { Streamdown } from "streamdown";
+import { MarkdownCode } from "../chat/MarkdownCode";
+
+const plugins = { code };
+
+export const CodeArtifactPreview = memo(function CodeArtifactPreview({ text, language }: {
+  text: string;
+  language: string;
+}) {
+  // Feed the file source directly to the shared code block: Markdown parsing
+  // adds a final newline and normalizes line endings, which must not affect copy.
+  const components = useMemo(() => ({
+    code: (props: ComponentProps<typeof MarkdownCode>) => <MarkdownCode {...props}>{text}</MarkdownCode>,
+  }), [text]);
+  const fencedSource = useMemo(() => {
+    // Source files can contain Markdown fences (e.g. template strings). A longer
+    // delimiter keeps all file contents literal, including HTML and links.
+    let fenceLength = 3;
+    for (const match of text.matchAll(/`+/g)) fenceLength = Math.max(fenceLength, match[0].length + 1);
+    const fence = "`".repeat(fenceLength);
+    return `${fence}${language}\n${text}\n${fence}`;
+  }, [text, language]);
+  return (
+    <Streamdown className="react-message-markdown" components={components} plugins={plugins}
+      mode="static" lineNumbers={false} skipHtml>
+      {fencedSource}
+    </Streamdown>
+  );
+});

--- a/src/react-workbench/sidecar/ImageArtifactPreview.tsx
+++ b/src/react-workbench/sidecar/ImageArtifactPreview.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { logRendererEvent } from "../../app-core/native/rendererLogger";
+
+export function ImageArtifactPreview({ src, title, path }: { src: string; title: string; path?: string }) {
+  const { t } = useTranslation("chat");
+  const [failed, setFailed] = useState(false);
+  return failed ? <p role="alert">{t("details.imagePreviewFailed", { name: title })}</p> : (
+    <img
+      alt={title}
+      className="react-artifact-detail__image"
+      src={src}
+      onError={() => {
+        logRendererEvent("error", "artifact.image.decode.failed", { path, title });
+        setFailed(true);
+      }}
+    />
+  );
+}

--- a/src/react-workbench/sidecar/README.md
+++ b/src/react-workbench/sidecar/README.md
@@ -1,5 +1,5 @@
 # Sidecar
-<!-- tinybot-module-fingerprint: sha256:60da5d203dabb6faf105b1cea0ba0f76e5ac6f3664613252b269d2eca47a05d6 -->
+<!-- tinybot-module-fingerprint: sha256:ea53ec7c790a9c4fd7a343ec9e7363853d219953236e07a29f31d0be16d71f2e -->
 
 Tabs retain a 150px width and scroll horizontally with the mouse wheel while hiding the scrollbar. Horizontal trackpad gestures and Ctrl-wheel zoom remain native. Activating a tab reveals its whole container, including Close; the unused More control is omitted.
 
@@ -41,8 +41,13 @@ close event.
 
 ## Presentation and lifecycle
 
-The header is 42px tall including its bottom border, aligned with the Chat
-session bar. Resource tab selection fills the available header height.
+The Sidecar header is 42px tall including its bottom border; the Chat session
+bar is 36px tall. Resource tab selection fills the available header height.
+
+`ImageArtifactPreview` displays local raster files proportionally and reports
+decode errors. `CodeArtifactPreview` reuses chat syntax highlighting, themes,
+wrapping and copying; copy preserves the original file text. Unknown text
+formats retain plain previews.
 
 `Sidecar.tsx` owns tabs, the resource menu, keyboard tab behavior, and the
 resize handle. Width is persisted separately from resource state. The live and

--- a/src/react-workbench/sidecar/SidecarResources.tsx
+++ b/src/react-workbench/sidecar/SidecarResources.tsx
@@ -4,6 +4,7 @@ import { Loader2 } from "lucide-react";
 import type { ChatStore, SessionSummary, WorkspaceStore } from "../services";
 import type { ArtifactRef, LoadedArtifactDetail } from "../../app-core/chat/chatTurnContracts";
 import type { OfficeArtifactSource, SpreadsheetCellChangeRequest } from "../../app-core/chat/officeArtifact";
+import { resolveCodeArtifactLanguage } from "../../app-core/chat/codeArtifact";
 import type { AgentInputReference } from "../../app-core/chat/agentInputReference";
 import type { NativeBrowserSnapshot, NativeBrowserSession } from "../../app-core/native/nativeBrowserSnapshot";
 import { officeContentReference } from "../../app-core/chat/officeContentReference";
@@ -18,6 +19,8 @@ import { ArtifactReviewPanel } from "./ArtifactReviewPanel";
 import { DelimitedTextPreview } from "./DelimitedTextPreview";
 import { artifactDelimiter } from "./delimitedText";
 import { OfficeArtifactPreview } from "./OfficeArtifactPreview";
+import { ImageArtifactPreview } from "./ImageArtifactPreview";
+import { CodeArtifactPreview } from "./CodeArtifactPreview";
 import { Sidecar } from "./Sidecar";
 import { SidecarBrowser } from "./SidecarBrowser";
 import { useSidecarBrowserState } from "./useSidecarBrowserState";
@@ -578,6 +581,7 @@ function ArtifactDetails({
   const delimiter = !markdown && !office && !detail?.dataView && !detail?.imageDataUrl
     ? artifactDelimiter(artifact.fetchPath || artifact.title, detail?.mimeType || artifact.mimeType) : undefined;
   const delimited = delimiter !== undefined && detail?.textContent !== undefined;
+  const codeLanguage = resolveCodeArtifactLanguage({ path: artifact.fetchPath, title: artifact.title, mimeType: detail?.mimeType || artifact.mimeType });
   const referenceAction = <button disabled={loading || Boolean(error)} onClick={referenceArtifact} type="button">{t("details.referenceInChat")}</button>;
   const markdownContent = detail?.textContent && markdown
     ? { text: detail.textContent, title: detail.title }
@@ -597,7 +601,7 @@ function ArtifactDetails({
       {loading ? <p aria-live="polite">{t("details.loadingArtifact")}</p> : null}
       {error ? <p role="alert">{error}</p> : null}
       {notice ? <p className="react-artifact-detail__notice">{notice}</p> : null}
-      {detail?.imageDataUrl ? <img alt={detail.title} src={detail.imageDataUrl} /> : null}
+      {detail?.imageDataUrl ? <ImageArtifactPreview key={detail.imageDataUrl} src={detail.imageDataUrl} title={detail.title} path={artifact.fetchPath} /> : null}
       {detail?.dataView ? <DataViewCard artifact={{ ...artifact, dataView: detail.dataView }} expanded /> : null}
       {office ? (
         <OfficeArtifactPreview
@@ -619,7 +623,9 @@ function ArtifactDetails({
             text={markdownContent.text}
           />
         </article>
-      ) : detail?.textContent ? <pre className="react-artifact-detail__text">{detail.textContent}</pre> : null}
+      ) : detail?.textContent ? codeLanguage
+        ? <CodeArtifactPreview text={detail.textContent} language={codeLanguage} />
+        : <pre className="react-artifact-detail__text">{detail.textContent}</pre> : null}
       {!markdown && !office ? <details className="react-artifact-detail__metadata">
         <summary>{t("details.fileDetails")}</summary>
         <dl>

--- a/src/react-workbench/styles/README.md
+++ b/src/react-workbench/styles/README.md
@@ -1,5 +1,5 @@
 # Workbench Styles
-<!-- tinybot-module-fingerprint: sha256:d6897bfd633c09e732a28bc28a3052b4f31dfec02b83f901b610fe882f241424 -->
+<!-- tinybot-module-fingerprint: sha256:3e7622d9c67b3569b9feafc2c57b4926668a004ca216dcbca011ad0964e5aa31 -->
 
 The sidebar title aligns with workspace folder icons. Its workspace menu anchors to the title row and fits the available width. Top-menu labels use a 1.5 line height to give glyph descenders room within their clipping boxes.
 
@@ -26,9 +26,10 @@ Workspace and project disclosures transition list height over 220 ms and opacity
 over 160 ms. Native details content visibility stays rendered until closing ends;
 only list bodies clip, preserving the absolutely positioned header actions.
 Keyboard activation and reduced-motion preferences disable these transitions.
-Session tab close controls use centered 32px targets, matching the
-Chat header and Sidecar toolbar actions. Tab selection fills the available height
-inside the 42px header without overflowing its bottom border.
+Session tab close controls and Chat header actions use centered 28px targets.
+Tab selection fills the available height inside the 36px header without
+overflowing its bottom border. The window frame is also 36px tall, with
+28px menu/history buttons and 36px-wide window controls.
 
 Shared scrollbar tokens keep native overflow thumbs quiet against the current
 theme, with stronger hover and drag states and transparent tracks. Desktop
@@ -61,14 +62,14 @@ Session-row entrance styles apply only to the workspace's explicitly eligible
 initial rows, with a bounded 30 ms stagger. Ordinary search/navigation never
 inherits an entrance animation from the list container.
 Its search action expands from the compact icon into a full-width inline input;
-the outer search field stays 32px high including its border, with a 28px input
+the outer search field stays 28px high including its border, with a 24px input
 and close button, so toggling search never shifts the session rows vertically.
 The mounted search layer reveals and retracts toward its trigger through reversible
 160ms clip-path and opacity transitions; the default title controls crossfade in
 the same fixed-height row. Focus-within styling keeps the active boundary visible,
 and reduced-motion mode disables these transitions.
-The collapsed sidebar is a 42px vertical shortcut rail matching the top bar's
-height, with centered 32px buttons, 16px action icons, and a 24px mascot.
+The collapsed sidebar is a 36px vertical shortcut rail matching the top bar's
+height, with centered 28px buttons, 16px action icons, and a 22px mascot.
 Its top control presents the Tinybot mascot at rest, then reveals the expand icon
 on pointer hover or keyboard focus; new-chat, add-workspace, and search actions
 follow in that order.

--- a/src/react-workbench/styles/workbench.css
+++ b/src/react-workbench/styles/workbench.css
@@ -191,7 +191,7 @@ button:disabled {
 
 .react-desktop-shell {
   display: grid;
-  grid-template-rows: 42px minmax(0, 1fr);
+  grid-template-rows: 36px minmax(0, 1fr);
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -201,8 +201,8 @@ button:disabled {
   display: grid;
   grid-template-columns: auto auto minmax(80px, 1fr) auto auto;
   align-items: center;
-  gap: 8px;
-  padding: 0 8px 0 12px;
+  gap: 4px;
+  padding: 0 8px;
   border-bottom: 1px solid var(--color-hairline);
   background: var(--color-canvas);
   user-select: none;
@@ -218,10 +218,10 @@ button:disabled {
 .react-window-frame__history button {
   display: inline-grid;
   place-items: center;
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
-  min-height: 32px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
   padding: 0;
   border: 0;
   border-radius: 7px;
@@ -273,10 +273,11 @@ button:disabled {
 .react-window-frame__control {
   display: inline-grid;
   place-items: center;
-  width: 44px;
-  min-width: 44px;
+  width: 36px;
+  min-width: 36px;
   height: 100%;
-  min-height: 42px;
+  min-height: 0;
+  padding: 0;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -314,13 +315,13 @@ button:disabled {
   flex: 0 0 auto;
   width: auto;
   max-width: 160px;
-  min-width: 32px;
-  height: 30px;
-  min-height: 30px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
   gap: 0;
   overflow: hidden;
   border-radius: 999px;
-  padding: 0 8px;
+  padding: 0 5px;
   color: var(--color-ink);
   cursor: default;
   font-size: 12px;
@@ -815,7 +816,7 @@ button:disabled {
 }
 
 .react-session-list[data-collapsed="true"] {
-  width: 42px;
+  width: 36px;
 }
 
 .react-session-list[data-resizing="true"][data-collapsed="false"] {
@@ -868,13 +869,13 @@ button:disabled {
 .react-session-list__header {
   display: grid;
   gap: 8px;
-  padding: 10px 8px 10px 14px;
+  padding: 4px 8px 4px 12px;
 }
 
 .react-session-list__title-row {
   position: relative;
   min-width: 0;
-  height: 32px;
+  height: 28px;
 }
 
 .react-session-list__title-default {
@@ -904,7 +905,7 @@ button:disabled {
 .react-session-list__workspace-menu {
   position: absolute;
   z-index: 30;
-  top: 36px;
+  top: 32px;
   right: 0;
   width: min(196px, 100%);
 }
@@ -945,10 +946,10 @@ button:disabled {
 .react-session-list__collapse {
   display: inline-grid;
   place-items: center;
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
-  min-height: 32px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
   padding: 0;
   color: var(--color-muted);
 }
@@ -957,10 +958,10 @@ button:disabled {
 .react-session-list__search {
   display: inline-grid;
   place-items: center;
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
-  min-height: 32px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
   padding: 0;
   color: var(--color-muted);
   transition:
@@ -982,19 +983,19 @@ button:disabled {
   z-index: 1;
   inset: 0;
   display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) 28px;
+  grid-template-columns: 18px minmax(0, 1fr) 24px;
   align-items: center;
   gap: 4px;
   width: 100%;
   min-width: 0;
-  height: 32px;
+  height: 28px;
   overflow: hidden;
   border: 1px solid var(--color-hairline);
   border-radius: 9px;
   background: var(--color-panel);
   padding: 0 3px 0 9px;
   color: var(--color-muted);
-  clip-path: inset(0 36px 0 calc(100% - 68px) round 9px);
+  clip-path: inset(0 32px 0 calc(100% - 60px) round 9px);
   opacity: 0;
   pointer-events: none;
   transition:
@@ -1016,7 +1017,7 @@ button:disabled {
 .react-session-list__inline-search input {
   width: 100%;
   min-width: 0;
-  height: 28px;
+  height: 24px;
   min-height: 0;
   border: 0;
   outline: 0;
@@ -1034,9 +1035,9 @@ button:disabled {
 .react-session-list__search-close {
   display: inline-grid;
   place-items: center;
-  width: 28px;
-  min-width: 28px;
-  height: 28px;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
   padding: 0;
   color: var(--color-muted);
 }
@@ -1045,17 +1046,17 @@ button:disabled {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
-  padding: 5px 4px;
+  gap: 4px;
+  padding: 4px 3px;
 }
 
 .react-session-list__collapsed-nav > button {
   display: inline-grid;
   place-items: center;
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
-  min-height: 32px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
   padding: 0;
   color: var(--color-muted);
 }
@@ -1085,7 +1086,7 @@ button:disabled {
 }
 
 .react-session-list__collapsed-mascot .react-tinybot-mascot {
-  --tinybot-mascot-size: 24px;
+  --tinybot-mascot-size: 22px;
 }
 
 .react-session-list__collapsed-expand {
@@ -1875,14 +1876,14 @@ button:disabled {
 .react-session-tab__select {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 6px;
   min-width: 0;
   height: 100%;
   min-height: 0;
   flex: 1;
   overflow: hidden;
   border-radius: 0;
-  padding: 0 4px 0 16px;
+  padding: 0 4px 0 12px;
   color: inherit;
   text-align: left;
 }
@@ -1937,10 +1938,10 @@ button:disabled {
 .react-session-tab__close {
   display: inline-grid;
   place-items: center;
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
-  min-height: 32px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
   border-radius: 0;
   padding: 0;
   color: var(--color-muted-soft);

--- a/tools/frontend-analysis/window-entry.test.mjs
+++ b/tools/frontend-analysis/window-entry.test.mjs
@@ -47,6 +47,7 @@ test("production bootstrap loads each window with its own CSS before importing i
       const styles = [];
       const loads = [];
       const imports = [];
+      const documentEvents = new EventTarget();
       const script = ts.transpileModule(entryChunk.code, {
         compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
       }).outputText;
@@ -55,6 +56,7 @@ test("production bootstrap loads each window with its own CSS before importing i
         URLSearchParams,
         window: { location: { search: `?surface=${surface}` } },
         document: {
+          addEventListener: documentEvents.addEventListener.bind(documentEvents),
           createElement: () => ({
             relList: { supports: () => true },
             addEventListener(event, callback) { if (event === "load") loads.push(callback); },
@@ -65,6 +67,9 @@ test("production bootstrap loads each window with its own CSS before importing i
         },
         require(id) { imports.push(id); return {}; },
       });
+      const contextMenu = new Event("contextmenu", { cancelable: true });
+      documentEvents.dispatchEvent(contextMenu);
+      assert.equal(contextMenu.defaultPrevented, true, "production windows must suppress the browser context menu");
       await new Promise(setImmediate);
       assert.deepEqual(imports, [], "entry must wait for its stylesheets");
       assert.equal(styles.length, 1);


### PR DESCRIPTION
## Summary
Local JPG/PNG links now open as proportional image previews in Sidecar, and recognized source/configuration files render with syntax highlighting. Image previews follow file revisions, release object URLs on replacement/close, and report decode failures. Code previews reuse chat themes, wrapping and copy controls while preserving the original source when copying.

- Set the desktop menu bar and Chat tab bar to 36px, and the collapsed session sidebar to 36px wide. Resize internal controls, spacing and search fields accordingly.
- Suppress the default browser context menu in production app-owned renderer windows while retaining it during development.
- Update module documentation and freshness fingerprints.

## Validation
- `npm run build` and `npm run lint` passed.
- Targeted image, syntax-preview, Markdown, timeline, shell, tab and sidebar tests passed.
- `npm run test:frontend-analysis` passed, including production context-menu suppression for all three renderer entry points.
- Staged README and engineering documentation freshness checks passed.
- Playwright measured both bars at 36px and the collapsed sidebar at 36px, with controls contained at a 900px viewport; search and menu interactions were checked.

Native packaged-window behavior has not been manually tested. Browser-only checks display the expected missing-Tauri-runtime notices.


## Memory CI regression
A heartbeat could finish a durable extraction before the worker received its queued notification, causing an unnecessary third model call. Check the SQLite pending state before invoking the model, record skipped stale notifications, and cover heartbeat completion followed by a stale notification with a deterministic regression test. The regression reproduced 3 calls instead of 2 before the fix; all 26 memory-related tests pass after it.


The original heartbeat retry test also passed 30 consecutive runs. Local full Rust runs each passed 1127 tests but hit an access-denied process-termination failure in desktop_terminal::tests::creates_each_terminal_resource_only_once (1 ignored); that terminal test passed when run alone. The full CI run remains the remote validation authority for this commit.


Remote validation completed: CI run 34697699251 passed frontend, Windows Rust tests, and the desktop aggregate check for commit 28d86cca5f67af215bb85333ceb8bfe5a6a1bfe0.

